### PR TITLE
fix(run): local frontend fallback when no docker service

### DIFF
--- a/src/teatree/core/management/commands/run.py
+++ b/src/teatree/core/management/commands/run.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import subprocess  # noqa: S404
 import urllib.request
 from pathlib import Path
@@ -12,6 +13,47 @@ from teatree.core.overlay import RunCommand, RunCommands
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import resolve_worktree
 from teatree.utils.ports import find_free_ports, get_service_port, get_worktree_ports
+
+
+def _compose_has_service(compose_file: str, service: str) -> bool:
+    """Check if a service is defined in docker-compose (uses ``docker compose config``)."""
+    result = subprocess.run(  # noqa: S603
+        ["docker", "compose", "-f", compose_file, "config", "--services"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return service in result.stdout.splitlines()
+
+
+def _detect_local_port(port: int) -> int | None:
+    """Return *port* if something is listening on localhost, else None."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.3)
+        if s.connect_ex(("127.0.0.1", port)) == 0:
+            return port
+    return None
+
+
+def _resolve_private_tests_path() -> Path | None:
+    """Resolve the private tests directory from env or config."""
+    from teatree.config import load_config  # noqa: PLC0415
+
+    private_tests = os.environ.get("T3_PRIVATE_TESTS", "")
+    if not private_tests:
+        private_tests = load_config().raw.get("teatree", {}).get("private_tests", "")
+    if not private_tests:
+        return None
+    path = Path(private_tests).expanduser()
+    return path if path.is_dir() else None
+
+
+def _discover_frontend_port(project: str, default: int = 4200) -> int | None:
+    """Try docker-compose service, then fall back to local port check."""
+    port = get_service_port(project, "frontend", default)
+    if port is not None:
+        return port
+    return _detect_local_port(default)
 
 
 class Command(TyperCommand):
@@ -94,24 +136,37 @@ class Command(TyperCommand):
 
     @command()
     def frontend(self, path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty).")) -> str:
-        """Start the frontend via docker-compose."""
+        """Start the frontend (docker-compose if available, otherwise local)."""
         worktree = resolve_worktree(path)
-        project = _compose_project(worktree)
         overlay = get_overlay()
+
+        # Check if "frontend" service exists in docker-compose.
         compose_file = overlay.get_compose_file(worktree)
-        if not compose_file:
-            return "No docker-compose file found."
+        if compose_file and _compose_has_service(compose_file, "frontend"):
+            from teatree.config import load_config  # noqa: PLC0415
+            from teatree.core.management.commands.lifecycle import _compose_env  # noqa: PLC0415
 
-        from teatree.config import load_config  # noqa: PLC0415
-        from teatree.core.management.commands.lifecycle import _compose_env  # noqa: PLC0415
+            ports = find_free_ports(str(load_config().user.workspace_dir))
+            env = {**os.environ, **overlay.get_env_extra(worktree), **_compose_env(ports)}
+            env.pop("VIRTUAL_ENV", None)
 
-        ports = find_free_ports(str(load_config().user.workspace_dir))
-        env = {**os.environ, **overlay.get_env_extra(worktree), **_compose_env(ports)}
-        env.pop("VIRTUAL_ENV", None)
+            project = _compose_project(worktree)
+            cmd = ["docker", "compose", "-p", project, "-f", compose_file, "up", "-d", "frontend"]
+            subprocess.run(cmd, env=env, check=False)  # noqa: S603
+            return "Frontend started via docker-compose."
 
-        cmd = ["docker", "compose", "-p", project, "-f", compose_file, "up", "-d", "frontend"]
-        subprocess.run(cmd, env=env, check=False)  # noqa: S603
-        return "Frontend started via docker-compose."
+        # Fall back to overlay's local run command.
+        commands = overlay.get_run_commands(worktree)
+        run_cmd = commands.get("frontend")
+        if not run_cmd:
+            return "No frontend command configured in overlay or docker-compose."
+        args = run_cmd.args if isinstance(run_cmd, RunCommand) else list(run_cmd)
+        cwd = run_cmd.cwd if isinstance(run_cmd, RunCommand) else None
+        self.stdout.write(f"  Starting frontend locally: {' '.join(args)}")
+        if cwd:
+            self.stdout.write(f"  cwd: {cwd}")
+        subprocess.Popen(args, cwd=cwd, env={**os.environ, **overlay.get_env_extra(worktree)})  # noqa: S603
+        return "Frontend started locally (background process)."
 
     @command(name="build-frontend")
     def build_frontend(
@@ -199,28 +254,22 @@ class Command(TyperCommand):
     def e2e_private(self, test_path: str = "", *, headed: bool = False) -> str:
         """Run private Playwright tests from T3_PRIVATE_TESTS repo.
 
-        Discovers the frontend port from docker-compose and reads the
-        tenant variant from .env.worktree.
+        Discovers the frontend port from docker-compose (or local process)
+        and reads the tenant variant from .env.worktree.
         """
-        from teatree.config import load_config  # noqa: PLC0415
+        private_tests_path = _resolve_private_tests_path()
+        if not private_tests_path:
+            return "private_tests not configured in ~/.teatree.toml / T3_PRIVATE_TESTS, or directory missing."
 
-        private_tests = os.environ.get("T3_PRIVATE_TESTS", "")
-        if not private_tests:
-            private_tests = load_config().raw.get("teatree", {}).get("private_tests", "")
-        if not private_tests:
-            return "private_tests not configured in ~/.teatree.toml and T3_PRIVATE_TESTS not set."
-        private_tests_path = Path(private_tests).expanduser()
-        if not private_tests_path.is_dir():
-            return f"Private tests directory does not exist: {private_tests_path}"
-
-        # Discover frontend port from docker-compose (single source of truth)
         worktree = resolve_worktree()
         project = _compose_project(worktree)
-        frontend_port = get_service_port(project, "frontend", 4200)
+        frontend_port = _discover_frontend_port(project)
         if frontend_port is None:
-            return f"Frontend service not running in compose project '{project}'. Run `t3 lifecycle start` first."
+            return (
+                f"Frontend not running (no docker service in '{project}', no local process on 4200). "
+                "Run `t3 run frontend` first."
+            )
 
-        # Read variant from .env.worktree
         from teatree.core.resolve import _find_env_worktree, _get_user_cwd, _parse_env_file  # noqa: PLC0415
 
         variant = ""

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -1520,7 +1520,7 @@ class TestRunBackend(TestCase):
 class TestRunFrontend(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_starts_via_docker_compose(self) -> None:
+    def test_starts_via_docker_compose_when_service_exists(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             wt_dir = tmp_path / "frontend"
@@ -1537,6 +1537,7 @@ class TestRunFrontend(TestCase):
             mock_config = MagicMock()
             mock_config.user.workspace_dir = tmp_path
             with (
+                patch.object(run_mod, "_compose_has_service", return_value=True),
                 patch.object(run_mod.subprocess, "run") as mock_run,
                 patch("teatree.config.load_config", return_value=mock_config),
                 patch.object(
@@ -1550,9 +1551,9 @@ class TestRunFrontend(TestCase):
             mock_run.assert_called_once()
             assert "docker-compose" in result.lower()
 
-    @_patch_overlays(MINIMAL_OVERLAY)
+    @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_no_compose_file_returns_message(self) -> None:
+    def test_falls_back_to_local_when_no_docker_service(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             wt_dir = tmp_path / "frontend"
@@ -1566,19 +1567,34 @@ class TestRunFrontend(TestCase):
                 extra={"worktree_path": str(wt_dir)},
             )
 
-            mock_config = MagicMock()
-            mock_config.user.workspace_dir = tmp_path
             with (
-                patch("teatree.config.load_config", return_value=mock_config),
-                patch.object(
-                    run_mod,
-                    "find_free_ports",
-                    return_value={"backend": 8001, "frontend": 4201, "postgres": 5432, "redis": 6379},
-                ),
+                patch.object(run_mod, "_compose_has_service", return_value=False),
+                patch.object(run_mod.subprocess, "Popen") as mock_popen,
             ):
                 result = cast("str", call_command("run", "frontend", path=str(wt_dir)))
 
-            assert "no docker-compose file" in result.lower()
+            mock_popen.assert_called_once()
+            assert "locally" in result.lower()
+
+    @_patch_overlays(MINIMAL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_no_command_configured_returns_message(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "frontend"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test")
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/frontend",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+            )
+
+            result = cast("str", call_command("run", "frontend", path=str(wt_dir)))
+
+            assert "no frontend command" in result.lower()
 
 
 class TestRunBuildFrontend(TestCase):
@@ -1835,7 +1851,7 @@ class TestRunE2ePrivate(TestCase):
             patch.dict("os.environ", {"T3_PRIVATE_TESTS": "/nonexistent/path"}),
         ):
             result = cast("str", call_command("run", "e2e-private"))
-        assert "does not exist" in result
+        assert "not configured" in result or "directory missing" in result
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1955,6 +1971,7 @@ class TestRunE2ePrivate(TestCase):
             with (
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
                 patch.object(run_mod, "get_service_port", return_value=None),
+                patch.object(run_mod, "_detect_local_port", return_value=None),
             ):
                 result = cast("str", call_command("run", "e2e-private"))
             assert "not running" in result

--- a/tests/teatree_core/test_run_command.py
+++ b/tests/teatree_core/test_run_command.py
@@ -276,6 +276,7 @@ class TestE2ePrivateCommand(TestCase):
                     },
                 ),
                 patch.object(run_mod, "get_service_port", return_value=None),
+                patch.object(run_mod, "_detect_local_port", return_value=None),
             ):
                 result = cast("str", call_command("run", "e2e-private"))
 


### PR DESCRIPTION
## Summary
- `t3 run frontend` checks if a "frontend" service exists in docker-compose; if not, falls back to the overlay's RunCommand (local npx process)
- `t3 run e2e-private` detects locally-running frontends when docker has no frontend service
- Extracted `_compose_has_service`, `_detect_local_port`, `_resolve_private_tests_path`, `_discover_frontend_port` helpers

Refs #145