### PR TITLE
relax(tasks): run interactive tasks inline from the terminal [none]

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1571,6 +1571,8 @@ Usage: t3 teatree tasks [OPTIONS] COMMAND [ARGS]...
 │ claim                 Claim the next available task.                         │
 │ cancel                Cancel a task by ID.                                   │
 │ list                  List tasks with optional filters.                      │
+│ start                 Claim and run the next interactive task in the current │
+│                       terminal.                                              │
 │ work-next-sdk         Claim and execute an headless task.                    │
 │ work-next-user-input  Claim and execute a user input task.                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -1611,6 +1613,25 @@ Usage: t3 teatree tasks list [OPTIONS]
 │ --status                  TEXT  Filter by status                             │
 │ --execution-target        TEXT  Filter by execution target                   │
 │ --help                          Show this message and exit.                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree tasks start`
+
+```
+Usage: t3 teatree tasks start [OPTIONS] [TASK_ID]
+
+ Claim an interactive task and exec ``claude`` in the current terminal.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│   task_id      [TASK_ID]  Task ID; omit to start the next pending            │
+│                           interactive task.                                  │
+│                           [default: 0]                                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --claimed-by        TEXT  Worker identifier stored on the claim.             │
+│                           [default: cli]                                     │
+│ --help                    Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/agents/web_terminal.py
+++ b/src/teatree/agents/web_terminal.py
@@ -18,10 +18,31 @@ from teatree.types import SkillMetadata
 logger = logging.getLogger(__name__)
 
 
+def build_interactive_command(task: Task, *, overlay_skill_metadata: SkillMetadata) -> list[str]:
+    """Build the ``claude`` argv for an interactive task.
+
+    Resumes the prior session when the task carries a Claude session UUID,
+    otherwise starts a fresh session with the interactive system context
+    pre-loaded via ``--append-system-prompt``.
+    """
+    claude_bin = shutil.which("claude")
+    if claude_bin is None:
+        msg = "claude CLI is not installed"
+        raise FileNotFoundError(msg)
+
+    resume_session_id = get_resume_session_id(task)
+    if resume_session_id:
+        logger.info("Resuming headless session %s for task %s", resume_session_id, task.pk)
+        return [claude_bin, "--resume", resume_session_id]
+
+    skills = resolve_skill_bundle(phase=task.phase, overlay_skill_metadata=overlay_skill_metadata)
+    system_context = build_interactive_context(task, skills=skills)
+    return [claude_bin, "--append-system-prompt", system_context]
+
+
 def launch_web_session(
     task: Task,
     *,
-    phase: str,
     overlay_skill_metadata: SkillMetadata,
     terminal_mode: str = "",
     terminal_app: str = "",
@@ -31,22 +52,7 @@ def launch_web_session(
     Returns a TaskAttempt with ``launch_url`` set for browser-based modes,
     or empty for native terminal modes.
     """
-    skills = resolve_skill_bundle(phase=phase, overlay_skill_metadata=overlay_skill_metadata)
-
-    claude_bin = shutil.which("claude")
-    if claude_bin is None:
-        msg = "claude CLI is not installed"
-        raise FileNotFoundError(msg)
-
-    resume_session_id = _get_resume_session_id(task)
-
-    if resume_session_id:
-        agent_command = [claude_bin, "--resume", resume_session_id]
-        logger.info("Resuming headless session %s for task %s", resume_session_id, task.pk)
-    else:
-        system_context = build_interactive_context(task, skills=skills)
-        agent_command = [claude_bin, "--append-system-prompt", system_context]
-
+    agent_command = build_interactive_command(task, overlay_skill_metadata=overlay_skill_metadata)
     mode = terminal_mode or get_terminal_mode()
     result = terminal_launch(agent_command, mode=mode, app=terminal_app)
 
@@ -57,7 +63,7 @@ def launch_web_session(
     )
 
 
-def _get_resume_session_id(task: Task) -> str:
+def get_resume_session_id(task: Task) -> str:
     """Return the Claude session ID to resume, if available.
 
     The session_id is stored on the Session's agent_id when the interactive

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -87,6 +87,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("claim", "Claim the next available task."),
             ("cancel", "Cancel a task by ID."),
             ("list", "List tasks with optional filters."),
+            ("start", "Claim and run the next interactive task in the current terminal."),
             ("work-next-sdk", "Claim and execute an headless task."),
             ("work-next-user-input", "Claim and execute a user input task."),
         ],

--- a/src/teatree/core/management/commands/tasks.py
+++ b/src/teatree/core/management/commands/tasks.py
@@ -1,9 +1,23 @@
-from typing import Annotated
+import os
+import pathlib
+from typing import IO, Annotated, TypedDict, cast
 
 import typer
 from django_typer.management import TyperCommand, command
+from rich.console import Console
+from rich.table import Table
 
-from teatree.core.models import Task
+from teatree.core.models import InvalidTransitionError, Task, TaskAttempt
+
+
+class TaskRow(TypedDict):
+    task_id: int
+    ticket_id: int
+    status: str
+    execution_target: str
+    phase: str
+    execution_reason: str
+    claimed_by: str
 
 
 class Command(TyperCommand):
@@ -34,26 +48,25 @@ class Command(TyperCommand):
         self,
         status: Annotated[str | None, typer.Option(help="Filter by status")] = None,
         execution_target: Annotated[str | None, typer.Option(help="Filter by execution target")] = None,
-    ) -> list[dict[str, object]]:
+    ) -> list[TaskRow]:
         qs = Task.objects.all().order_by("pk")
         if status:
             qs = qs.filter(status=status)
         if execution_target:
             qs = qs.filter(execution_target=execution_target)
