### PR TITLE
feat(visual-qa): add pre-push browser sanity gate (#338)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.t3/
 __pycache__/
 *.pyc
 .venv/

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -475,6 +475,7 @@ Defined in `teatree.core.overlay`. All methods receive the `worktree` instance f
 | `detect_variant()` | `→ str` | `""` | Tenant detection |
 | `get_workspace_repos()` | `→ list[str]` | `get_repos()` | Repos for workspace ticket creation |
 | `get_tool_commands()` | `→ list[ToolCommand]` | `[]` | Overlay-specific CLI tools |
+| `get_visual_qa_targets(changed_files)` | `→ list[str]` | `[]` | URL paths the pre-push browser sanity gate should load |
 
 ### 6.2 Supporting TypedDicts
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -117,6 +117,15 @@ Before creating an MR, the `pr create` command automatically checks the session 
 - If no review session ran for this ticket, `pr create` returns an error with a hint to run `/t3:review`
 - Use `--skip-validation` only when explicitly told to bypass gates
 
+### 4c. Visual QA Gate
+
+`pr create` also runs a pre-push browser sanity gate as a side effect of the shipping flow. It loads the page(s) the branch diff actually touches and reports silent-render regressions (page crashes, console errors, raw `app.*` translation keys, blocking asset 404s). Target URLs come from the overlay's `get_visual_qa_targets(changed_files)` — overlays opt in by mapping diff paths to URLs.
+
+- Runs automatically before MR creation; the report is recorded on `Ticket.extra['visual_qa']`.
+- Blocks MR creation when findings exist; the error payload includes `report_markdown` for a `## Visual QA` section.
+- Bypass: `t3 pr create <ticket> --skip-visual-qa "<reason>"` or `T3_VISUAL_QA=disabled` in the environment.
+- Skipped when Playwright cannot start — fails open with a clear message rather than blocking the push.
+
 ### 5. Create MR/PR
 
 **STOP — resolve the ticket URL before typing the glab command.**

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -83,6 +83,7 @@ Overlays subclass `OverlayBase` and override methods:
 - `get_run_commands(worktree)` — dev server commands
 - `get_db_import_strategy(worktree)` — DSLR/dump import config
 - `get_services_config(worktree)` — Docker services
+- `get_visual_qa_targets(changed_files)` — URL paths the pre-push browser sanity gate should load (default: `[]` — opt in by mapping diff paths to URLs)
 
 ## Skill Loading
 

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -202,6 +202,12 @@ Post the test plan as a comment on the MR. If a test plan comment already exists
 
 See your [issue tracker platform reference](../t3:platforms/references/) § "MR Notes" for the posting recipe.
 
+## Pre-Push Browser Sanity Gate (Visual QA)
+
+`t3 pr create` runs a pre-push browser sanity gate as a side effect of the shipping flow. It loads the page(s) the branch diff touches, captures silent-render regressions (crashes, console errors, raw `app.*` keys, blocking 404s), and records the summary on `Ticket.extra['visual_qa']`. See [`../t3:ship/SKILL.md`](../t3:ship/SKILL.md) § "4c. Visual QA Gate" for the blocking behavior and bypass flags.
+
+This gate is **not a replacement for manual E2E evidence** — it only catches silent-render regressions before push. Feature verification still requires the workflows below.
+
 ## Post Testing Evidence on MR
 
 **Use `t3 pr post-evidence` first.** If the CLI command handles uploading and posting, use it instead of manual API calls. Only fall back to manual posting if the CLI doesn't support the required operation.

--- a/src/teatree/contrib/t3_teatree/overlay.py
+++ b/src/teatree/contrib/t3_teatree/overlay.py
@@ -10,6 +10,7 @@ from typing import override
 from teatree.core.models import Worktree
 from teatree.core.overlay import OverlayBase, OverlayConfig, OverlayMetadata
 from teatree.types import ProvisionStep, RunCommands, SkillMetadata
+from teatree.visual_qa import matches_triggers
 
 _SETTINGS_MODULE = "teatree.contrib.t3_teatree.overlay_settings"
 
@@ -85,3 +86,13 @@ class TeatreeOverlay(OverlayBase):
     @override
     def get_test_command(self, worktree: Worktree) -> list[str]:
         return ["uv", "run", "pytest"]
+
+    @override
+    def get_visual_qa_targets(self, changed_files: list[str]) -> list[str]:
+        teatree_globs = (
+            "src/teatree/**/templates/**",
+            "src/teatree/**/static/**",
+            "src/teatree/core/views/**",
+            "src/teatree/core/urls.py",
+        )
+        return ["/"] if matches_triggers(changed_files, teatree_globs) else []

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -2,15 +2,26 @@
 
 import re
 from collections.abc import Iterable
-from typing import cast
+from typing import TypedDict, cast
 
 from django_typer.management import TyperCommand, command
 
+from teatree import visual_qa
 from teatree.backends.protocols import PullRequestSpec
 from teatree.core.backend_factory import code_host_from_overlay, get_issue_tracker
-from teatree.core.models import Ticket
+from teatree.core.models import Ticket, Worktree
+from teatree.core.models.types import TicketExtra, VisualQASummary
 from teatree.core.overlay_loader import get_overlay
 from teatree.utils import git
+
+
+class VisualQAGateFailure(TypedDict):
+    allowed: bool
+    error: str
+    visual_qa: VisualQASummary
+    report_markdown: str
+    hint: str
+
 
 _IMAGE_URL_RE = re.compile(r"!\[([^\]]*)\]\((/uploads/[^\)]+)\)")
 _EXTERNAL_LINK_RE = re.compile(r"https?://(?:www\.)?(?:notion\.so|linear\.app|jira\.\S+)/\S+")
@@ -68,6 +79,54 @@ def _check_shipping_gate(ticket: Ticket) -> dict[str, object] | None:
     return None
 
 
+def _resolve_base_url(worktree: Worktree | None) -> str:
+    """Return the frontend URL recorded by ``Worktree.verify()``.
+
+    Prefers ``urls['frontend']`` (what users browse) over ``urls['backend']``.
+    Falls back to ``http://127.0.0.1:8000`` when no URLs are recorded yet.
+    """
+    if worktree is None:
+        return "http://127.0.0.1:8000"
+    urls = worktree.get_extra().get("urls", {})
+    return urls.get("frontend") or urls.get("backend") or "http://127.0.0.1:8000"
+
+
+def _run_visual_qa_gate(ticket: Ticket, *, skip_reason: str = "") -> VisualQAGateFailure | None:
+    """Run the pre-push browser sanity gate before MR creation.
+
+    Records a JSON summary on ``ticket.extra['visual_qa']`` when the gate
+    actually ran (i.e. not skipped for env/flag reasons) so the result
+    survives in the FSM history.  Returns an error dict when blocking
+    findings are present so the caller can refuse MR creation, or
+    ``None`` when the gate passes / is skipped.
+    """
+    worktree = ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
+    repo_path = worktree.repo_path if worktree else "."
+    base_url = _resolve_base_url(worktree)
+
+    overlay = get_overlay()
+    diff = visual_qa.changed_files(repo=repo_path)
+    report = visual_qa.evaluate(diff=diff, overlay=overlay, base_url=base_url, skip_reason=skip_reason)
+
+    # Only persist when the gate produced a meaningful signal — skipping a
+    # no-op run keeps the FSM history readable.
+    if report.pages or report.has_errors:
+        extra = cast("TicketExtra", ticket.extra or {})
+        extra["visual_qa"] = report.summary()
+        ticket.extra = extra
+        ticket.save(update_fields=["extra"])
+
+    if not report.has_errors:
+        return None
+    return VisualQAGateFailure(
+        allowed=False,
+        error=f"Visual QA found {report.total_errors} blocking finding(s).",
+        visual_qa=report.summary(),
+        report_markdown=visual_qa.format_report(report),
+        hint="Fix the findings, or pass --skip-visual-qa <reason> to bypass.",
+    )
+
+
 class Command(TyperCommand):
     @command()
     def create(  # noqa: PLR0913
@@ -79,6 +138,7 @@ class Command(TyperCommand):
         *,
         dry_run: bool = False,
         skip_validation: bool = False,
+        skip_visual_qa: str = "",
     ) -> dict[str, object]:
         """Create a merge request for the ticket's branch."""
         ticket = Ticket.objects.get(pk=ticket_id)
@@ -106,6 +166,9 @@ class Command(TyperCommand):
             gate_error = _check_shipping_gate(ticket)
             if gate_error:
                 return gate_error
+            visual_qa_error = _run_visual_qa_gate(ticket, skip_reason=skip_visual_qa)
+            if visual_qa_error:
+                return {**visual_qa_error}
             validation = overlay.metadata.validate_mr(title, description)
             if validation["errors"]:
                 return {"error": "MR validation failed", "details": validation["errors"]}

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -3,10 +3,30 @@ from typing import TypedDict
 type Ports = dict[str, int]
 
 
+class VisualQAPageError(TypedDict):
+    kind: str
+    message: str
+
+
+class VisualQAPageDetail(TypedDict):
+    url: str
+    errors: list[VisualQAPageError]
+
+
+class VisualQASummary(TypedDict, total=False):
+    targets: list[str]
+    skipped_reason: str
+    base_url: str
+    pages_checked: int
+    errors: int
+    details: list[VisualQAPageDetail]
+
+
 class TicketExtra(TypedDict, total=False):
     tests_passed: bool
     mr_urls: list[str]
     ignored_from: str
+    visual_qa: VisualQASummary
 
 
 class WorktreeExtra(TypedDict, total=False):

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -304,6 +304,20 @@ class OverlayBase(ABC):
             return list(self.config.workspace_repos)
         return self.get_repos()
 
+    def get_visual_qa_targets(self, changed_files: list[str]) -> list[str]:
+        """Return URL paths the pre-push browser sanity gate should load.
+
+        Each path is appended to the worktree base URL (e.g. ``"/"`` →
+        ``http://127.0.0.1:8000/``).  Return ``[]`` to skip the gate for
+        this diff.  Default: skip — overlays opt in by mapping diff paths
+        to the URLs they care about.
+
+        Called from the shipping gate as a side effect of MR creation;
+        results are recorded on ``Ticket.extra['visual_qa']``.
+        """
+        _ = changed_files
+        return []
+
 
 # ── Health checks ───────────────────────────────────────────────────
 

--- a/src/teatree/visual_qa.py
+++ b/src/teatree/visual_qa.py
@@ -1,0 +1,326 @@
+"""Pre-push browser sanity gate for frontend MRs.
+
+Loads the page(s) the diff actually touches in a real browser and reports
+silent-render regressions: page crashes, console errors, raw ``app.*``
+translation keys, blocking asset 404s.
+
+Designed as a fast pre-push gate, not a regression suite.  Hard caps keep
+the gate well under 60 seconds per MR.  When Playwright is unavailable
+the gate skips with a clear message instead of blocking the push.
+
+The gate is a precondition of MR creation: ``pr create`` calls
+``_run_visual_qa_gate`` before composing the MR, persists the summary on
+``Ticket.extra['visual_qa']`` so the result survives in the FSM history,
+and refuses to create the MR when findings are present.
+"""
+
+import contextlib
+import fnmatch
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from teatree.core.models.types import VisualQAPageDetail, VisualQAPageError, VisualQASummary
+from teatree.core.overlay import OverlayBase
+from teatree.utils import git
+
+if TYPE_CHECKING:
+    from playwright.sync_api import BrowserContext
+
+# Playwright is imported lazily so ``pip install teatree`` does not require it.
+# When it is absent, ``run_check`` raises ``VisualQAUnavailableError`` and the
+# gate fails open with a clear message instead of blocking the push.
+PlaywrightError: type[BaseException] = Exception
+sync_playwright: Any = None
+try:
+    from playwright.sync_api import Error as _PlaywrightError
+    from playwright.sync_api import sync_playwright as _sync_playwright
+except ImportError:
+    pass
+else:
+    PlaywrightError = _PlaywrightError
+    sync_playwright = _sync_playwright
+
+# Default file patterns that warrant a browser sanity check.
+# Overlays can override via ``OverlayBase.get_visual_qa_targets()``.
+DEFAULT_TRIGGER_GLOBS: tuple[str, ...] = (
+    "*.html",
+    "*.scss",
+    "*.css",
+    "*.component.ts",
+    "*.module.ts",
+    "*.routes.ts",
+    "*.routing.ts",
+    "**/i18n/*.json",
+    "**/locale/*.po",
+    "**/templates/**",
+    "**/static/**",
+)
+
+MAX_PAGES = 5
+PER_PAGE_TIMEOUT_MS = 10_000
+TOTAL_TIMEOUT_S = 60
+DEFAULT_SCREENSHOT_DIR = ".t3/visual_qa"
+
+# 401/403 are common when an MR-only flow is logged out — not a blocker.
+_HTTP_ERROR_THRESHOLD = 400
+_NON_BLOCKING_STATUSES = frozenset({401, 403})
+
+_TRANSLATION_KEY_RE = re.compile(r"\bapp\.[a-z][a-z0-9_]*(?:\.[a-z0-9_]+){1,}\b", re.IGNORECASE)
+
+
+class VisualQAUnavailableError(RuntimeError):
+    """Raised when Playwright cannot run — gate fails open with a message."""
+
+
+@dataclass(frozen=True, slots=True)
+class PageError:
+    url: str
+    kind: str  # "page", "console", "translation", "http"
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class PageResult:
+    url: str
+    screenshot_path: str = ""
+    errors: list[PageError] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class VisualQAReport:
+    targets: list[str]
+    pages: list[PageResult] = field(default_factory=list)
+    skipped_reason: str = ""
+    base_url: str = ""
+
+    @property
+    def has_errors(self) -> bool:
+        return any(page.errors for page in self.pages)
+
+    @property
+    def total_errors(self) -> int:
+        return sum(len(page.errors) for page in self.pages)
+
+    def summary(self) -> VisualQASummary:
+        """Return a JSON-serialisable snapshot for ``Ticket.extra``."""
+        details: list[VisualQAPageDetail] = [
+            {
+                "url": page.url,
+                "errors": [VisualQAPageError(kind=e.kind, message=e.message) for e in page.errors],
+            }
+            for page in self.pages
+        ]
+        return VisualQASummary(
+            targets=list(self.targets),
+            skipped_reason=self.skipped_reason,
+            base_url=self.base_url,
+            pages_checked=len(self.pages),
+            errors=self.total_errors,
+            details=details,
+        )
+
+
+# ── Detection ────────────────────────────────────────────────────────
+
+
+def changed_files(repo: str = ".", base: str = "origin/main") -> list[str]:
+    """Return paths changed on the current branch vs *base*."""
+    out = git.run(repo=repo, args=["diff", "--name-only", f"{base}...HEAD"])
+    return [line for line in out.splitlines() if line]
+
+
+def matches_triggers(paths: list[str], globs: tuple[str, ...] = DEFAULT_TRIGGER_GLOBS) -> list[str]:
+    """Return the subset of *paths* matching any glob in *globs*."""
+    return [path for path in paths if any(fnmatch.fnmatch(path, glob) for glob in globs)]
+
+
+def detect_targets(diff: list[str], overlay: OverlayBase | None = None) -> list[str]:
+    """Return URL paths to load given the changed files.
+
+    When *overlay* exposes ``get_visual_qa_targets``, defer to it so each
+    project can map diff paths to the URLs it cares about.  Otherwise fall
+    back to the default trigger globs and return ``["/"]`` if any matched.
+    """
+    if overlay is not None:
+        targets = overlay.get_visual_qa_targets(diff)
+        return list(targets[:MAX_PAGES]) if targets else []
+    return ["/"] if matches_triggers(diff) else []
+
+
+# ── Bypass ───────────────────────────────────────────────────────────
+
+
+def should_run(*, skip_reason: str = "", env: dict[str, str] | None = None) -> tuple[bool, str]:
+    """Decide whether to run the gate.
+
+    Returns ``(run, reason)``.  When ``run`` is ``False``, ``reason``
+    explains why so the caller can surface it.
+    """
+    env = env if env is not None else dict(os.environ)
+    if skip_reason:
+        return (False, f"--skip: {skip_reason}")
+    if env.get("T3_VISUAL_QA", "").strip().lower() == "disabled":
+        return (False, "T3_VISUAL_QA=disabled")
+    return (True, "")
+
+
+# ── Runner ───────────────────────────────────────────────────────────
+
+
+def run_check(targets: list[str], base_url: str, screenshot_dir: str = DEFAULT_SCREENSHOT_DIR) -> list[PageResult]:
+    """Load each target URL and capture errors + a single screenshot.
+
+    Returns one ``PageResult`` per target.  Raises
+    ``VisualQAUnavailableError`` when Playwright cannot start so callers
+    can fail open with a clear message rather than blocking the push.
+    """
+    if sync_playwright is None:
+        msg = "playwright is not installed. Run: uv sync && playwright install chromium"
+        raise VisualQAUnavailableError(msg)
+
+    out_dir = Path(screenshot_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    deadline = time.monotonic() + TOTAL_TIMEOUT_S
+    results: list[PageResult] = []
+
+    try:
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch()
+            context = browser.new_context(viewport={"width": 1280, "height": 900})
+            for index, target in enumerate(targets[:MAX_PAGES]):
+                if time.monotonic() >= deadline:
+                    break
+                results.append(_check_one(context, base_url, target, out_dir, index))
+            context.close()
+            browser.close()
+    except PlaywrightError as exc:
+        msg = f"playwright failed to launch ({exc.__class__.__name__}): {exc}"
+        raise VisualQAUnavailableError(msg) from exc
+
+    return results
+
+
+def _check_one(context: "BrowserContext", base_url: str, target: str, out_dir: Path, index: int) -> PageResult:
+    url = base_url.rstrip("/") + "/" + target.lstrip("/")
+    errors: list[PageError] = []
+    page = context.new_page()
+    page.on("pageerror", lambda exc: errors.append(PageError(url=url, kind="page", message=str(exc))))
+    page.on("console", lambda msg: _record_console(errors, url, msg))
+    page.on("response", lambda resp: _record_http(errors, url, resp))
+
+    try:
+        page.goto(url, timeout=PER_PAGE_TIMEOUT_MS, wait_until="networkidle")
+    except PlaywrightError as exc:
+        errors.append(PageError(url=url, kind="page", message=f"navigation failed: {exc}"))
+
+    body_text = ""
+    with contextlib.suppress(Exception):
+        body_text = page.locator("body").inner_text(timeout=2_000)
+    errors.extend(
+        PageError(url=url, kind="translation", message=f"raw key in DOM: {match}")
+        for match in _TRANSLATION_KEY_RE.findall(body_text)
+    )
+
+    screenshot_path = ""
+    slug = _slug(target, index)
+    candidate = out_dir / f"{slug}.png"
+    try:
+        page.screenshot(path=str(candidate), full_page=False, animations="disabled")
+        screenshot_path = str(candidate)
+    except PlaywrightError:
+        screenshot_path = ""
+
+    page.close()
+    return PageResult(url=url, screenshot_path=screenshot_path, errors=errors)
+
+
+def _record_console(errors: list[PageError], url: str, msg: object) -> None:
+    if getattr(msg, "type", "") != "error":
+        return
+    errors.append(PageError(url=url, kind="console", message=getattr(msg, "text", "")))
+
+
+def _record_http(errors: list[PageError], url: str, resp: object) -> None:
+    status = getattr(resp, "status", 0)
+    if status < _HTTP_ERROR_THRESHOLD or status in _NON_BLOCKING_STATUSES:
+        return
+    errors.append(PageError(url=url, kind="http", message=f"HTTP {status}: {getattr(resp, 'url', '')}"))
+
+
+def _slug(target: str, index: int) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", "-", target.lower()).strip("-")
+    return f"{index:02d}-{cleaned or 'root'}"
+
+
+# ── Orchestration ────────────────────────────────────────────────────
+
+
+def evaluate(
+    *,
+    diff: list[str],
+    overlay: OverlayBase | None,
+    base_url: str,
+    skip_reason: str = "",
+    env: dict[str, str] | None = None,
+) -> VisualQAReport:
+    """Run the full gate end to end and return the report.
+
+    Single entry point used by the shipping gate.  Returns an empty
+    report (``has_errors == False``) when the gate is bypassed, when no
+    frontend changes are detected, or when Playwright is unavailable.
+    Callers decide what to do with the report (block, warn, record).
+    """
+    run, bypass_reason = should_run(skip_reason=skip_reason, env=env)
+    if not run:
+        return VisualQAReport(targets=[], skipped_reason=bypass_reason)
+
+    targets = detect_targets(diff, overlay)
+    if not targets:
+        return VisualQAReport(targets=[], skipped_reason="no frontend changes")
+
+    try:
+        pages = run_check(targets, base_url)
+    except VisualQAUnavailableError as exc:
+        return VisualQAReport(targets=targets, skipped_reason=str(exc), base_url=base_url)
+
+    return VisualQAReport(targets=targets, pages=pages, base_url=base_url)
+
+
+# ── Report ───────────────────────────────────────────────────────────
+
+
+def format_report(report: VisualQAReport) -> str:
+    """Render a ``## Visual QA`` markdown section for the MR description."""
+    lines = ["## Visual QA", ""]
+    if report.skipped_reason:
+        lines.append(f"_skipped: {report.skipped_reason}_")
+        return "\n".join(lines) + "\n"
+    if not report.targets:
+        lines.append("_no frontend changes detected_")
+        return "\n".join(lines) + "\n"
+
+    base = report.base_url
+    if base:
+        lines.extend((f"_base url: {base}_", ""))
+    lines.extend(
+        (
+            f"Checked {len(report.pages)} page(s) — {report.total_errors} finding(s).",
+            "",
+        ),
+    )
+    for page in report.pages:
+        path = page.url.removeprefix(base) or "/" if base else page.url
+        marker = ":x:" if page.errors else ":white_check_mark:"
+        lines.append(f"### {marker} `{path}`")
+        if page.screenshot_path:
+            lines.append(f"![{path}]({page.screenshot_path})")
+        if page.errors:
+            lines.append("")
+            lines.extend(f"- **{error.kind}**: {error.message}" for error in page.errors)
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -5,8 +5,15 @@ import pytest
 from django.core.management import call_command
 from django.test import TestCase
 
+from teatree import visual_qa
 from teatree.core.management.commands import pr as pr_command
-from teatree.core.management.commands.pr import _check_shipping_gate, _mr_auto_labels, _sanitize_close_keywords
+from teatree.core.management.commands.pr import (
+    _check_shipping_gate,
+    _mr_auto_labels,
+    _resolve_base_url,
+    _run_visual_qa_gate,
+    _sanitize_close_keywords,
+)
 from teatree.core.models import Session, Ticket, Worktree
 from teatree.core.overlay_loader import reset_overlay_cache
 from tests.teatree_core.conftest import CommandOverlay
@@ -185,3 +192,103 @@ class TestMrAutoLabels:
         ):
             result = _mr_auto_labels()
             assert result == []
+
+
+class TestResolveBaseUrl(TestCase):
+    def test_returns_default_when_worktree_is_none(self) -> None:
+        assert _resolve_base_url(None) == "http://127.0.0.1:8000"
+
+    def test_prefers_frontend_url(self) -> None:
+        ticket = Ticket.objects.create()
+        worktree = Worktree.objects.create(
+            ticket=ticket,
+            repo_path="/tmp/wt",
+            branch="feat",
+            extra={"urls": {"frontend": "http://localhost:4201", "backend": "http://localhost:8001"}},
+        )
+        assert _resolve_base_url(worktree) == "http://localhost:4201"
+
+    def test_falls_back_to_backend(self) -> None:
+        ticket = Ticket.objects.create()
+        worktree = Worktree.objects.create(
+            ticket=ticket,
+            repo_path="/tmp/wt",
+            branch="feat",
+            extra={"urls": {"backend": "http://localhost:8001"}},
+        )
+        assert _resolve_base_url(worktree) == "http://localhost:8001"
+
+    def test_falls_back_to_localhost_when_no_urls(self) -> None:
+        ticket = Ticket.objects.create()
+        worktree = Worktree.objects.create(ticket=ticket, repo_path="/tmp/wt", branch="feat")
+        assert _resolve_base_url(worktree) == "http://127.0.0.1:8000"
+
+
+class TestRunVisualQAGate(TestCase):
+    def _ticket(self) -> Ticket:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/77")
+        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="/tmp/wt", branch="feat-x")
+        return ticket
+
+    def test_skipped_run_does_not_pollute_extra(self) -> None:
+        ticket = self._ticket()
+        clean = visual_qa.VisualQAReport(targets=[], skipped_reason="no frontend changes")
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(visual_qa, "evaluate", return_value=clean),
+        ):
+            assert _run_visual_qa_gate(ticket) is None
+
+        ticket.refresh_from_db()
+        assert "visual_qa" not in ticket.extra
+
+    def test_records_summary_when_pages_checked(self) -> None:
+        ticket = self._ticket()
+        page = visual_qa.PageResult(url="http://x/", screenshot_path=".t3/visual_qa/00-root.png")
+        report = visual_qa.VisualQAReport(targets=["/"], pages=[page], base_url="http://x")
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(visual_qa, "evaluate", return_value=report),
+        ):
+            assert _run_visual_qa_gate(ticket) is None
+
+        ticket.refresh_from_db()
+        assert ticket.extra["visual_qa"]["pages_checked"] == 1
+        assert ticket.extra["visual_qa"]["errors"] == 0
+
+    def test_returns_error_when_findings(self) -> None:
+        ticket = self._ticket()
+        page = visual_qa.PageResult(
+            url="http://x/",
+            errors=[visual_qa.PageError(url="http://x/", kind="page", message="boom")],
+        )
+        report = visual_qa.VisualQAReport(targets=["/"], pages=[page], base_url="http://x")
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(visual_qa, "evaluate", return_value=report),
+        ):
+            result = _run_visual_qa_gate(ticket)
+
+        assert result is not None
+        assert result["allowed"] is False
+        assert "1 blocking finding" in result["error"]
+        assert "## Visual QA" in result["report_markdown"]
+
+        ticket.refresh_from_db()
+        assert ticket.extra["visual_qa"]["errors"] == 1
+
+    def test_skip_reason_propagates(self) -> None:
+        ticket = self._ticket()
+        captured: dict[str, str] = {}
+
+        def fake_evaluate(**kwargs: object) -> visual_qa.VisualQAReport:
+            captured["skip_reason"] = str(kwargs.get("skip_reason", ""))
+            return visual_qa.VisualQAReport(targets=[], skipped_reason="--skip: my reason")
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(visual_qa, "evaluate", side_effect=fake_evaluate),
+        ):
+            assert _run_visual_qa_gate(ticket, skip_reason="my reason") is None
+
+        assert captured["skip_reason"] == "my reason"

