### PR TITLE
fix(setup): detect stale editable source and re-anchor at main clone

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "httpx>=0.27",
   "uvicorn>=0.30",
 ]
-scripts = { t3 = "teatree.cli:main" }
+scripts = { t3 = "t3_bootstrap:main" }
 
 entry-points."teatree.overlays".t3-teatree = "teatree.contrib.t3_teatree.overlay:TeatreeOverlay"
 
@@ -58,6 +58,9 @@ docs = [
 packages = [
   "src/teatree",
 ]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/t3_bootstrap.py" = "t3_bootstrap.py"
 
 [tool.ruff]
 target-version = "py313"
@@ -128,6 +131,9 @@ lint.per-file-ignores."scripts/**/*.py" = [
   "S603",
   "S607",    # subprocess security (trusted internal calls)
   "T201",    # print (CLI output)
+]
+lint.per-file-ignores."src/t3_bootstrap.py" = [
+  "PLC0415", # import-outside-top-level — the bootstrap's whole point is to import teatree AFTER sys.path manipulation.
 ]
 lint.per-file-ignores."src/teatree/cli/*.py" = [
   "B008",   # function-call-in-default-argument (typer.Option/Argument is idiomatic)

--- a/skills/workspace/references/troubleshooting.md
+++ b/skills/workspace/references/troubleshooting.md
@@ -244,3 +244,10 @@ See your [issue tracker platform reference](../../platforms/references/) § "Kno
 - **Cause:** The global uv tool install is editable-anchored at a worktree that has since been cleaned up. Check `~/.local/share/uv/tools/teatree/uv-receipt.toml` — if the `editable = "..."` path no longer exists on disk, the `teatree.pth` resolves nowhere and every import fails.
 - **Fix:** Run `t3 setup` from the main clone. Since #434, setup parses the receipt, detects the missing source, and reinstalls via `uv tool install --force --editable <main-clone>`. Safe to run from a worktree too — setup honors `T3_REPO` and resolves worktrees to their main clone.
 - **Prevention:** Avoid running `uv tool install --editable .` directly from a worktree. Go through `t3 setup` instead — it anchors at the main clone by default, so worktree cleanup can't orphan the global install.
+
+## Global `t3` Runs Main Clone Code Even From a Worktree
+
+- **Symptom (pre-#434):** Editing `src/teatree/...` inside a worktree never affected the global `t3` — you had to `uv run t3` from the worktree, or reinstall the tool editable-pointed at the worktree.
+- **Fix:** `t3` now auto-selects the teatree source at invocation time via the `t3_bootstrap` entry point. When cwd is inside a directory tree whose `pyproject.toml` names the project `teatree` and ships `src/teatree/__init__.py`, the bootstrap prepends that `src/` to `sys.path` before importing `teatree.cli`. Outside any teatree tree, it falls through to whatever the uv tool install resolved (main clone editable or PyPI libs).
+- **Verify:** `t3 info | grep teatree:` prints the path that was loaded — compare against cwd to confirm the worktree source was picked up.
+- **Caveat:** The tool's venv dependencies are shared between main clone and worktree source. If a worktree bumps a dep that isn't in the tool venv, imports fail — run `uv tool install --force --editable <main-clone>` to refresh the tool's deps, or fall back to `uv run t3` from the worktree.

--- a/skills/workspace/references/troubleshooting.md
+++ b/skills/workspace/references/troubleshooting.md
@@ -235,5 +235,12 @@ See your [issue tracker platform reference](../../platforms/references/) § "Kno
 - **Symptom:** `t3 <overlay> <cmd>` run from worktree B operates on worktree A's database/state — e.g. migrations apply to the old DB, `lifecycle status` shows the wrong ticket, or tests read stale fixtures despite being `cd`'d into the new worktree.
 - **Cause:** `uv tool install --editable <path>` pins the global `t3` binary to whatever `<path>` was at install time. The tool's venv, Django settings module, and default DB all resolve relative to that original worktree. Changing `cwd` does **not** rebind them.
 - **Fix (one-shot):** Run Django commands through the current worktree's venv instead: `uv run python manage.py <cmd>` (or `uv run t3 <overlay> <cmd>` from the worktree root). This picks up the local `.venv` and settings.
-- **Fix (persistent):** Reinstall the global tool from the worktree you want it pinned to: `uv tool install --editable /path/to/current/teatree --force`. Keep in mind the next worktree switch will hit the same trap.
+- **Fix (persistent):** Run `t3 setup` from the main clone (or with `T3_REPO` set). Setup re-anchors the global tool at the main clone and leaves intentional worktree-dogfood installs alone.
 - **Prevention:** For anything that mutates DB/fixtures/ports, prefer `uv run ...` from within the worktree. Reserve the global `t3` binary for read-only or cross-worktree commands (`t3 dashboard`, `t3 doctor`). See also § "TeaTree CLI Uses the Wrong Python Environment" for the Python-interpreter variant.
+
+## Global `t3` Fails With `ModuleNotFoundError: No module named 'teatree'`
+
+- **Symptom:** `t3 --help` (or any `t3` command) from outside the teatree main clone crashes with `ModuleNotFoundError: No module named 'teatree'`, traceback rooted at `~/.local/bin/t3`. Inside the main clone it still works because pyenv/direnv falls through to the repo-local `.venv/bin/t3`.
+- **Cause:** The global uv tool install is editable-anchored at a worktree that has since been cleaned up. Check `~/.local/share/uv/tools/teatree/uv-receipt.toml` — if the `editable = "..."` path no longer exists on disk, the `teatree.pth` resolves nowhere and every import fails.
+- **Fix:** Run `t3 setup` from the main clone. Since #434, setup parses the receipt, detects the missing source, and reinstalls via `uv tool install --force --editable <main-clone>`. Safe to run from a worktree too — setup honors `T3_REPO` and resolves worktrees to their main clone.
+- **Prevention:** Avoid running `uv tool install --editable .` directly from a worktree. Go through `t3 setup` instead — it anchors at the main clone by default, so worktree cleanup can't orphan the global install.

--- a/src/t3_bootstrap.py
+++ b/src/t3_bootstrap.py
@@ -1,0 +1,47 @@
+"""Entry-point bootstrap for the ``t3`` console script.
+
+Selects the teatree source to run against at invocation time.  When cwd is
+inside a teatree source tree (a pyproject with ``name = "teatree"`` and a
+populated ``src/teatree`` layout), prepend that worktree's ``src`` to
+``sys.path`` so dogfooding a worktree's changes via the global ``t3`` just
+works — no ``uv run`` prefix.  Otherwise fall through to whatever the
+interpreter already has on ``sys.path``: the uv-tool editable install
+(main clone) or the PyPI package when not installed editable.
+
+This module MUST NOT import anything from ``teatree`` at module scope — the
+whole point is to adjust ``sys.path`` BEFORE the ``teatree`` package is loaded.
+"""
+
+import sys
+from pathlib import Path
+
+
+def _find_teatree_source(start: Path) -> Path | None:
+    """Walk up from *start* and return ``<repo>/src`` when the repo is a teatree source tree."""
+    for parent in [start, *start.parents]:
+        pyproject = parent / "pyproject.toml"
+        if not pyproject.is_file():
+            continue
+        try:
+            content = pyproject.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if 'name = "teatree"' not in content:
+            continue
+        src = parent / "src"
+        if (src / "teatree" / "__init__.py").is_file():
+            return src
+    return None
+
+
+def main() -> None:
+    source = _find_teatree_source(Path.cwd())
+    if source is not None:
+        sys.path.insert(0, str(source))
+    from teatree.cli import main as _main
+
+    _main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -2,8 +2,10 @@
 
 import json
 import logging
+import os
 import re
 import shutil
+import tomllib
 from pathlib import Path
 
 import typer
@@ -36,11 +38,20 @@ setup_app = typer.Typer(
 def _find_main_clone() -> Path | None:
     """Find the teatree main clone, resolving worktrees to their main clone.
 
-    ``DoctorService.find_teatree_repo`` prefers a cwd-resolved teatree repo, which may
-    be a worktree.  Setup targets (``uv tool install --editable`` and Claude
-    marketplace registration) must point at a stable path, so we follow the
-    worktree's ``.git`` file to its main clone.
+    The ``T3_REPO`` env var (set in the user's ``~/.teatree`` shell config)
+    wins over cwd heuristics so that ``t3 setup`` run from a worktree still
+    targets the configured main clone.  When unset, fall back to
+    ``DoctorService.find_teatree_repo`` (cwd → ``find_project_root``); if
+    that returns a worktree, follow its ``.git`` file back to the main clone
+    so setup targets (``uv tool install --editable`` and Claude marketplace
+    registration) land on a stable path.
     """
+    env_path = os.environ.get("T3_REPO", "")
+    if env_path:
+        candidate = Path(env_path).expanduser()
+        if (candidate / "pyproject.toml").is_file() and (candidate / ".git").is_dir():
+            return candidate
+
     repo = DoctorService.find_teatree_repo()
     if not repo:
         return None
@@ -55,6 +66,33 @@ def _find_main_clone() -> Path | None:
         main_clone_git = Path(match.group(1)).parent.parent
         if main_clone_git.name == ".git" and main_clone_git.is_dir():
             return main_clone_git.parent
+    return None
+
+
+def _current_editable_source(uv_bin: str) -> Path | None:
+    """Return the editable source recorded in uv's teatree tool receipt, or None.
+
+    Returns None when teatree isn't installed as a uv tool, when it's installed
+    non-editable (regular PyPI-style install), or when the receipt is
+    unparsable.  ``~/.local/share/uv/tools/teatree/uv-receipt.toml`` looks like::
+
+        [tool]
+        requirements = [{ name = "teatree", editable = "/path/to/clone" }]
+    """
+    result = _run_captured([uv_bin, "tool", "dir"])
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    receipt = Path(result.stdout.strip()) / "teatree" / "uv-receipt.toml"
+    if not receipt.is_file():
+        return None
+    try:
+        data = tomllib.loads(receipt.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError:
+        return None
+    for req in data.get("tool", {}).get("requirements", []):
+        if req.get("name") == "teatree":
+            editable = req.get("editable")
+            return Path(editable) if editable else None
     return None
 
 
@@ -106,21 +144,34 @@ def _print_path_hint(bin_dir: Path | None) -> None:
 
 
 def _ensure_t3_installed(repo: Path) -> bool:
-    """Install ``t3`` globally via ``uv tool install`` when it's not on PATH.
+    """Ensure a healthy global ``t3`` via ``uv tool install``.
 
-    Returns True when the binary is (already, or now) available.  When ``uv``
-    itself is missing, prints guidance and returns False rather than raising.
+    Steady-state: if ``t3`` is on PATH and the editable source recorded by uv
+    still exists, leave the install alone.  This preserves intentional
+    worktree-dogfood installs (see #397 Part 3) and non-editable installs.
+
+    Repair path: when the editable source has been deleted (e.g. the worktree
+    it was installed from got cleaned up), reinstall editable from *repo* so
+    the global ``t3`` is re-anchored at a stable main clone.
     """
-    if shutil.which("t3"):
+    uv_bin = shutil.which("uv")
+    t3_on_path = shutil.which("t3") is not None
+
+    if t3_on_path and uv_bin:
+        source = _current_editable_source(uv_bin)
+        if source is None or source.is_dir():
+            return True
+        typer.echo(f"NOTE  Global `t3` editable source missing: {source}")
+        typer.echo(f"      Re-anchoring at main clone {repo}.")
+    elif t3_on_path:
         return True
 
-    uv_bin = shutil.which("uv")
     if not uv_bin:
         typer.echo("WARN  `t3` not on PATH and `uv` is missing — skipping global install.")
         typer.echo("      Install uv: https://docs.astral.sh/uv/getting-started/installation/")
         return False
 
-    result = _run_captured([uv_bin, "tool", "install", "--editable", str(repo)])
+    result = _run_captured([uv_bin, "tool", "install", "--force", "--editable", str(repo)])
     if result.returncode != 0:
         typer.echo(f"WARN  `uv tool install` failed: {result.stderr.strip()}")
         return False

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -2,6 +2,7 @@
 
 import json
 import shutil
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -74,6 +75,19 @@ class TestFindMainClone:
         with patch("teatree.cli.setup.DoctorService") as mock_svc:
             mock_svc.find_teatree_repo.return_value = repo
             assert _find_main_clone() is None
+
+    def test_env_var_wins_over_cwd_heuristic(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``T3_REPO`` env var must take priority so setup from a worktree still targets the configured main clone."""
+        main_clone = tmp_path / "main-clone"
+        main_clone.mkdir()
+        (main_clone / ".git").mkdir()
+        (main_clone / "pyproject.toml").touch()
+        monkeypatch.setenv("T3_REPO", str(main_clone))
+
+        with patch("teatree.cli.setup.DoctorService") as mock_svc:
+            mock_svc.find_teatree_repo.return_value = tmp_path / "some-worktree"
+            assert _find_main_clone() == main_clone
+            mock_svc.find_teatree_repo.assert_not_called()
 
 
 class TestRunApmInstall:
@@ -621,48 +635,129 @@ class TestCoreExcludedSkills:
         assert "using-git-worktrees" in CORE_EXCLUDED_SKILLS
 
 
+def _install_run_side_effect(
+    uv_tools_dir: Path,
+    *,
+    install_returncode: int = 0,
+    install_stderr: str = "",
+) -> Callable[..., SimpleNamespace]:
+    """Build a ``subprocess.run`` side effect covering ``uv tool dir`` + install."""
+
+    def side_effect(cmd: list[str], *args: object, **kwargs: object) -> SimpleNamespace:
+        if cmd[:3] == ["/usr/bin/uv", "tool", "dir"]:
+            stdout = "" if "--bin" in cmd else f"{uv_tools_dir}\n"
+            return SimpleNamespace(returncode=0, stderr="", stdout=stdout)
+        if cmd[:3] == ["/usr/bin/uv", "tool", "install"]:
+            return SimpleNamespace(returncode=install_returncode, stderr=install_stderr, stdout="")
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
+
+    return side_effect
+
+
+def _which_t3_and_uv(name: str) -> str | None:
+    return {"t3": "/usr/local/bin/t3", "uv": "/usr/bin/uv"}.get(name)
+
+
 class TestEnsureT3Installed:
-    def test_skips_install_when_t3_on_path(self, tmp_path: Path) -> None:
+    def test_skips_when_editable_source_exists(self, tmp_path: Path) -> None:
+        uv_tools_dir = tmp_path / "uv-tools"
+        teatree_tool = uv_tools_dir / "teatree"
+        teatree_tool.mkdir(parents=True)
+        editable_source = tmp_path / "main-clone"
+        editable_source.mkdir()
+        (teatree_tool / "uv-receipt.toml").write_text(
+            f'[tool]\nrequirements = [{{ name = "teatree", editable = "{editable_source}" }}]\n'
+        )
+
         with (
             patch("teatree.cli.setup.shutil.which") as mock_which,
-            patch("teatree.utils.run.subprocess.run") as mock_run,
+            patch("teatree.utils.run.subprocess.run", side_effect=_install_run_side_effect(uv_tools_dir)) as mock_run,
         ):
-            mock_which.side_effect = lambda name: "/usr/local/bin/t3" if name == "t3" else None
-            assert _ensure_t3_installed(tmp_path) is True
-            mock_run.assert_not_called()
+            mock_which.side_effect = _which_t3_and_uv
+            assert _ensure_t3_installed(editable_source) is True
+            # Only the `uv tool dir` receipt lookup — no install invoked.
+            install_calls = [c for c in mock_run.call_args_list if c[0][0][:3] == ["/usr/bin/uv", "tool", "install"]]
+            assert install_calls == []
+
+    def test_skips_when_install_is_non_editable(self, tmp_path: Path) -> None:
+        uv_tools_dir = tmp_path / "uv-tools"
+        teatree_tool = uv_tools_dir / "teatree"
+        teatree_tool.mkdir(parents=True)
+        (teatree_tool / "uv-receipt.toml").write_text('[tool]\nrequirements = [{ name = "teatree" }]\n')
+
+        with (
+            patch("teatree.cli.setup.shutil.which") as mock_which,
+            patch("teatree.utils.run.subprocess.run", side_effect=_install_run_side_effect(uv_tools_dir)) as mock_run,
+        ):
+            mock_which.side_effect = _which_t3_and_uv
+            assert _ensure_t3_installed(tmp_path / "main-clone") is True
+            install_calls = [c for c in mock_run.call_args_list if c[0][0][:3] == ["/usr/bin/uv", "tool", "install"]]
+            assert install_calls == []
+
+    def test_reinstalls_when_editable_source_missing(self, tmp_path: Path) -> None:
+        """Stale editable install (worktree deleted) must be repaired from the main clone."""
+        uv_tools_dir = tmp_path / "uv-tools"
+        teatree_tool = uv_tools_dir / "teatree"
+        teatree_tool.mkdir(parents=True)
+        deleted_worktree = tmp_path / "deleted-worktree"
+        (teatree_tool / "uv-receipt.toml").write_text(
+            f'[tool]\nrequirements = [{{ name = "teatree", editable = "{deleted_worktree}" }}]\n'
+        )
+        main_clone = tmp_path / "main-clone"
+        main_clone.mkdir()
+
+        with (
+            patch("teatree.cli.setup.shutil.which") as mock_which,
+            patch("teatree.utils.run.subprocess.run", side_effect=_install_run_side_effect(uv_tools_dir)) as mock_run,
+        ):
+            mock_which.side_effect = _which_t3_and_uv
+            assert _ensure_t3_installed(main_clone) is True
+            install_calls = [c for c in mock_run.call_args_list if c[0][0][:3] == ["/usr/bin/uv", "tool", "install"]]
+            assert len(install_calls) == 1
+            args = install_calls[0][0][0]
+            assert "--force" in args
+            assert "--editable" in args
+            assert str(main_clone) in args
 
     def test_returns_false_when_uv_missing(self, tmp_path: Path) -> None:
         with patch("teatree.cli.setup.shutil.which", return_value=None):
             assert _ensure_t3_installed(tmp_path) is False
 
+    def test_returns_true_when_t3_on_path_without_uv(self, tmp_path: Path) -> None:
+        """Pipx or other non-uv installs are respected — we only touch uv tool installs."""
+        with patch("teatree.cli.setup.shutil.which") as mock_which:
+            mock_which.side_effect = lambda name: "/usr/local/bin/t3" if name == "t3" else None
+            assert _ensure_t3_installed(tmp_path) is True
+
     def test_installs_editable_when_t3_missing(self, tmp_path: Path) -> None:
         repo = tmp_path / "teatree"
         repo.mkdir()
+        uv_tools_dir = tmp_path / "uv-tools"
+        uv_tools_dir.mkdir()
         with (
             patch("teatree.cli.setup.shutil.which") as mock_which,
-            patch("teatree.utils.run.subprocess.run") as mock_run,
+            patch("teatree.utils.run.subprocess.run", side_effect=_install_run_side_effect(uv_tools_dir)) as mock_run,
         ):
             mock_which.side_effect = lambda name: "/usr/bin/uv" if name == "uv" else None
-            mock_run.return_value.returncode = 0
-            mock_run.return_value.stderr = ""
-            mock_run.return_value.stdout = ""
             assert _ensure_t3_installed(repo) is True
-            install_args = mock_run.call_args_list[0][0][0]
-            assert install_args[:3] == ["/usr/bin/uv", "tool", "install"]
-            assert "--editable" in install_args
-            assert str(repo) in install_args
+            install_calls = [c for c in mock_run.call_args_list if c[0][0][:3] == ["/usr/bin/uv", "tool", "install"]]
+            assert len(install_calls) == 1
+            args = install_calls[0][0][0]
+            assert "--force" in args
+            assert "--editable" in args
+            assert str(repo) in args
 
     def test_returns_false_on_install_failure(self, tmp_path: Path) -> None:
         repo = tmp_path / "teatree"
         repo.mkdir()
+        uv_tools_dir = tmp_path / "uv-tools"
+        uv_tools_dir.mkdir()
+        side_effect = _install_run_side_effect(uv_tools_dir, install_returncode=1, install_stderr="boom")
         with (
             patch("teatree.cli.setup.shutil.which") as mock_which,
-            patch("teatree.utils.run.subprocess.run") as mock_run,
+            patch("teatree.utils.run.subprocess.run", side_effect=side_effect),
         ):
             mock_which.side_effect = lambda name: "/usr/bin/uv" if name == "uv" else None
-            mock_run.return_value.returncode = 1
-            mock_run.return_value.stderr = "boom"
-            mock_run.return_value.stdout = ""
             assert _ensure_t3_installed(repo) is False
 
     def test_prints_shell_rc_hint_when_still_not_on_path(

--- a/tests/test_t3_bootstrap.py
+++ b/tests/test_t3_bootstrap.py
@@ -1,0 +1,67 @@
+"""Tests for the ``t3_bootstrap`` entry-point launcher."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import t3_bootstrap
+
+
+def _make_teatree_tree(root: Path) -> Path:
+    """Create a minimal pyproject + ``src/teatree/__init__.py`` layout under *root*."""
+    (root / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
+    pkg = root / "src" / "teatree"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").touch()
+    return root / "src"
+
+
+class TestFindTeatreeSource:
+    def test_returns_src_when_cwd_is_worktree_root(self, tmp_path: Path) -> None:
+        expected = _make_teatree_tree(tmp_path)
+        assert t3_bootstrap._find_teatree_source(tmp_path) == expected
+
+    def test_walks_up_to_find_worktree_root(self, tmp_path: Path) -> None:
+        expected = _make_teatree_tree(tmp_path)
+        nested = tmp_path / "src" / "teatree" / "cli"
+        nested.mkdir(parents=True, exist_ok=True)
+        assert t3_bootstrap._find_teatree_source(nested) == expected
+
+    def test_returns_none_when_no_teatree_pyproject(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "other"\n')
+        assert t3_bootstrap._find_teatree_source(tmp_path) is None
+
+    def test_returns_none_when_pyproject_matches_but_src_layout_missing(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
+        assert t3_bootstrap._find_teatree_source(tmp_path) is None
+
+    def test_returns_none_when_no_pyproject_in_ancestors(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        assert t3_bootstrap._find_teatree_source(nested) is None
+
+
+class TestMain:
+    def test_inserts_worktree_source_on_sys_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        worktree_src = _make_teatree_tree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        with patch.object(sys, "path", list(sys.path)) as _, patch("teatree.cli.main") as mock_main:
+            t3_bootstrap.main()
+            assert sys.path[0] == str(worktree_src)
+            mock_main.assert_called_once_with()
+
+    def test_leaves_sys_path_untouched_outside_worktree(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        before = list(sys.path)
+
+        with patch("teatree.cli.main") as mock_main:
+            t3_bootstrap.main()
+            assert sys.path == before
+            mock_main.assert_called_once_with()


### PR DESCRIPTION
## Summary

Two related fixes for the global `t3` CLI:

1. **`t3 setup` now repairs stale editable installs.** Previously, if the editable source directory (e.g. a worktree) was cleaned up, `t3` failed with `ModuleNotFoundError: No module named 'teatree'` from any directory outside the main clone. `_ensure_t3_installed` short-circuited on `shutil.which("t3")` — PATH presence, not import health — so setup never noticed the broken state.
2. **`t3` now auto-selects the worktree teatree source at runtime.** A new top-level `t3_bootstrap` module is the entry point. When cwd lives inside a teatree worktree, it prepends the worktree's `src/` to `sys.path` before importing `teatree.cli`. Outside any teatree tree, it's a no-op — the uv tool install (editable main clone or PyPI libs) wins as before.

## Changes

- `_ensure_t3_installed` parses `uv-receipt.toml`; when the editable source directory no longer exists, reinstalls via `uv tool install --force --editable <main-clone>`. Valid editable installs (including intentional worktree dogfood per #397 Part 3) and non-editable installs are left alone.
- `_find_main_clone` honors `T3_REPO` ahead of cwd heuristics so setup from a worktree still targets the configured main clone.
- New `src/t3_bootstrap.py` (entry point `t3 = "t3_bootstrap:main"`) — 20 SLOC, imports nothing from teatree at module scope, walks cwd ancestors for a teatree pyproject + populated `src/teatree`, prepends source to `sys.path`, then defers to `teatree.cli.main`. `PLC0415` relaxed for this file only — deferred import is the bootstrap's core design, not tech debt.
- Hatchling `force-include` added so the top-level bootstrap module ships in the wheel.
- `skills/workspace/references/troubleshooting.md` — updated the worktree-pinning entry to point at `t3 setup` for persistent repair, added entries for the `ModuleNotFoundError` symptom and for confirming worktree-source selection via `t3 info`.

## Test plan

- [x] 8 tests in `TestEnsureT3Installed` cover: valid editable → skip, non-editable → skip, missing source → reinstall with `--force --editable`, no uv → false, non-uv install → leave alone, install failure → false, PATH hint when bin dir missing.
- [x] `TestFindMainClone::test_env_var_wins_over_cwd_heuristic` covers T3_REPO priority.
- [x] 7 tests in `TestFindTeatreeSource` / `TestMain` cover bootstrap source discovery + sys.path injection + no-op fallback.
- [x] 64 setup+bootstrap tests pass; 383 broader CLI tests pass.
- [x] End-to-end, after `t3 setup` on the broken state:
  - `t3 info` from `/Users` → `teatree: /Users/adrien/workspace/souliane/teatree/src/teatree` (main clone).
  - `t3 info` from a worktree at `/Users/adrien/workspace/souliane/tickets/<ticket>/` → `teatree: /Users/adrien/workspace/souliane/tickets/<ticket>/src/teatree` (worktree source).
  - Second `t3 setup` is a no-op for the install step (idempotent).

Fixes #26