### PR TITLE
fix(e2e): propagate playwright/pytest exit code + feat(contrib): auto-discover sibling overlay repos

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1266,6 +1266,7 @@ graph TD
     teatree.backends --> teatree.core
     teatree.contrib --> teatree.types
     teatree.contrib --> teatree.core
+    teatree.contrib --> teatree.config
     teatree.cli --> teatree.config
     teatree.cli --> teatree.core
     teatree.cli --> teatree.agents

--- a/src/teatree/contrib/t3_teatree/overlay.py
+++ b/src/teatree/contrib/t3_teatree/overlay.py
@@ -7,6 +7,7 @@ teatree's own repo, skills, and GitHub project as the target.
 from pathlib import Path
 from typing import override
 
+from teatree.config import discover_overlays, load_config
 from teatree.core.models import Worktree
 from teatree.core.overlay import OverlayBase, OverlayConfig, OverlayMetadata
 from teatree.types import ProvisionStep, RunCommands, SkillMetadata
@@ -23,6 +24,31 @@ def _repo_root() -> Path:
             return parent
     msg = f"Cannot find teatree repo root from {here}"
     raise FileNotFoundError(msg)
+
+
+def _discover_workspace_repos() -> list[str]:
+    """Aggregate teatree's own repo + every discovered overlay project path.
+
+    Each path is returned relative to ``workspace_dir``. Overlays whose path
+    lives outside ``workspace_dir`` (or cannot be resolved on disk) are
+    skipped — callers can always override via ``config.workspace_repos``.
+    """
+    workspace_dir = load_config().user.workspace_dir.resolve()
+    candidates: list[Path] = [_repo_root()]
+    candidates.extend(entry.project_path for entry in discover_overlays() if entry.project_path is not None)
+
+    seen: set[str] = set()
+    repos: list[str] = []
+    for candidate in candidates:
+        try:
+            rel = candidate.resolve().relative_to(workspace_dir)
+        except ValueError:
+            continue
+        key = str(rel)
+        if key not in seen:
+            seen.add(key)
+            repos.append(key)
+    return repos
 
 
 class TeatreeMetadata(OverlayMetadata):
@@ -58,6 +84,13 @@ class TeatreeOverlay(OverlayBase):
     @override
     def get_repos(self) -> list[str]:
         return ["teatree"]
+
+    @override
+    def get_workspace_repos(self) -> list[str]:
+        if self.config.workspace_repos:
+            return list(self.config.workspace_repos)
+        discovered = _discover_workspace_repos()
+        return discovered or self.get_repos()
 
     @override
     def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -236,7 +236,10 @@ class Command(TyperCommand):
 
         cmd = ["npx", "playwright", "test", *opts.to_args()]
         result = subprocess.run(cmd, cwd=private_tests_path, check=False, env=env)  # noqa: S603
-        return "E2E passed." if result.returncode == 0 else f"E2E failed (exit {result.returncode})."
+        if result.returncode == 0:
+            return "E2E passed."
+        self.stderr.write(f"E2E failed (exit {result.returncode}).")
+        raise SystemExit(result.returncode)
 
     @command()
     def project(self, test_path: str = "", *, headed: bool = False, docker: bool = True) -> str:
@@ -256,7 +259,10 @@ class Command(TyperCommand):
             if compose_file.is_file():
                 cmd = ["docker", "compose", "-f", str(compose_file), "run", "--rm", "e2e"]
                 result = subprocess.run(cmd, cwd=wt_path, check=False)  # noqa: S603
-                return "E2E passed." if result.returncode == 0 else f"E2E failed (exit {result.returncode})."
+                if result.returncode == 0:
+                    return "E2E passed."
+                self.stderr.write(f"E2E failed (exit {result.returncode}).")
+                raise SystemExit(result.returncode)
 
         cmd = ["uv", "run", "pytest", test_dir]
         cmd.extend(["-o", f"DJANGO_SETTINGS_MODULE={settings_module}", "--no-cov", "-p", "no:tach", "-v"])
@@ -268,4 +274,7 @@ class Command(TyperCommand):
             env["CI"] = "1"
 
         result = subprocess.run(cmd, cwd=wt_path, check=False, env=env)  # noqa: S603
