### PR TITLE
refactor(cli): remove duplicate t3 doctor info and t3 overlays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ hooks/                 Agent platform hooks (Claude Code hook_router, statusline
 | Tier | Tool | Examples | Needs Django? |
 |------|------|----------|---------------|
 | Runtime commands | Django management commands (django-typer) | `lifecycle setup`, `tasks work-next-sdk`, `followup refresh` | Yes |
-| Bootstrap commands | `t3` Typer CLI | `t3 startoverlay`, `t3 agent`, `t3 overlays` | No |
+| Bootstrap commands | `t3` Typer CLI | `t3 startoverlay`, `t3 agent`, `t3 info` | No |
 | Internal utilities | Python modules in `utils/` | Port allocation, git helpers, DB ops | Imported by commands |
 
 ## Overlay System

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -612,9 +612,8 @@ Typer-based, work without Django:
 
 - `t3 startoverlay` — scaffold a new overlay package (see §6.3)
 - `t3 agent` — launch Claude Code with teatree context (for developing teatree itself)
-- `t3 info` — show entry point, sources, editable status
+- `t3 info` — show entry point, sources, editable status, and discovered overlays
 - `t3 sessions` — list/resume Claude conversation sessions
-- `t3 overlays` — list discovered overlays
 - `t3 docs` — serve mkdocs documentation (requires `docs` dependency group)
 - `t3 ci {cancel,divergence,fetch-errors,fetch-failed-tests,trigger-e2e,quality-check}` — CI helpers
 - `t3 e2e external [--repo <name>] [--test-path <path>]` — run Playwright tests from `T3_PRIVATE_TESTS` or a named `[e2e_repos.<name>]` git repo; skips port discovery when `BASE_URL` is already set (DEV/staging mode)

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -16,8 +16,6 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 │ agent           Launch Claude Code with auto-detected project context.       │
 │ sessions        List recent Claude conversation sessions with resume         │
 │                 commands.                                                    │
-│ overlays        List overlays (from ~/.teatree.toml and installed entry      │
-│                 points).                                                     │
 │ info            Show t3 installation, teatree/overlay sources, and editable  │
 │                 status.                                                      │
 │ dashboard       Migrate the database and start the dashboard dev server.     │
@@ -103,18 +101,6 @@ Usage: t3 sessions [OPTIONS]
 │ --limit    -n      INTEGER  Max sessions to show [default: 20]               │
 │ --all      -a               Show sessions from all projects                  │
 │ --help                      Show this message and exit.                      │
-╰──────────────────────────────────────────────────────────────────────────────╯
-```
-
-### `t3 overlays`
-
-```
-Usage: t3 overlays [OPTIONS]
-
- List overlays (from ~/.teatree.toml and installed entry points).
-
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -485,7 +471,6 @@ Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ check  Verify imports, required tools, and editable-install sanity.          │
-│ info   Show t3 path, teatree/overlay sources, and editable status.           │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -495,18 +480,6 @@ Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
 Usage: t3 doctor check [OPTIONS]
 
  Verify imports, required tools, and editable-install sanity.
-
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                  │
-╰──────────────────────────────────────────────────────────────────────────────╯
-```
-
-#### `t3 doctor info`
-
-```
-Usage: t3 doctor info [OPTIONS]
-
- Show t3 path, teatree/overlay sources, and editable status.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │

--- a/skills/code/references/troubleshooting.md
+++ b/skills/code/references/troubleshooting.md
@@ -20,7 +20,7 @@
 
 ## Overlay Discovery Returns Empty Despite Config
 
-- **Symptom:** `t3 overlays` shows "No overlays found" even though `~/.teatree.toml` has `[overlays.*]` sections.
+- **Symptom:** `t3 info` shows no installed overlays even though `~/.teatree.toml` has `[overlays.*]` sections.
 - **Cause:** `discover_overlays()` was only reading entry points, not the toml config.
 - **Fix:** `discover_overlays()` now reads `[overlays.<name>]` sections from `~/.teatree.toml` first, then falls back to entry points. Toml entries win on name conflict.
 - **Prevention:** When adding new discovery sources, test with both the toml config and entry points.

--- a/skills/workspace/references/scripts-and-functions.md
+++ b/skills/workspace/references/scripts-and-functions.md
@@ -20,9 +20,8 @@ uv run t3 <overlay> --help     # overlay-specific commands (from overlay project
 | `t3 ship <TICKET_ID>` | Code to MR — create merge request |
 | `t3 daily` | Daily followup — sync MRs, check gates, remind reviewers |
 | `t3 agent` | Launch agent with project context |
-| `t3 overlays` | List installed overlays |
 | `t3 full-status` | Show ticket, worktree, and session state summary |
-| `t3 doctor info` | Show binary, source paths, editable status |
+| `t3 info` | Show binary, source paths, editable status, and installed overlays |
 | `t3 doctor check` | Verify imports and editable-install sanity |
 | `t3 config autoload` | List skill auto-loading rules |
 | `t3 ci cancel` | Cancel stale CI pipelines |

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -299,28 +299,6 @@ def sessions(
     typer.echo("")
 
 
-@app.command()
-def overlays() -> None:
-    """List overlays (from ~/.teatree.toml and installed entry points)."""
-    from teatree.config import discover_active_overlay, discover_overlays  # noqa: PLC0415
-
-    installed = discover_overlays()
-    active = discover_active_overlay()
-
-    if not installed:
-        typer.echo("No overlays found.")
-        typer.echo("Add one to ~/.teatree.toml:")
-        typer.echo("")
-        typer.echo("  [overlays.my-project]")
-        typer.echo('  path = "~/workspace/my-project"')
-        return
-
-    typer.echo("Installed overlays:")
-    for entry in installed:
-        marker = " (active)" if active and entry.name == active.name else ""
-        typer.echo(f"  {entry.name:<20}{entry.overlay_class or '(local)'}{marker}")
-
-
 # ── Top-level info ─────────────────────────────────────────────────────
 
 

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -393,9 +393,3 @@ def check() -> bool:
     if ok:
         typer.echo("All checks passed")
     return ok
-
-
-@doctor_app.command(name="info")
-def doctor_info() -> None:
-    """Show t3 path, teatree/overlay sources, and editable status."""
-    DoctorService.show_info()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,39 +262,6 @@ class TestSessionsCommand:
             assert "done" in result.output
 
 
-# ── overlays command ──────────────────────────────────────────────────
-
-
-class TestOverlaysCommand:
-    def test_none_found(self):
-        """Overlays command shows help when no overlays found."""
-        with (
-            patch.object(config_mod, "discover_overlays", return_value=[]),
-            patch.object(config_mod, "discover_active_overlay", return_value=None),
-        ):
-            result = runner.invoke(app, ["overlays"])
-            assert result.exit_code == 0
-            assert "No overlays found" in result.output
-
-    def test_lists_installed(self):
-        """Overlays command lists installed overlays."""
-        from teatree.config import OverlayEntry  # noqa: PLC0415
-
-        entries = [
-            OverlayEntry(name="acme", overlay_class="acme.overlay.AcmeOverlay"),
-            OverlayEntry(name="demo", overlay_class="demo.overlay.DemoOverlay"),
-        ]
-        active = OverlayEntry(name="acme", overlay_class="acme.overlay.AcmeOverlay")
-        with (
-            patch.object(config_mod, "discover_overlays", return_value=entries),
-            patch.object(config_mod, "discover_active_overlay", return_value=active),
-        ):
-            result = runner.invoke(app, ["overlays"])
-            assert result.exit_code == 0
-            assert "acme" in result.output
-            assert "(active)" in result.output
-
-
 # ── info command ──────────────────────────────────────────────────────
 
 
@@ -310,6 +277,27 @@ class TestInfoCommand:
         ):
             result = runner.invoke(app, ["info"])
             assert result.exit_code == 0
+
+    def test_info_lists_overlays(self):
+        """Info command includes installed overlays, replacing the removed top-level `overlays` command."""
+        from teatree.config import OverlayEntry  # noqa: PLC0415
+
+        entries = [
+            OverlayEntry(name="acme", overlay_class="acme.overlay.AcmeOverlay"),
+            OverlayEntry(name="demo", overlay_class="demo.overlay.DemoOverlay"),
+        ]
+        active = OverlayEntry(name="acme", overlay_class="acme.overlay.AcmeOverlay")
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/t3"),
+            patch.object(cli_doctor_mod.IntrospectionHelpers, "editable_info", return_value=(True, "file:///home/src")),
+            patch.object(cli_doctor_mod.IntrospectionHelpers, "print_package_info"),
+            patch.object(config_mod, "discover_active_overlay", return_value=active),
+            patch.object(config_mod, "discover_overlays", return_value=entries),
+        ):
+            result = runner.invoke(app, ["info"])
+            assert result.exit_code == 0
+            assert "acme" in result.output
+            assert "demo" in result.output
 
 
 # ── config subcommands ────────────────────────────────────────────────

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -579,20 +579,6 @@ class TestDoctorCommands:
             result = runner.invoke(app, ["doctor", "check"])
             assert "FAIL" in result.output
 
