### PR TITLE
refactor: clear 6 PLR09xx/C901 complexity suppressions

### DIFF
--- a/src/teatree/backends/gitlab_sync.py
+++ b/src/teatree/backends/gitlab_sync.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast, override
 
 import httpx
@@ -39,6 +40,14 @@ _SKILL_WRITTEN_FIELDS = ("review_channel", "review_permalink", "e2e_test_plan_ur
 _STATE_ORDER = [s.value for s in Ticket.State]
 
 
+@dataclass(frozen=True, slots=True)
+class _MRContext:
+    mr: RawAPIDict
+    repo_short: str
+    client: "GitLabAPI"
+    project: "ProjectInfo | None"
+
+
 class GitLabSyncBackend(SyncBackend):
     @override
     def is_configured(self, overlay: object) -> bool:
@@ -73,19 +82,15 @@ class GitLabSyncBackend(SyncBackend):
         for mr in mrs:
             result.mrs_found += 1
             repo_path = self._extract_repo_path(mr)
+            repo_short = repo_path.rsplit("/", maxsplit=1)[-1]
             project_id = int(mr.get("project_id", 0))  # type: ignore[arg-type]
             project = (
-                ProjectInfo(
-                    project_id=project_id,
-                    path_with_namespace=repo_path,
-                    short_name=repo_path.rsplit("/", maxsplit=1)[-1],
-                )
+                ProjectInfo(project_id=project_id, path_with_namespace=repo_path, short_name=repo_short)
                 if project_id
                 else None
             )
-            self._upsert_ticket_from_mr(
-                mr, repo_path, client, project, result, username=username, overlay_name=overlay_name
-            )
+            ctx = _MRContext(mr=mr, repo_short=repo_short, client=client, project=project)
+            self._upsert_ticket_from_mr(ctx, result, username=username, overlay_name=overlay_name)
 
         self._fetch_assigned_issues(client, username, result, overlay_name=overlay_name)
 
@@ -109,69 +114,66 @@ class GitLabSyncBackend(SyncBackend):
         return match.group(1) if match else ""
 
     @classmethod
-    def _upsert_ticket_from_mr(  # noqa: PLR0913, PLR0914
-        cls,
-        mr: RawAPIDict,
-        repo_path: str,
-        client: "GitLabAPI",
-        project: "ProjectInfo | None",
-        result: SyncResult,
-        *,
-        username: str = "",
-        overlay_name: str = "",
-    ) -> None:
-        issue_url = cls._extract_issue_url(mr)
+    def _build_mr_entry(cls, ctx: "_MRContext", *, username: str) -> MREntry:
+        """Build a fully enriched MREntry from a raw MR dict."""
+        mr = ctx.mr
         web_url = str(mr.get("web_url", ""))
-        title = str(mr.get("title", ""))
-        source_branch = str(mr.get("source_branch", ""))
         is_draft = bool(mr.get("draft"))
         mr_iid = int(mr.get("iid", 0))  # type: ignore[arg-type]
-        repo_short = repo_path.rsplit("/", maxsplit=1)[-1]
 
         mr_entry = MREntry(
             url=web_url,
-            title=title,
-            branch=source_branch,
+            title=str(mr.get("title", "")),
+            branch=str(mr.get("source_branch", "")),
             draft=is_draft,
-            repo=repo_short,
+            repo=ctx.repo_short,
             iid=mr_iid,
             updated_at=str(mr.get("updated_at", "")),
         )
 
-        # Enrich non-draft MRs with pipeline and approval data
-        if not is_draft and project and mr_iid:
-            pipeline = client.get_mr_pipeline(project.project_id, mr_iid)
+        if not is_draft and ctx.project and mr_iid:
+            pipeline = ctx.client.get_mr_pipeline(ctx.project.project_id, mr_iid)
             mr_entry.pipeline_status = pipeline["status"]
             mr_entry.pipeline_url = pipeline["url"]
+            mr_entry.approvals = ctx.client.get_mr_approvals(ctx.project.project_id, mr_iid)
 
-            approvals = client.get_mr_approvals(project.project_id, mr_iid)
-            mr_entry.approvals = approvals
-
-            discussions = client.get_mr_discussions(project.project_id, mr_iid)
+            discussions = ctx.client.get_mr_discussions(ctx.project.project_id, mr_iid)
             mr_entry.discussions = cls._classify_discussions(discussions, username)
-
             e2e_url = cls._detect_e2e_evidence(discussions, web_url)
             if e2e_url:
                 mr_entry.e2e_test_plan_url = e2e_url
 
-            draft_count = client.get_draft_notes_count(project.project_id, mr_iid)
+            draft_count = ctx.client.get_draft_notes_count(ctx.project.project_id, mr_iid)
             mr_entry.draft_comments_pending = draft_count > 0
             mr_entry.draft_comments_count = draft_count if draft_count > 0 else None
 
-        # Reviewer info is available on all MRs (including drafts)
         reviewers = mr.get("reviewers", [])
         if isinstance(reviewers, list):
             mr_entry.review_requested = bool(reviewers)
             mr_entry.reviewer_names = [str(r.get("username", "")) for r in reviewers if isinstance(r, dict)]  # ty: ignore[no-matching-overload]
 
-        lookup_url = issue_url or web_url
+        return mr_entry
+
+    @classmethod
+    def _upsert_ticket_from_mr(
+        cls,
+        ctx: "_MRContext",
+        result: SyncResult,
+        *,
+        username: str = "",
+        overlay_name: str = "",
+    ) -> None:
+        mr_entry = cls._build_mr_entry(ctx, username=username)
+        web_url = mr_entry.url
+        lookup_url = cls._extract_issue_url(ctx.mr) or web_url
         mr_entry_dict = mr_entry.to_dict()
         inferred_state = cls._infer_state_from_mrs({web_url: mr_entry_dict})
+
         tickets = list(Ticket.objects.filter(issue_url=lookup_url).order_by("pk"))
         if not tickets:
             Ticket.objects.create(
                 issue_url=lookup_url,
-                repos=[repo_short],
+                repos=[ctx.repo_short],
                 extra={"mrs": {web_url: mr_entry_dict}},
                 state=inferred_state,
                 overlay=overlay_name,
@@ -185,7 +187,7 @@ class GitLabSyncBackend(SyncBackend):
             if overlay_name and not ticket.overlay:
                 ticket.overlay = overlay_name
                 ticket.save(update_fields=["overlay"])
-            cls._update_ticket(ticket, mr_entry_dict, web_url, repo_short, inferred_state)
+            cls._update_ticket(ticket, mr_entry_dict, web_url, ctx.repo_short, inferred_state)
             result.tickets_updated += 1
 
     @classmethod

--- a/src/teatree/backends/slack.py
+++ b/src/teatree/backends/slack.py
@@ -4,11 +4,13 @@ from typing import cast
 
 import httpx
 
+from teatree.core.sync import RawAPIDict
 
-def post_webhook_message(webhook_url: str, text: str) -> dict[str, object]:
+
+def post_webhook_message(webhook_url: str, text: str) -> RawAPIDict:
     response = httpx.post(webhook_url, json={"text": text}, timeout=10.0)
     response.raise_for_status()
-    return cast("dict[str, object]", response.json())
+    return cast("RawAPIDict", response.json())
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,82 +31,97 @@ def _resolve_workspace_domain(client: httpx.Client) -> str:
     return url.removeprefix("https://") if url.startswith("https://") else url
 
 
-def search_review_permalinks(  # noqa: C901, PLR0912, PLR0913
-    *,
-    token: str,
-    channel_id: str,
-    channel_name: str,
-    mr_urls: list[str],
-    max_pages: int = 10,
-    workspace_domain: str = "",
+@dataclass(frozen=True, slots=True)
+class _ChannelContext:
+    channel_id: str
+    channel_name: str
+    workspace_domain: str
+
+
+def _iter_review_matches(
+    msg: RawAPIDict,
+    mr_url_set: set[str],
+    seen: set[str],
+    ctx: _ChannelContext,
 ) -> list[SlackReviewMatch]:
+    """Extract SlackReviewMatch entries from a single Slack message."""
+    text = str(msg.get("text", ""))
+    ts = str(msg.get("ts", ""))
+    if not ts:
+        return []
+    found_urls = _MR_URL_RE.findall(text)
+    if not found_urls:
+        return []
+
+    permalink = f"https://{ctx.workspace_domain}/archives/{ctx.channel_id}/p{ts.replace('.', '')}"
+    matches: list[SlackReviewMatch] = []
+    for url in found_urls:
+        clean_url = url.rstrip("/").split("#")[0]
+        if clean_url in mr_url_set and clean_url not in seen:
+            seen.add(clean_url)
+            matches.append(SlackReviewMatch(mr_url=clean_url, permalink=permalink, channel=ctx.channel_name))
+    return matches
+
+
+def _fetch_history_page(
+    client: httpx.Client,
+    channel_id: str,
+    cursor: str | None,
+) -> RawAPIDict:
+    """Fetch one page of conversations.history. Returns {} on non-ok response."""
+    params: dict[str, str | int] = {"channel": channel_id, "limit": 100}
+    if cursor:
+        params["cursor"] = cursor
+    response = client.get("https://slack.com/api/conversations.history", params=params)
+    response.raise_for_status()
+    data = response.json()
+    return data if data.get("ok") else {}
+
+
+@dataclass(frozen=True, slots=True)
+class SlackReviewSearchRequest:
+    token: str
+    channel_id: str
+    channel_name: str
+    mr_urls: list[str]
+    max_pages: int = 10
+    workspace_domain: str = ""
+
+
+def search_review_permalinks(request: SlackReviewSearchRequest) -> list[SlackReviewMatch]:
     """Read recent messages from a Slack channel and match MR URLs.
 
     Uses conversations.history (no search:read scope needed).
     Matching is deterministic: exact MR URL substring match, no AI.
     """
-    if not token or not channel_id or not mr_urls:
+    if not request.token or not request.channel_id or not request.mr_urls:
         return []
 
-    mr_url_set = set(mr_urls)
+    mr_url_set = set(request.mr_urls)
     matches: list[SlackReviewMatch] = []
     seen: set[str] = set()
 
-    with httpx.Client(
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=15.0,
-    ) as client:
-        if not workspace_domain:
-            workspace_domain = _resolve_workspace_domain(client)
+    with httpx.Client(headers={"Authorization": f"Bearer {request.token}"}, timeout=15.0) as client:
+        workspace_domain = request.workspace_domain or _resolve_workspace_domain(client)
+        ctx = _ChannelContext(
+            channel_id=request.channel_id,
+            channel_name=request.channel_name,
+            workspace_domain=workspace_domain,
+        )
 
-        cursor = None
-        for _ in range(max_pages):  # pragma: no branch
-            params: dict[str, str | int] = {"channel": channel_id, "limit": 100}
-            if cursor:
-                params["cursor"] = cursor
-
-            response = client.get(
-                "https://slack.com/api/conversations.history",
-                params=params,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            if not data.get("ok"):
+        cursor: str | None = None
+        for _ in range(request.max_pages):  # pragma: no branch
+            data = _fetch_history_page(client, request.channel_id, cursor)
+            if not data:
                 break
 
-            for msg in data.get("messages", []):
-                text = str(msg.get("text", ""))
-                ts = str(msg.get("ts", ""))
-                if not ts:
-                    continue
+            for msg in data.get("messages", []):  # ty: ignore[not-iterable]
+                matches.extend(_iter_review_matches(msg, mr_url_set, seen, ctx))
 
-                found_urls = _MR_URL_RE.findall(text)
-                if not found_urls:
-                    continue
-
-                # Build permalink: https://workspace.slack.com/archives/CHANNEL/pTIMESTAMP
-                ts_clean = ts.replace(".", "")
-                permalink = f"https://{workspace_domain}/archives/{channel_id}/p{ts_clean}"
-
-                for url in found_urls:
-                    clean_url = url.rstrip("/").split("#")[0]
-                    if clean_url in mr_url_set and clean_url not in seen:
-                        seen.add(clean_url)
-                        matches.append(
-                            SlackReviewMatch(
-                                mr_url=clean_url,
-                                permalink=permalink,
-                                channel=channel_name,
-                            ),
-                        )
-
-            if seen == mr_url_set:
+            if seen == mr_url_set or not data.get("has_more"):
                 break
-            if not data.get("has_more"):
-                break  # pragma: no cover — always exits via seen==mr_url_set or no cursor
             meta = data.get("response_metadata", {})
-            cursor = meta.get("next_cursor")
+            cursor = meta.get("next_cursor") if isinstance(meta, dict) else None  # ty: ignore[invalid-argument-type]
             if not cursor:
                 break
 

--- a/src/teatree/backends/slack_review_sync.py
+++ b/src/teatree/backends/slack_review_sync.py
@@ -4,7 +4,7 @@ import logging
 
 import httpx
 
-from teatree.backends.slack import search_review_permalinks
+from teatree.backends.slack import SlackReviewSearchRequest, search_review_permalinks
 from teatree.core.models import Ticket
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.sync import SyncResult
@@ -58,10 +58,12 @@ def fetch_review_permalinks(result: SyncResult) -> None:
 
     try:
         matches = search_review_permalinks(
-            token=token,
-            channel_id=channel_id,
-            channel_name=channel_name,
-            mr_urls=mr_urls,
+            SlackReviewSearchRequest(
+                token=token,
+                channel_id=channel_id,
+                channel_name=channel_name,
+                mr_urls=mr_urls,
+            )
         )
     except (httpx.HTTPError, RuntimeError, ValueError) as exc:
         result.errors.append(f"Slack review sync: {exc}")

--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -155,41 +155,6 @@ def _compose_files(compose_file: str) -> list[str]:
     return flags
 
 
-def _docker_compose_up(  # noqa: PLR0913
-    project: str,
-    compose_file: str,
-    env: dict[str, str],
-    stdout: OutputWrapper,
-    stderr: OutputWrapper,
-    *,
-    timeout: int | None = 60,
-) -> bool:
-    """Start all services via docker-compose."""
-    cmd = [
-        "docker",
-        "compose",
-        "-p",
-        project,
-        *_compose_files(compose_file),
-        "up",
-        "-d",
-        "--no-build",
-        "--pull=never",
-    ]
-    try:
-        result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False, timeout=timeout)  # noqa: S603
-    except subprocess.TimeoutExpired:
-        stderr.write(f"  docker compose up: timed out after {timeout}s")
-        return False
-    if result.returncode != 0:
-        stderr.write(f"  docker compose up failed (exit {result.returncode}):")
-        stderr.write(f"  stderr: {result.stderr.strip()}")
-        stderr.write(f"  stdout: {result.stdout.strip()[:500]}")
-        return False
-    stdout.write("  docker compose up -d: OK")
-    return True
-
-
 class Command(TyperCommand):
     _verbose: bool = True
     _timeouts: TimeoutConfig = TimeoutConfig()
@@ -199,6 +164,39 @@ class Command(TyperCommand):
             self._timeouts = TimeoutConfig(values=dict.fromkeys(self._timeouts.values, 0))
         else:
             self._timeouts = load_timeouts(overlay)
+
+    def _docker_compose_up(
+        self,
+        project: str,
+        compose_file: str,
+        env: dict[str, str],
+        *,
+        timeout: int | None = 60,
+    ) -> bool:
+        """Start all services via docker-compose."""
+        cmd = [
+            "docker",
+            "compose",
+            "-p",
+            project,
+            *_compose_files(compose_file),
+            "up",
+            "-d",
+            "--no-build",
+            "--pull=never",
+        ]
+        try:
+            result = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False, timeout=timeout)  # noqa: S603
+        except subprocess.TimeoutExpired:
+            self.stderr.write(f"  docker compose up: timed out after {timeout}s")
+            return False
+        if result.returncode != 0:
+            self.stderr.write(f"  docker compose up failed (exit {result.returncode}):")
+            self.stderr.write(f"  stderr: {result.stderr.strip()}")
+            self.stderr.write(f"  stdout: {result.stdout.strip()[:500]}")
+            return False
+        self.stdout.write("  docker compose up -d: OK")
+        return True
 
     @command()
     def setup(  # noqa: PLR0913, PLR0917
@@ -489,12 +487,10 @@ class Command(TyperCommand):
 
         env = {**os.environ, **_compose_env(ports), **overlay.get_env_extra(worktree)}
         env.pop("VIRTUAL_ENV", None)
-        ok = _docker_compose_up(
+        ok = self._docker_compose_up(
             project,
             compose_file,
             env,
-            self.stdout,
-            self.stderr,
             timeout=self._timeouts.get("docker_compose_up"),
         )
 

--- a/tests/teatree_backends/test_slack.py
+++ b/tests/teatree_backends/test_slack.py
@@ -7,6 +7,7 @@ import pytest
 
 from teatree.backends.slack import (
     SlackReviewMatch,
+    SlackReviewSearchRequest,
     _resolve_workspace_domain,
     search_review_permalinks,
 )
@@ -70,10 +71,12 @@ def test_resolve_workspace_domain_failed_auth() -> None:
 def test_search_review_permalinks_returns_empty_when_no_token() -> None:
     """search_review_permalinks returns [] when token is empty (line 47)."""
     result = search_review_permalinks(
-        token="",
-        channel_id="C123",
-        channel_name="review",
-        mr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
+        SlackReviewSearchRequest(
+            token="",
+            channel_id="C123",
+            channel_name="review",
+            mr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
+        )
     )
     assert result == []
 
@@ -81,10 +84,12 @@ def test_search_review_permalinks_returns_empty_when_no_token() -> None:
 def test_search_review_permalinks_returns_empty_when_no_channel_id() -> None:
     """search_review_permalinks returns [] when channel_id is empty (line 47)."""
     result = search_review_permalinks(
-        token="xoxb-token",
-        channel_id="",
-        channel_name="review",
-        mr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
+        SlackReviewSearchRequest(
+            token="xoxb-token",
+            channel_id="",
+            channel_name="review",
+            mr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
+        )
     )
     assert result == []
 
@@ -92,10 +97,12 @@ def test_search_review_permalinks_returns_empty_when_no_channel_id() -> None:
 def test_search_review_permalinks_returns_empty_when_no_mr_urls() -> None:
     """search_review_permalinks returns [] when mr_urls is empty (line 47)."""
     result = search_review_permalinks(
-        token="xoxb-token",
-        channel_id="C123",
-        channel_name="review",
-        mr_urls=[],
+        SlackReviewSearchRequest(
+            token="xoxb-token",
+            channel_id="C123",
+            channel_name="review",
+            mr_urls=[],
+        )
     )
     assert result == []
 
@@ -117,10 +124,12 @@ def test_search_review_permalinks_finds_matching_mr(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr("teatree.backends.slack.httpx.Client", lambda **kw: fake_client)
 
     result = search_review_permalinks(
-        token="xoxb-token",
-        channel_id="C123",
-        channel_name="review-crew",
-        mr_urls=[mr_url],
+        SlackReviewSearchRequest(
+            token="xoxb-token",
+            channel_id="C123",
+            channel_name="review-crew",
+            mr_urls=[mr_url],
+        )
     )
 
     assert len(result) == 1
@@ -149,10 +158,12 @@ def test_search_review_permalinks_stops_when_all_found(monkeypatch: pytest.Monke
     monkeypatch.setattr("teatree.backends.slack.httpx.Client", lambda **kw: fake_client)
 
     result = search_review_permalinks(
-        token="xoxb-token",
-        channel_id="C456",
-        channel_name="reviews",
-        mr_urls=[mr_url],
+        SlackReviewSearchRequest(
+            token="xoxb-token",
+            channel_id="C456",
+            channel_name="reviews",
+            mr_urls=[mr_url],
+        )
     )
 
     assert len(result) == 1
@@ -179,10 +190,12 @@ def test_search_review_permalinks_paginates(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr("teatree.backends.slack.httpx.Client", lambda **kw: fake_client)
 
     result = search_review_permalinks(
-        token="xoxb-token",
-        channel_id="C789",
-        channel_name="review",
-        mr_urls=[mr_url1, mr_url2],
+        SlackReviewSearchRequest(
+            token="xoxb-token",
+            channel_id="C789",
+            channel_name="review",
+            mr_urls=[mr_url1, mr_url2],
+        )
     )
 
     assert len(result) == 2
@@ -196,10 +209,12 @@ def test_search_review_permalinks_stops_on_not_ok(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr("teatree.backends.slack.httpx.Client", lambda **kw: fake_client)
 
     result = search_review_permalinks(
-        token="xoxb-token",
-        channel_id="C999",
-        channel_name="review",
-        mr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
+        SlackReviewSearchRequest(
+            token="xoxb-token",
+            channel_id="C999",
+            channel_name="review",
+            mr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
+        )
     )
 
     assert result == []
@@ -220,10 +235,12 @@ def test_search_review_permalinks_skips_messages_without_ts(monkeypatch: pytest.
     monkeypatch.setattr("teatree.backends.slack.httpx.Client", lambda **kw: fake_client)
 
     result = search_review_permalinks(
-        token="xoxb-token",
-        channel_id="C111",
-        channel_name="review",
-        mr_urls=[mr_url],
+        SlackReviewSearchRequest(
+            token="xoxb-token",
+            channel_id="C111",
+            channel_name="review",
+            mr_urls=[mr_url],
+        )
     )
 
     assert len(result) == 1
@@ -242,11 +259,13 @@ def test_search_review_permalinks_uses_provided_workspace_domain(monkeypatch: py
     monkeypatch.setattr("teatree.backends.slack.httpx.Client", lambda **kw: fake_client)
 
     result = search_review_permalinks(
-        token="xoxb-token",
-        channel_id="C222",
-        channel_name="review",
-        mr_urls=[mr_url],
-        workspace_domain="custom.slack.com",
+        SlackReviewSearchRequest(
+            token="xoxb-token",
+            channel_id="C222",
+            channel_name="review",
+            mr_urls=[mr_url],
+            workspace_domain="custom.slack.com",
+        )
     )
 
     assert len(result) == 1
@@ -268,10 +287,12 @@ def test_search_review_permalinks_deduplicates_same_mr(monkeypatch: pytest.Monke
     monkeypatch.setattr("teatree.backends.slack.httpx.Client", lambda **kw: fake_client)
 
     result = search_review_permalinks(
-        token="xoxb-token",
-        channel_id="C333",
-        channel_name="review",
-        mr_urls=[mr_url],
+        SlackReviewSearchRequest(
+            token="xoxb-token",
+            channel_id="C333",
+            channel_name="review",
+            mr_urls=[mr_url],
+        )
     )
 
     assert len(result) == 1
@@ -289,10 +310,12 @@ def test_search_review_permalinks_stops_when_no_cursor(monkeypatch: pytest.Monke
     monkeypatch.setattr("teatree.backends.slack.httpx.Client", lambda **kw: fake_client)
 
     result = search_review_permalinks(
-        token="xoxb-token",
-        channel_id="C444",
-        channel_name="review",
-        mr_urls=["https://gitlab.com/org/repo/-/merge_requests/99"],
+        SlackReviewSearchRequest(
+            token="xoxb-token",
+            channel_id="C444",
+            channel_name="review",
+            mr_urls=["https://gitlab.com/org/repo/-/merge_requests/99"],
+        )
     )
 
     assert result == []

--- a/tests/teatree_core/test_sync.py
+++ b/tests/teatree_core/test_sync.py
@@ -660,7 +660,7 @@ class TestFetchReviewPermalinks(TestCase):
             },
         )
 
-        def _explode(**kw: object) -> list:
+        def _explode(request: object) -> list:
             msg = "Slack timeout"
             raise RuntimeError(msg)
 
@@ -686,7 +686,7 @@ class TestFetchReviewPermalinks(TestCase):
 
         self._monkeypatch.setattr(
             "teatree.backends.slack_review_sync.search_review_permalinks",
-            lambda **kw: [
+            lambda _request: [
                 SlackReviewMatch(
                     mr_url=mr_url,
                     permalink="https://team.slack.com/archives/C123/p170000",
@@ -714,7 +714,7 @@ class TestFetchReviewPermalinks(TestCase):
             state=Ticket.State.SHIPPED,
             extra={"mrs": "not-a-dict"},
         )
-        self._monkeypatch.setattr("teatree.backends.slack_review_sync.search_review_permalinks", lambda **kw: [])
+        self._monkeypatch.setattr("teatree.backends.slack_review_sync.search_review_permalinks", lambda _request: [])
 
         with _patch_overlay(self._SLACK_OVERLAY):
             result = SyncResult()
@@ -730,7 +730,7 @@ class TestFetchReviewPermalinks(TestCase):
             state=Ticket.State.SHIPPED,
             extra={"mrs": {"https://gitlab.com/mr/1": "not-a-dict"}},
         )
-        self._monkeypatch.setattr("teatree.backends.slack_review_sync.search_review_permalinks", lambda **kw: [])
+        self._monkeypatch.setattr("teatree.backends.slack_review_sync.search_review_permalinks", lambda _request: [])
 
         with _patch_overlay(self._SLACK_OVERLAY):
             result = SyncResult()


### PR DESCRIPTION
## Summary

Clears 6 ruff complexity suppressions across 3 hotspots by real decomposition — no loosened limits. Follow-up to #333 (skills Non-Negotiable dedupe) under the same umbrella ticket #324.

## Refactors

**`slack.search_review_permalinks`** (removed `C901 + PLR0912 + PLR0913`)
- `SlackReviewSearchRequest` frozen dataclass — single public arg replaces 6 kwargs
- `_ChannelContext` groups channel_id/channel_name/workspace_domain for helpers
- `_iter_review_matches(msg, set, seen, ctx)` — one-message match extraction
- `_fetch_history_page(client, channel_id, cursor)` — one page of conversations.history

**`gitlab_sync._upsert_ticket_from_mr`** (removed `PLR0913 + PLR0914`)
- `_MRContext` groups (mr, repo_short, client, project) at the call site
- `_build_mr_entry(ctx, *, username) -> MREntry` hydrates pipeline, approvals, discussions, e2e, reviewers
- `_upsert_ticket_from_mr(ctx, result, *, username, overlay_name)` is now just DB upsert

**`lifecycle._docker_compose_up`** (removed `PLR0913`)
- Moved onto `Command` as a method
- `self.stdout`/`self.stderr` replace the two `OutputWrapper` params

## Verification

- `uv run ruff check` — clean
- `uv run ty check` — clean
- `uv run pytest --no-cov -q` — **2122 passed**
- Pre-commit hooks pass (including module-health and quality-gates; `relax:` prefix acknowledges the pre-existing `# noqa: S603` moved alongside `_docker_compose_up`)

## Test plan

- [x] Slack refactor: 13 tests pass; `lambda **kw` mocks in `test_sync.py` updated to `lambda _request`
- [x] gitlab_sync refactor: integration tests via `sync()` still green (no direct unit tests for `_upsert_ticket_from_mr`)
- [x] lifecycle refactor: 185 management-command tests green; test at `test_new_management_commands.py:3382` uses `call_command`, unaffected by the method move

Relates-to #324