### PR TITLE
feat(core): Slack emoji reactions on ticket state transitions

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -104,6 +104,7 @@ src/teatree/
     gitlab_ci.py        # GitLab CI pipeline operations
     gitlab_sync.py      # GitLabSyncBackend — MR upsert, assigned-issue upsert, labels, merged MR cleanup, Slack review permalinks
     slack.py            # Slack notifications
+    slack_reactions.py  # Emoji reactions on MR permalinks (ticket state transitions)
     notion.py           # Notion integration
     sentry.py           # Sentry error tracking
 
@@ -800,6 +801,7 @@ Overlay-specific configuration that previously lived in `TEATREE_*` Django setti
 | `get_gitlab_username()` | `str` | `""` | `TEATREE_GITLAB_USERNAME` |
 | `get_slack_token()` | `str` | `""` | `TEATREE_SLACK_TOKEN` |
 | `get_review_channel()` | `tuple[str, str]` | `("", "")` | `TEATREE_REVIEW_CHANNEL` + `TEATREE_REVIEW_CHANNEL_ID` |
+| `get_transition_emojis()` | `dict[str, str]` | `DEFAULT_TRANSITION_EMOJIS` | — (overlay override merges onto defaults) |
 | `known_variants` | `list[str]` | `[]` | `TEATREE_KNOWN_VARIANTS` |
 | `mr_auto_labels` | `list[str]` | `[]` | `TEATREE_MR_AUTO_LABELS` |
 | `mr_close_ticket` | `bool` | `False` | `TEATREE_MR_CLOSE_TICKET` |

