### PR TITLE
feat(cli): automate overlay install/uninstall for dev vs test workflows (#120)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ htmlcov/
 
 # APM dependencies
 apm_modules/
+docs/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ htmlcov/
 # APM dependencies
 apm_modules/
 docs/plans/
+.t3.local.json

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -642,6 +642,16 @@ Each registered overlay gets a subcommand group (e.g., `t3 acme`). Commands dele
 
 `lifecycle`, `workspace`, `run`, `db`, `pr`, `tasks`, `followup` — see §8.1 for details.
 
+### 8.4 Overlay Dev Loop (`t3 overlay install|uninstall|status`)
+
+Ships alongside the three-tier split above. Purpose: in a teatree feature worktree (never the main clone), editable-install a sibling overlay checkout so `t3 dashboard` and agents immediately see unreleased teatree code plus the overlay that exercises it.
+
+- `install <name>` walks up from `cwd` to find the teatree worktree, resolves the overlay main clone via `[overlays.<name>].path` in `~/.teatree.toml`, adds a sibling `git worktree` matching the teatree branch (falls back to the overlay's default branch), then runs `uv pip install --editable --no-deps <sibling>` against the teatree worktree venv. State is persisted in `.t3.local.json` (gitignored).
+- `uninstall <name>` removes the overlay from the venv and state file.
+- `status` lists overlays tracked in `.t3.local.json`.
+
+Refuses to run in the main clone (detected via a real `.git` directory). Tests in the teatree worktree stay deterministic because `tests/conftest.py` pins `T3_OVERLAY_NAME=t3-teatree`.
+
 ---
 
 ## 9. Dashboard

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -27,6 +27,7 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 │ tool            Standalone utilities.                                        │
 │ setup           First-time setup and global skill management.                │
 │ assess          Codebase health assessment.                                  │
+│ overlay         Dev-mode overlay install/uninstall.                          │
 │ infra           Teatree-wide infrastructure services.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -647,6 +648,67 @@ Usage: t3 assess history [OPTIONS]
 │ --root           PATH     Repository root                                    │
 │ --limit  -n      INTEGER  Number of recent assessments to show [default: 10] │
 │ --help                    Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+### `t3 overlay`
+
+```
+Usage: t3 overlay [OPTIONS] COMMAND [ARGS]...                                  
+                                                                                
+ Dev-mode overlay install/uninstall.                                            
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ install    Install an overlay editable into the current teatree worktree for │
+│            dogfooding.                                                       │
+│ uninstall  Uninstall an overlay from the current teatree worktree venv.      │
+│ status     Show overlays currently installed into this teatree worktree.     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 overlay install`
+
+```
+Usage: t3 overlay install [OPTIONS] NAME                                       
+                                                                                
+ Install an overlay editable into the current teatree worktree for dogfooding.  
+                                                                                
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  Overlay name as configured in ~/.teatree.toml.          │
+│                      [required]                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 overlay uninstall`
+
+```
+Usage: t3 overlay uninstall [OPTIONS] NAME                                     
+                                                                                
+ Uninstall an overlay from the current teatree worktree venv.                   
+                                                                                
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  Overlay name to uninstall. [required]                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 overlay status`
+
+```
+Usage: t3 overlay status [OPTIONS]                                             
+                                                                                
+ Show overlays currently installed into this teatree worktree.                  
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -5,8 +5,8 @@ Generated from `t3` command tree.
 ## `t3`
 
 ```
-Usage: t3 [OPTIONS] COMMAND [ARGS]...                                          
-                                                                                
+Usage: t3 [OPTIONS] COMMAND [ARGS]...
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -35,10 +35,10 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 ### `t3 startoverlay`
 
 ```
-Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION                      
-                                                                                
- Create a new TeaTree overlay package.                                          
-                                                                                
+Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
+
+ Create a new TeaTree overlay package.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    project_name      TEXT  [required]                                      │
 │ *    destination       PATH  [required]                                      │
@@ -55,12 +55,12 @@ Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
 ### `t3 docs`
 
 ```
-Usage: t3 docs [OPTIONS]                                                       
-                                                                                
- Serve the project documentation with mkdocs.                                   
-                                                                                
- Requires the ``docs`` dependency group: ``uv sync --group docs``               
-                                                                                
+Usage: t3 docs [OPTIONS]
+
+ Serve the project documentation with mkdocs.
+
+ Requires the ``docs`` dependency group: ``uv sync --group docs``
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host        TEXT     Host to bind to [default: 127.0.0.1]                  │
 │ --port        INTEGER  Port to serve on [default: 8888]                      │
@@ -71,10 +71,10 @@ Usage: t3 docs [OPTIONS]
 ### `t3 agent`
 
 ```
-Usage: t3 agent [OPTIONS] [TASK]                                               
-                                                                                
- Launch Claude Code with auto-detected project context.                         
-                                                                                
+Usage: t3 agent [OPTIONS] [TASK]
+
+ Launch Claude Code with auto-detected project context.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   task      [TASK]  What to work on (e.g. 'fix the sync bug', 'add a new     │
 │                     command')                                                │
@@ -90,13 +90,13 @@ Usage: t3 agent [OPTIONS] [TASK]
 ### `t3 sessions`
 
 ```
-Usage: t3 sessions [OPTIONS]                                                   
-                                                                                
- List recent Claude conversation sessions with resume commands.                 
-                                                                                
- By default shows sessions for the current working directory.                   
- Use --all to show sessions across all projects.                                
-                                                                                
+Usage: t3 sessions [OPTIONS]
+
+ List recent Claude conversation sessions with resume commands.
+
+ By default shows sessions for the current working directory.
+ Use --all to show sessions across all projects.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --project          TEXT     Filter by project dir substring                  │
 │ --limit    -n      INTEGER  Max sessions to show [default: 20]               │
@@ -108,10 +108,10 @@ Usage: t3 sessions [OPTIONS]
 ### `t3 info`
 
 ```
-Usage: t3 info [OPTIONS]                                                       
-                                                                                
- Show t3 installation, teatree/overlay sources, and editable status.            
-                                                                                
+Usage: t3 info [OPTIONS]
+
+ Show t3 installation, teatree/overlay sources, and editable status.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -120,10 +120,10 @@ Usage: t3 info [OPTIONS]
 ### `t3 dashboard`
 
 ```
-Usage: t3 dashboard [OPTIONS]                                                  
-                                                                                
- Migrate the database and start the dashboard dev server.                       
-                                                                                
+Usage: t3 dashboard [OPTIONS]
+
+ Migrate the database and start the dashboard dev server.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host           TEXT     Host to bind to [default: 127.0.0.1]               │
 │ --port           INTEGER  Port to serve on [default: 8000]                   │
@@ -139,10 +139,10 @@ Usage: t3 dashboard [OPTIONS]
 ### `t3 config`
 
 ```
-Usage: t3 config [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Configuration and autoloading.                                                 
-                                                                                
+Usage: t3 config [OPTIONS] COMMAND [ARGS]...
+
+ Configuration and autoloading.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -161,10 +161,10 @@ Usage: t3 config [OPTIONS] COMMAND [ARGS]...
 #### `t3 config check-update`
 
 ```
-Usage: t3 config check-update [OPTIONS]                                        
-                                                                                
- Check if a newer version of teatree is available.                              
-                                                                                
+Usage: t3 config check-update [OPTIONS]
+
+ Check if a newer version of teatree is available.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -173,10 +173,10 @@ Usage: t3 config check-update [OPTIONS]
 #### `t3 config write-skill-cache`
 
 ```
-Usage: t3 config write-skill-cache [OPTIONS]                                   
-                                                                                
- Write overlay skill metadata to XDG cache for hook consumption.                
-                                                                                
+Usage: t3 config write-skill-cache [OPTIONS]
+
+ Write overlay skill metadata to XDG cache for hook consumption.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -185,10 +185,10 @@ Usage: t3 config write-skill-cache [OPTIONS]
 #### `t3 config autoload`
 
 ```
-Usage: t3 config autoload [OPTIONS]                                            
-                                                                                
- List skill auto-loading rules from context-match.yml files.                    
-                                                                                
+Usage: t3 config autoload [OPTIONS]
+
+ List skill auto-loading rules from context-match.yml files.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -197,10 +197,10 @@ Usage: t3 config autoload [OPTIONS]
 #### `t3 config cache`
 
 ```
-Usage: t3 config cache [OPTIONS]                                               
-                                                                                
- Show the XDG skill-metadata cache content.                                     
-                                                                                
+Usage: t3 config cache [OPTIONS]
+
+ Show the XDG skill-metadata cache content.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -209,10 +209,10 @@ Usage: t3 config cache [OPTIONS]
 #### `t3 config deps`
 
 ```
-Usage: t3 config deps [OPTIONS] SKILL                                          
-                                                                                
- Show resolved dependency chain for a skill.                                    
-                                                                                
+Usage: t3 config deps [OPTIONS] SKILL
+
+ Show resolved dependency chain for a skill.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    skill      TEXT  [required]                                             │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -224,10 +224,10 @@ Usage: t3 config deps [OPTIONS] SKILL
 #### `t3 config test-trigger`
 
 ```
-Usage: t3 config test-trigger [OPTIONS] PROMPT                                 
-                                                                                
- Test which skill would be triggered for a given prompt.                        
-                                                                                
+Usage: t3 config test-trigger [OPTIONS] PROMPT
+
+ Test which skill would be triggered for a given prompt.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    prompt      TEXT  [required]                                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -239,10 +239,10 @@ Usage: t3 config test-trigger [OPTIONS] PROMPT
 ### `t3 ci`
 
 ```
-Usage: t3 ci [OPTIONS] COMMAND [ARGS]...                                       
-                                                                                
- CI pipeline helpers.                                                           
-                                                                                
+Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
+
+ CI pipeline helpers.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -260,10 +260,10 @@ Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
 #### `t3 ci cancel`
 
 ```
-Usage: t3 ci cancel [OPTIONS] [BRANCH]                                         
-                                                                                
- Cancel stale CI pipelines for a branch.                                        
-                                                                                
+Usage: t3 ci cancel [OPTIONS] [BRANCH]
+
+ Cancel stale CI pipelines for a branch.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -275,10 +275,10 @@ Usage: t3 ci cancel [OPTIONS] [BRANCH]
 #### `t3 ci divergence`
 
 ```
-Usage: t3 ci divergence [OPTIONS]                                              
-                                                                                
- Check fork divergence from upstream.                                           
-                                                                                
+Usage: t3 ci divergence [OPTIONS]
+
+ Check fork divergence from upstream.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -287,10 +287,10 @@ Usage: t3 ci divergence [OPTIONS]
 #### `t3 ci fetch-errors`
 
 ```
-Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]                                   
-                                                                                
- Fetch error logs from the latest CI pipeline.                                  
-                                                                                
+Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
+
+ Fetch error logs from the latest CI pipeline.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -302,10 +302,10 @@ Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
 #### `t3 ci fetch-failed-tests`
 
 ```
-Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]                             
-                                                                                
- Extract failed test IDs from the latest CI pipeline.                           
-                                                                                
+Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
+
+ Extract failed test IDs from the latest CI pipeline.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -317,10 +317,10 @@ Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
 #### `t3 ci trigger-e2e`
 
 ```
-Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]                                    
-                                                                                
- Trigger E2E tests on CI.                                                       
-                                                                                
+Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
+
+ Trigger E2E tests on CI.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -332,10 +332,10 @@ Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
 #### `t3 ci quality-check`
 
 ```
-Usage: t3 ci quality-check [OPTIONS] [BRANCH]                                  
-                                                                                
- Run quality analysis (fetch test report from latest pipeline).                 
-                                                                                
+Usage: t3 ci quality-check [OPTIONS] [BRANCH]
+
+ Run quality analysis (fetch test report from latest pipeline).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -347,10 +347,10 @@ Usage: t3 ci quality-check [OPTIONS] [BRANCH]
 ### `t3 review`
 
 ```
-Usage: t3 review [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Code review helpers.                                                           
-                                                                                
+Usage: t3 review [OPTIONS] COMMAND [ARGS]...
+
+ Code review helpers.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -365,10 +365,10 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 #### `t3 review post-draft-note`
 
 ```
-Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE                        
-                                                                                
- Post a draft note on a GitLab MR (inline or general).                          
-                                                                                
+Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
+
+ Post a draft note on a GitLab MR (inline or general).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -386,10 +386,10 @@ Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
 #### `t3 review delete-draft-note`
 
 ```
-Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID                   
-                                                                                
- Delete a draft note from a GitLab MR.                                          
-                                                                                
+Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
+
+ Delete a draft note from a GitLab MR.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo         TEXT     GitLab project path [required]                    │
 │ *    mr           INTEGER  Merge request IID [required]                      │
@@ -403,10 +403,10 @@ Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
 #### `t3 review publish-draft-notes`
 
 ```
-Usage: t3 review publish-draft-notes [OPTIONS] REPO MR                         
-                                                                                
- Publish all draft notes on a GitLab MR (bulk submit).                          
-                                                                                
+Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
+
+ Publish all draft notes on a GitLab MR (bulk submit).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -420,10 +420,10 @@ Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
 #### `t3 review list-draft-notes`
 
 ```
-Usage: t3 review list-draft-notes [OPTIONS] REPO MR                            
-                                                                                
- List draft notes on a GitLab MR.                                               
-                                                                                
+Usage: t3 review list-draft-notes [OPTIONS] REPO MR
+
+ List draft notes on a GitLab MR.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path [required]                       │
 │ *    mr        INTEGER  Merge request IID [required]                         │
@@ -436,10 +436,10 @@ Usage: t3 review list-draft-notes [OPTIONS] REPO MR
 ### `t3 review-request`
 
 ```
-Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...                           
-                                                                                
- Batch review requests.                                                         
-                                                                                
+Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
+
+ Batch review requests.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -451,10 +451,10 @@ Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
 #### `t3 review-request discover`
 
 ```
-Usage: t3 review-request discover [OPTIONS]                                    
-                                                                                
- Discover open merge requests awaiting review.                                  
-                                                                                
+Usage: t3 review-request discover [OPTIONS]
+
+ Discover open merge requests awaiting review.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -463,10 +463,10 @@ Usage: t3 review-request discover [OPTIONS]
 ### `t3 doctor`
 
 ```
-Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Smoke-test hooks, imports, services.                                           
-                                                                                
+Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
+
+ Smoke-test hooks, imports, services.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -478,10 +478,10 @@ Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
 #### `t3 doctor check`
 
 ```
-Usage: t3 doctor check [OPTIONS]                                               
-                                                                                
- Verify imports, required tools, and editable-install sanity.                   
-                                                                                
+Usage: t3 doctor check [OPTIONS]
+
+ Verify imports, required tools, and editable-install sanity.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -490,10 +490,10 @@ Usage: t3 doctor check [OPTIONS]
 ### `t3 tool`
 
 ```
-Usage: t3 tool [OPTIONS] COMMAND [ARGS]...                                     
-                                                                                
- Standalone utilities.                                                          
-                                                                                
+Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
+
+ Standalone utilities.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -510,10 +510,10 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 #### `t3 tool privacy-scan`
 
 ```
-Usage: t3 tool privacy-scan [OPTIONS] [PATH]                                   
-                                                                                
- Scan text for privacy-sensitive patterns (emails, keys, IPs).                  
-                                                                                
+Usage: t3 tool privacy-scan [OPTIONS] [PATH]
+
+ Scan text for privacy-sensitive patterns (emails, keys, IPs).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   path      [PATH]  File or '-' for stdin [default: -]                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -525,10 +525,10 @@ Usage: t3 tool privacy-scan [OPTIONS] [PATH]
 #### `t3 tool analyze-video`
 
 ```
-Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH                              
-                                                                                
- Decompose video into frames for AI analysis.                                   
-                                                                                
+Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
+
+ Decompose video into frames for AI analysis.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    video_path      TEXT  Path to video file [required]                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -540,10 +540,10 @@ Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
 #### `t3 tool bump-deps`
 
 ```
-Usage: t3 tool bump-deps [OPTIONS]                                             
-                                                                                
- Bump pyproject.toml dependencies from uv.lock.                                 
-                                                                                
+Usage: t3 tool bump-deps [OPTIONS]
+
+ Bump pyproject.toml dependencies from uv.lock.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -552,10 +552,10 @@ Usage: t3 tool bump-deps [OPTIONS]
 #### `t3 tool sonar-check`
 
 ```
-Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]                               
-                                                                                
- Run local SonarQube analysis via Docker.                                       
-                                                                                
+Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
+
+ Run local SonarQube analysis via Docker.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   repo_path      [REPO_PATH]  Path to repo (default: current directory)      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -574,10 +574,10 @@ Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
 #### `t3 tool claude-handover`
 
 ```
-Usage: t3 tool claude-handover [OPTIONS]                                       
-                                                                                
- Show Claude handover telemetry and runtime recommendations.                    
-                                                                                
+Usage: t3 tool claude-handover [OPTIONS]
+
+ Show Claude handover telemetry and runtime recommendations.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --current-runtime        TEXT  Current CLI runtime. Defaults to the          │
 │                                highest-priority configured runtime.          │
@@ -593,10 +593,10 @@ Usage: t3 tool claude-handover [OPTIONS]
 ### `t3 setup`
 
 ```