-        return "E2E passed." if result.returncode == 0 else f"E2E failed (exit {result.returncode})."
+        if result.returncode == 0:
+            return "E2E passed."
+        self.stderr.write(f"E2E failed (exit {result.returncode}).")
+        raise SystemExit(result.returncode)

--- a/tach.toml
+++ b/tach.toml
@@ -78,7 +78,7 @@ depends_on = [
 
 [[modules]]
 path = "teatree.contrib"
-depends_on = ["teatree.types", "teatree.core"]
+depends_on = ["teatree.types", "teatree.core", "teatree.config"]
 
 [[modules]]
 path = "teatree.cli"

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -2615,10 +2615,11 @@ class TestE2eProject(TestCase):
         with (
             patch.object(e2e_mod, "resolve_worktree", return_value=None),
             patch.object(e2e_mod.subprocess, "run", return_value=mock_result),
+            pytest.raises(SystemExit) as exc_info,
         ):
-            result = cast("str", call_command("e2e", "project", docker=False))
+            call_command("e2e", "project", docker=False)
 
-        assert "failed" in result
+        assert exc_info.value.code == 1
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -2763,9 +2764,10 @@ class TestE2eExternal(TestCase):
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
                 patch.object(e2e_mod, "get_service_port", return_value=4200),
                 patch.object(e2e_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                pytest.raises(SystemExit) as exc_info,
             ):
-                result = cast("str", call_command("e2e", "external", headed=True))
-            assert "failed" in result
+                call_command("e2e", "external", headed=True)
+            assert exc_info.value.code == 1
             cmd = mock_run.call_args[0][0]
             assert "--headed" in cmd
             env = mock_run.call_args[1]["env"]

--- a/tests/test_contrib_overlay.py
+++ b/tests/test_contrib_overlay.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase
 
+import teatree.config as config_mod
 import teatree.contrib.t3_teatree.overlay as overlay_mod
 import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.contrib.t3_teatree.apps import T3TeatreeConfig
@@ -14,6 +15,26 @@ from teatree.contrib.t3_teatree.overlay import TeatreeOverlay, _repo_root
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_overlay
+
+
+@pytest.fixture
+def isolated_config(tmp_path: Path, monkeypatch) -> Path:
+    """Redirect overlay discovery to a fresh tmp toml, ignoring the user's real config.
+
+    ``CONFIG_PATH`` is baked into ``load_config`` / ``discover_overlays``
+    defaults at def-time, so monkeypatching the module constant alone is not
+    enough — we wrap both callables to always pass the tmp path explicitly.
+    """
+    from functools import partial  # noqa: PLC0415
+
+    toml_path = tmp_path / "teatree.toml"
+    monkeypatch.setattr(overlay_mod, "load_config", partial(config_mod.load_config, path=toml_path))
+    monkeypatch.setattr(
+        overlay_mod,
+        "discover_overlays",
+        partial(config_mod.discover_overlays, config_path=toml_path),
+    )
+    return toml_path
 
 
 class TestTeatreeOverlayIsValid:
@@ -37,7 +58,15 @@ class TestGetRepos:
 
 
 class TestGetWorkspaceRepos:
-    def test_falls_back_to_get_repos(self) -> None:
+    def test_falls_back_to_get_repos_when_discovery_empty(
+        self, tmp_path: Path, monkeypatch, isolated_config: Path
+    ) -> None:
+        """Discovery empty → final fallback is ``get_repos()``."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        isolated_config.write_text(f'[teatree]\nworkspace_dir = "{workspace}"\n', encoding="utf-8")
+        monkeypatch.setattr(overlay_mod, "_repo_root", lambda: tmp_path / "elsewhere")
+
         overlay = TeatreeOverlay()
         overlay.config.workspace_repos = []
         assert overlay.get_workspace_repos() == ["teatree"]
@@ -46,6 +75,47 @@ class TestGetWorkspaceRepos:
         overlay = TeatreeOverlay()
         overlay.config.workspace_repos = ["souliane/teatree"]
         assert overlay.get_workspace_repos() == ["souliane/teatree"]
+
+    def test_aggregates_teatree_and_toml_overlays(self, tmp_path: Path, monkeypatch, isolated_config: Path) -> None:
+        """Dynamic discovery aggregates teatree's repo + every ``[overlays.*].path``."""
+        workspace = tmp_path / "workspace"
+        (workspace / "souliane" / "teatree").mkdir(parents=True)
+        (workspace / "acme" / "t3-acme").mkdir(parents=True)
+
+        isolated_config.write_text(
+            f'[teatree]\nworkspace_dir = "{workspace}"\n\n'
+            f'[overlays.t3-acme]\npath = "{workspace / "acme" / "t3-acme"}"\n'
+            'class = "t3_acme.overlay:AcmeOverlay"\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(overlay_mod, "_repo_root", lambda: workspace / "souliane" / "teatree")
+
+        overlay = TeatreeOverlay()
+        overlay.config.workspace_repos = []
+        repos = overlay.get_workspace_repos()
+
+        assert "souliane/teatree" in repos
+        assert "acme/t3-acme" in repos
+
+    def test_skips_overlays_outside_workspace_dir(self, tmp_path: Path, monkeypatch, isolated_config: Path) -> None:
+        """Overlays whose path sits outside ``workspace_dir`` are silently skipped."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        outside = tmp_path / "elsewhere" / "rogue"
+        outside.mkdir(parents=True)
+
+        isolated_config.write_text(
+            f'[teatree]\nworkspace_dir = "{workspace}"\n\n'
+            f'[overlays.rogue]\npath = "{outside}"\nclass = "rogue:Overlay"\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(overlay_mod, "_repo_root", lambda: outside)
+
+        overlay = TeatreeOverlay()
+        overlay.config.workspace_repos = []
+        assert overlay.get_workspace_repos() == ["teatree"]
 
 
 class TestGetFollowupRepos:


### PR DESCRIPTION
## Summary

Bundles two unrelated-but-small fixes:

### 1. fix(e2e): propagate playwright/pytest exit code (closes #369)

The `t3 teatree e2e external` and `t3 teatree e2e project` commands swallowed non-zero exit codes from Playwright and pytest by *returning* a status string instead of *exiting* non-zero. CI jobs that ran the wrapper reported success even when the underlying tests failed.

This was caught while wiring up the product-a E2E job in `microservice-product-a` — a Playwright SSO timeout produced `E2E failed (exit 1).` in the job log, but the GitLab job exited green.

**Fix:** Raise `SystemExit(returncode)` after writing the failure message to stderr, so the wrapper exits with the same code as the underlying tool. Matches the existing pattern in `tasks.py` (`raise SystemExit(1)`). Applies to all three subprocess paths: `e2e external` (Playwright via `npx`), `e2e project` Docker path, `e2e project` local path.

### 2. feat(contrib): TeatreeOverlay discovers sibling overlay repos dynamically (relates-to #19)

`get_workspace_repos()` now aggregates teatree's own path plus every `[overlays.*].path` entry from `~/.teatree.toml`, each converted to a path relative to `workspace_dir`. Entries outside `workspace_dir` are silently skipped; an empty discovery result falls back to `get_repos()` so callers always receive a non-empty list.

Removes the need to hand-maintain `[overlays.teatree].workspace_repos` every time a new overlay is registered — the teatree worktree now includes all installed overlays automatically (`t3-teatree`, `t3-company`, future siblings). Explicitly-configured `workspace_repos` still wins, so existing setups are untouched.

Also: `tach.toml` — `teatree.contrib` gains a `teatree.config` dependency, required to read the overlay registry at runtime.

## Test plan

- [x] Updated `TestE2eProject::test_reports_failure` and `TestE2eExternal::test_headed_mode` to expect `SystemExit` with `code == 1`
- [x] Full suite green: `uv run pytest --no-cov -x -q` → 2224 passed
- [x] `uv run ruff check` clean
- [x] Pre-commit hooks pass
- [x] `tests/test_contrib_overlay.py` 21/21 pass on the bundled feat commit

Closes #369
Relates-to #19