### PR TITLE
feat(config): generic per-overlay override for UserSettings fields [none] (https://github.com/souliane/teatree/issues/374)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -814,6 +814,50 @@ posts, remote branch deletion):
 The env var `T3_MODE` overrides the toml setting. Unknown values raise
 `ValueError` — typos never silently downgrade to a less-safe mode.
 
+### 11.1.1 Per-Overlay Setting Overrides
+
+A subset of `[teatree]` keys can be overridden per-overlay in
+`[overlays.<name>]`. The resolution chain (first match wins):
+
+1. `T3_*` env var (currently only `T3_MODE` is wired as a one-off).
+2. Active overlay's override from `[overlays.<name>]`.
+3. Global `[teatree]` value.
+4. `UserSettings` dataclass default.
+
+The active overlay is resolved via (in order): `T3_OVERLAY_NAME` env var
+(runtime truth; matches `get_overlay()`), cwd-based discovery, then the
+single installed overlay.
+
+Overridable keys live in `OVERLAY_OVERRIDABLE_SETTINGS` in
+`src/teatree/config.py`:
+
+| Key | Why overridable |
+|-----|------------------|
+| `mode` | `auto` for a personal dogfooding overlay, `interactive` for a client overlay |
+| `branch_prefix` | Different prefix conventions per project |
+| `privacy` | Stricter for client code, looser for personal |
+| `contribute` | Contribute to one overlay's skills but not another |
+| `excluded_skills` | Project-specific skill exclusions |
+
+Callers use `get_effective_settings()` (returns a `UserSettings` with the
+active overlay's overrides applied) instead of reaching into
+`load_config().user` directly. Adding a new overridable key is a
+one-line change to the registry — the resolver picks it up via
+`dataclasses.replace`, no per-setting getter needed.
+
+```toml
+[teatree]
+mode = "interactive"         # global default
+branch_prefix = "ac"
+
+[overlays.teatree]
+mode = "auto"                # auto-mode for teatree dogfooding
+
+[overlays.client-project]
+mode = "interactive"         # stay gated on client code
+privacy = "strict"
+```
+
 ### 11.2 Django Settings (framework-level, in teatree's settings.py)
 
 | Setting | Type | Purpose |

--- a/README.md
+++ b/README.md
@@ -236,6 +236,21 @@ has for publishing actions:
 Unknown values raise an error — a typo in `mode` will never silently downgrade
 to a less-safe mode.
 
+A subset of `[teatree]` keys can be **overridden per-overlay** in
+`[overlays.<name>]` — `mode`, `branch_prefix`, `privacy`, `contribute`, and
+`excluded_skills`. For example, run `auto` mode on a personal dogfooding
+overlay while keeping `interactive` on a client project:
+
+```toml
+[teatree]
+mode = "interactive"
+
+[overlays.my-project]
+mode = "auto"
+```
+
+See `BLUEPRINT.md` § 11.1.1 for the full resolution chain.
+
 ## Contributing & Self-Improvement
 
 After every non-trivial session, the `retro` skill runs a retrospective, extracts what went wrong, and writes fixes back into skill files. When contributors enable this (`contribute = true` in `~/.teatree.toml`), improvements flow back upstream through a fork-based model.

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -167,6 +167,8 @@ The user has opted into end-to-end autonomy. The agent ships complete features w
 - Open the MR, watch the pipeline, merge when green, delete the remote branch.
 - Post the overlay-approved Slack messages (review request, release note) as part of the normal flow.
 
+**Mode is per-overlay.** The setting can live under `[overlays.<name>]` and override the global `[teatree].mode`. A user can run `auto` mode on a personal dogfooding overlay while keeping `interactive` on a client overlay — the active overlay (resolved via `T3_OVERLAY_NAME`) determines which doctrine applies. See `BLUEPRINT.md` § 11.1.1.
+
 **Quality gates still run — they just don't depend on user confirmation.** The objection auto mode answers is "stop gating on _confirmation_," not "skip quality checks."
 
 ### Always-Gated Actions (Non-Negotiable, both modes)

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -3,9 +3,11 @@
 import importlib.util
 import os
 import tomllib
-from dataclasses import dataclass, field
+from collections.abc import Callable
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from pathlib import Path
+from typing import Any
 
 CONFIG_PATH = Path.home() / ".teatree.toml"
 DATA_DIR = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))) / "teatree"
