### PR TITLE
fix(dashboard): finish Auto→Headless rename in no-MR branch

### DIFF
--- a/e2e/test_dashboard.py
+++ b/e2e/test_dashboard.py
@@ -93,7 +93,7 @@ def test_tickets_without_mrs(e2e_server: str, page: Page) -> None:
 
 def test_ticket_action_buttons(e2e_server: str, page: Page) -> None:
     page.goto(e2e_server)
-    expect(page.locator("button", has_text="Auto").first).to_be_visible()
+    expect(page.locator("button", has_text="Headless").first).to_be_visible()
     expect(page.locator("button", has_text="Interactive").first).to_be_visible()
 
 
@@ -149,8 +149,6 @@ def test_create_headless_task(e2e_server: str, page: Page) -> None:
     page.goto(e2e_server)
     # Accept the hx-confirm dialog so the POST goes through.
     page.on("dialog", lambda dialog: dialog.accept())
-    # "Headless" lives on tickets WITH MRs (visible under the default "Has PR"
-    # filter). The "Auto" variant is on the {% empty %} branch and is hidden.
     page.locator("button", has_text="Headless").first.click()
     page.wait_for_timeout(500)
     expect(page.locator("h2", has_text="In-Flight Tickets")).to_be_visible()

--- a/src/teatree/core/templates/teatree/partials/dashboard_tickets.html
+++ b/src/teatree/core/templates/teatree/partials/dashboard_tickets.html
@@ -322,7 +322,7 @@
                   hx-disable-elt="this"
                   hx-confirm="Start headless agent for ticket #{{ ticket.display_id }}?"
                   title="Start headless agent"
-                >Auto</button>
+                >Headless</button>
                 <div class="split-btn">
                   <button
                     class="pill-btn pill-xs split-main border border-clay/30 bg-clay/10 uppercase tracking-[0.18em] text-clay hover:bg-clay/20"


### PR DESCRIPTION
## Summary

[#252](https://github.com/souliane/teatree/pull/252) renamed the "Auto" button to "Headless" on the with-MRs row but missed the parallel branch rendered by \`{% empty %}\` for tickets that have no MRs. Result: \`e2e/test_dashboard.py::test_ticket_action_buttons\` has been failing on main because the only remaining "Auto" button lives in a row that the default "Has PR" filter hides — \`.first\` is always \`hidden\` and the assertion fails.

## Changes

- \`src/teatree/core/templates/teatree/partials/dashboard_tickets.html\`: rename the stray \`Auto\` button to \`Headless\` so both branches agree on one label.
- \`e2e/test_dashboard.py::test_ticket_action_buttons\`: assert the \`Headless\` label.
- Drop the now-stale explanatory comment in \`test_create_headless_task\`.

## Scope

This PR deliberately **does not** refresh \`test_full_dashboard_screenshot\`'s baseline PNG. Repeated \`t3 teatree e2e project --update-snapshots\` inside the Docker image produces a slightly different 286 KB PNG on every run (150-200 byte variance above the 10 % pixel threshold), so committing any single snapshot just swaps one flaky baseline for another. That's the exact problem [#275](https://github.com/souliane/teatree/issues/275) already tracks — refreshing all e2e goldens in one pass.

## Test plan

- \`t3 teatree e2e project\` locally: \`test_ticket_action_buttons\` passes; only \`test_full_dashboard_screenshot\` still fails (pre-existing flake per #275).
- CI e2e should go from 2 failures → 1 known flake.