### PR TITLE
feat(mr): add mr_close_ticket setting to prevent auto-closing issues (#309)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -771,6 +771,7 @@ Overlay-specific configuration that previously lived in `TEATREE_*` Django setti
 | `get_review_channel()` | `tuple[str, str]` | `("", "")` | `TEATREE_REVIEW_CHANNEL` + `TEATREE_REVIEW_CHANNEL_ID` |
 | `known_variants` | `list[str]` | `[]` | `TEATREE_KNOWN_VARIANTS` |
 | `mr_auto_labels` | `list[str]` | `[]` | `TEATREE_MR_AUTO_LABELS` |
+| `mr_close_ticket` | `bool` | `False` | `TEATREE_MR_CLOSE_TICKET` |
 | `frontend_repos` | `list[str]` | `[]` | `TEATREE_FRONTEND_REPOS` |
 | `dev_env_url` | `str` | `""` | `TEATREE_DEV_ENV_URL` |
 | `dashboard_logo` | `str` | `""` | `TEATREE_DASHBOARD_LOGO` |

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -13,6 +13,19 @@ from teatree.utils import git
 
 _IMAGE_URL_RE = re.compile(r"!\[([^\]]*)\]\((/uploads/[^\)]+)\)")
 _EXTERNAL_LINK_RE = re.compile(r"https?://(?:www\.)?(?:notion\.so|linear\.app|jira\.\S+)/\S+")
+_CLOSE_KEYWORD_RE = re.compile(r"\b(closes?|fixes?|resolves?)\s+(#\d+)", re.IGNORECASE)
+
+
+def _sanitize_close_keywords(description: str, *, close_ticket: bool) -> str:
+    """Replace GitLab auto-close keywords with a non-closing reference.
+
+    When *close_ticket* is ``False``, replaces ``Closes #N``, ``Fixes #N``,
+    ``Resolves #N`` (and their variants) with ``Relates to #N`` so the MR
+    does not auto-close the issue on merge.
+    """
+    if close_ticket:
+        return description
+    return _CLOSE_KEYWORD_RE.sub(r"Relates to \2", description)
 
 
 def _current_user() -> str:
@@ -83,6 +96,7 @@ class Command(TyperCommand):
                 description = commit_body
 
         overlay = get_overlay()
+        description = _sanitize_close_keywords(description, close_ticket=overlay.config.mr_close_ticket)
 
         if not skip_validation:
             gate_error = _check_shipping_gate(ticket)

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -61,6 +61,12 @@ class OverlayConfig:
     """GitHub Projects v2 board number (0 = not configured)."""
     require_ticket: bool = False
     """Whether to enforce a tracked issue before coding/shipping."""
+    mr_close_ticket: bool = False
+    """Whether MR descriptions should use auto-closing keywords (Closes #N).
+
+    When ``False`` (default), close keywords are replaced with ``Relates to #N``
+    so merging the MR does not auto-close the linked issue.
+    """
     known_variants: list[str]
     mr_auto_labels: list[str]
     frontend_repos: list[str]

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -6,7 +6,7 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from teatree.core.management.commands import pr as pr_command
-from teatree.core.management.commands.pr import _check_shipping_gate, _mr_auto_labels
+from teatree.core.management.commands.pr import _check_shipping_gate, _mr_auto_labels, _sanitize_close_keywords
 from teatree.core.models import Session, Ticket, Worktree
 from teatree.core.overlay_loader import reset_overlay_cache
 from tests.teatree_core.conftest import CommandOverlay
@@ -110,6 +110,28 @@ class TestCheckShippingGate(TestCase):
         assert "reviewing" in result["missing"]
         assert "testing" in result["missing"]
         assert "hint" in result
+
+
+class TestSanitizeCloseKeywords:
+    @pytest.mark.parametrize(
+        ("description", "expected"),
+        [
+            ("Closes #123", "Relates to #123"),
+            ("Fixes #42", "Relates to #42"),
+            ("Resolves #7", "Relates to #7"),
+            ("closes #123", "Relates to #123"),
+            ("fixes #42", "Relates to #42"),
+            ("resolves #7", "Relates to #7"),
+            ("See Closes #1 and Fixes #2", "See Relates to #1 and Relates to #2"),
+            ("No ticket ref here", "No ticket ref here"),
+            ("", ""),
+        ],
+    )
+    def test_replaces_close_keywords_when_close_ticket_false(self, description: str, expected: str) -> None:
+        assert _sanitize_close_keywords(description, close_ticket=False) == expected
+
+    def test_leaves_description_unchanged_when_close_ticket_true(self) -> None:
+        assert _sanitize_close_keywords("Closes #123", close_ticket=True) == "Closes #123"
 
 
 class TestMrAutoLabels:

--- a/uv.lock
+++ b/uv.lock
@@ -1105,7 +1105,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1114,9 +1114,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
feat(mr): add mr_close_ticket setting to prevent auto-closing issues (#309)

## Summary

- Add `OverlayConfig.mr_close_ticket: bool = False` — overlays opt in to auto-closing by setting it to `True`
- Add `_sanitize_close_keywords()` in `pr.py` to replace GitLab/GitHub auto-close keywords (`Closes/Fixes/Resolves #N`) with `Relates to #N` in MR descriptions when `mr_close_ticket` is `False`
- Wire sanitization into `t3 pr create` using the overlay's setting
- Document the new setting in `BLUEPRINT.md`

## Configuration

By default no ticket is auto-closed on merge. To opt in, set in your overlay settings module:

```python
MR_CLOSE_TICKET = True
```

Or in `~/.teatree.toml`:

```toml
[overlays.my-overlay]
mr_close_ticket = true
```

## Test plan

- [x] `TestSanitizeCloseKeywords` — parametrized across all keyword variants (`Closes`, `Fixes`, `Resolves`, lowercase, multiple refs), passthrough when `close_ticket=True`
- [x] Full test suite: 2034 passed, 0 failures
- [x] All pre-commit hooks passed (ruff, ty-check, banned-terms, BLUEPRINT sync)

Closes #309