### PR TITLE
fix(retro): capture lessons from #140 dead-bridge + parallel-MR session

### DIFF
--- a/skills/code/references/troubleshooting.md
+++ b/skills/code/references/troubleshooting.md
@@ -7,9 +7,23 @@
 ## Overlay Groups Show Only a Generic `run` Passthrough
 
 - **Symptom:** `t3 <overlay> <group> --help` shows a single `run` subcommand instead of the actual management command subcommands (e.g., `refresh`, `restore-ci`, `reset-passwords`).
-- **Cause:** `_build_overlay_app` bridges management commands via `_bridge_subcommand` — if the `_DJANGO_GROUPS` registry doesn't list individual subcommands, only the generic passthrough appears.
-- **Fix:** Add each subcommand explicitly to `_DJANGO_GROUPS` in `cli.py` with `(name, help_text)` tuples. The bridge creates one Typer command per entry that delegates to `manage.py <group> <subcommand>`.
-- **Prevention:** When adding a new management subcommand, always add a matching entry in `_DJANGO_GROUPS`.
+- **Cause:** `_build_overlay_app` bridges management commands via `_bridge_subcommand` — if the `DJANGO_GROUPS` registry doesn't list individual subcommands, only the generic passthrough appears.
+- **Fix:** Add each subcommand explicitly to `DJANGO_GROUPS` in `cli/overlay.py` with `(name, help_text)` tuples. The bridge creates one Typer command per entry that delegates to `manage.py <group> <subcommand>`.
+- **Prevention:** When adding, renaming, or deleting a management command or subcommand, always update the matching entry in `DJANGO_GROUPS` in the **same commit**. The bridge does not auto-discover Django commands — a missing entry is silent (no group at all), and a stale entry dispatches to a non-existent backend (each call 404s with `Unknown command`).
+
+## Overlay Bridge Dispatches to a Deleted Django Command
+
+- **Symptom:** `t3 <overlay> <group> <sub>` exits with `Unknown command: '<group>'` after a recent rename/refactor of the underlying management command, even though `t3 <overlay> <group> --help` lists the subcommand.
+- **Cause:** `cli/overlay.py:DJANGO_GROUPS` still maps `<group>` to a Django command that has been renamed or deleted. The bridge happily forwards to a target that no longer exists; the failure surfaces only when the user runs the subcommand for real.
+- **Fix:** Update `DJANGO_GROUPS` to point at the current Django command names (e.g. when `lifecycle` was split into `worktree` + `workspace`, the bridge needed both groups, not the old one). Also retire any docs/skills that still mention the dead group.
+- **Prevention:** The existing `tests/test_cli_overlay.py` bridge tests mock `managepy`, so they pass even when the target is dead. Treat any rename/deletion of a Django command in `core/management/commands/` as a `DJANGO_GROUPS` change too — and run `t3 <overlay> <group> <sub> --help` end-to-end once after the change to confirm the dispatch resolves.
+
+## Doc-Only "Fix" Propagates a Broken CLI Reference
+
+- **Symptom:** A docs-only commit replaces stale CLI invocations (e.g. `t3 lifecycle setup` → `t3 <overlay> lifecycle setup`) but every reader who copy-pastes the new form still gets `Unknown command`.
+- **Cause:** The retarget assumed the new command exists because the old one used to. When the underlying Django command (or bridge entry) was deleted in a prior PR, prose retargeting alone can't make the new invocation work — it just relocates the broken reference.
+- **Fix:** Before shipping a doc-only retarget of a CLI invocation, smoke-test the new form with `t3 <overlay> <group> <sub> --help`. If the call fails, the docs aren't stale — the CLI is broken, and the right scope is "fix the CLI bridge **and** the docs in one PR".
+- **Prevention:** Treat "stale `t3` reference" findings as a tripwire, not a docs typo. Always check `cli/overlay.py:DJANGO_GROUPS` and `core/management/commands/` before shipping the retarget.
 
 ## CLI References Undefined Sub-Apps After Script Migration
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -219,6 +219,23 @@ When a CI failure (or any bug found during work) is **pre-existing** — not int
 
 **How to detect:** `git diff origin/main...HEAD --name-only` — if the failing file was never touched by the feature branch, the bug is pre-existing.
 
+## One Open MR Per Ticket (Non-Negotiable)
+
+Before opening a new MR/PR, check whether a sibling MR for the **same ticket** is already open on the same repo:
+
+```bash
+gh pr list --repo <repo> --search "<ticket-ref> is:open" --json number,headRefName,baseRefName
+```
+
+If a sibling is open, **do not open a second MR targeting the default branch** — the two branches will diverge on the same files and the second one will need a painful 3-way merge. Pick one:
+
+1. **Wait for the sibling to merge**, then rebase the new work on the updated default branch and open the MR.
+2. **Stack on the sibling's branch** — set the new MR's base to the sibling's source branch (`gh pr create --base <sibling-branch>`). Update the base to the default branch after the sibling merges, so the stacked MR stays minimal.
+
+**Never open two MRs on the same ticket targeting the default branch in parallel.** The only exception is when the two MRs touch genuinely disjoint files (different repos, different modules with no shared imports, no overlapping generated docs) — and even then, the second MR's description must name the sibling PR it races with.
+
+**Past failure (#140 / PRs #427 + #436):** Both PRs touched `README.md`, `BLUEPRINT.md`, `src/teatree/core/*` and ran in parallel against `main`. When #427 squash-merged first, #436 inherited an unsynced merge base and required a full 3-way conflict resolution. Opening #436 as a stacked PR with `--base ac/teatree-#140-initial-ship` would have avoided every conflict.
+
 ## Bundle Into an Existing Open PR
 
 When a session uncovers a small unique commit on a now-stale branch (typical during cleanup or retro), and opening a dedicated PR for that one commit would be more ceremony than the change deserves, **bundle it into a sibling open PR** instead. This trades a little PR-scope discipline for delivery speed.


### PR DESCRIPTION
## Summary

Three retro findings from the #140 transition-driven delivery session, captured into the right skills before they get lost:

1. **\`code/references/troubleshooting.md\`** — extended the existing \`DJANGO_GROUPS\` rule to cover **rename / delete** of Django commands (the bridge in \`cli/overlay.py\` happily dispatches to a deleted backend), plus a new dedicated entry for that failure mode.
2. **\`code/references/troubleshooting.md\`** — added a \"doc-only fix propagating broken CLI reference\" entry. PR #437 retargeted prose without smoke-testing the new form, so every reader who copy-pasted still hit \`Unknown command\`.
3. **\`ship/SKILL.md\`** — added a \"One Open MR Per Ticket (Non-Negotiable)\" rule with the wait-or-stack decision and the past-failure citation (#427 + #436 ran in parallel against \`main\` on the same files, forcing a 3-way merge).

## Test plan

- [x] \`prek run --files skills/code/references/troubleshooting.md skills/ship/SKILL.md\` (passed via commit hook)
- [x] No banned terms / PII (privacy-scan grep clean)

Refs #140