### PR TITLE
feat(retro): add T3_AUTO_PUSH_FORK for fork auto-push (#137)

### DIFF
--- a/skills/contribute/SKILL.md
+++ b/skills/contribute/SKILL.md
@@ -29,6 +29,7 @@ Uses these `~/.teatree` variables (set by `/t3:setup`):
 
 - **`T3_CONTRIBUTE`** — must be `true` for this skill to do anything.
 - **`T3_PUSH`** — `false` (default) or `true`. When `false`, this skill refuses to push and tells the user to push manually. Exists as a safety stop for privacy/secret review.
+- **`T3_AUTO_PUSH_FORK`** — `false` (default) or `true`. When `true`, step 4 (push confirmation) is skipped **only** when the push target is the user's fork (`origin` push URL differs from `T3_UPSTREAM`). Upstream issue creation (step 6) always requires confirmation.
 - **`T3_UPSTREAM`** — upstream repo (e.g., `souliane/teatree`). Controls where the PR is created:
   - **Empty** → push to branch on `origin`, create PR on `origin` (same repo).
   - **Set** → push to branch on `origin` (your fork), create PR targeting `T3_UPSTREAM`.
@@ -87,9 +88,18 @@ BRANCH="fix/retro-$(date +%Y%m%d)-$(git log -1 --format=%s | sed 's/[^a-zA-Z0-9]
 git checkout -b "$BRANCH"
 ```
 
-### 4. Push Confirmation (Non-Negotiable)
+### 4. Push Confirmation
 
-**Every push requires explicit user consent.** No exceptions, no config to bypass this.
+**Default: every push requires explicit user consent.**
+
+**Auto-push exception** (`T3_AUTO_PUSH_FORK=true`): skip the confirmation below and proceed directly to push when **all** of the following hold:
+
+1. `T3_CONTRIBUTE=true` and `T3_PUSH=true` (already required to reach this step).
+2. `T3_AUTO_PUSH_FORK=true`.
+3. `origin`'s push URL does **not** match `T3_UPSTREAM` — the push lands on the user's fork, not upstream.
+4. Pre-flight checks in § 2 all passed, including the privacy scan.
+
+When any of the above fail, fall back to the confirmation flow below.
 
 Show:
 
@@ -284,8 +294,9 @@ After creation, print the issue URL.
 
 ## What NOT to Do
 
-- Do not push without explicit user consent — ever.
+- Do not push without explicit user consent — except when `T3_AUTO_PUSH_FORK=true` and the push target is the user's fork (see § 4).
 - Do not push to main — always use a branch.
+- Do not auto-create upstream issues — § 6 always requires confirmation, regardless of `T3_AUTO_PUSH_FORK`.
 - Do not create upstream issues from heavily diverged forks — they're not useful.
 - Do not use `git push` directly — always go through this skill for retro commits.
 - Do not create duplicate upstream issues — check for existing ones first.

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -41,6 +41,7 @@ Retro's behavior depends on these `~/.teatree` variables and on whether the curr
   - `false`: only improve the active project overlay. Core skill gaps are noted in conversation but not acted on.
   - `true`: also improve core skills in the user's fork at `$T3_REPO`. Retro creates a local commit but **never pushes automatically**. Use `/t3:contribute` to review and push when ready.
 - **`T3_PUSH`** — `false` (default) or `true`. When `false`, retro never asks about pushing — it only commits locally and reminds the user to run `/t3:contribute` later. Set to `true` to be prompted about pushing after each retro commit.
+- **`T3_AUTO_PUSH_FORK`** — `false` (default) or `true`. When `true` **and** `T3_PUSH=true` **and** `origin` differs from `T3_UPSTREAM` (i.e. pushing lands on the user's fork, not upstream), retro pushes automatically after the privacy scan passes, without prompting. Upstream issue creation still requires explicit confirmation.
 - **`T3_UPSTREAM`** — upstream GitHub repo (e.g., `souliane/teatree`). Used by `/t3:contribute` to open issues upstream after pushing. When `origin` matches `T3_UPSTREAM`, pushes already land directly on upstream.
 - **`T3_PRIVACY`** — privacy check strictness: `strict` (default) or `relaxed`. See § Privacy Scan.
 - **`T3_REVIEW_SKILL`** — name of an external skill review tool (e.g., `ac-reviewing-codebase`). If set, retro recommends running it after skill improvements. If not set, retro suggests installing one during first run and storing the preference.
@@ -386,7 +387,16 @@ Squash retro commits into clean, human-sized units **before chaining to the revi
 ════════════════════════════════════════════════════════════════
 ```
 
-**Always ask the user whether to push** using `AskUserQuestion` — even when `T3_PUSH=false`. Show the branch name and commit hash so the user can make an informed decision. If they say yes, load `/t3:contribute` and run it. If they decline, remind them to run `/t3:contribute` later.
+**Ask the user whether to push** using `AskUserQuestion` — even when `T3_PUSH=false`. Show the branch name and commit hash so the user can make an informed decision. If they say yes, load `/t3:contribute` and run it. If they decline, remind them to run `/t3:contribute` later.
+
+**Auto-push exception** (`T3_AUTO_PUSH_FORK=true`): skip the confirmation above and chain directly into `/t3:contribute` when **all** of the following hold:
+
+1. `T3_PUSH=true` — pushing is globally enabled.
+2. `T3_AUTO_PUSH_FORK=true` — auto-push to fork is opted in.
+3. `origin`'s push URL does **not** match `T3_UPSTREAM` — the push lands on the user's fork, not upstream.
+4. The privacy scan (§ Privacy Scan) passed.
+
+When any of these fail, fall back to the confirmation flow. Upstream issue creation always requires explicit confirmation regardless of `T3_AUTO_PUSH_FORK`.
 
 ### Chain to Review Skill
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -81,6 +81,7 @@ Useful optional values:
 | --- | --- | --- |
 | `T3_CONTRIBUTE` | Allow self-improvement commits in the teatree repo | `false` |
 | `T3_PUSH` | Allow pushing retro commits (safety gate for privacy review) | `false` |
+| `T3_AUTO_PUSH_FORK` | Auto-push retro commits to the user's fork without prompting (requires `T3_PUSH=true` and origin ≠ `T3_UPSTREAM`) | `false` |
 | `T3_UPSTREAM` | Upstream repo for PRs (empty = PR on origin, set = PR on upstream) | empty |
 | `T3_PRIVATE_TESTS` | Private QA repo path | empty |
 | `T3_BRANCH_PREFIX` | Branch prefix for generated worktrees | derived from git user |
@@ -100,6 +101,7 @@ T3_ISSUE_TRACKER="gitlab"
 T3_CHAT_PLATFORM="none"
 T3_CONTRIBUTE=false
 T3_PUSH=false
+T3_AUTO_PUSH_FORK=false
 T3_UPSTREAM=""
 T3_PRIVATE_TESTS=""
 T3_BRANCH_PREFIX="ac"

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -335,6 +335,7 @@ Report: bugs found, filed, fixed, skipped (with reasons).
 ```bash
 T3_REPO="$HOME/workspace/souliane/teatree"  # teatree repo path
 T3_CONTRIBUTE=true                           # allow retro to modify core skills
-T3_PUSH=false                                # never auto-push retro commits
+T3_PUSH=false                                # gate pushes behind an explicit prompt
+T3_AUTO_PUSH_FORK=false                      # auto-push to fork when T3_PUSH=true and origin ≠ T3_UPSTREAM
 T3_PRIVACY=strict                            # block commits with PII
 ```


### PR DESCRIPTION
## Summary

Adds `T3_AUTO_PUSH_FORK` opt-in config so retro improvements reach the user's fork without an extra prompt, while upstream issue creation stays gated.

Fixes #137

## Behaviour

When `T3_AUTO_PUSH_FORK=true` **and** `T3_PUSH=true` **and** `origin` push URL differs from `T3_UPSTREAM` (i.e. the push lands on the user's fork, not upstream), retro/contribute skip the push confirmation and push directly — after the privacy scan passes. Upstream issue creation still requires explicit user confirmation.

All other paths fall back to the existing confirmation flow, so the default remains unchanged.

## Scope

Skill docs only — no Python changes. Agent behaviour is governed by the skill text.

- `skills/setup/SKILL.md` — new env var in the table and the `~/.teatree` example
- `skills/retro/SKILL.md` — auto-push exception in § "After Committing"
- `skills/contribute/SKILL.md` — § 4 gains the exception scoped to fork targets; § 6 still confirms
- `skills/teatree/SKILL.md` — `~/.teatree` config example

## Acceptance criteria

- [x] `T3_AUTO_PUSH_FORK` config option
- [x] Auto-push to fork after retro (when enabled)
- [x] Upstream issue creation still requires confirmation
- [x] Privacy scan still runs before any push