### PR TITLE
feat(cli): add t3 assess command + fix pre-push hook overflow

### DIFF
--- a/dev/test-matrix.sh
+++ b/dev/test-matrix.sh
@@ -20,18 +20,26 @@ fi
 for py in "${versions[@]}"; do
     current=$((current + 1))
     echo "=== [$current/$total] Python $py ==="
+    # Capture output to a temp file — piping 1600+ test lines through
+    # Docker → git pre-push hook overflows the stderr buffer (Rust panic).
+    tmpout=$(mktemp)
     if docker run --rm \
         -v "$PWD":/app:ro \
         -e UV_PROJECT_ENVIRONMENT=/tmp/.venv \
         -e COVERAGE_FILE=/tmp/.coverage \
         "$IMAGE" \
-        uv run -p "$py" pytest --no-header --no-cov -v \
-            -o cache_dir=/tmp/.pytest_cache; then
+        uv run -p "$py" pytest --no-header --no-cov -q --tb=short \
+            -o cache_dir=/tmp/.pytest_cache > "$tmpout" 2>&1; then
+        # Show only the summary line (last non-empty line)
+        tail -3 "$tmpout"
         echo "  -> Python $py: OK"
     else
+        # On failure, show last 30 lines for diagnosis
+        tail -30 "$tmpout"
         echo "  -> Python $py: FAILED"
         failed=1
     fi
+    rm -f "$tmpout"
     echo
 done
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ lint.per-file-ignores."scripts/**/*.py" = [
   "TRY300",  # try-consider-else (readability preference)
 ]
 lint.per-file-ignores."src/teatree/cli/*.py" = [
+  "B008",   # function-call-in-default-argument (typer.Option/Argument is idiomatic)
   "FBT003", # boolean positional/default (typer CLI flags)
   "S607",   # partial executable paths (uv is a trusted internal tool)
 ]

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import typer
 
+from teatree.cli.assess import assess_app
 from teatree.cli.ci import ci_app
 from teatree.cli.doctor import DoctorService, IntrospectionHelpers, doctor_app
 from teatree.cli.overlay import OverlayAppBuilder, _uvicorn, managepy
@@ -564,6 +565,8 @@ app.add_typer(doctor_app, name="doctor")
 app.add_typer(tool_app, name="tool")
 
 app.add_typer(plugin_app, name="plugin")
+
+app.add_typer(assess_app, name="assess")
 
 
 # ── Review-request commands ──────────────────────────────────────────

