### PR TITLE
fix(workspace): tolerate per-worktree cleanup failures in clean-all

### DIFF
--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -403,7 +403,12 @@ class Command(TyperCommand):
     ) -> list[str]:
         """Prune merged worktrees, stale branches, orphaned stashes, orphan databases, and old DSLR snapshots."""
         workspace = _workspace_dir()
-        cleaned = [cleanup_worktree(wt) for wt in Worktree.objects.filter(state=Worktree.State.CREATED)]
+        cleaned: list[str] = []
+        for wt in Worktree.objects.filter(state=Worktree.State.CREATED):
+            try:
+                cleaned.append(cleanup_worktree(wt))
+            except RuntimeError as exc:
+                cleaned.append(f"Skipped: {exc}")
 
         for entry in workspace.iterdir():
             if entry.is_dir() and not any(entry.iterdir()):

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -896,6 +896,61 @@ class TestWorkspaceCleanAll(TestCase):
 
         assert any("old-snapshot-2025" in c for c in cleaned)
 
+    @_no_prune
+    @_no_stash
+    @_no_orphan_dbs
+    @_no_dslr_prune
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_continues_when_one_worktree_refuses_cleanup(self) -> None:
+        """clean-all skips worktrees with unsynced commits and still cleans the rest."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            for repo in ("frontend", "backend"):
+                repo_main = workspace / repo
+                repo_main.mkdir(parents=True)
+                (repo_main / ".git").mkdir()
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/360")
+            stuck_wt_dir = workspace / "ac-frontend-360-ticket" / "frontend"
+            stuck_wt_dir.mkdir(parents=True)
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="frontend",
+                branch="ac-frontend-360-ticket",
+                extra={"worktree_path": str(stuck_wt_dir)},
+            )
+            clean_wt_dir = workspace / "ac-backend-360-ticket" / "backend"
+            clean_wt_dir.mkdir(parents=True)
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="ac-backend-360-ticket",
+                extra={"worktree_path": str(clean_wt_dir)},
+            )
+
+            def _unsynced(_repo: str, branch: str) -> list[str]:
+                return ["abc123 chore: unpushed"] if branch == "ac-frontend-360-ticket" else []
+
+            mock_config = MagicMock()
+            mock_config.user.workspace_dir = workspace
+            with (
+                patch.object(cleanup_mod, "load_config", return_value=mock_config),
+                patch.object(cleanup_mod, "git") as mock_git,
+                patch.object(cleanup_mod, "get_overlay") as mock_overlay,
+            ):
+                mock_overlay.return_value.get_cleanup_steps.return_value = []
+                mock_git.status_porcelain.return_value = ""
+                mock_git.unsynced_commits.side_effect = _unsynced
+                cleaned = cast("list[str]", call_command("workspace", "clean-all"))
+
+            assert any("Cleaned: backend" in c for c in cleaned)
+            assert any("ac-frontend-360-ticket" in c and "unsynced" in c.lower() for c in cleaned)
+            assert Worktree.objects.filter(branch="ac-backend-360-ticket").count() == 0
+            assert Worktree.objects.filter(branch="ac-frontend-360-ticket").count() == 1
+
 
 def _subprocess_side_effect(gh_stdout: str, glab_stdout: str):
     """Return a side_effect function that dispatches mock stdout based on the CLI command."""


### PR DESCRIPTION
## Summary

`t3 <overlay> workspace clean-all` used a list comprehension over `cleanup_worktree(wt)` that bailed on the first `RuntimeError` (unsynced commits). One stuck worktree stopped the entire sweep — orphan DB pruning, stash cleanup, and DSLR snapshot pruning never ran.

Wrap the per-worktree call in `try/except RuntimeError`: record `Skipped: <reason>` for refused cleanups and continue.

## Repro (before the fix)

```
$ t3 company workspace clean-all
RuntimeError: client-workspace (ac-...): refused cleanup — 8 unsynced commit(s).
```

No orphan DBs pruned, no stashes cleaned, no DSLR snapshots pruned.

## Test plan

- [x] New test `TestWorkspaceCleanAll::test_continues_when_one_worktree_refuses_cleanup` — two worktrees, one stuck, one clean. Verifies the clean one still gets cleaned and the stuck one is reported in output.
- [x] Existing 8 `TestWorkspaceCleanAll` tests pass.
- [x] Full `teatree_core` test run: 311 passed.
- [x] `ruff check` + `prek run` on changed files: clean.

Closes #360