### PR TITLE
feat(workspace): idempotent ticket creation, diagnose command, and migration audit gaps

### DIFF
--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -280,8 +280,7 @@ class Command(TyperCommand):
         combined = ProvisionReport(
             steps=provision_report.steps + post_db_report.steps + pre_run_report.steps,
         )
-        if self._verbose:
-            self.stdout.write(combined.summary())
+        self._print_diagnostics(worktree, combined)
         return combined
 
     def _run_db_import(
@@ -336,6 +335,61 @@ class Command(TyperCommand):
                 self.stderr.write(f"  HEALTH CHECK ERROR: {check.name} — {exc}")
         if failures:
             self.stderr.write(f"  {len(failures)}/{len(checks)} health check(s) failed.")
+
+    def _print_diagnostics(self, worktree: Worktree, report: ProvisionReport) -> None:
+        """Print a structured checklist summarizing worktree state after provisioning."""
+        wt_path = (worktree.extra or {}).get("worktree_path", "")
+        self.stdout.write(f"\n  ── {worktree.repo_path} ──")
+        checks = [
+            ("worktree dir", bool(wt_path and Path(wt_path).is_dir())),
+            (".env.worktree", bool(wt_path and (Path(wt_path).parent / ".env.worktree").is_file())),
+            ("DB name", bool(worktree.db_name)),
+        ]
+        checks.extend((step.name, step.success) for step in report.steps)
+        ok = sum(1 for _, passed in checks if passed)
+        for name, passed in checks:
+            status = "OK" if passed else "FAIL"
+            self.stdout.write(f"  [{status}] {name}")
+        self.stdout.write(f"  {ok}/{len(checks)} checks passed\n")
+
+    @command()
+    def diagnose(
+        self,
+        path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
+    ) -> dict[str, object]:
+        """Check worktree health: git dir, env file, DB, docker services."""
+        worktree = resolve_worktree(path)
+        wt_path = (worktree.extra or {}).get("worktree_path", "")
+        ticket_dir = Path(wt_path).parent if wt_path else None
+
+        checks: dict[str, object] = {
+            "state": worktree.state,
+            "repo_path": worktree.repo_path,
+            "worktree_dir": bool(wt_path and Path(wt_path).is_dir()),
+            "git_marker": bool(wt_path and (Path(wt_path) / ".git").exists()),
+            "env_file": bool(ticket_dir and (ticket_dir / ".env.worktree").is_file()),
+            "db_name": worktree.db_name,
+        }
+
+        # Docker compose status
+        project = _compose_project(worktree)
+        result = subprocess.run(  # noqa: S603
+            ["docker", "compose", "-p", project, "ps", "--format", "{{.Name}} {{.State}}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        checks["docker_services"] = result.stdout.strip() if result.returncode == 0 else "not running"
+
+        # Print human-readable checklist
+        self.stdout.write(f"\n  ── {worktree.repo_path} ({worktree.state}) ──")
+        for key in ("worktree_dir", "git_marker", "env_file"):
+            status = "OK" if checks[key] else "FAIL"
+            self.stdout.write(f"  [{status}] {key}")
+        self.stdout.write(f"  [{'OK' if checks['db_name'] else 'FAIL'}] DB name: {checks['db_name'] or '(none)'}")
+        self.stdout.write(f"  docker: {checks['docker_services']}")
+
+        return checks
 
     @command()
     def start(

--- a/src/teatree/core/management/commands/run.py
+++ b/src/teatree/core/management/commands/run.py
@@ -73,7 +73,12 @@ class Command(TyperCommand):
         results: dict[str, dict[str, object]] = {}
 
         overlay = get_overlay()
-        health_paths = overlay.get_verify_endpoints(worktree)
+        health_paths = dict(overlay.get_verify_endpoints(worktree))
+        # Merge T3_HEALTH_ENDPOINTS env var (format: "service:path,service:path")
+        for entry in os.environ.get("T3_HEALTH_ENDPOINTS", "").split(","):
+            if ":" in entry:
+                svc, path = entry.split(":", 1)
+                health_paths[svc.strip()] = path.strip()
         endpoints = {
             name: f"http://localhost:{port}{health_paths.get(name, '/')}"
             for name, port in ports.items()

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -1,6 +1,7 @@
 """Workspace management: create ticket worktrees, finalize, clean stale branches."""
 
 import os
+import re
 import subprocess  # noqa: S404
 import sys
 from contextlib import suppress
@@ -201,11 +202,28 @@ def _branch_prefix() -> str:
 _WORKTREE_SKIPPED = Path("/dev/null/.skipped")  # sentinel: repo skipped, not a failure
 
 
+def _slugify(text: str, max_length: int = 40) -> str:
+    """Convert text to a URL-safe slug for branch names."""
+    return re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")[:max_length]
+
+
+def _build_branch_name(repo_names: list[str], ticket_number: str, description: str) -> str:
+    """Build the git branch name from repo list, ticket number, and description."""
+    prefix = _branch_prefix()
+    first_repo = repo_names[0] if repo_names else "repo"
+    slug = _slugify(description) if description else "ticket"
+    return f"{prefix}-{first_repo}-{ticket_number}-{slug}"
+
+
 def _create_git_worktree(workspace: Path, repo_name: str, ticket_dir: Path, branch: str) -> Path | None:
     """Run ``git worktree add`` for a single repo and return the worktree path.
 
     Returns ``_WORKTREE_SKIPPED`` when the repo doesn't exist or has no ``.git``,
     the existing ``wt_path`` when it already exists, and ``None`` on actual failure.
+
+    When ``git worktree add -b`` fails because the branch already exists
+    (e.g. partial failure recovery), retries without ``-b`` to reuse the
+    existing branch.
     """
     repo_path = workspace / repo_name
     if not (repo_path / ".git").is_dir():
@@ -227,6 +245,15 @@ def _create_git_worktree(workspace: Path, repo_name: str, ticket_dir: Path, bran
         text=True,
         check=False,
     )
+    # Retry without -b if branch already exists (partial failure recovery)
+    if result.returncode != 0 and "already exists" in result.stderr:
+        result = subprocess.run(  # noqa: S603
+            ["git", "worktree", "add", str(wt_path), branch],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
     if result.returncode != 0:
         print(f"  Error creating worktree for {repo_name}: {result.stderr.strip()}", file=sys.stderr)  # noqa: T201
         return None
@@ -250,7 +277,11 @@ class Command(TyperCommand):
         repos: str = "",
         description: str = "",
     ) -> int:
-        """Create a ticket with worktree entries for each affected repo."""
+        """Create or update a ticket with worktree entries for each affected repo.
+
+        Idempotent: safe to re-run after partial failures. Existing worktrees
+        are skipped, missing repos are added, and failed entries are cleaned up.
+        """
         overlay = get_overlay()
         repo_names = [r.strip() for r in repos.split(",") if r.strip()] if repos else overlay.get_workspace_repos()
 
@@ -260,41 +291,56 @@ class Command(TyperCommand):
         )
         if ticket.state == Ticket.State.NOT_STARTED:
             ticket.scope(issue_url=issue_url, variant=variant or None, repos=repo_names)
+        # Merge new repos into existing ticket (preserves order, deduplicates)
+        ticket.repos = list(dict.fromkeys((ticket.repos or []) + repo_names))
         ticket.save()
 
+        if not description:
+            description = overlay.metadata.get_issue_title(issue_url)
         workspace = _workspace_dir()
-        prefix = _branch_prefix()
-        first_repo = repo_names[0] if repo_names else "repo"
-        slug = description.strip().lower().replace(" ", "-")[:40] if description else "ticket"
-        branch = f"{prefix}-{first_repo}-{ticket.ticket_number}-{slug}"
+        branch = _build_branch_name(repo_names, ticket.ticket_number, description)
         ticket_dir = workspace / branch
 
         ticket_dir.mkdir(parents=True, exist_ok=True)
 
-        created_worktrees: list[Worktree] = []
-        failures = 0
+        new_worktrees: list[Worktree] = []
+        failed_worktrees: list[Worktree] = []
         for repo_name in repo_names:
-            wt_path = _create_git_worktree(workspace, repo_name, ticket_dir, branch)
-            is_real_path = wt_path is not None and wt_path != _WORKTREE_SKIPPED
-            worktree = Worktree.objects.create(
+            worktree, wt_created = Worktree.objects.get_or_create(
                 ticket=ticket,
                 repo_path=repo_name,
-                branch=branch,
-                extra={"worktree_path": str(wt_path)} if is_real_path else {},
+                defaults={"branch": branch},
             )
-            created_worktrees.append(worktree)
+            if not wt_created:
+                self.stdout.write(f"  {repo_name}: already tracked (worktree #{worktree.pk})")
+                continue
+
+            wt_path = _create_git_worktree(workspace, repo_name, ticket_dir, branch)
+            is_real_path = wt_path is not None and wt_path != _WORKTREE_SKIPPED
+            if is_real_path:
+                worktree.extra = {"worktree_path": str(wt_path)}
+                worktree.save(update_fields=["extra"])
+            new_worktrees.append(worktree)
             if wt_path is None:
-                failures += 1
+                failed_worktrees.append(worktree)
             self.stdout.write(f"  {repo_name}: {'created' if is_real_path else 'skipped'} (worktree #{worktree.pk})")
 
-        if failures == len(repo_names):
-            self.stderr.write("  All worktree creations failed — rolling back ticket and DB entries.")
-            for wt in created_worktrees:
-                wt.delete()
+        # Clean up DB entries for repos that actually failed
+        for wt in failed_worktrees:
+            wt.delete()
+            new_worktrees.remove(wt)
+
+        # Full rollback only when ALL new worktrees failed and no pre-existing ones
+        if failed_worktrees and not new_worktrees and not ticket.worktrees.exists():
+            self.stderr.write("  All worktree creations failed — rolling back ticket.")
             ticket.delete()
             with suppress(OSError):
                 ticket_dir.rmdir()
             return 0
+
+        if failed_worktrees:
+            names = [wt.repo_path for wt in failed_worktrees]
+            self.stderr.write(f"  WARNING: failed to create worktrees for: {', '.join(names)}")
 
         self.stdout.write(f"\nTicket #{ticket.pk} — worktrees in {ticket_dir}")
         self.stdout.write(f"  Branch: {branch}")
@@ -335,7 +381,13 @@ class Command(TyperCommand):
                 git.rebase(repo_dir, f"origin/{default_br}")
                 results.append(f"{repo}: rebased on {default_br}")
             except subprocess.CalledProcessError as exc:
-                results.append(f"{repo}: failed — {exc}")
+                results.extend(
+                    [
+                        f"{repo}: rebase failed — {exc}",
+                        f"  To abort: git -C {repo_dir} rebase --abort",
+                        f"  To resolve: fix conflicts, git add, then: git -C {repo_dir} rebase --continue",
+                    ]
+                )
         return "\n".join(results)
 
     def _clean_one_worktree(self, worktree: Worktree, workspace: Path) -> str:

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -236,6 +236,10 @@ class OverlayMetadata:
     def get_tool_commands(self) -> list[ToolCommand]:
         return []
 
+    def get_issue_title(self, url: str) -> str:
+        """Fetch the title of an issue from its URL. Returns empty string on failure."""
+        return ""
+
 
 # ── Overlay base class ───────────────────────────────────────────────
 

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -326,6 +326,41 @@ class TestWorkspaceTicket(TestCase):
         assert "ticket" not in worktree.branch
 
     @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_auto_derives_slug_from_issue_title(self) -> None:
+        """When no description given, uses overlay.metadata.get_issue_title to derive slug."""
+        overlay = import_string(FULL_OVERLAY)()
+        overlay.metadata.get_issue_title = lambda url: "Fix Login Flow"
+
+        with patch.object(overlay_loader_mod, "_discover_overlays", return_value={"test": overlay}):
+            ticket_id = cast(
+                "int",
+                call_command("workspace", "ticket", "https://example.com/issues/130"),
+            )
+
+        ticket = Ticket.objects.get(pk=ticket_id)
+        worktree = ticket.worktrees.first()
+        assert worktree.branch.endswith("-fix-login-flow")
+        assert "ticket" not in worktree.branch
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_falls_back_to_ticket_when_title_fetch_fails(self) -> None:
+        """When get_issue_title returns empty, falls back to 'ticket' slug."""
+        overlay = import_string(FULL_OVERLAY)()
+        overlay.metadata.get_issue_title = lambda url: ""
+
+        with patch.object(overlay_loader_mod, "_discover_overlays", return_value={"test": overlay}):
+            ticket_id = cast(
+                "int",
+                call_command("workspace", "ticket", "https://example.com/issues/131"),
+            )
+
+        ticket = Ticket.objects.get(pk=ticket_id)
+        worktree = ticket.worktrees.first()
+        assert worktree.branch.endswith("-ticket")
+
+    @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS, T3_WORKSPACE_DIR="/tmp/ws-test")
     def test_skips_non_git_repo(self) -> None:
         """Repos without .git directory are skipped."""
@@ -421,6 +456,112 @@ class TestWorkspaceTicket(TestCase):
             assert result == 0
             assert Ticket.objects.filter(issue_url="https://example.com/issues/83").count() == 0
             assert Worktree.objects.count() == 0
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_reruns_without_duplicates(self) -> None:
+        """Running ticket twice with the same issue_url does not duplicate Worktree entries."""
+        call_command("workspace", "ticket", "https://example.com/issues/100")
+        first_count = Worktree.objects.filter(ticket__issue_url="https://example.com/issues/100").count()
+
+        call_command("workspace", "ticket", "https://example.com/issues/100")
+        second_count = Worktree.objects.filter(ticket__issue_url="https://example.com/issues/100").count()
+
+        assert first_count == second_count
+        assert Ticket.objects.filter(issue_url="https://example.com/issues/100").count() == 1
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_adds_missing_repo_to_existing_ticket(self) -> None:
+        """Re-running ticket with additional repos adds them without duplicating existing ones."""
+        ticket_id = cast(
+            "int",
+            call_command("workspace", "ticket", "https://example.com/issues/101", repos="backend"),
+        )
+        assert Worktree.objects.filter(ticket_id=ticket_id).count() == 1
+
+        call_command("workspace", "ticket", "https://example.com/issues/101", repos="backend,frontend")
+        assert Worktree.objects.filter(ticket_id=ticket_id).count() == 2
+        assert Worktree.objects.filter(ticket_id=ticket_id, repo_path="frontend").exists()
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS, T3_WORKSPACE_DIR="/tmp/ws-test")
+    def test_recovers_from_branch_already_exists(self) -> None:
+        """When 'git worktree add -b' fails with 'already exists', retry without -b."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            (workspace / "backend").mkdir()
+            (workspace / "backend" / ".git").mkdir()
+
+            mock_pull = MagicMock(returncode=0)
+            mock_add_b_fail = MagicMock(returncode=1, stderr="fatal: a branch named 'x' already exists")
+            mock_add_ok = MagicMock(returncode=0)
+
+            call_count = {"worktree": 0}
+
+            def side_effect(cmd, **kwargs):
+                if "worktree" in cmd:
+                    call_count["worktree"] += 1
+                    if call_count["worktree"] == 1:
+                        return mock_add_b_fail  # first try with -b fails
+                    return mock_add_ok  # retry without -b succeeds
+                return mock_pull
+
+            with (
+                patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(git_mod.subprocess, "run", side_effect=side_effect),
+            ):
+                ticket_id = cast(
+                    "int",
+                    call_command("workspace", "ticket", "https://example.com/issues/102", repos="backend"),
+                )
+
+            assert ticket_id > 0
+            wt = Worktree.objects.get(ticket_id=ticket_id)
+            assert wt.extra.get("worktree_path")
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS, T3_WORKSPACE_DIR="/tmp/ws-test")
+    def test_cleans_up_failed_worktrees_on_partial_failure(self) -> None:
+        """When some repos fail, their Worktree DB entries are deleted but successful ones remain."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            workspace = tmp_path / "workspace"
+            workspace.mkdir()
+            (workspace / "backend").mkdir()
+            (workspace / "backend" / ".git").mkdir()
+            (workspace / "frontend").mkdir()
+            (workspace / "frontend" / ".git").mkdir()
+
+            mock_pull = MagicMock(returncode=0)
+            mock_add_ok = MagicMock(returncode=0)
+            mock_add_fail = MagicMock(returncode=1, stderr="fatal: some error")
+
+            def side_effect(cmd, **kwargs):
+                if "worktree" not in cmd:
+                    return mock_pull
+                # backend succeeds, frontend fails
+                cwd = kwargs.get("cwd", Path())
+                if hasattr(cwd, "name") and cwd.name == "frontend":
+                    return mock_add_fail
+                if str(cwd).endswith("frontend"):
+                    return mock_add_fail
+                return mock_add_ok
+
+            with (
+                patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(git_mod.subprocess, "run", side_effect=side_effect),
+            ):
+                ticket_id = cast("int", call_command("workspace", "ticket", "https://example.com/issues/103"))
+
+            assert ticket_id > 0
+            # Backend worktree should exist, frontend should have been cleaned up
+            assert Worktree.objects.filter(ticket_id=ticket_id, repo_path="backend").exists()
+            assert not Worktree.objects.filter(ticket_id=ticket_id, repo_path="frontend").exists()
 
 
 _no_prune = patch.object(workspace_mod, "_prune_branches", new=lambda _repo: [])
@@ -764,7 +905,9 @@ class TestWorkspaceFinalize(TestCase):
         ):
             result = cast("str", call_command("workspace", "finalize", str(ticket.pk)))
 
-        assert "failed" in result.lower()
+        assert "rebase failed" in result.lower()
+        assert "rebase --abort" in result
+        assert "rebase --continue" in result
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1769,7 +1912,127 @@ class TestRunTests(TestCase):
 
 
 class TestRunVerify(TestCase):
-    pass  # No verify tests in the original file — placeholder for future tests
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_verifies_endpoints_and_advances_fsm(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/110")
+            wt = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/backend",
+                branch="feature-110",
+                extra={"worktree_path": str(wt_dir)},
+            )
+            wt.provision()
+            wt.start_services(services=["backend"])
+            wt.save()
+
+            mock_response = MagicMock()
+            mock_response.status = 200
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+
+            with (
+                patch.object(run_mod, "get_worktree_ports", return_value={"backend": 8001}),
+                patch.object(run_mod, "resolve_worktree", return_value=wt),
+                patch.object(run_mod.urllib.request, "urlopen", return_value=mock_response),
+            ):
+                result = cast("dict[str, object]", call_command("run", "verify", path=str(wt_dir)))
+
+            wt.refresh_from_db()
+            assert wt.state == Worktree.State.READY
+            assert result["state"] == Worktree.State.READY
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_merges_env_health_endpoints(self) -> None:
+        """T3_HEALTH_ENDPOINTS env var overrides overlay-provided endpoints."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/111")
+            wt = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/backend",
+                branch="feature-111",
+                extra={"worktree_path": str(wt_dir)},
+            )
+            wt.provision()
+            wt.start_services(services=["backend"])
+            wt.save()
+
+            mock_response = MagicMock()
+            mock_response.status = 200
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+
+            urls_checked: list[str] = []
+
+            def capture_urlopen(url, **kwargs):
+                urls_checked.append(url)
+                return mock_response
+
+            with (
+                patch.object(run_mod, "get_worktree_ports", return_value={"backend": 8001}),
+                patch.object(run_mod, "resolve_worktree", return_value=wt),
+                patch.object(run_mod.urllib.request, "urlopen", side_effect=capture_urlopen),
+                patch.dict(os.environ, {"T3_HEALTH_ENDPOINTS": "backend:/api/health"}),
+            ):
+                call_command("run", "verify", path=str(wt_dir))
+
+            # Should use the env var path, not the overlay default
+            assert any("/api/health" in url for url in urls_checked)
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_skips_postgres_and_redis(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/112")
+            wt = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/backend",
+                branch="feature-112",
+                extra={"worktree_path": str(wt_dir)},
+            )
+            wt.provision()
+            wt.start_services(services=["backend"])
+            wt.save()
+
+            urls_checked: list[str] = []
+
+            mock_response = MagicMock()
+            mock_response.status = 200
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+
+            def capture_urlopen(url, **kwargs):
+                urls_checked.append(url)
+                return mock_response
+
+            with (
+                patch.object(
+                    run_mod,
+                    "get_worktree_ports",
+                    return_value={"backend": 8001, "postgres": 5432, "redis": 6379},
+                ),
+                patch.object(run_mod, "resolve_worktree", return_value=wt),
+                patch.object(run_mod.urllib.request, "urlopen", side_effect=capture_urlopen),
+            ):
+                call_command("run", "verify", path=str(wt_dir))
+
+            # Only backend should be checked, not postgres/redis
+            assert len(urls_checked) == 1
+            assert "8001" in urls_checked[0]
 
 
 class TestRunServices(TestCase):
@@ -2428,6 +2691,48 @@ class TestLifecycleSetup(TestCase):
                 mock_sp.run.return_value = MagicMock(returncode=0)
                 call_command("lifecycle", "setup", path=str(wt_path))
 
+    @override_settings(**SETTINGS)
+    def test_prints_diagnostic_summary(self) -> None:
+        """_print_diagnostics outputs a structured checklist with [OK]/[FAIL] markers."""
+        from teatree.core.step_runner import ProvisionReport, StepResult  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            # Create .env.worktree in parent (ticket dir)
+            (tmp_path / ".env.worktree").write_text("WT_DB_NAME=test\n")
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/115")
+            wt = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature-115",
+                extra={"worktree_path": str(wt_dir)},
+                db_name="wt_115",
+            )
+
+            report = ProvisionReport(
+                steps=[
+                    StepResult(name="migrations", success=True, duration=1.0),
+                    StepResult(name="docker-up", success=False, duration=0.5, error="exit 1"),
+                ]
+            )
+
+            buf = StringIO()
+            cmd = lifecycle_mod.Command()
+            cmd.stdout = OutputWrapper(buf)
+            cmd._print_diagnostics(wt, report)
+
+            output = buf.getvalue()
+            assert "[OK] worktree dir" in output
+            assert "[OK] .env.worktree" in output
+            assert "[OK] DB name" in output
+            assert "[OK] migrations" in output
+            assert "[FAIL] docker-up" in output
+            assert "4/5 checks passed" in output
+
 
 class TestLifecycleSetupHelpers(TestCase):
     @_patch_overlays(FULL_OVERLAY)
@@ -2831,6 +3136,65 @@ class TestDropOrphanDatabases(TestCase):
 
 class TestLifecycleStatus(TestCase):
     pass  # No status tests in the original file — placeholder for future tests
+
+
+class TestLifecycleDiagnose(TestCase):
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_healthy_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            # .git file marks this as a worktree (not a main clone)
+            (wt_dir / ".git").write_text("gitdir: /tmp/.git/worktrees/backend")
+            (tmp_path / ".env.worktree").write_text("WT_DB_NAME=wt_120\n")
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/120")
+            wt = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature-120",
+                extra={"worktree_path": str(wt_dir)},
+                db_name="wt_120",
+            )
+            wt.provision()
+            wt.save()
+
+            with patch.object(lifecycle_mod, "subprocess") as mock_sp:
+                # Mock docker compose ps (returns running services)
+                mock_sp.run.return_value = MagicMock(returncode=0, stdout="backend  running\n")
+                result = cast("dict[str, object]", call_command("lifecycle", "diagnose", path=str(wt_dir)))
+
+            assert result["worktree_dir"] is True
+            assert result["env_file"] is True
+            assert result["db_name"] == "wt_120"
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_missing_db_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            (wt_dir / ".git").write_text("gitdir: /tmp/.git/worktrees/backend")
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/121")
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature-121",
+                extra={"worktree_path": str(wt_dir)},
+            )
+
+            with patch.object(lifecycle_mod, "subprocess") as mock_sp:
+                mock_sp.run.return_value = MagicMock(returncode=0, stdout="")
+                result = cast("dict[str, object]", call_command("lifecycle", "diagnose", path=str(wt_dir)))
+
+            assert result["db_name"] == ""
+            assert result["worktree_dir"] is True
 
 
 @patch("subprocess.run", return_value=MagicMock(returncode=0))


### PR DESCRIPTION
## Summary

- **Idempotent `workspace ticket`**: safe to re-run after partial failures — uses `get_or_create` for Worktree entries, handles "branch already exists" with retry, cleans up failed entries, supports adding repos to existing tickets
- **`lifecycle diagnose`**: new command to check worktree health (git dir, env file, DB name, docker services) without re-running setup
- **Diagnostic checklist in `lifecycle setup`**: prints `[OK]`/`[FAIL]` status for each check after provisioning
- **`T3_HEALTH_ENDPOINTS` env var**: custom health check paths merged with overlay defaults in `run verify`
- **Finalize conflict recovery**: actionable `--abort` / `--continue` guidance when rebase fails
- **`OverlayMetadata.get_issue_title()`**: new hook for auto-deriving branch name slugs from issue titles

## Test plan

- [x] 12 new tests added (147 total, all passing)
- [x] ruff check + format clean
- [x] Pre-commit hooks pass
- [x] Pre-push pytest passes

Relates-to company-fork-org/t3-company#2