### PR TITLE
fix(cleanup): strip release-note suffix in squash-merge subject match [none] (https://github.com/souliane/teatree/issues/387)

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -21,6 +21,7 @@ from teatree.utils.db import drop_db
 logger = logging.getLogger(__name__)
 
 _PR_SUFFIX_RE = re.compile(r"(?:\s*\(#\d+\))+$")
+_RELEASE_NOTE_SUFFIX_RE = re.compile(r"\s*\[[^\]]*\]\s*\([^)]+\)\s*$")
 _TYPE_PREFIX_RE = re.compile(r"^[a-z]+(?:\([^)]+\))?!?:\s*", re.IGNORECASE)
 _BRANCH_LOG_FIELDS = 3
 _SUBJECT_PREVIEW_LIMIT = 3
@@ -58,12 +59,14 @@ class BranchClassification:
 def _canonicalize_subject(subject: str) -> str:
     """Normalize a commit subject for cross-branch matching.
 
-    Strips trailing ``(#NNN)`` suffixes (GitHub/GitLab adds these on squash-merge)
-    and the leading conventional-commit type prefix. Used to match a branch-local
-    commit against commits on the default branch whose subject was rewritten at
-    merge time (e.g. ``relax:`` -> ``feat(scope):``).
+    Strips, in order: trailing ``(#NNN)`` (added on squash-merge), trailing
+    ``[flag] (ticket_url)`` (release-note suffix enforced by the MR-metadata
+    hook — present on the merged title but usually absent from the local
+    commit), and leading ``type(scope):`` so the ``relax:`` → ``feat(scope):``
+    rewrite still matches.
     """
     stripped = _PR_SUFFIX_RE.sub("", subject).strip()
+    stripped = _RELEASE_NOTE_SUFFIX_RE.sub("", stripped).strip()
     stripped = _TYPE_PREFIX_RE.sub("", stripped).strip()
     return stripped.lower()
 

--- a/tests/teatree_core/test_cleanup.py
+++ b/tests/teatree_core/test_cleanup.py
@@ -360,3 +360,48 @@ class TestClassifyBranchCommits(TestCase):
 
         assert result.genuinely_ahead == []
         assert len(result.squash_merged) == 2
+
+    @patch("teatree.core.cleanup.git.run")
+    def test_release_note_suffix_on_target_matches_plain_local_subject(self, mock_run: MagicMock) -> None:
+        """Regression for #387 — target carries ``[flag] (url) (#NNN)``, local has only the plain subject."""
+        branch_log = "sha1\x00p1\x00fix(ship,workspace): pre-push main merge + t3 pr create over raw gh/glab"
+        target_log = (
+            "fix(ship,workspace): pre-push main merge + t3 pr create over raw gh/glab "
+            "[none] (https://github.com/souliane/teatree/issues/379) (#386)"
+        )
+        mock_run.side_effect = [branch_log, target_log]
+
+        result = classify_branch_commits("/repo", "feature")
+
+        assert [c.sha for c in result.squash_merged] == ["sha1"]
+        assert result.genuinely_ahead == []
+
+    @patch("teatree.core.cleanup.git.run")
+    def test_release_note_suffix_on_both_sides_matches(self, mock_run: MagicMock) -> None:
+        """Both local and target carry the release-note suffix — canonicalization must strip from both."""
+        branch_log = (
+            "sha1\x00p1\x00relax(workspace): squash-merge-aware cleanup "
+            "[none] (https://github.com/souliane/teatree/issues/379)"
+        )
+        target_log = (
+            "relax(workspace): squash-merge-aware cleanup "
+            "[none] (https://github.com/souliane/teatree/issues/379) (#384)"
+        )
+        mock_run.side_effect = [branch_log, target_log]
+
+        result = classify_branch_commits("/repo", "feature")
+
+        assert [c.sha for c in result.squash_merged] == ["sha1"]
+        assert result.genuinely_ahead == []
+
+    @patch("teatree.core.cleanup.git.run")
+    def test_plain_subjects_without_release_note_suffix_still_match(self, mock_run: MagicMock) -> None:
+        """Fallback case — neither title has a release-note suffix (e.g. ``chore:`` without ticket)."""
+        branch_log = "sha1\x00p1\x00chore(prek): move pip-audit to manual stage"
+        target_log = "chore(prek): move pip-audit to manual stage (#383)"
+        mock_run.side_effect = [branch_log, target_log]
+
+        result = classify_branch_commits("/repo", "feature")
+
+        assert [c.sha for c in result.squash_merged] == ["sha1"]
+        assert result.genuinely_ahead == []


### PR DESCRIPTION
fix(cleanup): strip release-note suffix in squash-merge subject match [none] (https://github.com/souliane/teatree/issues/387)

## Summary

- Add `_RELEASE_NOTE_SUFFIX_RE` to `_canonicalize_subject` in `src/teatree/core/cleanup.py` so the squash-merge classifier matches branches whose merged title carries the `[flag] (ticket_url)` suffix enforced by the MR-metadata hook.
- Branches squash-merged through the standard PR flow (including recent PRs #383, #384, #386) were bucketed as `genuinely_ahead` and refused cleanup. They're now correctly classified as `squash_merged`.
- Tests cover: target-only suffix, both-sides suffix, and plain-subject fallback.

## Test plan

- [x] `uv run pytest tests/teatree_core/test_cleanup.py --no-cov -q` (20 passed)
- [x] `uv run ruff check src/teatree/core/cleanup.py tests/teatree_core/test_cleanup.py`
- [x] prek (all hooks passed)

Fixes https://github.com/souliane/teatree/issues/387