@@ -103,11 +105,36 @@ class E2ERepo:
     e2e_dir: str = "e2e"
 
 
+def _parse_excluded_skills(raw: object) -> list[str]:
+    return [str(s) for s in raw] if isinstance(raw, list) else []
+
+
+# Registry of UserSettings fields that can be overridden per-overlay in
+# ``[overlays.<name>]``. To make another setting overridable, add an entry
+# here with a parser that coerces the raw toml value to the UserSettings
+# field type. The getter `get_effective_settings()` applies overrides
+# generically via ``dataclasses.replace`` — no per-setting wiring needed.
+OVERLAY_OVERRIDABLE_SETTINGS: dict[str, Callable[[Any], Any]] = {
+    "mode": Mode.parse,
+    "branch_prefix": str,
+    "privacy": str,
+    "contribute": bool,
+    "excluded_skills": _parse_excluded_skills,
+}
+
+# ``T3_*`` env vars that win over both the per-overlay override and the
+# global setting. Mapped to ``(UserSettings field, parser)``.
+ENV_SETTING_OVERRIDES: dict[str, tuple[str, Callable[[str], Any]]] = {
+    "T3_MODE": ("mode", Mode.parse),
+}
+
+
 @dataclass
 class OverlayEntry:
     name: str
     overlay_class: str
     project_path: Path | None = None
+    overrides: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -132,10 +159,7 @@ class TeaTreeConfig:
 
 def load_config(path: Path = CONFIG_PATH) -> TeaTreeConfig:
     if not path.is_file():
-        env_mode = os.environ.get("T3_MODE")
-        if env_mode is None:
-            return TeaTreeConfig()
-        return TeaTreeConfig(user=UserSettings(mode=Mode.parse(env_mode)))
+        return TeaTreeConfig()
 
     with path.open("rb") as f:
         raw = tomllib.load(f)
@@ -147,10 +171,8 @@ def load_config(path: Path = CONFIG_PATH) -> TeaTreeConfig:
     raw_excluded = teatree.get("excluded_skills", [])
     excluded_skills = [str(s) for s in raw_excluded] if isinstance(raw_excluded, list) else []
 
-    env_mode = os.environ.get("T3_MODE")
     toml_mode = teatree.get("mode")
