### PR TITLE
chore(deps): remove django-rich from dev group (already a runtime dep)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ entry-points."teatree.overlays".t3-teatree = "teatree.contrib.t3_teatree.overlay
 # Strategy: enable ALL rules, then ignore specific ones with justification.
 # https://docs.astral.sh/ruff/rules/
 dev = [
-  "django-rich>=2.2",
   "django-types>=0.23",
   "pip-audit>=2",
   "prek>=0.2.12",

--- a/uv.lock
+++ b/uv.lock
@@ -1366,7 +1366,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "django-rich" },
     { name = "django-types" },
     { name = "pip-audit" },
     { name = "prek" },
@@ -1402,7 +1401,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "django-rich", specifier = ">=2.2" },
     { name = "django-types", specifier = ">=0.23" },
     { name = "pip-audit", specifier = ">=2" },
     { name = "prek", specifier = ">=0.2.12" },


### PR DESCRIPTION
## Summary

\`django-rich\` is in \`INSTALLED_APPS\` in both \`src/teatree/settings.py\` and \`tests/django_settings.py\`, so it is a required **runtime** dependency. Listing it again in the dev group is redundant — runtime deps are always installed regardless of \`--no-dev\`.

## Test plan

- [x] \`uv run ruff check\` clean
- [x] \`uv run ty check\` clean
- [x] Full test suite: 2172 passed