### PR TITLE
refactor(backends): group CodeHost.create_pr args into PullRequestSpec

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -533,11 +533,11 @@ No manage.py, settings.py, urls.py, or wsgi/asgi — teatree is the Django proje
 
 ### 7.1 API Protocols (`backends/protocols.py`)
 
-Each external API concern is a `@runtime_checkable Protocol` in `teatree.backends.protocols`.
+Each external API concern is a `@runtime_checkable Protocol` in `teatree.backends.protocols`. Request parameters are grouped into frozen dataclasses (e.g. `PullRequestSpec`) so that signatures stay small and extensible.
 
 | Protocol | Methods |
 |----------|---------|
-| `CodeHost` | `create_pr()`, `list_open_prs()`, `post_mr_note()` |
+| `CodeHost` | `create_pr(PullRequestSpec)`, `list_open_prs()`, `post_mr_note()` |
 | `CIService` | `cancel_pipelines()`, `fetch_pipeline_errors()`, `fetch_failed_tests()`, `trigger_pipeline()`, `quality_check()` |
 | `IssueTracker` | `get_issue()` |
 | `ChatNotifier` | `send()` |

--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -5,6 +5,9 @@ import subprocess  # noqa: S404
 from dataclasses import dataclass
 from typing import cast
 
+from teatree.backends.protocols import PullRequestSpec
+from teatree.core.sync import RawAPIDict
+
 
 @dataclass(frozen=True, slots=True)
 class ProjectItem:
@@ -174,36 +177,26 @@ class GitHubCodeHost:
     def __init__(self, *, token: str = "") -> None:
         self._token = token
 
-    def create_pr(  # noqa: PLR0913
-        self,
-        *,
-        repo: str,
-        branch: str,
-        title: str,
-        description: str,
-        target_branch: str = "",
-        labels: list[str] | None = None,
-        assignee: str = "",
-    ) -> dict[str, object]:
+    def create_pr(self, spec: PullRequestSpec) -> RawAPIDict:
         cmd = [
             "gh",
             "pr",
             "create",
             "--repo",
-            repo,
+            spec.repo,
             "--head",
-            branch,
+            spec.branch,
             "--title",
-            title,
+            spec.title,
             "--body",
-            description,
+            spec.description,
         ]
-        if target_branch:
-            cmd.extend(["--base", target_branch])
-        if labels:
-            cmd.extend(["--label", ",".join(labels)])
-        if assignee:
-            cmd.extend(["--assignee", assignee])
+        if spec.target_branch:
+            cmd.extend(["--base", spec.target_branch])
+        if spec.labels:
+            cmd.extend(["--label", ",".join(spec.labels)])
+        if spec.assignee:
+            cmd.extend(["--assignee", spec.assignee])
 
         result = _run_gh(*cmd, token=self._token)
         return {"url": result.stdout.strip()}

--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
 from teatree.backends.gitlab_api import GitLabAPI, ProjectInfo
+from teatree.backends.protocols import PullRequestSpec
+from teatree.core.sync import RawAPIDict
 
 
 def get_client(*, token: str = "", base_url: str = "") -> GitLabAPI:
@@ -24,31 +26,21 @@ class GitLabCodeHost:
     ) -> None:
         self._client = client or get_client(token=token, base_url=base_url)
 
-    def create_pr(  # noqa: PLR0913
-        self,
-        *,
-        repo: str,
-        branch: str,
-        title: str,
-        description: str,
-        target_branch: str = "",
-        labels: list[str] | None = None,
-        assignee: str = "",
-    ) -> dict[str, object]:
-        project = self._resolve_project(repo)
+    def create_pr(self, spec: PullRequestSpec) -> RawAPIDict:
+        project = self._resolve_project(spec.repo)
         if project is None:
-            return {"error": f"Could not resolve project: {repo}"}
+            return {"error": f"Could not resolve project: {spec.repo}"}
 
