### PR TITLE
fix(run): discover frontend port from running nx serve process

### DIFF
--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -1,6 +1,7 @@
 """E2E test commands: trigger CI, run from external repo, run from project."""
 
 import os
+import re
 import socket
 import subprocess  # noqa: S404
 from dataclasses import dataclass, field
@@ -46,6 +47,30 @@ def _detect_local_port(port: int) -> int | None:
     return None
 
 
+def _detect_nx_serve_port(worktree_path: str) -> int | None:
+    """Find a running ``nx serve`` whose args contain *worktree_path* and extract ``--port``.
+
+    Prevents multi-worktree port collisions: a plain port scan finds the first
+    listening process and can pick up another worktree's frontend. Matching by
+    worktree path ensures we discover the right ``nx serve`` instance.
+    """
+    result = subprocess.run(  # noqa: S603
+        ["ps", "axo", "args"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    for line in result.stdout.splitlines():
+        if "nx serve" not in line or "--port=" not in line:
+            continue
+        if worktree_path not in line:
+            continue
+        match = re.search(r"--port=(\d+)", line)
+        if match:
+            return int(match.group(1))
+    return None
+
+
 def _clone_or_update_e2e_repo(repo: E2ERepo) -> Path:
     """Clone or update an external E2E repo to the local cache and return the playwright root.
 
@@ -80,7 +105,18 @@ def _resolve_private_tests_path() -> Path | None:
 
 
 def _discover_frontend_port(project: str, default: int = 4200) -> int | None:
-    """Discover frontend port: docker-compose → local port scan (4200-4210)."""
+    """Discover frontend port: nx serve match → docker-compose → local port scan.
+
+    nx serve process matching is tried first when a worktree env file is found.
+    A plain port scan would return the first listening port in the range, which
+    in multi-worktree setups can be another worktree's frontend.
+    """
+    cwd = _get_user_cwd()
+    envfile = _find_env_worktree(cwd)
+    if envfile is not None:
+        nx_port = _detect_nx_serve_port(str(envfile.parent))
+        if nx_port is not None:
+            return nx_port
     port = get_service_port(project, "frontend", default)
     if port is not None:
         return port

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -54,7 +54,7 @@ def _detect_nx_serve_port(worktree_path: str) -> int | None:
     listening process and can pick up another worktree's frontend. Matching by
     worktree path ensures we discover the right ``nx serve`` instance.
     """
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         ["ps", "axo", "args"],
         capture_output=True,
         text=True,

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -2424,13 +2424,61 @@ class TestDetectLocalPort:
             assert e2e_mod._detect_local_port(8080) is None
 
 
+class TestDetectNxServePort:
+    def _ps_output(self, lines: list[str]) -> MagicMock:
+        result = MagicMock()
+        result.stdout = "\n".join(lines)
+        return result
+
+    def test_returns_port_when_nx_serve_matches_worktree_path(self) -> None:
+        ps_output = self._ps_output(
+            ["node nx serve --port=4210 /home/user/tickets/my-ticket/frontend"]
+        )
+        with patch.object(e2e_mod.subprocess, "run", return_value=ps_output):
+            assert e2e_mod._detect_nx_serve_port("/home/user/tickets/my-ticket/frontend") == 4210
+
+    def test_returns_none_when_worktree_path_does_not_match(self) -> None:
+        ps_output = self._ps_output(
+            ["node nx serve --port=4210 /home/user/tickets/other-ticket/frontend"]
+        )
+        with patch.object(e2e_mod.subprocess, "run", return_value=ps_output):
+            assert e2e_mod._detect_nx_serve_port("/home/user/tickets/my-ticket/frontend") is None
+
+    def test_returns_none_when_no_nx_serve_running(self) -> None:
+        ps_output = self._ps_output(["python manage.py runserver"])
+        with patch.object(e2e_mod.subprocess, "run", return_value=ps_output):
+            assert e2e_mod._detect_nx_serve_port("/any/path") is None
+
+
+_no_envfile = patch("teatree.core.management.commands.e2e._find_env_worktree", return_value=None)
+
+
 class TestDiscoverFrontendPort:
-    def test_returns_docker_port_when_available(self) -> None:
-        with patch.object(e2e_mod, "get_service_port", return_value=4201):
+    def test_returns_nx_port_when_nx_running_in_worktree(self) -> None:
+        with (
+            patch.object(e2e_mod, "_find_env_worktree", return_value=Path("/wt/.env.worktree")),
+            patch.object(e2e_mod, "_detect_nx_serve_port", return_value=4215),
+        ):
+            assert e2e_mod._discover_frontend_port("project") == 4215
+
+    def test_returns_docker_port_when_nx_not_running(self) -> None:
+        with (
+            patch.object(e2e_mod, "_find_env_worktree", return_value=Path("/wt/.env.worktree")),
+            patch.object(e2e_mod, "_detect_nx_serve_port", return_value=None),
+            patch.object(e2e_mod, "get_service_port", return_value=4201),
+        ):
             assert e2e_mod._discover_frontend_port("project") == 4201
 
-    def test_scans_local_ports_as_fallback(self) -> None:
+    def test_returns_docker_port_when_no_envfile(self) -> None:
         with (
+            _no_envfile,
+            patch.object(e2e_mod, "get_service_port", return_value=4201),
+        ):
+            assert e2e_mod._discover_frontend_port("project") == 4201
+
+    def test_scans_local_ports_as_final_fallback(self) -> None:
+        with (
+            _no_envfile,
             patch.object(e2e_mod, "get_service_port", return_value=None),
             patch.object(e2e_mod, "_detect_local_port", side_effect=lambda p: 4203 if p == 4203 else None),
         ):
@@ -2438,6 +2486,7 @@ class TestDiscoverFrontendPort:
 
     def test_returns_none_when_no_port_found(self) -> None:
         with (
+            _no_envfile,
             patch.object(e2e_mod, "get_service_port", return_value=None),
             patch.object(e2e_mod, "_detect_local_port", return_value=None),
         ):

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -2431,16 +2431,12 @@ class TestDetectNxServePort:
         return result
 
     def test_returns_port_when_nx_serve_matches_worktree_path(self) -> None:
-        ps_output = self._ps_output(
-            ["node nx serve --port=4210 /home/user/tickets/my-ticket/frontend"]
-        )
+        ps_output = self._ps_output(["node nx serve --port=4210 /home/user/tickets/my-ticket/frontend"])
         with patch.object(e2e_mod.subprocess, "run", return_value=ps_output):
             assert e2e_mod._detect_nx_serve_port("/home/user/tickets/my-ticket/frontend") == 4210
 
     def test_returns_none_when_worktree_path_does_not_match(self) -> None:
-        ps_output = self._ps_output(
-            ["node nx serve --port=4210 /home/user/tickets/other-ticket/frontend"]
-        )
+        ps_output = self._ps_output(["node nx serve --port=4210 /home/user/tickets/other-ticket/frontend"])
         with patch.object(e2e_mod.subprocess, "run", return_value=ps_output):
             assert e2e_mod._detect_nx_serve_port("/home/user/tickets/my-ticket/frontend") is None
 


### PR DESCRIPTION
## Summary

- Adds \`_detect_nx_serve_port(worktree_path)\` to \`e2e.py\` — scans running processes for \`nx serve --port=N\` matching the current worktree path
- Updates \`_discover_frontend_port\` priority: nx serve match → docker-compose → local port scan
- The previous fallback (scanning 4200-4210) would return the first listening port in the range, picking up another worktree's frontend in multi-worktree setups

## Background

This work was in the \`fix/e2e-frontend-port-discovery-v2\` worktree branch (remote gone, PR merged). The original commits conflicted due to \`_discover_frontend_port\` having moved from \`run.py\` to \`e2e.py\` during the intervening refactor. The feature is still needed — the bug still exists in the current fallback.

## Test plan

- [x] \`TestDetectNxServePort\` — 3 tests: matches by path, wrong path returns None, no nx serve returns None
- [x] \`TestDiscoverFrontendPort\` — 5 tests: nx match wins, falls through to Docker, falls through to port scan, no port returns None
- [x] 2050 tests pass