### PR TITLE
chore(prek): move pip-audit to manual stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -194,7 +194,7 @@ repos:
         pass_filenames: false
         always_run: true
 
-  # Phase 8 - Slow (pip-audit)
+  # Phase 8 - Slow (pip-audit, manual-only — CI runs it on every PR)
   - repo: local
     hooks:
       - id: pip-audit
@@ -210,7 +210,7 @@ repos:
           "
         pass_filenames: false
         files: ^(pyproject\.toml|uv\.lock)$
-        stages: [commit, manual]
+        stages: [manual]
 
   # Phase 8b - Pre-push (Docker)
   - repo: local


### PR DESCRIPTION
## Summary

CI already runs `pip-audit` in a dedicated job on every PR (`.github/workflows/ci.yml` lines 24-38). Running it locally on every commit is redundant and noticeably slows down the commit hook chain.

This keeps the hook registered so it can still be invoked manually:

\`\`\`sh
prek run --hook-stage manual pip-audit
\`\`\`

## Change

- \`.pre-commit-config.yaml\`: \`stages: [commit, manual]\` → \`stages: [manual]\`

## Test plan

- [x] Commit on this branch ran without invoking \`pip-audit\` locally
- [ ] CI pip-audit job still runs on PR

One-liner config change; no code paths affected.