### PR TITLE
feat(safety): block cleanup and commits when branch has unsynced commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,20 @@ default_stages: [commit, manual]
 fail_fast: true
 
 repos:
+  # Phase 0 - Safety
+  - repo: local
+    hooks:
+      - id: no-commit-on-merged-branch
+        name: Refuse commits on branches whose remote is gone (merged PR)
+        language: system
+        entry: >-
+          bash -c 'git branch -vv 2>/dev/null | grep -qE "^\*[[:space:]].*\[gone\]" && {
+          echo "teatree: remote tracking branch is gone (PR merged?). Push to a new branch or use --no-verify.";
+          exit 1; } || exit 0'
+        pass_filenames: false
+        always_run: true
+        stages: [commit]
+
   # Phase 1 - Init
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 5ab6bd930e86ba0e929eedcee2be458f6b8e4936  # 0.8.16

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -13,12 +13,16 @@ from teatree.utils.db import drop_db
 logger = logging.getLogger(__name__)
 
 
-def cleanup_worktree(worktree: Worktree) -> str:
+def cleanup_worktree(worktree: Worktree, *, force: bool = False) -> str:
     """Remove a single worktree: git worktree, branch, DB, overlay cleanup.
 
     Deletes the Worktree record from the database and returns a summary label.
     Errors in individual cleanup steps are suppressed so that partial cleanup
     still succeeds.
+
+    Raises ``RuntimeError`` when *force* is ``False`` and the branch has local
+    commits unreachable from any remote (unsynced work that would be lost).
+    Pass ``force=True`` only from trusted callers (e.g. tests, programmatic API).
     """
     workspace = load_config().user.workspace_dir
     wt_path = (worktree.extra or {}).get("worktree_path", "")
@@ -34,6 +38,15 @@ def cleanup_worktree(worktree: Worktree) -> str:
     if wt_path:
         repo_main = workspace / worktree.repo_path
         if repo_main.is_dir():
+            if not force:
+                unsynced = git.unsynced_commits(str(repo_main), worktree.branch)
+                if unsynced:
+                    msg = (
+                        f"{worktree.repo_path} ({worktree.branch}): "
+                        f"refused cleanup — {len(unsynced)} unsynced commit(s). "
+                        "Push them to a new branch or pass force=True."
+                    )
+                    raise RuntimeError(msg)
             git.worktree_remove(str(repo_main), wt_path)
             git.branch_delete(str(repo_main), worktree.branch)
 

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -63,6 +63,26 @@ def _is_squash_merged(repo: str, branch: str, default: str) -> bool:
     return not diff
 
 
+def _prune_squash_merged(repo: str, name: str, wt_map: dict[str, str]) -> str:
+    """Remove a confirmed squash-merged branch (and its worktree if linked).
+
+    Returns a status message — either a SKIPPED notice when unsynced commits
+    are present or a confirmation that the branch was pruned.
+    """
+    unsynced = git.unsynced_commits(repo, name)
+    if unsynced:
+        return (
+            f"SKIPPED '{name}': {len(unsynced)} unsynced commit(s) — "
+            "push to a new branch:\n  " + "\n  ".join(unsynced)
+        )
+    wt_path = wt_map.get(name, "")
+    if wt_path:
+        git.worktree_remove(repo, wt_path)
+        git.run(repo=repo, args=["worktree", "prune"])
+    git.branch_delete(repo, name)
+    return f"Pruned squash-merged branch: {name}"
+
+
 def _prune_branches(repo: str) -> list[str]:
     """Delete local branches that are gone or merged.
 
@@ -109,19 +129,7 @@ def _prune_branches(repo: str) -> list[str]:
     for name in sorted(all_branches - protected):
         if not _is_squash_merged(repo, name, default):
             continue
-        unsynced = git.unsynced_commits(repo, name)
-        if unsynced:
-            cleaned.append(
-                f"SKIPPED '{name}': {len(unsynced)} unsynced commit(s) — "
-                "push to a new branch:\n  " + "\n  ".join(unsynced)
-            )
-            continue
-        wt_path = wt_map.get(name, "")
-        if wt_path:
-            git.worktree_remove(repo, wt_path)
-            git.run(repo=repo, args=["worktree", "prune"])
-        git.branch_delete(repo, name)
-        cleaned.append(f"Pruned squash-merged branch: {name}")
+        cleaned.append(_prune_squash_merged(repo, name, wt_map))
 
     # Pass 4: warn about remaining non-protected branches with no merged PR.
     # Re-read after deletions above.

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -71,9 +71,8 @@ def _prune_squash_merged(repo: str, name: str, wt_map: dict[str, str]) -> str:
     """
     unsynced = git.unsynced_commits(repo, name)
     if unsynced:
