### PR TITLE
feat(fsm): transition-driven workflow foundation — RETROSPECTED state (#140)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -135,13 +135,15 @@ scripts/                # Standalone utility scripts
 
 Five models in `teatree.core.models/` (split into domain-specific modules), all using `django-fsm` for state machines.
 
-**No FSM signals for external sync.** django-fsm-2 provides `post_transition` signals that could auto-update external systems (GitLab labels, Notion statuses) on every state change. We deliberately don't use them — external sync is the caller's responsibility, not the state machine's. This keeps FSM transitions fast, testable, and free of side-channel I/O.
+**Transitions own their work.** Every FSM transition composes the runners needed to make its new state true — git, MR I/O, retro writing, cleanup — and enqueues long work to an `@task` worker via `transaction.on_commit`. Transition bodies stay pure (state change + metadata + enqueue); the worker does the I/O, takes a row lock with `select_for_update()`, re-checks the source state for idempotency, and on success calls the next transition to advance the ticket. This replaces the previous caller-owned pattern — `t3 ... ship`, manual `mark_merged()`, etc. — with a single rule: "to move the ticket, call the transition; the transition does the rest."
+
+Rationale: at-least-once delivery is safe because workers guard with row-locked state checks; crash recovery is `django-tasks`' job, not ours; tests use `ImmediateBackend` to run workers synchronously. `post_transition` signals remain reserved for lossy cross-cutting side effects (audit log, Slack reactions) — never for the main work of the transition.
 
 ### 4.1 Ticket — Core delivery entity
 
 The central entity. One ticket per unit of work (maps to an issue/task in the tracker).
 
-**States:** `not_started` → `scoped` → `started` → `coded` → `tested` → `reviewed` → `shipped` → `in_review` → `merged` → `delivered`
+**States:** `not_started` → `scoped` → `started` → `coded` → `tested` → `reviewed` → `shipped` → `in_review` → `merged` → `retrospected` → `delivered`
 
 **Fields:**
 
@@ -166,7 +168,8 @@ The central entity. One ticket per unit of work (maps to an issue/task in the tr
 | `ship(mr_urls=[])` | reviewed → shipped | Stores MR URLs in extra |
 | `request_review()` | shipped → in_review | — |
 | `mark_merged()` | in_review → merged | — |
-| `mark_delivered()` | merged → delivered | — |
+| `retrospect()` | merged → retrospected | Enqueues `execute_retrospect` worker via `transaction.on_commit`. Worker runs `RetroExecutor` and calls `mark_delivered()` on success. |
+| `mark_delivered()` | retrospected → delivered | — |
 | `rework()` | coded/tested/reviewed → started | Clears tests_passed, cancels pending tasks |
 
 **Auto-scheduling:** `test()` auto-creates a headless reviewing task. `review()` auto-creates a headless shipping task. Both use fresh sessions (bias-free evaluation).

--- a/docs/management-commands.md
+++ b/docs/management-commands.md
@@ -93,7 +93,7 @@ Ticket state management.
 
 | Subcommand | Arguments | Returns | Description |
 |------------|-----------|---------|-------------|
-| `transition` | `ticket_id`, `transition_name` | dict | Transitions a ticket to a new state. Allowed transitions: `scope`, `start`, `code`, `test`, `review`, `ship`, `request_review`, `mark_merged`, `mark_delivered`, `rework`. |
+| `transition` | `ticket_id`, `transition_name` | dict | Transitions a ticket to a new state. Allowed transitions: `scope`, `start`, `code`, `test`, `review`, `ship`, `request_review`, `mark_merged`, `retrospect`, `mark_delivered`, `rework`. |
 | `list` | `--state`, `--overlay` | list of dicts | Lists tickets, optionally filtered by state and/or overlay |
 
 ## `e2e`

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -14,6 +14,7 @@ _ALLOWED_TRANSITIONS = {
     "ship",
     "request_review",
     "mark_merged",
+    "retrospect",
     "mark_delivered",
     "rework",
 }
@@ -25,7 +26,7 @@ class Command(TyperCommand):
         """Transition a ticket to a new state.
 
         Accepts any of the allowed transition names: scope, start, code, test,
-        review, ship, request_review, mark_merged, mark_delivered, rework.
+        review, ship, request_review, mark_merged, retrospect, mark_delivered, rework.
         """
         if transition_name not in _ALLOWED_TRANSITIONS:
             return {"error": f"Unknown transition: {transition_name}"}

--- a/src/teatree/core/migrations/0010_ticket_retrospected_state.py
+++ b/src/teatree/core/migrations/0010_ticket_retrospected_state.py
@@ -1,0 +1,33 @@
+import django_fsm
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0009_ticket_redis_db_index"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="ticket",
+            name="state",
+            field=django_fsm.FSMField(
+                choices=[
+                    ("not_started", "Not started"),
+                    ("scoped", "Scoped"),
+                    ("started", "Started"),
+                    ("coded", "Coded"),
+                    ("tested", "Tested"),
+                    ("reviewed", "Reviewed"),
+                    ("shipped", "Shipped"),
+                    ("in_review", "In review"),
+                    ("merged", "Merged"),
+                    ("retrospected", "Retrospected"),
+                    ("delivered", "Delivered"),
+                    ("ignored", "Ignored"),
+                ],
+                default="not_started",
+                max_length=32,
+            ),
+        ),
+    ]

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -1,7 +1,7 @@
 import re
 from typing import TYPE_CHECKING, ClassVar, cast
 
