### PR TITLE
feat(hooks): block direct infrastructure commands in PreToolUse

### DIFF
--- a/dev/test-matrix.sh
+++ b/dev/test-matrix.sh
@@ -30,6 +30,7 @@ for py in "${versions[@]}"; do
     mkdir -p "$venv_dir"
     if docker run --rm \
         --user "$(id -u):$(id -g)" \
+        -e HOME=/tmp \
         -v "$PWD":/app:ro \
         -v "${venv_dir}":/tmp/.venv \
         -v "${CACHE_DIR}/uv":/tmp/.uv \

--- a/dev/test-matrix.sh
+++ b/dev/test-matrix.sh
@@ -29,6 +29,7 @@ for py in "${versions[@]}"; do
     venv_dir="${CACHE_DIR}/venv-${py}"
     mkdir -p "$venv_dir"
     if docker run --rm \
+        --user "$(id -u):$(id -g)" \
         -v "$PWD":/app:ro \
         -v "${venv_dir}":/tmp/.venv \
         -v "${CACHE_DIR}/uv":/tmp/.uv \

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -51,6 +51,58 @@ _T3_CLI_REMINDER = (
     "If a `t3` command fails, fix the `t3` code — do not work around it."
 )
 
+# Commands that are legitimate t3 CLI invocations — never block these.
+_T3_CMD_PREFIX_RE = re.compile(
+    r"^(?:\w+=\S+\s+)*(?:uv\s+run\s+)?t3\s",
+)
+
+# Read-only commands that may mention infrastructure tools as arguments
+# (e.g. grep for 'playwright', echo about manage.py) — never block these.
+_READONLY_CMD_PREFIX_RE = re.compile(
+    r"^(?:echo|printf|cat|grep|rg|awk|sed|head|tail|less|wc|file|#)",
+)
+
+# Forbidden command patterns → deny messages.  Each entry is
+# (compiled regex matching the Bash command, human-readable deny reason).
+_BLOCKED_COMMANDS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"manage\.py\s+runserver"),
+        "BLOCKED: `manage.py runserver` — use `t3 <overlay> lifecycle start` instead.",
+    ),
+    (
+        re.compile(r"manage\.py\s+migrate"),
+        "BLOCKED: `manage.py migrate` — use `t3 <overlay> lifecycle setup` instead.",
+    ),
+    (
+        re.compile(r"\bnx\s+serve\b"),
+        "BLOCKED: `nx serve` — use `t3 <overlay> lifecycle start` instead.",
+    ),
+    (
+        re.compile(r"\bdocker\s+compose\s+(?:up|start)\b"),
+        "BLOCKED: `docker compose up/start` — use `t3 <overlay> lifecycle start` instead.",
+    ),
+    (
+        re.compile(r"\b(?:createdb|dropdb)\b"),
+        "BLOCKED: `createdb`/`dropdb` — use `t3 <overlay> db reset` instead.",
+    ),
+    (
+        re.compile(r"\b(?:npx\s+)?playwright\s+test\b"),
+        "BLOCKED: `playwright test` — use `t3 <overlay> e2e` instead.",
+    ),
+    (
+        re.compile(r"\bnpm\s+run\b"),
+        "BLOCKED: `npm run` — use `t3 <overlay> run frontend` instead.",
+    ),
+    (
+        re.compile(r"\b(?:pipenv|pip)\s+install\b"),
+        "BLOCKED: `pip/pipenv install` — use `t3 <overlay> lifecycle setup` instead.",
+    ),
+    (
+        re.compile(r"\b(?:pg_restore|pg_dump|dslr)\b"),
+        "BLOCKED: `pg_restore`/`pg_dump`/`dslr` — use `t3 <overlay> db refresh` instead.",
+    ),
+]
+
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Unified hook router")
@@ -154,26 +206,27 @@ def handle_user_prompt_submit(data: dict) -> None:
 # ── PreToolUse: enforce-skill-loading ───────────────────────────────
 
 
-def handle_enforce_skill_loading(data: dict) -> None:
+def handle_enforce_skill_loading(data: dict) -> bool:
     """Block Bash/Edit/Write when suggested skills haven't been loaded."""
     session_id = data.get("session_id", "")
     if not session_id:
