### PR TITLE
chore(agents): set opusplan model on every subagent

### DIFF
--- a/agents/coder.md
+++ b/agents/coder.md
@@ -14,6 +14,7 @@ skills:
   - rules
   - workspace
   - code
+model: opusplan
 ---
 
 # Coder Agent

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -14,6 +14,7 @@ skills:
   - rules
   - workspace
   - debug
+model: opusplan
 ---
 
 # Debugger Agent

--- a/agents/followup.md
+++ b/agents/followup.md
@@ -10,6 +10,7 @@ skills:
   - rules
   - platforms
   - followup
+model: opusplan
 ---
 
 # Followup Agent

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -13,7 +13,7 @@ tools:
 skills:
   - rules
   - workspace
-model: sonnet
+model: opusplan
 maxTurns: 50
 ---
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -11,6 +11,7 @@ skills:
   - platforms
   - review
   - code
+model: opusplan
 ---
 
 # Reviewer Agent

--- a/agents/shipper.md
+++ b/agents/shipper.md
@@ -16,6 +16,7 @@ skills:
   - platforms
   - ship
   - review-request
+model: opusplan
 ---
 
 # Shipper Agent

--- a/agents/tester.md
+++ b/agents/tester.md
@@ -15,6 +15,7 @@ skills:
   - workspace
   - test
   - platforms
+model: opusplan
 ---
 
 # Tester Agent


### PR DESCRIPTION
## Summary

Closes #307.

- Adds `model: opusplan` to all seven subagent frontmatters (`coder`, `debugger`, `followup`, `orchestrator`, `reviewer`, `shipper`, `tester`)
- Changes orchestrator from `sonnet` to `opusplan` for consistency — every subagent now plans on Opus and executes on Sonnet

## Test plan

- [x] Grep confirms all agents carry `model: opusplan`
- [x] Pre-commit checks pass