### PR TITLE
fix: address review findings from ac-python, ac-django audit

### DIFF
--- a/src/teetree/backends/figma.py
+++ b/src/teetree/backends/figma.py
@@ -35,8 +35,7 @@ class FigmaBackend:
             timeout=30.0,
         )
         resp.raise_for_status()
-        images = resp.json().get("images", {})
-        image_url = images.get(node_id, "")
+        image_url = resp.json().get("images", {}).get(node_id, "")
         if not image_url:
             return b""
         img_resp = httpx.get(image_url, timeout=30.0)

--- a/src/teetree/core/managers.py
+++ b/src/teetree/core/managers.py
@@ -17,6 +17,8 @@ class WorktreeQuerySet(models.QuerySet):
     def for_cwd(self, cwd: str | None = None) -> models.QuerySet:
         if cwd is None:
             cwd = os.environ.get("T3_ORIG_CWD", os.getcwd())
+        # Python-side filter: SQL has no portable "cwd starts with repo_path"
+        # operator. Worktree count is always small (< 50), so this is fine.
         matches = [wt.pk for wt in self.all() if cwd.startswith(wt.repo_path)]
         return self.filter(pk__in=matches)
 

--- a/src/teetree/core/middleware.py
+++ b/src/teetree/core/middleware.py
@@ -1,17 +1,19 @@
+from collections.abc import Callable
+
 from django.conf import settings
-from django.http import HttpRequest, HttpResponseForbidden
+from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 
 _LOCALHOST_ADDRS = {"127.0.0.1", "::1", "localhost"}
 
 
 class LocalOnlyMiddleware:
-    def __init__(self, get_response):  # noqa: ANN001
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
         self.get_response = get_response
-        self.allowed = set(
+        self.allowed: set[str] = set(
             getattr(settings, "TEATREE_DASHBOARD_ALLOWED_HOSTS", _LOCALHOST_ADDRS)
         )
 
-    def __call__(self, request: HttpRequest):  # noqa: ANN204
+    def __call__(self, request: HttpRequest) -> HttpResponse:
         if request.method == "POST":
             remote = request.META.get("REMOTE_ADDR", "")
             if remote not in self.allowed:

--- a/src/teetree/core/selectors.py
+++ b/src/teetree/core/selectors.py
@@ -367,8 +367,7 @@ def build_dashboard_ticket_rows() -> list[DashboardTicketRow]:
 
 def _ticket_sort_key(row: DashboardTicketRow) -> tuple[bool, str, int]:
     has_mr = bool(row.mrs)
-    latest_url = max((mr.url for mr in row.mrs), default="") if has_mr else ""
-    return (has_mr, latest_url, row.ticket_id)
+    return (has_mr, max((mr.url for mr in row.mrs), default=""), row.ticket_id)
 
 
 def _last_error_for_tasks(task_ids: list[int]) -> dict[int, str]:


### PR DESCRIPTION
## Summary

Address review findings from ac-python, ac-django, ac-reviewing-skills audit:

- **middleware.py**: Add full type annotations (`Callable[[HttpRequest], HttpResponse]`, `set[str]`, `-> None`, `-> HttpResponse`) — was missing per ac-python
- **selectors.py**: Remove redundant `if has_mr` conditional in `_ticket_sort_key`, `max()` with `default=""` handles empty case
- **managers.py**: Document why `for_cwd()` uses Python-side filtering (SQL has no portable `startswith` on stored column vs parameter)
- **figma.py**: Compress single-use `images` intermediate variable

Depends on #87

## Test plan

- [x] No behavior changes, only type annotations and style fixes