### PR TITLE
fix(db): never auto-fall-back to remote pg_dump

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -100,8 +100,16 @@ _BLOCKED_COMMANDS: list[tuple[re.Pattern[str], str]] = [
         "BLOCKED: `pip/pipenv install` — use `t3 <overlay> lifecycle setup` instead.",
     ),
     (
-        re.compile(r"\b(?:pg_restore|pg_dump|dslr)\b"),
-        "BLOCKED: `pg_restore`/`pg_dump`/`dslr` — use `t3 <overlay> db refresh` instead.",
+        re.compile(r"\b(?:pg_restore|pg_dump)\b"),
+        "BLOCKED: `pg_restore`/`pg_dump` — use `t3 <overlay> db refresh` instead.",
+    ),
+    (
+        re.compile(r"\bdslr\s+(?:restore|import|snapshot|rename|export)\b"),
+        (
+            "BLOCKED: mutating `dslr` subcommand — use "
+            "`t3 <overlay> db refresh --dslr-snapshot <name>` instead. "
+            "Only `dslr list` and `dslr delete` are allowed."
+        ),
     ),
     (
         re.compile(r"\buv\s+run\s+(?:\S+\s+)*?t3(?:\s|$)"),
@@ -582,6 +590,29 @@ def handle_session_end(data: dict) -> None:
 # ── PreToolUse: block-direct-commands ────────────────────────────────
 
 
+_REMOTE_DUMP_ENV_RE = re.compile(r"\bT3_ALLOW_REMOTE_DUMP\s*=\s*1\b")
+_REMOTE_DUMP_DENY_REASON = (
+    "BLOCKED: agents must never set `T3_ALLOW_REMOTE_DUMP=1`. "
+    "Remote pg_dump over VPN requires explicit human action in a terminal — "
+    "the agent cannot opt in. Ask the user to run the command themselves."
+)
+
+
+def _deny_match(command: str) -> str | None:
+    """Return a deny reason for *command*, or None if it should pass through."""
+    # Checked FIRST — even before t3/read-only bypass — because agents must
+    # never opt in to remote pg_dump regardless of the surrounding command.
+    if _REMOTE_DUMP_ENV_RE.search(command):
+        return _REMOTE_DUMP_DENY_REASON
+    stripped = command.lstrip()
+    if _T3_CMD_PREFIX_RE.match(stripped) or _READONLY_CMD_PREFIX_RE.match(stripped):
+        return None
+    for pattern, reason in _BLOCKED_COMMANDS:
+        if pattern.search(command):
+            return reason + " If `t3` fails, fix the CLI — do not work around it."
+    return None
+
+
 def handle_block_direct_commands(data: dict) -> bool:
     """Block Bash commands that bypass the t3 CLI.
 
@@ -589,31 +620,14 @@ def handle_block_direct_commands(data: dict) -> bool:
     """
     if data.get("tool_name") != "Bash":
         return False
-
     command = data.get("tool_input", {}).get("command", "")
     if not command:
         return False
-
-    stripped = command.lstrip()
-
-    # Never block legitimate t3 invocations.
-    if _T3_CMD_PREFIX_RE.match(stripped):
+    reason = _deny_match(command)
+    if reason is None:
         return False
-
-    # Never block read-only commands that may mention tools in arguments.
-    if _READONLY_CMD_PREFIX_RE.match(stripped):
-        return False
-
-    for pattern, reason in _BLOCKED_COMMANDS:
-        if pattern.search(command):
-            suffix = " If `t3` fails, fix the CLI — do not work around it."
-            json.dump(
-                {"permissionDecision": "deny", "permissionDecisionReason": reason + suffix},
-                sys.stdout,
-            )
-            return True
-
-    return False
+    json.dump({"permissionDecision": "deny", "permissionDecisionReason": reason}, sys.stdout)
+    return True
 
 
 # ── Router ──────────────────────────────────────────────────────────

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -462,11 +462,19 @@ def _try_restore_from_local_dump(ctx: _RestoreContext) -> bool:
 def _try_fetch_remote_dump(ctx: _RestoreContext) -> bool:
     """Fetch a fresh dump from the remote DB into dump_dir.
 
-    Returns True if a new dump file was saved (caller should re-run
-    local dump strategy). Returns False on failure.
+    Final safety gate: even when the caller passes ``allow_remote_dump=True``,
+    the environment variable ``T3_ALLOW_REMOTE_DUMP=1`` must also be set.
+    Prevents agent-triggered paths from auto-downloading gigabytes over VPN.
     """
     global _remote_dump_failed  # noqa: PLW0603
     cfg = ctx.cfg
+    if os.environ.get("T3_ALLOW_REMOTE_DUMP") != "1":
+        logger.warning(
+            "Remote pg_dump blocked for %s: set T3_ALLOW_REMOTE_DUMP=1 to allow "
+            "remote dump fallback. Agents must never set this env var.",
+            cfg.ref_db_name,
+        )
+        return False
     if not cfg.remote_db_url:
         logger.info("Remote dump skipped (no remote_db_url configured)")
         return False

--- a/tests/test_bash_command_blocker.py
+++ b/tests/test_bash_command_blocker.py
@@ -65,6 +65,8 @@ class TestBlocksForbiddenCommands:
             ("uv run t3 teatree lifecycle setup", "install teatree"),
             ("uv run --no-sync t3 dashboard", "install teatree"),
             ("cd /tmp && uv run t3 info", "install teatree"),
+            ("dslr restore my_snap", "db"),
+            ("T3_ALLOW_REMOTE_DUMP=1 t3 myapp db refresh", "T3_ALLOW_REMOTE_DUMP"),
         ],
     )
     def test_denies_with_t3_alternative(
@@ -109,6 +111,8 @@ class TestAllowsLegitimateCommands:
             "echo 'run uv run t3 command'",
             "cat README.md",
             "grep -r 'playwright' .",
+            "dslr list",
+            "dslr delete old_snap",
         ],
     )
     def test_allows_command(

--- a/tests/test_django_db.py
+++ b/tests/test_django_db.py
@@ -614,11 +614,24 @@ class TestTryRestoreFromLocalDump:
 
 
 class TestTryFetchRemoteDump:
-    def test_skips_when_no_remote_url(self, tmp_path: Path) -> None:
+    def test_blocks_when_env_gate_not_set(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression guard: even with remote_url configured, the env gate must block.
+
+        2026-04-20 incident: agent-triggered lifecycle path auto-fetched gigabyte
+        dumps over VPN. The env gate is the final safety net.
+        """
+        monkeypatch.delenv("T3_ALLOW_REMOTE_DUMP", raising=False)
+        cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
+        ctx = _RestoreContext(cfg=cfg, dslr_cmd="", dslr_env={}, pg_host="h", pg_user="u", pg_env={})
+        assert _try_fetch_remote_dump(ctx) is False
+
+    def test_skips_when_no_remote_url(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
         ctx = _make_ctx(tmp_path)
         assert _try_fetch_remote_dump(ctx) is False
 
     def test_skips_when_already_failed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
         mod._remote_dump_failed = True
         cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
         ctx = _RestoreContext(cfg=cfg, dslr_cmd="", dslr_env={}, pg_host="h", pg_user="u", pg_env={})
@@ -626,6 +639,7 @@ class TestTryFetchRemoteDump:
         reset_remote_dump_state()
 
     def test_handles_timeout(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
         reset_remote_dump_state()
         (tmp_path / ".data").mkdir()
         cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
@@ -639,6 +653,7 @@ class TestTryFetchRemoteDump:
         reset_remote_dump_state()
 
     def test_handles_pg_dump_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
         reset_remote_dump_state()
         (tmp_path / ".data").mkdir()
         cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
@@ -648,6 +663,7 @@ class TestTryFetchRemoteDump:
         reset_remote_dump_state()
 
     def test_returns_true_after_successful_fetch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
         reset_remote_dump_state()
         data_dir = tmp_path / ".data"
         data_dir.mkdir()


### PR DESCRIPTION
fix(db): never auto-fall-back to remote pg_dump

## Summary

Two changes harden the remote-dump gate so agent-triggered lifecycle paths can't silently download gigabyte dumps over VPN:

- `django_db._try_fetch_remote_dump`: require `T3_ALLOW_REMOTE_DUMP=1` in the environment as a final safety gate, even when the caller passes `allow_remote_dump=True`. Prevents any in-process code path from reaching `pg_dump` without an explicit environment opt-in.
- `hook_router.handle_block_direct_commands`: block any Bash command that sets `T3_ALLOW_REMOTE_DUMP=1` (checked BEFORE the `t3`/read-only bypass). Remote `pg_dump` requires explicit human action in a terminal. Also narrowed the `dslr` block to mutating subcommands only, allowing `dslr list` and `dslr delete` for read-only inspection and cleanup.

## Incident

2026-04-20: parallel lifecycle start commands triggered three simultaneous `pg_dump` attempts against a shared remote DB over VPN; the fallback chain silently reached the remote path. Tests guard against regression.

## Test plan

- [x] `uv run pytest tests/test_bash_command_blocker.py tests/test_django_db.py --no-cov` — 124 passed
- [x] Cherry-picked cleanly onto current `main` (one trivial merge in the test-blocker parametrize list)
- [ ] CI green end-to-end
