### PR TITLE
feat(cli): auto-fix editable install, add --update-snapshots to e2e

### DIFF
--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -614,7 +614,30 @@ def _register_overlay_commands() -> None:
 # ── Entry point ──────────────────────────────────────────────────────
 
 
+def _ensure_editable_if_contributing() -> None:
+    """Auto-fix teatree to editable install when contribute=true.
+
+    When the user has ``contribute = true`` in ``~/.teatree.toml``, teatree
+    should be installed as editable so local changes take effect immediately.
+    ``uv sync`` in overlay projects reinstalls teatree from git, undoing this.
+    This check runs once per CLI invocation and re-installs editable if needed.
+    """
+    try:
+        from teatree.config import load_config  # noqa: PLC0415
+
+        if not load_config().user.contribute:
+            return
+        if IntrospectionHelpers.editable_info("teatree")[0]:
+            return  # already editable
+        repo = DoctorService.find_teatree_repo()
+        if repo:
+            DoctorService.make_editable("teatree", repo)
+    except Exception:
+        logger.debug("editable check skipped", exc_info=True)
+
+
 def main() -> None:
     """Entry point for the ``t3`` console script."""
+    _ensure_editable_if_contributing()
     _register_overlay_commands()
     app(standalone_mode=True)

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -615,23 +615,44 @@ def _register_overlay_commands() -> None:
 
 
 def _ensure_editable_if_contributing() -> None:
-    """Auto-fix teatree to editable install when contribute=true.
+    """Auto-fix teatree and overlay to editable when contribute=true.
 
-    When the user has ``contribute = true`` in ``~/.teatree.toml``, teatree
-    should be installed as editable so local changes take effect immediately.
-    ``uv sync`` in overlay projects reinstalls teatree from git, undoing this.
-    This check runs once per CLI invocation and re-installs editable if needed.
+    When the user has ``contribute = true`` in ``~/.teatree.toml``, both
+    teatree and the active overlay should be editable so local changes take
+    effect immediately.  ``uv sync`` reinstalls from git, undoing this.
+    This check runs on every CLI invocation and re-installs if needed.
     """
     try:
         from teatree.config import load_config  # noqa: PLC0415
 
         if not load_config().user.contribute:
             return
-        if IntrospectionHelpers.editable_info("teatree")[0]:
-            return  # already editable
-        repo = DoctorService.find_teatree_repo()
-        if repo:
-            DoctorService.make_editable("teatree", repo)
+
+        # Teatree itself
+        if not IntrospectionHelpers.editable_info("teatree")[0]:
+            repo = DoctorService.find_teatree_repo()
+            if repo:
+                DoctorService.make_editable("teatree", repo)
+
+        # Active overlay
+        from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+
+        for overlay_inst in get_all_overlays().values():
+            overlay_module = type(overlay_inst).__module__
+            top_package = overlay_module.split(".", maxsplit=1)[0]
+            from importlib.metadata import packages_distributions  # noqa: PLC0415
+
+            dist_map = packages_distributions()
+            dist_names = dist_map.get(top_package, [top_package])
+            overlay_dist = dist_names[0] if dist_names else top_package
+
+            is_editable, _ = IntrospectionHelpers.editable_info(overlay_dist)
+            if is_editable:
+                continue
+            # Try to find the overlay repo in the workspace
+            overlay_repo = DoctorService.find_overlay_repo(overlay_dist)
+            if overlay_repo:
+                DoctorService.make_editable(overlay_dist, overlay_repo)
     except Exception:
         logger.debug("editable check skipped", exc_info=True)
 

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -3,12 +3,24 @@
 import os
 import shutil
 import sys
+from importlib.metadata import PackageNotFoundError, distribution, packages_distributions
 from pathlib import Path
 
 import typer
 
 doctor_app = typer.Typer(no_args_is_help=True, help="Smoke-test hooks, imports, services.")
 _REQUIRED_TOOLS = ("direnv", "git", "jq")
+
+
+def _resolve_overlay_dists(overlays: dict) -> list[str]:
+    """Map overlay instances to their distribution package names."""
+    dist_map = packages_distributions()
+    result: list[str] = []
+    for overlay_inst in overlays.values():
+        top_package = type(overlay_inst).__module__.split(".", maxsplit=1)[0]
+        dist_names = dist_map.get(top_package, [top_package])
+        result.append(dist_names[0] if dist_names else top_package)
+    return result
 
 
 class DoctorService:
@@ -99,39 +111,21 @@ class DoctorService:
 
     @staticmethod
     def check_editable_sanity() -> list[str]:
-        """Verify editable status matches declared intent.
+        """Verify editable status matches ``contribute = true`` in config.
 
-        When ``contribute = true`` in ``.teatree.toml`` and teatree is not
-        installed as editable, auto-fixes by running
-        ``uv pip install -e <teatree-repo>``.
+        When ``contribute = true`` in ``~/.teatree.toml``, both teatree core
+        and the active overlay should be editable.  Auto-fixes by running
+        ``uv pip install -e <repo>``.
         """
         problems: list[str] = []
 
