### PR TITLE
docs: extension-points, install, agent decision, commands, attribution, CLI hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -162,4 +162,14 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
+
+  # Phase 12 - Docs generation
+  - repo: local
+    hooks:
+      - id: generate-cli-docs
+        name: Generate CLI reference docs
+        entry: scripts/generate-cli-reference.sh
+        language: script
+        files: ^src/teetree/cli
+        pass_filenames: false
         args: [--verbose]

--- a/README.md
+++ b/README.md
@@ -295,6 +295,29 @@ Both. All scripts use `#!/usr/bin/env bash` and the shell helpers detect `$ZSH_V
 
 **TEA**'s **E**xtensible **A**rchitecture for work**tree** management. Also: teatree oil cuts through grime, and that's what this does to multi-repo worktree friction.
 
+## Installation
+
+**System-wide (recommended):**
+
+```bash
+# Using pipx (isolated, available from any directory)
+pipx install git+https://github.com/souliane/teatree.git
+
+# Using uv tool
+uv tool install git+https://github.com/souliane/teatree.git
+```
+
+**Development setup:**
+
+```bash
+git clone https://github.com/souliane/teatree.git
+cd teatree
+uv sync
+uv run t3 --help
+```
+
+After installation, `t3` is available from any directory.
+
 ## License
 
 MIT

--- a/docs/management-commands.md
+++ b/docs/management-commands.md
@@ -2,71 +2,66 @@
 
 Teatree's Django management commands handle all database-touching operations. They use [django-typer](https://github.com/bckohan/django-typer) so each command exposes typed subcommands.
 
-These are also accessible through the `t3` CLI (see [CLI Reference](cli.md)), but you can call them directly with `manage.py` if you prefer.
+## lifecycle
 
-## `lifecycle`
+| Subcommand | Description |
+|-----------|-------------|
+| `setup` | Create worktree, provision, run overlay steps |
+| `start` | Start backend/frontend services |
+| `status` | Show worktree state |
+| `teardown` | Tear down worktree |
+| `clean` | Full teardown + state cleanup |
+| `diagram` | Render Mermaid state diagram from FSM |
 
-Manages worktree state transitions.
+## workspace
 
-| Subcommand | Arguments | Returns | Description |
-|------------|-----------|---------|-------------|
-| `setup` | `ticket_id`, `repo_path`, `branch` | worktree ID | Creates a worktree, provisions it (port allocation, DB name), then runs overlay provision steps |
-| `start` | `worktree_id` | state string | Fetches run commands from the overlay, records services, transitions to `services_up` |
-| `status` | `worktree_id` | dict | Returns current state, repo path, and branch |
-| `teardown` | `worktree_id` | state string | Clears ports, DB name, and facts; resets to `created` |
+| Subcommand | Description |
+|-----------|-------------|
+| `ticket` | Create ticket + worktrees for all repos |
+| `inspect` | Show ticket/worktree details |
 
-## `workspace`
+## db
 
-Ticket and workspace management.
+| Subcommand | Description |
+|-----------|-------------|
+| `create` | Create database |
+| `refresh` | Re-import from snapshot/dump |
+| `export` | Export database |
+| `import` | Import database |
+| `restore-ci` | Restore from CI artifact |
 
-| Subcommand | Arguments | Returns | Description |
-|------------|-----------|---------|-------------|
-| `ticket` | `issue_url`, `variant`, `repos` | ticket ID | Creates a ticket, scopes it, and transitions to `started` |
-| `finalize` | `ticket_id` | state string | Transitions the ticket to `coded` |
-| `clean-all` | -- | count | Deletes all worktrees in `created` state |
+## run
 
-## `db`
+| Subcommand | Description |
+|-----------|-------------|
+| `backend` | Start backend service |
+| `frontend` | Start frontend service |
+| `build-frontend` | Build frontend |
+| `tests` | Run test suite |
+| `e2e` | Run E2E tests |
 
-Database operations on worktrees.
+## tasks
 
-| Subcommand | Arguments | Returns | Description |
-|------------|-----------|---------|-------------|
-| `refresh` | `worktree_id` | state string | Transitions to `provisioned` and records refresh timestamp |
-| `status` | `worktree_id` | dict | Returns DB name, state, and last refresh time |
+| Subcommand | Description |
+|-----------|-------------|
+| `claim` | Claim next pending task |
+| `work-next-sdk` | Execute headless task |
+| `work-next-user-input` | Create interactive session |
 
-## `run`
+## followup
 
-Service management.
+| Subcommand | Description |
+|-----------|-------------|
+| `refresh` | Count pending work |
+| `sync` | Sync from GitLab |
+| `discover-mrs` | Discover open MRs |
+| `remind` | Send reminders |
 
-| Subcommand | Arguments | Returns | Description |
-|------------|-----------|---------|-------------|
-| `verify` | `worktree_id` | dict | Transitions to `ready`, records backend/frontend URLs |
-| `services` | `worktree_id` | dict | Returns the overlay's run commands for this worktree |
+## pr
 
-## `mr`
-
-Merge request operations.
-
-| Subcommand | Arguments | Returns | Description |
-|------------|-----------|---------|-------------|
-| `validate` | `title`, `description` | `ValidationResult` | Runs the overlay's MR validation rules |
-| `check-gates` | `ticket_id` | bool | Verifies the most recent session has passed all required quality gates for shipping |
-
-## `tasks`
-
-Task queue for multi-agent coordination.
-
-| Subcommand | Arguments | Returns | Description |
-|------------|-----------|---------|-------------|
-| `claim` | `execution_target`, `claimed_by` | task ID or None | Claims the next pending task of the given target type |
-| `work-next-sdk` | `claimed_by` | dict or None | Claims and completes the next SDK task using the configured runtime |
-| `work-next-user-input` | `claimed_by` | dict or None | Claims and completes the next user-input task |
-
-## `followup`
-
-Monitoring and reminders.
-
-| Subcommand | Arguments | Returns | Description |
-|------------|-----------|---------|-------------|
-| `refresh` | -- | dict | Returns counts of tickets, tasks, and open tasks |
-| `remind` | -- | list of IDs | Returns IDs of pending user-input tasks |
+| Subcommand | Description |
+|-----------|-------------|
+| `create` | Create MR/PR |
+| `fetch-issue` | Fetch issue details |
+| `detect-tenant` | Detect tenant variant |
+| `post-evidence` | Post evidence to MR |

--- a/skills/t3-debug/SKILL.md
+++ b/skills/t3-debug/SKILL.md
@@ -19,6 +19,8 @@ metadata:
 
 ## Delegation
 
+> **Source:** Delegated skills originate from [obra/superpowers](https://github.com/obra/superpowers): systematic-debugging, verification-before-completion
+
 This skill delegates the generic debugging doctrine to:
 
 - `systematic-debugging` — root-cause-first investigation

--- a/skills/t3-review/SKILL.md
+++ b/skills/t3-review/SKILL.md
@@ -19,6 +19,8 @@ metadata:
 
 ## Delegation
 
+> **Source:** Delegated skills originate from [obra/superpowers](https://github.com/obra/superpowers): requesting-code-review
+
 This skill delegates the generic review doctrine to:
 
 - `requesting-code-review` — when to request an independent review pass

--- a/skills/t3-ship/SKILL.md
+++ b/skills/t3-ship/SKILL.md
@@ -20,6 +20,8 @@ metadata:
 
 ## Delegation
 
+> **Source:** Delegated skills originate from [obra/superpowers](https://github.com/obra/superpowers): finishing-a-development-branch
+
 This skill delegates the generic branch-finalization doctrine to:
 
 - `finishing-a-development-branch` — decide how to wrap up a ready branch

--- a/skills/t3-test/SKILL.md
+++ b/skills/t3-test/SKILL.md
@@ -37,7 +37,6 @@ Running tests, analyzing failures, quality checks, CI interaction, test plans, a
 
 ### Frontend Lint
 
-- `nx run-many --target=lint` — lint all frontend projects.
 - Fix lint errors before pushing.
 
 ### E2E Testing
@@ -262,8 +261,6 @@ Before claiming E2E success or posting screenshots as evidence, **visually inspe
 A screenshot with raw translation keys is **not valid evidence** — it proves the environment was broken, not that the feature works.
 
 ### Store Contamination Check (Non-Negotiable)
-
-E2E tests for features that load data via store dispatches (e.g., NgRx `loadResources`) must verify the data is loaded **from the tested page**, not from a prior navigation. If you visit page A (which loads resources into the store) and then navigate to page B (which reads from the store but never dispatches the load), page B will appear to work — but only because page A pre-populated the store.
 
 - **Each test must start from a clean state** — navigate directly to the page under test without visiting other pages first.
 - **Verify the page dispatches its own data load** — check the component source for the relevant dispatch call. If missing, the feature has a bug (empty dropdown, missing data), regardless of what the screenshot shows.

--- a/skills/t3-ticket/SKILL.md
+++ b/skills/t3-ticket/SKILL.md
@@ -24,6 +24,8 @@ metadata:
 
 ## Delegation
 
+> **Source:** Delegated skills originate from [obra/superpowers](https://github.com/obra/superpowers): writing-plans
+
 This skill delegates the generic planning doctrine to:
 
 - `writing-plans` — turn requirements into an execution plan before implementation starts

--- a/skills/t3-workspace/references/extension-points.md
+++ b/skills/t3-workspace/references/extension-points.md
@@ -1,75 +1,41 @@
-# Extension Points
+# Overlay Extension Points
 
-> **Current system:** Project overlays subclass `OverlayBase` (see `teetree.core.overlay`) and override methods like `get_repos()`, `get_provision_steps()`, `get_env_extra()`, `get_run_commands()`. The `wt_*` names below are the **conceptual extension point names** used in skill documentation — they map to `OverlayBase` methods, not to a function registry.
+*Updated to match the current `OverlayBase` API. See BLUEPRINT.md §6.1 for full documentation.*
 
-Project-specific behavior lives in the generated TeaTree Django host project. The active overlay class subclasses `OverlayBase`, and runtime code calls overlay methods directly.
+## OverlayBase Methods
 
-Priority: **default** (no-op) < **framework** (Django) < **project** (project-specific).
+| Method | Required | Purpose |
+|--------|----------|---------|
+| `get_repos()` | Yes | Declare repositories for provisioning |
+| `get_provision_steps(worktree)` | Yes | Ordered setup steps |
+| `get_env_extra(worktree)` | No | Extra environment variables |
+| `get_run_commands(worktree)` | No | Named service run commands |
+| `get_pre_run_steps(worktree, service)` | No | Per-service preparation steps |
+| `get_test_command(worktree)` | No | Test suite command |
+| `get_db_import_strategy(worktree)` | No | DB provisioning strategy |
+| `db_import(worktree)` | No | Custom DB import logic |
+| `get_post_db_steps(worktree)` | No | Post-DB-setup callbacks |
+| `get_reset_passwords_command(worktree)` | No | Dev password reset |
+| `get_envrc_lines(worktree)` | No | .envrc additions (for direnv) |
+| `get_symlinks(worktree)` | No | Extra symlinks |
+| `get_services_config(worktree)` | No | Service metadata |
+| `validate_mr(title, description)` | No | MR validation rules |
+| `get_followup_repos()` | No | GitLab project paths to sync |
+| `get_skill_metadata()` | No | Active skill path + companions |
+| `get_ci_project_path()` | No | GitLab project path for CI |
+| `get_e2e_config()` | No | E2E trigger configuration |
+| `detect_variant()` | No | Tenant detection |
+| `get_workspace_repos()` | No | Repos for workspace ticket creation |
+| `get_tool_commands()` | No | Overlay-specific CLI tools |
+
+## Resolution Flow
 
 ```mermaid
