### PR TITLE
refactor(backends): inject config instead of importing from core

### DIFF
--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -1,23 +1,28 @@
 from pathlib import Path
 
 from teatree.backends.gitlab_api import GitLabAPI, ProjectInfo
-from teatree.core.overlay import OverlayBase
 
 
-def get_client(overlay: OverlayBase | None = None) -> GitLabAPI:
-    if overlay is None:
-        from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+def get_client(*, token: str = "", base_url: str = "") -> GitLabAPI:
+    """Build a ``GitLabAPI`` from explicit credentials.
 
-        overlay = get_overlay()
+    When *token* is empty the ``GitLabAPI`` default (env-var fallback) is used.
+    """
     return GitLabAPI(
-        token=overlay.config.get_gitlab_token(),
-        base_url=overlay.config.get_gitlab_url(),
+        token=token,
+        base_url=base_url or "https://gitlab.com/api/v4",
     )
 
 
 class GitLabCodeHost:
-    def __init__(self, client: GitLabAPI | None = None) -> None:
-        self._client = client or get_client()
+    def __init__(
+        self,
+        *,
+        client: GitLabAPI | None = None,
+        token: str = "",
+        base_url: str = "",
+    ) -> None:
+        self._client = client or get_client(token=token, base_url=base_url)
 
     def create_pr(  # noqa: PLR0913
         self,

--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -1,4 +1,8 @@
-"""Backend loader — auto-configures code host, CI, chat from overlay config."""
+"""Backend loader — builds code host / CI from explicit credentials.
+
+The functions here do NOT import from ``teatree.core``; callers are
+responsible for resolving overlay config and passing tokens / URLs.
+"""
 
 from functools import lru_cache
 
@@ -6,23 +10,25 @@ from teatree.backends.protocols import ChatNotifier, CIService, CodeHost, ErrorT
 
 
 @lru_cache(maxsize=1)
-def get_code_host() -> CodeHost | None:
-    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+def get_code_host(
+    *,
+    github_token: str = "",
+    gitlab_token: str = "",
+    gitlab_url: str = "",
+) -> CodeHost | None:
+    """Return a configured code-host backend, or ``None``.
 
-    try:
-        overlay = get_overlay()
-    except Exception:  # noqa: BLE001
-        return None
-
-    if overlay.config.get_github_token():
+    Callers should resolve tokens from the overlay and pass them explicitly.
+    """
+    if github_token:
         from teatree.backends.github import GitHubCodeHost  # noqa: PLC0415
 
-        return GitHubCodeHost(token=overlay.config.get_github_token())
+        return GitHubCodeHost(token=github_token)
 
-    if overlay.config.get_gitlab_token():
+    if gitlab_token:
         from teatree.backends.gitlab import GitLabCodeHost  # noqa: PLC0415
 
-        return GitLabCodeHost()
+        return GitLabCodeHost(token=gitlab_token, base_url=gitlab_url)
     return None
 
 
@@ -42,18 +48,20 @@ def get_error_tracker() -> ErrorTracker | None:
 
 
 @lru_cache(maxsize=1)
-def get_ci_service() -> CIService | None:
-    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+def get_ci_service(
+    *,
+    gitlab_token: str = "",
+    gitlab_url: str = "",
+) -> CIService | None:
+    """Return a configured CI-service backend, or ``None``.
 
-    try:
-        overlay = get_overlay()
-    except Exception:  # noqa: BLE001
-        return None
-
-    if overlay.config.get_gitlab_token():
+    Callers should resolve tokens from the overlay and pass them explicitly.
+    """
+    if gitlab_token:
+        from teatree.backends.gitlab_api import GitLabAPI  # noqa: PLC0415
         from teatree.backends.gitlab_ci import GitLabCIService  # noqa: PLC0415
 
-        return GitLabCIService()
+        return GitLabCIService(client=GitLabAPI(token=gitlab_token, base_url=gitlab_url or "https://gitlab.com/api/v4"))
     return None
 
 

--- a/src/teatree/cli/ci.py
+++ b/src/teatree/cli/ci.py
@@ -14,21 +14,22 @@ class CICommands:
 
     @staticmethod
     def get_ci_service() -> CIService | None:
-        """Get CI service — tries Django settings first, falls back to env vars."""
+        """Get CI service — tries overlay first, falls back to env vars."""
         try:
-            from teatree.backends.loader import get_ci_service  # noqa: PLC0415
+            from teatree.core.backend_factory import ci_service_from_overlay  # noqa: PLC0415
 
-            return get_ci_service()
+            result = ci_service_from_overlay()
+            if result is not None:
+                return result
         except Exception:  # noqa: BLE001, S110 — fallback to env-based config
             pass
 
         token = os.environ.get("GITLAB_TOKEN", "")
         if token:
-            from teatree.backends.gitlab_api import GitLabAPI  # noqa: PLC0415
-            from teatree.backends.gitlab_ci import GitLabCIService  # noqa: PLC0415
+            from teatree.backends.loader import get_ci_service  # noqa: PLC0415
 
             base_url = os.environ.get("GITLAB_URL", "https://gitlab.com/api/v4")
-            return GitLabCIService(client=GitLabAPI(token=token, base_url=base_url))
+            return get_ci_service(gitlab_token=token, gitlab_url=base_url)
         return None
 
     @staticmethod

--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -1,0 +1,59 @@
+"""Overlay-aware backend factory — resolves config and builds backends.
+
+This module bridges ``teatree.core`` (overlay) and ``teatree.backends``
+(loader) so that callers in ``core`` and ``cli`` don't need to extract
+tokens themselves.
+"""
+
+from teatree.backends.loader import (
+    get_chat_notifier,
+    get_ci_service,
+    get_code_host,
+    get_error_tracker,
+    get_issue_tracker,
+    reset_backend_caches,
+)
+from teatree.backends.protocols import CIService, CodeHost
+
+
+def code_host_from_overlay() -> CodeHost | None:
+    """Build a code-host backend using the active overlay's credentials."""
+    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+
+    try:
+        overlay = get_overlay()
+    except Exception:  # noqa: BLE001
+        return None
+
+    return get_code_host(
+        github_token=overlay.config.get_github_token(),
+        gitlab_token=overlay.config.get_gitlab_token(),
+        gitlab_url=overlay.config.get_gitlab_url(),
+    )
+
+
+def ci_service_from_overlay() -> CIService | None:
+    """Build a CI-service backend using the active overlay's credentials."""
+    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+
+    try:
+        overlay = get_overlay()
+    except Exception:  # noqa: BLE001
+        return None
+
+    return get_ci_service(
+        gitlab_token=overlay.config.get_gitlab_token(),
+        gitlab_url=overlay.config.get_gitlab_url(),
+    )
+
+
+__all__ = [
+    "ci_service_from_overlay",
+    "code_host_from_overlay",
+    "get_chat_notifier",
+    "get_ci_service",
+    "get_code_host",
+    "get_error_tracker",
+    "get_issue_tracker",
+    "reset_backend_caches",
+]

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -47,14 +47,14 @@ class Command(TyperCommand):
     @command(name="trigger-ci")
     def trigger_ci(self, branch: str = "") -> dict[str, object]:
         """Trigger E2E tests on a remote CI pipeline."""
-        from teatree.backends.loader import get_ci_service  # noqa: PLC0415
+        from teatree.core.backend_factory import ci_service_from_overlay  # noqa: PLC0415
 
         overlay = get_overlay()
         config = overlay.metadata.get_e2e_config()
         if not config:
             return {"error": "No E2E config in the overlay (get_e2e_config)."}
 
-        ci = get_ci_service()
+        ci = ci_service_from_overlay()
         if ci is None:
             return {"error": "No CI service configured."}
 

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -7,7 +7,7 @@ from typing import cast
 
 from django_typer.management import TyperCommand, command
 
-from teatree.backends.loader import get_code_host, get_issue_tracker
+from teatree.core.backend_factory import code_host_from_overlay, get_issue_tracker
 from teatree.core.models import Ticket
 from teatree.core.overlay_loader import get_overlay
 
@@ -83,7 +83,7 @@ class Command(TyperCommand):
     ) -> dict[str, object]:
         """Create a merge request for the ticket's branch."""
         ticket = Ticket.objects.get(pk=ticket_id)