-        return
+        return False
 
     pending_lines = _read_lines(_state_file(session_id, "pending"))
     if not pending_lines:
-        return
+        return False
 
     loaded = set(_read_lines(_state_file(session_id, "skills")))
     unloaded = [f"/{s}" for s in pending_lines if s not in loaded]
     if not unloaded:
-        return
+        return False
 
     reason = (
         f"SKILL LOADING ENFORCEMENT: You MUST load these skills first: {' '.join(unloaded)}. "
         "Call the Skill tool for each one BEFORE calling Bash/Edit/Write."
     )
     json.dump({"permissionDecision": "deny", "permissionDecisionReason": reason}, sys.stdout)
+    return True
 
 
 # ── PreToolUse: protect-default-branch ─────────────────────────────
@@ -200,15 +253,15 @@ def _load_protected_branches() -> set[str]:
     return branches
 
 
-def handle_protect_default_branch(data: dict) -> None:
+def handle_protect_default_branch(data: dict) -> bool:
     """Block Edit/Write on files that live on a protected branch."""
     tool_name = data.get("tool_name", "")
     if tool_name not in _FILE_PATH_TOOLS:
-        return
+        return False
 
     file_path = data.get("tool_input", {}).get("file_path", "")
     if not file_path:
-        return
+        return False
 
     parent = str(Path(file_path).parent)
     try:
@@ -219,7 +272,7 @@ def handle_protect_default_branch(data: dict) -> None:
             stderr=subprocess.DEVNULL,
         ).strip()
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
-        return
+        return False
 
     if branch in _load_protected_branches():
         json.dump(
@@ -232,6 +285,8 @@ def handle_protect_default_branch(data: dict) -> None:
             },
             sys.stdout,
         )
+        return True
+    return False
 
 
 # ── PreToolUse: validate-mr-metadata ────────────────────────────────
@@ -255,15 +310,15 @@ def _extract_mr_fields(data: dict) -> tuple[str, str]:
     return "", ""
 
 
-def handle_validate_mr_metadata(data: dict) -> None:
+def handle_validate_mr_metadata(data: dict) -> bool:
     """Validate MR title/description against project-specific rules."""
     validate_script = os.environ.get("T3_MR_VALIDATE_SCRIPT", "")
     if not validate_script or not Path(validate_script).is_file():
-        return
+        return False
 
     title, description = _extract_mr_fields(data)
     if not title:
-        return
+        return False
 
     try:
         subprocess.run(  # noqa: S603
@@ -278,8 +333,10 @@ def handle_validate_mr_metadata(data: dict) -> None:
             {"permissionDecision": "deny", "permissionDecisionReason": exc.stdout or exc.stderr},
             sys.stdout,
         )
+        return True
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
+    return False
 
 
 # ── PostToolUse: track-active-repo ──────────────────────────────────
@@ -512,11 +569,53 @@ def handle_session_end(data: dict) -> None:
     )
 
 
