### PR TITLE
feat(setup): block 'uv run t3' via hook, auto-install t3 globally (#358)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,5 @@ jobs:
           python-version: "3.13"
       - run: uv sync
       - run: uv run playwright install --with-deps chromium
-      - run: uv run t3 teatree e2e project --no-docker
+      - run: uv tool install --editable .
+      - run: t3 teatree e2e project --no-docker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ A multi-repo worktree lifecycle manager for AI-assisted development. Target: ser
 
 It provides:
 
-- A unified CLI (`uv run t3`) for worktree creation, provisioning, dev servers, CI, and delivery
+- A unified CLI (`t3`) for worktree creation, provisioning, dev servers, CI, and delivery
 - A Django app (`teatree.core`) with 5 models driven by `django-fsm` state machines
 - An overlay system for downstream project customization (`OverlayBase`)
 - Backend protocols for pluggable external integrations
@@ -212,10 +212,10 @@ Selector-backed views with django-htmx. No domain logic in views.
 ### Running
 
 ```bash
-uv run t3 --help                    # CLI help
-uv run t3 acme dashboard            # Start overlay dashboard (auto-finds free port)
-uv run t3 acme agent                # Launch Claude Code with overlay context
-uv run t3 agent                     # Launch Claude Code (teatree-self development)
+t3 --help                           # CLI help
+t3 acme dashboard                   # Start overlay dashboard (auto-finds free port)
+t3 acme agent                       # Launch Claude Code with overlay context
+t3 agent                            # Launch Claude Code (teatree-self development)
 ```
 
 ### Testing

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -879,7 +879,9 @@ Three install paths, one source of truth:
 
 - **APM**: `apm install souliane/teatree` — deploys to any supported agent
 - **Claude Code plugin**: `/plugin install t3@souliane-teatree` — Claude-specific
-- **CLI-first**: `uv tool install teatree && t3 setup` — bootstraps from Python (runs APM install, syncs skill symlinks, and registers the Claude plugin in one step)
+- **CLI-first**: `uv tool install teatree && t3 setup` — bootstraps from Python (runs APM install, syncs skill symlinks, and registers the Claude plugin in one step). `t3 setup` also auto-runs `uv tool install --editable <repo>` when the global `t3` binary is missing, so `uv run t3 setup` from a fresh checkout upgrades itself in-place.
+
+The agent-facing hook layer (`hooks/scripts/hook_router.py`) blocks `uv run t3` Bash invocations and directs agents to call the globally installed `t3` instead.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,5 +30,5 @@ Teatree IS the Django project. Overlays are lightweight Python packages:
 uv run pytest --no-cov -x -q   # run tests
 uv run ruff check               # lint
 uv run ruff format               # format
-uv run t3 --help                 # CLI
+t3 --help                        # CLI (installed via `uv tool install --editable .`)
 ```

--- a/apm.yml
+++ b/apm.yml
@@ -21,4 +21,4 @@ dependencies:
   - souliane/teatree
 install:
   pip: teatree
-  post_install: uv run t3 config write-skill-cache
+  post_install: t3 config write-skill-cache

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -5,8 +5,8 @@ Generated from `t3` command tree.
 ## `t3`
 
 ```
-Usage: t3 [OPTIONS] COMMAND [ARGS]...
-
+Usage: t3 [OPTIONS] COMMAND [ARGS]...                                          
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -33,10 +33,10 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 ### `t3 startoverlay`
 
 ```
-Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
-
- Create a new TeaTree overlay package.
-
+Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION                      
+                                                                                
+ Create a new TeaTree overlay package.                                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    project_name      TEXT  [required]                                      │
 │ *    destination       PATH  [required]                                      │
@@ -53,12 +53,12 @@ Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
 ### `t3 docs`
 
 ```
-Usage: t3 docs [OPTIONS]
-
- Serve the project documentation with mkdocs.
-
- Requires the ``docs`` dependency group: ``uv sync --group docs``
-
+Usage: t3 docs [OPTIONS]                                                       
+                                                                                
+ Serve the project documentation with mkdocs.                                   
+                                                                                
+ Requires the ``docs`` dependency group: ``uv sync --group docs``               
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host        TEXT     Host to bind to [default: 127.0.0.1]                  │
 │ --port        INTEGER  Port to serve on [default: 8888]                      │
@@ -69,10 +69,10 @@ Usage: t3 docs [OPTIONS]
 ### `t3 agent`
 
 ```
-Usage: t3 agent [OPTIONS] [TASK]
-
- Launch Claude Code with auto-detected project context.
-
+Usage: t3 agent [OPTIONS] [TASK]                                               
+                                                                                
+ Launch Claude Code with auto-detected project context.                         
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   task      [TASK]  What to work on (e.g. 'fix the sync bug', 'add a new     │
 │                     command')                                                │
@@ -88,13 +88,13 @@ Usage: t3 agent [OPTIONS] [TASK]
 ### `t3 sessions`
 
 ```
-Usage: t3 sessions [OPTIONS]
-
- List recent Claude conversation sessions with resume commands.
-
- By default shows sessions for the current working directory.
- Use --all to show sessions across all projects.
-
+Usage: t3 sessions [OPTIONS]                                                   
+                                                                                
+ List recent Claude conversation sessions with resume commands.                 
+                                                                                
+ By default shows sessions for the current working directory.                   
+ Use --all to show sessions across all projects.                                
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --project          TEXT     Filter by project dir substring                  │
 │ --limit    -n      INTEGER  Max sessions to show [default: 20]               │
@@ -106,10 +106,10 @@ Usage: t3 sessions [OPTIONS]
 ### `t3 info`
 
 ```
-Usage: t3 info [OPTIONS]
-
- Show t3 installation, teatree/overlay sources, and editable status.
-
+Usage: t3 info [OPTIONS]                                                       
+                                                                                
+ Show t3 installation, teatree/overlay sources, and editable status.            
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -118,10 +118,10 @@ Usage: t3 info [OPTIONS]
 ### `t3 dashboard`
 
 ```
-Usage: t3 dashboard [OPTIONS]
-
- Migrate the database and start the dashboard dev server.
-
+Usage: t3 dashboard [OPTIONS]                                                  
+                                                                                
+ Migrate the database and start the dashboard dev server.                       
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host           TEXT     Host to bind to [default: 127.0.0.1]               │
 │ --port           INTEGER  Port to serve on [default: 8000]                   │
@@ -137,10 +137,10 @@ Usage: t3 dashboard [OPTIONS]
 ### `t3 config`
 
 ```
-Usage: t3 config [OPTIONS] COMMAND [ARGS]...
-
- Configuration and autoloading.
-
+Usage: t3 config [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Configuration and autoloading.                                                 
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -159,10 +159,10 @@ Usage: t3 config [OPTIONS] COMMAND [ARGS]...
 #### `t3 config check-update`
 
 ```
-Usage: t3 config check-update [OPTIONS]
-
- Check if a newer version of teatree is available.
-
+Usage: t3 config check-update [OPTIONS]                                        
+                                                                                
+ Check if a newer version of teatree is available.                              
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -171,10 +171,10 @@ Usage: t3 config check-update [OPTIONS]
 #### `t3 config write-skill-cache`
 
 ```
-Usage: t3 config write-skill-cache [OPTIONS]
-
- Write overlay skill metadata to XDG cache for hook consumption.
-
+Usage: t3 config write-skill-cache [OPTIONS]                                   
+                                                                                
+ Write overlay skill metadata to XDG cache for hook consumption.                
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -183,10 +183,10 @@ Usage: t3 config write-skill-cache [OPTIONS]
 #### `t3 config autoload`
 
 ```
-Usage: t3 config autoload [OPTIONS]
-
- List skill auto-loading rules from context-match.yml files.
-
+Usage: t3 config autoload [OPTIONS]                                            
+                                                                                
+ List skill auto-loading rules from context-match.yml files.                    
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -195,10 +195,10 @@ Usage: t3 config autoload [OPTIONS]
 #### `t3 config cache`
 
 ```
-Usage: t3 config cache [OPTIONS]
-
- Show the XDG skill-metadata cache content.
-
+Usage: t3 config cache [OPTIONS]                                               
+                                                                                
+ Show the XDG skill-metadata cache content.                                     
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -207,10 +207,10 @@ Usage: t3 config cache [OPTIONS]
 #### `t3 config deps`
 
 ```
-Usage: t3 config deps [OPTIONS] SKILL
-
- Show resolved dependency chain for a skill.
-
+Usage: t3 config deps [OPTIONS] SKILL                                          
+                                                                                
+ Show resolved dependency chain for a skill.                                    
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    skill      TEXT  [required]                                             │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -222,10 +222,10 @@ Usage: t3 config deps [OPTIONS] SKILL
 #### `t3 config test-trigger`
 
 ```
-Usage: t3 config test-trigger [OPTIONS] PROMPT
-
- Test which skill would be triggered for a given prompt.
-
+Usage: t3 config test-trigger [OPTIONS] PROMPT                                 
+                                                                                
+ Test which skill would be triggered for a given prompt.                        
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    prompt      TEXT  [required]                                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -237,10 +237,10 @@ Usage: t3 config test-trigger [OPTIONS] PROMPT
 ### `t3 ci`
 
 ```
-Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
-
- CI pipeline helpers.
-
+Usage: t3 ci [OPTIONS] COMMAND [ARGS]...                                       
+                                                                                
+ CI pipeline helpers.                                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -258,10 +258,10 @@ Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
 #### `t3 ci cancel`
 
 ```
-Usage: t3 ci cancel [OPTIONS] [BRANCH]
-
- Cancel stale CI pipelines for a branch.
-
+Usage: t3 ci cancel [OPTIONS] [BRANCH]                                         
+                                                                                
+ Cancel stale CI pipelines for a branch.                                        
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -273,10 +273,10 @@ Usage: t3 ci cancel [OPTIONS] [BRANCH]
 #### `t3 ci divergence`
 
 ```
-Usage: t3 ci divergence [OPTIONS]
-
- Check fork divergence from upstream.
-
+Usage: t3 ci divergence [OPTIONS]                                              
+                                                                                
+ Check fork divergence from upstream.                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -285,10 +285,10 @@ Usage: t3 ci divergence [OPTIONS]
 #### `t3 ci fetch-errors`
 
 ```
-Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
-
- Fetch error logs from the latest CI pipeline.
-
+Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]                                   
+                                                                                
+ Fetch error logs from the latest CI pipeline.                                  
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -300,10 +300,10 @@ Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
 #### `t3 ci fetch-failed-tests`
 
 ```
-Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
-
- Extract failed test IDs from the latest CI pipeline.
-
+Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]                             
+                                                                                
+ Extract failed test IDs from the latest CI pipeline.                           
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -315,10 +315,10 @@ Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
 #### `t3 ci trigger-e2e`
 
 ```
-Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
-
- Trigger E2E tests on CI.
-
+Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]                                    
+                                                                                
+ Trigger E2E tests on CI.                                                       
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -330,10 +330,10 @@ Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
 #### `t3 ci quality-check`
 
 ```
