### PR TITLE
test(config): convert test_config.py to integration-first

### DIFF
--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -159,7 +159,9 @@ class TeaTreeConfig:
     raw: dict = field(default_factory=dict)
 
 
-def load_config(path: Path = CONFIG_PATH) -> TeaTreeConfig:
+def load_config(path: Path | None = None) -> TeaTreeConfig:
+    if path is None:
+        path = CONFIG_PATH
     if not path.is_file():
         return TeaTreeConfig()
 
@@ -192,7 +194,7 @@ def load_config(path: Path = CONFIG_PATH) -> TeaTreeConfig:
     return TeaTreeConfig(user=user, raw=raw)
 
 
-def load_e2e_repos(path: Path = CONFIG_PATH) -> list[E2ERepo]:
+def load_e2e_repos(path: Path | None = None) -> list[E2ERepo]:
     """Load named E2E repos from ``[e2e_repos.<name>]`` sections in ``~/.teatree.toml``.
 
     Each entry may specify ``url``, ``branch``, and optionally ``e2e_dir``
@@ -352,7 +354,7 @@ def _write_update_cache(cache_path: Path, message: str) -> None:
     )
 
 
-def discover_overlays(config_path: Path = CONFIG_PATH) -> list[OverlayEntry]:
+def discover_overlays(config_path: Path | None = None) -> list[OverlayEntry]:
     """Discover overlays from ~/.teatree.toml and installed entry points.
 
     Sources (merged by name, toml wins on conflict):
