### PR TITLE
fix(sync): surface assigned-but-no-MR issues on dashboard

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -102,7 +102,7 @@ src/teatree/
     github_sync.py      # GitHubSyncBackend — Projects v2 board + reviewer PR sync
     gitlab.py           # GitLab API client (httpx)
     gitlab_ci.py        # GitLab CI pipeline operations
-    gitlab_sync.py      # GitLabSyncBackend — MR upsert, issue labels, merged MR cleanup, Slack review permalinks
+    gitlab_sync.py      # GitLabSyncBackend — MR upsert, assigned-issue upsert, labels, merged MR cleanup, Slack review permalinks
     slack.py            # Slack notifications
     notion.py           # Notion integration
     sentry.py           # Sentry error tracking

--- a/src/teatree/backends/gitlab_api.py
+++ b/src/teatree/backends/gitlab_api.py
@@ -4,6 +4,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import SupportsInt, cast
+from urllib.parse import urlencode
 
 import httpx
 
@@ -224,6 +225,26 @@ class GitLabAPI:
         if include_draft:
             return data
         return [mr for mr in data if not mr.get("draft")]
+
+    def list_open_issues_for_assignee(
+        self,
+        assignee: str,
+        *,
+        per_page: int = 100,
+        updated_after: str | None = None,
+    ) -> list[RawMR]:
+        """Fetch all open issues (and work items) assigned to *assignee* across accessible projects."""
+        query: dict[str, str | int] = {
+            "state": "opened",
+            "assignee_username": assignee,
+            "scope": "all",
+            "per_page": per_page,
+        }
+        if updated_after:
+            query["updated_after"] = updated_after
+        params = urlencode(query)
+        data = self.get_json(f"issues?{params}")
+        return data if isinstance(data, list) else []
 
     def list_open_mrs_as_reviewer(
         self,

--- a/src/teatree/backends/gitlab_sync.py
+++ b/src/teatree/backends/gitlab_sync.py
@@ -1,4 +1,4 @@
-"""GitLab sync backend — MR upsert, issue labels, merged MR cleanup, Slack review permalinks."""
+"""GitLab sync backend — MR upsert, issue labels, merged MR cleanup, assigned issues."""
 
 import logging
 import re
@@ -8,6 +8,7 @@ import httpx
 from django.core.cache import cache
 from django.utils import timezone
 
+from teatree.backends.slack_review_sync import fetch_review_permalinks
 from teatree.core.cleanup import cleanup_worktree
 from teatree.core.models import Ticket, Worktree
 from teatree.core.sync import (
@@ -86,13 +87,15 @@ class GitLabSyncBackend(SyncBackend):
                 mr, repo_path, client, project, result, username=username, overlay_name=overlay_name
             )
 
+        self._fetch_assigned_issues(client, username, result, overlay_name=overlay_name)
+
         # Backfill overlay on any in-flight tickets that still have it empty
         if overlay_name:
             Ticket.objects.in_flight().filter(overlay="").update(overlay=overlay_name)
 
         self._fetch_issue_labels(client, result)
         self._detect_merged_mrs(client, username, result, last_sync)
-        self._fetch_review_permalinks(result)
+        fetch_review_permalinks(result)
         self._sync_reviewer_mrs(client, username, result)
 
         cache.set(LAST_SYNC_CACHE_KEY, sync_started_at.isoformat(), timeout=None)
@@ -354,6 +357,58 @@ class GitLabSyncBackend(SyncBackend):
                 result.errors.append(f"Worktree cleanup failed: {worktree.repo_path}")
 
     @classmethod
+    def _fetch_assigned_issues(
+        cls,
+        client: "GitLabAPI",
+        username: str,
+        result: SyncResult,
+        *,
+        overlay_name: str = "",
+    ) -> None:
+        """Upsert tickets for issues assigned to *username* that have no MR yet.
+
+        Tickets keyed by the same ``issue_url`` are consolidated with MR-based
+        tickets so each ticket renders as a single dashboard row.
+        """
+        try:
+            issues = client.list_open_issues_for_assignee(username)
+        except httpx.HTTPError as exc:
+            result.errors.append(f"Assigned issues fetch failed: {exc}")
+            return
+
+        for issue in issues:
+            if not isinstance(issue, dict):
+                continue
+            issue_url = str(issue.get("web_url", ""))
+            if not issue_url:
+                continue
+            result.issues_found += 1
+            repo_path = cls._extract_issue_repo_path(issue_url)
+            repo_short = repo_path.rsplit("/", maxsplit=1)[-1] if repo_path else ""
+
+            existing = Ticket.objects.filter(issue_url=issue_url).first()
+            if existing is not None:
+                if repo_short and isinstance(existing.repos, list) and repo_short not in existing.repos:
+                    existing.repos = [*existing.repos, repo_short]
+                    existing.save(update_fields=["repos"])
+                    result.tickets_updated += 1
+                continue
+
+            Ticket.objects.create(
+                issue_url=issue_url,
+                repos=[repo_short] if repo_short else [],
+                extra={"issue_title": str(issue.get("title", ""))},
+                state=Ticket.State.NOT_STARTED,
+                overlay=overlay_name,
+            )
+            result.tickets_created += 1
+
+    @classmethod
+    def _extract_issue_repo_path(cls, issue_url: str) -> str:
+        match = _ISSUE_PARTS_RE.search(issue_url)
+        return match.group(1) if match else ""
+
+    @classmethod
     def _detect_merged_mrs(
         cls,
         client: "GitLabAPI",
@@ -486,65 +541,6 @@ class GitLabSyncBackend(SyncBackend):
             if match:
                 return match.group(1)
         return ""
-
-    @classmethod
-    def _collect_reviewable_mr_urls(cls) -> tuple[list[str], dict[str, tuple[Ticket, str]]]:
-        mr_urls: list[str] = []
-        url_to_ticket: dict[str, tuple[Ticket, str]] = {}
-        for ticket in Ticket.objects.in_flight():
-            extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-            mrs = extra.get("mrs", {})
-            if not isinstance(mrs, dict):
-                continue
-            for mr_url, mr in mrs.items():
-                if not isinstance(mr, dict) or mr.get("draft") or mr.get("review_permalink"):
-                    continue
-                clean_url = mr_url.rstrip("/").split("#")[0]
-                mr_urls.append(clean_url)
-                url_to_ticket[clean_url] = (ticket, mr_url)
-        return mr_urls, url_to_ticket
-
-    @classmethod
-    def _fetch_review_permalinks(cls, result: SyncResult) -> None:
-        from teatree.backends.slack import search_review_permalinks  # noqa: PLC0415
-        from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
-
-        overlay = get_overlay()
-        token = overlay.config.get_slack_token()
-        channel_name, channel_id = overlay.config.get_review_channel()
-        if not token or not channel_id:
-            return
-
-        mr_urls, url_to_ticket = cls._collect_reviewable_mr_urls()
-        if not mr_urls:
-            return
-
-        try:
-            matches = search_review_permalinks(
-                token=token,
-                channel_id=channel_id,
-                channel_name=channel_name,
-                mr_urls=mr_urls,
-            )
-        except Exception as exc:  # noqa: BLE001
-            result.errors.append(f"Slack review sync: {exc}")
-            return
-
-        for match in matches:
-            ticket, mr_url = url_to_ticket[match.mr_url]
-            extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-            mrs = extra.get("mrs", {})
-            if not isinstance(mrs, dict):  # pragma: no cover — defensive against concurrent extra mutation
-                continue
-            mr = mrs.get(mr_url)
-            if not isinstance(mr, dict):  # pragma: no cover — defensive against concurrent extra mutation
-                continue
-            mr["review_permalink"] = match.permalink
-            mr["review_channel"] = match.channel
-            extra["mrs"] = mrs
-            ticket.extra = extra
-            ticket.save(update_fields=["extra"])
-            result.reviews_synced += 1
 
     @classmethod
     def _sync_reviewer_mrs(cls, client: "GitLabAPI", username: str, result: SyncResult) -> None:

--- a/src/teatree/backends/slack_review_sync.py
+++ b/src/teatree/backends/slack_review_sync.py
@@ -1,0 +1,73 @@
+"""Slack review-permalink sync — attach review channel links to in-flight MRs."""
+
+import logging
+
+import httpx
+
+from teatree.backends.slack import search_review_permalinks
+from teatree.core.models import Ticket
+from teatree.core.overlay_loader import get_overlay
+from teatree.core.sync import SyncResult
+
+logger = logging.getLogger(__name__)
+
+
+def _collect_reviewable_mr_urls() -> tuple[list[str], dict[str, tuple[Ticket, str]]]:
+    mr_urls: list[str] = []
+    url_to_ticket: dict[str, tuple[Ticket, str]] = {}
+    for ticket in Ticket.objects.in_flight():
+        extra = ticket.extra if isinstance(ticket.extra, dict) else {}
+        mrs = extra.get("mrs", {})
+        if not isinstance(mrs, dict):
+            continue
+        for mr_url, mr in mrs.items():
+            if not isinstance(mr, dict) or mr.get("draft") or mr.get("review_permalink"):
+                continue
+            clean_url = mr_url.rstrip("/").split("#")[0]
+            mr_urls.append(clean_url)
+            url_to_ticket[clean_url] = (ticket, mr_url)
+    return mr_urls, url_to_ticket
+
+
+def _apply_match(ticket: Ticket, mr_url: str, permalink: str, channel: str) -> bool:
+    extra = ticket.extra if isinstance(ticket.extra, dict) else {}
+    mrs = extra.get("mrs", {})
+    if not isinstance(mrs, dict):
+        return False
+    mr = mrs.get(mr_url)
+    if not isinstance(mr, dict):
+        return False
+    mr["review_permalink"] = permalink
+    mr["review_channel"] = channel
+    extra["mrs"] = mrs
+    ticket.extra = extra
+    ticket.save(update_fields=["extra"])
+    return True
+
+
+def fetch_review_permalinks(result: SyncResult) -> None:
+    overlay = get_overlay()
+    token = overlay.config.get_slack_token()
+    channel_name, channel_id = overlay.config.get_review_channel()
+    if not token or not channel_id:
+        return
+
+    mr_urls, url_to_ticket = _collect_reviewable_mr_urls()
+    if not mr_urls:
+        return
+
+    try:
+        matches = search_review_permalinks(
+            token=token,
+            channel_id=channel_id,
+            channel_name=channel_name,
+            mr_urls=mr_urls,
+        )
+    except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+        result.errors.append(f"Slack review sync: {exc}")
+        return
+
+    for match in matches:
+        ticket, mr_url = url_to_ticket[match.mr_url]
+        if _apply_match(ticket, mr_url, match.permalink, match.channel):
+            result.reviews_synced += 1

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -16,7 +16,10 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
         from teatree.core.models.ticket import Ticket  # noqa: PLC0415
 
         return (
-            self.for_overlay(overlay).exclude(state__in=[Ticket.State.DELIVERED, Ticket.State.IGNORED]).order_by("pk")
+            self.for_overlay(overlay)
+            .exclude(state__in=[Ticket.State.DELIVERED, Ticket.State.IGNORED])
+            .filter(Q(extra__tracker_status__isnull=True) | ~Q(extra__tracker_status="Done"))
+            .order_by("pk")
         )
 
 

--- a/src/teatree/core/sync.py
+++ b/src/teatree/core/sync.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 @dataclass(slots=True)
 class SyncResult:
     mrs_found: int = 0
+    issues_found: int = 0
     tickets_created: int = 0
     tickets_updated: int = 0
     labels_fetched: int = 0
@@ -97,6 +98,7 @@ def _merge_results(a: SyncResult, b: SyncResult) -> SyncResult:
     """Merge two SyncResult instances, summing counts and concatenating lists."""
     return SyncResult(
         mrs_found=a.mrs_found + b.mrs_found,
+        issues_found=a.issues_found + b.issues_found,
         tickets_created=a.tickets_created + b.tickets_created,
         tickets_updated=a.tickets_updated + b.tickets_updated,
         labels_fetched=a.labels_fetched + b.labels_fetched,

--- a/tests/teatree_core/test_managers.py
+++ b/tests/teatree_core/test_managers.py
@@ -13,6 +13,12 @@ class TestTicketQuerySet(TestCase):
 
         assert list(Ticket.objects.in_flight()) == [active]
 
+    def test_in_flight_excludes_done_tracker_status(self) -> None:
+        active = Ticket.objects.create(state=Ticket.State.STARTED, extra={"tracker_status": "In progress"})
+        Ticket.objects.create(state=Ticket.State.STARTED, extra={"tracker_status": "Done"})
+
+        assert list(Ticket.objects.in_flight()) == [active]
+
 
 class TestWorktreeQuerySet(TestCase):
     def test_active_excludes_created_items(self) -> None:

--- a/tests/teatree_core/test_sync.py
+++ b/tests/teatree_core/test_sync.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from django.core.cache import cache
 from django.test import TestCase
@@ -8,6 +9,7 @@ from django.test import TestCase
 import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.backends.gitlab_api import ProjectInfo
 from teatree.backends.gitlab_sync import GitLabSyncBackend
+from teatree.backends.slack_review_sync import fetch_review_permalinks
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase, OverlayConfig, ProvisionStep
 from teatree.core.overlay_loader import reset_overlay_cache
@@ -145,6 +147,7 @@ def _make_mock_client(mrs: list[dict]) -> MagicMock:
     mock = MagicMock()
     mock.list_open_mrs.return_value = mrs
     mock.list_all_open_mrs.return_value = mrs
+    mock.list_open_issues_for_assignee.return_value = []
     mock.list_recently_merged_mrs.return_value = []
     mock.resolve_project.return_value = _PROJECT
     mock.get_mr_pipeline.return_value = {"status": "success", "url": "https://gitlab.com/pipelines/1"}
@@ -585,7 +588,7 @@ class TestFetchReviewPermalinks(TestCase):
         overlay = SyncOverlay(slack_token="", review_channel=("", ""))
         with _patch_overlay(overlay):
             result = SyncResult()
-            GitLabSyncBackend._fetch_review_permalinks(result)
+            fetch_review_permalinks(result)
         assert result.reviews_synced == 0
         assert result.errors == []
 
@@ -608,7 +611,7 @@ class TestFetchReviewPermalinks(TestCase):
 
         with _patch_overlay(self._SLACK_OVERLAY):
             result = SyncResult()
-            GitLabSyncBackend._fetch_review_permalinks(result)
+            fetch_review_permalinks(result)
         # No non-draft MRs -> no Slack call
         assert result.reviews_synced == 0
 
@@ -631,14 +634,14 @@ class TestFetchReviewPermalinks(TestCase):
 
         with _patch_overlay(self._SLACK_OVERLAY):
             result = SyncResult()
-            GitLabSyncBackend._fetch_review_permalinks(result)
+            fetch_review_permalinks(result)
         assert result.reviews_synced == 0
 
     def test_returns_early_when_no_urls(self) -> None:
         """_fetch_review_permalinks returns early when no eligible MR URLs (line 382-383)."""
         with _patch_overlay(self._SLACK_OVERLAY):
             result = SyncResult()
-            GitLabSyncBackend._fetch_review_permalinks(result)
+            fetch_review_permalinks(result)
         assert result.reviews_synced == 0
 
     def test_handles_search_exception(self) -> None:
@@ -661,11 +664,11 @@ class TestFetchReviewPermalinks(TestCase):
             msg = "Slack timeout"
             raise RuntimeError(msg)
 
-        self._monkeypatch.setattr("teatree.backends.slack.search_review_permalinks", _explode)
+        self._monkeypatch.setattr("teatree.backends.slack_review_sync.search_review_permalinks", _explode)
 
         with _patch_overlay(self._SLACK_OVERLAY):
             result = SyncResult()
-            GitLabSyncBackend._fetch_review_permalinks(result)
+            fetch_review_permalinks(result)
         assert any("Slack review sync" in e for e in result.errors)
 
     def test_stores_matches(self) -> None:
@@ -682,7 +685,7 @@ class TestFetchReviewPermalinks(TestCase):
         )
 
         self._monkeypatch.setattr(
-            "teatree.backends.slack.search_review_permalinks",
+            "teatree.backends.slack_review_sync.search_review_permalinks",
             lambda **kw: [
                 SlackReviewMatch(
                     mr_url=mr_url,
@@ -694,7 +697,7 @@ class TestFetchReviewPermalinks(TestCase):
 
         with _patch_overlay(self._SLACK_OVERLAY):
             result = SyncResult()
-            GitLabSyncBackend._fetch_review_permalinks(result)
+            fetch_review_permalinks(result)
 
         assert result.reviews_synced == 1
         ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/503")
@@ -711,11 +714,11 @@ class TestFetchReviewPermalinks(TestCase):
             state=Ticket.State.SHIPPED,
             extra={"mrs": "not-a-dict"},
         )
-        self._monkeypatch.setattr("teatree.backends.slack.search_review_permalinks", lambda **kw: [])
+        self._monkeypatch.setattr("teatree.backends.slack_review_sync.search_review_permalinks", lambda **kw: [])
 
         with _patch_overlay(self._SLACK_OVERLAY):
             result = SyncResult()
-            GitLabSyncBackend._fetch_review_permalinks(result)
+            fetch_review_permalinks(result)
         assert result.reviews_synced == 0
 
     def test_skips_non_dict_mr_entry_in_collection(self) -> None:
@@ -727,11 +730,11 @@ class TestFetchReviewPermalinks(TestCase):
             state=Ticket.State.SHIPPED,
             extra={"mrs": {"https://gitlab.com/mr/1": "not-a-dict"}},
         )
-        self._monkeypatch.setattr("teatree.backends.slack.search_review_permalinks", lambda **kw: [])
+        self._monkeypatch.setattr("teatree.backends.slack_review_sync.search_review_permalinks", lambda **kw: [])
 
         with _patch_overlay(self._SLACK_OVERLAY):
             result = SyncResult()
-            GitLabSyncBackend._fetch_review_permalinks(result)
+            fetch_review_permalinks(result)
         assert result.reviews_synced == 0
 
 
@@ -1180,6 +1183,92 @@ class TestSyncFollowup(TestCase):
         ticket_a.refresh_from_db()
         assert "https://mr/dup" in ticket_a.extra["mrs"]
         assert "other-repo" in ticket_a.repos
+
+
+_ASSIGNED_ISSUE = {
+    "web_url": "https://gitlab.com/org/repo/-/issues/500",
+    "title": "Some assigned task",
+    "state": "opened",
+}
+
+_ASSIGNED_WORK_ITEM = {
+    "web_url": "https://gitlab.com/org/repo/-/work_items/501",
+    "title": "Assigned work item",
+    "state": "opened",
+}
+
+
+class TestSyncFollowupAssignedIssues(TestCase):
+    _OVERLAY = SyncOverlay()
+
+    @pytest.fixture(autouse=True)
+    def _with_overlay(self, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+        self._monkeypatch = monkeypatch
+        with _patch_overlay(self._OVERLAY):
+            yield
+
+    def test_creates_ticket_from_assigned_issue_without_mr(self) -> None:
+        mock_client = _make_mock_client([])
+        mock_client.list_open_issues_for_assignee.return_value = [_ASSIGNED_ISSUE]
+        self._monkeypatch.setattr("teatree.backends.gitlab_api.GitLabAPI", lambda **_kw: mock_client)
+
+        result = sync_followup()
+
+        assert result.issues_found == 1
+        assert result.tickets_created == 1
+        ticket = Ticket.objects.get(issue_url=_ASSIGNED_ISSUE["web_url"])
+        assert ticket.state == Ticket.State.NOT_STARTED
+        assert ticket.repos == ["repo"]
+        # issue_title starts from the list response then gets refreshed by _fetch_issue_labels
+        assert ticket.extra["issue_title"]
+        assert "mrs" not in ticket.extra or ticket.extra["mrs"] == {}
+
+    def test_skips_duplicate_when_mr_already_created_ticket(self) -> None:
+        mock_client = _make_mock_client([_MR_WITH_ISSUE])
+        mock_client.list_open_issues_for_assignee.return_value = [
+            {
+                "web_url": "https://gitlab.com/org/repo/-/issues/100",
+                "title": "Issue title",
+                "state": "opened",
+            },
+        ]
+        self._monkeypatch.setattr("teatree.backends.gitlab_api.GitLabAPI", lambda **_kw: mock_client)
+
+        sync_followup()
+
+        tickets = Ticket.objects.filter(issue_url="https://gitlab.com/org/repo/-/issues/100")
+        assert tickets.count() == 1
+        assert _MR_WITH_ISSUE["web_url"] in tickets.first().extra["mrs"]
+
+    def test_captures_api_errors(self) -> None:
+        mock_client = _make_mock_client([])
+        mock_client.list_open_issues_for_assignee.side_effect = httpx.RequestError("boom")
+        self._monkeypatch.setattr("teatree.backends.gitlab_api.GitLabAPI", lambda **_kw: mock_client)
+
+        result = sync_followup()
+
+        assert any("Assigned issues fetch failed: boom" in e for e in result.errors)
+        assert result.issues_found == 0
+
+    def test_creates_work_item_ticket(self) -> None:
+        mock_client = _make_mock_client([])
+        mock_client.list_open_issues_for_assignee.return_value = [_ASSIGNED_WORK_ITEM]
+        self._monkeypatch.setattr("teatree.backends.gitlab_api.GitLabAPI", lambda **_kw: mock_client)
+
+        sync_followup()
+
+        ticket = Ticket.objects.get(issue_url=_ASSIGNED_WORK_ITEM["web_url"])
+        assert ticket.repos == ["repo"]
+
+    def test_skips_entries_missing_url(self) -> None:
+        mock_client = _make_mock_client([])
+        mock_client.list_open_issues_for_assignee.return_value = [{"title": "no url"}]
+        self._monkeypatch.setattr("teatree.backends.gitlab_api.GitLabAPI", lambda **_kw: mock_client)
+
+        result = sync_followup()
+
+        assert result.tickets_created == 0
+        assert result.issues_found == 0
 
 
 class TestSyncFollowupWorkItems(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -816,6 +816,32 @@ def test_list_open_mrs_as_reviewer(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "not%5Bauthor_username%5D=adrien" in captured_endpoints[0]
 
 
+def test_list_open_issues_for_assignee(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = gitlab_api.GitLabAPI(token="test-token")
+    captured_endpoints: list[str] = []
+
+    def _capture(endpoint: str) -> list[dict[str, object]]:
+        captured_endpoints.append(endpoint)
+        return [{"iid": 42, "web_url": "https://gitlab.com/org/repo/-/issues/42"}]
+
+    monkeypatch.setattr(client, "get_json", _capture)
+
+    result = client.list_open_issues_for_assignee("adrien", updated_after="2024-01-01T00:00:00Z")
+
+    assert result == [{"iid": 42, "web_url": "https://gitlab.com/org/repo/-/issues/42"}]
+    assert captured_endpoints[0].startswith("issues?")
+    assert "assignee_username=adrien" in captured_endpoints[0]
+    assert "state=opened" in captured_endpoints[0]
+    assert "updated_after=2024-01-01T00%3A00%3A00Z" in captured_endpoints[0]
+
+
+def test_list_open_issues_for_assignee_returns_empty_on_non_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = gitlab_api.GitLabAPI(token="test-token")
+    monkeypatch.setattr(client, "get_json", lambda _endpoint: None)
+
+    assert client.list_open_issues_for_assignee("adrien") == []
+
+
 def test_list_recently_merged_mrs_returns_data(monkeypatch: pytest.MonkeyPatch) -> None:
     client = gitlab_api.GitLabAPI(token="test-token")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Dashboard **In-Flight Tickets** only showed issues that had a companion MR — assigned issues without an MR were invisible.

- Add `list_open_issues_for_assignee` on `GitLabAPI`
- `GitLabSyncBackend._fetch_assigned_issues` upserts `Ticket` rows keyed by `issue_url`, so MR-based and issue-based syncs consolidate into a single dashboard row
- `TicketQuerySet.in_flight()` hides tickets whose `tracker_status == "Done"`
- Extract Slack review-permalink logic into `slack_review_sync.py`, keeping `gitlab_sync.py` focused on GitLab concerns

Fixes #332

## Test plan

- [x] Unit tests: `TestSyncFollowupAssignedIssues` (new), `TestFetchReviewPermalinks` (rewired to new module), `TestTicketQuerySet.test_in_flight_excludes_done_tracker_status` (new)
- [x] Full suite: 2122 tests pass
- [ ] Manual dashboard verification: run `t3 dashboard`, confirm assigned-but-no-MR company tickets appear