### PR TITLE
docs(review): forbid "unsure?" review comments — investigate first

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -193,6 +193,18 @@ Only after all reachable sources are exhausted can you post a question-style com
 
 **When the investigation confirms the code is correct, say nothing.** Silence on a check you performed is the correct outcome — not a "looks good, but…" comment. Positive comments belong in the summary to the user, not in the MR.
 
+**Step 0e — Don't Police Other Authors' Title/Description Format (Non-Negotiable):**
+
+Do NOT leave review comments about an external author's MR title format, description wording, commit-message style, work-item link spacing, or whether their description "reads better" in a different shape. These rules are enforced by CI and by the overlay's `validate_pr()` check — not by the reviewer. Raising them manually duplicates the bot and nags a colleague for something a machine already polices.
+
+The reviewer's responsibility is to ensure **their own** MRs pass the title/description check. On other authors' MRs, silence on formatting is the correct outcome. If something is objectively wrong in a way that affects traceability or release notes (e.g., the title references the wrong ticket), frame it as a **correctness** finding, not as a style nit.
+
+**Step 0f — Respect the Overlay's Auto-Close Policy (Non-Negotiable):**
+
+Do NOT suggest adding `Closes #NNN`, `Fixes #NNN`, `Resolves #NNN`, or any other auto-close keyword to an MR description unless the active overlay's conventions explicitly require it. Many overlays manage issue closure via their own ticket/MR linking rather than via GitHub-style auto-close trailers, and suggesting them contradicts the overlay convention.
+
+Check the overlay skill's commit-message and MR-description rules **before** proposing any trailer. The default when the overlay is silent on the topic is: do not suggest auto-close trailers.
+
 **Step 1 — Structured Review Checklist:**
 
 1. **Correctness** — does the code do what the ticket requires? Are all acceptance criteria met? When a change tightens a public contract (e.g., serializer field becomes required, API parameter becomes mandatory), trace all callers — the change affects every flow that uses that interface, not just the one the ticket describes.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -165,6 +165,34 @@ Present ALL findings to the user before posting any comments. Never silently dro
 
 When raising concerns about caching, stale data, or side effects: **investigate first**. Check the actual code paths and real data before speculating. A concern backed by evidence ("I checked the DB — durations do vary") is useful; a speculative "this might be a problem" wastes the author's time.
 
+**Step 0d — Answer Your Own Questions Before Posting (Non-Negotiable):**
+
+Every review comment is posted under the user's name. A comment that boils down to "I'm unsure, please confirm" makes the *user* look like they don't know their own codebase. Do not post it.
+
+Before drafting any comment, if it would contain any of the following phrases — or their equivalents — **STOP and investigate first**:
+
+- "worth confirming with the business that…"
+- "can you confirm this value matches what upstream emits?"
+- "is this string / identifier / enum value correct?"
+- "does this field exist in the producer schema?"
+- "I'm not sure whether…"
+- "does this mean that… / or… / or…?" (listing options instead of picking one)
+
+Investigate first by exhausting the sources you **can** reach:
+
+1. **Grep the repo** for the symbol / string / identifier — producers, consumers, enums, tests, fixtures, docs.
+2. **Grep sibling repos** when the value crosses a service boundary (e.g., webhook producer → consumer, API schema → client). The upstream producer's source of truth lives there. Discover sibling repos via `T3_WORKSPACE_DIR` or the overlay's configured repo list — never hardcode a user-specific path.
+3. **Read the producer's schema / enum / migration** — whichever repo emits the value. If it's a Django model, check the field's `choices=` and the migration history. If it's a Pydantic model, check the field type.
+4. **Check commit history** for the rename, addition, or removal — `git log -S "<symbol>" --all --oneline` often shows exactly when and why the value changed.
+5. **Read the test fixtures** — realistic test inputs show what the producer actually sends.
+6. **Check related MRs** on the same or upstream repos for the same symbol — someone may have already merged or discussed it.
+
+Only after all reachable sources are exhausted can you post a question-style comment — and only when the answer truly requires access you do not have (partner portal behind SSO, vendor-only documentation, product owner's desk knowledge). State what you checked and why the answer isn't reachable, so the author sees you did the work.
+
+**Scale severity to confidence.** A speculative "maybe wrong?" is a nit at best; drop it. A verified finding ("grepped `foo-producer`, canonical spelling is `X`, branch has `Y` — will fail at runtime") is a blocker and belongs in the review.
+
+**When the investigation confirms the code is correct, say nothing.** Silence on a check you performed is the correct outcome — not a "looks good, but…" comment. Positive comments belong in the summary to the user, not in the MR.
+
 **Step 1 — Structured Review Checklist:**
 
 1. **Correctness** — does the code do what the ticket requires? Are all acceptance criteria met? When a change tightens a public contract (e.g., serializer field becomes required, API parameter becomes mandatory), trace all callers — the change affects every flow that uses that interface, not just the one the ticket describes.


### PR DESCRIPTION
## Summary

Adds **Step 0d — Answer Your Own Questions Before Posting (Non-Negotiable)** to `/t3:review`. Every MR comment is posted under the reviewer's name, so question-style "worth confirming?" / "is this correct?" notes make the reviewer look uncertain about their own codebase.

## Behavior change

- Bans the phrasing (lists the patterns to stop on).
- Requires exhausting reachable sources first: grep the repo, grep sibling repos (discovered via `T3_WORKSPACE_DIR` or the overlay's configured repo list — never a hardcoded `~/workspace/`), read the producer's enum/migration/schema, `git log -S` for the symbol, and check test fixtures.
- A speculative "maybe wrong?" is not a comment at all — drop it.
- When investigation confirms the code is correct, post nothing. Positive observations belong in the summary to the user, not in the MR.
- Scales severity to confidence: a verified finding (grepped upstream, canonical is X, branch has Y) is a blocker; an unverified hunch is not.

## Why now

Real session on 2026-04-24 reviewing three MRs on `microservice-partner-banking`. Three question-style drafts were posted that could all have been answered by reading `main-product`'s enums and migrations:

- one confirmed the code was correct (snake↔camel conversion via `EnumWebhookSerializer`), so the comment became noise;
- one turned into a concrete blocker (`homeSavingsBankLoan` → `home_savings_bank_loan`, not `home_savings_loan`), which was worth posting only after the investigation;
- one became an assertive acceptance-not-met finding instead of a "does this mean... or... or...?" listing.

The skill now requires that investigation before the draft exists.

## Test plan

- [ ] Next review session: verify no "worth confirming?" / "is this correct?" drafts reach the MR.
- [ ] When a draft would be speculative, it either becomes a verified finding or is dropped.
- [ ] Positive "looks good" notes no longer appear on MRs — only in the summary back to the user.