### PR TITLE
fix(lifecycle): include docker-compose.override.yml, verbose default, FSM fix

### DIFF
--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -12,6 +12,7 @@ from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import resolve_worktree
 from teatree.core.step_runner import ProvisionReport, run_provision_steps, run_step
 from teatree.core.worktree_env import write_env_worktree
+from teatree.timeouts import TimeoutConfig, load_timeouts
 from teatree.utils.ports import find_free_ports, get_worktree_ports
 
 
@@ -120,16 +121,20 @@ def _compose_env(ports: dict[str, int]) -> dict[str, str]:
     }
 
 
-def _docker_compose_down(project: str, stdout: OutputWrapper) -> None:
+def _docker_compose_down(project: str, stdout: OutputWrapper, *, timeout: int | None = 30) -> None:
     """Stop and remove containers for the compose project."""
-    result = subprocess.run(  # noqa: S603
-        ["docker", "compose", "-p", project, "down", "--remove-orphans"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        stdout.write(f"  docker compose down: {result.stderr.strip()[:300]}")
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["docker", "compose", "-p", project, "down", "--remove-orphans"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            stdout.write(f"  docker compose down: {result.stderr.strip()[:300]}")
+    except subprocess.TimeoutExpired:
+        stdout.write(f"  docker compose down: timed out after {timeout}s")
 
 
 def _compose_files(compose_file: str) -> list[str]:
@@ -141,12 +146,14 @@ def _compose_files(compose_file: str) -> list[str]:
     return flags
 
 
-def _docker_compose_up(
+def _docker_compose_up(  # noqa: PLR0913
     project: str,
     compose_file: str,
     env: dict[str, str],
     stdout: OutputWrapper,
     stderr: OutputWrapper,
+    *,
+    timeout: int | None = 60,
 ) -> bool:
     """Start all services via docker-compose."""
     cmd = [
@@ -160,7 +167,11 @@ def _docker_compose_up(
         "--no-build",
         "--pull=never",
     ]
-    result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False)  # noqa: S603
+    try:
+        result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False, timeout=timeout)  # noqa: S603
+    except subprocess.TimeoutExpired:
+        stderr.write(f"  docker compose up: timed out after {timeout}s")
+        return False
     if result.returncode != 0:
         stderr.write(f"  docker compose up failed (exit {result.returncode}):")
         stderr.write(f"  stderr: {result.stderr.strip()}")
@@ -173,15 +184,23 @@ def _docker_compose_up(
 class Command(TyperCommand):
     _DB_IMPORT_MAX_FAILURES = 3
     _verbose: bool = True
+    _timeouts: TimeoutConfig = TimeoutConfig()
+
+    def _init_timeouts(self, overlay: OverlayBase | None = None, *, no_timeout: bool = False) -> None:
+        if no_timeout:
+            self._timeouts = TimeoutConfig(values=dict.fromkeys(self._timeouts.values, 0))
+        else:
+            self._timeouts = load_timeouts(overlay)
 
     @command()
-    def setup(
+    def setup(  # noqa: PLR0913, PLR0917
         self,
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
         variant: str = typer.Option("", help="Tenant variant. Updates ticket if provided."),
         overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
         force: bool = typer.Option(default=False, help="Bypass DB import circuit breaker."),  # noqa: FBT001
         verbose: bool = typer.Option(default=True, help="Show step stdout/stderr."),  # noqa: FBT001
+        no_timeout: bool = typer.Option(default=False, help="Disable operation timeouts."),  # noqa: FBT001
     ) -> int:
         """Provision a worktree (DB name, env file, overlay steps). No port allocation."""
         variant, overlay, verbose = _resolve_typer_defaults(variant, overlay, verbose)
@@ -195,6 +214,7 @@ class Command(TyperCommand):
         _register_new_repos(worktree, self.stdout)
 
         resolved_overlay = get_overlay()
+        self._init_timeouts(resolved_overlay, no_timeout=no_timeout)
 
         failed_repos: list[str] = []
         for wt in ticket.worktrees.all():
@@ -316,6 +336,7 @@ class Command(TyperCommand):
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
         overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
         verbose: bool = typer.Option(default=True, help="Show step stdout/stderr."),  # noqa: FBT001
+        no_timeout: bool = typer.Option(default=False, help="Disable operation timeouts."),  # noqa: FBT001
     ) -> str:
         """Start all services via docker-compose with dynamically allocated ports.
 
@@ -328,10 +349,11 @@ class Command(TyperCommand):
             os.environ["T3_OVERLAY_NAME"] = overlay
         worktree = resolve_worktree(path)
         resolved_overlay = get_overlay()
+        self._init_timeouts(resolved_overlay, no_timeout=no_timeout)
         project = _compose_project(worktree)
 
         # 1. Stop previous containers
-        _docker_compose_down(project, self.stdout)
+        _docker_compose_down(project, self.stdout, timeout=self._timeouts.get("docker_compose_down"))
 
         # 2. Run pre-run steps (translation sync, customer.json patch, etc.)
         commands = resolved_overlay.get_run_commands(worktree)
@@ -364,7 +386,14 @@ class Command(TyperCommand):
 
         env = {**os.environ, **resolved_overlay.get_env_extra(worktree), **_compose_env(ports)}
         env.pop("VIRTUAL_ENV", None)
-        ok = _docker_compose_up(project, compose_file, env, self.stdout, self.stderr)
+        ok = _docker_compose_up(
+            project,
+            compose_file,
+            env,
+            self.stdout,
+            self.stderr,
+            timeout=self._timeouts.get("docker_compose_up"),
+        )
 
         if not ok:
             return "error"
@@ -396,6 +425,7 @@ class Command(TyperCommand):
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
         overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
         verbose: bool = typer.Option(default=True, help="Show step stdout/stderr."),  # noqa: FBT001
+        no_timeout: bool = typer.Option(default=False, help="Disable operation timeouts."),  # noqa: FBT001
     ) -> str:
         """Stop containers, allocate fresh ports, and restart all services."""
         if isinstance(verbose, bool):
@@ -406,10 +436,10 @@ class Command(TyperCommand):
 
         if worktree.state == Worktree.State.CREATED:
             self.stdout.write("  Worktree not provisioned — running setup + start instead.")
-            self.setup(path=path, variant="", overlay=overlay)
-            return self.start(path=path, overlay=overlay)
+            self.setup(path=path, variant="", overlay=overlay, no_timeout=no_timeout)
+            return self.start(path=path, overlay=overlay, no_timeout=no_timeout)
 
-        return self.start(path=path, overlay=overlay)
+        return self.start(path=path, overlay=overlay, no_timeout=no_timeout)
 
     @command()
     def teardown(self, path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty).")) -> str:

--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -198,7 +198,12 @@ class Command(TyperCommand):
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
         variant: str = typer.Option("", help="Tenant variant. Updates ticket if provided."),
         overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
-        force: bool = typer.Option(default=False, help="Bypass DB import circuit breaker."),  # noqa: FBT001
+        force: bool = typer.Option(  # noqa: FBT001
+            default=False, help="Reset DB import circuit breaker (retry after repeated failures)."
+        ),
+        slow_import: bool = typer.Option(  # noqa: FBT001
+            default=False, help="Allow slow DB fallbacks (pg_restore, remote dump). DSLR-only by default."
+        ),
         verbose: bool = typer.Option(default=True, help="Show step stdout/stderr."),  # noqa: FBT001
         no_timeout: bool = typer.Option(default=False, help="Disable operation timeouts."),  # noqa: FBT001
     ) -> int:
@@ -219,7 +224,7 @@ class Command(TyperCommand):
         failed_repos: list[str] = []
         for wt in ticket.worktrees.all():
             try:
-                report = self._provision_worktree(wt, resolved_overlay, force=force)
+                report = self._provision_worktree(wt, resolved_overlay, force=force, slow_import=slow_import)
                 if not report.success:
                     failed_repos.append(wt.repo_path)
             except Exception as exc:  # noqa: BLE001
@@ -233,7 +238,7 @@ class Command(TyperCommand):
         return int(worktree.pk)
 
     def _provision_worktree(
-        self, worktree: Worktree, overlay: "OverlayBase", *, force: bool = False
+        self, worktree: Worktree, overlay: "OverlayBase", *, force: bool = False, slow_import: bool = False
     ) -> ProvisionReport:
         self.stdout.write(f"  Provisioning: {worktree.repo_path}")
 
@@ -248,7 +253,7 @@ class Command(TyperCommand):
         _setup_worktree_dir((worktree.extra or {}).get("worktree_path", ""), worktree, overlay, self.stdout)
 
         if overlay.get_db_import_strategy(worktree) is not None:
-            self._run_db_import(worktree, overlay, force=force)
+            self._run_db_import(worktree, overlay, force=force, slow_import=slow_import)
 
         provision_report = run_provision_steps(
             overlay.get_provision_steps(worktree),
@@ -279,7 +284,9 @@ class Command(TyperCommand):
             self.stdout.write(combined.summary())
         return combined
 
-    def _run_db_import(self, worktree: Worktree, overlay: OverlayBase, *, force: bool = False) -> None:
+    def _run_db_import(
+        self, worktree: Worktree, overlay: OverlayBase, *, force: bool = False, slow_import: bool = False
+    ) -> None:
         extra = worktree.extra or {}
         failures = extra.get("db_import_failures", 0)
         if failures >= self._DB_IMPORT_MAX_FAILURES and not force:
@@ -289,7 +296,7 @@ class Command(TyperCommand):
         env = {**os.environ, **overlay.get_env_extra(worktree)}
         env.pop("VIRTUAL_ENV", None)
         os.environ.update(env)
-        if overlay.db_import(worktree):
+        if overlay.db_import(worktree, slow_import=slow_import):
             extra.pop("db_import_failures", None)
             worktree.extra = extra
             worktree.save(update_fields=["extra"])

--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -132,6 +132,15 @@ def _docker_compose_down(project: str, stdout: OutputWrapper) -> None:
         stdout.write(f"  docker compose down: {result.stderr.strip()[:300]}")
 
 
+def _compose_files(compose_file: str) -> list[str]:
+    """Return -f flags for compose file and its override (if present)."""
+    flags = ["-f", compose_file]
+    override = Path(compose_file).parent / "docker-compose.override.yml"
+    if override.is_file():
+        flags.extend(["-f", str(override)])
+    return flags
+
+
 def _docker_compose_up(
     project: str,
     compose_file: str,
@@ -145,15 +154,17 @@ def _docker_compose_up(
         "compose",
         "-p",
         project,
-        "-f",
-        compose_file,
+        *_compose_files(compose_file),
         "up",
         "-d",
         "--no-build",
+        "--pull=never",
     ]
     result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False)  # noqa: S603
     if result.returncode != 0:
-        stderr.write(f"  docker compose up failed: {result.stderr.strip()[:500]}")
+        stderr.write(f"  docker compose up failed (exit {result.returncode}):")
+        stderr.write(f"  stderr: {result.stderr.strip()}")
+        stderr.write(f"  stdout: {result.stdout.strip()[:500]}")
         return False
     stdout.write("  docker compose up -d: OK")
     return True
@@ -161,7 +172,7 @@ def _docker_compose_up(
 
 class Command(TyperCommand):
     _DB_IMPORT_MAX_FAILURES = 3
-    _verbose: bool = False
+    _verbose: bool = True
 
     @command()
     def setup(
@@ -170,7 +181,7 @@ class Command(TyperCommand):
         variant: str = typer.Option("", help="Tenant variant. Updates ticket if provided."),
         overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
         force: bool = typer.Option(default=False, help="Bypass DB import circuit breaker."),  # noqa: FBT001
-        verbose: bool = typer.Option(default=False, help="Show step stdout/stderr."),  # noqa: FBT001
+        verbose: bool = typer.Option(default=True, help="Show step stdout/stderr."),  # noqa: FBT001
     ) -> int:
         """Provision a worktree (DB name, env file, overlay steps). No port allocation."""
         variant, overlay, verbose = _resolve_typer_defaults(variant, overlay, verbose)
@@ -304,12 +315,15 @@ class Command(TyperCommand):
         self,
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
         overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
+        verbose: bool = typer.Option(default=True, help="Show step stdout/stderr."),  # noqa: FBT001
     ) -> str:
         """Start all services via docker-compose with dynamically allocated ports.
 
         Finds free host ports at runtime, passes them to docker-compose,
         and starts all containers.  Safe to re-run (runs compose down first).
         """
+        if isinstance(verbose, bool):
+            self._verbose = verbose
         if overlay:
             os.environ["T3_OVERLAY_NAME"] = overlay
         worktree = resolve_worktree(path)
@@ -381,8 +395,11 @@ class Command(TyperCommand):
         self,
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
         overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
+        verbose: bool = typer.Option(default=True, help="Show step stdout/stderr."),  # noqa: FBT001
     ) -> str:
         """Stop containers, allocate fresh ports, and restart all services."""
+        if isinstance(verbose, bool):
+            self._verbose = verbose
         if overlay:
             os.environ["T3_OVERLAY_NAME"] = overlay
         worktree = resolve_worktree(path)

--- a/src/teatree/core/models/worktree.py
+++ b/src/teatree/core/models/worktree.py
@@ -38,7 +38,7 @@ class Worktree(models.Model):
     def provision(self) -> None:
         self.db_name = self._build_db_name()
 
-    @transition(field=state, source=[State.PROVISIONED, State.SERVICES_UP], target=State.SERVICES_UP)
+    @transition(field=state, source=[State.PROVISIONED, State.SERVICES_UP, State.READY], target=State.SERVICES_UP)
     def start_services(self, *, services: list[str] | None = None) -> None:
         if services is not None:
             extra = self._extra()

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -261,7 +261,7 @@ class OverlayBase(ABC):
     def get_db_import_strategy(self, worktree: "Worktree") -> DbImportStrategy | None:
         return None
 
-    def db_import(self, worktree: "Worktree", *, force: bool = False) -> bool:
+    def db_import(self, worktree: "Worktree", *, force: bool = False, slow_import: bool = False) -> bool:
         return False
 
     def get_post_db_steps(self, worktree: "Worktree") -> list[ProvisionStep]:

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -303,6 +303,15 @@ class OverlayBase(ABC):
         """
         return {}
 
+    def get_timeouts(self) -> dict[str, int]:
+        """Return overlay-specific timeout overrides (seconds).
+
+        Keys match ``teatree.timeouts`` operation names (e.g. ``"setup"``,
+        ``"db_import"``).  ``0`` disables the timeout for that operation.
+        Only return overrides — missing keys fall through to core defaults.
+        """
+        return {}
+
     def get_cleanup_steps(self, worktree: "Worktree") -> list[ProvisionStep]:
         """Return extra cleanup steps run before a worktree is removed.
 

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -91,6 +91,19 @@ LOGGING = default_logging("teatree")
 
 # Framework-level config (not overlay-specific)
 TEATREE_TERMINAL_MODE = "same-terminal"
+
+# Operation timeouts (seconds).  0 = no timeout.
+# Override per-overlay via OverlayBase.get_timeouts() or per-user
+# via [teatree.timeouts] in ~/.teatree.toml.
+TEATREE_TIMEOUTS = {
+    "setup": 120,
+    "start": 60,
+    "db_import": 180,
+    "docker_compose_up": 60,
+    "docker_compose_down": 30,
+    "provision_step": 120,
+    "pre_run_step": 60,
+}
 TEATREE_CLAUDE_STATUSLINE_STATE_DIR = "/tmp/claude-statusline"  # noqa: S108
 
 TASKS = {

--- a/src/teatree/timeouts.py
+++ b/src/teatree/timeouts.py
@@ -10,6 +10,10 @@ means "no timeout" for that operation.
 """
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from teatree.core.overlay import OverlayBase
 
 # Operation names used as keys.
 SETUP = "setup"
@@ -44,7 +48,7 @@ class TimeoutConfig:
         return val if val > 0 else None
 
 
-def load_timeouts(overlay: object | None = None) -> TimeoutConfig:
+def load_timeouts(overlay: "OverlayBase | None" = None) -> TimeoutConfig:
     """Build a TimeoutConfig by merging all three tiers."""
     merged = dict(CORE_DEFAULTS)
 

--- a/src/teatree/timeouts.py
+++ b/src/teatree/timeouts.py
@@ -1,0 +1,71 @@
+"""Multi-tier timeout configuration for lifecycle operations.
+
+Resolution order (first non-None wins):
+1. User settings — ``[teatree.timeouts]`` in ``~/.teatree.toml``
+2. Overlay settings — ``OverlayBase.get_timeouts()``
+3. Core defaults — ``TEATREE_TIMEOUTS`` in Django settings.py
+
+Each tier returns a dict of ``{operation: seconds}``.  A value of ``0``
+means "no timeout" for that operation.
+"""
+
+from dataclasses import dataclass, field
+
+# Operation names used as keys.
+SETUP = "setup"
+START = "start"
+DB_IMPORT = "db_import"
+DOCKER_COMPOSE_UP = "docker_compose_up"
+DOCKER_COMPOSE_DOWN = "docker_compose_down"
+PROVISION_STEP = "provision_step"
+PRE_RUN_STEP = "pre_run_step"
+
+# Sane defaults (seconds).  Override at any tier.
+CORE_DEFAULTS: dict[str, int] = {
+    SETUP: 120,
+    START: 60,
+    DB_IMPORT: 180,
+    DOCKER_COMPOSE_UP: 60,
+    DOCKER_COMPOSE_DOWN: 30,
+    PROVISION_STEP: 120,
+    PRE_RUN_STEP: 60,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class TimeoutConfig:
+    """Resolved timeout values for all operations."""
+
+    values: dict[str, int] = field(default_factory=lambda: dict(CORE_DEFAULTS))
+
+    def get(self, operation: str) -> int | None:
+        """Return timeout in seconds, or ``None`` if timeouts are disabled."""
+        val = self.values.get(operation, CORE_DEFAULTS.get(operation, 120))
+        return val if val > 0 else None
+
+
+def load_timeouts(overlay: object | None = None) -> TimeoutConfig:
+    """Build a TimeoutConfig by merging all three tiers."""
+    merged = dict(CORE_DEFAULTS)
+
+    # Tier 3: Django settings (core defaults, already in merged)
+    from django.conf import settings  # noqa: PLC0415
+
+    django_timeouts = getattr(settings, "TEATREE_TIMEOUTS", None)
+    if isinstance(django_timeouts, dict):
+        merged.update(django_timeouts)
+
+    # Tier 2: Overlay
+    if overlay is not None and hasattr(overlay, "get_timeouts"):
+        overlay_timeouts = overlay.get_timeouts()
+        if overlay_timeouts:
+            merged.update(overlay_timeouts)
+
+    # Tier 1: User settings (~/.teatree.toml [teatree.timeouts])
+    from teatree.config import load_config  # noqa: PLC0415
+
+    user_timeouts = load_config().raw.get("teatree", {}).get("timeouts", {})
+    if isinstance(user_timeouts, dict):
+        merged.update({k: int(v) for k, v in user_timeouts.items()})
+
+    return TimeoutConfig(values=merged)

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -469,17 +469,27 @@ def reset_remote_dump_state() -> None:
     _remote_dump_failed = False
 
 
+def _warn_slow_path(label: str) -> None:
+    """Print a prominent warning when a non-DSLR (slow) restore path executes."""
+    print(f"  WARNING [SLOW PATH]: {label}", file=sys.stderr)  # noqa: T201
+    print("  DSLR snapshots are the expected fast path. This operation is significantly slower.", file=sys.stderr)  # noqa: T201
+
+
 def django_db_import(
     cfg: DjangoDbImportConfig,
     *,
     skip_dslr: bool = False,
+    slow_import: bool = False,
     allow_remote_dump: bool = False,
 ) -> bool:
     """Import a Django database with fallback chain.
 
-    Remote dumps are slow and network-dependent. They are only attempted
-    when *allow_remote_dump* is True (e.g., user explicitly requested
-    ``--force`` or confirmed via interactive prompt).
+    By default only DSLR snapshots are tried — the fast, expected path.
+    Non-DSLR fallbacks (pg_restore from dump, remote dump download) are
+    gated behind *slow_import=True* to prevent accidentally triggering
+    multi-minute operations.  Pass ``--slow-import`` on the CLI to enable.
+
+    Remote dumps additionally require *allow_remote_dump=True*.
 
     Returns True on success, False if no source was available.
     """
@@ -497,10 +507,27 @@ def django_db_import(
 
     if _try_restore_from_dslr(ctx, skip_dslr=skip_dslr):
         return True
+
+    # --- Non-DSLR fallbacks (slow) — gated behind --slow-import --------
+    if not slow_import:
+        print(  # noqa: T201
+            "\n  DSLR restore failed or unavailable. Non-DSLR fallbacks are disabled by default.\n"
+            "  Non-DSLR paths (pg_restore, remote dump) take minutes instead of seconds.\n"
+            "  To allow slow fallback paths, re-run with: --slow-import\n",
+            file=sys.stderr,
+        )
+        return False
+
+    _warn_slow_path("Falling back to pg_restore from local dump file.")
     if _try_restore_from_local_dump(ctx):
         return True
-    if allow_remote_dump and _try_fetch_remote_dump(ctx) and _try_restore_from_local_dump(ctx):
-        return True
+
+    if allow_remote_dump:
+        _warn_slow_path("Downloading fresh dump from remote database (pg_dump over network).")
+        if _try_fetch_remote_dump(ctx) and _try_restore_from_local_dump(ctx):
+            return True
+
+    _warn_slow_path("Trying CI dump as last resort (pg_restore).")
     if _try_restore_from_ci_dump(ctx):
         return True
 
@@ -511,7 +538,7 @@ def django_db_import(
     print(f"  - No CI dump matching {cfg.ci_dump_glob} in {cfg.main_repo_path}")  # noqa: T201
     print()  # noqa: T201
     if cfg.remote_db_url:
-        print("  To fetch a fresh dump from the remote DB, re-run with network access.")  # noqa: T201
+        print("  To fetch a fresh dump from the remote DB, re-run with --slow-import.")  # noqa: T201
     else:
         print("  Configure remote_db_url in DjangoDbImportConfig to enable remote dump fetching.")  # noqa: T201
     return False

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -125,22 +125,17 @@ def _copy_ref_to_ticket(ctx: _RestoreContext) -> bool:
 
 
 def _find_dslr_cmd(tool_name: str) -> list[str]:
-    """Return a command prefix for invoking dslr (e.g. ``["dslr"]`` or ``["uv", "run", "dslr"]``)."""
+    """Return a command prefix for invoking dslr.
+
+    Prefers ``uv run`` (resolves project venv where dslr + psycopg live).
+    Bare ``dslr`` on PATH is unreliable (pyenv shims, missing deps).
+    Honour ``DSLR_CMD`` env var as an explicit override.
+    """
     dslr = os.environ.get("DSLR_CMD", "")
     if dslr and shutil.which(dslr):
         return [dslr]
-    if shutil.which(tool_name):
-        return [tool_name]
-    # dslr is a Python tool — invoke via uv which resolves the correct venv.
     if shutil.which("uv"):
-        result = subprocess.run(
-            ["uv", "run", tool_name, "list"],
-            capture_output=True,
-            check=False,
-            timeout=15,
-        )
-        if result.returncode == 0:
-            return ["uv", "run", tool_name]
+        return ["uv", "run", tool_name]
     return []
 
 

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -178,7 +178,7 @@ class DbOverlay(CommandOverlay):
     def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy | None:
         return DbImportStrategy(kind="dslr")
 
-    def db_import(self, worktree: Worktree, *, force: bool = False) -> bool:
+    def db_import(self, worktree: Worktree, *, force: bool = False, slow_import: bool = False) -> bool:
         return False
 
 

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -112,7 +112,7 @@ class FullOverlay(OverlayBase):
     def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy:
         return {"kind": "test", "source_database": "test_db"}
 
-    def db_import(self, worktree: Worktree, *, force: bool = False) -> bool:
+    def db_import(self, worktree: Worktree, *, force: bool = False, slow_import: bool = False) -> bool:
         return True
 
     def get_reset_passwords_command(self, worktree: Worktree) -> ProvisionStep | None:
@@ -179,7 +179,7 @@ class PostDbStepsOverlay(FullOverlay):
 class FailingImportOverlay(FullOverlay):
     """Overlay where db_import always fails — tests error reporting."""
 
-    def db_import(self, worktree: Worktree, *, force: bool = False) -> bool:
+    def db_import(self, worktree: Worktree, *, force: bool = False, slow_import: bool = False) -> bool:
         return False
 
 

--- a/tests/test_django_db.py
+++ b/tests/test_django_db.py
@@ -138,19 +138,15 @@ class TestFindDslrCmd:
         monkeypatch.setattr(mod.shutil, "which", lambda p: p)
         assert _find_dslr_cmd("dslr") == ["/custom/dslr"]
 
-    def test_falls_back_to_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_prefers_uv_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without DSLR_CMD, always uses uv run (avoids broken pyenv shims)."""
         monkeypatch.delenv("DSLR_CMD", raising=False)
-
-        def which(p: str) -> str | None:
-            return p if p == "dslr" else None
-
-        monkeypatch.setattr(mod.shutil, "which", which)
-        assert _find_dslr_cmd("dslr") == ["dslr"]
+        monkeypatch.setattr(mod.shutil, "which", lambda p: p)
+        assert _find_dslr_cmd("dslr") == ["uv", "run", "dslr"]
 
     def test_falls_back_to_uv_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("DSLR_CMD", raising=False)
         monkeypatch.setattr(mod.shutil, "which", lambda p: "uv" if p == "uv" else None)
-        monkeypatch.setattr(mod.subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
         assert _find_dslr_cmd("dslr") == ["uv", "run", "dslr"]
 
     def test_returns_empty_when_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_django_db.py
+++ b/tests/test_django_db.py
@@ -678,7 +678,16 @@ class TestDjangoDbImport:
         monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
         monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: True)
         cfg = _make_cfg(tmp_path)
-        assert django_db_import(cfg) is True
+        assert django_db_import(cfg, slow_import=True) is True
+
+    def test_blocks_fallback_without_slow_import(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-DSLR fallbacks require --slow-import."""
+        reset_remote_dump_state()
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda tool: [])
+        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
+        monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: True)
+        cfg = _make_cfg(tmp_path)
+        assert django_db_import(cfg) is False
 
     def test_falls_through_to_remote_fetch_then_local(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         reset_remote_dump_state()
@@ -693,7 +702,7 @@ class TestDjangoDbImport:
         monkeypatch.setattr(mod, "_try_restore_from_local_dump", local_dump)
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: True)
         cfg = _make_cfg(tmp_path)
-        assert django_db_import(cfg, allow_remote_dump=True) is True
+        assert django_db_import(cfg, slow_import=True, allow_remote_dump=True) is True
         assert len(local_calls) == 2  # called twice: before and after remote fetch
 
     def test_skips_remote_when_not_allowed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -705,7 +714,7 @@ class TestDjangoDbImport:
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: remote_called.append(1) or True)
         monkeypatch.setattr(mod, "_try_restore_from_ci_dump", lambda ctx: True)
         cfg = _make_cfg(tmp_path)
-        assert django_db_import(cfg, allow_remote_dump=False) is True
+        assert django_db_import(cfg, slow_import=True, allow_remote_dump=False) is True
         assert remote_called == []
 
     def test_falls_through_to_ci(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -716,7 +725,7 @@ class TestDjangoDbImport:
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
         monkeypatch.setattr(mod, "_try_restore_from_ci_dump", lambda ctx: True)
         cfg = _make_cfg(tmp_path)
-        assert django_db_import(cfg) is True
+        assert django_db_import(cfg, slow_import=True) is True
 
     def test_fails_when_all_strategies_fail(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         reset_remote_dump_state()
@@ -726,7 +735,7 @@ class TestDjangoDbImport:
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
         monkeypatch.setattr(mod, "_try_restore_from_ci_dump", lambda ctx: False)
         cfg = _make_cfg(tmp_path)
-        assert django_db_import(cfg) is False
+        assert django_db_import(cfg, slow_import=True) is False
 
     def test_failure_message_with_remote_url(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
@@ -738,8 +747,8 @@ class TestDjangoDbImport:
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
         monkeypatch.setattr(mod, "_try_restore_from_ci_dump", lambda ctx: False)
         cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
-        django_db_import(cfg)
-        assert "network access" in capsys.readouterr().out
+        django_db_import(cfg, slow_import=True)
+        assert "--slow-import" in capsys.readouterr().out
 
     def test_failure_message_without_remote_url(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
@@ -751,7 +760,7 @@ class TestDjangoDbImport:
         monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
         monkeypatch.setattr(mod, "_try_restore_from_ci_dump", lambda ctx: False)
         cfg = _make_cfg(tmp_path)
-        django_db_import(cfg)
+        django_db_import(cfg, slow_import=True)
         assert "Configure remote_db_url" in capsys.readouterr().out
 
     def test_skip_dslr_passed_through(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -781,4 +790,4 @@ class TestDjangoDbImport:
             ci_dump_glob="*.sql.gz",
             snapshot_tool="",
         )
-        assert django_db_import(cfg) is True
+        assert django_db_import(cfg, slow_import=True) is True

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,0 +1,120 @@
+"""Tests for the multi-tier timeout configuration system."""
+
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase, override_settings
+
+from teatree.timeouts import (
+    CORE_DEFAULTS,
+    DB_IMPORT,
+    DOCKER_COMPOSE_DOWN,
+    DOCKER_COMPOSE_UP,
+    PRE_RUN_STEP,
+    PROVISION_STEP,
+    SETUP,
+    START,
+    TimeoutConfig,
+    load_timeouts,
+)
+
+
+class TestTimeoutConfig:
+    def test_defaults(self) -> None:
+        cfg = TimeoutConfig()
+        assert cfg.get(SETUP) == 120
+        assert cfg.get(START) == 60
+        assert cfg.get(DB_IMPORT) == 180
+
+    def test_custom_values(self) -> None:
+        cfg = TimeoutConfig(values={SETUP: 300, START: 90})
+        assert cfg.get(SETUP) == 300
+        assert cfg.get(START) == 90
+
+    def test_zero_disables_timeout(self) -> None:
+        cfg = TimeoutConfig(values={SETUP: 0})
+        assert cfg.get(SETUP) is None
+
+    def test_unknown_operation_uses_default(self) -> None:
+        cfg = TimeoutConfig(values={})
+        assert cfg.get(SETUP) == CORE_DEFAULTS[SETUP]
+
+    def test_completely_unknown_operation_returns_120(self) -> None:
+        cfg = TimeoutConfig(values={})
+        assert cfg.get("nonexistent_operation") == 120
+
+    def test_frozen(self) -> None:
+        cfg = TimeoutConfig()
+        with pytest.raises(AttributeError):
+            cfg.values = {}  # type: ignore[misc]
+
+
+class TestLoadTimeouts(TestCase):
+    def test_core_defaults(self) -> None:
+        cfg = load_timeouts()
+        for op, default in CORE_DEFAULTS.items():
+            assert cfg.get(op) == default
+
+    @override_settings(TEATREE_TIMEOUTS={"setup": 999, "db_import": 0})
+    def test_django_settings_override(self) -> None:
+        cfg = load_timeouts()
+        assert cfg.get(SETUP) == 999
+        assert cfg.get(DB_IMPORT) is None  # 0 disables
+
+    def test_overlay_overrides_django_settings(self) -> None:
+        class FakeOverlay:
+            def get_timeouts(self) -> dict[str, int]:
+                return {"setup": 500, "provision_step": 300}
+
+        cfg = load_timeouts(FakeOverlay())
+        assert cfg.get(SETUP) == 500
+        assert cfg.get(PROVISION_STEP) == 300
+        # Non-overridden values use core defaults
+        assert cfg.get(DOCKER_COMPOSE_UP) == CORE_DEFAULTS[DOCKER_COMPOSE_UP]
+
+    @override_settings(TEATREE_TIMEOUTS={"setup": 999})
+    def test_overlay_beats_django_settings(self) -> None:
+        class FakeOverlay:
+            def get_timeouts(self) -> dict[str, int]:
+                return {"setup": 500}
+
+        cfg = load_timeouts(FakeOverlay())
+        assert cfg.get(SETUP) == 500  # overlay wins over Django settings
+
+    def test_user_toml_beats_overlay(self) -> None:
+        class FakeOverlay:
+            def get_timeouts(self) -> dict[str, int]:
+                return {"setup": 500}
+
+        fake_config_raw = {"teatree": {"timeouts": {"setup": 10}}}
+
+        class FakeConfig:
+            raw = fake_config_raw
+
+        with patch("teatree.config.load_config", return_value=FakeConfig()):
+            cfg = load_timeouts(FakeOverlay())
+        assert cfg.get(SETUP) == 10  # user TOML wins over overlay
+
+    def test_overlay_without_get_timeouts(self) -> None:
+        """Overlay that doesn't implement get_timeouts() is fine."""
+
+        class BareOverlay:
+            pass
+
+        cfg = load_timeouts(BareOverlay())
+        assert cfg.get(SETUP) == CORE_DEFAULTS[SETUP]
+
+    def test_overlay_returning_empty(self) -> None:
+        class EmptyOverlay:
+            def get_timeouts(self) -> dict[str, int]:
+                return {}
+
+        cfg = load_timeouts(EmptyOverlay())
+        assert cfg.get(SETUP) == CORE_DEFAULTS[SETUP]
+
+    def test_all_operations_have_defaults(self) -> None:
+        cfg = load_timeouts()
+        for op in (SETUP, START, DB_IMPORT, DOCKER_COMPOSE_UP, DOCKER_COMPOSE_DOWN, PROVISION_STEP, PRE_RUN_STEP):
+            val = cfg.get(op)
+            assert val is not None, f"{op} should not be None"
+            assert val > 0, f"{op} should have a positive default"


### PR DESCRIPTION
## Summary
- `_docker_compose_up` now includes `docker-compose.override.yml` via `_compose_files()` helper
- `--verbose` defaults to `True` on `setup`/`start`/`restart` commands
- `start_services` FSM allows `READY → SERVICES_UP` transition (re-start)
- Better error output for docker compose failures (full stderr + exit code)
- `--pull=never` added to prevent pulling images from registry
- Gate non-DSLR DB fallbacks behind `--slow-import` flag
- Multi-tier operation timeouts with `--no-timeout`
- Fix dslr discovery: always use `uv run` to skip unreliable pyenv shims

Refs #145

## Test plan
- [ ] Verify `t3 lifecycle setup --variant partner-b` uses DSLR snapshots
- [ ] Verify `t3 lifecycle start` includes override file (CORS, image reuse)
- [ ] Verify `t3 lifecycle start` works on already-READY worktrees
- [ ] Run full test suite