@@ -361,6 +363,8 @@ def discover_overlays(config_path: Path = CONFIG_PATH) -> list[OverlayEntry]:
     """
     from importlib.metadata import entry_points  # noqa: PLC0415
 
+    if config_path is None:
+        config_path = CONFIG_PATH
     seen: dict[str, OverlayEntry] = {}
 
     # 1. Toml config

--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -44,11 +44,17 @@ def _parse_env_file(path: Path) -> dict[str, str]:
 
 
 def _find_env_cache(cwd: str) -> Path | None:
-    """Walk up from *cwd* looking for the env cache (file or symlink)."""
+    """Walk up from *cwd* looking for the env cache.
+
+    Only returns a path whose target can actually be read. ``is_file()``
+    follows symlinks and returns False for broken ones, so this naturally
+    skips worktree symlinks whose target is not present in the current
+    filesystem view (e.g. Docker mounts that don't include the ticket dir).
+    """
     cwd_path = Path(cwd)
     for parent in [cwd_path, *cwd_path.parents]:
         candidate = parent / CACHE_FILENAME
-        if candidate.is_file() or candidate.is_symlink():
+        if candidate.is_file():
             return candidate
     return None
 

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -88,6 +88,20 @@ class TestFindEnvCache:
 
         assert result is None
 
+    def test_broken_symlink_is_ignored(self, tmp_path: Path) -> None:
+        """Broken symlinks are not returned.
+
+        Under a Docker mount that does not include the ticket dir, the
+        worktree's ``.t3-env.cache`` symlink stays present but its target
+        disappears; returning it would crash downstream ``read_text``.
+        """
+        link = tmp_path / ".t3-env.cache"
+        link.symlink_to(tmp_path / "does-not-exist" / ".t3-env.cache")
+
+        result = _find_env_cache(str(tmp_path))
+
+        assert result is None
+
 
 class TestMatchWorktreeByPath(TestCase):
     def test_exact_match(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,16 +1,25 @@
-"""Tests for overlay discovery from ~/.teatree.toml and entry points."""
+"""Tests for overlay discovery from ~/.teatree.toml and entry points.
 
-import importlib.util
+Integration-first per the Test-Writing Doctrine: real TOML fixtures under
+``tmp_path`` with ``teatree.config.CONFIG_PATH`` monkeypatched to them.
+Mocks are reserved for unstoppable externals: the ``gh`` CLI call in
+``check_for_updates`` (network) and ``importlib.metadata.entry_points``
+(represents installed overlay packages — otherwise we'd have to install
+fixture packages per test).
+"""
+
 import json
 import subprocess
-import types
+import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from teatree.config import (
     E2ERepo,
     Mode,
-    OverlayEntry,
     _extract_settings_module,
     _resolve_ep_project_path,
     _write_update_cache,
@@ -37,7 +46,34 @@ def _write_toml(config_path: Path, content: str) -> None:
     config_path.write_text(content, encoding="utf-8")
 
 
-def test_discover_overlays_from_toml(tmp_path):
+@pytest.fixture
+def config_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Stage a real ``~/.teatree.toml`` under ``tmp_path`` and wire it to the module."""
+    cfg = tmp_path / ".teatree.toml"
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+    return cfg
+
+
+@pytest.fixture
+def no_installed_overlays(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``importlib.metadata.entry_points`` report no teatree overlays.
+
+    Installed teatree entry points (``t3-teatree``) would otherwise leak
+    into overlay discovery and shadow the TOML fixtures.
+    """
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda **_kw: [])
+
+
+@pytest.fixture
+def elsewhere(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run the test from a cwd free of ``manage.py`` ancestors."""
+    away = tmp_path / "no_manage"
+    away.mkdir()
+    monkeypatch.chdir(away)
+    return away
+
+
+def test_discover_overlays_from_toml(tmp_path: Path) -> None:
     project = tmp_path / "my-overlay"
     _write_manage_py(project, "myoverlay.settings")
 
@@ -57,7 +93,7 @@ path = "{project}"
     assert by_name["my-overlay"].project_path == project
 
 
-def test_discover_overlays_with_explicit_class(tmp_path):
+def test_discover_overlays_with_explicit_class(tmp_path: Path) -> None:
     config_path = tmp_path / ".teatree.toml"
     _write_toml(
         config_path,
@@ -74,7 +110,7 @@ class = "my_overlay.overlay:MyOverlay"
     assert by_name["my-overlay"].project_path is None
 
 
-def test_discover_overlays_empty_toml(tmp_path):
+def test_discover_overlays_empty_toml(tmp_path: Path) -> None:
     config_path = tmp_path / ".teatree.toml"
     _write_toml(config_path, "[teatree]\n")
 
@@ -85,7 +121,7 @@ def test_discover_overlays_empty_toml(tmp_path):
     assert "my-overlay" not in toml_names  # no TOML overlay was configured
 
 
-def test_discover_overlays_missing_toml(tmp_path):
+def test_discover_overlays_missing_toml(tmp_path: Path) -> None:
     config_path = tmp_path / "nonexistent.toml"
     result = discover_overlays(config_path=config_path)
     # No TOML file at all — only entry-point overlays may appear.
@@ -93,7 +129,7 @@ def test_discover_overlays_missing_toml(tmp_path):
     assert "my-overlay" not in toml_names
 
 
-def test_discover_overlays_path_without_manage_py(tmp_path):
+def test_discover_overlays_path_without_manage_py(tmp_path: Path) -> None:
     project = tmp_path / "empty-overlay"
     project.mkdir()
 
@@ -112,7 +148,7 @@ path = "{project}"
     assert by_name["empty-overlay"].overlay_class == ""
 
 
-def test_discover_overlays_multiple(tmp_path):
+def test_discover_overlays_multiple(tmp_path: Path) -> None:
     for name, settings in [("proj-a", "a.settings"), ("proj-b", "b.settings")]:
         _write_manage_py(tmp_path / name, settings)
 
@@ -133,7 +169,7 @@ path = "{tmp_path / "proj-b"}"
     assert {"proj-a", "proj-b"} <= names
 
 
-def test_discover_overlays_tilde_expansion(tmp_path, monkeypatch):
+def test_discover_overlays_tilde_expansion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     project = tmp_path / "home" / "workspace" / "my-project"
     _write_manage_py(project, "myproj.settings")
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
@@ -157,7 +193,7 @@ path = "~/workspace/my-project"
 # ── load_config ───────────────────────────────────────────────────────
 
 
-def test_load_config_from_file(tmp_path):
+def test_load_config_from_file(tmp_path: Path) -> None:
     config_path = tmp_path / ".teatree.toml"
     _write_toml(
         config_path,
@@ -175,14 +211,14 @@ privacy = "strict"
     assert "teatree" in config.raw
 
 
-def test_load_config_missing_file(tmp_path):
+def test_load_config_missing_file(tmp_path: Path) -> None:
     config = load_config(tmp_path / "nonexistent.toml")
     assert config.user.workspace_dir == Path.home() / "workspace"
     assert config.user.branch_prefix == ""
     assert config.user.privacy == ""
 
 
-def test_load_config_defaults_when_teatree_section_empty(tmp_path):
+def test_load_config_defaults_when_teatree_section_empty(tmp_path: Path) -> None:
     config_path = tmp_path / ".teatree.toml"
     _write_toml(config_path, "[other]\nfoo = 1\n")
     config = load_config(config_path)
@@ -192,7 +228,7 @@ def test_load_config_defaults_when_teatree_section_empty(tmp_path):
 # ── get_data_dir ──────────────────────────────────────────────────────
 
 
-def test_get_data_dir_creates_directory(tmp_path, monkeypatch):
+def test_get_data_dir_creates_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path / "data")
     result = get_data_dir("test-namespace")
     assert result == tmp_path / "data" / "test-namespace"
@@ -202,7 +238,7 @@ def test_get_data_dir_creates_directory(tmp_path, monkeypatch):
 # ── default_logging ───────────────────────────────────────────────────
 
 
-def test_default_logging_returns_dict(tmp_path, monkeypatch):
+def test_default_logging_returns_dict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path / "data")
     config = default_logging("test-ns")
     assert config["version"] == 1
@@ -215,13 +251,13 @@ def test_default_logging_returns_dict(tmp_path, monkeypatch):
 # ── _extract_settings_module ──────────────────────────────────────────
 
 
-def test_extract_settings_module_found(tmp_path):
+def test_extract_settings_module_found(tmp_path: Path) -> None:
     manage_py = tmp_path / "manage.py"
     manage_py.write_text('os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myapp.settings")\n')
     assert _extract_settings_module(manage_py) == "myapp.settings"
 
 
-def test_extract_settings_module_not_found(tmp_path):
+def test_extract_settings_module_not_found(tmp_path: Path) -> None:
     manage_py = tmp_path / "manage.py"
     manage_py.write_text("#!/usr/bin/env python\npass\n")
     assert _extract_settings_module(manage_py) == ""
@@ -230,7 +266,7 @@ def test_extract_settings_module_not_found(tmp_path):
 # ── discover_active_overlay ──────────────────────────────────────────
 
 
-def test_discover_active_overlay_from_manage_py(tmp_path, monkeypatch):
+def test_discover_active_overlay_from_manage_py(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """discover_active_overlay finds overlay from manage.py in cwd ancestors."""
     _write_manage_py(tmp_path, "active.settings")
     monkeypatch.chdir(tmp_path)
@@ -239,48 +275,49 @@ def test_discover_active_overlay_from_manage_py(tmp_path, monkeypatch):
     assert result.project_path == tmp_path
 
 
-def test_discover_active_overlay_single_installed(tmp_path, monkeypatch):
-    """discover_active_overlay returns single installed overlay."""
-    # No manage.py in cwd hierarchy
-    sub = tmp_path / "no_manage"
-    sub.mkdir()
-    monkeypatch.chdir(sub)
-    from teatree.config import OverlayEntry  # noqa: PLC0415
+def test_discover_active_overlay_single_installed(
+    config_file: Path, elsewhere: Path, no_installed_overlays: None
+) -> None:
+    """Single TOML-declared overlay (no manage.py in cwd ancestors) is picked as active."""
+    del elsewhere, no_installed_overlays
+    _write_toml(config_file, '[overlays.acme]\nclass = "acme.settings"\n')
 
-    single = [OverlayEntry(name="acme", overlay_class="acme.settings")]
-    with patch("teatree.config.discover_overlays", return_value=single):
-        result = discover_active_overlay()
-        assert result is not None
-        assert result.name == "acme"
+    result = discover_active_overlay()
+
+    assert result is not None
+    assert result.name == "acme"
 
 
-def test_discover_active_overlay_none_when_multiple(tmp_path, monkeypatch):
-    """discover_active_overlay returns None when multiple overlays installed."""
-    sub = tmp_path / "no_manage"
-    sub.mkdir()
-    monkeypatch.chdir(sub)
-    from teatree.config import OverlayEntry  # noqa: PLC0415
+def test_discover_active_overlay_none_when_multiple(
+    config_file: Path, elsewhere: Path, no_installed_overlays: None
+) -> None:
+    """Multiple declared overlays + no cwd hint → cannot pick an active one."""
+    del elsewhere, no_installed_overlays
+    _write_toml(
+        config_file,
+        """
+[overlays.a]
+class = "a.settings"
 
-    multiple = [
-        OverlayEntry(name="a", overlay_class="a.settings"),
-        OverlayEntry(name="b", overlay_class="b.settings"),
-    ]
-    with patch("teatree.config.discover_overlays", return_value=multiple):
-        assert discover_active_overlay() is None
+[overlays.b]
+class = "b.settings"
+""",
+    )
 
-
-def test_discover_active_overlay_none_when_no_overlays(tmp_path, monkeypatch):
-    sub = tmp_path / "no_manage"
-    sub.mkdir()
-    monkeypatch.chdir(sub)
-    with patch("teatree.config.discover_overlays", return_value=[]):
-        assert discover_active_overlay() is None
+    assert discover_active_overlay() is None
 
 
-def test_discover_overlays_entry_points(tmp_path, monkeypatch):
+def test_discover_active_overlay_none_when_no_overlays(
+    config_file: Path, elsewhere: Path, no_installed_overlays: None
+) -> None:
+    """No TOML overlays + no entry points + no manage.py → None."""
+    del config_file, elsewhere, no_installed_overlays
+
+    assert discover_active_overlay() is None
+
+
+def test_discover_overlays_entry_points(tmp_path: Path) -> None:
     """Overlays can be discovered from installed entry points."""
-    from unittest.mock import MagicMock  # noqa: PLC0415
-
     config_path = tmp_path / ".teatree.toml"
     _write_toml(config_path, "[teatree]\n")
 
@@ -298,10 +335,8 @@ def test_discover_overlays_entry_points(tmp_path, monkeypatch):
         assert result[0].overlay_class == "ep_overlay.settings"
 
 
-def test_discover_overlays_toml_wins_over_entry_point(tmp_path):
+def test_discover_overlays_toml_wins_over_entry_point(tmp_path: Path) -> None:
     """Toml config takes precedence over entry points with same name."""
-    from unittest.mock import MagicMock  # noqa: PLC0415
-
     project = tmp_path / "my-overlay"
     _write_manage_py(project, "myoverlay.settings")
 
@@ -318,49 +353,55 @@ def test_discover_overlays_toml_wins_over_entry_point(tmp_path):
         assert result[0].overlay_class == "myoverlay.settings"
 
 
-def test_discover_from_manage_py_no_settings(tmp_path, monkeypatch):
-    """_discover_from_manage_py returns None when manage.py has no settings."""
+def test_discover_from_manage_py_no_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, no_installed_overlays: None
+) -> None:
+    """discover_active_overlay returns None when manage.py has no settings module and no overlays installed."""
+    del no_installed_overlays
     (tmp_path / "manage.py").write_text("#!/usr/bin/env python\npass\n")
     monkeypatch.chdir(tmp_path)
-    result = discover_active_overlay()
-    # It finds manage.py but can't extract settings module, so returns None
-    with patch("teatree.config.discover_overlays", return_value=[]):
-        result = discover_active_overlay()
-    assert result is None
+
+    assert discover_active_overlay() is None
 
 
 # ── _resolve_ep_project_path ─────────────────────────────────────────
 
 
-def test_resolve_ep_project_path_finds_manage_py(tmp_path):
+def test_resolve_ep_project_path_finds_manage_py(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Resolves project root by walking up from the package to manage.py."""
     project_root = tmp_path / "myproject"
-    pkg_dir = project_root / "src" / "mypkg"
+    pkg_dir = project_root / "src" / "mypkg_resolve_finds"
     pkg_dir.mkdir(parents=True)
-    _write_manage_py(project_root, "mypkg.settings")
+    (pkg_dir / "__init__.py").write_text("")
+    _write_manage_py(project_root, "mypkg_resolve_finds.settings")
 
-    mock_spec = types.SimpleNamespace(submodule_search_locations=[str(pkg_dir)])
-    with patch.object(importlib.util, "find_spec", return_value=mock_spec):
-        result = _resolve_ep_project_path("mypkg.settings")
+    monkeypatch.syspath_prepend(str(project_root / "src"))
+    # Ensure a fresh import so the spec points at our tmp pkg.
+    monkeypatch.delitem(sys.modules, "mypkg_resolve_finds", raising=False)
+
+    result = _resolve_ep_project_path("mypkg_resolve_finds.settings")
+
     assert result == project_root
 
 
-def test_resolve_ep_project_path_no_manage_py(tmp_path):
+def test_resolve_ep_project_path_no_manage_py(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Returns None when no manage.py exists in any ancestor."""
-    pkg_dir = tmp_path / "site-packages" / "mypkg"
+    pkg_dir = tmp_path / "site-packages" / "mypkg_resolve_no_manage"
     pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("")
 
-    mock_spec = types.SimpleNamespace(submodule_search_locations=[str(pkg_dir)])
-    with patch.object(importlib.util, "find_spec", return_value=mock_spec):
-        assert _resolve_ep_project_path("mypkg.settings") is None
+    monkeypatch.syspath_prepend(str(tmp_path / "site-packages"))
+    monkeypatch.delitem(sys.modules, "mypkg_resolve_no_manage", raising=False)
+
+    assert _resolve_ep_project_path("mypkg_resolve_no_manage.settings") is None
 
 
-def test_resolve_ep_project_path_unknown_package():
+def test_resolve_ep_project_path_unknown_package() -> None:
     """Returns None for a package that cannot be found."""
     assert _resolve_ep_project_path("nonexistent_pkg_xyz.settings") is None
 
 
-def test_discover_overlays_entry_point_with_project_path(tmp_path):
+def test_discover_overlays_entry_point_with_project_path(tmp_path: Path) -> None:
     """Entry-point overlay gets project_path resolved from package location."""
     config_path = tmp_path / ".teatree.toml"
     _write_toml(config_path, "[teatree]\n")
@@ -385,55 +426,62 @@ def test_discover_overlays_entry_point_with_project_path(tmp_path):
 
 
 class TestWorkspaceDir:
-    def test_returns_path_from_django_settings(self, tmp_path, settings):
+    def test_returns_path_from_django_settings(self, tmp_path: Path, settings) -> None:
         custom = tmp_path / "custom-ws"
         settings.T3_WORKSPACE_DIR = str(custom)
         result = workspace_dir()
         assert result == custom
 
-    def test_falls_back_to_config_file(self, tmp_path):
-        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
+    def test_falls_back_to_config_file(self, tmp_path: Path, config_file: Path, settings) -> None:
+        del config_file
+        _write_toml(
+            tmp_path / ".teatree.toml",
+            '[teatree]\nworkspace_dir = "/from/config"\n',
+        )
+        if hasattr(settings, "T3_WORKSPACE_DIR"):
+            del settings.T3_WORKSPACE_DIR
 
-        fake_config = TeaTreeConfig(user=UserSettings(workspace_dir=Path("/from/config")))
-        with patch("teatree.config.load_config", return_value=fake_config):
-            result = workspace_dir()
-        assert result == Path("/from/config")
+        assert workspace_dir() == Path("/from/config")
 
 
 class TestWorktreesDir:
-    def test_returns_path_from_django_settings(self, tmp_path, settings):
+    def test_returns_path_from_django_settings(self, tmp_path: Path, settings) -> None:
         custom = tmp_path / "custom-wt"
         settings.T3_WORKTREES_DIR = str(custom)
         result = worktrees_dir()
         assert result == custom
 
-    def test_falls_back_to_config_file(self, tmp_path):
-        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
+    def test_falls_back_to_config_file(self, tmp_path: Path, config_file: Path, settings) -> None:
+        del config_file
+        _write_toml(
+            tmp_path / ".teatree.toml",
+            '[teatree]\nworktrees_dir = "/from/config/wt"\n',
+        )
+        if hasattr(settings, "T3_WORKTREES_DIR"):
+            del settings.T3_WORKTREES_DIR
 
-        fake_config = TeaTreeConfig(user=UserSettings(worktrees_dir=Path("/from/config/wt")))
-        with patch("teatree.config.load_config", return_value=fake_config):
-            result = worktrees_dir()
-        assert result == Path("/from/config/wt")
+        assert worktrees_dir() == Path("/from/config/wt")
 
 
 # ── check_for_updates ────────────────────────────────────────────────
 
 
+def _write_check_updates_toml(config_file: Path, *, enabled: bool) -> None:
+    _write_toml(config_file, f"[teatree]\ncheck_updates = {'true' if enabled else 'false'}\n")
+
+
 class TestCheckForUpdates:
-    def _fake_config(self, *, check_updates: bool = True):
-        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
+    def test_returns_none_when_updates_disabled(self, config_file: Path) -> None:
+        """Early return None when check_updates=false and force=False."""
+        _write_check_updates_toml(config_file, enabled=False)
 
-        return TeaTreeConfig(user=UserSettings(check_updates=check_updates))
+        assert check_for_updates(force=False) is None
 
-    def test_returns_none_when_updates_disabled(self):
-        """Line 144: early return None when check_updates=false and force=False."""
-        with patch("teatree.config.load_config", return_value=self._fake_config(check_updates=False)):
-            assert check_for_updates(force=False) is None
-
-    def test_cached_result_returned_when_fresh(self, tmp_path, monkeypatch):
-        """Lines 153-156: return cached message when within TTL."""
-        import time  # noqa: PLC0415
-
+    def test_cached_result_returned_when_fresh(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_file: Path
+    ) -> None:
+        """Return cached message when within TTL."""
+        _write_check_updates_toml(config_file, enabled=True)
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         cache_path = data_dir / "update-check.json"
@@ -443,14 +491,13 @@ class TestCheckForUpdates:
         )
         monkeypatch.setattr("teatree.config.DATA_DIR", data_dir)
 
-        with patch("teatree.config.load_config", return_value=self._fake_config()):
-            result = check_for_updates(force=False)
-        assert result == "teatree v9.9 available"
+        assert check_for_updates(force=False) == "teatree v9.9 available"
 
-    def test_cached_empty_message_returns_none(self, tmp_path, monkeypatch):
-        """Lines 153-154: cached empty message means up-to-date => None."""
-        import time  # noqa: PLC0415
-
+    def test_cached_empty_message_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_file: Path
+    ) -> None:
+        """Cached empty message means up-to-date => None."""
+        _write_check_updates_toml(config_file, enabled=True)
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         cache_path = data_dir / "update-check.json"
@@ -460,11 +507,13 @@ class TestCheckForUpdates:
         )
         monkeypatch.setattr("teatree.config.DATA_DIR", data_dir)
 
