### PR TITLE
fix: ttyd sessions inherit host timezone via TZ env var

### DIFF
--- a/src/teetree/agents/web_terminal.py
+++ b/src/teetree/agents/web_terminal.py
@@ -5,8 +5,10 @@ the terminal session accessible from a browser at ``http://host:port``.
 """
 
 import logging
+import os
 import shutil
 import subprocess  # noqa: S404
+from pathlib import Path
 
 from teetree.agents.prompt import build_interactive_context
 from teetree.agents.skill_bundle import resolve_skill_bundle
@@ -53,6 +55,7 @@ def launch_web_session(
         [ttyd_binary, "--writable", "--port", str(port), "--once", *agent_command],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
+        env=_build_ttyd_env(),
     )
     logger.info("Launched ttyd session for task %s (pid=%s, port=%s)", task.pk, proc.pid, port)
 
@@ -76,6 +79,29 @@ def _get_resume_session_id(task: Task) -> str:
     agent_id = task.session.agent_id if task.session else ""
     if agent_id and _UUID_RE.match(agent_id):
         return agent_id
+    return ""
+
+
+def _build_ttyd_env() -> dict[str, str]:
+    env = os.environ.copy()
+    if "TZ" not in env:
+        tz = _detect_host_timezone()
+        if tz:
+            env["TZ"] = tz
+    return env
+
+
+def _detect_host_timezone() -> str:
+    try:
+        return Path("/etc/timezone").read_text(encoding="utf-8").strip()
+    except OSError:
+        pass
+    try:
+        target = os.path.realpath("/etc/localtime")
+        if "zoneinfo/" in target:
+            return target.split("zoneinfo/", 1)[1]
+    except OSError:
+        pass
     return ""
 
 

--- a/tests/teetree_agents/test_web_terminal.py
+++ b/tests/teetree_agents/test_web_terminal.py
@@ -1,10 +1,12 @@
 """Tests for teetree.agents.web_terminal — ttyd session launching."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from teetree.agents.web_terminal import (
+    _build_ttyd_env,
+    _detect_host_timezone,
     _find_free_port,
     _get_resume_session_id,
     launch_web_session,
@@ -142,3 +144,47 @@ def test_launch_web_session_new_session_uses_system_context(monkeypatch: pytest.
     call_args = popen_mock.call_args[0][0]
     assert "--append-system-prompt" in call_args
     assert "--resume" not in call_args
+
+
+# --- _build_ttyd_env / _detect_host_timezone ---
+
+
+def test_build_ttyd_env_preserves_existing_tz(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TZ", "America/New_York")
+    env = _build_ttyd_env()
+    assert env["TZ"] == "America/New_York"
+
+
+def test_build_ttyd_env_injects_detected_tz(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TZ", raising=False)
+    with patch("teetree.agents.web_terminal._detect_host_timezone", return_value="Europe/Vienna"):
+        env = _build_ttyd_env()
+    assert env["TZ"] == "Europe/Vienna"
+
+
+def test_build_ttyd_env_skips_tz_when_detection_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TZ", raising=False)
+    with patch("teetree.agents.web_terminal._detect_host_timezone", return_value=""):
+        env = _build_ttyd_env()
+    assert "TZ" not in env
+
+
+def test_detect_host_timezone_reads_etc_timezone() -> None:
+    with patch("teetree.agents.web_terminal.Path.read_text", return_value="Europe/Paris\n"):
+        assert _detect_host_timezone() == "Europe/Paris"
+
+
+def test_detect_host_timezone_falls_back_to_localtime_symlink() -> None:
+    with (
+        patch("teetree.agents.web_terminal.Path.read_text", side_effect=OSError),
+        patch("os.path.realpath", return_value="/usr/share/zoneinfo/Europe/Berlin"),
+    ):
+        assert _detect_host_timezone() == "Europe/Berlin"
+
+
+def test_detect_host_timezone_returns_empty_on_failure() -> None:
+    with (
+        patch("teetree.agents.web_terminal.Path.read_text", side_effect=OSError),
+        patch("os.path.realpath", return_value="/some/other/path"),
+    ):
+        assert _detect_host_timezone() == ""


### PR DESCRIPTION
## Summary

- Pass `TZ` environment variable to ttyd subprocess so web terminal sessions inherit the host timezone
- Auto-detect timezone from `/etc/timezone` or `/etc/localtime` symlink when `TZ` is not set
- Use `Path.read_text()` instead of bare `open()` per ac-python standards

Closes #24

Depends on #73

## Test plan

- [x] Test preserves existing TZ env var
- [x] Test injects detected TZ when missing
- [x] Test skips TZ when detection fails
- [x] Test reads /etc/timezone
- [x] Test falls back to /etc/localtime symlink
- [x] Test returns empty on complete failure