### PR TITLE
refactor: add explicit db_table to all models for reusable app compat

### DIFF
--- a/src/teetree/core/migrations/0005_alter_session_table_alter_task_table_and_more.py
+++ b/src/teetree/core/migrations/0005_alter_session_table_alter_task_table_and_more.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0004_task_parent_task"),
+    ]
+
+    operations = [
+        migrations.AlterModelTable(
+            name="session",
+            table="teetree_session",
+        ),
+        migrations.AlterModelTable(
+            name="task",
+            table="teetree_task",
+        ),
+        migrations.AlterModelTable(
+            name="taskattempt",
+            table="teetree_taskattempt",
+        ),
+        migrations.AlterModelTable(
+            name="ticket",
+            table="teetree_ticket",
+        ),
+        migrations.AlterModelTable(
+            name="worktree",
+            table="teetree_worktree",
+        ),
+    ]

--- a/src/teetree/core/models.py
+++ b/src/teetree/core/models.py
@@ -52,6 +52,9 @@ class Ticket(models.Model):
 
     objects = TicketManager()
 
+    class Meta:
+        db_table = "teetree_ticket"
+
     def __str__(self) -> str:
         return str(self.issue_url or f"ticket-{self.pk}")
 
@@ -174,6 +177,9 @@ class Worktree(models.Model):
 
     objects = WorktreeManager()
 
+    class Meta:
+        db_table = "teetree_worktree"
+
     def __str__(self) -> str:
         return str(self.repo_path)
 
@@ -288,6 +294,9 @@ class Session(models.Model):
 
     objects = SessionManager()
 
+    class Meta:
+        db_table = "teetree_session"
+
     _REQUIRED_PHASES: ClassVar[dict[str, list[str]]] = {
         "reviewing": ["testing"],
         "shipping": ["testing", "reviewing"],
@@ -360,6 +369,9 @@ class Task(models.Model):
     result_artifact_path = models.CharField(max_length=500, blank=True)
 
     objects = TaskManager()
+
+    class Meta:
+        db_table = "teetree_task"
 
     def __str__(self) -> str:
         return f"task-{self.pk}-{self.execution_target!s}"
@@ -526,6 +538,9 @@ class TaskAttempt(models.Model):
     result = models.JSONField(default=dict, blank=True)
     launch_url = models.URLField(max_length=500, blank=True)
     agent_session_id = models.CharField(max_length=255, blank=True)
+
+    class Meta:
+        db_table = "teetree_taskattempt"
 
     def __str__(self) -> str:
         return f"attempt-{self.pk or 'new'!s}"

--- a/src/teetree/core/views/actions.py
+++ b/src/teetree/core/views/actions.py
@@ -46,7 +46,9 @@ class CancelTaskView(View):
 
 
 def _has_active_session(task: Task) -> bool:
-    attempt = task.attempts.order_by("-pk").first()
+    from teetree.core.models import TaskAttempt  # noqa: PLC0415
+
+    attempt = TaskAttempt.objects.filter(task=task).order_by("-pk").first()
     if attempt is None or not attempt.agent_session_id:
         return False
     session_file = Path.home() / ".claude" / "sessions" / f"{attempt.agent_session_id}.json"


### PR DESCRIPTION
## Summary

- Add `db_table = "teetree_<model>"` to all 5 core models (Ticket, Worktree, Session, Task, TaskAttempt)
- Add migration 0005 with AlterModelTable operations
- Prevents table name collisions when teatree is installed alongside other Django apps with a `core` app label

This also affects t3-company: the overlay's test DB will use the namespaced table names after migrating.

Closes #46

Depends on #78

## Test plan

- [x] Migration created with AlterModelTable for all 5 models
- [ ] Run `makemigrations --check` to verify no drift
- [ ] Run existing test suite (tables are transparent to ORM)