### PR TITLE
feat(tasks,next): add `tasks create` CLI + auto-enqueue on phase handoff

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -631,6 +631,7 @@ Implementations: `GitHubSyncBackend` (`backends/github_sync.py`), `GitLabSyncBac
 
 **tasks** — Task routing and execution:
 
+- `create(ticket, phase, reason | reason-file, interactive=False)` → enqueues the next-phase task (used by `/t3:next` for phase handoff; headless by default so a worker claims immediately)
 - `claim(execution_target, claimed_by, lease_seconds=120)` → claims next pending task
 - `work-next-sdk(claimed_by)` → executes headless task via `claude -p`
 - `work-next-user-input(claimed_by)` → creates interactive ttyd session

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -23,9 +23,37 @@ Run this before ending any session. It captures lessons, reports what happened, 
 
 Load `/t3:retro` and execute it. This captures lessons while the full session context is still available. Do NOT skip this — it compounds learning.
 
-### 2. Emit Structured Result
+### 2. Auto-Enqueue the Next-Phase Task
 
-Output a JSON block on the **last line** of the session:
+**When:** the current task is an interactive phase task (`scoping`, `coding`, `testing`, `reviewing`, `shipping`) with a clear outcome that does **not** require further user input. Skip when the user hasn't confirmed the outcome, or when you'll set `needs_user_input: true` below.
+
+**Why:** the `next_steps` JSON field is descriptive — the pipeline does NOT parse it to create follow-up tasks. Interactive task completion does NOT record a `TaskAttempt`, so `_advance_ticket()` never fires and the ticket is orphaned. The next pending task the worker picks up will be for a different ticket, and the just-completed phase stalls.
+
+**What to do:** enqueue the next-phase Task as `HEADLESS` (so a worker claims it immediately) via Django shell. The `execution_reason` body is the prompt the headless worker will see — include the locked decision from this session and the concrete implementation task list.
+
+```bash
+cd "$T3_REPO" && PYENV_VERSION=3.13.11 uv run python manage.py shell -c "
+from teatree.core.models import Ticket, Task, Session
+t = Ticket.objects.get(pk=<TICKET_PK>)
+sess = Session.objects.filter(ticket=t).order_by('-pk').first() or Session.objects.create(ticket=t, agent_id='phase-handoff')
+reason = '''<decision summary + numbered implementation tasks>'''
+task = Task.objects.create(
+    ticket=t, session=sess,
+    phase='<next phase>',
+    execution_target=Task.ExecutionTarget.HEADLESS,
+    execution_reason=reason,
+)
+print(task.pk, task.status)
+"
+```
+
+**Phase transitions:** `scoping → coding`, `coding → testing`, `testing → reviewing`, `reviewing → shipping`.
+
+**Gotcha:** `Ticket.objects.get(pk=N)` takes the teatree **ticket PK** (visible as `ticket_id` in `t3 <overlay> tasks list`), NOT the external issue number. Confirm via `ticket.issue_url` before creating the task.
+
+### 3. Emit Structured Result
+
+Output a JSON block on the **last line** of the session. **When step 2 enqueued a next-phase task, include its `task_id` in `next_steps`** so the user can trace the handoff.
 
 ```json
 {
@@ -39,7 +67,7 @@ Output a JSON block on the **last line** of the session:
 
 Set `needs_user_input: true` if the next step requires human judgment. The system will create a new interactive task for it.
 
-### 3. Display Summary
+### 4. Display Summary
 
 Before ending, show the user what happened:
 
@@ -61,4 +89,5 @@ This is non-negotiable — the user must see what `/t3:next` did.
 - Do not skip the retro to save time
 - Do not output the JSON block without running retro first
 - Do not end without displaying the summary
-- Do not manually advance the ticket state — the system does that via `_advance_ticket()`
+- Do not manually advance the ticket **state** — the FSM transitions are owned by `_advance_ticket()`. Step 2 creates the next-phase **Task** (which is different) so the headless worker has something to claim.
+- Do not skip step 2 with "the user can dispatch it from the dashboard." A session that locked a phase decision but left no follow-up Task orphans the ticket — the pipeline picks unrelated pending tasks instead.

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -29,27 +29,19 @@ Load `/t3:retro` and execute it. This captures lessons while the full session co
 
 **Why:** the `next_steps` JSON field is descriptive — the pipeline does NOT parse it to create follow-up tasks. Interactive task completion does NOT record a `TaskAttempt`, so `_advance_ticket()` never fires and the ticket is orphaned. The next pending task the worker picks up will be for a different ticket, and the just-completed phase stalls.
 
-**What to do:** enqueue the next-phase Task as `HEADLESS` (so a worker claims it immediately) via Django shell. The `execution_reason` body is the prompt the headless worker will see — include the locked decision from this session and the concrete implementation task list.
+**What to do:** use `t3 <overlay> tasks create` to enqueue the next-phase Task as `HEADLESS` (so a worker claims it immediately). The `--reason` body is the prompt the headless worker will see — include the locked decision from this session and the concrete implementation task list.
 
 ```bash
-cd "$T3_REPO" && PYENV_VERSION=3.13.11 uv run python manage.py shell -c "
-from teatree.core.models import Ticket, Task, Session
-t = Ticket.objects.get(pk=<TICKET_PK>)
-sess = Session.objects.filter(ticket=t).order_by('-pk').first() or Session.objects.create(ticket=t, agent_id='phase-handoff')
-reason = '''<decision summary + numbered implementation tasks>'''
-task = Task.objects.create(
-    ticket=t, session=sess,
-    phase='<next phase>',
-    execution_target=Task.ExecutionTarget.HEADLESS,
-    execution_reason=reason,
-)
-print(task.pk, task.status)
-"
+t3 <overlay> tasks create <TICKET_PK> \
+  --phase <next phase> \
+  --reason-file <path-to-prompt>.md
 ```
+
+For short prompts, pass `--reason "<text>"` directly. For multiline prompts, write them to a tempfile and use `--reason-file`, or pipe via `--reason -` (stdin).
 
 **Phase transitions:** `scoping → coding`, `coding → testing`, `testing → reviewing`, `reviewing → shipping`.
 
-**Gotcha:** `Ticket.objects.get(pk=N)` takes the teatree **ticket PK** (visible as `ticket_id` in `t3 <overlay> tasks list`), NOT the external issue number. Confirm via `ticket.issue_url` before creating the task.
+**Gotcha:** the `<TICKET_PK>` argument takes the teatree **ticket PK** (visible as `ticket_id` in `t3 <overlay> tasks list`), NOT the external issue number — they differ. Confirm via the CLI output, not by guessing.
 
 ### 3. Emit Structured Result
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -163,6 +163,41 @@ Never modify skill files outside a git repo. Resolve real path with `readlink -f
 
 When a teatree or skill infrastructure bug is discovered during any task, fix it immediately as first priority. Never defer to focus on the user's task — broken infrastructure causes cascading failures.
 
+## Do Work Now, Don't Defer to "Later" Tickets (Non-Negotiable)
+
+When the user asks for work that is actionable in the current session — a small skill edit, a one-file CLI addition, a test fix, a rule promotion — **do it in the current response**. Do not propose filing a ticket for "later", do not frame the work as a follow-up suggestion, do not ask for confirmation to proceed on obviously in-scope work. Deferring concrete work to a ticket queue is the single most common way an agent wastes the user's time — the ticket piles up, context evaporates, and work that could have shipped in the same PR now takes a fresh session.
+
+**Banned patterns when the work is actionable in this turn:**
+
+- "I'd suggest filing a ticket to…"
+- "Follow-up (not in this PR)…"
+- "Want me to open an issue for …?"
+- "As a separate ticket, we should …"
+- "File tickets for (a) and (b), or one combined…?"
+
+**When deferral IS legitimate** (narrow set):
+
+- The user explicitly asked for planning only, not execution.
+- The work requires an external dependency that is unavailable right now (missing auth, missing approval from a third party, missing DB snapshot).
+- The work would genuinely balloon this change into scope creep — and even then, ask the user directly, don't announce a ticket.
+
+**When in doubt, do the work.** A tiny PR adding the fix alongside the main change is always preferable to a stand-alone ticket that lives in the backlog for weeks.
+
+## Contribute Mode: Promote Findings to Skills, Not Personal Memory (Non-Negotiable)
+
+When `contribute = true` in `~/.teatree.toml`, retro findings and cross-cutting rules **must land in teatree skill files**, not in the agent's personal memory/config. Personal memory is the fallback for user-specific facts — paths, credentials, editor preferences, one-machine workflow choices. For anything that would help another user of these skills, write to the skill.
+
+**Before writing a feedback/guardrail to personal memory, check:**
+
+1. `contribute = true` in `~/.teatree.toml`? → yes almost always makes this a skill edit.
+2. Does the rule encode a guardrail, pattern, or "do this not that"? → skill.
+3. Would another user benefit? → skill.
+4. Is it a user preference (tone, formatting) or environment fact (path, credential)? → personal memory is legitimate.
+
+**Promote means edit an existing skill.** Pick the best-fit existing skill (`/t3:rules`, `/t3:next`, `/t3:ship`, etc.) and insert the rule there. Do not invent a new skill for a single rule — that fragments the skill graph.
+
+**Past failure (2026-04-24):** Retro saved a scoping-phase auto-enqueue rule to `~/.claude/.../memory/feedback_scoping_auto_enqueue_coding.md` when `contribute = true` and the correct home was `skills/next/SKILL.md`. The user had to explicitly call out the deferral and push for the promotion. Prevention: this checklist.
+
 ## Ask About Auth Before External Service Integrations
 
 When implementing features that require an external service (Notion, Slack, CI, etc.), ask "how do you authenticate with this service?" BEFORE writing any code. The answer (direct API token, CLI auth, MCP tool, OAuth, etc.) determines the entire architecture. Skipping this question leads to multiple implementation pivots.

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -99,6 +99,12 @@ Teatree's CLI groups (`t3 <overlay> <group> <sub>`) are django-typer `TyperComma
 
 **Known failure (2026-04-22):** `e2e` management command returned `"E2E failed (exit 1)."` as a string instead of raising. CI jobs running `t3 teatree e2e *` reported success on Playwright/pytest failures. Fixed in [#370](https://github.com/souliane/teatree/pull/370) by raising `SystemExit(result.returncode)` after `self.stderr.write(...)`.
 
+### Annotated typer options must have defaults for `call_command`
+
+`Annotated[str, typer.Option(help="...")]` parameters without a default value make the command unusable via Django's `call_command` — it raises `Missing parameter: <name>` even when the caller passes the kwarg. Give every `typer.Option`-annotated parameter a default (e.g. `= ""`) and validate at runtime (`if not phase.strip(): raise SystemExit(1)`). This keeps both CLI and `call_command` call sites happy.
+
+Canonical example: `src/teatree/core/management/commands/tasks.py` `create` subcommand — `phase: Annotated[str, typer.Option(...)] = ""` + runtime non-blank check.
+
 ## Configuration
 
 `~/.teatree` sourced by hooks:

--- a/src/teatree/core/management/commands/tasks.py
+++ b/src/teatree/core/management/commands/tasks.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import sys
 from typing import IO, Annotated, TypedDict, cast
 
 import typer
@@ -7,7 +8,7 @@ from django_typer.management import TyperCommand, command
 from rich.console import Console
 from rich.table import Table
 
-from teatree.core.models import InvalidTransitionError, Task, TaskAttempt
+from teatree.core.models import InvalidTransitionError, Session, Task, TaskAttempt, Ticket
 
 
 class TaskRow(TypedDict):
@@ -21,6 +22,64 @@ class TaskRow(TypedDict):
 
 
 class Command(TyperCommand):
+    @command()
+    def create(
+        self,
+        ticket: Annotated[int, typer.Argument(help="Ticket PK (see `ticket_id` in `tasks list`).")],
+        *,
+        phase: Annotated[
+            str,
+            typer.Option(help="Phase: scoping, coding, testing, reviewing, shipping."),
+        ] = "",
+        reason: Annotated[
+            str,
+            typer.Option(help="Prompt body for the worker. Use '-' to read from stdin. Overrides --reason-file."),
+        ] = "",
+        reason_file: Annotated[
+            pathlib.Path | None,
+            typer.Option(help="Read the prompt body from a file."),
+        ] = None,
+        interactive: Annotated[
+            bool,
+            typer.Option(help="Create an interactive task instead of the default headless one."),
+        ] = False,
+    ) -> dict[str, int | str]:
+        """Enqueue the next-phase task for a ticket.
+
+        Used by `/t3:next` to hand off from one phase to the next. Headless by default so a worker
+        claims it immediately; pass `--interactive` for tasks that require human input.
+        """
+        if not phase.strip():
+            self.stderr.write("--phase is required (scoping, coding, testing, reviewing, or shipping).")
+            raise SystemExit(1)
+        body = _resolve_reason(reason=reason, reason_file=reason_file)
+        if not body.strip():
+            self.stderr.write(
+                "--reason (or --reason-file, or stdin via '--reason -') is required and must not be blank."
+            )
+            raise SystemExit(1)
+
+        try:
+            ticket_obj = Ticket.objects.get(pk=ticket)
+        except Ticket.DoesNotExist:
+            self.stderr.write(f"Ticket {ticket} not found.")
+            raise SystemExit(1) from None
+
+        session = Session.objects.filter(ticket=ticket_obj).order_by("-pk").first() or Session.objects.create(
+            ticket=ticket_obj,
+            agent_id="phase-handoff",
+        )
+        target = Task.ExecutionTarget.INTERACTIVE if interactive else Task.ExecutionTarget.HEADLESS
+        task = Task.objects.create(
+            ticket=ticket_obj,
+            session=session,
+            phase=phase,
+            execution_target=target,
+            execution_reason=body,
+        )
+        self.stdout.write(f"Created task {task.pk} (ticket {ticket_obj.pk}, phase={phase}, target={target}).")
+        return {"task_id": task.pk, "ticket_id": ticket_obj.pk, "phase": phase, "execution_target": target}
+
     @command()
     def cancel(self, task_id: int, *, confirm: bool = False) -> None:
         from django.db import transaction  # noqa: PLC0415
@@ -211,6 +270,16 @@ def _build_claude_command(task: Task) -> list[str]:
         task,
         overlay_skill_metadata=get_overlay().metadata.get_skill_metadata(),
     )
+
+
+def _resolve_reason(*, reason: str, reason_file: pathlib.Path | None) -> str:
+    if reason == "-":
+        return sys.stdin.read()
+    if reason:
+        return reason
+    if reason_file is not None:
+        return reason_file.read_text()
+    return ""
 
 
 def _exec_inline(argv: list[str]) -> None:

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -415,6 +415,70 @@ class TestTicketCommand(TestCase):
         assert result[0]["overlay"] == "alpha"
 
 
+class TestTasksCreateCommand(TestCase):
+    """Tests for the tasks create subcommand — phase handoff used by /t3:next."""
+
+    def test_create_headless_defaults(self) -> None:
+        ticket = Ticket.objects.create(overlay="test")
+        result = cast(
+            "dict[str, object]",
+            call_command("tasks", "create", ticket.pk, phase="coding", reason="Implement X."),
+        )
+        assert result["phase"] == "coding"
+        assert result["execution_target"] == Task.ExecutionTarget.HEADLESS
+        task = Task.objects.get(pk=result["task_id"])
+        assert task.ticket_id == ticket.pk
+        assert task.execution_reason == "Implement X."
+        assert task.execution_target == Task.ExecutionTarget.HEADLESS
+        assert task.session.ticket_id == ticket.pk
+
+    def test_create_reuses_latest_session(self) -> None:
+        ticket = Ticket.objects.create(overlay="test")
+        existing = Session.objects.create(ticket=ticket, overlay="test")
+        result = cast(
+            "dict[str, object]",
+            call_command("tasks", "create", ticket.pk, phase="coding", reason="x"),
+        )
+        task = Task.objects.get(pk=result["task_id"])
+        assert task.session_id == existing.pk
+
+    def test_create_interactive_flag(self) -> None:
+        ticket = Ticket.objects.create(overlay="test")
+        result = cast(
+            "dict[str, object]",
+            call_command("tasks", "create", ticket.pk, phase="scoping", reason="Decide X.", interactive=True),
+        )
+        task = Task.objects.get(pk=result["task_id"])
+        assert task.execution_target == Task.ExecutionTarget.INTERACTIVE
+
+    def test_create_reason_from_file(self) -> None:
+        ticket = Ticket.objects.create(overlay="test")
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False, encoding="utf-8") as fh:
+            fh.write("Long multiline prompt.\nWith details.")
+            reason_path = Path(fh.name)
+        self.addCleanup(reason_path.unlink)
+        result = cast(
+            "dict[str, object]",
+            call_command("tasks", "create", ticket.pk, phase="coding", reason_file=reason_path),
+        )
+        task = Task.objects.get(pk=result["task_id"])
+        assert task.execution_reason == "Long multiline prompt.\nWith details."
+
+    def test_create_requires_non_blank_reason(self) -> None:
+        ticket = Ticket.objects.create(overlay="test")
+        with pytest.raises(SystemExit):
+            call_command("tasks", "create", ticket.pk, phase="coding", reason="   ")
+
+    def test_create_requires_phase(self) -> None:
+        ticket = Ticket.objects.create(overlay="test")
+        with pytest.raises(SystemExit):
+            call_command("tasks", "create", ticket.pk, reason="x")
+
+    def test_create_nonexistent_ticket(self) -> None:
+        with pytest.raises(SystemExit):
+            call_command("tasks", "create", 99999, phase="coding", reason="x")
+
+
 class TestTasksCancelCommand(TestCase):
     """Tests for the tasks cancel subcommand."""
 


