### PR TITLE
fix(overlay): symlink health check requires populated source directory

### DIFF
--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -387,6 +387,17 @@ class HealthCheck:
     description: str = ""
 
 
+def _symlink_source_healthy(dest: Path, source: Path) -> bool:
+    """Return True when *dest* resolves and *source* is populated (non-empty if a dir)."""
+    if not (dest.exists() or dest.is_symlink()):
+        return False
+    if not source.exists():
+        return False
+    if source.is_dir():
+        return any(source.iterdir())
+    return True
+
+
 def _default_health_checks(overlay: OverlayBase, worktree: "Worktree") -> list[HealthCheck]:
     """Return standard post-provision checks applicable to any overlay."""
     checks: list[HealthCheck] = []
@@ -402,7 +413,10 @@ def _default_health_checks(overlay: OverlayBase, worktree: "Worktree") -> list[H
             )
         )
 
-        # Verify symlinks point to valid targets
+        # Verify symlinks point to valid, non-empty targets.
+        # An empty source directory (e.g. a pre-existing but never-populated
+        # `node_modules/`) previously passed the check and masked broken
+        # provisioning — see t3-o.#55.
         for spec in overlay.get_symlinks(worktree):
             dest = Path(wt_path) / spec.get("path", "")
             source = Path(spec.get("source", ""))
@@ -410,8 +424,8 @@ def _default_health_checks(overlay: OverlayBase, worktree: "Worktree") -> list[H
                 checks.append(
                     HealthCheck(
                         name=f"symlink-{spec.get('path', '?')}",
-                        check=lambda d=dest: d.exists() or d.is_symlink(),
-                        description=f"Symlink exists: {spec.get('path', '')}",
+                        check=lambda d=dest, s=source: _symlink_source_healthy(d, s),
+                        description=f"Symlink target populated: {spec.get('path', '')}",
                     )
                 )
 

--- a/tests/teatree_core/test_overlay.py
+++ b/tests/teatree_core/test_overlay.py
@@ -245,3 +245,75 @@ class TestDefaultHealthChecks(TestCase):
             assert "worktree-exists" in names
             assert "symlink-link" in names
             assert "db-name-set" in names
+
+    def test_symlink_check_fails_when_source_directory_is_empty(self) -> None:
+        """A symlink pointing at an empty source directory must fail the health check.
+
+        Regression guard for t3-o.#55 Bug 1: ``node_modules`` symlinks whose
+        main-clone target was an empty directory silently passed health, so
+        lifecycle setup reported ``[OK] symlinks`` while every worktree's
+        frontend was broken.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_path = Path(tmp) / "worktree"
+            wt_path.mkdir()
+            empty_source = Path(tmp) / "empty_source"
+            empty_source.mkdir()
+
+            link_dest = wt_path / "node_modules"
+            link_dest.symlink_to(empty_source)
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/2")
+            worktree = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature",
+                db_name="test_db",
+                extra={"worktree_path": str(wt_path)},
+            )
+
+            overlay = DummyOverlay()
+            with patch.object(
+                overlay,
+                "get_symlinks",
+                return_value=[
+                    {"path": "node_modules", "source": str(empty_source), "mode": "symlink"},
+                ],
+            ):
+                checks = overlay.get_health_checks(worktree)
+            symlink_check = next(c for c in checks if c.name == "symlink-node_modules")
+            assert symlink_check.check() is False
+
+    def test_symlink_check_passes_when_source_directory_is_populated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_path = Path(tmp) / "worktree"
+            wt_path.mkdir()
+            populated_source = Path(tmp) / "populated_source"
+            populated_source.mkdir()
+            (populated_source / "some-package").mkdir()
+
+            link_dest = wt_path / "node_modules"
+            link_dest.symlink_to(populated_source)
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/3")
+            worktree = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature",
+                db_name="test_db",
+                extra={"worktree_path": str(wt_path)},
+            )
+
+            overlay = DummyOverlay()
+            with patch.object(
+                overlay,
+                "get_symlinks",
+                return_value=[
+                    {"path": "node_modules", "source": str(populated_source), "mode": "symlink"},
+                ],
+            ):
+                checks = overlay.get_health_checks(worktree)
+            symlink_check = next(c for c in checks if c.name == "symlink-node_modules")
+            assert symlink_check.check() is True


### PR DESCRIPTION
## Summary

Default symlink health check previously accepted *any* existing symlink-dest, so a main-clone `node_modules/` that was an empty directory passed ``[OK] symlinks`` while every worktree's frontend was broken (overlay issue t3-o.#55 Bug 1). Now the check also requires the source to be populated (non-empty, for directory sources).

Small helper ``_symlink_source_healthy(dest, source)`` keeps the intent close to the check; the description reads ``Symlink target populated`` so failures name the actual problem.

## Test plan

- [x] `uv run pytest --no-cov -q` (1876 passed / 12 skipped / 0 failed)
- [x] `uv run ruff check` / `ruff format --check` green on touched files
- [x] New regression tests: `test_symlink_check_fails_when_source_directory_is_empty`, `test_symlink_check_passes_when_source_directory_is_populated`