### PR TITLE
docs(retro): baseline-recovery recipe + live job-trace tailing

### DIFF
--- a/skills/platforms/references/gitlab.md
+++ b/skills/platforms/references/gitlab.md
@@ -179,6 +179,27 @@ glab api "projects/<PROJECT_ID>/merge_requests/<IID>/notes?per_page=100"
 glab ci status --branch <source_branch> -R <repo>
 ```
 
+### Watch a Manually-Triggered Job by ID
+
+`glab ci status --branch` only finds the latest pipeline; it misses manually-triggered stage jobs and old pipelines. When you already have a job URL (e.g., from `glab mr view`'s `head_pipeline.jobs[]`), hit the REST API directly:
+
+```bash
+TOKEN=$(glab config get token --host gitlab.com)
+PROJ="<group>%2F<repo>"  # URL-encoded path
+JOB=<job_id>
+
+# Status + duration
+curl -sL -H "PRIVATE-TOKEN: $TOKEN" \
+  "https://gitlab.com/api/v4/projects/$PROJ/jobs/$JOB" | \
+  python3 -c "import json,sys;j=json.load(sys.stdin);print(f\"{j['status']} {j.get('duration')}s\")"
+
+# Live trace tail — test-by-test progress visible
+curl -sL -H "PRIVATE-TOKEN: $TOKEN" \
+  "https://gitlab.com/api/v4/projects/$PROJ/jobs/$JOB/trace" | tail -c 3000
+```
+
+Pair with `ScheduleWakeup` to poll at sensible intervals (5-10 min for multi-minute jobs) rather than tight loops.
+
 ## Code Review — Draft Notes
 
 **Always use draft notes**, not direct discussions. Draft notes are only visible to the reviewer until explicitly submitted — this lets the user review, edit, and submit as a batch.

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -88,6 +88,19 @@ The repo's `AGENTS.md` § "Test-Writing Doctrine" carries the authoritative rule
 
 **Regenerate baselines inside the same Docker image CI uses.** Never regenerate on the host with `uv run pytest --update-snapshots` — macOS Chromium renders differently. Use `t3 teatree e2e project --update-snapshots` (which runs in the pinned Docker image).
 
+**Recovering a baseline that was never committed.** Different from drift: Playwright fails with `A snapshot doesn't exist at ...`. If the test runs against a DEV/staging environment that can't be reproduced locally (shared SSO, external services), pull the `{name}-actual.png` from the failing job's artifacts and commit it as the baseline:
+
+```bash
+TOKEN=$(glab auth status --show-token 2>&1 | grep -o 'glpat-[^ ]*')  # see t3:platforms gitlab.md
+curl -sL -H "PRIVATE-TOKEN: $TOKEN" \
+  "https://gitlab.com/api/v4/projects/<path>/jobs/<job_id>/artifacts" \
+  -o /tmp/artifacts.zip
+unzip -j /tmp/artifacts.zip "<path-to>/<name>-actual.png" -d <baseline-dir>/
+mv <baseline-dir>/<name>-actual.png <baseline-dir>/<name>.png
+```
+
+Inspect the extracted PNG before committing — confirm it captures the intended deterministic state (mock data, masked dynamic rows) rather than a transient error page.
+
 ### Private Test Suite
 
 E2E and integration tests ideally live in the project repo they test (e.g., the frontend repo's `e2e/` directory). But sometimes a **separate test repo** reduces friction — no conflicts with the QA team's tests, no build pipeline overhead, freedom to use different tooling or test data. This is especially useful for personal verification tests that complement (not replace) the project's official suite.


### PR DESCRIPTION
## Summary

Two retro-derived doc improvements from an E2E debugging session on a private downstream repo.

- **`skills/test/SKILL.md`** — new "Recovering a baseline that was never committed" subsection. When Playwright fails with *A snapshot doesn't exist at ...* and the test runs against a DEV/staging environment that can't be reproduced locally (shared SSO, external services), pull the `{name}-actual.png` from the failing job's artifacts and commit it as the baseline. Includes the exact `glab`/`curl`/`unzip` recipe.

- **`skills/platforms/references/gitlab.md`** — new "Watch a Manually-Triggered Job by ID" subsection under § CI Pipelines. `glab ci status --branch` only finds the latest pipeline; it misses manually-triggered stage jobs. When tracking a job by ID (from `glab mr view`'s `head_pipeline.jobs[]`), use the REST API `/jobs/<id>` and `/jobs/<id>/trace` endpoints. Paired with `ScheduleWakeup`, this lets an agent watch a long-running E2E to completion without tight polling.

## Validation

- `prek run --files skills/platforms/references/gitlab.md skills/test/SKILL.md` — all passed (including banned-terms, codespell, markdownlint)
- `uv run pytest --no-cov -x -q` — 2354 passed in 63s
- `t3 tool privacy-scan` on the diff — exit 0 (no emails, paths, keys, banned terms)

## Origin

Derived from a 44-minute manually-triggered E2E job on a private downstream repo where:
1. A baseline was missing and had to be recovered from CI artifacts.
2. `glab ci status --branch` could not locate the manually-triggered job, requiring the REST API trace endpoint.

No internal identifiers leak into the skills — recipes use `<group>`, `<repo>`, `<job_id>` placeholders.