-        with patch("teatree.config.load_config", return_value=self._fake_config()):
-            assert check_for_updates(force=False) is None
+        assert check_for_updates(force=False) is None
 
-    def test_cached_corrupt_json_falls_through(self, tmp_path, monkeypatch):
-        """Lines 155-156: corrupt cache JSON is silently ignored, proceeds to network check."""
+    def test_cached_corrupt_json_falls_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_file: Path
+    ) -> None:
+        """Corrupt cache JSON is silently ignored, proceeds to network check."""
+        _write_check_updates_toml(config_file, enabled=True)
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         cache_path = data_dir / "update-check.json"
@@ -473,60 +522,61 @@ class TestCheckForUpdates:
 
         mock_result = MagicMock(stdout="v1.0.0\n")
         with (
-            patch("teatree.config.load_config", return_value=self._fake_config()),
             patch("subprocess.run", return_value=mock_result),
             patch("importlib.metadata.version", return_value="1.0.0"),
         ):
             # Falls through corrupt cache, hits network, finds same version
             assert check_for_updates(force=False) is None
 
-    def test_empty_tag_returns_none(self, tmp_path, monkeypatch):
-        """Line 175: when gh returns empty tag, returns None."""
+    def test_empty_tag_returns_none(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_file: Path) -> None:
+        """When gh returns empty tag, returns None."""
+        _write_check_updates_toml(config_file, enabled=True)
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         monkeypatch.setattr("teatree.config.DATA_DIR", data_dir)
 
         mock_result = MagicMock(stdout="\n")
         with (
-            patch("teatree.config.load_config", return_value=self._fake_config()),
             patch("subprocess.run", return_value=mock_result),
             patch("importlib.metadata.version", return_value="1.0.0"),
         ):
             assert check_for_updates(force=True) is None
 
