### PR TITLE
fix(ship): bare-repo 404 + default MR description missing subject

### DIFF
--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -94,6 +94,14 @@ class GitLabCodeHost:
         return self._client.upload_file(project.project_id, filepath) or {}
 
     def _resolve_project(self, repo: str) -> ProjectInfo | None:
+        """Resolve a GitLab project from a local path, ``namespace/repo`` slug, or bare name.
+
+        Bare repo names (no slash, no matching path) fall back to the CWD's
+        git remote — ``Worktree.repo_path`` stores a bare name, and callers
+        that hand it straight to the code host would otherwise 404.
+        """
         if Path(repo).exists():
             return self._client.resolve_project_from_remote(repo)
-        return self._client.resolve_project(repo)
+        if "/" in repo:
+            return self._client.resolve_project(repo)
+        return self._client.resolve_project_from_remote(".")

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -86,7 +86,8 @@ def _ship_preview(ticket: Ticket, worktree: Worktree) -> tuple[str, str, str]:
     repo_path = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
     subject, body = git.last_commit_message(repo=repo_path)
     title = subject or f"Resolve {ticket.issue_url}"
-    description = sanitize_close_keywords(body, close_ticket=get_overlay().config.mr_close_ticket)
+    raw_description = f"{subject}\n\n{body}" if subject and body else (subject or body)
+    description = sanitize_close_keywords(raw_description, close_ticket=get_overlay().config.mr_close_ticket)
     return repo_path, title, description
 
 

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -88,7 +88,8 @@ class ShipExecutor(RunnerBase):
         title_override = str(extra.get("mr_title_override") or "")
         subject, body = git.last_commit_message(repo=repo_path)
         title = title_override or subject or f"Resolve {ticket.issue_url}"
-        description = sanitize_close_keywords(body, close_ticket=get_overlay().config.mr_close_ticket)
+        raw_description = f"{subject}\n\n{body}" if subject and body else (subject or body)
+        description = sanitize_close_keywords(raw_description, close_ticket=get_overlay().config.mr_close_ticket)
         assignee = host.current_user() or git.config_value(key="user.name")
         return PullRequestSpec(
             repo=repo_path,

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -168,3 +168,35 @@ def test_current_user_proxies_to_api_username() -> None:
 
     assert host.current_user() == "adrien.cossa"
     client.current_username.assert_called_once_with()
+
+
+def test_create_pr_falls_back_to_cwd_remote_for_bare_repo_name(tmp_path, monkeypatch) -> None:
+    """A bare repo name (no slash, no existing path) resolves via the CWD's git remote.
+
+    Regression guard for overlay issue t3-o.#54: ``Worktree.repo_path`` stores
+    a bare repo name, so callers passing it directly must still reach the
+    GitLab project via the CWD's ``origin`` remote.
+    """
+    monkeypatch.chdir(tmp_path)
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project_from_remote.return_value = _project()
+    client.post_json.return_value = {"iid": 9}
+    host = GitLabCodeHost(client=client)
+
+    host.create_pr(PullRequestSpec(repo="teatree", branch="feat", title="x", description="y"))
+
+    client.resolve_project_from_remote.assert_called_once_with(".")
+    client.resolve_project.assert_not_called()
+
+
+def test_create_pr_uses_explicit_slug_when_repo_has_namespace() -> None:
+    """A ``namespace/repo`` slug still hits ``resolve_project`` directly — no CWD fallback."""
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.post_json.return_value = {"iid": 11}
+    host = GitLabCodeHost(client=client)
+
+    host.create_pr(PullRequestSpec(repo="org/nested/repo", branch="feat", title="x", description="y"))
+
+    client.resolve_project.assert_called_once_with("org/nested/repo")
+    client.resolve_project_from_remote.assert_not_called()

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -87,6 +87,53 @@ class TestShipExecutor(TestCase):
         assert result.ok is False
         assert "worktree" in result.detail.lower()
 
+    def test_description_starts_with_commit_subject(self) -> None:
+        """Default MR description prepends the commit subject.
+
+        Some overlays' CI jobs validate that the first description line matches
+        the title format; previously the description was only the commit body,
+        so every MR without an explicit description tripped the pipeline.
+        Regression guard for overlay issue t3-o.#54 Bug 2.
+        """
+        ticket = self._ticket_with_worktree()
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://example.com/mr/2"}
+        host.current_user.return_value = "souliane"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push"),
+            patch(
+                "teatree.core.runners.ship.git.last_commit_message",
+                return_value=("feat(core): add thing (https://example.com/issues/77)", "Longer body.\nMore detail."),
+            ),
+        ):
+            ShipExecutor(ticket).run()
+
+        (spec,) = host.create_pr.call_args.args
+        assert spec.description.startswith("feat(core): add thing (https://example.com/issues/77)")
+        assert spec.description == (
+            "feat(core): add thing (https://example.com/issues/77)\n\nLonger body.\nMore detail."
+        )
+
+    def test_description_is_just_subject_when_body_empty(self) -> None:
+        ticket = self._ticket_with_worktree()
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "u"}
+        host.current_user.return_value = "dev"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push"),
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat: x", "")),
+        ):
+            ShipExecutor(ticket).run()
+
+        (spec,) = host.create_pr.call_args.args
+        assert spec.description == "feat: x"
+
     def test_assignee_falls_back_to_git_user_name_when_host_returns_empty(self) -> None:
         ticket = self._ticket_with_worktree()
         host = MagicMock()


### PR DESCRIPTION
## Summary

Fixes both bugs reported in the overlay issue (t3-o.#54) that make `pr create` fail out of the box on a valid worktree. Both live in teatree core.

- **Bug 1 — `_resolve_project` 404s on bare repo names.** `Worktree.repo_path` stores a bare name (e.g. `teatree`), not an absolute path. From most CWDs `Path("teatree").exists()` is False, so the caller fell through to `resolve_project("teatree")` → `GET /projects/teatree` → 404. Fix: route no-slash bare names through `resolve_project_from_remote(".")` so the CLI's CWD `origin` remote supplies the namespace.
- **Bug 2 — default MR description drops the commit subject.** Previously `description = commit_body`. Some overlays' CI validators require the first description line to match the conventional-commit title format, so every default-body MR tripped the pipeline. Fix: build the description as `subject\n\nbody` (subject-only when body is empty) so the first line always mirrors the title.

## Test plan

- [x] `uv run pytest --no-cov -q` (1874 passed / 12 skipped / 0 failed)
- [x] `uv run ruff check` + `ruff format --check` green on touched files
- [x] `uv run ty check` green
- [x] New regression tests: `tests/teatree_backends/test_gitlab_code_host.py::test_create_pr_falls_back_to_cwd_remote_for_bare_repo_name`, `test_create_pr_uses_explicit_slug_when_repo_has_namespace`, `tests/teatree_core/test_runners_ship.py::test_description_starts_with_commit_subject`, `test_description_is_just_subject_when_body_empty`