### PR TITLE
chore(config): drop stale coverage exclude and ty allowlist entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,7 +232,6 @@ exclude_lines = [
   "if TYPE_CHECKING",
   "def main\\(",
   "pragma: no cover",
-  "_scripts_dir not in sys\\.path",
 ]
 partial_branches = [
   "pragma: no branch",
@@ -263,15 +262,11 @@ python-version = "3.13"
 
 [tool.ty.analysis]
 allowed-unresolved-imports = [
-  "django.tasks",        # Django 6 exposes this dynamically and ty cannot resolve it yet, even with django-types
-  "mkdocs",              # Optional dependency, guarded by try/except ImportError
-  "lib.env",             # Legacy scripts — guarded by try/except ImportError
-  "lib.gitlab",          # Legacy scripts — guarded by try/except ImportError
-  "lib.registry",        # Legacy scripts — guarded by try/except ImportError
-  "playwright.sync_api",
-  "requests",
-  "typer",
-  "pytest",
+  "django.tasks", # Django 6 exposes this dynamically and ty cannot resolve it yet, even with django-types
+  "mkdocs",       # Optional dependency, guarded by try/except ImportError
+  "lib.env",      # Legacy scripts — guarded by try/except ImportError
+  "lib.gitlab",   # Legacy scripts — guarded by try/except ImportError
+  "lib.registry", # Legacy scripts — guarded by try/except ImportError
   "tomlkit",
 ]
 


### PR DESCRIPTION
## Summary

Two stale config entries confirmed empirically (remove, re-run checks, count errors — zero).

- \`_scripts_dir not in sys.path\` coverage exclude: no source line matches this pattern (actual code uses uppercase \`_SRC_DIR\` in scripts/lib/skill_loader.py).
- Four ty \`allowed-unresolved-imports\` entries (\`playwright.sync_api\`, \`requests\`, \`typer\`, \`pytest\`): \`ty check\` now resolves them cleanly. Kept \`django.tasks\`, \`mkdocs\`, \`lib.env\`, \`lib.gitlab\`, \`lib.registry\`, \`tomlkit\` — removing any of those still produces unresolved-import errors.

## Test plan

- [x] \`uv run ruff check\` clean
- [x] \`uv run ty check\` clean