### PR TITLE
fix(cleanup): add workspace clean-merged + surface MR-merge cleanup errors (https://github.com/souliane/teatree/issues/380)

### DIFF
--- a/src/teatree/backends/gitlab_sync.py
+++ b/src/teatree/backends/gitlab_sync.py
@@ -354,9 +354,9 @@ class GitLabSyncBackend(SyncBackend):
             try:
                 cleanup_worktree(worktree)
                 result.worktrees_cleaned += 1
-            except Exception:
+            except Exception as exc:
                 logger.exception("Failed to clean worktree %s", worktree.repo_path)
-                result.errors.append(f"Worktree cleanup failed: {worktree.repo_path}")
+                result.errors.append(f"Worktree cleanup failed for {worktree.repo_path} ({worktree.branch}): {exc}")
 
     @classmethod
     def _fetch_assigned_issues(

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -396,6 +396,29 @@ class Command(TyperCommand):
                 )
         return "\n".join(results)
 
+    @command(name="clean-merged")
+    def clean_merged(self) -> list[str]:
+        """Tear down every worktree whose ticket is already MERGED.
+
+        On-demand reconciler for the daily followup sync. Use when merged-MR
+        cleanup silently failed and stale docker containers, branches, or
+        databases linger. Errors are surfaced inline — no suppression.
+        """
+        cleaned: list[str] = []
+        merged_tickets = Ticket.objects.filter(state=Ticket.State.MERGED)
+        for ticket in merged_tickets:
+            worktrees = list(Worktree.objects.filter(ticket=ticket))
+            if not worktrees:
+                continue
+            for wt in worktrees:
+                try:
+                    cleaned.append(cleanup_worktree(wt, force=True))
+                except RuntimeError as exc:
+                    cleaned.append(f"FAILED {wt.repo_path} ({wt.branch}): {exc}")
+        if not cleaned:
+            return ["No merged tickets have lingering worktrees."]
+        return cleaned
+
     @command(name="clean-all")
     def clean_all(
         self,

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -952,6 +952,44 @@ class TestWorkspaceCleanAll(TestCase):
             assert Worktree.objects.filter(branch="ac-frontend-360-ticket").count() == 1
 
 
+class TestWorkspaceCleanMerged(TestCase):
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_no_merged_tickets_returns_placeholder(self) -> None:
+        cleaned = cast("list[str]", call_command("workspace", "clean-merged"))
+        assert cleaned == ["No merged tickets have lingering worktrees."]
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_cleans_worktrees_of_merged_tickets(self) -> None:
+        merged = Ticket.objects.create(
+            overlay="test", issue_url="https://example.com/issues/70", state=Ticket.State.MERGED
+        )
+        Worktree.objects.create(overlay="test", ticket=merged, repo_path="repo", branch="ac-repo-70")
+        other = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/71")
+        Worktree.objects.create(overlay="test", ticket=other, repo_path="repo2", branch="ac-repo2-71")
+
+        with patch.object(workspace_mod, "cleanup_worktree", return_value="Cleaned: repo (ac-repo-70)") as mock_cleanup:
+            cleaned = cast("list[str]", call_command("workspace", "clean-merged"))
+
+        assert cleaned == ["Cleaned: repo (ac-repo-70)"]
+        assert mock_cleanup.call_count == 1
+        assert mock_cleanup.call_args.kwargs.get("force") is True
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_surfaces_cleanup_failures(self) -> None:
+        merged = Ticket.objects.create(
+            overlay="test", issue_url="https://example.com/issues/72", state=Ticket.State.MERGED
+        )
+        Worktree.objects.create(overlay="test", ticket=merged, repo_path="repo", branch="ac-repo-72")
+
+        with patch.object(workspace_mod, "cleanup_worktree", side_effect=RuntimeError("docker down failed")):
+            cleaned = cast("list[str]", call_command("workspace", "clean-merged"))
+
+        assert any("FAILED" in c and "docker down failed" in c for c in cleaned)
+
+
 def _subprocess_side_effect(gh_stdout: str, glab_stdout: str):
     """Return a side_effect function that dispatches mock stdout based on the CLI command."""
 

--- a/tests/teatree_core/test_sync.py
+++ b/tests/teatree_core/test_sync.py
@@ -877,6 +877,8 @@ class TestApplyMergedStatusAllMerged(TestCase):
         assert ticket.state == Ticket.State.MERGED
         assert result.worktrees_cleaned == 0
         assert any("cleanup failed" in e for e in result.errors)
+        # Error must carry the repo + branch so the dashboard can point at the stuck worktree.
+        assert any("org/repo" in e and "fix-4" in e for e in result.errors)
 
 
 class TestSyncFollowup(TestCase):


### PR DESCRIPTION
fix(cleanup): add workspace clean-merged + surface MR-merge cleanup errors (https://github.com/souliane/teatree/issues/380)

## Summary

Two robustness fixes for the merged-ticket cleanup flow — diagnosed from the repeated port 6379 collisions on merged-ticket containers (see [#380](https://github.com/souliane/teatree/issues/380)):

- **`t3 workspace clean-merged`**: on-demand reconciler that iterates tickets in state `MERGED` and tears down any lingering worktrees (docker containers, git worktree, branch, database, redis slot). Today the only entry point is the daily followup sync — when that silently drops an error, stale docker containers (e.g. old `-wt72-rd-1`) linger for hours holding host port 6379 and blocking future `lifecycle start` calls. This command gives a fast recovery path without running the full followup.
- **Enriched cleanup errors**: `_cleanup_merged_worktrees` now includes the repo + branch in `SyncResult.errors` so the dashboard shows which worktree is stuck instead of a bare `"Worktree cleanup failed: <repo_path>"`.

## Test plan

- [x] `tests/teatree_core/test_new_management_commands.py::TestWorkspaceCleanMerged` — 3 cases covering no-op, happy path (with `force=True`), error surfacing.
- [x] `tests/teatree_core/test_sync.py::TestApplyMergedStatusAllMerged::test_cleanup_failure_does_not_block_merge` — extended to assert repo + branch appear in the error string.
- [x] Full sync + management-commands suite: 307 passed, 0 failed.
- [ ] Manual: run `t3 workspace clean-merged` against a workspace with a merged ticket and verify stale containers drop, `ticket.redis_db_index` goes null.

Relates-to #380