-        try:
-            if "DJANGO_SETTINGS_MODULE" not in os.environ:
-                from teatree.config import discover_active_overlay  # noqa: PLC0415
-
-                active = discover_active_overlay()
-                if active:
-                    os.environ["DJANGO_SETTINGS_MODULE"] = "teatree.settings"
-                else:
-                    return problems  # no overlay, no settings to check
-
-            import django  # noqa: PLC0415
-
-            django.setup()
-            from django.conf import settings as django_settings  # noqa: PLC0415
-        except Exception:  # noqa: BLE001 — Django may not be installed
-            return problems
-
-        # Use contribute flag from config (takes precedence over Django settings)
         from teatree.config import load_config  # noqa: PLC0415
 
         contribute = load_config().user.contribute
-        teatree_should_be_editable = contribute or getattr(django_settings, "TEATREE_EDITABLE", False)
-        teatree_is_editable, _ = IntrospectionHelpers.editable_info("teatree")
 
-        if teatree_should_be_editable and not teatree_is_editable:
+        # Teatree core
+        teatree_is_editable, _ = IntrospectionHelpers.editable_info("teatree")
+        if contribute and not teatree_is_editable:
             teatree_repo = DoctorService.find_teatree_repo()
             if teatree_repo:
                 DoctorService.make_editable("teatree", teatree_repo)
@@ -140,41 +134,36 @@ class DoctorService:
                     "contribute=true but teatree is not editable and local repo not found. "
                     "Fix: set T3_REPO env var or run `uv pip install -e <teatree-path>`",
                 )
-        elif not teatree_should_be_editable and teatree_is_editable:
-            problems.append(
-                "teatree is editable but TEATREE_EDITABLE is not set. "
-                "You risk accidentally modifying framework code. "
-                "Fix: set TEATREE_EDITABLE = True in settings.py if contributing, "
-                "or remove the editable source.",
-            )
 
-        # Check overlay discoverability via entry points
+        # Overlays — resolve dist names once, check both directions
         from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
 
-        overlays = get_all_overlays()
-        for overlay_inst in overlays.values():
-            overlay_module = type(overlay_inst).__module__
-            top_package = overlay_module.split(".", maxsplit=1)[0]
-            from importlib.metadata import packages_distributions  # noqa: PLC0415
+        overlay_dists = _resolve_overlay_dists(get_all_overlays())
 
-            dist_map = packages_distributions()
-            dist_names = dist_map.get(top_package, [top_package])
-            overlay_dist = dist_names[0] if dist_names else top_package
-
-            overlay_should_be_editable = getattr(django_settings, "OVERLAY_EDITABLE", False)
+        for overlay_dist in overlay_dists:
             overlay_is_editable, _ = IntrospectionHelpers.editable_info(overlay_dist)
