### PR TITLE
feat(info): show overlay paths, Claude plugin, and sync skills to Codex

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -612,7 +612,7 @@ Typer-based, work without Django:
 
 - `t3 startoverlay` — scaffold a new overlay package (see §6.3)
 - `t3 agent` — launch Claude Code with teatree context (for developing teatree itself)
-- `t3 info` — show entry point, sources, editable status, and discovered overlays
+- `t3 info` — show entry point, sources, editable status, discovered overlays (with project paths), Claude plugin install, and agent runtime skill dirs
 - `t3 sessions` — list/resume Claude conversation sessions
 - `t3 docs` — serve mkdocs documentation (requires `docs` dependency group)
 - `t3 ci {cancel,divergence,fetch-errors,fetch-failed-tests,trigger-e2e,quality-check}` — CI helpers

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -5,8 +5,8 @@ Generated from `t3` command tree.
 ## `t3`
 
 ```
-Usage: t3 [OPTIONS] COMMAND [ARGS]...
-
+Usage: t3 [OPTIONS] COMMAND [ARGS]...                                          
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -33,10 +33,10 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 ### `t3 startoverlay`
 
 ```
-Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
-
- Create a new TeaTree overlay package.
-
+Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION                      
+                                                                                
+ Create a new TeaTree overlay package.                                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    project_name      TEXT  [required]                                      │
 │ *    destination       PATH  [required]                                      │
@@ -53,12 +53,12 @@ Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
 ### `t3 docs`
 
 ```
-Usage: t3 docs [OPTIONS]
-
- Serve the project documentation with mkdocs.
-
- Requires the ``docs`` dependency group: ``uv sync --group docs``
-
+Usage: t3 docs [OPTIONS]                                                       
+                                                                                
+ Serve the project documentation with mkdocs.                                   
+                                                                                
+ Requires the ``docs`` dependency group: ``uv sync --group docs``               
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host        TEXT     Host to bind to [default: 127.0.0.1]                  │
 │ --port        INTEGER  Port to serve on [default: 8888]                      │
@@ -69,10 +69,10 @@ Usage: t3 docs [OPTIONS]
 ### `t3 agent`
 
 ```
-Usage: t3 agent [OPTIONS] [TASK]
-
- Launch Claude Code with auto-detected project context.
-
+Usage: t3 agent [OPTIONS] [TASK]                                               
+                                                                                
+ Launch Claude Code with auto-detected project context.                         
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   task      [TASK]  What to work on (e.g. 'fix the sync bug', 'add a new     │
 │                     command')                                                │
@@ -88,13 +88,13 @@ Usage: t3 agent [OPTIONS] [TASK]
 ### `t3 sessions`
 
 ```
-Usage: t3 sessions [OPTIONS]
-
- List recent Claude conversation sessions with resume commands.
-
- By default shows sessions for the current working directory.
- Use --all to show sessions across all projects.
-
+Usage: t3 sessions [OPTIONS]                                                   
+                                                                                
+ List recent Claude conversation sessions with resume commands.                 
+                                                                                
+ By default shows sessions for the current working directory.                   
+ Use --all to show sessions across all projects.                                
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --project          TEXT     Filter by project dir substring                  │
 │ --limit    -n      INTEGER  Max sessions to show [default: 20]               │
@@ -106,10 +106,10 @@ Usage: t3 sessions [OPTIONS]
 ### `t3 info`
 
 ```
-Usage: t3 info [OPTIONS]
-
- Show t3 installation, teatree/overlay sources, and editable status.
-
+Usage: t3 info [OPTIONS]                                                       
+                                                                                
+ Show t3 installation, teatree/overlay sources, and editable status.            
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -118,10 +118,10 @@ Usage: t3 info [OPTIONS]
 ### `t3 dashboard`
 
 ```
-Usage: t3 dashboard [OPTIONS]
-
- Migrate the database and start the dashboard dev server.
-
+Usage: t3 dashboard [OPTIONS]                                                  
+                                                                                
+ Migrate the database and start the dashboard dev server.                       
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host           TEXT     Host to bind to [default: 127.0.0.1]               │
 │ --port           INTEGER  Port to serve on [default: 8000]                   │
@@ -137,10 +137,10 @@ Usage: t3 dashboard [OPTIONS]
 ### `t3 config`
 
 ```
-Usage: t3 config [OPTIONS] COMMAND [ARGS]...
-
- Configuration and autoloading.
-
+Usage: t3 config [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Configuration and autoloading.                                                 
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -159,10 +159,10 @@ Usage: t3 config [OPTIONS] COMMAND [ARGS]...
 #### `t3 config check-update`
 
 ```
-Usage: t3 config check-update [OPTIONS]
-
- Check if a newer version of teatree is available.
-
+Usage: t3 config check-update [OPTIONS]                                        
+                                                                                
+ Check if a newer version of teatree is available.                              
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -171,10 +171,10 @@ Usage: t3 config check-update [OPTIONS]
 #### `t3 config write-skill-cache`
 
 ```
-Usage: t3 config write-skill-cache [OPTIONS]
-
- Write overlay skill metadata to XDG cache for hook consumption.
-
+Usage: t3 config write-skill-cache [OPTIONS]                                   
+                                                                                
+ Write overlay skill metadata to XDG cache for hook consumption.                
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -183,10 +183,10 @@ Usage: t3 config write-skill-cache [OPTIONS]
 #### `t3 config autoload`
 
 ```
-Usage: t3 config autoload [OPTIONS]
-
- List skill auto-loading rules from context-match.yml files.
-
+Usage: t3 config autoload [OPTIONS]                                            
+                                                                                
+ List skill auto-loading rules from context-match.yml files.                    
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -195,10 +195,10 @@ Usage: t3 config autoload [OPTIONS]
 #### `t3 config cache`
 
 ```
-Usage: t3 config cache [OPTIONS]
-
- Show the XDG skill-metadata cache content.
-
+Usage: t3 config cache [OPTIONS]                                               
+                                                                                
+ Show the XDG skill-metadata cache content.                                     
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -207,10 +207,10 @@ Usage: t3 config cache [OPTIONS]
 #### `t3 config deps`
 
 ```
-Usage: t3 config deps [OPTIONS] SKILL
-
- Show resolved dependency chain for a skill.
-
+Usage: t3 config deps [OPTIONS] SKILL                                          
+                                                                                
+ Show resolved dependency chain for a skill.                                    
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    skill      TEXT  [required]                                             │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -222,10 +222,10 @@ Usage: t3 config deps [OPTIONS] SKILL
 #### `t3 config test-trigger`
 
 ```
-Usage: t3 config test-trigger [OPTIONS] PROMPT
-
- Test which skill would be triggered for a given prompt.
-
+Usage: t3 config test-trigger [OPTIONS] PROMPT                                 
+                                                                                
+ Test which skill would be triggered for a given prompt.                        
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    prompt      TEXT  [required]                                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -237,10 +237,10 @@ Usage: t3 config test-trigger [OPTIONS] PROMPT
 ### `t3 ci`
 
 ```
-Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
-
- CI pipeline helpers.
-
+Usage: t3 ci [OPTIONS] COMMAND [ARGS]...                                       
+                                                                                
+ CI pipeline helpers.                                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -258,10 +258,10 @@ Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
 #### `t3 ci cancel`
 
 ```
-Usage: t3 ci cancel [OPTIONS] [BRANCH]
-
- Cancel stale CI pipelines for a branch.
-
+Usage: t3 ci cancel [OPTIONS] [BRANCH]                                         
+                                                                                
+ Cancel stale CI pipelines for a branch.                                        
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -273,10 +273,10 @@ Usage: t3 ci cancel [OPTIONS] [BRANCH]
 #### `t3 ci divergence`
 
 ```
-Usage: t3 ci divergence [OPTIONS]
-
- Check fork divergence from upstream.
-
+Usage: t3 ci divergence [OPTIONS]                                              
+                                                                                
+ Check fork divergence from upstream.                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -285,10 +285,10 @@ Usage: t3 ci divergence [OPTIONS]
 #### `t3 ci fetch-errors`
 
 ```
-Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
-
- Fetch error logs from the latest CI pipeline.
-
+Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]                                   
+                                                                                
+ Fetch error logs from the latest CI pipeline.                                  
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -300,10 +300,10 @@ Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
 #### `t3 ci fetch-failed-tests`
 
 ```
-Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
-
- Extract failed test IDs from the latest CI pipeline.
-
+Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]                             
+                                                                                
+ Extract failed test IDs from the latest CI pipeline.                           
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -315,10 +315,10 @@ Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
 #### `t3 ci trigger-e2e`
 
 ```
-Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
-
- Trigger E2E tests on CI.
-
+Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]                                    
+                                                                                
+ Trigger E2E tests on CI.                                                       
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -330,10 +330,10 @@ Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
 #### `t3 ci quality-check`
 
 ```
-Usage: t3 ci quality-check [OPTIONS] [BRANCH]
-
- Run quality analysis (fetch test report from latest pipeline).
-
+Usage: t3 ci quality-check [OPTIONS] [BRANCH]                                  
+                                                                                
+ Run quality analysis (fetch test report from latest pipeline).                 
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -345,10 +345,10 @@ Usage: t3 ci quality-check [OPTIONS] [BRANCH]
 ### `t3 review`
 
 ```
