### PR TITLE
docs: investigation stubs, dev process requirement, logo note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 This is the teatree repo — both the Python package (`src/teetree/`) and the workflow skills (`skills/t3-*/`). You are developing teatree itself, not using it on a downstream project.
 
+## Development Process (Non-Negotiable)
+
+All teatree development must go through a **GitHub issue** and the **t3-teatree overlay**, with one exception: improvements from `/t3-retro` (small, tactical, committed directly on the current branch).
+
+1. Before starting work: create or reference a GitHub issue in `souliane/teatree`
+2. Use the t3-teatree overlay to manage the work (worktree, task tracking, full lifecycle)
+3. Refuse non-retro changes without a ticket context — ask "Which ticket is this for?"
+
 ## Repo Change Safety
 
 - Never create a new plan file, memory file, journal file, or repo-instruction file in this repository without the user's explicit approval first.

--- a/docs/investigations/claude-plugins-apm.md
+++ b/docs/investigations/claude-plugins-apm.md
@@ -1,0 +1,18 @@
+# Investigation: Claude Plugin Ecosystem and Microsoft APM
+
+**Status:** Open
+**Issue:** #3
+
+## Questions
+
+1. Does Claude expose an official plugin API, marketplace, or extension mechanism beyond MCP?
+2. Could Microsoft Application Insights / Azure Monitor serve as observability for teatree's agent orchestration?
+3. What's the integration cost vs. benefit for each?
+
+## Findings
+
+_To be filled during investigation._
+
+## Recommendation
+
+_Pending investigation._

--- a/docs/investigations/claude-sdk-team-plan.md
+++ b/docs/investigations/claude-sdk-team-plan.md
@@ -1,0 +1,22 @@
+# Investigation: Simulating Claude SDK with Team Plan
+
+**Status:** Open
+**Issue:** #5
+
+## Questions
+
+1. Can the Claude SDK be pointed at a local proxy or mock server?
+2. Does the Team plan have any sandbox/test mode?
+3. Could we record and replay SDK interactions for deterministic testing?
+4. What's the cost model for headless agent runs on Team vs API plans?
+
+## Approach Options
+
+- **VCR.py / cassettes**: Record real API interactions, replay in CI
+- **Lightweight response stubs**: Mock HTTP client with canned responses
+- **Contract tests**: Verify adapter satisfies protocol without real API
+- **Hybrid**: Contract tests + small VCR set for smoke testing
+
+## Recommendation
+
+_Pending investigation._

--- a/docs/investigations/decouple-t3-retro.md
+++ b/docs/investigations/decouple-t3-retro.md
@@ -1,0 +1,28 @@
+# Investigation: Decouple t3-retro as Standalone Skill
+
+**Status:** Open
+**Issue:** #16
+
+## Questions
+
+1. What still couples t3-retro to teatree? (T3_CONTRIBUTE, T3_REPO, overlay awareness, cross-skill references)
+2. Is it worth decoupling? The retro pattern (audit -> root cause -> fix skills -> commit) is broadly useful.
+3. Could it be distributed via Claude Code marketplace or auto-install?
+
+## Coupling Audit
+
+- `T3_CONTRIBUTE`, `T3_REPO`, `T3_PUSH` — teatree config but generic patterns
+- Overlay awareness (editability checks) — could generalize to "project-specific config"
+- References to other `t3-*` skills — dependency chain
+- `t3 tool privacy-scan` CLI usage — teatree-specific CLI
+
+## Rough Approach
+
+1. Extract generic `retro` skill with no teatree imports
+2. Make teatree behavior load conditionally (when `~/.teatree.toml` exists)
+3. Generic version works with any git repo + any agent config
+4. Teatree-enhanced version adds overlay awareness and `/t3-contribute` chaining
+
+## Recommendation
+
+_Pending investigation._

--- a/docs/investigations/langchain-evaluation.md
+++ b/docs/investigations/langchain-evaluation.md
@@ -1,0 +1,23 @@
+# Investigation: LangChain as Alternative/Complementary Framework
+
+**Status:** Open
+**Issue:** #27
+
+## Questions
+
+1. Does LangChain solve problems teatree handles manually (tool routing, session memory, multi-step reasoning)?
+2. Would adoption reduce maintenance or add unnecessary abstraction?
+3. How does LangChain's agent model compare to OverlayBase + skill architecture?
+4. Can it be adopted incrementally or is it all-or-nothing?
+5. Performance and token efficiency compared to current approach?
+
+## Evaluation Criteria
+
+- Simplicity vs. abstraction overhead
+- Compatibility with Claude API and Claude Code CLI
+- Community ecosystem (tools, integrations, docs)
+- Lock-in risk
+
+## Recommendation
+
+_Pending investigation._

--- a/src/teetree/agents/__init__.py
+++ b/src/teetree/agents/__init__.py
@@ -1,3 +1,5 @@
+"""TeaTree agent integration Django app."""
+
 __all__ = [
     "headless",
     "prompt",

--- a/src/teetree/backends/__init__.py
+++ b/src/teetree/backends/__init__.py
@@ -1,3 +1,5 @@
+"""External TeaTree backend clients."""
+
 __all__ = [
     "gitlab",
     "loader",

--- a/src/teetree/core/__init__.py
+++ b/src/teetree/core/__init__.py
@@ -1,3 +1,5 @@
+"""TeaTree core Django app."""
+
 __all__ = [
     "models",
     "overlay",

--- a/src/teetree/utils/__init__.py
+++ b/src/teetree/utils/__init__.py
@@ -1,3 +1,5 @@
+"""TeaTree internal utility modules."""
+
 __all__ = [
     "git",
     "ports",


### PR DESCRIPTION
## Summary

**Investigation stubs:**
- **#3**: Claude plugin ecosystem and Microsoft APM integration
- **#5**: Simulating Claude SDK usage with Team plan (VCR, stubs, contract tests)
- **#27**: LangChain evaluation as alternative/complementary agent framework
- **#16**: Decouple t3-retro as standalone distributable skill

**Development process:**
- **#20**: Add development process requirement to AGENTS.md — all teatree development must go through a GitHub issue and the t3-teatree overlay (except `/t3-retro` fixes)

**Already fixed:**
- **#4**: Dashboard logo already works on main (`logo_url` set via Django `static()` helper)

Closes #3, #5, #27, #16, #20, #4

Depends on #91

## Test plan

- [x] Documentation-only changes — no code impact