### PR TITLE
refactor: remove hardcoded gitlab.com URLs from backends and CLI

### DIFF
--- a/src/teetree/backends/slack.py
+++ b/src/teetree/backends/slack.py
@@ -18,7 +18,7 @@ class SlackReviewMatch:
     channel: str
 
 
-_MR_URL_RE = re.compile(r"https://gitlab\.com/[^\s|>]+/merge_requests/\d+")
+_MR_URL_RE = re.compile(r"https://[^\s|>]+/merge_requests/\d+")
 
 
 def _resolve_workspace_domain(client: httpx.Client) -> str:

--- a/src/teetree/cli.py
+++ b/src/teetree/cli.py
@@ -571,9 +571,10 @@ def delete_draft_note(
         typer.echo("No GitLab token found.")
         raise typer.Exit(code=1)
 
+    base_url = os.environ.get("TEATREE_GITLAB_URL", "https://gitlab.com/api/v4")
     encoded = repo.replace("/", "%2F")
     response = _httpx.delete(
-        f"https://gitlab.com/api/v4/projects/{encoded}/merge_requests/{mr}/draft_notes/{note_id}",
+        f"{base_url}/projects/{encoded}/merge_requests/{mr}/draft_notes/{note_id}",
         headers={"PRIVATE-TOKEN": token},
         timeout=10.0,
     )


### PR DESCRIPTION
## Summary

- `slack.py`: MR URL regex now matches any GitLab instance, not just gitlab.com
- `cli.py` `delete_draft_note`: reads `TEATREE_GITLAB_URL` env var instead of hardcoding `gitlab.com/api/v4`
- `backends/gitlab.py` and `utils/gitlab_api.py` already supported configurable base_url

This matters for t3-company which uses a self-hosted GitLab instance.

Closes #39

Depends on #77

## Test plan

- [ ] Verify MR URL extraction from Slack works with non-gitlab.com instances
- [ ] Verify draft note deletion uses TEATREE_GITLAB_URL when set