-from django.db import models
+from django.db import models, transaction
 from django_fsm import FSMField, TransitionNotAllowed, transition
 
 from teatree.core.managers import TicketManager
@@ -24,6 +24,7 @@ class Ticket(models.Model):
         SHIPPED = "shipped", "Shipped"
         IN_REVIEW = "in_review", "In review"
         MERGED = "merged", "Merged"
+        RETROSPECTED = "retrospected", "Retrospected"
         DELIVERED = "delivered", "Delivered"
         IGNORED = "ignored", "Ignored"
 
@@ -151,7 +152,21 @@ class Ticket(models.Model):
     def mark_merged(self) -> None:
         pass
 
-    @transition(field=state, source=State.MERGED, target=State.DELIVERED)
+    @transition(field=state, source=State.MERGED, target=State.RETROSPECTED)
+    def retrospect(self) -> None:
+        """Schedule retrospection I/O.
+
+        The worker writes retro artifacts and calls ``mark_delivered()`` on
+        success. FSM invariant (BLUEPRINT §4): transition bodies stay pure —
+        long I/O is offloaded to an ``@task`` worker, enqueued after commit so
+        the state change and the queued work land atomically.
+        """
+        from teatree.core.tasks import execute_retrospect  # noqa: PLC0415
+
+        ticket_pk = int(self.pk)
+        transaction.on_commit(lambda: execute_retrospect.enqueue(ticket_pk))
+
+    @transition(field=state, source=State.RETROSPECTED, target=State.DELIVERED)
     def mark_delivered(self) -> None:
         pass
 
@@ -174,6 +189,7 @@ class Ticket(models.Model):
             State.SHIPPED,
             State.IN_REVIEW,
             State.MERGED,
+            State.RETROSPECTED,
         ],
         target=State.IGNORED,
     )

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -45,6 +45,7 @@ DEFAULT_TRANSITION_EMOJIS: dict[str, str] = {
     "test": "white_check_mark",
     "request_review": "eyes",
     "mark_merged": "tada",
+    "retrospect": "memo",
     "mark_delivered": "white_check_mark",
     "rework": "arrows_counterclockwise",
     "ignore": "wastebasket",

--- a/src/teatree/core/runners/__init__.py
+++ b/src/teatree/core/runners/__init__.py
@@ -1,0 +1,13 @@
+"""Transition runners — composed work executed by ``@task`` workers.
+
+Each runner performs the long I/O for a specific lifecycle transition.
+Workers enqueue at transition time, claim via ``select_for_update()``, and
+on success call the next transition to advance the ticket.
+
+See BLUEPRINT.md §4 for the invariant and §4.1 for the per-transition map.
+"""
+
+from teatree.core.runners.base import RunnerBase
+from teatree.core.runners.retro import RetroExecutor
+
+__all__ = ["RetroExecutor", "RunnerBase"]

--- a/src/teatree/core/runners/base.py
+++ b/src/teatree/core/runners/base.py
@@ -1,0 +1,26 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from teatree.core.models import Ticket
+
+
+@dataclass(frozen=True, slots=True)
+class RunnerResult:
+    ok: bool
+    detail: str = ""
+
+
+class RunnerBase(ABC):
+    """Base for composable transition runners.
+
+    Subclasses hold a reference to their ``Ticket`` and expose a ``run()`` that
+    performs the I/O. Workers invoke ``run()`` after claiming the ticket with
+    ``select_for_update()``; on success the worker advances the FSM.
+    """
+
+    def __init__(self, ticket: Ticket) -> None:
+        self.ticket = ticket
+
+    @abstractmethod
+    def run(self) -> RunnerResult:
+        raise NotImplementedError

--- a/src/teatree/core/runners/retro.py
+++ b/src/teatree/core/runners/retro.py
@@ -1,0 +1,23 @@
+import logging
+
+from teatree.core.runners.base import RunnerBase, RunnerResult
+
+logger = logging.getLogger(__name__)
+
+
+class RetroExecutor(RunnerBase):
+    """Write retrospection artifacts for a merged ticket.
+
+    Scaffold implementation: records that retro ran and leaves a short marker
+    on ``ticket.extra``. The agent-driven retro (skill bundle, prompt build,
+    artifact generation) lands in a follow-up PR.
+    """
+
+    def run(self) -> RunnerResult:
+        ticket = self.ticket
+        extra = dict(ticket.extra or {})
+        extra["retro_scheduled"] = True
+        ticket.extra = extra
+        ticket.save(update_fields=["extra"])
+        logger.info("Retro scheduled for ticket %s", ticket.pk)
+        return RunnerResult(ok=True, detail="retro-scheduled")

--- a/src/teatree/core/selectors/dashboard.py
+++ b/src/teatree/core/selectors/dashboard.py
@@ -39,6 +39,7 @@ _TICKET_TRANSITIONS = [
     ("review", "Review"),
     ("ship", "Ship"),
     ("request_review", "Request review"),
+    ("retrospect", "Retrospect"),
     ("mark_delivered", "Mark delivered"),
     ("rework", "Rework"),
 ]

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -1,6 +1,21 @@
+import logging
+from typing import TypedDict
+
+from django.db import transaction
 from django.tasks import task
 
 from teatree.core.models import Task, Ticket
+from teatree.core.runners import RetroExecutor
+
+logger = logging.getLogger(__name__)
+
+
+class RetrospectResult(TypedDict, total=False):
+    ticket_id: int
+    ok: bool
+    skipped: bool
+    state: str
+    detail: str
 
 
 @task()
@@ -63,3 +78,34 @@ def refresh_followup_snapshot() -> dict[str, int]:
         "tasks": Task.objects.count(),
         "open_tasks": Task.objects.exclude(status=Task.Status.COMPLETED).count(),
     }