-Usage: t3 ci quality-check [OPTIONS] [BRANCH]
-
- Run quality analysis (fetch test report from latest pipeline).
-
+Usage: t3 ci quality-check [OPTIONS] [BRANCH]                                  
+                                                                                
+ Run quality analysis (fetch test report from latest pipeline).                 
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -345,10 +345,10 @@ Usage: t3 ci quality-check [OPTIONS] [BRANCH]
 ### `t3 review`
 
 ```
-Usage: t3 review [OPTIONS] COMMAND [ARGS]...
-
- Code review helpers.
-
+Usage: t3 review [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Code review helpers.                                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -363,10 +363,10 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 #### `t3 review post-draft-note`
 
 ```
-Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
-
- Post a draft note on a GitLab MR (inline or general).
-
+Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE                        
+                                                                                
+ Post a draft note on a GitLab MR (inline or general).                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -384,10 +384,10 @@ Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
 #### `t3 review delete-draft-note`
 
 ```
-Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
-
- Delete a draft note from a GitLab MR.
-
+Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID                   
+                                                                                
+ Delete a draft note from a GitLab MR.                                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo         TEXT     GitLab project path [required]                    │
 │ *    mr           INTEGER  Merge request IID [required]                      │
@@ -401,10 +401,10 @@ Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
 #### `t3 review publish-draft-notes`
 
 ```
-Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
-
- Publish all draft notes on a GitLab MR (bulk submit).
-
+Usage: t3 review publish-draft-notes [OPTIONS] REPO MR                         
+                                                                                
+ Publish all draft notes on a GitLab MR (bulk submit).                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -418,10 +418,10 @@ Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
 #### `t3 review list-draft-notes`
 
 ```
-Usage: t3 review list-draft-notes [OPTIONS] REPO MR
-
- List draft notes on a GitLab MR.
-
+Usage: t3 review list-draft-notes [OPTIONS] REPO MR                            
+                                                                                
+ List draft notes on a GitLab MR.                                               
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path [required]                       │
 │ *    mr        INTEGER  Merge request IID [required]                         │
@@ -434,10 +434,10 @@ Usage: t3 review list-draft-notes [OPTIONS] REPO MR
 ### `t3 review-request`
 
 ```
-Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
-
- Batch review requests.
-
+Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...                           
+                                                                                
+ Batch review requests.                                                         
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -449,10 +449,10 @@ Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
 #### `t3 review-request discover`
 
 ```
-Usage: t3 review-request discover [OPTIONS]
-
- Discover open merge requests awaiting review.
-
+Usage: t3 review-request discover [OPTIONS]                                    
+                                                                                
+ Discover open merge requests awaiting review.                                  
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -461,10 +461,10 @@ Usage: t3 review-request discover [OPTIONS]
 ### `t3 doctor`
 
 ```
-Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
-
- Smoke-test hooks, imports, services.
-
+Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Smoke-test hooks, imports, services.                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -476,10 +476,10 @@ Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
 #### `t3 doctor check`
 
 ```
-Usage: t3 doctor check [OPTIONS]
-
- Verify imports, required tools, and editable-install sanity.
-
+Usage: t3 doctor check [OPTIONS]                                               
+                                                                                
+ Verify imports, required tools, and editable-install sanity.                   
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -488,10 +488,10 @@ Usage: t3 doctor check [OPTIONS]
 ### `t3 tool`
 
 ```
-Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
-
- Standalone utilities.
-
+Usage: t3 tool [OPTIONS] COMMAND [ARGS]...                                     
+                                                                                
+ Standalone utilities.                                                          
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -508,10 +508,10 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 #### `t3 tool privacy-scan`
 
 ```
-Usage: t3 tool privacy-scan [OPTIONS] [PATH]
-
- Scan text for privacy-sensitive patterns (emails, keys, IPs).
-
+Usage: t3 tool privacy-scan [OPTIONS] [PATH]                                   
+                                                                                
+ Scan text for privacy-sensitive patterns (emails, keys, IPs).                  
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   path      [PATH]  File or '-' for stdin [default: -]                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -523,10 +523,10 @@ Usage: t3 tool privacy-scan [OPTIONS] [PATH]
 #### `t3 tool analyze-video`
 
 ```
-Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
-
- Decompose video into frames for AI analysis.
-
+Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH                              
+                                                                                
+ Decompose video into frames for AI analysis.                                   
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    video_path      TEXT  Path to video file [required]                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -538,10 +538,10 @@ Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
 #### `t3 tool bump-deps`
 
 ```
-Usage: t3 tool bump-deps [OPTIONS]
-
- Bump pyproject.toml dependencies from uv.lock.
-
+Usage: t3 tool bump-deps [OPTIONS]                                             
+                                                                                
+ Bump pyproject.toml dependencies from uv.lock.                                 
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -550,10 +550,10 @@ Usage: t3 tool bump-deps [OPTIONS]
 #### `t3 tool sonar-check`
 
 ```
-Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
-
- Run local SonarQube analysis via Docker.
-
+Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]                               
+                                                                                
+ Run local SonarQube analysis via Docker.                                       
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   repo_path      [REPO_PATH]  Path to repo (default: current directory)      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -572,10 +572,10 @@ Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
 #### `t3 tool claude-handover`
 
 ```
-Usage: t3 tool claude-handover [OPTIONS]
-
- Show Claude handover telemetry and runtime recommendations.
-
+Usage: t3 tool claude-handover [OPTIONS]                                       
+                                                                                
+ Show Claude handover telemetry and runtime recommendations.                    
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --current-runtime        TEXT  Current CLI runtime. Defaults to the          │
 │                                highest-priority configured runtime.          │
@@ -591,10 +591,10 @@ Usage: t3 tool claude-handover [OPTIONS]
 ### `t3 setup`
 
 ```
-Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
-
- First-time setup and global skill management.
-
+Usage: t3 setup [OPTIONS] COMMAND [ARGS]...                                    
+                                                                                
+ First-time setup and global skill management.                                  
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --claude-scope        TEXT  Claude plugin install scope: user or project.    │
 │                             [default: user]                                  │
@@ -606,10 +606,10 @@ Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
 ### `t3 assess`
 
 ```
-Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
-
- Codebase health assessment.
-
+Usage: t3 assess [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Codebase health assessment.                                                    
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -622,10 +622,10 @@ Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
 #### `t3 assess run`
 
 ```
-Usage: t3 assess run [OPTIONS]
-
- Run deterministic codebase metrics on a repository.
-
+Usage: t3 assess run [OPTIONS]                                                 
+                                                                                
+ Run deterministic codebase metrics on a repository.                            
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root                 PATH  Repository root to assess                       │
 │ --json                       Output raw JSON                                 │
@@ -638,13 +638,14 @@ Usage: t3 assess run [OPTIONS]
 #### `t3 assess history`
 
 ```
-Usage: t3 assess history [OPTIONS]
-
- Show assessment history for a repository.
-
+Usage: t3 assess history [OPTIONS]                                             
+                                                                                
+ Show assessment history for a repository.                                      
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root           PATH     Repository root                                    │
 │ --limit  -n      INTEGER  Number of recent assessments to show [default: 10] │
 │ --help                    Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
+

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -5,8 +5,8 @@ Generated from `t3` command tree.
 ## `t3`
 
 ```
