### PR TITLE
docs(ship): dedupe Co-Authored-By rule to a 1-line pointer

### DIFF
--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -269,7 +269,7 @@ When a session uncovers a small unique commit on a now-stale branch (typical dur
 - **Clickable references:** Every MR, ticket, or note reference must be a markdown link — see [`../rules/SKILL.md`](../rules/SKILL.md) § "Clickable References".
 - **Commit early, commit often.** Never accumulate more than 1-2 tickets of uncommitted changes. Commit after completing each ticket or logical unit of work. Squash later with `t3 <overlay> workspace finalize`.
 - **Publishing actions are mode-conditional.** Canonical rule: see [`../rules/SKILL.md`](../rules/SKILL.md) § "Publishing Actions Are Mode-Conditional". In `interactive` mode (default) every push/MR/merge/remote-delete needs separate explicit approval. In `auto` mode (`t3.mode = "auto"` or `T3_MODE=auto`) the agent ships end-to-end without confirm prompts; only the always-gated list (force-push to defaults, history rewrites on shared defaults, destructive shared-state ops, unauthorised external writes, `--no-verify`) remains confirm-gated.
-- **Respect commit trailer preferences.** Check the user's global agent config for rules about `Co-Authored-By` trailers before committing. Some users explicitly opt out. When in doubt, **do not add trailers** — the user can always configure their agent to add them.
+- **Commit trailer preferences** (`Co-Authored-By`) live in the user's global agent config — check it before committing; when in doubt, omit the trailer.
 
 ### Git History Rewriting
 


### PR DESCRIPTION
## Summary

Phase 2 of [#324](https://github.com/souliane/teatree/issues/324) — the mechanical dedup of cross-cutting rules across teatree skills. The canonical home for commit-trailer preferences is the user's global agent config (\`~/.claude/CLAUDE.md\`); \`ship/SKILL.md\` had a three-sentence paraphrase, which is now a one-line pointer so the rule lives in exactly one place.

Every other rule the issue table lists was already deduped:

| Rule | Canonical | Pointer in |
|---|---|---|
| Publishing Actions / Never Push Without Approval | \`rules/SKILL.md\` | \`ship/SKILL.md\` |
| Always Create Tasks | \`rules/SKILL.md\` | \`workspace/SKILL.md\` |
| Worktree-First Work | \`rules/SKILL.md\` | \`workspace/SKILL.md\` |
| Fix the CLI, Never Work Around It | \`workspace/SKILL.md\` | — |
| Sub-Agent Limitations | \`rules/SKILL.md\` | \`workspace/SKILL.md\` |

Phases 3 (global \`CLAUDE.md\`) and 4 (memory consolidation) are user-local and happen outside this repo.

## Test plan

- [x] No code paths changed — docs-only MR; CI's doc gates cover it.