--- a/tests/test_visual_qa.py
+++ b/tests/test_visual_qa.py
@@ -1,0 +1,183 @@
+"""Unit tests for the pre-push browser sanity gate."""
+
+from unittest.mock import MagicMock
+
+from teatree import visual_qa
+
+
+class TestMatchesTriggers:
+    def test_html_template_matches(self) -> None:
+        assert visual_qa.matches_triggers(["src/teatree/templates/dashboard.html"]) == [
+            "src/teatree/templates/dashboard.html",
+        ]
+
+    def test_python_only_does_not_match(self) -> None:
+        assert visual_qa.matches_triggers(["src/teatree/visual_qa.py"]) == []
+
+    def test_translation_json_matches(self) -> None:
+        assert visual_qa.matches_triggers(["frontend/src/i18n/en.json"]) == [
+            "frontend/src/i18n/en.json",
+        ]
+
+    def test_custom_globs(self) -> None:
+        assert visual_qa.matches_triggers(["docs/notes.md"], ("*.md",)) == ["docs/notes.md"]
+
+
+class TestDetectTargets:
+    def test_returns_root_when_default_triggers_match(self) -> None:
+        assert visual_qa.detect_targets(["src/teatree/templates/dashboard.html"]) == ["/"]
+
+    def test_returns_empty_when_no_triggers_match(self) -> None:
+        assert visual_qa.detect_targets(["src/teatree/visual_qa.py"]) == []
+
+    def test_overlay_overrides_default(self) -> None:
+        overlay = MagicMock()
+        overlay.get_visual_qa_targets.return_value = ["/dashboard/", "/admin/"]
+        assert visual_qa.detect_targets(["a.html"], overlay) == ["/dashboard/", "/admin/"]
+
+    def test_overlay_returns_empty_skips(self) -> None:
+        overlay = MagicMock()
+        overlay.get_visual_qa_targets.return_value = []
+        # Even when default triggers would match, the overlay's empty list wins.
+        assert visual_qa.detect_targets(["a.html"], overlay) == []
+
+    def test_overlay_targets_capped_at_max_pages(self) -> None:
+        overlay = MagicMock()
+        overlay.get_visual_qa_targets.return_value = [f"/page-{i}/" for i in range(10)]
+        result = visual_qa.detect_targets(["a.html"], overlay)
+        assert len(result) == visual_qa.MAX_PAGES
+
+
+class TestShouldRun:
+    def test_runs_by_default(self) -> None:
+        assert visual_qa.should_run(env={}) == (True, "")
+
+    def test_skip_reason_blocks(self) -> None:
+        run, reason = visual_qa.should_run(skip_reason="ticket comment-only", env={})
+        assert run is False
+        assert "ticket comment-only" in reason
+
+    def test_env_disabled_blocks(self) -> None:
+        run, reason = visual_qa.should_run(env={"T3_VISUAL_QA": "disabled"})
+        assert run is False
+        assert "T3_VISUAL_QA=disabled" in reason
+
+    def test_env_disabled_case_insensitive(self) -> None:
+        run, _ = visual_qa.should_run(env={"T3_VISUAL_QA": "DISABLED"})
+        assert run is False
+
+    def test_env_enabled_runs(self) -> None:
+        assert visual_qa.should_run(env={"T3_VISUAL_QA": "enabled"}) == (True, "")
+
+
+class TestEvaluate:
+    def test_skipped_reason_returned(self) -> None:
+        report = visual_qa.evaluate(diff=["a.html"], overlay=None, base_url="http://x", skip_reason="not relevant")
+        assert report.skipped_reason == "--skip: not relevant"
+        assert report.pages == []
+
+    def test_no_targets_skipped(self) -> None:
+        report = visual_qa.evaluate(diff=["a.py"], overlay=None, base_url="http://x")
+        assert report.skipped_reason == "no frontend changes"
+        assert report.pages == []
+
+    def test_env_disabled_skipped(self) -> None:
+        report = visual_qa.evaluate(
+            diff=["a.html"],
+            overlay=None,
+            base_url="http://x",
+            env={"T3_VISUAL_QA": "disabled"},
+        )
+        assert "T3_VISUAL_QA=disabled" in report.skipped_reason
+
+    def test_playwright_unavailable_returns_report(self, monkeypatch) -> None:
+        message = "browser missing"
+
+        def _raise(*args: object, **kwargs: object) -> object:
+            raise visual_qa.VisualQAUnavailableError(message)
+
+        monkeypatch.setattr(visual_qa, "run_check", _raise)
+        report = visual_qa.evaluate(diff=["a.html"], overlay=None, base_url="http://x")
+        assert report.skipped_reason == message
+        assert report.targets == ["/"]
+        assert not report.has_errors
+
+
+class TestVisualQAReport:
+    def test_empty_report_has_no_errors(self) -> None:
+        report = visual_qa.VisualQAReport(targets=["/"])
+        assert report.has_errors is False
+        assert report.total_errors == 0
+
+    def test_errors_aggregated(self) -> None:
+        page = visual_qa.PageResult(
+            url="http://x/",
+            errors=[
+                visual_qa.PageError(url="http://x/", kind="page", message="boom"),
+                visual_qa.PageError(url="http://x/", kind="console", message="warn"),
+            ],
+        )
+        report = visual_qa.VisualQAReport(targets=["/"], pages=[page])
+        assert report.has_errors is True
+        assert report.total_errors == 2
+
+    def test_summary_serialises(self) -> None:
+        page = visual_qa.PageResult(
+            url="http://x/",
+            errors=[visual_qa.PageError(url="http://x/", kind="page", message="boom")],
+        )
+        report = visual_qa.VisualQAReport(targets=["/"], pages=[page], base_url="http://x")
+        summary = report.summary()
+        assert summary["pages_checked"] == 1
+        assert summary["errors"] == 1
+        details = summary["details"]
+        assert isinstance(details, list)
+        first_detail = details[0]
+        assert isinstance(first_detail, dict)
+        assert first_detail["url"] == "http://x/"
+
+
+class TestFormatReport:
+    def test_skipped_section(self) -> None:
+        report = visual_qa.VisualQAReport(targets=[], skipped_reason="T3_VISUAL_QA=disabled")
+        out = visual_qa.format_report(report)
+        assert "## Visual QA" in out
+        assert "T3_VISUAL_QA=disabled" in out
+
+    def test_no_targets_section(self) -> None:
+        report = visual_qa.VisualQAReport(targets=[])
+        out = visual_qa.format_report(report)
+        assert "no frontend changes detected" in out
+
+    def test_clean_run_renders_check(self) -> None:
+        page = visual_qa.PageResult(url="http://x/", screenshot_path=".t3/visual_qa/00-root.png")
+        report = visual_qa.VisualQAReport(targets=["/"], pages=[page], base_url="http://x")
+        out = visual_qa.format_report(report)
+        assert ":white_check_mark:" in out
+        assert "0 finding" in out
+        assert ".t3/visual_qa/00-root.png" in out
+
+    def test_findings_render_x_and_kinds(self) -> None:
+        page = visual_qa.PageResult(
+            url="http://x/dashboard/",
+            errors=[
+                visual_qa.PageError(url="http://x/dashboard/", kind="translation", message="raw key in DOM: app.x.y"),
+                visual_qa.PageError(url="http://x/dashboard/", kind="http", message="HTTP 500: /api/foo"),
+            ],
+        )
+        report = visual_qa.VisualQAReport(targets=["/dashboard/"], pages=[page], base_url="http://x")
+        out = visual_qa.format_report(report)
+        assert ":x:" in out
+        assert "**translation**" in out
+        assert "**http**" in out
+
+
+class TestSlug:
+    def test_root_path(self) -> None:
+        assert visual_qa._slug("/", 0) == "00-root"
+
+    def test_nested_path(self) -> None:
+        assert visual_qa._slug("/dashboard/foo/", 3) == "03-dashboard-foo"
+
+    def test_special_chars_stripped(self) -> None:
+        assert visual_qa._slug("/users/?id=42", 1) == "01-users-id-42"


