### PR TITLE
docs(ship,retro): scope-match gate before Closes/Fixes #N

### DIFF
--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -197,7 +197,11 @@ flowchart TD
 
 ### 1. Conversation Audit
 
-**Check dashboard server logs first.** Before reviewing the conversation, inspect the teatree dashboard log for errors that may not have surfaced in the conversation:
+**Scope-match check first (Non-Negotiable).** Before auditing individual failures, re-open the ticket/issue body that framed this session and map every acceptance criterion, phase, or deliverable to what actually shipped. If ANY AC is unshipped and the session was declared complete (MR merged with `Closes/Fixes`, `/t3:next` run, ticket marked done), that is a **False completion** finding and it outranks every tactical finding below. Re-reading the issue body is not optional — scoping→implementation drift is invisible from the conversation alone.
+
+**Past failure (#97):** Scoping session focused on Phase 5 (of 5). Implementation shipped Phase 5 only, but the PR used `Closes #97`, auto-closing the issue. Retro ran and found tactical workspace-troubleshooting nuggets while never noticing that 4/5 phases of the issue body were unshipped. The user had to manually call it out. Prevention: this step.
+
+**Check dashboard server logs next.** Inspect the teatree dashboard log for errors that may not have surfaced in the conversation:
 
 ```bash
 LOG="$HOME/.local/share/teatree/$(basename "$PWD")/logs/dashboard.log"

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -140,6 +140,16 @@ Before creating an MR, the `pr create` command automatically checks the session 
 
 **Prefer `t3 <overlay> pr create` over raw `gh`/`glab`.** The CLI handles the title/body format, ticket URL injection, assignee, and fork-vs-upstream remote resolution — all of which are easy to get wrong by hand. Reach for raw `gh`/`glab` only when the overlay doesn't expose a `pr create` subcommand, or when you're fixing the CLI itself and need to bypass it for this one call.
 
+#### Scope-Match Gate Before `Closes/Fixes #N` (Non-Negotiable)
+
+Before writing `Closes #N` or `Fixes #N` in a PR body, re-read the linked issue end-to-end and **enumerate every acceptance criterion, phase, or deliverable it names**. For each one, mark it ✅ shipped, ⚠️ partial, or ❌ not started, and paste the matrix into the PR body. `Closes/Fixes` is only legal when every row is ✅. Otherwise:
+
+- Use `Relates-to #N` (so the issue stays open).
+- List the unshipped phases/AC in the PR body under a "Remaining scope" heading so the next agent sees the gap.
+- Do NOT rely on "I'll do the rest later" memory. The issue body is the contract; a partial PR that auto-closes the issue silently discards the rest of the contract.
+
+**Past failure (#97, PR #423):** Issue #97 defined 5 phases (`Phase 1` teardown cleanup through `Phase 5` teatree core hooks). PR #423 shipped only Phase 5 but used `Closes #97`, auto-closing the issue when 4/5 phases remained. The user had to reopen the issue manually. Prevention: the phase-by-phase ✅/❌ matrix in the PR body would have forced the correct verb (`Relates-to`).
+
 **STOP — resolve the ticket URL before typing the glab command.**
 
 Before composing any `glab mr create` or `glab mr update` call, answer these three questions:


### PR DESCRIPTION
## Summary

Adds a non-negotiable scope-match check in two places so the #97 partial-scope auto-close cannot silently recur:

- **ship § 5 (PR/MR creation):** before writing \`Closes/Fixes #N\`, enumerate every AC/phase from the issue and paste a ✅/❌ matrix into the PR body. Only legal when every row is ✅; otherwise switch to \`Relates-to\` and list remaining scope explicitly.
- **retro § 1 (Conversation Audit):** first step is re-reading the issue body and mapping it to what shipped — BEFORE scanning for tactical failures. Unshipped AC after a \"complete\" declaration is a False-completion finding and outranks everything tactical.

Relates-to #97

## Test plan

- [x] prek + markdownlint pass on both edited skill files
- [x] No duplicate guidance — the existing sections on \`Closes vs Relates-to\` state the choice but did not require AC-level enumeration