### PR TITLE
feat: singleton guard for dashboard server (PID file)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -633,7 +633,7 @@ Each registered overlay gets a subcommand group (e.g., `t3 acme`). Commands dele
 - `t3 <overlay> daily` — sync MRs, check gates, remind reviewers
 - `t3 <overlay> full-status` — ticket/worktree/session summary
 - `t3 <overlay> agent [TASK]` — launch Claude Code with overlay context
-- `t3 dashboard [--project PATH]` — start dashboard via uvicorn (use `--project` to serve from a worktree)
+- `t3 dashboard [--project PATH] [--stop]` — start dashboard via uvicorn (singleton: kills existing server first; `--stop` to stop without starting)
 - `t3 <overlay> resetdb` — drop and recreate SQLite database
 - `t3 <overlay> worker` — start background task workers
 

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -4,8 +4,10 @@ DB-touching commands are django-typer management commands, exposed here after
 ``django.setup()``.  Django-free commands live as plain Typer groups.
 """
 
+import contextlib
 import logging
 import os
+import signal
 import subprocess  # noqa: S404
 import sys
 from datetime import UTC
@@ -471,6 +473,44 @@ def _find_overlay_project() -> Path:
     return _find_project_root()
 
 
+class DashboardGuard:
+    """Singleton guard for the dashboard server using a PID file."""
+
+    def __init__(self, pid_file: Path) -> None:
+        self._pid_file = pid_file
+
+    def _read_pid(self) -> int | None:
+        try:
+            pid = int(self._pid_file.read_text().strip())
+        except (FileNotFoundError, ValueError):
+            return None
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            self._pid_file.unlink(missing_ok=True)
+            return None
+        return pid
+
+    def stop_existing(self) -> bool:
+        """Kill an existing dashboard process. Returns True if one was stopped."""
+        pid = self._read_pid()
+        if pid is None:
+            return False
+        typer.echo(f"Stopping existing dashboard (PID {pid})...")
+        os.kill(pid, signal.SIGTERM)
+        with contextlib.suppress(ChildProcessError):
+            os.waitpid(pid, 0)
+        self._pid_file.unlink(missing_ok=True)
+        return True
+
+    def write_pid(self) -> None:
+        self._pid_file.parent.mkdir(parents=True, exist_ok=True)
+        self._pid_file.write_text(str(os.getpid()))
+
+    def cleanup(self) -> None:
+        self._pid_file.unlink(missing_ok=True)
+
+
 @app.command()
 def dashboard(
     host: str = typer.Option("127.0.0.1", help="Host to bind to"),
@@ -478,11 +518,24 @@ def dashboard(
     *,
     project: Path | None = typer.Option(None, help="Project root to serve from (worktree path)."),
     workers: int = typer.Option(1, help="Number of background task workers to start (0 to disable)"),
+    stop: bool = typer.Option(False, "--stop", help="Stop the running dashboard and exit."),
 ) -> None:
     """Migrate the database and start the dashboard dev server."""
     import socket  # noqa: PLC0415
 
     from teatree.cli.overlay import uv_cmd  # noqa: PLC0415
+    from teatree.config import DATA_DIR  # noqa: PLC0415
+
+    guard = DashboardGuard(DATA_DIR / "dashboard.pid")
+
+    if stop:
+        if guard.stop_existing():
+            typer.echo("Dashboard stopped.")
+        else:
+            typer.echo("No running dashboard found.")
+        return
+
+    guard.stop_existing()
 
     project_path, overlay_name, settings_module = _resolve_overlay_for_server(project=project)
     managepy(project_path, "migrate", "--no-input", overlay_name=overlay_name)
@@ -495,6 +548,8 @@ def dashboard(
             actual_port = s2.getsockname()[1]
             s2.close()
             typer.echo(f"Port {port} in use, using {actual_port}")
+
+    guard.write_pid()
 
     worker_procs: list[subprocess.Popen] = []
     if workers > 0 and project_path:
@@ -522,6 +577,7 @@ def dashboard(
             p.terminate()
         for p in worker_procs:
             p.wait(timeout=5)
+        guard.cleanup()
 
 
 def _resolve_overlay_for_server(*, project: Path | None = None) -> tuple[Path, str, str]:

--- a/tests/test_cli_overlay.py
+++ b/tests/test_cli_overlay.py
@@ -7,6 +7,7 @@ lifecycle), overlay config subcommands, and overlay tool registration.
 """
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -188,6 +189,12 @@ class TestOverlayCommands:
         """Return a mock active overlay pointing at tmp_path."""
         return config_mod.OverlayEntry(name="test", overlay_class="test.settings", project_path=tmp_path)
 
+    def _mock_guard(self):
+        """Return a context manager that patches DashboardGuard to be a no-op."""
+        guard = MagicMock()
+        guard.stop_existing.return_value = False
+        return patch.object(cli_mod, "DashboardGuard", return_value=guard)
+
     def test_dashboard(self, tmp_path):
         """Dashboard command migrates and starts uvicorn."""
         from teatree.cli import app  # noqa: PLC0415
@@ -201,6 +208,7 @@ class TestOverlayCommands:
             patch.object(cli_mod, "subprocess"),
             patch("teatree.cli.discover_active_overlay", return_value=self._mock_active_overlay(tmp_path)),
             patch("socket.socket") as mock_socket_cls,
+            self._mock_guard(),
         ):
             mock_sock = MagicMock()
             mock_sock.connect_ex.return_value = 1