+
+
+@task()
+def execute_retrospect(ticket_id: int) -> RetrospectResult:
+    """Run retrospection I/O for a ticket in the RETROSPECTED state.
+
+    Idempotency: the worker takes a row lock and re-checks state before running.
+    At-least-once delivery from django-tasks means this can fire more than once
+    for the same transition — a lost update or a redelivered job must be safe.
+
+    On success, advances ``RETROSPECTED → DELIVERED`` via ``mark_delivered()``.
+    """
+    with transaction.atomic():
+        ticket = Ticket.objects.select_for_update().get(pk=ticket_id)
+        if ticket.state != Ticket.State.RETROSPECTED:
+            logger.info(
+                "execute_retrospect skipped for ticket %s: state=%s (not RETROSPECTED)",
+                ticket_id,
+                ticket.state,
+            )
+            return {"ticket_id": ticket_id, "skipped": True, "state": str(ticket.state)}
+
+        result = RetroExecutor(ticket).run()
+        if not result.ok:
+            logger.warning("Retro failed for ticket %s: %s", ticket_id, result.detail)
+            return {"ticket_id": ticket_id, "ok": False, "detail": result.detail}
+
+        ticket.mark_delivered()
+        ticket.save()
+
+    return {"ticket_id": ticket_id, "ok": True, "detail": result.detail}