-graph TB
-  subgraph "Extension Point Resolution"
-    direction TB
-    call["overlay.run_backend()"] --> resolve["Resolve via MRO"]
-    resolve --> project["Project Layer<br/>(your overlay)<br/>Priority: highest"]
-    resolve --> framework["Framework Layer<br/>(e.g., Django plugin)<br/>Priority: middle"]
-    resolve --> default["Default Layer<br/>(teatree core)<br/>Priority: lowest"]
-  end
-
-  project -.->|"if registered"| result["Use project handler"]
-  framework -.->|"if no project"| result2["Use framework handler"]
-  default -.->|"fallback"| result3["Use default (usually no-op)"]
-
-  style project fill:#c8e6c9
-  style framework fill:#bbdefb
-  style default fill:#f5f5f5
+graph TD
+    A[settings.TEATREE_OVERLAY_CLASS] --> B[import_string]
+    B --> C[Validate OverlayBase subclass]
+    C --> D[lru_cache singleton]
+    D --> E[Management commands call overlay methods]
 ```
 
-**Prefix convention (intentional):** Most extension points use the `wt_` prefix (worktree-scoped). This includes delivery operations (`wt_create_mr`, `wt_monitor_pipeline`, `wt_send_review_request`) that conceptually operate beyond a single worktree — but they always run *from within* a worktree context and use its branch/env. The `ticket_*` and `followup_*` prefixes are reserved for operations that span multiple worktrees or operate at the workspace level.
-
-| Point | Default | Django Plugin | Override in overlay for... |
-|---|---|---|---|
-| `wt_symlinks` | Replicate symlinks from main repo + share `.venv`, `node_modules`, `.python-version`, `.data` | — | Additional project-specific symlinks |
-| `wt_env_extra` | No-op | `DJANGO_SETTINGS_MODULE`, `POSTGRES_DB` | Project-specific env vars |
-| `wt_services` | `docker compose up -d` from main repo | — | Different service selection |
-| `wt_db_import` | Return False (no default) | — | Project-specific dump discovery + restore |
-| `wt_post_db` | No-op | `migrate` + `createsuperuser` | Custom post-restore steps |
-| `wt_detect_variant` | Read `$WT_VARIANT` or `.env.worktree` | — | Project-specific variant detection |
-| `wt_run_backend` | Print "not configured" | `manage.py runserver` + Docker up | Custom backend startup |
-| `wt_run_frontend` | Print "not configured" | — | Custom frontend startup |
-| `wt_build_frontend` | Print "not configured" | — | Custom frontend build |
-| `wt_run_tests` | Print "not configured" | `pytest` or `manage.py test` | Custom test runner |
-| `wt_create_mr` | Print "not configured" | — | MR/PR creation (GitLab, GitHub, etc.) |
-| `wt_monitor_pipeline` | Print "not configured" | — | CI pipeline polling (GitLab CI, GitHub Actions, etc.) |
-| `wt_send_review_request` | Print "not configured" | — | Review notification (Slack, Teams, email, etc.) |
-| `wt_fetch_failed_tests` | Print "not configured" | — | Failed test extraction from CI |
-| `wt_restore_ci_db` | Print "not configured" | — | Restore DB from a CI-produced dump |
-| `wt_reset_passwords` | Print "not configured" | — | Reset all user passwords to a known dev value |
-| `wt_trigger_e2e` | Print "not configured" | — | Trigger E2E tests on CI |
-| `wt_quality_check` | Print "not configured" | — | Quality analysis (SonarQube, CodeClimate, etc.) |
-| `wt_fetch_ci_errors` | Print "not configured" | — | Fetch error logs from CI (distinct from failed test IDs) |
-| `wt_start_session` | Print "not configured" | — | Full dev session entrypoint: self-heal (`t3 lifecycle setup` if needed) + start everything |
-| `ticket_check_deployed` | Return False | — | Check if merged code is deployed to target env (CI pipeline, GCP, k8s) |
-| `ticket_update_external_tracker` | No-op (log warning) | — | Update ticket status in Notion/Jira/external tracker |
-| `ticket_get_mrs` | List MRs by branch name via issue tracker CLI | — | Custom MR discovery for multi-repo tickets |
-| `followup_enrich_data` | No-op | — | Add project-specific fields to `followup.json` entries (e.g., Notion status, tenant) |
-| `followup_enrich_dashboard` | No-op | — | Inject extra columns/sections into the HTML dashboard |
-
-## How the Override Chain Works
-
-TeaTree packages the generic runtime. The generated host project owns the project layer:
-
-Inside each Python script:
-
-```python
-from teetree.core.overlay_loader import get_overlay
-
-overlay = get_overlay()
-overlay.post_db_setup(project_dir)  # example project-layer hook
-```
-
-Use `uv run t3 startproject ...` to create the host project, set `TEATREE_OVERLAY_CLASS` in settings, and implement the required hooks on the generated overlay app.
-
-## Legacy Note
-
-The old `scripts/lib/registry.py` bridge has been removed. New project integrations use `OverlayBase` subclasses exclusively — do not add `project_hooks.py`, shell bootstraps, or custom `t3` subcommand groups.
+The legacy `wt_*` function-based extension system with 3-layer priority is removed. Overlays are resolved via Django settings and Python's MRO.

--- a/tests/teetree_agents/AGENT_DECISION.md
+++ b/tests/teetree_agents/AGENT_DECISION.md
@@ -1,0 +1,14 @@
+# Agent Backend Decision
+
+**Decision:** TeaTree uses Claude as the sole agent backend (see BLUEPRINT.md §5.7).
+
+## Implications for Tests
+
+- **No Codex integration tests needed.** The generic agent abstraction was removed.
+- **`EchoRuntime` is for tests only.** It provides a deterministic, no-network
+  runtime for testing the dispatch and session management code paths.
+- **`Session.agent_id` is a Claude session ID** used for resume functionality,
+  not an agent backend identifier.
+
+If a second agent backend is ever added, integration tests should be added here
+to verify the dispatch path works end-to-end for each backend.


### PR DESCRIPTION
## Summary

- **#18**: Rewrite `extension-points.md` — replace legacy `wt_*` table with current OverlayBase method reference + Mermaid resolution flow
- **#26**: Add Installation section to README (pipx, uv tool, development setup)
- **#28**: Create `AGENT_DECISION.md` documenting Claude-only backend decision
- **#43**: Complete `management-commands.md` with all subcommand tables
- **#44**: Add obra/superpowers source attribution to t3-debug, t3-review, t3-ship, t3-ticket
- **#45**: Remove NgRx/Nx project-specific content from t3-test (belongs in overlays)
- **#67**: Add `generate-cli-docs` pre-commit hook (Phase 12)

Closes #18, #26, #28, #43, #44, #45, #67

Depends on #90

## Test plan

- [x] Documentation changes — no code impact
- [ ] Pre-commit hook runs when cli.py changes