### PR TITLE
relax(cleanup): enforce no-orphan invariant across branch lifecycle (#435)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -235,6 +235,13 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [push]
+      - id: ensure-draft-pr
+        name: ensure draft PR exists (no-orphan invariant)
+        language: system
+        entry: t3 teatree pr ensure-draft
+        pass_filenames: false
+        always_run: true
+        stages: [push]
 
   # Phase 9 - Manual
   - repo: https://github.com/semgrep/semgrep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -238,7 +238,7 @@ repos:
       - id: ensure-draft-pr
         name: ensure draft PR exists (no-orphan invariant)
         language: system
-        entry: t3 teatree pr ensure-draft
+        entry: uv run t3 teatree pr ensure-draft
         pass_filenames: false
         always_run: true
         stages: [push]

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1021,28 +1021,7 @@ Usage: t3 teatree lifecycle [OPTIONS] COMMAND [ARGS]...
 ```
 Usage: t3 teatree lifecycle setup [OPTIONS]
 
- Provision a worktree (DB name, env file, overlay steps). No port allocation.
-
- Idempotent — safe to re-run. Auto-retries DB import when the DB
- doesn't exist, regardless of previous failure count.
-
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --path                               TEXT  Worktree path (auto-detects from  │
-│                                            PWD if empty).                    │
-│ --variant                            TEXT  Tenant variant. Updates ticket if │
-│                                            provided.                         │
-│ --overlay                            TEXT  Overlay name (auto-detects if     │
-│                                            empty).                           │
-│ --slow-import    --no-slow-import          Allow slow DB fallbacks           │
-│                                            (pg_restore, remote dump).        │
-│                                            DSLR-only by default.             │
-│                                            [default: no-slow-import]         │
-│ --verbose        --no-verbose              Show step stdout/stderr.          │
-│                                            [default: verbose]                │
-│ --no-timeout     --no-no-timeout           Disable operation timeouts.       │
-│                                            [default: no-no-timeout]          │
-│ --help                                     Show this message and exit.       │
-╰──────────────────────────────────────────────────────────────────────────────╯
+ Create and provision a worktree.
 ```
 
 ##### `t3 teatree lifecycle start`
@@ -1050,25 +1029,7 @@ Usage: t3 teatree lifecycle setup [OPTIONS]
 ```
 Usage: t3 teatree lifecycle start [OPTIONS]
 
- Provision (if needed) and start all services for the ticket.
-
- Runs setup for all worktrees in the ticket, then starts docker-compose
- services for each. Allocates free host ports at runtime.
- Safe to re-run — stops previous containers first.
-
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --path                             TEXT  Worktree path (auto-detects from    │
-│                                          PWD if empty).                      │
-│ --variant                          TEXT  Tenant variant (passed to setup if  │
-│                                          needed).                            │
-│ --overlay                          TEXT  Overlay name (auto-detects if       │
-│                                          empty).                             │
-│ --verbose       --no-verbose             Show step stdout/stderr.            │
-│                                          [default: verbose]                  │
-│ --no-timeout    --no-no-timeout          Disable operation timeouts.         │
-│                                          [default: no-no-timeout]            │
-│ --help                                   Show this message and exit.         │
-╰──────────────────────────────────────────────────────────────────────────────╯
+ Provision (if needed) and start all services.
 ```
 
 ##### `t3 teatree lifecycle status`
@@ -1076,10 +1037,7 @@ Usage: t3 teatree lifecycle start [OPTIONS]
 ```
 Usage: t3 teatree lifecycle status [OPTIONS]
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
-│ --help              Show this message and exit.                              │
-╰──────────────────────────────────────────────────────────────────────────────╯
+ Return worktree state information.
 ```
 
 ##### `t3 teatree lifecycle teardown`
@@ -1087,10 +1045,7 @@ Usage: t3 teatree lifecycle status [OPTIONS]
 ```
 Usage: t3 teatree lifecycle teardown [OPTIONS]
 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
-│ --help              Show this message and exit.                              │
-╰──────────────────────────────────────────────────────────────────────────────╯
+ Tear down a worktree.
 ```
 
 ##### `t3 teatree lifecycle clean`
@@ -1098,12 +1053,7 @@ Usage: t3 teatree lifecycle teardown [OPTIONS]
 ```
 Usage: t3 teatree lifecycle clean [OPTIONS]
 
- Teardown worktree — stop containers, drop DB, clean state.
-
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
-│ --help              Show this message and exit.                              │
-╰──────────────────────────────────────────────────────────────────────────────╯
+ Teardown worktree — stop services, drop DB, clean state.
 ```
 
 ##### `t3 teatree lifecycle diagram`
@@ -1111,13 +1061,7 @@ Usage: t3 teatree lifecycle clean [OPTIONS]
 ```
 Usage: t3 teatree lifecycle diagram [OPTIONS]
 
- Print a state diagram as Mermaid. Models: worktree, ticket, task.
-
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --model         TEXT     [default: worktree]                                 │
-│ --ticket        INTEGER                                                      │
-│ --help                   Show this message and exit.                         │
-╰──────────────────────────────────────────────────────────────────────────────╯
+ Print the lifecycle state diagram as Mermaid.
 ```
 
 #### `t3 teatree workspace`
@@ -1131,9 +1075,10 @@ Usage: t3 teatree workspace [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ ticket     Create a ticket with worktree entries for each repo.              │
-│ finalize   Squash worktree commits and rebase on the default branch.         │
-│ clean-all  Prune worktrees whose branches have been merged or deleted.       │
+│ ticket        Create a ticket with worktree entries for each repo.           │
+│ finalize      Squash worktree commits and rebase on the default branch.      │
+│ clean-all     Prune worktrees whose branches have been merged or deleted.    │
+│ list-orphans  List orphan branches (commits not on main, no open PR).        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -1142,10 +1087,15 @@ Usage: t3 teatree workspace [OPTIONS] COMMAND [ARGS]...
 ```
 Usage: t3 teatree workspace ticket [OPTIONS] ISSUE_URL
 
- Create or update a ticket with worktree entries for each affected repo.
+ Create or update a ticket and trigger worktree provisioning.
 
- Idempotent: safe to re-run after partial failures. Existing worktrees
- are skipped, missing repos are added, and failed entries are cleaned up.
+ Thin wrapper around the FSM (BLUEPRINT §4): persist branch + description
+ on ``ticket.extra``, advance ``NOT_STARTED → SCOPED → STARTED`` via
+ ``scope()`` and ``start()``, and let ``execute_provision`` materialise
+ the per-repo git worktrees on the worker side.
+
+ Idempotent: re-running over an already-started ticket merges new repos
+ into ``ticket.repos`` so the next ``execute_provision`` picks them up.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    issue_url      TEXT  [required]                                         │
@@ -1186,6 +1136,24 @@ Usage: t3 teatree workspace clean-all [OPTIONS]
 │ --keep-dslr        INTEGER  Number of DSLR snapshots to keep per tenant.     │
 │                             [default: 1]                                     │
 │ --help                      Show this message and exit.                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree workspace list-orphans`
+
+```
+Usage: t3 teatree workspace list-orphans [OPTIONS]
+
+ List orphan branches (commits ahead of origin/main AND no open PR) across the
+ workspace.
+
+ Used by the session-end hook and the ``workspace ticket`` warning to
+ surface work that would otherwise be lost when a session closes or a
+ new worktree is created. Emits a JSON-serialisable list — one entry
+ per orphan.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -1460,6 +1428,7 @@ Usage: t3 teatree pr [OPTIONS] COMMAND [ARGS]...
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ create         Create a merge request for the ticket's branch.               │
+│ ensure-draft   Create a draft PR for an orphan branch (idempotent).          │
 │ check-gates    Check whether session gates allow a phase transition.         │
 │ fetch-issue    Fetch issue details from the configured tracker.              │
 │ detect-tenant  Detect the current tenant variant from the overlay.           │
@@ -1472,21 +1441,47 @@ Usage: t3 teatree pr [OPTIONS] COMMAND [ARGS]...
 ```
 Usage: t3 teatree pr create [OPTIONS] TICKET_ID
 
- Create a merge request for the ticket's branch.
+ Validate ship gates and trigger the ship transition.
+
+ On success the ``execute_ship`` worker pushes the branch, opens the MR,
+ and advances ``SHIPPED → IN_REVIEW``. The return value reports the MR
+ URL once the worker completes (synchronous in interactive mode).
+
+ ``--title`` overrides the MR title (default: last commit subject).
+ Stored on ``ticket.extra['mr_title_override']`` so the worker reads it.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    ticket_id      INTEGER  [required]                                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --repo                                       TEXT                            │
 │ --title                                      TEXT                            │
-│ --description                                TEXT                            │
 │ --dry-run            --no-dry-run                  [default: no-dry-run]     │
 │ --skip-validation    --no-skip-validation          [default:                 │
 │                                                    no-skip-validation]       │
 │ --skip-visual-qa                             TEXT                            │
 │ --help                                             Show this message and     │
 │                                                    exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree pr ensure-draft`
+
+```
+Usage: t3 teatree pr ensure-draft [OPTIONS]
+
+ Create a draft PR for an orphan branch (idempotent, no-op when a PR already
+ exists).
+
+ An orphan is a branch with commits not on ``origin/main`` (after
+ subject-match + tree-equality checks) and no open PR/MR. When this
+ runs inside a git pre-push hook for a *first* push, the branch is not
+ yet on the remote — creating the PR is deferred with a warning so the
+ push proceeds and the agent can re-run this command afterwards.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --branch        TEXT                                                         │
+│ --repo          TEXT                                                         │
+│ --help                Show this message and exit.                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -559,32 +559,80 @@ def handle_post_compact(data: dict) -> None:
     json.dump({"additionalContext": context}, sys.stdout)
 
 
+_SESSION_END_ORPHAN_TIMEOUT = 4
+_SESSION_END_ORPHAN_PREVIEW = 5
+
+
+def _fetch_orphans() -> list[dict]:
+    """Invoke ``t3 teatree workspace list-orphans`` and return its JSON, or ``[]``."""
+    import shutil  # noqa: PLC0415
+
+    t3_bin = shutil.which("t3")
+    if not t3_bin:
+        return []
+    try:
+        result = subprocess.run(  # noqa: S603
+            [t3_bin, "teatree", "workspace", "list-orphans"],
+            capture_output=True,
+            text=True,
+            timeout=_SESSION_END_ORPHAN_TIMEOUT,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return []
+    if result.returncode != 0 or not result.stdout.strip():
+        return []
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _format_orphan_summary(orphans: list[dict]) -> str:
+    """Return a one-line-per-orphan bullet list, truncated to _SESSION_END_ORPHAN_PREVIEW entries."""
+    preview = orphans[:_SESSION_END_ORPHAN_PREVIEW]
+    lines = [f"  - {o.get('repo', '?')} ({o.get('branch', '?')}, {o.get('ahead_count', 0)} ahead)" for o in preview]
+    if len(orphans) > _SESSION_END_ORPHAN_PREVIEW:
+        lines.append(f"  - …and {len(orphans) - _SESSION_END_ORPHAN_PREVIEW} more")
+    return "\n".join(lines)
+
+
 def handle_session_end(data: dict) -> None:
-    """Suggest retro when lifecycle skills were loaded during the session."""
+    """Suggest retro and surface orphan branches at session close."""
     session_id = data.get("session_id", "")
     if not session_id:
         return
 
     skills_file = STATE_DIR / f"{session_id}.skills"
-    if not skills_file.is_file():
-        return
-
-    loaded = {line.strip() for line in skills_file.read_text(encoding="utf-8").splitlines() if line.strip()}
+    loaded: set[str] = set()
+    if skills_file.is_file():
+        loaded = {line.strip() for line in skills_file.read_text(encoding="utf-8").splitlines() if line.strip()}
 
     lifecycle_skills = {"t3:code", "t3:debug", "t3:test", "t3:ship", "t3:review", "t3:ticket"}
-    if not loaded & lifecycle_skills:
+    retro_relevant = bool(loaded & lifecycle_skills)
+
+    orphans = _fetch_orphans() if retro_relevant else []
+
+    if not retro_relevant and not orphans:
         return
 
-    json.dump(
-        {
-            "additionalContext": (
-                "SESSION ENDING — lifecycle skills were loaded during this session "
-                f"({', '.join(sorted(loaded & lifecycle_skills))}). "
-                "Consider running /t3:retro to capture learnings before the session ends."
-            ),
-        },
-        sys.stdout,
-    )
+    parts: list[str] = []
+    if retro_relevant:
+        parts.append(
+            "SESSION ENDING — lifecycle skills were loaded during this session "
+            f"({', '.join(sorted(loaded & lifecycle_skills))}). "
+            "Consider running /t3:retro to capture learnings before the session ends.",
+        )
+    if orphans:
+        parts.append(
+            f"ORPHAN BRANCHES DETECTED ({len(orphans)}) — branches with local work and no open PR:\n"
+            f"{_format_orphan_summary(orphans)}\n"
+            "Run `t3 teatree pr ensure-draft --branch <name>` to track them, "
+            "or `t3 teatree workspace clean-all` to reap synced ones.",
+        )
+
+    json.dump({"additionalContext": "\n\n".join(parts)}, sys.stdout)
 
 
 # ── PreToolUse: block-direct-commands ────────────────────────────────

--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -191,6 +191,8 @@ class GitHubCodeHost:
             cmd.extend(["--label", ",".join(spec.labels)])
         if spec.assignee:
             cmd.extend(["--assignee", spec.assignee])
+        if spec.draft:
+            cmd.append("--draft")
 
         result = _run_gh(*cmd, token=self._token)
         return {"url": result.stdout.strip()}

--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -41,6 +41,8 @@ class GitLabCodeHost:
             payload["labels"] = ",".join(spec.labels)
         if spec.assignee:
             payload["assignee_username"] = spec.assignee
+        if spec.draft and not spec.title.startswith("Draft:"):
+            payload["title"] = f"Draft: {spec.title}"
 
         return self._client.post_json(f"projects/{project.project_id}/merge_requests", payload) or {}
 

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -24,6 +24,7 @@ class PullRequestSpec:
     target_branch: str = ""
     labels: list[str] = field(default_factory=list)
     assignee: str = ""
+    draft: bool = False
 
 
 @runtime_checkable

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -42,6 +42,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("ticket", "Create a ticket with worktree entries for each repo."),
             ("finalize", "Squash worktree commits and rebase on the default branch."),
             ("clean-all", "Prune worktrees whose branches have been merged or deleted."),
+            ("list-orphans", "List orphan branches (commits not on main, no open PR)."),
         ],
     ),
     "run": (
@@ -75,6 +76,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
         "Pull request helpers.",
         [
             ("create", "Create a merge request for the ticket's branch."),
+            ("ensure-draft", "Create a draft PR for an orphan branch (idempotent)."),
             ("check-gates", "Check whether session gates allow a phase transition."),
             ("fetch-issue", "Fetch issue details from the configured tracker."),
             ("detect-tenant", "Detect the current tenant variant from the overlay."),

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -123,21 +123,21 @@ def _pr_merge_commit_sha(repo: str, branch: str) -> str:
     Returns ``""`` when neither CLI is available (sandbox, CI without auth) —
     the caller falls back to subject-match classification.
     """
-    sha = _probe_host_cli(
+    sha = probe_host_cli(
         ["gh", "pr", "list", "--head", branch, "--state", "merged", "--json", "mergeCommit", "--limit", "1"],
         repo,
         lambda data: data[0]["mergeCommit"]["oid"],
     )
     if sha:
         return sha
-    return _probe_host_cli(
+    return probe_host_cli(
         ["glab", "mr", "list", "--merged", "--source-branch", branch, "--output", "json", "-P", "1"],
         repo,
         lambda data: data[0]["merge_commit_sha"],
     )
 
 
-def _probe_host_cli(cmd: list[str], repo: str, extract: Callable[[Any], str]) -> str:
+def probe_host_cli(cmd: list[str], repo: str, extract: Callable[[Any], str]) -> str:
     """Invoke a host CLI that may be missing, parse its JSON, extract the SHA.
 
     Swallows ``OSError`` (missing binary, permission denied in sandboxes) and

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -13,9 +13,11 @@ from django.db import transaction
 from django_typer.management import TyperCommand, command
 
 from teatree import visual_qa
+from teatree.backends.protocols import PullRequestSpec
 from teatree.core.backend_factory import code_host_from_overlay, get_issue_tracker
 from teatree.core.models import Ticket, Worktree
 from teatree.core.models.types import TicketExtra, VisualQASummary
+from teatree.core.orphan_guard import BranchStatus, classify_branch
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.runners.ship import overlay_mr_labels, sanitize_close_keywords
 from teatree.utils import git
@@ -59,8 +61,24 @@ class ShippingGateFailure(TypedDict):
     hint: str
 
 
+class EnsureDraftResult(TypedDict, total=False):
+    skipped: str
+    branch: str
+    url: str
+    hint: str
+    error: str
+
+
 _IMAGE_URL_RE = re.compile(r"!\[([^\]]*)\]\((/uploads/[^\)]+)\)")
 _EXTERNAL_LINK_RE = re.compile(r"https?://(?:www\.)?(?:notion\.so|linear\.app|jira\.\S+)/\S+")
+_REMOTE_HOST_RE = re.compile(r"^(?:git@[^:]+:|https?://[^/]+/|ssh://[^/]+/|git://[^/]+/)")
+
+
+def _slug_from_remote(remote_url: str) -> str:
+    """Extract the ``org/repo`` (or ``ns/group/repo``) slug from a git remote URL."""
+    if not remote_url:
+        return ""
+    return _REMOTE_HOST_RE.sub("", remote_url.strip()).removesuffix(".git")
 
 
 def _ship_preview(ticket: Ticket, worktree: Worktree) -> tuple[str, str, str]:
@@ -215,6 +233,64 @@ class Command(TyperCommand):
             ticket.ship()
             ticket.save()
         return ShipEnqueued(ticket_id=int(ticket.pk), state=str(ticket.state))
+
+    @command(name="ensure-draft")
+    def ensure_draft(
+        self,
+        branch: str = "",
+        repo: str = "",
+    ) -> EnsureDraftResult:
+        """Create a draft PR for an orphan branch (idempotent, no-op when a PR already exists).
+
+        An orphan is a branch with commits not on ``origin/main`` (after
+        subject-match + tree-equality checks) and no open PR/MR. When this
+        runs inside a git pre-push hook for a *first* push, the branch is not
+        yet on the remote — creating the PR is deferred with a warning so the
+        push proceeds and the agent can re-run this command afterwards.
+        """
+        repo_path = repo or "."
+        branch_name = branch or git.current_branch(repo=repo_path)
+        if not branch_name or branch_name in {"HEAD", "main", "master"}:
+            return EnsureDraftResult(skipped="not on a feature branch", branch=branch_name)
+
+        report = classify_branch(repo_path, branch_name)
+
+        if report.status is BranchStatus.SYNCED:
+            return EnsureDraftResult(skipped="branch synced to origin/main", branch=branch_name)
+        if report.status is BranchStatus.OPEN_PR:
+            return EnsureDraftResult(skipped="open PR exists", branch=branch_name, url=report.open_pr_url)
+        if report.status is BranchStatus.UNPUSHED_ORPHAN:
+            return EnsureDraftResult(
+                skipped="branch not on remote yet — re-run after push completes",
+                branch=branch_name,
+                hint=f"t3 <overlay> pr ensure-draft --branch {branch_name}",
+            )
+
+        host = code_host_from_overlay()
+        if host is None:
+            return EnsureDraftResult(error="no code host configured")
+
+        commit_subject, commit_body = git.last_commit_message(repo=repo_path)
+        title = commit_subject or f"WIP: {branch_name}"
+        description = commit_body or f"Draft PR auto-created to track branch `{branch_name}`."
+        description = sanitize_close_keywords(description, close_ticket=get_overlay().config.mr_close_ticket)
+
+        remote = git.remote_url(repo=repo_path)
+        repo_slug = _slug_from_remote(remote)
+        assignee = host.current_user() or git.config_value(key="user.name")
+
+        raw = host.create_pr(
+            PullRequestSpec(
+                repo=repo_slug,
+                branch=branch_name,
+                title=title,
+                description=description,
+                labels=overlay_mr_labels(),
+                assignee=assignee,
+                draft=True,
+            ),
+        )
+        return EnsureDraftResult(branch=branch_name, url=str(raw.get("url", raw.get("web_url", ""))))
 
     @command(name="check-gates")
     def check_gates(self, ticket_id: int, target_phase: str = "shipping") -> dict[str, object]:

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -3,9 +3,10 @@
 import os
 import re
 import sys
+from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, cast
+from typing import TYPE_CHECKING, Annotated, TypedDict, cast
 
 import typer
 from django.db import transaction
@@ -20,6 +21,7 @@ from teatree.core.management.commands._workspace_cleanup import (
     resolve_unsynced_worktree,
 )
 from teatree.core.models import Ticket, Worktree
+from teatree.core.orphan_guard import find_orphans_in_workspace
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.reconcile import Drift, reconcile_all, reconcile_ticket
 from teatree.core.resolve import resolve_worktree
@@ -37,6 +39,29 @@ from teatree.utils.run import CommandFailedError, run_checked
 
 if TYPE_CHECKING:
     from teatree.core.models.types import TicketExtra
+
+
+class OrphanEntry(TypedDict):
+    repo: str
+    branch: str
+    status: str
+    ahead_count: int
+
+
+def _warn_orphans(write: Callable[[str], None]) -> None:
+    orphans = find_orphans_in_workspace()
+    if not orphans:
+        return
+    preview = orphans[:5]
+    write(f"WARNING: {len(orphans)} orphan branch(es) in the workspace:")
+    for r in preview:
+        write(f"  - {r.repo} ({r.branch}, {r.ahead_count} ahead, {r.status.value})")
+    if len(orphans) > len(preview):
+        write(f"  - …and {len(orphans) - len(preview)} more")
+    write(
+        "Run `t3 <overlay> pr ensure-draft --branch <name>` to track them, "
+        "or `t3 <overlay> workspace clean-all` to reap synced ones.",
+    )
 
 
 def _workspace_dir() -> Path:
@@ -127,6 +152,7 @@ class Command(TyperCommand):
         Idempotent: re-running over an already-started ticket merges new repos
         into ``ticket.repos`` so the next ``execute_provision`` picks them up.
         """
+        _warn_orphans(self.stderr.write)
         overlay = get_overlay()
         repo_names = [r.strip() for r in repos.split(",") if r.strip()] if repos else overlay.get_workspace_repos()
 
@@ -388,6 +414,20 @@ class Command(TyperCommand):
         if not fix:
             lines.extend(("", "Rerun with --fix to apply fixes."))
         return lines
+
+    @command(name="list-orphans")
+    def list_orphans(self) -> list[OrphanEntry]:
+        """List orphan branches (commits ahead of origin/main AND no open PR) across the workspace.
+
+        Used by the session-end hook and the ``workspace ticket`` warning to
+        surface work that would otherwise be lost when a session closes or a
+        new worktree is created. Emits a JSON-serialisable list — one entry
+        per orphan.
+        """
+        return [
+            OrphanEntry(repo=r.repo, branch=r.branch, status=r.status.value, ahead_count=r.ahead_count)
+            for r in find_orphans_in_workspace()
+        ]
 
     @command(name="clean-all")
     def clean_all(

--- a/src/teatree/core/orphan_guard.py
+++ b/src/teatree/core/orphan_guard.py
@@ -1,0 +1,122 @@
+"""Detect and guard against orphan branches.
+
+An ORPHAN is a local branch that carries work not on ``origin/main`` (after
+subject-match and tree-equality checks) AND has no open PR/MR on the remote.
+Orphans silently leak work: they accumulate between weekly cleanups and are
+easy to miss when closing a session.
+
+This module is the single source of truth used by the three enforcement
+points that keep the no-orphan invariant:
+
+- pre-push CLI (``t3 pr ensure-draft``) — auto-create a draft before pushing
+    an orphan so the branch has a tracking artifact from the first push.
+- session-end hook — surface orphans in ``additionalContext`` so the agent
+    sees them before the session closes.
+- ``workspace ticket`` — warn before creating a new worktree when the
+    workspace already contains orphans.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from teatree.config import load_config
+from teatree.core.cleanup import _branch_tree_matches_squash, classify_branch_commits, probe_host_cli
+from teatree.core.models import Worktree
+from teatree.utils import git
+
+
+class BranchStatus(StrEnum):
+    """Classification of a branch's sync state against ``origin/main``."""
+
+    SYNCED = "synced"
+    OPEN_PR = "open_pr"
+    UNPUSHED_ORPHAN = "unpushed_orphan"
+    PUSHED_ORPHAN = "pushed_orphan"
+
+
+_ORPHAN_STATUSES = frozenset({BranchStatus.UNPUSHED_ORPHAN, BranchStatus.PUSHED_ORPHAN})
+
+
+@dataclass(frozen=True)
+class BranchReport:
+    """Sync status of a single branch in a single repo."""
+
+    repo: str
+    branch: str
+    status: BranchStatus
+    ahead_count: int
+    open_pr_url: str = ""
+
+    @property
+    def is_orphan(self) -> bool:
+        return self.status in _ORPHAN_STATUSES
+
+
+def find_open_pr(repo: str, branch: str) -> str:
+    """Return the URL of the open PR/MR for ``branch``, or ``""`` if none.
+
+    Queries GitHub (``gh pr list``) and GitLab (``glab mr list``). Returns ``""``
+    when neither CLI is available (sandbox, CI without auth) — callers treat
+    that as "no open PR known" rather than erroring.
+    """
+    url = probe_host_cli(
+        ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "url", "--limit", "1"],
+        repo,
+        lambda data: data[0]["url"],
+    )
+    if url:
+        return url
+    return probe_host_cli(
+        ["glab", "mr", "list", "--source-branch", branch, "--state", "opened", "--output", "json", "-P", "1"],
+        repo,
+        lambda data: data[0]["web_url"],
+    )
+
+
+def classify_branch(repo: str, branch: str) -> BranchReport:
+    """Classify ``branch`` in ``repo`` as synced, open PR, or orphan (unpushed / pushed)."""
+    classification = classify_branch_commits(repo, branch)
+    ahead = len(classification.genuinely_ahead)
+
+    if ahead == 0:
+        return BranchReport(repo=repo, branch=branch, status=BranchStatus.SYNCED, ahead_count=0)
+
+    if _branch_tree_matches_squash(repo, branch):
+        return BranchReport(repo=repo, branch=branch, status=BranchStatus.SYNCED, ahead_count=ahead)
+
+    pr_url = find_open_pr(repo, branch)
+    if pr_url:
+        return BranchReport(
+            repo=repo,
+            branch=branch,
+            status=BranchStatus.OPEN_PR,
+            ahead_count=ahead,
+            open_pr_url=pr_url,
+        )
+
+    has_remote = bool(git.run(repo=repo, args=["ls-remote", "--heads", "origin", branch]))
+    status = BranchStatus.PUSHED_ORPHAN if has_remote else BranchStatus.UNPUSHED_ORPHAN
+    return BranchReport(repo=repo, branch=branch, status=status, ahead_count=ahead)
+
+
+def find_orphans_in_workspace() -> list[BranchReport]:
+    """Return orphan branches across all tracked worktrees in the workspace.
+
+    Deduplicates by ``(repo, branch)`` — multiple Worktree rows sharing a
+    branch produce a single report.
+    """
+    workspace = load_config().user.workspace_dir
+    reports: list[BranchReport] = []
+    seen: set[tuple[str, str]] = set()
+    for wt in Worktree.objects.all():
+        repo_main = workspace / wt.repo_path
+        if not repo_main.is_dir():
+            continue
+        key = (str(repo_main), wt.branch)
+        if key in seen:
+            continue
+        seen.add(key)
+        report = classify_branch(str(repo_main), wt.branch)
+        if report.is_orphan:
+            reports.append(report)
+    return reports

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -370,6 +370,28 @@ class TestWorkspaceTicket(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
+    def test_warns_about_existing_orphans_before_creating(self) -> None:
+        """Creating a new ticket surfaces orphan branches already in the workspace."""
+        from io import StringIO  # noqa: PLC0415
+
+        from teatree.core.orphan_guard import BranchReport, BranchStatus  # noqa: PLC0415
+
+        fake_orphans = [
+            BranchReport(repo="/ws/org/repo", branch="feat-old", status=BranchStatus.PUSHED_ORPHAN, ahead_count=3),
+        ]
+        stderr_buf = StringIO()
+        with patch(
+            "teatree.core.management.commands.workspace.find_orphans_in_workspace",
+            return_value=fake_orphans,
+        ):
+            call_command("workspace", "ticket", "https://example.com/issues/500", stderr=stderr_buf)
+
+        written = stderr_buf.getvalue()
+        assert "orphan branch" in written.lower()
+        assert "feat-old" in written
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
     def test_auto_derives_slug_from_issue_title(self) -> None:
         """When no description given, uses overlay.metadata.get_issue_title to derive slug."""
         overlay = import_string(FULL_OVERLAY)()

--- a/tests/teatree_core/test_orphan_guard.py
+++ b/tests/teatree_core/test_orphan_guard.py
@@ -1,0 +1,195 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from teatree.core.cleanup import BranchClassification, BranchCommit
+from teatree.core.models import Ticket, Worktree
+from teatree.core.orphan_guard import (
+    BranchReport,
+    BranchStatus,
+    classify_branch,
+    find_orphans_in_workspace,
+)
+
+_patch_classify = patch("teatree.core.orphan_guard.classify_branch_commits")
+_patch_tree_match = patch("teatree.core.orphan_guard._branch_tree_matches_squash")
+_patch_open_pr = patch("teatree.core.orphan_guard.find_open_pr")
+_patch_git = patch("teatree.core.orphan_guard.git")
+
+
+def _classification(ahead: list[BranchCommit] | None = None) -> BranchClassification:
+    return BranchClassification(genuinely_ahead=ahead or [])
+
+
+def _commit(sha: str = "abc", subject: str = "feat: x") -> BranchCommit:
+    return BranchCommit(sha=sha, subject=subject, is_merge=False)
+
+
+class TestClassifyBranch(TestCase):
+    @_patch_classify
+    def test_synced_when_no_commits_ahead(self, mock_classify: MagicMock) -> None:
+        mock_classify.return_value = _classification()
+        report = classify_branch("/repo", "feature")
+        assert report.status is BranchStatus.SYNCED
+        assert report.ahead_count == 0
+        assert not report.is_orphan
+
+    @_patch_tree_match
+    @_patch_classify
+    def test_synced_when_tree_matches_squash_commit(
+        self,
+        mock_classify: MagicMock,
+        mock_tree_match: MagicMock,
+    ) -> None:
+        mock_classify.return_value = _classification([_commit()])
+        mock_tree_match.return_value = True
+        report = classify_branch("/repo", "feature")
+        assert report.status is BranchStatus.SYNCED
+
+    @_patch_open_pr
+    @_patch_tree_match
+    @_patch_classify
+    def test_open_pr_when_branch_has_open_pr(
+        self,
+        mock_classify: MagicMock,
+        mock_tree_match: MagicMock,
+        mock_open_pr: MagicMock,
+    ) -> None:
+        mock_classify.return_value = _classification([_commit()])
+        mock_tree_match.return_value = False
+        mock_open_pr.return_value = "https://github.com/org/repo/pull/42"
+        report = classify_branch("/repo", "feature")
+        assert report.status is BranchStatus.OPEN_PR
+        assert report.open_pr_url == "https://github.com/org/repo/pull/42"
+        assert not report.is_orphan
+
+    @_patch_git
+    @_patch_open_pr
+    @_patch_tree_match
+    @_patch_classify
+    def test_pushed_orphan_when_remote_exists_but_no_open_pr(
+        self,
+        mock_classify: MagicMock,
+        mock_tree_match: MagicMock,
+        mock_open_pr: MagicMock,
+        mock_git: MagicMock,
+    ) -> None:
+        mock_classify.return_value = _classification([_commit(), _commit("def", "feat: y")])
+        mock_tree_match.return_value = False
+        mock_open_pr.return_value = ""
+        mock_git.run.return_value = "abc123\trefs/heads/feature"
+        report = classify_branch("/repo", "feature")
+        assert report.status is BranchStatus.PUSHED_ORPHAN
+        assert report.ahead_count == 2
+        assert report.is_orphan
+
+    @_patch_git
+    @_patch_open_pr
+    @_patch_tree_match
+    @_patch_classify
+    def test_unpushed_orphan_when_no_remote_branch_exists(
+        self,
+        mock_classify: MagicMock,
+        mock_tree_match: MagicMock,
+        mock_open_pr: MagicMock,
+        mock_git: MagicMock,
+    ) -> None:
+        mock_classify.return_value = _classification([_commit()])
+        mock_tree_match.return_value = False
+        mock_open_pr.return_value = ""
+        mock_git.run.return_value = ""
+        report = classify_branch("/repo", "feature")
+        assert report.status is BranchStatus.UNPUSHED_ORPHAN
+        assert report.is_orphan
+
+
+class TestFindOrphansInWorkspace(TestCase):
+    def _make_worktree(self, repo_path: str, branch: str) -> Worktree:
+        ticket = Ticket.objects.create(
+            issue_url=f"https://gitlab.com/org/{repo_path}/-/issues/{branch}",
+            state=Ticket.State.IN_REVIEW,
+        )
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path=repo_path,
+            branch=branch,
+        )
+
+    @patch("teatree.core.orphan_guard.load_config")
+    @patch("teatree.core.orphan_guard.classify_branch")
+    def test_returns_only_orphans(
+        self,
+        mock_classify: MagicMock,
+        mock_config: MagicMock,
+    ) -> None:
+        fake_workspace = MagicMock()
+
+        def _fake_div(_self: object, x: str) -> MagicMock:
+            return MagicMock(spec=Path, is_dir=lambda: True, __str__=lambda _s: f"/ws/{x}")
+
+        fake_workspace.__truediv__ = _fake_div
+        mock_config.return_value.user.workspace_dir = fake_workspace
+
+        self._make_worktree("org/alpha", "feat-1")
+        self._make_worktree("org/beta", "feat-2")
+        self._make_worktree("org/gamma", "feat-3")
+
+        def classify(_repo: str, branch: str) -> BranchReport:
+            statuses = {
+                "feat-1": BranchStatus.SYNCED,
+                "feat-2": BranchStatus.PUSHED_ORPHAN,
+                "feat-3": BranchStatus.UNPUSHED_ORPHAN,
+            }
+            return BranchReport(repo=_repo, branch=branch, status=statuses[branch], ahead_count=1)
+
+        mock_classify.side_effect = classify
+
+        orphans = find_orphans_in_workspace()
+
+        branches = [o.branch for o in orphans]
+        assert "feat-1" not in branches
+        assert "feat-2" in branches
+        assert "feat-3" in branches
+        assert len(orphans) == 2
+
+    @patch("teatree.core.orphan_guard.load_config")
+    @patch("teatree.core.orphan_guard.classify_branch")
+    def test_deduplicates_by_repo_and_branch(
+        self,
+        mock_classify: MagicMock,
+        mock_config: MagicMock,
+    ) -> None:
+        fake_workspace = MagicMock()
+
+        def _fake_div(_self: object, x: str) -> MagicMock:
+            return MagicMock(spec=Path, is_dir=lambda: True, __str__=lambda _s: f"/ws/{x}")
+
+        fake_workspace.__truediv__ = _fake_div
+        mock_config.return_value.user.workspace_dir = fake_workspace
+
+        self._make_worktree("org/alpha", "feat-1")
+        # Same repo+branch across tickets
+        ticket2 = Ticket.objects.create(
+            issue_url="https://gitlab.com/org/alpha/-/issues/200",
+            state=Ticket.State.IN_REVIEW,
+        )
+        Worktree.objects.create(
+            overlay="test",
+            ticket=ticket2,
+            repo_path="org/alpha",
+            branch="feat-1",
+        )
+
+        mock_classify.return_value = BranchReport(
+            repo="/ws/org/alpha",
+            branch="feat-1",
+            status=BranchStatus.PUSHED_ORPHAN,
+            ahead_count=1,
+        )
+
+        orphans = find_orphans_in_workspace()
+
+        assert len(orphans) == 1
+        assert mock_classify.call_count == 1

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -12,8 +12,10 @@ from teatree.core.management.commands.pr import (
     _check_shipping_gate,
     _resolve_base_url,
     _run_visual_qa_gate,
+    _slug_from_remote,
 )
 from teatree.core.models import Session, Ticket, Worktree
+from teatree.core.orphan_guard import BranchReport, BranchStatus
 from teatree.core.overlay_loader import reset_overlay_cache
 from tests.teatree_core.conftest import CommandOverlay
 
@@ -108,6 +110,133 @@ class TestPrCreateThinWrapper(TestCase):
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.REVIEWED  # not advanced
         assert result["allowed"] is False
+
+
+class TestSlugFromRemote(TestCase):
+    def test_github_ssh(self) -> None:
+        assert _slug_from_remote("git@github.com:souliane/teatree.git") == "souliane/teatree"
+
+    def test_github_https(self) -> None:
+        assert _slug_from_remote("https://github.com/souliane/teatree.git") == "souliane/teatree"
+
+    def test_gitlab_nested_namespace(self) -> None:
+        assert _slug_from_remote("git@gitlab.com:acme/team/backend.git") == "acme/team/backend"
+
+    def test_no_dot_git_suffix(self) -> None:
+        assert _slug_from_remote("https://github.com/souliane/teatree") == "souliane/teatree"
+
+    def test_empty_returns_empty(self) -> None:
+        assert _slug_from_remote("") == ""
+
+
+class TestEnsureDraft(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._monkeypatch = monkeypatch
+
+    def test_no_op_when_branch_has_open_pr(self) -> None:
+        host = MagicMock()
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command.git, "current_branch", return_value="feat-x"),
+            patch.object(
+                pr_command,
+                "classify_branch",
+                return_value=BranchReport(
+                    repo=".",
+                    branch="feat-x",
+                    status=BranchStatus.OPEN_PR,
+                    ahead_count=3,
+                    open_pr_url="https://gitlab.com/org/repo/-/merge_requests/42",
+                ),
+            ),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "ensure-draft"))
+
+        assert result["skipped"] == "open PR exists"
+        assert "42" in str(result["url"])
+        host.create_pr.assert_not_called()
+
+    def test_no_op_when_branch_synced(self) -> None:
+        host = MagicMock()
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command.git, "current_branch", return_value="feat-y"),
+            patch.object(
+                pr_command,
+                "classify_branch",
+                return_value=BranchReport(
+                    repo=".",
+                    branch="feat-y",
+                    status=BranchStatus.SYNCED,
+                    ahead_count=0,
+                ),
+            ),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "ensure-draft"))
+
+        assert "synced" in str(result["skipped"])
+        host.create_pr.assert_not_called()
+
+    def test_defers_when_branch_not_on_remote(self) -> None:
+        host = MagicMock()
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command.git, "current_branch", return_value="feat-z"),
+            patch.object(
+                pr_command,
+                "classify_branch",
+                return_value=BranchReport(
+                    repo=".",
+                    branch="feat-z",
+                    status=BranchStatus.UNPUSHED_ORPHAN,
+                    ahead_count=2,
+                ),
+            ),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "ensure-draft"))
+
+        assert "not on remote yet" in str(result["skipped"])
+        assert "feat-z" in str(result["hint"])
+        host.create_pr.assert_not_called()
+
+    def test_creates_draft_when_pushed_orphan(self) -> None:
+        host = MagicMock()
+        host.create_pr.return_value = {"url": "https://github.com/souliane/teatree/pull/999"}
+        host.current_user.return_value = "souliane"
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command.git, "current_branch", return_value="feat-q"),
+            patch.object(pr_command.git, "remote_url", return_value="git@github.com:souliane/teatree.git"),
+            patch.object(pr_command.git, "last_commit_message", return_value=("feat: cool thing", "body")),
+            patch.object(
+                pr_command,
+                "classify_branch",
+                return_value=BranchReport(
+                    repo=".",
+                    branch="feat-q",
+                    status=BranchStatus.PUSHED_ORPHAN,
+                    ahead_count=5,
+                ),
+            ),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "ensure-draft"))
+
+        assert result["url"] == "https://github.com/souliane/teatree/pull/999"
+        assert result["branch"] == "feat-q"
+        (spec,) = host.create_pr.call_args.args
+        assert spec.draft is True
+        assert spec.branch == "feat-q"
+        assert spec.repo == "souliane/teatree"
+        assert spec.title == "feat: cool thing"
 
 
 class TestPostEvidence(TestCase):