--- a/src/teatree/core/views/actions.py
+++ b/src/teatree/core/views/actions.py
@@ -70,6 +70,7 @@ _ALLOWED_TRANSITIONS = {
     "ship",
     "request_review",
     "mark_merged",
+    "retrospect",
     "mark_delivered",
     "rework",
     "ignore",

--- a/tests/teatree_core/test_models.py
+++ b/tests/teatree_core/test_models.py
@@ -56,6 +56,8 @@ class TestTicketTransitions(TestCase):
         ticket.save()
         ticket.mark_merged()
         ticket.save()
+        ticket.retrospect()
+        ticket.save()
         ticket.mark_delivered()
         ticket.save()
 

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -5,7 +5,12 @@ from django.test import TestCase, override_settings
 
 import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.core.models import Session, Task, TaskAttempt, Ticket
-from teatree.core.tasks import drain_headless_queue, refresh_followup_snapshot, sync_followup
+from teatree.core.tasks import (
+    drain_headless_queue,
+    execute_retrospect,
+    refresh_followup_snapshot,
+    sync_followup,
+)
 from tests.teatree_core.conftest import CommandOverlay
 
 IMMEDIATE_BACKEND = {
@@ -90,6 +95,43 @@ class TestDrainHeadlessQueue(TestCase):
             result = drain_headless_queue.enqueue()
 
         assert result.return_value == {"enqueued": []}
+
+
+class TestExecuteRetrospect(TestCase):
+    @staticmethod
+    def _ticket_in_merged() -> Ticket:
+        ticket = Ticket.objects.create(overlay="test")
+        ticket.state = Ticket.State.MERGED
+        ticket.save(update_fields=["state"])
+        return ticket
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_advances_merged_ticket_to_delivered(self) -> None:
+        ticket = self._ticket_in_merged()
+        ticket.state = Ticket.State.RETROSPECTED
+        ticket.save(update_fields=["state"])
+
+        result = execute_retrospect.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.DELIVERED
+        assert ticket.extra.get("retro_scheduled") is True
+        assert result.return_value == {"ticket_id": ticket.pk, "ok": True, "detail": "retro-scheduled"}
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_skips_when_state_does_not_match(self) -> None:
+        """At-least-once delivery: redelivered jobs must be no-ops."""
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.DELIVERED)
+
+        result = execute_retrospect.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.DELIVERED
+        assert result.return_value == {
+            "ticket_id": ticket.pk,
+            "skipped": True,
+            "state": "delivered",
+        }
 
 
 class TestExecuteHeadlessTask(TestCase):

--- a/tests/teatree_core/test_workflow_integration.py
+++ b/tests/teatree_core/test_workflow_integration.py
@@ -72,6 +72,7 @@ class TestTicketLifecycle(TestCase):
 
         ticket.request_review()
         ticket.mark_merged()
+        ticket.retrospect()
         ticket.mark_delivered()
         ticket.save()
         assert ticket.state == "delivered"


### PR DESCRIPTION
## Summary

Foundation slice for #140 — staged PR **1 of 5**. Establishes the transition-driven workflow pattern and adds the `RETROSPECTED` state to the ticket lifecycle.

Reverses BLUEPRINT §4's previous "no FSM signals for external sync" invariant in favor of **transitions own their work**:

- Transition bodies stay pure (state change + metadata + enqueue).
- Long I/O runs in `@task` workers, enqueued via `transaction.on_commit`.
- Workers take a row lock with `select_for_update()`, re-check the source state for idempotency (at-least-once delivery is safe), and on success call the next transition.
- `post_transition` signals remain reserved for lossy cross-cutting side effects (audit log, Slack reactions).

## What this PR does

**Model / FSM:**
- Adds `Ticket.State.RETROSPECTED` between `MERGED` and `DELIVERED`.
- Adds `retrospect()` transition (MERGED → RETROSPECTED) that enqueues `execute_retrospect` via `transaction.on_commit`.
- Changes `mark_delivered` source from `MERGED` to `RETROSPECTED`.
- Extends `ignore()` sources to include `RETROSPECTED`.

**Workers / runners:**
- New `core/runners/` package with `RunnerBase` (ABC) + `RetroExecutor` scaffold. The agent-driven retro implementation lands in a follow-up slice.
- New `execute_retrospect(ticket_id)` task: `select_for_update()` + state re-check, runs `RetroExecutor`, calls `mark_delivered()` on success. Returns a typed `RetrospectResult`.

**Consumers updated:**
- `core/views/actions.py` — added `retrospect` to allowed transitions.
- `core/management/commands/ticket.py` — added `retrospect` to the management command's allow-list.
- `core/selectors/dashboard.py` — added `retrospect` button.
- `core/overlay.py` — added default Slack emoji (`memo`).

**Docs:**
- `BLUEPRINT.md §4` invariant rewritten.
- `BLUEPRINT.md §4.1` state list and transition table updated.
- `docs/management-commands.md` transition list updated.

**Migration:**
- `0010_ticket_retrospected_state.py` — choices-only migration.

**Tests:**
- Updated `test_models.py` and `test_workflow_integration.py` to insert `retrospect()` between `mark_merged()` and `mark_delivered()`.
- Added `TestExecuteRetrospect` covering the success path and the at-least-once skip path.

## Remaining slices (per the scoping comment on #140)

1. **Foundation** (this PR): RETROSPECTED + runners package + invariant update.
2. Shipping slice: move commit/push/MR creation into `ship()` via `ShipExecutor`.
3. Setup/scope slice: `scope()` and `start()` enqueue `WorktreeProvisioner`.
4. Test/review slice: consolidate headless test + review workers under the new pattern.
5. Final cleanup: retire caller-driven lifecycle helpers; CLI `t3 transition` becomes the only entry point.

## Test plan

- [x] ruff check / format — clean
- [x] pytest full suite — 2217 passed, coverage 96.94 percent (gate 93 percent)
- [x] makemigrations dry-run — no pending changes
- [x] Pre-commit hooks pass (module-health, quality-gate, conventional-commit, BLUEPRINT sync, Docker pytest matrix)

## Relaxation acknowledged

`core/models/ticket.py:164` adds a new `# noqa: PLC0415` on the `execute_retrospect` import inside `retrospect()`. This is the same circular-dep pattern already used 5× elsewhere in `ticket.py` (`schedule_review`, `schedule_shipping`, `_cancel_pending_tasks`) — `tasks.py` imports `Ticket` at the top, so `ticket.py` must import the task function lazily. No other relaxations.

Relates to #140