-        rows: list[dict[str, object]] = [
-            {
-                "task_id": task.pk,
-                "ticket_id": task.ticket_id,
-                "status": task.status,
-                "execution_target": task.execution_target,
-                "phase": task.phase,
-                "execution_reason": task.execution_reason,
-                "claimed_by": task.claimed_by,
-            }
+        rows: list[TaskRow] = [
+            TaskRow(
+                task_id=task.pk,
+                ticket_id=task.ticket_id,
+                status=task.status,
+                execution_target=task.execution_target,
+                phase=task.phase,
+                execution_reason=task.execution_reason,
+                claimed_by=task.claimed_by,
+            )
             for task in qs
         ]
-        for row in rows:
-            self.stdout.write(str(row))
+        _render_tasks_table(rows, stream=cast("IO[str]", self.stdout))
         return rows
 
     @command()
@@ -74,6 +87,45 @@ class Command(TyperCommand):
         if task is None:
             return None
         return self._execute_runtime(task)
+
+    @command()
+    def start(
+        self,
+        task_id: Annotated[int, typer.Argument(help="Task ID; omit to start the next pending interactive task.")] = 0,
+        claimed_by: Annotated[str, typer.Option(help="Worker identifier stored on the claim.")] = "cli",
+    ) -> None:
+        """Claim an interactive task and exec ``claude`` in the current terminal."""
+        task = self._resolve_interactive_task(task_id=task_id, claimed_by=claimed_by)
+        if task is None:
+            self.stdout.write("No interactive tasks pending.")
+            return
+
+        command_argv = _build_claude_command(task)
+        TaskAttempt.objects.create(task=task, execution_target=task.execution_target, launch_url="")
+
+        self.stdout.write(f"Starting task {task.pk} (ticket {task.ticket.ticket_number}) in the current terminal…")
+        _exec_inline(command_argv)
+
+    def _resolve_interactive_task(self, *, task_id: int, claimed_by: str) -> Task | None:
+        if task_id:
+            try:
+                task = Task.objects.get(pk=task_id)
+            except Task.DoesNotExist:
+                self.stderr.write(f"Task {task_id} not found.")
+                raise SystemExit(1) from None
+
+            if task.execution_target != Task.ExecutionTarget.INTERACTIVE:
+                self.stderr.write(f"Task {task_id} is not an interactive task.")
+                raise SystemExit(1)
+
+            try:
+                task.claim(claimed_by=claimed_by)
+            except InvalidTransitionError as exc:
+                self.stderr.write(f"Cannot claim task {task_id}: {exc}")
+                raise SystemExit(1) from None
+            return task
+
+        return self._claim_next_task(execution_target=Task.ExecutionTarget.INTERACTIVE, claimed_by=claimed_by)
 
     def _claim_next_task(self, *, execution_target: str, claimed_by: str) -> Task | None:
         if execution_target == Task.ExecutionTarget.INTERACTIVE:
@@ -107,7 +159,64 @@ class Command(TyperCommand):
 
         attempt = launch_web_session(
             task,
-            phase=task.phase,
             overlay_skill_metadata=get_overlay().metadata.get_skill_metadata(),
         )
         return {"launch_url": attempt.launch_url, "attempt_id": str(attempt.pk)}
+
+
+_STATUS_STYLES: dict[str, str] = {
+    "pending": "yellow",
+    "claimed": "cyan",
+    "completed": "green",
+    "failed": "red",
+}
+
+
+def _render_tasks_table(rows: list[TaskRow], *, stream: IO[str] | None = None) -> None:
+    console = Console(file=stream) if stream is not None else Console()
+    if not rows:
+        console.print("[dim]No tasks.[/dim]")
+        return
+
+    table = Table(title=f"Tasks ({len(rows)})", show_lines=False)
+    table.add_column("ID", justify="right", style="bold")
+    table.add_column("Ticket", justify="right")
+    table.add_column("Status")
+    table.add_column("Target")
+    table.add_column("Phase")
+    table.add_column("Claimed by")
+    table.add_column("Reason", overflow="fold", max_width=60)
+
+    for row in rows:
+        status = row["status"]
+        style = _STATUS_STYLES.get(status, "")
+        table.add_row(
+            str(row["task_id"]),
+            str(row["ticket_id"]),
+            f"[{style}]{status}[/]" if style else status,
+            row["execution_target"],
+            row["phase"] or "-",
+            row["claimed_by"] or "-",
+            row["execution_reason"] or "-",
+        )
+
+    console.print(table)
+
+
+def _build_claude_command(task: Task) -> list[str]:
+    from teatree.agents.web_terminal import build_interactive_command  # noqa: PLC0415
+    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+
+    return build_interactive_command(
+        task,
+        overlay_skill_metadata=get_overlay().metadata.get_skill_metadata(),
+    )
+
+
+def _exec_inline(argv: list[str]) -> None:
+    from teatree.utils.run import run_streamed  # noqa: PLC0415
+
+    orig_cwd = os.environ.get("T3_ORIG_CWD", "")
+    cwd = orig_cwd if orig_cwd and pathlib.Path(orig_cwd).is_dir() else None
+    rc = run_streamed(argv, cwd=cwd, check=False)
+    raise SystemExit(rc)

--- a/src/teatree/core/views/launch.py
+++ b/src/teatree/core/views/launch.py
@@ -52,7 +52,6 @@ def launch_interactive_task(
 
     attempt = launch_web_session(
         task,
-        phase=task.phase,
         overlay_skill_metadata=skill_metadata,
         terminal_mode=terminal_mode,
         terminal_app=terminal_app,

--- a/tests/teatree_agents/test_web_terminal.py
+++ b/tests/teatree_agents/test_web_terminal.py
@@ -9,7 +9,7 @@ import teatree.agents.terminal_launcher as terminal_launcher_mod
 import teatree.agents.web_terminal as web_terminal_mod
 import teatree.utils.run as utils_run_mod
 from teatree.agents.web_terminal import (
-    _get_resume_session_id,
+    get_resume_session_id,
     launch_web_session,
 )
 from teatree.core.models import Session, Task, TaskAttempt, Ticket
@@ -24,7 +24,7 @@ def test_find_free_port_returns_int() -> None:
     assert port > 0
 
 
-# --- _get_resume_session_id ---
+# --- get_resume_session_id ---
 
 
 class TestGetResumeSessionId(TestCase):
@@ -39,19 +39,19 @@ class TestGetResumeSessionId(TestCase):
         )
         task = Task.objects.create(ticket=self.ticket, session=session)
 
-        assert _get_resume_session_id(task) == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        assert get_resume_session_id(task) == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
     def test_non_uuid_agent_id(self) -> None:
         session = Session.objects.create(ticket=self.ticket, agent_id="not-a-uuid")
         task = Task.objects.create(ticket=self.ticket, session=session)
 
-        assert _get_resume_session_id(task) == ""
+        assert get_resume_session_id(task) == ""
 
     def test_empty_agent_id(self) -> None:
         session = Session.objects.create(ticket=self.ticket, agent_id="")
         task = Task.objects.create(ticket=self.ticket, session=session)
 
-        assert _get_resume_session_id(task) == ""
+        assert get_resume_session_id(task) == ""
 
 
 # --- launch_web_session ---
@@ -71,7 +71,7 @@ class TestLaunchWebSession(TestCase):
             session = Session.objects.create(ticket=self.ticket)
             task = Task.objects.create(ticket=self.ticket, session=session)
 
-            attempt = launch_web_session(task, phase="coding", overlay_skill_metadata={})
+            attempt = launch_web_session(task, overlay_skill_metadata={})
 
             assert attempt.launch_url == "http://127.0.0.1:8888"
             assert TaskAttempt.objects.count() == 1
@@ -85,7 +85,7 @@ class TestLaunchWebSession(TestCase):
             task = Task.objects.create(ticket=self.ticket, session=session)
 
             with pytest.raises(FileNotFoundError, match="claude CLI is not installed"):
-                launch_web_session(task, phase="coding", overlay_skill_metadata={})
+                launch_web_session(task, overlay_skill_metadata={})
 
     def test_returns_empty_url_when_ttyd_missing(self) -> None:
         def which_mock(name: str) -> str | None:
@@ -97,7 +97,7 @@ class TestLaunchWebSession(TestCase):
             session = Session.objects.create(ticket=self.ticket)
             task = Task.objects.create(ticket=self.ticket, session=session)
 
-            attempt = launch_web_session(task, phase="coding", overlay_skill_metadata={})
+            attempt = launch_web_session(task, overlay_skill_metadata={})
 
             assert attempt.launch_url == ""
             assert TaskAttempt.objects.count() == 1
@@ -114,7 +114,7 @@ class TestLaunchWebSession(TestCase):
             )
             task = Task.objects.create(ticket=self.ticket, session=session)
 
-            attempt = launch_web_session(task, phase="coding", overlay_skill_metadata={})
+            attempt = launch_web_session(task, overlay_skill_metadata={})
 
             assert attempt.launch_url == "http://127.0.0.1:7777"
 
@@ -133,7 +133,7 @@ class TestLaunchWebSession(TestCase):
             session = Session.objects.create(ticket=self.ticket, agent_id="not-a-uuid")
             task = Task.objects.create(ticket=self.ticket, session=session)
 
-            launch_web_session(task, phase="coding", overlay_skill_metadata={})
+            launch_web_session(task, overlay_skill_metadata={})
 
             call_args = popen_mock.call_args[0][0]
             assert "--append-system-prompt" in call_args

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -1,5 +1,6 @@
 import tempfile
 from collections.abc import Iterator
+from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -529,3 +530,146 @@ class TestTasksListCommand(TestCase):
         )
         assert len(result) == 1
         assert result[0]["execution_target"] == "interactive"