--- a/src/teatree/cli/assess.py
+++ b/src/teatree/cli/assess.py
@@ -1,0 +1,169 @@
+"""Assess CLI — run deterministic codebase metrics and track history."""
+
+import json
+import subprocess  # noqa: S404
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+assess_app = typer.Typer(no_args_is_help=True, help="Codebase health assessment.")
+console = Console()
+
+ASSESSMENTS_DIR = ".t3/assessments"
+
+
+def _find_skill_cli() -> Path | None:
+    """Find ac-reviewing-codebase's cli.py in known skill locations."""
+    candidates = [
+        Path.home() / ".claude" / "skills" / "ac-reviewing-codebase" / "scripts" / "cli.py",
+        Path.home() / ".agents" / "skills" / "ac-reviewing-codebase" / "scripts" / "cli.py",
+        Path.home() / ".cursor" / "skills" / "ac-reviewing-codebase" / "scripts" / "cli.py",
+    ]
+    return next((p for p in candidates if p.exists()), None)
+
+
+@assess_app.command("run")
+def run_assessment(
+    root: Path = typer.Option(None, help="Repository root to assess"),
+    *,
+    output_json: bool = typer.Option(False, "--json", help="Output raw JSON"),
+    save: bool = typer.Option(True, "--save/--no-save", help="Save results to .t3/assessments/"),
+) -> None:
+    """Run deterministic codebase metrics on a repository."""
+    if root is None:
+        root = Path.cwd()
+    cli_path = _find_skill_cli()
+    if not cli_path:
+        typer.echo("ac-reviewing-codebase skill not found. Install: apm install souliane/skills/ac-reviewing-codebase")
+        raise typer.Exit(1)
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(cli_path), "assess", "--root", str(root), "--json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        typer.echo(f"Assessment failed: {result.stderr.strip()}")
+        raise typer.Exit(1)
+
+    try:
+        metrics = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        typer.echo(f"Invalid JSON from skill CLI: {result.stdout[:200]}")
+        raise typer.Exit(1) from None
+
+    if save:
+        _save_assessment(root, metrics)
+
+    if output_json:
+        typer.echo(json.dumps(metrics, indent=2))
+    else:
+        _print_summary(metrics)
+
+
+@assess_app.command("history")
+def show_history(
+    root: Path = typer.Option(None, help="Repository root"),
+    limit: int = typer.Option(10, "--limit", "-n", help="Number of recent assessments to show"),
+) -> None:
+    """Show assessment history for a repository."""
+    if root is None:
+        root = Path.cwd()
+    assessments_dir = root / ASSESSMENTS_DIR
+    if not assessments_dir.exists():
+        typer.echo("No assessments found. Run: t3 assess run")
+        raise typer.Exit(1)
+
+    files = sorted(assessments_dir.glob("*.json"), reverse=True)[:limit]
+    if not files:
+        typer.echo("No assessment files found.")
+        raise typer.Exit(1)
+
+    table = Table(title="Assessment History", show_lines=False)
+    table.add_column("Date", style="bold")
+    table.add_column("Lint", justify="right")
+    table.add_column("TODOs", justify="right")
+    table.add_column("Complex", justify="right")
+    table.add_column("Coverage", justify="right")
+    table.add_column("Outdated", justify="right")
+    table.add_column("Suppressions", justify="right")
+
+    for f in files:
+        data = json.loads(f.read_text(encoding="utf-8"))
+        metrics = data.get("metrics", data)
+        lint = metrics.get("lint", {})
+        todos = metrics.get("todos", {})
+        cx = metrics.get("complexity", {})
+        cov = metrics.get("coverage", {})
+        deps = metrics.get("dependencies", {})
+        supps = metrics.get("suppressions", {})
+
+        table.add_row(
+            f.stem,
+            str(lint.get("total", "?")),
+            str(todos.get("total", "?")),
+            str(cx.get("violations", "?")),
+            f"{cov['percent']:.0f}%" if cov.get("available") else "-",
+            str(deps.get("outdated_count", "-")) if deps.get("available") else "-",
+            str(sum(supps.values())) if supps else "0",
+        )
+
+    console.print(table)
+
+
+def _save_assessment(root: Path, metrics: dict) -> None:
+    """Save assessment to .t3/assessments/YYYY-MM-DD.json."""
+    assessments_dir = root / ASSESSMENTS_DIR
+    assessments_dir.mkdir(parents=True, exist_ok=True)
+
+    date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    output = {
+        "date": date_str,
+        "repo": root.name,
+        "metrics": metrics,
+    }
+
+    out_path = assessments_dir / f"{date_str}.json"
+    out_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+    typer.echo(f"Saved: {out_path}")
+
+
+def _print_summary(metrics: dict) -> None:
+    """Print a human-readable assessment summary."""
+    console.print("[bold]Codebase Assessment[/bold]")
+    console.print()
+
+    lint = metrics.get("lint", {})
+    if "error" not in lint:
+        color = "green" if lint.get("total", 0) == 0 else "yellow"
+        console.print(f"  Lint violations: [{color}]{lint.get('total', '?')}[/{color}]")
+
+    todos = metrics.get("todos", {})
+    console.print(f"  TODOs/FIXMEs: {todos.get('total', '?')}")
+
+    cx = metrics.get("complexity", {})
+    if "error" not in cx:
+        console.print(f"  Complex functions: {cx.get('violations', '?')}")
+
+    cov = metrics.get("coverage", {})
+    if cov.get("available"):
+        pct = cov["percent"]
+        color = "green" if pct >= 80 else "yellow" if pct >= 60 else "red"  # noqa: PLR2004
+        console.print(f"  Test coverage: [{color}]{pct:.1f}%[/{color}]")
+
+    deps = metrics.get("dependencies", {})
+    if deps.get("available"):
+        n = deps["outdated_count"]
+        color = "green" if n == 0 else "yellow"
+        console.print(f"  Outdated deps: [{color}]{n}[/{color}]")
+
+    supps = metrics.get("suppressions", {})
+    total_supps = sum(supps.values()) if supps else 0
+    color = "green" if total_supps == 0 else "yellow"
+    console.print(f"  Lint suppressions: [{color}]{total_supps}[/{color}]")

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -300,7 +300,7 @@ class OverlayAppBuilder:
         def overlay_agent(
             task: str = typer.Argument("", help="What to work on"),
             phase: str = typer.Option("", "--phase", help="Explicit TeaTree phase override."),
-            skill: list[str] = typer.Option(  # noqa: B008
+            skill: list[str] = typer.Option(
                 None,
                 "--skill",
                 help="Explicit skill override. Repeat to load multiple skills.",

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -93,7 +93,7 @@ def claude_handover(
         help="Current CLI runtime. Defaults to the highest-priority configured runtime.",
     ),
     session_id: str = typer.Option("", help="Claude session ID to inspect. Defaults to latest telemetry."),
-    state_dir: Path | None = typer.Option(None, help="Override the Claude statusline telemetry directory."),  # noqa: B008
+    state_dir: Path | None = typer.Option(None, help="Override the Claude statusline telemetry directory."),
     json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
 ) -> None:
     """Show Claude handover telemetry and runtime recommendations."""

--- a/tests/test_cli_assess.py
+++ b/tests/test_cli_assess.py
@@ -1,0 +1,198 @@
+"""Tests for the ``t3 assess`` CLI commands."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+import teatree.cli.assess as assess_mod
+from teatree.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _suppress_update_check(monkeypatch):
+    """Prevent the root callback update check from polluting CLI output."""
+    monkeypatch.setattr("teatree.cli._maybe_show_update_notice", lambda: None)
+
+
+class TestAssessRun:
+    def test_skill_not_found(self):
+        """Fails when ac-reviewing-codebase skill CLI is not installed."""
+        with patch.object(assess_mod, "_find_skill_cli", return_value=None):
+            result = runner.invoke(app, ["assess", "run"])
+            assert result.exit_code == 1
+            assert "skill not found" in result.output
+
+    def test_subprocess_failure(self, tmp_path):
+        """Fails when the skill CLI returns non-zero."""
+        fake_cli = tmp_path / "cli.py"
+        fake_cli.touch()
+        with (
+            patch.object(assess_mod, "_find_skill_cli", return_value=fake_cli),
+            patch.object(assess_mod.subprocess, "run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 1
+            mock_run.return_value.stderr = "ruff not found"
+            result = runner.invoke(app, ["assess", "run", "--no-save"])
+            assert result.exit_code == 1
+            assert "Assessment failed" in result.output
+
+    def test_invalid_json(self, tmp_path):
+        """Fails when the skill CLI returns invalid JSON."""
+        fake_cli = tmp_path / "cli.py"
+        fake_cli.touch()
+        with (
+            patch.object(assess_mod, "_find_skill_cli", return_value=fake_cli),
+            patch.object(assess_mod.subprocess, "run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "not json"
+            result = runner.invoke(app, ["assess", "run", "--no-save"])
+            assert result.exit_code == 1
+            assert "Invalid JSON" in result.output
+
+    def test_successful_run_json_output(self, tmp_path):
+        """Outputs JSON metrics when --json flag is used."""
+        fake_cli = tmp_path / "cli.py"
+        fake_cli.touch()
+        metrics = {"lint": {"total": 5}, "todos": {"total": 3}}
+        with (
+            patch.object(assess_mod, "_find_skill_cli", return_value=fake_cli),
+            patch.object(assess_mod.subprocess, "run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = json.dumps(metrics)
+            result = runner.invoke(app, ["assess", "run", "--json", "--no-save"])
+            assert result.exit_code == 0
+            parsed = json.loads(result.output)
+            assert parsed["lint"]["total"] == 5
+
+    def test_successful_run_human_output(self, tmp_path):
+        """Prints human-readable summary by default."""
+        fake_cli = tmp_path / "cli.py"
+        fake_cli.touch()
+        metrics = {
+            "lint": {"total": 0},
+            "todos": {"total": 2},
+            "complexity": {"violations": 1},
+            "coverage": {"available": True, "percent": 85.3},
+            "dependencies": {"available": True, "outdated_count": 0},
+            "suppressions": {"noqa": 3},
+        }
+        with (
+            patch.object(assess_mod, "_find_skill_cli", return_value=fake_cli),
+            patch.object(assess_mod.subprocess, "run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = json.dumps(metrics)
+            result = runner.invoke(app, ["assess", "run", "--no-save"])
+            assert result.exit_code == 0
+            assert "Lint violations" in result.output
+            assert "TODOs" in result.output
+            assert "85.3%" in result.output
+
+    def test_saves_assessment(self, tmp_path):
+        """Saves assessment JSON to .t3/assessments/."""
+        fake_cli = tmp_path / "cli.py"
+        fake_cli.touch()
+        metrics = {"lint": {"total": 0}, "todos": {"total": 0}}
+        with (
+            patch.object(assess_mod, "_find_skill_cli", return_value=fake_cli),
+            patch.object(assess_mod.subprocess, "run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = json.dumps(metrics)
+            result = runner.invoke(app, ["assess", "run", "--root", str(tmp_path)])
+            assert result.exit_code == 0
+            assert "Saved:" in result.output
+            saved_files = list((tmp_path / ".t3" / "assessments").glob("*.json"))
+            assert len(saved_files) == 1
+            saved = json.loads(saved_files[0].read_text())
+            assert saved["metrics"] == metrics
+
+
+class TestAssessHistory:
+    def test_no_assessments_dir(self, tmp_path):
+        """Fails when no assessments directory exists."""
+        result = runner.invoke(app, ["assess", "history", "--root", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "No assessments found" in result.output
+
+    def test_empty_assessments_dir(self, tmp_path):
+        """Fails when assessments directory is empty."""
+        (tmp_path / ".t3" / "assessments").mkdir(parents=True)
+        result = runner.invoke(app, ["assess", "history", "--root", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "No assessment files found" in result.output
+
+    def test_shows_history(self, tmp_path):
+        """Displays history table from saved assessments."""
+        assessments_dir = tmp_path / ".t3" / "assessments"
+        assessments_dir.mkdir(parents=True)
+        data = {
+            "date": "2026-04-07",
+            "repo": "test-repo",
+            "metrics": {
+                "lint": {"total": 5},
+                "todos": {"total": 3},
+                "complexity": {"violations": 2},
+                "coverage": {"available": True, "percent": 80.0},
+                "dependencies": {"available": True, "outdated_count": 1},
+                "suppressions": {"noqa": 2, "type_ignore": 1},
+            },
+        }
+        (assessments_dir / "2026-04-07.json").write_text(json.dumps(data))
+        result = runner.invoke(app, ["assess", "history", "--root", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "2026-04-07" in result.output
+
+
+class TestFindSkillCli:
+    def test_returns_none_when_not_found(self, tmp_path, monkeypatch):
+        """Returns None when skill CLI is not in any known location."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = assess_mod._find_skill_cli()
+        assert result is None
+
+    def test_finds_in_claude_skills(self, tmp_path, monkeypatch):
+        """Finds CLI in ~/.claude/skills/."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        cli_path = tmp_path / ".claude" / "skills" / "ac-reviewing-codebase" / "scripts" / "cli.py"
+        cli_path.parent.mkdir(parents=True)
+        cli_path.touch()
+        result = assess_mod._find_skill_cli()
+        assert result == cli_path
+
+
+class TestSaveAssessment:
+    def test_creates_dir_and_writes(self, tmp_path):
+        """Creates .t3/assessments/ and writes JSON."""
+        metrics = {"lint": {"total": 0}}
+        assess_mod._save_assessment(tmp_path, metrics)
+        files = list((tmp_path / ".t3" / "assessments").glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text())
+        assert data["repo"] == tmp_path.name
+        assert data["metrics"] == metrics
+
+
+class TestPrintSummary:
+    def test_handles_empty_metrics(self):
+        """Doesn't crash on empty metrics dict."""
+        assess_mod._print_summary({})
+
+    def test_all_sections(self, capsys):
+        """Prints all metric sections when available."""
+        metrics = {
+            "lint": {"total": 3},
+            "todos": {"total": 5},
+            "complexity": {"violations": 2},
+            "coverage": {"available": True, "percent": 92.0},
+            "dependencies": {"available": True, "outdated_count": 0},
+            "suppressions": {"noqa": 1},
+        }
+        assess_mod._print_summary(metrics)

--- a/tests/test_contrib_overlay.py
+++ b/tests/test_contrib_overlay.py
@@ -39,7 +39,9 @@ class TestGetRepos:
 class TestGetWorkspaceRepos:
     def test_returns_teatree(self) -> None:
         overlay = TeatreeOverlay()
-        assert overlay.get_workspace_repos() == ["teatree"]
+        repos = overlay.get_workspace_repos()
+        assert len(repos) == 1
+        assert repos[0].endswith("teatree")
 
 
 class TestGetFollowupRepos:


### PR DESCRIPTION
## Summary
- Add `t3 assess run` / `t3 assess history` CLI wrapping `ac-reviewing-codebase` skill for deterministic codebase metrics (lint, coverage, complexity, TODOs, dependency staleness)
- Fix pre-push hook stderr overflow by capturing Docker test output to temp file
- Make `workspace_repos` test resilient to nested paths (`souliane/teatree`)
- Centralize B008 (typer.Option in defaults) suppression for all CLI files

## Test plan
- [x] 14 new tests for assess CLI (run, history, save, find_skill, print_summary)
- [x] 1662 tests pass locally and in Docker
- [x] Pre-push hook completes without stderr overflow

Relates-to #99