-    def test_subprocess_timeout_returns_none(self, tmp_path, monkeypatch):
-        """Lines 171-172: TimeoutExpired from gh CLI returns None."""
+    def test_subprocess_timeout_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_file: Path
+    ) -> None:
+        """TimeoutExpired from gh CLI returns None."""
+        _write_check_updates_toml(config_file, enabled=True)
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         monkeypatch.setattr("teatree.config.DATA_DIR", data_dir)
 
-        with (
-            patch("teatree.config.load_config", return_value=self._fake_config()),
-            patch("subprocess.run", side_effect=subprocess.TimeoutExpired("gh", 10)),
-        ):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("gh", 10)):
             assert check_for_updates(force=True) is None
 
-    def test_file_not_found_returns_none(self, tmp_path, monkeypatch):
-        """Lines 171-172: FileNotFoundError (gh not installed) returns None."""
+    def test_file_not_found_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_file: Path
+    ) -> None:
+        """FileNotFoundError (gh not installed) returns None."""
+        _write_check_updates_toml(config_file, enabled=True)
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         monkeypatch.setattr("teatree.config.DATA_DIR", data_dir)
 
-        with (
-            patch("teatree.config.load_config", return_value=self._fake_config()),
-            patch("subprocess.run", side_effect=FileNotFoundError),
-        ):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
             assert check_for_updates(force=True) is None
 
