### PR TITLE
feat(review): t3 review reply-to-discussion + resolve-discussion

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -633,7 +633,7 @@ Typer-based, work without Django:
 - `t3 docs` — serve mkdocs documentation (requires `docs` dependency group)
 - `t3 ci {cancel,divergence,fetch-errors,fetch-failed-tests,trigger-e2e,quality-check}` — CI helpers
 - `t3 e2e external [--repo <name>] [--test-path <path>]` — run Playwright tests from `T3_PRIVATE_TESTS` or a named `[e2e_repos.<name>]` git repo; skips port discovery when `BASE_URL` is already set (DEV/staging mode)
-- `t3 review {post-draft-note,delete-draft-note,list-draft-notes,publish-draft-notes}` — GitLab draft notes
+- `t3 review {post-draft-note,delete-draft-note,list-draft-notes,publish-draft-notes,reply-to-discussion,resolve-discussion}` — GitLab draft notes plus immediate replies on existing discussion threads and resolve/unresolve toggle
 - `t3 review-request discover` — discover open MRs
 - `t3 tool {privacy-scan,analyze-video,bump-deps}` — standalone utilities
 - `t3 config write-skill-cache` — write overlay skill metadata to cache

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -360,6 +360,10 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 │ delete-draft-note    Delete a draft note from a GitLab MR.                   │
 │ publish-draft-notes  Publish all draft notes on a GitLab MR (bulk submit).   │
 │ list-draft-notes     List draft notes on a GitLab MR.                        │
+│ reply-to-discussion  Reply to a GitLab MR discussion thread (immediate, not  │
+│                      draft).                                                 │
+│ resolve-discussion   Mark a GitLab MR discussion thread resolved or          │
+│                      unresolved.                                             │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -431,6 +435,44 @@ Usage: t3 review list-draft-notes [OPTIONS] REPO MR
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 review reply-to-discussion`
+
+```
+Usage: t3 review reply-to-discussion [OPTIONS] REPO MR DISCUSSION_ID BODY
+
+ Reply to a GitLab MR discussion thread (immediate, not draft).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    repo               TEXT     GitLab project path (e.g., my-org/my-repo)  │
+│                                  [required]                                  │
+│ *    mr                 INTEGER  Merge request IID [required]                │
+│ *    discussion_id      TEXT     Discussion (thread) ID [required]           │
+│ *    body               TEXT     Reply body (markdown) [required]            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 review resolve-discussion`
+
+```
+Usage: t3 review resolve-discussion [OPTIONS] REPO MR DISCUSSION_ID
+
+ Mark a GitLab MR discussion thread resolved or unresolved.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    repo               TEXT     GitLab project path [required]              │
+│ *    mr                 INTEGER  Merge request IID [required]                │
+│ *    discussion_id      TEXT     Discussion (thread) ID [required]           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --resolved    --no-resolved      Mark resolved (default) or re-open.         │
+│                                  [default: resolved]                         │
+│ --help                           Show this message and exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/skills/contribute/SKILL.md
+++ b/skills/contribute/SKILL.md
@@ -58,9 +58,36 @@ If no unpushed commits exist, inform the user and stop.
 
 Show the commit log to the user.
 
+### 1a. Bundle Sibling Retro Branches (Default)
+
+When multiple local branches hold unpushed retro commits from the **same session** or same logical topic, **bundle them into a single PR by default** — do not open one PR per branch. Each PR costs a review cycle; the user's explicit policy is to minimise the number of PRs when commits belong together.
+
+**Detect siblings:**
+
+```bash
+cd "$T3_REPO"
+DEFAULT=$(git config init.defaultBranch || echo main)
+for ref in $(git for-each-ref --format='%(refname:short)' refs/heads/); do
+  [ "$ref" = "$DEFAULT" ] && continue
+  ahead=$(git rev-list --count "$DEFAULT..$ref" 2>/dev/null)
+  [ "${ahead:-0}" -gt 0 ] && git log --format="  %h %s  [$ref]" "$DEFAULT..$ref"
+done
+```
+
+A sibling is another branch whose commits (a) trace back to the same retro session or (b) touch overlapping skills / cross-reference each other's changes. When in doubt, show the list to the user and ask whether to bundle.
+
+**Bundle procedure:**
+
+1. Pick the branch whose scope most naturally covers the combined change as the umbrella (rename if helpful).
+2. `git cherry-pick` the commits from each sibling branch onto the umbrella (oldest-first, preserving authorship).
+3. Re-run § 2 pre-flight on the combined branch.
+4. Delete the now-empty sibling branches after the combined PR lands: `git branch -D <sibling>` and `git worktree remove <path>`.
+
+**Opt-out:** if the user explicitly asks for separate PRs (different review audiences, staged rollout, one-change-per-revert policy), skip bundling. Separate PRs are the exception, not the default.
+
 ### 1b. Squash Option
 