--- a/tests/test_skill_tracking_hook.py
+++ b/tests/test_skill_tracking_hook.py
@@ -21,6 +21,13 @@ def _isolate_state_dir(tmp_path: Path):
     router.STATE_DIR = original
 
 
+@pytest.fixture(autouse=True)
+def _no_real_orphan_fetch():
+    """Prevent session-end tests from shelling out to the real t3 CLI."""
+    with patch.object(router, "_fetch_orphans", return_value=[]):
+        yield
+
+
 def _read_skills(session_id: str) -> list[str]:
     skills_file = router.STATE_DIR / f"{session_id}.skills"
     if not skills_file.is_file():
@@ -204,3 +211,64 @@ class TestSessionEndRetro:
         assert "t3:code" in output["additionalContext"]
         assert "t3:review" in output["additionalContext"]
         assert "ac-python" not in output["additionalContext"]
+
+
+class TestSessionEndOrphans:
+    """SessionEnd surfaces orphan branches alongside the retro suggestion."""
+
+    def test_orphan_summary_included_when_orphans_exist(self) -> None:
+        skills_file = router.STATE_DIR / "sess-orphan-1.skills"
+        skills_file.write_text("t3:code\n", encoding="utf-8")
+
+        fake_orphans = [
+            {"repo": "/ws/org/backend", "branch": "feat-1", "status": "pushed_orphan", "ahead_count": 3},
+            {"repo": "/ws/org/frontend", "branch": "feat-2", "status": "unpushed_orphan", "ahead_count": 1},
+        ]
+        stdout = StringIO()
+        with (
+            patch.object(router, "_fetch_orphans", return_value=fake_orphans),
+            patch("sys.stdout", stdout),
+        ):
+            handle_session_end({"session_id": "sess-orphan-1"})
+
+        output = json.loads(stdout.getvalue())
+        ctx = output["additionalContext"]
+        assert "ORPHAN BRANCHES DETECTED (2)" in ctx
+        assert "feat-1" in ctx
+        assert "feat-2" in ctx
+        assert "/ws/org/backend" in ctx
+        assert "ensure-draft" in ctx
+
+    def test_orphan_preview_truncates_long_lists(self) -> None:
+        skills_file = router.STATE_DIR / "sess-orphan-2.skills"
+        skills_file.write_text("t3:code\n", encoding="utf-8")
+
+        many = [
+            {"repo": f"/ws/r{i}", "branch": f"br-{i}", "status": "pushed_orphan", "ahead_count": 1} for i in range(8)
+        ]
+        stdout = StringIO()
+        with (
+            patch.object(router, "_fetch_orphans", return_value=many),
+            patch("sys.stdout", stdout),
+        ):
+            handle_session_end({"session_id": "sess-orphan-2"})
+
+        output = json.loads(stdout.getvalue())
+        ctx = output["additionalContext"]
+        assert "ORPHAN BRANCHES DETECTED (8)" in ctx
+        assert "and 3 more" in ctx
+
+    def test_no_orphans_but_lifecycle_skills_still_shows_retro(self) -> None:
+        skills_file = router.STATE_DIR / "sess-orphan-3.skills"
+        skills_file.write_text("t3:code\n", encoding="utf-8")
+
+        stdout = StringIO()
+        with (
+            patch.object(router, "_fetch_orphans", return_value=[]),
+            patch("sys.stdout", stdout),
+        ):
+            handle_session_end({"session_id": "sess-orphan-3"})
+
+        output = json.loads(stdout.getvalue())
+        assert "retro" in output["additionalContext"].lower()
+        assert "ORPHAN" not in output["additionalContext"]


