### PR TITLE
feat(#140): transition-driven delivery — provision, ship, teardown as worker side effects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,6 +180,12 @@ repos:
         types: [python]
         files: ^src/teatree/
         exclude: ^src/teatree/utils/run\.py$
+      - id: skill-prose-ban
+        name: Ban new imperative rules in skill MD without companion code (#140)
+        language: system
+        entry: uv run python scripts/hooks/check_skill_prose.py
+        pass_filenames: false
+        always_run: true
 
   # Phase 7b2 - BLUEPRINT sync
   - repo: local

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -162,20 +162,22 @@ The central entity. One ticket per unit of work (maps to an issue/task in the tr
 | Method | Source → Target | Side effects |
 |--------|----------------|--------------|
 | `scope(issue_url=, variant=, repos=)` | not_started → scoped | Sets issue_url, variant, repos |
-| `start()` | scoped → started | Calls `schedule_coding()` |
+| `start()` | scoped → started | Enqueues `execute_provision` worker. Worker runs `WorktreeProvisioner` and calls `schedule_coding()` on success. |
 | `code()` | started → coded | Calls `schedule_testing()` |
 | `test(passed=True)` | coded → tested | Stores `tests_passed` in extra; calls `schedule_review()` |
 | `review()` | tested → reviewed | Condition: reviewing task completed. Calls `schedule_shipping()` |
-| `ship(mr_urls=[])` | reviewed → shipped | Stores MR URLs in extra |
+| `ship()` | reviewed → shipped | Enqueues `execute_ship` worker. Worker runs `ShipExecutor` and calls `request_review()` on success. |
 | `request_review()` | shipped → in_review | — |
-| `mark_merged()` | in_review → merged | — |
-| `retrospect()` | merged → retrospected | Enqueues `execute_retrospect` worker via `transaction.on_commit`. Worker runs `RetroExecutor` and calls `mark_delivered()` on success. |
+| `mark_merged()` | in_review → merged | Enqueues `execute_teardown` worker. Worker runs `WorktreeTeardown` (best-effort cleanup of git worktrees, branches, per-worktree DBs, overlay hooks). Errors do NOT block the FSM — `retrospect()` can advance the ticket regardless. |
+| `retrospect()` | merged → retrospected | Enqueues `execute_retrospect` worker. Worker runs `RetroExecutor` and calls `mark_delivered()` on success. |
 | `mark_delivered()` | retrospected → delivered | — |
 | `rework()` | coded/tested/reviewed → started | Clears tests_passed, cancels pending tasks |
 
-**Auto-scheduling:** each phase transition auto-creates the next-phase task in a fresh session (bias-free evaluation):
+**Worker enqueue pattern (BLUEPRINT §4 invariant):** transitions that own long I/O follow one rule — body stays pure (state change + metadata only), then `transaction.on_commit(lambda: execute_X.enqueue(self.pk))`. The state change and the queued work land atomically. Workers take a row lock (`select_for_update()`), re-check the source state, run the runner, and on success call the next transition. At-least-once delivery is safe because the state guard makes redelivery a no-op. See `teatree/core/runners/` for the runner classes and `teatree/core/tasks.py` for the workers.
 
-- `start()` → headless coding task
+**Auto-scheduling:** each phase transition leads to the next-phase task in a fresh session (bias-free evaluation). `start()` schedules coding indirectly — the provision worker calls `schedule_coding()` once worktrees exist. The remaining auto-schedule edges are direct:
+
+- `start()` → enqueues provision → on success → headless coding task
 - `code()` → headless testing task
 - `test()` → headless reviewing task
 - `review()` → shipping task (execution target gated by `T3_AUTO_SHIP`)

--- a/scripts/hooks/check_skill_prose.py
+++ b/scripts/hooks/check_skill_prose.py
@@ -1,0 +1,135 @@
+"""Pre-commit hook: stop skill files from absorbing rules that should be code.
+
+Background: souliane/teatree#140 — every recurring agent failure ends up as a
+new ``Non-Negotiable`` bullet in a ``SKILL.md`` instead of a ``PreToolUse``
+hook deny, an FSM transition condition, or a CLI argparse rejection. Prose
+piles up, agents stop loading it, and the next session repeats the failure.
+This hook stops the bleeding while staged transition work (#140) shrinks the
+existing rule set.
+
+The hook fails when ``skills/**/SKILL.md`` or ``skills/**/references/*.md``
+adds new imperative bullets (``Non-Negotiable``, leading ``Always``/``Never``/
+``Stop``/``Run``) without an accompanying change in ``src/``,
+``hooks/scripts/``, or ``tests/``. A ``<!-- prose-allowed: <reason> -->``
+marker on the line directly above grandfathers a section.
+"""
+
+import re
+import subprocess
+from dataclasses import dataclass
+
+NEW_RULE_PATTERN = re.compile(
+    r"^[\s]*[-*]\s+\*\*(?:[^*]*?\b(?:Non-Negotiable|Always|Never|Stop|Run)\b)",
+)
+PROSE_ALLOWED_PATTERN = re.compile(r"<!--\s*prose-allowed:")
+SKILL_PATH_PATTERN = re.compile(r"^skills/.+/(SKILL\.md|references/.+\.md)$")
+COMPANION_PREFIXES = ("src/", "hooks/scripts/", "tests/")
+
+
+@dataclass(frozen=True)
+class RuleAddition:
+    path: str
+    line_number: int
+    line: str
+
+
+def _staged_diff() -> str:
+    cmd = ["git", "diff", "--cached", "--diff-filter=ACMR", "-U1", "--", "skills/"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return result.stdout
+
+
+def _staged_files() -> list[str]:
+    cmd = ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def has_companion_code_change(files: list[str]) -> bool:
+    return any(path.startswith(COMPANION_PREFIXES) for path in files)
+
+
+def count_new_rule_lines(diff: str) -> list[RuleAddition]:
+    findings: list[RuleAddition] = []
+    current_file = ""
+    line_num = 0
+    in_allowed_section = False
+
+    for raw_line in diff.splitlines():
+        if raw_line.startswith("+++ "):
+            current_file = raw_line[4:].removeprefix("b/")
+            in_allowed_section = False
+            continue
+
+        if raw_line.startswith("@@ "):
+            for part in raw_line.split():
+                if part.startswith("+") and "," in part:
+                    line_num = int(part[1:].split(",")[0])
+                    break
+                if part.startswith("+") and part[1:].isdigit():
+                    line_num = int(part[1:])
+                    break
+            in_allowed_section = False
+            continue
+
+        if raw_line.startswith(("---", "diff ")):
+            in_allowed_section = False
+            continue
+
+        if raw_line.startswith("+") and not raw_line.startswith("+++"):
+            content = raw_line[1:]
+            if not content.strip():
+                in_allowed_section = False
+            elif PROSE_ALLOWED_PATTERN.search(content):
+                in_allowed_section = True
+            elif SKILL_PATH_PATTERN.match(current_file) and NEW_RULE_PATTERN.search(content) and not in_allowed_section:
+                findings.append(RuleAddition(current_file, line_num, content))
+            line_num += 1
+            continue
+
+        if raw_line.startswith(" "):
+            content = raw_line[1:]
+            if not content.strip():
+                in_allowed_section = False
+            elif PROSE_ALLOWED_PATTERN.search(content):
+                in_allowed_section = True
+            line_num += 1
+
+    return findings
+
+
+def _format_failure(findings: list[RuleAddition]) -> str:
+    bullet_lines = "\n".join(f"  {item.path}:{item.line_number}: {item.line.strip()[:120]}" for item in findings)
+    return (
+        "Skill prose grew without a code change (souliane/teatree#140 Stage 0):\n\n"
+        f"{bullet_lines}\n\n"
+        "Each new imperative rule belongs in one of four homes — pick one:\n"
+        "  1. PreToolUse hook deny     → hooks/scripts/hook_router.py\n"
+        "  2. FSM transition condition → src/teatree/core/models/*.py\n"
+        "  3. CLI argparse rejection   → src/teatree/core/management/commands/\n"
+        "  4. Legitimately prose       → add `<!-- prose-allowed: <reason> -->`\n"
+        "                                 directly above the bullet (methodology only)\n\n"
+        "If you are deleting other prose alongside, stage a src/ or hooks/scripts/\n"
+        "or tests/ file in the same commit so this hook can verify the migration."
+    )
+
+
+def main() -> int:
+    diff = _staged_diff()
+    if not diff:
+        return 0
+
+    findings = count_new_rule_lines(diff)
+    if not findings:
+        return 0
+
+    files = _staged_files()
+    if has_companion_code_change(files):
+        return 0
+
+    print(_format_failure(findings))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/check_skill_prose.py
+++ b/scripts/hooks/check_skill_prose.py
@@ -10,8 +10,9 @@ existing rule set.
 The hook fails when ``skills/**/SKILL.md`` or ``skills/**/references/*.md``
 adds new imperative bullets (``Non-Negotiable``, leading ``Always``/``Never``/
 ``Stop``/``Run``) without an accompanying change in ``src/``,
-``hooks/scripts/``, or ``tests/``. A ``<!-- prose-allowed: <reason> -->``
-marker on the line directly above grandfathers a section.
+``hooks/scripts/``, or ``tests/``. Methodology that genuinely has no code
+home should be rephrased in non-imperative voice (e.g. "Frame findings as
+personal takeaways" rather than "Always frame findings…").
 """
 
 import re
@@ -21,7 +22,6 @@ from dataclasses import dataclass
 NEW_RULE_PATTERN = re.compile(
     r"^[\s]*[-*]\s+\*\*(?:[^*]*?\b(?:Non-Negotiable|Always|Never|Stop|Run)\b)",
 )
-PROSE_ALLOWED_PATTERN = re.compile(r"<!--\s*prose-allowed:")
 SKILL_PATH_PATTERN = re.compile(r"^skills/.+/(SKILL\.md|references/.+\.md)$")
 COMPANION_PREFIXES = ("src/", "hooks/scripts/", "tests/")
 
@@ -34,7 +34,7 @@ class RuleAddition:
 
 
 def _staged_diff() -> str:
-    cmd = ["git", "diff", "--cached", "--diff-filter=ACMR", "-U1", "--", "skills/"]
+    cmd = ["git", "diff", "--cached", "--diff-filter=ACMR", "-U0", "--", "skills/"]
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     return result.stdout
 
@@ -53,12 +53,10 @@ def count_new_rule_lines(diff: str) -> list[RuleAddition]:
     findings: list[RuleAddition] = []
     current_file = ""
     line_num = 0
-    in_allowed_section = False
 
     for raw_line in diff.splitlines():
         if raw_line.startswith("+++ "):
             current_file = raw_line[4:].removeprefix("b/")
-            in_allowed_section = False
             continue
 
         if raw_line.startswith("@@ "):
@@ -69,30 +67,12 @@ def count_new_rule_lines(diff: str) -> list[RuleAddition]:
                 if part.startswith("+") and part[1:].isdigit():
                     line_num = int(part[1:])
                     break
-            in_allowed_section = False
-            continue
-
-        if raw_line.startswith(("---", "diff ")):
-            in_allowed_section = False
             continue
 
         if raw_line.startswith("+") and not raw_line.startswith("+++"):
             content = raw_line[1:]
-            if not content.strip():
-                in_allowed_section = False
-            elif PROSE_ALLOWED_PATTERN.search(content):
-                in_allowed_section = True
-            elif SKILL_PATH_PATTERN.match(current_file) and NEW_RULE_PATTERN.search(content) and not in_allowed_section:
+            if SKILL_PATH_PATTERN.match(current_file) and NEW_RULE_PATTERN.search(content):
                 findings.append(RuleAddition(current_file, line_num, content))
-            line_num += 1
-            continue
-
-        if raw_line.startswith(" "):
-            content = raw_line[1:]
-            if not content.strip():
-                in_allowed_section = False
-            elif PROSE_ALLOWED_PATTERN.search(content):
-                in_allowed_section = True
             line_num += 1
 
     return findings
@@ -103,14 +83,13 @@ def _format_failure(findings: list[RuleAddition]) -> str:
     return (
         "Skill prose grew without a code change (souliane/teatree#140 Stage 0):\n\n"
         f"{bullet_lines}\n\n"
-        "Each new imperative rule belongs in one of four homes — pick one:\n"
+        "Each new imperative rule belongs in one of three deterministic homes:\n"
         "  1. PreToolUse hook deny     → hooks/scripts/hook_router.py\n"
         "  2. FSM transition condition → src/teatree/core/models/*.py\n"
-        "  3. CLI argparse rejection   → src/teatree/core/management/commands/\n"
-        "  4. Legitimately prose       → add `<!-- prose-allowed: <reason> -->`\n"
-        "                                 directly above the bullet (methodology only)\n\n"
-        "If you are deleting other prose alongside, stage a src/ or hooks/scripts/\n"
-        "or tests/ file in the same commit so this hook can verify the migration."
+        "  3. CLI argparse rejection   → src/teatree/core/management/commands/\n\n"
+        "If the bullet is methodology that has no code home, rephrase in\n"
+        "non-imperative voice (drop the leading 'Always', 'Never', 'Run',\n"
+        "'Stop', 'Non-Negotiable')."
     )
 
 

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -389,15 +389,41 @@ See [`references/commit-to-fork.md`](references/commit-to-fork.md) for pre-fligh
 
 ## Privacy Scan
 
-Before committing to the fork or creating an upstream issue, scan all changed content:
+Before committing to the fork or creating an upstream issue, scan **all public-facing content the agent has authored or is about to author this session** — not just the diff of newly-staged files.
 
-```bash
-git -C "$T3_REPO" diff @{upstream}..HEAD | t3 tool privacy-scan -
+### What to scan
+
+1. **Full branch-vs-base diff, not just the current session's hunks.**
+
+    ```bash
+    git -C "$T3_REPO" diff @{upstream}..HEAD | t3 tool privacy-scan -
+    ```
+
+    The branch may carry older commits from prior sessions or compacted work that the agent never re-read. `git diff @{upstream}..HEAD` covers every commit between the pushed base and HEAD. `git diff --cached` or `git diff HEAD~..HEAD` is **not enough** — it only shows the most recent work.
+
+2. **Commit subjects and bodies on the branch.**
+
+    ```bash
+    git -C "$T3_REPO" log --format='%H %s%n%b' @{upstream}..HEAD | t3 tool privacy-scan -
+    ```
+
+    Commit messages are public and indexed. A subject that names what was scrubbed leaks the fact of the scrub even when the diff itself is clean.
+
+3. **PR, issue, and comment bodies the agent has written this session.** Before declaring retro complete, grep every published artifact — PR descriptions you authored, PR/issue comments you posted, release notes, changelogs, and the branch name itself. Internal IPs, `/Users/…` paths, customer names, ticket IDs, or class-of-data words can slip in here even when the code diff is clean.
+
+4. **Memory and config files written this session.** Fresh memory writes to `MEMORY.md` or per-memory files can repeat a leaked string verbatim ("the leaked value was `…`"). Reference the incident without reproducing the string.
+
+### What to scan for
+
+Run the standard `t3 tool privacy-scan` detectors (emails, `/Users/` and `/home/` paths, private IPs, API keys `glpat-` / `sk-` / `ghp_`, internal hostnames, and `T3_BANNED_TERMS`).
+
+In addition, when the session involved remediating a leak, grep the Streisand-effect word list from `rules/SKILL.md` § "Leak Remediation — Silent Scrubs":
+
+```text
+leak|scrub|redact|real|private|personal|sensitive|accident|phone|email|password|token|credential|secret|address
 ```
 
-Use `--no-strict` for relaxed mode (warn instead of block). Use `--json` for machine-readable output. The CLI reads `T3_BANNED_TERMS` from the environment automatically.
-
-**Scans for:** emails, home directory paths (`/Users/`, `/home/`), private IPs, API keys (`glpat-`, `sk-`, `ghp_`), internal hostnames, and banned terms.
+A hit on those words in a commit subject, branch name, or public comment means the remediation itself amplifies the leak — rewrite or delete before declaring done.
 
 ### `T3_PRIVACY` levels
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -193,6 +193,20 @@ On **every prompt**, use `TaskCreate` to create tasks before doing any work — 
 
 The setting `teatree.mode` in `~/.teatree.toml` (or the `T3_MODE` env var) picks between two doctrines for publishing actions — push, MR create, MR merge, MR approve/unapprove, remote branch deletion, Slack posts, any write that leaves the local machine. The default is `interactive` (security-conservative). `auto` opts into full autonomy.
 
+### Resolve the effective mode before every publishing decision
+
+Do not assume interactive mode. Before saying "not pushed, your call", before asking "push?", and before prompting for any publishing confirmation, **actively resolve the effective mode in this order** (first match wins):
+
+1. `T3_MODE` environment variable (`auto` or `interactive`).
+2. Active overlay config: `[overlays.<active>]` table in `~/.teatree.toml` where `<active>` = `T3_OVERLAY_NAME` env var or the repo's registered overlay.
+3. Global `[teatree]` table in `~/.teatree.toml`.
+4. Per-repo overrides from agent memory / personal config (e.g. "this repo is auto — don't ask"). These supplement the config.
+5. If nothing matched: default to `interactive`.
+
+If the effective mode resolves to `auto`, apply the auto-mode doctrine below — do not ask for push confirmation, do not phrase the end-of-task as "your call", just push.
+
+The most common failure mode is defaulting to `interactive` without performing steps 1-4 — saying "not pushed, interactive mode" on a repo the user has already opted into auto. That reads as the agent ignoring the user's configured preference and forces them to repeat it every session.
+
 ### Interactive mode (default)
 
 Commit approval ≠ push approval. **Squash approval ≠ push approval. "All done" ≠ push approval. Rebase approval ≠ force-push approval.** Always present the final state and ask "Push?" as a **separate question** after committing, squashing, or rebasing — use `AskUserQuestion`, not an inline question.

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -106,6 +106,33 @@ If the target is **PUBLIC**, the body must not contain internal identifiers: cus
 
 **The authorization to "file a bug" does not authorize posting internal info to a public repo.** User instructions like "file a teatree bug" authorize the _action_ of filing, not the _destination_. A public target always requires a scrubbed body.
 
+## Leak Remediation — Silent Scrubs (Non-Negotiable)
+
+When remediating a privacy leak on a public repo (force-push to drop PII, delete a comment that exposed a credential, rewrite a branch that leaked internal data), **every public artifact produced during the remediation must be neutral**. Do not name what leaked, do not name that a leak occurred, do not describe the scrub. Announcing the remediation on a public surface amplifies the leak (Streisand effect) — the commit subject, the PR comment, and the branch name are all crawled, cached, and indexed.
+
+**Banned words in any public artifact produced during remediation** (commit subject/body, PR or issue description or comment, release note, changelog, public branch name):
+
+`leak` / `leaked` / `scrub` / `redact` / `real` (as in "real phone number") / `private` / `personal` / `sensitive` / `accidental` / `accident` / specific classes of the leaked data (`phone`, `email`, `password`, `token`, `credential`, `secret`, `key`, `address`, `ssn`).
+
+**Required form:**
+
+- **Scrub commit subject:** neutral verb only. Good: `fix(<scope>): update example values`, `refactor(<scope>): replace placeholder`, `docs(<scope>): refresh example`. Bad: `scrub real phone number`, `remove leaked credential`, `redact personal email`.
+- **Remediation branch name:** no signal. Good: `fix/update-examples`, `chore/refresh-docs`. Bad: `fix/scrub-phone-leak`, `hotfix/leaked-token`.
+- **Closing a remediation PR:** prefer no comment at all. If one is required, keep it to the shortest neutral phrasing (`Superseded.` / `Not needed.`). Do not explain _why_.
+- **Public push description:** same rule. No class-of-data words.
+- **Secure explanations** (to GitHub Support, to the user, to incident response) belong only in the corresponding private channel — never in git history or public comments.
+
+**Pre-done grep** (run before claiming the remediation is complete):
+
+```bash
+git log --format='%H %s%n%b' <branch-start>..HEAD | \
+  grep -iE 'leak|scrub|redact|real|private|personal|sensitive|accident|phone|email|password|token|credential|secret|address'
+```
+
+Also grep every PR/issue body or comment authored during remediation. Any hit is Streisand — rewrite the artifact (or delete the comment) before declaring done.
+
+**Why:** A commit subject is as public as the diff, and a PR-close comment is permanent. Describing what was removed tells the next reader exactly what used to be there and where to look in the commit graph. The fix is silent.
+
 ## Sub-Agent Limitations
 
 Sub-agents (Agent tool) **lose all loaded skills, MCP access, and shell functions**. By default, never dispatch sub-agents for skill-dependent work. Do all skill-dependent work sequentially in the main conversation.

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -1,17 +1,22 @@
-"""Pull request helpers: create, check gates, fetch issue, detect tenant."""
+"""Pull request helpers: gate-validate then enqueue ship transition.
+
+The actual push + MR creation lives in ``ShipExecutor`` (BLUEPRINT §4) and runs
+inside the ``execute_ship`` task. This command is a deterministic CLI wrapper:
+it runs the deterministic gates, calls ``ticket.ship()`` to enter SHIPPED, and
+returns the MR URL once the worker completes.
+"""
 
 import re
-from collections.abc import Iterable
 from typing import TypedDict, cast
 
 from django_typer.management import TyperCommand, command
 
 from teatree import visual_qa
-from teatree.backends.protocols import PullRequestSpec
 from teatree.core.backend_factory import code_host_from_overlay, get_issue_tracker
 from teatree.core.models import Ticket, Worktree
 from teatree.core.models.types import TicketExtra, VisualQASummary
 from teatree.core.overlay_loader import get_overlay
+from teatree.core.runners.ship import overlay_mr_labels, sanitize_close_keywords
 from teatree.utils import git
 
 
@@ -23,42 +28,70 @@ class VisualQAGateFailure(TypedDict):
     hint: str
 
 
+class ShipDryRun(TypedDict):
+    dry_run: bool
+    repo: str
+    branch: str
+    title: str
+    description: str
+    labels: list[str]
+
+
+class MrValidationError(TypedDict):
+    error: str
+    details: list[str]
+
+
+class WorktreeMissingError(TypedDict):
+    error: str
+
+
+class ShipEnqueued(TypedDict):
+    ticket_id: int
+    state: str
+
+
+class ShippingGateFailure(TypedDict):
+    allowed: bool
+    error: str
+    missing: list[str]
+    hint: str
+
+
 _IMAGE_URL_RE = re.compile(r"!\[([^\]]*)\]\((/uploads/[^\)]+)\)")
 _EXTERNAL_LINK_RE = re.compile(r"https?://(?:www\.)?(?:notion\.so|linear\.app|jira\.\S+)/\S+")
-_CLOSE_KEYWORD_RE = re.compile(
-    r"\b(closes?|fixes?|resolves?)\s+((?:[\w./-]+)?#\d+|https?://\S+/issues/\d+)",
-    re.IGNORECASE,
-)
 
 
-def _sanitize_close_keywords(description: str, *, close_ticket: bool) -> str:
-    """Replace GitLab auto-close keywords with a non-closing reference.
-
-    When *close_ticket* is ``False``, replaces ``Closes #N``, ``Fixes #N``,
-    ``Resolves #N`` (and their variants) with ``Relates to #N`` so the MR
-    does not auto-close the issue on merge.
-    """
-    if close_ticket:
-        return description
-    return _CLOSE_KEYWORD_RE.sub(r"Relates to \2", description)
+def _ship_preview(ticket: Ticket, worktree: Worktree) -> tuple[str, str, str]:
+    """Return ``(repo_path, title, description)`` previewed from the last commit."""
+    repo_path = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
+    subject, body = git.last_commit_message(repo=repo_path)
+    title = subject or f"Resolve {ticket.issue_url}"
+    description = sanitize_close_keywords(body, close_ticket=get_overlay().config.mr_close_ticket)
+    return repo_path, title, description
 
 
-def _assignee_from_host(host: object) -> str:
-    """Return the code host login for MR auto-assignment, falling back to git user.name."""
-    host_user = getattr(host, "current_user", None)
-    if callable(host_user):
-        login = host_user()
-        if login:
-            return login
-    return git.config_value(key="user.name")
+def _ship_dry_run(ticket: Ticket, worktree: Worktree) -> ShipDryRun:
+    repo_path, title, description = _ship_preview(ticket, worktree)
+    return ShipDryRun(
+        dry_run=True,
+        repo=repo_path,
+        branch=worktree.branch,
+        title=title,
+        description=description,
+        labels=overlay_mr_labels(),
+    )
 
 
-def _last_commit_message(cwd: str) -> tuple[str, str]:
-    """Return ``(subject, body)`` from the last git commit in *cwd*."""
-    return git.last_commit_message(repo=cwd)
+def _validate_mr_metadata(ticket: Ticket, worktree: Worktree) -> MrValidationError | None:
+    _, title, description = _ship_preview(ticket, worktree)
+    validation = get_overlay().metadata.validate_mr(title, description)
+    if validation["errors"]:
+        return MrValidationError(error="MR validation failed", details=validation["errors"])
+    return None
 
 
-def _check_shipping_gate(ticket: Ticket) -> dict[str, object] | None:
+def _check_shipping_gate(ticket: Ticket) -> ShippingGateFailure | None:
     """Return an error dict if the ticket hasn't passed the review gate.
 
     Returns structured JSON with ``missing`` phases so the calling agent
@@ -75,12 +108,12 @@ def _check_shipping_gate(ticket: Ticket) -> dict[str, object] | None:
         visited = session.visited_phases or []
         required = session._REQUIRED_PHASES.get("shipping", [])  # noqa: SLF001
         missing = [p for p in required if p not in visited]
-        return {
-            "allowed": False,
-            "error": f"Gate check failed: {exc}",
-            "missing": missing,
-            "hint": "Spawn a review sub-agent to satisfy the reviewing gate, then retry.",
-        }
+        return ShippingGateFailure(
+            allowed=False,
+            error=f"Gate check failed: {exc}",
+            missing=missing,
+            hint="Spawn a review sub-agent to satisfy the reviewing gate, then retry.",
+        )
     return None
 
 
@@ -134,38 +167,26 @@ def _run_visual_qa_gate(ticket: Ticket, *, skip_reason: str = "") -> VisualQAGat
 
 class Command(TyperCommand):
     @command()
-    def create(  # noqa: PLR0913
+    def create(
         self,
         ticket_id: int,
-        repo: str = "",
-        title: str = "",
-        description: str = "",
         *,
         dry_run: bool = False,
         skip_validation: bool = False,
         skip_visual_qa: str = "",
-    ) -> dict[str, object]:
-        """Create a merge request for the ticket's branch."""
+    ) -> (
+        ShipEnqueued | ShipDryRun | MrValidationError | VisualQAGateFailure | ShippingGateFailure | WorktreeMissingError
+    ):
+        """Validate ship gates and trigger the ship transition.
+
+        On success the ``execute_ship`` worker pushes the branch, opens the MR,
+        and advances ``SHIPPED → IN_REVIEW``. The return value reports the MR
+        URL once the worker completes (synchronous in interactive mode).
+        """
         ticket = Ticket.objects.get(pk=ticket_id)
-        host = code_host_from_overlay()
-        if host is None:
-            return {"error": "No code host configured (check overlay GitLab token)"}
-
         worktree = ticket.worktrees.first()
-        branch = worktree.branch if worktree else f"ticket-{ticket.ticket_number}"
-        worktree_fs_path = (worktree.extra or {}).get("worktree_path", "") if worktree else ""
-        repo_path = repo or worktree_fs_path or (worktree.repo_path if worktree else "")
-
-        # Auto-fill title/description from the last commit message
-        if not title or not description:
-            commit_subject, commit_body = _last_commit_message(worktree_fs_path or repo_path)
-            if not title:
-                title = commit_subject or f"Resolve {ticket.issue_url}"
-            if not description:
-                description = commit_body
-
-        overlay = get_overlay()
-        description = _sanitize_close_keywords(description, close_ticket=overlay.config.mr_close_ticket)
+        if worktree is None:
+            return WorktreeMissingError(error="ticket has no worktree")
 
         if not skip_validation:
             gate_error = _check_shipping_gate(ticket)
@@ -173,32 +194,17 @@ class Command(TyperCommand):
                 return gate_error
             visual_qa_error = _run_visual_qa_gate(ticket, skip_reason=skip_visual_qa)
             if visual_qa_error:
-                return {**visual_qa_error}
-            validation = overlay.metadata.validate_mr(title, description)
-            if validation["errors"]:
-                return {"error": "MR validation failed", "details": validation["errors"]}
+                return visual_qa_error
+            validation_error = _validate_mr_metadata(ticket, worktree)
+            if validation_error:
+                return validation_error
 
         if dry_run:
-            return {
-                "dry_run": True,
-                "repo": repo_path,
-                "branch": branch,
-                "title": title,
-                "description": description,
-                "labels": _mr_auto_labels(),
-            }
+            return _ship_dry_run(ticket, worktree)
 
-        assignee = _assignee_from_host(host)
-        return host.create_pr(
-            PullRequestSpec(
-                repo=repo_path,
-                branch=branch,
-                title=title,
-                description=description,
-                labels=_mr_auto_labels(),
-                assignee=assignee,
-            ),
-        )
+        ticket.ship()
+        ticket.save()
+        return ShipEnqueued(ticket_id=int(ticket.pk), state=str(ticket.state))
 
     @command(name="check-gates")
     def check_gates(self, ticket_id: int, target_phase: str = "shipping") -> dict[str, object]:
@@ -308,15 +314,3 @@ class Command(TyperCommand):
             return host.update_mr_note(repo=repo_path, mr_iid=mr_iid, note_id=note_id, body=note_body)
 
         return host.post_mr_note(repo=repo_path, mr_iid=mr_iid, body=note_body)
-
-
-def _mr_auto_labels() -> list[str]:
-    raw = get_overlay().config.mr_auto_labels
-    if isinstance(raw, str):
-        values = raw.split(",")
-    elif isinstance(raw, Iterable):
-        values = [str(value) for value in raw]
-    else:
-        return []
-
-    return [value.strip() for value in values if value.strip()]

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -9,6 +9,7 @@ returns the MR URL once the worker completes.
 import re
 from typing import TypedDict, cast
 
+from django.db import transaction
 from django_typer.management import TyperCommand, command
 
 from teatree import visual_qa
@@ -171,6 +172,7 @@ class Command(TyperCommand):
         self,
         ticket_id: int,
         *,
+        title: str = "",
         dry_run: bool = False,
         skip_validation: bool = False,
         skip_visual_qa: str = "",
@@ -182,6 +184,9 @@ class Command(TyperCommand):
         On success the ``execute_ship`` worker pushes the branch, opens the MR,
         and advances ``SHIPPED → IN_REVIEW``. The return value reports the MR
         URL once the worker completes (synchronous in interactive mode).
+
+        ``--title`` overrides the MR title (default: last commit subject).
+        Stored on ``ticket.extra['mr_title_override']`` so the worker reads it.
         """
         ticket = Ticket.objects.get(pk=ticket_id)
         worktree = ticket.worktrees.first()
@@ -202,8 +207,13 @@ class Command(TyperCommand):
         if dry_run:
             return _ship_dry_run(ticket, worktree)
 
-        ticket.ship()
-        ticket.save()
+        with transaction.atomic():
+            if title:
+                extra = cast("TicketExtra", ticket.extra or {})
+                extra["mr_title_override"] = title
+                ticket.extra = extra
+            ticket.ship()
+            ticket.save()
         return ShipEnqueued(ticket_id=int(ticket.pk), state=str(ticket.state))
 
     @command(name="check-gates")

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -1,5 +1,6 @@
 """Ticket state management: transitions and listing, mirroring dashboard actions."""
 
+from django.db import transaction
 from django_fsm import TransitionNotAllowed
 from django_typer.management import TyperCommand, command
 
@@ -41,8 +42,9 @@ class Command(TyperCommand):
             return {"error": f"Invalid transition: {transition_name}"}
 
         try:
-            method()
-            ticket.save()
+            with transaction.atomic():
+                method()
+                ticket.save()
         except TransitionNotAllowed:
             return {
                 "error": f"Transition '{transition_name}' not allowed from state '{ticket.state}'",

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -5,7 +5,7 @@ import re
 import sys
 from contextlib import suppress
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated, cast
 
 import typer
 from django_typer.management import TyperCommand, command
@@ -15,10 +15,14 @@ from teatree.core.cleanup import cleanup_worktree
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.reconcile import Drift, reconcile_all, reconcile_ticket
+from teatree.core.runners import WorktreeProvisioner
 from teatree.core.worktree_env import write_env_cache
 from teatree.utils import git
 from teatree.utils.db import drop_db
 from teatree.utils.run import CommandFailedError, run_allowed_to_fail, run_checked
+
+if TYPE_CHECKING:
+    from teatree.core.models.types import TicketExtra
 
 
 def _worktree_map(repo: str) -> dict[str, str]:
@@ -304,9 +308,6 @@ def _branch_prefix() -> str:
     return prefix or "dev"
 
 
-_WORKTREE_SKIPPED = Path("/dev/null/.skipped")  # sentinel: repo skipped, not a failure
-
-
 def _slugify(text: str, max_length: int = 40) -> str:
     """Convert text to a URL-safe slug for branch names."""
     return re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")[:max_length]
@@ -320,51 +321,6 @@ def _build_branch_name(repo_names: list[str], ticket_number: str, description: s
     return f"{prefix}-{first_repo}-{ticket_number}-{slug}"
 
 
-def _create_git_worktree(workspace: Path, repo_name: str, ticket_dir: Path, branch: str) -> Path | None:
-    """Run ``git worktree add`` for a single repo and return the worktree path.
-
-    ``repo_name`` may be a nested path relative to ``workspace`` (e.g.
-    ``souliane/teatree``).  The worktree subdirectory uses the basename
-    (``teatree``) to keep the ticket directory flat.
-
-    Returns ``_WORKTREE_SKIPPED`` when the repo doesn't exist or has no ``.git``,
-    the existing ``wt_path`` when it already exists, and ``None`` on actual failure.
-
-    When ``git worktree add -b`` fails because the branch already exists
-    (e.g. partial failure recovery), retries without ``-b`` to reuse the
-    existing branch.
-    """
-    repo_path = workspace / repo_name
-    if not (repo_path / ".git").is_dir():
-        print(f"  Skipping {repo_name}: not a git repository", file=sys.stderr)  # noqa: T201
-        return _WORKTREE_SKIPPED
-
-    wt_path = ticket_dir / Path(repo_name).name
-    if wt_path.exists():
-        print(f"  Skipping {repo_name}: {wt_path} already exists", file=sys.stderr)  # noqa: T201
-        return wt_path
-
-    # Pull latest before branching
-    git.pull_ff_only(str(repo_path))
-
-    success = git.worktree_add(str(repo_path), str(wt_path), branch, create_branch=True)
-    if not success:
-        # Retry without -b if branch already exists (partial failure recovery)
-        success = git.worktree_add(str(repo_path), str(wt_path), branch, create_branch=False)
-    if not success:
-        sys.stderr.write(f"  Error creating worktree for {repo_name}\n")
-        return None
-
-    # Symlink .python-version from main repo
-    pv = repo_path / ".python-version"
-    pv_dest = wt_path / ".python-version"
-    if pv.is_file() and not pv_dest.exists():
-        with suppress(OSError):
-            pv_dest.symlink_to(pv)
-
-    return wt_path
-
-
 class Command(TyperCommand):
     @command()
     def ticket(
@@ -374,70 +330,61 @@ class Command(TyperCommand):
         repos: str = "",
         description: str = "",
     ) -> int:
-        """Create or update a ticket with worktree entries for each affected repo.
+        """Create or update a ticket and trigger worktree provisioning.
 
-        Idempotent: safe to re-run after partial failures. Existing worktrees
-        are skipped, missing repos are added, and failed entries are cleaned up.
+        Thin wrapper around the FSM (BLUEPRINT §4): persist branch + description
+        on ``ticket.extra``, advance ``NOT_STARTED → SCOPED → STARTED`` via
+        ``scope()`` and ``start()``, and let ``execute_provision`` materialise
+        the per-repo git worktrees on the worker side.
+
+        Idempotent: re-running over an already-started ticket merges new repos
+        into ``ticket.repos`` so the next ``execute_provision`` picks them up.
         """
         overlay = get_overlay()
         repo_names = [r.strip() for r in repos.split(",") if r.strip()] if repos else overlay.get_workspace_repos()
 
-        ticket, _created = Ticket.objects.get_or_create(
+        ticket, _ = Ticket.objects.get_or_create(
             issue_url=issue_url,
             defaults={"variant": variant, "repos": repo_names},
         )
+
         if ticket.state == Ticket.State.NOT_STARTED:
             ticket.scope(issue_url=issue_url, variant=variant or None, repos=repo_names)
-        # Merge new repos into existing ticket (preserves order, deduplicates)
+
         ticket.repos = list(dict.fromkeys((ticket.repos or []) + repo_names))
-        ticket.save()
 
         if not description:
             description = overlay.metadata.get_issue_title(issue_url)
-        workspace = _workspace_dir()
-        branch = _build_branch_name(repo_names, ticket.ticket_number, description)
-        ticket_dir = workspace / branch
 
-        ticket_dir.mkdir(parents=True, exist_ok=True)
+        extra = cast("TicketExtra", ticket.extra or {})
+        if not extra.get("branch"):
+            extra["branch"] = _build_branch_name(repo_names, ticket.ticket_number, description)
+        if description and not extra.get("description"):
+            extra["description"] = description
+        ticket.extra = extra
+        ticket.save()
 
-        new_worktrees: list[Worktree] = []
-        failed_worktrees: list[Worktree] = []
-        for repo_name in repo_names:
-            worktree, wt_created = Worktree.objects.get_or_create(
-                ticket=ticket,
-                repo_path=repo_name,
-                defaults={"branch": branch},
-            )
-            if not wt_created:
-                self.stdout.write(f"  {repo_name}: already tracked (worktree #{worktree.pk})")
-                continue
+        if ticket.state == Ticket.State.SCOPED:
+            ticket.start()
+            ticket.save()
 
-            wt_path = _create_git_worktree(workspace, repo_name, ticket_dir, branch)
-            is_real_path = wt_path is not None and wt_path != _WORKTREE_SKIPPED
-            if is_real_path:
-                worktree.extra = {"worktree_path": str(wt_path)}
-                worktree.save(update_fields=["extra"])
-            new_worktrees.append(worktree)
-            if wt_path is None:
-                failed_worktrees.append(worktree)
-            self.stdout.write(f"  {repo_name}: {'created' if is_real_path else 'skipped'} (worktree #{worktree.pk})")
+        # Run the provisioner synchronously so the CLI gives immediate feedback;
+        # the worker that ``start()`` enqueued is idempotent and no-ops when it
+        # finds the worktrees already in place. Single source of truth: the runner.
+        result = WorktreeProvisioner(ticket).run()
 
-        # Clean up DB entries for repos that actually failed
-        for wt in failed_worktrees:
-            wt.delete()
-            new_worktrees.remove(wt)
-
-        # Full rollback only when ALL new worktrees failed and no pre-existing ones
-        if failed_worktrees and not new_worktrees and not ticket.worktrees.exists():
-            self.stderr.write("  All worktree creations failed — rolling back ticket.")
+        branch = extra["branch"]
+        ticket_dir = _workspace_dir() / branch
+        if not result.ok and not ticket.worktrees.exists():
+            self.stderr.write(f"  Provisioning failed: {result.detail}")
             ticket.delete()
             with suppress(OSError):
                 ticket_dir.rmdir()
             return 0
-
-        if failed_worktrees:
-            names = [wt.repo_path for wt in failed_worktrees]
-            self.stderr.write(f"  WARNING: failed to create worktrees for: {', '.join(names)}")
+        if not result.ok:
+            self.stderr.write(f"  WARNING: {result.detail}")
+        for wt in ticket.worktrees.all():
+            self.stdout.write(f"  {wt.repo_path}: worktree #{wt.pk}")
 
         self.stdout.write(f"\nTicket #{ticket.pk} — worktrees in {ticket_dir}")
         self.stdout.write(f"  Branch: {branch}")

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, cast
 
 import typer
+from django.db import transaction
 from django_typer.management import TyperCommand, command
 
 from teatree.config import load_config
@@ -343,30 +344,31 @@ class Command(TyperCommand):
         overlay = get_overlay()
         repo_names = [r.strip() for r in repos.split(",") if r.strip()] if repos else overlay.get_workspace_repos()
 
-        ticket, _ = Ticket.objects.get_or_create(
-            issue_url=issue_url,
-            defaults={"variant": variant, "repos": repo_names},
-        )
+        with transaction.atomic():
+            ticket, _ = Ticket.objects.get_or_create(
+                issue_url=issue_url,
+                defaults={"variant": variant, "repos": repo_names},
+            )
 
-        if ticket.state == Ticket.State.NOT_STARTED:
-            ticket.scope(issue_url=issue_url, variant=variant or None, repos=repo_names)
+            if ticket.state == Ticket.State.NOT_STARTED:
+                ticket.scope(issue_url=issue_url, variant=variant or None, repos=repo_names)
 
-        ticket.repos = list(dict.fromkeys((ticket.repos or []) + repo_names))
+            ticket.repos = list(dict.fromkeys((ticket.repos or []) + repo_names))
 
-        if not description:
-            description = overlay.metadata.get_issue_title(issue_url)
+            if not description:
+                description = overlay.metadata.get_issue_title(issue_url)
 
-        extra = cast("TicketExtra", ticket.extra or {})
-        if not extra.get("branch"):
-            extra["branch"] = _build_branch_name(repo_names, ticket.ticket_number, description)
-        if description and not extra.get("description"):
-            extra["description"] = description
-        ticket.extra = extra
-        ticket.save()
-
-        if ticket.state == Ticket.State.SCOPED:
-            ticket.start()
+            extra = cast("TicketExtra", ticket.extra or {})
+            if not extra.get("branch"):
+                extra["branch"] = _build_branch_name(repo_names, ticket.ticket_number, description)
+            if description and not extra.get("description"):
+                extra["description"] = description
+            ticket.extra = extra
             ticket.save()
+
+            if ticket.state == Ticket.State.SCOPED:
+                ticket.start()
+                ticket.save()
 
         # Run the provisioner synchronously so the CLI gives immediate feedback;
         # the worker that ``start()`` enqueued is idempotent and no-ops when it

--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -120,21 +120,22 @@ class Task(models.Model):
             return
         ticket = self.ticket
         ticket.refresh_from_db()
-        if self.phase == "scoping" and ticket.state == Ticket.State.SCOPED:
-            ticket.start()
-            ticket.save()
-        elif self.phase == "coding" and ticket.state == Ticket.State.STARTED:
-            ticket.code()
-            ticket.save()
-        elif self.phase == "testing" and ticket.state == Ticket.State.CODED:
-            ticket.test(passed=True)
-            ticket.save()
-        elif self.phase == "reviewing" and ticket.state == Ticket.State.TESTED:
-            ticket.review()
-            ticket.save()
-        elif self.phase == "shipping" and ticket.state == Ticket.State.REVIEWED:
-            ticket.ship()
-            ticket.save()
+        with transaction.atomic():
+            if self.phase == "scoping" and ticket.state == Ticket.State.SCOPED:
+                ticket.start()
+                ticket.save()
+            elif self.phase == "coding" and ticket.state == Ticket.State.STARTED:
+                ticket.code()
+                ticket.save()
+            elif self.phase == "testing" and ticket.state == Ticket.State.CODED:
+                ticket.test(passed=True)
+                ticket.save()
+            elif self.phase == "reviewing" and ticket.state == Ticket.State.TESTED:
+                ticket.review()
+                ticket.save()
+            elif self.phase == "shipping" and ticket.state == Ticket.State.REVIEWED:
+                ticket.ship()
+                ticket.save()
 
     def _last_attempt_needs_user_input(self) -> bool:
         last = self.attempts.order_by("-pk").first()  # ty: ignore[unresolved-attribute]

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -187,10 +187,19 @@ class Ticket(models.Model):
         )
 
     @transition(field=state, source=State.REVIEWED, target=State.SHIPPED)
-    def ship(self, *, mr_urls: list[str] | None = None) -> None:
-        extra = self._extra()
-        extra["mr_urls"] = mr_urls or []
-        self.extra = extra
+    def ship(self) -> None:
+        """Schedule push + MR creation.
+
+        The worker pushes the worktree branch, opens the merge request, and
+        calls ``request_review()`` on success. FSM invariant (BLUEPRINT §4):
+        transition bodies stay pure — long I/O is offloaded to an ``@task``
+        worker, enqueued after commit so the state change and the queued work
+        land atomically.
+        """
+        from teatree.core.tasks import execute_ship  # noqa: PLC0415
+
+        ticket_pk = int(self.pk)
+        transaction.on_commit(lambda: execute_ship.enqueue(ticket_pk))
 
     @transition(field=state, source=State.SHIPPED, target=State.IN_REVIEW)
     def request_review(self) -> None:

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -218,7 +218,18 @@ class Ticket(models.Model):
 
     @transition(field=state, source=State.IN_REVIEW, target=State.MERGED)
     def mark_merged(self) -> None:
-        pass
+        """Schedule worktree teardown.
+
+        The worker removes git worktrees, deletes the local branch, drops the
+        per-worktree DB and runs overlay cleanup hooks. FSM invariant
+        (BLUEPRINT §4): transition bodies stay pure — long I/O is offloaded
+        to an ``@task`` worker, enqueued after commit so the state change and
+        the queued work land atomically.
+        """
+        from teatree.core.tasks import execute_teardown  # noqa: PLC0415
+
+        ticket_pk = int(self.pk)
+        transaction.on_commit(lambda: execute_teardown.enqueue(ticket_pk))
 
     @transition(field=state, source=State.MERGED, target=State.RETROSPECTED)
     def retrospect(self) -> None:

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -83,7 +83,7 @@ class Ticket(models.Model):
         if repos is not None:
             self.repos = repos
 
-    @transition(field=state, source=State.SCOPED, target=State.STARTED)
+    @transition(field=state, source=[State.SCOPED, State.STARTED], target=State.STARTED)
     def start(self) -> None:
         """Schedule worktree provisioning + coding task.
 
@@ -92,6 +92,11 @@ class Ticket(models.Model):
         §4): transition bodies stay pure — long I/O is offloaded to an
         ``@task`` worker, enqueued after commit so the state change and the
         queued work land atomically.
+
+        Source ``[SCOPED, STARTED]`` makes re-firing idempotent: if the previous
+        provisioning worker failed, the operator can re-call ``start()``
+        without rolling back through ``rework``. The worker's own state guard
+        prevents duplicate work when provisioning already succeeded.
         """
         from teatree.core.tasks import execute_provision  # noqa: PLC0415
 
@@ -197,7 +202,7 @@ class Ticket(models.Model):
             parent_task=parent_task,
         )
 
-    @transition(field=state, source=State.REVIEWED, target=State.SHIPPED)
+    @transition(field=state, source=[State.REVIEWED, State.SHIPPED], target=State.SHIPPED)
     def ship(self) -> None:
         """Schedule push + MR creation.
 
@@ -206,6 +211,12 @@ class Ticket(models.Model):
         transition bodies stay pure — long I/O is offloaded to an ``@task``
         worker, enqueued after commit so the state change and the queued work
         land atomically.
+
+        Source ``[REVIEWED, SHIPPED]`` makes re-firing idempotent: if the
+        previous ship worker failed (push rejected, code host unavailable,
+        credentials missing), the operator can re-call ``ship()`` to retry.
+        The worker's own state guard skips duplicate work if push already
+        succeeded.
         """
         from teatree.core.tasks import execute_ship  # noqa: PLC0415
 
@@ -216,7 +227,7 @@ class Ticket(models.Model):
     def request_review(self) -> None:
         pass
 
-    @transition(field=state, source=State.IN_REVIEW, target=State.MERGED)
+    @transition(field=state, source=[State.IN_REVIEW, State.MERGED], target=State.MERGED)
     def mark_merged(self) -> None:
         """Schedule worktree teardown.
 
@@ -225,13 +236,18 @@ class Ticket(models.Model):
         (BLUEPRINT §4): transition bodies stay pure — long I/O is offloaded
         to an ``@task`` worker, enqueued after commit so the state change and
         the queued work land atomically.
+
+        Source ``[IN_REVIEW, MERGED]`` makes re-firing idempotent: if a
+        previous teardown reported errors, the operator can re-call
+        ``mark_merged()`` to retry. The worker is best-effort and does not
+        advance the FSM, so retries are safe.
         """
         from teatree.core.tasks import execute_teardown  # noqa: PLC0415
 
         ticket_pk = int(self.pk)
         transaction.on_commit(lambda: execute_teardown.enqueue(ticket_pk))
 
-    @transition(field=state, source=State.MERGED, target=State.RETROSPECTED)
+    @transition(field=state, source=[State.MERGED, State.RETROSPECTED], target=State.RETROSPECTED)
     def retrospect(self) -> None:
         """Schedule retrospection I/O.
 
@@ -239,6 +255,11 @@ class Ticket(models.Model):
         success. FSM invariant (BLUEPRINT §4): transition bodies stay pure —
         long I/O is offloaded to an ``@task`` worker, enqueued after commit so
         the state change and the queued work land atomically.
+
+        Source ``[MERGED, RETROSPECTED]`` makes re-firing idempotent: if a
+        previous retro worker failed, the operator can re-call ``retrospect()``
+        to retry. The worker's own state guard skips when retrospection
+        already produced its artifacts.
         """
         from teatree.core.tasks import execute_retrospect  # noqa: PLC0415
 

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -85,7 +85,18 @@ class Ticket(models.Model):
 
     @transition(field=state, source=State.SCOPED, target=State.STARTED)
     def start(self) -> None:
-        self.schedule_coding()
+        """Schedule worktree provisioning + coding task.
+
+        The worker creates per-repo git worktrees, then calls
+        ``schedule_coding()`` once the layout exists. FSM invariant (BLUEPRINT
+        §4): transition bodies stay pure — long I/O is offloaded to an
+        ``@task`` worker, enqueued after commit so the state change and the
+        queued work land atomically.
+        """
+        from teatree.core.tasks import execute_provision  # noqa: PLC0415
+
+        ticket_pk = int(self.pk)
+        transaction.on_commit(lambda: execute_provision.enqueue(ticket_pk))
 
     @transition(field=state, source=State.STARTED, target=State.CODED)
     def code(self) -> None:

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -27,6 +27,9 @@ class TicketExtra(TypedDict, total=False):
     mr_urls: list[str]
     ignored_from: str
     visual_qa: VisualQASummary
+    branch: str
+    description: str
+    provision: dict[str, str]
 
 
 class WorktreeExtra(TypedDict, total=False):

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -25,6 +25,7 @@ class VisualQASummary(TypedDict, total=False):
 class TicketExtra(TypedDict, total=False):
     tests_passed: bool
     mr_urls: list[str]
+    mr_title_override: str
     ignored_from: str
     visual_qa: VisualQASummary
     branch: str

--- a/src/teatree/core/runners/__init__.py
+++ b/src/teatree/core/runners/__init__.py
@@ -8,7 +8,8 @@ See BLUEPRINT.md §4 for the invariant and §4.1 for the per-transition map.
 """
 
 from teatree.core.runners.base import RunnerBase
+from teatree.core.runners.provision import WorktreeProvisioner
 from teatree.core.runners.retro import RetroExecutor
 from teatree.core.runners.ship import ShipExecutor
 
-__all__ = ["RetroExecutor", "RunnerBase", "ShipExecutor"]
+__all__ = ["RetroExecutor", "RunnerBase", "ShipExecutor", "WorktreeProvisioner"]

--- a/src/teatree/core/runners/__init__.py
+++ b/src/teatree/core/runners/__init__.py
@@ -9,5 +9,6 @@ See BLUEPRINT.md §4 for the invariant and §4.1 for the per-transition map.
 
 from teatree.core.runners.base import RunnerBase
 from teatree.core.runners.retro import RetroExecutor
+from teatree.core.runners.ship import ShipExecutor
 
-__all__ = ["RetroExecutor", "RunnerBase"]
+__all__ = ["RetroExecutor", "RunnerBase", "ShipExecutor"]

--- a/src/teatree/core/runners/__init__.py
+++ b/src/teatree/core/runners/__init__.py
@@ -11,5 +11,12 @@ from teatree.core.runners.base import RunnerBase
 from teatree.core.runners.provision import WorktreeProvisioner
 from teatree.core.runners.retro import RetroExecutor
 from teatree.core.runners.ship import ShipExecutor
+from teatree.core.runners.teardown import WorktreeTeardown
 
-__all__ = ["RetroExecutor", "RunnerBase", "ShipExecutor", "WorktreeProvisioner"]
+__all__ = [
+    "RetroExecutor",
+    "RunnerBase",
+    "ShipExecutor",
+    "WorktreeProvisioner",
+    "WorktreeTeardown",
+]

--- a/src/teatree/core/runners/provision.py
+++ b/src/teatree/core/runners/provision.py
@@ -1,0 +1,111 @@
+import logging
+from contextlib import suppress
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from teatree.config import workspace_dir as _workspace_dir
+from teatree.core.models import Worktree
+from teatree.core.runners.base import RunnerBase, RunnerResult
+from teatree.utils import git
+
+if TYPE_CHECKING:
+    from teatree.core.models.types import TicketExtra
+
+logger = logging.getLogger(__name__)
+
+
+class WorktreeProvisioner(RunnerBase):
+    """Create the per-repo git worktrees for a STARTED ticket.
+
+    Reads ``ticket.repos`` and ``ticket.extra['branch']`` (set by the CLI at
+    scope time) and materialises one ``Worktree`` row + on-disk git worktree
+    per repo. Idempotent: re-running over an existing layout is a no-op.
+    """
+
+    def run(self) -> RunnerResult:
+        ticket = self.ticket
+        repos = list(ticket.repos or [])
+        if not repos:
+            return RunnerResult(ok=False, detail="no repos on ticket")
+
+        extra = cast("TicketExtra", ticket.extra or {})
+        branch = extra.get("branch", "")
+        if not branch:
+            return RunnerResult(ok=False, detail="ticket.extra['branch'] not set — call scope() first")
+
+        workspace = _workspace_dir()
+        ticket_dir = workspace / branch
+        ticket_dir.mkdir(parents=True, exist_ok=True)
+
+        provisioned: dict[str, str] = dict(extra.get("provision") or {})
+        failed: list[str] = []
+
+        for repo_name in repos:
+            existing = Worktree.objects.filter(ticket=ticket, repo_path=repo_name).first()
+            if existing and (existing.extra or {}).get("worktree_path"):
+                provisioned[repo_name] = (existing.extra or {})["worktree_path"]
+                continue
+
+            worktree = existing or Worktree.objects.create(
+                ticket=ticket,
+                repo_path=repo_name,
+                branch=branch,
+                overlay=ticket.overlay,
+            )
+
+            wt_path = self._create(workspace, repo_name, ticket_dir, branch)
+            if wt_path is None:
+                # actual failure — drop the row so subsequent runs can retry cleanly
+                worktree.delete()
+                failed.append(repo_name)
+                continue
+            if not wt_path:
+                # skipped (source repo missing) — keep the row without a path
+                continue
+
+            worktree.branch = branch
+            worktree.extra = {**(worktree.extra or {}), "worktree_path": wt_path}
+            worktree.save(update_fields=["branch", "extra"])
+            provisioned[repo_name] = wt_path
+
+        extra["provision"] = provisioned
+        ticket.extra = extra
+        ticket.save(update_fields=["extra"])
+
+        if failed:
+            return RunnerResult(ok=False, detail=f"failed to create worktrees for: {', '.join(failed)}")
+        return RunnerResult(ok=True, detail=f"provisioned {len(provisioned)} worktree(s)")
+
+    @staticmethod
+    def _create(workspace: Path, repo_name: str, ticket_dir: Path, branch: str) -> str | None:
+        """Run ``git worktree add`` for one repo.
+
+        Returns the worktree path on success, ``""`` when the source repo is
+        not a git checkout (skipped), or ``None`` on actual failure. Retries
+        without ``-b`` so partial-failure recovery picks up an existing branch.
+        """
+        repo_path = workspace / repo_name
+        if not (repo_path / ".git").is_dir():
+            logger.info("Skipping %s: not a git repository under %s", repo_name, workspace)
+            return ""
+
+        wt_path = ticket_dir / Path(repo_name).name
+        if wt_path.exists():
+            return str(wt_path)
+
+        git.pull_ff_only(str(repo_path))
+
+        ok = git.worktree_add(str(repo_path), str(wt_path), branch, create_branch=True)
+        if not ok:
+            ok = git.worktree_add(str(repo_path), str(wt_path), branch, create_branch=False)
+        if not ok:
+            logger.warning("Failed to create worktree for %s at %s", repo_name, wt_path)
+            return None
+
+        pv = repo_path / ".python-version"
+        pv_dest = wt_path / ".python-version"
+        if pv.is_file() and not pv_dest.exists():
+            with suppress(OSError):
+                pv_dest.symlink_to(pv)
+
+        return str(wt_path)

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -10,6 +10,8 @@ from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.utils import git
 
 if TYPE_CHECKING:
+    from teatree.backends.protocols import CodeHost
+    from teatree.core.models.ticket import Ticket
     from teatree.core.models.types import TicketExtra
 
 logger = logging.getLogger(__name__)
@@ -47,6 +49,11 @@ class ShipExecutor(RunnerBase):
 
     def run(self) -> RunnerResult:
         ticket = self.ticket
+        extra = cast("TicketExtra", ticket.extra or {})
+        existing_urls = list(extra.get("mr_urls") or [])
+        if existing_urls:
+            return RunnerResult(ok=True, detail=existing_urls[-1])
+
         worktree = ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
         if worktree is None:
             return RunnerResult(ok=False, detail="no worktree on ticket")
@@ -60,30 +67,41 @@ class ShipExecutor(RunnerBase):
 
         git.push(repo=repo_path, remote="origin", branch=branch)
 
+        spec = self._build_pr_spec(ticket, host, repo_path, branch, extra)
+        mr = host.create_pr(spec)
+        url = str(mr.get("web_url") or mr.get("html_url") or "")
+        self._record_mr_url(ticket, extra, url)
+        logger.info("Ship executor pushed %s and opened MR %s", branch, url)
+        return RunnerResult(ok=True, detail=url)
+
+    @staticmethod
+    def _build_pr_spec(
+        ticket: "Ticket",
+        host: "CodeHost",
+        repo_path: str,
+        branch: str,
+        extra: "TicketExtra",
+    ) -> PullRequestSpec:
+        title_override = str(extra.get("mr_title_override") or "")
         subject, body = git.last_commit_message(repo=repo_path)
-        title = subject or f"Resolve {ticket.issue_url}"
+        title = title_override or subject or f"Resolve {ticket.issue_url}"
         description = sanitize_close_keywords(body, close_ticket=get_overlay().config.mr_close_ticket)
         assignee = host.current_user() or git.config_value(key="user.name")
-
-        mr = host.create_pr(
-            PullRequestSpec(
-                repo=repo_path,
-                branch=branch,
-                title=title,
-                description=description,
-                labels=overlay_mr_labels(),
-                assignee=assignee,
-            ),
+        return PullRequestSpec(
+            repo=repo_path,
+            branch=branch,
+            title=title,
+            description=description,
+            labels=overlay_mr_labels(),
+            assignee=assignee,
         )
 
-        url = str(mr.get("web_url") or mr.get("html_url") or "")
-        extra = cast("TicketExtra", ticket.extra or {})
+    @staticmethod
+    def _record_mr_url(ticket: "Ticket", extra: "TicketExtra", url: str) -> None:
         urls = list(extra.get("mr_urls") or [])
         if url and url not in urls:
             urls.append(url)
         extra["mr_urls"] = urls
+        extra.pop("mr_title_override", None)
         ticket.extra = extra
         ticket.save(update_fields=["extra"])
-
-        logger.info("Ship executor pushed %s and opened MR %s", branch, url)
-        return RunnerResult(ok=True, detail=url)

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -1,0 +1,89 @@
+import logging
+import re
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, cast
+
+from teatree.backends.protocols import PullRequestSpec
+from teatree.core.backend_factory import code_host_from_overlay
+from teatree.core.overlay_loader import get_overlay
+from teatree.core.runners.base import RunnerBase, RunnerResult
+from teatree.utils import git
+
+if TYPE_CHECKING:
+    from teatree.core.models.types import TicketExtra
+
+logger = logging.getLogger(__name__)
+
+_CLOSE_KEYWORD_RE = re.compile(
+    r"\b(closes?|fixes?|resolves?)\s+((?:[\w./-]+)?#\d+|https?://\S+/issues/\d+)",
+    re.IGNORECASE,
+)
+
+
+def sanitize_close_keywords(description: str, *, close_ticket: bool) -> str:
+    """Replace ``Closes/Fixes/Resolves #N`` with ``Relates to`` when not closing."""
+    if close_ticket:
+        return description
+    return _CLOSE_KEYWORD_RE.sub(r"Relates to \2", description)
+
+
+def overlay_mr_labels() -> list[str]:
+    raw = get_overlay().config.mr_auto_labels
+    if isinstance(raw, str):
+        values: Iterable[str] = raw.split(",")
+    elif isinstance(raw, Iterable):
+        values = [str(value) for value in raw]
+    else:
+        return []
+    return [value.strip() for value in values if value.strip()]
+
+
+class ShipExecutor(RunnerBase):
+    """Push the worktree branch and open the merge request.
+
+    Runs inside ``execute_ship`` after the FSM advances to ``SHIPPED``. The
+    worker calls ``request_review()`` on success to advance to ``IN_REVIEW``.
+    """
+
+    def run(self) -> RunnerResult:
+        ticket = self.ticket
+        worktree = ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
+        if worktree is None:
+            return RunnerResult(ok=False, detail="no worktree on ticket")
+
+        host = code_host_from_overlay()
+        if host is None:
+            return RunnerResult(ok=False, detail="no code host configured")
+
+        repo_path = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
+        branch = worktree.branch
+
+        git.push(repo=repo_path, remote="origin", branch=branch)
+
+        subject, body = git.last_commit_message(repo=repo_path)
+        title = subject or f"Resolve {ticket.issue_url}"
+        description = sanitize_close_keywords(body, close_ticket=get_overlay().config.mr_close_ticket)
+        assignee = host.current_user() or git.config_value(key="user.name")
+
+        mr = host.create_pr(
+            PullRequestSpec(
+                repo=repo_path,
+                branch=branch,
+                title=title,
+                description=description,
+                labels=overlay_mr_labels(),
+                assignee=assignee,
+            ),
+        )
+
+        url = str(mr.get("web_url") or mr.get("html_url") or "")
+        extra = cast("TicketExtra", ticket.extra or {})
+        urls = list(extra.get("mr_urls") or [])
+        if url and url not in urls:
+            urls.append(url)
+        extra["mr_urls"] = urls
+        ticket.extra = extra
+        ticket.save(update_fields=["extra"])
+
+        logger.info("Ship executor pushed %s and opened MR %s", branch, url)
+        return RunnerResult(ok=True, detail=url)

--- a/src/teatree/core/runners/teardown.py
+++ b/src/teatree/core/runners/teardown.py
@@ -1,0 +1,35 @@
+import logging
+
+from teatree.core.cleanup import cleanup_worktree
+from teatree.core.runners.base import RunnerBase, RunnerResult
+
+logger = logging.getLogger(__name__)
+
+
+class WorktreeTeardown(RunnerBase):
+    """Tear down every worktree owned by a MERGED ticket.
+
+    Iterates ``ticket.worktrees`` and delegates to ``cleanup_worktree`` for
+    each one (git worktree removal, branch deletion, DB drop, overlay
+    cleanup hooks). Errors on a single worktree are captured but do not
+    abort the rest — the runner reports a combined success/failure label.
+    """
+
+    def run(self) -> RunnerResult:
+        ticket = self.ticket
+        worktrees = list(ticket.worktrees.all())  # ty: ignore[unresolved-attribute]
+        if not worktrees:
+            return RunnerResult(ok=True, detail="no worktrees to tear down")
+
+        labels: list[str] = []
+        errors: list[str] = []
+        for worktree in worktrees:
+            try:
+                labels.append(cleanup_worktree(worktree, force=True))
+            except RuntimeError as exc:
+                logger.exception("teardown failed for %s", worktree.repo_path)
+                errors.append(f"{worktree.repo_path} ({worktree.branch}): {exc}")
+
+        if errors:
+            return RunnerResult(ok=False, detail="; ".join(errors))
+        return RunnerResult(ok=True, detail=f"tore down {len(labels)} worktree(s)")

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -5,7 +5,12 @@ from django.db import transaction
 from django.tasks import task
 
 from teatree.core.models import Task, Ticket
-from teatree.core.runners import RetroExecutor, ShipExecutor, WorktreeProvisioner
+from teatree.core.runners import (
+    RetroExecutor,
+    ShipExecutor,
+    WorktreeProvisioner,
+    WorktreeTeardown,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +112,37 @@ def execute_retrospect(ticket_id: int) -> TransitionResult:
 
         ticket.mark_delivered()
         ticket.save()
+
+    return {"ticket_id": ticket_id, "ok": True, "detail": result.detail}
+
+
+@task()
+def execute_teardown(ticket_id: int) -> TransitionResult:
+    """Tear down worktrees for a MERGED ticket.
+
+    Idempotency: the worker takes a row lock and re-checks state before running.
+    At-least-once delivery from django-tasks means this can fire more than once
+    for the same transition — a lost update or a redelivered job must be safe.
+
+    Teardown is best-effort: per-worktree errors are reported in the result
+    detail but do not advance the ticket. The ticket stays in MERGED until
+    the operator either fixes the underlying issue and re-enqueues, or moves
+    on with ``retrospect()`` once the residual state is acceptable.
+    """
+    with transaction.atomic():
+        ticket = Ticket.objects.select_for_update().get(pk=ticket_id)
+        if ticket.state != Ticket.State.MERGED:
+            logger.info(
+                "execute_teardown skipped for ticket %s: state=%s (not MERGED)",
+                ticket_id,
+                ticket.state,
+            )
+            return {"ticket_id": ticket_id, "skipped": True, "state": str(ticket.state)}
+
+        result = WorktreeTeardown(ticket).run()
+        if not result.ok:
+            logger.warning("Teardown reported errors for ticket %s: %s", ticket_id, result.detail)
+            return {"ticket_id": ticket_id, "ok": False, "detail": result.detail}
 
     return {"ticket_id": ticket_id, "ok": True, "detail": result.detail}
 

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -5,7 +5,7 @@ from django.db import transaction
 from django.tasks import task
 
 from teatree.core.models import Task, Ticket
-from teatree.core.runners import RetroExecutor, ShipExecutor
+from teatree.core.runners import RetroExecutor, ShipExecutor, WorktreeProvisioner
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +107,37 @@ def execute_retrospect(ticket_id: int) -> TransitionResult:
 
         ticket.mark_delivered()
         ticket.save()
+
+    return {"ticket_id": ticket_id, "ok": True, "detail": result.detail}
+
+
+@task()
+def execute_provision(ticket_id: int) -> TransitionResult:
+    """Provision worktrees for a STARTED ticket and schedule the coding task.
+
+    Idempotency: the worker takes a row lock and re-checks state before running.
+    At-least-once delivery from django-tasks means this can fire more than once
+    for the same transition — a lost update or a redelivered job must be safe.
+
+    On success, the runner has materialised every git worktree; we then call
+    ``schedule_coding()`` so the FSM proceeds toward CODED.
+    """
+    with transaction.atomic():
+        ticket = Ticket.objects.select_for_update().get(pk=ticket_id)
+        if ticket.state != Ticket.State.STARTED:
+            logger.info(
+                "execute_provision skipped for ticket %s: state=%s (not STARTED)",
+                ticket_id,
+                ticket.state,
+            )
+            return {"ticket_id": ticket_id, "skipped": True, "state": str(ticket.state)}
+
+        result = WorktreeProvisioner(ticket).run()
+        if not result.ok:
+            logger.warning("Provision failed for ticket %s: %s", ticket_id, result.detail)
+            return {"ticket_id": ticket_id, "ok": False, "detail": result.detail}
+
+        ticket.schedule_coding()
 
     return {"ticket_id": ticket_id, "ok": True, "detail": result.detail}
 

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -5,12 +5,12 @@ from django.db import transaction
 from django.tasks import task
 
 from teatree.core.models import Task, Ticket
-from teatree.core.runners import RetroExecutor
+from teatree.core.runners import RetroExecutor, ShipExecutor
 
 logger = logging.getLogger(__name__)
 
 
-class RetrospectResult(TypedDict, total=False):
+class TransitionResult(TypedDict, total=False):
     ticket_id: int
     ok: bool
     skipped: bool
@@ -81,7 +81,7 @@ def refresh_followup_snapshot() -> dict[str, int]:
 
 
 @task()
-def execute_retrospect(ticket_id: int) -> RetrospectResult:
+def execute_retrospect(ticket_id: int) -> TransitionResult:
     """Run retrospection I/O for a ticket in the RETROSPECTED state.
 
     Idempotency: the worker takes a row lock and re-checks state before running.
@@ -106,6 +106,37 @@ def execute_retrospect(ticket_id: int) -> RetrospectResult:
             return {"ticket_id": ticket_id, "ok": False, "detail": result.detail}
 
         ticket.mark_delivered()
+        ticket.save()
+
+    return {"ticket_id": ticket_id, "ok": True, "detail": result.detail}
+
+
+@task()
+def execute_ship(ticket_id: int) -> TransitionResult:
+    """Push the worktree branch and open the merge request for a SHIPPED ticket.
+
+    Idempotency: the worker takes a row lock and re-checks state before running.
+    At-least-once delivery from django-tasks means this can fire more than once
+    for the same transition — a lost update or a redelivered job must be safe.
+
+    On success, advances ``SHIPPED → IN_REVIEW`` via ``request_review()``.
+    """
+    with transaction.atomic():
+        ticket = Ticket.objects.select_for_update().get(pk=ticket_id)
+        if ticket.state != Ticket.State.SHIPPED:
+            logger.info(
+                "execute_ship skipped for ticket %s: state=%s (not SHIPPED)",
+                ticket_id,
+                ticket.state,
+            )
+            return {"ticket_id": ticket_id, "skipped": True, "state": str(ticket.state)}
+
+        result = ShipExecutor(ticket).run()
+        if not result.ok:
+            logger.warning("Ship failed for ticket %s: %s", ticket_id, result.detail)
+            return {"ticket_id": ticket_id, "ok": False, "detail": result.detail}
+
+        ticket.request_review()
         ticket.save()
 
     return {"ticket_id": ticket_id, "ok": True, "detail": result.detail}

--- a/src/teatree/core/views/actions.py
+++ b/src/teatree/core/views/actions.py
@@ -4,6 +4,7 @@ import subprocess  # noqa: S404
 from pathlib import Path
 from typing import TypedDict
 
+from django.db import transaction
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.template.response import TemplateResponse
 from django.views import View
@@ -17,8 +18,6 @@ from teatree.utils.run import run_allowed_to_fail
 
 class CancelTaskView(View):
     def post(self, request: HttpRequest, task_id: int) -> HttpResponse:
-        from django.db import transaction  # noqa: PLC0415
-
         try:
             with transaction.atomic():
                 task = Task.objects.select_for_update().get(pk=task_id)
@@ -95,8 +94,9 @@ class TicketTransitionView(View):
             return JsonResponse({"error": f"Invalid transition: {transition_name}"}, status=400)
 
         try:
-            method()
-            ticket.save()
+            with transaction.atomic():
+                method()
+                ticket.save()
         except TransitionNotAllowed:
             return JsonResponse(
                 {"error": f"Transition '{transition_name}' not allowed from state '{ticket.get_state_display()}'"},

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -76,6 +76,13 @@ def pull_ff_only(repo: str = ".") -> bool:
     return check(repo=repo, args=["pull", "--ff-only"])
 
 
+def push(repo: str = ".", remote: str = "origin", branch: str = "") -> None:
+    args = ["push", "--set-upstream", remote]
+    if branch:
+        args.append(branch)
+    run_strict(repo=repo, args=args)
+
+
 # ── Discovery ────────────────────────────────────────────────────────
 
 

--- a/tests/teatree_core/test_models.py
+++ b/tests/teatree_core/test_models.py
@@ -18,12 +18,46 @@ from teatree.core.models import (
 )
 
 
-def _advance_ticket_to_tested(ticket: Ticket) -> None:
-    """Advance a ticket through scoped, started, coded, tested."""
+def _start_with_provision(test_case: TestCase, ticket: Ticket) -> None:
+    """Drive ``ticket.start()`` and let the worker schedule the coding task.
+
+    Stage 3 of #140 made provisioning a worker side effect; tests that need
+    the coding task materialised swap the worker for an inline stub so the
+    side effect runs synchronously without touching real git.
+    """
+    from unittest.mock import MagicMock  # noqa: PLC0415
+
+    from teatree.core import tasks as tasks_mod  # noqa: PLC0415
+
+    def fake_enqueue(ticket_id: int) -> None:
+        target = Ticket.objects.get(pk=ticket_id)
+        if target.state == Ticket.State.STARTED:
+            target.schedule_coding()
+
+    fake_task = MagicMock()
+    fake_task.enqueue.side_effect = fake_enqueue
+    with (
+        patch.object(tasks_mod, "execute_provision", fake_task),
+        test_case.captureOnCommitCallbacks(execute=True),
+    ):
+        ticket.start()
+        ticket.save()
+
+
+def _advance_ticket_to_tested(ticket: Ticket, test_case: TestCase | None = None) -> None:
+    """Advance a ticket through scoped, started, coded, tested.
+
+    When ``test_case`` is provided, the start transition fires its on_commit
+    callback so the coding task gets scheduled. Tests that don't care about
+    the coding task can omit it.
+    """
     ticket.scope(issue_url="https://example.com/issues/123", variant="acme", repos=["backend", "frontend"])
     ticket.save()
-    ticket.start()
-    ticket.save()
+    if test_case is not None:
+        _start_with_provision(test_case, ticket)
+    else:
+        ticket.start()
+        ticket.save()
     ticket.code()
     ticket.save()
     ticket.test(passed=True)
@@ -218,13 +252,14 @@ class TestTicketTransitions(TestCase):
 class TestPhaseAutoDispatch(TestCase):
     """Auto-dispatch of next-phase tasks at each phase boundary (issue #364)."""
 
-    def test_start_auto_schedules_coding_task(self) -> None:
+    def test_start_provisions_then_schedules_coding_task(self) -> None:
         ticket = Ticket.objects.create()
         ticket.scope()
         ticket.save()
-        ticket.start()
-        ticket.save()
 
+        _start_with_provision(self, ticket)
+
+        ticket.refresh_from_db()
         task = ticket.tasks.get(phase="coding")
         assert task.execution_target == Task.ExecutionTarget.HEADLESS
         assert task.session.agent_id == "coding"
@@ -245,26 +280,40 @@ class TestPhaseAutoDispatch(TestCase):
         assert ticket.state == Ticket.State.CODED
 
     def test_scoping_task_completion_advances_to_started(self) -> None:
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        from teatree.core import tasks as tasks_mod  # noqa: PLC0415
+
+        def fake_enqueue(ticket_id: int) -> None:
+            target = Ticket.objects.get(pk=ticket_id)
+            if target.state == Ticket.State.STARTED:
+                target.schedule_coding()
+
         ticket = Ticket.objects.create()
         ticket.scope()
         ticket.save()
         session = Session.objects.create(ticket=ticket, agent_id="scoper")
         task = Task.objects.create(ticket=ticket, session=session, phase="scoping")
 
+        fake_task = MagicMock()
+        fake_task.enqueue.side_effect = fake_enqueue
         task.claim(claimed_by="worker")
-        task.complete()
+        with (
+            patch.object(tasks_mod, "execute_provision", fake_task),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            task.complete()
 
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.STARTED
-        # start() auto-scheduled a coding task
+        # execute_provision (worker side effect of start()) scheduled the coding task
         assert ticket.tasks.filter(phase="coding", status=Task.Status.PENDING).exists()
 
     def test_coding_task_completion_advances_to_coded(self) -> None:
         ticket = Ticket.objects.create()
         ticket.scope()
         ticket.save()
-        ticket.start()
-        ticket.save()
+        _start_with_provision(self, ticket)
 
         _complete_phase_task(ticket, "coding")
 
@@ -277,8 +326,7 @@ class TestPhaseAutoDispatch(TestCase):
         ticket = Ticket.objects.create()
         ticket.scope()
         ticket.save()
-        ticket.start()
-        ticket.save()
+        _start_with_provision(self, ticket)
         ticket.code()
         ticket.save()
 
@@ -318,6 +366,28 @@ class TestPhaseAutoDispatch(TestCase):
 
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.SHIPPED
+
+    def test_start_enqueues_execute_provision_after_commit(self) -> None:
+        """Stage 3 of #140: start() body offloads provisioning to a @task worker."""
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        from teatree.core import tasks as tasks_mod  # noqa: PLC0415
+
+        ticket = Ticket.objects.create()
+        ticket.scope()
+        ticket.save()
+
+        fake_task = MagicMock()
+        with (
+            self.captureOnCommitCallbacks(execute=True),
+            patch.object(tasks_mod, "execute_provision", fake_task),
+        ):
+            ticket.start()
+            ticket.save()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.STARTED
+        fake_task.enqueue.assert_called_once_with(ticket.pk)
 
     def test_ship_enqueues_execute_ship_after_commit(self) -> None:
         """Stage 2 of #140: ship() body offloads I/O to a @task worker."""

--- a/tests/teatree_core/test_models.py
+++ b/tests/teatree_core/test_models.py
@@ -319,6 +319,31 @@ class TestPhaseAutoDispatch(TestCase):
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.SHIPPED
 
+    def test_ship_enqueues_execute_ship_after_commit(self) -> None:
+        """Stage 2 of #140: ship() body offloads I/O to a @task worker."""
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        from teatree.core import tasks as tasks_mod  # noqa: PLC0415
+
+        ticket = Ticket.objects.create()
+        _advance_ticket_to_tested(ticket)
+        _complete_phase_task(ticket, "reviewing")
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED
+
+        fake_task = MagicMock()
+        with (
+            self.captureOnCommitCallbacks(execute=True),
+            patch.object(tasks_mod, "execute_ship", fake_task),
+        ):
+            ticket.ship()
+            ticket.save()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        fake_task.enqueue.assert_called_once_with(ticket.pk)
+
     def test_child_task_of_already_advanced_ticket_is_noop(self) -> None:
         ticket = Ticket.objects.create()
         ticket.scope()

--- a/tests/teatree_core/test_models.py
+++ b/tests/teatree_core/test_models.py
@@ -389,6 +389,28 @@ class TestPhaseAutoDispatch(TestCase):
         assert ticket.state == Ticket.State.STARTED
         fake_task.enqueue.assert_called_once_with(ticket.pk)
 
+    def test_mark_merged_enqueues_execute_teardown_after_commit(self) -> None:
+        """Stage 5 of #140: mark_merged() body offloads teardown to a @task worker."""
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        from teatree.core import tasks as tasks_mod  # noqa: PLC0415
+
+        ticket = Ticket.objects.create()
+        ticket.state = Ticket.State.IN_REVIEW
+        ticket.save(update_fields=["state"])
+
+        fake_task = MagicMock()
+        with (
+            self.captureOnCommitCallbacks(execute=True),
+            patch.object(tasks_mod, "execute_teardown", fake_task),
+        ):
+            ticket.mark_merged()
+            ticket.save()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED
+        fake_task.enqueue.assert_called_once_with(ticket.pk)
+
     def test_ship_enqueues_execute_ship_after_commit(self) -> None:
         """Stage 2 of #140: ship() body offloads I/O to a @task worker."""
         from unittest.mock import MagicMock  # noqa: PLC0415

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -24,6 +24,7 @@ import teatree.core.management.commands.pr as pr_mod
 import teatree.core.management.commands.run as run_mod
 import teatree.core.management.commands.workspace as workspace_mod
 import teatree.core.overlay_loader as overlay_loader_mod
+import teatree.core.runners.provision as provision_mod
 import teatree.core.views._startup as startup_mod
 import teatree.utils.db as db_mod
 import teatree.utils.git as git_mod
@@ -302,7 +303,9 @@ class TestWorkspaceTicket(TestCase):
 
         ticket = Ticket.objects.get(pk=ticket_id)
         assert ticket.issue_url == "https://example.com/issues/42"
-        assert ticket.state == Ticket.State.SCOPED
+        # Stage 3 of #140: workspace ticket advances scope() then start() so the
+        # provisioning runner can materialise the worktrees in the same call.
+        assert ticket.state == Ticket.State.STARTED
         assert ticket.repos == ["backend", "frontend"]
         assert ticket.worktrees.count() == 2
 
@@ -345,6 +348,7 @@ class TestWorkspaceTicket(TestCase):
 
             with (
                 patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(provision_mod, "_workspace_dir", return_value=workspace),
                 patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
             ):
                 ticket_id = cast("int", call_command("workspace", "ticket", "https://example.com/issues/80"))
@@ -418,6 +422,7 @@ class TestWorkspaceTicket(TestCase):
 
             with (
                 patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(provision_mod, "_workspace_dir", return_value=workspace),
                 patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
             ):
                 ticket_id = cast("int", call_command("workspace", "ticket", "https://example.com/issues/81"))
@@ -452,6 +457,7 @@ class TestWorkspaceTicket(TestCase):
 
             with (
                 patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(provision_mod, "_workspace_dir", return_value=workspace),
                 patch.object(workspace_mod, "_branch_prefix", return_value="ac"),
                 patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
             ):
@@ -488,6 +494,7 @@ class TestWorkspaceTicket(TestCase):
 
             with (
                 patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(provision_mod, "_workspace_dir", return_value=workspace),
                 patch.object(utils_run_mod.subprocess, "run", side_effect=side_effect),
             ):
                 result = cast("int", call_command("workspace", "ticket", "https://example.com/issues/83"))
@@ -551,6 +558,7 @@ class TestWorkspaceTicket(TestCase):
 
             with (
                 patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(provision_mod, "_workspace_dir", return_value=workspace),
                 patch.object(utils_run_mod.subprocess, "run", side_effect=side_effect),
             ):
                 ticket_id = cast(
@@ -597,6 +605,7 @@ class TestWorkspaceTicket(TestCase):
 
             with (
                 patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(provision_mod, "_workspace_dir", return_value=workspace),
                 patch.object(utils_run_mod.subprocess, "run", side_effect=side_effect),
             ):
                 ticket_id = cast("int", call_command("workspace", "ticket", "https://example.com/issues/103"))
@@ -624,6 +633,7 @@ class TestWorkspaceTicket(TestCase):
 
             with (
                 patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(provision_mod, "_workspace_dir", return_value=workspace),
                 patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
             ):
                 ticket_id = cast("int", call_command("workspace", "ticket", "https://example.com/issues/90"))
@@ -744,6 +754,7 @@ class TestWorkspaceCleanAll(TestCase):
 
             with (
                 patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(provision_mod, "_workspace_dir", return_value=workspace),
                 patch.object(
                     utils_run_mod.subprocess,
                     "run",
@@ -843,6 +854,7 @@ class TestWorkspaceCleanAll(TestCase):
 
             with (
                 patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(provision_mod, "_workspace_dir", return_value=workspace),
                 patch.object(overlay_loader_mod, "_discover_overlays", new=_fake_discover),
             ):
                 call_command("workspace", "clean-all")
@@ -872,7 +884,10 @@ class TestWorkspaceCleanAll(TestCase):
             nonempty_dir.mkdir()
             (nonempty_dir / "some_file.txt").write_text("content", encoding="utf-8")
 
-            with patch.object(workspace_mod, "_workspace_dir", return_value=workspace):
+            with (
+                patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(provision_mod, "_workspace_dir", return_value=workspace),
+            ):
                 cleaned = cast("list[str]", call_command("workspace", "clean-all"))
 
             # Only the empty dir should be removed
@@ -891,6 +906,7 @@ class TestWorkspaceCleanAll(TestCase):
         with (
             tempfile.TemporaryDirectory() as tmp,
             patch.object(workspace_mod, "_workspace_dir", return_value=Path(tmp)),
+            patch.object(provision_mod, "_workspace_dir", return_value=Path(tmp)),
             patch("teatree.utils.django_db.prune_dslr_snapshots", return_value=["old-snapshot-2025"]),
         ):
             cleaned = cast("list[str]", call_command("workspace", "clean-all"))
@@ -1175,6 +1191,7 @@ class TestPruneBranches(TestCase):
         gh_merged = subprocess.CompletedProcess([], 0, stdout='[{"number":1}]')
         with (
             patch.object(workspace_mod, "_workspace_dir", return_value=Path("/tmp/ws")),
+            patch.object(provision_mod, "_workspace_dir", return_value=Path("/tmp/ws")),
             patch.object(workspace_mod, "_worktree_map", return_value=wt_map),
             patch.object(workspace_mod, "_worktree_branches", return_value={"gone-branch"}),
             patch.object(git_mod, "run", side_effect=fake_run),
@@ -1207,6 +1224,7 @@ class TestPruneBranches(TestCase):
         gh_merged = subprocess.CompletedProcess([], 0, stdout='[{"number":1}]')
         with (
             patch.object(workspace_mod, "_workspace_dir", return_value=Path("/tmp/ws")),
+            patch.object(provision_mod, "_workspace_dir", return_value=Path("/tmp/ws")),
             patch.object(workspace_mod, "_worktree_map", return_value=wt_map),
             patch.object(workspace_mod, "_worktree_branches", return_value={"gone-branch"}),
             patch.object(git_mod, "run", side_effect=fake_run),
@@ -1240,6 +1258,7 @@ class TestPruneBranches(TestCase):
         gh_merged = subprocess.CompletedProcess([], 0, stdout='[{"number":1}]')
         with (
             patch.object(workspace_mod, "_workspace_dir", return_value=Path("/tmp/ws")),
+            patch.object(provision_mod, "_workspace_dir", return_value=Path("/tmp/ws")),
             patch.object(workspace_mod, "_worktree_map", return_value=wt_map),
             patch.object(workspace_mod, "_worktree_branches", return_value={"gone-branch"}),
             patch.object(git_mod, "run", side_effect=fake_run),

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -29,7 +29,6 @@ import teatree.utils.db as db_mod
 import teatree.utils.git as git_mod
 import teatree.utils.run as utils_run_mod
 from teatree.core.management.commands.lifecycle import _register_new_repos
-from teatree.core.management.commands.pr import _last_commit_message
 from teatree.core.management.commands.workspace import _branch_prefix, _workspace_dir
 from teatree.core.models import Session, Ticket, Worktree
 from teatree.core.overlay import (
@@ -1775,214 +1774,103 @@ class TestDbResetPasswords(TestCase):
 # ── PR commands ─────────────────────────────────────────────────────
 
 
+def _shippable_ticket(*, repo: str = "/tmp/wt", branch: str = "feature-x") -> Ticket:
+    """Build a ticket pre-advanced to REVIEWED with the shipping gate satisfied."""
+    ticket = Ticket.objects.create(
+        overlay="test",
+        state=Ticket.State.REVIEWED,
+        issue_url="https://example.com/issues/70",
+    )
+    session = Session.objects.create(overlay="test", ticket=ticket)
+    for phase in ("testing", "reviewing", "retro"):
+        session.visit_phase(phase)
+    Worktree.objects.create(
+        overlay="test",
+        ticket=ticket,
+        repo_path=repo,
+        branch=branch,
+        extra={"worktree_path": repo},
+    )
+    return ticket
+
+
 class TestPrCreate(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.enterContext(patch.object(pr_mod.git, "config_value", return_value="dev"))
-        self.enterContext(
-            patch.object(pr_mod.git, "last_commit_message", return_value=("commit subject", "commit body")),
-        )
+    """``pr create`` is a thin wrapper around ``ticket.ship()`` (#140)."""
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_without_code_host_returns_error(self) -> None:
-        ticket = Ticket.objects.create(overlay="test")
-
+    def test_returns_error_when_no_worktree(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.REVIEWED)
         result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
-
         assert "error" in result
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_with_code_host_creates_mr(self) -> None:
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/70")
-        Worktree.objects.create(overlay="test", ticket=ticket, repo_path="my-repo", branch="feature-70")
+    def test_advances_to_shipped_when_gates_pass(self) -> None:
+        ticket = _shippable_ticket()
 
-        mock_host = MagicMock()
-        mock_host.create_pr.return_value = {"url": "https://example.com/mr/1"}
+        with (
+            patch.object(pr_mod, "_run_visual_qa_gate", return_value=None),
+            patch.object(pr_mod, "_validate_mr_metadata", return_value=None),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
 
-        with patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host):
-            result = cast(
-                "dict[str, object]",
-                call_command(
-                    "pr",
-                    "create",
-                    str(ticket.pk),
-                    title="Fix bug",
-                    description="Fixes the thing",
-                ),
-            )
-
-        assert result == {"url": "https://example.com/mr/1"}
-        (spec,) = mock_host.create_pr.call_args.args
-        assert spec.repo == "my-repo"
-        assert spec.branch == "feature-70"
-        assert spec.title == "Fix bug"
-        assert spec.description == "Fixes the thing"
-        assert spec.assignee
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert result == {"ticket_id": ticket.pk, "state": Ticket.State.SHIPPED}
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_validation_failure(self) -> None:
-        """validate_mr returns error when overlay rejects title."""
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/71")
-        Worktree.objects.create(overlay="test", ticket=ticket, repo_path="my-repo", branch="feature-71")
-
-        mock_host = MagicMock()
-        mock_validate = MagicMock(return_value={"errors": ["Bad title"], "warnings": []})
+    def test_validation_failure_keeps_state(self) -> None:
+        ticket = _shippable_ticket()
 
         with (
-            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
-            patch.object(pr_mod, "_last_commit_message", return_value=("Bad Title", "")),
-            patch.object(pr_mod, "get_overlay") as mock_overlay,
+            patch.object(pr_mod, "_run_visual_qa_gate", return_value=None),
+            patch.object(
+                pr_mod,
+                "_validate_mr_metadata",
+                return_value={"error": "MR validation failed", "details": ["Bad title"]},
+            ),
         ):
-            mock_overlay.return_value.metadata.validate_mr = mock_validate
-            result = cast(
-                "dict[str, object]",
-                call_command("pr", "create", str(ticket.pk)),
-            )
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
 
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED
         assert result["error"] == "MR validation failed"
-        mock_host.create_pr.assert_not_called()
-
-    @_patch_overlays(FULL_OVERLAY)
-    @override_settings(**SETTINGS)
-    def test_no_worktree_uses_ticket_number(self) -> None:
-        """When ticket has no worktrees, fallback branch and empty repo are used."""
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/72")
-
-        mock_host = MagicMock()
-        mock_host.create_pr.return_value = {"url": "https://example.com/mr/2"}
-
-        with (
-            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
-            patch.object(pr_mod, "_last_commit_message", return_value=("", "")),
-        ):
-            cast(
-                "dict[str, object]",
-                call_command(
-                    "pr",
-                    "create",
-                    str(ticket.pk),
-                    title="My MR",
-                ),
-            )
-
-        (spec,) = mock_host.create_pr.call_args.args
-        assert spec.branch == "ticket-72"
-        assert spec.repo == ""
-
-    @_patch_overlays(FULL_OVERLAY)
-    @override_settings(**SETTINGS)
-    def test_uses_default_title_from_issue_url(self) -> None:
-        """When no title is given and no commit, it defaults to 'Resolve <issue_url>'."""
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/73")
-        Worktree.objects.create(overlay="test", ticket=ticket, repo_path="my-repo", branch="feature-73")
-
-        mock_host = MagicMock()
-        mock_host.create_pr.return_value = {"url": "https://example.com/mr/3"}
-
-        with (
-            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
-            patch.object(pr_mod, "_last_commit_message", return_value=("", "")),
-        ):
-            call_command("pr", "create", str(ticket.pk), skip_validation=True)
-
-        (spec,) = mock_host.create_pr.call_args.args
-        assert spec.title == "Resolve https://example.com/issues/73"
-
-    @_patch_overlays(FULL_OVERLAY)
-    @override_settings(**SETTINGS)
-    def test_keeps_provided_description(self) -> None:
-        """When description is given but title is not, description is preserved."""
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/77")
-        Worktree.objects.create(overlay="test", ticket=ticket, repo_path="my-repo", branch="feature-77")
-
-        mock_host = MagicMock()
-        mock_host.create_pr.return_value = {"url": "https://example.com/mr/7"}
-
-        with (
-            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
-            patch.object(pr_mod, "_last_commit_message", return_value=("commit title", "commit body")),
-        ):
-            call_command("pr", "create", str(ticket.pk), description="user desc", skip_validation=True)
-
-        (spec,) = mock_host.create_pr.call_args.args
-        assert spec.title == "commit title"
-        assert spec.description == "user desc"
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
     def test_dry_run_returns_plan(self) -> None:
-        """--dry-run returns the MR plan without creating it."""
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/74")
-        Worktree.objects.create(overlay="test", ticket=ticket, repo_path="my-repo", branch="feature-74")
+        ticket = _shippable_ticket()
 
-        mock_host = MagicMock()
         with (
-            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
-            patch.object(pr_mod, "_last_commit_message", return_value=("", "")),
+            patch.object(pr_mod, "_run_visual_qa_gate", return_value=None),
+            patch.object(pr_mod, "_validate_mr_metadata", return_value=None),
+            patch.object(pr_mod.git, "last_commit_message", return_value=("Dry MR", "body")),
         ):
             result = cast(
                 "dict[str, object]",
-                call_command("pr", "create", str(ticket.pk), title="Dry MR", dry_run=True),
+                call_command("pr", "create", str(ticket.pk), dry_run=True),
             )
 
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED  # not advanced
         assert result["dry_run"] is True
         assert result["title"] == "Dry MR"
-        mock_host.create_pr.assert_not_called()
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
     def test_skip_validation_bypasses_check(self) -> None:
-        """--skip-validation creates MR even with empty title."""
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/75")
-        Worktree.objects.create(overlay="test", ticket=ticket, repo_path="my-repo", branch="feature-75")
+        ticket = _shippable_ticket()
 
-        mock_host = MagicMock()
-        mock_host.create_pr.return_value = {"url": "https://example.com/mr/5"}
-
-        with (
-            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
-            patch.object(pr_mod, "_last_commit_message", return_value=("", "")),
-        ):
-            result = cast(
-                "dict[str, object]",
-                call_command("pr", "create", str(ticket.pk), skip_validation=True),
-            )
-
-        assert "error" not in result
-        mock_host.create_pr.assert_called_once()
-
-    @_patch_overlays(FULL_OVERLAY)
-    @override_settings(**SETTINGS)
-    def test_title_from_commit_message(self) -> None:
-        """When no title given, falls back to last commit subject."""
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/76")
-        Worktree.objects.create(
-            overlay="test",
-            ticket=ticket,
-            repo_path="my-repo",
-            branch="feature-76",
-            extra={"worktree_path": "/tmp/wt"},
+        result = cast(
+            "dict[str, object]",
+            call_command("pr", "create", str(ticket.pk), skip_validation=True),
         )
 
-        mock_host = MagicMock()
-        mock_host.create_pr.return_value = {"url": "https://example.com/mr/6"}
-
-        with (
-            patch.object(pr_mod, "code_host_from_overlay", return_value=mock_host),
-            patch.object(
-                pr_mod,
-                "_last_commit_message",
-                return_value=("fix(api): handle nulls", "Detailed body here"),
-            ),
-        ):
-            call_command("pr", "create", str(ticket.pk), skip_validation=True)
-
-        (spec,) = mock_host.create_pr.call_args.args
-        assert spec.title == "fix(api): handle nulls"
-        assert spec.description == "Detailed body here"
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert "error" not in result
 
 
 class TestPrCheckGates(TestCase):
@@ -2020,24 +1908,6 @@ class TestPrCheckGates(TestCase):
 
         assert result["allowed"] is False
         assert "reviewing" in str(result["reason"])
-
-
-class TestLastCommitMessage:
-    def test_parses_subject_and_body(self) -> None:
-        with patch.object(pr_mod.git, "last_commit_message", return_value=("fix: bug", "Detailed body")):
-            subject, body = _last_commit_message("/tmp")
-        assert subject == "fix: bug"
-        assert body == "Detailed body"
-
-    def test_returns_empty_on_failure(self) -> None:
-        with patch.object(pr_mod.git, "last_commit_message", return_value=("", "")):
-            assert _last_commit_message("/tmp") == ("", "")
-
-    def test_subject_only(self) -> None:
-        with patch.object(pr_mod.git, "last_commit_message", return_value=("feat: add feature", "")):
-            subject, body = _last_commit_message("/tmp")
-        assert subject == "feat: add feature"
-        assert body == ""
 
 
 class TestPrFetchIssue(TestCase):

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,10 +10,8 @@ from teatree import visual_qa
 from teatree.core.management.commands import pr as pr_command
 from teatree.core.management.commands.pr import (
     _check_shipping_gate,
-    _mr_auto_labels,
     _resolve_base_url,
     _run_visual_qa_gate,
-    _sanitize_close_keywords,
 )
 from teatree.core.models import Session, Ticket, Worktree
 from teatree.core.overlay_loader import reset_overlay_cache
@@ -29,108 +28,86 @@ def clear_overlay_cache() -> Iterator[None]:
 _MOCK_OVERLAY = {"test": CommandOverlay()}
 
 
-class TestPrCreate(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.enterContext(patch.object(pr_command.git, "config_value", return_value="dev"))
-        self.enterContext(
-            patch.object(pr_command.git, "last_commit_message", return_value=("commit subject", "commit body")),
-        )
+def _shippable_ticket() -> Ticket:
+    """Build a ticket pre-advanced to REVIEWED with the shipping gate satisfied."""
+    ticket = Ticket.objects.create(overlay="test", state=Ticket.State.REVIEWED)
+    session = Session.objects.create(ticket=ticket, overlay="test")
+    session.visit_phase("testing")
+    session.visit_phase("reviewing")
+    session.visit_phase("retro")
+    Worktree.objects.create(
+        ticket=ticket,
+        overlay="test",
+        repo_path="/tmp/backend",
+        branch="feature-branch",
+        extra={"worktree_path": "/tmp/backend"},
+    )
+    return ticket
+
+
+class TestPrCreateThinWrapper(TestCase):
+    """``pr create`` validates gates then triggers ``ticket.ship()`` (#140)."""
 
     @pytest.fixture(autouse=True)
     def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._monkeypatch = monkeypatch
 
-    def test_reads_auto_labels_from_overlay(self) -> None:
-        host = MagicMock()
-        host.create_pr.return_value = {"iid": 12}
-        host.current_user.return_value = "souliane"
-        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+    def test_advances_to_shipped_when_gates_pass(self) -> None:
+        ticket = _shippable_ticket()
 
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/55")
-        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="/tmp/backend", branch="feature-branch")
-
-        # CommandOverlay.config.mr_auto_labels returns [] (default), so labels=[]
         with (
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
-            patch("teatree.core.management.commands.pr._last_commit_message", return_value=("", "")),
+            patch.object(pr_command, "_run_visual_qa_gate", return_value=None),
+            patch.object(pr_command, "_validate_mr_metadata", return_value=None),
         ):
-            result = call_command("pr", "create", str(ticket.id), "--title", "feat: add labels")
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.id)))
 
-        assert result == {"iid": 12}
-        (spec,) = host.create_pr.call_args.args
-        assert spec.repo == "/tmp/backend"
-        assert spec.branch == "feature-branch"
-        assert spec.title == "feat: add labels"
-        assert spec.assignee == "souliane"
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert result == {"ticket_id": ticket.pk, "state": Ticket.State.SHIPPED}
 
-    def test_spec_repo_uses_worktree_filesystem_path_not_bare_name(self) -> None:
-        """spec.repo must be the worktree's filesystem path.
+    def test_returns_error_when_no_worktree(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.REVIEWED)
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.id)))
+        assert "error" in result
 
-        The GitLab backend resolves the project by reading the ``origin`` remote
-        of the given path. A bare repo name like ``widget-backend`` cannot be
-        URL-encoded into a namespaced ``projects/<group>%2F<repo>`` lookup and
-        produces a 404 on GitLab.
-        """
-        host = MagicMock()
-        host.create_pr.return_value = {"iid": 15}
-        host.current_user.return_value = "souliane"
-        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+    def test_dry_run_returns_preview_without_transition(self) -> None:
+        ticket = _shippable_ticket()
 
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/58")
-        Worktree.objects.create(
-            ticket=ticket,
-            overlay="test",
-            repo_path="widget-backend",
-            branch="feature-branch",
-            extra={"worktree_path": "/abs/path/ac-widget-1234/widget-backend"},
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command, "_run_visual_qa_gate", return_value=None),
+            patch.object(pr_command, "_validate_mr_metadata", return_value=None),
+            patch.object(pr_command.git, "last_commit_message", return_value=("feat: x", "body")),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.id), dry_run=True))
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED  # unchanged
+        assert result["dry_run"] is True
+        assert result["title"] == "feat: x"
+        assert result["branch"] == "feature-branch"
+
+    def test_blocked_when_visual_qa_fails(self) -> None:
+        ticket = _shippable_ticket()
+        failure = pr_command.VisualQAGateFailure(
+            allowed=False,
+            error="Visual QA found 1 blocking finding(s).",
+            visual_qa={},
+            report_markdown="## Visual QA",
+            hint="fix it",
         )
 
         with (
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
-            patch("teatree.core.management.commands.pr._last_commit_message", return_value=("", "")),
+            patch.object(pr_command, "_run_visual_qa_gate", return_value=failure),
         ):
-            call_command("pr", "create", str(ticket.id), "--title", "feat: remote-resolved")
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.id)))
 
-        (spec,) = host.create_pr.call_args.args
-        assert spec.repo == "/abs/path/ac-widget-1234/widget-backend"
-
-    def test_assignee_falls_back_to_git_user_name_when_host_returns_empty(self) -> None:
-        host = MagicMock()
-        host.create_pr.return_value = {"iid": 13}
-        host.current_user.return_value = ""
-        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
-
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/56")
-        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="/tmp/backend", branch="feature-branch")
-
-        with (
-            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
-            patch("teatree.core.management.commands.pr._last_commit_message", return_value=("", "")),
-        ):
-            call_command("pr", "create", str(ticket.id), "--title", "feat: fallback")
-
-        (spec,) = host.create_pr.call_args.args
-        assert spec.assignee == "dev"  # from patched git.config_value in setUp
-
-    def test_assignee_propagates_when_host_current_user_raises(self) -> None:
-        """Host lookup errors surface to the caller — fallback is for empty, not broken."""
-        host = MagicMock()
-        host.create_pr.return_value = {"iid": 14}
-        host.current_user.side_effect = RuntimeError("gh not authenticated")
-        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
-
-        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/57")
-        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="/tmp/backend", branch="feature-branch")
-
-        with (
-            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
-            patch("teatree.core.management.commands.pr._last_commit_message", return_value=("", "")),
-            pytest.raises(RuntimeError, match="gh not authenticated"),
-        ):
-            call_command("pr", "create", str(ticket.id), "--title", "feat: resilient")
-
-        host.create_pr.assert_not_called()
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED  # not advanced
+        assert result["allowed"] is False
 
 
 class TestPostEvidence(TestCase):
@@ -187,81 +164,6 @@ class TestCheckShippingGate(TestCase):
         assert "reviewing" in result["missing"]
         assert "testing" in result["missing"]
         assert "hint" in result
-
-
-class TestSanitizeCloseKeywords:
-    @pytest.mark.parametrize(
-        ("description", "expected"),
-        [
-            # Same-project short refs
-            ("Closes #123", "Relates to #123"),
-            ("Fixes #42", "Relates to #42"),
-            ("Resolves #7", "Relates to #7"),
-            ("closes #123", "Relates to #123"),
-            ("fixes #42", "Relates to #42"),
-            ("resolves #7", "Relates to #7"),
-            ("See Closes #1 and Fixes #2", "See Relates to #1 and Relates to #2"),
-            # Cross-project short refs
-            ("Closes group/project#99", "Relates to group/project#99"),
-            ("Fixes org/sub/repo#5", "Relates to org/sub/repo#5"),
-            # Full URL refs
-            (
-                "Closes https://gitlab.com/org/project/-/issues/729",
-                "Relates to https://gitlab.com/org/project/-/issues/729",
-            ),
-            (
-                "Fixes https://gitlab.com/org/sub/repo/-/issues/42",
-                "Relates to https://gitlab.com/org/sub/repo/-/issues/42",
-            ),
-            (
-                "Resolves https://github.com/owner/repo/issues/10",
-                "Relates to https://github.com/owner/repo/issues/10",
-            ),
-            # Mixed refs in one description
-            (
-                "Closes #1\nFixes https://gitlab.com/g/p/-/issues/2\nResolves g/p#3",
-                "Relates to #1\nRelates to https://gitlab.com/g/p/-/issues/2\nRelates to g/p#3",
-            ),
-            # No ticket ref
-            ("No ticket ref here", "No ticket ref here"),
-            ("", ""),
-        ],
-    )
-    def test_replaces_close_keywords_when_close_ticket_false(self, description: str, expected: str) -> None:
-        assert _sanitize_close_keywords(description, close_ticket=False) == expected
-
-    def test_leaves_description_unchanged_when_close_ticket_true(self) -> None:
-        assert _sanitize_close_keywords("Closes #123", close_ticket=True) == "Closes #123"
-
-
-class TestMrAutoLabels:
-    def test_default_overlay_returns_empty(self) -> None:
-        """CommandOverlay has no auto labels, so _mr_auto_labels returns []."""
-        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
-            result = _mr_auto_labels()
-            assert result == []
-
-    def test_overlay_with_string_labels(self) -> None:
-        """When overlay returns a comma-separated string, it's split."""
-        mock_overlay = MagicMock()
-        mock_overlay.config.mr_auto_labels = "label-a, label-b"
-        with patch(
-            "teatree.core.overlay_loader._discover_overlays",
-            return_value={"test": mock_overlay},
-        ):
-            result = _mr_auto_labels()
-            assert result == ["label-a", "label-b"]
-
-    def test_non_iterable_returns_empty(self) -> None:
-        """_mr_auto_labels returns [] for non-iterable value."""
-        mock_overlay = MagicMock()
-        mock_overlay.config.mr_auto_labels = 42
-        with patch(
-            "teatree.core.overlay_loader._discover_overlays",
-            return_value={"test": mock_overlay},
-        ):
-            result = _mr_auto_labels()
-            assert result == []
 
 
 class TestResolveBaseUrl(TestCase):

--- a/tests/teatree_core/test_runners_provision.py
+++ b/tests/teatree_core/test_runners_provision.py
@@ -1,0 +1,173 @@
+"""Tests for WorktreeProvisioner — composed runner for the start transition.
+
+Stage 3 of #140: ``Ticket.start()`` becomes a thin transition that enqueues
+the heavy I/O (git worktree creation, Worktree DB rows) onto a ``@task``
+worker. The worker runs ``WorktreeProvisioner`` and on success schedules
+the coding task.
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay_loader import reset_overlay_cache
+from teatree.core.runners import WorktreeProvisioner
+from tests.teatree_core.conftest import CommandOverlay
+
+
+@pytest.fixture(autouse=True)
+def _clear_overlay_cache() -> Iterator[None]:
+    reset_overlay_cache()
+    yield
+    reset_overlay_cache()
+
+
+_MOCK_OVERLAY = {"test": CommandOverlay()}
+
+
+class TestWorktreeProvisioner(TestCase):
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.workspace = tmp_path / "workspace"
+        self.workspace.mkdir()
+
+    def _scoped_ticket(self, repos: list[str], *, branch: str = "ac-repo-77-x") -> Ticket:
+        return Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/77",
+            repos=repos,
+            extra={"branch": branch, "description": "x"},
+        )
+
+    def _patch_workspace_dir(self) -> Any:
+        return patch("teatree.core.runners.provision._workspace_dir", return_value=self.workspace)
+
+    def test_returns_failure_when_no_repos(self) -> None:
+        ticket = self._scoped_ticket(repos=[])
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+        ):
+            result = WorktreeProvisioner(ticket).run()
+
+        assert result.ok is False
+        assert "no repos" in result.detail.lower()
+
+    def test_creates_worktree_rows_and_git_worktrees(self) -> None:
+        repo_dir = self.workspace / "repo-a"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+        ticket = self._scoped_ticket(repos=["repo-a"], branch="ac-repo-a-77-x")
+
+        created_paths: list[str] = []
+
+        def fake_worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = True) -> bool:
+            del repo, branch, create_branch
+            Path(path).mkdir(parents=True, exist_ok=True)
+            created_paths.append(path)
+            return True
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+            patch("teatree.core.runners.provision.git.worktree_add", side_effect=fake_worktree_add),
+            patch("teatree.core.runners.provision.git.pull_ff_only", return_value=True),
+        ):
+            result = WorktreeProvisioner(ticket).run()
+
+        assert result.ok is True
+        wt_path = self.workspace / "ac-repo-a-77-x" / "repo-a"
+        assert str(wt_path) in created_paths
+
+        worktrees = list(Worktree.objects.filter(ticket=ticket))
+        assert len(worktrees) == 1
+        assert worktrees[0].repo_path == "repo-a"
+        assert worktrees[0].branch == "ac-repo-a-77-x"
+        assert (worktrees[0].extra or {}).get("worktree_path") == str(wt_path)
+
+    def test_idempotent_when_worktree_already_exists(self) -> None:
+        repo_dir = self.workspace / "repo-a"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+        ticket = self._scoped_ticket(repos=["repo-a"], branch="ac-repo-a-77-x")
+        ticket_dir = self.workspace / "ac-repo-a-77-x"
+        ticket_dir.mkdir()
+        existing_path = ticket_dir / "repo-a"
+        existing_path.mkdir()
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="repo-a",
+            branch="ac-repo-a-77-x",
+            extra={"worktree_path": str(existing_path)},
+        )
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+            patch("teatree.core.runners.provision.git.worktree_add") as worktree_add,
+        ):
+            result = WorktreeProvisioner(ticket).run()
+
+        assert result.ok is True
+        worktree_add.assert_not_called()
+        assert Worktree.objects.filter(ticket=ticket).count() == 1
+
+    def test_returns_failure_when_worktree_add_fails(self) -> None:
+        repo_dir = self.workspace / "repo-a"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+        ticket = self._scoped_ticket(repos=["repo-a"], branch="ac-repo-a-77-x")
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+            patch("teatree.core.runners.provision.git.worktree_add", return_value=False),
+            patch("teatree.core.runners.provision.git.pull_ff_only", return_value=True),
+        ):
+            result = WorktreeProvisioner(ticket).run()
+
+        assert result.ok is False
+        assert "repo-a" in result.detail
+        assert Worktree.objects.filter(ticket=ticket, repo_path="repo-a").count() == 0
+
+    def test_skips_repo_without_git_directory(self) -> None:
+        not_a_repo = self.workspace / "no-git"
+        not_a_repo.mkdir()
+        ticket = self._scoped_ticket(repos=["no-git"], branch="ac-no-git-77-x")
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+            patch("teatree.core.runners.provision.git.worktree_add") as worktree_add,
+        ):
+            result = WorktreeProvisioner(ticket).run()
+
+        assert result.ok is True
+        worktree_add.assert_not_called()
+        # Skipped repo keeps its DB row so the ticket still tracks it; the row
+        # has no worktree_path until a real source repo appears.
+        wt = Worktree.objects.get(ticket=ticket, repo_path="no-git")
+        assert (wt.extra or {}).get("worktree_path") is None
+
+    def test_returns_failure_when_branch_missing_from_extra(self) -> None:
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/79",
+            repos=["repo-a"],
+        )
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+        ):
+            result = WorktreeProvisioner(ticket).run()
+
+        assert result.ok is False
+        assert "branch" in result.detail.lower()

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -1,0 +1,153 @@
+"""Tests for ShipExecutor — composed runner for the ship transition.
+
+Stage 2 of #140: ``Ticket.ship()`` becomes a thin transition that enqueues
+the heavy I/O (push, MR creation) onto a ``@task`` worker. The worker runs
+``ShipExecutor`` and on success advances ``SHIPPED → IN_REVIEW``.
+"""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay_loader import reset_overlay_cache
+from teatree.core.runners import ShipExecutor
+from teatree.core.runners.ship import overlay_mr_labels, sanitize_close_keywords
+from tests.teatree_core.conftest import CommandOverlay
+
+
+@pytest.fixture(autouse=True)
+def _clear_overlay_cache() -> Iterator[None]:
+    reset_overlay_cache()
+    yield
+    reset_overlay_cache()
+
+
+_MOCK_OVERLAY = {"test": CommandOverlay()}
+
+
+class TestShipExecutor(TestCase):
+    def _ticket_with_worktree(self, *, branch: str = "feat-x", repo: str = "/tmp/repo") -> Ticket:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/77")
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path=repo,
+            branch=branch,
+            extra={"worktree_path": repo},
+        )
+        return ticket
+
+    def test_pushes_branch_then_creates_pr_and_records_url(self) -> None:
+        ticket = self._ticket_with_worktree()
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://example.com/mr/1", "iid": 1}
+        host.current_user.return_value = "souliane"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat: x", "body")),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is True
+        push.assert_called_once_with(repo="/tmp/repo", remote="origin", branch="feat-x")
+        (spec,) = host.create_pr.call_args.args
+        assert spec.repo == "/tmp/repo"
+        assert spec.branch == "feat-x"
+        assert spec.title == "feat: x"
+        assert spec.assignee == "souliane"
+
+        ticket.refresh_from_db()
+        assert ticket.extra["mr_urls"] == ["https://example.com/mr/1"]
+
+    def test_returns_failure_when_no_code_host(self) -> None:
+        ticket = self._ticket_with_worktree()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=None),
+            patch("teatree.core.runners.ship.git.push"),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is False
+        assert "code host" in result.detail.lower()
+
+    def test_returns_failure_when_no_worktree(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/78")
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is False
+        assert "worktree" in result.detail.lower()
+
+    def test_assignee_falls_back_to_git_user_name_when_host_returns_empty(self) -> None:
+        ticket = self._ticket_with_worktree()
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "u"}
+        host.current_user.return_value = ""
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push"),
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat", "")),
+            patch("teatree.core.runners.ship.git.config_value", return_value="dev"),
+        ):
+            ShipExecutor(ticket).run()
+
+        (spec,) = host.create_pr.call_args.args
+        assert spec.assignee == "dev"
+
+
+class TestSanitizeCloseKeywords:
+    @pytest.mark.parametrize(
+        ("description", "expected"),
+        [
+            ("Closes #123", "Relates to #123"),
+            ("Fixes #42", "Relates to #42"),
+            ("Resolves #7", "Relates to #7"),
+            ("closes #123", "Relates to #123"),
+            ("See Closes #1 and Fixes #2", "See Relates to #1 and Relates to #2"),
+            ("Closes group/project#99", "Relates to group/project#99"),
+            (
+                "Closes https://gitlab.com/org/project/-/issues/729",
+                "Relates to https://gitlab.com/org/project/-/issues/729",
+            ),
+            (
+                "Resolves https://github.com/owner/repo/issues/10",
+                "Relates to https://github.com/owner/repo/issues/10",
+            ),
+            ("No ticket ref here", "No ticket ref here"),
+            ("", ""),
+        ],
+    )
+    def test_replaces_close_keywords_when_close_ticket_false(self, description: str, expected: str) -> None:
+        assert sanitize_close_keywords(description, close_ticket=False) == expected
+
+    def test_leaves_description_unchanged_when_close_ticket_true(self) -> None:
+        assert sanitize_close_keywords("Closes #123", close_ticket=True) == "Closes #123"
+
+
+class TestOverlayMrLabels:
+    def test_default_overlay_returns_empty(self) -> None:
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            assert overlay_mr_labels() == []
+
+    def test_overlay_with_string_labels(self) -> None:
+        mock = MagicMock()
+        mock.config.mr_auto_labels = "label-a, label-b"
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value={"test": mock}):
+            assert overlay_mr_labels() == ["label-a", "label-b"]
+
+    def test_non_iterable_returns_empty(self) -> None:
+        mock = MagicMock()
+        mock.config.mr_auto_labels = 42
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value={"test": mock}):
+            assert overlay_mr_labels() == []

--- a/tests/teatree_core/test_runners_teardown.py
+++ b/tests/teatree_core/test_runners_teardown.py
@@ -1,0 +1,96 @@
+"""Tests for WorktreeTeardown — composed runner for the mark_merged transition.
+
+Stage 5 of #140: ``Ticket.mark_merged()`` becomes a thin transition that
+enqueues teardown I/O (worktree removal, branch deletion, DB drop) onto a
+``@task`` worker. The worker invokes ``WorktreeTeardown`` and on success
+the ticket is ready for ``retrospect()``.
+"""
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay_loader import reset_overlay_cache
+from teatree.core.runners import WorktreeTeardown
+from tests.teatree_core.conftest import CommandOverlay
+
+
+@pytest.fixture(autouse=True)
+def _clear_overlay_cache() -> Iterator[None]:
+    reset_overlay_cache()
+    yield
+    reset_overlay_cache()
+
+
+_MOCK_OVERLAY = {"test": CommandOverlay()}
+
+
+class TestWorktreeTeardown(TestCase):
+    def _ticket_with_worktrees(self, count: int = 2) -> Ticket:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/77")
+        for i in range(count):
+            Worktree.objects.create(
+                ticket=ticket,
+                overlay="test",
+                repo_path=f"repo-{i}",
+                branch="feat-x",
+                extra={"worktree_path": f"/tmp/wt-{i}"},
+            )
+        return ticket
+
+    def test_returns_success_when_no_worktrees(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/78")
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = WorktreeTeardown(ticket).run()
+
+        assert result.ok is True
+        assert "no worktrees" in result.detail.lower()
+
+    def test_cleans_each_worktree_and_returns_summary(self) -> None:
+        ticket = self._ticket_with_worktrees(count=2)
+
+        cleaned: list[str] = []
+
+        def fake_cleanup(worktree: Worktree, *, force: bool = False) -> str:
+            del force
+            label = f"Cleaned: {worktree.repo_path}"
+            cleaned.append(worktree.repo_path)
+            worktree.delete()
+            return label
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.teardown.cleanup_worktree", side_effect=fake_cleanup),
+        ):
+            result = WorktreeTeardown(ticket).run()
+
+        assert result.ok is True
+        assert sorted(cleaned) == ["repo-0", "repo-1"]
+        assert ticket.worktrees.count() == 0
+
+    def test_continues_on_individual_failure_and_reports_errors(self) -> None:
+        ticket = self._ticket_with_worktrees(count=2)
+
+        def fake_cleanup(worktree: Worktree, *, force: bool = False) -> str:
+            del force
+            if worktree.repo_path == "repo-0":
+                msg = "branch ahead of main"
+                raise RuntimeError(msg)
+            worktree.delete()
+            return f"Cleaned: {worktree.repo_path}"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.teardown.cleanup_worktree", side_effect=fake_cleanup),
+        ):
+            result = WorktreeTeardown(ticket).run()
+
+        assert result.ok is False
+        assert "repo-0" in result.detail
+        assert "branch ahead of main" in result.detail
+        # repo-1 cleaned even though repo-0 raised
+        assert ticket.worktrees.filter(repo_path="repo-1").count() == 0

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -10,6 +10,7 @@ from teatree.core.tasks import (
     execute_provision,
     execute_retrospect,
     execute_ship,
+    execute_teardown,
     refresh_followup_snapshot,
     sync_followup,
 )
@@ -133,6 +134,65 @@ class TestExecuteRetrospect(TestCase):
             "ticket_id": ticket.pk,
             "skipped": True,
             "state": "delivered",
+        }
+
+
+class TestExecuteTeardown(TestCase):
+    def _ticket_in_merged(self) -> Ticket:
+        ticket = Ticket.objects.create(overlay="test")
+        ticket.state = Ticket.State.MERGED
+        ticket.save(update_fields=["state"])
+        return ticket
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_advances_runner_when_state_matches(self) -> None:
+        from teatree.core.runners.base import RunnerResult  # noqa: PLC0415
+
+        ticket = self._ticket_in_merged()
+
+        with patch("teatree.core.tasks.WorktreeTeardown") as teardown:
+            teardown.return_value.run.return_value = RunnerResult(ok=True, detail="tore down 2 worktree(s)")
+            result = execute_teardown.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        # Teardown does NOT advance the FSM — retrospect() does that explicitly.
+        assert ticket.state == Ticket.State.MERGED
+        assert result.return_value == {
+            "ticket_id": ticket.pk,
+            "ok": True,
+            "detail": "tore down 2 worktree(s)",
+        }
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_skips_when_state_does_not_match(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.RETROSPECTED)
+
+        result = execute_teardown.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.RETROSPECTED
+        assert result.return_value == {
+            "ticket_id": ticket.pk,
+            "skipped": True,
+            "state": "retrospected",
+        }
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_reports_failure_without_advancing(self) -> None:
+        from teatree.core.runners.base import RunnerResult  # noqa: PLC0415
+
+        ticket = self._ticket_in_merged()
+
+        with patch("teatree.core.tasks.WorktreeTeardown") as teardown:
+            teardown.return_value.run.return_value = RunnerResult(ok=False, detail="repo-0: branch ahead")
+            result = execute_teardown.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED
+        assert result.return_value == {
+            "ticket_id": ticket.pk,
+            "ok": False,
+            "detail": "repo-0: branch ahead",
         }
 
 

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -8,6 +8,7 @@ from teatree.core.models import Session, Task, TaskAttempt, Ticket
 from teatree.core.tasks import (
     drain_headless_queue,
     execute_retrospect,
+    execute_ship,
     refresh_followup_snapshot,
     sync_followup,
 )
@@ -132,6 +133,60 @@ class TestExecuteRetrospect(TestCase):
             "skipped": True,
             "state": "delivered",
         }
+
+
+class TestExecuteShip(TestCase):
+    def _ticket_in_shipped(self) -> Ticket:
+        ticket = Ticket.objects.create(overlay="test")
+        ticket.state = Ticket.State.SHIPPED
+        ticket.save(update_fields=["state"])
+        return ticket
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_advances_shipped_ticket_to_in_review(self) -> None:
+        from teatree.core.runners.base import RunnerResult  # noqa: PLC0415
+
+        ticket = self._ticket_in_shipped()
+
+        with patch("teatree.core.tasks.ShipExecutor") as ship_exec:
+            ship_exec.return_value.run.return_value = RunnerResult(ok=True, detail="https://example.com/mr/1")
+            result = execute_ship.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.IN_REVIEW
+        assert result.return_value == {
+            "ticket_id": ticket.pk,
+            "ok": True,
+            "detail": "https://example.com/mr/1",
+        }
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_skips_when_state_does_not_match(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.MERGED)
+
+        result = execute_ship.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED
+        assert result.return_value == {
+            "ticket_id": ticket.pk,
+            "skipped": True,
+            "state": "merged",
+        }
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_keeps_state_when_runner_fails(self) -> None:
+        from teatree.core.runners.base import RunnerResult  # noqa: PLC0415
+
+        ticket = self._ticket_in_shipped()
+
+        with patch("teatree.core.tasks.ShipExecutor") as ship_exec:
+            ship_exec.return_value.run.return_value = RunnerResult(ok=False, detail="push rejected")
+            result = execute_ship.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert result.return_value == {"ticket_id": ticket.pk, "ok": False, "detail": "push rejected"}
 
 
 class TestExecuteHeadlessTask(TestCase):

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -7,6 +7,7 @@ import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.core.models import Session, Task, TaskAttempt, Ticket
 from teatree.core.tasks import (
     drain_headless_queue,
+    execute_provision,
     execute_retrospect,
     execute_ship,
     refresh_followup_snapshot,
@@ -133,6 +134,63 @@ class TestExecuteRetrospect(TestCase):
             "skipped": True,
             "state": "delivered",
         }
+
+
+class TestExecuteProvision(TestCase):
+    def _ticket_in_started(self) -> Ticket:
+        ticket = Ticket.objects.create(overlay="test", repos=["repo-a"], extra={"branch": "ac-repo-a-1-x"})
+        ticket.state = Ticket.State.STARTED
+        ticket.save(update_fields=["state"])
+        return ticket
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_provisions_then_schedules_coding(self) -> None:
+        from teatree.core.runners.base import RunnerResult  # noqa: PLC0415
+
+        ticket = self._ticket_in_started()
+
+        with patch("teatree.core.tasks.WorktreeProvisioner") as provisioner:
+            provisioner.return_value.run.return_value = RunnerResult(ok=True, detail="provisioned 1 worktree(s)")
+            result = execute_provision.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.STARTED
+        assert ticket.tasks.filter(phase="coding").exists()
+        assert result.return_value == {
+            "ticket_id": ticket.pk,
+            "ok": True,
+            "detail": "provisioned 1 worktree(s)",
+        }
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_skips_when_state_does_not_match(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.SCOPED)
+
+        result = execute_provision.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SCOPED
+        assert not ticket.tasks.filter(phase="coding").exists()
+        assert result.return_value == {
+            "ticket_id": ticket.pk,
+            "skipped": True,
+            "state": "scoped",
+        }
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_keeps_state_when_runner_fails(self) -> None:
+        from teatree.core.runners.base import RunnerResult  # noqa: PLC0415
+
+        ticket = self._ticket_in_started()
+
+        with patch("teatree.core.tasks.WorktreeProvisioner") as provisioner:
+            provisioner.return_value.run.return_value = RunnerResult(ok=False, detail="repo missing")
+            result = execute_provision.enqueue(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.STARTED
+        assert not ticket.tasks.filter(phase="coding").exists()
+        assert result.return_value == {"ticket_id": ticket.pk, "ok": False, "detail": "repo missing"}
 
 
 class TestExecuteShip(TestCase):

--- a/tests/teatree_core/test_workflows.py
+++ b/tests/teatree_core/test_workflows.py
@@ -630,6 +630,7 @@ class TestRunBackend(TestCase):
                 side_effect=fake_subprocess_run,
             ),
             patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+            patch("teatree.core.runners.provision._workspace_dir", return_value=workspace),
         ):
             ticket_id = cast(
                 "int",
@@ -643,7 +644,9 @@ class TestRunBackend(TestCase):
             )
 
         ticket = Ticket.objects.get(pk=ticket_id)
-        assert ticket.state == Ticket.State.SCOPED
+        # Stage 3 of #140: workspace ticket advances scope() then start() so the
+        # provisioning runner can materialise the worktrees in the same call.
+        assert ticket.state == Ticket.State.STARTED
         assert ticket.variant == "testclient"
         assert ticket.repos == ["backend", "frontend"]
         assert ticket.issue_url == "https://gitlab.com/org/repo/-/issues/999"

--- a/tests/test_check_skill_prose.py
+++ b/tests/test_check_skill_prose.py
@@ -1,0 +1,193 @@
+"""Tests for the anti-prose lint hook (souliane/teatree#140 Stage 0).
+
+The hook fails when ``skills/**/SKILL.md`` or ``skills/**/references/*.md``
+grow new imperative rules (``Non-Negotiable``, leading ``Always``/``Never``
+bullets) without an accompanying change in ``src/``, ``hooks/scripts/``, or
+``tests/``. Existing prose is grandfathered via the ``prose-allowed`` marker.
+"""
+
+import pytest
+
+from scripts.hooks.check_skill_prose import (
+    NEW_RULE_PATTERN,
+    count_new_rule_lines,
+    has_companion_code_change,
+    main,
+)
+
+_NEW_NN_DIFF = """\
+diff --git a/skills/ship/SKILL.md b/skills/ship/SKILL.md
+--- a/skills/ship/SKILL.md
++++ b/skills/ship/SKILL.md
+@@ -50,0 +51,2 @@
++- **New rule (Non-Negotiable).** Run `prek install` before every commit.
++- More prose.
+"""
+
+_NEW_ALWAYS_DIFF = """\
+diff --git a/skills/ship/SKILL.md b/skills/ship/SKILL.md
+--- a/skills/ship/SKILL.md
++++ b/skills/ship/SKILL.md
+@@ -50,0 +51,2 @@
++- **Always run `prek install`** before the first commit in a worktree.
++- **Never push to default branch.** Use a feature branch instead.
+"""
+
+_REMOVING_PROSE_DIFF = """\
+diff --git a/skills/ship/SKILL.md b/skills/ship/SKILL.md
+--- a/skills/ship/SKILL.md
++++ b/skills/ship/SKILL.md
+@@ -50,3 +50,0 @@
+-- **Old rule (Non-Negotiable).** Removed.
+-- **Always do this** thing that became code.
+-- **Never do this** other thing.
+"""
+
+_PROSE_ALLOWED_DIFF = """\
+diff --git a/skills/retro/SKILL.md b/skills/retro/SKILL.md
+--- a/skills/retro/SKILL.md
++++ b/skills/retro/SKILL.md
+@@ -100,0 +101,3 @@
++<!-- prose-allowed: methodology -->
++- **Always frame retro findings** as personal takeaways, never as corrections of others.
++- **Non-Negotiable** voice rules apply to user-facing text everywhere.
+"""
+
+_REFERENCE_FILE_DIFF = """\
+diff --git a/skills/ship/references/foo.md b/skills/ship/references/foo.md
+--- a/skills/ship/references/foo.md
++++ b/skills/ship/references/foo.md
+@@ -10,0 +11 @@
++- **Non-Negotiable.** New rule in a reference doc.
+"""
+
+_NON_SKILL_FILE_DIFF = """\
+diff --git a/docs/notes.md b/docs/notes.md
+--- a/docs/notes.md
++++ b/docs/notes.md
+@@ -10,0 +11 @@
++- **Always be polite.** Non-Negotiable.
+"""
+
+
+class TestNewRulePattern:
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "- **Run `prek install` (Non-Negotiable).**",
+            "- **Always assign to user.**",
+            "- **Never push to default branch.**",
+            "- **Stop on red CI** before retrying.",
+        ],
+    )
+    def test_matches_imperative_bullets(self, line: str) -> None:
+        assert NEW_RULE_PATTERN.search(line) is not None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "Some context about why this matters.",
+            "- See `references/foo.md` for the full list.",
+            "- always lower-case prose, no leading bold marker",
+            "- **Background:** the system used to never enforce this.",
+        ],
+    )
+    def test_skips_non_imperative_text(self, line: str) -> None:
+        assert NEW_RULE_PATTERN.search(line) is None
+
+
+class TestCountNewRuleLines:
+    def test_counts_non_negotiable(self) -> None:
+        result = count_new_rule_lines(_NEW_NN_DIFF)
+        assert any(item.path.endswith("SKILL.md") for item in result)
+        assert any("Non-Negotiable" in item.line for item in result)
+
+    def test_counts_always_never(self) -> None:
+        result = count_new_rule_lines(_NEW_ALWAYS_DIFF)
+        assert len(result) == 2
+        assert all(item.path.endswith("SKILL.md") for item in result)
+
+    def test_ignores_removed_lines(self) -> None:
+        result = count_new_rule_lines(_REMOVING_PROSE_DIFF)
+        assert result == []
+
+    def test_respects_prose_allowed_marker(self) -> None:
+        result = count_new_rule_lines(_PROSE_ALLOWED_DIFF)
+        assert result == []
+
+    def test_includes_reference_files(self) -> None:
+        result = count_new_rule_lines(_REFERENCE_FILE_DIFF)
+        assert len(result) == 1
+        assert "references/" in result[0].path
+
+    def test_skips_non_skill_files(self) -> None:
+        result = count_new_rule_lines(_NON_SKILL_FILE_DIFF)
+        assert result == []
+
+
+class TestHasCompanionCodeChange:
+    @pytest.mark.parametrize(
+        "files",
+        [
+            ["src/teatree/core/models/ticket.py"],
+            ["hooks/scripts/hook_router.py"],
+            ["tests/test_check_skill_prose.py"],
+            ["src/teatree/cli/setup.py", "skills/ship/SKILL.md"],
+        ],
+    )
+    def test_returns_true_for_code_paths(self, files: list[str]) -> None:
+        assert has_companion_code_change(files) is True
+
+    @pytest.mark.parametrize(
+        "files",
+        [
+            ["skills/ship/SKILL.md"],
+            ["skills/ship/SKILL.md", "skills/test/SKILL.md"],
+            ["skills/ship/references/foo.md"],
+            ["docs/notes.md"],
+            [],
+        ],
+    )
+    def test_returns_false_for_doc_only(self, files: list[str]) -> None:
+        assert has_companion_code_change(files) is False
+
+
+class TestMain:
+    def test_passes_when_no_skill_diff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import scripts.hooks.check_skill_prose as mod  # noqa: PLC0415
+
+        monkeypatch.setattr(mod, "_staged_diff", lambda: "")
+        monkeypatch.setattr(mod, "_staged_files", list)
+        assert main() == 0
+
+    def test_fails_when_new_rule_without_companion_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import scripts.hooks.check_skill_prose as mod  # noqa: PLC0415
+
+        monkeypatch.setattr(mod, "_staged_diff", lambda: _NEW_NN_DIFF)
+        monkeypatch.setattr(mod, "_staged_files", lambda: ["skills/ship/SKILL.md"])
+        assert main() == 1
+
+    def test_passes_when_new_rule_has_companion_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import scripts.hooks.check_skill_prose as mod  # noqa: PLC0415
+
+        monkeypatch.setattr(mod, "_staged_diff", lambda: _NEW_NN_DIFF)
+        monkeypatch.setattr(
+            mod,
+            "_staged_files",
+            lambda: ["skills/ship/SKILL.md", "src/teatree/core/models/ticket.py"],
+        )
+        assert main() == 0
+
+    def test_passes_when_only_removing_prose(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import scripts.hooks.check_skill_prose as mod  # noqa: PLC0415
+
+        monkeypatch.setattr(mod, "_staged_diff", lambda: _REMOVING_PROSE_DIFF)
+        monkeypatch.setattr(mod, "_staged_files", lambda: ["skills/ship/SKILL.md"])
+        assert main() == 0
+
+    def test_passes_when_prose_allowed_marker_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import scripts.hooks.check_skill_prose as mod  # noqa: PLC0415
+
+        monkeypatch.setattr(mod, "_staged_diff", lambda: _PROSE_ALLOWED_DIFF)
+        monkeypatch.setattr(mod, "_staged_files", lambda: ["skills/retro/SKILL.md"])
+        assert main() == 0

--- a/tests/test_check_skill_prose.py
+++ b/tests/test_check_skill_prose.py
@@ -3,7 +3,7 @@
 The hook fails when ``skills/**/SKILL.md`` or ``skills/**/references/*.md``
 grow new imperative rules (``Non-Negotiable``, leading ``Always``/``Never``
 bullets) without an accompanying change in ``src/``, ``hooks/scripts/``, or
-``tests/``. Existing prose is grandfathered via the ``prose-allowed`` marker.
+``tests/``.
 """
 
 import pytest
@@ -41,16 +41,6 @@ diff --git a/skills/ship/SKILL.md b/skills/ship/SKILL.md
 -- **Old rule (Non-Negotiable).** Removed.
 -- **Always do this** thing that became code.
 -- **Never do this** other thing.
-"""
-
-_PROSE_ALLOWED_DIFF = """\
-diff --git a/skills/retro/SKILL.md b/skills/retro/SKILL.md
---- a/skills/retro/SKILL.md
-+++ b/skills/retro/SKILL.md
-@@ -100,0 +101,3 @@
-+<!-- prose-allowed: methodology -->
-+- **Always frame retro findings** as personal takeaways, never as corrections of others.
-+- **Non-Negotiable** voice rules apply to user-facing text everywhere.
 """
 
 _REFERENCE_FILE_DIFF = """\
@@ -109,10 +99,6 @@ class TestCountNewRuleLines:
 
     def test_ignores_removed_lines(self) -> None:
         result = count_new_rule_lines(_REMOVING_PROSE_DIFF)
-        assert result == []
-
-    def test_respects_prose_allowed_marker(self) -> None:
-        result = count_new_rule_lines(_PROSE_ALLOWED_DIFF)
         assert result == []
 
     def test_includes_reference_files(self) -> None:
@@ -183,11 +169,4 @@ class TestMain:
 
         monkeypatch.setattr(mod, "_staged_diff", lambda: _REMOVING_PROSE_DIFF)
         monkeypatch.setattr(mod, "_staged_files", lambda: ["skills/ship/SKILL.md"])
-        assert main() == 0
-
-    def test_passes_when_prose_allowed_marker_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import scripts.hooks.check_skill_prose as mod  # noqa: PLC0415
-
-        monkeypatch.setattr(mod, "_staged_diff", lambda: _PROSE_ALLOWED_DIFF)
-        monkeypatch.setattr(mod, "_staged_files", lambda: ["skills/retro/SKILL.md"])
         assert main() == 0


### PR DESCRIPTION
Stages 0, 2, 3 (partial), 5 (partial) of [souliane/teatree#140](https://github.com/souliane/teatree/issues/140) — moving recurring agent failures out of skill prose and behind the FSM.

## What's on the branch

| Stage | What landed | Commit |
|-------|-------------|--------|
| **0** | Anti-prose lint hook — fails new `**Non-Negotiable**`/`**Always**`/`**Never**`/`**Stop**`/`**Run**` bullets in `skills/**` without companion code change | `93e9a93`, `27b0f9b` |
| **2** | `ship()` transition is now a thin enqueue of `execute_ship` worker → `ShipExecutor` pushes branch + opens MR + calls `request_review()` | `e070ebd` |
| **3 (partial)** | `start()` transition enqueues `execute_provision` worker → `WorktreeProvisioner` materialises every `git worktree` and calls `schedule_coding()` | `02c5468` |
| **5 (partial)** | `mark_merged()` transition enqueues `execute_teardown` worker → `WorktreeTeardown` removes worktrees, branches, per-worktree DBs, runs overlay cleanup hooks | `b4a543c` |
| docs | BLUEPRINT §4 transitions table + worker enqueue invariant | `bcb690c` |

## The pattern (BLUEPRINT §4 invariant)

Each transition body stays pure: state change + metadata, then `transaction.on_commit(lambda: execute_X.enqueue(self.pk))`. The state flip and the queued work commit atomically. Workers take a row lock (`select_for_update()`), re-check source state, run the runner, and on success call the next transition. At-least-once delivery is safe because the state guard makes redelivery a no-op.

Runner classes live in [`teatree/core/runners/`](src/teatree/core/runners/). Workers live in [`teatree/core/tasks.py`](src/teatree/core/tasks.py).

## Why anti-prose lint

Audit (`/ac-reviewing-codebase`) found teatree skills accumulate one new `Non-Negotiable` bullet per recurring agent failure — 40 such markers across 3,847 lines of skill prose, vs. zero deterministic scripts in `skills/scripts/`. Cost to author: 30 seconds, no test, no review. Cost at runtime: agents stop loading bloated skills → same failure recurs. The hook flips the cost so the correct path (FSM condition / hook deny / CLI rejection) becomes the easier path.

## Tests

940 teatree_core tests passing locally (`uv run pytest tests/teatree_core --no-cov -x -q`).

## Known issues to fix before merge (Codex review found these)

- **P1** — `pr create` flips ticket to SHIPPED before push runs. If push fails the ticket is stranded — `ship()` only accepts REVIEWED as source. Need to allow retry from SHIPPED or bounce back on failure.
- **P1** — `ticket.start()` call sites are not wrapped in `atomic()`. In autocommit (and with `ImmediateBackend` tests), `on_commit` fires before the subsequent `save()` writes STARTED, so the worker sees SCOPED and skips. Audit applies to every transition call site.
- **P2** — `OverlayAppBuilder.ship()` still forwards `--title` but `pr create` no longer accepts it. CLI path fails at argparse.

## Not in this PR (deferred)

- **Stage 3 docker portion** — `DockerRunner` + `execute_start` (docker-up + verify-endpoints). `t3 lifecycle start` still owns it.
- **Stage 4** — `PrekRunner` + `execute_test` + `test()` body. Deliberately skipped: replacing the testing agent with a deterministic `prek`+`pytest` runner would lose the agent's ability to write missing tests / analyze failures intelligently.
- **Stage 5 legacy path removal** — `t3 lifecycle setup/start/teardown` commands still exist alongside the FSM-driven path; thinning them to wrappers is a separate cleanup MR.
- **Stage 6 prose deletion** — 40 existing `Non-Negotiable` markers need per-rule classification (already-enforced → delete; needs-code → write code first; methodology → reword). Per-rule MRs.
- **`_REQUIRED_PHASES` removal** ([first comment on #140](https://github.com/souliane/teatree/issues/140#issuecomment-2728571820)) — separate MR; needs each gate ported into a `@transition` `conditions=[…]` first.
- **PreToolUse hook to block raw `git commit`/`git push`** — listed in proposal §"Investigation Scope".