### PR TITLE
feat(overlay): scaffold CI workflow and document editable teatree setup

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -68,6 +68,28 @@ uv run t3 doctor check           # verify both are editable
 
 Now changes to teatree source files are picked up immediately.
 
+#### CI compatibility
+
+The local editable path won't exist in CI. Add this step **before** `uv sync`
+in your CI workflow to override the source:
+
+```yaml
+- run: uv add teatree --no-editable --git https://github.com/souliane/teatree.git
+```
+
+This replaces the local path with a git install for that CI run only.
+The committed `pyproject.toml` is unchanged.
+
+When teatree is published to an index, replace the override with:
+
+```yaml
+env:
+  UV_NO_SOURCES_PACKAGE: teatree
+```
+
+This tells uv to ignore `[tool.uv.sources]` for teatree and resolve
+from the index instead.
+
 ### Contribute to both
 
 Same as above — both the overlay and teatree are editable:

--- a/skills/workspace/references/troubleshooting.md
+++ b/skills/workspace/references/troubleshooting.md
@@ -163,6 +163,14 @@ See your [issue tracker platform reference](../../t3:platforms/references/) § "
 - **Fix (applied):** Set `GIT_EDITOR=true` and `GIT_SEQUENCE_EDITOR=true` in the subprocess environment for `git pull`. This makes interactive rebase silently accept the default todo (equivalent to a normal rebase).
 - **Prevention:** Any `git` subprocess that might trigger an editor (pull, rebase, commit without `-m`) should set `GIT_EDITOR=true` in the env to avoid TTY dependency.
 
+## GitHub Branch Protection Check Names Don't Match CI
+
+- **Symptom:** PR shows "Expected — Waiting for status to be reported" for required checks, even though all CI jobs passed. Both pending and successful checks appear with identical display names.
+- **Cause:** GitHub displays check runs as `CI / lint (pull_request)` in the UI, but the actual check name used by the API is just `lint` (the job key in the workflow YAML). Branch protection rules must use the raw job name, not the display name.
+- **Diagnosis:** `gh api repos/OWNER/REPO/commits/BRANCH/check-runs --jq '.check_runs[] | .name'` — shows the real names.
+- **Fix:** Update branch protection to use raw names (e.g., `lint`, `test (3.13)`, `e2e`), not the display format (`CI / lint (pull_request)`).
+- **Prevention:** After setting branch protection, always verify with `gh api repos/OWNER/REPO/branches/main/protection --jq '.required_status_checks.checks[].context'` and compare against actual check-run names.
+
 ## direnv Not Loading `.envrc`
 
 - **Cause:** direnv not hooked into the shell or `.envrc` not allowed.

--- a/src/teatree/overlay_init/generator.py
+++ b/src/teatree/overlay_init/generator.py
@@ -86,10 +86,12 @@ class OverlayScaffolder:
             ".markdownlint-cli2.yaml": ".markdownlint-cli2.yaml",
             ".pre-commit-config.yaml.tmpl": ".pre-commit-config.yaml",
             ".python-version": ".python-version",
+            "ci.yml.tmpl": ".github/workflows/ci.yml",
         }
         for source_name, dest_name in templates.items():
             source = template_dir.joinpath(source_name)
             dest = self.project_root / dest_name
+            dest.parent.mkdir(parents=True, exist_ok=True)
             dest.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
 
     def write_pyproject(self, project_name: str) -> None:

--- a/src/teatree/templates/overlay/ci.yml.tmpl
+++ b/src/teatree/templates/overlay/ci.yml.tmpl
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: uv sync
+      - uses: j178/prek-action@v2
+        env:
+          SKIP: pytest,safety
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync
+      - run: uv run pytest --no-header -q

--- a/src/teatree/templates/overlay/pyproject.toml.tmpl
+++ b/src/teatree/templates/overlay/pyproject.toml.tmpl
@@ -134,3 +134,6 @@ unresolved-attribute = "ignore"
 [tool.uv]
 managed = true
 package = true
+
+[tool.uv.sources]
+teatree = { git = "https://github.com/souliane/teatree.git" }

--- a/tests/test_startproject.py
+++ b/tests/test_startproject.py
@@ -20,6 +20,7 @@ def test_startoverlay_creates_lightweight_package(tmp_path: Path) -> None:
     assert (project_root / "pyproject.toml").is_file()
     assert (project_root / ".editorconfig").is_file()
     assert (project_root / ".gitignore").is_file()
+    assert (project_root / ".github" / "workflows" / "ci.yml").is_file()
 
     # No Django project files
     assert not (project_root / "manage.py").exists()


### PR DESCRIPTION
## Summary

- Add `ci.yml.tmpl` to overlay template — new overlays get lint + test CI out of the box
- Add `[tool.uv.sources]` with git source to `pyproject.toml.tmpl` — CI works without local teatree checkout
- Update scaffolder to generate `.github/workflows/ci.yml`
- Document CI override pattern for editable teatree in `docs/install.md`
- When teatree is on the local path (for contributing), CI uses `uv add teatree --no-editable --git ...` to override

## Test plan

- [x] `test_startoverlay_creates_lightweight_package` passes — verifies CI file generated
- [x] Pre-commit passes
- [x] Pre-push pytest passes