### PR TITLE
fix(setup): stop duplicating Claude core skills already shipped by the plugin

### DIFF
--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -113,12 +113,18 @@ EOF
 
 ## Step 3: Install Skills
 
-`t3 setup` creates symlinks from each supported agent runtime's skills
-directory to the teatree skills.  Claude is always targeted (the directory is
-created if missing); other runtimes listed in
-`teatree.cli.setup.AGENT_SKILL_RUNTIMES` are targeted only when their home
-directory already exists.  Contributor-mode symlinks that point inside the
-configured `workspace_dir` are preserved.
+`t3 setup` installs teatree's skills per runtime:
+
+- **Claude** — core skills ship inside the `t3@souliane` plugin, so `t3 setup`
+  does **not** symlink them into `~/.claude/skills/`. Any leftover core
+  symlinks from pre-plugin installs are pruned to avoid duplicate entries.
+  Overlay skills (not shipped by the plugin) are still symlinked.
+- **Other runtimes** listed in `teatree.cli.setup.AGENT_SKILL_RUNTIMES`
+  (e.g. Codex) are targeted when their home directory already exists, and
+  receive symlinks for both core and overlay skills.
+
+Contributor-mode symlinks that point inside the configured `workspace_dir`
+are preserved across runs.
 
 Inspect the result with `t3 info` — the "Skills installed to" section lists
 every runtime dir teatree detected along with the count of managed symlinks.

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -209,25 +209,53 @@ def _ensure_skill_link(
     return 1, 0
 
 
-def _sync_skill_symlinks(claude_skills: Path, workspace_dir: Path) -> tuple[int, int]:
+def _remove_core_skill_links(runtime_skills: Path, core_skills_dir: Path) -> int:
+    """Remove symlinks in *runtime_skills* whose names match a core skill.
+
+    Used by runtimes where core skills are delivered via a plugin (e.g. Claude),
+    to prune duplicates inherited from earlier symlink-based installs.
+    """
+    removed = 0
+    for skill in sorted(core_skills_dir.iterdir()):
+        if not (skill / "SKILL.md").is_file():
+            continue
+        link = runtime_skills / skill.name
+        if link.is_symlink():
+            link.unlink()
+            removed += 1
+    return removed
+
+
+def _sync_skill_symlinks(
+    runtime_skills: Path,
+    workspace_dir: Path,
+    *,
+    sync_core: bool = True,
+) -> tuple[int, int]:
     """Create or fix symlinks for core and overlay skills.
 
-    Returns ``(created, fixed)`` counts.
+    When ``sync_core`` is ``False``, core skills are assumed to be delivered via
+    a plugin; any existing core symlinks are pruned and only overlays are linked.
+
+    Returns ``(created, fixed)`` counts (pruned links are not counted).
     """
     from teatree.agents.skill_bundle import DEFAULT_SKILLS_DIR  # noqa: PLC0415
 
     created = 0
     fixed = 0
 
-    for skill in sorted(DEFAULT_SKILLS_DIR.iterdir()):
-        if not (skill / "SKILL.md").is_file():
-            continue
-        c, f = _ensure_skill_link(skill, claude_skills / skill.name, workspace_dir)
-        created += c
-        fixed += f
+    if sync_core:
+        for skill in sorted(DEFAULT_SKILLS_DIR.iterdir()):
+            if not (skill / "SKILL.md").is_file():
+                continue
+            c, f = _ensure_skill_link(skill, runtime_skills / skill.name, workspace_dir)
+            created += c
+            fixed += f
+    else:
+        _remove_core_skill_links(runtime_skills, DEFAULT_SKILLS_DIR)
 
     for target, link_name in DoctorService.collect_overlay_skills():
-        c, f = _ensure_skill_link(target, claude_skills / link_name, workspace_dir)
+        c, f = _ensure_skill_link(target, runtime_skills / link_name, workspace_dir)
         created += c
         fixed += f
 
@@ -295,8 +323,8 @@ def run(
     all_excluded = list(dict.fromkeys(CORE_EXCLUDED_SKILLS + config.user.excluded_skills))
     workspace_dir = Path(config.user.workspace_dir).expanduser()
 
-    # The Claude skills dir is always ensured (it's where the plugin looks for skills).
-    # Other runtimes are opt-in by the presence of their home directory.
+    # Ensure the Claude skills dir exists so overlay symlinks have a target.
+    # Core skills reach Claude via the t3 plugin, not via this directory.
     claude_skills = Path.home() / ".claude" / "skills"
     claude_skills.mkdir(parents=True, exist_ok=True)
 
@@ -307,8 +335,10 @@ def run(
         if removed:
             typer.echo(f"OK    {label}: removed {removed} excluded skill(s).")
 
-        created, fixed = _sync_skill_symlinks(skills_dir, workspace_dir)
-        typer.echo(f"OK    {label}: {created} created, {fixed} fixed.")
+        sync_core = label != "claude"
+        created, fixed = _sync_skill_symlinks(skills_dir, workspace_dir, sync_core=sync_core)
+        suffix = "" if sync_core else " (core skills via plugin)"
+        typer.echo(f"OK    {label}: {created} created, {fixed} fixed{suffix}.")
 
         broken = _clean_broken_symlinks(skills_dir)
         if broken:

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -351,6 +351,68 @@ class TestSyncSkillSymlinks:
         assert created == 1
         assert (claude_skills / "my-skill").is_symlink()
 
+    def test_sync_core_false_skips_core_symlinks(self, tmp_path: Path) -> None:
+        skills_src = tmp_path / "core_skills"
+        skills_src.mkdir()
+        (skills_src / "code").mkdir()
+        (skills_src / "code" / "SKILL.md").touch()
+
+        runtime_skills = tmp_path / "runtime_skills"
+        runtime_skills.mkdir()
+
+        with (
+            patch("teatree.agents.skill_bundle.DEFAULT_SKILLS_DIR", skills_src),
+            patch("teatree.cli.setup.DoctorService") as mock_svc,
+        ):
+            mock_svc.collect_overlay_skills.return_value = []
+            created, fixed = _sync_skill_symlinks(runtime_skills, tmp_path / "workspace", sync_core=False)
+
+        assert created == 0
+        assert fixed == 0
+        assert not (runtime_skills / "code").exists()
+
+    def test_sync_core_false_prunes_existing_core_links(self, tmp_path: Path) -> None:
+        skills_src = tmp_path / "core_skills"
+        skills_src.mkdir()
+        (skills_src / "code").mkdir()
+        (skills_src / "code" / "SKILL.md").touch()
+
+        runtime_skills = tmp_path / "runtime_skills"
+        runtime_skills.mkdir()
+        (runtime_skills / "code").symlink_to(skills_src / "code")
+
+        with (
+            patch("teatree.agents.skill_bundle.DEFAULT_SKILLS_DIR", skills_src),
+            patch("teatree.cli.setup.DoctorService") as mock_svc,
+        ):
+            mock_svc.collect_overlay_skills.return_value = []
+            _sync_skill_symlinks(runtime_skills, tmp_path / "workspace", sync_core=False)
+
+        assert not (runtime_skills / "code").exists()
+
+    def test_sync_core_false_still_adds_overlays(self, tmp_path: Path) -> None:
+        skills_src = tmp_path / "core_skills"
+        skills_src.mkdir()
+        (skills_src / "code").mkdir()
+        (skills_src / "code" / "SKILL.md").touch()
+
+        overlay_skill = tmp_path / "overlay" / "my-skill"
+        overlay_skill.mkdir(parents=True)
+
+        runtime_skills = tmp_path / "runtime_skills"
+        runtime_skills.mkdir()
+
+        with (
+            patch("teatree.agents.skill_bundle.DEFAULT_SKILLS_DIR", skills_src),
+            patch("teatree.cli.setup.DoctorService") as mock_svc,
+        ):
+            mock_svc.collect_overlay_skills.return_value = [(overlay_skill, "my-skill")]
+            created, _fixed = _sync_skill_symlinks(runtime_skills, tmp_path / "workspace", sync_core=False)
+
+        assert created == 1
+        assert (runtime_skills / "my-skill").is_symlink()
+        assert not (runtime_skills / "code").exists()
+
 
 class TestAgentSkillDirs:
     def test_includes_claude_and_codex(self) -> None:
@@ -369,8 +431,12 @@ class TestAgentSkillDirs:
 
 
 class TestSetupSyncsCodexWhenDirExists:
-    def test_syncs_to_both_claude_and_codex(self, tmp_path: Path, monkeypatch) -> None:
-        """Setup mirrors skill symlinks into ~/.codex/skills when it exists."""
+    def test_syncs_codex_core_but_leaves_claude_to_plugin(self, tmp_path: Path, monkeypatch) -> None:
+        """Claude core skills come from the t3 plugin; Codex gets symlinks.
+
+        Setup should symlink core skills into ~/.codex/skills but NOT into
+        ~/.claude/skills.
+        """
         from teatree.cli import setup as setup_module  # noqa: PLC0415
 
         skills_src = tmp_path / "core_skills"
@@ -378,7 +444,6 @@ class TestSetupSyncsCodexWhenDirExists:
         (skills_src / "code").mkdir()
         (skills_src / "code" / "SKILL.md").touch()
 
-        # Simulate home layout: both dirs already exist so setup should target both
         home = tmp_path / "home"
         claude_skills = home / ".claude" / "skills"
         codex_skills = home / ".codex" / "skills"
@@ -406,8 +471,50 @@ class TestSetupSyncsCodexWhenDirExists:
             mock_load.return_value.user.workspace_dir = str(tmp_path / "workspace")
             setup_module.run(claude_scope="user", skip_plugin=True)
 
-        assert (claude_skills / "code").is_symlink()
+        assert not (claude_skills / "code").exists()
         assert (codex_skills / "code").is_symlink()
+
+    def test_prunes_stale_claude_core_symlinks(self, tmp_path: Path, monkeypatch) -> None:
+        """Leftover core symlinks from pre-plugin installs are removed.
+
+        ~/.claude/skills/ may still contain symlinks created by earlier
+        teatree versions; they must be pruned so they don't shadow the
+        plugin's copies of the same skills.
+        """
+        from teatree.cli import setup as setup_module  # noqa: PLC0415
+
+        skills_src = tmp_path / "core_skills"
+        skills_src.mkdir()
+        (skills_src / "code").mkdir()
+        (skills_src / "code" / "SKILL.md").touch()
+
+        home = tmp_path / "home"
+        claude_skills = home / ".claude" / "skills"
+        claude_skills.mkdir(parents=True)
+        (claude_skills / "code").symlink_to(skills_src / "code")
+
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: home))
+
+        repo = tmp_path / "teatree"
+        repo.mkdir()
+        (repo / "apm.yml").touch()
+        (repo / ".git").mkdir()
+
+        with (
+            patch("teatree.agents.skill_bundle.DEFAULT_SKILLS_DIR", skills_src),
+            patch.object(setup_module, "_find_main_clone", return_value=repo),
+            patch.object(setup_module, "_run_apm_install", return_value=True),
+            patch.object(setup_module, "_install_claude_plugin", return_value=True),
+            patch.object(setup_module, "DoctorService") as mock_svc,
+            patch("teatree.config.load_config") as mock_load,
+        ):
+            mock_svc.collect_overlay_skills.return_value = []
+            mock_load.return_value.user.contribute = False
+            mock_load.return_value.user.excluded_skills = []
+            mock_load.return_value.user.workspace_dir = str(tmp_path / "workspace")
+            setup_module.run(claude_scope="user", skip_plugin=True)
+
+        assert not (claude_skills / "code").exists()
 
     def test_skips_codex_when_dir_missing(self, tmp_path: Path, monkeypatch) -> None:
         """Setup does not create ~/.codex/skills if it doesn't already exist."""


### PR DESCRIPTION
## Summary

- The `t3@souliane` plugin already ships core skills as `t3:*`. `t3 setup` was also symlinking the same core skills into `~/.claude/skills/`, so each one showed up twice in Claude (`/code` AND `/t3:code`, `/ship` AND `/t3:ship`, …).
- `_sync_skill_symlinks` gets a `sync_core` flag; it's `False` for the Claude runtime. Setup now skips core symlinks for Claude and prunes any leftovers from pre-plugin installs via a new `_remove_core_skill_links` helper.
- Codex keeps receiving core symlinks (no plugin delivery path). Overlay skills (e.g. `t3-company`) are still symlinked on both runtimes.

## Test plan

- [x] New unit tests in `TestSyncSkillSymlinks` cover the `sync_core=False` branch (skip + prune + keep overlays).
- [x] Setup-level tests assert Claude is left to the plugin while Codex gets symlinks, and that stale core symlinks are pruned.
- [x] `uv run pytest --no-cov` — 2358 passed.
- [x] `uv run ruff check` and `uv run ruff format --check` clean.
- [x] `uv run ty check src/teatree/cli/setup.py` clean.