-Usage: t3 [OPTIONS] COMMAND [ARGS]...                                          
-                                                                                
+Usage: t3 [OPTIONS] COMMAND [ARGS]...
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -33,10 +33,10 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 ### `t3 startoverlay`
 
 ```
-Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION                      
-                                                                                
- Create a new TeaTree overlay package.                                          
-                                                                                
+Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
+
+ Create a new TeaTree overlay package.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    project_name      TEXT  [required]                                      │
 │ *    destination       PATH  [required]                                      │
@@ -53,12 +53,12 @@ Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
 ### `t3 docs`
 
 ```
-Usage: t3 docs [OPTIONS]                                                       
-                                                                                
- Serve the project documentation with mkdocs.                                   
-                                                                                
- Requires the ``docs`` dependency group: ``uv sync --group docs``               
-                                                                                
+Usage: t3 docs [OPTIONS]
+
+ Serve the project documentation with mkdocs.
+
+ Requires the ``docs`` dependency group: ``uv sync --group docs``
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host        TEXT     Host to bind to [default: 127.0.0.1]                  │
 │ --port        INTEGER  Port to serve on [default: 8888]                      │
@@ -69,10 +69,10 @@ Usage: t3 docs [OPTIONS]
 ### `t3 agent`
 
 ```
-Usage: t3 agent [OPTIONS] [TASK]                                               
-                                                                                
- Launch Claude Code with auto-detected project context.                         
-                                                                                
+Usage: t3 agent [OPTIONS] [TASK]
+
+ Launch Claude Code with auto-detected project context.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   task      [TASK]  What to work on (e.g. 'fix the sync bug', 'add a new     │
 │                     command')                                                │
@@ -88,13 +88,13 @@ Usage: t3 agent [OPTIONS] [TASK]
 ### `t3 sessions`
 
 ```
-Usage: t3 sessions [OPTIONS]                                                   
-                                                                                
- List recent Claude conversation sessions with resume commands.                 
-                                                                                
- By default shows sessions for the current working directory.                   
- Use --all to show sessions across all projects.                                
-                                                                                
+Usage: t3 sessions [OPTIONS]
+
+ List recent Claude conversation sessions with resume commands.
+
+ By default shows sessions for the current working directory.
+ Use --all to show sessions across all projects.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --project          TEXT     Filter by project dir substring                  │
 │ --limit    -n      INTEGER  Max sessions to show [default: 20]               │
@@ -106,10 +106,10 @@ Usage: t3 sessions [OPTIONS]
 ### `t3 info`
 
 ```
-Usage: t3 info [OPTIONS]                                                       
-                                                                                
- Show t3 installation, teatree/overlay sources, and editable status.            
-                                                                                
+Usage: t3 info [OPTIONS]
+
+ Show t3 installation, teatree/overlay sources, and editable status.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -118,10 +118,10 @@ Usage: t3 info [OPTIONS]
 ### `t3 dashboard`
 
 ```
-Usage: t3 dashboard [OPTIONS]                                                  
-                                                                                
- Migrate the database and start the dashboard dev server.                       
-                                                                                
+Usage: t3 dashboard [OPTIONS]
+
+ Migrate the database and start the dashboard dev server.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host           TEXT     Host to bind to [default: 127.0.0.1]               │
 │ --port           INTEGER  Port to serve on [default: 8000]                   │
@@ -137,10 +137,10 @@ Usage: t3 dashboard [OPTIONS]
 ### `t3 config`
 
 ```
-Usage: t3 config [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Configuration and autoloading.                                                 
-                                                                                
+Usage: t3 config [OPTIONS] COMMAND [ARGS]...
+
+ Configuration and autoloading.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -159,10 +159,10 @@ Usage: t3 config [OPTIONS] COMMAND [ARGS]...
 #### `t3 config check-update`
 
 ```
-Usage: t3 config check-update [OPTIONS]                                        
-                                                                                
- Check if a newer version of teatree is available.                              
-                                                                                
+Usage: t3 config check-update [OPTIONS]
+
+ Check if a newer version of teatree is available.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -171,10 +171,10 @@ Usage: t3 config check-update [OPTIONS]
 #### `t3 config write-skill-cache`
 
 ```
-Usage: t3 config write-skill-cache [OPTIONS]                                   
-                                                                                
- Write overlay skill metadata to XDG cache for hook consumption.                
-                                                                                
+Usage: t3 config write-skill-cache [OPTIONS]
+
+ Write overlay skill metadata to XDG cache for hook consumption.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -183,10 +183,10 @@ Usage: t3 config write-skill-cache [OPTIONS]
 #### `t3 config autoload`
 
 ```
-Usage: t3 config autoload [OPTIONS]                                            
-                                                                                
- List skill auto-loading rules from context-match.yml files.                    
-                                                                                
+Usage: t3 config autoload [OPTIONS]
+
+ List skill auto-loading rules from context-match.yml files.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -195,10 +195,10 @@ Usage: t3 config autoload [OPTIONS]
 #### `t3 config cache`
 
 ```
-Usage: t3 config cache [OPTIONS]                                               
-                                                                                
- Show the XDG skill-metadata cache content.                                     
-                                                                                
+Usage: t3 config cache [OPTIONS]
+
+ Show the XDG skill-metadata cache content.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -207,10 +207,10 @@ Usage: t3 config cache [OPTIONS]
 #### `t3 config deps`
 
 ```
-Usage: t3 config deps [OPTIONS] SKILL                                          
-                                                                                
- Show resolved dependency chain for a skill.                                    
-                                                                                
+Usage: t3 config deps [OPTIONS] SKILL
+
+ Show resolved dependency chain for a skill.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    skill      TEXT  [required]                                             │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -222,10 +222,10 @@ Usage: t3 config deps [OPTIONS] SKILL
 #### `t3 config test-trigger`
 
 ```
-Usage: t3 config test-trigger [OPTIONS] PROMPT                                 
-                                                                                
- Test which skill would be triggered for a given prompt.                        
-                                                                                
+Usage: t3 config test-trigger [OPTIONS] PROMPT
+
+ Test which skill would be triggered for a given prompt.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    prompt      TEXT  [required]                                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -237,10 +237,10 @@ Usage: t3 config test-trigger [OPTIONS] PROMPT
 ### `t3 ci`
 
 ```
