### PR TITLE
feat(tool): `t3 tool label-issues` — first slice of #49 auto-labeling

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -664,7 +664,7 @@ Typer-based, work without Django:
 - `t3 e2e external [--repo <name>] [--test-path <path>]` — run Playwright tests from `T3_PRIVATE_TESTS` or a named `[e2e_repos.<name>]` git repo; skips port discovery when `BASE_URL` is already set (DEV/staging mode)
 - `t3 review {post-draft-note,delete-draft-note,list-draft-notes,publish-draft-notes,reply-to-discussion,resolve-discussion}` — GitLab draft notes plus immediate replies on existing discussion threads and resolve/unresolve toggle
 - `t3 review-request discover` — discover open MRs
-- `t3 tool {privacy-scan,analyze-video,bump-deps}` — standalone utilities
+- `t3 tool {privacy-scan,analyze-video,bump-deps,label-issues}` — standalone utilities
 - `t3 config write-skill-cache` — write overlay skill metadata to cache
 - `t3 doctor {check,repair}` — health checks and symlink repair
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -546,6 +546,8 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 │ analyze-video    Decompose video into frames for AI analysis.                │
 │ bump-deps        Bump pyproject.toml dependencies from uv.lock.              │
 │ sonar-check      Run local SonarQube analysis via Docker.                    │
+│ label-issues     Suggest labels for unlabeled open issues by                 │
+│                  keyword-matching title and body.                            │
 │ claude-handover  Show Claude handover telemetry and runtime recommendations. │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -611,6 +613,23 @@ Usage: t3 tool sonar-check [OPTIONS] [REPO_PATH]
 │ --remote-status    --no-remote-status      Fetch CI Sonar results            │
 │                                            [default: no-remote-status]       │
 │ --help                                     Show this message and exit.       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 tool label-issues`
+
+```
+Usage: t3 tool label-issues [OPTIONS] REPO
+
+ Suggest labels for unlabeled open issues by keyword-matching title and body.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    repo      TEXT  Repository in owner/name form (e.g. souliane/teatree)   │
+│                      [required]                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --apply          Apply labels via `gh issue edit` (default: print only).     │
+│ --help           Show this message and exit.                                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import typer
 
+from teatree.triage import LabelSuggester
 from teatree.utils.run import run_allowed_to_fail
 
 tool_app = typer.Typer(no_args_is_help=True, help="Standalone utilities.")