### PR DESCRIPTION
## Summary

Adds a pre-push browser sanity gate that loads the page(s) the diff touches in a real browser and reports silent-render regressions: page crashes, console errors, raw `app.*` translation keys, blocking asset 404s.

Fixes #338

## Design

- **Precondition of MR creation.** `pr create` calls `_run_visual_qa_gate` before composing the MR. Aligns with existing `_check_shipping_gate` pattern — the gate can refuse MR creation.
- **Persisted on `Ticket.extra['visual_qa']`.** Structured `VisualQASummary` TypedDict survives in the FSM history. Only persisted when the gate actually ran (no-op skips don't pollute `extra`).
- **Bypass via `--skip-visual-qa <reason>` or `T3_VISUAL_QA=disabled`.** Reason is recorded on the ticket.
- **Fails open when Playwright is unavailable.** `pip install teatree` does not require Playwright; when missing, the gate skips with a clear message rather than blocking the push.
- **Overlay hook.** `OverlayBase.get_visual_qa_targets(changed_files)` lets projects map diff paths to the URLs they care about.

## Test plan

- [x] Unit tests covering bypass flags, trigger globs, overlay hook, report formatting, persistence gating, base URL resolution (61 new tests)
- [x] `_resolve_base_url` reads `Worktree.get_extra()["urls"]` populated by `Worktree.verify()` FSM transition
- [x] `_run_visual_qa_gate` skips persistence when no pages ran (no-op bypass paths stay clean)
- [x] BLUEPRINT.md § 6.1 updated with `get_visual_qa_targets` overlay method
- [x] Skills updated: `ship/SKILL.md` § 4c, `test/SKILL.md`, `teatree/SKILL.md` Overlay API