### PR TITLE
feat(shipping): enforce retro-before-push via gate

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -263,7 +263,7 @@ Tracks which workflow phases an agent visited within a conversation, to enforce 
 ```python
 _REQUIRED_PHASES = {
     "reviewing": ["testing"],
-    "shipping": ["testing", "reviewing"],
+    "shipping": ["testing", "reviewing", "retro"],
     "requesting_review": ["shipping"],
 }
 ```

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -122,6 +122,16 @@ Retro is not complete until every confirmed finding is written to a durable home
 - any helper scripts created or reused
 - what still requires human follow-up, if anything
 
+## Mark Phase Visited (Ticket-Scoped Sessions)
+
+When retro runs for a teatree-managed ticket, mark the `retro` phase on the active session so the `t3 <overlay> pr create` shipping gate can enforce retro-before-push:
+
+```bash
+t3 <overlay> lifecycle visit-phase <ticket_id> retro
+```
+
+Skip this step when retro runs outside a ticket context (no session exists). The shipping gate fails open when no session is found, so skipping is safe — the marker only matters when a session is already tracking phases.
+
 ## Fastest Reliable Tool
 
 Retro should optimize for **speed with repeatability**. Use AI for judgment and synthesis; use scripts for deterministic evidence gathering and bulk transformations.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -104,13 +104,15 @@ If the changes touch architecture, add new modules, rename commands, or change e
 
 Skipping this step is the #1 cause of wasted push-fix-push cycles. The rules exist in `t3:review` and the project's code-review skill — this step ensures they are applied even when the agent goes directly from code to ship without a formal review phase.
 
-### 3c. Retrospective Before Push (Non-Negotiable)
+### 3c. Retrospective Before Push (Non-Negotiable, Enforced)
 
 Run `/t3:retro` **before** pushing — not after merge. Retro findings often surface skill fixes, guardrail improvements, or documentation updates that belong in the same PR as the feature. Running retro after push/merge means those improvements ship as a separate follow-up PR (or, worse, get lost to context compaction before they land anywhere).
 
 Sequence: code → test → review gate → **retro** → push → MR → monitor CI.
 
 If retro produces file edits (skill fixes, reference updates, docs), commit them on the current branch before § 4 Push so they ride along with the MR.
+
+**Enforcement:** `t3 <overlay> pr create` refuses to create the MR until the `retro` phase is marked visited on the active session. Retro marks its own visit via `t3 <overlay> lifecycle visit-phase <ticket_id> retro` (documented in `/t3:retro`). If the shipping gate complains that `retro` is missing, run retro — do not bypass with `--skip-validation` unless explicitly instructed.
 
 ### 4. Push
 

--- a/src/teatree/agents/prompt.py
+++ b/src/teatree/agents/prompt.py
@@ -184,6 +184,10 @@ def build_system_context(task: Task, *, skills: list[str], lifecycle_skill: str 
                     " `t3 <overlay> lifecycle visit-phase <ticket_id> reviewing`."
                 ),
                 "3. Retry `t3 <overlay> pr create <ticket_id>`.",
+                "If the result shows `retro` in the `missing` list:",
+                "1. Run `/t3:retro` to capture lessons from this session and commit any skill fixes.",
+                ("2. Mark retro as visited: `t3 <overlay> lifecycle visit-phase <ticket_id> retro`."),
+                "3. Retry `t3 <overlay> pr create <ticket_id>`.",
                 "Do NOT create a new session for the review — use a sub-agent within this session.",
             ),
         )

--- a/src/teatree/core/models/session.py
+++ b/src/teatree/core/models/session.py
@@ -35,7 +35,7 @@ class Session(models.Model):
 
     _REQUIRED_PHASES: ClassVar[dict[str, list[str]]] = {
         "reviewing": ["testing"],
-        "shipping": ["testing", "reviewing"],
+        "shipping": ["testing", "reviewing", "retro"],
         "requesting_review": ["shipping"],
     }
 

--- a/tests/teatree_core/test_models.py
+++ b/tests/teatree_core/test_models.py
@@ -421,6 +421,7 @@ class TestSession(TestCase):
 
         session.visit_phase("testing")
         session.visit_phase("reviewing")
+        session.visit_phase("retro")
         session.check_gate("shipping")
         session.begin_manual_handoff()
 