-Usage: t3 setup [OPTIONS] COMMAND [ARGS]...                                    
-                                                                                
- First-time setup and global skill management.                                  
-                                                                                
+Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
+
+ First-time setup and global skill management.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --claude-scope        TEXT  Claude plugin install scope: user or project.    │
 │                             [default: user]                                  │
@@ -608,10 +608,10 @@ Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
 ### `t3 assess`
 
 ```
-Usage: t3 assess [OPTIONS] COMMAND [ARGS]...                                   
-                                                                                
- Codebase health assessment.                                                    
-                                                                                
+Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
+
+ Codebase health assessment.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -624,10 +624,10 @@ Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
 #### `t3 assess run`
 
 ```
-Usage: t3 assess run [OPTIONS]                                                 
-                                                                                
- Run deterministic codebase metrics on a repository.                            
-                                                                                
+Usage: t3 assess run [OPTIONS]
+
+ Run deterministic codebase metrics on a repository.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root                 PATH  Repository root to assess                       │
 │ --json                       Output raw JSON                                 │
@@ -640,10 +640,10 @@ Usage: t3 assess run [OPTIONS]
 #### `t3 assess history`
 
 ```
-Usage: t3 assess history [OPTIONS]                                             
-                                                                                
- Show assessment history for a repository.                                      
-                                                                                
+Usage: t3 assess history [OPTIONS]
+
+ Show assessment history for a repository.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root           PATH     Repository root                                    │
 │ --limit  -n      INTEGER  Number of recent assessments to show [default: 10] │
@@ -654,10 +654,10 @@ Usage: t3 assess history [OPTIONS]
 ### `t3 overlay`
 
 ```