-        return (
-            f"SKIPPED '{name}': {len(unsynced)} unsynced commit(s) — "
-            "push to a new branch:\n  " + "\n  ".join(unsynced)
+        return f"SKIPPED '{name}': {len(unsynced)} unsynced commit(s) — push to a new branch:\n  " + "\n  ".join(
+            unsynced
         )
     wt_path = wt_map.get(name, "")
     if wt_path:

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -109,6 +109,13 @@ def _prune_branches(repo: str) -> list[str]:
     for name in sorted(all_branches - protected):
         if not _is_squash_merged(repo, name, default):
             continue
+        unsynced = git.unsynced_commits(repo, name)
+        if unsynced:
+            cleaned.append(
+                f"SKIPPED '{name}': {len(unsynced)} unsynced commit(s) — "
+                "push to a new branch:\n  " + "\n  ".join(unsynced)
+            )
+            continue
         wt_path = wt_map.get(name, "")
         if wt_path:
             git.worktree_remove(repo, wt_path)

--- a/src/teatree/templates/overlay/.pre-commit-config.yaml.tmpl
+++ b/src/teatree/templates/overlay/.pre-commit-config.yaml.tmpl
@@ -3,6 +3,20 @@ default_stages: [commit, manual]
 fail_fast: true
 
 repos:
+  # Phase 0 - Safety
+  - repo: local
+    hooks:
+      - id: no-commit-on-merged-branch
+        name: Refuse commits on branches whose remote is gone (merged PR)
+        language: system
+        entry: >-
+          bash -c 'git branch -vv 2>/dev/null | grep -qE "^\*[[:space:]].*\[gone\]" && {
+          echo "teatree: remote tracking branch is gone (PR merged?). Push to a new branch or use --no-verify.";
+          exit 1; } || exit 0'
+        pass_filenames: false
+        always_run: true
+        stages: [commit]
+
   # Phase 1 - Init
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 5ab6bd930e86ba0e929eedcee2be458f6b8e4936  # 0.8.16

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -48,6 +48,16 @@ def log_oneline(repo: str = ".", range_spec: str = "") -> str:
     return run(repo=repo, args=["log", "--oneline", range_spec])
 
 
+def unsynced_commits(repo: str, branch: str) -> list[str]:
+    """Return one-line commit descriptions on *branch* not reachable from any remote.
+
+    An empty list means the branch is fully synced.
+    Uses ``git log <branch> --not --remotes --oneline``.
+    """
+    output = run(repo=repo, args=["log", branch, "--not", "--remotes", "--oneline"])
+    return [line for line in output.splitlines() if line.strip()]
+
+
 def status_porcelain(repo: str = ".") -> str:
     return run(repo=repo, args=["status", "--porcelain"])
 