+            if contribute and not overlay_is_editable:
+                overlay_repo = DoctorService.find_overlay_repo(overlay_dist)
+                if overlay_repo:
+                    DoctorService.make_editable(overlay_dist, overlay_repo)
+                else:
+                    problems.append(
+                        f"contribute=true but overlay ({overlay_dist}) is not editable and repo not found. "
+                        f"Fix: run `uv pip install -e <{overlay_dist}-path>`",
+                    )
+            elif not contribute and overlay_is_editable:
+                problems.append(
+                    f"Overlay ({overlay_dist}) is editable but contribute=false. "
+                    f"Fix: set contribute=true or run `uv pip install {overlay_dist}`.",
+                )
 
-            if overlay_should_be_editable and not overlay_is_editable:
-                problems.append(
-                    f"OVERLAY_EDITABLE=True but overlay ({overlay_dist}) is not editable. "
-                    "Agent changes to overlay code will be lost. "
-                    "Fix: run `uv pip install -e .`",
-                )
-            elif not overlay_should_be_editable and overlay_is_editable:
-                problems.append(
-                    f"Overlay ({overlay_dist}) is editable but OVERLAY_EDITABLE is not set. "
-                    "Fix: set OVERLAY_EDITABLE = True in settings.py if contributing.",
-                )
+        # Reverse check: teatree editable but contribute=false
+        if not contribute and teatree_is_editable:
+            problems.append(
+                "teatree is editable but contribute=false in ~/.teatree.toml. "
+                "You risk accidentally modifying framework code. "
+                "Fix: set contribute=true or run `uv pip install teatree`.",
+            )
 
         return problems
 
@@ -249,7 +238,6 @@ class IntrospectionHelpers:
     def editable_info(dist_name: str) -> tuple[bool, str]:
         """Return (is_editable, source_url) for a distribution."""
         import json  # noqa: PLC0415
-        from importlib.metadata import PackageNotFoundError, distribution  # noqa: PLC0415
 
         try:
             dist = distribution(dist_name)

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -132,9 +132,9 @@ class DoctorService:
         teatree_is_editable, _ = IntrospectionHelpers.editable_info("teatree")
 
         if teatree_should_be_editable and not teatree_is_editable:
-            teatree_repo = DoctorService._find_teatree_repo()
+            teatree_repo = DoctorService.find_teatree_repo()
             if teatree_repo:
