### PR TITLE
fix: dockerfile e2e + update-snapshots path + worktree editable install (#397)

### DIFF
--- a/dev/Dockerfile.e2e
+++ b/dev/Dockerfile.e2e
@@ -1,13 +1,7 @@
-FROM ubuntu:latest AS base
+FROM mcr.microsoft.com/playwright/python:v1.58.0-noble AS base
 RUN apt-get update -qq && \
-    apt-get install -y -qq curl direnv git jq >/dev/null 2>&1 && \
-    rm -rf /var/lib/apt/lists/* && \
-    useradd -m testuser
-USER testuser
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s -- -q 2>/dev/null
-ENV PATH="/home/testuser/.local/bin:$PATH"
+    apt-get install -y -qq direnv jq && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s -- -q
+ENV PATH="/root/.local/bin:$PATH"
 WORKDIR /app
-
-# Pre-install Playwright browsers (cached in image layer).
-# This avoids re-downloading ~150MB of browser binaries on every run.
-RUN uv tool install playwright && playwright install --with-deps chromium 2>/dev/null

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -27,12 +27,14 @@ services:
 
   e2e:
     <<: *base
+    volumes:
+      - ..:/app:ro
+      - ../e2e/snapshots:/app/e2e/snapshots
     build:
       context: ..
       dockerfile: dev/Dockerfile.e2e
-    command: >
-      uv run pytest e2e/
-      -o DJANGO_SETTINGS_MODULE=e2e.settings --no-cov
-      -p no:tach -v
-      -o cache_dir=/tmp/.pytest_cache
+    entrypoint: ["uv", "run", "pytest", "e2e/",
+      "-o", "DJANGO_SETTINGS_MODULE=e2e.settings", "--no-cov",
+      "-p", "no:tach", "-v",
+      "-o", "cache_dir=/tmp/.pytest_cache"]
     profiles: [e2e]

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -47,6 +47,26 @@ def _find_host_project_root() -> Path | None:
     return None
 
 
+def _find_teatree_pyproject_from_cwd() -> Path | None:
+    """Return the teatree repo rooted at cwd, if any.
+
+    Walks up from cwd looking for a ``pyproject.toml`` whose ``[project].name`` is
+    ``teatree``.  Lets dogfood worktrees override ``T3_REPO`` so that running
+    ``t3`` from a worktree reinstalls editable from the worktree, not the main clone.
+    """
+    for directory in [Path.cwd(), *Path.cwd().parents]:
+        pyproject = directory / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        try:
+            if re.search(r'^\s*name\s*=\s*"teatree"', pyproject.read_text(), re.MULTILINE):
+                return directory
+        except OSError:
+            pass
+        return None
+    return None
+
+
 def _patch_uv_source(pyproject: Path, package: str, repo_path: Path) -> bool:
     """Rewrite the ``[tool.uv.sources]`` entry for *package* to a local editable path."""
     text = pyproject.read_text(encoding="utf-8")
@@ -248,12 +268,14 @@ class DoctorService:
 
     @staticmethod
     def find_teatree_repo() -> Path | None:
+        cwd_worktree = _find_teatree_pyproject_from_cwd()
+        if cwd_worktree:
+            return cwd_worktree
         env_path = os.environ.get("T3_REPO", "")
         if env_path:
             p = Path(env_path).expanduser()
             if (p / "pyproject.toml").is_file():
                 return p
-        # Auto-detect from package location (editable or source checkout)
         from teatree import find_project_root  # noqa: PLC0415
 
         return find_project_root()

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -503,19 +503,35 @@ class TestDoctorService:
         """Finds teatree repo via T3_REPO env var."""
         (tmp_path / "pyproject.toml").write_text("[project]\nname = 'teatree'\n")
         monkeypatch.setenv("T3_REPO", str(tmp_path))
+        # Run from a neutral cwd so the worktree preference does not trigger.
+        monkeypatch.chdir(tmp_path.parent)
         assert DoctorService.find_teatree_repo() == tmp_path
 
     def test_find_teatree_repo_auto_detect(self, tmp_path, monkeypatch):
         """Auto-detects teatree repo via find_project_root."""
         monkeypatch.delenv("T3_REPO", raising=False)
+        monkeypatch.chdir(tmp_path.parent)
         with patch("teatree.find_project_root", return_value=tmp_path):
             assert DoctorService.find_teatree_repo() == tmp_path
 
     def test_find_teatree_repo_returns_none(self, tmp_path, monkeypatch):
         """Returns None when T3_REPO not set and auto-detect fails."""
         monkeypatch.delenv("T3_REPO", raising=False)
+        monkeypatch.chdir(tmp_path)
         with patch("teatree.find_project_root", return_value=None):
             assert DoctorService.find_teatree_repo() is None
+
+    def test_find_teatree_repo_prefers_cwd_worktree_over_env(self, tmp_path, monkeypatch):
+        """When cwd lives inside a teatree worktree, prefer it over T3_REPO (main clone)."""
+        main_clone = tmp_path / "main"
+        main_clone.mkdir()
+        (main_clone / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
+        worktree = tmp_path / "ac-123-ticket" / "teatree"
+        worktree.mkdir(parents=True)
+        (worktree / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
+        monkeypatch.setenv("T3_REPO", str(main_clone))
+        monkeypatch.chdir(worktree)
+        assert DoctorService.find_teatree_repo() == worktree
 
     # ── find_overlay_repo ───────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #397

Bundles four follow-ups from #393:

## Summary
- **Dockerfile.e2e**: switch to the official `mcr.microsoft.com/playwright/python` base image. The previous layering installed Playwright as a non-root user and ran `playwright install --with-deps` with its stderr muted, so apt-get failures went unnoticed.
- **docker-compose e2e**: `command:` → `entrypoint:`. `docker compose run e2e --update-snapshots` now appends the flag to pytest instead of replacing the whole command. Also makes `../e2e/snapshots` rw so regen can write back.
- **find_teatree_repo() cwd preference**: `_ensure_editable_if_contributing` used to reinstall from `T3_REPO` even when called from a different teatree worktree, silently reverting the active worktree's editable install. Now prefers a teatree repo rooted at cwd.
- **Doctor tests**: existing tests `chdir` away from `tmp_path` so the new cwd-preference does not shadow the env-var code paths under test.

## Test plan
- [x] `uv run pytest tests/test_cli_doctor.py --no-cov` — 61 passed
- [ ] CI pipeline green

## Note on snapshots

The 3 platform-sensitive snapshot tests remain `@pytest.mark.skip`-ed from #393. Regenerating baselines inside the new Docker image is tracked as a follow-up — deferred to keep this PR fast.