### PR TITLE
docs(install): lead with `uv tool install` + shell-rc PATH hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,12 @@ The agent batch-processes your assigned tickets, checks CI statuses, nudges stal
 ### For users
 
 ```bash
-pip install teatree
+uv tool install teatree           # installs `t3` globally (pipx install teatree also works)
 apm install -g souliane/teatree   # installs skills + companion dependencies
 t3 startoverlay my-overlay ~/workspace/my-overlay
 ```
+
+`uv tool install` puts `t3` in `~/.local/bin/`. If that directory isn't on your `PATH`, add `export PATH="$HOME/.local/bin:$PATH"` to your shell rc.
 
 ### For contributors
 
@@ -159,12 +161,11 @@ t3 startoverlay my-overlay ~/workspace/my-overlay
 ```bash
 git clone git@github.com:YOUR_USERNAME/teatree.git ~/workspace/teatree
 cd ~/workspace/teatree
-uv sync
-uv pip install -e .
-t3 setup   # installs skills globally, respects local symlinks
+uv tool install --editable .   # global `t3` binary, live-reloaded from this clone
+t3 setup                       # installs skills globally, respects local symlinks
 ```
 
-`t3 setup` runs [APM](https://github.com/microsoft/apm) to install companion dependencies (superpowers, ac-django, etc.), symlinks teatree skills to `~/.claude/skills/`, and writes the skill metadata cache. It must be run from the main clone, not a worktree.
+`uv tool install --editable .` produces the same global `~/.local/bin/t3` as the user flow — edits in this clone take effect on the next invocation, no `uv run` prefix. `t3 setup` runs [APM](https://github.com/microsoft/apm) to install companion dependencies (superpowers, ac-django, etc.), symlinks teatree skills to `~/.claude/skills/`, registers the Claude plugin, and — if `t3` isn't on `PATH` — re-runs `uv tool install --editable .` to self-install. Must be run from the main clone, not a worktree.
 
 ## Skills
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1299,7 +1299,7 @@ Usage: t3 teatree e2e external [OPTIONS]
      config key.
 
  Discovers the frontend port from docker-compose (or local process)
- and reads the tenant variant from .env.worktree.
+ and reads the tenant variant from the env cache.
 
  Extra Playwright flags (--config, --timeout, --grep, etc.) can be
  passed via --playwright-args: ``--playwright-args="--config x.ts --timeout

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -75,6 +75,21 @@ def _install_claude_plugin(repo: Path, *, scope: str) -> bool:
     return True
 
 
+def _uv_tool_bin_dir(uv_bin: str) -> Path | None:
+    """Return the directory ``uv tool`` installs binaries into, or None on error."""
+    result = _run_captured([uv_bin, "tool", "dir", "--bin"])
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return Path(result.stdout.strip()).expanduser()
+
+
+def _print_path_hint(bin_dir: Path | None) -> None:
+    """Print a shell-rc instruction when the uv tool bin dir is not on PATH."""
+    target = bin_dir or Path.home() / ".local" / "bin"
+    typer.echo(f"NOTE  `{target}` is not on your PATH.")
+    typer.echo(f'      Add to your shell rc (~/.zshrc or ~/.bashrc): export PATH="{target}:$PATH"')
+
+
 def _ensure_t3_installed(repo: Path) -> bool:
     """Install ``t3`` globally via ``uv tool install`` when it's not on PATH.
 
@@ -96,7 +111,7 @@ def _ensure_t3_installed(repo: Path) -> bool:
         return False
     typer.echo("OK    Installed `t3` globally via `uv tool install --editable`.")
     if not shutil.which("t3"):
-        typer.echo("NOTE  Ensure `~/.local/bin` is on your PATH (see `uv tool dir --bin`).")
+        _print_path_hint(_uv_tool_bin_dir(uv_bin))
     return True
 
 

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import click
@@ -518,11 +519,12 @@ class TestEnsureT3Installed:
             mock_which.side_effect = lambda name: "/usr/bin/uv" if name == "uv" else None
             mock_run.return_value.returncode = 0
             mock_run.return_value.stderr = ""
+            mock_run.return_value.stdout = ""
             assert _ensure_t3_installed(repo) is True
-            args = mock_run.call_args[0][0]
-            assert args[:3] == ["/usr/bin/uv", "tool", "install"]
-            assert "--editable" in args
-            assert str(repo) in args
+            install_args = mock_run.call_args_list[0][0][0]
+            assert install_args[:3] == ["/usr/bin/uv", "tool", "install"]
+            assert "--editable" in install_args
+            assert str(repo) in install_args
 
     def test_returns_false_on_install_failure(self, tmp_path: Path) -> None:
         repo = tmp_path / "teatree"
@@ -534,4 +536,31 @@ class TestEnsureT3Installed:
             mock_which.side_effect = lambda name: "/usr/bin/uv" if name == "uv" else None
             mock_run.return_value.returncode = 1
             mock_run.return_value.stderr = "boom"
+            mock_run.return_value.stdout = ""
             assert _ensure_t3_installed(repo) is False
+
+    def test_prints_shell_rc_hint_when_still_not_on_path(
+        self,
+        tmp_path: Path,
+        capsys: "pytest.CaptureFixture[str]",
+    ) -> None:
+        repo = tmp_path / "teatree"
+        repo.mkdir()
+        bin_dir = tmp_path / "uv-bin"
+        bin_dir.mkdir()
+
+        def mock_run_side_effect(cmd: list[str], *args: object, **kwargs: object) -> SimpleNamespace:
+            stdout = f"{bin_dir}\n" if cmd[:3] == ["/usr/bin/uv", "tool", "dir"] else ""
+            return SimpleNamespace(returncode=0, stderr="", stdout=stdout)
+
+        with (
+            patch("teatree.cli.setup.shutil.which") as mock_which,
+            patch("teatree.utils.run.subprocess.run", side_effect=mock_run_side_effect),
+        ):
+            mock_which.side_effect = lambda name: "/usr/bin/uv" if name == "uv" else None
+            _ensure_t3_installed(repo)
+
+        out = capsys.readouterr().out
+        assert str(bin_dir) in out
+        assert "is not on your PATH" in out
+        assert 'export PATH="' in out


### PR DESCRIPTION
## Summary

Fixes #26.

- **README** now leads with `uv tool install teatree` for users and `uv tool install --editable .` for contributors. Both produce a global `~/.local/bin/t3` — no more `uv run t3` prefix in the contributor guide.
- **`t3 setup`** improves the already-existing self-install fallback: when `t3` is still missing after `uv tool install --editable`, it now queries `uv tool dir --bin` and prints the exact `export PATH="<dir>:\$PATH"` line to add to the user's shell rc, instead of a generic \"see `uv tool dir --bin`\" hint.

## Tests

- New: `test_prints_shell_rc_hint_when_still_not_on_path` verifies setup emits the shell-rc hint with the queried bin directory.
- Existing `TestEnsureT3Installed` suite updated to include `stdout` on mocked subprocess results.
- Full non-agent suite green (2175 passed).

## Acceptance

- [x] README/setup docs lead with `uv tool install teatree`.
- [x] `t3 setup` detects venv-not-on-PATH and auto-runs `uv tool install --editable`.
- [x] Clear `export PATH=...` message when `~/.local/bin` (or the actual `uv tool dir --bin`) isn't on PATH.
- [x] BLUEPRINT.md already documents the real install story (§ CLI-first, line 969).