### PR TITLE
relax(ticket): auto-dispatch next-phase task after every phase boundary

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -159,8 +159,8 @@ The central entity. One ticket per unit of work (maps to an issue/task in the tr
 | Method | Source → Target | Side effects |
 |--------|----------------|--------------|
 | `scope(issue_url=, variant=, repos=)` | not_started → scoped | Sets issue_url, variant, repos |
-| `start()` | scoped → started | — |
-| `code()` | started → coded | — |
+| `start()` | scoped → started | Calls `schedule_coding()` |
+| `code()` | started → coded | Calls `schedule_testing()` |
 | `test(passed=True)` | coded → tested | Stores `tests_passed` in extra; calls `schedule_review()` |
 | `review()` | tested → reviewed | Condition: reviewing task completed. Calls `schedule_shipping()` |
 | `ship(mr_urls=[])` | reviewed → shipped | Stores MR URLs in extra |
@@ -169,7 +169,14 @@ The central entity. One ticket per unit of work (maps to an issue/task in the tr
 | `mark_delivered()` | merged → delivered | — |
 | `rework()` | coded/tested/reviewed → started | Clears tests_passed, cancels pending tasks |
 
-**Auto-scheduling:** `test()` auto-creates a headless reviewing task. `review()` auto-creates a headless shipping task. Both use fresh sessions (bias-free evaluation).
+**Auto-scheduling:** each phase transition auto-creates the next-phase task in a fresh session (bias-free evaluation):
+
+- `start()` → headless coding task
+- `code()` → headless testing task
+- `test()` → headless reviewing task
+- `review()` → shipping task (execution target gated by `T3_AUTO_SHIP`)
+
+`schedule_shipping()` defaults to `ExecutionTarget.INTERACTIVE` so the user must explicitly approve the push. Set `T3_AUTO_SHIP=true` in the environment to make shipping headless.
 
 **`extra` structure:**
 
@@ -287,8 +294,13 @@ Represents a unit of work for an agent (headless or interactive).
 **Completion flow:** `complete()` → clears claim → calls `_advance_ticket()`:
 
 - If last attempt has `needs_user_input: true`: creates interactive followup task (same phase, parent_task linked, session carries the `agent_session_id` for resume)
-- If phase is "reviewing" and ticket is TESTED: calls `ticket.review()`
+- If phase is "scoping" and ticket is SCOPED: calls `ticket.start()` (→ schedules coding)
+- If phase is "coding" and ticket is STARTED: calls `ticket.code()` (→ schedules testing)
+- If phase is "testing" and ticket is CODED: calls `ticket.test(passed=True)` (→ schedules reviewing)
+- If phase is "reviewing" and ticket is TESTED: calls `ticket.review()` (→ schedules shipping)
 - If phase is "shipping" and ticket is REVIEWED: calls `ticket.ship()`
+
+Each guard is `phase + state` so repeat calls (e.g. from parallel child tasks) find the state mismatch and safely no-op after the first advance.
 
 **Session resume:** Both headless and interactive runners walk the `parent_task` chain to find a previous `agent_session_id`. When found, the CLI is invoked with `--resume <session_id>` to preserve full conversation context across execution mode switches.
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -82,6 +82,7 @@ Useful optional values:
 | `T3_CONTRIBUTE` | Allow self-improvement commits in the teatree repo | `false` |
 | `T3_PUSH` | Allow pushing retro commits (safety gate for privacy review) | `false` |
 | `T3_AUTO_PUSH_FORK` | Auto-push retro commits to the user's fork without prompting (requires `T3_PUSH=true` and origin ≠ `T3_UPSTREAM`) | `false` |
+| `T3_AUTO_SHIP` | Create shipping tasks as headless instead of interactive. When `false`, the pipeline pauses at shipping for user approval before push. | `false` |
 | `T3_UPSTREAM` | Upstream repo for PRs (empty = PR on origin, set = PR on upstream) | empty |
 | `T3_PRIVATE_TESTS` | Private QA repo path | empty |
 | `T3_BRANCH_PREFIX` | Branch prefix for generated worktrees | derived from git user |
@@ -102,6 +103,7 @@ T3_CHAT_PLATFORM="none"
 T3_CONTRIBUTE=false
 T3_PUSH=false
 T3_AUTO_PUSH_FORK=false
+T3_AUTO_SHIP=false
 T3_UPSTREAM=""
 T3_PRIVATE_TESTS=""
 T3_BRANCH_PREFIX="ac"

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -338,5 +338,6 @@ T3_REPO="$HOME/workspace/souliane/teatree"  # teatree repo path
 T3_CONTRIBUTE=true                           # allow retro to modify core skills
 T3_PUSH=false                                # gate pushes behind an explicit prompt
 T3_AUTO_PUSH_FORK=false                      # auto-push to fork when T3_PUSH=true and origin ≠ T3_UPSTREAM
+T3_AUTO_SHIP=false                           # when true, shipping tasks are headless; default gates push on user approval
 T3_PRIVACY=strict                            # block commits with PII
 ```

--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -107,13 +107,29 @@ class Task(models.Model):
         self._advance_ticket()
 
     def _advance_ticket(self) -> None:
-        """Auto-advance ticket state based on the completed task's phase."""
+        """Auto-advance ticket state based on the completed task's phase.
+
+        Each phase's completion triggers the matching FSM transition, which in
+        turn auto-schedules the next-phase task via the ``schedule_*`` methods
+        on ``Ticket``. The guards on ``self.phase`` + ``ticket.state`` make
+        this safe for repeat calls (e.g. parallel child tasks): once a ticket
+        has advanced, later calls find the state mismatch and no-op.
+        """
         if self._last_attempt_needs_user_input():
             self._schedule_interactive_followup()
             return
         ticket = self.ticket
         ticket.refresh_from_db()
-        if self.phase == "reviewing" and ticket.state == Ticket.State.TESTED:
+        if self.phase == "scoping" and ticket.state == Ticket.State.SCOPED:
+            ticket.start()
+            ticket.save()
+        elif self.phase == "coding" and ticket.state == Ticket.State.STARTED:
+            ticket.code()
+            ticket.save()
+        elif self.phase == "testing" and ticket.state == Ticket.State.CODED:
+            ticket.test(passed=True)
+            ticket.save()
+        elif self.phase == "reviewing" and ticket.state == Ticket.State.TESTED:
             ticket.review()
             ticket.save()
         elif self.phase == "shipping" and ticket.state == Ticket.State.REVIEWED:

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -1,3 +1,4 @@
+import os
 import re
 from typing import TYPE_CHECKING, ClassVar, cast
 
@@ -6,6 +7,17 @@ from django_fsm import FSMField, TransitionNotAllowed, transition
 
 from teatree.core.managers import TicketManager
 from teatree.utils import redis_container
+
+
+def _auto_ship_enabled() -> bool:
+    """Return True when ``T3_AUTO_SHIP`` opts into headless shipping.
+
+    Default is ``False`` — shipping tasks land in the interactive queue so the
+    user must approve the push explicitly. Set ``T3_AUTO_SHIP=true`` in
+    ``~/.teatree`` to allow headless shipping.
+    """
+    return os.environ.get("T3_AUTO_SHIP", "").lower() == "true"
+
 
 if TYPE_CHECKING:
     from teatree.core.models.session import Session
@@ -72,11 +84,11 @@ class Ticket(models.Model):
 
     @transition(field=state, source=State.SCOPED, target=State.STARTED)
     def start(self) -> None:
-        pass
+        self.schedule_coding()
 
     @transition(field=state, source=State.STARTED, target=State.CODED)
     def code(self) -> None:
-        pass
+        self.schedule_testing()
 
     @transition(field=state, source=State.CODED, target=State.TESTED)
     def test(self, *, passed: bool = True) -> None:
@@ -93,6 +105,36 @@ class Ticket(models.Model):
     )
     def review(self) -> None:
         self.schedule_shipping()
+
+    def schedule_coding(self, *, parent_task: "Task | None" = None) -> "Task":
+        """Create a fresh headless coding task after scoping completes."""
+        from teatree.core.models.session import Session  # noqa: PLC0415
+        from teatree.core.models.task import Task  # noqa: PLC0415
+
+        session = Session.objects.create(ticket=self, agent_id="coding")
+        return Task.objects.create(
+            ticket=self,
+            session=session,
+            phase="coding",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Auto-scheduled coding — implement the ticket",
+            parent_task=parent_task,
+        )
+
+    def schedule_testing(self, *, parent_task: "Task | None" = None) -> "Task":
+        """Create a fresh headless testing task after coding completes."""
+        from teatree.core.models.session import Session  # noqa: PLC0415
+        from teatree.core.models.task import Task  # noqa: PLC0415
+
+        session = Session.objects.create(ticket=self, agent_id="testing")
+        return Task.objects.create(
+            ticket=self,
+            session=session,
+            phase="testing",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Auto-scheduled testing — run + QA the coding work",
+            parent_task=parent_task,
+        )
 
     def schedule_review(self, *, parent_task: "Task | None" = None) -> "Task":
         """Create a fresh headless review+retro task (new session for bias-free evaluation)."""
@@ -123,17 +165,23 @@ class Ticket(models.Model):
         )
 
     def schedule_shipping(self, *, parent_task: "Task | None" = None) -> "Task":
-        """Create a fresh headless shipping task."""
+        """Create a shipping task. Defaults to interactive; headless when ``T3_AUTO_SHIP=true``."""
         from teatree.core.models.session import Session  # noqa: PLC0415
         from teatree.core.models.task import Task  # noqa: PLC0415
 
         session = Session.objects.create(ticket=self, agent_id="shipping")
+        if _auto_ship_enabled():
+            target = Task.ExecutionTarget.HEADLESS
+            reason = "Auto-scheduled shipping — T3_AUTO_SHIP=true, push will proceed headlessly"
+        else:
+            target = Task.ExecutionTarget.INTERACTIVE
+            reason = "Auto-scheduled shipping — gated for user approval (set T3_AUTO_SHIP=true to skip)"
         return Task.objects.create(
             ticket=self,
             session=session,
             phase="shipping",
-            execution_target=Task.ExecutionTarget.HEADLESS,
-            execution_reason="Auto-scheduled shipping — MR creation and delivery",
+            execution_target=target,
+            execution_reason=reason,
             parent_task=parent_task,
         )
 

--- a/tests/teatree_core/test_models.py
+++ b/tests/teatree_core/test_models.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.contrib import admin
 from django.test import TestCase
@@ -209,6 +211,131 @@ class TestTicketTransitions(TestCase):
 
         with pytest.raises(TransitionNotAllowed):
             ticket.review()
+
+
+class TestPhaseAutoDispatch(TestCase):
+    """Auto-dispatch of next-phase tasks at each phase boundary (issue #364)."""
+
+    def test_start_auto_schedules_coding_task(self) -> None:
+        ticket = Ticket.objects.create()
+        ticket.scope()
+        ticket.save()
+        ticket.start()
+        ticket.save()
+
+        task = ticket.tasks.get(phase="coding")
+        assert task.execution_target == Task.ExecutionTarget.HEADLESS
+        assert task.session.agent_id == "coding"
+        assert ticket.state == Ticket.State.STARTED
+
+    def test_code_auto_schedules_testing_task(self) -> None:
+        ticket = Ticket.objects.create()
+        ticket.scope()
+        ticket.save()
+        ticket.start()
+        ticket.save()
+        ticket.code()
+        ticket.save()
+
+        task = ticket.tasks.get(phase="testing")
+        assert task.execution_target == Task.ExecutionTarget.HEADLESS
+        assert task.session.agent_id == "testing"
+        assert ticket.state == Ticket.State.CODED
+
+    def test_scoping_task_completion_advances_to_started(self) -> None:
+        ticket = Ticket.objects.create()
+        ticket.scope()
+        ticket.save()
+        session = Session.objects.create(ticket=ticket, agent_id="scoper")
+        task = Task.objects.create(ticket=ticket, session=session, phase="scoping")
+
+        task.claim(claimed_by="worker")
+        task.complete()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.STARTED
+        # start() auto-scheduled a coding task
+        assert ticket.tasks.filter(phase="coding", status=Task.Status.PENDING).exists()
+
+    def test_coding_task_completion_advances_to_coded(self) -> None:
+        ticket = Ticket.objects.create()
+        ticket.scope()
+        ticket.save()
+        ticket.start()
+        ticket.save()
+
+        _complete_phase_task(ticket, "coding")
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.CODED
+        # code() auto-scheduled a testing task
+        assert ticket.tasks.filter(phase="testing", status=Task.Status.PENDING).exists()
+
+    def test_testing_task_completion_advances_to_tested(self) -> None:
+        ticket = Ticket.objects.create()
+        ticket.scope()
+        ticket.save()
+        ticket.start()
+        ticket.save()
+        ticket.code()
+        ticket.save()
+
+        _complete_phase_task(ticket, "testing")
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.TESTED
+        # test() auto-scheduled a reviewing task
+        assert ticket.tasks.filter(phase="reviewing", status=Task.Status.PENDING).exists()
+
+    def test_shipping_defaults_to_interactive_without_t3_auto_ship(self) -> None:
+        ticket = Ticket.objects.create()
+
+        with patch.dict("os.environ", {}, clear=False) as env:
+            env.pop("T3_AUTO_SHIP", None)
+            task = ticket.schedule_shipping()
+
+        assert task.execution_target == Task.ExecutionTarget.INTERACTIVE
+        assert "user approval" in task.execution_reason
+
+    def test_shipping_is_headless_when_t3_auto_ship_true(self) -> None:
+        ticket = Ticket.objects.create()
+
+        with patch.dict("os.environ", {"T3_AUTO_SHIP": "true"}):
+            task = ticket.schedule_shipping()
+
+        assert task.execution_target == Task.ExecutionTarget.HEADLESS
+        assert "T3_AUTO_SHIP=true" in task.execution_reason
+
+    def test_shipping_task_completion_advances_to_shipped(self) -> None:
+        ticket = Ticket.objects.create()
+        _advance_ticket_to_tested(ticket)
+        _complete_phase_task(ticket, "reviewing")
+        # reviewing completion → REVIEWED + shipping task (interactive by default)
+
+        _complete_phase_task(ticket, "shipping")
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+
+    def test_child_task_of_already_advanced_ticket_is_noop(self) -> None:
+        ticket = Ticket.objects.create()
+        ticket.scope()
+        ticket.save()
+        session = Session.objects.create(ticket=ticket, agent_id="scoper")
+        first = Task.objects.create(ticket=ticket, session=session, phase="scoping")
+        second = Task.objects.create(ticket=ticket, session=session, phase="scoping")
+
+        first.claim(claimed_by="worker-1")
+        first.complete()
+        # First completion advanced SCOPED → STARTED
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.STARTED
+
+        second.claim(claimed_by="worker-2")
+        second.complete()
+        # Second completion no-ops because state is no longer SCOPED
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.STARTED
 
 
 class TestWorktree(TestCase):

--- a/tests/teatree_core/test_unified_sessions.py
+++ b/tests/teatree_core/test_unified_sessions.py
@@ -67,9 +67,11 @@ class TestBuildUnifiedSessions(TestCase):
         with patch("teatree.core.selectors.unified.build_active_sessions", return_value=[]):
             rows = build_unified_sessions()
 
-        assert len(rows) == 1
-        assert rows[0].row_status == "completed"
-        assert rows[0].result_summary == "Done"
+        # Completing the coding task auto-dispatches a testing task (issue #364),
+        # so the view contains both the completed coding row and the queued testing row.
+        completed = next(r for r in rows if r.task_id == task.pk)
+        assert completed.row_status == "completed"
+        assert completed.result_summary == "Done"
 
     def test_includes_failed_activity(self) -> None:
         ticket = Ticket.objects.create(state=Ticket.State.STARTED)

--- a/tests/teatree_core/test_workflows.py
+++ b/tests/teatree_core/test_workflows.py
@@ -390,8 +390,11 @@ class TestTaskWorkflow(TestCase):
         ticket.save()
         assert ticket.state == Ticket.State.TESTED
 
-        review_task = Task.objects.filter(ticket=ticket, phase="reviewing").first()
-        assert review_task is not None
+        # start()/code()/test() each auto-schedule a task; the worker picks them
+        # up FIFO. Drain the coding + testing tasks (the "work" already happened
+        # above) so claim() returns the reviewing task we want to verify.
+        ticket.tasks.filter(phase__in=["coding", "testing"], status=Task.Status.PENDING).delete()
+        review_task = Task.objects.get(ticket=ticket, phase="reviewing")
         assert review_task.status == Task.Status.PENDING
 
         claimed_id = cast(


### PR DESCRIPTION
## Summary

Fixes #364 — the pipeline now queues the next phase's Task automatically at every FSM boundary:

- `start()` → schedules a headless **coding** task
- `code()` → schedules a headless **testing** task
- `test()` → still schedules a headless **reviewing** task (unchanged)
- `review()` → schedules a **shipping** task (see gate below)

The unified `Task._advance_ticket()` post-save hook now covers all four boundaries so completion from ANY phase advances the ticket and enqueues the next phase's task.

### `T3_AUTO_SHIP` gate (new)

Shipping defaults to **INTERACTIVE** (requires user approval). Set `T3_AUTO_SHIP=true` in `~/.teatree` to dispatch shipping as HEADLESS. Documented in `skills/setup/SKILL.md` and `skills/teatree/SKILL.md`.

### Test coverage

`TestPhaseAutoDispatch` in `tests/teatree_core/test_models.py` — 9 new tests covering:

- `start()` schedules a coding task
- `code()` schedules a testing task
- Scoping/coding/testing task completion advances the ticket
- Shipping is INTERACTIVE without `T3_AUTO_SHIP`, HEADLESS when `T3_AUTO_SHIP=true`
- Child task of an already-advanced ticket is a no-op (idempotent)

Two existing tests updated to account for the extra auto-dispatched tasks:

- `test_includes_completed_activity` — finds task by pk instead of asserting row count
- `test_claim_work_complete_advances_ticket` — drains leftover coding + testing PENDING tasks before claiming the reviewing task

Full suite: **2224 passed, 96.96% coverage**.

### `relax:` prefix — why

This commit adds four `# noqa: PLC0415` markers inside the new `schedule_coding()` and `schedule_testing()` methods. They follow the same circular-import pattern already used in the adjacent `schedule_review()`, `schedule_review_in_session()`, and `schedule_shipping()` methods in the same file. The quality-gates hook flags any addition, so the `relax:` commit type acknowledges the intentional continuation of the existing pattern.

## Test plan

- [x] Unit tests for every phase auto-dispatch path
- [x] Unit tests for both `T3_AUTO_SHIP` states
- [x] Full suite green (2224 tests, 96.96% coverage)
- [x] Lint + format clean
- [x] BLUEPRINT.md updated
- [x] Skill docs updated (`setup/SKILL.md`, `teatree/SKILL.md`)