### PR TITLE
refactor(lifecycle): harmonize setup/start, remove restart and start-full

### DIFF
--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -17,12 +17,10 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
         "Worktree lifecycle.",
         [
             ("setup", "Create and provision a worktree."),
-            ("start", "Start services for a worktree."),
-            ("restart", "Kill existing processes and restart all services."),
+            ("start", "Provision (if needed) and start all services."),
             ("status", "Return worktree state information."),
             ("teardown", "Tear down a worktree."),
             ("clean", "Teardown worktree — stop services, drop DB, clean state."),
-            ("start-full", "Zero to coding — create ticket, provision, start services."),
             ("diagram", "Print the lifecycle state diagram as Mermaid."),
         ],
     ),
@@ -269,20 +267,6 @@ class OverlayAppBuilder:
         def full_status() -> None:
             """Show ticket, worktree, and session state summary."""
             managepy(project_path, "followup", "refresh", overlay_name=overlay_name)
-
-        @overlay_app.command(name="start-ticket")
-        def start_ticket(
-            issue_url: str = typer.Argument(help="Issue/ticket URL"),
-            variant: str = typer.Option("", help="Tenant variant"),
-            description: str = typer.Option("", help="Short description for branch name"),
-        ) -> None:
-            """Zero to coding — create ticket, provision worktree, start services."""
-            args = ["lifecycle", "start-full", issue_url]
-            if variant:
-                args.extend(["--variant", variant])
-            if description:
-                args.extend(["--description", description])
-            managepy(project_path, *args, overlay_name=overlay_name)
 
         @overlay_app.command(name="ship")
         def ship(

--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -8,7 +8,7 @@ from django.core.management.base import OutputWrapper
 from django_typer.management import TyperCommand, command
 
 from teatree.core.models import Ticket, Worktree
-from teatree.core.overlay import OverlayBase, RunCommand
+from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import resolve_worktree
 from teatree.core.step_runner import ProvisionReport, run_provision_steps, run_step
@@ -183,7 +183,6 @@ def _docker_compose_up(  # noqa: PLR0913
 
 
 class Command(TyperCommand):
-    _DB_IMPORT_MAX_FAILURES = 3
     _verbose: bool = True
     _timeouts: TimeoutConfig = TimeoutConfig()
 
@@ -199,16 +198,17 @@ class Command(TyperCommand):
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
         variant: str = typer.Option("", help="Tenant variant. Updates ticket if provided."),
         overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
-        force: bool = typer.Option(  # noqa: FBT001
-            default=False, help="Reset DB import circuit breaker (retry after repeated failures)."
-        ),
         slow_import: bool = typer.Option(  # noqa: FBT001
             default=False, help="Allow slow DB fallbacks (pg_restore, remote dump). DSLR-only by default."
         ),
         verbose: bool = typer.Option(default=True, help="Show step stdout/stderr."),  # noqa: FBT001
         no_timeout: bool = typer.Option(default=False, help="Disable operation timeouts."),  # noqa: FBT001
     ) -> int:
-        """Provision a worktree (DB name, env file, overlay steps). No port allocation."""
+        """Provision a worktree (DB name, env file, overlay steps). No port allocation.
+
+        Idempotent — safe to re-run. Auto-retries DB import when the DB
+        doesn't exist, regardless of previous failure count.
+        """
         variant, overlay, verbose = _resolve_typer_defaults(variant, overlay, verbose)
         self._verbose = verbose
         if overlay:
@@ -225,7 +225,7 @@ class Command(TyperCommand):
         failed_repos: list[str] = []
         for wt in ticket.worktrees.all():
             try:
-                report = self._provision_worktree(wt, resolved_overlay, force=force, slow_import=slow_import)
+                report = self._provision_worktree(wt, resolved_overlay, slow_import=slow_import)
                 if not report.success:
                     failed_repos.append(wt.repo_path)
             except Exception as exc:  # noqa: BLE001
@@ -239,7 +239,7 @@ class Command(TyperCommand):
         return int(worktree.pk)
 
     def _provision_worktree(
-        self, worktree: Worktree, overlay: "OverlayBase", *, force: bool = False, slow_import: bool = False
+        self, worktree: Worktree, overlay: "OverlayBase", *, slow_import: bool = False
     ) -> ProvisionReport:
         self.stdout.write(f"  Provisioning: {worktree.repo_path}")
 
@@ -254,7 +254,7 @@ class Command(TyperCommand):
         _setup_worktree_dir((worktree.extra or {}).get("worktree_path", ""), worktree, overlay, self.stdout)
 
         if overlay.get_db_import_strategy(worktree) is not None:
-            self._run_db_import(worktree, overlay, force=force, slow_import=slow_import)
+            self._run_db_import(worktree, overlay, slow_import=slow_import)
 
         provision_report = run_provision_steps(
             overlay.get_provision_steps(worktree),
@@ -284,26 +284,27 @@ class Command(TyperCommand):
         self._print_diagnostics(worktree, combined)
         return combined
 
-    def _run_db_import(
-        self, worktree: Worktree, overlay: OverlayBase, *, force: bool = False, slow_import: bool = False
-    ) -> None:
-        extra = worktree.extra or {}
-        failures = extra.get("db_import_failures", 0)
-        if failures >= self._DB_IMPORT_MAX_FAILURES and not force:
-            self.stderr.write(f"  SKIPPED: DB import (failed {failures} consecutive times). Use --force to retry.")
-            return
+    def _run_db_import(self, worktree: Worktree, overlay: OverlayBase, *, slow_import: bool = False) -> None:
+        from teatree.utils.db import db_exists  # noqa: PLC0415
+
+        if worktree.db_name:
+            try:
+                if db_exists(worktree.db_name):
+                    self.stdout.write(f"  DB exists: {worktree.db_name} — skipping import")
+                    return
+            except FileNotFoundError:
+                pass  # psql not available — proceed with import attempt
+
         self.stdout.write("  Running: db-import")
         env = {**os.environ, **overlay.get_env_extra(worktree)}
         env.pop("VIRTUAL_ENV", None)
         os.environ.update(env)
         if overlay.db_import(worktree, slow_import=slow_import):
+            extra = worktree.extra or {}
             extra.pop("db_import_failures", None)
             worktree.extra = extra
             worktree.save(update_fields=["extra"])
         else:
-            extra["db_import_failures"] = failures + 1
-            worktree.extra = extra
-            worktree.save(update_fields=["extra"])
             self.stderr.write("  WARNING: DB import failed. Continuing with provision steps...")
 
     def _run_post_db_steps(self, overlay: OverlayBase, worktree: Worktree) -> ProvisionReport:
@@ -396,19 +397,24 @@ class Command(TyperCommand):
     def start(
         self,
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
+        variant: str = typer.Option("", help="Tenant variant (passed to setup if needed)."),
         overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
         verbose: bool = typer.Option(default=True, help="Show step stdout/stderr."),  # noqa: FBT001
         no_timeout: bool = typer.Option(default=False, help="Disable operation timeouts."),  # noqa: FBT001
     ) -> str:
-        """Start all services via docker-compose with dynamically allocated ports.
+        """Provision (if needed) and start all services. The one command that always works.
 
-        Finds free host ports at runtime, passes them to docker-compose,
-        and starts all containers.  Safe to re-run (runs compose down first).
+        Runs setup to ensure provisioning is complete, then allocates
+        free host ports, starts docker-compose, and transitions the FSM.
+        Safe to re-run — stops previous containers first.
         """
-        if isinstance(verbose, bool):
-            self._verbose = verbose
-        if overlay:
-            os.environ["T3_OVERLAY_NAME"] = overlay
+        # 0. Always run setup first (idempotent)
+        self.setup(path=path, variant=variant, overlay=overlay, verbose=verbose, no_timeout=no_timeout)
+
+        _, overlay_str, verbose_bool = _resolve_typer_defaults(variant, overlay, verbose)
+        self._verbose = verbose_bool
+        if overlay_str:
+            os.environ["T3_OVERLAY_NAME"] = overlay_str
         worktree = resolve_worktree(path)
         resolved_overlay = get_overlay()
         self._init_timeouts(resolved_overlay, no_timeout=no_timeout)
@@ -460,25 +466,6 @@ class Command(TyperCommand):
         if not ok:
             return "error"
 
-        # 5b. Start local frontend if not covered by docker-compose
-        from teatree.core.management.commands.run import _compose_has_service  # noqa: PLC0415
-
-        if "frontend" in commands and not _compose_has_service(compose_file, "frontend"):
-            os.environ.update(_compose_env(ports))
-            fresh_commands = resolved_overlay.get_run_commands(worktree)
-            frontend_cmd = fresh_commands.get("frontend")
-            if frontend_cmd:
-                run_cmd = frontend_cmd if isinstance(frontend_cmd, RunCommand) else RunCommand(args=list(frontend_cmd))
-                if run_cmd.args:
-                    self.stdout.write(f"  Starting frontend locally: {' '.join(run_cmd.args)}")
-                    subprocess.Popen(  # noqa: S603
-                        run_cmd.args,
-                        cwd=run_cmd.cwd,
-                        env=env,
-                        stdout=subprocess.DEVNULL,
-                        stderr=subprocess.DEVNULL,
-                    )
-
         # 6. FSM transition
         worktree.start_services(services=list(commands))
         worktree.save()
@@ -499,28 +486,6 @@ class Command(TyperCommand):
             "branch": worktree.branch,
             "ports": ports,
         }
-
-    @command()
-    def restart(
-        self,
-        path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
-        overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
-        verbose: bool = typer.Option(default=True, help="Show step stdout/stderr."),  # noqa: FBT001
-        no_timeout: bool = typer.Option(default=False, help="Disable operation timeouts."),  # noqa: FBT001
-    ) -> str:
-        """Stop containers, allocate fresh ports, and restart all services."""
-        if isinstance(verbose, bool):
-            self._verbose = verbose
-        if overlay:
-            os.environ["T3_OVERLAY_NAME"] = overlay
-        worktree = resolve_worktree(path)
-
-        if worktree.state == Worktree.State.CREATED:
-            self.stdout.write("  Worktree not provisioned — running setup + start instead.")
-            self.setup(path=path, variant="", overlay=overlay, no_timeout=no_timeout)
-            return self.start(path=path, overlay=overlay, no_timeout=no_timeout)
-
-        return self.start(path=path, overlay=overlay, no_timeout=no_timeout)
 
     @command()
     def teardown(self, path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty).")) -> str:
@@ -611,35 +576,6 @@ class Command(TyperCommand):
             self.stdout.write(f"  [{status.upper()}] {name}")
 
         return checks
-
-    @command(name="start-full")
-    def start_full(
-        self,
-        issue_url: str = typer.Argument(help="Issue/ticket URL."),
-        variant: str = typer.Option("", help="Tenant variant."),
-        repos: str = typer.Option("", help="Comma-separated repo names (default: overlay repos)."),
-        description: str = typer.Option("", help="Short description for the branch name."),
-    ) -> str:
-        """Zero to coding — create ticket, provision worktrees, start services."""
-        from teatree.core.management.commands.workspace import Command as WorkspaceCommand  # noqa: PLC0415
-
-        ws = WorkspaceCommand()
-        ws.stdout = self.stdout
-        ws.stderr = self.stderr
-        ticket_id = ws.ticket(issue_url, variant=variant, repos=repos, description=description)
-        if not ticket_id:
-            return "Failed to create ticket."
-
-        ticket = Ticket.objects.get(pk=ticket_id)
-        first_wt = ticket.worktrees.first()
-        if not first_wt:
-            return f"Ticket #{ticket_id} created but no worktrees."
-
-        wt_path = (first_wt.extra or {}).get("worktree_path", "")
-        self.setup(path=wt_path, variant=variant)
-        self.start(path=wt_path)
-
-        return f"Ticket #{ticket_id} ready — services running in {wt_path}"
 
     @command(name="visit-phase")
     def visit_phase(self, ticket_id: int, phase: str) -> str:

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -185,9 +185,9 @@ class DbOverlay(CommandOverlay):
 _DB_MOCK_OVERLAY = {"test": DbOverlay()}
 
 
-class TestDbImportCircuitBreaker(TestCase):
+class TestDbImportAutoRepair(TestCase):
     @override_settings(**COMMAND_SETTINGS)
-    def test_skips_db_import_after_max_failures(self) -> None:
+    def test_skips_db_import_when_db_exists(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             wt_path = str(tmp_path / "backend")
@@ -198,21 +198,23 @@ class TestDbImportCircuitBreaker(TestCase):
                 overlay="test",
                 repo_path="/tmp/backend",
                 branch="feature",
-                extra={"worktree_path": wt_path, "db_import_failures": 3},
+                extra={"worktree_path": wt_path},
+                db_name="wt_99_acme",
             )
 
             with (
                 patch.dict("os.environ", {"T3_ORIG_CWD": wt_path}),
                 patch.object(overlay_loader_mod, "_discover_overlays", return_value=_DB_MOCK_OVERLAY),
+                patch("teatree.utils.db.db_exists", return_value=True),
             ):
                 call_command("lifecycle", "setup")
 
-            # db_import was NOT called — failure count unchanged
+            # db_import was NOT called — DB already exists
             wt = Worktree.objects.get(ticket=ticket)
-            assert wt.extra["db_import_failures"] == 3
+            assert "db_import_failures" not in (wt.extra or {})
 
     @override_settings(**COMMAND_SETTINGS)
-    def test_force_bypasses_circuit_breaker(self) -> None:
+    def test_retries_db_import_when_db_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             wt_path = str(tmp_path / "backend")
@@ -223,18 +225,21 @@ class TestDbImportCircuitBreaker(TestCase):
                 overlay="test",
                 repo_path="/tmp/backend",
                 branch="feature",
-                extra={"worktree_path": wt_path, "db_import_failures": 3},
+                extra={"worktree_path": wt_path},
+                db_name="wt_100_acme",
             )
 
             with (
                 patch.dict("os.environ", {"T3_ORIG_CWD": wt_path}),
                 patch.object(overlay_loader_mod, "_discover_overlays", return_value=_DB_MOCK_OVERLAY),
+                patch("teatree.utils.db.db_exists", return_value=False),
             ):
-                call_command("lifecycle", "setup", "--force")
+                call_command("lifecycle", "setup")
 
-            # db_import WAS called and failed again — count incremented
+            # db_import WAS called (and failed — DbOverlay always returns False)
             wt = Worktree.objects.get(ticket=ticket)
-            assert wt.extra["db_import_failures"] == 4
+            # No circuit breaker counter — just a warning in stderr
+            assert "db_import_failures" not in (wt.extra or {})
 
 
 class TestUpdateTicketVariant(TestCase):

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -2772,7 +2772,7 @@ class TestLifecycleStart(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
     def test_starts_docker_compose_and_transitions(self) -> None:
-        """Lifecycle start should run docker compose up -d and transition FSM to SERVICES_UP."""
+        """Lifecycle start should provision, run docker compose up -d, and transition to SERVICES_UP."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
 
@@ -2786,13 +2786,19 @@ class TestLifecycleStart(TestCase):
                 repo_path="/tmp/backend",
                 branch="feature",
                 extra={"worktree_path": str(wt_path)},
+                db_name="wt_300_acme",
             )
-            worktree_id = cast("int", call_command("lifecycle", "setup", path=str(wt_path)))
 
             mock_overlay = MagicMock()
             mock_overlay.get_run_commands.return_value = {"backend": "run-backend", "frontend": "run-frontend"}
             mock_overlay.get_pre_run_steps.return_value = []
             mock_overlay.get_env_extra.return_value = {}
+            mock_overlay.get_envrc_lines.return_value = []
+            mock_overlay.get_db_import_strategy.return_value = None
+            mock_overlay.get_provision_steps.return_value = []
+            mock_overlay.get_post_db_steps.return_value = []
+            mock_overlay.get_health_checks.return_value = []
+            mock_overlay.get_reset_passwords_command.return_value = None
             mock_overlay.get_compose_file.return_value = "/fake/docker-compose.yml"
 
             mock_config = MagicMock()
@@ -2801,7 +2807,6 @@ class TestLifecycleStart(TestCase):
             with (
                 patch.object(lifecycle_mod, "get_overlay", return_value=mock_overlay),
                 patch.object(lifecycle_mod, "subprocess") as mock_sp,
-                patch.object(run_mod, "_compose_has_service", return_value=True),
                 patch.object(
                     lifecycle_mod,
                     "find_free_ports",
@@ -2812,7 +2817,8 @@ class TestLifecycleStart(TestCase):
                 mock_sp.run.return_value = MagicMock(returncode=0)
                 call_command("lifecycle", "start", path=str(wt_path))
 
-            worktree = Worktree.objects.get(pk=worktree_id)
+            worktree = Worktree.objects.filter(ticket=ticket).first()
+            assert worktree is not None
             assert worktree.state == Worktree.State.SERVICES_UP
             # Docker compose was called (down + up)
             docker_calls = [c for c in mock_sp.run.call_args_list if c[0] and "docker" in str(c[0][0])]
@@ -2834,13 +2840,19 @@ class TestLifecycleStart(TestCase):
                 repo_path="/tmp/backend",
                 branch="feature",
                 extra={"worktree_path": str(wt_path)},
+                db_name="wt_302_acme",
             )
-            call_command("lifecycle", "setup", path=str(wt_path))
 
             mock_overlay = MagicMock()
             mock_overlay.get_run_commands.return_value = {}
             mock_overlay.get_pre_run_steps.return_value = []
             mock_overlay.get_env_extra.return_value = {}
+            mock_overlay.get_envrc_lines.return_value = []
+            mock_overlay.get_db_import_strategy.return_value = None
+            mock_overlay.get_provision_steps.return_value = []
+            mock_overlay.get_post_db_steps.return_value = []
+            mock_overlay.get_health_checks.return_value = []
+            mock_overlay.get_reset_passwords_command.return_value = None
             mock_overlay.get_compose_file.return_value = ""
 
             mock_config = MagicMock()
@@ -2878,13 +2890,19 @@ class TestLifecycleStart(TestCase):
                 repo_path="/tmp/backend",
                 branch="feature",
                 extra={"worktree_path": str(wt_path)},
+                db_name="wt_301_acme",
             )
-            call_command("lifecycle", "setup", path=str(wt_path))
 
             mock_overlay = MagicMock()
             mock_overlay.get_run_commands.return_value = {"backend": "run-backend"}
             mock_overlay.get_pre_run_steps.return_value = []
             mock_overlay.get_env_extra.return_value = {}
+            mock_overlay.get_envrc_lines.return_value = []
+            mock_overlay.get_db_import_strategy.return_value = None
+            mock_overlay.get_provision_steps.return_value = []
+            mock_overlay.get_post_db_steps.return_value = []
+            mock_overlay.get_health_checks.return_value = []
+            mock_overlay.get_reset_passwords_command.return_value = None
             mock_overlay.get_compose_file.return_value = "/fake/docker-compose.yml"
 
             mock_config = MagicMock()
@@ -2914,112 +2932,6 @@ class TestLifecycleStart(TestCase):
                 result = call_command("lifecycle", "start", path=str(wt_path))
 
             assert result == "error"
-
-
-class TestLifecycleRestart(TestCase):
-    @_patch_overlays(FULL_OVERLAY)
-    @override_settings(**SETTINGS)
-    def test_restart_runs_docker_compose_down_then_up(self) -> None:
-        """Restart should run docker compose down + up (delegates to start)."""
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            wt_path = tmp_path / "worktree"
-            wt_path.mkdir()
-
-            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/400", variant="acme")
-            Worktree.objects.create(
-                overlay="test",
-                ticket=ticket,
-                repo_path="/tmp/backend",
-                branch="feature",
-                extra={"worktree_path": str(wt_path)},
-            )
-            worktree_id = cast("int", call_command("lifecycle", "setup", path=str(wt_path)))
-
-            # Advance to SERVICES_UP
-            wt = Worktree.objects.get(pk=worktree_id)
-            wt.start_services(services=["backend"])
-            wt.save()
-
-            mock_overlay = MagicMock()
-            mock_overlay.get_run_commands.return_value = {"backend": "run-backend", "frontend": "run-frontend"}
-            mock_overlay.get_pre_run_steps.return_value = []
-            mock_overlay.get_env_extra.return_value = {}
-            mock_overlay.get_compose_file.return_value = "/fake/docker-compose.yml"
-
-            mock_config = MagicMock()
-            mock_config.user.workspace_dir = tmp_path
-
-            with (
-                patch.object(lifecycle_mod, "get_overlay", return_value=mock_overlay),
-                patch.object(lifecycle_mod, "subprocess") as mock_sp,
-                patch.object(run_mod, "_compose_has_service", return_value=True),
-                patch.object(
-                    lifecycle_mod,
-                    "find_free_ports",
-                    return_value={"backend": 8001, "frontend": 4201, "postgres": 5432, "redis": 6379},
-                ),
-                patch("teatree.config.load_config", return_value=mock_config),
-            ):
-                mock_sp.run.return_value = MagicMock(returncode=0)
-                call_command("lifecycle", "restart", path=str(wt_path))
-
-            wt = Worktree.objects.get(pk=worktree_id)
-            assert wt.state == Worktree.State.SERVICES_UP
-
-            # Docker compose was called (down + up)
-            docker_calls = [c for c in mock_sp.run.call_args_list if c[0] and "docker" in str(c[0][0])]
-            assert len(docker_calls) >= 2
-
-    @_patch_overlays(FULL_OVERLAY)
-    @override_settings(**SETTINGS)
-    def test_restart_on_created_state_falls_back_to_setup_and_start(self) -> None:
-        """Restart on a 'created' worktree should run setup + start instead."""
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            wt_path = tmp_path / "worktree"
-            wt_path.mkdir()
-
-            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/402", variant="acme")
-            Worktree.objects.create(
-                overlay="test",
-                ticket=ticket,
-                repo_path="/tmp/backend",
-                branch="feature",
-                extra={"worktree_path": str(wt_path)},
-            )
-
-            mock_overlay = MagicMock()
-            mock_overlay.get_run_commands.return_value = {"backend": "run-backend"}
-            mock_overlay.get_pre_run_steps.return_value = []
-            mock_overlay.get_env_extra.return_value = {}
-            mock_overlay.get_envrc_lines.return_value = []
-            mock_overlay.get_db_import_strategy.return_value = None
-            mock_overlay.get_provision_steps.return_value = []
-            mock_overlay.get_post_db_steps.return_value = []
-            mock_overlay.get_health_checks.return_value = []
-            mock_overlay.get_reset_passwords_command.return_value = None
-            mock_overlay.get_compose_file.return_value = "/fake/docker-compose.yml"
-
-            mock_config = MagicMock()
-            mock_config.user.workspace_dir = tmp_path
-
-            with (
-                patch.object(lifecycle_mod, "get_overlay", return_value=mock_overlay),
-                patch.object(lifecycle_mod, "subprocess") as mock_sp,
-                patch.object(
-                    lifecycle_mod,
-                    "find_free_ports",
-                    return_value={"backend": 8001, "frontend": 4201, "postgres": 5432, "redis": 6379},
-                ),
-                patch("teatree.config.load_config", return_value=mock_config),
-            ):
-                mock_sp.run.return_value = MagicMock(returncode=0)
-                call_command("lifecycle", "restart", path=str(wt_path))
-
-            wt = Worktree.objects.filter(ticket=ticket).first()
-            assert wt is not None
-            assert wt.state == Worktree.State.SERVICES_UP
 
 
 class TestLifecycleClean(TestCase):

--- a/tests/test_cli_overlay.py
+++ b/tests/test_cli_overlay.py
@@ -340,30 +340,6 @@ class TestOverlayCommands:
             assert result.exit_code == 0
             mock_manage.assert_called_once_with(tmp_path, "followup", "refresh", overlay_name="test")
 
-    def test_start_ticket(self, tmp_path):
-        """start-ticket delegates to lifecycle start-full."""
-        overlay_app = OverlayAppBuilder("test", tmp_path, "test.settings").build()
-        test_runner = CliRunner()
-
-        with patch.object(cli_overlay_mod, "managepy") as mock_manage:
-            result = test_runner.invoke(overlay_app, ["start-ticket", "https://issue/123"])
-            assert result.exit_code == 0
-            mock_manage.assert_called_once_with(
-                tmp_path, "lifecycle", "start-full", "https://issue/123", overlay_name="test"
-            )
-
-    def test_start_ticket_with_variant(self, tmp_path):
-        """start-ticket passes variant when specified."""
-        overlay_app = OverlayAppBuilder("test", tmp_path, "test.settings").build()
-        test_runner = CliRunner()
-
-        with patch.object(cli_overlay_mod, "managepy") as mock_manage:
-            result = test_runner.invoke(overlay_app, ["start-ticket", "https://issue/123", "--variant", "tenant-a"])
-            assert result.exit_code == 0
-            mock_manage.assert_called_once_with(
-                tmp_path, "lifecycle", "start-full", "https://issue/123", "--variant", "tenant-a", overlay_name="test"
-            )
-
     def test_ship(self, tmp_path):
         """Ship delegates to pr create."""
         overlay_app = OverlayAppBuilder("test", tmp_path, "test.settings").build()


### PR DESCRIPTION
## Summary

- `setup`: removed `--force` flag — auto-skips DB import when DB exists, always retries when DB is missing
- `start`: calls `setup` first (idempotent) then starts services — the one command that always works
- Removed `restart` command (was just a conditional wrapper around `start`)
- Removed `start-full` command and `start-ticket` CLI shortcut
- Removed step 5b local frontend hack from `start`
- Replaced circuit breaker tests with auto-repair tests

## Test plan

- [x] 1650 local tests pass
- [x] Docker test matrix passes (1646 tests)