-Usage: t3 ci [OPTIONS] COMMAND [ARGS]...                                       
-                                                                                
- CI pipeline helpers.                                                           
-                                                                                
+Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
+
+ CI pipeline helpers.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -258,10 +258,10 @@ Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
 #### `t3 ci cancel`
 
 ```
-Usage: t3 ci cancel [OPTIONS] [BRANCH]                                         
-                                                                                
- Cancel stale CI pipelines for a branch.                                        
-                                                                                
+Usage: t3 ci cancel [OPTIONS] [BRANCH]
+
+ Cancel stale CI pipelines for a branch.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -273,10 +273,10 @@ Usage: t3 ci cancel [OPTIONS] [BRANCH]
 #### `t3 ci divergence`
 
 ```
-Usage: t3 ci divergence [OPTIONS]                                              
-                                                                                
- Check fork divergence from upstream.                                           
-                                                                                
+Usage: t3 ci divergence [OPTIONS]
+
+ Check fork divergence from upstream.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -285,10 +285,10 @@ Usage: t3 ci divergence [OPTIONS]
 #### `t3 ci fetch-errors`
 
 ```
-Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]                                   
-                                                                                
- Fetch error logs from the latest CI pipeline.                                  
-                                                                                
+Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
+
+ Fetch error logs from the latest CI pipeline.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -300,10 +300,10 @@ Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
 #### `t3 ci fetch-failed-tests`
 
 ```
-Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]                             
-                                                                                
- Extract failed test IDs from the latest CI pipeline.                           
-                                                                                
+Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
+
+ Extract failed test IDs from the latest CI pipeline.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -315,10 +315,10 @@ Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
 #### `t3 ci trigger-e2e`
 
 ```
-Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]                                    
-                                                                                
- Trigger E2E tests on CI.                                                       
-                                                                                
+Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
+
+ Trigger E2E tests on CI.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -330,10 +330,10 @@ Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
 #### `t3 ci quality-check`
 
 ```
-Usage: t3 ci quality-check [OPTIONS] [BRANCH]                                  
-                                                                                
- Run quality analysis (fetch test report from latest pipeline).                 
-                                                                                
+Usage: t3 ci quality-check [OPTIONS] [BRANCH]
+
+ Run quality analysis (fetch test report from latest pipeline).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -345,10 +345,10 @@ Usage: t3 ci quality-check [OPTIONS] [BRANCH]
 ### `t3 review`
 
 ```
-Usage: t3 review [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Code review helpers.                                                           
-                                                                                
+Usage: t3 review [OPTIONS] COMMAND [ARGS]...
+
+ Code review helpers.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -363,10 +363,10 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 #### `t3 review post-draft-note`
 
 ```
-Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE                        
-                                                                                
- Post a draft note on a GitLab MR (inline or general).                          
-                                                                                
+Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
+
+ Post a draft note on a GitLab MR (inline or general).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -384,10 +384,10 @@ Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
 #### `t3 review delete-draft-note`
 
 ```
-Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID                   
-                                                                                
- Delete a draft note from a GitLab MR.                                          
-                                                                                
+Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
+
+ Delete a draft note from a GitLab MR.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo         TEXT     GitLab project path [required]                    │
 │ *    mr           INTEGER  Merge request IID [required]                      │
@@ -401,10 +401,10 @@ Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
 #### `t3 review publish-draft-notes`
 
 ```
-Usage: t3 review publish-draft-notes [OPTIONS] REPO MR                         
-                                                                                
- Publish all draft notes on a GitLab MR (bulk submit).                          
-                                                                                
+Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
+
+ Publish all draft notes on a GitLab MR (bulk submit).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -418,10 +418,10 @@ Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
 #### `t3 review list-draft-notes`
 
 ```
-Usage: t3 review list-draft-notes [OPTIONS] REPO MR                            
-                                                                                
- List draft notes on a GitLab MR.                                               
-                                                                                
+Usage: t3 review list-draft-notes [OPTIONS] REPO MR
+
+ List draft notes on a GitLab MR.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path [required]                       │
 │ *    mr        INTEGER  Merge request IID [required]                         │
@@ -434,10 +434,10 @@ Usage: t3 review list-draft-notes [OPTIONS] REPO MR
 ### `t3 review-request`
 
 ```
-Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...                           
-                                                                                
- Batch review requests.                                                         
-                                                                                
+Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
+
+ Batch review requests.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -449,10 +449,10 @@ Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
 #### `t3 review-request discover`
 
 ```
-Usage: t3 review-request discover [OPTIONS]                                    
-                                                                                
- Discover open merge requests awaiting review.                                  
-                                                                                
+Usage: t3 review-request discover [OPTIONS]
+
+ Discover open merge requests awaiting review.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -461,10 +461,10 @@ Usage: t3 review-request discover [OPTIONS]
 ### `t3 doctor`
 
 ```
-Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Smoke-test hooks, imports, services.                                           
-                                                                                
+Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
+
+ Smoke-test hooks, imports, services.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -476,10 +476,10 @@ Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
 #### `t3 doctor check`
 
 ```
-Usage: t3 doctor check [OPTIONS]                                               
-                                                                                
- Verify imports, required tools, and editable-install sanity.                   
-                                                                                
+Usage: t3 doctor check [OPTIONS]
+
+ Verify imports, required tools, and editable-install sanity.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -488,10 +488,10 @@ Usage: t3 doctor check [OPTIONS]
 ### `t3 tool`
 
 ```
-Usage: t3 tool [OPTIONS] COMMAND [ARGS]...                                     
-                                                                                
- Standalone utilities.                                                          
-                                                                                
+Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
+
+ Standalone utilities.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -508,10 +508,10 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 #### `t3 tool privacy-scan`
 
 ```
-Usage: t3 tool privacy-scan [OPTIONS] [PATH]                                   
-                                                                                
- Scan text for privacy-sensitive patterns (emails, keys, IPs).                  
-                                                                                
+Usage: t3 tool privacy-scan [OPTIONS] [PATH]
+
+ Scan text for privacy-sensitive patterns (emails, keys, IPs).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   path      [PATH]  File or '-' for stdin [default: -]                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -523,10 +523,10 @@ Usage: t3 tool privacy-scan [OPTIONS] [PATH]
 #### `t3 tool analyze-video`
 
 ```
-Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH                              
-                                                                                
- Decompose video into frames for AI analysis.                                   
-                                                                                
+Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
+
+ Decompose video into frames for AI analysis.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    video_path      TEXT  Path to video file [required]                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -538,10 +538,10 @@ Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
 #### `t3 tool bump-deps`
 
 ```
-Usage: t3 tool bump-deps [OPTIONS]                                             
-                                                                                
- Bump pyproject.toml dependencies from uv.lock.                                 
-                                                                                
+Usage: t3 tool bump-deps [OPTIONS]
+
+ Bump pyproject.toml dependencies from uv.lock.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -550,10 +550,10 @@ Usage: t3 tool bump-deps [OPTIONS]
 #### `t3 tool sonar-check`
 
 ```
-Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]                               
-                                                                                
- Run local SonarQube analysis via Docker.                                       
-                                                                                
+Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
+
+ Run local SonarQube analysis via Docker.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   repo_path      [REPO_PATH]  Path to repo (default: current directory)      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -572,10 +572,10 @@ Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
 #### `t3 tool claude-handover`
 
 ```
-Usage: t3 tool claude-handover [OPTIONS]                                       
-                                                                                
- Show Claude handover telemetry and runtime recommendations.                    
-                                                                                
+Usage: t3 tool claude-handover [OPTIONS]
+
+ Show Claude handover telemetry and runtime recommendations.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --current-runtime        TEXT  Current CLI runtime. Defaults to the          │
 │                                highest-priority configured runtime.          │
@@ -591,10 +591,10 @@ Usage: t3 tool claude-handover [OPTIONS]
 ### `t3 setup`
 
 ```
-Usage: t3 setup [OPTIONS] COMMAND [ARGS]...                                    
-                                                                                
- First-time setup and global skill management.                                  
-                                                                                
+Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
+
+ First-time setup and global skill management.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --claude-scope        TEXT  Claude plugin install scope: user or project.    │
 │                             [default: user]                                  │
@@ -606,10 +606,10 @@ Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
 ### `t3 assess`
 
 ```
-Usage: t3 assess [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Codebase health assessment.                                                    
-                                                                                
+Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
+
+ Codebase health assessment.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -622,10 +622,10 @@ Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
 #### `t3 assess run`
 
 ```
-Usage: t3 assess run [OPTIONS]                                                 
-                                                                                
- Run deterministic codebase metrics on a repository.                            
-                                                                                
+Usage: t3 assess run [OPTIONS]
+
+ Run deterministic codebase metrics on a repository.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root                 PATH  Repository root to assess                       │
 │ --json                       Output raw JSON                                 │
@@ -638,14 +638,13 @@ Usage: t3 assess run [OPTIONS]
 #### `t3 assess history`
 
 ```
-Usage: t3 assess history [OPTIONS]                                             
-                                                                                
- Show assessment history for a repository.                                      
-                                                                                
+Usage: t3 assess history [OPTIONS]
+
+ Show assessment history for a repository.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root           PATH     Repository root                                    │
 │ --limit  -n      INTEGER  Number of recent assessments to show [default: 10] │
 │ --help                    Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ The core idea: each workflow phase -- ticket intake, coding, testing, review, de
 pip install teatree   # or: uv add teatree
 
 # Create an overlay package for your project
-uv run t3 startoverlay my-overlay ~/workspace/my-overlay
+t3 startoverlay my-overlay ~/workspace/my-overlay
 ```
 
 Your overlay is a lightweight Python package with an `OverlayBase` subclass and a `teatree.overlays` entry point. Once installed alongside teatree, `t3 teatree dashboard` picks it up automatically -- no settings to configure.

--- a/docs/install.md
+++ b/docs/install.md
@@ -40,7 +40,7 @@ and you see the changes immediately):
 
 ```sh
 uv pip install -e .              # install overlay itself as editable
-uv run t3 doctor check           # verify editable status
+t3 doctor check                    # verify editable status
 ```
 
 ### Contribute to teatree
@@ -63,7 +63,7 @@ Then:
 
 ```sh
 uv sync                          # teatree installed as editable
-uv run t3 doctor check           # verify both are editable
+t3 doctor check                    # verify both are editable
 ```
 
 Now changes to teatree source files are picked up immediately.
@@ -99,7 +99,7 @@ cd ~/workspace/t3-acme
 uv pip install -e .              # overlay editable
 # pyproject.toml already points teatree to editable path
 uv sync
-uv run t3 doctor check           # both show as editable
+t3 doctor check                    # both show as editable
 ```
 
 ## Overlay discovery

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -52,8 +52,10 @@ _T3_CLI_REMINDER = (
 )
 
 # Commands that are legitimate t3 CLI invocations — never block these.
+# `uv run t3 ...` is intentionally NOT whitelisted here: it is caught by the
+# blocked-commands list below so agents switch to the globally-installed t3.
 _T3_CMD_PREFIX_RE = re.compile(
-    r"^(?:\w+=\S+\s+)*(?:uv\s+run\s+)?t3\s",
+    r"^(?:\w+=\S+\s+)*t3\s",
 )
 
 # Read-only commands that may mention infrastructure tools as arguments
@@ -100,6 +102,14 @@ _BLOCKED_COMMANDS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(r"\b(?:pg_restore|pg_dump|dslr)\b"),
         "BLOCKED: `pg_restore`/`pg_dump`/`dslr` — use `t3 <overlay> db refresh` instead.",
+    ),
+    (
+        re.compile(r"\buv\s+run\s+(?:\S+\s+)*?t3(?:\s|$)"),
+        (
+            "BLOCKED: `uv run t3` — teatree is installed globally; call `t3` directly. "
+            "If `t3` is missing on this machine, install teatree (`uv tool install teatree` "
+            "or `uv tool install --editable <teatree-repo>`)."
+        ),
     ),
 ]
 

--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -18,7 +18,7 @@ Use this when the user wants to switch away from Claude without losing the threa
 Run:
 
 ```bash
-uv run t3 tool claude-handover --json --current-runtime <runtime>
+t3 tool claude-handover --json --current-runtime <runtime>
 ```
 
 Read these fields from the JSON:

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -185,13 +185,13 @@ Use the TeaTree bootstrap CLI, not shell overlay scaffolding.
 Basic form:
 
 ```bash
-uv run t3 startoverlay <overlay-name> <destination-dir>
+t3 startoverlay <overlay-name> <destination-dir>
 ```
 
 When the filesystem directory and Python package should differ, also pass:
 
 ```bash
