### PR TITLE
relax(cli): shrink __init__ per-file-ignores from 4 rules to 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,10 +141,7 @@ lint.per-file-ignores."src/teatree/cli/*.py" = [
   "S607",   # partial executable paths (uv is a trusted internal tool)
 ]
 lint.per-file-ignores."src/teatree/cli/__init__.py" = [
-  "FBT003",
-  "PLR2004",
-  "RSE102",
-  "RUF067",  # __init__ contains the full CLI app, not just re-exports
+  "RUF067", # __init__ contains the full CLI app, not just re-exports
 ]
 lint.per-file-ignores."src/teatree/core/management/commands/*.py" = [
   "PLR6301", # django-typer command methods intentionally live on Command classes

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -234,21 +234,28 @@ def agent(
     )
 
 
+_MILLISECOND_TIMESTAMP_THRESHOLD = 1e12
+_SECONDS_PER_HOUR = 3600
+_SECONDS_PER_DAY = 86400
+_PROMPT_DISPLAY_MAX = 80
+_PROMPT_DISPLAY_TRUNCATE = 77
+
+
 def _format_session_age(raw_ts: float | str, now: float) -> str:
     if isinstance(raw_ts, str):
         try:
             raw_ts = float(raw_ts)
         except (ValueError, TypeError):
             raw_ts = 0
-    ts = raw_ts / 1000 if raw_ts > 1e12 else raw_ts
+    ts = raw_ts / 1000 if raw_ts > _MILLISECOND_TIMESTAMP_THRESHOLD else raw_ts
     if not ts:
         return "?"
     age_s = now - ts
-    if age_s < 3600:
+    if age_s < _SECONDS_PER_HOUR:
         return f"{int(age_s / 60)}m ago"
-    if age_s < 86400:
-        return f"{int(age_s / 3600)}h ago"
-    return f"{int(age_s / 86400)}d ago"
+    if age_s < _SECONDS_PER_DAY:
+        return f"{int(age_s / _SECONDS_PER_HOUR)}h ago"
+    return f"{int(age_s / _SECONDS_PER_DAY)}d ago"
 
 
 @app.command()
@@ -277,14 +284,14 @@ def sessions(
 
     if not results:
         typer.echo("No sessions found.")
-        raise typer.Exit()
+        raise typer.Exit
 
     now = datetime.now(tz=UTC).timestamp()
     for r in results:
         age = _format_session_age(r.timestamp, now)
         prompt = r.first_prompt.replace("\n", " ").strip()
-        if len(prompt) > 80:
-            prompt = prompt[:77] + "..."
+        if len(prompt) > _PROMPT_DISPLAY_MAX:
+            prompt = prompt[:_PROMPT_DISPLAY_TRUNCATE] + "..."
 
         status_label = "done" if r.status == "finished" else r.status
 


### PR DESCRIPTION
## Summary

Follow-up to #337 (which cleared 6 `PLR09xx`/`C901` suppressions).

- Magic values in `_format_session_age` and the `sessions` command replaced with named constants
- `raise typer.Exit()` → `raise typer.Exit` (RSE102)
- `per-file-ignores` for `cli/__init__.py` reduced from four rules (`FBT003`, `PLR2004`, `RSE102`, `RUF067`) to one (`RUF067` kept — the file genuinely hosts the full CLI app)

## Test plan

- [x] `uv run ruff check src/teatree/cli/__init__.py` → clean
- [x] `uv run pytest tests/test_cli.py --no-cov -q` → 57 passed