### PR TITLE
fix(retro,workspace): squash-merge cross-check recipe, skip-worktree pitfall

### DIFF
--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -349,6 +349,42 @@ For each touched repo, collect and display:
 7. Suggest consolidating multiple commits targeting the same skill into one
 8. Present a concrete consolidation proposal and ask before acting
 
+#### Squash-merge cross-check (Non-Negotiable)
+
+Before treating any local branch or stash as "unpushed work", **cross-reference against merged PRs**. Squash merges create new commit hashes — ancestry checks return false even when the work is already on main. A false-positive here leads to pushing stale content or recommitting already-merged changes.
+
+For each candidate branch, run **both** checks:
+
+1. **Subject match** — does the branch's tip commit subject match a merged PR's title?
+
+   ```bash
+   gh pr list --repo <org>/<repo> --state merged --limit 80 --json number,title > /tmp/merged.json
+   ```
+
+   Strip `\s*\(#\d+\)$` from both `git log -1 --pretty=%s <branch>` and each `pr.title`. An exact match = squash-merged → safe to delete.
+
+2. **File existence check for stashes / orphan commits** — if the stash/branch edits a file, does that file still exist on main? `git show main:<path>` — if the file was deleted by a merged PR, the stash is obsolete regardless of subject.
+
+Any branch or stash that fails to match via (1) AND whose files still exist per (2) **must be treated as real unpushed work** and surfaced to the user with a concrete choice (push+PR / drop / show diff).
+
+Store the Python helper inline when needed — 20+ branches across 2 repos is repetitive enough to justify a script. Small script recipe (save output to `/tmp/` for session reuse):
+
+```python
+# Input: gh pr list --state merged JSON at /tmp/merged.json, list of branches to check
+# Output: classification per branch (SAFE_TO_DELETE / NEEDS_REVIEW / NO_COMMITS_AHEAD)
+import json, subprocess, re
+with open("/tmp/merged.json") as f:
+    merged = {re.sub(r"\s*\(#\d+\)$", "", p["title"]).strip() for p in json.load(f)}
+for b in branches:
+    subj = re.sub(r"\s*\(#\d+\)$", "",
+        subprocess.check_output(["git", "log", "-1", "--pretty=%s", b], text=True).strip()).strip()
+    ahead = subprocess.check_output(["git", "log", "origin/main..%s" % b, "--pretty=%s"], text=True).strip().splitlines()
+    status = "SAFE_TO_DELETE" if subj in merged else ("NEEDS_REVIEW" if ahead else "NO_COMMITS_AHEAD")
+    print(f"{status:20} {b}")
+```
+
+`NEEDS_REVIEW` branches may still be merged — the PR may have a retitled subject. Fall back to broader needle searches (`gh pr list --search "<keyword>"`) or ask the user before deleting.
+
 ### 6. Verification
 
 After applying all fixes:

--- a/skills/workspace/references/troubleshooting.md
+++ b/skills/workspace/references/troubleshooting.md
@@ -29,6 +29,16 @@
 - **Cause:** A worktree for this branch already exists elsewhere.
 - **Fix:** Run `git worktree list` to find it. Remove with `git worktree remove <path>` if no longer needed.
 
+## Branch Switch Fails on "Clean" File (skip-worktree Pitfall)
+
+- **Symptom:** `git switch <branch>` or `git checkout <branch>` fails with `Your local changes to the following files would be overwritten by checkout` on a file that `git status` reports as clean.
+- **Cause:** The file has the `skip-worktree` flag set (commonly used to keep a local `pyproject.toml` override pointing at a sibling editable-install path — e.g. `teatree = { path = "../../souliane/teatree", editable = true }`). `git status` hides the difference; `git checkout` honors it and blocks the switch to prevent clobbering the local content.
+- **Diagnosis:** `git ls-files -v <file>` — lowercase `h` = skip-worktree is on (`H` = normal).
+- **Fix (safe):** Do not naively branch-switch in a clone that carries skip-worktree overrides. Either:
+  1. Leave the clone on its current branch and do the work in a dedicated worktree (`git worktree add`), OR
+  2. Temporarily clear the flag with `git update-index --no-skip-worktree <file>`, commit or stash the local override, switch branches, then restore the flag. **Never `git checkout <file>` to "resolve" it — that wipes the override.**
+- **Prevention:** Keep the dogfood override on a dedicated branch, not on whichever branch the main clone happens to be sitting on. If the override must live in the main clone, document it in the repo's `AGENTS.md` so future agents don't try to check out another branch there.
+
 ## DSLR Restore Fails Silently
 
 - **Cause:** `dslr` not installed or the snapshot is from an incompatible Postgres version.


### PR DESCRIPTION
fix(retro,workspace): squash-merge cross-check recipe, skip-worktree pitfall

## Summary

Two retro findings from the #120 session:

### Retro § 5b — squash-merge cross-check recipe

Adds a **Non-Negotiable** subsection: before treating any local branch or stash as "unpushed work", cross-reference against merged PRs via subject match. Squash merges create new hashes — ancestry checks return false even when the work is on main. Includes:

- The subject-match algorithm (strip `\s*\(#\d+\)$` from both local tip and PR titles)
- A file-level check for stashes / orphan commits (verify files still exist on main)
- An inline Python helper for batch classification (SAFE_TO_DELETE / NEEDS_REVIEW / NO_COMMITS_AHEAD)

**Why:** Session #120 was about to apply a 2-week-old t3-company stash whose `docker/Dockerfile.frontend` edit targeted a file that merged PR #31 had already deleted. Caught only by the user's "double check that stuff has not been squash merged" interrupt.

### Workspace troubleshooting — skip-worktree pitfall

`git switch <branch>` fails with "local changes would be overwritten" on a file that `git status` reports clean. Root cause: `skip-worktree` flag on a locally-modified `pyproject.toml` (common dogfood pattern pointing teatree to a sibling editable-install). Entry covers:

- Diagnosis via `git ls-files -v <file>` (lowercase `h`)
- Safe fixes (use a dedicated worktree, or `--no-skip-worktree` + stash/commit override + switch + restore)
- Prevention (keep the override on a dedicated branch)

## Test plan

- [x] Pre-commit hooks pass (markdownlint, EOF, trailing whitespace, quality gates)
- [x] Privacy scan exit 0
