### PR TITLE
fix: pass all prek hooks — ruff, ty, editorconfig, format

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1175,11 +1175,13 @@ Overlay-supplied commands (from `get_run_commands()`, `get_post_db_steps()`,
 `tool.py`).  This is intentional and documented:
 
 **Trust model:**
+
 - Overlay authors control these strings — they write the overlay code
 - Overlays are installed by the project operator (not end users)
 - The strings are configuration, not user input
 
 **Mitigations:**
+
 - `# noqa: S602` comments acknowledge the `shell=True` usage
 - Overlay commands are logged before execution
 - No user-controlled input is interpolated into shell strings

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -20,6 +20,7 @@
 ## Debugging
 
 Capture server stdout/stderr to a log file instead of DEVNULL:
+
 ```python
 server = subprocess.Popen(..., stdout=log_file, stderr=log_file)
 ```

--- a/src/teetree/agents/__init__.py
+++ b/src/teetree/agents/__init__.py
@@ -1,8 +1,1 @@
 """TeaTree agent integration Django app."""
-
-__all__ = [
-    "headless",
-    "prompt",
-    "skill_bundle",
-    "web_terminal",
-]

--- a/src/teetree/backends/__init__.py
+++ b/src/teetree/backends/__init__.py
@@ -1,8 +1,1 @@
 """External TeaTree backend clients."""
-
-__all__ = [
-    "gitlab",
-    "loader",
-    "protocols",
-    "slack",
-]

--- a/src/teetree/backends/figma.py
+++ b/src/teetree/backends/figma.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import httpx
 
@@ -22,7 +23,7 @@ class FigmaBackend:
     def _headers(self) -> dict[str, str]:
         return {"X-FIGMA-TOKEN": self.token}
 
-    def get_file(self, file_key: str) -> dict[str, object]:
+    def get_file(self, file_key: str) -> dict[str, Any]:
         resp = httpx.get(f"{_FIGMA_API}/files/{file_key}", headers=self._headers(), timeout=30.0)
         resp.raise_for_status()
         return resp.json()
@@ -49,13 +50,13 @@ class FigmaBackend:
             return []
         return [FigmaChildNode(id=c.get("id", ""), name=c.get("name", "")) for c in node.get("children", [])]
 
-    def get_comments(self, file_key: str) -> list[dict[str, object]]:
+    def get_comments(self, file_key: str) -> list[dict[str, Any]]:
         resp = httpx.get(f"{_FIGMA_API}/files/{file_key}/comments", headers=self._headers(), timeout=30.0)
         resp.raise_for_status()
         return resp.json().get("comments", [])
 
 
-def _find_node(tree: dict[str, object], node_id: str) -> dict[str, object] | None:
+def _find_node(tree: dict[str, Any], node_id: str) -> dict[str, Any] | None:
     if tree.get("id") == node_id:
         return tree
     for child in tree.get("children", []):

--- a/src/teetree/cli.py
+++ b/src/teetree/cli.py
@@ -3,20 +3,22 @@
 DB-touching commands are django-typer management commands, exposed here after
 ``django.setup()``.  Django-free commands live as plain Typer groups.
 
