### PR TITLE
fix(ci): move playwright to dev deps for E2E CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,6 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - run: uv sync --group e2e
+      - run: uv sync
       - run: uv run playwright install --with-deps chromium
       - run: uv run t3 teatree run e2e-local --no-docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ dev = [
   "pytest>=9.0.2",
   "pytest-cov>=7",
   "pytest-django>=4.11.1",
+  "pytest-playwright>=0.7",
   "pytest-timeout>=2.4",
+  "pytest-xdist>=3.5",
   "ruff>=0.14.2",
   "safety>=3",
   "tach>=0.34",
@@ -49,10 +51,6 @@ dev = [
 docs = [
   "mkdocs>=1.6",
   "mkdocs-material>=9",
-]
-e2e = [
-  "pytest-playwright>=0.7",
-  "pytest-xdist>=3.5",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -1474,7 +1474,9 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
+    { name = "pytest-playwright" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "safety" },
     { name = "tach" },
@@ -1484,10 +1486,6 @@ dev = [
 docs = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
-]
-e2e = [
-    { name = "pytest-playwright" },
-    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -1511,7 +1509,9 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7" },
     { name = "pytest-django", specifier = ">=4.11.1" },
+    { name = "pytest-playwright", specifier = ">=0.7" },
     { name = "pytest-timeout", specifier = ">=2.4" },
+    { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "ruff", specifier = ">=0.14.2" },
     { name = "safety", specifier = ">=3" },
     { name = "tach", specifier = ">=0.34" },
@@ -1521,10 +1521,6 @@ dev = [
 docs = [
     { name = "mkdocs", specifier = ">=1.6" },
     { name = "mkdocs-material", specifier = ">=9" },
-]
-e2e = [
-    { name = "pytest-playwright", specifier = ">=0.7" },
-    { name = "pytest-xdist", specifier = ">=3.5" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Move `pytest-playwright` and `pytest-xdist` from optional `e2e` group to dev dependencies
- `uv sync` now installs them, fixing the E2E CI job that failed with `Failed to spawn: playwright`

## Test plan

- [x] `uv sync` installs playwright (verified locally)
- [ ] CI e2e job finds playwright and runs tests