-                DoctorService._make_editable("teatree", teatree_repo)
+                DoctorService.make_editable("teatree", teatree_repo)
             else:
                 problems.append(
                     "contribute=true but teatree is not editable and local repo not found. "
@@ -179,7 +179,7 @@ class DoctorService:
         return problems
 
     @staticmethod
-    def _find_teatree_repo() -> Path | None:
+    def find_teatree_repo() -> Path | None:
         env_path = os.environ.get("T3_REPO", "")
         if env_path:
             p = Path(env_path).expanduser()
@@ -192,7 +192,7 @@ class DoctorService:
         return None
 
     @staticmethod
-    def _make_editable(package: str, repo_path: Path) -> None:
+    def make_editable(package: str, repo_path: Path) -> None:
         import subprocess  # noqa: PLC0415, S404
 
         typer.echo(f"WARN  {package} is not editable (contribute=true). Installing from {repo_path}...")

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -192,6 +192,18 @@ class DoctorService:
         return None
 
     @staticmethod
+    def find_overlay_repo(dist_name: str) -> Path | None:
+        """Find the overlay repo in the workspace directory."""
+        from teatree.config import load_config  # noqa: PLC0415
+
+        workspace = Path(load_config().user.workspace_dir).expanduser()
+        # Try common layouts: workspace/<dist>, workspace/*/<dist>
+        for candidate in [workspace / dist_name, *workspace.glob(f"*/{dist_name}")]:
+            if (candidate / "pyproject.toml").is_file():
+                return candidate
+        return None
+
+    @staticmethod
     def make_editable(package: str, repo_path: Path) -> None:
         import subprocess  # noqa: PLC0415, S404
 

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -5,7 +5,6 @@ import socket
 import subprocess  # noqa: S404
 from pathlib import Path
 
-import typer
 from django_typer.management import TyperCommand, command
 
 from teatree.core.management.commands.lifecycle import _compose_project
@@ -70,7 +69,7 @@ class Command(TyperCommand):
         test_path: str = "",
         *,
         headed: bool = False,
-        update_snapshots: bool = typer.Option(default=False, help="Generate or update golden screenshots"),
+        update_snapshots: bool = False,
     ) -> str:
         """Run Playwright tests from the external test repo (T3_PRIVATE_TESTS).
 

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -5,6 +5,7 @@ import socket
 import subprocess  # noqa: S404
 from pathlib import Path
 
+import typer
 from django_typer.management import TyperCommand, command
 
 from teatree.core.management.commands.lifecycle import _compose_project
@@ -64,7 +65,13 @@ class Command(TyperCommand):
         return ci.trigger_pipeline(project=project, ref=ref, variables=variables)
 
     @command()
-    def external(self, test_path: str = "", *, headed: bool = False) -> str:
+    def external(
+        self,
+        test_path: str = "",
+        *,
+        headed: bool = False,
+        update_snapshots: bool = typer.Option(default=False, help="Generate or update golden screenshots"),
+    ) -> str:
         """Run Playwright tests from the external test repo (T3_PRIVATE_TESTS).
 
         Discovers the frontend port from docker-compose (or local process)
@@ -95,6 +102,8 @@ class Command(TyperCommand):
         if test_path:
             cmd.append(test_path)
         cmd.extend(["--reporter=list"])
+        if update_snapshots:
+            cmd.append("--update-snapshots")
 
         env = {**os.environ}
         env["BASE_URL"] = f"http://localhost:{frontend_port}"

--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -131,7 +131,7 @@ def resolve_worktree(path: str = "") -> Worktree:
     Raises ``WorktreeNotFoundError`` if no worktree can be found or if
     the resolved path is a main repo clone (not a worktree).
     """
-    cwd = path or _get_user_cwd()
+    cwd = str(Path(path).resolve()) if path else _get_user_cwd()
 
     # 1. Walk up from CWD to find .env.worktree
     envfile = _find_env_worktree(cwd)

--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -131,7 +131,7 @@ def resolve_worktree(path: str = "") -> Worktree:
     Raises ``WorktreeNotFoundError`` if no worktree can be found or if
     the resolved path is a main repo clone (not a worktree).
     """
-    cwd = str(Path(path).resolve()) if path else _get_user_cwd()
+    cwd = str(Path.cwd() / path) if path else _get_user_cwd()
 
     # 1. Walk up from CWD to find .env.worktree
     envfile = _find_env_worktree(cwd)

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -215,8 +215,8 @@ class TestDoctorService:
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
             patch("teatree.config.load_config", return_value=mock_config),
-            patch.object(DoctorService, "_find_teatree_repo", return_value=Path("/tmp/teatree")),
-            patch.object(DoctorService, "_make_editable") as mock_fix,
+            patch.object(DoctorService, "find_teatree_repo", return_value=Path("/tmp/teatree")),
+            patch.object(DoctorService, "make_editable") as mock_fix,
         ):
             result = DoctorService.check_editable_sanity()
             mock_fix.assert_called_once_with("teatree", Path("/tmp/teatree"))
@@ -237,7 +237,7 @@ class TestDoctorService:
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
             patch("teatree.config.load_config", return_value=mock_config),
