### PR TITLE
fix(run): discover frontend port from running nx serve process

### DIFF
--- a/src/teatree/core/management/commands/run.py
+++ b/src/teatree/core/management/commands/run.py
@@ -1,4 +1,5 @@
 import os
+import re
 import socket
 import subprocess  # noqa: S404
 import urllib.request
@@ -48,8 +49,36 @@ def _resolve_private_tests_path() -> Path | None:
     return path if path.is_dir() else None
 
 
+def _detect_nx_serve_port(worktree_path: str) -> int | None:
+    """Find a running ``nx serve`` whose cwd matches *worktree_path* and extract ``--port``."""
+    result = subprocess.run(
+        ["ps", "axo", "args"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    for line in result.stdout.splitlines():
+        if "nx serve" not in line or "--port=" not in line:
+            continue
+        if worktree_path not in line:
+            continue
+        match = re.search(r"--port=(\d+)", line)
+        if match:
+            return int(match.group(1))
+    return None
+
+
 def _discover_frontend_port(project: str, default: int = 4200) -> int | None:
-    """Try docker-compose service, then fall back to local port check."""
+    """Try nx serve process match, then docker-compose, then local port check."""
+    from teatree.core.resolve import _find_env_worktree, _get_user_cwd  # noqa: PLC0415
+
+    cwd = _get_user_cwd()
+    envfile = _find_env_worktree(cwd)
+    if envfile is not None:
+        worktree_root = str(envfile.parent)
+        nx_port = _detect_nx_serve_port(worktree_root)
+        if nx_port is not None:
+            return nx_port
     port = get_service_port(project, "frontend", default)
     if port is not None:
         return port

--- a/tests/teatree_core/test_run_command.py
+++ b/tests/teatree_core/test_run_command.py
@@ -328,3 +328,68 @@ class TestCliOverlay:
         cmd = mock_run.call_args[0][0]
         assert "-m" in cmd
         assert "uvicorn" in cmd
+
+
+class TestDetectNxServePort:
+    def _ps_output(self, lines: list[str]) -> MagicMock:
+        result = MagicMock()
+        result.stdout = "\n".join(lines)
+        return result
+
+    def test_returns_port_when_nx_serve_matches_worktree_path(self) -> None:
+        ps_output = self._ps_output(
+            [
+                "node nx serve --port=4210 /home/user/tickets/my-ticket/frontend",
+            ]
+        )
+        with patch.object(run_mod.subprocess, "run", return_value=ps_output):
+            assert run_mod._detect_nx_serve_port("/home/user/tickets/my-ticket/frontend") == 4210
+
+    def test_returns_none_when_worktree_path_does_not_match(self) -> None:
+        ps_output = self._ps_output(
+            [
+                "node nx serve --port=4210 /home/user/tickets/other-ticket/frontend",
+            ]
+        )
+        with patch.object(run_mod.subprocess, "run", return_value=ps_output):
+            assert run_mod._detect_nx_serve_port("/home/user/tickets/my-ticket/frontend") is None
+
+    def test_returns_none_when_no_nx_serve_running(self) -> None:
+        ps_output = self._ps_output(["python manage.py runserver"])
+        with patch.object(run_mod.subprocess, "run", return_value=ps_output):
+            assert run_mod._detect_nx_serve_port("/any/path") is None
+
+
+class TestDiscoverFrontendPort:
+    def test_returns_nx_port_when_envfile_found_and_nx_running(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            envfile = Path(tmp) / ".env.worktree"
+            envfile.write_text("WT_VARIANT=acme\n", encoding="utf-8")
+            with (
+                patch("teatree.core.resolve._get_user_cwd", return_value=Path(tmp)),
+                patch("teatree.core.resolve._find_env_worktree", return_value=envfile),
+                patch.object(run_mod, "_detect_nx_serve_port", return_value=4215),
+            ):
+                assert run_mod._discover_frontend_port("my-project") == 4215
+
+    def test_falls_through_to_docker_port_when_nx_not_running(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            envfile = Path(tmp) / ".env.worktree"
+            envfile.write_text("WT_VARIANT=acme\n", encoding="utf-8")
+            with (
+                patch("teatree.core.resolve._get_user_cwd", return_value=Path(tmp)),
+                patch("teatree.core.resolve._find_env_worktree", return_value=envfile),
+                patch.object(run_mod, "_detect_nx_serve_port", return_value=None),
+                patch.object(run_mod, "get_service_port", return_value=4201),
+            ):
+                assert run_mod._discover_frontend_port("my-project") == 4201
+
+    def test_falls_through_to_local_port_when_no_envfile_and_no_docker(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch("teatree.core.resolve._get_user_cwd", return_value=Path(tmp)),
+            patch("teatree.core.resolve._find_env_worktree", return_value=None),
+            patch.object(run_mod, "get_service_port", return_value=None),
+            patch.object(run_mod, "_detect_local_port", return_value=4200),
+        ):
+            assert run_mod._discover_frontend_port("my-project") == 4200


### PR DESCRIPTION
## Summary

- `_discover_frontend_port` was falling back to scanning port 4200, which picks up another worktree's frontend when multiple worktrees run concurrently.
- Now matches the `nx serve` process whose command line contains the current worktree path and extracts `--port=XXXX` from the args.
- Aligns with the dynamic port architecture from #141 — ports are never stored in files or DB; they're discovered from running processes.

Supersedes #312 (stale branch with broken CI trigger).