+
+    def test_render_tasks_table_formats_rows(self) -> None:
+        from io import StringIO  # noqa: PLC0415
+
+        from teatree.core.management.commands.tasks import TaskRow, _render_tasks_table  # noqa: PLC0415
+
+        rows: list[TaskRow] = [
+            TaskRow(
+                task_id=7,
+                ticket_id=42,
+                status="pending",
+                execution_target="interactive",
+                phase="coding",
+                execution_reason="resume after user input",
+                claimed_by="",
+            )
+        ]
+        buf = StringIO()
+        _render_tasks_table(rows, stream=buf)
+        out = buf.getvalue()
+        assert "Tasks (1)" in out
+        assert "ID" in out
+        assert "Ticket" in out
+        assert "Phase" in out
+        assert "interactive" in out
+        assert "coding" in out
+        assert "resume after" in out
+
+    def test_render_tasks_table_handles_empty(self) -> None:
+        from io import StringIO  # noqa: PLC0415
+
+        from teatree.core.management.commands.tasks import _render_tasks_table  # noqa: PLC0415
+
+        buf = StringIO()
+        _render_tasks_table([], stream=buf)
+        assert "No tasks" in buf.getvalue()
+
+
+class TestTasksStartCommand(TestCase):
+    """Tests for the tasks start subcommand (inline interactive launch)."""
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/99")
+        self.session = Session.objects.create(ticket=self.ticket, overlay="test", agent_id="agent-1")
+
+    @staticmethod
+    def _patch_env(run_mock: MagicMock) -> list[AbstractContextManager[object]]:
+        return [
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(web_terminal_mod.shutil, "which", return_value="/usr/bin/claude"),
+            patch("teatree.utils.run.run_streamed", new=run_mock),
+        ]
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_start_claims_next_interactive_task_and_runs_claude(self) -> None:
+        Task.objects.create(
+            ticket=self.ticket,
+            session=self.session,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+        )
+        user_task = Task.objects.create(
+            ticket=self.ticket,
+            session=self.session,
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+            phase="coding",
+        )
+
+        run_mock = MagicMock(return_value=0)
+        p1, p2, p3 = self._patch_env(run_mock)
+        with p1, p2, p3, pytest.raises(SystemExit) as exc:
+            call_command("tasks", "start")
+
+        assert exc.value.code == 0
+        run_mock.assert_called_once()
+        argv = run_mock.call_args[0][0]
+        assert argv[0] == "/usr/bin/claude"
+        assert "--append-system-prompt" in argv
+
+        user_task.refresh_from_db()
+        assert user_task.status == Task.Status.CLAIMED
+        assert user_task.claimed_by == "cli"
+        assert TaskAttempt.objects.filter(task=user_task, launch_url="").count() == 1
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_start_with_task_id_claims_specific_task(self) -> None:
+        task = Task.objects.create(
+            ticket=self.ticket,
+            session=self.session,
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+        )
+
+        run_mock = MagicMock(return_value=0)
+        p1, p2, p3 = self._patch_env(run_mock)
+        with p1, p2, p3, pytest.raises(SystemExit):
+            call_command("tasks", "start", task.pk)
+
+        run_mock.assert_called_once()
+        task.refresh_from_db()
+        assert task.status == Task.Status.CLAIMED
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_start_with_no_pending_tasks_skips_run(self) -> None:
+        run_mock = MagicMock(return_value=0)
+        p1, p2, p3 = self._patch_env(run_mock)
+        with p1, p2, p3:
+            call_command("tasks", "start")
+        run_mock.assert_not_called()
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_start_rejects_headless_task_id(self) -> None:
+        task = Task.objects.create(
+            ticket=self.ticket,
+            session=self.session,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+        )
+
+        run_mock = MagicMock(return_value=0)
+        p1, p2, p3 = self._patch_env(run_mock)
+        with p1, p2, p3, pytest.raises(SystemExit):
+            call_command("tasks", "start", task.pk)
+
+        run_mock.assert_not_called()
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_start_resumes_when_session_has_claude_uuid(self) -> None:
+        uuid = "01234567-89ab-cdef-0123-456789abcdef"
+        session = Session.objects.create(ticket=self.ticket, overlay="test", agent_id=uuid)
+        Task.objects.create(
+            ticket=self.ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+        )
+
+        run_mock = MagicMock(return_value=0)
+        p1, p2, p3 = self._patch_env(run_mock)
+        with p1, p2, p3, pytest.raises(SystemExit):
+            call_command("tasks", "start")
+
+        argv = run_mock.call_args[0][0]
+        assert "--resume" in argv
+        assert uuid in argv


### PR DESCRIPTION
Add `t3 <overlay> tasks start [TASK_ID]`: claims the next pending interactive task (or a specific ID) and runs `claude` inline in the current shell, mirroring the dashboard's launch flow without ttyd or a new window.

Extract `build_interactive_command` and `get_resume_session_id` as public helpers on `web_terminal` so both the dashboard launch view and the new CLI share the same claude argv construction. Drops the unused `phase` kwarg from `launch_web_session` (task carries it already).

Also render `tasks list` as a rich table instead of dumping one dict per line.

The new in-function imports follow the file's existing lazy-import baseline (`# noqa: PLC0415`), which avoids pulling web_terminal, overlay_loader, and run_streamed at Django command registration time.