### PR TITLE
test(cli): convert test_cli_doctor.py to integration-first

### DIFF
--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,4 +1,20 @@
-"""Tests for doctor-related CLI commands, extracted from test_cli.py."""
+"""Tests for doctor-related CLI commands.
+
+Integration-first per the Test-Writing Doctrine: real ``~/.teatree.toml``
+fixtures, real ``~/.claude/plugins/installed_plugins.json`` files, and real
+filesystem layouts replace patches of teatree-internal helpers
+(``discover_overlays``, ``load_config``, ``find_teatree_repo``,
+``find_overlay_repo``, ``find_installed_claude_plugin``, …).
+
+Remaining mocks cover unstoppable externals only:
+
+- ``importlib.metadata.distribution`` / ``packages_distributions`` (installed-package
+    introspection — would otherwise require fixture packages actually installed into
+    the test venv).
+- ``importlib.import_module`` (used by ``print_package_info``).
+- ``shutil.which`` (PATH lookup for ``t3`` / ``direnv`` / ``git`` / ``jq``).
+- ``subprocess.run`` (``uv pip install``, ``git update-index`` …).
+"""
 
 import json
 import subprocess
@@ -8,7 +24,6 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 import teatree.cli.doctor as teatree_cli_doctor
-import teatree.config as teatree_config
 import teatree.core.overlay_loader as teatree_overlay_loader
 from teatree.cli import app
 from teatree.cli.doctor import DoctorService, IntrospectionHelpers
@@ -16,124 +31,227 @@ from teatree.cli.doctor import DoctorService, IntrospectionHelpers
 runner = CliRunner()
 
 