-Module sections (future split targets — see #41):
-  1. Bootstrap (app, main, _find_project_root)
-  2. Config commands (startproject, docs, start)
-  3. CI commands (ci_app: trigger, cancel, errors)
-  4. Review commands (review_app: draft notes)
-  5. Doctor commands (doctor_app: connectivity checks)
-  6. Tool commands (tool_app: custom overlay tools)
-  7. Overlay registration (_register_overlay_commands)
-  8. Internal helpers (_get_gitlab_token, _camelize, etc.)
+Module sections (future split targets — see #41)::
 
-DB-free command migration candidates (#22):
-  - generate_skill_docs, generate_overlay_docs (introspection only)
-  - tool subcommands (overlay-provided, use subprocess)
-  - doctor checks (filesystem + network probes)
+    1. Bootstrap (app, main, _find_project_root)
+    2. Config commands (startproject, docs, start)
+    3. CI commands (ci_app: trigger, cancel, errors)
+    4. Review commands (review_app: draft notes)
+    5. Doctor commands (doctor_app: connectivity checks)
+    6. Tool commands (tool_app: custom overlay tools)
+    7. Overlay registration (_register_overlay_commands)
+    8. Internal helpers (_get_gitlab_token, _camelize, etc.)
+
+DB-free command migration candidates (#22)::
+
+    generate_skill_docs, generate_overlay_docs (introspection only),
+    tool subcommands (overlay-provided, use subprocess),
+    doctor checks (filesystem + network probes).
 """
 
 import contextlib
@@ -110,10 +112,8 @@ def startproject(
 def start() -> None:
     """Detect context, setup if needed, and start services.
 
-    Filesystem-first single command replacing the multi-step workflow:
-      1. Detect overlay from cwd (manage.py or ~/.teatree.toml)
-      2. If worktree not provisioned, run lifecycle setup
-      3. Start backend/frontend services
+    Filesystem-first single command: detect overlay from cwd, run lifecycle
+    setup if needed, then start backend/frontend services.
     """
     from teetree.config import discover_active_overlay  # noqa: PLC0415
 

--- a/src/teetree/config.py
+++ b/src/teetree/config.py
@@ -2,10 +2,10 @@
 
 Config resolution convention:
 
-- Django-backed flows (management commands, views) → use Django settings,
-  with ``load_config()`` as fallback for values not yet in settings.
-- Non-Django flows (bash hooks, CLI pre-bootstrap) → read from
-  ``~/.teatree.toml`` or ``overlay.toml`` directly.
+Django-backed flows (management commands, views) use Django settings,
+with ``load_config()`` as fallback for values not yet in settings.
+Non-Django flows (bash hooks, CLI pre-bootstrap) read from
+``~/.teatree.toml`` or ``overlay.toml`` directly.
 
 The goal is to migrate all runtime config to Django settings over time,
 leaving ``~/.teatree.toml`` only for overlay discovery and bootstrap.

--- a/src/teetree/core/__init__.py
+++ b/src/teetree/core/__init__.py
@@ -1,7 +1,1 @@
 """TeaTree core Django app."""
-
-__all__ = [
-    "models",
-    "overlay",
-    "selectors",
-]

--- a/src/teetree/core/managers.py
+++ b/src/teetree/core/managers.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from django.db import models
 from django.db.models import Q
@@ -16,7 +17,7 @@ class WorktreeQuerySet(models.QuerySet):
 
     def for_cwd(self, cwd: str | None = None) -> models.QuerySet:
         if cwd is None:
-            cwd = os.environ.get("T3_ORIG_CWD", os.getcwd())
+            cwd = os.environ.get("T3_ORIG_CWD", str(Path.cwd()))
         # Python-side filter: SQL has no portable "cwd starts with repo_path"
         # operator. Worktree count is always small (< 50), so this is fine.
         matches = [wt.pk for wt in self.all() if cwd.startswith(wt.repo_path)]

--- a/src/teetree/core/middleware.py
+++ b/src/teetree/core/middleware.py
@@ -9,9 +9,7 @@ _LOCALHOST_ADDRS = {"127.0.0.1", "::1", "localhost"}
 class LocalOnlyMiddleware:
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
         self.get_response = get_response
-        self.allowed: set[str] = set(
-            getattr(settings, "TEATREE_DASHBOARD_ALLOWED_HOSTS", _LOCALHOST_ADDRS)
-        )
+        self.allowed: set[str] = set(getattr(settings, "TEATREE_DASHBOARD_ALLOWED_HOSTS", _LOCALHOST_ADDRS))
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
         if request.method == "POST":

--- a/src/teetree/core/migrations/0005_alter_session_table_alter_task_table_and_more.py
+++ b/src/teetree/core/migrations/0005_alter_session_table_alter_task_table_and_more.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0004_task_parent_task"),
     ]

--- a/src/teetree/core/selectors.py
+++ b/src/teetree/core/selectors.py
@@ -340,7 +340,7 @@ def build_dashboard_ticket_rows() -> list[DashboardTicketRow]:
         )
         .order_by("pk")
     )
-    return [
+    rows = [
         DashboardTicketRow(
             ticket_id=ticket.pk,
             display_id=_display_id(ticket),

--- a/src/teetree/core/views/actions.py
+++ b/src/teetree/core/views/actions.py
@@ -46,7 +46,9 @@ class CancelTaskView(View):
 
 
 def _has_active_session(task: Task) -> bool:
-    attempt = task.attempts.order_by("-pk").first()
+    from teetree.core.models import TaskAttempt  # noqa: PLC0415
+
+    attempt = TaskAttempt.objects.filter(task=task).order_by("-pk").first()
     if attempt is None or not attempt.agent_session_id:
         return False
     session_file = Path.home() / ".claude" / "sessions" / f"{attempt.agent_session_id}.json"

--- a/src/teetree/core/views/dashboard.py
+++ b/src/teetree/core/views/dashboard.py
@@ -17,7 +17,6 @@ from teetree.core.selectors import (
     build_task_detail,
     build_worktree_rows,
 )
-from teetree.core.views._startup import perform_sync
 
 _PANEL_TEMPLATES = {
     "summary": "teetree/partials/dashboard_summary.html",

--- a/src/teetree/overlays/teatree/overlay.py
+++ b/src/teetree/overlays/teatree/overlay.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 from teetree.core.overlay import OverlayBase, ProvisionStep, SkillMetadata
 
@@ -8,10 +8,13 @@ if TYPE_CHECKING:
 
 
 class TeaTreeOverlay(OverlayBase):
+    @override
     def get_repos(self) -> list[str]:
         return ["teatree"]
 
+    @override
     def get_provision_steps(self, worktree: "Worktree") -> list[ProvisionStep]:
+        _ = worktree
         return [
             ProvisionStep(
                 name="install-deps",
@@ -20,17 +23,21 @@ class TeaTreeOverlay(OverlayBase):
             ),
         ]
 
+    @override
     def get_test_command(self, worktree: "Worktree") -> str:
+        _ = worktree
         return "uv run pytest"
 
+    @override
     def get_skill_metadata(self) -> SkillMetadata:
         skill_dir = Path(__file__).resolve().parents[3] / "skills"
         return {
             "skill_path": str(skill_dir),
-            "companion_skills": [],
         }
 
+    @override
     def get_run_commands(self, worktree: "Worktree") -> dict[str, str]:
+        _ = worktree
         return {
             "docs": "uv run mkdocs serve",
         }

--- a/src/teetree/utils/__init__.py
+++ b/src/teetree/utils/__init__.py
@@ -1,7 +1,1 @@
 """TeaTree internal utility modules."""
-
-__all__ = [
-    "git",
-    "ports",
-    "text",
-]

--- a/src/teetree/utils/tickets.py
+++ b/src/teetree/utils/tickets.py
@@ -14,8 +14,7 @@ _LABEL_PATTERNS: dict[str, list[str]] = {
 def find_duplicates(title: str, existing_titles: list[str], *, threshold: float = 0.7) -> list[tuple[str, float]]:
     normalized = title.lower().strip()
     matches = [
-        (existing, SequenceMatcher(None, normalized, existing.lower().strip()).ratio())
-        for existing in existing_titles
+        (existing, SequenceMatcher(None, normalized, existing.lower().strip()).ratio()) for existing in existing_titles
     ]
     return sorted(
         [(t, s) for t, s in matches if s >= threshold],
@@ -27,7 +26,5 @@ def find_duplicates(title: str, existing_titles: list[str], *, threshold: float 
 def suggest_labels(title: str, body: str = "") -> list[str]:
     text = f"{title} {body}".lower()
     return [
-        label
-        for label, patterns in _LABEL_PATTERNS.items()
-        if any(re.search(p, text, re.IGNORECASE) for p in patterns)
+        label for label, patterns in _LABEL_PATTERNS.items() if any(re.search(p, text, re.IGNORECASE) for p in patterns)
     ]

--- a/src/teetree/utils/update_check.py
+++ b/src/teetree/utils/update_check.py
@@ -1,5 +1,5 @@
 import json
-import subprocess  # noqa: S404
+import subprocess
 import time
 from pathlib import Path
 
@@ -16,23 +16,32 @@ def check_for_updates(repo_dir: str = "") -> str | None:
         if not repo_dir:
             repo_dir = str(Path(__file__).resolve().parents[3])
 
-        current = subprocess.run(  # noqa: S603, S607
+        current = subprocess.run(
             ["git", "-C", repo_dir, "rev-parse", "HEAD"],
-            capture_output=True, text=True, check=True, timeout=5,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
         ).stdout.strip()
 
-        latest_tag = subprocess.run(  # noqa: S603, S607
+        latest_tag = subprocess.run(
             ["git", "-C", repo_dir, "describe", "--tags", "--abbrev=0"],
-            capture_output=True, text=True, check=False, timeout=5,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
         ).stdout.strip()
 
         if not latest_tag:
             _write_cache("")
             return None
 
-        tag_sha = subprocess.run(  # noqa: S603, S607
+        tag_sha = subprocess.run(
             ["git", "-C", repo_dir, "rev-parse", latest_tag],
-            capture_output=True, text=True, check=True, timeout=5,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
         ).stdout.strip()
 
         if current != tag_sha:
@@ -41,9 +50,10 @@ def check_for_updates(repo_dir: str = "") -> str | None:
             return msg
 
         _write_cache("")
-        return None
 
     except (subprocess.SubprocessError, OSError):
+        return None
+    else:
         return None
 
 
@@ -61,8 +71,6 @@ def _read_cache() -> str | None:
 def _write_cache(msg: str) -> None:
     try:
         _CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        _CACHE_FILE.write_text(
-            json.dumps({"ts": time.time(), "msg": msg}), encoding="utf-8"
-        )
+        _CACHE_FILE.write_text(json.dumps({"ts": time.time(), "msg": msg}), encoding="utf-8")
     except OSError:
         pass

--- a/tests/teetree_utils/test_venv.py
+++ b/tests/teetree_utils/test_venv.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
## Summary

Fix all linting/type-checking/formatting issues found by `prek run --all-files`:

- **F822**: Remove invalid `__all__` from `__init__.py` files (names were listed but not imported)
- **F821**: Fix undefined `rows` variable in `build_dashboard_ticket_rows()` (was `return [...]` then `rows.sort()` — now properly assigned)
- **F401**: Remove unused `perform_sync` import from `dashboard.py` (removed blocking sync in #2)
- **F401**: Remove unused `patch` import from `test_venv.py`
- **PTH109**: Replace `os.getcwd()` with `Path.cwd()` in `managers.py`
- **TRY300**: Move return to `else` block in `update_check.py`
- **ty invalid-argument-type/not-iterable**: Fix `figma.py` type annotations from `dict[str, object]` to `dict[str, Any]` for nested JSON
- **ty unresolved-attribute**: Use `TaskAttempt.objects.filter(task=task)` instead of reverse FK `task.attempts`
- **PLR6301/ARG002**: Add `@override` decorators and `_ = worktree` in `TeaTreeOverlay` instead of adding per-file-ignores
- **invalid-key**: Remove invalid `companion_skills` key from `SkillMetadata` TypedDict
- **editorconfig**: Fix 2-space indentation in Python docstrings → 4-space
- Auto-format via `ruff format` and `markdownlint-cli2`

All `prek run --all-files` hooks pass (ruff, ty, editorconfig, codespell, markdownlint, etc.)

Depends on #92

## Test plan

- [x] `uv run ruff check` — 0 errors
- [x] `uv run ruff format --check` — all formatted
- [x] `uv run ty check` — 0 errors
- [x] Full `prek run --all-files` — all hooks pass