### PR TITLE
refactor(ship): dedupe internal rule statements (#324)

### DIFF
--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -73,7 +73,7 @@ When the active overlay has `require_ticket = True`, refuse to commit or push wi
 **Squash rules:**
 
 - **Use `git reset --soft`, not interactive rebase.** `git rebase -i` with custom editors is fragile when pre-commit hooks run on each commit. Use `git reset --soft $(git merge-base origin/<default-branch> HEAD) && git commit` to squash, or cherry-pick for non-adjacent commits.
-- **Never rewrite pushed history.** Check `git log origin/<branch>..HEAD` to confirm which commits are local-only before squashing.
+- **Never rewrite pushed history** — see § Rules below for the full statement. Before any squash, check `git log origin/<branch>..HEAD` to confirm which commits are local-only.
 - Group by topic, keep human-sized commits.
 - Squash integrity check: save `OLD_TIP=$(git rev-parse HEAD)`, verify `git diff $OLD_TIP..HEAD` is empty after rewrite.
 - Respect `T3_AUTO_SQUASH` (`true` = auto, `false` = ask first).
@@ -106,8 +106,7 @@ Skipping this step is the #1 cause of wasted push-fix-push cycles. The rules exi
 
 ### 4. Push
 
-- Cancel stale pipelines before pushing (if branch has an existing MR).
-- Push to remote.
+- Push to remote. Cancel stale pipelines first if the branch has an existing MR (see § Rules).
 
 ### 4b. Review Gate
 


### PR DESCRIPTION
## Summary

Small internal dedupe within \`skills/ship/SKILL.md\`:

- \`Never rewrite pushed history\` was stated twice (Squash rules + Rules). Canonical stays in Rules; Squash rules references it.
- \`Cancel stale pipelines\` was stated twice (Push + Rules). Canonical stays in Rules; Push references it.

## Context

Part of [#324](https://github.com/souliane/teatree/issues/324) Opus 4.7 skill simplification — Phase 2 teatree dedupe.

Most of the plan's dedupe targets were already addressed in earlier commits (CLAUDE.md uses pointers; workspace/ship already reference rules/SKILL.md as canonical for push/task/worktree rules).

Remaining high-value work in the #324 plan is **Phase 4 memory consolidation** which lives in user-local config, not this repo.

Relates-to #324