### PR TITLE
feat(plugin): bundle cleanup permissions in plugin settings

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -124,7 +124,7 @@ hooks/                  # Plugin hooks
   hooks.json            # Event → script mapping
   scripts/              # Hook scripts (bootstrap, skill loading, statusline)
 apm.yml                 # APM package manifest
-settings.json           # Plugin settings (statusline)
+settings.json           # Plugin settings (statusline + permissions allow/deny)
 tests/                  # Pytest suite (>90% branch coverage)
 e2e/                    # Playwright E2E tests for dashboard
 scripts/                # Standalone utility scripts
@@ -965,6 +965,15 @@ Three install paths, one source of truth:
 - **CLI-first**: `uv tool install teatree && t3 setup` — bootstraps from Python (runs APM install, syncs skill symlinks, and registers the Claude plugin in one step). `t3 setup` also auto-runs `uv tool install --editable <repo>` when the global `t3` binary is missing, so `uv run t3 setup` from a fresh checkout upgrades itself in-place.
 
 The agent-facing hook layer (`hooks/scripts/hook_router.py`) blocks `uv run t3` Bash invocations and directs agents to call the globally installed `t3` instead.
+
+### 12.4 Bash Permission Defaults
+
+The plugin's `settings.json` ships a small `permissions.allow` / `permissions.deny` block so t3 lifecycle commands run end-to-end in auto mode without per-command prompts. The design is **broad allow, targeted deny**:
+
+- **Allow** — one wildcard per tool family the workflow needs: `t3:*`, `git:*`, `gh:*`, `glab:*`, `uv:*`, `prek:*`, `npm:*`, `pytest:*`, `python:*`, `curl:*`, `psql:*`, `docker:*`, etc. The `t3` CLI is the safety wrapper that enforces worktree isolation, branch naming, ticket gating, and push gating; denying it inside the CLI would be the wrong layer.
+- **Deny** — the load-bearing list. Mirrors the non-negotiable rules from `t3:rules` and `t3:ship`: pushes to default branches (`main`/`master`/`development`/`develop`/`release`/`trunk`), `--force` pushes, `--no-verify` on any git command, `git config --global`/`--system`, history rewrites with `filter-branch`, `gh/glab repo delete`, auth logout, `curl | bash`, and `rm -rf` on system roots or `$HOME`.
+
+Deny wins over allow, so a misbehaving agent — or a misclicked ticket — cannot bypass these guardrails even with broad allow wildcards in place. This complements but does not replace Claude Code's `autoMode` classifier, which remains the semantic safety net for novel patterns the static list cannot anticipate. The plugin permissions reduce the volume of classifier prompts, not the strictness of the trust boundary.
 
 ---
 

--- a/settings.json
+++ b/settings.json
@@ -10,5 +10,68 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(t3:*)",
+      "Bash(prek:*)",
+      "Bash(uv:*)",
+      "Bash(uvx:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(glab:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(yarn:*)",
+      "Bash(pnpm:*)",
+      "Bash(pytest:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(ruff:*)",
+      "Bash(mypy:*)",
+      "Bash(ty:*)",
+      "Bash(make:*)",
+      "Bash(curl:*)",
+      "Bash(psql:*)",
+      "Bash(redis-cli:*)",
+      "Bash(docker:*)",
+      "Bash(pass show:*)",
+      "Bash(command:*)",
+      "Skill(t3:*)"
+    ],
+    "deny": [
+      "Bash(git push * main:*)",
+      "Bash(git push * master:*)",
+      "Bash(git push * development:*)",
+      "Bash(git push * develop:*)",
+      "Bash(git push * release:*)",
+      "Bash(git push * trunk:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git * --no-verify:*)",
+      "Bash(git config --global:*)",
+      "Bash(git config --system:*)",
+      "Bash(git filter-branch:*)",
+      "Bash(git update-ref -d:*)",
+
+      "Bash(rm -rf /:*)",
+      "Bash(rm -rf /*)",
+      "Bash(rm -rf ~:*)",
+      "Bash(rm -rf $HOME:*)",
+      "Bash(rm -rf .:*)",
+
+      "Bash(gh repo delete:*)",
+      "Bash(gh release delete:*)",
+      "Bash(gh gist delete:*)",
+      "Bash(gh auth logout:*)",
+      "Bash(glab repo delete:*)",
+      "Bash(glab release delete:*)",
+      "Bash(glab auth logout:*)",
+
+      "Bash(curl * | bash:*)",
+      "Bash(curl * | sh:*)",
+      "Bash(wget * | bash:*)",
+      "Bash(wget * | sh:*)"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds `permissions.allow` / `permissions.deny` to `settings.json` so t3 lifecycle commands run end-to-end in auto mode without per-command prompts.

## Design

**Broad allow, targeted deny.**

- **Allow** — one wildcard per tool family the workflow needs: `t3:*`, `git:*`, `gh:*`, `glab:*`, `uv:*`, `prek:*`, `npm:*`, `pytest:*`, `python:*`, `curl:*`, `psql:*`, `docker:*`, etc.
- **Deny** — load-bearing rules mirroring t3:rules / t3:ship non-negotiables: pushes to default branches, `--force`, `--no-verify`, `git config --global`/`--system`, `filter-branch`, `repo delete`, `auth logout`, `curl | bash`, `rm -rf` on system roots.

Deny wins over allow, so the broad wildcards are safe — a misbehaving agent or a misclicked ticket cannot bypass the guardrails. This complements but does not replace the autoMode classifier.

77 lines total in `settings.json` (was 14 — only the `statusLine` hook).

## Files

- `settings.json` — adds `permissions` block (25 allow + 29 deny entries)
- `BLUEPRINT.md` — new section 12.4 documenting the design