### PR TITLE
feat: middleware, update check, settings, CLI parity docs

### DIFF
--- a/docs/cli-parity.md
+++ b/docs/cli-parity.md
@@ -1,0 +1,22 @@
+# CLI Parity with Dashboard
+
+Every dashboard action must have a corresponding `t3` CLI subcommand.
+
+| Dashboard Action | CLI Equivalent | Status |
+|-----------------|---------------|--------|
+| Sync All | `t3 <overlay> followup sync` | Done |
+| Launch Terminal | `t3 <overlay> tasks work-next-user-input` | Done |
+| Launch Agent | `t3 <overlay> tasks work-next-sdk` | Done |
+| Cancel Task | `t3 <overlay> tasks cancel <id>` | TODO |
+| Ticket Transition | `t3 <overlay> workspace ticket --transition <name>` | TODO |
+| Create Task | `t3 <overlay> tasks create <ticket_id>` | TODO |
+| View Session History | `t3 <overlay> tasks history <session_id>` | TODO |
+| View Task Detail | `t3 <overlay> tasks detail <task_id>` | TODO |
+| Sort Tickets | N/A (display logic) | N/A |
+| Toggle Dismissed | N/A (filter state) | N/A |
+
+## Principles
+
+- CLI must work when dashboard is down or rate-limited
+- Every mutating action needs a CLI path
+- CLI output should be machine-parseable (JSON option)

--- a/src/teetree/core/middleware.py
+++ b/src/teetree/core/middleware.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+from django.http import HttpRequest, HttpResponseForbidden
+
+_LOCALHOST_ADDRS = {"127.0.0.1", "::1", "localhost"}
+
+
+class LocalOnlyMiddleware:
+    def __init__(self, get_response):  # noqa: ANN001
+        self.get_response = get_response
+        self.allowed = set(
+            getattr(settings, "TEATREE_DASHBOARD_ALLOWED_HOSTS", _LOCALHOST_ADDRS)
+        )
+
+    def __call__(self, request: HttpRequest):  # noqa: ANN204
+        if request.method == "POST":
+            remote = request.META.get("REMOTE_ADDR", "")
+            if remote not in self.allowed:
+                return HttpResponseForbidden("Dashboard POST restricted to local access.")
+        return self.get_response(request)

--- a/src/teetree/dev_settings.py
+++ b/src/teetree/dev_settings.py
@@ -72,9 +72,22 @@ STATIC_URL = "static/"
 
 LOGGING = default_logging("dev")
 
+# Worktree storage: when set, worktrees are created under this directory
+# instead of as subdirectories of the workspace. Keeps the workspace clean.
+TEATREE_WORKTREE_DIR = ""  # e.g. "~/.teatree/worktrees"
+
+# Single-repo mode: skip multi-repo workflows when only one repo is configured.
+TEATREE_SINGLE_REPO_MODE = False
+
+# Terminal mode for interactive sessions:
+#   "ttyd"          — browser-based terminal (default)
+#   "new-window"    — open a native OS terminal window
+#   "new-tab"       — open a tab in the current terminal emulator (best-effort)
+#   "same-terminal" — run in the current terminal
+TEATREE_TERMINAL_MODE = "same-terminal"
+
 TEATREE_HEADLESS_RUNTIME = "claude-code"
 TEATREE_INTERACTIVE_RUNTIME = "codex"
-TEATREE_TERMINAL_MODE = "same-terminal"
 TEATREE_CLAUDE_STATUSLINE_STATE_DIR = "/tmp/claude-statusline"  # noqa: S108
 TEATREE_AGENT_HANDOVER = [
     {

--- a/src/teetree/utils/update_check.py
+++ b/src/teetree/utils/update_check.py
@@ -1,0 +1,68 @@
+import json
+import subprocess  # noqa: S404
+import time
+from pathlib import Path
+
+_CACHE_FILE = Path.home() / ".local" / "share" / "teatree" / "update-check.json"
+_CHECK_INTERVAL = 86400  # 24 hours
+
+
+def check_for_updates(repo_dir: str = "") -> str | None:
+    cached = _read_cache()
+    if cached is not None:
+        return cached
+
+    try:
+        if not repo_dir:
+            repo_dir = str(Path(__file__).resolve().parents[3])
+
+        current = subprocess.run(  # noqa: S603, S607
+            ["git", "-C", repo_dir, "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True, timeout=5,
+        ).stdout.strip()
+
+        latest_tag = subprocess.run(  # noqa: S603, S607
+            ["git", "-C", repo_dir, "describe", "--tags", "--abbrev=0"],
+            capture_output=True, text=True, check=False, timeout=5,
+        ).stdout.strip()
+
+        if not latest_tag:
+            _write_cache("")
+            return None
+
+        tag_sha = subprocess.run(  # noqa: S603, S607
+            ["git", "-C", repo_dir, "rev-parse", latest_tag],
+            capture_output=True, text=True, check=True, timeout=5,
+        ).stdout.strip()
+
+        if current != tag_sha:
+            msg = f"Update available: {latest_tag} (you are on {current[:8]})"
+            _write_cache(msg)
+            return msg
+
+        _write_cache("")
+        return None
+
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def _read_cache() -> str | None:
+    try:
+        if _CACHE_FILE.is_file():
+            data = json.loads(_CACHE_FILE.read_text(encoding="utf-8"))
+            if time.time() - data.get("ts", 0) < _CHECK_INTERVAL:
+                return data.get("msg") or None
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+def _write_cache(msg: str) -> None:
+    try:
+        _CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _CACHE_FILE.write_text(
+            json.dumps({"ts": time.time(), "msg": msg}), encoding="utf-8"
+        )
+    except OSError:
+        pass


### PR DESCRIPTION
## Summary

- **#35**: `LocalOnlyMiddleware` rejects non-localhost POST requests to dashboard endpoints
- **#25**: `update_check.py` compares HEAD against latest git tag with 24h cache
- **#11**: `TEATREE_WORKTREE_DIR` setting for external worktree storage location
- **#23**: `TEATREE_SINGLE_REPO_MODE` setting to skip multi-repo workflows
- **#30**: Document `TEATREE_TERMINAL_MODE` options (ttyd, new-window, new-tab, same-terminal)
- **#29**: `docs/cli-parity.md` tracking dashboard/CLI action equivalence

Closes #35, #25, #11, #23, #30, #29

Depends on #83

## Test plan

- [ ] LocalOnlyMiddleware blocks non-localhost POST
- [ ] update_check returns message when behind latest tag
- [ ] New settings are respected by existing code paths