### PR TITLE
fix(setup): resolve worktree to main clone in _find_main_clone [none] (https://github.com/souliane/teatree/issues/430)

### DIFF
--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 import shutil
 from pathlib import Path
 
@@ -33,14 +34,28 @@ setup_app = typer.Typer(
 
 
 def _find_main_clone() -> Path | None:
-    """Find the teatree main clone (not a worktree)."""
+    """Find the teatree main clone, resolving worktrees to their main clone.
+
+    ``DoctorService.find_teatree_repo`` prefers a cwd-resolved teatree repo, which may
+    be a worktree.  Setup targets (``uv tool install --editable`` and Claude
+    marketplace registration) must point at a stable path, so we follow the
+    worktree's ``.git`` file to its main clone.
+    """
     repo = DoctorService.find_teatree_repo()
     if not repo:
         return None
-    # Main clone has .git as a directory; worktrees have .git as a file
-    if not (repo / ".git").is_dir():
-        return None
-    return repo
+    git = repo / ".git"
+    if git.is_dir():
+        return repo
+    if git.is_file():
+        match = re.match(r"^gitdir:\s*(.+)$", git.read_text().strip())
+        if not match:
+            return None
+        # `.git` points to `<main-clone>/.git/worktrees/<name>`; step back up to main clone.
+        main_clone_git = Path(match.group(1)).parent.parent
+        if main_clone_git.name == ".git" and main_clone_git.is_dir():
+            return main_clone_git.parent
+    return None
 
 
 def _run_captured(args: list[str], cwd: Path | None = None) -> CompletedProcess[str]:
@@ -275,14 +290,9 @@ def _clean_broken_symlinks(claude_skills: Path) -> int:
 def _validate_repo(repo: Path | None) -> Path:
     """Validate the teatree repo is a main clone with apm.yml. Raises typer.Exit on failure."""
     if not repo:
-        candidate = DoctorService.find_teatree_repo()
-        if candidate and not (candidate / ".git").is_dir():
-            typer.echo(f"ERROR Running from a git worktree ({candidate}).")
-            typer.echo("      Run t3 setup from the main clone instead.")
-        else:
-            typer.echo("ERROR Teatree main clone not found.")
-            typer.echo("      Set T3_REPO env var or install teatree in editable mode.")
-            typer.echo("      Consumers without a local clone: use `apm install -g souliane/teatree`.")
+        typer.echo("ERROR Teatree main clone not found.")
+        typer.echo("      Set T3_REPO env var or install teatree in editable mode.")
+        typer.echo("      Consumers without a local clone: use `apm install -g souliane/teatree`.")
         raise typer.Exit(code=1)
 
     if not (repo / "apm.yml").is_file():
@@ -301,9 +311,10 @@ def run(
     """Install and configure teatree skills globally.
 
     Runs APM dependency install, syncs skill symlinks, and registers the
-    t3 plugin with Claude Code.  Must be run from the teatree main clone
-    (not a worktree).  Consumers without a local clone can bootstrap via
-    ``apm install -g souliane/teatree``.
+    t3 plugin with Claude Code.  Safe to run from a teatree worktree — the
+    main clone is resolved via the worktree's ``.git`` file so the global
+    install stays anchored to a stable path.  Consumers without a local
+    clone can bootstrap via ``apm install -g souliane/teatree``.
     """
     repo = _validate_repo(_find_main_clone())
     typer.echo(f"Teatree repo: {repo}")

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -1,6 +1,7 @@
 """Tests for t3 setup — global skill installation command."""
 
 import json
+import shutil
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -23,6 +24,18 @@ from teatree.cli.setup import (
     _validate_repo,
 )
 
+GIT_BIN = shutil.which("git") or "git"
+
+
+def _init_git_repo(path: Path) -> None:
+    """Initialize a minimal git repo with an empty commit so `git worktree add` works."""
+    import subprocess  # noqa: PLC0415
+
+    path.mkdir(parents=True, exist_ok=True)
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run([GIT_BIN, "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run([GIT_BIN, "commit", "-q", "--allow-empty", "-m", "init"], cwd=path, check=True, env=env)
+
 
 class TestFindMainClone:
     def test_returns_none_when_no_repo(self) -> None:
@@ -30,13 +43,20 @@ class TestFindMainClone:
             mock_svc.find_teatree_repo.return_value = None
             assert _find_main_clone() is None
 
-    def test_returns_none_when_worktree(self, tmp_path: Path) -> None:
-        repo = tmp_path / "teatree"
-        repo.mkdir()
-        (repo / ".git").write_text("gitdir: /some/other/path\n")
+    def test_resolves_worktree_to_main_clone(self, tmp_path: Path) -> None:
+        import subprocess  # noqa: PLC0415
+
+        main_clone = tmp_path / "teatree"
+        _init_git_repo(main_clone)
+        worktree = tmp_path / "wt"
+        subprocess.run(
+            [GIT_BIN, "worktree", "add", "-q", "-b", "feature", str(worktree)],
+            cwd=main_clone,
+            check=True,
+        )
         with patch("teatree.cli.setup.DoctorService") as mock_svc:
-            mock_svc.find_teatree_repo.return_value = repo
-            assert _find_main_clone() is None
+            mock_svc.find_teatree_repo.return_value = worktree
+            assert _find_main_clone() == main_clone
 
     def test_returns_repo_when_main_clone(self, tmp_path: Path) -> None:
         repo = tmp_path / "teatree"
@@ -46,6 +66,14 @@ class TestFindMainClone:
             mock_svc.find_teatree_repo.return_value = repo
             result = _find_main_clone()
             assert result == repo
+
+    def test_returns_none_when_git_file_unparseable(self, tmp_path: Path) -> None:
+        repo = tmp_path / "teatree"
+        repo.mkdir()
+        (repo / ".git").write_text("not a gitdir line\n")
+        with patch("teatree.cli.setup.DoctorService") as mock_svc:
+            mock_svc.find_teatree_repo.return_value = repo
+            assert _find_main_clone() is None
 
 
 class TestRunApmInstall:
@@ -569,15 +597,6 @@ class TestValidateRepo:
     def test_exits_when_no_repo(self) -> None:
         with patch("teatree.cli.setup.DoctorService") as mock_svc:
             mock_svc.find_teatree_repo.return_value = None
-            with pytest.raises(click.exceptions.Exit):
-                _validate_repo(None)
-
-    def test_exits_when_worktree(self, tmp_path: Path) -> None:
-        repo = tmp_path / "teatree"
-        repo.mkdir()
-        (repo / ".git").write_text("gitdir: /other\n")
-        with patch("teatree.cli.setup.DoctorService") as mock_svc:
-            mock_svc.find_teatree_repo.return_value = repo
             with pytest.raises(click.exceptions.Exit):
                 _validate_repo(None)
 


### PR DESCRIPTION
fix(setup): resolve worktree to main clone in _find_main_clone [none] (https://github.com/souliane/teatree/issues/430)

## Problem

Since [#397](https://github.com/souliane/teatree/pull/397) changed `DoctorService.find_teatree_repo()` to prefer the cwd-resolved teatree repo (so dogfood worktrees pick up their own editable install), `t3 setup` from a worktree has failed:

```
$ cd ~/workspace/souliane/tickets/<any-worktree>
$ t3 setup
ERROR Running from a git worktree (...).
      Run t3 setup from the main clone instead.
```

The two helpers contradicted each other — `find_teatree_repo()` preferred worktrees; `_find_main_clone()` hard-rejected them — so `_validate_repo()` always raised.

## Fix

`_find_main_clone()` now resolves a worktree candidate to its main clone by parsing the worktree's `.git` file (`gitdir: .../<main-clone>/.git/worktrees/<name>`) and stepping back up to the main-clone directory. Setup targets — `uv tool install --editable` and the Claude marketplace registration — still anchor to the stable main-clone path.

`_validate_repo()` loses its now-dead worktree branch in the same change.

## Scope matrix

- ✅ Worktree cwd → resolves to main clone (verified via tmp_path real-git integration test + live dogfood from this worktree)
- ✅ Main clone cwd → unchanged passthrough
- ✅ Unparseable `.git` file → returns `None` (covered by new edge-case test)
- ✅ No teatree repo found → unchanged error path

Fixes [#430](https://github.com/souliane/teatree/issues/430).

## Test plan

- [x] `uv run pytest tests/test_cli_setup.py -q` — 53 passed
- [x] Full suite — 2377 passed
- [x] `uv run ruff check src/teatree/cli/setup.py tests/test_cli_setup.py` — clean
- [x] `uv run ty check src/teatree/cli/setup.py` — clean
- [x] Live dogfood from this worktree cwd: `_find_main_clone()` → `/Users/adrien/workspace/souliane/teatree`; `_validate_repo()` passes