-        host = get_code_host()
+        host = code_host_from_overlay()
         if host is None:
             return {"error": "No code host configured (check overlay GitLab token)"}
 
@@ -203,7 +203,7 @@ class Command(TyperCommand):
         Files (screenshots, videos) are uploaded and embedded as ``![name](url)`` in the body.
         If an existing note contains ``## Test Plan``, it is updated instead of creating a new one.
         """
-        host = get_code_host()
+        host = code_host_from_overlay()
         if host is None:
             return {"error": "No code host configured (check overlay GitLab token)"}
 

--- a/tach.toml
+++ b/tach.toml
@@ -22,7 +22,7 @@ depends_on = []
 
 [[modules]]
 path = "teatree.backends"
-depends_on = ["teatree.core", "teatree.utils"]
+depends_on = ["teatree.utils"]
 
 [[modules]]
 path = "teatree.agents"

--- a/tests/teatree_backends/test_backends.py
+++ b/tests/teatree_backends/test_backends.py
@@ -45,32 +45,20 @@ def test_notion_backend_fetches_page_with_version_header(monkeypatch: pytest.Mon
     assert client.get_page("page-123") == {"id": "page-123"}
 
 
-def test_gitlab_backend_builds_client_from_overlay() -> None:
-    from unittest.mock import MagicMock, patch  # noqa: PLC0415
-
-    mock_overlay = MagicMock()
-    mock_overlay.config.get_gitlab_url.return_value = "https://gitlab.example.com/api/v4"
-    mock_overlay.config.get_gitlab_token.return_value = "gl-token"
-
-    with patch(
-        "teatree.core.overlay_loader._discover_overlays",
-        return_value={"test": mock_overlay},
-    ):
-        client = gitlab.get_client()
+def test_gitlab_backend_builds_client_with_explicit_args() -> None:
+    client = gitlab.get_client(
+        token="gl-token",
+        base_url="https://gitlab.example.com/api/v4",
+    )
 
     assert client.base_url == "https://gitlab.example.com/api/v4"
     assert client.token == "gl-token"
 
 
-def test_get_client_with_explicit_overlay():
-    mock_overlay = MagicMock()
-    mock_overlay.config.get_gitlab_url.return_value = "https://custom.gitlab/api/v4"
-    mock_overlay.config.get_gitlab_token.return_value = "custom-token"
+def test_get_client_defaults():
+    client = gitlab.get_client()
 
-    client = gitlab.get_client(overlay=mock_overlay)
-
-    assert client.base_url == "https://custom.gitlab/api/v4"
-    assert client.token == "custom-token"
+    assert client.base_url == "https://gitlab.com/api/v4"
 
 
 def test_gitlab_code_host_update_mr_note(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/teatree_backends/test_loader.py
+++ b/tests/teatree_backends/test_loader.py
@@ -1,8 +1,5 @@
-"""Tests for the overlay-driven backend loader."""
+"""Tests for the backend loader (no overlay dependency)."""
 
-from unittest.mock import patch
-
-import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab_ci import GitLabCIService
 from teatree.backends.loader import (
@@ -13,30 +10,6 @@ from teatree.backends.loader import (
     get_issue_tracker,
     reset_backend_caches,
 )
-from teatree.core.overlay import OverlayBase, OverlayConfig
-
-
-class _TokenConfig(OverlayConfig):
-    def get_gitlab_token(self) -> str:
-        return "gl-test-token"
-
-
-class _TokenOverlay(OverlayBase):
-    config = _TokenConfig()
-
-    def get_repos(self):
-        return []
-
-    def get_provision_steps(self, worktree):
-        return []
-
-
-class _NoTokenOverlay(OverlayBase):
-    def get_repos(self):
-        return []
-
-    def get_provision_steps(self, worktree):
-        return []
 
 
 def setup_function() -> None:
@@ -47,23 +20,13 @@ def teardown_function() -> None:
     reset_backend_caches()
 
 
-def _patch_overlay(overlay_cls):
-    return patch.object(
-        overlay_loader_mod,
-        "_discover_overlays",
-        return_value={"test": overlay_cls()},
-    )
-
-
 def test_get_code_host_returns_none_when_no_token() -> None:
-    with _patch_overlay(_NoTokenOverlay):
-        assert get_code_host() is None
+    assert get_code_host() is None
 
 
 def test_get_code_host_returns_gitlab_when_token_present() -> None:
-    with _patch_overlay(_TokenOverlay):
-        result = get_code_host()
-        assert isinstance(result, GitLabCodeHost)
+    result = get_code_host(gitlab_token="gl-test-token")
+    assert isinstance(result, GitLabCodeHost)
 
 
 def test_get_issue_tracker_returns_none() -> None:
@@ -79,39 +42,18 @@ def test_get_error_tracker_returns_none() -> None:
 
 
 def test_get_ci_service_returns_none_when_no_token() -> None:
-    with _patch_overlay(_NoTokenOverlay):
-        assert get_ci_service() is None
+    assert get_ci_service() is None
 
 
 def test_get_ci_service_returns_gitlab_when_token_present() -> None:
-    with _patch_overlay(_TokenOverlay):
-        result = get_ci_service()
-        assert isinstance(result, GitLabCIService)
-
-
-def test_get_code_host_returns_none_when_overlay_not_configured() -> None:
-    with patch.object(
-        overlay_loader_mod,
-        "_discover_overlays",
-        return_value={},
-    ):
-        assert get_code_host() is None
-
-
-def test_get_ci_service_returns_none_when_overlay_not_configured() -> None:
-    with patch.object(
-        overlay_loader_mod,
-        "_discover_overlays",
-        return_value={},
-    ):
-        assert get_ci_service() is None
+    result = get_ci_service(gitlab_token="gl-test-token")
+    assert isinstance(result, GitLabCIService)
 
 
 def test_reset_backend_caches_clears_all() -> None:
     reset_backend_caches()
-    with _patch_overlay(_NoTokenOverlay):
-        assert get_code_host() is None
-        assert get_issue_tracker() is None
-        assert get_chat_notifier() is None
-        assert get_error_tracker() is None
-        assert get_ci_service() is None
+    assert get_code_host() is None
+    assert get_issue_tracker() is None
+    assert get_chat_notifier() is None
+    assert get_error_tracker() is None
+    assert get_ci_service() is None

--- a/tests/teatree_core/test_backend_factory.py
+++ b/tests/teatree_core/test_backend_factory.py
@@ -1,0 +1,89 @@
+"""Tests for the overlay-aware backend factory bridge."""
+
+from unittest.mock import patch
+
+import teatree.core.overlay_loader as overlay_loader_mod
+from teatree.backends.gitlab import GitLabCodeHost
+from teatree.backends.gitlab_ci import GitLabCIService
+from teatree.backends.loader import reset_backend_caches
+from teatree.core.backend_factory import ci_service_from_overlay, code_host_from_overlay
+from teatree.core.overlay import OverlayBase, OverlayConfig
+
+
+class _TokenConfig(OverlayConfig):
+    def get_gitlab_token(self) -> str:
+        return "gl-test-token"
+
+
+class _TokenOverlay(OverlayBase):
+    config = _TokenConfig()
+
+    def get_repos(self):
+        return []
+
+    def get_provision_steps(self, worktree):
+        return []
+
+
+class _NoTokenOverlay(OverlayBase):
+    def get_repos(self):
+        return []
+
+    def get_provision_steps(self, worktree):
+        return []
+
+
+def setup_function() -> None:
+    reset_backend_caches()
+
+
+def teardown_function() -> None:
+    reset_backend_caches()
+
+
+def _patch_overlay(overlay_cls):
+    return patch.object(
+        overlay_loader_mod,
+        "_discover_overlays",
+        return_value={"test": overlay_cls()},
+    )
+
+
+def test_code_host_from_overlay_returns_none_when_no_token() -> None:
+    with _patch_overlay(_NoTokenOverlay):
+        assert code_host_from_overlay() is None
+
+
+def test_code_host_from_overlay_returns_gitlab_when_token_present() -> None:
+    with _patch_overlay(_TokenOverlay):
+        result = code_host_from_overlay()
+        assert isinstance(result, GitLabCodeHost)
+
+
+def test_ci_service_from_overlay_returns_none_when_no_token() -> None:
+    with _patch_overlay(_NoTokenOverlay):
+        assert ci_service_from_overlay() is None
+
+
+def test_ci_service_from_overlay_returns_gitlab_when_token_present() -> None:
+    with _patch_overlay(_TokenOverlay):
+        result = ci_service_from_overlay()
+        assert isinstance(result, GitLabCIService)
+
+
+def test_code_host_from_overlay_returns_none_when_overlay_not_configured() -> None:
+    with patch.object(
+        overlay_loader_mod,
+        "_discover_overlays",
+        return_value={},
+    ):
+        assert code_host_from_overlay() is None
+
+
+def test_ci_service_from_overlay_returns_none_when_overlay_not_configured() -> None:
+    with patch.object(
+        overlay_loader_mod,
+        "_discover_overlays",
+        return_value={},
+    ):
+        assert ci_service_from_overlay() is None

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -15,8 +15,8 @@ from django.core.management.base import OutputWrapper
 from django.test import TestCase, override_settings
 from django.utils.module_loading import import_string
 
-import teatree.backends.loader as backends_loader_mod
 import teatree.config as config_mod
+import teatree.core.backend_factory as backend_factory_mod
 import teatree.core.management.commands.e2e as e2e_mod
 import teatree.core.management.commands.lifecycle as lifecycle_mod
 import teatree.core.management.commands.pr as pr_mod
@@ -1288,7 +1288,7 @@ class TestPrCreate(TestCase):
         mock_host = MagicMock()
         mock_host.create_pr.return_value = {"url": "https://example.com/mr/1"}
 
-        with patch.object(pr_mod, "get_code_host", return_value=mock_host):
+        with patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host):
             result = cast(
                 "dict[str, object]",
                 call_command(
@@ -1319,7 +1319,7 @@ class TestPrCreate(TestCase):
         mock_validate = MagicMock(return_value={"errors": ["Bad title"], "warnings": []})
 
         with (
-            patch.object(pr_mod, "get_code_host", return_value=mock_host),
+            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
             patch.object(pr_mod, "_last_commit_message", return_value=("Bad Title", "")),
             patch.object(pr_mod, "get_overlay") as mock_overlay,
         ):
@@ -1342,7 +1342,7 @@ class TestPrCreate(TestCase):
         mock_host.create_pr.return_value = {"url": "https://example.com/mr/2"}
 
         with (
-            patch.object(pr_mod, "get_code_host", return_value=mock_host),
+            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
             patch.object(pr_mod, "_last_commit_message", return_value=("", "")),
         ):
             cast(
@@ -1370,7 +1370,7 @@ class TestPrCreate(TestCase):
         mock_host.create_pr.return_value = {"url": "https://example.com/mr/3"}
 
         with (
-            patch.object(pr_mod, "get_code_host", return_value=mock_host),
+            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
             patch.object(pr_mod, "_last_commit_message", return_value=("", "")),
         ):
             call_command("pr", "create", str(ticket.pk), skip_validation=True)
@@ -1389,7 +1389,7 @@ class TestPrCreate(TestCase):
         mock_host.create_pr.return_value = {"url": "https://example.com/mr/7"}
 
         with (
-            patch.object(pr_mod, "get_code_host", return_value=mock_host),
+            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
             patch.object(pr_mod, "_last_commit_message", return_value=("commit title", "commit body")),
         ):
             call_command("pr", "create", str(ticket.pk), description="user desc", skip_validation=True)
@@ -1407,7 +1407,7 @@ class TestPrCreate(TestCase):
 
         mock_host = MagicMock()
         with (
-            patch.object(pr_mod, "get_code_host", return_value=mock_host),
+            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
             patch.object(pr_mod, "_last_commit_message", return_value=("", "")),
         ):
             result = cast(
@@ -1430,7 +1430,7 @@ class TestPrCreate(TestCase):
         mock_host.create_pr.return_value = {"url": "https://example.com/mr/5"}
 
         with (
-            patch.object(pr_mod, "get_code_host", return_value=mock_host),
+            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
             patch.object(pr_mod, "_last_commit_message", return_value=("", "")),
         ):
             result = cast(
@@ -1458,7 +1458,7 @@ class TestPrCreate(TestCase):
         mock_host.create_pr.return_value = {"url": "https://example.com/mr/6"}
 
         with (
-            patch.object(pr_mod, "get_code_host", return_value=mock_host),
+            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
             patch.object(
                 pr_mod,
                 "_last_commit_message",
@@ -1631,7 +1631,7 @@ class TestPrPostEvidence(TestCase):
         mock_host.post_mr_note.return_value = {"id": 42}
         mock_host.list_mr_notes.return_value = []  # no existing note
 
-        with patch.object(pr_mod, "get_code_host", return_value=mock_host):
+        with patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host):
             result = cast(
                 "dict[str, object]",
                 call_command(
@@ -1659,7 +1659,7 @@ class TestPrPostEvidence(TestCase):
         ]
         mock_host.update_mr_note.return_value = {"id": 999}
 
-        with patch.object(pr_mod, "get_code_host", return_value=mock_host):
+        with patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host):
             result = cast(
                 "dict[str, object]",
                 call_command(
@@ -1686,7 +1686,7 @@ class TestPrPostEvidence(TestCase):
         mock_host.list_mr_notes.return_value = []
         mock_host.post_mr_note.return_value = {"id": 55}
 
-        with patch.object(pr_mod, "get_code_host", return_value=mock_host):
+        with patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host):
             cast(
                 "dict[str, object]",
                 call_command(
@@ -1712,7 +1712,7 @@ class TestPrPostEvidence(TestCase):
         mock_host.list_mr_notes.return_value = []
         mock_host.post_mr_note.return_value = {"id": 56}
 
-        with patch.object(pr_mod, "get_code_host", return_value=mock_host):
+        with patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host):
             cast(
                 "dict[str, object]",
                 call_command("pr", "post-evidence", "100", repo="my/repo", body="x", files=["/tmp/bad.png"]),
@@ -1728,7 +1728,7 @@ class TestPrPostEvidence(TestCase):
         mock_host.post_mr_note.return_value = {"id": 43}
         mock_host.list_mr_notes.return_value = []
 
-        with patch.object(pr_mod, "get_code_host", return_value=mock_host):
+        with patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host):
             cast(
                 "dict[str, object]",
                 call_command(
@@ -1750,7 +1750,7 @@ class TestPrPostEvidence(TestCase):
         mock_host.post_mr_note.return_value = {"id": 44}
         mock_host.list_mr_notes.return_value = []
 
-        with patch.object(pr_mod, "get_code_host", return_value=mock_host):
+        with patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host):
             call_command("pr", "post-evidence", "102", title="T")
 
         call_kwargs = mock_host.post_mr_note.call_args[1]
@@ -2100,7 +2100,7 @@ class TestE2eTriggerCi(TestCase):
         mock_ci = MagicMock()
         mock_ci.trigger_pipeline.return_value = {"pipeline_id": 123}
 
-        with patch.object(backends_loader_mod, "get_ci_service", return_value=mock_ci):
+        with patch.object(backend_factory_mod, "ci_service_from_overlay", return_value=mock_ci):
             result = cast("dict[str, object]", call_command("e2e", "trigger-ci"))
 
         assert result == {"pipeline_id": 123}
@@ -2116,7 +2116,7 @@ class TestE2eTriggerCi(TestCase):
         mock_ci = MagicMock()
         mock_ci.trigger_pipeline.return_value = {"pipeline_id": 456}
 
-        with patch.object(backends_loader_mod, "get_ci_service", return_value=mock_ci):
+        with patch.object(backend_factory_mod, "ci_service_from_overlay", return_value=mock_ci):
             cast("dict[str, object]", call_command("e2e", "trigger-ci", branch="feature-branch"))
 
         mock_ci.trigger_pipeline.assert_called_once_with(
@@ -2135,7 +2135,7 @@ class TestE2eTriggerCi(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
     def test_no_ci_service_returns_error(self) -> None:
-        with patch.object(backends_loader_mod, "get_ci_service", return_value=None):
+        with patch.object(backend_factory_mod, "ci_service_from_overlay", return_value=None):
             result = cast("dict[str, object]", call_command("e2e", "trigger-ci"))
 
         assert "error" in result

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -30,7 +30,7 @@ class TestPrCreate(TestCase):
     def test_reads_auto_labels_from_overlay(self) -> None:
         host = MagicMock()
         host.create_pr.return_value = {"iid": 12}
-        self._monkeypatch.setattr(pr_command, "get_code_host", lambda: host)
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
 
         ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/55")
         Worktree.objects.create(ticket=ticket, overlay="test", repo_path="/tmp/backend", branch="feature-branch")
@@ -59,7 +59,7 @@ class TestPostEvidence(TestCase):
         """post-evidence posts an MR note via the code host."""
         host = MagicMock()
         host.post_mr_note.return_value = {"id": 55}
-        self._monkeypatch.setattr(pr_command, "get_code_host", lambda: host)
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
 
         with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
             result = call_command("pr", "post-evidence", "10", "--body", "All tests pass")
@@ -72,7 +72,7 @@ class TestPostEvidence(TestCase):
 
     def test_returns_error_without_code_host(self) -> None:
         """post-evidence returns error when no code host configured."""
-        self._monkeypatch.setattr(pr_command, "get_code_host", lambda: None)
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: None)
 
         with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
             result = call_command("pr", "post-evidence", "10")

--- a/tests/test_cli_ci.py
+++ b/tests/test_cli_ci.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 import teatree.backends.gitlab_api as gitlab_api_mod
-import teatree.backends.loader as backends_loader_mod
+import teatree.core.backend_factory as backend_factory_mod
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.utils.git as git_mod
 from teatree.cli import app
@@ -19,16 +19,15 @@ runner = CliRunner()
 
 class TestGetCIService:
     def test_from_env(self, monkeypatch):
-        """Creates service from env when Django fails."""
+        """Creates service from env when overlay fails."""
         monkeypatch.setenv("GITLAB_TOKEN", "token")
-        with patch.object(backends_loader_mod, "get_ci_service", side_effect=Exception("no django")):
+        with patch.object(backend_factory_mod, "ci_service_from_overlay", side_effect=Exception("no django")):
             service = CICommands.get_ci_service()
             assert service is not None
 
     def test_no_token(self, monkeypatch):
         monkeypatch.delenv("GITLAB_TOKEN", raising=False)
-        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
-        with patch.object(backends_loader_mod, "get_ci_service", side_effect=Exception("no django")):
+        with patch.object(backend_factory_mod, "ci_service_from_overlay", side_effect=Exception("no django")):
             assert CICommands.get_ci_service() is None
 
 


### PR DESCRIPTION
## Summary

- Created `src/teatree/core/backend_factory.py` that bridges overlay config and backend instantiation
- `backends/loader.py` now accepts explicit token/url parameters — no more importing `get_overlay()` from core
- `backends/gitlab.py` `get_client()` requires explicit token/base_url (removed OverlayBase import)
- Updated all callers in `core/management/commands/` and `cli/` to use `backend_factory`
- Removed `teatree.core` from `teatree.backends` `depends_on` in `tach.toml`

Closes #101

## Test plan

- [x] 1726 tests pass
- [x] `tach check` passes — backends no longer depends on core
- [x] Pre-commit hooks pass