### PR TITLE
fix(db): use uv run for dslr, add parallel pg_restore

### DIFF
--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -149,6 +149,7 @@ def _docker_compose_up(
         compose_file,
         "up",
         "-d",
+        "--no-build",
     ]
     result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False)  # noqa: S603
     if result.returncode != 0:

--- a/src/teatree/utils/db.py
+++ b/src/teatree/utils/db.py
@@ -48,8 +48,17 @@ def db_restore(db_name: str, dump_path: str) -> None:
     if inspection.returncode == 0:
         jobs = min(os.cpu_count() or 2, 4)
         cmd = [
-            "pg_restore", "-h", host, "-U", user, "-d", db_name,
-            "--no-owner", "--no-acl", f"--jobs={jobs}", dump_path,
+            "pg_restore",
+            "-h",
+            host,
+            "-U",
+            user,
+            "-d",
+            db_name,
+            "--no-owner",
+            "--no-acl",
+            f"--jobs={jobs}",
+            dump_path,
         ]
         restore = subprocess.run(
             cmd,

--- a/src/teatree/utils/db.py
+++ b/src/teatree/utils/db.py
@@ -46,8 +46,13 @@ def db_restore(db_name: str, dump_path: str) -> None:
 
     inspection = subprocess.run(["pg_restore", "-l", dump_path], capture_output=True, text=True, check=False)
     if inspection.returncode == 0:
+        jobs = min(os.cpu_count() or 2, 4)
+        cmd = [
+            "pg_restore", "-h", host, "-U", user, "-d", db_name,
+            "--no-owner", "--no-acl", f"--jobs={jobs}", dump_path,
+        ]
         restore = subprocess.run(
-            ["pg_restore", "-h", host, "-U", user, "-d", db_name, "--no-owner", "--no-acl", dump_path],
+            cmd,
             env=env,
             capture_output=True,
             text=True,

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -135,7 +135,9 @@ def _find_dslr_cmd(tool_name: str) -> list[str]:
     if shutil.which("uv"):
         result = subprocess.run(
             ["uv", "run", tool_name, "list"],
-            capture_output=True, check=False, timeout=15,
+            capture_output=True,
+            check=False,
+            timeout=15,
         )
         if result.returncode == 0:
             return ["uv", "run", tool_name]

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -36,7 +36,7 @@ class DjangoDbImportConfig:
 @dataclass(frozen=True)
 class _RestoreContext:
     cfg: DjangoDbImportConfig
-    dslr_cmd: str
+    dslr_cmd: list[str]
     dslr_env: dict[str, str]
     pg_host: str
     pg_user: str
@@ -124,16 +124,22 @@ def _copy_ref_to_ticket(ctx: _RestoreContext) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _find_dslr_cmd(tool_name: str) -> str:
+def _find_dslr_cmd(tool_name: str) -> list[str]:
+    """Return a command prefix for invoking dslr (e.g. ``["dslr"]`` or ``["uv", "run", "dslr"]``)."""
     dslr = os.environ.get("DSLR_CMD", "")
     if dslr and shutil.which(dslr):
-        return dslr
-    pyenv_path = str(Path("~/.pyenv/versions/3.12.6/bin").expanduser() / tool_name)
-    if shutil.which(pyenv_path):
-        return pyenv_path
+        return [dslr]
     if shutil.which(tool_name):
-        return tool_name
-    return ""
+        return [tool_name]
+    # dslr is a Python tool — invoke via uv which resolves the correct venv.
+    if shutil.which("uv"):
+        result = subprocess.run(
+            ["uv", "run", tool_name, "list"],
+            capture_output=True, check=False, timeout=15,
+        )
+        if result.returncode == 0:
+            return ["uv", "run", tool_name]
+    return []
 
 
 def _dslr_env(ref_db: str) -> dict[str, str]:
@@ -150,10 +156,10 @@ def _dslr_artifact_key(snap_name: str) -> str:
     return f"dslr:{snap_name}"
 
 
-def _find_dslr_snapshots(dslr_cmd: str, env: dict[str, str], ref_db: str) -> list[str]:
+def _find_dslr_snapshots(dslr_cmd: list[str], env: dict[str, str], ref_db: str) -> list[str]:
     """Return matching DSLR snapshots sorted newest-first, excluding bad artifacts."""
     suffix = f"_{ref_db}"
-    result = subprocess.run([dslr_cmd, "list"], env=env, capture_output=True, text=True, check=False)
+    result = subprocess.run([*dslr_cmd, "list"], env=env, capture_output=True, text=True, check=False)
     if result.returncode != 0:
         return []
     names: list[str] = []
@@ -181,10 +187,10 @@ def _is_env_error(stderr: str) -> bool:
     return any(p.lower() in lower for p in env_patterns)
 
 
-def _restore_ref_from_dslr(dslr_cmd: str, env: dict[str, str], snap_name: str) -> tuple[bool, bool]:
+def _restore_ref_from_dslr(dslr_cmd: list[str], env: dict[str, str], snap_name: str) -> tuple[bool, bool]:
     """Restore a DSLR snapshot. Returns (success, is_env_error)."""
     result = subprocess.run(
-        [dslr_cmd, "restore", snap_name],
+        [*dslr_cmd, "restore", snap_name],
         env=env,
         capture_output=True,
         text=True,
@@ -195,11 +201,11 @@ def _restore_ref_from_dslr(dslr_cmd: str, env: dict[str, str], snap_name: str) -
     return False, _is_env_error(result.stderr)
 
 
-def _take_dslr_snapshot(dslr_cmd: str, env: dict[str, str], ref_db: str) -> None:
+def _take_dslr_snapshot(dslr_cmd: list[str], env: dict[str, str], ref_db: str) -> None:
     snap_name = _dslr_snap_name(ref_db)
     print(f"  Taking DSLR snapshot: {snap_name}")  # noqa: T201
     subprocess.run(
-        [dslr_cmd, "snapshot", "-y", snap_name],
+        [*dslr_cmd, "snapshot", "-y", snap_name],
         env=env,
         capture_output=True,
         check=False,
@@ -475,7 +481,7 @@ def django_db_import(
 
     Returns True on success, False if no source was available.
     """
-    dslr_cmd = _find_dslr_cmd(cfg.snapshot_tool) if cfg.snapshot_tool else ""
+    dslr_cmd = _find_dslr_cmd(cfg.snapshot_tool) if cfg.snapshot_tool else []
     pg_host, pg_user, pg_env = _pg_args()
     dslr_e = _dslr_env(cfg.ref_db_name) if dslr_cmd else {}
     ctx = _RestoreContext(

--- a/tests/test_django_db.py
+++ b/tests/test_django_db.py
@@ -136,17 +136,7 @@ class TestFindDslrCmd:
     def test_uses_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DSLR_CMD", "/custom/dslr")
         monkeypatch.setattr(mod.shutil, "which", lambda p: p)
-        assert _find_dslr_cmd("dslr") == "/custom/dslr"
-
-    def test_falls_back_to_pyenv(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("DSLR_CMD", raising=False)
-        pyenv_path = str(Path("~/.pyenv/versions/3.12.6/bin/dslr").expanduser())
-
-        def which(p: str) -> str | None:
-            return p if p == pyenv_path else None
-
-        monkeypatch.setattr(mod.shutil, "which", which)
-        assert _find_dslr_cmd("dslr") == pyenv_path
+        assert _find_dslr_cmd("dslr") == ["/custom/dslr"]
 
     def test_falls_back_to_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("DSLR_CMD", raising=False)
@@ -155,12 +145,18 @@ class TestFindDslrCmd:
             return p if p == "dslr" else None
 
         monkeypatch.setattr(mod.shutil, "which", which)
-        assert _find_dslr_cmd("dslr") == "dslr"
+        assert _find_dslr_cmd("dslr") == ["dslr"]
+
+    def test_falls_back_to_uv_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DSLR_CMD", raising=False)
+        monkeypatch.setattr(mod.shutil, "which", lambda p: "uv" if p == "uv" else None)
+        monkeypatch.setattr(mod.subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
+        assert _find_dslr_cmd("dslr") == ["uv", "run", "dslr"]
 
     def test_returns_empty_when_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("DSLR_CMD", raising=False)
         monkeypatch.setattr(mod.shutil, "which", lambda _: None)
-        assert _find_dslr_cmd("dslr") == ""
+        assert _find_dslr_cmd("dslr") == []
 
 
 class TestDslrEnv:
@@ -185,7 +181,7 @@ class TestFindDslrSnapshots:
             "run",
             lambda *a, **kw: CompletedProcess(a, 0, output, ""),
         )
-        result = _find_dslr_snapshots("/bin/dslr", {}, "development-acme")
+        result = _find_dslr_snapshots(["/bin/dslr"], {}, "development-acme")
         assert result == ["20260315_development-acme", "20260301_development-acme"]
 
     def test_returns_empty_when_no_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -194,7 +190,7 @@ class TestFindDslrSnapshots:
             "run",
             lambda *a, **kw: CompletedProcess(a, 0, "", ""),
         )
-        assert _find_dslr_snapshots("/bin/dslr", {}, "development-acme") == []
+        assert _find_dslr_snapshots(["/bin/dslr"], {}, "development-acme") == []
 
     def test_returns_empty_when_command_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
@@ -202,17 +198,17 @@ class TestFindDslrSnapshots:
             "run",
             lambda *a, **kw: CompletedProcess(a, 1, "", "error"),
         )
-        assert _find_dslr_snapshots("/bin/dslr", {}, "development-acme") == []
+        assert _find_dslr_snapshots(["/bin/dslr"], {}, "development-acme") == []
 
 
 class TestRestoreRefFromDslr:
     def test_returns_success_tuple_on_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(mod.subprocess, "run", _ok_run)
-        assert _restore_ref_from_dslr("/bin/dslr", {}, "snap1") == (True, False)
+        assert _restore_ref_from_dslr(["/bin/dslr"], {}, "snap1") == (True, False)
 
     def test_returns_failure_tuple_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(mod.subprocess, "run", _fail_run)
-        ok, _is_env = _restore_ref_from_dslr("/bin/dslr", {}, "snap1")
+        ok, _is_env = _restore_ref_from_dslr(["/bin/dslr"], {}, "snap1")
         assert ok is False
 
 
@@ -224,7 +220,7 @@ class TestTakeDslrSnapshot:
             "run",
             lambda args, **kw: commands.append(args) or _ok_run(),
         )
-        _take_dslr_snapshot("/bin/dslr", {}, "development-acme")
+        _take_dslr_snapshot(["/bin/dslr"], {}, "development-acme")
         assert commands[0][0] == "/bin/dslr"
         assert commands[0][1] == "snapshot"
 
@@ -671,14 +667,14 @@ class TestTryRestoreFromCiDump:
 class TestDjangoDbImport:
     def test_succeeds_via_dslr(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: "/bin/dslr")
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: [["/bin/dslr"]])
         monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: True)
         cfg = _make_cfg(tmp_path)
         assert django_db_import(cfg) is True
 
     def test_falls_through_to_local_dump(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: "")
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: [])
         monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
         monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: True)
         cfg = _make_cfg(tmp_path)
@@ -687,7 +683,7 @@ class TestDjangoDbImport:
     def test_falls_through_to_remote_fetch_then_local(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         reset_remote_dump_state()
         local_calls: list[int] = []
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: "")
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: [])
         monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
 
         def local_dump(ctx):
@@ -703,7 +699,7 @@ class TestDjangoDbImport:
     def test_skips_remote_when_not_allowed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         reset_remote_dump_state()
         remote_called: list[int] = []
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: "")
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: [])
         monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
         monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: False)
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: remote_called.append(1) or True)
@@ -714,7 +710,7 @@ class TestDjangoDbImport:
 
     def test_falls_through_to_ci(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: "")
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: [])
         monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
         monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: False)
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
@@ -724,7 +720,7 @@ class TestDjangoDbImport:
 
     def test_fails_when_all_strategies_fail(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: "")
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: [])
         monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
         monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: False)
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
@@ -736,7 +732,7 @@ class TestDjangoDbImport:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
     ) -> None:
         reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: "")
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: [])
         monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
         monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: False)
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
@@ -749,7 +745,7 @@ class TestDjangoDbImport:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
     ) -> None:
         reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: "")
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: [])
         monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
         monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: False)
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
@@ -761,7 +757,7 @@ class TestDjangoDbImport:
     def test_skip_dslr_passed_through(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         reset_remote_dump_state()
         captured_skip: list[bool] = []
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: "/bin/dslr")
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: [["/bin/dslr"]])
 
         def capture_dslr(ctx, *, skip_dslr):
             captured_skip.append(skip_dslr)


### PR DESCRIPTION
## Summary

- Replace hardcoded `~/.pyenv/versions/3.12.6/bin/dslr` with `uv run dslr` fallback
- Change `dslr_cmd` from `str` to `list[str]` to support multi-word commands
- Add `--jobs=min(cpu_count, 4)` to `pg_restore` for parallel restore

## Test plan

- [ ] All 1508 tests pass
- [ ] `t3 company lifecycle setup --variant partner-b` uses DSLR (fast path)
- [ ] When DSLR unavailable, `pg_restore --jobs=4` runs in parallel