-    mode_value = env_mode if env_mode is not None else toml_mode
-    mode = Mode.parse(mode_value) if mode_value is not None else Mode.INTERACTIVE
+    mode = Mode.parse(toml_mode) if toml_mode is not None else Mode.INTERACTIVE
 
     user = UserSettings(
         workspace_dir=workspace_dir,
@@ -206,16 +228,59 @@ def worktrees_dir() -> Path:
     return load_config().user.worktrees_dir
 
 
-def get_mode() -> Mode:
-    """Return the active operating mode.
+def get_effective_settings() -> UserSettings:
+    """Return the user settings with env and per-overlay overrides applied.
 
-    Reads ``T3_MODE`` (env) first, then ``teatree.mode`` from
-    ``~/.teatree.toml``, defaulting to ``Mode.INTERACTIVE``. Call sites
-    branch with ``get_mode() is Mode.AUTO`` — we deliberately avoid thin
-    ``is_auto`` / ``is_interactive`` wrappers so the config module stays
-    within its public-function budget.
+    Resolution per field (first match wins): ``T3_*`` env var (see
+    ``ENV_SETTING_OVERRIDES``), active overlay's override from
+    ``[overlays.<name>]``, global ``[teatree]`` value, ``UserSettings``
+    dataclass default.
+
+    The active overlay is resolved via ``T3_OVERLAY_NAME`` first (matches
+    ``get_overlay()``), then cwd-based discovery, then the single
+    installed overlay.
+
+    To make an additional setting overridable, add it to
+    ``OVERLAY_OVERRIDABLE_SETTINGS`` (per-overlay) or
+    ``ENV_SETTING_OVERRIDES`` (env). The resolver picks it up generically
+    via ``dataclasses.replace`` — no per-setting getter glue required.
+    Callers read the effective value with ``get_effective_settings().X``.
     """
-    return load_config().user.mode
+    base = load_config().user
+    active = _active_overlay_entry()
+    overrides: dict[str, Any] = dict(active.overrides) if active is not None else {}
+    for env_var, (field_name, parser) in ENV_SETTING_OVERRIDES.items():
+        raw = os.environ.get(env_var)
+        if raw is not None:
+            overrides[field_name] = parser(raw)
+    if not overrides:
+        return base
+    return replace(base, **overrides)
+
+
+def _active_overlay_entry() -> OverlayEntry | None:
+    """Find the active overlay's toml entry (carrying any overrides).
+
+    Prefers ``T3_OVERLAY_NAME`` (the same env var ``get_overlay()`` uses)
+    to avoid worktree-dir/overlay-name mismatch.
+    """
+    overlays = discover_overlays()
+    by_name = {entry.name: entry for entry in overlays}
+
+    name = os.environ.get("T3_OVERLAY_NAME")
+    if name and name in by_name:
+        return by_name[name]
+
+    fallback = discover_active_overlay()
+    if fallback is not None and fallback.name in by_name:
+        # The cwd-based lookup returns a bare OverlayEntry without overrides;
+        # swap in the toml entry so override parsing applies.
+        return by_name[fallback.name]
+
+    if len(overlays) == 1:
+        return overlays[0]
+
+    return None
 
 
 def check_for_updates(*, force: bool = False) -> str | None:
@@ -311,7 +376,16 @@ def discover_overlays(config_path: Path = CONFIG_PATH) -> list[OverlayEntry]:
             settings_module = _extract_settings_module(manage_py) if manage_py.is_file() else ""
             # Store settings module as overlay_class fallback so callers can still use it
             overlay_class = settings_module
-        seen[name] = OverlayEntry(name=name, overlay_class=overlay_class, project_path=project_path)
+        overrides: dict[str, Any] = {}
+        for key, parser in OVERLAY_OVERRIDABLE_SETTINGS.items():
+            if key in overlay_cfg:
+                overrides[key] = parser(overlay_cfg[key])
+        seen[name] = OverlayEntry(
+            name=name,
+            overlay_class=overlay_class,
+            project_path=project_path,
+            overrides=overrides,
+        )
 
     # 2. Entry points (skip if already found via toml)
     for ep in entry_points(group="teatree.overlays"):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from teatree.config import (
     E2ERepo,
     Mode,
+    OverlayEntry,
     _extract_settings_module,
     _resolve_ep_project_path,
     _write_update_cache,
@@ -18,7 +19,7 @@ from teatree.config import (
     discover_active_overlay,
     discover_overlays,
     get_data_dir,
-    get_mode,
+    get_effective_settings,
     load_config,
     load_e2e_repos,
     workspace_dir,
@@ -692,16 +693,28 @@ class TestMode:
         assert config.user.mode is Mode.AUTO
 
     def test_env_var_overrides_toml(self, tmp_path, monkeypatch):
+        """T3_MODE wins over the toml global — verified via get_effective_settings."""
         config_path = tmp_path / ".teatree.toml"
         _write_toml(config_path, '[teatree]\nmode = "auto"\n')
         monkeypatch.setenv("T3_MODE", "interactive")
-        config = load_config(config_path)
-        assert config.user.mode is Mode.INTERACTIVE
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        with (
+            patch("teatree.config.load_config", return_value=load_config(config_path)),
+            patch("teatree.config.discover_overlays", return_value=[]),
+            patch("teatree.config.discover_active_overlay", return_value=None),
+        ):
+            assert get_effective_settings().mode is Mode.INTERACTIVE
 
     def test_env_var_applies_without_toml(self, tmp_path, monkeypatch):
+        """T3_MODE applies even when no toml file exists."""
         monkeypatch.setenv("T3_MODE", "auto")
-        config = load_config(tmp_path / "nonexistent.toml")
-        assert config.user.mode is Mode.AUTO
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        with (
+            patch("teatree.config.load_config", return_value=load_config(tmp_path / "nonexistent.toml")),
+            patch("teatree.config.discover_overlays", return_value=[]),
+            patch("teatree.config.discover_active_overlay", return_value=None),
+        ):
+            assert get_effective_settings().mode is Mode.AUTO
 
     def test_load_config_invalid_mode_raises(self, tmp_path, monkeypatch):
         monkeypatch.delenv("T3_MODE", raising=False)
@@ -716,10 +729,134 @@ class TestMode:
     def test_get_mode_reflects_loaded_config(self, monkeypatch):
         from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
 
+        monkeypatch.delenv("T3_MODE", raising=False)
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+
         auto_config = TeaTreeConfig(user=UserSettings(mode=Mode.AUTO))
-        with patch("teatree.config.load_config", return_value=auto_config):
-            assert get_mode() is Mode.AUTO
+        with (
+            patch("teatree.config.load_config", return_value=auto_config),
+            patch("teatree.config.discover_overlays", return_value=[]),
+            patch("teatree.config.discover_active_overlay", return_value=None),
+        ):
+            assert get_effective_settings().mode is Mode.AUTO
 
         interactive_config = TeaTreeConfig(user=UserSettings(mode=Mode.INTERACTIVE))
-        with patch("teatree.config.load_config", return_value=interactive_config):
-            assert get_mode() is Mode.INTERACTIVE
+        with (
+            patch("teatree.config.load_config", return_value=interactive_config),
+            patch("teatree.config.discover_overlays", return_value=[]),
+            patch("teatree.config.discover_active_overlay", return_value=None),
+        ):
+            assert get_effective_settings().mode is Mode.INTERACTIVE
+
+
+# ── per-overlay override machinery ───────────────────────────────────
+
+
+class TestOverlayOverrides:
+    """Per-overlay overrides for any key in ``OVERLAY_OVERRIDABLE_SETTINGS``.
+
+    The resolution chain is env (where applicable) → active overlay override
+    → global → dataclass default. The active overlay is picked via
+    ``T3_OVERLAY_NAME`` when set, else cwd-based discovery.
+    """
+
+    def test_overlay_toml_mode_parsed(self, tmp_path):
+        config_path = tmp_path / ".teatree.toml"
+        _write_toml(
+            config_path,
+            """
+[teatree]
+mode = "interactive"
+
+[overlays.my-overlay]
+class = "x.y:Z"
+mode = "auto"
+""",
+        )
+        entries = discover_overlays(config_path=config_path)
+        by_name = {e.name: e for e in entries}
+        assert by_name["my-overlay"].overrides["mode"] is Mode.AUTO
+
+    def test_overlay_invalid_mode_raises(self, tmp_path):
+        config_path = tmp_path / ".teatree.toml"
+        _write_toml(
+            config_path,
+            """
+[overlays.my-overlay]
+class = "x.y:Z"
+mode = "nope"
+""",
+        )
+        import pytest  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="Invalid t3 mode"):
+            discover_overlays(config_path=config_path)
+
+    def test_overlay_override_wins_over_global(self, monkeypatch):
+        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
+
+        monkeypatch.delenv("T3_MODE", raising=False)
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+
+        global_config = TeaTreeConfig(user=UserSettings(mode=Mode.INTERACTIVE, branch_prefix="ac"))
+        active = OverlayEntry(
+            name="my-overlay",
+            overlay_class="x",
+            overrides={"mode": Mode.AUTO, "branch_prefix": "xp"},
+        )
+        with (
+            patch("teatree.config.load_config", return_value=global_config),
+            patch("teatree.config.discover_overlays", return_value=[active]),
+            patch("teatree.config.discover_active_overlay", return_value=active),
+        ):
+            effective = get_effective_settings()
+            assert effective.mode is Mode.AUTO
+            assert effective.branch_prefix == "xp"
+            assert get_effective_settings().mode is Mode.AUTO
+
+    def test_overlay_without_override_inherits_global(self, monkeypatch):
+        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
+
+        monkeypatch.delenv("T3_MODE", raising=False)
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+
+        global_config = TeaTreeConfig(user=UserSettings(mode=Mode.AUTO))
+        active = OverlayEntry(name="x", overlay_class="y", overrides={})
+        with (
+            patch("teatree.config.load_config", return_value=global_config),
+            patch("teatree.config.discover_overlays", return_value=[active]),
+            patch("teatree.config.discover_active_overlay", return_value=active),
+        ):
+            assert get_effective_settings().mode is Mode.AUTO
+
+    def test_env_var_beats_overlay_override(self, monkeypatch):
+        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
+
+        monkeypatch.setenv("T3_MODE", "interactive")
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+
+        global_config = TeaTreeConfig(user=UserSettings(mode=Mode.INTERACTIVE))
+        active = OverlayEntry(name="x", overlay_class="y", overrides={"mode": Mode.AUTO})
+        with (
+            patch("teatree.config.load_config", return_value=global_config),
+            patch("teatree.config.discover_overlays", return_value=[active]),
+            patch("teatree.config.discover_active_overlay", return_value=active),
+        ):
+            assert get_effective_settings().mode is Mode.INTERACTIVE
+
+    def test_t3_overlay_name_selects_entry(self, monkeypatch):
+        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
+
+        monkeypatch.delenv("T3_MODE", raising=False)
+        monkeypatch.setenv("T3_OVERLAY_NAME", "b")
+
+        global_config = TeaTreeConfig(user=UserSettings(mode=Mode.INTERACTIVE))
+        entry_a = OverlayEntry(name="a", overlay_class="x", overrides={"mode": Mode.INTERACTIVE})
+        entry_b = OverlayEntry(name="b", overlay_class="y", overrides={"mode": Mode.AUTO})
+        with (
+            patch("teatree.config.load_config", return_value=global_config),
+            patch("teatree.config.discover_overlays", return_value=[entry_a, entry_b]),
+            # cwd-based fallback would pick "a" — but T3_OVERLAY_NAME must win.
+            patch("teatree.config.discover_active_overlay", return_value=entry_a),
+        ):
+            assert get_effective_settings().mode is Mode.AUTO


### PR DESCRIPTION
feat(config): generic per-overlay override for UserSettings fields [none] (https://github.com/souliane/teatree/issues/374)

## Summary
- Adds a generic registry-driven mechanism to override any `UserSettings` field per overlay via `[overlays.<name>]` sections in `~/.teatree.toml`.
- Resolution chain: `T3_*` env var → active overlay override → global `[teatree]` → dataclass default. Exposed through a single pivot `get_effective_settings() -> UserSettings`.
- First customers: `mode`, `branch_prefix`, `privacy`, `contribute`, `excluded_skills`. Active overlay is resolved from `T3_OVERLAY_NAME` (falls back to cwd-based discovery, then single-overlay).
- Removes the ad-hoc `get_mode()` helper — all callers read `get_effective_settings().mode`. Keeps the module-health public-function budget at 10.

## Test plan
- [x] `uv run pytest tests/test_config.py --no-cov -x -q` (61 tests, including new `TestOverlayOverrides` covering parse, invalid value, per-overlay wins, inheritance, env beats overlay, `T3_OVERLAY_NAME` selection).
- [ ] CI pipeline green on this PR.

Fixes #374