-Usage: t3 overlay [OPTIONS] COMMAND [ARGS]...                                  
-                                                                                
- Dev-mode overlay install/uninstall.                                            
-                                                                                
+Usage: t3 overlay [OPTIONS] COMMAND [ARGS]...
+
+ Dev-mode overlay install/uninstall.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -672,10 +672,10 @@ Usage: t3 overlay [OPTIONS] COMMAND [ARGS]...
 #### `t3 overlay install`
 
 ```
-Usage: t3 overlay install [OPTIONS] NAME                                       
-                                                                                
- Install an overlay editable into the current teatree worktree for dogfooding.  
-                                                                                
+Usage: t3 overlay install [OPTIONS] NAME
+
+ Install an overlay editable into the current teatree worktree for dogfooding.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    name      TEXT  Overlay name as configured in ~/.teatree.toml.          │
 │                      [required]                                              │
@@ -688,10 +688,10 @@ Usage: t3 overlay install [OPTIONS] NAME
 #### `t3 overlay uninstall`
 
 ```
-Usage: t3 overlay uninstall [OPTIONS] NAME                                     
-                                                                                
- Uninstall an overlay from the current teatree worktree venv.                   
-                                                                                
+Usage: t3 overlay uninstall [OPTIONS] NAME
+
+ Uninstall an overlay from the current teatree worktree venv.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    name      TEXT  Overlay name to uninstall. [required]                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -703,10 +703,10 @@ Usage: t3 overlay uninstall [OPTIONS] NAME
 #### `t3 overlay status`
 
 ```
-Usage: t3 overlay status [OPTIONS]                                             
-                                                                                
- Show overlays currently installed into this teatree worktree.                  
-                                                                                
+Usage: t3 overlay status [OPTIONS]
+
+ Show overlays currently installed into this teatree worktree.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -715,10 +715,10 @@ Usage: t3 overlay status [OPTIONS]
 ### `t3 infra`
 
 ```
-Usage: t3 infra [OPTIONS] COMMAND [ARGS]...                                    
-                                                                                
- Teatree-wide infrastructure services.                                          
-                                                                                
+Usage: t3 infra [OPTIONS] COMMAND [ARGS]...
+
+ Teatree-wide infrastructure services.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -730,10 +730,10 @@ Usage: t3 infra [OPTIONS] COMMAND [ARGS]...
 #### `t3 infra redis`
 
 ```
-Usage: t3 infra redis [OPTIONS] COMMAND [ARGS]...                              
-                                                                                
- Shared Redis container (teatree-redis).                                        
-                                                                                
+Usage: t3 infra redis [OPTIONS] COMMAND [ARGS]...
+
+ Shared Redis container (teatree-redis).
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -747,10 +747,10 @@ Usage: t3 infra redis [OPTIONS] COMMAND [ARGS]...
 ##### `t3 infra redis up`
 
 ```
-Usage: t3 infra redis up [OPTIONS]                                             
-                                                                                
- Start the shared Redis container (idempotent).                                 
-                                                                                
+Usage: t3 infra redis up [OPTIONS]
+
+ Start the shared Redis container (idempotent).
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -759,10 +759,10 @@ Usage: t3 infra redis up [OPTIONS]
 ##### `t3 infra redis down`
 
 ```
-Usage: t3 infra redis down [OPTIONS]                                           
-                                                                                
- Stop the shared Redis container.                                               
-                                                                                
+Usage: t3 infra redis down [OPTIONS]
+
+ Stop the shared Redis container.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -771,12 +771,11 @@ Usage: t3 infra redis down [OPTIONS]
 ##### `t3 infra redis status`
 
 ```
-Usage: t3 infra redis status [OPTIONS]                                         
-                                                                                
- Print the shared Redis container status.                                       
-                                                                                
+Usage: t3 infra redis status [OPTIONS]
+
+ Print the shared Redis container status.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
-

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -5,8 +5,8 @@ Generated from `t3` command tree.
 ## `t3`
 
 ```
-Usage: t3 [OPTIONS] COMMAND [ARGS]...
-
+Usage: t3 [OPTIONS] COMMAND [ARGS]...                                          
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -34,10 +34,10 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 ### `t3 startoverlay`
 
 ```
-Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
-
- Create a new TeaTree overlay package.
-
+Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION                      
+                                                                                
+ Create a new TeaTree overlay package.                                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    project_name      TEXT  [required]                                      │
 │ *    destination       PATH  [required]                                      │
@@ -54,12 +54,12 @@ Usage: t3 startoverlay [OPTIONS] PROJECT_NAME DESTINATION
 ### `t3 docs`
 
 ```
-Usage: t3 docs [OPTIONS]
-
- Serve the project documentation with mkdocs.
-
- Requires the ``docs`` dependency group: ``uv sync --group docs``
-
+Usage: t3 docs [OPTIONS]                                                       
+                                                                                
+ Serve the project documentation with mkdocs.                                   
+                                                                                
+ Requires the ``docs`` dependency group: ``uv sync --group docs``               
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host        TEXT     Host to bind to [default: 127.0.0.1]                  │
 │ --port        INTEGER  Port to serve on [default: 8888]                      │
@@ -70,10 +70,10 @@ Usage: t3 docs [OPTIONS]
 ### `t3 agent`
 
 ```
