### PR TITLE
fix(ship,workspace): pre-push main merge + t3 pr create over raw gh/glab [none] (https://github.com/souliane/teatree/issues/379)

### DIFF
--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -107,6 +107,7 @@ Skipping this step is the #1 cause of wasted push-fix-push cycles. The rules exi
 
 ### 4. Push
 
+- **Reconcile with the default branch first.** `git fetch origin <default> && git log <branch>..origin/<default> --oneline` — if any commits appear, merge them in (`git merge origin/<default>`) and re-run lint/tests before pushing. Opening a PR that is already BEHIND main forces the user (or you) to do a second round-trip to resolve conflicts; catch them now, while you have the context of your own change open.
 - Push to remote. Cancel stale pipelines first if the branch has an existing MR (see § Rules).
 
 ### 4b. Review Gate
@@ -127,6 +128,8 @@ Before creating an MR, the `pr create` command automatically checks the session 
 - Skipped when Playwright cannot start — fails open with a clear message rather than blocking the push.
 
 ### 5. Create MR/PR
+
+**Prefer `t3 <overlay> pr create` over raw `gh`/`glab`.** The CLI handles the title/body format, ticket URL injection, assignee, and fork-vs-upstream remote resolution — all of which are easy to get wrong by hand. Reach for raw `gh`/`glab` only when the overlay doesn't expose a `pr create` subcommand, or when you're fixing the CLI itself and need to bypass it for this one call.
 
 **STOP — resolve the ticket URL before typing the glab command.**
 

--- a/skills/workspace/references/troubleshooting.md
+++ b/skills/workspace/references/troubleshooting.md
@@ -39,6 +39,13 @@
   2. Temporarily clear the flag with `git update-index --no-skip-worktree <file>`, commit or stash the local override, switch branches, then restore the flag. **Never `git checkout <file>` to "resolve" it — that wipes the override.**
 - **Prevention:** Keep the dogfood override on a dedicated branch, not on whichever branch the main clone happens to be sitting on. If the override must live in the main clone, document it in the repo's `AGENTS.md` so future agents don't try to check out another branch there.
 
+## `gh pr create` Refuses `"push the current branch to a remote, or use the --head flag"`
+
+- **Symptom:** `gh pr create` aborts with `you must first push the current branch to a remote, or use the --head flag` even though you just ran `git push -u origin <branch>` successfully.
+- **Cause:** the repo has both `origin` (your personal fork, possibly under a host alias like `github.com-<alias>:<user>/<repo>.git`) and `upstream` (the canonical `github.com:<org>/<repo>.git`). `gh` picks a "default repo" from the set of known remotes (usually `upstream`) and looks for your branch there — but the branch only exists on `origin`.
+- **Fix:** pass both flags explicitly: `gh pr create --repo <owner>/<repo> --head <branch> ...`. Example: `gh pr create --repo souliane/teatree --head ac-teatree-379-ticket ...`.
+- **Prevention:** when the fork layout differs from upstream, always be explicit about `--repo` and `--head` on `gh pr create`; never rely on the "default repo" inference.
+
 ## `gh pr merge --delete-branch` Fails When `main` Is in Another Worktree
 
 - **Symptom:** `gh pr merge <n> --squash --delete-branch` exits with `failed to run git: fatal: 'main' is already used by worktree at '<path>'`. The PR may have already merged on the remote despite the error.


### PR DESCRIPTION
fix(ship,workspace): pre-push main merge + t3 pr create over raw gh/glab [none] (https://github.com/souliane/teatree/issues/379)

Follow-up to #384 — retro findings from that session, kept in a separate PR for a clean diff.

## Summary

- **`ship/SKILL.md § 4 Push`** — add a "reconcile with the default branch first" step so long-running sessions don't open PRs that are already BEHIND main. In the #379 session, #381 and #383 landed on main while work was in flight and the user had to flag the conflict after the PR was already open; catching it before push avoids a second round-trip.
- **`ship/SKILL.md § 5 Create MR/PR`** — lead with `t3 <overlay> pr create` over raw `gh`/`glab`. The CLI handles ticket-URL + title format rules AND fork-vs-upstream remote resolution. Reach for raw `gh`/`glab` only when the overlay does not expose `pr create`, or when fixing the CLI itself.
- **`workspace/references/troubleshooting.md`** — document the `gh pr create` "you must first push the current branch to a remote, or use the --head flag" failure mode, its cause (origin on a fork host alias, `gh` defaults to `upstream`), and the `--repo`/`--head` escape hatch.

## Test plan

- [x] `prek run --files skills/ship/SKILL.md skills/workspace/references/troubleshooting.md` passes.
- [ ] Next time a session spans multiple upstream merges, verify the new § 4 bullet catches the BEHIND-main state before push.