### PR TITLE
fix(pr): resolve GitLab project from worktree path, not bare repo name (Closes #293)

### DIFF
--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -153,12 +153,12 @@ class Command(TyperCommand):
 
         worktree = ticket.worktrees.first()
         branch = worktree.branch if worktree else f"ticket-{ticket.ticket_number}"
-        repo_path = repo or (worktree.repo_path if worktree else "")
+        worktree_fs_path = (worktree.extra or {}).get("worktree_path", "") if worktree else ""
+        repo_path = repo or worktree_fs_path or (worktree.repo_path if worktree else "")
 
         # Auto-fill title/description from the last commit message
         if not title or not description:
-            wt_path = (worktree.extra or {}).get("worktree_path", "") if worktree else ""
-            commit_subject, commit_body = _last_commit_message(wt_path or repo_path)
+            commit_subject, commit_body = _last_commit_message(worktree_fs_path or repo_path)
             if not title:
                 title = commit_subject or f"Resolve {ticket.issue_url}"
             if not description:

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -64,6 +64,37 @@ class TestPrCreate(TestCase):
         assert spec.title == "feat: add labels"
         assert spec.assignee == "souliane"
 
+    def test_spec_repo_uses_worktree_filesystem_path_not_bare_name(self) -> None:
+        """spec.repo must be the worktree's filesystem path.
+
+        The GitLab backend resolves the project by reading the ``origin`` remote
+        of the given path. A bare repo name like ``widget-backend`` cannot be
+        URL-encoded into a namespaced ``projects/<group>%2F<repo>`` lookup and
+        produces a 404 on GitLab.
+        """
+        host = MagicMock()
+        host.create_pr.return_value = {"iid": 15}
+        host.current_user.return_value = "souliane"
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/58")
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="widget-backend",
+            branch="feature-branch",
+            extra={"worktree_path": "/abs/path/ac-widget-1234/widget-backend"},
+        )
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.management.commands.pr._last_commit_message", return_value=("", "")),
+        ):
+            call_command("pr", "create", str(ticket.id), "--title", "feat: remote-resolved")
+
+        (spec,) = host.create_pr.call_args.args
+        assert spec.repo == "/abs/path/ac-widget-1234/widget-backend"
+
     def test_assignee_falls_back_to_git_user_name_when_host_returns_empty(self) -> None:
         host = MagicMock()
         host.create_pr.return_value = {"iid": 13}


### PR DESCRIPTION
## Summary

`t3 <overlay> pr create` was failing with `GET projects/<bare-repo-name> → 404` for every GitLab project under a group namespace, because `PullRequestSpec.repo` was the bare `Worktree.repo_path` (a directory name like `backend`). `GitLabCodeHost._resolve_project` falls back to `GitLabAPI.resolve_project(repo)` when `Path(repo).exists()` is false, and that endpoint needs a namespaced path (`org%2Fbackend`), not a bare one.

Now `pr.create` prefers `worktree.extra["worktree_path"]` (absolute filesystem path) so `_resolve_project` goes through `resolve_project_from_remote`, which reads `origin` and resolves the namespaced project URL from the actual clone — transparently working for any namespace depth.

## Change
- `src/teatree/core/management/commands/pr.py` — pass the worktree filesystem path as `spec.repo` when available; dedupe the now-duplicated `wt_path` extraction.
- `tests/teatree_core/test_pr_command.py` — failing test first, now green: asserts `spec.repo` is the worktree path, not the bare name.

## Test plan

- [x] `uv run pytest --no-cov -q tests/teatree_core/test_pr_command.py tests/teatree_backends/test_gitlab_code_host.py` — 46 passed
- [x] `uv run ruff check` on touched files — clean
- [ ] CI green