### PR TITLE
docs: reframe teatree as personal code factory

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "t3",
-      "description": "Multi-repo worktree lifecycle manager for AI-assisted development",
+      "description": "Personal code factory for multi-repo projects",
       "source": "./",
       "category": "development",
       "homepage": "https://github.com/souliane/teatree"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "t3",
   "version": "0.0.1",
-  "description": "Multi-repo worktree lifecycle manager for AI-assisted development",
+  "description": "Personal code factory for multi-repo projects",
   "author": {
     "name": "souliane",
     "url": "https://github.com/souliane"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This is the teatree repo — both the Python package (`src/teatree/`) and the wo
 
 ## What TeaTree Is
 
-A multi-repo worktree lifecycle manager for AI-assisted development. Target: service-oriented projects with databases and CI pipelines (any language). Not for docs-only repos or CLI tools.
+A personal code factory for multi-repo projects. It turns a ticket URL into a merged pull request by coordinating worktrees, databases, ports, AI agents, and code-host sync across every repo the ticket touches. Target: service-oriented projects with databases and CI pipelines (any language). Not for docs-only repos or CLI tools.
 
 It provides:
 

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -10,7 +10,7 @@ If the entire `src/` and `tests/` tree were deleted, this document alone — plu
 
 ## 1. What TeaTree Is
 
-A multi-repo worktree lifecycle manager for AI-assisted development. It manages the full lifecycle of a development ticket: from intake through coding, testing, review, shipping, and delivery — coordinating across multiple repositories, worktrees, and agent sessions.
+A personal code factory for multi-repo projects. It turns a ticket URL into a merged pull request by coordinating the full lifecycle — intake, coding, testing, review, shipping, delivery — across multiple repositories, worktrees, and agent sessions.
 
 **Target:** service-oriented projects with databases and CI pipelines (any language). Not for docs-only repos or CLI tools.
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
   <a href="https://github.com/souliane/teatree/blob/main/LICENSE"><img src="https://img.shields.io/github/license/souliane/teatree" alt="License"></a>
 </p>
 
-Multi-repo worktree lifecycle manager for AI-assisted development.
+Personal code factory for multi-repo projects.
 
-Teatree coordinates development work across multiple repositories: creating worktrees, provisioning databases, allocating ports, running services, syncing with code hosts, and tracking tickets through their entire lifecycle. It's a Django project — overlays are lightweight Python packages that plug in project-specific behaviour via entry points.
+Teatree turns a ticket URL into a merged pull request. It creates synchronized worktrees across every repo the ticket touches, provisions isolated databases and ports, routes AI agents through code → test → review → ship phases, and tracks each ticket through a state machine until delivery. If your work lives in a single repo, use a simpler tool — teatree is built for projects where one ticket means changes in several repos, each needing its own environment.
+
+Under the hood it's a Django project with a plugin system (overlays) that adapts it to your repos, CI, and services.
 
 ```mermaid
 graph TB
@@ -44,6 +46,54 @@ graph TB
   skills -->|"delegates to"| lifecycle & workspace & db & run & pr
   hooks -->|"enforces"| skills
 ```
+
+## Core concepts
+
+Teatree coordinates work through **four state machines** — each transition is a typed code path with tests, not a prompt the model might skip.
+
+**Ticket** — tracks a unit of work from intake to delivery. The state flow mirrors the [Skills diagram](#skills) below: each phase (ticket → code → test → review → ship) completes a corresponding ticket state (scoped → coded → tested → reviewed → shipped), plus terminal states `merged` and `delivered`.
+
+**Worktree** — one repo checkout inside a ticket's workspace.
+
+```mermaid
+stateDiagram-v2
+  [*] --> created
+  created --> provisioned: provision
+  provisioned --> services_up: start
+  services_up --> ready: verify
+  ready --> provisioned: db_refresh
+  services_up --> provisioned: db_refresh
+  ready --> created: teardown
+  services_up --> created: teardown
+  provisioned --> created: teardown
+```
+
+**Task** — claimable work unit with lease and heartbeat.
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending
+  pending --> claimed: claim
+  claimed --> completed: success
+  claimed --> failed: error
+  claimed --> pending: lease_expired
+```
+
+**MergeRequest** — tracks delivery state on the code host.
+
+```mermaid
+stateDiagram-v2
+  [*] --> open
+  open --> review_requested: request_review
+  review_requested --> approved: approve
+  approved --> merged: merge
+```
+
+Agents read skills to do the *creative* work (writing code, reviewing a diff, choosing how to test); the CLI owns the *mechanical* work (branching, ports, DB refresh, pipeline waits, MR validation). Three interfaces sit on top:
+
+- **CLI** (`t3 ...`) — the source of truth. Everything else is a view on top.
+- **Dashboard** — web UI for tickets, MRs, pipelines, and agent sessions.
+- **Claude plugin** — skills and hooks that teach an agent how to drive the CLI.
 
 ## Three Tiers
 
@@ -158,24 +208,32 @@ graph LR
 | `workspace` | Environment and workspace lifecycle — worktree creation, setup, DB provisioning, dev servers, cleanup |
 <!-- END SKILLS -->
 
-### Skill Dependencies
+### Extended `SKILL.md` frontmatter
 
-Skills declare hard dependencies (`requires:`) and optional companion skills (`companions:`) in their YAML frontmatter:
+Teatree adds a small schema on top of Claude Code's standard `SKILL.md` frontmatter so skills can declare *when* they should load and *what* they need alongside them:
 
 ```yaml
 ---
-name: code
-requires:
-  - workspace
-companions:
-  - test-driven-development
-  - verification-before-completion
+name: ship
+triggers:
+  priority: 20
+  keywords: ['\b(commit|push|ship)\b']
+  exclude: '\breview\b'
+  end_of_session: true
+requires: [rules, platforms]
+companions: [verification-before-completion]
+search_hints: [deliver, merge request, PR]
 ---
 ```
 
-The `UserPromptSubmit` hook resolves these automatically — when it suggests loading `code`, it also loads `workspace` (required) and `test-driven-development` + `verification-before-completion` (companions, if installed). Missing companions produce a warning; missing requirements produce an error.
+- `triggers` — deterministic auto-load rules (keywords, URLs, priority, exclude, end-of-session phrases)
+- `requires` — hard dependencies, resolved transitively with cycle detection
+- `companions` — optional third-party skills (e.g. from [obra/superpowers](https://github.com/obra/superpowers), installed via [APM](https://github.com/microsoft/apm), never modified by teatree)
+- `search_hints` — keyword synonyms used to route headless tasks to the right skill
 
-Companion skills come from third-party packages like [obra/superpowers](https://github.com/obra/superpowers) and are installed via [APM](https://github.com/microsoft/apm). Teatree skills are never modified — the `companions:` field lives in teatree's frontmatter, not in the companion's.
+The `UserPromptSubmit` hook matches the prompt against a cached trigger index and injects `LOAD THESE SKILLS NOW: ...`. `PreToolUse` blocks edits until the injected skills are loaded. Matching is regex, not the model — skill loading is no longer the agent's decision.
+
+See [docs/skill-triggers.md](docs/skill-triggers.md) for the full schema and [docs/claude-code-internals.md](docs/claude-code-internals.md) for how the hooks wire into Claude Code.
 
 ## Project Overlay
 
@@ -312,7 +370,7 @@ Because skills reference the CLI and the overlay API. Keeping them together mean
 
 **Why "teatree"?**
 
-**TEA**'s **E**xtensible **A**rchitecture for work**tree** management. Also: teatree oil cuts through grime, and that's what this does to multi-repo worktree friction.
+**TEA**'s **E**xtensible **A**rchitecture for work**tree** management.
 
 ## License
 

--- a/apm.yml
+++ b/apm.yml
@@ -1,6 +1,6 @@
 name: souliane/teatree
 version: 0.0.1
-description: Multi-repo worktree lifecycle manager for AI-assisted development
+description: Personal code factory for multi-repo projects
 homepage: https://github.com/souliane/teatree
 license: MIT
 keywords:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Teatree is structured in three tiers:
+Teatree is a personal code factory: four state machines (`Ticket`, `Worktree`, `Task`, `MergeRequest`) coordinate the work; three interfaces (CLI, Dashboard, Claude plugin) let a human and an agent drive it. The implementation is layered into three tiers.
 
 ```mermaid
 graph TB

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,24 @@
 # TeaTree
 
-A Django extension package that manages multi-repo development workflows with worktree isolation, port allocation, and AI agent orchestration.
+A personal code factory for multi-repo projects. Teatree drives a ticket from intake to merged MR by orchestrating worktrees, databases, ports, AI agents, and code-host sync across every repo the ticket touches.
 
 ## What it does
 
-If your project spans several repos (backend, frontend, translations, configuration), starting work on a ticket means creating the same branch everywhere, setting up worktrees, remapping ports, provisioning databases, and wiring it all together. Teatree automates that.
+If your project spans several repos (backend, frontend, translations, configuration), starting work on a ticket means creating the same branch everywhere, setting up worktrees, remapping ports, provisioning databases, and wiring it all together. Teatree automates that — and then drives each ticket through its lifecycle: code, test, review, ship.
 
-The core idea: each workflow phase -- ticket intake, coding, testing, review, delivery -- is encoded as a skill file that an AI agent reads and follows. Skills are plain markdown and shell scripts. Any agent that can read files and run commands can use them.
+## Core concepts
+
+Teatree coordinates work through **four state machines** — `Ticket`, `Worktree`, `Task`, `MergeRequest` — each with typed transitions and tests. Agents read skills to do the *creative* work; the CLI owns the *mechanical* work.
+
+Three interfaces sit on top:
+
+- **CLI** (`t3 ...`) — the source of truth. Everything else is a view on top.
+- **Dashboard** — web UI for tickets, MRs, pipelines, and agent sessions.
+- **Claude plugin** — skills and hooks that teach an agent how to drive the CLI.
 
 ## How it fits together
 
-- **`teatree/`** -- the Django extension package. Models, management commands, overlay loader, views, and the `t3` CLI.
+- **`teatree/`** -- the Django project. Models, management commands, overlay loader, views, and the `t3` CLI.
 - **`skills/*/`** -- skill directories. Each teaches the agent one phase of the development lifecycle.
 - **Overlay pattern** -- project-specific behaviour lives in a lightweight overlay package that subclasses `OverlayBase` and registers via a `teatree.overlays` entry point. Teatree stays generic; the overlay wires in your repos, services, and provisioning steps.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: TeaTree
-site_description: Multi-repo worktree lifecycle manager for AI-assisted development
+site_description: Personal code factory for multi-repo projects
 repo_url: https://github.com/souliane/teatree
 
 theme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.7,<0.12" ]
 [project]
 name = "teatree"
 version = "0.0.1"
-description = "Multi-repo worktree lifecycle manager for AI-assisted development"
+description = "Personal code factory for multi-repo projects"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.13"

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -35,7 +35,7 @@ search_hints:
 
 # TeaTree — Agent Lifecycle Platform
 
-TeaTree is a Django project that orchestrates agent workflows through lifecycle phases. Overlays are lightweight Python packages that extend it for specific projects.
+TeaTree is a personal code factory for multi-repo projects — it turns a ticket URL into a merged pull request by driving AI agents through lifecycle phases. Under the hood it's a Django project; overlays are lightweight Python packages that extend it for specific projects.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Reframes teatree's top-level story across README, docs, BLUEPRINT, AGENTS, and package descriptions. Replaces *"multi-repo worktree lifecycle manager for AI-assisted development"* with *"personal code factory for multi-repo projects"* and moves Django to an under-the-hood detail rather than the lead.

- Inspired by the djangocon-teatree-I deck framing (4 state machines, 3 interfaces, output-oriented).
- README picks up a new **Core concepts** section with mermaid `stateDiagram-v2` blocks for `Worktree`, `Task`, and `MergeRequest`. `Ticket` references the existing Skills diagram rather than duplicating its flow.
- Elevates the extended `SKILL.md` frontmatter schema (`triggers`, `requires`, `companions`, `search_hints`) from a footnote to its own section with a worked example — this is a real contribution teatree makes to the Claude Code skill ecosystem.
- Drops the "teatree oil cuts through grime" FAQ line.

## Files changed

- `README.md` — new tagline, opening, Core concepts + mermaid, elevated frontmatter section, FAQ tweak
- `docs/index.md`, `docs/architecture.md` — matching reframe
- `BLUEPRINT.md` §1, `AGENTS.md` "What TeaTree Is" — matching lead
- `skills/teatree/SKILL.md` — body intro matches new framing
- `apm.yml`, `mkdocs.yml`, `pyproject.toml`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` — one-liner descriptions updated

## Test plan

- [x] Pre-commit hooks pass (ruff, markdown, codespell, banned-terms, frontmatter validator, version sync, quality gates)
- [ ] CI green
- [ ] Render mermaid diagrams on GitHub

Docs-only; no code paths or tests affected.