-uv run t3 startoverlay my-overlay ~/workspace/my-org --overlay-package my_overlay
+t3 startoverlay my-overlay ~/workspace/my-org --overlay-package my_overlay
 ```
 
 Generated shape:
@@ -248,5 +248,5 @@ npx skills add <upstream-owner>/skills --skill ac-django --skill ac-python -g -y
 
 - Do not reintroduce `T3_OVERLAY` as a required bootstrap concept.
 - Do not scaffold shell wrappers or `project_hooks.py`.
-- Prefer `uv run t3 ...` and Django settings over `PYTHONPATH` tricks.
+- Prefer `t3 ...` and Django settings over `PYTHONPATH` tricks.
 - Stop at the first broken prerequisite and fix that before continuing.

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -101,7 +101,7 @@ Hooks are registered in `hooks/hooks.json` (shipped with the plugin). This is th
 
 When modifying CLI commands, dashboard views, or server startup:
 
-1. **Run the command yourself** — don't rely on unit tests alone. `uv run t3 <command>` from a worktree (not the main clone) to catch cwd-dependent bugs.
+1. **Run the command yourself** — don't rely on unit tests alone. `t3 <command>` from a worktree (not the main clone) to catch cwd-dependent bugs.
 2. **Verify HTTP 200** — for dashboard/server changes: `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:<port>/` must return 200.
 3. **Run E2E tests** — dashboard changes require Playwright E2E tests in `e2e/test_dashboard.py`. **Pre-flight:** kill any zombie servers first (`pkill -9 -f "uvicorn teatree.asgi"; pkill -9 -f "chrome-headless"; pkill -9 -f "playwright/driver"`). Then: `DJANGO_SETTINGS_MODULE=e2e.settings uv run pytest e2e/ --ds e2e.settings --no-cov -v`. Each timed-out run leaves zombie processes — kill before retrying. For full-suite validation prefer CI (clean environment, ~seconds/test vs. 7+ min locally on a loaded machine).
 4. **Test the full flow** — if the change involves task execution, create a task and verify the worker picks it up. Don't declare "auto-start works" without observing a task transition from PENDING to CLAIMED.

--- a/skills/workspace/references/extension-points.md
+++ b/skills/workspace/references/extension-points.md
@@ -79,7 +79,7 @@ Settings are defined in `overlay_settings.py` and overridden per-user in `~/.tea
 ## Creating an Overlay
 
 ```bash
-uv run t3 startoverlay my-project ~/workspace/
+t3 startoverlay my-project ~/workspace/
 ```
 
 This creates a minimal overlay package with:

--- a/skills/workspace/references/scripts-and-functions.md
+++ b/skills/workspace/references/scripts-and-functions.md
@@ -7,8 +7,8 @@
 ## CLI Entry Point
 
 ```bash
-uv run t3 --help               # from any project with teatree installed
-uv run t3 <overlay> --help     # overlay-specific commands (from overlay project)
+t3 --help                      # from any project with teatree installed
+t3 <overlay> --help            # overlay-specific commands (from overlay project)
 ```
 
 ## Global Commands (no overlay needed)

--- a/skills/workspace/references/troubleshooting.md
+++ b/skills/workspace/references/troubleshooting.md
@@ -59,7 +59,7 @@
 
 - **Symptom:** `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` on `str | None` type hints, or other 3.10+ syntax errors.
 - **Cause:** The shell wrapper or direct command resolved a Python outside the TeaTree `uv` environment.
-- **Fix:** Run `uv run t3 ...` from the TeaTree repo, or source the legacy bootstrap wrapper which now delegates to `uv run t3`.
+- **Fix:** Ensure the globally-installed `t3` was installed with `uv tool install --editable <teatree-repo>` so it picks up the 3.13 interpreter, then call `t3 ...` directly.
 - **Prevention:** Never patch syntax to accommodate older Python (e.g. `from __future__ import annotations`). Fix the Python resolution instead.
 
 ## Issue Tracker CLI Quirks

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -160,7 +160,7 @@ def _launch_claude(
                 "Before doing any work, ask the user which lifecycle skill to load.",
             ),
         )
-    context_lines.extend(("", "Run `uv run t3 --help` to see available commands.", "Run `uv run pytest` to run tests."))
+    context_lines.extend(("", "Run `t3 --help` to see available commands.", "Run `uv run pytest` to run tests."))
     if task:
         context_lines.extend(("", f"Task: {task}"))
 
@@ -384,7 +384,7 @@ def cache() -> None:
     cache_path = DATA_DIR / "skill-metadata.json"
     if not cache_path.is_file():
         typer.echo(f"No cache found at {cache_path}")
-        typer.echo("Run: uv run t3 config write-skill-cache")
+        typer.echo("Run: t3 config write-skill-cache")
         raise typer.Exit(code=1)
 
     data = _json.loads(cache_path.read_text(encoding="utf-8"))
@@ -403,7 +403,7 @@ def deps(skill: str) -> None:
     cache_path = DATA_DIR / "skill-metadata.json"
     if not cache_path.is_file():
         typer.echo(f"No cache found at {cache_path}")
-        typer.echo("Run: uv run t3 config write-skill-cache")
+        typer.echo("Run: t3 config write-skill-cache")
         raise typer.Exit(code=1)
 
     data = _json.loads(cache_path.read_text(encoding="utf-8"))

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -75,6 +75,31 @@ def _install_claude_plugin(repo: Path, *, scope: str) -> bool:
     return True
 
 
+def _ensure_t3_installed(repo: Path) -> bool:
+    """Install ``t3`` globally via ``uv tool install`` when it's not on PATH.
+
+    Returns True when the binary is (already, or now) available.  When ``uv``
+    itself is missing, prints guidance and returns False rather than raising.
+    """
+    if shutil.which("t3"):
+        return True
+
+    uv_bin = shutil.which("uv")
+    if not uv_bin:
+        typer.echo("WARN  `t3` not on PATH and `uv` is missing — skipping global install.")
+        typer.echo("      Install uv: https://docs.astral.sh/uv/getting-started/installation/")
+        return False
+
+    result = _run_captured([uv_bin, "tool", "install", "--editable", str(repo)])
+    if result.returncode != 0:
+        typer.echo(f"WARN  `uv tool install` failed: {result.stderr.strip()}")
+        return False
+    typer.echo("OK    Installed `t3` globally via `uv tool install --editable`.")
+    if not shutil.which("t3"):
+        typer.echo("NOTE  Ensure `~/.local/bin` is on your PATH (see `uv tool dir --bin`).")
+    return True
+
+
 def _run_apm_install(repo: Path) -> bool:
     """Run apm install -g --target claude from the teatree repo."""
     apm_path = shutil.which("apm")
