### PR TITLE
relax(workspace): squash-merge-aware cleanup + interactive clean-all + github sync auto-clean [none] (https://github.com/souliane/teatree/issues/379)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -62,6 +62,7 @@ src/teatree/
     overlay.py          # OverlayBase ABC (see §6)
     overlay_loader.py   # Settings-driven overlay instantiation
     sync.py             # Shared types, SyncBackend ABC, orchestrator (sync_followup)
+    cleanup.py          # Shared worktree cleanup + squash-merge-aware branch classifier (classify_branch_commits)
     tasks.py            # django-tasks integration
     docgen.py           # Overlay/skill documentation generation
     urls.py             # URL routing
@@ -99,7 +100,7 @@ src/teatree/
     protocols.py        # Protocol classes (see §7)
     loader.py           # Settings-driven backend loader with lru_cache
     github.py           # GitHub API client
-    github_sync.py      # GitHubSyncBackend — Projects v2 board + reviewer PR sync
+    github_sync.py      # GitHubSyncBackend — Projects v2 board + reviewer PR sync + auto-cleanup on board "Done"
     gitlab.py           # GitLab API client (httpx)
     gitlab_ci.py        # GitLab CI pipeline operations
     gitlab_sync.py      # GitLabSyncBackend — MR upsert, assigned-issue upsert, labels, merged MR cleanup, Slack review permalinks

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -351,39 +351,11 @@ For each touched repo, collect and display:
 
 #### Squash-merge cross-check (Non-Negotiable)
 
-Before treating any local branch or stash as "unpushed work", **cross-reference against merged PRs**. Squash merges create new commit hashes — ancestry checks return false even when the work is already on main. A false-positive here leads to pushing stale content or recommitting already-merged changes.
+Before treating any local branch as "unpushed work", **cross-reference against the default branch**. Squash-merges create new SHAs, so `git log --not --remotes` by SHA alone will flag merged branches as unsynced.
 
-For each candidate branch, run **both** checks:
+Delegate this to the CLI: **run `t3 teatree workspace clean-all`**. It classifies each branch's unsynced commits into `squash_merged` (subject matches a commit on `origin/main` after stripping `(#NNN)` suffix and conventional-commit type prefix), `merge_commits` (multi-parent — safe to discard), and `genuinely_ahead` (real pending work). Only genuinely-ahead branches block cleanup.
 
-1. **Subject match** — does the branch's tip commit subject match a merged PR's title?
-
-   ```bash
-   gh pr list --repo <org>/<repo> --state merged --limit 80 --json number,title > /tmp/merged.json
-   ```
-
-   Strip `\s*\(#\d+\)$` from both `git log -1 --pretty=%s <branch>` and each `pr.title`. An exact match = squash-merged → safe to delete.
-
-2. **File existence check for stashes / orphan commits** — if the stash/branch edits a file, does that file still exist on main? `git show main:<path>` — if the file was deleted by a merged PR, the stash is obsolete regardless of subject.
-
-Any branch or stash that fails to match via (1) AND whose files still exist per (2) **must be treated as real unpushed work** and surfaced to the user with a concrete choice (push+PR / drop / show diff).
-
-Store the Python helper inline when needed — 20+ branches across 2 repos is repetitive enough to justify a script. Small script recipe (save output to `/tmp/` for session reuse):
-
-```python
-# Input: gh pr list --state merged JSON at /tmp/merged.json, list of branches to check
-# Output: classification per branch (SAFE_TO_DELETE / NEEDS_REVIEW / NO_COMMITS_AHEAD)
-import json, subprocess, re
-with open("/tmp/merged.json") as f:
-    merged = {re.sub(r"\s*\(#\d+\)$", "", p["title"]).strip() for p in json.load(f)}
-for b in branches:
-    subj = re.sub(r"\s*\(#\d+\)$", "",
-        subprocess.check_output(["git", "log", "-1", "--pretty=%s", b], text=True).strip()).strip()
-    ahead = subprocess.check_output(["git", "log", "origin/main..%s" % b, "--pretty=%s"], text=True).strip().splitlines()
-    status = "SAFE_TO_DELETE" if subj in merged else ("NEEDS_REVIEW" if ahead else "NO_COMMITS_AHEAD")
-    print(f"{status:20} {b}")
-```
-
-`NEEDS_REVIEW` branches may still be merged — the PR may have a retitled subject. Fall back to broader needle searches (`gh pr list --search "<keyword>"`) or ask the user before deleting.
+Inside a TTY, `clean-all` prompts for each blocked worktree — `[P]ush to remote / [A]bandon (force delete) / [S]kip`. In a non-TTY context it preserves the old skip-and-report behaviour. Reach for the subject-matching Python recipe only when you need to classify raw stashes or stray local branches outside a tracked worktree.
 
 ### 6. Verification
 

--- a/skills/workspace/references/troubleshooting.md
+++ b/skills/workspace/references/troubleshooting.md
@@ -46,6 +46,21 @@
 - **Fix:** Re-run without `--delete-branch`: `gh pr merge <n> --squash`. Then clean up manually: `git fetch --prune origin` deletes the remote-tracking ref, and from the main clone run `git worktree remove <path>` and `git branch -D <branch>` to drop the local worktree and branch.
 - **Prevention:** When the main clone is in a sibling worktree, omit `--delete-branch` on `gh pr merge`. The remote delete is handled by GitHub's "auto-delete branch on merge" setting; local cleanup belongs to `git fetch --prune` and `git worktree remove`.
 
+## `clean-all` Refuses a Worktree as "Unsynced" After a Squash Merge
+
+- **Symptom:** `t3 teatree workspace clean-all` reports `refused cleanup — N unsynced commit(s) not on origin/main` for a branch whose PR you just merged via squash.
+- **Cause:** `git log --not --remotes` detects merged-ness by SHA. Squash-merges create a new SHA on `main`, so the branch commit is still "not on any remote" by hash. The cleanup classifier catches this (see `teatree/core/cleanup.py::classify_branch_commits`) by matching commit subjects — after stripping `(#NNN)` PR suffixes and conventional-commit type prefixes (`relax:` vs `feat(scope):`). If the match still fails (e.g. the MR was merged under a completely rewritten title), the branch is reported as genuinely ahead.
+- **Fix (interactive TTY):** `clean-all` prompts `[P]ush to remote / [A]bandon (force delete) / [S]kip (default)`. Choose **A** once you've confirmed the PR was merged (`gh pr list --state merged --head <branch>`). Choose **P** to push the unreviewed work to a new MR.
+- **Fix (non-TTY / CI):** the worktree is left in place and listed as `Skipped:` — rerun interactively or clean it by hand with `git worktree remove <path> --force && git branch -D <branch>`.
+- **Prevention:** keep PR titles aligned with the squash commit message produced by the MR template — the classifier's subject-normalisation covers the common `type(scope): …` + `(#NNN)` case automatically.
+
+## GitHub Board "Done" Transitions Don't Clean Worktrees
+
+- **Symptom:** A ticket is moved to the GitHub Projects v2 "Done" column (or the GitLab MR is merged) but the worktree is still on disk after the next `t3 followup sync`.
+- **Cause:** The branch has genuinely-unpushed commits, so `cleanup_worktree()` refused the delete. The sync logs an `INFO` line (`Keeping worktree … (unpushed work): …`) rather than raising — same squash-merge-aware classifier as `clean-all`.
+- **Fix:** run `t3 teatree workspace clean-all` interactively and choose **P** (push) or **A** (abandon) per the previous entry.
+- **Prevention:** commit or drop scratch work before moving the ticket to Done. `clean-all` never silently loses unpushed content.
+
 ## DSLR Restore Fails Silently
 
 - **Cause:** `dslr` not installed or the snapshot is from an incompatible Postgres version.

--- a/src/teatree/backends/github_sync.py
+++ b/src/teatree/backends/github_sync.py
@@ -5,11 +5,15 @@ import logging
 import os
 import shutil
 import subprocess  # noqa: S404
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from django.core.cache import cache
 
+from teatree.core.cleanup import cleanup_worktree
 from teatree.core.sync import PENDING_REVIEWS_CACHE_KEY, RawAPIDict, SyncBackend, SyncResult
+
+if TYPE_CHECKING:
+    from teatree.core.models import Ticket
 
 logger = logging.getLogger(__name__)
 
@@ -72,16 +76,39 @@ class GitHubSyncBackend(SyncBackend):
                 result.tickets_created += 1
             else:
                 ticket = tickets[0]
+                prior_state = ticket.state
                 existing_extra = ticket.extra if isinstance(ticket.extra, dict) else {}
                 existing_extra.update(extra)
                 ticket.extra = existing_extra
                 ticket.state = state
                 ticket.save(update_fields=["extra", "state"])
                 result.tickets_updated += 1
+                if state == Ticket.State.DELIVERED and prior_state != Ticket.State.DELIVERED:
+                    self._cleanup_ticket_worktrees(ticket, result)
 
         self._sync_reviewer_prs(token, result)
 
         return result
+
+    @classmethod
+    def _cleanup_ticket_worktrees(cls, ticket: "Ticket", result: SyncResult) -> None:
+        """Free worktrees when the project board moves a ticket to Done.
+
+        Squash-merge-aware cleanup via :func:`cleanup_worktree`. Worktrees whose
+        branches carry genuinely-unpushed work are kept (the RuntimeError path);
+        the user resolves those by running ``t3 teatree workspace clean-all``.
+        """
+        from teatree.core.models import Worktree  # noqa: PLC0415
+
+        for worktree in Worktree.objects.filter(ticket=ticket):
+            try:
+                cleanup_worktree(worktree)
+                result.worktrees_cleaned += 1
+            except RuntimeError as exc:
+                logger.info("Keeping worktree %s (unpushed work): %s", worktree.repo_path, exc)
+            except Exception:
+                logger.exception("Failed to clean worktree %s", worktree.repo_path)
+                result.errors.append(f"Worktree cleanup failed: {worktree.repo_path}")
 
     @classmethod
     def _fetch_reviewer_prs(cls, token: str) -> list[dict[str, str]]:

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -1,7 +1,15 @@
-"""Shared worktree cleanup logic used by sync (auto-clean on merge) and workspace commands."""
+"""Shared worktree cleanup logic used by sync (auto-clean on merge) and workspace commands.
+
+The classifier below is the reason this module can be honest about squash-merges:
+``git log --not --remotes`` detects commits by SHA, but a squash-merge creates a
+new SHA on the default branch. Without subject-matching, every squash-merged
+branch looks "unsynced" and blocks cleanup.
+"""
 
 import logging
+import re
 from contextlib import suppress
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from teatree.config import load_config
@@ -12,6 +20,116 @@ from teatree.utils.db import drop_db
 
 logger = logging.getLogger(__name__)
 
+_PR_SUFFIX_RE = re.compile(r"(?:\s*\(#\d+\))+$")
+_TYPE_PREFIX_RE = re.compile(r"^[a-z]+(?:\([^)]+\))?!?:\s*", re.IGNORECASE)
+_BRANCH_LOG_FIELDS = 3
+_SUBJECT_PREVIEW_LIMIT = 3
+
+
+@dataclass(frozen=True)
+class BranchCommit:
+    """A commit on a branch that is not reachable from any remote by SHA."""
+
+    sha: str
+    subject: str
+    is_merge: bool
+
+
+@dataclass(frozen=True)
+class BranchClassification:
+    """Structured view of a branch's unsynced commits, split by disposition.
+
+    ``squash_merged`` — subject matches a commit on the target branch, so the
+    content is already integrated (typical squash-merge case, including the
+    ``relax:`` → ``feat:`` prefix rewrite).
+
+    ``merge_commits`` — commits with multiple parents (Merge branch 'main' into
+    feature). They carry no net content of their own and are safe to discard.
+
+    ``genuinely_ahead`` — everything else. The branch has work that does not
+    appear on the target, so removing it would lose content.
+    """
+
+    squash_merged: list[BranchCommit] = field(default_factory=list)
+    merge_commits: list[BranchCommit] = field(default_factory=list)
+    genuinely_ahead: list[BranchCommit] = field(default_factory=list)
+
+
+def _canonicalize_subject(subject: str) -> str:
+    """Normalize a commit subject for cross-branch matching.
+
+    Strips trailing ``(#NNN)`` suffixes (GitHub/GitLab adds these on squash-merge)
+    and the leading conventional-commit type prefix. Used to match a branch-local
+    commit against commits on the default branch whose subject was rewritten at
+    merge time (e.g. ``relax:`` -> ``feat(scope):``).
+    """
+    stripped = _PR_SUFFIX_RE.sub("", subject).strip()
+    stripped = _TYPE_PREFIX_RE.sub("", stripped).strip()
+    return stripped.lower()
+
+
+def classify_branch_commits(repo: str, branch: str, target: str = "origin/main") -> BranchClassification:
+    """Split the branch's unsynced commits into squash-merged / merge / genuinely-ahead buckets.
+
+    Runs two git log invocations: one to list branch commits not on any remote
+    (same as :func:`git.unsynced_commits`), one to fetch subjects on ``target``
+    for subject matching.
+    """
+    raw = git.run(
+        repo=repo,
+        args=["log", branch, "--not", "--remotes", "--format=%H%x00%P%x00%s"],
+    )
+    classification = BranchClassification()
+    if not raw.strip():
+        return classification
+
+    target_raw = git.run(repo=repo, args=["log", target, "--format=%s", "-n", "500"])
+    target_subjects = {_canonicalize_subject(line) for line in target_raw.splitlines() if line.strip()}
+    target_subjects.discard("")
+
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\x00", 2)
+        if len(parts) < _BRANCH_LOG_FIELDS:
+            continue
+        sha, parents, subject = parts
+        is_merge = len(parents.split()) > 1
+        commit = BranchCommit(sha=sha, subject=subject, is_merge=is_merge)
+        if is_merge:
+            classification.merge_commits.append(commit)
+        elif _canonicalize_subject(subject) in target_subjects:
+            classification.squash_merged.append(commit)
+        else:
+            classification.genuinely_ahead.append(commit)
+    return classification
+
+
+def _raise_if_genuinely_ahead(repo_main: str, worktree: Worktree) -> None:
+    """Raise ``RuntimeError`` when the branch carries commits not on ``origin/main``.
+
+    Merge commits and squash-merged commits are ignored — only ``genuinely_ahead``
+    work blocks cleanup. The error message lists up to ``_SUBJECT_PREVIEW_LIMIT``
+    commit subjects so the caller can decide whether to push or abandon.
+    """
+    unsynced = git.unsynced_commits(repo_main, worktree.branch)
+    if not unsynced:
+        return
+    classification = classify_branch_commits(repo_main, worktree.branch)
+    if not classification.genuinely_ahead:
+        return
+    preview = classification.genuinely_ahead[:_SUBJECT_PREVIEW_LIMIT]
+    subjects = ", ".join(c.subject for c in preview)
+    if len(classification.genuinely_ahead) > _SUBJECT_PREVIEW_LIMIT:
+        subjects += ", …"
+    msg = (
+        f"{worktree.repo_path} ({worktree.branch}): "
+        f"refused cleanup — {len(classification.genuinely_ahead)} unsynced commit(s) "
+        f"not on origin/main: {subjects}. "
+        "Push them to a new branch or pass force=True."
+    )
+    raise RuntimeError(msg)
+
 
 def cleanup_worktree(worktree: Worktree, *, force: bool = False) -> str:
     """Remove a single worktree: git worktree, branch, DB, overlay cleanup.
@@ -21,8 +139,9 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False) -> str:
     still succeeds.
 
     Raises ``RuntimeError`` when *force* is ``False`` and the branch has local
-    commits unreachable from any remote (unsynced work that would be lost).
-    Pass ``force=True`` only from trusted callers (e.g. tests, programmatic API).
+    commits that are genuinely ahead of the default branch (i.e. not merge
+    commits and not squash-merged under a new SHA). Pass ``force=True`` only
+    from trusted callers (e.g. tests, programmatic API).
     """
     workspace = load_config().user.workspace_dir
     wt_path = (worktree.extra or {}).get("worktree_path", "")
@@ -39,14 +158,7 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False) -> str:
         repo_main = workspace / worktree.repo_path
         if repo_main.is_dir():
             if not force:
