### PR TITLE
fix(pr): use code host login as MR assignee (Fixes #356)

### DIFF
--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -2,11 +2,17 @@
 
 import json
 from dataclasses import dataclass
-from typing import cast
+from typing import TypedDict, cast
 
 from teatree.backends.protocols import PullRequestSpec
 from teatree.core.sync import RawAPIDict
 from teatree.utils.run import CompletedProcess, run_checked
+
+
+class _GitHubUser(TypedDict, total=False):
+    """Subset of the GitHub ``/user`` response that teatree reads."""
+
+    login: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -188,6 +194,14 @@ class GitHubCodeHost:
 
         result = _run_gh(*cmd, token=self._token)
         return {"url": result.stdout.strip()}
+
+    def current_user(self) -> str:
+        """Return the authenticated GitHub login (e.g. ``souliane``)."""
+        data = _gh_api_get("user", token=self._token)
+        if not isinstance(data, dict):
+            return ""
+        user = cast("_GitHubUser", data)
+        return user.get("login", "")
 
     def list_open_prs(self, repo: str, author: str) -> list[dict[str, object]]:
         data = _gh_api_get(f"repos/{repo}/pulls?state=open&per_page=100", token=self._token)

--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -44,6 +44,10 @@ class GitLabCodeHost:
 
         return self._client.post_json(f"projects/{project.project_id}/merge_requests", payload) or {}
 
+    def current_user(self) -> str:
+        """Return the authenticated GitLab username."""
+        return self._client.current_username()
+
     def list_open_prs(self, repo: str, author: str) -> list[dict[str, object]]:
         project = self._resolve_project(repo)
         if project is None:

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -32,6 +32,8 @@ class CodeHost(Protocol):
 
     def create_pr(self, spec: PullRequestSpec) -> RawAPIDict: ...  # pragma: no branch
 
+    def current_user(self) -> str: ...  # pragma: no branch
+
     def list_open_prs(self, repo: str, author: str) -> list[RawAPIDict]: ...  # pragma: no branch
 
     def post_mr_note(self, *, repo: str, mr_iid: int, body: str) -> RawAPIDict: ...  # pragma: no branch

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -43,8 +43,13 @@ def _sanitize_close_keywords(description: str, *, close_ticket: bool) -> str:
     return _CLOSE_KEYWORD_RE.sub(r"Relates to \2", description)
 
 
-def _current_user() -> str:
-    """Return the git user name for MR auto-assignment."""
+def _assignee_from_host(host: object) -> str:
+    """Return the code host login for MR auto-assignment, falling back to git user.name."""
+    host_user = getattr(host, "current_user", None)
+    if callable(host_user):
+        login = host_user()
+        if login:
+            return login
     return git.config_value(key="user.name")
 
 
@@ -183,7 +188,7 @@ class Command(TyperCommand):
                 "labels": _mr_auto_labels(),
             }
 