-    def test_newer_version_returns_upgrade_message(self, tmp_path, monkeypatch):
-        """Lines 177-184: when latest != current, returns upgrade message."""
+    def test_newer_version_returns_upgrade_message(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_file: Path
+    ) -> None:
+        """When latest != current, returns upgrade message."""
+        _write_check_updates_toml(config_file, enabled=True)
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         monkeypatch.setattr("teatree.config.DATA_DIR", data_dir)
 
         mock_result = MagicMock(stdout="v2.0.0\n")
         with (
-            patch("teatree.config.load_config", return_value=self._fake_config()),
             patch("subprocess.run", return_value=mock_result),
             patch("importlib.metadata.version", return_value="1.0.0"),
         ):
@@ -537,21 +587,22 @@ class TestCheckForUpdates:
         assert "1.0.0" in result
         assert "uv pip install --upgrade teatree" in result
 
-        # Verify cache was written
         cache_path = data_dir / "update-check.json"
         assert cache_path.is_file()
         cached = json.loads(cache_path.read_text(encoding="utf-8"))
         assert "v2.0.0" in cached["message"]
 
-    def test_same_version_returns_none_and_caches(self, tmp_path, monkeypatch):
-        """Lines 178-180: when latest == current, returns None and caches empty."""
+    def test_same_version_returns_none_and_caches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config_file: Path
+    ) -> None:
+        """When latest == current, returns None and caches empty."""
+        _write_check_updates_toml(config_file, enabled=True)
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         monkeypatch.setattr("teatree.config.DATA_DIR", data_dir)
 
         mock_result = MagicMock(stdout="v1.0.0\n")
         with (
-            patch("teatree.config.load_config", return_value=self._fake_config()),
             patch("subprocess.run", return_value=mock_result),
             patch("importlib.metadata.version", return_value="1.0.0"),
         ):