-Usage: t3 agent [OPTIONS] [TASK]
-
- Launch Claude Code with auto-detected project context.
-
+Usage: t3 agent [OPTIONS] [TASK]                                               
+                                                                                
+ Launch Claude Code with auto-detected project context.                         
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   task      [TASK]  What to work on (e.g. 'fix the sync bug', 'add a new     │
 │                     command')                                                │
@@ -89,13 +89,13 @@ Usage: t3 agent [OPTIONS] [TASK]
 ### `t3 sessions`
 
 ```
-Usage: t3 sessions [OPTIONS]
-
- List recent Claude conversation sessions with resume commands.
-
- By default shows sessions for the current working directory.
- Use --all to show sessions across all projects.
-
+Usage: t3 sessions [OPTIONS]                                                   
+                                                                                
+ List recent Claude conversation sessions with resume commands.                 
+                                                                                
+ By default shows sessions for the current working directory.                   
+ Use --all to show sessions across all projects.                                
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --project          TEXT     Filter by project dir substring                  │
 │ --limit    -n      INTEGER  Max sessions to show [default: 20]               │
@@ -107,10 +107,10 @@ Usage: t3 sessions [OPTIONS]
 ### `t3 info`
 
 ```
-Usage: t3 info [OPTIONS]
-
- Show t3 installation, teatree/overlay sources, and editable status.
-
+Usage: t3 info [OPTIONS]                                                       
+                                                                                
+ Show t3 installation, teatree/overlay sources, and editable status.            
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -119,10 +119,10 @@ Usage: t3 info [OPTIONS]
 ### `t3 dashboard`
 
 ```
-Usage: t3 dashboard [OPTIONS]
-
- Migrate the database and start the dashboard dev server.
-
+Usage: t3 dashboard [OPTIONS]                                                  
+                                                                                
+ Migrate the database and start the dashboard dev server.                       
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --host           TEXT     Host to bind to [default: 127.0.0.1]               │
 │ --port           INTEGER  Port to serve on [default: 8000]                   │
@@ -138,10 +138,10 @@ Usage: t3 dashboard [OPTIONS]
 ### `t3 config`
 
 ```
-Usage: t3 config [OPTIONS] COMMAND [ARGS]...
-
- Configuration and autoloading.
-
+Usage: t3 config [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Configuration and autoloading.                                                 
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -160,10 +160,10 @@ Usage: t3 config [OPTIONS] COMMAND [ARGS]...
 #### `t3 config check-update`
 
 ```
-Usage: t3 config check-update [OPTIONS]
-
- Check if a newer version of teatree is available.
-
+Usage: t3 config check-update [OPTIONS]                                        
+                                                                                
+ Check if a newer version of teatree is available.                              
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -172,10 +172,10 @@ Usage: t3 config check-update [OPTIONS]
 #### `t3 config write-skill-cache`
 
 ```
-Usage: t3 config write-skill-cache [OPTIONS]
-
- Write overlay skill metadata to XDG cache for hook consumption.
-
+Usage: t3 config write-skill-cache [OPTIONS]                                   
+                                                                                
+ Write overlay skill metadata to XDG cache for hook consumption.                
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -184,10 +184,10 @@ Usage: t3 config write-skill-cache [OPTIONS]
 #### `t3 config autoload`
 
 ```
-Usage: t3 config autoload [OPTIONS]
-
- List skill auto-loading rules from context-match.yml files.
-
+Usage: t3 config autoload [OPTIONS]                                            
+                                                                                
+ List skill auto-loading rules from context-match.yml files.                    
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -196,10 +196,10 @@ Usage: t3 config autoload [OPTIONS]
 #### `t3 config cache`
 
 ```
-Usage: t3 config cache [OPTIONS]
-
- Show the XDG skill-metadata cache content.
-
+Usage: t3 config cache [OPTIONS]                                               
+                                                                                
+ Show the XDG skill-metadata cache content.                                     
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -208,10 +208,10 @@ Usage: t3 config cache [OPTIONS]
 #### `t3 config deps`
 
 ```
-Usage: t3 config deps [OPTIONS] SKILL
-
- Show resolved dependency chain for a skill.
-
+Usage: t3 config deps [OPTIONS] SKILL                                          
+                                                                                
+ Show resolved dependency chain for a skill.                                    
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    skill      TEXT  [required]                                             │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -223,10 +223,10 @@ Usage: t3 config deps [OPTIONS] SKILL
 #### `t3 config test-trigger`
 
 ```
-Usage: t3 config test-trigger [OPTIONS] PROMPT
-
- Test which skill would be triggered for a given prompt.
-
+Usage: t3 config test-trigger [OPTIONS] PROMPT                                 
+                                                                                
+ Test which skill would be triggered for a given prompt.                        
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    prompt      TEXT  [required]                                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -238,10 +238,10 @@ Usage: t3 config test-trigger [OPTIONS] PROMPT
 ### `t3 ci`
 
 ```
-Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
-
- CI pipeline helpers.
-
+Usage: t3 ci [OPTIONS] COMMAND [ARGS]...                                       
+                                                                                
+ CI pipeline helpers.                                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -259,10 +259,10 @@ Usage: t3 ci [OPTIONS] COMMAND [ARGS]...
 #### `t3 ci cancel`
 
 ```
-Usage: t3 ci cancel [OPTIONS] [BRANCH]
-
- Cancel stale CI pipelines for a branch.
-
+Usage: t3 ci cancel [OPTIONS] [BRANCH]                                         
+                                                                                
+ Cancel stale CI pipelines for a branch.                                        
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -274,10 +274,10 @@ Usage: t3 ci cancel [OPTIONS] [BRANCH]
 #### `t3 ci divergence`
 
 ```
-Usage: t3 ci divergence [OPTIONS]
-
- Check fork divergence from upstream.
-
+Usage: t3 ci divergence [OPTIONS]                                              
+                                                                                
+ Check fork divergence from upstream.                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -286,10 +286,10 @@ Usage: t3 ci divergence [OPTIONS]
 #### `t3 ci fetch-errors`
 
 ```
-Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
-
- Fetch error logs from the latest CI pipeline.
-
+Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]                                   
+                                                                                
+ Fetch error logs from the latest CI pipeline.                                  
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -301,10 +301,10 @@ Usage: t3 ci fetch-errors [OPTIONS] [BRANCH]
 #### `t3 ci fetch-failed-tests`
 
 ```
-Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
-
- Extract failed test IDs from the latest CI pipeline.
-
+Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]                             
+                                                                                
+ Extract failed test IDs from the latest CI pipeline.                           
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -316,10 +316,10 @@ Usage: t3 ci fetch-failed-tests [OPTIONS] [BRANCH]
 #### `t3 ci trigger-e2e`
 
 ```
-Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
-
- Trigger E2E tests on CI.
-
+Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]                                    
+                                                                                
+ Trigger E2E tests on CI.                                                       
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -331,10 +331,10 @@ Usage: t3 ci trigger-e2e [OPTIONS] [BRANCH]
 #### `t3 ci quality-check`
 
 ```
-Usage: t3 ci quality-check [OPTIONS] [BRANCH]
-
- Run quality analysis (fetch test report from latest pipeline).
-
+Usage: t3 ci quality-check [OPTIONS] [BRANCH]                                  
+                                                                                
+ Run quality analysis (fetch test report from latest pipeline).                 
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   branch      [BRANCH]  Branch name (default: current branch)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -346,10 +346,10 @@ Usage: t3 ci quality-check [OPTIONS] [BRANCH]
 ### `t3 review`
 
 ```
