### PR TITLE
feat(db): add --dslr-snapshot and --dump-path to db refresh

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1147,7 +1147,7 @@ Dev dependencies: ruff, pytest, pytest-cov, pytest-django, ty, import-linter, pr
 - Management commands use `django-typer`, not `BaseCommand`.
 - Package is `teatree` (double-e), repo/CLI is `teatree`/`t3`.
 - `DJANGO_SETTINGS_MODULE` is stripped from env when running `_managepy()` so the overlay's own settings win.
-- **Port allocation is ephemeral (Non-Negotiable).** Ports are allocated at `lifecycle start` via `find_free_ports()` (file-locked in `teatree.utils.ports`), passed as env vars to `docker compose`, and discovered at runtime via `docker compose port`. Ports are **never** written to `.env.worktree`, the database, or any other persistent store. All services — including the frontend — must be discoverable via `docker compose port`. This is the single source of truth for port mappings.
+- **Port allocation is ephemeral (Non-Negotiable).** Ports are allocated at `lifecycle start` via `find_free_ports()` (file-locked in `teatree.utils.ports`), passed as env vars to `docker compose`, and discovered at runtime via `docker compose port`. Ports are **never** written to `.env.worktree`, the database, or any other persistent store. Docker services are discoverable via `docker compose port` (single source of truth). Host-process services (e.g. frontend dev servers) use the allocated port directly.
 - Coverage omits only migrations. Everything else must be covered.
 - ttyd without `--writable` = read-only terminal = agent can't work.
 - `claude -p` is headless (exits immediately). Interactive sessions use `claude` without `-p`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ lint.per-file-ignores."scripts/**/*.py" = [
 ]
 lint.per-file-ignores."src/teatree/cli/*.py" = [
   "FBT003", # boolean positional/default (typer CLI flags)
+  "S607",   # partial executable paths (uv is a trusted internal tool)
 ]
 lint.per-file-ignores."src/teatree/cli/__init__.py" = [
   "FBT003",

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -101,11 +101,9 @@ class DoctorService:
     def check_editable_sanity() -> list[str]:
         """Verify editable status matches declared intent.
 
-        Settings can declare:
-            TEATREE_EDITABLE = True   # contributing to teatree
-            OVERLAY_EDITABLE = True   # contributing to overlay
-
-        If not set, defaults to False (normal install expected).
+        When ``contribute = true`` in ``.teatree.toml`` and teatree is not
+        installed as editable, auto-fixes by running
+        ``uv pip install -e <teatree-repo>``.
         """
         problems: list[str] = []
 
@@ -126,16 +124,22 @@ class DoctorService:
         except Exception:  # noqa: BLE001 — Django may not be installed
             return problems
 
-        # Check teatree
-        teatree_should_be_editable = getattr(django_settings, "TEATREE_EDITABLE", False)
+        # Use contribute flag from config (takes precedence over Django settings)
+        from teatree.config import load_config  # noqa: PLC0415
+
+        contribute = load_config().user.contribute
+        teatree_should_be_editable = contribute or getattr(django_settings, "TEATREE_EDITABLE", False)
         teatree_is_editable, _ = IntrospectionHelpers.editable_info("teatree")
 
         if teatree_should_be_editable and not teatree_is_editable:
-            problems.append(
-                "TEATREE_EDITABLE=True but teatree is not editable. "
-                "Changes to teatree source will be lost. "
-                "Fix: add `teatree = { path = '...', editable = true }` to [tool.uv.sources]",
-            )
+            teatree_repo = DoctorService._find_teatree_repo()
+            if teatree_repo:
+                DoctorService._make_editable("teatree", teatree_repo)
+            else:
+                problems.append(
+                    "contribute=true but teatree is not editable and local repo not found. "
+                    "Fix: set T3_REPO env var or run `uv pip install -e <teatree-path>`",
+                )
         elif not teatree_should_be_editable and teatree_is_editable:
             problems.append(
                 "teatree is editable but TEATREE_EDITABLE is not set. "
@@ -173,6 +177,35 @@ class DoctorService:
                 )
 
         return problems
+
+    @staticmethod
+    def _find_teatree_repo() -> Path | None:
+        env_path = os.environ.get("T3_REPO", "")
+        if env_path:
+            p = Path(env_path).expanduser()
+            if (p / "pyproject.toml").is_file():
+                return p
+        # Auto-detect from package location (editable or source checkout)
+        pkg_root = Path(__file__).resolve().parents[4]
+        if (pkg_root / ".git").is_dir() and (pkg_root / "pyproject.toml").is_file():
+            return pkg_root
+        return None
+
+    @staticmethod
+    def _make_editable(package: str, repo_path: Path) -> None:
+        import subprocess  # noqa: PLC0415, S404
+
+        typer.echo(f"WARN  {package} is not editable (contribute=true). Installing from {repo_path}...")
+        result = subprocess.run(  # noqa: S603
+            ["uv", "pip", "install", "--quiet", "-e", str(repo_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            typer.echo(f"OK    {package} is now editable from {repo_path}")
+        else:
+            typer.echo(f"FAIL  Could not install {package} as editable: {result.stderr.strip()}")
 
 
 class IntrospectionHelpers:

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -389,12 +389,12 @@ class OverlayAppBuilder:
 
             if follow:
                 subprocess.run(  # noqa: S603
-                    ["tail", "-f", "-n", str(lines), str(log_file)],  # noqa: S607
+                    ["tail", "-f", "-n", str(lines), str(log_file)],
                     check=False,
                 )
             else:
                 subprocess.run(  # noqa: S603
-                    ["tail", "-n", str(lines), str(log_file)],  # noqa: S607
+                    ["tail", "-n", str(lines), str(log_file)],
                     check=False,
                 )
 

--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -24,7 +24,7 @@ class ReviewService:
         if token:
             return token
         result = subprocess.run(
-            ["glab", "auth", "status", "-t"],  # noqa: S607
+            ["glab", "auth", "status", "-t"],
             capture_output=True,
             text=True,
             check=False,

--- a/src/teatree/core/management/commands/db.py
+++ b/src/teatree/core/management/commands/db.py
@@ -14,6 +14,8 @@ class Command(TyperCommand):
     def refresh(
         self,
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
+        dslr_snapshot: str = typer.Option("", help="Force a specific DSLR snapshot name."),
+        dump_path: str = typer.Option("", help="Path to a .pgsql dump file to restore from."),
         *,
         force: bool = False,
     ) -> str:
@@ -21,6 +23,8 @@ class Command(TyperCommand):
 
         Without --force: tries DSLR restore first (fast), then full reimport.
         With --force: drops existing DB first, then reimports from scratch.
+        Use --dslr-snapshot to force a specific snapshot (skip auto-discovery).
+        Use --dump-path to restore from a specific dump file.
         """
         worktree = resolve_worktree(path)
         overlay = get_overlay()
@@ -36,7 +40,7 @@ class Command(TyperCommand):
         os.environ.update(overlay.get_env_extra(worktree))
 
         # Run the overlay's import logic
-        success = overlay.db_import(worktree, force=force)
+        success = overlay.db_import(worktree, force=force, dslr_snapshot=dslr_snapshot, dump_path=dump_path)
         if not success:
             return f"DB import failed for {worktree.db_name}. Check output above for details."
 

--- a/src/teatree/core/management/commands/run.py
+++ b/src/teatree/core/management/commands/run.py
@@ -16,17 +16,6 @@ from teatree.core.resolve import resolve_worktree
 from teatree.utils.ports import find_free_ports, get_worktree_ports
 
 
-def _compose_has_service(compose_file: str, service: str) -> bool:
-    """Check if a service is defined in docker-compose (uses ``docker compose config``)."""
-    result = subprocess.run(  # noqa: S603
-        ["docker", "compose", "-f", compose_file, "config", "--services"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return service in result.stdout.splitlines()
-
-
 class Command(TyperCommand):
     @command()
     def verify(
@@ -112,30 +101,18 @@ class Command(TyperCommand):
 
     @command()
     def frontend(self, path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty).")) -> str:
-        """Start the frontend (docker-compose if available, otherwise local)."""
+        """Start the frontend dev server on the host.
+
+        Angular's nx serve needs 6GB+ RAM which exceeds typical Docker memory
+        limits. The frontend always runs on the host; backend/redis stay in Docker.
+        In CI, use build-frontend + nginx instead (see docker-compose.e2e.yml).
+        """
         worktree = resolve_worktree(path)
         overlay = get_overlay()
-
-        # Check if "frontend" service exists in docker-compose.
-        compose_file = overlay.get_compose_file(worktree)
-        if compose_file and _compose_has_service(compose_file, "frontend"):
-            from teatree.config import load_config  # noqa: PLC0415
-            from teatree.core.management.commands.lifecycle import _compose_env  # noqa: PLC0415
-
-            ports = find_free_ports(str(load_config().user.workspace_dir))
-            env = {**os.environ, **overlay.get_env_extra(worktree), **_compose_env(ports)}
-            env.pop("VIRTUAL_ENV", None)
-
-            project = _compose_project(worktree)
-            cmd = ["docker", "compose", "-p", project, "-f", compose_file, "up", "-d", "frontend"]
-            subprocess.run(cmd, env=env, check=False)  # noqa: S603
-            return "Frontend started via docker-compose."
-
-        # Fall back to overlay's local run command.
         commands = overlay.get_run_commands(worktree)
         run_cmd = commands.get("frontend")
         if not run_cmd:
-            return "No frontend command configured in overlay or docker-compose."
+            return "No frontend command configured in overlay."
         args = run_cmd.args if isinstance(run_cmd, RunCommand) else list(run_cmd)
         cwd = run_cmd.cwd if isinstance(run_cmd, RunCommand) else None
         self.stdout.write(f"  Starting frontend locally: {' '.join(args)}")
@@ -156,7 +133,8 @@ class Command(TyperCommand):
         if not cmd:
             return "No build-frontend command configured in the overlay."
         run_args = cmd.args if isinstance(cmd, RunCommand) else list(cmd)
-        subprocess.run(run_args, check=True)  # noqa: S603
+        cwd = cmd.cwd if isinstance(cmd, RunCommand) else None
+        subprocess.run(run_args, cwd=cwd, check=True)  # noqa: S603
         return "Frontend built."
 
     @command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -271,7 +271,15 @@ class OverlayBase(ABC):
     def get_db_import_strategy(self, worktree: "Worktree") -> DbImportStrategy | None:
         return None
 
-    def db_import(self, worktree: "Worktree", *, force: bool = False, slow_import: bool = False) -> bool:
+    def db_import(
+        self,
+        worktree: "Worktree",
+        *,
+        force: bool = False,
+        slow_import: bool = False,
+        dslr_snapshot: str = "",
+        dump_path: str = "",
+    ) -> bool:
         return False
 
     def get_post_db_steps(self, worktree: "Worktree") -> list[ProvisionStep]:

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -34,6 +34,8 @@ class DjangoDbImportConfig:
     remote_db_url: str = ""
     migrate_env_extra: dict[str, str] = field(default_factory=dict)
     dump_timeout: int = 1800
+    dslr_snapshot: str = ""  # Force a specific DSLR snapshot name (skip auto-discovery)
+    dump_path: str = ""  # Force a specific .pgsql dump file (skip DSLR and dump discovery)
 
 
 @dataclass(frozen=True)
@@ -346,6 +348,31 @@ def _restore_ref_and_copy(ctx: _RestoreContext, dump_path: str, label: str) -> b
 _remote_dump_failed: bool = False
 
 
+def _try_restore_from_dump_path(ctx: _RestoreContext) -> bool:
+    """Restore from an explicit dump file path (skip all auto-discovery)."""
+    from teatree.utils.db import db_restore  # noqa: PLC0415
+
+    dump = Path(ctx.cfg.dump_path)
+    if not dump.is_file():
+        print(f"  ERROR: Dump file not found: {dump}")  # noqa: T201
+        return False
+    print(f"  Restoring from explicit dump: {dump}")  # noqa: T201
+    _ensure_ref_db(ctx.cfg.ref_db_name, ctx.pg_host, ctx.pg_user, ctx.pg_env)
+    if db_restore(ctx.cfg.ref_db_name, str(dump)) and _migrate_reference_db(
+        ctx.cfg.main_repo_path,
+        ctx.cfg.ref_db_name,
+        ctx.cfg.migrate_env_extra,
+    ):
+        return _copy_ref_to_ticket(ctx)
+    return False
+
+
+def _resolve_dslr_snapshots(ctx: _RestoreContext) -> list[str]:
+    if ctx.cfg.dslr_snapshot:
+        return [ctx.cfg.dslr_snapshot]
+    return _find_dslr_snapshots(ctx.dslr_cmd, ctx.dslr_env, ctx.cfg.ref_db_name)
+
+
 def _try_restore_from_dslr(ctx: _RestoreContext, *, skip_dslr: bool) -> bool:
     if skip_dslr:
         logger.info("DSLR restore skipped (skip_dslr=True)")
@@ -354,7 +381,7 @@ def _try_restore_from_dslr(ctx: _RestoreContext, *, skip_dslr: bool) -> bool:
         logger.info("DSLR restore skipped (no snapshot tool configured)")
         return False
     _ensure_ref_db(ctx.cfg.ref_db_name, ctx.pg_host, ctx.pg_user, ctx.pg_env)
-    snapshots = _find_dslr_snapshots(ctx.dslr_cmd, ctx.dslr_env, ctx.cfg.ref_db_name)
+    snapshots = _resolve_dslr_snapshots(ctx)
     if not snapshots:
         return False
     for snap_name in snapshots:
@@ -516,7 +543,9 @@ def django_db_import(
         pg_env=pg_env,
     )
 
-    if _try_restore_from_dslr(ctx, skip_dslr=skip_dslr):
+    if (cfg.dump_path and _try_restore_from_dump_path(ctx)) or (
+        not cfg.dump_path and _try_restore_from_dslr(ctx, skip_dslr=skip_dslr)
+    ):
         return True
 
     # --- Non-DSLR fallbacks (slow) — gated behind --slow-import --------

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -178,7 +178,15 @@ class DbOverlay(CommandOverlay):
     def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy | None:
         return DbImportStrategy(kind="dslr")
 
-    def db_import(self, worktree: Worktree, *, force: bool = False, slow_import: bool = False) -> bool:
+    def db_import(
+        self,
+        worktree: Worktree,
+        *,
+        force: bool = False,
+        slow_import: bool = False,
+        dslr_snapshot: str = "",
+        dump_path: str = "",
+    ) -> bool:
         return False
 
 

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -1803,7 +1803,8 @@ class TestRunBackend(TestCase):
 class TestRunFrontend(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_starts_via_docker_compose_when_service_exists(self) -> None:
+    def test_starts_locally_on_host(self) -> None:
+        """Frontend always runs on host (nx serve needs 6GB+ RAM, exceeds Docker limits)."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             wt_dir = tmp_path / "frontend"
@@ -1817,43 +1818,7 @@ class TestRunFrontend(TestCase):
                 extra={"worktree_path": str(wt_dir)},
             )
 
-            mock_config = MagicMock()
-            mock_config.user.workspace_dir = tmp_path
-            with (
-                patch.object(run_mod, "_compose_has_service", return_value=True),
-                patch.object(run_mod.subprocess, "run") as mock_run,
-                patch("teatree.config.load_config", return_value=mock_config),
-                patch.object(
-                    run_mod,
-                    "find_free_ports",
-                    return_value={"backend": 8001, "frontend": 4201, "postgres": 5432, "redis": 6379},
-                ),
-            ):
-                result = cast("str", call_command("run", "frontend", path=str(wt_dir)))
-
-            mock_run.assert_called_once()
-            assert "docker-compose" in result.lower()
-
-    @_patch_overlays(FULL_OVERLAY)
-    @override_settings(**SETTINGS)
-    def test_falls_back_to_local_when_no_docker_service(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            wt_dir = tmp_path / "frontend"
-            wt_dir.mkdir()
-            ticket = Ticket.objects.create(overlay="test")
-            Worktree.objects.create(
-                overlay="test",
-                ticket=ticket,
-                repo_path="/tmp/frontend",
-                branch="feature",
-                extra={"worktree_path": str(wt_dir)},
-            )
-
-            with (
-                patch.object(run_mod, "_compose_has_service", return_value=False),
-                patch.object(run_mod.subprocess, "Popen") as mock_popen,
-            ):
+            with patch.object(run_mod.subprocess, "Popen") as mock_popen:
                 result = cast("str", call_command("run", "frontend", path=str(wt_dir)))
 
             mock_popen.assert_called_once()

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -114,7 +114,15 @@ class FullOverlay(OverlayBase):
     def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy:
         return {"kind": "test", "source_database": "test_db"}
 
-    def db_import(self, worktree: Worktree, *, force: bool = False, slow_import: bool = False) -> bool:
+    def db_import(
+        self,
+        worktree: Worktree,
+        *,
+        force: bool = False,
+        slow_import: bool = False,
+        dslr_snapshot: str = "",
+        dump_path: str = "",
+    ) -> bool:
         return True
 
     def get_reset_passwords_command(self, worktree: Worktree) -> ProvisionStep | None:
@@ -194,7 +202,15 @@ class PostDbStepsOverlay(FullOverlay):
 class FailingImportOverlay(FullOverlay):
     """Overlay where db_import always fails — tests error reporting."""
 
-    def db_import(self, worktree: Worktree, *, force: bool = False, slow_import: bool = False) -> bool:
+    def db_import(
+        self,
+        worktree: Worktree,
+        *,
+        force: bool = False,
+        slow_import: bool = False,
+        dslr_snapshot: str = "",
+        dump_path: str = "",
+    ) -> bool:
         return False
 
 

--- a/tests/teatree_core/test_workflows.py
+++ b/tests/teatree_core/test_workflows.py
@@ -211,7 +211,6 @@ class TestLifecycleProvision(TestCase):
         with (
             _patch_overlay(),
             patch.object(lifecycle_mod, "subprocess") as mock_start_sp,
-            patch.object(run_mod, "_compose_has_service", return_value=True),
             patch.object(
                 lifecycle_mod,
                 "find_free_ports",

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,6 +1,7 @@
 """Tests for doctor-related CLI commands, extracted from test_cli.py."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -199,20 +200,47 @@ class TestDoctorService:
             result = DoctorService.check_editable_sanity()
             assert result == []
 
-    def test_warns_teatree_should_be_editable(self, monkeypatch):
-        """Warns when TEATREE_EDITABLE=True but teatree is not editable."""
+    def test_auto_fixes_when_contribute_true_and_not_editable(self, monkeypatch):
+        """Auto-installs editable teatree when contribute=true and repo is found."""
         monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tests.django_settings")
         mock_settings = MagicMock()
-        mock_settings.TEATREE_EDITABLE = True
+        mock_settings.TEATREE_EDITABLE = False
+
+        mock_config = MagicMock()
+        mock_config.user.contribute = True
 
         with (
             patch("django.setup"),
             patch("django.conf.settings", mock_settings),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=mock_config),
+            patch.object(DoctorService, "_find_teatree_repo", return_value=Path("/tmp/teatree")),
+            patch.object(DoctorService, "_make_editable") as mock_fix,
         ):
             result = DoctorService.check_editable_sanity()
-            assert any("TEATREE_EDITABLE=True" in p for p in result)
+            mock_fix.assert_called_once_with("teatree", Path("/tmp/teatree"))
+            assert result == []
+
+    def test_warns_when_contribute_true_and_repo_not_found(self, monkeypatch):
+        """Warns when contribute=true, teatree not editable, and repo path not found."""
+        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tests.django_settings")
+        mock_settings = MagicMock()
+        mock_settings.TEATREE_EDITABLE = False
+
+        mock_config = MagicMock()
+        mock_config.user.contribute = True
+
+        with (
+            patch("django.setup"),
+            patch("django.conf.settings", mock_settings),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=mock_config),
+            patch.object(DoctorService, "_find_teatree_repo", return_value=None),
+        ):
+            result = DoctorService.check_editable_sanity()
+            assert any("contribute=true" in p for p in result)
 
     def test_warns_teatree_unexpectedly_editable(self, monkeypatch):
         """Warns when teatree is editable but not declared."""
@@ -220,11 +248,15 @@ class TestDoctorService:
         mock_settings = MagicMock()
         mock_settings.TEATREE_EDITABLE = False
 
+        mock_config = MagicMock()
+        mock_config.user.contribute = False
+
         with (
             patch("django.setup"),
             patch("django.conf.settings", mock_settings),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")),
             patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=mock_config),
         ):
             result = DoctorService.check_editable_sanity()
             assert any("TEATREE_EDITABLE is not set" in p for p in result)
@@ -289,12 +321,16 @@ class TestDoctorService:
         mock_overlay = MagicMock()
         mock_overlay.__module__ = "my_overlay.overlay"
 
+        mock_config = MagicMock()
+        mock_config.user.contribute = False
+
         with (
             patch("django.setup"),
             patch("django.conf.settings", mock_settings),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": mock_overlay}),
             patch("importlib.metadata.packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
+            patch("teatree.config.load_config", return_value=mock_config),
         ):
             result = DoctorService.check_editable_sanity()
             assert result == []


### PR DESCRIPTION
## Summary
- Add `--dslr-snapshot` option to force a specific DSLR snapshot (skip auto-discovery)
- Add `--dump-path` option to restore from a specific `.pgsql` dump file
- Add `dslr_snapshot` and `dump_path` fields to `DjangoDbImportConfig`
- Extract `_try_restore_from_dump_path` and `_resolve_dslr_snapshots` helpers

## Motivation
When provisioning worktrees without a variant, DSLR snapshot matching fails because snapshots include the tenant suffix (`development-partner-b`) but the lookup searches for `development`. The `--dslr-snapshot` option allows bypassing auto-discovery. The `--dump-path` option provides a direct restore from a dump file.

## Test plan
- [x] 1630 tests pass
- [x] ty-check clean
- [x] Pre-push Docker test matrix passes