### PR TITLE
refactor(skills): demote Non-Negotiable markers to load-bearing only

### DIFF
--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -45,7 +45,7 @@ The implementation phase. Follow test-driven development and project conventions
 
 ## Workflow
 
-### 0. Ticket-Required Overlay Check (Non-Negotiable)
+### 0. Ticket-Required Overlay Check
 
 When the active overlay has `require_ticket = True` in its configuration, a tracked issue must exist before writing any code.
 
@@ -118,7 +118,7 @@ Any frontend change that affects UI behavior (new fields, form logic, visibility
 
 ### 6. Quality Gates During Development
 
-- **When adding a prek hook, check for CI duplication (Non-Negotiable).** After adding a new hook to `.pre-commit-config.yaml`, grep the repo's `.gitlab-ci.yml` (or equivalent) for any job that runs the same script directly. If found, remove the standalone CI job — having the check run twice wastes CI time and creates maintenance confusion. One source of truth: prek.
+- **When adding a prek hook, check for CI duplication.** After adding a new hook to `.pre-commit-config.yaml`, grep the repo's `.gitlab-ci.yml` (or equivalent) for any job that runs the same script directly. If found, remove the standalone CI job — having the check run twice wastes CI time and creates maintenance confusion. One source of truth: prek.
 - Run linting after each significant change.
 - Run type checking if the project uses it.
 - Run the relevant test suite frequently — don't batch test runs.

--- a/skills/contribute/SKILL.md
+++ b/skills/contribute/SKILL.md
@@ -147,7 +147,7 @@ After creating the PR, check if an upstream issue should also be created (for vi
 - **Fork's `origin` matches `T3_UPSTREAM`** → stop, the PR already landed upstream.
 - **Otherwise** → proceed with divergence analysis and issue creation.
 
-#### 6a. Divergence Analysis (Non-Negotiable)
+#### 6a. Divergence Analysis
 
 Before creating an issue, run the divergence check (requires an `upstream` git remote):
 
@@ -276,7 +276,7 @@ gh issue create -R "$T3_UPSTREAM" \
 
 After creation, print the issue URL.
 
-### Issue Body Rules (Non-Negotiable)
+### Issue Body Rules
 
 - **Never include:** personal names, email addresses, company names, internal URLs, project-specific repo names, API keys, hostnames, IP addresses, file paths outside `$T3_REPO`, customer/tenant names.
 - **Always include:** generic description of the problem, which core skill is affected, link to the fork branch, validation evidence, divergence status.

--- a/skills/followup/SKILL.md
+++ b/skills/followup/SKILL.md
@@ -77,7 +77,7 @@ Parse the response to extract: issue ID, project ID, title, URL, and project pat
 
 Ask the user to pick "All" or specific ticket numbers. Use the agent platform's native question UI if it has one; otherwise ask plainly in the conversation. **Never start without explicit user approval.**
 
-### 4. Pre-Fetch External Context (Non-Negotiable)
+### 4. Pre-Fetch External Context
 
 For each confirmed ticket:
 
@@ -87,7 +87,7 @@ For each confirmed ticket:
 
 **c.** Download any embedded images from issues or external pages.
 
-### 5. Scope Analysis (Non-Negotiable)
+### 5. Scope Analysis
 
 For each confirmed ticket, analyze the external spec + issue description to determine:
 
@@ -264,7 +264,7 @@ The dashboard is a Django view served by teatree. Start it with `t3 <overlay> da
 
 **Extension point: `followup_enrich_data`** — project overlays can add project-specific fields to followup entries (e.g., Notion status, tenant info).
 
-### 13. Data Sync (Non-Negotiable — First Action on Every Load)
+### 13. Data Sync (First Action on Every Load)
 
 **Execute immediately when the skill is loaded** — before responding to the user, before asking what they want, before anything else. This is the first thing followup does on every invocation (both interactive and periodic). The user should never have to ask for a data refresh.
 

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -63,7 +63,7 @@ Systematic review of the current conversation to extract failures, near-misses, 
 - After a failure mode that existing skills didn't prevent
 - **Before context compaction** — if the conversation is getting long, run retro first to capture lessons before they're lost to compression
 
-### Pre-Compaction Persistence (Non-Negotiable)
+### Pre-Compaction Persistence
 
 If retro is in progress when compaction is imminent (long conversation, many tool calls), **write findings to a temporary file immediately** before they are lost. Use the `t3-snapshot-` prefix so the `PostCompact` hook can find and inject the file back into context automatically:
 
@@ -104,7 +104,7 @@ When writing to fallback locations, clearly mark the entry as originating from a
 
 If you can't determine whether a skill is editable, or if you're unsure whether an improvement belongs in the skill vs. the agent config vs. memory — **ask the user**. Retro is meta-work; human-in-the-loop is expected.
 
-## Persistence First (Non-Negotiable)
+## Persistence First
 
 Retro is not complete until every confirmed finding is written to a durable home in the same retro pass. Conversation output is not durable storage.
 
@@ -220,7 +220,7 @@ For each issue, determine **why** it happened:
 
 ### 3. Fix Skills
 
-**Pre-write editability check (Non-Negotiable):** Before writing to ANY skill, verify it is editable (see § Scope & Editability). For teatree-specific paths:
+**Pre-write editability check:** Before writing to ANY skill, verify it is editable (see § Scope & Editability). For teatree-specific paths:
 
 ```bash
 # Check core (when T3_CONTRIBUTE=true)
@@ -229,7 +229,7 @@ git -C "$T3_REPO" rev-parse --git-dir >/dev/null 2>&1 || echo "STOP: T3_REPO is 
 
 If a skill is not editable (no local git repo), write improvements to the best fallback location — repo-level agent instructions, user config, or memory files. See § Scope & Editability for the full decision table. In standalone mode with no overlay project, skip the overlay check.
 
-**Load coding skills before implementing (Non-Negotiable):** Retro fixes often involve writing code (Python, Django, shell). Load the appropriate coding skill (`/ac-django`, `/ac-python`, etc.) before implementing — not just for model/view work but for any code: settings, logging, CLI commands, hook scripts. Retro is not exempt from coding standards.
+**Load coding skills before implementing:** Retro fixes often involve writing code (Python, Django, shell). Load the appropriate coding skill (`/ac-django`, `/ac-python`, etc.) before implementing — not just for model/view work but for any code: settings, logging, CLI commands, hook scripts. Retro is not exempt from coding standards.
 
 **Determine the target** based on `T3_CONTRIBUTE` and the nature of the fix:
 
@@ -261,9 +261,9 @@ Retro can also modify core teatree skills in the user's fork:
 
 **After modifying core skills:** follow § Commit to Fork.
 
-### 4. Quality Rules (Non-Negotiable)
+### 4. Quality Rules
 
-- **Ask when ambiguous (Non-Negotiable).** Retro involves design decisions (what to promote, where to put it, which repos to touch). When a choice has multiple valid options or the scope is unclear, **stop and ask the user**. Do not assume. Daily coding workflows can be autonomous; meta-work (retro, review, skill editing) requires human-in-the-loop.
+- **Ask when ambiguous.** Retro involves design decisions (what to promote, where to put it, which repos to touch). When a choice has multiple valid options or the scope is unclear, **stop and ask the user**. Do not assume. Daily coding workflows can be autonomous; meta-work (retro, review, skill editing) requires human-in-the-loop.
 - **No duplication.** Before writing, search all skills for existing coverage. Merge into existing sections.
 - **Single source of truth.** Each piece of guidance lives in exactly one place. Other skills reference it.
 - **Skills ≠ repo config.** Do not duplicate rules from a repo's agent instruction files into skill files. Reference the repo file instead. If the skill adds extra detail (rationale, examples, edge cases), write the detail in the skill and reference the repo file for the base rule. Duplication is tolerated ONLY when fully acknowledged — mark it with `(Source: AGENTS.md § <section>)` or equivalent. A duplicate without a reference is a duplication bug that will drift silently.
@@ -273,8 +273,8 @@ Retro can also modify core teatree skills in the user's fork:
 - **Never change `version:`** in YAML frontmatter — that's auto-managed.
 - **Respect content publication status.** Blog posts and articles with `draft: false` in frontmatter are published — never modify them. Draft content (`draft: true` or no frontmatter) may be improved.
 - **Defer structural changes to review skill.** When your fixes involve merging, splitting, or restructuring skills, suggest running the review skill first — retro is tactical; the review skill provides systematic analysis before structural changes.
-- **Never write CLI procedures into skills (Non-Negotiable).** Skills must contain WHEN/WHY/WHAT (judgment, guardrails, domain knowledge) — never HOW (step-by-step commands that `t3` already executes). Before writing a finding that includes a command or procedure, check: does `t3` already handle this? If yes, the skill should say "use `t3 <command>`" — not reproduce the steps the CLI performs internally. Procedural documentation belongs in BLUEPRINT.md, AGENTS.md, CLAUDE.md, README.md, or docs/ — not in skills. Violating this tempts agents to follow the documented manual steps instead of calling the CLI.
-- **Skills over personal config (Non-Negotiable).** When fixing an issue, always prefer updating **skill files** (`SKILL.md`, `references/`) over writing to user-specific config (the agent's personal config and memory files). Skills benefit ALL users; personal config only helps one machine. Memory/config files are only for: user preferences (formatting, tone), environment-specific facts (paths, usernames, credentials), and user-specific workflow choices. Guardrails, troubleshooting, patterns, and "do this not that" rules belong in skills. **Checklist before writing to memory/config:** "Would another user of these skills need this too?" — if yes, put it in a skill. When in doubt, prefer skill files over personal config — skills are portable, personal config is not.
+- **Never write CLI procedures into skills.** Skills must contain WHEN/WHY/WHAT (judgment, guardrails, domain knowledge) — never HOW (step-by-step commands that `t3` already executes). Before writing a finding that includes a command or procedure, check: does `t3` already handle this? If yes, the skill should say "use `t3 <command>`" — not reproduce the steps the CLI performs internally. Procedural documentation belongs in BLUEPRINT.md, AGENTS.md, CLAUDE.md, README.md, or docs/ — not in skills. Violating this tempts agents to follow the documented manual steps instead of calling the CLI.
+- **Skills over personal config.** When fixing an issue, always prefer updating **skill files** (`SKILL.md`, `references/`) over writing to user-specific config (the agent's personal config and memory files). Skills benefit ALL users; personal config only helps one machine. Memory/config files are only for: user preferences (formatting, tone), environment-specific facts (paths, usernames, credentials), and user-specific workflow choices. Guardrails, troubleshooting, patterns, and "do this not that" rules belong in skills. **Checklist before writing to memory/config:** "Would another user of these skills need this too?" — if yes, put it in a skill. When in doubt, prefer skill files over personal config — skills are portable, personal config is not.
 - **Scan personal config for promotable entries.** During every retro, read the agent's memory and personal config files. Any entry that encodes a guardrail, pattern, or "do this not that" rule (not a user preference or env-specific fact) should be **promoted to the appropriate skill file**. However, always-loaded agent config/memory files serve as a safety net — critical guardrails that are already in skills may still deserve a one-line reminder there, because skills are only available when loaded. When keeping a duplicate, mark it clearly as "Safety net — source: `<skill> § <section>`" to prevent drift. Only fully remove entries that are truly redundant (pure cross-references with no actionable content).
 - **Prefer deterministic helpers over repeated manual work.** If the same audit or extraction step is likely to recur, capture it in a shell/Python helper or reusable command snippet and document where it lives.
 - **Ask about backward compatibility before adding compat shims.** When a retro fix involves renaming, removing, or changing an API, ask the user whether backward compatibility matters before adding wrappers, re-exports, or deprecation paths. Clean code is preferred over compat shims unless the user explicitly needs them.
@@ -326,7 +326,7 @@ After applying all fixes:
 - If helper scripts were created or reused for recurring work, verify their paths and usage are recorded in the relevant durable docs
 - **Definition of Done check:** Re-run the conversation audit (§ 1) on your own changes. If the re-run produces new findings, you are not done — fix them before claiming completion.
 - **No “conversation-only” findings.** If a lesson exists only in the final response and not in a file, retro is not done.
-- **Commit before declaring done (Non-Negotiable).** After completing all retro changes, commit them immediately before declaring done. Never declare "done" with uncommitted skill modifications — this is the most common retro failure mode.
+- **Commit before declaring done.** After completing all retro changes, commit them immediately before declaring done. Never declare "done" with uncommitted skill modifications — this is the most common retro failure mode.
 
 ## Commit to Fork (`T3_CONTRIBUTE=true`) — Automatic
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -114,7 +114,7 @@ Run gates → Any failure? → Fix → Re-run gates → Repeat until clean
 
 ### Giving Code Review
 
-**Pre-flight gate (Non-Negotiable) — complete BEFORE reading any diff:**
+**Pre-flight gate — complete BEFORE reading any diff:**
 
 1. Determine own vs external MR (Step -1)
 2. Fetch ticket context for every MR (Step 0) — without this you cannot judge correctness
@@ -123,11 +123,11 @@ Run gates → Any failure? → Fix → Re-run gates → Repeat until clean
 
 Do NOT skip these steps to "save time" when reviewing multiple MRs. Each step exists because skipping it caused missed findings in real reviews.
 
-**Step -1 — Own MR vs External MR (Non-Negotiable):**
+**Step -1 — Own MR vs External MR:**
 
 When the MR under review belongs to the **user themselves**, do NOT post review comments. Instead, **implement the fixes directly** on the branch — commit and push. Present findings to the user as a summary of what you fixed, not as review comments to post. The user is asking you to take over and improve their code, not to leave notes for themselves.
 
-**Step 0 — Gather Ticket Context (Non-Negotiable):**
+**Step 0 — Gather Ticket Context:**
 
 Before reading any code, fetch the referenced ticket/issue to understand the *intended* behavior:
 
@@ -138,7 +138,7 @@ Before reading any code, fetch the referenced ticket/issue to understand the *in
 
 Without ticket context you cannot judge whether the implementation is correct — only whether it compiles.
 
-**Step 0b — Review All Commits, Not Just the Final Diff (Non-Negotiable):**
+**Step 0b — Review All Commits, Not Just the Final Diff:**
 
 The combined diff can hide mistakes. Always check individual commits:
 
@@ -146,7 +146,7 @@ The combined diff can hide mistakes. Always check individual commits:
 2. Inspect each commit's diff individually — a later commit may accidentally revert an earlier fix.
 3. Look for "Tests fix" / "Fix tests" follow-up commits that change production code alongside test adjustments.
 
-**Step 0c — Discuss Before Posting (Non-Negotiable):**
+**Step 0c — Discuss Before Posting:**
 
 Present ALL findings to the user before posting any comments. Never silently drop findings between the discussion phase and the posting phase — if a finding was discussed, it gets posted unless the user explicitly removes it. The user curates; you surface.
 
@@ -164,7 +164,7 @@ When raising concerns about caching, stale data, or side effects: **investigate 
 8. **Scope** — are unrelated changes bundled in? Flag only if genuinely unrelated; small related fixes alongside the main change are normal practice.
 9. **MR metadata** — title and description comply with the overlay's commit message format? If the overlay provides `validate_pr()`, run it programmatically rather than checking by eye.
 
-**Step 2 — Review Tone & Formatting (Non-Negotiable):**
+**Step 2 — Review Tone & Formatting:**
 
 Follow the [Google Engineering Practices — Code Review Standard](https://google.github.io/eng-practices/review/reviewer/standard.html): approve if the CL improves overall code health, even if it isn't perfect. Don't block on style preferences or theoretical improvements. The bar is "does this improve the codebase?" — not "is this how I would have written it?"
 
@@ -188,7 +188,7 @@ Comments are posted under the user's name. They must sound like a **real human c
 - **Readable structure for longer comments.** Use empty lines to separate distinct sections (problem, suggestion, example). Within a section, use line breaks between sentences (without empty lines) to keep things scannable. Short comments stay on one line — don't over-structure a one-liner.
 - **No walls of text.** If a comment needs more than ~5 lines, break it up visually. Paragraphs, not monoliths.
 
-**Step 3 — Post Draft Review Comments (Non-Negotiable):**
+**Step 3 — Post Draft Review Comments:**
 
 **Always use draft notes** (or the platform's equivalent "pending review" feature), not direct/immediate comments. Draft notes are only visible to the reviewer until explicitly submitted — this lets the user review, edit, and submit all comments as a batch.
 
@@ -205,7 +205,7 @@ This prevents noise from multiple review passes or multiple reviewers covering t
 
 When reviewing an external MR/PR, **always post comments inline on the correct file and line** in the diff view. For comments that aren't tied to a specific line (e.g., description feedback), post a general note without position data.
 
-**Extend the CLI, never inline API recipes (Non-Negotiable).** If a `t3 review` operation is missing (e.g., bulk-publish, reply, resolve), implement it in `src/teatree/cli/review.py` — do NOT document a raw API snippet or inline script here. Skills describe what command to run, not how to replicate missing CLI functionality.
+**Extend the CLI, never inline API recipes.** If a `t3 review` operation is missing (e.g., bulk-publish, reply, resolve), implement it in `src/teatree/cli/review.py` — do NOT document a raw API snippet or inline script here. Skills describe what command to run, not how to replicate missing CLI functionality.
 
 **Use `t3 review post-draft-note` (Mandatory).** It handles token extraction, diff refs, position serialization, and added-line validation. Never use raw API calls.
 
@@ -213,7 +213,7 @@ When reviewing an external MR/PR, **always post comments inline on the correct f
 t3 review post-draft-note <REPO> <MR_IID> "Comment text" --file <path/to/file> --line <line_number>
 ```
 
-**Pre-flight: verify target line is an added line (Non-Negotiable).** Before posting each inline note, confirm the target `new_line` corresponds to an added (`+`) or modified line in the diff — never a context (unchanged) line. Targeting a context line causes GitLab to render the comment in **every hunk** that references that line, creating duplicates. When the finding is about an unchanged line, target the nearest added line and reference the unchanged line in the comment text instead.
+**Pre-flight: verify target line is an added line.** Before posting each inline note, confirm the target `new_line` corresponds to an added (`+`) or modified line in the diff — never a context (unchanged) line. Targeting a context line causes GitLab to render the comment in **every hunk** that references that line, creating duplicates. When the finding is about an unchanged line, target the nearest added line and reference the unchanged line in the comment text instead.
 
 **Post-flight: verify response.** Response must confirm the comment landed on the correct file/line — if position data is missing in the response, the comment landed as a general comment (wrong). After posting all notes, list them via the API and confirm the count and positions match expectations.
 
@@ -243,7 +243,7 @@ t3 review publish-draft-notes <REPO> <MR_IID>
 - **Anti-performative:** No "You're absolutely right!" — just state the fix or the technical disagreement.
 - **Technical rigor:** verify reviewer suggestions against the actual codebase before implementing.
 
-#### Replying to Review Discussions (Non-Negotiable)
+#### Replying to Review Discussions
 
 When posting replies to reviewer discussions (e.g., "Done in `<commit>`"):
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 Cross-cutting rules that apply to all teatree skills. Loaded automatically via `requires:`.
 
-## Invoke Skills Before ANY Response (Non-Negotiable)
+## Invoke Skills Before ANY Response
 
 _Adapted from [superpowers/using-superpowers](https://github.com/obra/superpowers)._
 
@@ -43,17 +43,17 @@ _Adapted from [superpowers/verification-before-completion](https://github.com/ob
 
 **Banned language without evidence:** "should pass", "probably works", "seems correct", "looks good", "I'm confident". These words without a command output are lies, not claims.
 
-## User Instructions Are Priority 1 (Non-Negotiable)
+## User Instructions Are Priority 1
 
 When the user gives a direct, explicit instruction (skip tests, push now, use this approach), execute it IMMEDIATELY. Do not try a "better" approach first, do not retry the same failing approach hoping it works, and do not silently substitute your own plan. Execute the instruction first (it's fast and safe), then suggest an alternative if you have one.
 
-## Context Transparency (Non-Negotiable)
+## Context Transparency
 
 The user cannot see system-reminders, memory content, or hook output injected into your context. When your response is influenced by any of this invisible context, **briefly state what you received** so the user can follow your reasoning. For example: "Teatree suggested loading `/t3:code`. Memory mentions X."
 
 If the user's message is ambiguous (references "this", "it", a link they forgot to paste, etc.) — **ask for clarification**. Do NOT guess based on context the user can't see. Guessing leads to confusing exchanges where the user has no idea what you're talking about.
 
-## Clickable References (Non-Negotiable)
+## Clickable References
 
 Every MR, ticket, issue, or note reference — in markdown files, platform comments, **and** agent responses — must be a clickable markdown link.
 
@@ -62,13 +62,13 @@ Every MR, ticket, issue, or note reference — in markdown files, platform comme
 
 This applies everywhere: MR/PR descriptions, inline comments, test evidence, chat messages, and responses to the user.
 
-## Token Extraction (Non-Negotiable)
+## Token Extraction
 
 When extracting an API token from a CLI tool, always extract to a variable first — never inline in curl. See your platform reference (`t3:platforms`) § "Token Extraction" for the platform-specific recipe.
 
 **In Python heredocs:** shell variables are NOT inherited. Use `os.popen(...)` inside Python or `export TOKEN` before the heredoc.
 
-## Temp File Safety (Non-Negotiable)
+## Temp File Safety
 
 When using temporary files (for MR note bodies, test data, etc.):
 
@@ -78,13 +78,13 @@ When using temporary files (for MR note bodies, test data, etc.):
 - **Always clean up** the temp file immediately after use (`os.unlink()` in Python, `rm` in shell).
 - **Exception: pre-compaction snapshots** — files matching `/tmp/t3-snapshot-*.md` are recovered automatically by the `PostCompact` hook. Use `t3-snapshot-${CLAUDE_SESSION_ID:-manual}-$(date +%Y%m%d-%H%M).md` for the filename. Delete after persisting findings to durable storage.
 
-## Complex API Payloads: Use curl or Python (Non-Negotiable)
+## Complex API Payloads: Use curl or Python
 
 Some issue tracker CLIs cannot serialize nested JSON. **Always use `curl`** with `-H "Content-Type: application/json"` and a proper JSON `-d` body for payloads containing nested objects.
 
 For note bodies containing markdown images (`![alt](url)`), shell variable interpolation and `jq --arg` both escape `!` to `\!`. **Always use Python** (`urllib.request` or `requests`) to serialize the JSON payload.
 
-## Preserve Existing UX Patterns (Non-Negotiable)
+## Preserve Existing UX Patterns
 
 When fixing a broken UX mechanism (web terminal, browser launch, notification method), fix it **in-kind** — do not replace it with a different mechanism without asking. If proposing a different approach, ask the user first: "Currently this uses X. Want to keep that or switch to Y?"
 
@@ -92,7 +92,7 @@ When fixing a broken UX mechanism (web terminal, browser launch, notification me
 
 MR/PR comment posting (test plans, evidence, review notes) must be **serialized** — never dispatch two parallel agents that both post comments on MRs. Parallel agents cannot check for each other's posts, resulting in duplicate comments. Post all MR comments from the main conversation thread, or serialize agent tasks so only one posts at a time.
 
-## Sub-Agent Limitations (Non-Negotiable)
+## Sub-Agent Limitations
 
 Sub-agents (Agent tool) **lose all loaded skills, MCP access, and shell functions**. By default, never dispatch sub-agents for skill-dependent work. Do all skill-dependent work sequentially in the main conversation.
 
@@ -118,11 +118,11 @@ Use `command rm`, `command cp`, `command mv` in Bash tool calls to avoid zsh int
 
 Never modify skill files outside a git repo. Resolve real path with `readlink -f`, verify `git rev-parse --git-dir` succeeds. Changes to non-git copies are silently lost.
 
-## Fix TeaTree/Skill Bugs Immediately (Non-Negotiable)
+## Fix TeaTree/Skill Bugs Immediately
 
 When a teatree or skill infrastructure bug is discovered during any task, fix it immediately as first priority. Never defer to focus on the user's task — broken infrastructure causes cascading failures.
 
-## Ask About Auth Before External Service Integrations (Non-Negotiable)
+## Ask About Auth Before External Service Integrations
 
 When implementing features that require an external service (Notion, Slack, CI, etc.), ask "how do you authenticate with this service?" BEFORE writing any code. The answer (direct API token, CLI auth, MCP tool, OAuth, etc.) determines the entire architecture. Skipping this question leads to multiple implementation pivots.
 
@@ -136,7 +136,7 @@ When an MR targets a non-default branch, that is intentional — it means the MR
 
 Destroying MR dependency chains wastes hours of carefully organized work.
 
-## Always Create Tasks (Non-Negotiable)
+## Always Create Tasks
 
 On **every prompt**, use `TaskCreate` to create tasks before doing any work — even for a single task. Mark each task `in_progress` when starting, `completed` when done. Never skip this. Visible task tracking prevents forgotten steps and shows the user your progress.
 
@@ -144,7 +144,7 @@ On **every prompt**, use `TaskCreate` to create tasks before doing any work — 
 - **Complex tasks** (3+ steps): use the task tracking tools for each step, update status as you go.
 - **Never skip this.** If you find yourself doing 3+ things without a plan, stop and create one.
 
-## Always Use AskUserQuestion for Questions (Non-Negotiable)
+## Always Use AskUserQuestion for Questions
 
 **Never ask questions inline in text responses.** Always use the `AskUserQuestion` tool — it gives the user a structured UI to respond and prevents questions from being buried in output. One question at a time; wait for the answer before asking the next.
 
@@ -156,14 +156,14 @@ Commit approval ≠ push approval. **Squash approval ≠ push approval. "All don
 - **Never use `--no-verify`** on any git command — commit, push, nothing. If a hook fails, fix the underlying issue.
 - Applies to all repos, all contexts, all branches.
 
-## Run Retro Before Ending Non-Trivial Sessions (Non-Negotiable)
+## Run Retro Before Ending Non-Trivial Sessions
 
 Before ending any session that involved multi-file edits, debugging, or implementation work, run `/t3:next` (which includes `/t3:retro`). Do NOT wait for the user to ask — self-trigger this. A session without retro loses compound learning.
 
 - **Trivial sessions** (single question, quick lookup, one-line fix): skip.
 - **Everything else**: run `/t3:next` before your final response.
 
-## Verify Imports Before Applying External Code (Non-Negotiable)
+## Verify Imports Before Applying External Code
 
 When cherry-picking code from orphan commits, stashes, snapshots, or other branches, verify every import and function call exists in the target codebase before applying. Snapshot code assumes a different state — modules, classes, and function signatures may not exist in HEAD. Apply each change surgically and run the type checker (`ty-check`) before moving on.
 
@@ -180,7 +180,7 @@ Long sessions lose context to automatic compaction. Proactively manage session l
 
 When implementation is complete (all files written, tests pass or verified), **commit immediately** in the same response — do not wait for the user to ask. An uncommitted change is not "done"; it is in-progress work at risk of being lost to context compaction, parallel agents, or session timeout.
 
-## Pre-Commit Hook Failures on Unrelated Tests (Non-Negotiable)
+## Pre-Commit Hook Failures on Unrelated Tests
 
 When a pre-commit hook runs the full test suite and fails on tests **unrelated to your changes** (pre-existing failures), do not fix them one by one in a loop. After the **second** unrelated failure, stop and tell the user: the hook is failing on pre-existing test issues, and list the failing tests so they can be fixed separately. Never suggest or use `--no-verify` — see `t3:ship § Never use --no-verify`.
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -45,7 +45,7 @@ From "code is done" to "MR is merged."
 
 ## Workflow
 
-### 0. Ticket-Required Overlay Gate (Non-Negotiable)
+### 0. Ticket-Required Overlay Gate
 
 When the active overlay has `require_ticket = True`, refuse to commit or push without a ticket reference.
 
@@ -61,7 +61,7 @@ When the active overlay has `require_ticket = True`, refuse to commit or push wi
 - **Verify branch matches ticket** before committing. If on the wrong branch, create a clean branch from the default branch and cherry-pick.
 - **Check for pre-existing changes before staging.** If the diff includes changes you did not make in this session, **warn the user** — either stage only your hunks or ask how to proceed.
 - Format commit message following the project's commit format reference.
-- **Link commits to issues (Non-Negotiable).** Check `t3 overlay config --key mr_close_ticket`: when `true`, use `Fixes #<number>` or `Closes #<number>` in the commit message body (auto-closes on merge); when `false`, use `Relates-to #<number>` (links without closing). This applies to ALL repos.
+- **Link commits to issues.** Check `t3 overlay config --key mr_close_ticket`: when `true`, use `Fixes #<number>` or `Closes #<number>` in the commit message body (auto-closes on merge); when `false`, use `Relates-to #<number>` (links without closing). This applies to ALL repos.
 - Read `TICKET_URL` from `.env.worktree` — never construct it from the branch name.
 
 ### 2. Finalize Branch
@@ -85,7 +85,7 @@ When the active overlay has `require_ticket = True`, refuse to commit or push wi
 - **E2E gate:** If the project requires E2E tests for the type of changes made (UI, forms, user flows), those tests must be written and passing BEFORE proceeding. E2E is part of implementation, not a post-push activity.
 - **Wait for user feedback.** Do NOT proceed to push without user approval.
 
-### 3a. BLUEPRINT.md Sync (Non-Negotiable)
+### 3a. BLUEPRINT.md Sync
 
 If the changes touch architecture, add new modules, rename commands, or change extension points:
 
@@ -93,7 +93,7 @@ If the changes touch architecture, add new modules, rename commands, or change e
 2. If it doesn't, update it **before** pushing. Ask the user before modifying.
 3. This applies to all repos that have a `BLUEPRINT.md`.
 
-### 3b. Self-Review Against Repo Rules (Non-Negotiable)
+### 3b. Self-Review Against Repo Rules
 
 **Before every push**, run the self-review gate from [`../t3:review/SKILL.md`](../t3:review/SKILL.md) § "Active Verification Against Repo Rules":
 
@@ -109,7 +109,7 @@ Skipping this step is the #1 cause of wasted push-fix-push cycles. The rules exi
 - Cancel stale pipelines before pushing (if branch has an existing MR).
 - Push to remote.
 
-### 4b. Review Gate (Non-Negotiable)
+### 4b. Review Gate
 
 Before creating an MR, the `pr create` command automatically checks the session gate:
 
@@ -119,7 +119,7 @@ Before creating an MR, the `pr create` command automatically checks the session 
 
 ### 5. Create MR/PR
 
-**STOP — resolve the ticket URL before typing the glab command (Non-Negotiable).**
+**STOP — resolve the ticket URL before typing the glab command.**
 
 Before composing any `glab mr create` or `glab mr update` call, answer these three questions:
 
@@ -200,7 +200,7 @@ After delivery is complete (MR created, pipeline green), run `/t3:retro` to capt
 - **Cancel stale pipelines** before every push to a branch with an existing MR.
 - **Cancel running pipelines when closing an MR/PR.** When an MR is closed (abandoned, superseded, or replaced), cancel any running or pending pipelines for that branch immediately — they waste CI resources on code that will never be merged.
 - **Clickable references:** Every MR, ticket, or note reference must be a markdown link — see [`../t3:rules/SKILL.md`](../t3:rules/SKILL.md) § "Clickable References".
-- **Commit early, commit often (Non-Negotiable).** Never accumulate more than 1-2 tickets of uncommitted changes. Commit after completing each ticket or logical unit of work. Squash later with `t3 workspace finalize`.
+- **Commit early, commit often.** Never accumulate more than 1-2 tickets of uncommitted changes. Commit after completing each ticket or logical unit of work. Squash later with `t3 workspace finalize`.
 - **Never push without explicit approval.** Canonical rule: see [`../t3:rules/SKILL.md`](../t3:rules/SKILL.md) § "Never Push Without Separate Explicit Approval". Covers commit/squash/rebase/force-push approval boundaries and the `--no-verify` ban.
 - **Respect commit trailer preferences.** Check the user's global agent config for rules about `Co-Authored-By` trailers before committing. Some users explicitly opt out. When in doubt, **do not add trailers** — the user can always configure their agent to add them.
 

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -92,7 +92,7 @@ Hooks are registered in `hooks/hooks.json` (shipped with the plugin). This is th
 
 **Known failure (2026-04-02):** PR #109 moved hooks from `settings.json` to plugin `hooks.json` but didn't remove the old ones. This caused double hook execution on every tool call, accelerating context consumption and triggering aggressive microcompaction. Prevention: when migrating hooks to the plugin, always remove the `settings.json` equivalents in the same change.
 
-## Dogfooding Checklist (Non-Negotiable for CLI/Server Changes)
+## Dogfooding Checklist (CLI/Server Changes)
 
 When modifying CLI commands, dashboard views, or server startup:
 

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -56,7 +56,7 @@ Running tests, analyzing failures, quality checks, CI interaction, test plans, a
 
 **Full worktree per MR (Non-Negotiable):** Each MR under test MUST have its own full worktree setup (backend + frontend via `t3 lifecycle setup` + `t3 lifecycle start`). Never mix backends from one worktree with frontends from another. Never patch an incomplete worktree by hand — if it's missing repos, env files, or DB, delete it and start over with `t3 workspace ticket`. Anti-pattern: manually adding repos with `git worktree add`, copying env files, editing `.env.worktree` by hand.
 
-**E2E for backend/API changes (Non-Negotiable):** When backend or microservice changes affect data visible in the frontend (e.g., webhook payload fields, API serializer fields, new model fields exposed via API), E2E tests are still required even if there is no frontend MR. The frontend form already has the fields — E2E proves the end-to-end data flow. Do NOT skip E2E just because the change is "backend-only."
+**E2E for backend/API changes:** When backend or microservice changes affect data visible in the frontend (e.g., webhook payload fields, API serializer fields, new model fields exposed via API), E2E tests are still required even if there is no frontend MR. The frontend form already has the fields — E2E proves the end-to-end data flow. Do NOT skip E2E just because the change is "backend-only."
 
 **`storageState` in Playwright:** `test.use({ storageState: undefined })` means "use default" (inherits global setup state). For truly unauthenticated tests, use `test.use({ storageState: { cookies: [], origins: [] } })`.
 
@@ -74,9 +74,9 @@ E2E and integration tests ideally live in the project repo they test (e.g., the 
 
 **Prerequisites:** Always start dev servers via `t3 lifecycle start` (see `/t3:workspace`) before running tests. Never start services manually. Before running E2E tests, verify that **translations are loaded** — the frontend i18n directory is gitignored and only populated at startup (by `t3 lifecycle start`). If the frontend was started manually, translations will be missing. Quick check: open any page and confirm labels show human-readable text, not raw keys like `app.feature.xxx.label`.
 
-**Test depth (Non-Negotiable):** Don't just verify "page loads with 200". Read the source code to understand what the feature does, then test specific behaviors: form fields, filters, CRUD operations, access control, edge cases.
+**Test depth:** Don't just verify "page loads with 200". Read the source code to understand what the feature does, then test specific behaviors: form fields, filters, CRUD operations, access control, edge cases.
 
-**Component placement (Non-Negotiable):** Before writing E2E tests for a UI component, check the **routing module** to find which page/route renders it. Components may only appear at specific wizard steps or behind navigation — not on the page you'd naively navigate to. Grep for the component selector in `.html` templates to find its host, then check the routing module for the URL path.
+**Component placement:** Before writing E2E tests for a UI component, check the **routing module** to find which page/route renders it. Components may only appear at specific wizard steps or behind navigation — not on the page you'd naively navigate to. Grep for the component selector in `.html` templates to find its host, then check the routing module for the URL path.
 
 **Test integrity (Non-Negotiable):** Never weaken, simplify, or remove test cases to work around failures. If a test fails, fix the underlying issue (environment, selectors, timing) — don't dilute the test. Tests must cover both happy paths and edge cases.
 
@@ -214,13 +214,13 @@ Upload via the platform's file upload API and get the markdown embed syntax. See
 
 **Video embedding:** Use the same `![alt](url)` markdown syntax as images. GitLab auto-detects video formats (.webm, .mov, .mp4) and renders an inline player. Do NOT use `<video>` HTML tags — they don't work in GitLab markdown.
 
-### 2. Post or Update Comment — Always Use Python (Non-Negotiable)
+### 2. Post or Update Comment — Always Use Python
 
 Shell variable interpolation and `jq --arg` both escape `!` to `\!`, breaking image syntax `![alt](url)`. **Always** use inline Python with the note body as a heredoc string — see [`../t3:rules/SKILL.md`](../t3:rules/SKILL.md) § "Temp File Safety" for the full rules. See your [issue tracker platform reference](../t3:platforms/references/) § "MR Notes (Comments)" for the complete Python recipe.
 
 When editing: check the verified boxes (`- [ ]` → `- [x]`), insert screenshot markdown below the relevant section, leave unchecked items as-is.
 
-### Visual Comparison Format (Non-Negotiable)
+### Visual Comparison Format
 
 Evidence screenshots must always use a **side-by-side comparison table**. Minimum 2 columns, up to 3 when a design mockup is available.
 
@@ -254,12 +254,12 @@ Evidence screenshots must always use a **side-by-side comparison table**. Minimu
 - **Clickable references:** Every MR, ticket, or note reference must be a markdown link — see [`../t3:rules/SKILL.md`](../t3:rules/SKILL.md) § "Clickable References".
 - Write in first person, casual tone ("Tested on local...", "Works as expected")
 - **Never mention automation, E2E, Playwright, or scripts** — must read as manual testing
-- **Update the existing test plan (Non-Negotiable)** — never post a second evidence comment. Always GET existing notes first, find the test plan, and PUT to update it.
+- **Update the existing test plan** — never post a second evidence comment. Always GET existing notes first, find the test plan, and PUT to update it.
 - If a separate evidence comment already exists, delete it after merging evidence into the test plan
 - **Don't post code findings as bugs without asking the user first.** Behavior that looks like a bug may be intentional. Ask "Is this expected?" before posting a finding on the MR.
-- **Match evidence type to MR type (Non-Negotiable).** UI screenshots are evidence for frontend MRs. Backend MRs need backend evidence: unit test output, API response diffs, or logs. Don't post frontend screenshots on a backend-only MR — they prove the frontend works, not the backend fix. When both MRs exist, put screenshots on the frontend MR and reference it from the backend MR.
+- **Match evidence type to MR type.** UI screenshots are evidence for frontend MRs. Backend MRs need backend evidence: unit test output, API response diffs, or logs. Don't post frontend screenshots on a backend-only MR — they prove the frontend works, not the backend fix. When both MRs exist, put screenshots on the frontend MR and reference it from the backend MR.
 
-## Re-Read Before Debugging (Non-Negotiable)
+## Re-Read Before Debugging
 
 When an E2E test fails or the environment misbehaves, **re-read this skill's verification sections** (Screenshot Sanity Check, Store Contamination Check, Establish Baseline) before spending more than 2 minutes on ad-hoc debugging. Skill guidance loaded at the start of a long session gets compressed out of active context — re-reading takes 10 seconds and prevents 30-minute debugging detours.
 
@@ -291,7 +291,7 @@ Before claiming E2E success or posting screenshots as evidence, **visually inspe
 
 A screenshot with raw translation keys is **not valid evidence** — it proves the environment was broken, not that the feature works. A screenshot that doesn't show the tested element is **not valid evidence** either — it proves nothing.
 
-### Store Contamination Check (Non-Negotiable)
+### Store Contamination Check
 
 E2E tests for features that load data via a state management store must verify the data is loaded **from the tested page**, not from a prior navigation. If you visit page A (which dispatches a data load into the store) and then navigate to page B (which reads from the store but never dispatches the load itself), page B will appear to work — but only because page A pre-populated the store.
 

--- a/skills/ticket/SKILL.md
+++ b/skills/ticket/SKILL.md
@@ -58,7 +58,7 @@ From zero to ready-to-code. Combines understanding the ticket with setting up th
 - Extract and list acceptance criteria before coding.
 - If the ticket is vague, clarify with the user.
 
-### 2b. Infer Deliverables (Non-Negotiable)
+### 2b. Infer Deliverables
 
 After extracting acceptance criteria, **proactively list all required artifacts** — don't wait for the user to tell you. Common deliverables to infer:
 
@@ -82,7 +82,7 @@ Present the inferred list and let the user confirm or adjust before proceeding. 
 - Determine which repos are affected by the ticket.
 - Load repository-specific references for each repo in scope.
 
-### 5. Detect Variant/Tenant (Non-Negotiable for Multi-Tenant Projects)
+### 5. Detect Variant/Tenant (Multi-Tenant Projects)
 
 **Always detect the target tenant before coding.** This determines environment setup, feature flag scope, and config repos.
 

--- a/skills/workspace/SKILL.md
+++ b/skills/workspace/SKILL.md
@@ -107,13 +107,13 @@ When a `t3` command fails, **fix the CLI code first** — never manually run the
 3. **Fix** the code, add a test, and commit.
 4. **Re-run** the `t3` command to verify the fix.
 
-### Never Hand-Edit Generated Files (Non-Negotiable)
+### Never Hand-Edit Generated Files
 
 Setup tools (`t3 lifecycle setup`, etc.) generate configuration files (`.env.worktree`, docker overrides, port allocations). **Manual edits create drift** and are overwritten on the next setup run.
 
 When a generated file is wrong or incomplete, **re-run the setup tool** — don't manually patch the file. If setup fails, diagnose the root cause in the setup script (see `/t3:debug`), don't work around it.
 
-### Never Run Infrastructure Commands Directly (Non-Negotiable)
+### Never Run Infrastructure Commands Directly
 
 Use the `t3` CLI (`t3 lifecycle start`, `t3 run backend`, `t3 run frontend`, etc.) instead of running `docker compose`, language-specific dev servers, or build tools directly. The CLI commands handle:
 
@@ -146,15 +146,15 @@ After importing a database or downloading an artifact, always validate it:
 - **Spot-check data** — empty seed/reference tables indicate a corrupt import; the application will crash on every request with lookup errors
 - If validation fails, **delete the corrupt artifact and re-run provisioning**. Never try to manually fix corrupt data — interdependent reference tables make this a losing game.
 
-### Service Startup Ordering (Non-Negotiable)
+### Service Startup Ordering
 
 Setup tools enforce ordering: **data store → migrations → application server**. Starting the application before migrations causes "relation does not exist" errors. Always use the orchestration functions (`t3 lifecycle start`) rather than starting services individually.
 
-### Never Delegate Skill-Dependent Work to Sub-Agents (Non-Negotiable)
+### Never Delegate Skill-Dependent Work to Sub-Agents
 
 See [`../t3:rules/SKILL.md`](../t3:rules/SKILL.md) § "Sub-Agent Limitations". If parallelism is needed, pass the **full skill file contents** in the sub-agent prompt — but prefer sequential main-conversation execution.
 
-### Verify Services Before Declaring Running (Non-Negotiable)
+### Verify Services Before Declaring Running
 
 After starting dev servers, **verify each service responds via HTTP** before reporting success. Check that frontend, backend, and API endpoints return expected status codes (2xx/3xx). If any check fails (000, 500, connection refused), diagnose before reporting — see troubleshooting docs.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1234,15 +1234,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Opus 4.7 best-practices guidance: reserve `(Non-Negotiable)` markers for rules whose violation caused a **documented incident** (data loss, destructive ops, past pipeline failures). Style, procedural, and quality rules get demoted — they remain in place as plain rules, just without the capital marker.

**Before:** 106 markers across 12 skill files.
**After:** 29 markers, each backed by a specific past incident (git stash eating work, manual workarounds wasting hours, silent hook failures, screenshot evidence from broken environments, duplicate MR comments, etc.).

Self-reviewed with `t3:reviewer` sub-agent before push; reviewer flagged 4 incident-backed rules I had over-demoted and they were restored:

- `ship/SKILL.md` — `prek install` before first commit
- `test/SKILL.md` — Browser Console First
- `test/SKILL.md` — Screenshot Sanity Check
- `review/SKILL.md` — Pre-flight: read existing comments

Also bumps transitive `rich` 14.3.3 → 15.0.0 via `uv lock --upgrade-package rich`. Smoke-tested the two call sites (`Console`, `Table` in `cli/assess.py`).

Relates-to #324.

## Test plan

- [x] Ruff check + format clean
- [x] `ty check` clean
- [x] Full pytest suite green (2114 passed)
- [x] Pre-commit gates pass on push