### PR TITLE
feat(dashboard): add Automation summary panel with success rate

### DIFF
--- a/src/teetree/core/selectors.py
+++ b/src/teetree/core/selectors.py
@@ -51,6 +51,9 @@ class DashboardSummary:
     active_worktrees: int
     pending_headless_tasks: int
     pending_interactive_tasks: int
+    completed_headless_tasks: int = 0
+    failed_headless_tasks: int = 0
+    headless_success_rate: int = 0
 
 
 _PIPELINE_DISPLAY: dict[str, tuple[str, str]] = {
@@ -281,11 +284,21 @@ def build_task_detail(task_id: int) -> TaskDetail | None:
 
 
 def build_dashboard_summary() -> DashboardSummary:
+    automation = Task.objects.filter(
+        execution_target=Task.ExecutionTarget.HEADLESS,
+    ).aggregate(
+        completed=Count("pk", filter=Q(status=Task.Status.COMPLETED)),
+        failed=Count("pk", filter=Q(status=Task.Status.FAILED)),
+    )
+    total_finished = automation["completed"] + automation["failed"]
     return DashboardSummary(
         in_flight_tickets=Ticket.objects.in_flight().count(),
         active_worktrees=Worktree.objects.active().count(),
         pending_headless_tasks=Task.objects.claimable_for_headless().count(),
         pending_interactive_tasks=Task.objects.claimable_for_interactive().count(),
+        completed_headless_tasks=automation["completed"],
+        failed_headless_tasks=automation["failed"],
+        headless_success_rate=round(automation["completed"] * 100 / total_finished) if total_finished else 0,
     )
 
 

--- a/src/teetree/core/templates/teetree/partials/dashboard_summary.html
+++ b/src/teetree/core/templates/teetree/partials/dashboard_summary.html
@@ -16,3 +16,19 @@
     <div class="mt-3 font-display text-4xl leading-none">{{ summary.pending_interactive_tasks }}</div>
   </article>
 </div>
+{% if summary.completed_headless_tasks or summary.failed_headless_tasks %}
+<div class="mt-4 grid gap-4 sm:grid-cols-3">
+  <article class="rounded-2xl border border-bark/10 bg-gradient-to-b from-green-50 to-white px-5 py-4">
+    <span class="font-sans text-[11px] font-semibold uppercase tracking-[0.2em] text-bark/55">Automated Completed</span>
+    <div class="mt-3 font-display text-4xl leading-none text-green-700">{{ summary.completed_headless_tasks }}</div>
+  </article>
+  <article class="rounded-2xl border border-bark/10 bg-gradient-to-b from-red-50 to-white px-5 py-4">
+    <span class="font-sans text-[11px] font-semibold uppercase tracking-[0.2em] text-bark/55">Automated Failed</span>
+    <div class="mt-3 font-display text-4xl leading-none text-red-700">{{ summary.failed_headless_tasks }}</div>
+  </article>
+  <article class="rounded-2xl border border-bark/10 bg-gradient-to-b from-moss/10 to-white px-5 py-4">
+    <span class="font-sans text-[11px] font-semibold uppercase tracking-[0.2em] text-bark/55">Success Rate</span>
+    <div class="mt-3 font-display text-4xl leading-none">{{ summary.headless_success_rate }}%</div>
+  </article>
+</div>
+{% endif %}

--- a/tests/teetree_core/test_selectors.py
+++ b/tests/teetree_core/test_selectors.py
@@ -51,12 +51,28 @@ def test_build_dashboard_summary_counts_in_flight_work() -> None:
         status=Task.Status.COMPLETED,
     )
 
+    Task.objects.create(
+        ticket=active_ticket,
+        session=active_session,
+        execution_target=Task.ExecutionTarget.HEADLESS,
+        status=Task.Status.COMPLETED,
+    )
+    Task.objects.create(
+        ticket=active_ticket,
+        session=active_session,
+        execution_target=Task.ExecutionTarget.HEADLESS,
+        status=Task.Status.FAILED,
+    )
+
     summary = build_dashboard_summary()
 
     assert summary.in_flight_tickets == 1
     assert summary.active_worktrees == 1
     assert summary.pending_headless_tasks == 1
     assert summary.pending_interactive_tasks == 1
+    assert summary.completed_headless_tasks == 1
+    assert summary.failed_headless_tasks == 1
+    assert summary.headless_success_rate == 50
 
 
 def test_build_dashboard_ticket_rows_annotates_related_counts() -> None:


### PR DESCRIPTION
## Summary

- Add completed/failed headless task counts and success rate to `DashboardSummary` dataclass
- Use a single `aggregate()` query with conditional `Count` instead of two separate queries (better ORM performance)
- Show automation stats row in the summary template when any headless tasks have finished

Closes #10

## Test plan

- [x] Existing test updated to create completed+failed headless tasks and assert automation stats
- [ ] Verify dashboard renders the automation row only when tasks exist