-                unsynced = git.unsynced_commits(str(repo_main), worktree.branch)
-                if unsynced:
-                    msg = (
-                        f"{worktree.repo_path} ({worktree.branch}): "
-                        f"refused cleanup — {len(unsynced)} unsynced commit(s). "
-                        "Push them to a new branch or pass force=True."
-                    )
-                    raise RuntimeError(msg)
+                _raise_if_genuinely_ahead(str(repo_main), worktree)
             git.worktree_remove(str(repo_main), wt_path)
             git.branch_delete(str(repo_main), worktree.branch)
 

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -204,6 +204,59 @@ def _workspace_dir() -> Path:
     return load_config().user.workspace_dir
 
 
+def _resolve_unsynced_worktree(worktree: Worktree, exc: RuntimeError, *, interactive: bool) -> str:
+    """Decide what to do with a worktree whose branch has genuinely-unpushed work.
+
+    In a TTY, prompt the user: push to remote, abandon (force-clean), or skip.
+    Non-interactive contexts (CI, scripts) preserve the old behaviour of
+    listing the skip and exiting so the user can investigate.
+    """
+    if not interactive:
+        return f"Skipped: {exc}"
+
+    prompt = (
+        f"\n{worktree.repo_path} ({worktree.branch}) — genuinely unpushed work.\n"
+        f"  {exc}\n"
+        "  [P]ush to remote / [A]bandon (force delete) / [S]kip (default): "
+    )
+    try:
+        choice = input(prompt).strip().lower()
+    except EOFError:
+        return f"Skipped: {exc}"
+
+    if choice == "p":
+        return _push_unsynced_branch(worktree)
+    if choice == "a":
+        return _abandon_unsynced_branch(worktree)
+    return f"Skipped: {exc}"
+
+
+def _push_unsynced_branch(worktree: Worktree) -> str:
+    wt_path = (worktree.extra or {}).get("worktree_path", "")
+    if not wt_path or not Path(wt_path).is_dir():
+        return f"Push failed: {worktree.repo_path} ({worktree.branch}) — worktree path missing"
+    result = subprocess.run(  # noqa: S603
+        ["git", "-C", wt_path, "push", "-u", "origin", worktree.branch],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return f"Push failed: {worktree.repo_path} ({worktree.branch}) — {result.stderr.strip()}"
+    overlay_name = worktree.ticket.overlay or "<overlay>"
+    return (
+        f"Pushed: {worktree.repo_path} ({worktree.branch}). "
+        f"Run `t3 {overlay_name} pr create {worktree.ticket.pk}` to open an MR."
+    )
+
+
+def _abandon_unsynced_branch(worktree: Worktree) -> str:
+    try:
+        return cleanup_worktree(worktree, force=True)
+    except Exception as exc:  # noqa: BLE001
+        return f"Abandon failed: {worktree.repo_path} ({worktree.branch}) — {exc}"
+
+
 def _branch_prefix() -> str:
     prefix = os.environ.get("T3_BRANCH_PREFIX", "")
     if not prefix:
@@ -404,11 +457,12 @@ class Command(TyperCommand):
         """Prune merged worktrees, stale branches, orphaned stashes, orphan databases, and old DSLR snapshots."""
         workspace = _workspace_dir()
         cleaned: list[str] = []
+        interactive = sys.stdin.isatty() and sys.stdout.isatty()
         for wt in Worktree.objects.filter(state=Worktree.State.CREATED):
             try:
                 cleaned.append(cleanup_worktree(wt))
             except RuntimeError as exc:
-                cleaned.append(f"Skipped: {exc}")
+                cleaned.append(_resolve_unsynced_worktree(wt, exc, interactive=interactive))
 
         for entry in workspace.iterdir():
             if entry.is_dir() and not any(entry.iterdir()):

--- a/tests/teatree_core/test_cleanup.py
+++ b/tests/teatree_core/test_cleanup.py
@@ -3,12 +3,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.test import TestCase
 
-from teatree.core.cleanup import cleanup_worktree
+from teatree.core.cleanup import (
+    BranchClassification,
+    BranchCommit,
+    classify_branch_commits,
+    cleanup_worktree,
+)
 from teatree.core.models import Ticket, Worktree
 
 _patch_config = patch("teatree.core.cleanup.load_config")
 _patch_git = patch("teatree.core.cleanup.git")
 _patch_overlay = patch("teatree.core.cleanup.get_overlay")
+_patch_classify = patch("teatree.core.cleanup.classify_branch_commits")
 
 
 def _mock_workspace(mock_config: MagicMock) -> None:
@@ -109,19 +115,24 @@ class TestCleanupWorktree(TestCase):
 
         assert not Worktree.objects.filter(pk=wt_id).exists()
 
+    @_patch_classify
     @_patch_overlay
     @_patch_git
     @_patch_config
-    def test_raises_when_unsynced_commits_present(
+    def test_raises_when_genuinely_ahead_commits_present(
         self,
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
+        mock_classify: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 chore: cve fix"]
+        mock_classify.return_value = BranchClassification(
+            genuinely_ahead=[BranchCommit(sha="abc123", subject="chore: cve fix", is_merge=False)]
+        )
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         with pytest.raises(RuntimeError, match="unsynced commit"):
@@ -129,6 +140,34 @@ class TestCleanupWorktree(TestCase):
 
         mock_git.worktree_remove.assert_not_called()
         mock_git.branch_delete.assert_not_called()
+
+    @_patch_classify
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_cleans_when_only_squash_merged_and_merge_commits(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+        mock_classify: MagicMock,
+    ) -> None:
+        """Branches whose only "unsynced" commits are squash-merged or merge commits are safe to clean."""
+        _mock_workspace(mock_config)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = ["abc123 feat: squashed on main"]
+        mock_classify.return_value = BranchClassification(
+            squash_merged=[BranchCommit(sha="abc123", subject="feat: squashed on main", is_merge=False)],
+            merge_commits=[BranchCommit(sha="mrg001", subject="Merge branch 'main'", is_merge=True)],
+            genuinely_ahead=[],
+        )
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        cleanup_worktree(wt)
+
+        mock_git.worktree_remove.assert_called_once()
+        mock_git.branch_delete.assert_called_once()
 
     @_patch_overlay
     @_patch_git
@@ -229,3 +268,95 @@ class TestCleanupWorktree(TestCase):
 
         mock_git.worktree_remove.assert_called_once()
         mock_git.branch_delete.assert_called_once()
+
+
+class TestClassifyBranchCommits(TestCase):
+    """``classify_branch_commits`` sorts branch-local commits into three buckets.
+
+    The classifier is the foundation for squash-merge-aware cleanup: it lets
+    the caller distinguish content already on the default branch (under a new
+    SHA, via squash-merge) from work that still needs pushing.
+    """
+
+    @patch("teatree.core.cleanup.git.run")
+    def test_empty_when_no_unsynced_commits(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = ["", ""]  # unsynced log empty, target log empty
+        result = classify_branch_commits("/repo", "feature")
+        assert result == BranchClassification(squash_merged=[], merge_commits=[], genuinely_ahead=[])
+
+    @patch("teatree.core.cleanup.git.run")
+    def test_subject_match_with_pr_suffix_marks_squash_merged(self, mock_run: MagicMock) -> None:
+        branch_log = "abc123\x00parent1\x00fix(ui): button alignment"
+        target_log = "fix(ui): button alignment (#42)\nfeat(core): unrelated"
+        mock_run.side_effect = [branch_log, target_log]
+
+        result = classify_branch_commits("/repo", "feature")
+
+        assert result.squash_merged == [BranchCommit(sha="abc123", subject="fix(ui): button alignment", is_merge=False)]
+        assert result.genuinely_ahead == []
+
+    @patch("teatree.core.cleanup.git.run")
+    def test_strips_type_prefix_for_relax_to_feat_rewrite(self, mock_run: MagicMock) -> None:
+        """Branch has ``relax: X (#140)``; main has ``feat(fsm): X (#140) (#368)`` — same content, different prefix."""
+        branch_log = "def456\x00parent1\x00relax: transition-driven workflow (#140)"
+        target_log = "feat(fsm): transition-driven workflow (#140) (#368)"
+        mock_run.side_effect = [branch_log, target_log]
+
+        result = classify_branch_commits("/repo", "feature")
+
+        assert len(result.squash_merged) == 1
+        assert result.squash_merged[0].sha == "def456"
+        assert result.genuinely_ahead == []
+
+    @patch("teatree.core.cleanup.git.run")
+    def test_merge_commit_detected_via_multiple_parents(self, mock_run: MagicMock) -> None:
+        branch_log = "mrg001\x00parent1 parent2\x00Merge branch 'main' into feature"
+        target_log = ""
+        mock_run.side_effect = [branch_log, target_log]
+
+        result = classify_branch_commits("/repo", "feature")
+
+        assert len(result.merge_commits) == 1
+        assert result.merge_commits[0].is_merge is True
+        assert result.genuinely_ahead == []
+        assert result.squash_merged == []
+
+    @patch("teatree.core.cleanup.git.run")
+    def test_genuinely_ahead_when_no_subject_match(self, mock_run: MagicMock) -> None:
+        branch_log = "new001\x00parent1\x00fix(hooks): strip trailing whitespace"
+        target_log = "chore(deps): bump pytest\nfeat(config): add t3.mode"
+        mock_run.side_effect = [branch_log, target_log]
+
+        result = classify_branch_commits("/repo", "feature")
+
+        assert result.squash_merged == []
+        assert len(result.genuinely_ahead) == 1
+        assert result.genuinely_ahead[0].sha == "new001"
+
+    @patch("teatree.core.cleanup.git.run")
+    def test_mixed_buckets(self, mock_run: MagicMock) -> None:
+        branch_log = (
+            "sha1\x00p1\x00feat(config): add setting\n"
+            "sha2\x00p1 p2\x00Merge branch 'main'\n"
+            "sha3\x00p1\x00fix(hooks): strip whitespace"
+        )
+        target_log = "feat(config): add setting (#100)\nchore: unrelated"
+        mock_run.side_effect = [branch_log, target_log]
+
+        result = classify_branch_commits("/repo", "feature")
+
+        assert [c.sha for c in result.squash_merged] == ["sha1"]
+        assert [c.sha for c in result.merge_commits] == ["sha2"]
+        assert [c.sha for c in result.genuinely_ahead] == ["sha3"]
+
+    @patch("teatree.core.cleanup.git.run")
+    def test_unsynced_fully_merged_via_squash_returns_empty_genuinely_ahead(self, mock_run: MagicMock) -> None:
+        """Every unsynced commit has a subject match on target → branch is safe to clean."""
+        branch_log = "sha1\x00p1\x00feat(config): generic per-overlay override\nsha2\x00p1\x00fix: trailing whitespace"
+        target_log = "feat(config): generic per-overlay override (#375)\nfix: trailing whitespace (#200)"
+        mock_run.side_effect = [branch_log, target_log]
+
+        result = classify_branch_commits("/repo", "feature")
+
+        assert result.genuinely_ahead == []
+        assert len(result.squash_merged) == 2

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -934,12 +934,22 @@ class TestWorkspaceCleanAll(TestCase):
             def _unsynced(_repo: str, branch: str) -> list[str]:
                 return ["abc123 chore: unpushed"] if branch == "ac-frontend-360-ticket" else []
 
+            def _classify(_repo: str, branch: str, target: str = "origin/main") -> cleanup_mod.BranchClassification:
+                if branch == "ac-frontend-360-ticket":
+                    return cleanup_mod.BranchClassification(
+                        genuinely_ahead=[
+                            cleanup_mod.BranchCommit(sha="abc123", subject="chore: unpushed", is_merge=False),
+                        ],
+                    )
+                return cleanup_mod.BranchClassification()
+
             mock_config = MagicMock()
             mock_config.user.workspace_dir = workspace
             with (
                 patch.object(cleanup_mod, "load_config", return_value=mock_config),
                 patch.object(cleanup_mod, "git") as mock_git,
                 patch.object(cleanup_mod, "get_overlay") as mock_overlay,
+                patch.object(cleanup_mod, "classify_branch_commits", side_effect=_classify),
             ):
                 mock_overlay.return_value.get_cleanup_steps.return_value = []
                 mock_git.status_porcelain.return_value = ""
@@ -950,6 +960,100 @@ class TestWorkspaceCleanAll(TestCase):
             assert any("ac-frontend-360-ticket" in c and "unsynced" in c.lower() for c in cleaned)
             assert Worktree.objects.filter(branch="ac-backend-360-ticket").count() == 0
             assert Worktree.objects.filter(branch="ac-frontend-360-ticket").count() == 1
+
+
+class TestResolveUnsyncedWorktree(TestCase):
+    """Interactive push/abandon/skip resolution for worktrees with unpushed work."""
+
+    def _make_worktree(self, wt_path: str = "/tmp/wt") -> Worktree:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/379")
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="backend",
+            branch="ac-backend-379-ticket",
+            extra={"worktree_path": wt_path},
+        )
+
+    def test_non_tty_preserves_skip_behaviour(self) -> None:
+        wt = self._make_worktree()
+        exc = RuntimeError("2 unsynced commit(s) not on origin/main: foo")
+        result = workspace_mod._resolve_unsynced_worktree(wt, exc, interactive=False)
+        assert result.startswith("Skipped:")
+        assert "unsynced" in result
+
+    def test_interactive_default_is_skip(self) -> None:
+        wt = self._make_worktree()
+        exc = RuntimeError("1 unsynced commit(s) not on origin/main: bar")
+        with patch("builtins.input", return_value=""):
+            result = workspace_mod._resolve_unsynced_worktree(wt, exc, interactive=True)
+        assert result.startswith("Skipped:")
+
+    def test_interactive_eof_falls_back_to_skip(self) -> None:
+        wt = self._make_worktree()
+        exc = RuntimeError("whatever")
+        with patch("builtins.input", side_effect=EOFError):
+            result = workspace_mod._resolve_unsynced_worktree(wt, exc, interactive=True)
+        assert result.startswith("Skipped:")
+
+    def test_interactive_push_success_suggests_pr_create(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = self._make_worktree(wt_path=tmp)
+            exc = RuntimeError("work pending")
+            fake_push = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+            with (
+                patch("builtins.input", return_value="p"),
+                patch.object(workspace_mod.subprocess, "run", return_value=fake_push) as mock_run,
+            ):
+                result = workspace_mod._resolve_unsynced_worktree(wt, exc, interactive=True)
+        assert result.startswith("Pushed:")
+        assert "pr create" in result
+        args = mock_run.call_args[0][0]
+        assert args[:2] == ["git", "-C"]
+        assert args[-3:] == ["push", "-u", "origin"] or args[-4:-1] == ["push", "-u", "origin"]
+
+    def test_interactive_push_failure_reports_stderr(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = self._make_worktree(wt_path=tmp)
+            exc = RuntimeError("work pending")
+            fake_push = subprocess.CompletedProcess([], 1, stdout="", stderr="remote rejected: protected branch")
+            with (
+                patch("builtins.input", return_value="p"),
+                patch.object(workspace_mod.subprocess, "run", return_value=fake_push),
+            ):
+                result = workspace_mod._resolve_unsynced_worktree(wt, exc, interactive=True)
+        assert result.startswith("Push failed:")
+        assert "protected branch" in result
+
+    def test_interactive_push_missing_worktree_path(self) -> None:
+        wt = self._make_worktree(wt_path="/tmp/does-not-exist-12345")
+        exc = RuntimeError("pending")
+        with patch("builtins.input", return_value="p"):
+            result = workspace_mod._resolve_unsynced_worktree(wt, exc, interactive=True)
+        assert result.startswith("Push failed:")
+        assert "worktree path missing" in result
+
+    def test_interactive_abandon_force_cleans(self) -> None:
+        wt = self._make_worktree()
+        exc = RuntimeError("pending")
+        with (
+            patch("builtins.input", return_value="a"),
+            patch.object(workspace_mod, "cleanup_worktree", return_value="Cleaned: backend (branch)") as mock_clean,
+        ):
+            result = workspace_mod._resolve_unsynced_worktree(wt, exc, interactive=True)
+        assert result == "Cleaned: backend (branch)"
+        mock_clean.assert_called_once_with(wt, force=True)
+
+    def test_interactive_abandon_failure_reports_error(self) -> None:
+        wt = self._make_worktree()
+        exc = RuntimeError("pending")
+        with (
+            patch("builtins.input", return_value="a"),
+            patch.object(workspace_mod, "cleanup_worktree", side_effect=OSError("boom")),
+        ):
+            result = workspace_mod._resolve_unsynced_worktree(wt, exc, interactive=True)
+        assert result.startswith("Abandon failed:")
+        assert "boom" in result
 
 
 def _subprocess_side_effect(gh_stdout: str, glab_stdout: str):

--- a/tests/teatree_core/test_sync.py
+++ b/tests/teatree_core/test_sync.py
@@ -1823,6 +1823,7 @@ class TestSyncGitHub(TestCase):
             _patch_overlay(overlay),
             patch("teatree.backends.github.fetch_project_items", return_value=[item]),
             patch.object(GitHubSyncBackend, "_sync_reviewer_prs"),
+            patch("teatree.backends.github_sync.cleanup_worktree"),
         ):
             result = GitHubSyncBackend().sync(overlay)
 
@@ -1831,6 +1832,110 @@ class TestSyncGitHub(TestCase):
         assert ticket.state == Ticket.State.DELIVERED
         assert ticket.extra["custom_key"] == "preserved"
         assert ticket.extra["issue_title"] == "Updated issue"
+
+    def test_auto_cleans_worktrees_on_board_done_transition(self) -> None:
+        """Board moves ticket to ``Done`` → cleanup runs for each worktree."""
+        from teatree.backends.github import ProjectItem  # noqa: PLC0415
+        from teatree.backends.github_sync import GitHubSyncBackend  # noqa: PLC0415
+
+        overlay = self._make_overlay()
+        ticket = Ticket.objects.create(
+            issue_url="https://github.com/souliane/teatree/issues/44",
+            state=Ticket.State.IN_REVIEW,
+        )
+        Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="souliane/teatree",
+            branch="fix-44",
+        )
+        item = ProjectItem(
+            issue_number=44,
+            title="Ready for cleanup",
+            url="https://github.com/souliane/teatree/issues/44",
+            status="Done",
+            position=3,
+            labels=[],
+        )
+
+        with (
+            _patch_overlay(overlay),
+            patch("teatree.backends.github.fetch_project_items", return_value=[item]),
+            patch.object(GitHubSyncBackend, "_sync_reviewer_prs"),
+            patch("teatree.backends.github_sync.cleanup_worktree") as mock_cleanup,
+        ):
+            result = GitHubSyncBackend().sync(overlay)
+
+        mock_cleanup.assert_called_once()
+        assert result.worktrees_cleaned == 1
+
+    def test_skips_cleanup_when_ticket_already_delivered(self) -> None:
+        """Ticket already Done on a prior sync → no double cleanup."""
+        from teatree.backends.github import ProjectItem  # noqa: PLC0415
+        from teatree.backends.github_sync import GitHubSyncBackend  # noqa: PLC0415
+
+        overlay = self._make_overlay()
+        Ticket.objects.create(
+            issue_url="https://github.com/souliane/teatree/issues/45",
+            state=Ticket.State.DELIVERED,
+        )
+        item = ProjectItem(
+            issue_number=45,
+            title="Already delivered",
+            url="https://github.com/souliane/teatree/issues/45",
+            status="Done",
+            position=4,
+            labels=[],
+        )
+
+        with (
+            _patch_overlay(overlay),
+            patch("teatree.backends.github.fetch_project_items", return_value=[item]),
+            patch.object(GitHubSyncBackend, "_sync_reviewer_prs"),
+            patch("teatree.backends.github_sync.cleanup_worktree") as mock_cleanup,
+        ):
+            GitHubSyncBackend().sync(overlay)
+
+        mock_cleanup.assert_not_called()
+
+    def test_keeps_worktree_with_unpushed_work(self) -> None:
+        """RuntimeError from cleanup_worktree (unsynced commits) doesn't add to errors — logged as info."""
+        from teatree.backends.github import ProjectItem  # noqa: PLC0415
+        from teatree.backends.github_sync import GitHubSyncBackend  # noqa: PLC0415
+
+        overlay = self._make_overlay()
+        ticket = Ticket.objects.create(
+            issue_url="https://github.com/souliane/teatree/issues/46",
+            state=Ticket.State.IN_REVIEW,
+        )
+        Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="souliane/teatree",
+            branch="fix-46",
+        )
+        item = ProjectItem(
+            issue_number=46,
+            title="Has unpushed work",
+            url="https://github.com/souliane/teatree/issues/46",
+            status="Done",
+            position=5,
+            labels=[],
+        )
+
+        with (
+            _patch_overlay(overlay),
+            patch("teatree.backends.github.fetch_project_items", return_value=[item]),
+            patch.object(GitHubSyncBackend, "_sync_reviewer_prs"),
+            patch(
+                "teatree.backends.github_sync.cleanup_worktree",
+                side_effect=RuntimeError("refused cleanup — 1 unsynced commit(s)"),
+            ),
+        ):
+            result = GitHubSyncBackend().sync(overlay)
+
+        assert result.worktrees_cleaned == 0
+        assert result.errors == []  # info-level keep, not error
 
     def test_returns_error_for_non_overlay(self) -> None:
         from teatree.backends.github_sync import GitHubSyncBackend  # noqa: PLC0415


### PR DESCRIPTION
relax(workspace): squash-merge-aware cleanup + interactive clean-all + github sync auto-clean [none] (https://github.com/souliane/teatree/issues/379)

Fixes #379

## Summary

Three-layer change so teatree stops asking humans to run squash-merge cross-checks by hand:

- **`core/cleanup.py`** — new `BranchClassification` (`squash_merged`, `merge_commits`, `genuinely_ahead`) driven by subject-matching against `origin/main` after stripping `(#NNN)` suffixes and conventional-commit type prefixes (so `relax:` → `feat(scope):` rewrites still match). `cleanup_worktree()` raises only on `genuinely_ahead` work and reports the first offending commit subjects.
- **`backends/github_sync.py`** — when a ticket transitions to "Done" on the Projects v2 board, clean up its worktrees (parity with `gitlab_sync._cleanup_merged_worktrees`). `RuntimeError` from unpushed work is logged at `INFO`, not treated as a sync error — the user resolves it via `clean-all`.
- **`core/management/commands/workspace.py`** — `clean-all` now prompts `[P]ush / [A]bandon / [S]kip` for each genuinely-unpushed worktree in a TTY, preserving the old skip-and-report behaviour in CI/non-TTY. `Push` invokes `git push -u` and suggests `t3 <overlay> pr create`; `Abandon` calls `cleanup_worktree(force=True)`.

## Why `relax:`?

Three `noqa` suppressions at legitimate boundary points:

- `PLC0415` — local `Worktree` import in `github_sync._cleanup_ticket_worktrees` to avoid circular imports (same pattern already used elsewhere in this file).
- `S603` + `BLE001` on `workspace._push_unsynced_branch` / `_abandon_unsynced_branch` — the `subprocess.run(["git", "-C", wt_path, "push", ...])` and error-wrapping `except Exception` are user-facing CLI boundaries.

## Tests

- 7 new `TestClassifyBranchCommits` covering empty input, PR-suffix match, type-prefix rewrites, merge commits, genuinely-ahead, mixed buckets, all-squash-merged.
- Renamed `test_raises_when_unsynced_commits_present` → `test_raises_when_genuinely_ahead_commits_present` + new `test_cleans_when_only_squash_merged_and_merge_commits`.
- 3 new sync tests covering GitHub board Done → cleanup, skip when already delivered, keep worktree with unpushed work.
- 8 new `TestResolveUnsyncedWorktree` covering non-TTY skip, TTY default/EOF skip, push success/failure/missing path, abandon success/failure.
- `test_continues_when_one_worktree_refuses_cleanup` updated to patch the classifier.

Full suite: 2284 passed.

## Test plan

- [ ] Merge a PR on GitHub, run `t3 followup sync`, verify the worktree is removed and the ticket reaches `DELIVERED`.
- [ ] Keep an unpushed commit on a merged-branch worktree, run `t3 teatree workspace clean-all`, confirm the interactive prompt and that each of `P`, `A`, `S` behave as described.
- [ ] Run `clean-all` in CI (non-TTY) and confirm output still lists `Skipped:` lines for unsynced worktrees.