### PR DESCRIPTION
## Summary

- New CLI subcommand `t3 <overlay> tasks create <TICKET_PK> --phase <phase> --reason-file <path>` replaces the Django shell one-liner for phase handoff. Headless by default so a worker claims immediately; `--interactive` for human-input tasks; `--reason -` reads stdin.
- `/t3:next` skill now uses the CLI in its required "Auto-Enqueue the Next-Phase Task" step.
- Two new Non-Negotiable rules in `skills/rules/SKILL.md`:
  1. **Do Work Now, Don't Defer to 'Later' Tickets** — ban suggesting follow-up tickets in place of implementing the obvious next step.
  2. **Contribute Mode: Promote Findings to Skills, Not Personal Memory** — when `T3_CONTRIBUTE=true`, edit the canonical skill file instead of writing to personal memory.
- `BLUEPRINT.md` updated to list the new `tasks create` command.

## Why this matters

Discovered during scoping of #115 — the session locked a decision, emitted `/t3:next` JSON, and the ticket stalled. Interactive phase tasks don't record a `TaskAttempt`, so `_advance_ticket()` never fires and the worker picks unrelated pending tasks. The rule + CLI now make the next-phase handoff a first-class operation.

## Test plan

- [x] 7 new tests in `TestTasksCreateCommand` covering: headless defaults, session reuse, `--interactive`, `--reason-file`, blank-reason rejection, missing-phase rejection, nonexistent ticket (all pass).
- [x] Full `tests/teatree_core/test_management_commands.py` suite: 38 passing.
- [ ] Next scoping/coding/testing session follows the updated skill — next-phase Task appears in `t3 <overlay> tasks list` after `/t3:next`.

Relates-to https://github.com/souliane/teatree/issues/115