### PR DESCRIPTION
## Summary

Closes #435. Adds a single source of truth for orphan-branch detection (`src/teatree/core/orphan_guard.py`) and wires it into the three enforcement points called out in the issue:

- **Pre-push CLI** — `t3 <overlay> pr ensure-draft` auto-opens a draft PR for orphan branches; registered as a prek `pre-push` hook so every push that would create an orphan now leaves a tracking artifact from the first push. For first-push cases where the branch isn't on the remote yet, the command returns a skip hint instead of erroring.
- **Session-end hook** — `handle_session_end()` in `hooks/scripts/hook_router.py` shells out to `t3 teatree workspace list-orphans` (4s timeout) and includes a 5-line orphan preview in `additionalContext` alongside the existing retro suggestion, so the agent sees orphans before the session closes.
- **`workspace ticket`** — warns on `stderr` when the workspace already contains orphans before creating a new worktree. Users can follow the suggested remediation (`ensure-draft` or `clean-all`) before adding to the pile.

The fourth point from the issue (teardown) is already enforced by `cleanup.py`'s `_raise_if_genuinely_ahead` guard (#429), so no change was needed there.

### Design

- `classify_branch(repo, branch)` returns a `BranchReport` with status `SYNCED | OPEN_PR | UNPUSHED_ORPHAN | PUSHED_ORPHAN` using the existing subject-match + tree-equality heuristics.
- `find_orphans_in_workspace()` iterates `Worktree.objects.all()`, deduplicating by `(repo, branch)`.
- `_probe_host_cli` in `cleanup.py` is renamed to `probe_host_cli` (public) so `orphan_guard` can reuse the GitHub/GitLab CLI probing without duplicating it.
- `PullRequestSpec` gains a `draft: bool = False` field; `github.py` passes `--draft`, `gitlab.py` prefixes the title with `Draft:`.

## Test plan

- [x] Unit tests for `orphan_guard.classify_branch` covering all 4 statuses (7 tests)
- [x] Unit tests for `find_orphans_in_workspace` (dedup + filter) (2 tests)
- [x] `test_pr_command.py::TestSlugFromRemote` (5 tests) + `TestEnsureDraft` (4 tests)
- [x] `test_skill_tracking_hook.py::TestSessionEndOrphans` (3 tests)
- [x] `test_new_management_commands.py::test_warns_about_existing_orphans_before_creating`
- [x] Full suite: 2451 passed, 12 skipped
- [x] ruff + ty + module-health + version-sync + blueprint-sync + pre-push hook all green