-    # ── info ─────────────────────────────────────────────────────────
-
-    def test_info(self):
-        """Doctor info delegates to _show_info."""
-        with (
-            patch("shutil.which", return_value="/usr/local/bin/t3"),
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(IntrospectionHelpers, "print_package_info"),
-            patch.object(teatree_config, "discover_active_overlay", return_value=None),
-            patch.object(teatree_config, "discover_overlays", return_value=[]),
-        ):
-            result = runner.invoke(app, ["doctor", "info"])
-            assert result.exit_code == 0
-
 
 class TestFindHostProjectRoot:
     def test_finds_project_in_current_dir(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

First consolidation pass for #278.

- `t3 doctor info` and `t3 info` both called `DoctorService.show_info()`. Keep the top-level one.
- `t3 overlays` was a strict subset of what `t3 info` already prints (active overlay + installed-overlays table). Dropped.

## Follow-ups (separate PRs)

- Fold `t3 plugin install` into `t3 setup` (overlap #2 from the ticket).
- Broader CLI surface audit.

## Test plan

- [x] `uv run pytest --no-cov` — full suite green (2181 passing).
- [x] `test_info_lists_overlays` added to cover the path that previously lived in `TestOverlaysCommand`.
- [x] BLUEPRINT.md, AGENTS.md, and skill docs updated. CLI reference regenerates via pre-commit.