### PR TITLE
fix(tests): remove unused cli.review import

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from typer.testing import CliRunner
 import teatree.agents.skill_bundle as skill_bundle_mod
 import teatree.claude_sessions as claude_sessions_mod
 import teatree.cli as cli_mod
-import teatree.cli.review as cli_review_mod
 import teatree.config as config_mod
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.core.resolve as resolve_mod


### PR DESCRIPTION
## Summary
- Remove unused `import teatree.cli.review as cli_review_mod` in `tests/test_cli.py`
- Fixes ruff F401 lint failure breaking CI

## Test plan
- [x] `ruff check` passes locally
- [x] Pre-commit hooks pass