### PR TITLE
fix: skill review — agent agnosticism, missing frontmatter, unused import

### DIFF
--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -143,7 +143,7 @@ When a pre-commit hook runs the full test suite and fails on tests **unrelated t
 
 1. Before writing to a file, run `git status`. If you see unexpected modifications to files you did not touch, **another agent is working in the same directory**.
 2. **If you are NOT in a worktree:** STOP writing code. Move all your work to a worktree immediately (`t3 workspace ticket` or `EnterWorktree`), then continue there.
-3. **If you ARE in a worktree and see someone else's changes:** STOP ALL WORK IMMEDIATELY. Alert the user with `AskUserQuestion`: *"ALERT: Another agent is modifying files in my worktree at `<path>`. I've stopped all work to avoid conflicts. Please resolve before I continue."* Do NOT attempt to continue, merge, or work around the collision.
+3. **If you ARE in a worktree and see someone else's changes:** STOP ALL WORK IMMEDIATELY. Alert the user: *"ALERT: Another agent is modifying files in my worktree at `<path>`. I've stopped all work to avoid conflicts. Please resolve before I continue."* Do NOT attempt to continue, merge, or work around the collision.
 
 **Why:** Parallel agents modifying the same checkout cause silent data loss — commits overwrite each other, stashes destroy in-progress work, and merge conflicts go undetected. This has cost hours of wasted work. Worktrees give each agent an isolated copy. The rules below are secondary defenses.
 

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: teatree
 description: TeaTree agent lifecycle platform — installation, configuration, lifecycle phases, overlay concept, CLI reference, and skill loading. Use when working on teatree itself or when understanding how teatree orchestrates agent workflows.
+metadata:
+  version: 0.0.1
 triggers:
   priority: 90
   keywords:
@@ -26,8 +28,8 @@ TeaTree is a Django project that orchestrates agent workflows through lifecycle 
 
 - **TeaTree IS the Django project.** `pip install teatree` works standalone.
 - **Overlays** register via `teatree.overlays` entry points and provide project-specific configuration.
-- **Skills** live in `skills/` and are loaded by Claude Code's skill system.
-- **Hooks** in `hooks/scripts/` run on Claude Code lifecycle events (UserPromptSubmit, PreToolUse, PostToolUse).
+- **Skills** live in `skills/` and are loaded by the agent's skill system.
+- **Hooks** in `hooks/scripts/` run on agent lifecycle events (e.g., prompt submit, pre/post tool use).
 
 ## Lifecycle Phases
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,6 @@ from typer.testing import CliRunner
 import teatree.agents.skill_bundle as skill_bundle_mod
 import teatree.claude_sessions as claude_sessions_mod
 import teatree.cli as cli_mod
-import teatree.cli.review as cli_review_mod
 import teatree.config as config_mod
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.core.resolve as resolve_mod


### PR DESCRIPTION
## Summary

- **skills/teatree**: add missing `metadata.version`, generalize Claude Code references to agent-neutral phrasing
- **skills/rules**: remove hardcoded `AskUserQuestion` tool name from worktree collision detection rule
- **tests/test_cli.py**: remove unused `cli_review_mod` import (F401)

## Test plan

- [ ] Deterministic checker passes (`uv run .../cli.py --root .`)
- [ ] `prek run --all-files` clean (includes pytest)
- [ ] Agent agnosticism grep shows no remaining hardcoded tool names in rules