-        payload: dict[str, object] = {
-            "source_branch": branch,
-            "target_branch": target_branch or project.default_branch,
-            "title": title,
-            "description": description,
+        payload: RawAPIDict = {
+            "source_branch": spec.branch,
+            "target_branch": spec.target_branch or project.default_branch,
+            "title": spec.title,
+            "description": spec.description,
         }
-        if labels:
-            payload["labels"] = ",".join(labels)
-        if assignee:
-            payload["assignee_username"] = assignee
+        if spec.labels:
+            payload["labels"] = ",".join(spec.labels)
+        if spec.assignee:
+            payload["assignee_username"] = spec.assignee
 
         return self._client.post_json(f"projects/{project.project_id}/merge_requests", payload) or {}
 

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -7,28 +7,34 @@ A single class can satisfy multiple protocols when the platform provides
 multiple concerns (e.g. GitLab provides code hosting, CI, and issue tracking).
 """
 
+from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
+
+from teatree.core.sync import RawAPIDict
+
+
+@dataclass(frozen=True, slots=True)
+class PullRequestSpec:
+    """Fields needed to open a pull/merge request on a CodeHost."""
+
+    repo: str
+    branch: str
+    title: str
+    description: str
+    target_branch: str = ""
+    labels: list[str] = field(default_factory=list)
+    assignee: str = ""
 
 
 @runtime_checkable
 class CodeHost(Protocol):
     """Create and list pull/merge requests."""
 
-    def create_pr(  # noqa: PLR0913
-        self,
-        *,
-        repo: str,
-        branch: str,
-        title: str,
-        description: str,
-        target_branch: str = "",
-        labels: list[str] | None = None,
-        assignee: str = "",
-    ) -> dict[str, object]: ...  # pragma: no branch
+    def create_pr(self, spec: PullRequestSpec) -> RawAPIDict: ...  # pragma: no branch
 
-    def list_open_prs(self, repo: str, author: str) -> list[dict[str, object]]: ...  # pragma: no branch
+    def list_open_prs(self, repo: str, author: str) -> list[RawAPIDict]: ...  # pragma: no branch
 
-    def post_mr_note(self, *, repo: str, mr_iid: int, body: str) -> dict[str, object]: ...  # pragma: no branch
+    def post_mr_note(self, *, repo: str, mr_iid: int, body: str) -> RawAPIDict: ...  # pragma: no branch
 
     def update_mr_note(
         self,
@@ -37,11 +43,11 @@ class CodeHost(Protocol):
         mr_iid: int,
         note_id: int,
         body: str,
-    ) -> dict[str, object]: ...  # pragma: no branch
+    ) -> RawAPIDict: ...  # pragma: no branch
 
-    def list_mr_notes(self, *, repo: str, mr_iid: int) -> list[dict[str, object]]: ...  # pragma: no branch
+    def list_mr_notes(self, *, repo: str, mr_iid: int) -> list[RawAPIDict]: ...  # pragma: no branch
 
-    def upload_file(self, *, repo: str, filepath: str) -> dict[str, object]: ...  # pragma: no branch
+    def upload_file(self, *, repo: str, filepath: str) -> RawAPIDict: ...  # pragma: no branch
 
 
 @runtime_checkable
@@ -60,27 +66,27 @@ class CIService(Protocol):
         project: str,
         ref: str,
         variables: dict[str, str] | None = None,
-    ) -> dict[str, object]: ...  # pragma: no branch
+    ) -> RawAPIDict: ...  # pragma: no branch
 
-    def quality_check(self, *, project: str, ref: str) -> dict[str, object]: ...  # pragma: no branch
+    def quality_check(self, *, project: str, ref: str) -> RawAPIDict: ...  # pragma: no branch
 
 
 @runtime_checkable
 class IssueTracker(Protocol):
     """Fetch issue details from a project tracker."""
 
-    def get_issue(self, issue_url: str) -> dict[str, object]: ...  # pragma: no branch
+    def get_issue(self, issue_url: str) -> RawAPIDict: ...  # pragma: no branch
 
 
 @runtime_checkable
 class ChatNotifier(Protocol):
     """Send notifications to a team chat channel."""
 
-    def send(self, *, channel: str, text: str) -> dict[str, object]: ...  # pragma: no branch
+    def send(self, *, channel: str, text: str) -> RawAPIDict: ...  # pragma: no branch
 
 
 @runtime_checkable
 class ErrorTracker(Protocol):
     """Fetch error/issue data from an error tracking service."""
 
-    def get_top_issues(self, *, project: str, limit: int = 10) -> list[dict[str, object]]: ...  # pragma: no branch
+    def get_top_issues(self, *, project: str, limit: int = 10) -> list[RawAPIDict]: ...  # pragma: no branch

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -6,6 +6,7 @@ from typing import cast
 
 from django_typer.management import TyperCommand, command
 
+from teatree.backends.protocols import PullRequestSpec
 from teatree.core.backend_factory import code_host_from_overlay, get_issue_tracker
 from teatree.core.models import Ticket
 from teatree.core.overlay_loader import get_overlay
@@ -121,12 +122,14 @@ class Command(TyperCommand):
 
         assignee = _current_user()
         return host.create_pr(
-            repo=repo_path,
-            branch=branch,
-            title=title,
-            description=description,
-            labels=_mr_auto_labels() or None,
-            assignee=assignee,
+            PullRequestSpec(
+                repo=repo_path,
+                branch=branch,
+                title=title,
+                description=description,
+                labels=_mr_auto_labels(),
+                assignee=assignee,
+            ),
         )
 
     @command(name="check-gates")

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab_api import GitLabAPI, ProjectInfo
+from teatree.backends.protocols import PullRequestSpec
 
 
 def _project() -> ProjectInfo:
@@ -17,11 +18,13 @@ def test_create_pr_uses_repo_remote_and_auto_labels(tmp_path) -> None:
     repo_path.mkdir()
 
     result = host.create_pr(
-        repo=str(repo_path),
-        branch="feature-branch",
-        title="feat: add labels",
-        description="body",
-        labels=["Process::Technical review", "customer::foo"],
+        PullRequestSpec(
+            repo=str(repo_path),
+            branch="feature-branch",
+            title="feat: add labels",
+            description="body",
+            labels=["Process::Technical review", "customer::foo"],
+        ),
     )
 
     assert result == {"iid": 7}
@@ -45,11 +48,13 @@ def test_create_pr_uses_explicit_target_branch() -> None:
     host = GitLabCodeHost(client=client)
 
     host.create_pr(
-        repo="org/repo",
-        branch="feature-branch",
-        title="feat: add labels",
-        description="body",
-        target_branch="develop",
+        PullRequestSpec(
+            repo="org/repo",
+            branch="feature-branch",
+            title="feat: add labels",
+            description="body",
+            target_branch="develop",
+        ),
     )
 
     client.resolve_project.assert_called_once_with("org/repo")
@@ -79,10 +84,12 @@ def test_create_pr_returns_error_when_project_not_resolved() -> None:
     host = GitLabCodeHost(client=client)
 
     result = host.create_pr(
-        repo="org/unknown",
-        branch="feat",
-        title="test",
-        description="desc",
+        PullRequestSpec(
+            repo="org/unknown",
+            branch="feat",
+            title="test",
+            description="desc",
+        ),
     )
 
     assert result == {"error": "Could not resolve project: org/unknown"}

--- a/tests/teatree_backends/test_protocols.py
+++ b/tests/teatree_backends/test_protocols.py
@@ -1,6 +1,6 @@
 """Tests for backend protocol structural typing."""
 
-from teatree.backends.protocols import ChatNotifier, CIService, CodeHost, ErrorTracker, IssueTracker
+from teatree.backends.protocols import ChatNotifier, CIService, CodeHost, ErrorTracker, IssueTracker, PullRequestSpec
 
 
 def test_ci_service_protocol_is_structural() -> None:
@@ -31,15 +31,8 @@ def test_ci_service_protocol_is_structural() -> None:
 
 def test_code_host_protocol_is_structural() -> None:
     class MyCodeHost:
-        def create_pr(
-            self,
-            *,
-            repo: str,
-            branch: str,
-            title: str,
-            description: str,
-            target_branch: str = "",
-        ) -> dict[str, object]:
+        def create_pr(self, spec: PullRequestSpec) -> dict[str, object]:
+            _ = spec
             return {}
 
         def list_open_prs(self, repo: str, author: str) -> list[dict[str, object]]:

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -1613,12 +1613,12 @@ class TestPrCreate(TestCase):
             )
 
         assert result == {"url": "https://example.com/mr/1"}
-        call_kwargs = mock_host.create_pr.call_args.kwargs
-        assert call_kwargs["repo"] == "my-repo"
-        assert call_kwargs["branch"] == "feature-70"
-        assert call_kwargs["title"] == "Fix bug"
-        assert call_kwargs["description"] == "Fixes the thing"
-        assert "assignee" in call_kwargs
+        (spec,) = mock_host.create_pr.call_args.args
+        assert spec.repo == "my-repo"
+        assert spec.branch == "feature-70"
+        assert spec.title == "Fix bug"
+        assert spec.description == "Fixes the thing"
+        assert spec.assignee
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1667,9 +1667,9 @@ class TestPrCreate(TestCase):
                 ),
             )
 
-        call_kwargs = mock_host.create_pr.call_args[1]
-        assert call_kwargs["branch"] == "ticket-72"
-        assert call_kwargs["repo"] == ""
+        (spec,) = mock_host.create_pr.call_args.args
+        assert spec.branch == "ticket-72"
+        assert spec.repo == ""
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1687,8 +1687,8 @@ class TestPrCreate(TestCase):
         ):
             call_command("pr", "create", str(ticket.pk), skip_validation=True)
 
-        call_kwargs = mock_host.create_pr.call_args[1]
-        assert call_kwargs["title"] == "Resolve https://example.com/issues/73"
+        (spec,) = mock_host.create_pr.call_args.args
+        assert spec.title == "Resolve https://example.com/issues/73"
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1706,9 +1706,9 @@ class TestPrCreate(TestCase):
         ):
             call_command("pr", "create", str(ticket.pk), description="user desc", skip_validation=True)
 
-        call_kwargs = mock_host.create_pr.call_args[1]
-        assert call_kwargs["title"] == "commit title"
-        assert call_kwargs["description"] == "user desc"
+        (spec,) = mock_host.create_pr.call_args.args
+        assert spec.title == "commit title"
+        assert spec.description == "user desc"
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1779,9 +1779,9 @@ class TestPrCreate(TestCase):
         ):
             call_command("pr", "create", str(ticket.pk), skip_validation=True)
 
-        call_kwargs = mock_host.create_pr.call_args[1]
-        assert call_kwargs["title"] == "fix(api): handle nulls"
-        assert call_kwargs["description"] == "Detailed body here"
+        (spec,) = mock_host.create_pr.call_args.args
+        assert spec.title == "fix(api): handle nulls"
+        assert spec.description == "Detailed body here"
 
 
 class TestPrCheckGates(TestCase):

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -42,7 +42,7 @@ class TestPrCreate(TestCase):
         ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/55")
         Worktree.objects.create(ticket=ticket, overlay="test", repo_path="/tmp/backend", branch="feature-branch")
 
-        # CommandOverlay.config.mr_auto_labels returns [] (default), so labels=None
+        # CommandOverlay.config.mr_auto_labels returns [] (default), so labels=[]
         with (
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
             patch("teatree.core.management.commands.pr._last_commit_message", return_value=("", "")),
@@ -50,11 +50,11 @@ class TestPrCreate(TestCase):
             result = call_command("pr", "create", str(ticket.id), "--title", "feat: add labels")
 
         assert result == {"iid": 12}
-        call_kwargs = host.create_pr.call_args.kwargs
-        assert call_kwargs["repo"] == "/tmp/backend"
-        assert call_kwargs["branch"] == "feature-branch"
-        assert call_kwargs["title"] == "feat: add labels"
-        assert "assignee" in call_kwargs
+        (spec,) = host.create_pr.call_args.args
+        assert spec.repo == "/tmp/backend"
+        assert spec.branch == "feature-branch"
+        assert spec.title == "feat: add labels"
+        assert spec.assignee == "dev"
 
 
 class TestPostEvidence(TestCase):

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -15,6 +15,7 @@ from teatree.backends.github import (
     _run_gh,
     fetch_project_items,
 )
+from teatree.backends.protocols import PullRequestSpec
 
 
 class TestRunGh:
@@ -208,10 +209,12 @@ class TestGitHubCodeHost:
             mock_run.return_value = MagicMock(stdout="https://github.com/org/repo/pull/1\n")
             host = GitHubCodeHost(token="tok")
             result = host.create_pr(
-                repo="org/repo",
-                branch="feature",
-                title="Add feature",
-                description="Description",
+                PullRequestSpec(
+                    repo="org/repo",
+                    branch="feature",
+                    title="Add feature",
+                    description="Description",
+                ),
             )
         assert result == {"url": "https://github.com/org/repo/pull/1"}
 
@@ -220,13 +223,15 @@ class TestGitHubCodeHost:
             mock_run.return_value = MagicMock(stdout="https://github.com/org/repo/pull/2\n")
             host = GitHubCodeHost()
             host.create_pr(
-                repo="org/repo",
-                branch="feature",
-                title="Title",
-                description="Desc",
-                target_branch="develop",
-                labels=["bug", "urgent"],
-                assignee="user1",
+                PullRequestSpec(
+                    repo="org/repo",
+                    branch="feature",
+                    title="Title",
+                    description="Desc",
+                    target_branch="develop",
+                    labels=["bug", "urgent"],
+                    assignee="user1",
+                ),
             )
         args = mock_run.call_args[0]
         cmd = list(args)


### PR DESCRIPTION
## Summary

- Introduces a frozen, slotted `PullRequestSpec` dataclass in `teatree.backends.protocols` so `CodeHost.create_pr` takes a single `spec` parameter instead of 6 keyword arguments.
- Clears the three `# noqa: PLR0913` suppressions on the `Protocol` method and its `GitLabCodeHost` / `GitHubCodeHost` implementations.
- Adopts the existing `RawAPIDict` alias from `teatree.core.sync` for the return-type annotations on lines that moved as part of the refactor — matches the pattern already used in `slack.py`, `github_sync.py`, and `gitlab_sync.py`.

This continues the Opus 4.7 quick-wins thread of clearing complexity-debt suppressions one at a time. Follow-up to #337.

## Changes

- `protocols.py`: add `PullRequestSpec` dataclass (`frozen=True, slots=True`, `labels` via `field(default_factory=list)`); update Protocol signatures to use `RawAPIDict`.
- `gitlab.py`, `github.py`: adopt single-arg signature; unpack via `spec.*`.
- `pr.py`: wrap callsite in `PullRequestSpec(...)`; `labels` now always a list.
- `tests/`: update call sites and switch mock inspection from `call_args.kwargs` to positional spec unpacking.
- `BLUEPRINT.md`: mention `PullRequestSpec` under backend protocols.

## Test plan

- [x] `uv run pytest --no-cov -q` — 2122 passed
- [x] `uv run ruff check` — clean
- [x] `uv run ty check` — clean
- [x] All pre-commit hooks pass (incl. module-health, tach)
- [ ] CI green