-Usage: t3 review [OPTIONS] COMMAND [ARGS]...
-
- Code review helpers.
-
+Usage: t3 review [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Code review helpers.                                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -363,10 +363,10 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 #### `t3 review post-draft-note`
 
 ```
-Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
-
- Post a draft note on a GitLab MR (inline or general).
-
+Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE                        
+                                                                                
+ Post a draft note on a GitLab MR (inline or general).                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -384,10 +384,10 @@ Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
 #### `t3 review delete-draft-note`
 
 ```
-Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
-
- Delete a draft note from a GitLab MR.
-
+Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID                   
+                                                                                
+ Delete a draft note from a GitLab MR.                                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo         TEXT     GitLab project path [required]                    │
 │ *    mr           INTEGER  Merge request IID [required]                      │
@@ -401,10 +401,10 @@ Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
 #### `t3 review publish-draft-notes`
 
 ```
-Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
-
- Publish all draft notes on a GitLab MR (bulk submit).
-
+Usage: t3 review publish-draft-notes [OPTIONS] REPO MR                         
+                                                                                
+ Publish all draft notes on a GitLab MR (bulk submit).                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -418,10 +418,10 @@ Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
 #### `t3 review list-draft-notes`
 
 ```
-Usage: t3 review list-draft-notes [OPTIONS] REPO MR
-
- List draft notes on a GitLab MR.
-
+Usage: t3 review list-draft-notes [OPTIONS] REPO MR                            
+                                                                                
+ List draft notes on a GitLab MR.                                               
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path [required]                       │
 │ *    mr        INTEGER  Merge request IID [required]                         │
@@ -434,10 +434,10 @@ Usage: t3 review list-draft-notes [OPTIONS] REPO MR
 ### `t3 review-request`
 
 ```
-Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
-
- Batch review requests.
-
+Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...                           
+                                                                                
+ Batch review requests.                                                         
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -449,10 +449,10 @@ Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
 #### `t3 review-request discover`
 
 ```
-Usage: t3 review-request discover [OPTIONS]
-
- Discover open merge requests awaiting review.
-
+Usage: t3 review-request discover [OPTIONS]                                    
+                                                                                
+ Discover open merge requests awaiting review.                                  
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -461,10 +461,10 @@ Usage: t3 review-request discover [OPTIONS]
 ### `t3 doctor`
 
 ```
-Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
-
- Smoke-test hooks, imports, services.
-
+Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Smoke-test hooks, imports, services.                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -476,10 +476,10 @@ Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
 #### `t3 doctor check`
 
 ```
-Usage: t3 doctor check [OPTIONS]
-
- Verify imports, required tools, and editable-install sanity.
-
+Usage: t3 doctor check [OPTIONS]                                               
+                                                                                
+ Verify imports, required tools, and editable-install sanity.                   
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -488,10 +488,10 @@ Usage: t3 doctor check [OPTIONS]
 ### `t3 tool`
 
 ```
-Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
-
- Standalone utilities.
-
+Usage: t3 tool [OPTIONS] COMMAND [ARGS]...                                     
+                                                                                
+ Standalone utilities.                                                          
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -508,10 +508,10 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 #### `t3 tool privacy-scan`
 
 ```
-Usage: t3 tool privacy-scan [OPTIONS] [PATH]
-
- Scan text for privacy-sensitive patterns (emails, keys, IPs).
-
+Usage: t3 tool privacy-scan [OPTIONS] [PATH]                                   
+                                                                                
+ Scan text for privacy-sensitive patterns (emails, keys, IPs).                  
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   path      [PATH]  File or '-' for stdin [default: -]                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -523,10 +523,10 @@ Usage: t3 tool privacy-scan [OPTIONS] [PATH]
 #### `t3 tool analyze-video`
 
 ```
-Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
-
- Decompose video into frames for AI analysis.
-
+Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH                              
+                                                                                
+ Decompose video into frames for AI analysis.                                   
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    video_path      TEXT  Path to video file [required]                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -538,10 +538,10 @@ Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
 #### `t3 tool bump-deps`
 
 ```
-Usage: t3 tool bump-deps [OPTIONS]
-
- Bump pyproject.toml dependencies from uv.lock.
-
+Usage: t3 tool bump-deps [OPTIONS]                                             
+                                                                                
+ Bump pyproject.toml dependencies from uv.lock.                                 
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -550,10 +550,10 @@ Usage: t3 tool bump-deps [OPTIONS]
 #### `t3 tool sonar-check`
 
 ```
-Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
-
- Run local SonarQube analysis via Docker.
-
+Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]                               
+                                                                                
+ Run local SonarQube analysis via Docker.                                       
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   repo_path      [REPO_PATH]  Path to repo (default: current directory)      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -572,10 +572,10 @@ Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
 #### `t3 tool claude-handover`
 
 ```
-Usage: t3 tool claude-handover [OPTIONS]
-
- Show Claude handover telemetry and runtime recommendations.
-
+Usage: t3 tool claude-handover [OPTIONS]                                       
+                                                                                
+ Show Claude handover telemetry and runtime recommendations.                    
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --current-runtime        TEXT  Current CLI runtime. Defaults to the          │
 │                                highest-priority configured runtime.          │
@@ -591,10 +591,10 @@ Usage: t3 tool claude-handover [OPTIONS]
 ### `t3 setup`
 
 ```
-Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
-
- First-time setup and global skill management.
-
+Usage: t3 setup [OPTIONS] COMMAND [ARGS]...                                    
+                                                                                
+ First-time setup and global skill management.                                  
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --claude-scope        TEXT  Claude plugin install scope: user or project.    │
 │                             [default: user]                                  │
@@ -606,10 +606,10 @@ Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
 ### `t3 assess`
 
 ```
-Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
-
- Codebase health assessment.
-
+Usage: t3 assess [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Codebase health assessment.                                                    
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -622,10 +622,10 @@ Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
 #### `t3 assess run`
 
 ```
-Usage: t3 assess run [OPTIONS]
-
- Run deterministic codebase metrics on a repository.
-
+Usage: t3 assess run [OPTIONS]                                                 
+                                                                                
+ Run deterministic codebase metrics on a repository.                            
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root                 PATH  Repository root to assess                       │
 │ --json                       Output raw JSON                                 │
@@ -638,13 +638,14 @@ Usage: t3 assess run [OPTIONS]
 #### `t3 assess history`
 
 ```
-Usage: t3 assess history [OPTIONS]
-
- Show assessment history for a repository.
-
+Usage: t3 assess history [OPTIONS]                                             
+                                                                                
+ Show assessment history for a repository.                                      
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root           PATH     Repository root                                    │
 │ --limit  -n      INTEGER  Number of recent assessments to show [default: 10] │
 │ --help                    Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
+

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -5,8 +5,8 @@ Generated from `t3` command tree.
 ## `t3`
 
 ```
-Usage: t3 [OPTIONS] COMMAND [ARGS]...                                          
-                                                                                
+Usage: t3 [OPTIONS] COMMAND [ARGS]...
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -33,10 +33,10 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 ### `t3 startoverlay`
 
 ```
-Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION                      
-                                                                                
- Create a new TeaTree overlay package.                                          
-                                                                                
+Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
+
+ Create a new TeaTree overlay package.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    project_name      TEXT  [required]                                      │
 │ *    destination       PATH  [required]                                      │
@@ -53,12 +53,12 @@ Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
 ### `t3 docs`
 
 ```
-Usage: t3 docs [OPTIONS]                                                       
-                                                                                
- Serve the project documentation with mkdocs.                                   
-                                                                                
- Requires the ``docs`` dependency group: ``uv sync --group docs``               
-                                                                                
+Usage: t3 docs [OPTIONS]
+
+ Serve the project documentation with mkdocs.
+
+ Requires the ``docs`` dependency group: ``uv sync --group docs``
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host        TEXT     Host to bind to [default: 127.0.0.1]                  │
 │ --port        INTEGER  Port to serve on [default: 8888]                      │
@@ -69,10 +69,10 @@ Usage: t3 docs [OPTIONS]
 ### `t3 agent`
 
 ```
-Usage: t3 agent [OPTIONS] [TASK]                                               
-                                                                                
- Launch Claude Code with auto-detected project context.                         
-                                                                                
+Usage: t3 agent [OPTIONS] [TASK]
+
+ Launch Claude Code with auto-detected project context.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   task      [TASK]  What to work on (e.g. 'fix the sync bug', 'add a new     │
 │                     command')                                                │
@@ -88,13 +88,13 @@ Usage: t3 agent [OPTIONS] [TASK]
 ### `t3 sessions`
 
 ```
-Usage: t3 sessions [OPTIONS]                                                   
-                                                                                
- List recent Claude conversation sessions with resume commands.                 
-                                                                                
- By default shows sessions for the current working directory.                   
- Use --all to show sessions across all projects.                                
-                                                                                
+Usage: t3 sessions [OPTIONS]
+
+ List recent Claude conversation sessions with resume commands.
+
+ By default shows sessions for the current working directory.
+ Use --all to show sessions across all projects.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --project          TEXT     Filter by project dir substring                  │
 │ --limit    -n      INTEGER  Max sessions to show [default: 20]               │
@@ -106,10 +106,10 @@ Usage: t3 sessions [OPTIONS]
 ### `t3 info`
 
 ```
-Usage: t3 info [OPTIONS]                                                       
-                                                                                
- Show t3 installation, teatree/overlay sources, and editable status.            
-                                                                                
+Usage: t3 info [OPTIONS]
+
+ Show t3 installation, teatree/overlay sources, and editable status.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -118,10 +118,10 @@ Usage: t3 info [OPTIONS]
 ### `t3 dashboard`
 
 ```
-Usage: t3 dashboard [OPTIONS]                                                  
-                                                                                
- Migrate the database and start the dashboard dev server.                       
-                                                                                
+Usage: t3 dashboard [OPTIONS]
+
+ Migrate the database and start the dashboard dev server.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host           TEXT     Host to bind to [default: 127.0.0.1]               │
 │ --port           INTEGER  Port to serve on [default: 8000]                   │
@@ -137,10 +137,10 @@ Usage: t3 dashboard [OPTIONS]
 ### `t3 config`
 
 ```
-Usage: t3 config [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Configuration and autoloading.                                                 
-                                                                                
+Usage: t3 config [OPTIONS] COMMAND [ARGS]...
+
+ Configuration and autoloading.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -159,10 +159,10 @@ Usage: t3 config [OPTIONS] COMMAND [ARGS]...
 #### `t3 config check-update`
 
 ```
-Usage: t3 config check-update [OPTIONS]                                        
-                                                                                
- Check if a newer version of teatree is available.                              
-                                                                                
+Usage: t3 config check-update [OPTIONS]
+
+ Check if a newer version of teatree is available.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -171,10 +171,10 @@ Usage: t3 config check-update [OPTIONS]
 #### `t3 config write-skill-cache`
 
 ```
-Usage: t3 config write-skill-cache [OPTIONS]                                   
-                                                                                
- Write overlay skill metadata to XDG cache for hook consumption.                
-                                                                                
+Usage: t3 config write-skill-cache [OPTIONS]
+
+ Write overlay skill metadata to XDG cache for hook consumption.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -183,10 +183,10 @@ Usage: t3 config write-skill-cache [OPTIONS]
 #### `t3 config autoload`
 
 ```
-Usage: t3 config autoload [OPTIONS]                                            
-                                                                                
- List skill auto-loading rules from context-match.yml files.                    
-                                                                                
+Usage: t3 config autoload [OPTIONS]
+
+ List skill auto-loading rules from context-match.yml files.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -195,10 +195,10 @@ Usage: t3 config autoload [OPTIONS]
 #### `t3 config cache`
 
 ```
-Usage: t3 config cache [OPTIONS]                                               
-                                                                                
- Show the XDG skill-metadata cache content.                                     
-                                                                                
+Usage: t3 config cache [OPTIONS]
+
+ Show the XDG skill-metadata cache content.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -207,10 +207,10 @@ Usage: t3 config cache [OPTIONS]
 #### `t3 config deps`
 
 ```
-Usage: t3 config deps [OPTIONS] SKILL                                          
-                                                                                
- Show resolved dependency chain for a skill.                                    
-                                                                                
+Usage: t3 config deps [OPTIONS] SKILL
+
+ Show resolved dependency chain for a skill.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    skill      TEXT  [required]                                             │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -222,10 +222,10 @@ Usage: t3 config deps [OPTIONS] SKILL
 #### `t3 config test-trigger`
 
 ```
-Usage: t3 config test-trigger [OPTIONS] PROMPT                                 
-                                                                                
- Test which skill would be triggered for a given prompt.                        
-                                                                                
+Usage: t3 config test-trigger [OPTIONS] PROMPT
+
+ Test which skill would be triggered for a given prompt.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    prompt      TEXT  [required]                                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -237,10 +237,10 @@ Usage: t3 config test-trigger [OPTIONS] PROMPT
 ### `t3 ci`
 
 ```
-Usage: t3 ci [OPTIONS] COMMAND [ARGS]...                                       
-                                                                                
- CI pipeline helpers.                                                           
-                                                                                
+Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
+
+ CI pipeline helpers.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -258,10 +258,10 @@ Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
 #### `t3 ci cancel`
 
 ```
-Usage: t3 ci cancel [OPTIONS] [BRANCH]                                         
-                                                                                
- Cancel stale CI pipelines for a branch.                                        
-                                                                                
+Usage: t3 ci cancel [OPTIONS] [BRANCH]
+
+ Cancel stale CI pipelines for a branch.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -273,10 +273,10 @@ Usage: t3 ci cancel [OPTIONS] [BRANCH]
 #### `t3 ci divergence`
 
 ```
-Usage: t3 ci divergence [OPTIONS]                                              
-                                                                                
- Check fork divergence from upstream.                                           
-                                                                                
+Usage: t3 ci divergence [OPTIONS]
+
+ Check fork divergence from upstream.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -285,10 +285,10 @@ Usage: t3 ci divergence [OPTIONS]
 #### `t3 ci fetch-errors`
 
 ```
-Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]                                   
-                                                                                
- Fetch error logs from the latest CI pipeline.                                  
-                                                                                
+Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
+
+ Fetch error logs from the latest CI pipeline.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -300,10 +300,10 @@ Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
 #### `t3 ci fetch-failed-tests`
 
 ```
-Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]                             
-                                                                                
- Extract failed test IDs from the latest CI pipeline.                           
-                                                                                
+Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
+
+ Extract failed test IDs from the latest CI pipeline.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -315,10 +315,10 @@ Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
 #### `t3 ci trigger-e2e`
 
 ```
-Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]                                    
-                                                                                
- Trigger E2E tests on CI.                                                       
-                                                                                
+Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
+
+ Trigger E2E tests on CI.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -330,10 +330,10 @@ Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
 #### `t3 ci quality-check`
 
 ```
-Usage: t3 ci quality-check [OPTIONS] [BRANCH]                                  
-                                                                                
- Run quality analysis (fetch test report from latest pipeline).                 
-                                                                                
+Usage: t3 ci quality-check [OPTIONS] [BRANCH]
+
+ Run quality analysis (fetch test report from latest pipeline).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -345,10 +345,10 @@ Usage: t3 ci quality-check [OPTIONS] [BRANCH]
 ### `t3 review`
 
 ```
-Usage: t3 review [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Code review helpers.                                                           
-                                                                                
+Usage: t3 review [OPTIONS] COMMAND [ARGS]...
+
+ Code review helpers.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -363,10 +363,10 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 #### `t3 review post-draft-note`
 
 ```
-Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE                        
-                                                                                
- Post a draft note on a GitLab MR (inline or general).                          
-                                                                                
+Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
+
+ Post a draft note on a GitLab MR (inline or general).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -384,10 +384,10 @@ Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
 #### `t3 review delete-draft-note`
 
 ```
-Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID                   
-                                                                                
- Delete a draft note from a GitLab MR.                                          
-                                                                                
+Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
+
+ Delete a draft note from a GitLab MR.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo         TEXT     GitLab project path [required]                    │
 │ *    mr           INTEGER  Merge request IID [required]                      │
@@ -401,10 +401,10 @@ Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
 #### `t3 review publish-draft-notes`
 
 ```
-Usage: t3 review publish-draft-notes [OPTIONS] REPO MR                         
-                                                                                
- Publish all draft notes on a GitLab MR (bulk submit).                          
-                                                                                
+Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
+
+ Publish all draft notes on a GitLab MR (bulk submit).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -418,10 +418,10 @@ Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
 #### `t3 review list-draft-notes`
 
 ```
-Usage: t3 review list-draft-notes [OPTIONS] REPO MR                            
-                                                                                
- List draft notes on a GitLab MR.                                               
-                                                                                
+Usage: t3 review list-draft-notes [OPTIONS] REPO MR
+
+ List draft notes on a GitLab MR.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path [required]                       │
 │ *    mr        INTEGER  Merge request IID [required]                         │
@@ -434,10 +434,10 @@ Usage: t3 review list-draft-notes [OPTIONS] REPO MR
 ### `t3 review-request`
 
 ```
-Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...                           
-                                                                                
- Batch review requests.                                                         
-                                                                                
+Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
+
+ Batch review requests.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -449,10 +449,10 @@ Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
 #### `t3 review-request discover`
 
 ```
-Usage: t3 review-request discover [OPTIONS]                                    
-                                                                                
- Discover open merge requests awaiting review.                                  
-                                                                                
+Usage: t3 review-request discover [OPTIONS]
+
+ Discover open merge requests awaiting review.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -461,10 +461,10 @@ Usage: t3 review-request discover [OPTIONS]
 ### `t3 doctor`
 
 ```
-Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Smoke-test hooks, imports, services.                                           
-                                                                                
+Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
+
+ Smoke-test hooks, imports, services.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -476,10 +476,10 @@ Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
 #### `t3 doctor check`
 
 ```
-Usage: t3 doctor check [OPTIONS]                                               
-                                                                                
- Verify imports, required tools, and editable-install sanity.                   
-                                                                                
+Usage: t3 doctor check [OPTIONS]
+
+ Verify imports, required tools, and editable-install sanity.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -488,10 +488,10 @@ Usage: t3 doctor check [OPTIONS]
 ### `t3 tool`
 
 ```
-Usage: t3 tool [OPTIONS] COMMAND [ARGS]...                                     
-                                                                                
- Standalone utilities.                                                          
-                                                                                
+Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
+
+ Standalone utilities.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -508,10 +508,10 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 #### `t3 tool privacy-scan`
 
 ```
-Usage: t3 tool privacy-scan [OPTIONS] [PATH]                                   
-                                                                                
- Scan text for privacy-sensitive patterns (emails, keys, IPs).                  
-                                                                                
+Usage: t3 tool privacy-scan [OPTIONS] [PATH]
+
+ Scan text for privacy-sensitive patterns (emails, keys, IPs).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   path      [PATH]  File or '-' for stdin [default: -]                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -523,10 +523,10 @@ Usage: t3 tool privacy-scan [OPTIONS] [PATH]
 #### `t3 tool analyze-video`
 
 ```
-Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH                              
-                                                                                
- Decompose video into frames for AI analysis.                                   
-                                                                                
+Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
+
+ Decompose video into frames for AI analysis.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    video_path      TEXT  Path to video file [required]                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -538,10 +538,10 @@ Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
 #### `t3 tool bump-deps`
 
 ```
-Usage: t3 tool bump-deps [OPTIONS]                                             
-                                                                                
- Bump pyproject.toml dependencies from uv.lock.                                 
-                                                                                
+Usage: t3 tool bump-deps [OPTIONS]
+
+ Bump pyproject.toml dependencies from uv.lock.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -550,10 +550,10 @@ Usage: t3 tool bump-deps [OPTIONS]
 #### `t3 tool sonar-check`
 
 ```
-Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]                               
-                                                                                
- Run local SonarQube analysis via Docker.                                       
-                                                                                
+Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
+
+ Run local SonarQube analysis via Docker.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   repo_path      [REPO_PATH]  Path to repo (default: current directory)      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -572,10 +572,10 @@ Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
 #### `t3 tool claude-handover`
 
 ```
-Usage: t3 tool claude-handover [OPTIONS]                                       
-                                                                                
- Show Claude handover telemetry and runtime recommendations.                    
-                                                                                
+Usage: t3 tool claude-handover [OPTIONS]
+
+ Show Claude handover telemetry and runtime recommendations.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --current-runtime        TEXT  Current CLI runtime. Defaults to the          │
 │                                highest-priority configured runtime.          │
@@ -591,10 +591,10 @@ Usage: t3 tool claude-handover [OPTIONS]
 ### `t3 setup`
 
 ```
-Usage: t3 setup [OPTIONS] COMMAND [ARGS]...                                    
-                                                                                
- First-time setup and global skill management.                                  
-                                                                                
+Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
+
+ First-time setup and global skill management.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --claude-scope        TEXT  Claude plugin install scope: user or project.    │
 │                             [default: user]                                  │
@@ -606,10 +606,10 @@ Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
 ### `t3 assess`
 
 ```
-Usage: t3 assess [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Codebase health assessment.                                                    
-                                                                                
+Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
+
+ Codebase health assessment.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -622,10 +622,10 @@ Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
 #### `t3 assess run`
 
 ```
-Usage: t3 assess run [OPTIONS]                                                 
-                                                                                
- Run deterministic codebase metrics on a repository.                            
-                                                                                
+Usage: t3 assess run [OPTIONS]
+
+ Run deterministic codebase metrics on a repository.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root                 PATH  Repository root to assess                       │
 │ --json                       Output raw JSON                                 │
@@ -638,14 +638,13 @@ Usage: t3 assess run [OPTIONS]
 #### `t3 assess history`
 
 ```
-Usage: t3 assess history [OPTIONS]                                             
-                                                                                
- Show assessment history for a repository.                                      
-                                                                                
+Usage: t3 assess history [OPTIONS]
+
+ Show assessment history for a repository.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root           PATH     Repository root                                    │
 │ --limit  -n      INTEGER  Number of recent assessments to show [default: 10] │
 │ --help                    Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
-

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -111,30 +111,15 @@ EOF
 
 ## Step 3: Install Skills
 
-Create symlinks from each agent runtime's skills directory to the teatree skills:
+`t3 setup` creates symlinks from each supported agent runtime's skills
+directory to the teatree skills.  Claude is always targeted (the directory is
+created if missing); other runtimes listed in
+`teatree.cli.setup.AGENT_SKILL_RUNTIMES` are targeted only when their home
+directory already exists.  Contributor-mode symlinks that point inside the
+configured `workspace_dir` are preserved.
 
-```bash
-for root in "$HOME/.claude/skills" "$HOME/.codex/skills" "$HOME/.cursor/skills" "$HOME/.copilot/skills" "$HOME/.agents/skills"; do
-  [ -d "$root" ] || continue
-  for skill in "$T3_REPO"/skills/*/; do
-    [ -f "$skill/SKILL.md" ] || continue  # skip non-skill dirs
-    name="$(basename "$skill")"
-    [ -L "$root/$name" ] && continue  # already symlinked
-    ln -s "$skill" "$root/$name"
-  done
-done
-```
-
-Verify that each teatree skill is symlinked into the active runtime skill directory:
-
-```bash
-for root in "$HOME/.claude/skills" "$HOME/.codex/skills" "$HOME/.cursor/skills" "$HOME/.copilot/skills" "$HOME/.agents/skills"; do
-  [ -d "$root" ] || continue
-  find "$root" -maxdepth 1 -type l | sort
-done
-```
-
-Do not overwrite existing contributor-mode symlinks for third-party companion skills.
+Inspect the result with `t3 info` — the "Skills installed to" section lists
+every runtime dir teatree detected along with the count of managed symlinks.
 
 ## Step 4: Claude Code Plugin Hooks
 

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -1,5 +1,6 @@
 """Doctor CLI commands — smoke-test hooks, imports, services."""
 
+import json
 import os
 import re
 import shutil
@@ -11,6 +12,17 @@ import typer
 
 doctor_app = typer.Typer(no_args_is_help=True, help="Smoke-test hooks, imports, services.")
 _REQUIRED_TOOLS = ("direnv", "git", "jq")
+_CLAUDE_PLUGIN_ID = "t3@souliane"
+
+# Agent runtimes that consume teatree skills.  ``t3 setup`` creates symlinks
+# into each runtime's skills directory that already exists — missing dirs are
+# skipped silently.  The Claude dir is always ensured by setup.
+AGENT_SKILL_RUNTIMES: tuple[str, ...] = ("claude", "codex")
+
+
+def agent_skill_dirs() -> list[tuple[str, Path]]:
+    """Return (runtime_label, skills_dir) pairs, resolved against the current HOME."""
+    return [(name, Path.home() / f".{name}" / "skills") for name in AGENT_SKILL_RUNTIMES]
 
 
 def _resolve_overlay_dists(overlays: dict) -> list[str]:
@@ -87,6 +99,44 @@ class DoctorService:
             typer.echo("Installed overlays:")
             for entry in installed:
                 typer.echo(f"  {entry.name:<20}{entry.overlay_class or '(local)'}")
+                if entry.project_path:
+                    typer.echo(f"  {'':<20}{entry.project_path}")
+
+        plugin = DoctorService.find_installed_claude_plugin()
+        typer.echo()
+        if plugin:
+            typer.echo(f"Claude plugin:    {_CLAUDE_PLUGIN_ID} v{plugin['version']}")
+            typer.echo(f"                  {plugin['installPath']} ({plugin['scope']} scope)")
+        else:
+            typer.echo(f"Claude plugin:    {_CLAUDE_PLUGIN_ID} (not installed)")
+
+        existing = [(label, path) for label, path in agent_skill_dirs() if path.is_dir()]
+        if existing:
+            typer.echo()
+            typer.echo("Skills installed to:")
+            for _label, path in existing:
+                count = sum(1 for link in path.iterdir() if link.is_symlink())
+                typer.echo(f"  {path} ({count} t3-managed)")
+
+    @staticmethod
+    def find_installed_claude_plugin() -> dict[str, str] | None:
+        """Return plugin version/installPath/scope, or None when not installed."""
+        plugins_json = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+        if not plugins_json.is_file():
+            return None
+        try:
+            data = json.loads(plugins_json.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+        entries = (data.get("plugins") or {}).get(_CLAUDE_PLUGIN_ID) or []
+        if not entries:
+            return None
+        first = entries[0]
+        return {
+            "version": first.get("version", ""),
+            "installPath": first.get("installPath", ""),
+            "scope": first.get("scope", ""),
+        }
 
     @staticmethod
     def collect_overlay_skills() -> list[tuple[Path, str]]:

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -8,7 +8,12 @@ from pathlib import Path
 
 import typer
 
-from teatree.cli.doctor import DoctorService
+from teatree.cli.doctor import AGENT_SKILL_RUNTIMES, DoctorService, agent_skill_dirs
+
+# Re-exported here so external callers and tests see a single import path for
+# setup-adjacent knobs; the canonical definition lives in ``doctor`` to keep
+# ``setup → doctor`` imports one-directional.
+__all__ = ["AGENT_SKILL_RUNTIMES", "agent_skill_dirs"]
 
 # Skills that conflict with teatree's multi-repo architecture.
 # Always excluded — not user-configurable.  Users can add extra
@@ -17,6 +22,7 @@ CORE_EXCLUDED_SKILLS = ["using-superpowers", "using-git-worktrees"]
 
 _PLUGIN_NAME = "t3"
 _MARKETPLACE_NAME = "souliane"
+
 
 logger = logging.getLogger(__name__)
 
@@ -250,21 +256,27 @@ def run(
 
     config = load_config()
 
+    all_excluded = list(dict.fromkeys(CORE_EXCLUDED_SKILLS + config.user.excluded_skills))
+    workspace_dir = Path(config.user.workspace_dir).expanduser()
+
+    # The Claude skills dir is always ensured (it's where the plugin looks for skills).
+    # Other runtimes are opt-in by the presence of their home directory.
     claude_skills = Path.home() / ".claude" / "skills"
     claude_skills.mkdir(parents=True, exist_ok=True)
 
-    all_excluded = list(dict.fromkeys(CORE_EXCLUDED_SKILLS + config.user.excluded_skills))
-    removed = _remove_excluded_skills(claude_skills, all_excluded)
-    if removed:
-        typer.echo(f"OK    Removed {removed} excluded skill(s).")
+    for label, skills_dir in agent_skill_dirs():
+        if not skills_dir.is_dir():
+            continue
+        removed = _remove_excluded_skills(skills_dir, all_excluded)
+        if removed:
+            typer.echo(f"OK    {label}: removed {removed} excluded skill(s).")
 
-    workspace_dir = Path(config.user.workspace_dir).expanduser()
-    created, fixed = _sync_skill_symlinks(claude_skills, workspace_dir)
-    typer.echo(f"OK    Skills: {created} created, {fixed} fixed.")
+        created, fixed = _sync_skill_symlinks(skills_dir, workspace_dir)
+        typer.echo(f"OK    {label}: {created} created, {fixed} fixed.")
 
-    broken = _clean_broken_symlinks(claude_skills)
-    if broken:
-        typer.echo(f"OK    Removed {broken} broken symlink(s).")
+        broken = _clean_broken_symlinks(skills_dir)
+        if broken:
+            typer.echo(f"OK    {label}: removed {broken} broken symlink(s).")
 
     if not skip_plugin:
         _install_claude_plugin(repo, scope=claude_scope)

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -54,8 +54,174 @@ class TestDoctorService:
             patch.object(IntrospectionHelpers, "print_package_info"),
             patch.object(teatree_config, "discover_active_overlay", return_value=None),
             patch.object(teatree_config, "discover_overlays", return_value=[]),
+            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
         ):
             DoctorService.show_info()
+
+    def test_show_info_prints_overlay_project_path(self, capsys, tmp_path):
+        from teatree.config import OverlayEntry  # noqa: PLC0415
+
+        project = tmp_path / "my-overlay"
+        project.mkdir()
+        entries = [OverlayEntry(name="acme", overlay_class="acme.Overlay", project_path=project)]
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/t3"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(IntrospectionHelpers, "print_package_info"),
+            patch.object(teatree_config, "discover_active_overlay", return_value=None),
+            patch.object(teatree_config, "discover_overlays", return_value=entries),
+            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
+        ):
+            DoctorService.show_info()
+        out = capsys.readouterr().out
+        assert "acme" in out
+        assert str(project) in out
+
+    def test_show_info_omits_project_path_when_none(self, capsys):
+        from teatree.config import OverlayEntry  # noqa: PLC0415
+
+        entries = [OverlayEntry(name="acme", overlay_class="acme.Overlay", project_path=None)]
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/t3"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(IntrospectionHelpers, "print_package_info"),
+            patch.object(teatree_config, "discover_active_overlay", return_value=None),
+            patch.object(teatree_config, "discover_overlays", return_value=entries),
+            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
+        ):
+            DoctorService.show_info()
+        out = capsys.readouterr().out
+        lines = [line for line in out.splitlines() if "acme" in line]
+        assert len(lines) == 1  # overlay row, no project_path row
+
+    def test_show_info_shows_claude_plugin_when_installed(self, capsys):
+        plugin = {
+            "version": "0.0.1",
+            "installPath": "/Users/x/.claude/plugins/cache/souliane/t3/0.0.1",
+            "scope": "user",
+        }
+        with (
+            patch("shutil.which", return_value="/usr/bin/t3"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(IntrospectionHelpers, "print_package_info"),
+            patch.object(teatree_config, "discover_active_overlay", return_value=None),
+            patch.object(teatree_config, "discover_overlays", return_value=[]),
+            patch.object(DoctorService, "find_installed_claude_plugin", return_value=plugin),
+        ):
+            DoctorService.show_info()
+        out = capsys.readouterr().out
+        assert "Claude plugin:" in out
+        assert "0.0.1" in out
+        assert "user" in out
+        assert plugin["installPath"] in out
+
+    def test_show_info_says_not_installed_when_plugin_missing(self, capsys):
+        with (
+            patch("shutil.which", return_value="/usr/bin/t3"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(IntrospectionHelpers, "print_package_info"),
+            patch.object(teatree_config, "discover_active_overlay", return_value=None),
+            patch.object(teatree_config, "discover_overlays", return_value=[]),
+            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
+        ):
+            DoctorService.show_info()
+        out = capsys.readouterr().out
+        assert "Claude plugin:" in out
+        assert "not installed" in out
+
+    # ── find_installed_claude_plugin ─────────────────────────────────
+
+    def test_find_installed_claude_plugin_returns_entry(self, tmp_path, monkeypatch):
+        plugins_file = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
+        plugins_file.parent.mkdir(parents=True)
+        plugins_file.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "plugins": {
+                        "t3@souliane": [
+                            {
+                                "scope": "user",
+                                "installPath": "/path/to/t3/0.0.1",
+                                "version": "0.0.1",
+                            }
+                        ],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        result = DoctorService.find_installed_claude_plugin()
+        assert result == {
+            "version": "0.0.1",
+            "installPath": "/path/to/t3/0.0.1",
+            "scope": "user",
+        }
+
+    def test_find_installed_claude_plugin_missing_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        assert DoctorService.find_installed_claude_plugin() is None
+
+    def test_find_installed_claude_plugin_entry_missing(self, tmp_path, monkeypatch):
+        plugins_file = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
+        plugins_file.parent.mkdir(parents=True)
+        plugins_file.write_text(json.dumps({"version": 2, "plugins": {}}), encoding="utf-8")
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        assert DoctorService.find_installed_claude_plugin() is None
+
+    def test_find_installed_claude_plugin_malformed_json(self, tmp_path, monkeypatch):
+        plugins_file = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
+        plugins_file.parent.mkdir(parents=True)
+        plugins_file.write_text("not json", encoding="utf-8")
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        assert DoctorService.find_installed_claude_plugin() is None
+
+    # ── show_info (skills installed-to section) ──────────────────────
+
+    def test_show_info_lists_existing_runtime_skill_dirs(self, capsys, tmp_path, monkeypatch):
+        (tmp_path / ".claude" / "skills").mkdir(parents=True)
+        (tmp_path / ".codex" / "skills").mkdir(parents=True)
+        # Populate one t3-managed symlink in each
+        fake_target = tmp_path / "source" / "code"
+        fake_target.mkdir(parents=True)
+        (tmp_path / ".claude" / "skills" / "code").symlink_to(fake_target)
+        (tmp_path / ".codex" / "skills" / "code").symlink_to(fake_target)
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/t3"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(IntrospectionHelpers, "print_package_info"),
+            patch.object(teatree_config, "discover_active_overlay", return_value=None),
+            patch.object(teatree_config, "discover_overlays", return_value=[]),
+            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
+        ):
+            DoctorService.show_info()
+        out = capsys.readouterr().out
+        assert "Skills installed to:" in out
+        assert str(tmp_path / ".claude" / "skills") in out
+        assert str(tmp_path / ".codex" / "skills") in out
+
+    def test_show_info_skips_missing_runtime_skill_dirs(self, capsys, tmp_path, monkeypatch):
+        (tmp_path / ".claude" / "skills").mkdir(parents=True)
+        # No ~/.codex
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/t3"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(IntrospectionHelpers, "print_package_info"),
+            patch.object(teatree_config, "discover_active_overlay", return_value=None),
+            patch.object(teatree_config, "discover_overlays", return_value=[]),
+            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
+        ):
+            DoctorService.show_info()
+        out = capsys.readouterr().out
+        assert str(tmp_path / ".claude" / "skills") in out
+        assert ".codex" not in out
 
     # ── collect_overlay_skills ───────────────────────────────────────
 

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -350,6 +350,100 @@ class TestSyncSkillSymlinks:
         assert (claude_skills / "my-skill").is_symlink()
 
 
+class TestAgentSkillDirs:
+    def test_includes_claude_and_codex(self) -> None:
+        from teatree.cli.setup import AGENT_SKILL_RUNTIMES  # noqa: PLC0415
+
+        assert "claude" in AGENT_SKILL_RUNTIMES
+        assert "codex" in AGENT_SKILL_RUNTIMES
+
+    def test_factory_resolves_against_home(self, tmp_path, monkeypatch) -> None:
+        from teatree.cli.setup import agent_skill_dirs  # noqa: PLC0415
+
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        dirs = dict(agent_skill_dirs())
+        assert dirs["codex"] == tmp_path / ".codex" / "skills"
+        assert dirs["claude"] == tmp_path / ".claude" / "skills"
+
+
+class TestSetupSyncsCodexWhenDirExists:
+    def test_syncs_to_both_claude_and_codex(self, tmp_path: Path, monkeypatch) -> None:
+        """Setup mirrors skill symlinks into ~/.codex/skills when it exists."""
+        from teatree.cli import setup as setup_module  # noqa: PLC0415
+
+        skills_src = tmp_path / "core_skills"
+        skills_src.mkdir()
+        (skills_src / "code").mkdir()
+        (skills_src / "code" / "SKILL.md").touch()
+
+        # Simulate home layout: both dirs already exist so setup should target both
+        home = tmp_path / "home"
+        claude_skills = home / ".claude" / "skills"
+        codex_skills = home / ".codex" / "skills"
+        claude_skills.mkdir(parents=True)
+        codex_skills.mkdir(parents=True)
+
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: home))
+
+        repo = tmp_path / "teatree"
+        repo.mkdir()
+        (repo / "apm.yml").touch()
+        (repo / ".git").mkdir()
+
+        with (
+            patch("teatree.agents.skill_bundle.DEFAULT_SKILLS_DIR", skills_src),
+            patch.object(setup_module, "_find_main_clone", return_value=repo),
+            patch.object(setup_module, "_run_apm_install", return_value=True),
+            patch.object(setup_module, "_install_claude_plugin", return_value=True),
+            patch.object(setup_module, "DoctorService") as mock_svc,
+            patch("teatree.config.load_config") as mock_load,
+        ):
+            mock_svc.collect_overlay_skills.return_value = []
+            mock_load.return_value.user.contribute = False
+            mock_load.return_value.user.excluded_skills = []
+            mock_load.return_value.user.workspace_dir = str(tmp_path / "workspace")
+            setup_module.run(claude_scope="user", skip_plugin=True)
+
+        assert (claude_skills / "code").is_symlink()
+        assert (codex_skills / "code").is_symlink()
+
+    def test_skips_codex_when_dir_missing(self, tmp_path: Path, monkeypatch) -> None:
+        """Setup does not create ~/.codex/skills if it doesn't already exist."""
+        from teatree.cli import setup as setup_module  # noqa: PLC0415
+
+        skills_src = tmp_path / "core_skills"
+        skills_src.mkdir()
+        (skills_src / "code").mkdir()
+        (skills_src / "code" / "SKILL.md").touch()
+
+        home = tmp_path / "home"
+        (home / ".claude" / "skills").mkdir(parents=True)
+        # No ~/.codex dir
+
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: home))
+
+        repo = tmp_path / "teatree"
+        repo.mkdir()
+        (repo / "apm.yml").touch()
+        (repo / ".git").mkdir()
+
+        with (
+            patch("teatree.agents.skill_bundle.DEFAULT_SKILLS_DIR", skills_src),
+            patch.object(setup_module, "_find_main_clone", return_value=repo),
+            patch.object(setup_module, "_run_apm_install", return_value=True),
+            patch.object(setup_module, "_install_claude_plugin", return_value=True),
+            patch.object(setup_module, "DoctorService") as mock_svc,
+            patch("teatree.config.load_config") as mock_load,
+        ):
+            mock_svc.collect_overlay_skills.return_value = []
+            mock_load.return_value.user.contribute = False
+            mock_load.return_value.user.excluded_skills = []
+            mock_load.return_value.user.workspace_dir = str(tmp_path / "workspace")
+            setup_module.run(claude_scope="user", skip_plugin=True)
+
+        assert not (home / ".codex").exists()
+
+
 class TestCleanBrokenSymlinks:
     def test_removes_broken(self, tmp_path: Path) -> None:
         (tmp_path / "broken").symlink_to(tmp_path / "nonexistent")