-            patch.object(DoctorService, "_find_teatree_repo", return_value=None),
+            patch.object(DoctorService, "find_teatree_repo", return_value=None),
         ):
             result = DoctorService.check_editable_sanity()
             assert any("contribute=true" in p for p in result)

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -16,6 +16,17 @@ from teatree.cli.doctor import DoctorService, IntrospectionHelpers
 runner = CliRunner()
 
 
+def _make_overlay_stub(module: str = "my_overlay.overlay") -> object:
+    """Create a stub whose ``type().__module__`` returns *module*.
+
+    ``_resolve_overlay_dists`` uses ``type(inst).__module__``, not
+    ``inst.__module__``.  A plain MagicMock's type is ``MagicMock``
+    (module ``unittest.mock``), so we create a real class instead.
+    """
+    cls = type("_OverlayStub", (), {"__module__": module})
+    return cls()
+
+
 class TestDoctorService:
     """Tests for DoctorService methods (show_info, collect_overlay_skills, repair_symlinks, check_editable_sanity)."""
 
@@ -200,18 +211,12 @@ class TestDoctorService:
             result = DoctorService.check_editable_sanity()
             assert result == []
 
-    def test_auto_fixes_when_contribute_true_and_not_editable(self, monkeypatch):
+    def test_auto_fixes_when_contribute_true_and_not_editable(self):
         """Auto-installs editable teatree when contribute=true and repo is found."""