-If there is **more than one** unpushed commit, offer to squash following the squash rules in [`../ship/SKILL.md`](../ship/SKILL.md) § "Finalize Branch".
+If the (possibly-bundled) branch has **more than one** commit, offer to squash following the squash rules in [`../ship/SKILL.md`](../ship/SKILL.md) § "Finalize Branch". Keep commits separate when each lands a distinct change that deserves its own revert boundary.
 
 ### 2. Pre-Flight Checks (all must pass)
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -209,7 +209,7 @@ Comments are posted under the user's name. They must sound like a **real human c
 
 1. **List all discussions** via `GET .../merge_requests/<IID>/discussions?per_page=100` and read each note's `body`.
 2. **For each finding**, check whether an existing comment already raises the same concern — same file, same line range, same substance. If so, **do not post a duplicate**.
-3. **If you have something to add** to an existing discussion (additional context, a related concern on the same code), **reply in that thread** instead of creating a new top-level comment. Use the Reply to Discussion recipe from the platform reference.
+3. **If you have something to add** to an existing discussion (additional context, a related concern on the same code), **reply in that thread** via `t3 review reply-to-discussion <REPO> <MR_IID> <DISCUSSION_ID> "body"` instead of creating a new top-level comment.
 4. **Only post new draft notes** for findings not already covered by existing comments.
 
 This prevents noise from multiple review passes or multiple reviewers covering the same ground.
@@ -218,7 +218,7 @@ This prevents noise from multiple review passes or multiple reviewers covering t
 
 When reviewing an external MR/PR, **always post comments inline on the correct file and line** in the diff view. For comments that aren't tied to a specific line (e.g., description feedback), post a general note without position data.
 
-**Extend the CLI, never inline API recipes.** If a `t3 review` operation is missing (e.g., bulk-publish, reply, resolve), implement it in `src/teatree/cli/review.py` — do NOT document a raw API snippet or inline script here. Skills describe what command to run, not how to replicate missing CLI functionality.
+**Extend the CLI, never inline API recipes.** If a `t3 review` operation is missing, implement it in `src/teatree/cli/review.py` — do NOT document a raw API snippet or inline script here. Skills describe what command to run, not how to replicate missing CLI functionality. Current subcommands: `post-draft-note`, `delete-draft-note`, `publish-draft-notes`, `list-draft-notes`, `reply-to-discussion`, `resolve-discussion`.
 
 **Use `t3 review post-draft-note` (Mandatory).** It handles token extraction, diff refs, position serialization, and added-line validation. Never use raw API calls.
 
@@ -271,7 +271,7 @@ When posting replies to reviewer discussions (e.g., "Done in `<commit>`"):
 3. **Skip already-answered discussions.** If the user (or someone else) already replied with a resolution, do not post a duplicate reply.
 4. **Present the mapping to the user before posting.** Show a table: `| Discussion | Topic | Reply |` and get confirmation. Never batch-post replies without review.
 
-See your [issue tracker platform reference](../platforms/references/) § "Reply to Discussion" for the API recipe.
+Post each reply via `t3 review reply-to-discussion <REPO> <MR_IID> <DISCUSSION_ID> "body"`. To mark a thread resolved after the reply, use `t3 review resolve-discussion <REPO> <MR_IID> <DISCUSSION_ID>` (pass `--no-resolved` to re-open).
 
 ## Commands
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -164,13 +164,13 @@ On **every prompt**, use `TaskCreate` to create tasks before doing any work — 
 
 ## Publishing Actions Are Mode-Conditional (Non-Negotiable)
 