@@ -239,6 +264,8 @@ def run(
     """
     repo = _validate_repo(_find_main_clone())
     typer.echo(f"Teatree repo: {repo}")
+
+    _ensure_t3_installed(repo)
 
     _run_apm_install(repo)
 

--- a/tests/test_bash_command_blocker.py
+++ b/tests/test_bash_command_blocker.py
@@ -61,6 +61,10 @@ class TestBlocksForbiddenCommands:
             ("pg_restore -d mydb dump.sql", "db"),
             ("pg_dump mydb > dump.sql", "db"),
             ("dslr snapshot mydb", "db"),
+            ("uv run t3 lifecycle start", "install teatree"),
+            ("uv run t3 teatree lifecycle setup", "install teatree"),
+            ("uv run --no-sync t3 dashboard", "install teatree"),
+            ("cd /tmp && uv run t3 info", "install teatree"),
         ],
     )
     def test_denies_with_t3_alternative(
@@ -93,14 +97,16 @@ class TestAllowsLegitimateCommands:
         "command",
         [
             "t3 myapp lifecycle start",
-            "uv run t3 teatree lifecycle setup",
+            "t3 teatree lifecycle setup",
             "PYENV_VERSION=3.13.11 t3 myapp e2e external",
             "git status",
             "git push origin main",
             "ruff check src/",
             "uv run pytest --no-cov -x",
+            "uv run pytest tests/test_t3_cli.py",
             "ls -la",
             "echo 'manage.py runserver is not allowed'",
+            "echo 'run uv run t3 command'",
             "cat README.md",
             "grep -r 'playwright' .",
         ],

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -11,6 +11,7 @@ from teatree.cli.setup import (
     CORE_EXCLUDED_SKILLS,
     _clean_broken_symlinks,
     _ensure_skill_link,
+    _ensure_t3_installed,
     _find_main_clone,
     _install_claude_plugin,
     _register_claude_marketplace,
@@ -397,3 +398,46 @@ class TestCoreExcludedSkills:
     def test_default_exclusions_present(self) -> None:
         assert "using-superpowers" in CORE_EXCLUDED_SKILLS
         assert "using-git-worktrees" in CORE_EXCLUDED_SKILLS
+
+
+class TestEnsureT3Installed:
+    def test_skips_install_when_t3_on_path(self, tmp_path: Path) -> None:
+        with (
+            patch("teatree.cli.setup.shutil.which") as mock_which,
+            patch("teatree.cli.setup.subprocess.run") as mock_run,
+        ):
+            mock_which.side_effect = lambda name: "/usr/local/bin/t3" if name == "t3" else None
+            assert _ensure_t3_installed(tmp_path) is True
+            mock_run.assert_not_called()
+
+    def test_returns_false_when_uv_missing(self, tmp_path: Path) -> None:
+        with patch("teatree.cli.setup.shutil.which", return_value=None):
+            assert _ensure_t3_installed(tmp_path) is False
+
+    def test_installs_editable_when_t3_missing(self, tmp_path: Path) -> None:
+        repo = tmp_path / "teatree"
+        repo.mkdir()
+        with (
+            patch("teatree.cli.setup.shutil.which") as mock_which,
+            patch("teatree.cli.setup.subprocess.run") as mock_run,
+        ):
+            mock_which.side_effect = lambda name: "/usr/bin/uv" if name == "uv" else None
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stderr = ""
+            assert _ensure_t3_installed(repo) is True
+            args = mock_run.call_args[0][0]
+            assert args[:3] == ["/usr/bin/uv", "tool", "install"]
+            assert "--editable" in args
+            assert str(repo) in args
+
+    def test_returns_false_on_install_failure(self, tmp_path: Path) -> None:
+        repo = tmp_path / "teatree"
+        repo.mkdir()
+        with (
+            patch("teatree.cli.setup.shutil.which") as mock_which,
+            patch("teatree.cli.setup.subprocess.run") as mock_run,
+        ):
+            mock_which.side_effect = lambda name: "/usr/bin/uv" if name == "uv" else None
+            mock_run.return_value.returncode = 1
+            mock_run.return_value.stderr = "boom"
+            assert _ensure_t3_installed(repo) is False


### PR DESCRIPTION
Closes #358. Depends on (and will follow) #357.

## Summary

- **Hook blocker** — `hooks/scripts/hook_router.py` gains a `_BLOCKED_COMMANDS` entry that denies `uv run ... t3` Bash invocations with a message telling the agent to call bare `t3`. The t3-allowlist prefix no longer matches `uv run t3`.
- **Auto-install** — `t3 setup` now runs `uv tool install --editable <repo>` when the global `t3` binary is missing, so a fresh `uv run t3 setup` bootstraps a global CLI on the first run. PATH guidance is printed if `~/.local/bin` is not yet reachable.
- **Docs/config cleanup** — every `uv run t3 ...` occurrence in `CLAUDE.md`, `AGENTS.md`, `apm.yml`, `skills/**`, `docs/**`, CI, and in-CLI help is replaced with bare `t3`. CI now runs `uv tool install --editable .` before `t3 teatree e2e`.
- `BLUEPRINT.md` updated to describe both the hook blocker and the auto-install step.
- Tests in `tests/test_bash_command_blocker.py` cover the new deny cases; `tests/test_cli_setup.py` covers every branch of `_ensure_t3_installed`.

## Test plan

- [x] `uv run pytest tests/ --no-cov` — 2182 passed
- [x] `uv run ruff check src/ tests/ hooks/` — clean
- [ ] On merge, verify CI e2e job still succeeds with the `uv tool install` step
- [ ] Follow-up PR on `t3-company` mirrors the docs update