-def _make_overlay_stub(module: str = "my_overlay.overlay") -> object:
-    """Create a stub whose ``type().__module__`` returns *module*.
+# ── Helpers ──────────────────────────────────────────────────────────────
 
-    ``_resolve_overlay_dists`` uses ``type(inst).__module__``, not
-    ``inst.__module__``.  A plain MagicMock's type is ``MagicMock``
-    (module ``unittest.mock``), so we create a real class instead.
+
+def _write_teatree_toml(config_path: Path, content: str) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(content, encoding="utf-8")
+
+
+def _stage_home(tmp_path: Path, monkeypatch) -> Path:
+    """Isolate overlay discovery under ``tmp_path``.
+
+    - Redirects ``Path.home()`` to ``tmp_path`` so ``~/.claude/...`` lookups are sandboxed.
+    - Redirects ``teatree.config.CONFIG_PATH`` to ``tmp_path/.teatree.toml``.
+    - Muzzles ``importlib.metadata.entry_points`` so installed overlays (``t3-teatree``)
+        don't leak into ``discover_overlays()`` / ``discover_active_overlay()``.
+    - Moves cwd under ``tmp_path`` so ``_discover_from_manage_py`` cannot climb into
+        the real teatree checkout.
+    """
+    monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", tmp_path / ".teatree.toml")
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda **_kw: [])
+    neutral = tmp_path / "_neutral_cwd"
+    neutral.mkdir(exist_ok=True)
+    monkeypatch.chdir(neutral)
+    monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+    return tmp_path
+
+
+def _stub_overlay_instance(module: str = "my_overlay.overlay") -> object:
+    """Return an instance whose ``type(inst).__module__`` is *module*.
+
+    ``_resolve_overlay_dists`` inspects the instance's class module, not the
+    instance module. A plain ``MagicMock`` would report ``unittest.mock``.
     """
     cls = type("_OverlayStub", (), {"__module__": module})
     return cls()
 
 
-class TestDoctorService:
-    """Tests for DoctorService methods (show_info, collect_overlay_skills, repair_symlinks, check_editable_sanity)."""
+def _editable_map(**dists: tuple[bool, str]):
+    """Build an ``editable_info`` side_effect from a ``dist_name -> (editable, url)`` map."""
 
-    # ── show_info ────────────────────────────────────────────────────
+    def side_effect(dist_name: str) -> tuple[bool, str]:
+        return dists.get(dist_name, (False, ""))
 
-    def test_show_info_with_overlay(self, capsys):
-        from teatree.config import OverlayEntry  # noqa: PLC0415
+    return side_effect
 
-        active = OverlayEntry(name="acme", overlay_class="acme.overlay.AcmeOverlay")
-        entries = [OverlayEntry(name="acme", overlay_class="acme.overlay.AcmeOverlay")]
+
+# ── DoctorService.show_info ─────────────────────────────────────────────
+
+
+class TestShowInfo:
+    """``DoctorService.show_info`` pretty-prints environment + overlay state."""
+
+    def test_prints_active_overlay_from_toml(self, tmp_path, monkeypatch, capsys):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(
+            tmp_path / ".teatree.toml",
+            '[overlays.acme]\nclass = "acme.overlay:AcmeOverlay"\n',
+        )
+        monkeypatch.setenv("T3_OVERLAY_NAME", "acme")
 
         with (
             patch("shutil.which", return_value="/usr/bin/t3"),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(IntrospectionHelpers, "print_package_info"),
-            patch.object(teatree_config, "discover_active_overlay", return_value=active),
-            patch.object(teatree_config, "discover_overlays", return_value=entries),
         ):
             DoctorService.show_info()
 
-    def test_show_info_no_overlay(self, capsys):
+        out = capsys.readouterr().out
+        assert "Active overlay:" in out
+        assert "acme" in out
+
+    def test_prints_no_overlay_when_toml_missing(self, tmp_path, monkeypatch, capsys):
+        _stage_home(tmp_path, monkeypatch)
+
         with (
             patch("shutil.which", return_value=None),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(IntrospectionHelpers, "print_package_info"),
-            patch.object(teatree_config, "discover_active_overlay", return_value=None),
-            patch.object(teatree_config, "discover_overlays", return_value=[]),
-            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
         ):
             DoctorService.show_info()
 
-    def test_show_info_prints_overlay_project_path(self, capsys, tmp_path):
-        from teatree.config import OverlayEntry  # noqa: PLC0415
+        out = capsys.readouterr().out
+        assert "Active overlay:   (none)" in out
 
+    def test_prints_overlay_project_path_when_set(self, tmp_path, monkeypatch, capsys):
+        _stage_home(tmp_path, monkeypatch)
         project = tmp_path / "my-overlay"
         project.mkdir()
-        entries = [OverlayEntry(name="acme", overlay_class="acme.Overlay", project_path=project)]
+        (project / "manage.py").write_text('os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myproj.settings")\n')
+        _write_teatree_toml(
+            tmp_path / ".teatree.toml",
+            f'[overlays.acme]\npath = "{project}"\n',
+        )
 
         with (
             patch("shutil.which", return_value="/usr/bin/t3"),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(IntrospectionHelpers, "print_package_info"),
-            patch.object(teatree_config, "discover_active_overlay", return_value=None),
-            patch.object(teatree_config, "discover_overlays", return_value=entries),
-            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
         ):
             DoctorService.show_info()
+
         out = capsys.readouterr().out
         assert "acme" in out
         assert str(project) in out
 
-    def test_show_info_omits_project_path_when_none(self, capsys):
-        from teatree.config import OverlayEntry  # noqa: PLC0415
-
-        entries = [OverlayEntry(name="acme", overlay_class="acme.Overlay", project_path=None)]
+    def test_omits_project_path_row_when_none(self, tmp_path, monkeypatch, capsys):
+        """When an overlay has no ``project_path``, no second indented path row is printed."""
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(
+            tmp_path / ".teatree.toml",
+            '[overlays.acme]\nclass = "acme.overlay:AcmeOverlay"\n',
+        )
 
         with (
             patch("shutil.which", return_value="/usr/bin/t3"),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(IntrospectionHelpers, "print_package_info"),
-            patch.object(teatree_config, "discover_active_overlay", return_value=None),
-            patch.object(teatree_config, "discover_overlays", return_value=entries),
-            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
         ):
             DoctorService.show_info()
-        out = capsys.readouterr().out
-        lines = [line for line in out.splitlines() if "acme" in line]
-        assert len(lines) == 1  # overlay row, no project_path row
 
-    def test_show_info_shows_claude_plugin_when_installed(self, capsys):
-        plugin = {
-            "version": "0.0.1",
-            "installPath": "/Users/x/.claude/plugins/cache/souliane/t3/0.0.1",
-            "scope": "user",
-        }
+        lines = capsys.readouterr().out.splitlines()
+        # The "Installed overlays:" block lists ``acme`` once but must NOT emit a
+        # trailing indented path row for the TOML entry (which has no ``path``).
+        installed_idx = next(i for i, line in enumerate(lines) if line.startswith("Installed overlays:"))
+        overlay_block = lines[installed_idx + 1 : installed_idx + 3]
+        assert any("acme" in line for line in overlay_block)
+        assert all(str(tmp_path) not in line for line in overlay_block)
+
+    def test_shows_claude_plugin_when_installed(self, tmp_path, monkeypatch, capsys):
+        _stage_home(tmp_path, monkeypatch)
+        plugins_file = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
+        plugins_file.parent.mkdir(parents=True)
+        plugins_file.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "plugins": {
+                        "t3@souliane": [
+                            {
+                                "scope": "user",
+                                "installPath": "/Users/x/.claude/plugins/cache/souliane/t3/0.0.1",
+                                "version": "0.0.1",
+                            },
+                        ],
+                    },
+                },
+            ),
+        )
+
         with (
             patch("shutil.which", return_value="/usr/bin/t3"),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(IntrospectionHelpers, "print_package_info"),
-            patch.object(teatree_config, "discover_active_overlay", return_value=None),
-            patch.object(teatree_config, "discover_overlays", return_value=[]),
-            patch.object(DoctorService, "find_installed_claude_plugin", return_value=plugin),
         ):
             DoctorService.show_info()
+
         out = capsys.readouterr().out
         assert "Claude plugin:" in out
         assert "0.0.1" in out
         assert "user" in out
-        assert plugin["installPath"] in out
+        assert "/Users/x/.claude/plugins/cache/souliane/t3/0.0.1" in out
 
-    def test_show_info_says_not_installed_when_plugin_missing(self, capsys):
+    def test_says_plugin_not_installed_when_missing(self, tmp_path, monkeypatch, capsys):
+        _stage_home(tmp_path, monkeypatch)
+
         with (
             patch("shutil.which", return_value="/usr/bin/t3"),
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(IntrospectionHelpers, "print_package_info"),
-            patch.object(teatree_config, "discover_active_overlay", return_value=None),
-            patch.object(teatree_config, "discover_overlays", return_value=[]),
-            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
         ):
             DoctorService.show_info()
+
         out = capsys.readouterr().out
         assert "Claude plugin:" in out
         assert "not installed" in out
 
-    # ── find_installed_claude_plugin ─────────────────────────────────
+    def test_lists_existing_runtime_skill_dirs(self, tmp_path, monkeypatch, capsys):
+        _stage_home(tmp_path, monkeypatch)
+        (tmp_path / ".claude" / "skills").mkdir(parents=True)
+        (tmp_path / ".codex" / "skills").mkdir(parents=True)
+        fake_target = tmp_path / "source" / "code"
+        fake_target.mkdir(parents=True)
+        (tmp_path / ".claude" / "skills" / "code").symlink_to(fake_target)
+        (tmp_path / ".codex" / "skills" / "code").symlink_to(fake_target)
 
-    def test_find_installed_claude_plugin_returns_entry(self, tmp_path, monkeypatch):
+        with (
+            patch("shutil.which", return_value="/usr/bin/t3"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(IntrospectionHelpers, "print_package_info"),
+        ):
+            DoctorService.show_info()
+
+        out = capsys.readouterr().out
+        assert "Skills installed to:" in out
+        assert str(tmp_path / ".claude" / "skills") in out
+        assert str(tmp_path / ".codex" / "skills") in out
+
+    def test_skips_missing_runtime_skill_dirs(self, tmp_path, monkeypatch, capsys):
+        _stage_home(tmp_path, monkeypatch)
+        (tmp_path / ".claude" / "skills").mkdir(parents=True)
+        # No ~/.codex.
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/t3"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(IntrospectionHelpers, "print_package_info"),
+        ):
+            DoctorService.show_info()
+
+        out = capsys.readouterr().out
+        assert str(tmp_path / ".claude" / "skills") in out
+        assert ".codex" not in out
+
+
+# ── DoctorService.find_installed_claude_plugin ───────────────────────────
+
+
+class TestFindInstalledClaudePlugin:
+    def test_returns_entry_when_installed(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
         plugins_file = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
         plugins_file.parent.mkdir(parents=True)
         plugins_file.write_text(
@@ -146,383 +264,370 @@ class TestDoctorService:
                                 "scope": "user",
                                 "installPath": "/path/to/t3/0.0.1",
                                 "version": "0.0.1",
-                            }
+                            },
                         ],
                     },
-                }
+                },
             ),
-            encoding="utf-8",
         )
-        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
-        result = DoctorService.find_installed_claude_plugin()
-        assert result == {
+        assert DoctorService.find_installed_claude_plugin() == {
             "version": "0.0.1",
             "installPath": "/path/to/t3/0.0.1",
             "scope": "user",
         }
 
-    def test_find_installed_claude_plugin_missing_file(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+    def test_returns_none_when_file_missing(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
         assert DoctorService.find_installed_claude_plugin() is None
 
-    def test_find_installed_claude_plugin_entry_missing(self, tmp_path, monkeypatch):
+    def test_returns_none_when_entry_missing(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
         plugins_file = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
         plugins_file.parent.mkdir(parents=True)
-        plugins_file.write_text(json.dumps({"version": 2, "plugins": {}}), encoding="utf-8")
-        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        plugins_file.write_text(json.dumps({"version": 2, "plugins": {}}))
         assert DoctorService.find_installed_claude_plugin() is None
 
-    def test_find_installed_claude_plugin_malformed_json(self, tmp_path, monkeypatch):
+    def test_returns_none_when_malformed_json(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
         plugins_file = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
         plugins_file.parent.mkdir(parents=True)
-        plugins_file.write_text("not json", encoding="utf-8")
-        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        plugins_file.write_text("not json")
         assert DoctorService.find_installed_claude_plugin() is None
 
-    # ── show_info (skills installed-to section) ──────────────────────
 
-    def test_show_info_lists_existing_runtime_skill_dirs(self, capsys, tmp_path, monkeypatch):
-        (tmp_path / ".claude" / "skills").mkdir(parents=True)
-        (tmp_path / ".codex" / "skills").mkdir(parents=True)
-        # Populate one t3-managed symlink in each
-        fake_target = tmp_path / "source" / "code"
-        fake_target.mkdir(parents=True)
-        (tmp_path / ".claude" / "skills" / "code").symlink_to(fake_target)
-        (tmp_path / ".codex" / "skills" / "code").symlink_to(fake_target)
-        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+# ── DoctorService.collect_overlay_skills ─────────────────────────────────
 
-        with (
-            patch("shutil.which", return_value="/usr/bin/t3"),
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(IntrospectionHelpers, "print_package_info"),
-            patch.object(teatree_config, "discover_active_overlay", return_value=None),
-            patch.object(teatree_config, "discover_overlays", return_value=[]),
-            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
-        ):
-            DoctorService.show_info()
-        out = capsys.readouterr().out
-        assert "Skills installed to:" in out
-        assert str(tmp_path / ".claude" / "skills") in out
-        assert str(tmp_path / ".codex" / "skills") in out
 
-    def test_show_info_skips_missing_runtime_skill_dirs(self, capsys, tmp_path, monkeypatch):
-        (tmp_path / ".claude" / "skills").mkdir(parents=True)
-        # No ~/.codex
-        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
-
-        with (
-            patch("shutil.which", return_value="/usr/bin/t3"),
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(IntrospectionHelpers, "print_package_info"),
-            patch.object(teatree_config, "discover_active_overlay", return_value=None),
-            patch.object(teatree_config, "discover_overlays", return_value=[]),
-            patch.object(DoctorService, "find_installed_claude_plugin", return_value=None),
-        ):
-            DoctorService.show_info()
-        out = capsys.readouterr().out
-        assert str(tmp_path / ".claude" / "skills") in out
-        assert ".codex" not in out
-
-    # ── collect_overlay_skills ───────────────────────────────────────
-
-    def test_returns_overlay_skills_from_skills_dir(self, tmp_path):
-        """Overlay skills are collected from projects' skills/ dirs."""
-        from teatree.config import OverlayEntry  # noqa: PLC0415
-
+class TestCollectOverlaySkills:
+    def test_returns_skills_from_skills_subdir(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
         project = tmp_path / "my-project"
         skill = project / "skills" / "custom"
         skill.mkdir(parents=True)
         (skill / "SKILL.md").touch()
+        _write_teatree_toml(
+            tmp_path / ".teatree.toml",
+            f'[overlays.my-overlay]\npath = "{project}"\n',
+        )
 
-        entry = OverlayEntry(name="test", overlay_class="test.overlay.TestOverlay", project_path=project)
-        with patch.object(teatree_config, "discover_overlays", return_value=[entry]):
-            results = DoctorService.collect_overlay_skills()
-            assert len(results) == 1
-            assert results[0][1] == "custom"
+        results = DoctorService.collect_overlay_skills()
 
-    def test_ignores_legacy_overlay_convention(self, tmp_path):
-        """Overlay skills only found via skills/ directory, not legacy subdir convention."""
-        from teatree.config import OverlayEntry  # noqa: PLC0415
+        assert (skill, "custom") in results
 
+    def test_ignores_legacy_subdir_convention(self, tmp_path, monkeypatch):
+        """Overlay skills require a ``skills/`` dir; loose SKILL.md siblings don't count."""
+        _stage_home(tmp_path, monkeypatch)
         project = tmp_path / "my-overlay"
         project.mkdir()
         overlay_subdir = project / "my_app"
         overlay_subdir.mkdir()
         (overlay_subdir / "SKILL.md").touch()
+        _write_teatree_toml(
+            tmp_path / ".teatree.toml",
+            f'[overlays.my-overlay]\npath = "{project}"\n',
+        )
 
-        entry = OverlayEntry(name="my-overlay", overlay_class="test.overlay.TestOverlay", project_path=project)
-        with patch.object(teatree_config, "discover_overlays", return_value=[entry]):
-            results = DoctorService.collect_overlay_skills()
-            assert results == []
+        results = DoctorService.collect_overlay_skills()
 
-    def test_returns_empty_when_no_project_path(self):
-        from teatree.config import OverlayEntry  # noqa: PLC0415
+        assert all(name != "my_app" for _, name in results)
 
-        entry = OverlayEntry(name="test", overlay_class="test.overlay.TestOverlay", project_path=None)
-        with patch.object(teatree_config, "discover_overlays", return_value=[entry]):
-            results = DoctorService.collect_overlay_skills()
-            assert results == []
+    def test_skips_entries_without_project_path(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(
+            tmp_path / ".teatree.toml",
+            '[overlays.classonly]\nclass = "acme.overlay:AcmeOverlay"\n',
+        )
 
-    # ── repair_symlinks ──────────────────────────────────────────────
+        results = DoctorService.collect_overlay_skills()
 
-    def test_creates_links(self, tmp_path):
+        assert all(name != "classonly" for _, name in results)
+
+
+# ── DoctorService.repair_symlinks ────────────────────────────────────────
+
+
+class TestRepairSymlinks:
+    def test_creates_missing_link(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir()
         (skills_dir / "code").mkdir()
         (skills_dir / "code" / "SKILL.md").touch()
-
         claude_skills = tmp_path / "claude_skills"
         claude_skills.mkdir()
 
-        with patch.object(DoctorService, "collect_overlay_skills", return_value=[]):
-            created, fixed = DoctorService.repair_symlinks(skills_dir, claude_skills)
-            assert created == 1
-            assert fixed == 0
-            assert (claude_skills / "code").is_symlink()
+        created, fixed = DoctorService.repair_symlinks(skills_dir, claude_skills)
 
-    def test_handles_empty_skills_dir(self, tmp_path):
-        """_repair_symlinks handles empty skills dir (no SKILL.md files)."""
+        assert (created, fixed) == (1, 0)
+        assert (claude_skills / "code").is_symlink()
+
+    def test_handles_empty_skills_dir(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir()
-        # Dir with no SKILL.md inside
-        (skills_dir / "not-a-skill").mkdir()
-
+        (skills_dir / "not-a-skill").mkdir()  # No SKILL.md.
         claude_skills = tmp_path / "claude_skills"
         claude_skills.mkdir()
 
-        with patch.object(DoctorService, "collect_overlay_skills", return_value=[]):
-            created, fixed = DoctorService.repair_symlinks(skills_dir, claude_skills)
-            assert created == 0
-            assert fixed == 0
+        created, fixed = DoctorService.repair_symlinks(skills_dir, claude_skills)
 
-    def test_fixes_wrong_target(self, tmp_path):
+        assert (created, fixed) == (0, 0)
+
+    def test_fixes_wrong_target(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
         skills_dir = tmp_path / "skills"
-        skills_dir.mkdir()
         skill = skills_dir / "code"
-        skill.mkdir()
+        skill.mkdir(parents=True)
         (skill / "SKILL.md").touch()
-
         claude_skills = tmp_path / "claude_skills"
         claude_skills.mkdir()
-        # Create a symlink with wrong target
         wrong_target = tmp_path / "wrong"
         wrong_target.mkdir()
         (claude_skills / "code").symlink_to(wrong_target)
 
-        with patch.object(DoctorService, "collect_overlay_skills", return_value=[]):
-            created, fixed = DoctorService.repair_symlinks(skills_dir, claude_skills)
-            assert created == 1  # re-created after unlinking
-            assert fixed == 1
+        created, fixed = DoctorService.repair_symlinks(skills_dir, claude_skills)
 
-    def test_skips_real_dir(self, tmp_path):
+        assert (created, fixed) == (1, 1)
+
+    def test_skips_real_directory(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
         skills_dir = tmp_path / "skills"
-        skills_dir.mkdir()
         skill = skills_dir / "code"
-        skill.mkdir()
+        skill.mkdir(parents=True)
         (skill / "SKILL.md").touch()
-
         claude_skills = tmp_path / "claude_skills"
         claude_skills.mkdir()
-        # A real directory, not a symlink
         (claude_skills / "code").mkdir()
 
-        with patch.object(DoctorService, "collect_overlay_skills", return_value=[]):
-            created, fixed = DoctorService.repair_symlinks(skills_dir, claude_skills)
-            assert created == 0
-            assert fixed == 0
+        created, fixed = DoctorService.repair_symlinks(skills_dir, claude_skills)
 
-    def test_leaves_correct_link_unchanged(self, tmp_path):
+        assert (created, fixed) == (0, 0)
+
+    def test_leaves_correct_link_unchanged(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
         skills_dir = tmp_path / "skills"
-        skills_dir.mkdir()
         skill = skills_dir / "code"
-        skill.mkdir()
+        skill.mkdir(parents=True)
         (skill / "SKILL.md").touch()
-
         claude_skills = tmp_path / "claude_skills"
         claude_skills.mkdir()
         (claude_skills / "code").symlink_to(skill)
 
-        with patch.object(DoctorService, "collect_overlay_skills", return_value=[]):
-            created, fixed = DoctorService.repair_symlinks(skills_dir, claude_skills)
-            assert created == 0
-            assert fixed == 0
+        created, fixed = DoctorService.repair_symlinks(skills_dir, claude_skills)
 
-    # ── check_editable_sanity ────────────────────────────────────────
+        assert (created, fixed) == (0, 0)
 
-    def test_returns_empty_when_contribute_false_and_nothing_editable(self):
-        """Returns empty when contribute=false and nothing is editable."""
-        mock_config = MagicMock()
-        mock_config.user.contribute = False
 
-        with (
-            patch("teatree.config.load_config", return_value=mock_config),
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
-        ):
-            result = DoctorService.check_editable_sanity()
-            assert result == []
+# ── DoctorService.check_editable_sanity ──────────────────────────────────
 
-    def test_returns_empty_when_contribute_true_and_all_editable(self):
-        """Returns empty when contribute=true and everything is already editable."""
-        mock_config = MagicMock()
-        mock_config.user.contribute = True
 
-        with (
-            patch("teatree.config.load_config", return_value=mock_config),
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
-        ):
-            result = DoctorService.check_editable_sanity()
-            assert result == []
+class TestCheckEditableSanity:
+    """End-to-end sanity check wired to a real ``~/.teatree.toml``.
 
-    def test_auto_fixes_when_contribute_true_and_not_editable(self):
-        """Auto-installs editable teatree when contribute=true and repo is found."""
-        mock_config = MagicMock()
-        mock_config.user.contribute = True
+    ``editable_info`` and ``get_all_overlays`` are the two external boundaries
+    we cannot make real without installing actual packages, so they stay as
+    mocks. Everything else (config loading, repo discovery) runs live.
+    """
+
+    def test_empty_when_contribute_false_and_nothing_editable(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = false\n")
 
         with (
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
             patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
-            patch("teatree.config.load_config", return_value=mock_config),
-            patch.object(DoctorService, "find_teatree_repo", return_value=Path("/tmp/teatree")),
-            patch.object(DoctorService, "make_editable") as mock_fix,
         ):
-            result = DoctorService.check_editable_sanity()
-            mock_fix.assert_called_once_with("teatree", Path("/tmp/teatree"))
-            assert result == []
+            assert DoctorService.check_editable_sanity() == []
 
-    def test_warns_when_contribute_true_and_repo_not_found(self):
-        """Warns when contribute=true, teatree not editable, and repo path not found."""
-        mock_config = MagicMock()
-        mock_config.user.contribute = True
-
-        with (
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
-            patch("teatree.config.load_config", return_value=mock_config),
-            patch.object(DoctorService, "find_teatree_repo", return_value=None),
-        ):
-            result = DoctorService.check_editable_sanity()
-            assert any("contribute=true" in p for p in result)
-
-    def test_warns_teatree_unexpectedly_editable(self):
-        """Warns when teatree is editable but contribute=false."""
-        mock_config = MagicMock()
-        mock_config.user.contribute = False
+    def test_empty_when_contribute_true_and_all_editable(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = true\n")
 
         with (
             patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")),
             patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
-            patch("teatree.config.load_config", return_value=mock_config),
         ):
-            result = DoctorService.check_editable_sanity()
-            assert any("contribute=false" in p for p in result)
+            assert DoctorService.check_editable_sanity() == []
 
-    def test_auto_fixes_overlay_when_contribute_true(self):
-        """Auto-installs editable overlay when contribute=true and repo is found."""
-        mock_config = MagicMock()
-        mock_config.user.contribute = True
-
-        overlay_stub = _make_overlay_stub("my_overlay.overlay")
-
-        def editable_info(dist_name):
-            return (dist_name == "teatree", "")  # teatree editable, overlay not
-
-        with (
-            patch.object(IntrospectionHelpers, "editable_info", side_effect=editable_info),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": overlay_stub}),
-            patch.object(teatree_cli_doctor, "packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
-            patch("teatree.config.load_config", return_value=mock_config),
-            patch.object(DoctorService, "find_overlay_repo", return_value=Path("/tmp/my-overlay")),
-            patch.object(DoctorService, "make_editable") as mock_fix,
-        ):
-            result = DoctorService.check_editable_sanity()
-            mock_fix.assert_called_once_with("my-overlay", Path("/tmp/my-overlay"))
-            assert result == []
-
-    def test_warns_overlay_unexpectedly_editable(self):
-        """Warns when overlay is editable but contribute=false."""
-        mock_config = MagicMock()
-        mock_config.user.contribute = False
-
-        overlay_stub = _make_overlay_stub("my_overlay.overlay")
-
-        def editable_info(dist_name):
-            if dist_name == "teatree":
-                return (False, "")
-            return (True, "file:///src")
-
-        with (
-            patch.object(IntrospectionHelpers, "editable_info", side_effect=editable_info),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": overlay_stub}),
-            patch.object(teatree_cli_doctor, "packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
-            patch("teatree.config.load_config", return_value=mock_config),
-        ):
-            result = DoctorService.check_editable_sanity()
-            assert any("contribute=false" in p for p in result)
-
-    def test_no_warnings_when_editable_state_matches(self):
-        """No warnings when contribute=false and nothing is editable."""
-        mock_config = MagicMock()
-        mock_config.user.contribute = False
-
-        overlay_stub = _make_overlay_stub("my_overlay.overlay")
+    def test_auto_fixes_teatree_when_contribute_true(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = true\n")
+        teatree_repo = tmp_path / "repos" / "teatree"
+        teatree_repo.mkdir(parents=True)
+        (teatree_repo / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
+        monkeypatch.setenv("T3_REPO", str(teatree_repo))
+        monkeypatch.chdir(tmp_path)
 
         with (
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": overlay_stub}),
-            patch.object(teatree_cli_doctor, "packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
-            patch("teatree.config.load_config", return_value=mock_config),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+            patch.object(DoctorService, "make_editable") as mock_fix,
         ):
-            result = DoctorService.check_editable_sanity()
-            assert result == []
+            problems = DoctorService.check_editable_sanity()
 
-    def test_warns_overlay_contribute_true_repo_not_found(self):
-        """Warns when contribute=true, overlay not editable, and repo not found."""
-        mock_config = MagicMock()
-        mock_config.user.contribute = True
+        mock_fix.assert_called_once_with("teatree", teatree_repo)
+        assert problems == []
 
-        overlay_stub = _make_overlay_stub("my_overlay.overlay")
-
-        def editable_info(dist_name):
-            return (dist_name == "teatree", "")  # teatree editable, overlay not
+    def test_warns_when_contribute_true_and_teatree_repo_not_found(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = true\n")
+        monkeypatch.delenv("T3_REPO", raising=False)
+        monkeypatch.chdir(tmp_path)
 
         with (
-            patch.object(IntrospectionHelpers, "editable_info", side_effect=editable_info),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={"test": overlay_stub}),
-            patch.object(teatree_cli_doctor, "packages_distributions", return_value={"my_overlay": ["my-overlay"]}),
-            patch("teatree.config.load_config", return_value=mock_config),
-            patch.object(DoctorService, "find_overlay_repo", return_value=None),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+            patch("teatree.find_project_root", return_value=None),
         ):
-            result = DoctorService.check_editable_sanity()
-            assert any("overlay" in p and "repo not found" in p for p in result)
+            problems = DoctorService.check_editable_sanity()
 
-    # ── find_teatree_repo ───────────────────────────────────────────
+        assert any("contribute=true" in p for p in problems)
 
-    def test_find_teatree_repo_from_env(self, tmp_path, monkeypatch):
-        """Finds teatree repo via T3_REPO env var."""
-        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'teatree'\n")
+    def test_warns_when_teatree_editable_but_contribute_false(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = false\n")
+
+        with (
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+        ):
+            problems = DoctorService.check_editable_sanity()
+
+        assert any("contribute=false" in p for p in problems)
+
+    def test_auto_fixes_overlay_when_contribute_true(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(
+            tmp_path / ".teatree.toml",
+            f'[teatree]\ncontribute = true\nworkspace_dir = "{tmp_path}"\n',
+        )
+        overlay_repo = tmp_path / "my-overlay"
+        overlay_repo.mkdir()
+        (overlay_repo / "pyproject.toml").write_text('[project]\nname = "my-overlay"\n')
+
+        with (
+            patch.object(
+                IntrospectionHelpers,
+                "editable_info",
+                side_effect=_editable_map(teatree=(True, ""), **{"my-overlay": (False, "")}),
+            ),
+            patch.object(
+                teatree_overlay_loader,
+                "get_all_overlays",
+                return_value={"test": _stub_overlay_instance()},
+            ),
+            patch.object(
+                teatree_cli_doctor,
+                "packages_distributions",
+                return_value={"my_overlay": ["my-overlay"]},
+            ),
+            patch.object(DoctorService, "make_editable") as mock_fix,
+        ):
+            problems = DoctorService.check_editable_sanity()
+
+        mock_fix.assert_called_once_with("my-overlay", overlay_repo)
+        assert problems == []
+
+    def test_warns_when_overlay_editable_but_contribute_false(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = false\n")
+
+        with (
+            patch.object(
+                IntrospectionHelpers,
+                "editable_info",
+                side_effect=_editable_map(teatree=(False, ""), **{"my-overlay": (True, "file:///src")}),
+            ),
+            patch.object(
+                teatree_overlay_loader,
+                "get_all_overlays",
+                return_value={"test": _stub_overlay_instance()},
+            ),
+            patch.object(
+                teatree_cli_doctor,
+                "packages_distributions",
+                return_value={"my_overlay": ["my-overlay"]},
+            ),
+        ):
+            problems = DoctorService.check_editable_sanity()
+
+        assert any("contribute=false" in p for p in problems)
+
+    def test_empty_when_all_states_align_with_contribute_false(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = false\n")
+
+        with (
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(
+                teatree_overlay_loader,
+                "get_all_overlays",
+                return_value={"test": _stub_overlay_instance()},
+            ),
+            patch.object(
+                teatree_cli_doctor,
+                "packages_distributions",
+                return_value={"my_overlay": ["my-overlay"]},
+            ),
+        ):
+            assert DoctorService.check_editable_sanity() == []
+
+    def test_warns_when_overlay_repo_not_found(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(
+            tmp_path / ".teatree.toml",
+            f'[teatree]\ncontribute = true\nworkspace_dir = "{tmp_path}"\n',
+        )
+        # No ``my-overlay`` directory under workspace_dir.
+
+        with (
+            patch.object(
+                IntrospectionHelpers,
+                "editable_info",
+                side_effect=_editable_map(teatree=(True, ""), **{"my-overlay": (False, "")}),
+            ),
+            patch.object(
+                teatree_overlay_loader,
+                "get_all_overlays",
+                return_value={"test": _stub_overlay_instance()},
+            ),
+            patch.object(
+                teatree_cli_doctor,
+                "packages_distributions",
+                return_value={"my_overlay": ["my-overlay"]},
+            ),
+        ):
+            problems = DoctorService.check_editable_sanity()
+
+        assert any("overlay" in p and "repo not found" in p for p in problems)
+
+
+# ── DoctorService.find_teatree_repo ──────────────────────────────────────
+
+
+class TestFindTeatreeRepo:
+    def test_finds_via_t3_repo_env(self, tmp_path, monkeypatch):
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
         monkeypatch.setenv("T3_REPO", str(tmp_path))
-        # Run from a neutral cwd so the worktree preference does not trigger.
         monkeypatch.chdir(tmp_path.parent)
+
         assert DoctorService.find_teatree_repo() == tmp_path
 
-    def test_find_teatree_repo_auto_detect(self, tmp_path, monkeypatch):
-        """Auto-detects teatree repo via find_project_root."""
+    def test_auto_detects_via_find_project_root(self, tmp_path, monkeypatch):
         monkeypatch.delenv("T3_REPO", raising=False)
         monkeypatch.chdir(tmp_path.parent)
+
         with patch("teatree.find_project_root", return_value=tmp_path):
             assert DoctorService.find_teatree_repo() == tmp_path
 
-    def test_find_teatree_repo_returns_none(self, tmp_path, monkeypatch):
-        """Returns None when T3_REPO not set and auto-detect fails."""
+    def test_returns_none_when_env_missing_and_auto_detect_fails(self, tmp_path, monkeypatch):
         monkeypatch.delenv("T3_REPO", raising=False)
         monkeypatch.chdir(tmp_path)
+
         with patch("teatree.find_project_root", return_value=None):
             assert DoctorService.find_teatree_repo() is None
 
-    def test_find_teatree_repo_prefers_cwd_worktree_over_env(self, tmp_path, monkeypatch):
-        """When cwd lives inside a teatree worktree, prefer it over T3_REPO (main clone)."""
+    def test_prefers_cwd_worktree_over_t3_repo_env(self, tmp_path, monkeypatch):
         main_clone = tmp_path / "main"
         main_clone.mkdir()
         (main_clone / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
@@ -531,223 +636,305 @@ class TestDoctorService:
         (worktree / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
         monkeypatch.setenv("T3_REPO", str(main_clone))
         monkeypatch.chdir(worktree)
+
         assert DoctorService.find_teatree_repo() == worktree
 
-    # ── find_overlay_repo ───────────────────────────────────────────
 
-    def test_find_overlay_repo_found(self, tmp_path):
-        """Finds overlay repo in workspace directory."""
+# ── DoctorService.find_overlay_repo ──────────────────────────────────────
+
+
+class TestFindOverlayRepo:
+    def test_finds_overlay_in_workspace(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(
+            tmp_path / ".teatree.toml",
+            f'[teatree]\nworkspace_dir = "{tmp_path}"\n',
+        )
         overlay_dir = tmp_path / "my-overlay"
         overlay_dir.mkdir()
-        (overlay_dir / "pyproject.toml").write_text("[project]\nname = 'my-overlay'\n")
+        (overlay_dir / "pyproject.toml").write_text('[project]\nname = "my-overlay"\n')
 
-        mock_config = MagicMock()
-        mock_config.user.workspace_dir = str(tmp_path)
-        with patch("teatree.config.load_config", return_value=mock_config):
-            assert DoctorService.find_overlay_repo("my-overlay") == overlay_dir
+        assert DoctorService.find_overlay_repo("my-overlay") == overlay_dir
 
-    def test_find_overlay_repo_not_found(self, tmp_path):
-        """Returns None when overlay repo not in workspace."""
-        mock_config = MagicMock()
-        mock_config.user.workspace_dir = str(tmp_path)
-        with patch("teatree.config.load_config", return_value=mock_config):
-            assert DoctorService.find_overlay_repo("nonexistent") is None
+    def test_returns_none_when_overlay_absent(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(
+            tmp_path / ".teatree.toml",
+            f'[teatree]\nworkspace_dir = "{tmp_path}"\n',
+        )
 
-    # ── make_editable ───────────────────────────────────────────────
+        assert DoctorService.find_overlay_repo("nonexistent") is None
 
-    def test_make_editable_success(self, capsys, tmp_path):
-        """Patches pyproject.toml sources and reports success."""
+
+# ── DoctorService.make_editable ──────────────────────────────────────────
+
+
+class TestMakeEditable:
+    """``make_editable`` shells out to ``uv``/``git``; those are the boundary mocks."""
+
+    def test_success_patches_pyproject_and_writes_marker(self, tmp_path, capsys):
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text('[tool.uv.sources]\nteatree = { git = "https://example.com", branch = "main" }\n')
-        (tmp_path / "manage.py").write_text("")  # host project marker
+        (tmp_path / "manage.py").write_text("")
 
-        mock_result = MagicMock()
-        mock_result.returncode = 0
+        success = subprocess.CompletedProcess([], 0)
         with (
             patch("teatree.cli.doctor._find_host_project_root", return_value=tmp_path),
-            patch("subprocess.run", return_value=mock_result),
+            patch("subprocess.run", return_value=success),
         ):
             DoctorService.make_editable("teatree", Path("/tmp/teatree"))
-        captured = capsys.readouterr()
-        assert "now editable" in captured.out
-        assert (tmp_path / ".t3-dev-sources").is_file()
 
-    def test_make_editable_no_host_project(self, capsys):
-        """Falls back to ephemeral uv pip install when no host project found."""
-        mock_result = MagicMock()
-        mock_result.returncode = 0
+        assert "now editable" in capsys.readouterr().out
+        assert (tmp_path / ".t3-dev-sources").is_file()
+        rewritten = pyproject.read_text()
+        assert "path =" in rewritten
+        assert "editable = true" in rewritten
+
+    def test_falls_back_to_ephemeral_install_without_host_project(self, capsys):
+        success = subprocess.CompletedProcess([], 0)
         with (
             patch("teatree.cli.doctor._find_host_project_root", return_value=None),
-            patch("subprocess.run", return_value=mock_result),
+            patch("subprocess.run", return_value=success),
         ):
             DoctorService.make_editable("teatree", Path("/tmp/teatree"))
-        captured = capsys.readouterr()
-        assert "ephemeral" in captured.out
 
-    def test_make_editable_patch_failure(self, capsys, tmp_path):
-        """Reports failure when pyproject.toml has no matching source entry."""
+        assert "ephemeral" in capsys.readouterr().out
+
+    def test_reports_fail_when_pyproject_has_no_source_entry(self, tmp_path, capsys):
         pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text("[project]\nname = 'myproject'\n")
+        pyproject.write_text('[project]\nname = "myproject"\n')
         (tmp_path / "manage.py").write_text("")
 
         with patch("teatree.cli.doctor._find_host_project_root", return_value=tmp_path):
             DoctorService.make_editable("teatree", Path("/tmp/teatree"))
-        captured = capsys.readouterr()
-        assert "FAIL" in captured.out
+
+        assert "FAIL" in capsys.readouterr().out
+
+    def test_reports_fail_without_host_project_when_install_fails(self, tmp_path):
+        failure = subprocess.CompletedProcess([], 1, "", "install failed")
+        with (
+            patch("teatree.cli.doctor._find_host_project_root", return_value=None),
+            patch("subprocess.run", return_value=failure),
+        ):
+            DoctorService.make_editable("teatree", tmp_path)
+
+    def test_reports_fail_when_uv_sync_fails(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test"\n\n[tool.uv.sources]\nteatree = { git = "https://x" }\n',
+        )
+        failure = subprocess.CompletedProcess([], 1, "", "sync failed")
+        with (
+            patch("teatree.cli.doctor._find_host_project_root", return_value=tmp_path),
+            patch("subprocess.run", return_value=failure),
+        ):
+            DoctorService.make_editable("teatree", Path("/repos/teatree"))
 
 
-class TestIntrospectionHelpers:
-    """Tests for IntrospectionHelpers methods (print_package_info, editable_info)."""
+# ── IntrospectionHelpers ─────────────────────────────────────────────────
 
-    # ── editable_info ────────────────────────────────────────────────
 
-    def test_not_installed(self):
-        with patch.object(teatree_cli_doctor, "distribution", side_effect=teatree_cli_doctor.PackageNotFoundError("x")):
+class TestEditableInfo:
+    """``editable_info`` parses ``direct_url.json`` from an installed dist.
+
+    ``importlib.metadata.distribution`` is the external boundary — it walks
+    the real site-packages. We mock it rather than install fixture packages.
+    """
+
+    def test_returns_false_when_not_installed(self):
+        with patch.object(
+            teatree_cli_doctor,
+            "distribution",
+            side_effect=teatree_cli_doctor.PackageNotFoundError("x"),
+        ):
             assert IntrospectionHelpers.editable_info("nonexistent") == (False, "")
 
-    def test_no_direct_url(self):
-        mock_dist = MagicMock()
-        mock_dist.read_text.return_value = None
-        with patch.object(teatree_cli_doctor, "distribution", return_value=mock_dist):
+    def test_returns_false_when_no_direct_url(self):
+        dist = MagicMock()
+        dist.read_text.return_value = None
+        with patch.object(teatree_cli_doctor, "distribution", return_value=dist):
             assert IntrospectionHelpers.editable_info("some-pkg") == (False, "")
 
-    def test_editable(self):
-        mock_dist = MagicMock()
-        mock_dist.read_text.return_value = json.dumps(
-            {
-                "dir_info": {"editable": True},
-                "url": "file:///home/user/project",
-            }
+    def test_returns_editable_metadata_from_direct_url(self):
+        dist = MagicMock()
+        dist.read_text.return_value = json.dumps(
+            {"dir_info": {"editable": True}, "url": "file:///home/user/project"},
         )
-        with patch.object(teatree_cli_doctor, "distribution", return_value=mock_dist):
+        with patch.object(teatree_cli_doctor, "distribution", return_value=dist):
             editable, url = IntrospectionHelpers.editable_info("some-pkg")
-            assert editable is True
-            assert url == "file:///home/user/project"
 
-    def test_invalid_json(self):
-        mock_dist = MagicMock()
-        mock_dist.read_text.return_value = "not json"
-        with patch.object(teatree_cli_doctor, "distribution", return_value=mock_dist):
+        assert editable is True
+        assert url == "file:///home/user/project"
+
+    def test_returns_false_on_invalid_direct_url_json(self):
+        dist = MagicMock()
+        dist.read_text.return_value = "not json"
+        with patch.object(teatree_cli_doctor, "distribution", return_value=dist):
             assert IntrospectionHelpers.editable_info("some-pkg") == (False, "")
 
-    # ── print_package_info ───────────────────────────────────────────
 
-    def test_installed(self, capsys):
+class TestPrintPackageInfo:
+    """``print_package_info`` resolves ``import_name`` via ``importlib.import_module``."""
+
+    def test_prints_source_dir_for_installed_package(self, capsys):
         with (
             patch("importlib.import_module") as mock_import,
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
         ):
-            mock_mod = MagicMock()
-            mock_mod.__file__ = "/usr/lib/python/teatree/__init__.py"
-            mock_import.return_value = mock_mod
+            mod = MagicMock()
+            mod.__file__ = "/usr/lib/python/teatree/__init__.py"
+            mock_import.return_value = mod
             IntrospectionHelpers.print_package_info("teatree", "teatree")
-            # Just verifying it runs without error; output goes through typer.echo
 
-    def test_not_installed_package(self, capsys):
+        out = capsys.readouterr().out
+        assert "/usr/lib/python/teatree" in out
+        assert "installed" in out
+
+    def test_handles_import_error(self, capsys):
         with patch("importlib.import_module", side_effect=ImportError("nope")):
             IntrospectionHelpers.print_package_info("teatree", "teatree")
-            # Verifying it handles ImportError gracefully
 
-    def test_editable_with_url(self, capsys):
+        assert "not installed" in capsys.readouterr().out
+
+    def test_prints_editable_url_when_available(self, capsys):
         with (
             patch("importlib.import_module") as mock_import,
             patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")),
         ):
-            mock_mod = MagicMock()
-            mock_mod.__file__ = "/src/teatree/__init__.py"
-            mock_import.return_value = mock_mod
+            mod = MagicMock()
+            mod.__file__ = "/src/teatree/__init__.py"
+            mock_import.return_value = mod
             IntrospectionHelpers.print_package_info("teatree", "teatree")
 
-    def test_editable_no_url(self, capsys):
-        """_print_package_info doesn't print URL when editable but no url."""
+        out = capsys.readouterr().out
+        assert "editable" in out
+        assert "file:///src" in out
+
+    def test_omits_url_when_editable_but_none(self, capsys):
         with (
             patch("importlib.import_module") as mock_import,
             patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "")),
         ):
-            mock_mod = MagicMock()
-            mock_mod.__file__ = "/src/teatree/__init__.py"
-            mock_import.return_value = mock_mod
+            mod = MagicMock()
+            mod.__file__ = "/src/teatree/__init__.py"
+            mock_import.return_value = mod
             IntrospectionHelpers.print_package_info("teatree", "teatree")
 
+        out = capsys.readouterr().out
+        assert "editable" in out
+        assert "file://" not in out
 
-class TestDoctorCommands:
-    """Tests for CLI command wrappers (using CliRunner)."""
 
-    # ── check ────────────────────────────────────────────────────────
+# ── t3 doctor check (CliRunner) ──────────────────────────────────────────
 
-    def test_check_ok(self):
-        """Doctor check passes when all checks pass."""
+
+class TestDoctorCheckCommand:
+    """End-to-end ``t3 doctor check`` dispatch via ``CliRunner``.
+
+    The command's sanity check runs live against the staged
+    ``~/.teatree.toml``; ``editable_info`` + ``shutil.which`` stay mocked
+    because they touch the real site-packages and PATH.
+    """
+
+    def _write_noop_toml(self, home: Path) -> None:
+        _write_teatree_toml(home / ".teatree.toml", "[teatree]\ncontribute = false\n")
+
+    def test_reports_all_checks_passed(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
+
         with (
-            patch.object(DoctorService, "check_editable_sanity", return_value=[]),
+            patch.object(teatree_cli_doctor.shutil, "which", side_effect=lambda t: f"/usr/bin/{t}"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
         ):
             result = runner.invoke(app, ["doctor", "check"])
-            assert result.exit_code == 0
-            assert "All checks passed" in result.output
 
-    def test_check_with_warnings(self):
-        """Doctor check shows warnings."""
-        with patch.object(
-            DoctorService,
-            "check_editable_sanity",
-            return_value=["teatree is editable but not declared"],
+        assert result.exit_code == 0
+        assert "All checks passed" in result.output
+
+    def test_reports_warning_when_editable_state_mismatches(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        # contribute=false but teatree is editable → WARN
+        self._write_noop_toml(tmp_path)
+
+        with (
+            patch.object(teatree_cli_doctor.shutil, "which", side_effect=lambda t: f"/usr/bin/{t}"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
         ):
             result = runner.invoke(app, ["doctor", "check"])
-            assert result.exit_code == 0
-            assert "WARN" in result.output
 
-    def test_check_fails_when_required_tool_missing(self):
-        """Doctor check fails when a required tool is not on PATH."""
+        assert result.exit_code == 0
+        assert "WARN" in result.output
+
+    def test_fails_when_required_tool_missing(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
+
         with (
             patch.object(
                 teatree_cli_doctor.shutil,
                 "which",
                 side_effect=lambda t: None if t == "direnv" else f"/usr/bin/{t}",
             ),
-            patch.object(DoctorService, "check_editable_sanity", return_value=[]),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
         ):
             result = runner.invoke(app, ["doctor", "check"])
-            assert result.exit_code == 0  # typer returns 0; check() returns bool
-            assert "FAIL  Required tool not found: direnv" in result.output
 
-    def test_check_validates_skills(self, tmp_path, monkeypatch):
-        """Doctor check validates SKILL.md files in skills directory."""
+        assert "FAIL  Required tool not found: direnv" in result.output
+
+    def test_validates_skills_in_claude_dir(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
         claude_skills = tmp_path / ".claude" / "skills"
-        ok = claude_skills / "ok-skill"
-        ok.mkdir(parents=True)
-        (ok / "SKILL.md").write_text("---\nname: ok-skill\ndescription: d\n---\n")
+        (claude_skills / "ok-skill").mkdir(parents=True)
+        (claude_skills / "ok-skill" / "SKILL.md").write_text("---\nname: ok-skill\ndescription: d\n---\n")
 
-        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
-        with patch.object(DoctorService, "check_editable_sanity", return_value=[]):
+        with (
+            patch.object(teatree_cli_doctor.shutil, "which", side_effect=lambda t: f"/usr/bin/{t}"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+        ):
             result = runner.invoke(app, ["doctor", "check"])
-            assert result.exit_code == 0
-            assert "1 skill(s) validated" in result.output
 
-    def test_check_skill_validation_errors(self, tmp_path, monkeypatch):
-        """Doctor check reports skill validation errors."""
-        claude_skills = tmp_path / ".claude" / "skills"
-        bad = claude_skills / "bad-skill"
+        assert result.exit_code == 0
+        assert "1 skill(s) validated" in result.output
+
+    def test_reports_skill_validation_errors(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
+        bad = tmp_path / ".claude" / "skills" / "bad-skill"
         bad.mkdir(parents=True)
         (bad / "SKILL.md").write_text("no frontmatter here")
 
-        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
-        with patch.object(DoctorService, "check_editable_sanity", return_value=[]):
+        with (
+            patch.object(teatree_cli_doctor.shutil, "which", side_effect=lambda t: f"/usr/bin/{t}"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+        ):
             result = runner.invoke(app, ["doctor", "check"])
-            assert "FAIL" in result.output
 
-    def test_check_skill_validation_warnings(self, tmp_path, monkeypatch):
-        """Doctor check reports skill validation warnings for unknown fields."""
-        claude_skills = tmp_path / ".claude" / "skills"
-        skill = claude_skills / "warn-skill"
+        assert "FAIL" in result.output
+
+    def test_reports_skill_validation_warnings(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
+        skill = tmp_path / ".claude" / "skills" / "warn-skill"
         skill.mkdir(parents=True)
         (skill / "SKILL.md").write_text("---\nname: warn-skill\ndescription: d\nunknown-field: x\n---\n")
 
-        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
-        with patch.object(DoctorService, "check_editable_sanity", return_value=[]):
+        with (
+            patch.object(teatree_cli_doctor.shutil, "which", side_effect=lambda t: f"/usr/bin/{t}"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+        ):
             result = runner.invoke(app, ["doctor", "check"])
-            assert "WARN" in result.output
 
-    def test_check_import_failure(self):
-        """Doctor check returns False on import failure."""
+        assert "WARN" in result.output
+
+    def test_fails_on_import_error(self):
         import builtins  # noqa: PLC0415
 
         real_import = builtins.__import__
@@ -759,82 +946,54 @@ class TestDoctorCommands:
 
         with patch("builtins.__import__", side_effect=fail_import):
             result = runner.invoke(app, ["doctor", "check"])
-            assert "FAIL" in result.output
+
+        assert "FAIL" in result.output
+
+
+# ── Pure-function modules ────────────────────────────────────────────────
 
 
 class TestFindHostProjectRoot:
-    def test_finds_project_in_current_dir(self, tmp_path: Path) -> None:
-        (tmp_path / "manage.py").write_text("", encoding="utf-8")
-        (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
-        with patch("teatree.cli.doctor.Path") as mock_path:
-            mock_path.cwd.return_value = tmp_path
-            result = teatree_cli_doctor._find_host_project_root()
-        assert result == tmp_path
+    def test_finds_project_in_current_dir(self, tmp_path, monkeypatch):
+        (tmp_path / "manage.py").write_text("")
+        (tmp_path / "pyproject.toml").write_text("")
+        monkeypatch.chdir(tmp_path)
 
-    def test_returns_none_when_not_found(self, tmp_path: Path) -> None:
-        with patch("teatree.cli.doctor.Path") as mock_path:
-            mock_path.cwd.return_value = tmp_path
-            result = teatree_cli_doctor._find_host_project_root()
-        assert result is None
+        assert teatree_cli_doctor._find_host_project_root() == tmp_path
+
+    def test_returns_none_when_not_found(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        assert teatree_cli_doctor._find_host_project_root() is None
 
 
 class TestWriteDevSourcesMarker:
-    def test_creates_new_marker(self, tmp_path: Path) -> None:
+    def test_creates_new_marker_file(self, tmp_path):
         marker = tmp_path / ".t3-dev-sources"
         teatree_cli_doctor._write_dev_sources_marker(marker, "teatree", Path("/repos/teatree"))
-        content = marker.read_text(encoding="utf-8")
-        assert "teatree=/repos/teatree" in content
+        assert "teatree=/repos/teatree" in marker.read_text()
 
-    def test_updates_existing_entry(self, tmp_path: Path) -> None:
+    def test_updates_existing_entry_in_place(self, tmp_path):
         marker = tmp_path / ".t3-dev-sources"
-        marker.write_text("teatree=/old/path\nother=/other/path\n", encoding="utf-8")
+        marker.write_text("teatree=/old/path\nother=/other/path\n")
         teatree_cli_doctor._write_dev_sources_marker(marker, "teatree", Path("/new/path"))
-        content = marker.read_text(encoding="utf-8")
+        content = marker.read_text()
         assert "teatree=/new/path" in content
         assert "other=/other/path" in content
         assert "/old/path" not in content
 
 
 class TestRestoreSources:
-    def test_restores_from_marker(self, tmp_path: Path) -> None:
+    def test_reverts_from_marker_via_git(self, tmp_path):
         marker = tmp_path / ".t3-dev-sources"
-        marker.write_text("teatree=/repos/teatree\n", encoding="utf-8")
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text("[project]\nname = 'test'\n", encoding="utf-8")
+        marker.write_text("teatree=/repos/teatree\n")
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test"\n')
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess([], 0)
+        with patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as mock_run:
             DoctorService.restore_sources(tmp_path)
+
         assert not marker.exists()
         assert mock_run.call_count == 2  # git update-index + git checkout
 
-    def test_noop_when_no_marker(self, tmp_path: Path) -> None:
-        # No marker file — nothing should happen
-        DoctorService.restore_sources(tmp_path)
-
-
-class TestMakeEditableFailure:
-    def test_reports_failure_without_host_project(self, tmp_path: Path) -> None:
-        with (
-            patch("teatree.cli.doctor._find_host_project_root", return_value=None),
-            patch(
-                "subprocess.run",
-                return_value=subprocess.CompletedProcess([], 1, "", "install failed"),
-            ),
-        ):
-            DoctorService.make_editable("teatree", tmp_path)
-
-    def test_reports_failure_on_uv_sync(self, tmp_path: Path) -> None:
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text(
-            '[project]\nname = "test"\n\n[tool.uv.sources]\nteatree = { git = "https://x" }\n',
-            encoding="utf-8",
-        )
-        with (
-            patch("teatree.cli.doctor._find_host_project_root", return_value=tmp_path),
-            patch(
-                "subprocess.run",
-                return_value=subprocess.CompletedProcess([], 1, "", "sync failed"),
-            ),
-        ):
-            DoctorService.make_editable("teatree", Path("/repos/teatree"))
+    def test_noop_when_no_marker(self, tmp_path):
+        DoctorService.restore_sources(tmp_path)  # must not raise


### PR DESCRIPTION
## Summary

Picks up item #1 from the [#412](https://github.com/souliane/teatree/issues/412) batch-resume plan: convert the second mock offender (``test_cli_doctor.py``, 59 ``patch(`` occurrences) to integration-first per the Test-Writing Doctrine.

- Real ``~/.teatree.toml`` fixtures under ``tmp_path`` + monkeypatched ``Path.home`` / ``teatree.config.CONFIG_PATH`` / ``entry_points`` replace internal ``discover_overlays`` / ``discover_active_overlay`` / ``load_config`` / ``find_installed_claude_plugin`` / ``find_teatree_repo`` / ``find_overlay_repo`` / ``collect_overlay_skills`` patches.
- Real ``~/.claude/plugins/installed_plugins.json`` under ``tmp_path`` replaces ``find_installed_claude_plugin`` mocks.
- Real pyproject.toml / workspace directory layouts replace ``find_teatree_repo`` / ``find_overlay_repo`` / host-project-root patches on the happy paths.
- Remaining mocks cover external boundaries only: ``importlib.metadata.distribution`` / ``packages_distributions`` (site-packages introspection), ``importlib.import_module``, ``shutil.which`` (PATH lookup), ``subprocess.run`` (``uv`` / ``git``).
- ``IntrospectionHelpers.editable_info`` and ``teatree.core.overlay_loader.get_all_overlays`` stay mocked — both require actually installed fixture packages to exercise for real.

### Class restructure

One test class per method under test (``TestShowInfo``, ``TestFindInstalledClaudePlugin``, ``TestCollectOverlaySkills``, ``TestRepairSymlinks``, ``TestCheckEditableSanity``, ``TestFindTeatreeRepo``, ``TestFindOverlayRepo``, ``TestMakeEditable``, ``TestEditableInfo``, ``TestPrintPackageInfo``, ``TestDoctorCheckCommand``, ``TestFindHostProjectRoot``, ``TestWriteDevSourcesMarker``, ``TestRestoreSources``), replacing the previous three god-classes.

### Verification

- Mock reference count: **174 → 103** (41% reduction).
- ``uv run pytest tests/test_cli_doctor.py --no-cov -q`` → 61 passed.
- Full suite: 2472 passed, 12 skipped.
- Docker pre-push matrix green (hook ran on push).

Relates-to [#412](https://github.com/souliane/teatree/issues/412).

## Test plan

- [x] ``uv run pytest tests/test_cli_doctor.py --no-cov -q`` → green.
- [x] Full suite (``uv run pytest --no-cov``) → green.
- [x] ruff check, ruff format, ty-check → pass.
- [x] Pre-push Docker matrix → pass.
- [x] Mock count reduction confirmed (174 → 103).