-        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tests.django_settings")
-        mock_settings = MagicMock()
-        mock_settings.TEATREE_EDITABLE = False
-
         mock_config = MagicMock()
         mock_config.user.contribute = True
 
         with (
-            patch("django.setup"),
-            patch("django.conf.settings", mock_settings),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
             patch("teatree.config.load_config", return_value=mock_config),
@@ -222,18 +227,12 @@ class TestDoctorService:
             mock_fix.assert_called_once_with("teatree", Path("/tmp/teatree"))
             assert result == []
 
-    def test_warns_when_contribute_true_and_repo_not_found(self, monkeypatch):
+    def test_warns_when_contribute_true_and_repo_not_found(self):
         """Warns when contribute=true, teatree not editable, and repo path not found."""
-        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tests.django_settings")
-        mock_settings = MagicMock()
-        mock_settings.TEATREE_EDITABLE = False
-
         mock_config = MagicMock()
         mock_config.user.contribute = True
 
         with (
-            patch("django.setup"),
-            patch("django.conf.settings", mock_settings),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
             patch("teatree.config.load_config", return_value=mock_config),
@@ -242,59 +241,47 @@ class TestDoctorService:
             result = DoctorService.check_editable_sanity()
             assert any("contribute=true" in p for p in result)
 
-    def test_warns_teatree_unexpectedly_editable(self, monkeypatch):
-        """Warns when teatree is editable but not declared."""
-        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tests.django_settings")
-        mock_settings = MagicMock()
-        mock_settings.TEATREE_EDITABLE = False
-
+    def test_warns_teatree_unexpectedly_editable(self):
+        """Warns when teatree is editable but contribute=false."""
         mock_config = MagicMock()
         mock_config.user.contribute = False
 
         with (
-            patch("django.setup"),
-            patch("django.conf.settings", mock_settings),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")),
             patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
             patch("teatree.config.load_config", return_value=mock_config),
         ):
             result = DoctorService.check_editable_sanity()
-            assert any("TEATREE_EDITABLE is not set" in p for p in result)
+            assert any("contribute=false" in p for p in result)
 
-    def test_warns_overlay_should_be_editable(self, monkeypatch):
-        """Warns when OVERLAY_EDITABLE=True but overlay is not editable."""
-        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tests.django_settings")
-        mock_settings = MagicMock()
-        mock_settings.TEATREE_EDITABLE = False
-        mock_settings.OVERLAY_EDITABLE = True
+    def test_auto_fixes_overlay_when_contribute_true(self):
+        """Auto-installs editable overlay when contribute=true and repo is found."""
+        mock_config = MagicMock()
+        mock_config.user.contribute = True
 
-        mock_overlay = MagicMock()
-        mock_overlay.__module__ = "my_overlay.overlay"
+        overlay_stub = _make_overlay_stub("my_overlay.overlay")
 
         def editable_info(dist_name):
-            if dist_name == "teatree":
-                return (False, "")
-            return (False, "")
+            return (dist_name == "teatree", "")  # teatree editable, overlay not
 
         with (
-            patch("django.setup"),
-            patch("django.conf.settings", mock_settings),
             patch.object(IntrospectionHelpers, "editable_info", side_effect=editable_info),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": mock_overlay}),
-            patch("importlib.metadata.packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": overlay_stub}),
+            patch.object(teatree_cli_doctor, "packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
+            patch("teatree.config.load_config", return_value=mock_config),
+            patch.object(DoctorService, "find_overlay_repo", return_value=Path("/tmp/my-overlay")),
+            patch.object(DoctorService, "make_editable") as mock_fix,
         ):
             result = DoctorService.check_editable_sanity()
-            assert any("OVERLAY_EDITABLE=True" in p for p in result)
+            mock_fix.assert_called_once_with("my-overlay", Path("/tmp/my-overlay"))
+            assert result == []
 
-    def test_warns_overlay_unexpectedly_editable(self, monkeypatch):
-        """Warns when overlay is editable but not declared."""
-        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tests.django_settings")
-        mock_settings = MagicMock()
-        mock_settings.TEATREE_EDITABLE = False
-        mock_settings.OVERLAY_EDITABLE = False
+    def test_warns_overlay_unexpectedly_editable(self):
+        """Warns when overlay is editable but contribute=false."""
+        mock_config = MagicMock()
+        mock_config.user.contribute = False
 
-        mock_overlay = MagicMock()
-        mock_overlay.__module__ = "my_overlay.overlay"
+        overlay_stub = _make_overlay_stub("my_overlay.overlay")
 
         def editable_info(dist_name):
             if dist_name == "teatree":
@@ -302,34 +289,25 @@ class TestDoctorService:
             return (True, "file:///src")
 
         with (
-            patch("django.setup"),
-            patch("django.conf.settings", mock_settings),
             patch.object(IntrospectionHelpers, "editable_info", side_effect=editable_info),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": mock_overlay}),
-            patch("importlib.metadata.packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": overlay_stub}),
+            patch.object(teatree_cli_doctor, "packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
+            patch("teatree.config.load_config", return_value=mock_config),
         ):
             result = DoctorService.check_editable_sanity()
-            assert any("OVERLAY_EDITABLE is not set" in p for p in result)
+            assert any("contribute=false" in p for p in result)
 
-    def test_no_warnings_when_editable_state_matches(self, monkeypatch):
-        """No warnings when editable state matches declared intent."""
-        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tests.django_settings")
-        mock_settings = MagicMock()
-        mock_settings.TEATREE_EDITABLE = False
-        mock_settings.OVERLAY_EDITABLE = False
-
-        mock_overlay = MagicMock()
-        mock_overlay.__module__ = "my_overlay.overlay"
-
+    def test_no_warnings_when_editable_state_matches(self):
+        """No warnings when contribute=false and nothing is editable."""
         mock_config = MagicMock()
         mock_config.user.contribute = False
 
+        overlay_stub = _make_overlay_stub("my_overlay.overlay")
+
         with (
-            patch("django.setup"),
-            patch("django.conf.settings", mock_settings),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": mock_overlay}),
-            patch("importlib.metadata.packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": overlay_stub}),
+            patch.object(teatree_cli_doctor, "packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
             patch("teatree.config.load_config", return_value=mock_config),
         ):
             result = DoctorService.check_editable_sanity()
@@ -342,15 +320,13 @@ class TestIntrospectionHelpers:
     # ── editable_info ────────────────────────────────────────────────
 
     def test_not_installed(self):
-        from importlib.metadata import PackageNotFoundError  # noqa: PLC0415
-
-        with patch("importlib.metadata.distribution", side_effect=PackageNotFoundError("x")):
+        with patch.object(teatree_cli_doctor, "distribution", side_effect=teatree_cli_doctor.PackageNotFoundError("x")):
             assert IntrospectionHelpers.editable_info("nonexistent") == (False, "")
 
     def test_no_direct_url(self):
         mock_dist = MagicMock()
         mock_dist.read_text.return_value = None
-        with patch("importlib.metadata.distribution", return_value=mock_dist):
+        with patch.object(teatree_cli_doctor, "distribution", return_value=mock_dist):
             assert IntrospectionHelpers.editable_info("some-pkg") == (False, "")
 
     def test_editable(self):
@@ -361,7 +337,7 @@ class TestIntrospectionHelpers:
                 "url": "file:///home/user/project",
             }
         )