@@ -430,6 +431,15 @@ class TestSession(TestCase):
         assert session.has_visited("reviewing") is True
         assert session.ended_at is not None
         assert str(session) == "agent-1"
+
+    def test_shipping_gate_blocks_when_retro_not_visited(self) -> None:
+        session = Session.objects.create(ticket=Ticket.objects.create())
+
+        session.visit_phase("testing")
+        session.visit_phase("reviewing")
+
+        with pytest.raises(QualityGateError, match="shipping requires: retro"):
+            session.check_gate("shipping")
 
     def test_ignores_duplicate_phase_visits_and_force_bypasses_gate(self) -> None:
         session = Session.objects.create(ticket=Ticket.objects.create())
@@ -465,6 +475,7 @@ class TestSession(TestCase):
         session.visit_phase("testing", agent_id="agent-1")
         session.visit_phase("coding", agent_id="agent-1")
         session.visit_phase("reviewing", agent_id="agent-1")
+        session.visit_phase("retro", agent_id="agent-1")
 
         with pytest.raises(QualityGateError, match="Maker≠checker violation"):
             session.check_gate("shipping")
@@ -475,6 +486,7 @@ class TestSession(TestCase):
         session.visit_phase("testing", agent_id="agent-1")
         session.visit_phase("coding", agent_id="agent-1")
         session.visit_phase("reviewing", agent_id="agent-2")
+        session.visit_phase("retro", agent_id="agent-1")
 
         session.check_gate("shipping")  # should not raise
 
@@ -484,6 +496,7 @@ class TestSession(TestCase):
         session.visit_phase("testing")
         session.visit_phase("coding")
         session.visit_phase("reviewing")
+        session.visit_phase("retro")
 
         session.check_gate("shipping")  # no agent_ids recorded → no enforcement
 

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -2002,6 +2002,7 @@ class TestPrCheckGates(TestCase):
         session = Session.objects.create(overlay="test", ticket=ticket, agent_id="agent-1")
         session.visit_phase("testing")
         session.visit_phase("reviewing")
+        session.visit_phase("retro")
 
         result = cast("dict[str, object]", call_command("pr", "check-gates", str(ticket.pk), target_phase="shipping"))
 

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -142,6 +142,7 @@ class TestCheckShippingGate(TestCase):
         session = Session.objects.create(ticket=ticket)
         session.visit_phase("testing")
         session.visit_phase("reviewing")
+        session.visit_phase("retro")
         assert _check_shipping_gate(ticket) is None
 
     def test_returns_structured_error_with_missing_phases(self) -> None:

--- a/tests/teatree_core/test_transition.py
+++ b/tests/teatree_core/test_transition.py
@@ -176,6 +176,7 @@ class TestCheckGatesStructured(TestCase):
         session = Session.objects.create(ticket=ticket)
         session.visit_phase("testing")
         session.visit_phase("reviewing")
+        session.visit_phase("retro")
 
         result = cast("dict[str, object]", call_command("pr", "check-gates", ticket.pk, target_phase="shipping"))
 


### PR DESCRIPTION
## Summary

Closes #392.

`t3 <overlay> pr create` now refuses to create the MR until the `retro` phase is marked visited on the active session. Retro findings therefore land in the same PR as the feature, instead of as a separate follow-up PR (or getting lost to context compaction).

- `Session._REQUIRED_PHASES[\"shipping\"]` adds `\"retro\"` alongside `\"testing\"` and `\"reviewing\"`.
- Retro skill documents `t3 <overlay> lifecycle visit-phase <ticket_id> retro` as the final persistence step — same pattern as the existing reviewing/coding visit markers.
- Ship skill § 3c upgraded from doctrine-only to doctrine + enforced-gate.
- Agent shipping prompt learns a `retro`-missing branch mirroring the existing `reviewing`-missing one.
- BLUEPRINT.md § 4.3 reflects the new required-phase list.

## Tests

- New: `test_shipping_gate_blocks_when_retro_not_visited`.
- Updated: 5 existing tests visit `retro` before calling `check_gate(\"shipping\")`.
- Full non-agent suite green (2174 passed).

## Acceptance

- [x] `/t3:ship` documentation mentions retro as a pre-push gate.
- [x] Pushing without a retro produces a visible prompt/warning (via `t3 pr create` shipping gate).
- [x] Retro-produced edits are eligible to land in the same PR as the feature.