### PR TITLE
fix(statusline): display rate-limit reset time

### DIFF
--- a/hooks/scripts/statusline-command.sh
+++ b/hooks/scripts/statusline-command.sh
@@ -499,10 +499,20 @@ fi
 rate_reset=""
 if [ -n "$five_hour_resets_at" ]; then
     tz_name="${T3_TIMEZONE:-$(date +%Z)}"
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        reset_time=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${five_hour_resets_at%%.*}" "+%H:%M" 2>/dev/null)
+    if [[ "$five_hour_resets_at" =~ ^[0-9]+$ ]]; then
+        # Unix epoch (seconds)
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            reset_time=$(date -j -r "$five_hour_resets_at" "+%H:%M" 2>/dev/null)
+        else
+            reset_time=$(date -d "@$five_hour_resets_at" "+%H:%M" 2>/dev/null)
+        fi
     else
-        reset_time=$(date -d "$five_hour_resets_at" "+%H:%M" 2>/dev/null)
+        # ISO 8601
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            reset_time=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${five_hour_resets_at%%[.Z]*}" "+%H:%M" 2>/dev/null)
+        else
+            reset_time=$(date -d "$five_hour_resets_at" "+%H:%M" 2>/dev/null)
+        fi
     fi
     [ -n "$reset_time" ] && rate_reset=" until ${reset_time} ${tz_name}"
 fi

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -31,6 +31,7 @@ def test_statusline_renders_and_persists_five_hour_usage(tmp_path: Path) -> None
     env = os.environ.copy()
     env["T3_WORKSPACE_DIR"] = str(workspace)
     env["TEATREE_CLAUDE_STATUSLINE_STATE_DIR"] = str(state_dir)
+    env["TZ"] = "UTC"
 
     result = subprocess.run(
         ["./hooks/scripts/statusline-command.sh"],
@@ -45,6 +46,7 @@ def test_statusline_renders_and_persists_five_hour_usage(tmp_path: Path) -> None
     assert result.returncode == 0, result.stderr
     output = _strip_ansi(result.stdout)
     assert "96%" in output
+    assert "17:00" in output, f"Reset time not displayed in output: {output}"
 
     latest = json.loads((state_dir / "latest-telemetry.json").read_text(encoding="utf-8"))
     assert latest["session_id"] == "session-123"
@@ -53,3 +55,45 @@ def test_statusline_renders_and_persists_five_hour_usage(tmp_path: Path) -> None
 
     session_file = state_dir / "session-123.telemetry.json"
     assert session_file.is_file()
+
+
+def test_statusline_handles_epoch_resets_at(tmp_path: Path) -> None:
+    """resets_at may be a Unix epoch (seconds) instead of ISO 8601."""
+    workspace = tmp_path / "workspace"
+    cwd = workspace / "teatree"
+    cwd.mkdir(parents=True)
+    state_dir = tmp_path / "state"
+
+    # 1775062800 = 2026-04-01T17:00:00 UTC
+    payload = {
+        "workspace": {"current_dir": str(cwd)},
+        "model": {"display_name": "Claude Opus"},
+        "session_id": "session-epoch",
+        "context_window": {"used_percentage": 10},
+        "rate_limits": {
+            "five_hour": {
+                "used_percentage": 30,
+                "resets_at": "1775062800",
+            }
+        },
+    }
+
+    env = os.environ.copy()
+    env["T3_WORKSPACE_DIR"] = str(workspace)
+    env["TEATREE_CLAUDE_STATUSLINE_STATE_DIR"] = str(state_dir)
+    env["TZ"] = "UTC"
+
+    result = subprocess.run(
+        ["./hooks/scripts/statusline-command.sh"],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = _strip_ansi(result.stdout)
+    assert "30%" in output
+    assert "17:00" in output, f"Reset time not displayed for epoch input: {output}"


### PR DESCRIPTION
## Summary
- On macOS, the `date -j -f` parser failed silently when the ISO timestamp had no fractional seconds (e.g. `2026-03-23T17:00:00Z`) because the trailing `Z` was not stripped by `%%.*`.
- Changed the parameter expansion from `%%.*` to `%%[.Z]*` so both fractional seconds and the `Z` timezone suffix are removed before parsing.
- Added `TZ=UTC` to test env and asserted the reset time appears in output.

## Test plan
- [x] Existing statusline test passes with new assertion for reset time display
- [ ] Verify on macOS that the statusline shows "until HH:MM TZ" next to the rate percentage