### PR DESCRIPTION
## Summary

Closes #353.

- `t3 info` now shows:
  - each overlay's `project_path` on a second line under its entry
  - the Claude plugin install — version, path, scope (reads `~/.claude/plugins/installed_plugins.json`)
  - each agent runtime skills dir that exists with the count of t3-managed symlinks
- `t3 setup` mirrors skill symlinks into `~/.codex/skills/` (and any runtime in `AGENT_SKILL_RUNTIMES`) when the directory already exists. The Claude dir is always ensured; others are opt-in by presence.
- Replaces the manual multi-runtime symlink loop in `skills/setup/SKILL.md` with a short pointer to `t3 info`.

## Output sample (from this worktree)

```
Installed overlays:
  teatree             (local)
  t3-company             company.settings
                      /Users/adrien/workspace/company-fork-org/t3-company
  t3-teatree          teatree.contrib.t3_teatree.overlay:TeatreeOverlay
                      /Users/adrien/workspace/ac-teatree-353-ticket/teatree

Claude plugin:    t3@souliane v0.0.1
                  /Users/adrien/.claude/plugins/cache/souliane/t3/0.0.1 (user scope)

Skills installed to:
  /Users/adrien/.claude/skills (51 t3-managed)
  /Users/adrien/.codex/skills (71 t3-managed)
```

## Test plan

- [x] Unit tests — `tests/test_cli_doctor.py` (+166 lines), `tests/test_cli_setup.py` (+94 lines)
- [x] Full suite — 2186 passed locally
- [x] Dogfood — `uv run t3 info` from the worktree shows all new sections
- [ ] Codex skills sync verified on first `t3 setup` run (will run post-merge)