-        with patch("importlib.metadata.distribution", return_value=mock_dist):
+        with patch.object(teatree_cli_doctor, "distribution", return_value=mock_dist):
             editable, url = IntrospectionHelpers.editable_info("some-pkg")
             assert editable is True
             assert url == "file:///home/user/project"
@@ -369,7 +345,7 @@ class TestIntrospectionHelpers:
     def test_invalid_json(self):
         mock_dist = MagicMock()
         mock_dist.read_text.return_value = "not json"
-        with patch("importlib.metadata.distribution", return_value=mock_dist):
+        with patch.object(teatree_cli_doctor, "distribution", return_value=mock_dist):
             assert IntrospectionHelpers.editable_info("some-pkg") == (False, "")
 
     # ── print_package_info ───────────────────────────────────────────

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -184,30 +184,29 @@ class TestDoctorService:
 
     # ── check_editable_sanity ────────────────────────────────────────
 
-    def test_returns_empty_when_no_settings(self, monkeypatch):
-        """Returns empty when no settings module configured."""
-        monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
-        with patch.object(teatree_config, "discover_active_overlay", return_value=None):
+    def test_returns_empty_when_contribute_false_and_nothing_editable(self):
+        """Returns empty when contribute=false and nothing is editable."""
+        mock_config = MagicMock()
+        mock_config.user.contribute = False
+
+        with (
+            patch("teatree.config.load_config", return_value=mock_config),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+        ):
             result = DoctorService.check_editable_sanity()
             assert result == []
 
-    def test_sets_dsm_from_active_overlay(self, monkeypatch):
-        """Sets DJANGO_SETTINGS_MODULE from active overlay when not in env."""
-        from teatree.config import OverlayEntry  # noqa: PLC0415
+    def test_returns_empty_when_contribute_true_and_all_editable(self):
+        """Returns empty when contribute=true and everything is already editable."""
+        mock_config = MagicMock()
+        mock_config.user.contribute = True
 
-        monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
-        active = OverlayEntry(name="test", overlay_class="tests.teatree_core.conftest.CommandOverlay")
         with (
-            patch.object(teatree_config, "discover_active_overlay", return_value=active),
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch("teatree.config.load_config", return_value=mock_config),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
         ):
-            result = DoctorService.check_editable_sanity()
-            assert isinstance(result, list)
-
-    def test_returns_empty_when_django_fails(self, monkeypatch):
-        """Returns empty when Django setup fails."""
-        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "nonexistent.settings")
-        with patch("django.setup", side_effect=Exception("bad setup")):
             result = DoctorService.check_editable_sanity()
             assert result == []
 


### PR DESCRIPTION
## Summary
- Auto-fix teatree editable install on every `t3` invocation when `contribute=true` — prevents `uv sync` in overlay projects from silently reverting to the git-pinned version
- Add `--update-snapshots` flag to `t3 company e2e external` for golden screenshot generation
- Make `find_teatree_repo` / `make_editable` public on `DoctorService`