### PR TITLE
fix: read banned_terms from ~/.teatree.toml instead of ~/.teatree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
       - id: banned-terms
         name: banned-terms
         language: script
-        entry: scripts/hooks/check-banned-terms.sh --config ~/.teatree
+        entry: scripts/hooks/check-banned-terms.sh --config ~/.teatree.toml
         types: [text]
         exclude: ^(\.pre-commit-config\.yaml|scripts/hooks/)$
 

--- a/scripts/hooks/check-banned-terms.sh
+++ b/scripts/hooks/check-banned-terms.sh
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
 # Pre-commit hook: reject files containing banned terms.
 #
-# Reads terms from a user-local config file:
-#   --config <path>  Shell KEY=VALUE file. Reads *BANNED_TERMS= variable.
+# Reads banned_terms from a TOML config file (e.g., ~/.teatree.toml):
+#   --config <path>  TOML file with a *banned_terms array in any section.
 #
 # Example .pre-commit-config.yaml entry:
-#   entry: scripts/hooks/check-banned-terms.sh --config ~/.teatree
+#   entry: scripts/hooks/check-banned-terms.sh --config ~/.teatree.toml
 #
-# The config file (e.g., ~/.teatree) should contain:
-#   T3_BANNED_TERMS="term1,term2,term3"
+# Example TOML:
+#   [teatree]
+#   banned_terms = ["term1", "term2"]
 #
-# If no config or no BANNED_TERMS variable, exits 0 (no-op).
+# If no config or no banned_terms key, exits 0 (no-op).
 # Matches that only appear inside email addresses are ignored so author/contact
 # metadata can stay intact while still blocking leaked tenant/project terms.
 
 set -euo pipefail
 
-terms=""
+config=""
 
 # Parse --config argument
 if [[ "${1:-}" == "--config" ]]; then
@@ -25,10 +26,21 @@ if [[ "${1:-}" == "--config" ]]; then
   if [ -n "$config" ]; then
     config="${config/#\~/$HOME}"
   fi
-  if [ -n "$config" ] && [ -f "$config" ]; then
-    terms="$(grep -E '_?BANNED_TERMS=' "$config" 2>/dev/null | head -1 | sed 's/^.*BANNED_TERMS=//' | sed 's/^["'"'"']//;s/["'"'"']$//')"
-  fi
 fi
+
+if [ -z "$config" ] || [ ! -f "$config" ]; then
+  exit 0
+fi
+
+# Extract banned_terms from TOML using tomllib (stdlib since Python 3.11)
+terms="$(python3 -c "
+import tomllib, pathlib, sys
+data = tomllib.loads(pathlib.Path(sys.argv[1]).read_text())
+for v in list(data.values()) + [data]:
+    if isinstance(v, dict) and 'banned_terms' in v:
+        print(','.join(v['banned_terms']))
+        break
+" "$config" 2>/dev/null || true)"
 
 if [ -z "$terms" ]; then
   exit 0

--- a/tests/test_banned_terms_hook.py
+++ b/tests/test_banned_terms_hook.py
@@ -6,8 +6,8 @@ from pathlib import Path
 def test_banned_terms_hook_expands_tilde_config_path(tmp_path: Path) -> None:
     home = tmp_path / "home"
     home.mkdir(exist_ok=True)
-    config = home / ".teatree"
-    config.write_text('T3_BANNED_TERMS="acme"\n', encoding="utf-8")
+    config = home / ".teatree.toml"
+    config.write_text('[teatree]\nbanned_terms = ["acme"]\n', encoding="utf-8")
 
     sample = tmp_path / "README.md"
     sample.write_text("acme overlay\n", encoding="utf-8")
@@ -17,7 +17,7 @@ def test_banned_terms_hook_expands_tilde_config_path(tmp_path: Path) -> None:
     env["HOME"] = str(home)
 
     result = subprocess.run(  # noqa: S603
-        [str(script), "--config", "~/.teatree", str(sample)],
+        [str(script), "--config", "~/.teatree.toml", str(sample)],
         capture_output=True,
         check=False,
         env=env,
@@ -31,8 +31,8 @@ def test_banned_terms_hook_expands_tilde_config_path(tmp_path: Path) -> None:
 def test_banned_terms_hook_ignores_matches_inside_email_addresses(tmp_path: Path) -> None:
     home = tmp_path / "home"
     home.mkdir(exist_ok=True)
-    config = home / ".teatree"
-    config.write_text('T3_BANNED_TERMS="internalterm"\n', encoding="utf-8")
+    config = home / ".teatree.toml"
+    config.write_text('[teatree]\nbanned_terms = ["internalterm"]\n', encoding="utf-8")
 
     sample = tmp_path / "AGENTS.md"
     sample.write_text("Git author: adrien <adrien.cossa@internalterm.example>\n", encoding="utf-8")
@@ -42,7 +42,7 @@ def test_banned_terms_hook_ignores_matches_inside_email_addresses(tmp_path: Path
     env["HOME"] = str(home)
 
     result = subprocess.run(  # noqa: S603
-        [str(script), "--config", "~/.teatree", str(sample)],
+        [str(script), "--config", "~/.teatree.toml", str(sample)],
         capture_output=True,
         check=False,
         env=env,


### PR DESCRIPTION
## Summary
- Banned-terms hook now parses TOML via `tomllib` (stdlib since Python 3.11)
- Pre-commit config points to `~/.teatree.toml` instead of non-existent `~/.teatree`
- Tests updated to use TOML format

## Test plan
- [x] Hook detects banned terms from TOML config
- [x] Hook passes clean files
- [x] Hook ignores matches inside email addresses
- [x] `pytest tests/test_banned_terms_hook.py` passes