@@ -84,6 +85,29 @@ def sonar_check(
         cmd.append("--remote-status")
     result = run_allowed_to_fail(cmd, expected_codes=None)
     raise typer.Exit(code=result.returncode)
+
+
+@tool_app.command("label-issues")
+def label_issues(
+    repo: str = typer.Argument(..., help="Repository in owner/name form (e.g. souliane/teatree)"),
+    *,
+    apply: bool = typer.Option(False, "--apply", help="Apply labels via `gh issue edit` (default: print only)."),
+) -> None:
+    """Suggest labels for unlabeled open issues by keyword-matching title and body."""
+    suggester = LabelSuggester(repo)
+    suggestions = suggester.collect_suggestions()
+    if not suggestions:
+        typer.echo("No labelable issues found.")
+        return
+
+    for s in suggestions:
+        typer.echo(f"#{s.number} {s.title}  -> {', '.join(s.labels)}")
+
+    if apply:
+        suggester.apply(suggestions)
+        typer.echo(f"Applied labels to {len(suggestions)} issue(s).")
+    else:
+        typer.echo(f"\n{len(suggestions)} issue(s) to label. Re-run with --apply to apply.")
 
 
 @tool_app.command("claude-handover")

--- a/src/teatree/triage.py
+++ b/src/teatree/triage.py
@@ -1,0 +1,88 @@
+"""Auto-labeling for GitHub issues — first slice of the triage tool (see #49)."""
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+
+from teatree.utils.run import run_allowed_to_fail
+
+LABEL_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "bug": ("bug", "error", "broken", "crash", "crashes", "fails", "failing", "regression"),
+    "enhancement": ("feat", "feature", "add", "improve", "improvement", "support"),
+    "documentation": ("docs", "doc", "documentation", "readme"),
+    "architecture": ("refactor", "split", "merge", "restructure", "consolidate", "deduplicate"),
+    "dashboard": ("dashboard", "panel", "view", "widget"),
+}
+
+
+def infer_labels(title: str, body: str) -> list[str]:
+    """Return labels whose keywords match the issue title or body (case-insensitive, word-boundary)."""
+    text = f"{title} {body}".lower()
+    matched: list[str] = []
+    for label, keywords in LABEL_KEYWORDS.items():
+        pattern = r"\b(" + "|".join(re.escape(kw) for kw in keywords) + r")\b"
+        if re.search(pattern, text):
+            matched.append(label)
+    return matched
+
+
+@dataclass(frozen=True)
+class LabelSuggestion:
+    number: int
+    title: str
+    labels: list[str]
+
+
+class LabelSuggester:
+    """Fetch unlabeled issues from a repo and infer labels via keyword matching."""
+
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+
+    def collect_suggestions(self) -> list[LabelSuggestion]:
+        result = run_allowed_to_fail(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                self.repo,
+                "--state",
+                "open",
+                "--limit",
+                "200",
+                "--json",
+                "number,title,body,labels",
+            ],
+            expected_codes=None,
+        )
+        if result.returncode != 0:
+            sys.stderr.write(f"gh issue list failed: {result.stderr.strip()}\n")
+            return []
+
+        issues = json.loads(result.stdout or "[]")
+        suggestions: list[LabelSuggestion] = []
+        for issue in issues:
+            if issue.get("labels"):
+                continue
+            labels = infer_labels(issue.get("title", ""), issue.get("body", "") or "")
+            if not labels:
+                continue
+            suggestions.append(LabelSuggestion(number=issue["number"], title=issue["title"], labels=labels))
+        return suggestions
+
+    def apply(self, suggestions: list[LabelSuggestion]) -> None:
+        for suggestion in suggestions:
+            run_allowed_to_fail(
+                [
+                    "gh",
+                    "issue",
+                    "edit",
+                    str(suggestion.number),
+                    "--repo",
+                    self.repo,
+                    *[arg for label in suggestion.labels for arg in ("--add-label", label)],
+                ],
+                expected_codes=None,
+            )

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,0 +1,110 @@
+"""Tests for teatree.triage — label inference for GitHub issues."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from teatree.triage import LABEL_KEYWORDS, LabelSuggester, infer_labels
+
+
+def _issue_fixture() -> list[dict]:
+    return [
+        {"number": 1, "title": "feat: add new tool command", "body": "", "labels": []},
+        {"number": 2, "title": "Server crash on DB disconnect", "body": "", "labels": []},
+        {"number": 3, "title": "Update README", "body": "", "labels": [{"name": "documentation"}]},
+    ]
+
+
+class TestInferLabels:
+    def test_bug_keywords(self) -> None:
+        assert "bug" in infer_labels("Server crash on startup", "")
+        assert "bug" in infer_labels("Error when saving", "")
+        assert "bug" in infer_labels("Broken foo flow", "")
+
+    def test_enhancement_keywords(self) -> None:
+        assert "enhancement" in infer_labels("feat: add new setting", "")
+        assert "enhancement" in infer_labels("add tenant filter", "")
+        assert "enhancement" in infer_labels("improve cold-start latency", "")
+
+    def test_documentation_keywords(self) -> None:
+        assert "documentation" in infer_labels("Update README", "")
+        assert "documentation" in infer_labels("Add docs for X", "")
+
+    def test_architecture_keywords(self) -> None:
+        assert "architecture" in infer_labels("Refactor overlay loader", "")
+        assert "architecture" in infer_labels("split god-module", "")
+
+    def test_dashboard_keywords(self) -> None:
+        assert "dashboard" in infer_labels("Add panel to dashboard", "")
+        assert "dashboard" in infer_labels("New view in admin", "")
+
+    def test_multiple_matches(self) -> None:
+        labels = infer_labels("refactor: split dashboard panel", "")
+        assert {"architecture", "dashboard"}.issubset(set(labels))
+
+    def test_no_match_returns_empty(self) -> None:
+        assert infer_labels("random title", "random body") == []
+
+    def test_body_contributes(self) -> None:
+        assert "bug" in infer_labels("Something", "The server crashes under load.")
+
+    def test_case_insensitive(self) -> None:
+        assert "bug" in infer_labels("CRASH on startup", "")
+
+    def test_word_boundary(self) -> None:
+        labels = infer_labels("make the UI addressable by screen readers", "")
+        assert "enhancement" not in labels
+
+    def test_label_keywords_populated(self) -> None:
+        assert set(LABEL_KEYWORDS) == {"bug", "enhancement", "documentation", "architecture", "dashboard"}
+        assert all(LABEL_KEYWORDS[label] for label in LABEL_KEYWORDS)
+
+
+def _fake_list_result(issues: list[dict]):
+    return SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0)
+
+
+class TestLabelSuggester:
+    def test_suggest_skips_already_labeled(self) -> None:
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = _fake_list_result(_issue_fixture())
+            suggestions = LabelSuggester("souliane/teatree").collect_suggestions()
+
+        assert {s.number for s in suggestions} == {1, 2}
+
+    def test_suggest_returns_inferred_labels(self) -> None:
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = _fake_list_result(_issue_fixture())
+            suggestions = LabelSuggester("souliane/teatree").collect_suggestions()
+
+        by_number = {s.number: s for s in suggestions}
+        assert "enhancement" in by_number[1].labels
+        assert "bug" in by_number[2].labels
+
+    def test_suggest_omits_issues_with_no_inferred_labels(self) -> None:
+        fixture = [{"number": 99, "title": "blah blah", "body": "", "labels": []}]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = _fake_list_result(fixture)
+            suggestions = LabelSuggester("souliane/teatree").collect_suggestions()
+
+        assert suggestions == []
+
+    def test_apply_shells_out_once_per_issue(self) -> None:
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = _fake_list_result(_issue_fixture())
+            suggester = LabelSuggester("souliane/teatree")
+            suggestions = suggester.collect_suggestions()
+            suggester.apply(suggestions)
+
+        # 1 list call + 2 edit calls
+        assert mock_run.call_count == 3
+        edit_calls = [call for call in mock_run.call_args_list if "edit" in call.args[0]]
+        assert len(edit_calls) == 2
+        numbers_edited = {call.args[0][call.args[0].index("edit") + 1] for call in edit_calls}
+        assert numbers_edited == {"1", "2"}
+
+    def test_gh_failure_returns_empty(self) -> None:
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = SimpleNamespace(stdout="", stderr="gh: not found", returncode=1)
+            suggestions = LabelSuggester("souliane/teatree").collect_suggestions()
+        assert suggestions == []


### PR DESCRIPTION
## Summary

First slice of the smart ticket management idea in [#49](https://github.com/souliane/teatree/issues/49). Adds a keyword-based classifier that walks open unlabeled issues in a given repo and infers labels from title + body text. Prints suggestions by default; `--apply` calls `gh issue edit` to apply them.

- `LABEL_KEYWORDS` covers the five labels the issue proposes — `bug`, `enhancement`, `documentation`, `architecture`, `dashboard`.
- Matching is case-insensitive and word-bounded, so `addressable` won't trip `add`.
- `LabelSuggester` skips issues that already have labels.

## Scope

Only the auto-labeling slice is in this PR. Duplicate detection and "auto-close issues referencing merged PRs" are separate slices that can be layered on top of the same `teatree.triage` module later.

## Usage

```bash
t3 tool label-issues souliane/teatree           # preview suggestions
t3 tool label-issues souliane/teatree --apply   # apply via gh issue edit
```

## Test plan

- [x] 16 new tests in `tests/test_triage.py` — pure logic (`infer_labels`) + suggester flow with `gh` mocked at the `run_allowed_to_fail` boundary
- [x] Full suite: 2468 passed, 12 skipped
- [x] ruff check + format clean