@@ -568,8 +619,8 @@ class TestCheckForUpdates:
 
 
 class TestWriteUpdateCache:
-    def test_creates_parent_dirs_and_writes_json(self, tmp_path):
-        """Lines 189-193: creates parent dirs and writes valid JSON cache."""
+    def test_creates_parent_dirs_and_writes_json(self, tmp_path: Path) -> None:
+        """Creates parent dirs and writes valid JSON cache."""
         cache_path = tmp_path / "nested" / "dir" / "update-check.json"
         _write_update_cache(cache_path, "test message")
 
@@ -583,7 +634,7 @@ class TestWriteUpdateCache:
 # ── load_e2e_repos ────────────────────────────────────────────────────
 
 
-def test_load_e2e_repos_from_toml(tmp_path):
+def test_load_e2e_repos_from_toml(tmp_path: Path) -> None:
     config_path = tmp_path / ".teatree.toml"
     _write_toml(
         config_path,
@@ -602,13 +653,13 @@ e2e_dir = "e2e"
     assert repos[0].e2e_dir == "e2e"
 
 
-def test_load_e2e_repos_missing_section(tmp_path):
+def test_load_e2e_repos_missing_section(tmp_path: Path) -> None:
     config_path = tmp_path / ".teatree.toml"
     _write_toml(config_path, '[teatree]\nbranch_prefix = "ac-"\n')
     assert load_e2e_repos(config_path) == []
 
 
-def test_load_e2e_repos_default_e2e_dir(tmp_path):
+def test_load_e2e_repos_default_e2e_dir(tmp_path: Path) -> None:
     config_path = tmp_path / ".teatree.toml"
     _write_toml(
         config_path,
@@ -622,7 +673,7 @@ branch = "feature/e2e"
     assert repos[0].e2e_dir == "e2e"
 
 
-def test_load_e2e_repos_multiple(tmp_path):
+def test_load_e2e_repos_multiple(tmp_path: Path) -> None:
     config_path = tmp_path / ".teatree.toml"
     _write_toml(
         config_path,
@@ -643,11 +694,11 @@ e2e_dir = "playwright"
     assert by_name["service-b"].e2e_dir == "playwright"
 
 
-def test_load_e2e_repos_missing_toml(tmp_path):
+def test_load_e2e_repos_missing_toml(tmp_path: Path) -> None:
     assert load_e2e_repos(tmp_path / "nonexistent.toml") == []
 
 
-def test_e2e_repo_is_dataclass():
+def test_e2e_repo_is_dataclass() -> None:
     repo = E2ERepo(name="x", url="u", branch="b")
     assert repo.name == "x"
     assert repo.e2e_dir == "e2e"  # default
@@ -664,89 +715,85 @@ class TestMode:
     config must never silently downgrade to it.
     """
 
-    def test_parse_interactive(self):
+    def test_parse_interactive(self) -> None:
         assert Mode.parse("interactive") is Mode.INTERACTIVE
 
-    def test_parse_auto(self):
+    def test_parse_auto(self) -> None:
         assert Mode.parse("auto") is Mode.AUTO
 
-    def test_parse_is_case_insensitive(self):
+    def test_parse_is_case_insensitive(self) -> None:
         assert Mode.parse("AUTO") is Mode.AUTO
         assert Mode.parse("  Interactive  ") is Mode.INTERACTIVE
 
-    def test_parse_invalid_raises(self):
-        import pytest  # noqa: PLC0415
-
+    def test_parse_invalid_raises(self) -> None:
         with pytest.raises(ValueError, match="Invalid t3 mode"):
             Mode.parse("headless")
 
-    def test_load_config_default_is_interactive(self, tmp_path, monkeypatch):
+    def test_load_config_default_is_interactive(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("T3_MODE", raising=False)
         config = load_config(tmp_path / "nonexistent.toml")
         assert config.user.mode is Mode.INTERACTIVE
 
-    def test_load_config_reads_toml(self, tmp_path, monkeypatch):
+    def test_load_config_reads_toml(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("T3_MODE", raising=False)
         config_path = tmp_path / ".teatree.toml"
         _write_toml(config_path, '[teatree]\nmode = "auto"\n')
         config = load_config(config_path)
         assert config.user.mode is Mode.AUTO
 
-    def test_env_var_overrides_toml(self, tmp_path, monkeypatch):
+    def test_env_var_overrides_toml(
+        self,
+        config_file: Path,
+        elsewhere: Path,
+        no_installed_overlays: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """T3_MODE wins over the toml global — verified via get_effective_settings."""
-        config_path = tmp_path / ".teatree.toml"
-        _write_toml(config_path, '[teatree]\nmode = "auto"\n')
+        del elsewhere, no_installed_overlays
+        _write_toml(config_file, '[teatree]\nmode = "auto"\n')
         monkeypatch.setenv("T3_MODE", "interactive")
         monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
-        with (
-            patch("teatree.config.load_config", return_value=load_config(config_path)),
-            patch("teatree.config.discover_overlays", return_value=[]),
-            patch("teatree.config.discover_active_overlay", return_value=None),
-        ):
-            assert get_effective_settings().mode is Mode.INTERACTIVE
 
-    def test_env_var_applies_without_toml(self, tmp_path, monkeypatch):
+        assert get_effective_settings().mode is Mode.INTERACTIVE
+
+    def test_env_var_applies_without_toml(
+        self,
+        config_file: Path,
+        elsewhere: Path,
+        no_installed_overlays: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """T3_MODE applies even when no toml file exists."""
+        del config_file, elsewhere, no_installed_overlays
         monkeypatch.setenv("T3_MODE", "auto")
         monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
-        with (
-            patch("teatree.config.load_config", return_value=load_config(tmp_path / "nonexistent.toml")),
-            patch("teatree.config.discover_overlays", return_value=[]),
-            patch("teatree.config.discover_active_overlay", return_value=None),
-        ):
-            assert get_effective_settings().mode is Mode.AUTO
 
-    def test_load_config_invalid_mode_raises(self, tmp_path, monkeypatch):
+        assert get_effective_settings().mode is Mode.AUTO
+
+    def test_load_config_invalid_mode_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("T3_MODE", raising=False)
         config_path = tmp_path / ".teatree.toml"
         _write_toml(config_path, '[teatree]\nmode = "headless"\n')
 
-        import pytest  # noqa: PLC0415
-
         with pytest.raises(ValueError, match="Invalid t3 mode"):
             load_config(config_path)
 
-    def test_get_mode_reflects_loaded_config(self, monkeypatch):
-        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
-
+    def test_get_mode_reflects_loaded_config(
+        self,
+        config_file: Path,
+        elsewhere: Path,
+        no_installed_overlays: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        del elsewhere, no_installed_overlays
         monkeypatch.delenv("T3_MODE", raising=False)
         monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
 
-        auto_config = TeaTreeConfig(user=UserSettings(mode=Mode.AUTO))
-        with (
-            patch("teatree.config.load_config", return_value=auto_config),
-            patch("teatree.config.discover_overlays", return_value=[]),
-            patch("teatree.config.discover_active_overlay", return_value=None),
-        ):
-            assert get_effective_settings().mode is Mode.AUTO
+        _write_toml(config_file, '[teatree]\nmode = "auto"\n')
+        assert get_effective_settings().mode is Mode.AUTO
 
-        interactive_config = TeaTreeConfig(user=UserSettings(mode=Mode.INTERACTIVE))
-        with (
-            patch("teatree.config.load_config", return_value=interactive_config),
-            patch("teatree.config.discover_overlays", return_value=[]),
-            patch("teatree.config.discover_active_overlay", return_value=None),
-        ):
-            assert get_effective_settings().mode is Mode.INTERACTIVE
+        _write_toml(config_file, '[teatree]\nmode = "interactive"\n')
+        assert get_effective_settings().mode is Mode.INTERACTIVE
 
 
 # ── per-overlay override machinery ───────────────────────────────────
@@ -760,7 +807,7 @@ class TestOverlayOverrides:
     ``T3_OVERLAY_NAME`` when set, else cwd-based discovery.
     """
 
-    def test_overlay_toml_mode_parsed(self, tmp_path):
+    def test_overlay_toml_mode_parsed(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".teatree.toml"
         _write_toml(
             config_path,
@@ -777,7 +824,7 @@ mode = "auto"
         by_name = {e.name: e for e in entries}
         assert by_name["my-overlay"].overrides["mode"] is Mode.AUTO
 
-    def test_overlay_invalid_mode_raises(self, tmp_path):
+    def test_overlay_invalid_mode_raises(self, tmp_path: Path) -> None:
         config_path = tmp_path / ".teatree.toml"
         _write_toml(
             config_path,
@@ -787,76 +834,112 @@ class = "x.y:Z"
 mode = "nope"
 """,
         )
-        import pytest  # noqa: PLC0415
-
         with pytest.raises(ValueError, match="Invalid t3 mode"):
             discover_overlays(config_path=config_path)
 
-    def test_overlay_override_wins_over_global(self, monkeypatch):
-        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
-
+    def test_overlay_override_wins_over_global(
+        self,
+        config_file: Path,
+        elsewhere: Path,
+        no_installed_overlays: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        del elsewhere, no_installed_overlays
         monkeypatch.delenv("T3_MODE", raising=False)
-        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        monkeypatch.setenv("T3_OVERLAY_NAME", "my-overlay")
 
-        global_config = TeaTreeConfig(user=UserSettings(mode=Mode.INTERACTIVE, branch_prefix="ac"))
-        active = OverlayEntry(
-            name="my-overlay",
-            overlay_class="x",
-            overrides={"mode": Mode.AUTO, "branch_prefix": "xp"},
+        _write_toml(
+            config_file,
+            """
+[teatree]
+mode = "interactive"
+branch_prefix = "ac"
+
+[overlays.my-overlay]
+class = "x.y:Z"
+mode = "auto"
+branch_prefix = "xp"
+""",
         )
-        with (
-            patch("teatree.config.load_config", return_value=global_config),
-            patch("teatree.config.discover_overlays", return_value=[active]),
-            patch("teatree.config.discover_active_overlay", return_value=active),
-        ):
-            effective = get_effective_settings()
-            assert effective.mode is Mode.AUTO
-            assert effective.branch_prefix == "xp"
-            assert get_effective_settings().mode is Mode.AUTO
 
-    def test_overlay_without_override_inherits_global(self, monkeypatch):
-        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
+        effective = get_effective_settings()
+        assert effective.mode is Mode.AUTO
+        assert effective.branch_prefix == "xp"
 
+    def test_overlay_without_override_inherits_global(
+        self,
+        config_file: Path,
+        elsewhere: Path,
+        no_installed_overlays: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        del elsewhere, no_installed_overlays
         monkeypatch.delenv("T3_MODE", raising=False)
-        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        monkeypatch.setenv("T3_OVERLAY_NAME", "x")
 
-        global_config = TeaTreeConfig(user=UserSettings(mode=Mode.AUTO))
-        active = OverlayEntry(name="x", overlay_class="y", overrides={})
-        with (
-            patch("teatree.config.load_config", return_value=global_config),
-            patch("teatree.config.discover_overlays", return_value=[active]),
-            patch("teatree.config.discover_active_overlay", return_value=active),
-        ):
-            assert get_effective_settings().mode is Mode.AUTO
+        _write_toml(
+            config_file,
+            """
+[teatree]
+mode = "auto"
 
-    def test_env_var_beats_overlay_override(self, monkeypatch):
-        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
+[overlays.x]
+class = "x.y:Z"
+""",
+        )
 
+        assert get_effective_settings().mode is Mode.AUTO
+
+    def test_env_var_beats_overlay_override(
+        self,
+        config_file: Path,
+        elsewhere: Path,
+        no_installed_overlays: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        del elsewhere, no_installed_overlays
         monkeypatch.setenv("T3_MODE", "interactive")
-        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        monkeypatch.setenv("T3_OVERLAY_NAME", "x")
 
-        global_config = TeaTreeConfig(user=UserSettings(mode=Mode.INTERACTIVE))
-        active = OverlayEntry(name="x", overlay_class="y", overrides={"mode": Mode.AUTO})
-        with (
-            patch("teatree.config.load_config", return_value=global_config),
-            patch("teatree.config.discover_overlays", return_value=[active]),
-            patch("teatree.config.discover_active_overlay", return_value=active),
-        ):
-            assert get_effective_settings().mode is Mode.INTERACTIVE
+        _write_toml(
+            config_file,
+            """
+[teatree]
+mode = "interactive"
 
-    def test_t3_overlay_name_selects_entry(self, monkeypatch):
-        from teatree.config import TeaTreeConfig, UserSettings  # noqa: PLC0415
+[overlays.x]
+class = "x.y:Z"
+mode = "auto"
+""",
+        )
 
+        assert get_effective_settings().mode is Mode.INTERACTIVE
+
+    def test_t3_overlay_name_selects_entry(
+        self,
+        config_file: Path,
+        elsewhere: Path,
+        no_installed_overlays: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        del elsewhere, no_installed_overlays
         monkeypatch.delenv("T3_MODE", raising=False)
         monkeypatch.setenv("T3_OVERLAY_NAME", "b")
 
-        global_config = TeaTreeConfig(user=UserSettings(mode=Mode.INTERACTIVE))
-        entry_a = OverlayEntry(name="a", overlay_class="x", overrides={"mode": Mode.INTERACTIVE})
-        entry_b = OverlayEntry(name="b", overlay_class="y", overrides={"mode": Mode.AUTO})
-        with (
-            patch("teatree.config.load_config", return_value=global_config),
-            patch("teatree.config.discover_overlays", return_value=[entry_a, entry_b]),
-            # cwd-based fallback would pick "a" — but T3_OVERLAY_NAME must win.
-            patch("teatree.config.discover_active_overlay", return_value=entry_a),
-        ):
-            assert get_effective_settings().mode is Mode.AUTO
+        _write_toml(
+            config_file,
+            """
+[teatree]
+mode = "interactive"
+
+[overlays.a]
+class = "x"
+mode = "interactive"
+
+[overlays.b]
+class = "y"
+mode = "auto"
+""",
+        )
+
+        assert get_effective_settings().mode is Mode.AUTO


### PR DESCRIPTION
## Summary

Picks up item #1 from the #412 batch-resume plan: convert the top
mock offender (``test_config.py``, 74 mocks) to integration-first
per the Test-Writing Doctrine.

- Real ``~/.teatree.toml`` fixtures under ``tmp_path`` + monkeypatched
  ``teatree.config.CONFIG_PATH`` replace internal ``load_config`` /
  ``discover_overlays`` / ``discover_active_overlay`` / ``find_spec``
  patches.
- Remaining mocks cover external boundaries only: the ``gh`` CLI
  subprocess, ``importlib.metadata.entry_points``, and
  ``importlib.metadata.version``.
- Mock count: **74 → 29**. All 61 tests still pass (full suite: 2451
  passed, 12 skipped).

### Source-side tweaks

- ``load_config``, ``discover_overlays``, and ``load_e2e_repos``
  default ``path`` to ``None`` and resolve ``CONFIG_PATH`` inside.
  The previous ``= CONFIG_PATH`` default was captured at import time,
  so monkeypatching ``teatree.config.CONFIG_PATH`` in tests didn't
  affect no-arg callers.

### Bundled fix: broken env-cache symlinks

The Docker pre-push test matrix mounts the worktree at ``/app:ro``.
Worktree ``.t3-env.cache`` is a symlink into the ticket directory,
which isn't mounted, so the symlink is present but broken. The old
``_find_env_cache`` returned broken symlinks on ``is_symlink()``;
downstream ``read_text`` then crashed. ``Path.is_file()`` follows
symlinks and returns False for broken ones, so dropping the
``is_symlink()`` branch cleanly skips them and lets callers fall
back to DB-based worktree resolution. Regression test added in
``tests/teatree_core/test_resolve.py``.

Resolves item #1 of #412.

## Test plan

- [x] Full suite green locally (``uv run pytest --no-cov``): 2451 passed, 12 skipped.
- [x] ``tests/test_config.py``: 61 passed.
- [x] ``tests/teatree_core/test_resolve.py``: regression test for broken symlink.
- [x] Pre-push Docker matrix (``dev/test-matrix.sh``) passes.
- [x] Mock count reduction confirmed: 74 → 29.