### PR TITLE
fix(skills): wire schema validation + fail-fast logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,6 +113,12 @@ repos:
   # Phase 7 - Project-specific
   - repo: local
     hooks:
+      - id: validate-skill-md
+        name: Validate SKILL.md frontmatter
+        language: system
+        entry: uv run python -m teatree.skill_schema
+        files: 'SKILL\.md$'
+        types: [markdown]
       - id: update-readme-skills
         name: Update README skills catalogue
         language: system

--- a/src/teatree/autostart.py
+++ b/src/teatree/autostart.py
@@ -3,10 +3,17 @@
 No Django imports — works without django.setup().
 """
 
+import logging
 import subprocess  # noqa: S404
 import sys
 from importlib.resources import files
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _stderr(result: subprocess.CompletedProcess[bytes]) -> str:
+    return result.stderr.decode(errors="replace") if result.stderr else ""
 
 
 class UnsupportedPlatformError(RuntimeError):
@@ -126,20 +133,25 @@ def _launchd_enable(overlay_name: str, context: dict[str, str]) -> str:
 
     # Unload first if already installed
     if plist_path.is_file():
-        subprocess.run(  # noqa: S603
+        result = subprocess.run(  # noqa: S603
             ["launchctl", "unload", str(plist_path)],  # noqa: S607
             check=False,
             capture_output=True,
         )
+        if result.returncode:
+            logger.warning("launchctl unload failed (rc=%d): %s", result.returncode, _stderr(result))
 
     content = _render_template("launchd.plist.tmpl", context)
     plist_path.write_text(content, encoding="utf-8")
 
-    subprocess.run(  # noqa: S603
+    result = subprocess.run(  # noqa: S603
         ["launchctl", "load", str(plist_path)],  # noqa: S607
         check=False,
         capture_output=True,
     )
+    if result.returncode:
+        msg = f"launchctl load failed (rc={result.returncode}): {_stderr(result)}"
+        raise RuntimeError(msg)
 
     return f"Dashboard daemon installed and started. URL: http://{context['host']}:{context['port']}/"
 
@@ -150,11 +162,13 @@ def _launchd_disable(overlay_name: str) -> str:
     if not plist_path.is_file():
         return f"Autostart not installed for {overlay_name}."
 
-    subprocess.run(  # noqa: S603
+    result = subprocess.run(  # noqa: S603
         ["launchctl", "unload", str(plist_path)],  # noqa: S607
         check=False,
         capture_output=True,
     )
+    if result.returncode:
+        logger.warning("launchctl unload failed (rc=%d): %s", result.returncode, _stderr(result))
     plist_path.unlink()
 
     return f"Dashboard daemon removed for {overlay_name}."
@@ -171,8 +185,13 @@ def _systemd_enable(overlay_name: str, context: dict[str, str]) -> str:
     content = _render_template("systemd.service.tmpl", context)
     unit_path.write_text(content, encoding="utf-8")
 
-    subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, capture_output=True)  # noqa: S607
-    subprocess.run(["systemctl", "--user", "enable", "--now", unit_name], check=False, capture_output=True)  # noqa: S603, S607
+    result = subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, capture_output=True)  # noqa: S607
+    if result.returncode:
+        logger.warning("systemctl daemon-reload failed (rc=%d): %s", result.returncode, _stderr(result))
+    result = subprocess.run(["systemctl", "--user", "enable", "--now", unit_name], check=False, capture_output=True)  # noqa: S603, S607
+    if result.returncode:
+        msg = f"systemctl enable failed (rc={result.returncode}): {_stderr(result)}"
+        raise RuntimeError(msg)
 
     return f"Dashboard daemon installed and started. URL: http://{context['host']}:{context['port']}/"
 
@@ -184,8 +203,12 @@ def _systemd_disable(overlay_name: str) -> str:
     if not unit_path.is_file():
         return f"Autostart not installed for {overlay_name}."
 
-    subprocess.run(["systemctl", "--user", "disable", "--now", unit_name], check=False, capture_output=True)  # noqa: S603, S607
+    result = subprocess.run(["systemctl", "--user", "disable", "--now", unit_name], check=False, capture_output=True)  # noqa: S603, S607
+    if result.returncode:
+        logger.warning("systemctl disable failed (rc=%d): %s", result.returncode, _stderr(result))
     unit_path.unlink()
-    subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, capture_output=True)  # noqa: S607
+    result = subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, capture_output=True)  # noqa: S607
+    if result.returncode:
+        logger.warning("systemctl daemon-reload failed (rc=%d): %s", result.returncode, _stderr(result))
 
     return f"Dashboard daemon removed for {overlay_name}."

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -118,8 +118,9 @@ def _detect_agent_ticket_status(project_root: Path) -> str:
         from teatree.core.resolve import resolve_worktree  # noqa: PLC0415
 
         return str(resolve_worktree().ticket.state)
-    except Exception:  # noqa: BLE001
-        return ""
+    except Exception:
+        logger.debug("Failed to detect agent ticket status", exc_info=True)
+        return "(error)"
 
 
 def _launch_claude(

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -1,5 +1,7 @@
 """Overlay CLI — builds Typer sub-apps that delegate to manage.py commands."""
 
+import json as _json
+import logging
 import os
 import shutil
 import subprocess  # noqa: S404
@@ -7,6 +9,8 @@ import sys
 from pathlib import Path
 
 import typer
+
+logger = logging.getLogger(__name__)
 
 DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
     "lifecycle": (
@@ -444,15 +448,17 @@ class OverlayAppBuilder:
         if project_path is None:
             return
 
-        import json  # noqa: PLC0415
-
         tool_commands: list[dict[str, str]] = []
         for candidate in project_path.rglob("hook-config/tool-commands.json"):
             try:
-                data = json.loads(candidate.read_text(encoding="utf-8"))
+                data = _json.loads(candidate.read_text(encoding="utf-8"))
                 if isinstance(data, list):  # pragma: no branch
                     tool_commands.extend(data)
-            except Exception:  # noqa: BLE001, S112
+            except _json.JSONDecodeError:
+                logger.warning("Invalid JSON in %s", candidate)
+                continue
+            except OSError as exc:
+                logger.warning("Cannot read %s: %s", candidate, exc)
                 continue
 
         if not tool_commands:

--- a/src/teatree/core/views/_startup.py
+++ b/src/teatree/core/views/_startup.py
@@ -1,6 +1,7 @@
 """Shared startup/sync logic called by both dashboard init and sync-now button."""
 
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -9,6 +10,9 @@ from teatree.config import DATA_DIR
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.sync import SyncResult, sync_followup
 from teatree.skill_deps import resolve_all
+from teatree.skill_schema import validate_skill_md
+
+logger = logging.getLogger(__name__)
 
 # Allow importing the shared trigger parser from scripts/lib/.
 _SCRIPTS_LIB = Path(__file__).resolve().parents[4] / "scripts" / "lib"
@@ -54,6 +58,21 @@ def _write_skill_metadata_cache() -> None:
     cache_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
 
 
+def _validate_skills(known_skills: set[str]) -> None:
+    for d in sorted(_CLAUDE_SKILLS_DIR.iterdir()):
+        resolved = d.resolve() if d.is_symlink() else d
+        if not resolved.is_dir():
+            continue
+        skill_md = resolved / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+        errors, warnings = validate_skill_md(skill_md, known_skills=known_skills)
+        for warning in warnings:
+            logger.warning("%s", warning)
+        for error in errors:
+            logger.warning("Skill validation error: %s", error)
+
+
 def _build_trigger_index() -> list[dict]:
     """Scan ``~/.claude/skills/*/SKILL.md`` and extract ``triggers:`` blocks.
 
@@ -65,6 +84,14 @@ def _build_trigger_index() -> list[dict]:
 
     if not _CLAUDE_SKILLS_DIR.is_dir():
         return index
+
+    known_skills: set[str] = set()
+    for d in _CLAUDE_SKILLS_DIR.iterdir():
+        resolved = d.resolve() if d.is_symlink() else d
+        if resolved.is_dir() and (resolved / "SKILL.md").is_file():
+            known_skills.add(d.name)
+
+    _validate_skills(known_skills)
 
     for skill_dir in sorted(_CLAUDE_SKILLS_DIR.iterdir()):
         # Resolve symlinks so we can check if target exists

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -7,6 +7,7 @@ Overlays configure the engine via ``DjangoDbImportConfig``; the engine
 does the rest.  No Django imports — shells out to ``manage.py``.
 """
 
+import logging
 import os
 import re
 import shutil
@@ -17,6 +18,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from teatree.utils import bad_artifacts
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -344,7 +347,11 @@ _remote_dump_failed: bool = False
 
 
 def _try_restore_from_dslr(ctx: _RestoreContext, *, skip_dslr: bool) -> bool:
-    if skip_dslr or not ctx.dslr_cmd:
+    if skip_dslr:
+        logger.info("DSLR restore skipped (skip_dslr=True)")
+        return False
+    if not ctx.dslr_cmd:
+        logger.info("DSLR restore skipped (no snapshot tool configured)")
         return False
     _ensure_ref_db(ctx.cfg.ref_db_name, ctx.pg_host, ctx.pg_user, ctx.pg_env)
     snapshots = _find_dslr_snapshots(ctx.dslr_cmd, ctx.dslr_env, ctx.cfg.ref_db_name)
@@ -370,6 +377,7 @@ def _try_restore_from_dslr(ctx: _RestoreContext, *, skip_dslr: bool) -> bool:
             print(f"  Created {ctx.cfg.ticket_db_name} from DSLR snapshot.")  # noqa: T201
             return True
         print(f"  WARNING: Template copy after DSLR {snap_name} failed, trying older...")  # noqa: T201
+    logger.warning("All DSLR snapshots failed for %s", ctx.cfg.ref_db_name)
     print("  WARNING: All DSLR snapshots failed. Trying local dump fallback...")  # noqa: T201
     return False
 
@@ -377,6 +385,7 @@ def _try_restore_from_dslr(ctx: _RestoreContext, *, skip_dslr: bool) -> bool:
 def _try_restore_from_local_dump(ctx: _RestoreContext) -> bool:
     dump_dir = Path(ctx.cfg.dump_dir)
     if not dump_dir.is_dir():
+        logger.info("Local dump dir %s does not exist", dump_dir)
         return False
     dumps = sorted(
         (p for p in dump_dir.glob(ctx.cfg.dump_glob) if validate_dump(p) and not bad_artifacts.is_bad(str(p))),
@@ -393,6 +402,7 @@ def _try_restore_from_local_dump(ctx: _RestoreContext) -> bool:
         if _restore_ref_and_copy(ctx, str(dump), f"local dump ({dump.name})"):
             return True
         print(f"  WARNING: Local dump {dump.name} failed, trying older...")  # noqa: T201
+    logger.warning("All local dumps failed for %s", ctx.cfg.ref_db_name)
     print("  WARNING: All local dumps failed. Trying remote dump...")  # noqa: T201
     return False
 
@@ -406,6 +416,7 @@ def _try_fetch_remote_dump(ctx: _RestoreContext) -> bool:
     global _remote_dump_failed  # noqa: PLW0603
     cfg = ctx.cfg
     if not cfg.remote_db_url:
+        logger.info("Remote dump skipped (no remote_db_url configured)")
         return False
     if _remote_dump_failed:
         print("  Skipping remote dump (already failed in this run).")  # noqa: T201
@@ -433,6 +444,7 @@ def _try_fetch_remote_dump(ctx: _RestoreContext) -> bool:
     _remote_dump_failed = True
     raw = result.stderr or b""
     stderr_text = raw.decode(errors="replace").strip() if isinstance(raw, bytes) else raw.strip()
+    logger.warning("pg_dump failed (rc=%d) for %s: %s", result.returncode, cfg.ref_db_name, stderr_text)
     print(f"  WARNING: pg_dump failed: {stderr_text}")  # noqa: T201
     return False
 
@@ -449,6 +461,7 @@ def _try_restore_from_ci_dump(ctx: _RestoreContext) -> bool:
     print(f"  Restoring from CI dump (last resort): {ci_dump.name}")  # noqa: T201
     if _restore_ref_and_copy(ctx, str(ci_dump), f"CI dump ({ci_dump.name})"):
         return True
+    logger.warning("CI dump restore failed for %s", ctx.cfg.ref_db_name)
     print("  WARNING: CI dump restore failed.")  # noqa: T201
     return False
 

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 from pathlib import Path
 
@@ -120,7 +121,7 @@ class TestEnable:
         commands_run: list[list[str]] = []
         monkeypatch.setattr(
             "teatree.autostart.subprocess.run",
-            lambda *a, **kw: commands_run.append(a[0]),
+            lambda *a, **kw: (commands_run.append(a[0]), subprocess.CompletedProcess(a[0], 0))[1],
         )
 
         msg = enable("acme", project, "acme.settings", "127.0.0.1", 8000)
@@ -147,7 +148,7 @@ class TestEnable:
         commands_run: list[list[str]] = []
         monkeypatch.setattr(
             "teatree.autostart.subprocess.run",
-            lambda *a, **kw: commands_run.append(a[0]),
+            lambda *a, **kw: (commands_run.append(a[0]), subprocess.CompletedProcess(a[0], 0))[1],
         )
 
         enable("acme", project, "acme.settings", "127.0.0.1", 8000)
@@ -166,7 +167,7 @@ class TestEnable:
         commands_run: list[list[str]] = []
         monkeypatch.setattr(
             "teatree.autostart.subprocess.run",
-            lambda *a, **kw: commands_run.append(a[0]),
+            lambda *a, **kw: (commands_run.append(a[0]), subprocess.CompletedProcess(a[0], 0))[1],
         )
 
         msg = enable("acme", project, "acme.settings", "127.0.0.1", 8000)
@@ -188,7 +189,7 @@ class TestDisable:
         commands_run: list[list[str]] = []
         monkeypatch.setattr(
             "teatree.autostart.subprocess.run",
-            lambda *a, **kw: commands_run.append(a[0]),
+            lambda *a, **kw: (commands_run.append(a[0]), subprocess.CompletedProcess(a[0], 0))[1],
         )
 
         msg = disable("acme")
@@ -206,7 +207,7 @@ class TestDisable:
         commands_run: list[list[str]] = []
         monkeypatch.setattr(
             "teatree.autostart.subprocess.run",
-            lambda *a, **kw: commands_run.append(a[0]),
+            lambda *a, **kw: (commands_run.append(a[0]), subprocess.CompletedProcess(a[0], 0))[1],
         )
 
         msg = disable("acme")
@@ -228,6 +229,67 @@ class TestDisable:
         msg = disable("acme")
 
         assert "not installed" in msg.lower()
+
+
+class TestEnableFailures:
+    def test_launchd_load_failure_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("teatree.autostart.sys.platform", "darwin")
+        project = tmp_path / "myproject"
+        project.mkdir()
+        (project / "manage.py").touch()
+
+        def fake_run(*a, **kw):
+            cmd = a[0]
+            if "load" in cmd:
+                return subprocess.CompletedProcess(cmd, 1, stderr=b"load error")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr("teatree.autostart.subprocess.run", fake_run)
+
+        with pytest.raises(RuntimeError, match="launchctl load failed"):
+            enable("acme", project, "acme.settings", "127.0.0.1", 8000)
+
+    def test_systemd_enable_failure_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("teatree.autostart.sys.platform", "linux")
+        project = tmp_path / "myproject"
+        project.mkdir()
+        (project / "manage.py").touch()
+
+        def fake_run(*a, **kw):
+            cmd = a[0]
+            if "enable" in cmd:
+                return subprocess.CompletedProcess(cmd, 1, stderr=b"enable error")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr("teatree.autostart.subprocess.run", fake_run)
+
+        with pytest.raises(RuntimeError, match="systemctl enable failed"):
+            enable("acme", project, "acme.settings", "127.0.0.1", 8000)
+
+    def test_launchd_unload_failure_logs_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setattr("teatree.autostart.sys.platform", "darwin")
+        project = tmp_path / "myproject"
+        project.mkdir()
+        (project / "manage.py").touch()
+
+        plist_path = _launchd_plist_path("acme")
+        plist_path.parent.mkdir(parents=True, exist_ok=True)
+        plist_path.write_text("<plist/>")
+
+        def fake_run(*a, **kw):
+            cmd = a[0]
+            if "unload" in cmd:
+                return subprocess.CompletedProcess(cmd, 1, stderr=b"unload err")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr("teatree.autostart.subprocess.run", fake_run)
+
+        with caplog.at_level("WARNING", logger="teatree.autostart"):
+            enable("acme", project, "acme.settings", "127.0.0.1", 8000)
+
+        assert "launchctl unload failed" in caplog.text
 
 
 class TestLogPaths:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -679,11 +679,11 @@ class TestDetectAgentTicketStatus:
     def test_returns_empty_without_manage_py(self, tmp_path):
         assert _detect_agent_ticket_status(tmp_path) == ""
 
-    def test_returns_empty_on_exception(self, tmp_path):
+    def test_returns_error_on_exception(self, tmp_path):
         (tmp_path / "manage.py").write_text("# stub\n", encoding="utf-8")
 
         with patch("django.setup", side_effect=Exception("boom")):
-            assert _detect_agent_ticket_status(tmp_path) == ""
+            assert _detect_agent_ticket_status(tmp_path) == "(error)"
 
     def test_returns_ticket_state(self, tmp_path):
         (tmp_path / "manage.py").write_text("# stub\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Wire `validate_skill_md()` into `_build_trigger_index()` at cache-build time — skill validation errors/warnings are now logged instead of silently ignored
- Add `validate-skill-md` pre-commit hook for SKILL.md files
- **FIX 1:** `django_db.py` fallback chain now logs at each level via `logging.warning`
- **FIX 2:** `cli/__init__.py` returns `"(error)"` instead of `""` on Django setup failure
- **FIX 3:** `autostart.py` validates subprocess returncodes; `launchctl load` and `systemctl enable` raise `RuntimeError` on failure
- **FIX 4:** `overlay.py` bare `except Exception` split into `JSONDecodeError` + `OSError` with `logger.warning`

Completes the remaining gaps from PR #151 (plan: `happy-honking-river.md` Phases 3+5).

## Test plan
- [x] 1629 tests pass
- [x] 93.2% coverage (above 93% threshold)
- [x] `ruff check` clean
- [x] `ty check` clean
- [x] All pre-commit hooks pass
- [x] Docker test matrix passes (pre-push)
- [x] 3 new autostart failure tests (raise on load, log on unload)

Relates-to #151