-        assignee = _current_user()
+        assignee = _assignee_from_host(host)
         return host.create_pr(
             PullRequestSpec(
                 repo=repo_path,

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -159,3 +159,12 @@ def test_post_mr_note_returns_empty_dict_when_post_returns_none() -> None:
     result = host.post_mr_note(repo="org/repo", mr_iid=5, body="note")
 
     assert result == {}
+
+
+def test_current_user_proxies_to_api_username() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.current_username.return_value = "adrien.cossa"
+    host = GitLabCodeHost(client=client)
+
+    assert host.current_user() == "adrien.cossa"
+    client.current_username.assert_called_once_with()

--- a/tests/teatree_backends/test_protocols.py
+++ b/tests/teatree_backends/test_protocols.py
@@ -35,6 +35,9 @@ def test_code_host_protocol_is_structural() -> None:
             _ = spec
             return {}
 
+        def current_user(self) -> str:
+            return ""
+
         def list_open_prs(self, repo: str, author: str) -> list[dict[str, object]]:
             return []
 

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -44,6 +44,7 @@ class TestPrCreate(TestCase):
     def test_reads_auto_labels_from_overlay(self) -> None:
         host = MagicMock()
         host.create_pr.return_value = {"iid": 12}
+        host.current_user.return_value = "souliane"
         self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
 
         ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/55")
@@ -61,7 +62,44 @@ class TestPrCreate(TestCase):
         assert spec.repo == "/tmp/backend"
         assert spec.branch == "feature-branch"
         assert spec.title == "feat: add labels"
-        assert spec.assignee == "dev"
+        assert spec.assignee == "souliane"
+
+    def test_assignee_falls_back_to_git_user_name_when_host_returns_empty(self) -> None:
+        host = MagicMock()
+        host.create_pr.return_value = {"iid": 13}
+        host.current_user.return_value = ""
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/56")
+        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="/tmp/backend", branch="feature-branch")
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.management.commands.pr._last_commit_message", return_value=("", "")),
+        ):
+            call_command("pr", "create", str(ticket.id), "--title", "feat: fallback")
+
+        (spec,) = host.create_pr.call_args.args
+        assert spec.assignee == "dev"  # from patched git.config_value in setUp
+
+    def test_assignee_propagates_when_host_current_user_raises(self) -> None:
+        """Host lookup errors surface to the caller — fallback is for empty, not broken."""
+        host = MagicMock()
+        host.create_pr.return_value = {"iid": 14}
+        host.current_user.side_effect = RuntimeError("gh not authenticated")
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/57")
+        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="/tmp/backend", branch="feature-branch")
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.management.commands.pr._last_commit_message", return_value=("", "")),
+            pytest.raises(RuntimeError, match="gh not authenticated"),
+        ):
+            call_command("pr", "create", str(ticket.id), "--title", "feat: resilient")
+
+        host.create_pr.assert_not_called()
 
 
 class TestPostEvidence(TestCase):

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -255,6 +255,25 @@ class TestGitHubCodeHost:
         assert len(result) == 1
         assert result[0]["number"] == 1
 
+    def test_current_user_returns_login(self) -> None:
+        with patch.object(github_mod, "_gh_api_get", return_value={"login": "souliane", "id": 42}) as mock_get:
+            host = GitHubCodeHost(token="tok")
+            result = host.current_user()
+        assert result == "souliane"
+        mock_get.assert_called_once_with("user", token="tok")
+
+    def test_current_user_returns_empty_when_api_non_dict(self) -> None:
+        with patch.object(github_mod, "_gh_api_get", return_value=["unexpected"]):
+            host = GitHubCodeHost()
+            result = host.current_user()
+        assert result == ""
+
+    def test_current_user_returns_empty_when_login_missing(self) -> None:
+        with patch.object(github_mod, "_gh_api_get", return_value={"id": 42}):
+            host = GitHubCodeHost()
+            result = host.current_user()
+        assert result == ""
+
     def test_list_open_prs_returns_empty_for_non_list(self) -> None:
         with patch.object(github_mod, "_gh_api_get", return_value={"error": "bad"}):
             host = GitHubCodeHost()


### PR DESCRIPTION
## Summary

`t3 teatree pr create <ticket>` was passing `git config user.name` (e.g. \`Adrien Cossa\`) to \`gh pr create --assignee\`, which expects a GitHub login (e.g. \`souliane\`). Result: \`CalledProcessError\` on every PR creation.

## Approach

Push user-lookup down to the backend:

- \`CodeHost.current_user()\` added to the protocol.
- \`GitHubCodeHost\` calls \`gh api user\` and reads \`.login\` through a \`_GitHubUser\` TypedDict (the module-health hook rejects fresh \`dict[str, object]\` occurrences).
- \`GitLabCodeHost\` proxies to the existing \`GitLabAPI.current_username()\`.

\`_assignee_from_host\` in \`pr.py\` calls the host first and falls back to \`git config user.name\` **only** when the lookup returns empty. Errors propagate so broken auth surfaces rather than getting masked by a wrong-but-truthy fallback.

Fixes [#356](https://github.com/souliane/teatree/issues/356).

## Test plan

- \`uv run pytest --no-cov -q\` — 2348 passed.
- \`uv run ruff check\` — clean.
- \`uv run ty check\` — clean.
- New unit tests:
  - \`test_github_backend.py::test_current_user_*\` (3 cases: login returned, non-dict API response, missing login)
  - \`test_gitlab_code_host.py::test_current_user_proxies_to_api_username\`
  - \`test_pr_command.py::test_reads_auto_labels_from_overlay\` — assigns \`souliane\` (host login)
  - \`test_pr_command.py::test_assignee_falls_back_to_git_user_name_when_host_returns_empty\`
  - \`test_pr_command.py::test_assignee_propagates_when_host_current_user_raises\`