### PR TITLE
feat: add venv-agnostic discovery utilities for overlay use

### DIFF
--- a/src/teetree/utils/venv.py
+++ b/src/teetree/utils/venv.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from pathlib import Path
+
+
+def find_python(cwd: str | Path = ".") -> str:
+    venv = os.environ.get("VIRTUAL_ENV")
+    if venv:
+        candidate = Path(venv) / "bin" / "python"
+        if candidate.is_file():
+            return str(candidate)
+
+    local = Path(cwd) / ".venv" / "bin" / "python"
+    if local.is_file():
+        return str(local)
+
+    return sys.executable
+
+
+def find_activate(cwd: str | Path = ".") -> str:
+    venv = os.environ.get("VIRTUAL_ENV")
+    if venv:
+        candidate = Path(venv) / "bin" / "activate"
+        if candidate.is_file():
+            return str(candidate)
+
+    local = Path(cwd) / ".venv" / "bin" / "activate"
+    if local.is_file():
+        return str(local)
+
+    return ""

--- a/tests/teetree_utils/test_venv.py
+++ b/tests/teetree_utils/test_venv.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+from teetree.utils.venv import find_activate, find_python
+
+
+@pytest.fixture
+def venv_tree(tmp_path: Path) -> Path:
+    (tmp_path / ".venv" / "bin").mkdir(parents=True)
+    (tmp_path / ".venv" / "bin" / "python").touch()
+    (tmp_path / ".venv" / "bin" / "activate").touch()
+    return tmp_path
+
+
+class TestFindPython:
+    def test_uses_virtual_env_when_set(self, venv_tree: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VIRTUAL_ENV", str(venv_tree / ".venv"))
+        assert find_python() == str(venv_tree / ".venv" / "bin" / "python")
+
+    def test_falls_back_to_local_venv(self, venv_tree: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        assert find_python(venv_tree) == str(venv_tree / ".venv" / "bin" / "python")
+
+    def test_falls_back_to_sys_executable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        assert find_python(tmp_path) == sys.executable
+
+
+class TestFindActivate:
+    def test_uses_virtual_env_when_set(self, venv_tree: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VIRTUAL_ENV", str(venv_tree / ".venv"))
+        assert find_activate() == str(venv_tree / ".venv" / "bin" / "activate")
+
+    def test_falls_back_to_local_venv(self, venv_tree: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        assert find_activate(venv_tree) == str(venv_tree / ".venv" / "bin" / "activate")
+
+    def test_returns_empty_when_no_venv(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        assert find_activate(tmp_path) == ""


### PR DESCRIPTION
## Summary

- New `utils/venv.py` provides `find_python()` and `find_activate()` helpers
- Check `VIRTUAL_ENV` env var first, then `.venv/bin/`, then `sys.executable`
- Overlays should use these instead of hardcoding `.venv/bin/` paths

This is the teatree-core foundation for company-fork-org/t3-company#6 (replace `.venv/bin` with `uv --directory`).

Closes #68

Depends on #79

## Test plan

- [x] Test find_python with VIRTUAL_ENV set
- [x] Test find_python with local .venv
- [x] Test find_python fallback to sys.executable
- [x] Test find_activate with all 3 fallback levels