-Usage: t3 review [OPTIONS] COMMAND [ARGS]...
-
- Code review helpers.
-
+Usage: t3 review [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Code review helpers.                                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -364,10 +364,10 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 #### `t3 review post-draft-note`
 
 ```
-Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
-
- Post a draft note on a GitLab MR (inline or general).
-
+Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE                        
+                                                                                
+ Post a draft note on a GitLab MR (inline or general).                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -385,10 +385,10 @@ Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
 #### `t3 review delete-draft-note`
 
 ```
-Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
-
- Delete a draft note from a GitLab MR.
-
+Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID                   
+                                                                                
+ Delete a draft note from a GitLab MR.                                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo         TEXT     GitLab project path [required]                    │
 │ *    mr           INTEGER  Merge request IID [required]                      │
@@ -402,10 +402,10 @@ Usage: t3 review delete-draft-note [OPTIONS] REPO MR NOTE_ID
 #### `t3 review publish-draft-notes`
 
 ```
-Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
-
- Publish all draft notes on a GitLab MR (bulk submit).
-
+Usage: t3 review publish-draft-notes [OPTIONS] REPO MR                         
+                                                                                
+ Publish all draft notes on a GitLab MR (bulk submit).                          
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -419,10 +419,10 @@ Usage: t3 review publish-draft-notes [OPTIONS] REPO MR
 #### `t3 review list-draft-notes`
 
 ```
-Usage: t3 review list-draft-notes [OPTIONS] REPO MR
-
- List draft notes on a GitLab MR.
-
+Usage: t3 review list-draft-notes [OPTIONS] REPO MR                            
+                                                                                
+ List draft notes on a GitLab MR.                                               
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path [required]                       │
 │ *    mr        INTEGER  Merge request IID [required]                         │
@@ -435,10 +435,10 @@ Usage: t3 review list-draft-notes [OPTIONS] REPO MR
 ### `t3 review-request`
 
 ```
-Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
-
- Batch review requests.
-
+Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...                           
+                                                                                
+ Batch review requests.                                                         
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -450,10 +450,10 @@ Usage: t3 review-request [OPTIONS] COMMAND [ARGS]...
 #### `t3 review-request discover`
 
 ```
-Usage: t3 review-request discover [OPTIONS]
-
- Discover open merge requests awaiting review.
-
+Usage: t3 review-request discover [OPTIONS]                                    
+                                                                                
+ Discover open merge requests awaiting review.                                  
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -462,10 +462,10 @@ Usage: t3 review-request discover [OPTIONS]
 ### `t3 doctor`
 
 ```
-Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
-
- Smoke-test hooks, imports, services.
-
+Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Smoke-test hooks, imports, services.                                           
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -477,10 +477,10 @@ Usage: t3 doctor [OPTIONS] COMMAND [ARGS]...
 #### `t3 doctor check`
 
 ```
-Usage: t3 doctor check [OPTIONS]
-
- Verify imports, required tools, and editable-install sanity.
-
+Usage: t3 doctor check [OPTIONS]                                               
+                                                                                
+ Verify imports, required tools, and editable-install sanity.                   
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -489,10 +489,10 @@ Usage: t3 doctor check [OPTIONS]
 ### `t3 tool`
 
 ```
-Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
-
- Standalone utilities.
-
+Usage: t3 tool [OPTIONS] COMMAND [ARGS]...                                     
+                                                                                
+ Standalone utilities.                                                          
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -509,10 +509,10 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 #### `t3 tool privacy-scan`
 
 ```
-Usage: t3 tool privacy-scan [OPTIONS] [PATH]
-
- Scan text for privacy-sensitive patterns (emails, keys, IPs).
-
+Usage: t3 tool privacy-scan [OPTIONS] [PATH]                                   
+                                                                                
+ Scan text for privacy-sensitive patterns (emails, keys, IPs).                  
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   path      [PATH]  File or '-' for stdin [default: -]                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -524,10 +524,10 @@ Usage: t3 tool privacy-scan [OPTIONS] [PATH]
 #### `t3 tool analyze-video`
 
 ```
-Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
-
- Decompose video into frames for AI analysis.
-
+Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH                              
+                                                                                
+ Decompose video into frames for AI analysis.                                   
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    video_path      TEXT  Path to video file [required]                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -539,10 +539,10 @@ Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
 #### `t3 tool bump-deps`
 
 ```
-Usage: t3 tool bump-deps [OPTIONS]
-
- Bump pyproject.toml dependencies from uv.lock.
-
+Usage: t3 tool bump-deps [OPTIONS]                                             
+                                                                                
+ Bump pyproject.toml dependencies from uv.lock.                                 
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -551,10 +551,10 @@ Usage: t3 tool bump-deps [OPTIONS]
 #### `t3 tool sonar-check`
 
 ```
-Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
-
- Run local SonarQube analysis via Docker.
-
+Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]                               
+                                                                                
+ Run local SonarQube analysis via Docker.                                       
+                                                                                
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   repo_path      [REPO_PATH]  Path to repo (default: current directory)      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -573,10 +573,10 @@ Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
 #### `t3 tool claude-handover`
 
 ```
-Usage: t3 tool claude-handover [OPTIONS]
-
- Show Claude handover telemetry and runtime recommendations.
-
+Usage: t3 tool claude-handover [OPTIONS]                                       
+                                                                                
+ Show Claude handover telemetry and runtime recommendations.                    
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --current-runtime        TEXT  Current CLI runtime. Defaults to the          │
 │                                highest-priority configured runtime.          │
@@ -592,10 +592,10 @@ Usage: t3 tool claude-handover [OPTIONS]
 ### `t3 setup`
 
 ```
-Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
-
- First-time setup and global skill management.
-
+Usage: t3 setup [OPTIONS] COMMAND [ARGS]...                                    
+                                                                                
+ First-time setup and global skill management.                                  
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --claude-scope        TEXT  Claude plugin install scope: user or project.    │
 │                             [default: user]                                  │
@@ -607,10 +607,10 @@ Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
 ### `t3 assess`
 
 ```
-Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
-
- Codebase health assessment.
-
+Usage: t3 assess [OPTIONS] COMMAND [ARGS]...                                   
+                                                                                
+ Codebase health assessment.                                                    
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -623,10 +623,10 @@ Usage: t3 assess [OPTIONS] COMMAND [ARGS]...
 #### `t3 assess run`
 
 ```
-Usage: t3 assess run [OPTIONS]
-
- Run deterministic codebase metrics on a repository.
-
+Usage: t3 assess run [OPTIONS]                                                 
+                                                                                
+ Run deterministic codebase metrics on a repository.                            
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root                 PATH  Repository root to assess                       │
 │ --json                       Output raw JSON                                 │
@@ -639,10 +639,10 @@ Usage: t3 assess run [OPTIONS]
 #### `t3 assess history`
 
 ```
-Usage: t3 assess history [OPTIONS]
-
- Show assessment history for a repository.
-
+Usage: t3 assess history [OPTIONS]                                             
+                                                                                
+ Show assessment history for a repository.                                      
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --root           PATH     Repository root                                    │
 │ --limit  -n      INTEGER  Number of recent assessments to show [default: 10] │
@@ -653,10 +653,10 @@ Usage: t3 assess history [OPTIONS]
 ### `t3 infra`
 
 ```
-Usage: t3 infra [OPTIONS] COMMAND [ARGS]...
-
- Teatree-wide infrastructure services.
-
+Usage: t3 infra [OPTIONS] COMMAND [ARGS]...                                    
+                                                                                
+ Teatree-wide infrastructure services.                                          
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -668,10 +668,10 @@ Usage: t3 infra [OPTIONS] COMMAND [ARGS]...
 #### `t3 infra redis`
 
 ```
-Usage: t3 infra redis [OPTIONS] COMMAND [ARGS]...
-
- Shared Redis container (teatree-redis).
-
+Usage: t3 infra redis [OPTIONS] COMMAND [ARGS]...                              
+                                                                                
+ Shared Redis container (teatree-redis).                                        
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -685,10 +685,10 @@ Usage: t3 infra redis [OPTIONS] COMMAND [ARGS]...
 ##### `t3 infra redis up`
 
 ```
-Usage: t3 infra redis up [OPTIONS]
-
- Start the shared Redis container (idempotent).
-
+Usage: t3 infra redis up [OPTIONS]                                             
+                                                                                
+ Start the shared Redis container (idempotent).                                 
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -697,10 +697,10 @@ Usage: t3 infra redis up [OPTIONS]
 ##### `t3 infra redis down`
 
 ```
-Usage: t3 infra redis down [OPTIONS]
-
- Stop the shared Redis container.
-
+Usage: t3 infra redis down [OPTIONS]                                           
+                                                                                
+ Stop the shared Redis container.                                               
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -709,11 +709,12 @@ Usage: t3 infra redis down [OPTIONS]
 ##### `t3 infra redis status`
 
 ```
-Usage: t3 infra redis status [OPTIONS]
-
- Print the shared Redis container status.
-
+Usage: t3 infra redis status [OPTIONS]                                         
+                                                                                
+ Print the shared Redis container status.                                       
+                                                                                
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
+

--- a/docs/install.md
+++ b/docs/install.md
@@ -102,6 +102,34 @@ uv sync
 t3 doctor check                    # both show as editable
 ```
 
+### Dogfood a teatree branch with an overlay
+
+When developing a teatree feature on a ticket branch and you need to drive it through an overlay in the browser:
+
+```sh
+cd ~/workspace/ac-teatree-123-my-branch/teatree     # teatree worktree
+t3 overlay install <overlay-name>                    # e.g. t3-acme
+t3 dashboard
+```
+
+This creates a sibling `git worktree` for the overlay (matching the teatree branch when it exists, otherwise the overlay's default branch) and installs it editable into the teatree worktree's `.venv`. The worktree's `t3` shadows the global install while you're inside it, so the dashboard and any agents use that branch's code.
+
+Configure the overlay's main clone path in `~/.teatree.toml`:
+
+```toml
+[overlays.t3-acme]
+path = "~/workspace/t3-acme"
+```
+
+Undo and inspect:
+
+```sh
+t3 overlay status
+t3 overlay uninstall <overlay-name>
+```
+
+The main clone (detected via a real `.git` directory) refuses `install` — use this in worktrees only. Tracked overlays persist in `.t3.local.json` (gitignored).
+
 ## Overlay discovery
 
 Overlays register via standard Python entry points in `pyproject.toml`:

--- a/scripts/hooks/check_quality_gates.py
+++ b/scripts/hooks/check_quality_gates.py
@@ -122,6 +122,8 @@ def main() -> int:
             and not filename.startswith("tests/")
             and not filename.startswith("scripts/hooks/")
             and not filename.startswith("e2e/")
+            and not filename.startswith("skills/")
+            and not filename.startswith("docs/")
             for pattern in _CODE_RELAXATION_PATTERNS
             if pattern in line
         )

--- a/scripts/hooks/generate_cli_reference.py
+++ b/scripts/hooks/generate_cli_reference.py
@@ -23,6 +23,7 @@ def main(argv: list[str] | None = None) -> int:
     from teatree.cli_reference import build_cli_reference_from_app
 
     markdown = build_cli_reference_from_app(app)
+    markdown = "\n".join(line.rstrip() for line in markdown.splitlines()).rstrip("\n") + "\n"
 
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(markdown, encoding="utf-8")

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -63,6 +63,7 @@ When the active overlay has `require_ticket = True`, refuse to commit or push wi
 - Format commit message following the project's commit format reference.
 - **Link commits to issues.** Check `t3 overlay config --key mr_close_ticket`: when `true`, use `Fixes #<number>` or `Closes #<number>` in the commit message body (auto-closes on merge); when `false`, use `Relates-to #<number>` (links without closing). This applies to ALL repos.
 - Read `TICKET_URL` from `.env.worktree` — never construct it from the branch name.
+- **Baseline noqa in new files uses `relax:` type.** The teatree `quality-gates` hook flags any new `# noqa` / `# type: ignore` / `# pragma: no cover` in source files (excluding `tests/`, `scripts/hooks/`, `e2e/`). When a new file needs the house pattern `# noqa: S404` at `import subprocess` and `# noqa: S603` at each `subprocess.run` call (the pattern used by every existing CLI module), the hook treats it as a relaxation. Use `relax(<scope>): …` as the commit type, with a body explaining it follows the established baseline. Do NOT remove the suppressions — the ruff config relies on them.
 
 ### 2. Finalize Branch
 

--- a/skills/workspace/SKILL.md
+++ b/skills/workspace/SKILL.md
@@ -136,7 +136,7 @@ Each worktree gets its own **isolated environment** — dedicated database, port
 - Never use the main repo's database for worktree work
 - Never manually set ports — let `t3 lifecycle setup` allocate them via `find_free_ports()`
 
-When testing an MR, create a full worktree (`t3 workspace ticket` + `t3 lifecycle setup` + `t3 lifecycle start`).
+When testing an MR, create a full worktree (`t3 <overlay> workspace ticket` + `t3 lifecycle setup` + `t3 lifecycle start`).
 
 ### Validate After Provisioning (Non-Negotiable)
 

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -20,6 +20,7 @@ from teatree.cli.ci import ci_app
 from teatree.cli.doctor import DoctorService, IntrospectionHelpers, doctor_app
 from teatree.cli.infra import infra_app
 from teatree.cli.overlay import OverlayAppBuilder, _uvicorn, managepy
+from teatree.cli.overlay_dev import overlay_dev_app
 from teatree.cli.review import review_app
 from teatree.cli.setup import setup_app
 from teatree.cli.tools import tool_app
@@ -642,6 +643,8 @@ app.add_typer(tool_app, name="tool")
 app.add_typer(setup_app, name="setup")
 
 app.add_typer(assess_app, name="assess")
+
+app.add_typer(overlay_dev_app, name="overlay")
 
 app.add_typer(infra_app, name="infra")
 

--- a/src/teatree/cli/overlay_dev.py
+++ b/src/teatree/cli/overlay_dev.py
@@ -1,0 +1,5 @@
+"""Dev-mode overlay install/uninstall for dogfooding teatree branches."""
+
+import typer
+
+overlay_dev_app = typer.Typer(no_args_is_help=True, help="Dev-mode overlay install/uninstall.")

--- a/src/teatree/cli/overlay_dev.py
+++ b/src/teatree/cli/overlay_dev.py
@@ -1,11 +1,18 @@
 """Dev-mode overlay install/uninstall for dogfooding teatree branches."""
 
+import json
+import subprocess  # noqa: S404
 import tomllib
 from pathlib import Path
 
 import typer
 
+from teatree.config import CONFIG_PATH, load_config
+
 overlay_dev_app = typer.Typer(no_args_is_help=True, help="Dev-mode overlay install/uninstall.")
+
+
+STATE_FILENAME = ".t3.local.json"
 
 
 class OverlayDevError(RuntimeError):
@@ -31,3 +38,140 @@ def _resolve_teatree_worktree(cwd: Path) -> Path:
         return candidate
     msg = f"No teatree worktree found walking up from {cwd}"
     raise OverlayDevError(msg)
+
+
+def _resolve_overlay_source(name: str, config_path: Path | None = None) -> Path:
+    effective_path = config_path if config_path is not None else CONFIG_PATH
+    config = load_config(effective_path)
+    overlay_cfg = config.raw.get("overlays", {}).get(name)
+    if not overlay_cfg:
+        msg = f"Overlay {name!r} not configured in {effective_path}"
+        raise OverlayDevError(msg)
+    path = overlay_cfg.get("path", "")
+    if not path:
+        msg = f"Overlay {name!r} has no path configured in {effective_path}"
+        raise OverlayDevError(msg)
+    return Path(path).expanduser().resolve()
+
+
+def _branch_exists(repo: Path, branch: str) -> bool:
+    result = subprocess.run(  # noqa: S603
+        ["git", "-C", str(repo), "rev-parse", "--verify", branch],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _default_branch(repo: Path) -> str:
+    result = subprocess.run(  # noqa: S603
+        ["git", "-C", str(repo), "symbolic-ref", "refs/remotes/origin/HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip().rsplit("/", 1)[-1]
+    return "main"
+
+
+def _current_branch(worktree: Path) -> str:
+    result = subprocess.run(  # noqa: S603
+        ["git", "-C", str(worktree), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() or "main"
+
+
+def _ensure_sibling_worktree(teatree_worktree: Path, main_clone: Path, *, branch: str) -> Path:
+    sibling = teatree_worktree.parent / main_clone.name
+    if sibling.exists():
+        return sibling
+    target_branch = branch if _branch_exists(main_clone, branch) else _default_branch(main_clone)
+    subprocess.run(  # noqa: S603
+        ["git", "-C", str(main_clone), "worktree", "add", str(sibling), target_branch],
+        check=True,
+    )
+    return sibling
+
+
+def _uv_pip_install_editable(teatree_worktree: Path, overlay_path: Path) -> None:
+    subprocess.run(  # noqa: S603
+        ["uv", "pip", "install", "--editable", "--no-deps", str(overlay_path)],
+        cwd=teatree_worktree,
+        check=True,
+    )
+
+
+def _uv_pip_uninstall(teatree_worktree: Path, name: str) -> None:
+    subprocess.run(  # noqa: S603
+        ["uv", "pip", "uninstall", name],
+        cwd=teatree_worktree,
+        check=False,
+    )
+
+
+def _load_state(worktree: Path) -> dict:
+    path = worktree / STATE_FILENAME
+    if not path.is_file():
+        return {"overlays": {}}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _save_state(worktree: Path, state: dict) -> None:
+    (worktree / STATE_FILENAME).write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+@overlay_dev_app.command("install")
+def install(name: str = typer.Argument(..., help="Overlay name as configured in ~/.teatree.toml.")) -> None:
+    """Install an overlay editable into the current teatree worktree for dogfooding."""
+    try:
+        worktree = _resolve_teatree_worktree(Path.cwd())
+        main_clone = _resolve_overlay_source(name)
+        branch = _current_branch(worktree)
+        sibling = _ensure_sibling_worktree(worktree, main_clone, branch=branch)
+        _uv_pip_install_editable(worktree, sibling)
+    except OverlayDevError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    state = _load_state(worktree)
+    state.setdefault("overlays", {})[name] = {"source": str(sibling)}
+    _save_state(worktree, state)
+    typer.echo(f"Installed {name} from {sibling}")
+
+
+@overlay_dev_app.command("uninstall")
+def uninstall(name: str = typer.Argument(..., help="Overlay name to uninstall.")) -> None:
+    """Uninstall an overlay from the current teatree worktree venv."""
+    try:
+        worktree = _resolve_teatree_worktree(Path.cwd())
+    except OverlayDevError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    _uv_pip_uninstall(worktree, name)
+    state = _load_state(worktree)
+    state.setdefault("overlays", {}).pop(name, None)
+    _save_state(worktree, state)
+    typer.echo(f"Uninstalled {name}")
+
+
+@overlay_dev_app.command("status")
+def status() -> None:
+    """Show overlays currently installed into this teatree worktree."""
+    try:
+        worktree = _resolve_teatree_worktree(Path.cwd())
+    except OverlayDevError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    overlays = _load_state(worktree).get("overlays", {})
+    if not overlays:
+        typer.echo("No overlays installed in this worktree.")
+        return
+    for overlay_name, info in sorted(overlays.items()):
+        typer.echo(f"  {overlay_name}  <-  {info.get('source', '?')}")

--- a/src/teatree/cli/overlay_dev.py
+++ b/src/teatree/cli/overlay_dev.py
@@ -1,5 +1,33 @@
 """Dev-mode overlay install/uninstall for dogfooding teatree branches."""
 
+import tomllib
+from pathlib import Path
+
 import typer
 
 overlay_dev_app = typer.Typer(no_args_is_help=True, help="Dev-mode overlay install/uninstall.")
+
+
+class OverlayDevError(RuntimeError):
+    """Raised when an overlay dev operation can't proceed."""
+
+
+def _resolve_teatree_worktree(cwd: Path) -> Path:
+    for candidate in [cwd, *cwd.parents]:
+        pyproject = candidate / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        if data.get("project", {}).get("name") != "teatree":
+            msg = f"{candidate} is not a teatree worktree"
+            raise OverlayDevError(msg)
+        git_marker = candidate / ".git"
+        if git_marker.is_dir():
+            msg = f"{candidate} is the main clone, not a worktree — refusing to install overlays"
+            raise OverlayDevError(msg)
+        if not git_marker.is_file():
+            msg = f"{candidate} has no .git marker"
+            raise OverlayDevError(msg)
+        return candidate
+    msg = f"No teatree worktree found walking up from {cwd}"
+    raise OverlayDevError(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,10 @@ import pytest
 # a dashboard session). pytest-django falls back to pyproject.toml when the
 # env var is absent.
 os.environ.pop("DJANGO_SETTINGS_MODULE", None)
-# Strip T3_OVERLAY_NAME so tests don't resolve the host overlay (e.g. t3-teatree)
-os.environ.pop("T3_OVERLAY_NAME", None)
+# Pin T3_OVERLAY_NAME to the in-repo overlay so tests stay deterministic even
+# when extra overlays are editable-installed for dogfooding (see #120). Tests
+# that exercise overlay resolution override via monkeypatch.setenv/delenv.
+os.environ["T3_OVERLAY_NAME"] = "t3-teatree"
 
 # Guard against import-time side effects in script modules that call _init.init()
 # at module import. Route HOME/T3_WORKSPACE_DIR to a disposable temp sandbox.

--- a/tests/test_cli_overlay_dev.py
+++ b/tests/test_cli_overlay_dev.py
@@ -1,0 +1,10 @@
+import teatree.cli.overlay_dev
+from teatree.cli.overlay_dev import overlay_dev_app
+
+
+class TestOverlayDevModule:
+    def test_module_importable(self) -> None:
+        assert teatree.cli.overlay_dev is not None
+
+    def test_has_typer_app(self) -> None:
+        assert overlay_dev_app is not None

--- a/tests/test_cli_overlay_dev.py
+++ b/tests/test_cli_overlay_dev.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+
+import pytest
+
 import teatree.cli.overlay_dev
-from teatree.cli.overlay_dev import overlay_dev_app
+from teatree.cli.overlay_dev import OverlayDevError, _resolve_teatree_worktree, overlay_dev_app
 
 
 class TestOverlayDevModule:
@@ -8,3 +12,47 @@ class TestOverlayDevModule:
 
     def test_has_typer_app(self) -> None:
         assert overlay_dev_app is not None
+
+
+class TestResolveTeatreeWorktree:
+    def _make_worktree(self, path: Path) -> Path:
+        path.mkdir(parents=True)
+        (path / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
+        (path / ".git").write_text("gitdir: /fake\n")
+        return path
+
+    def test_returns_worktree_root_when_cwd_is_worktree(self, tmp_path: Path) -> None:
+        worktree = self._make_worktree(tmp_path / "ac-teatree-120-xyz" / "teatree")
+
+        assert _resolve_teatree_worktree(worktree) == worktree
+
+    def test_walks_up_from_subdirectory(self, tmp_path: Path) -> None:
+        worktree = self._make_worktree(tmp_path / "ac-teatree-120-xyz" / "teatree")
+        (worktree / "src" / "teatree").mkdir(parents=True)
+
+        assert _resolve_teatree_worktree(worktree / "src" / "teatree") == worktree
+
+    def test_refuses_main_clone(self, tmp_path: Path) -> None:
+        clone = tmp_path / "souliane" / "teatree"
+        clone.mkdir(parents=True)
+        (clone / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
+        (clone / ".git").mkdir()
+
+        with pytest.raises(OverlayDevError, match="main clone"):
+            _resolve_teatree_worktree(clone)
+
+    def test_refuses_non_teatree_dir(self, tmp_path: Path) -> None:
+        other = tmp_path / "other-repo"
+        other.mkdir()
+        (other / "pyproject.toml").write_text('[project]\nname = "other"\n')
+        (other / ".git").write_text("gitdir: /fake\n")
+
+        with pytest.raises(OverlayDevError, match="not a teatree"):
+            _resolve_teatree_worktree(other)
+
+    def test_raises_when_no_pyproject_found(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        with pytest.raises(OverlayDevError, match="No teatree worktree"):
+            _resolve_teatree_worktree(empty)

--- a/tests/test_cli_overlay_dev.py
+++ b/tests/test_cli_overlay_dev.py
@@ -1,9 +1,26 @@
+import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
+from typer.testing import CliRunner
 
 import teatree.cli.overlay_dev
-from teatree.cli.overlay_dev import OverlayDevError, _resolve_teatree_worktree, overlay_dev_app
+from teatree.cli.overlay_dev import (
+    OverlayDevError,
+    _ensure_sibling_worktree,
+    _resolve_overlay_source,
+    _resolve_teatree_worktree,
+    _uv_pip_install_editable,
+    overlay_dev_app,
+)
+
+
+def _make_worktree(path: Path) -> Path:
+    path.mkdir(parents=True)
+    (path / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
+    (path / ".git").write_text("gitdir: /fake\n")
+    return path
 
 
 class TestOverlayDevModule:
@@ -15,19 +32,13 @@ class TestOverlayDevModule:
 
 
 class TestResolveTeatreeWorktree:
-    def _make_worktree(self, path: Path) -> Path:
-        path.mkdir(parents=True)
-        (path / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
-        (path / ".git").write_text("gitdir: /fake\n")
-        return path
-
     def test_returns_worktree_root_when_cwd_is_worktree(self, tmp_path: Path) -> None:
-        worktree = self._make_worktree(tmp_path / "ac-teatree-120-xyz" / "teatree")
+        worktree = _make_worktree(tmp_path / "ac-teatree-120-xyz" / "teatree")
 
         assert _resolve_teatree_worktree(worktree) == worktree
 
     def test_walks_up_from_subdirectory(self, tmp_path: Path) -> None:
-        worktree = self._make_worktree(tmp_path / "ac-teatree-120-xyz" / "teatree")
+        worktree = _make_worktree(tmp_path / "ac-teatree-120-xyz" / "teatree")
         (worktree / "src" / "teatree").mkdir(parents=True)
 
         assert _resolve_teatree_worktree(worktree / "src" / "teatree") == worktree
@@ -56,3 +67,176 @@ class TestResolveTeatreeWorktree:
 
         with pytest.raises(OverlayDevError, match="No teatree worktree"):
             _resolve_teatree_worktree(empty)
+
+
+class TestResolveOverlaySource:
+    def test_resolves_from_toml_path(self, tmp_path: Path) -> None:
+        main_clone = tmp_path / "acme-workspace" / "example-overlay"
+        main_clone.mkdir(parents=True)
+        config = tmp_path / "teatree.toml"
+        config.write_text(f'[overlays.example-overlay]\npath = "{main_clone}"\n')
+
+        assert _resolve_overlay_source("example-overlay", config_path=config) == main_clone
+
+    def test_raises_when_overlay_missing(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        config.write_text("")
+
+        with pytest.raises(OverlayDevError, match="not configured"):
+            _resolve_overlay_source("ghost", config_path=config)
+
+    def test_raises_when_path_missing(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        config.write_text('[overlays.example-overlay]\nclass = "foo:Bar"\n')
+
+        with pytest.raises(OverlayDevError, match="no path configured"):
+            _resolve_overlay_source("example-overlay", config_path=config)
+
+
+class TestEnsureSiblingWorktree:
+    def test_returns_existing_sibling(self, tmp_path: Path) -> None:
+        ticket_dir = tmp_path / "ac-teatree-120-xyz"
+        teatree_wt = ticket_dir / "teatree"
+        teatree_wt.mkdir(parents=True)
+        sibling = ticket_dir / "example-overlay"
+        sibling.mkdir()
+        main_clone = tmp_path / "main" / "example-overlay"
+        main_clone.mkdir(parents=True)
+
+        assert _ensure_sibling_worktree(teatree_wt, main_clone, branch="any") == sibling
+
+    def test_creates_sibling_via_git_worktree_add(self, tmp_path: Path) -> None:
+        ticket_dir = tmp_path / "ac-teatree-120-xyz"
+        teatree_wt = ticket_dir / "teatree"
+        teatree_wt.mkdir(parents=True)
+        main_clone = tmp_path / "main" / "example-overlay"
+        main_clone.mkdir(parents=True)
+
+        with patch("teatree.cli.overlay_dev.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = _ensure_sibling_worktree(teatree_wt, main_clone, branch="ac-teatree-120")
+
+        assert result == ticket_dir / "example-overlay"
+        cmds = [call.args[0] for call in run.call_args_list]
+        assert any(("worktree" in c and "add" in c) for c in cmds)
+        add_cmd = next(c for c in cmds if "add" in c)
+        assert str(ticket_dir / "example-overlay") in add_cmd
+
+    def test_falls_back_to_default_branch_when_branch_missing(self, tmp_path: Path) -> None:
+        ticket_dir = tmp_path / "ac-teatree-120-xyz"
+        teatree_wt = ticket_dir / "teatree"
+        teatree_wt.mkdir(parents=True)
+        main_clone = tmp_path / "main" / "example-overlay"
+        main_clone.mkdir(parents=True)
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            calls.append(cmd)
+            if "rev-parse" in cmd and "--verify" in cmd:
+                return MagicMock(returncode=1, stdout="", stderr="not a branch")
+            if "symbolic-ref" in cmd:
+                return MagicMock(returncode=0, stdout="refs/remotes/origin/development\n", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("teatree.cli.overlay_dev.subprocess.run", side_effect=fake_run):
+            _ensure_sibling_worktree(teatree_wt, main_clone, branch="missing-branch")
+
+        add_cmd = next(c for c in calls if "add" in c)
+        assert "missing-branch" not in add_cmd
+        assert "development" in add_cmd
+
+
+class TestUvPipInstall:
+    def test_runs_uv_pip_install_editable_no_deps(self, tmp_path: Path) -> None:
+        worktree = tmp_path / "teatree"
+        worktree.mkdir()
+        overlay = tmp_path / "example-overlay"
+        overlay.mkdir()
+
+        with patch("teatree.cli.overlay_dev.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0)
+            _uv_pip_install_editable(worktree, overlay)
+
+        cmd = run.call_args.args[0]
+        assert cmd[:3] == ["uv", "pip", "install"]
+        assert "--editable" in cmd
+        assert "--no-deps" in cmd
+        assert str(overlay) in cmd
+        assert run.call_args.kwargs["cwd"] == worktree
+
+
+class TestInstallCommand:
+    def test_install_end_to_end(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        ticket_dir = tmp_path / "ac-teatree-120-xyz"
+        teatree_wt = _make_worktree(ticket_dir / "teatree")
+        main_clone = tmp_path / "workspace" / "example-overlay"
+        main_clone.mkdir(parents=True)
+        config = tmp_path / "teatree.toml"
+        config.write_text(f'[overlays.example-overlay]\npath = "{main_clone}"\n')
+        monkeypatch.setattr("teatree.cli.overlay_dev.CONFIG_PATH", config)
+        monkeypatch.chdir(teatree_wt)
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0, stdout="main\n", stderr="")
+
+        with patch("teatree.cli.overlay_dev.subprocess.run", side_effect=fake_run):
+            result = CliRunner().invoke(overlay_dev_app, ["install", "example-overlay"])
+
+        assert result.exit_code == 0, result.output
+        assert any(("worktree" in c and "add" in c) for c in captured)
+        assert any(("uv" in c and "install" in c) for c in captured)
+        state = json.loads((teatree_wt / ".t3.local.json").read_text())
+        assert "example-overlay" in state["overlays"]
+
+
+class TestUninstallCommand:
+    def test_uninstall_removes_editable_and_state(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        teatree_wt = _make_worktree(tmp_path / "ac-teatree-120-xyz" / "teatree")
+        (teatree_wt / ".t3.local.json").write_text('{"overlays": {"example-overlay": {"source": "/tmp/x"}}}')
+        monkeypatch.chdir(teatree_wt)
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            captured.append(cmd)
+            return MagicMock(returncode=0)
+
+        with patch("teatree.cli.overlay_dev.subprocess.run", side_effect=fake_run):
+            result = CliRunner().invoke(overlay_dev_app, ["uninstall", "example-overlay"])
+
+        assert result.exit_code == 0, result.output
+        assert any(("uv" in c and "uninstall" in c and "example-overlay" in c) for c in captured)
+        state = json.loads((teatree_wt / ".t3.local.json").read_text())
+        assert "example-overlay" not in state["overlays"]
+
+
+class TestStatusCommand:
+    def test_status_lists_installed_overlays(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        teatree_wt = _make_worktree(tmp_path / "ac-teatree-120-xyz" / "teatree")
+        (teatree_wt / ".t3.local.json").write_text(
+            '{"overlays": {"example-overlay": {"source": "/tmp/example-overlay"}}}'
+        )
+        monkeypatch.chdir(teatree_wt)
+
+        result = CliRunner().invoke(overlay_dev_app, ["status"])
+
+        assert result.exit_code == 0, result.output
+        assert "example-overlay" in result.output
+        assert "/tmp/example-overlay" in result.output
+
+    def test_status_reports_none_when_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        teatree_wt = _make_worktree(tmp_path / "ac-teatree-120-xyz" / "teatree")
+        monkeypatch.chdir(teatree_wt)
+
+        result = CliRunner().invoke(overlay_dev_app, ["status"])
+
+        assert result.exit_code == 0
+        assert "No overlays installed" in result.output


### PR DESCRIPTION
feat(cli): automate overlay install/uninstall for dev vs test workflows (#120)

## Summary

Adds `t3 overlay install|uninstall|status` to automate the dogfood loop between a teatree worktree and a sibling overlay worktree.

- `t3 overlay install <name>` — resolves overlay path from `~/.teatree.toml[overlays.<name>].path`, creates a sibling git worktree under the ticket dir (falls back to the overlay's default branch if the ticket branch doesn't exist), runs `uv pip install --editable --no-deps`, and records state in `.t3.local.json`.
- `t3 overlay uninstall <name>` — `uv pip uninstall` + clears state entry.
- `t3 overlay status` — lists installed overlays with source paths.
- Refuses to run in the main clone (detects via `.git` as a real directory).
- `conftest.py` pins `T3_OVERLAY_NAME=t3-teatree` so test determinism survives extra editable installs.

Fixes #120.

## Secondary fix (bundled)

`scripts/hooks/generate_cli_reference.py` now strips trailing whitespace per line and normalizes EOF before writing. Eliminates a pre-commit iteration loop between `generate_cli_reference` and `trailing-whitespace` / `end-of-file-fixer` — 199 trailing-whitespace lines eliminated in one pass.

`scripts/hooks/check_quality_gates.py` excludes `skills/` and `docs/` so prose mentioning `# noqa` in instructional content isn't flagged as source-level lint suppression.

## Test plan

- [x] 18 new unit tests in `tests/test_cli_overlay_dev.py` all pass
- [x] Full suite green locally (`uv run pytest --no-cov -x -q`)
- [x] Ruff + prek hooks green
- [x] `t3 overlay --help` shows the new commands (verified via generated CLI reference)
- [ ] Dogfood: install a real overlay (e.g. `t3-company`) into a teatree worktree and verify editable install resolves to the sibling worktree
