### PR TITLE
docs: E2E checklist, diagrams, CLI reference, reorg plan

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1152,6 +1152,19 @@ Dev dependencies: ruff, pytest, pytest-cov, pytest-django, ty, import-linter, pr
 
 ## 17. Appendix
 
+### 17.0 Codebase Reorganization (Incremental)
+
+The codebase reorganization is decomposed into individually-shippable subtasks:
+
+- [x] #46 — Add `db_table` to all models (reusable app compatibility)
+- [x] #39 — Remove hardcoded `gitlab.com` URLs
+- [ ] #42 — Add `__all__` exports to public `__init__.py` files
+- [ ] #40 — Deduplicate `_find_free_port()`, `_camelize()`, and skill cache
+- [ ] #41 — Split `cli.py` into focused submodules (document sections first)
+- [ ] #36 — Move config resolution to Django settings only
+
+Each item is a standalone PR. No big-bang refactor.
+
 ### 17.1 Shell Execution Security Contract
 
 **All `subprocess` calls in teatree core use `shell=False`** (the safe default).

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,28 @@
+# Diagrams as Code
+
+Store diagram sources here. Render during CI. Reference from docs, README, and skills.
+
+## Conventions
+
+- **Mermaid** for flowcharts and sequence diagrams (renders natively in GitHub markdown)
+- **PlantUML** for complex class/component diagrams (requires CI rendering)
+- Source files: `*.mmd` (Mermaid) or `*.puml` (PlantUML)
+- Generated outputs: `*.svg` or `*.png` (gitignored, regenerated in CI)
+
+## Usage
+
+Reference diagrams from markdown using relative paths:
+
+```markdown
+![Architecture](docs/diagrams/architecture.svg)
+```
+
+## CI Integration
+
+Add a workflow step that renders all diagram sources:
+
+```yaml
+- name: Render diagrams
+  run: |
+    npx @mermaid-js/mermaid-cli -i docs/diagrams/*.mmd -o docs/diagrams/
+```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,25 @@
+# E2E Test Coverage
+
+## Panels to cover
+
+- [x] summary
+- [x] tickets
+- [x] headless_queue
+- [x] queue (interactive)
+- [x] sessions
+- [ ] action_required
+- [ ] worktrees
+- [ ] review_comments
+- [ ] activity
+- [ ] Task detail modal
+- [ ] Session history endpoint
+- [ ] SSE connection (real-time updates)
+- [ ] Launch terminal flow (ttyd)
+- [ ] Launch agent flow (headless execute)
+
+## Debugging
+
+Capture server stdout/stderr to a log file instead of DEVNULL:
+```python
+server = subprocess.Popen(..., stdout=log_file, stderr=log_file)
+```

--- a/scripts/generate-cli-reference.sh
+++ b/scripts/generate-cli-reference.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Generate full t3 CLI reference from --help introspection.
+# Output: docs/cli-reference.md
+
+set -euo pipefail
+
+OUTPUT="docs/cli-reference.md"
+
+echo "# t3 CLI Reference" > "$OUTPUT"
+echo "" >> "$OUTPUT"
+echo "_Auto-generated from \`t3 --help\` introspection. Do not edit manually._" >> "$OUTPUT"
+echo "" >> "$OUTPUT"
+
+# Top-level help
+echo "## t3" >> "$OUTPUT"
+echo '```' >> "$OUTPUT"
+t3 --help >> "$OUTPUT" 2>&1 || true
+echo '```' >> "$OUTPUT"
+echo "" >> "$OUTPUT"
+
+# Walk subcommands
+for cmd in $(t3 --help 2>&1 | grep -E '^\s+\w' | awk '{print $1}'); do
+    echo "## t3 $cmd" >> "$OUTPUT"
+    echo '```' >> "$OUTPUT"
+    t3 "$cmd" --help >> "$OUTPUT" 2>&1 || true
+    echo '```' >> "$OUTPUT"
+    echo "" >> "$OUTPUT"
+done
+
+echo "Generated: $OUTPUT"


### PR DESCRIPTION
## Summary

- **#19**: `e2e/README.md` with dashboard panel coverage checklist and debugging tips
- **#12**: `docs/diagrams/README.md` — conventions for Mermaid/PlantUML diagram sources
- **#7**: `scripts/generate-cli-reference.sh` — auto-generate CLI docs from `--help` introspection
- **#69**: BLUEPRINT §17.0 documenting codebase reorganization as incremental subtasks

Closes #19, #12, #7, #69

Depends on #85

## Test plan

- [x] Documentation-only changes (no code impact)
- [ ] `scripts/generate-cli-reference.sh` produces valid markdown