+# ── PreToolUse: block-direct-commands ────────────────────────────────
+
+
+def handle_block_direct_commands(data: dict) -> bool:
+    """Block Bash commands that bypass the t3 CLI.
+
+    Returns True when a deny was emitted (caller should stop the handler chain).
+    """
+    if data.get("tool_name") != "Bash":
+        return False
+
+    command = data.get("tool_input", {}).get("command", "")
+    if not command:
+        return False
+
+    stripped = command.lstrip()
+
+    # Never block legitimate t3 invocations.
+    if _T3_CMD_PREFIX_RE.match(stripped):
+        return False
+
+    # Never block read-only commands that may mention tools in arguments.
+    if _READONLY_CMD_PREFIX_RE.match(stripped):
+        return False
+
+    for pattern, reason in _BLOCKED_COMMANDS:
+        if pattern.search(command):
+            suffix = " If `t3` fails, fix the CLI — do not work around it."
+            json.dump(
+                {"permissionDecision": "deny", "permissionDecisionReason": reason + suffix},
+                sys.stdout,
+            )
+            return True
+
+    return False
+
+
 # ── Router ──────────────────────────────────────────────────────────
 
 _HANDLERS: dict[str, list] = {
     "UserPromptSubmit": [handle_user_prompt_submit],
-    "PreToolUse": [handle_protect_default_branch, handle_enforce_skill_loading, handle_validate_mr_metadata],
+    "PreToolUse": [
+        handle_protect_default_branch,
+        handle_enforce_skill_loading,
+        handle_block_direct_commands,
+        handle_validate_mr_metadata,
+    ],
     "PostToolUse": [handle_track_active_repo, handle_track_skill_usage, handle_read_dedup],
     "InstructionsLoaded": [handle_track_skill_usage],
     "PostCompact": [handle_post_compact],
@@ -535,7 +634,10 @@ def main() -> None:
         return
 
     for handler in handlers:
-        handler(data)
+        # Handlers that return True emitted a deny — stop the chain to avoid
+        # writing multiple JSON objects to stdout (which would be invalid JSON).
+        if handler(data) is True:
+            break
 
 
 if __name__ == "__main__":

--- a/tests/teatree_core/test_run_command.py
+++ b/tests/teatree_core/test_run_command.py
@@ -294,7 +294,7 @@ class TestCliOverlay:
 
         assert mock_run.call_count == 1
         cmd = mock_run.call_args[0][0]
-        assert cmd[0].endswith("/uv")
+        assert Path(cmd[0]).name == "uv"
         assert cmd[1:3] == ["--directory", str(tmp_path)]
         assert cmd[-2:] == ["migrate", "--no-input"]
 
@@ -308,7 +308,7 @@ class TestCliOverlay:
 
         assert mock_run.call_count == 1
         cmd = mock_run.call_args[0][0]
-        assert cmd[0].endswith("/uv")
+        assert Path(cmd[0]).name == "uv"
         assert cmd[1:3] == ["--directory", str(tmp_path)]
         assert "uvicorn" in cmd
         assert "teatree.asgi:application" in cmd

--- a/tests/test_bash_command_blocker.py
+++ b/tests/test_bash_command_blocker.py
@@ -1,0 +1,164 @@
+"""Tests for PreToolUse Bash command blocker in hook_router.
+
+Verifies that forbidden infrastructure commands (manage.py, playwright, docker compose, etc.)
+are denied with a specific t3 alternative, while legitimate t3 and git commands pass through.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import handle_block_direct_commands
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state_dir(tmp_path: Path):
+    original = router.STATE_DIR
+    router.STATE_DIR = tmp_path / "state"
+    router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    yield
+    router.STATE_DIR = original
+
+
+def _bash_event(command: str, tool_name: str = "Bash") -> dict:
+    return {
+        "session_id": "sess-block",
+        "tool_name": tool_name,
+        "tool_input": {"command": command},
+    }
+
+
+def _parse_deny(capsys: pytest.CaptureFixture[str]) -> dict | None:
+    output = capsys.readouterr().out.strip()
+    if not output:
+        return None
+    return json.loads(output)
+
+
+class TestBlocksForbiddenCommands:
+    """Forbidden infrastructure commands are denied with specific t3 alternatives."""
+
+    @pytest.mark.parametrize(
+        ("command", "expected_fragment"),
+        [
+            ("python manage.py runserver", "lifecycle start"),
+            ("./manage.py runserver 0.0.0.0:8000", "lifecycle start"),
+            ("python manage.py migrate", "lifecycle setup"),
+            ("./manage.py migrate --run-syncdb", "lifecycle setup"),
+            ("nx serve my-app", "lifecycle start"),
+            ("docker compose up -d", "lifecycle start"),
+            ("docker compose start", "lifecycle start"),
+            ("createdb mydb", "db"),
+            ("dropdb mydb", "db"),
+            ("npx playwright test", "e2e"),
+            ("playwright test --headed", "e2e"),
+            ("npm run serve", "run"),
+            ("npm run start", "run"),
+            ("pipenv install requests", "lifecycle setup"),
+            ("pip install -r requirements.txt", "lifecycle setup"),
+            ("pg_restore -d mydb dump.sql", "db"),
+            ("pg_dump mydb > dump.sql", "db"),
+            ("dslr snapshot mydb", "db"),
+        ],
+    )
+    def test_denies_with_t3_alternative(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        command: str,
+        expected_fragment: str,
+    ) -> None:
+        result = handle_block_direct_commands(_bash_event(command))
+        assert result is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert deny["permissionDecision"] == "deny"
+        assert expected_fragment in deny["permissionDecisionReason"]
+
+    def test_deny_message_includes_blocked_command(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        handle_block_direct_commands(_bash_event("python manage.py runserver"))
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert "manage.py runserver" in deny["permissionDecisionReason"]
+
+
+class TestAllowsLegitimateCommands:
+    """Legitimate t3, git, and general commands pass through."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "t3 myapp lifecycle start",
+            "uv run t3 teatree lifecycle setup",
+            "PYENV_VERSION=3.13.11 t3 myapp e2e external",
+            "git status",
+            "git push origin main",
+            "ruff check src/",
+            "uv run pytest --no-cov -x",
+            "ls -la",
+            "echo 'manage.py runserver is not allowed'",
+            "cat README.md",
+            "grep -r 'playwright' .",
+        ],
+    )
+    def test_allows_command(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        command: str,
+    ) -> None:
+        result = handle_block_direct_commands(_bash_event(command))
+        assert result is not True
+        output = capsys.readouterr().out.strip()
+        assert output == ""
+
+    def test_ignores_non_bash_tools(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        result = handle_block_direct_commands(_bash_event("manage.py runserver", tool_name="Read"))
+        assert result is not True
+        assert capsys.readouterr().out.strip() == ""
+
+
+class TestHandlerChainStopsAfterDeny:
+    """The router stops running handlers after the first deny."""
+
+    def test_second_handler_not_called_after_deny(self) -> None:
+        call_log: list[str] = []
+
+        def handler_deny(data: dict) -> bool:
+            call_log.append("deny")
+            return True
+
+        def handler_pass(data: dict) -> bool:
+            call_log.append("pass")
+            return False
+
+        handlers = [handler_deny, handler_pass]
+        for handler in handlers:
+            if handler({}) is True:
+                break
+
+        assert call_log == ["deny"]
+
+    def test_all_handlers_run_when_none_deny(self) -> None:
+        call_log: list[str] = []
+
+        def handler_a(data: dict) -> bool:
+            call_log.append("a")
+            return False
+
+        def handler_b(data: dict) -> bool:
+            call_log.append("b")
+            return False
+
+        handlers = [handler_a, handler_b]
+        for handler in handlers:
+            if handler({}) is True:
+                break
+
+        assert call_log == ["a", "b"]

--- a/tests/test_cli_overlay.py
+++ b/tests/test_cli_overlay.py
@@ -106,7 +106,7 @@ class TestUvicorn:
             _uvicorn_fn(tmp_path, "127.0.0.1", 8000, "myapp.settings")
             mock_run.assert_called_once()
             call_args = mock_run.call_args[0][0]
-            assert call_args[0].endswith("/uv")
+            assert Path(call_args[0]).name == "uv"
             assert call_args[1:3] == ["--directory", str(tmp_path)]
             assert "uvicorn" in str(call_args)
             assert "teatree.asgi:application" in str(call_args)


### PR DESCRIPTION
## Summary

- Add `handle_block_direct_commands()` PreToolUse handler that inspects Bash `tool_input["command"]` and denies forbidden infrastructure commands (`manage.py runserver`, `playwright test`, `docker compose up`, `createdb`, `npm run`, etc.) with specific `t3` alternatives
- Fix handler chain to stop after the first deny — prevents invalid concatenated JSON on stdout (pre-existing bug)
- Update all deny handlers (`handle_protect_default_branch`, `handle_enforce_skill_loading`, `handle_validate_mr_metadata`) to return `bool` for chain control
- Fix Docker test-matrix UID/GID portability: `--user "$(id -u):$(id -g)"` + `HOME=/tmp`
- Fix pre-existing flaky `endswith("/uv")` assertions in Docker (use `Path.name`)

## Test plan

- [x] 33 new tests covering blocked commands, allowed commands, and handler chain semantics
- [x] Full test suite passes locally (2098 tests)
- [x] Docker test matrix passes (pre-push hook)
- [x] ruff check + ruff format clean

Fixes [#321](https://github.com/souliane/teatree/issues/321)