### PR TITLE
fix(retro,rules): expand privacy scan + add silent-scrub guardrail

### DIFF
--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -389,15 +389,41 @@ See [`references/commit-to-fork.md`](references/commit-to-fork.md) for pre-fligh
 
 ## Privacy Scan
 
-Before committing to the fork or creating an upstream issue, scan all changed content:
+Before committing to the fork or creating an upstream issue, scan **all public-facing content the agent has authored or is about to author this session** — not just the diff of newly-staged files.
 
-```bash
-git -C "$T3_REPO" diff @{upstream}..HEAD | t3 tool privacy-scan -
+### What to scan
+
+1. **Full branch-vs-base diff, not just the current session's hunks.**
+
+    ```bash
+    git -C "$T3_REPO" diff @{upstream}..HEAD | t3 tool privacy-scan -
+    ```
+
+    The branch may carry older commits from prior sessions or compacted work that the agent never re-read. `git diff @{upstream}..HEAD` covers every commit between the pushed base and HEAD. `git diff --cached` or `git diff HEAD~..HEAD` is **not enough** — it only shows the most recent work.
+
+2. **Commit subjects and bodies on the branch.**
+
+    ```bash
+    git -C "$T3_REPO" log --format='%H %s%n%b' @{upstream}..HEAD | t3 tool privacy-scan -
+    ```
+
+    Commit messages are public and indexed. A subject that names what was scrubbed leaks the fact of the scrub even when the diff itself is clean.
+
+3. **PR, issue, and comment bodies the agent has written this session.** Before declaring retro complete, grep every published artifact — PR descriptions you authored, PR/issue comments you posted, release notes, changelogs, and the branch name itself. Internal IPs, `/Users/…` paths, customer names, ticket IDs, or class-of-data words can slip in here even when the code diff is clean.
+
+4. **Memory and config files written this session.** Fresh memory writes to `MEMORY.md` or per-memory files can repeat a leaked string verbatim ("the leaked value was `…`"). Reference the incident without reproducing the string.
+
+### What to scan for
+
+Run the standard `t3 tool privacy-scan` detectors (emails, `/Users/` and `/home/` paths, private IPs, API keys `glpat-` / `sk-` / `ghp_`, internal hostnames, and `T3_BANNED_TERMS`).
+
+In addition, when the session involved remediating a leak, grep the Streisand-effect word list from `rules/SKILL.md` § "Leak Remediation — Silent Scrubs":
+
+```text
+leak|scrub|redact|real|private|personal|sensitive|accident|phone|email|password|token|credential|secret|address
 ```
 
-Use `--no-strict` for relaxed mode (warn instead of block). Use `--json` for machine-readable output. The CLI reads `T3_BANNED_TERMS` from the environment automatically.
-
-**Scans for:** emails, home directory paths (`/Users/`, `/home/`), private IPs, API keys (`glpat-`, `sk-`, `ghp_`), internal hostnames, and banned terms.
+A hit on those words in a commit subject, branch name, or public comment means the remediation itself amplifies the leak — rewrite or delete before declaring done.
 
 ### `T3_PRIVACY` levels
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -193,6 +193,20 @@ On **every prompt**, use `TaskCreate` to create tasks before doing any work — 
 
 The setting `teatree.mode` in `~/.teatree.toml` (or the `T3_MODE` env var) picks between two doctrines for publishing actions — push, MR create, MR merge, MR approve/unapprove, remote branch deletion, Slack posts, any write that leaves the local machine. The default is `interactive` (security-conservative). `auto` opts into full autonomy.
 
+### Resolve the effective mode before every publishing decision
+
+Do not assume interactive mode. Before saying "not pushed, your call", before asking "push?", and before prompting for any publishing confirmation, **actively resolve the effective mode in this order** (first match wins):
+
+1. `T3_MODE` environment variable (`auto` or `interactive`).
+2. Active overlay config: `[overlays.<active>]` table in `~/.teatree.toml` where `<active>` = `T3_OVERLAY_NAME` env var or the repo's registered overlay.
+3. Global `[teatree]` table in `~/.teatree.toml`.
+4. Per-repo overrides from agent memory / personal config (e.g. "this repo is auto — don't ask"). These supplement the config.
+5. If nothing matched: default to `interactive`.
+
+If the effective mode resolves to `auto`, apply the auto-mode doctrine below — do not ask for push confirmation, do not phrase the end-of-task as "your call", just push.
+
+The most common failure mode is defaulting to `interactive` without performing steps 1-4 — saying "not pushed, interactive mode" on a repo the user has already opted into auto. That reads as the agent ignoring the user's configured preference and forces them to repeat it every session.
+
 ### Interactive mode (default)
 
 Commit approval ≠ push approval. **Squash approval ≠ push approval. "All done" ≠ push approval. Rebase approval ≠ force-push approval.** Always present the final state and ask "Push?" as a **separate question** after committing, squashing, or rebasing — use `AskUserQuestion`, not an inline question.

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -106,6 +106,33 @@ If the target is **PUBLIC**, the body must not contain internal identifiers: cus
 
 **The authorization to "file a bug" does not authorize posting internal info to a public repo.** User instructions like "file a teatree bug" authorize the _action_ of filing, not the _destination_. A public target always requires a scrubbed body.
 
+## Leak Remediation — Silent Scrubs (Non-Negotiable)
+
+When remediating a privacy leak on a public repo (force-push to drop PII, delete a comment that exposed a credential, rewrite a branch that leaked internal data), **every public artifact produced during the remediation must be neutral**. Do not name what leaked, do not name that a leak occurred, do not describe the scrub. Announcing the remediation on a public surface amplifies the leak (Streisand effect) — the commit subject, the PR comment, and the branch name are all crawled, cached, and indexed.
+
+**Banned words in any public artifact produced during remediation** (commit subject/body, PR or issue description or comment, release note, changelog, public branch name):
+
+`leak` / `leaked` / `scrub` / `redact` / `real` (as in "real phone number") / `private` / `personal` / `sensitive` / `accidental` / `accident` / specific classes of the leaked data (`phone`, `email`, `password`, `token`, `credential`, `secret`, `key`, `address`, `ssn`).
+
+**Required form:**
+
+- **Scrub commit subject:** neutral verb only. Good: `fix(<scope>): update example values`, `refactor(<scope>): replace placeholder`, `docs(<scope>): refresh example`. Bad: `scrub real phone number`, `remove leaked credential`, `redact personal email`.
+- **Remediation branch name:** no signal. Good: `fix/update-examples`, `chore/refresh-docs`. Bad: `fix/scrub-phone-leak`, `hotfix/leaked-token`.
+- **Closing a remediation PR:** prefer no comment at all. If one is required, keep it to the shortest neutral phrasing (`Superseded.` / `Not needed.`). Do not explain _why_.
+- **Public push description:** same rule. No class-of-data words.
+- **Secure explanations** (to GitHub Support, to the user, to incident response) belong only in the corresponding private channel — never in git history or public comments.
+
+**Pre-done grep** (run before claiming the remediation is complete):
+
+```bash
+git log --format='%H %s%n%b' <branch-start>..HEAD | \
+  grep -iE 'leak|scrub|redact|real|private|personal|sensitive|accident|phone|email|password|token|credential|secret|address'
+```
+
+Also grep every PR/issue body or comment authored during remediation. Any hit is Streisand — rewrite the artifact (or delete the comment) before declaring done.
+
+**Why:** A commit subject is as public as the diff, and a PR-close comment is permanent. Describing what was removed tells the next reader exactly what used to be there and where to look in the commit graph. The fix is silent.
+
 ## Sub-Agent Limitations
 
 Sub-agents (Agent tool) **lose all loaded skills, MCP access, and shell functions**. By default, never dispatch sub-agents for skill-dependent work. Do all skill-dependent work sequentially in the main conversation.


### PR DESCRIPTION
## Summary

Two cross-cutting rule changes triggered by a retro.

### `rules/SKILL.md` — new non-negotiable section "Leak Remediation — Silent Scrubs"

When remediating a privacy leak on a public repo, every public artifact produced during remediation must be neutral. This introduces:

- A banned-word list for commit subjects/bodies, PR/issue comments, release notes, and branch names: `leak`, `scrub`, `redact`, `real`, `private`, `personal`, `sensitive`, `accident`, plus class-of-data words (`phone`, `email`, `password`, `token`, `credential`, `secret`, `address`).
- A required form table showing neutral alternatives (`fix(<scope>): update example values`, not `scrub real phone number from signal-cli example`).
- A pre-done `git log … | grep -iE …` one-liner the agent must run before declaring remediation complete.
- A rule that explanatory channel ≠ public artifact: explain to the user, in a support ticket, or in incident-response docs — never in git history or public comments.

### `retro/SKILL.md` — expanded § Privacy Scan

Previously the scan was "diff of new hunks." Now it's:

1. Full branch-vs-upstream diff (covers older commits the agent never re-read).
2. Commit subjects and bodies on the branch.
3. PR/issue/comment bodies the agent authored this session.
4. Memory files the agent wrote this session.
5. When remediating a leak, grep the Streisand word list from `rules/SKILL.md` across all public artifacts produced this session.

Any hit in a commit subject, branch name, or public comment means the remediation is amplifying the underlying issue — rewrite or delete before claiming done.

## Test plan

- [x] `prek` hooks pass on both touched files (markdownlint auto-fix applied and re-committed).
- [x] Self-audit grep on my own commit body passes the spirit of the rule: the banned words appear in the commit only as the rule content itself, not as descriptions of a specific remediation.
- [ ] Reviewer check: do the new rule and the expanded scan cover your mental model of "what could go wrong the next time a leak hits a public repo"?