--- a/src/teatree/backends/slack_reactions.py
+++ b/src/teatree/backends/slack_reactions.py
@@ -1,0 +1,119 @@
+"""Slack reactions on ticket state transitions.
+
+When a ticket transitions between FSM states, we want the corresponding
+Slack review-request message to get an emoji reaction so reviewers can see
+the state change at a glance (``:tada:`` on merge, ``:arrows_counterclockwise:``
+on rework, …).  The review permalink stored on each MR entry gives us the
+Slack ``channel`` and ``timestamp`` needed for ``reactions.add``.
+"""
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+import httpx
+
+from teatree.core.overlay_loader import get_overlay
+
+if TYPE_CHECKING:
+    from teatree.core.models import Ticket
+
+logger = logging.getLogger(__name__)
+
+_PERMALINK_RE = re.compile(r"/archives/(?P<channel>[^/]+)/p(?P<ts>\d+)")
+_SLACK_TS_FRACTIONAL_DIGITS = 6
+
+
+def parse_permalink(permalink: str) -> tuple[str, str] | None:
+    """Extract ``(channel_id, timestamp)`` from a Slack archive permalink.
+
+    Permalinks look like ``https://team.slack.com/archives/C0123/p1700000000000100``.
+    The timestamp format expected by the Slack API reinserts the dot 6 digits
+    from the right: ``1700000000.000100``.
+    """
+    if not permalink:
+        return None
+    match = _PERMALINK_RE.search(permalink)
+    if not match:
+        return None
+    channel = match.group("channel")
+    raw_ts = match.group("ts")
+    if len(raw_ts) <= _SLACK_TS_FRACTIONAL_DIGITS:
+        return None
+    split_at = -_SLACK_TS_FRACTIONAL_DIGITS
+    ts = f"{raw_ts[:split_at]}.{raw_ts[split_at:]}"
+    return channel, ts
+
+
+def add_reaction(token: str, channel_id: str, timestamp: str, emoji: str) -> bool:
+    """Call Slack ``reactions.add``. Return True on success, False otherwise.
+
+    Treats ``already_reacted`` as success — the desired end state is the
+    emoji being present on the message.  All failures are logged but never
+    raised; Slack outages must not block FSM transitions.
+    """
+    if not (token and channel_id and timestamp and emoji):
+        return False
+    try:
+        response = httpx.post(
+            "https://slack.com/api/reactions.add",
+            headers={"Authorization": f"Bearer {token}"},
+            data={"channel": channel_id, "timestamp": timestamp, "name": emoji},
+            timeout=10.0,
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("Slack reactions.add failed: %s", exc)
+        return False
+    if not response.is_success:
+        logger.warning("Slack reactions.add HTTP %s", response.status_code)
+        return False
+    payload = response.json()
+    if payload.get("ok"):
+        return True
+    error = payload.get("error", "")
+    if error == "already_reacted":
+        return True
+    logger.warning("Slack reactions.add error: %s", error)
+    return False
+
+
+def _iter_mr_permalinks(ticket: "Ticket") -> list[str]:
+    """Collect non-empty ``review_permalink`` values from the ticket's MRs."""
+    extra = ticket.extra if isinstance(ticket.extra, dict) else {}
+    mrs = extra.get("mrs", {})
+    if not isinstance(mrs, dict):
+        return []
+    permalinks: list[str] = []
+    for mr in mrs.values():
+        if not isinstance(mr, dict):
+            continue
+        permalink = mr.get("review_permalink")
+        if isinstance(permalink, str) and permalink:
+            permalinks.append(permalink)
+    return permalinks
+
+
+def add_reactions_for_transition(ticket: "Ticket", transition_name: str) -> int:
+    """Add the emoji mapped to *transition_name* to every MR permalink.
+
+    Returns the number of successful reaction posts.  Missing credentials,
+    missing permalinks, and unmapped transitions are all silent no-ops.
+    """
+    overlay = get_overlay()
+    emoji = overlay.config.get_transition_emojis().get(transition_name)
+    if not emoji:
+        return 0
+
+    token = overlay.config.get_slack_token()
+    if not token:
+        return 0
+
+    posted = 0
+    for permalink in _iter_mr_permalinks(ticket):
+        parsed = parse_permalink(permalink)
+        if not parsed:
+            continue
+        channel_id, timestamp = parsed
+        if add_reaction(token, channel_id, timestamp, emoji):
+            posted += 1
+    return posted

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 # Re-export all types so existing ``from teatree.core.overlay import X`` still works.
 __all__ = [
+    "DEFAULT_TRANSITION_EMOJIS",
     "DbImportStrategy",
     "OverlayBase",
     "OverlayConfig",
@@ -38,6 +39,16 @@ __all__ = [
 
 
 # ── Overlay configuration ────────────────────────────────────────────
+
+
+DEFAULT_TRANSITION_EMOJIS: dict[str, str] = {
+    "test": "white_check_mark",
+    "request_review": "eyes",
+    "mark_merged": "tada",
+    "mark_delivered": "white_check_mark",
+    "rework": "arrows_counterclockwise",
+    "ignore": "wastebasket",
+}
 
 
 class OverlayConfig:
@@ -155,6 +166,18 @@ class OverlayConfig:
     def get_review_channel(self) -> tuple[str, str]:
         """Return (channel_name, channel_id) for review notifications."""
         return ("", "")
+
+    def get_transition_emojis(self) -> dict[str, str]:
+        """Map FSM transition names to Slack emoji reactions.
+
+        Override via the settings module (``TRANSITION_EMOJIS = {...}``) or
+        by subclassing. The override is *merged* on top of the defaults so
+        overlays only need to specify the keys they change.
+        """
+        override = getattr(self, "transition_emojis", None)
+        if isinstance(override, dict):
+            return {**DEFAULT_TRANSITION_EMOJIS, **override}
+        return dict(DEFAULT_TRANSITION_EMOJIS)
 
 
 # ── Overlay metadata ─────────────────────────────────────────────────

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -3,6 +3,7 @@ import logging
 from django.db.models.signals import post_save
 from django_fsm.signals import post_transition
 
+from teatree.backends.slack_reactions import add_reactions_for_transition
 from teatree.core.models.task import Task
 from teatree.core.models.ticket import Ticket
 
@@ -29,6 +30,18 @@ def _log_ticket_transition(
     )
 
 
+def _add_slack_reactions_on_transition(
+    instance: Ticket,
+    name: str,
+    **_kwargs: object,
+) -> None:
+    """Post a Slack emoji reaction on the MR review message for this transition."""
+    try:
+        add_reactions_for_transition(instance, name)
+    except Exception:
+        logger.exception("Failed to add Slack reactions for ticket %s transition %s", instance.pk, name)
+
+
 def _auto_enqueue_headless_task(
     sender: type,  # noqa: ARG001
     instance: Task,
@@ -50,4 +63,7 @@ def _auto_enqueue_headless_task(
 
 def register_signals() -> None:
     post_transition.connect(_log_ticket_transition, sender=Ticket, dispatch_uid="ticket_transition_audit")
+    post_transition.connect(
+        _add_slack_reactions_on_transition, sender=Ticket, dispatch_uid="ticket_transition_slack_reactions"
+    )
     post_save.connect(_auto_enqueue_headless_task, sender=Task, dispatch_uid="auto_enqueue_headless")

--- a/tests/teatree_backends/test_slack_reactions.py
+++ b/tests/teatree_backends/test_slack_reactions.py
@@ -1,0 +1,246 @@
+"""Tests for teatree.backends.slack_reactions."""
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from teatree.backends import slack_reactions
+from teatree.backends.slack_reactions import (
+    _iter_mr_permalinks,
+    add_reaction,
+    add_reactions_for_transition,
+    parse_permalink,
+)
+from teatree.core.overlay import DEFAULT_TRANSITION_EMOJIS
+
+
+class TestParsePermalink:
+    def test_extracts_channel_and_inserts_ts_dot(self) -> None:
+        assert parse_permalink("https://team.slack.com/archives/C0123/p1700000000000100") == (
+            "C0123",
+            "1700000000.000100",
+        )
+
+    def test_returns_none_on_empty(self) -> None:
+        assert parse_permalink("") is None
+
+    def test_returns_none_when_no_archive_segment(self) -> None:
+        assert parse_permalink("https://team.slack.com/messages/C0123/p1700000000000100") is None
+
+    def test_returns_none_when_ts_too_short(self) -> None:
+        assert parse_permalink("https://team.slack.com/archives/C0123/p12345") is None
+
+    def test_handles_thread_reply_with_query_string(self) -> None:
+        permalink = (
+            "https://team.slack.com/archives/C0AM3TENTLK/p1774852840536479?thread_ts=1774618737.744799&cid=C0AM3TENTLK"
+        )
+        assert parse_permalink(permalink) == ("C0AM3TENTLK", "1774852840.536479")
+
+
+@dataclass
+class _FakePost:
+    responses: list[httpx.Response]
+    calls: list[dict[str, object]] = field(default_factory=list)
+
+    def __call__(self, url: str, **kwargs: object) -> httpx.Response:
+        self.calls.append({"url": url, **kwargs})
+        return self.responses.pop(0)
+
+
+class TestAddReaction:
+    def test_returns_false_when_any_arg_missing(self) -> None:
+        assert add_reaction("", "C1", "1.0", "tada") is False
+        assert add_reaction("t", "", "1.0", "tada") is False
+        assert add_reaction("t", "C1", "", "tada") is False
+        assert add_reaction("t", "C1", "1.0", "") is False
+
+    def test_posts_and_returns_true_on_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        post = _FakePost(responses=[httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", "x"))])
+        monkeypatch.setattr(slack_reactions.httpx, "post", post)
+
+        assert add_reaction("xoxb", "C1", "1700.000100", "tada") is True
+        assert post.calls[0]["url"] == "https://slack.com/api/reactions.add"
+        assert post.calls[0]["data"] == {"channel": "C1", "timestamp": "1700.000100", "name": "tada"}
+
+    def test_already_reacted_counts_as_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        post = _FakePost(
+            responses=[
+                httpx.Response(200, json={"ok": False, "error": "already_reacted"}, request=httpx.Request("POST", "x"))
+            ]
+        )
+        monkeypatch.setattr(slack_reactions.httpx, "post", post)
+        assert add_reaction("xoxb", "C1", "1.0", "tada") is True
+
+    def test_other_error_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        post = _FakePost(
+            responses=[
+                httpx.Response(
+                    200, json={"ok": False, "error": "channel_not_found"}, request=httpx.Request("POST", "x")
+                )
+            ]
+        )
+        monkeypatch.setattr(slack_reactions.httpx, "post", post)
+        assert add_reaction("xoxb", "C1", "1.0", "tada") is False
+
+    def test_http_error_swallowed_and_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise(*_a: object, **_kw: object) -> httpx.Response:
+            msg = "boom"
+            raise httpx.ConnectError(msg)
+
+        monkeypatch.setattr(slack_reactions.httpx, "post", _raise)
+        assert add_reaction("xoxb", "C1", "1.0", "tada") is False
+
+    def test_non_2xx_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        post = _FakePost(responses=[httpx.Response(500, request=httpx.Request("POST", "x"))])
+        monkeypatch.setattr(slack_reactions.httpx, "post", post)
+        assert add_reaction("xoxb", "C1", "1.0", "tada") is False
+
+
+class TestIterMrPermalinks:
+    def test_collects_only_non_empty_string_permalinks(self) -> None:
+        ticket = SimpleNamespace(
+            extra={
+                "mrs": {
+                    "a": {"review_permalink": "https://team.slack.com/archives/C1/p1700000000000100"},
+                    "b": {"review_permalink": ""},
+                    "c": {},
+                    "d": {"review_permalink": 42},
+                    "e": "not-a-dict",
+                }
+            }
+        )
+        assert _iter_mr_permalinks(ticket) == ["https://team.slack.com/archives/C1/p1700000000000100"]
+
+    def test_empty_when_no_mrs(self) -> None:
+        assert _iter_mr_permalinks(SimpleNamespace(extra={})) == []
+        assert _iter_mr_permalinks(SimpleNamespace(extra={"mrs": "garbage"})) == []
+        assert _iter_mr_permalinks(SimpleNamespace(extra=None)) == []
+
+
+@dataclass
+class _StubConfig:
+    token: str
+    emojis: dict[str, str] = field(default_factory=lambda: dict(DEFAULT_TRANSITION_EMOJIS))
+
+    def get_slack_token(self) -> str:
+        return self.token
+
+    def get_transition_emojis(self) -> dict[str, str]:
+        return self.emojis
+
+
+@dataclass
+class _StubOverlay:
+    config: _StubConfig
+
+
+class TestAddReactionsForTransition:
+    def _ticket(self, permalinks: list[str]) -> SimpleNamespace:
+        return SimpleNamespace(extra={"mrs": {f"mr-{i}": {"review_permalink": p} for i, p in enumerate(permalinks)}})
+
+    def test_posts_one_reaction_per_permalink(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        overlay = _StubOverlay(_StubConfig(token="xoxb"))
+        monkeypatch.setattr(
+            "teatree.backends.slack_reactions.get_overlay",
+            lambda: overlay,
+        )
+        calls: list[tuple[str, str, str, str]] = []
+
+        def _fake_add(token: str, channel: str, ts: str, emoji: str) -> bool:
+            calls.append((token, channel, ts, emoji))
+            return True
+
+        monkeypatch.setattr(slack_reactions, "add_reaction", _fake_add)
+
+        ticket = self._ticket(
+            [
+                "https://team.slack.com/archives/C111/p1700000001000100",
+                "https://team.slack.com/archives/C222/p1700000002000200",
+            ]
+        )
+        assert add_reactions_for_transition(ticket, "mark_merged") == 2
+        assert calls == [
+            ("xoxb", "C111", "1700000001.000100", "tada"),
+            ("xoxb", "C222", "1700000002.000200", "tada"),
+        ]
+
+    def test_skips_unparseable_permalinks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        overlay = _StubOverlay(_StubConfig(token="xoxb"))
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda: overlay)
+        monkeypatch.setattr(slack_reactions, "add_reaction", lambda *a, **kw: True)
+
+        ticket = self._ticket(["not-a-permalink", "https://team.slack.com/archives/C1/p1700000000000100"])
+        assert add_reactions_for_transition(ticket, "mark_merged") == 1
+
+    def test_no_op_when_transition_unmapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        overlay = _StubOverlay(_StubConfig(token="xoxb"))
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda: overlay)
+        called = []
+        monkeypatch.setattr(slack_reactions, "add_reaction", lambda *a, **kw: called.append(a) or True)
+
+        ticket = self._ticket(["https://team.slack.com/archives/C1/p1700000000000100"])
+        assert add_reactions_for_transition(ticket, "unmapped_transition") == 0
+        assert called == []
+
+    def test_no_op_when_no_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        overlay = _StubOverlay(_StubConfig(token=""))
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda: overlay)
+        called = []
+        monkeypatch.setattr(slack_reactions, "add_reaction", lambda *a, **kw: called.append(a) or True)
+
+        ticket = self._ticket(["https://team.slack.com/archives/C1/p1700000000000100"])
+        assert add_reactions_for_transition(ticket, "mark_merged") == 0
+        assert called == []
+
+    def test_counts_only_successful_reactions(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        overlay = _StubOverlay(_StubConfig(token="xoxb"))
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda: overlay)
+        results = iter([True, False, True])
+        monkeypatch.setattr(slack_reactions, "add_reaction", lambda *a, **kw: next(results))
+
+        ticket = self._ticket(
+            [
+                "https://team.slack.com/archives/C1/p1700000001000100",
+                "https://team.slack.com/archives/C2/p1700000002000100",
+                "https://team.slack.com/archives/C3/p1700000003000100",
+            ]
+        )
+        assert add_reactions_for_transition(ticket, "mark_merged") == 2
+
+    def test_overlay_override_takes_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        overlay = _StubOverlay(_StubConfig(token="xoxb", emojis={"mark_merged": "rocket"}))
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda: overlay)
+        recorded: list[str] = []
+        monkeypatch.setattr(slack_reactions, "add_reaction", lambda _t, _c, _ts, emoji: recorded.append(emoji) or True)
+
+        ticket = self._ticket(["https://team.slack.com/archives/C1/p1700000000000100"])
+        add_reactions_for_transition(ticket, "mark_merged")
+        assert recorded == ["rocket"]
+
+
+class TestOverlayConfigTransitionEmojis:
+    """OverlayConfig.get_transition_emojis merges override onto defaults."""
+
+    def test_returns_defaults_when_unset(self) -> None:
+        from teatree.core.overlay import OverlayConfig  # noqa: PLC0415
+
+        config = OverlayConfig()
+        emojis = config.get_transition_emojis()
+        assert emojis == DEFAULT_TRANSITION_EMOJIS
+        # returned dict is a copy — mutating it must not affect future calls
+        emojis["mark_merged"] = "poop"
+        assert config.get_transition_emojis()["mark_merged"] == DEFAULT_TRANSITION_EMOJIS["mark_merged"]
+
+    def test_override_merges_on_top_of_defaults(self) -> None:
+        from teatree.core.overlay import OverlayConfig  # noqa: PLC0415
+
+        config = OverlayConfig()
+        config.transition_emojis = {"mark_merged": "rocket", "ship": "ship"}
+        merged = config.get_transition_emojis()
+        assert merged["mark_merged"] == "rocket"
+        assert merged["ship"] == "ship"
+        # Default keys still present
+        assert merged["rework"] == DEFAULT_TRANSITION_EMOJIS["rework"]
+        assert merged["test"] == DEFAULT_TRANSITION_EMOJIS["test"]

--- a/tests/teatree_core/test_signals.py
+++ b/tests/teatree_core/test_signals.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.test import TestCase, override_settings
 
 import teatree.core.overlay_loader as overlay_loader_mod
+import teatree.core.signals as signals_mod
 from teatree.core.models import Session, Task, Ticket
 from tests.teatree_core.conftest import CommandOverlay
 
@@ -133,3 +134,72 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
 
         task.refresh_from_db()
         assert task.status == Task.Status.COMPLETED
+
+
+class TestSlackReactionsOnTransition(TestCase):
+    """post_transition signal triggers Slack reactions via the overlay config."""
+
+    def _ticket_with_mr(self) -> Ticket:
+        return Ticket.objects.create(
+            overlay="test",
+            state=Ticket.State.IN_REVIEW,
+            extra={
+                "mrs": {
+                    "https://gitlab.com/org/repo/-/merge_requests/1": {
+                        "review_permalink": "https://team.slack.com/archives/C999/p1700000000000100",
+                    }
+                }
+            },
+        )
+
+    def test_mark_merged_invokes_reactions(self) -> None:
+        ticket = self._ticket_with_mr()
+        called: list[tuple[object, str]] = []
+
+        def _fake(t: object, name: str) -> int:
+            called.append((t, name))
+            return 1
+
+        with patch.object(signals_mod, "add_reactions_for_transition", _fake):
+            ticket.mark_merged()
+            ticket.save()
+
+        assert len(called) == 1
+        assert called[0][1] == "mark_merged"
+
+    def test_transition_survives_reaction_failure(self) -> None:
+        ticket = self._ticket_with_mr()
+
+        def _boom(*_a: object, **_kw: object) -> int:
+            msg = "slack down"
+            raise RuntimeError(msg)
+
+        with patch.object(signals_mod, "add_reactions_for_transition", _boom):
+            ticket.mark_merged()
+            ticket.save()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_different_transitions_forward_their_name(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.REVIEWED, extra={"mrs": {}})
+        names: list[str] = []
+
+        def _record(_ticket: object, name: str) -> int:
+            names.append(name)
+            return 0
+
+        with patch.object(signals_mod, "add_reactions_for_transition", _record):
+            ticket.rework()
+            ticket.save()
+
+        assert names == ["rework"]
+
+    def test_ticket_without_mrs_is_noop(self) -> None:
+        """The real handler is a silent no-op when the ticket has no MRs."""
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.IN_REVIEW, extra={})
+        # No patching — the real code path must not raise.
+        ticket.mark_merged()
+        ticket.save()
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED


### PR DESCRIPTION
## Summary

Closes #251

Adds Slack emoji reactions to MR review-permalink messages whenever a ticket transitions FSM states. Reviewers see state changes at a glance (tada on merge, arrows_counterclockwise on rework, etc.) without opening the tracker.

## Design

- **New module** `teatree.backends.slack_reactions` — permalink parsing, `reactions.add` API wrapper, and per-ticket fan-out across every `ticket.extra["mrs"][*].review_permalink`.
- **New method** `OverlayConfig.get_transition_emojis()` — merges overlay-specific overrides onto `DEFAULT_TRANSITION_EMOJIS`. Overlays that want rocket instead of tada just set `transition_emojis = {"mark_merged": "rocket"}`.
- **Signal hook** `post_transition` dispatches on `Ticket` — Slack failures are caught + logged so FSM transitions never depend on Slack uptime.
- `already_reacted` Slack errors count as success (desired end state reached).

## Defaults

| Transition | Emoji |
|---|---|
| `test` | `white_check_mark` |
| `request_review` | `eyes` |
| `mark_merged` | `tada` |
| `mark_delivered` | `white_check_mark` |
| `rework` | `arrows_counterclockwise` |
| `ignore` | `wastebasket` |

## Test plan

- [x] 30 unit tests in `tests/teatree_backends/test_slack_reactions.py` cover permalink parsing (thread replies with query strings, too-short timestamps, malformed URLs), HTTP error paths, unmapped transitions, missing tokens, overlay override precedence.
- [x] 4 integration tests in `tests/teatree_core/test_signals.py` confirm the `post_transition` signal is wired and swallows Slack failures.
- [x] Full suite: 2183 tests passing.