--- a/tests/teatree_core/test_cleanup.py
+++ b/tests/teatree_core/test_cleanup.py
@@ -42,6 +42,7 @@ class TestCleanupWorktree(TestCase):
         _mock_workspace(mock_config)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = []
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         wt_id = wt.pk
@@ -106,3 +107,64 @@ class TestCleanupWorktree(TestCase):
         cleanup_worktree(wt)
 
         assert not Worktree.objects.filter(pk=wt_id).exists()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_raises_when_unsynced_commits_present(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        _mock_workspace(mock_config)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = ["abc123 chore: cve fix"]
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        with self.assertRaises(RuntimeError, msg="unsynced commit"):
+            cleanup_worktree(wt)
+
+        mock_git.worktree_remove.assert_not_called()
+        mock_git.branch_delete.assert_not_called()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_force_bypasses_unsynced_check(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        _mock_workspace(mock_config)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = ["abc123 chore: cve fix"]
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        cleanup_worktree(wt, force=True)
+
+        mock_git.worktree_remove.assert_called_once()
+        mock_git.branch_delete.assert_called_once()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_proceeds_normally_when_fully_synced(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        _mock_workspace(mock_config)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = []
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        cleanup_worktree(wt)
+
+        mock_git.worktree_remove.assert_called_once()
+        mock_git.branch_delete.assert_called_once()

--- a/tests/teatree_core/test_cleanup.py
+++ b/tests/teatree_core/test_cleanup.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.test import TestCase
 
 from teatree.core.cleanup import cleanup_worktree
@@ -123,7 +124,7 @@ class TestCleanupWorktree(TestCase):
         mock_git.unsynced_commits.return_value = ["abc123 chore: cve fix"]
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
-        with self.assertRaises(RuntimeError, msg="unsynced commit"):
+        with pytest.raises(RuntimeError, match="unsynced commit"):
             cleanup_worktree(wt)
 
         mock_git.worktree_remove.assert_not_called()

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -711,6 +711,7 @@ class TestWorkspaceCleanAll(TestCase):
             ):
                 mock_overlay.return_value.get_cleanup_steps.return_value = []
                 mock_git.status_porcelain.return_value = ""
+                mock_git.unsynced_commits.return_value = []
                 cleaned = cast("list[str]", call_command("workspace", "clean-all"))
 
             assert any("Cleaned: backend" in c for c in cleaned)
@@ -990,6 +991,72 @@ class TestPruneBranches(TestCase):
         assert any("squash-merged" in c for c in cleaned)
         mock_wt_rm.assert_called_once_with("/repo", "/tmp/old-worktree")
         mock_br_del.assert_called_once_with("/repo", "gone-branch")
+
+    def test_pass3_blocks_squash_merged_branch_with_unsynced_commits(self) -> None:
+        wt_map = {"gone-branch": "/tmp/old-worktree"}
+
+        def fake_run(*, repo: str = ".", args: list[str]) -> str:
+            if args == ["branch", "-v", "--no-color"]:
+                return "  gone-branch abc123 [gone] some msg"
+            if args == ["branch", "--merged", "origin/main", "--no-color"]:
+                return ""
+            if args == ["branch", "--no-color"]:
+                return "* main\n  gone-branch"
+            if args == ["worktree", "list", "--porcelain"]:
+                return "worktree /tmp/old-worktree\nHEAD abc123\nbranch refs/heads/gone-branch\n"
+            return ""
+
+        gh_merged = subprocess.CompletedProcess([], 0, stdout='[{"number":1}]')
+        with (
+            patch.object(workspace_mod, "_workspace_dir", return_value=Path("/tmp/ws")),
+            patch.object(workspace_mod, "_worktree_map", return_value=wt_map),
+            patch.object(workspace_mod, "_worktree_branches", return_value={"gone-branch"}),
+            patch.object(git_mod, "run", side_effect=fake_run),
+            patch.object(git_mod, "current_branch", return_value="main"),
+            patch.object(git_mod, "default_branch", return_value="main"),
+            patch.object(git_mod, "unsynced_commits", return_value=["abc123 chore: cve fix"]),
+            patch.object(git_mod, "worktree_remove", return_value=True) as mock_wt_rm,
+            patch.object(git_mod, "branch_delete", return_value=True) as mock_br_del,
+            patch("teatree.core.management.commands.workspace.subprocess.run", return_value=gh_merged),
+        ):
+            cleaned = workspace_mod._prune_branches("/repo")
+
+        assert any("SKIPPED" in c and "gone-branch" in c for c in cleaned)
+        mock_wt_rm.assert_not_called()
+        mock_br_del.assert_not_called()
+
+    def test_pass3_proceeds_normally_when_fully_synced(self) -> None:
+        wt_map = {"gone-branch": "/tmp/old-worktree"}
+
+        def fake_run(*, repo: str = ".", args: list[str]) -> str:
+            if args == ["branch", "-v", "--no-color"]:
+                return "  gone-branch abc123 [gone] some msg"
+            if args == ["branch", "--merged", "origin/main", "--no-color"]:
+                return ""
+            if args == ["branch", "--no-color"]:
+                return "* main\n  gone-branch"
+            if args == ["worktree", "list", "--porcelain"]:
+                return "worktree /tmp/old-worktree\nHEAD abc123\nbranch refs/heads/gone-branch\n"
+            return ""
+
+        gh_merged = subprocess.CompletedProcess([], 0, stdout='[{"number":1}]')
+        with (
+            patch.object(workspace_mod, "_workspace_dir", return_value=Path("/tmp/ws")),
+            patch.object(workspace_mod, "_worktree_map", return_value=wt_map),
+            patch.object(workspace_mod, "_worktree_branches", return_value={"gone-branch"}),
+            patch.object(git_mod, "run", side_effect=fake_run),
+            patch.object(git_mod, "current_branch", return_value="main"),
+            patch.object(git_mod, "default_branch", return_value="main"),
+            patch.object(git_mod, "unsynced_commits", return_value=[]),
+            patch.object(git_mod, "worktree_remove", return_value=True) as mock_wt_rm,
+            patch.object(git_mod, "branch_delete", return_value=True) as mock_br_del,
+            patch("teatree.core.management.commands.workspace.subprocess.run", return_value=gh_merged),
+        ):
+            cleaned = workspace_mod._prune_branches("/repo")
+
+        assert any("squash-merged" in c for c in cleaned)
+        mock_wt_rm.assert_called_once()
+        mock_br_del.assert_called_once()
 
 
 class TestPruneBranchesPassOneAndTwo(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1161,3 +1161,33 @@ class TestGitLabAPICacheHits:
         client.clear_response_cache()
         client.current_username()
         assert len(calls) == 2
+
+
+class TestUnsyncedCommits:
+    def test_returns_empty_list_when_fully_synced(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            git.subprocess,
+            "run",
+            lambda *_a, **_k: CompletedProcess([], 0, stdout="", stderr=""),
+        )
+        assert git.unsynced_commits("/repo", "feature") == []
+
+    def test_returns_commit_lines_when_commits_exist(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        output = "abc123 chore: cve fix\ndef456 feat: add something\n"
+        monkeypatch.setattr(
+            git.subprocess,
+            "run",
+            lambda *_a, **_k: CompletedProcess([], 0, stdout=output, stderr=""),
+        )
+        result = git.unsynced_commits("/repo", "feature")
+        assert result == ["abc123 chore: cve fix", "def456 feat: add something"]
+
+    def test_filters_blank_lines_from_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        output = "abc123 fix something\n\n   \ndef456 another fix\n"
+        monkeypatch.setattr(
+            git.subprocess,
+            "run",
+            lambda *_a, **_k: CompletedProcess([], 0, stdout=output, stderr=""),
+        )
+        result = git.unsynced_commits("/repo", "feature")
+        assert result == ["abc123 fix something", "def456 another fix"]


### PR DESCRIPTION
## Summary

- Adds \`git.unsynced_commits()\` — checks \`git log <branch> --not --remotes --oneline\`
- **Detection**: \`_prune_branches\` Pass 3 skips squash-merged branches with unsynced commits
- **Detection**: \`cleanup_worktree\` raises \`RuntimeError\` on unsynced commits (\`force=True\` in Python API only)
- **Prevention**: Phase 0 prek hook in both \`.pre-commit-config.yaml\` files refuses commits on branches whose tracking remote is \`[gone]\` (merged PR)

## Root cause

During a worktree audit, a CVE fix commit was found only in a local worktree whose PR had already merged and the remote branch deleted. \`clean-all\` would have silently lost this work.

## Test plan

- [x] \`TestUnsyncedCommits\` — 3 unit tests
- [x] \`TestCleanupWorktree\` — 3 new cases (raises, force bypasses, synced proceeds)
- [x] \`TestPruneBranches\` — 2 new cases (blocks unsynced, allows synced)
- [x] 2053 tests pass