-The setting `teatree.mode` in `~/.teatree.toml` (or the `T3_MODE` env var) picks between two doctrines for publishing actions — push, MR create, MR merge, remote branch deletion, Slack posts, any write that leaves the local machine. The default is `interactive` (security-conservative). `auto` opts into full autonomy.
+The setting `teatree.mode` in `~/.teatree.toml` (or the `T3_MODE` env var) picks between two doctrines for publishing actions — push, MR create, MR merge, MR approve/unapprove, remote branch deletion, Slack posts, any write that leaves the local machine. The default is `interactive` (security-conservative). `auto` opts into full autonomy.
 
 ### Interactive mode (default)
 
 Commit approval ≠ push approval. **Squash approval ≠ push approval. "All done" ≠ push approval. Rebase approval ≠ force-push approval.** Always present the final state and ask "Push?" as a **separate question** after committing, squashing, or rebasing — use `AskUserQuestion`, not an inline question.
 
-- Every publishing action (push, MR create/update, MR merge, remote branch delete, Slack post) requires a separate explicit confirmation.
+- Every publishing action (push, MR create/update, MR merge, MR approve/unapprove, remote branch delete, Slack post) requires a separate explicit confirmation. "Recheck" / "re-review" / "look again" are verify-only instructions — they do **not** authorize re-approval.
 - **Force-push (`--force-with-lease`)**: get separate explicit confirmation even if the user already approved the rebase. A rebase and a force-push are two decisions.
 
 ### Auto mode (`t3.mode = "auto"` or `T3_MODE=auto`)

--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -2,6 +2,7 @@
 
 from http import HTTPStatus
 
+import httpx
 import typer
 
 from teatree.utils.run import run_allowed_to_fail
@@ -100,8 +101,6 @@ class ReviewService:
 
     def delete_draft_note(self, repo: str, mr: int, note_id: int) -> tuple[str, int]:
         """Delete a draft note. Returns (message, exit_code)."""
-        import httpx  # noqa: PLC0415
-
         api = self._get_api()
         encoded = repo.replace("/", "%2F")
         response = httpx.delete(
@@ -114,7 +113,6 @@ class ReviewService:
         return f"Failed: HTTP {response.status_code}", 1
 
     def publish_draft_notes(self, repo: str, mr: int) -> tuple[str, int]:
-        import httpx  # noqa: PLC0415
 
         api = self._get_api()
         encoded = repo.replace("/", "%2F")
@@ -125,6 +123,33 @@ class ReviewService:
         )
         if response.status_code in {HTTPStatus.OK, HTTPStatus.NO_CONTENT}:
             return "OK — all draft notes published", 0
+        return f"Failed: HTTP {response.status_code}", 1
+
+    def reply_to_discussion(self, repo: str, mr: int, discussion_id: str, body: str) -> tuple[str, int]:
+        """Reply to an existing discussion thread on an MR. Returns (message, exit_code)."""
+        api = self._get_api()
+        encoded = repo.replace("/", "%2F")
+        result = api.post_json(
+            f"projects/{encoded}/merge_requests/{mr}/discussions/{discussion_id}/notes",
+            {"body": body},
+        )
+        if not result:
+            return "Failed to post reply", 1
+        note_id = dict(result).get("id")
+        return f"OK reply_note_id={note_id}", 0
+
+    def resolve_discussion(self, repo: str, mr: int, discussion_id: str, *, resolved: bool = True) -> tuple[str, int]:
+        """Mark a discussion thread resolved or unresolved. Returns (message, exit_code)."""
+        api = self._get_api()
+        encoded = repo.replace("/", "%2F")
+        flag = "true" if resolved else "false"
+        response = httpx.put(
+            f"{api.base_url}/projects/{encoded}/merge_requests/{mr}/discussions/{discussion_id}?resolved={flag}",
+            headers={"PRIVATE-TOKEN": self.token},
+            timeout=10.0,
+        )
+        if response.status_code in {HTTPStatus.OK, HTTPStatus.NO_CONTENT}:
+            return f"OK resolved={resolved}", 0
         return f"Failed: HTTP {response.status_code}", 1
 
     def list_draft_notes(self, repo: str, mr: int) -> tuple[str, int]:
@@ -210,3 +235,34 @@ def list_draft_notes(
     service = _require_token()
     msg, _code = service.list_draft_notes(repo, mr)
     typer.echo(msg)
+
+
+@review_app.command(name="reply-to-discussion")
+def reply_to_discussion(
+    repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
+    mr: int = typer.Argument(help="Merge request IID"),
+    discussion_id: str = typer.Argument(help="Discussion (thread) ID"),
+    body: str = typer.Argument(help="Reply body (markdown)"),
+) -> None:
+    """Reply to a GitLab MR discussion thread (immediate, not draft)."""
+    service = _require_token()
+    msg, code = service.reply_to_discussion(repo, mr, discussion_id, body)
+    typer.echo(msg)
+    if code:
+        raise typer.Exit(code=code)
+
+
+@review_app.command(name="resolve-discussion")
+def resolve_discussion(
+    repo: str = typer.Argument(help="GitLab project path"),
+    mr: int = typer.Argument(help="Merge request IID"),
+    discussion_id: str = typer.Argument(help="Discussion (thread) ID"),
+    *,
+    resolved: bool = typer.Option(True, "--resolved/--no-resolved", help="Mark resolved (default) or re-open."),
+) -> None:
+    """Mark a GitLab MR discussion thread resolved or unresolved."""
+    service = _require_token()
+    msg, code = service.resolve_discussion(repo, mr, discussion_id, resolved=resolved)
+    typer.echo(msg)
+    if code:
+        raise typer.Exit(code=code)

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -213,6 +213,72 @@ class TestReviewService:
             assert result.exit_code == 1
             assert "Failed: HTTP 403" in result.output
 
+    def test_reply_to_discussion_success(self, monkeypatch):
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        mock_api = MagicMock()
+        mock_api.post_json.return_value = {"id": 777, "body": "thanks"}
+        with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
+            result = runner.invoke(
+                app,
+                ["review", "reply-to-discussion", "org/repo", "1", "abc123", "thanks"],
+            )
+            assert result.exit_code == 0
+            assert "OK reply_note_id=777" in result.output
+            mock_api.post_json.assert_called_once()
+            endpoint, payload = mock_api.post_json.call_args.args
+            assert "discussions/abc123/notes" in endpoint
+            assert payload == {"body": "thanks"}
+
+    def test_reply_to_discussion_failure(self, monkeypatch):
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        mock_api = MagicMock()
+        mock_api.post_json.return_value = None
+        with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
+            result = runner.invoke(
+                app,
+                ["review", "reply-to-discussion", "org/repo", "1", "abc123", "thanks"],
+            )
+            assert result.exit_code == 1
+            assert "Failed to post reply" in result.output
+
+    def test_resolve_discussion_success(self, monkeypatch):
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        mock_response = MagicMock(status_code=200)
+        with patch.object(httpx, "put", return_value=mock_response) as mock_put:
+            result = runner.invoke(
+                app,
+                ["review", "resolve-discussion", "org/repo", "1", "abc123"],
+            )
+            assert result.exit_code == 0
+            assert "OK resolved=True" in result.output
+            call_url = mock_put.call_args.args[0]
+            assert "discussions/abc123" in call_url
+            assert "resolved=true" in call_url
+
+    def test_unresolve_discussion_success(self, monkeypatch):
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        mock_response = MagicMock(status_code=200)
+        with patch.object(httpx, "put", return_value=mock_response) as mock_put:
+            result = runner.invoke(
+                app,
+                ["review", "resolve-discussion", "org/repo", "1", "abc123", "--no-resolved"],
+            )
+            assert result.exit_code == 0
+            assert "OK resolved=False" in result.output
+            call_url = mock_put.call_args.args[0]
+            assert "resolved=false" in call_url
+
+    def test_resolve_discussion_failure(self, monkeypatch):
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        mock_response = MagicMock(status_code=403)
+        with patch.object(httpx, "put", return_value=mock_response):
+            result = runner.invoke(
+                app,
+                ["review", "resolve-discussion", "org/repo", "1", "abc123"],
+            )
+            assert result.exit_code == 1
+            assert "Failed: HTTP 403" in result.output
+
 
 # -- _require_token helper -----------------------------------------------------
 
@@ -250,5 +316,21 @@ class TestRequireToken:
         with patch.object(utils_run_mod.subprocess, "run") as mock_run:
             mock_run.return_value = MagicMock(stderr="", returncode=1)
             result = runner.invoke(app, ["review", "list-draft-notes", "org/repo", "1"])
+            assert result.exit_code == 1
+            assert "No GitLab token" in result.output
+
+    def test_reply_to_discussion_rejected(self, monkeypatch):
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        with patch.object(utils_run_mod.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(stderr="", returncode=1)
+            result = runner.invoke(app, ["review", "reply-to-discussion", "org/repo", "1", "abc", "hi"])
+            assert result.exit_code == 1
+            assert "No GitLab token" in result.output
+
+    def test_resolve_discussion_rejected(self, monkeypatch):
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        with patch.object(utils_run_mod.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(stderr="", returncode=1)
+            result = runner.invoke(app, ["review", "resolve-discussion", "org/repo", "1", "abc"])
             assert result.exit_code == 1
             assert "No GitLab token" in result.output


### PR DESCRIPTION
## Summary

Adds two new GitLab review CLI subcommands and codifies related retro/contribute policy:

- **`t3 review reply-to-discussion <REPO> <MR> <DISCUSSION_ID> "<body>"`** — post an immediate (non-draft) reply on an existing MR discussion thread. Uses the `/discussions/{id}/notes` endpoint.
- **`t3 review resolve-discussion <REPO> <MR> <DISCUSSION_ID> [--resolved/--no-resolved]`** — mark a discussion thread resolved (default) or re-open it. Uses `PUT /discussions/{id}?resolved=<bool>`.
- **`docs(rules)`** — adds MR approve/unapprove to the `/t3:rules` Publishing Actions list so a sub-agent must ask before approving, and clarifies that "recheck / re-review / look again" is verify-only and does **not** authorize re-approval.
- **`docs(contribute)`** — adds § 1a Bundle Sibling Retro Branches (Default) to `/t3:contribute`. When multiple local branches hold unpushed retro commits from the same session, bundle them into one PR by default (cherry-pick onto an umbrella, re-run pre-flight, delete the empty siblings after merge). Separate PRs become the explicit exception.

## Why

Both new CLI subcommands were already documented in `skills/review/SKILL.md` as the canonical mechanism for MR thread handling, but the commands did not exist yet — the skill referenced a platform recipe as a workaround. This PR closes that gap so `/t3:review` stops leaking raw `glab api` calls into the conversation.

The rules/contribute doc updates codify two user policies that surfaced while shipping this change: recheck ≠ re-approve, and retro commits from the same session ship together.

## Changes

- `src/teatree/cli/review.py` — 2 new `ReviewService` methods + 2 new Typer commands. Moved `import httpx` to module scope (dropped 3 `# noqa: PLC0415` suppressions).
- `tests/test_cli_review.py` — 7 new tests (success/failure/rejected paths for both commands, plus `--no-resolved`). Full suite: 2362 passing.
- `skills/review/SKILL.md` — 3 call-sites updated to point at the new commands.
- `skills/rules/SKILL.md` — Publishing Actions list + Recheck clarification.
- `skills/contribute/SKILL.md` — new § 1a bundle policy + § 1b rewording.
- `BLUEPRINT.md` — CLI command list synced.

## Test plan

- [x] `uv run pytest` — 2362 tests pass in 64s
- [x] `prek run --all-files` — all hooks pass (including banned-terms, quality-gate relaxations detector, BLUEPRINT sync, conventional commits)
- [x] Manually exercised on a real GitLab MR (`/t3:review` sub-agent posted, replied, and resolved discussions during this session's reviews of MRs !231, !234, !235, !345)
- [x] Privacy scan: no tenant names, emails, or ticket IDs in the diff