### PR TITLE
fix(overlay): derive config fields from OverlayConfig annotations

### DIFF
--- a/src/teatree/core/management/commands/overlay.py
+++ b/src/teatree/core/management/commands/overlay.py
@@ -3,23 +3,13 @@
 import typer
 from django_typer.management import TyperCommand, command
 
+from teatree.core.overlay import OverlayConfig
 from teatree.core.overlay_loader import get_overlay
 
-# Fields exposed by ``overlay config``.
-_CONFIG_FIELDS = (
-    "gitlab_url",
-    "github_owner",
-    "github_project_number",
-    "require_ticket",
-    "mr_close_ticket",
-    "mr_auto_labels",
-    "known_variants",
-    "frontend_repos",
-    "workspace_repos",
-    "protected_branches",
-    "dev_env_url",
-    "dashboard_logo",
-)
+
+def _config_fields() -> tuple[str, ...]:
+    """Derive config fields from OverlayConfig class annotations."""
+    return tuple(OverlayConfig.__annotations__)
 
 
 class Command(TyperCommand):
@@ -27,13 +17,14 @@ class Command(TyperCommand):
     def config(self, key: str = typer.Option("", help="Show a single config key's value")) -> str:
         """Show overlay configuration."""
         cfg = get_overlay().config
+        fields = _config_fields()
 
         if key:
-            if key not in _CONFIG_FIELDS:
-                return f"Unknown config key: {key}. Available: {', '.join(_CONFIG_FIELDS)}"
+            if key not in fields:
+                return f"Unknown config key: {key}. Available: {', '.join(fields)}"
             return str(getattr(cfg, key))
 
-        return "\n".join(f"{field}: {getattr(cfg, field)}" for field in _CONFIG_FIELDS)
+        return "\n".join(f"{field}: {getattr(cfg, field)}" for field in fields)
 
     @command()
     def info(self) -> str:


### PR DESCRIPTION
## Summary
- Replace hardcoded `_CONFIG_FIELDS` tuple with `_config_fields()` that reads from `OverlayConfig.__annotations__`, avoiding staleness when config fields are added/removed

Follow-up to #326.