@@ -245,12 +253,109 @@ class TestOverlayCommands:
             patch.object(cli_mod, "subprocess"),
             patch("teatree.cli.discover_active_overlay", return_value=self._mock_active_overlay(tmp_path)),
             patch("socket.socket", side_effect=socket_factory),
+            self._mock_guard(),
         ):
             result = test_runner.invoke(app, ["dashboard"])
             assert result.exit_code == 0
             assert "Port 8000 in use" in result.output
             assert mock_uvicorn.call_args[0][2] == 9999
 
+    def test_dashboard_stop(self, tmp_path):
+        """Dashboard --stop kills existing server and exits."""
+        from teatree.cli import app  # noqa: PLC0415
+
+        test_runner = CliRunner()
+        guard = MagicMock()
+        guard.stop_existing.return_value = True
+
+        with patch.object(cli_mod, "DashboardGuard", return_value=guard):
+            result = test_runner.invoke(app, ["dashboard", "--stop"])
+            assert result.exit_code == 0
+            assert "Dashboard stopped" in result.output
+            guard.stop_existing.assert_called_once()
+
+    def test_dashboard_stop_no_server(self, tmp_path):
+        """Dashboard --stop reports when no server is running."""
+        from teatree.cli import app  # noqa: PLC0415
+
+        test_runner = CliRunner()
+        guard = MagicMock()
+        guard.stop_existing.return_value = False
+
+        with patch.object(cli_mod, "DashboardGuard", return_value=guard):
+            result = test_runner.invoke(app, ["dashboard", "--stop"])
+            assert result.exit_code == 0
+            assert "No running dashboard" in result.output
+
+    def test_dashboard_kills_existing_on_start(self, tmp_path):
+        """Dashboard startup kills any existing server before starting."""
+        from teatree.cli import app  # noqa: PLC0415
+
+        test_runner = CliRunner()
+        (tmp_path / "manage.py").write_text("pass\n")
+        guard = MagicMock()
+        guard.stop_existing.return_value = True
+
+        with (
+            patch.object(cli_mod, "managepy"),
+            patch.object(cli_mod, "_uvicorn"),
+            patch.object(cli_mod, "subprocess"),
+            patch("teatree.cli.discover_active_overlay", return_value=self._mock_active_overlay(tmp_path)),
+            patch("socket.socket") as mock_socket_cls,
+            patch.object(cli_mod, "DashboardGuard", return_value=guard),
+        ):
+            mock_sock = MagicMock()
+            mock_sock.connect_ex.return_value = 1
+            mock_socket_cls.return_value.__enter__ = MagicMock(return_value=mock_sock)
+            mock_socket_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = test_runner.invoke(app, ["dashboard"])
+            assert result.exit_code == 0
+            guard.stop_existing.assert_called_once()
+            guard.write_pid.assert_called_once()
+
+
+class TestDashboardGuard:
+    def test_write_and_read_pid(self, tmp_path):
+        """Guard writes and reads current process PID."""
+        from teatree.cli import DashboardGuard  # noqa: PLC0415
+
+        pid_file = tmp_path / "dashboard.pid"
+        guard = DashboardGuard(pid_file=pid_file)
+        guard.write_pid()
+        assert pid_file.exists()
+        assert pid_file.read_text().strip() == str(os.getpid())
+
+    def test_read_pid_stale(self, tmp_path):
+        """Guard cleans up PID file for a dead process."""
+        from teatree.cli import DashboardGuard  # noqa: PLC0415
+
+        pid_file = tmp_path / "dashboard.pid"
+        pid_file.write_text("99999999")  # unlikely to be a real PID
+        guard = DashboardGuard(pid_file=pid_file)
+        assert guard._read_pid() is None
+        assert not pid_file.exists()
+
+    def test_read_pid_missing(self, tmp_path):
+        """Guard returns None when no PID file exists."""
+        from teatree.cli import DashboardGuard  # noqa: PLC0415
+
+        guard = DashboardGuard(pid_file=tmp_path / "dashboard.pid")
+        assert guard._read_pid() is None
+
+    def test_cleanup(self, tmp_path):
+        """Guard removes PID file on cleanup."""
+        from teatree.cli import DashboardGuard  # noqa: PLC0415
+
+        pid_file = tmp_path / "dashboard.pid"
+        guard = DashboardGuard(pid_file=pid_file)
+        guard.write_pid()
+        assert pid_file.exists()
+        guard.cleanup()
+        assert not pid_file.exists()
+
+
+class TestOverlaySubcommands:
     def test_resetdb(self, tmp_path, monkeypatch):
         """Resetdb deletes DB and migrates."""
         monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path / "data")


### PR DESCRIPTION
## Summary

- Add `DashboardGuard` class with PID file at `DATA_DIR/dashboard.pid`
- Dashboard startup kills any existing server before starting a new one
- Add `--stop` flag to stop the running dashboard without starting a new one
- PID file cleanup on graceful exit; stale PIDs auto-detected and cleaned

## Test plan

- [x] `TestDashboardGuard` — 4 unit tests (write/read PID, stale cleanup, missing, cleanup)
- [x] `test_dashboard_stop` — stop flag kills existing
- [x] `test_dashboard_stop_no_server` — stop when nothing running
- [x] `test_dashboard_kills_existing_on_start` — startup kills existing
- [x] All 50 overlay CLI tests pass
- [x] BLUEPRINT.md updated with `--stop` flag

Closes #305