### PR TITLE
feat(hooks): auto-suggest retro via SessionEnd hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -76,6 +76,17 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook_router.py --event SessionEnd",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -484,6 +484,34 @@ def handle_post_compact(data: dict) -> None:
     json.dump({"additionalContext": context}, sys.stdout)
 
 
+def handle_session_end(data: dict) -> None:
+    """Suggest retro when lifecycle skills were loaded during the session."""
+    session_id = data.get("session_id", "")
+    if not session_id:
+        return
+
+    skills_file = STATE_DIR / f"{session_id}.skills"
+    if not skills_file.is_file():
+        return
+
+    loaded = {line.strip() for line in skills_file.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+    lifecycle_skills = {"t3:code", "t3:debug", "t3:test", "t3:ship", "t3:review", "t3:ticket"}
+    if not loaded & lifecycle_skills:
+        return
+
+    json.dump(
+        {
+            "additionalContext": (
+                "SESSION ENDING — lifecycle skills were loaded during this session "
+                f"({', '.join(sorted(loaded & lifecycle_skills))}). "
+                "Consider running /t3:retro to capture learnings before the session ends."
+            ),
+        },
+        sys.stdout,
+    )
+
+
 # ── Router ──────────────────────────────────────────────────────────
 
 _HANDLERS: dict[str, list] = {
@@ -492,6 +520,7 @@ _HANDLERS: dict[str, list] = {
     "PostToolUse": [handle_track_active_repo, handle_track_skill_usage, handle_read_dedup],
     "InstructionsLoaded": [handle_track_skill_usage],
     "PostCompact": [handle_post_compact],
+    "SessionEnd": [handle_session_end],
 }
 
 

--- a/tests/test_skill_tracking_hook.py
+++ b/tests/test_skill_tracking_hook.py
@@ -1,11 +1,14 @@
-"""Tests for skill tracking in the hook router (handle_track_skill_usage)."""
+"""Tests for skill tracking and session-end retro in the hook router."""
 
+import json
+from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 import hooks.scripts.hook_router as router
-from hooks.scripts.hook_router import handle_track_skill_usage
+from hooks.scripts.hook_router import handle_session_end, handle_track_skill_usage
 
 
 @pytest.fixture(autouse=True)
@@ -148,3 +151,56 @@ class TestPostToolUsePrecedence:
         )
         # Only the PostToolUse path fires — t3:debug from InstructionsLoaded is NOT tracked
         assert _read_skills("sess-20") == ["t3:code"]
+
+
+class TestSessionEndRetro:
+    """SessionEnd hook suggests retro when lifecycle skills were loaded."""
+
+    def test_suggests_retro_when_lifecycle_skills_loaded(self) -> None:
+        skills_file = router.STATE_DIR / "sess-end-1.skills"
+        skills_file.write_text("t3:code\nt3:test\n", encoding="utf-8")
+
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            handle_session_end({"session_id": "sess-end-1"})
+
+        output = json.loads(stdout.getvalue())
+        assert "retro" in output["additionalContext"].lower()
+        assert "t3:code" in output["additionalContext"]
+
+    def test_no_output_when_no_lifecycle_skills(self) -> None:
+        skills_file = router.STATE_DIR / "sess-end-2.skills"
+        skills_file.write_text("ac-python\nac-django\n", encoding="utf-8")
+
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            handle_session_end({"session_id": "sess-end-2"})
+
+        assert stdout.getvalue() == ""
+
+    def test_no_output_when_no_skills_file(self) -> None:
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            handle_session_end({"session_id": "sess-end-3"})
+
+        assert stdout.getvalue() == ""
+
+    def test_no_output_when_empty_session_id(self) -> None:
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            handle_session_end({"session_id": ""})
+
+        assert stdout.getvalue() == ""
+
+    def test_includes_only_lifecycle_skills_in_message(self) -> None:
+        skills_file = router.STATE_DIR / "sess-end-5.skills"
+        skills_file.write_text("t3:code\nac-python\nt3:review\n", encoding="utf-8")
+
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            handle_session_end({"session_id": "sess-end-5"})
+
+        output = json.loads(stdout.getvalue())
+        assert "t3:code" in output["additionalContext"]
+        assert "t3:review" in output["additionalContext"]
+        assert "ac-python" not in output["additionalContext"]


### PR DESCRIPTION
## Summary

- Added `SessionEnd` hook to `hooks.json` that fires `handle_session_end` in the hook router
- Handler checks if lifecycle skills were loaded during the session (via `.skills` file)
- If lifecycle skills found, injects `additionalContext` suggesting `/t3:retro`
- 5 new tests covering all paths (lifecycle skills loaded, non-lifecycle only, no file, empty session)

Closes #134

## Test plan

- [x] 1721 tests pass
- [x] Pre-commit hooks pass