### PR TITLE
feat(tool): `t3 tool find-duplicates` — second slice of #49

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -664,7 +664,7 @@ Typer-based, work without Django:
 - `t3 e2e external [--repo <name>] [--test-path <path>]` — run Playwright tests from `T3_PRIVATE_TESTS` or a named `[e2e_repos.<name>]` git repo; skips port discovery when `BASE_URL` is already set (DEV/staging mode)
 - `t3 review {post-draft-note,delete-draft-note,list-draft-notes,publish-draft-notes,reply-to-discussion,resolve-discussion}` — GitLab draft notes plus immediate replies on existing discussion threads and resolve/unresolve toggle
 - `t3 review-request discover` — discover open MRs
-- `t3 tool {privacy-scan,analyze-video,bump-deps,label-issues}` — standalone utilities
+- `t3 tool {privacy-scan,analyze-video,bump-deps,label-issues,find-duplicates}` — standalone utilities
 - `t3 config write-skill-cache` — write overlay skill metadata to cache
 - `t3 doctor {check,repair}` — health checks and symlink repair
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -548,6 +548,7 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 │ sonar-check      Run local SonarQube analysis via Docker.                    │
 │ label-issues     Suggest labels for unlabeled open issues by                 │
 │                  keyword-matching title and body.                            │
+│ find-duplicates  Flag pairs of open issues with near-identical titles.       │
 │ claude-handover  Show Claude handover telemetry and runtime recommendations. │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -630,6 +631,25 @@ Usage: t3 tool label-issues [OPTIONS] REPO
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --apply          Apply labels via `gh issue edit` (default: print only).     │
 │ --help           Show this message and exit.                                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 tool find-duplicates`
+
+```
+Usage: t3 tool find-duplicates [OPTIONS] REPO
+
+ Flag pairs of open issues with near-identical titles.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    repo      TEXT  Repository in owner/name form (e.g. souliane/teatree)   │
+│                      [required]                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --threshold        FLOAT RANGE [0.0<=x<=1.0]  Similarity ratio required to   │
+│                                               flag a pair (0.0-1.0).         │
+│                                               [default: 0.75]                │
+│ --help                                        Show this message and exit.    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import typer
 
-from teatree.triage import LabelSuggester
+from teatree.triage import DuplicateFinder, LabelSuggester
 from teatree.utils.run import run_allowed_to_fail
 
 tool_app = typer.Typer(no_args_is_help=True, help="Standalone utilities.")
@@ -108,6 +108,32 @@ def label_issues(
         typer.echo(f"Applied labels to {len(suggestions)} issue(s).")
     else:
         typer.echo(f"\n{len(suggestions)} issue(s) to label. Re-run with --apply to apply.")
+
+
+@tool_app.command("find-duplicates")
+def find_duplicates(
+    repo: str = typer.Argument(..., help="Repository in owner/name form (e.g. souliane/teatree)"),
+    *,
+    threshold: float = typer.Option(
+        0.75,
+        "--threshold",
+        min=0.0,
+        max=1.0,
+        help="Similarity ratio required to flag a pair (0.0-1.0).",
+    ),
+) -> None:
+    """Flag pairs of open issues with near-identical titles."""
+    finder = DuplicateFinder(repo, threshold=threshold)
+    matches = finder.find()
+    if not matches:
+        typer.echo("No potential duplicates found.")
+        return
+
+    for match in matches:
+        typer.echo(
+            f"  {match.score:.2f}  #{match.a_number} {match.a_title}\n         #{match.b_number} {match.b_title}"
+        )
+    typer.echo(f"\n{len(matches)} potential duplicate pair(s).")
 
 
 @tool_app.command("claude-handover")

--- a/src/teatree/triage.py
+++ b/src/teatree/triage.py
@@ -1,9 +1,11 @@
-"""Auto-labeling for GitHub issues — first slice of the triage tool (see #49)."""
+"""Auto-labeling and duplicate detection for GitHub issues — triage tool (see #49)."""
 
 import json
 import re
 import sys
 from dataclasses import dataclass
+from difflib import SequenceMatcher
+from itertools import combinations
 
 from teatree.utils.run import run_allowed_to_fail
 
@@ -86,3 +88,82 @@ class LabelSuggester:
                 ],
                 expected_codes=None,
             )
+
+
+# Conventional-commit prefix: `type(scope)!:` with optional scope and breaking `!`.
+_CONVENTIONAL_PREFIX = re.compile(r"^\s*[a-z]+(?:\([^)]+\))?!?:\s*", flags=re.IGNORECASE)
+# Trailing PR/issue reference: " (#123)".
+_PR_SUFFIX = re.compile(r"\s*\(#\d+\)\s*$")
+# Leading bracket tag: "[WIP]", "[RFC]", etc.
+_BRACKET_TAG = re.compile(r"^\s*\[[^\]]+\]\s*")
+_NON_ALNUM = re.compile(r"[^a-z0-9\s]+")
+_WHITESPACE = re.compile(r"\s+")
+
+
+def normalize_title(title: str) -> str:
+    """Lower-case, strip conventional-commit prefix / PR suffix / bracket tags / punctuation."""
+    text = title.lower()
+    text = _BRACKET_TAG.sub("", text)
+    text = _CONVENTIONAL_PREFIX.sub("", text)
+    text = _PR_SUFFIX.sub("", text)
+    text = _NON_ALNUM.sub(" ", text)
+    return _WHITESPACE.sub(" ", text).strip()
+
+
+@dataclass(frozen=True)
+class DuplicateMatch:
+    a_number: int
+    b_number: int
+    a_title: str
+    b_title: str
+    score: float
+
+
+class DuplicateFinder:
+    """Find potentially duplicate open issues by normalized-title similarity."""
+
+    def __init__(self, repo: str, *, threshold: float = 0.75) -> None:
+        self.repo = repo
+        self.threshold = threshold
+
+    def find(self) -> list[DuplicateMatch]:
+        result = run_allowed_to_fail(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                self.repo,
+                "--state",
+                "open",
+                "--limit",
+                "200",
+                "--json",
+                "number,title,body,labels",
+            ],
+            expected_codes=None,
+        )
+        if result.returncode != 0:
+            sys.stderr.write(f"gh issue list failed: {result.stderr.strip()}\n")
+            return []
+
+        issues = json.loads(result.stdout or "[]")
+        normalized = [(issue["number"], issue["title"], normalize_title(issue["title"])) for issue in issues]
+
+        matches: list[DuplicateMatch] = []
+        for (num_a, title_a, norm_a), (num_b, title_b, norm_b) in combinations(normalized, 2):
+            if not norm_a or not norm_b:
+                continue
+            score = SequenceMatcher(None, norm_a, norm_b).ratio()
+            if score >= self.threshold:
+                matches.append(
+                    DuplicateMatch(
+                        a_number=num_a,
+                        b_number=num_b,
+                        a_title=title_a,
+                        b_title=title_b,
+                        score=score,
+                    )
+                )
+        matches.sort(key=lambda m: m.score, reverse=True)
+        return matches

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,10 +1,16 @@
-"""Tests for teatree.triage — label inference for GitHub issues."""
+"""Tests for teatree.triage — label inference and duplicate detection for GitHub issues."""
 
 import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from teatree.triage import LABEL_KEYWORDS, LabelSuggester, infer_labels
+from teatree.triage import (
+    LABEL_KEYWORDS,
+    DuplicateFinder,
+    LabelSuggester,
+    infer_labels,
+    normalize_title,
+)
 
 
 def _issue_fixture() -> list[dict]:
@@ -108,3 +114,106 @@ class TestLabelSuggester:
             mock_run.return_value = SimpleNamespace(stdout="", stderr="gh: not found", returncode=1)
             suggestions = LabelSuggester("souliane/teatree").collect_suggestions()
         assert suggestions == []
+
+
+class TestNormalizeTitle:
+    def test_lowercases(self) -> None:
+        assert normalize_title("Fix DASHBOARD bug") == normalize_title("fix dashboard bug")
+
+    def test_strips_conventional_prefix(self) -> None:
+        assert normalize_title("feat: add a thing") == normalize_title("add a thing")
+        assert normalize_title("fix(cli): add a thing") == normalize_title("add a thing")
+        assert normalize_title("docs(scope)!: add a thing") == normalize_title("add a thing")
+
+    def test_strips_pr_suffix(self) -> None:
+        assert normalize_title("add a thing (#123)") == normalize_title("add a thing")
+
+    def test_strips_punctuation(self) -> None:
+        assert normalize_title("add a thing!") == normalize_title("add a thing")
+        assert normalize_title("add, a thing.") == normalize_title("add a thing")
+
+    def test_collapses_whitespace(self) -> None:
+        assert normalize_title("add   a   thing") == normalize_title("add a thing")
+
+    def test_strips_leading_emoji(self) -> None:
+        # Common "noise" words we don't want to count as signal.
+        assert normalize_title("[WIP] add a thing") == normalize_title("add a thing")
+
+
+def _dup_issue(number: int, title: str, labels: list[dict] | None = None) -> dict:
+    return {"number": number, "title": title, "body": "", "labels": labels or []}
+
+
+class TestDuplicateFinder:
+    def test_finds_near_identical_titles(self) -> None:
+        issues = [
+            _dup_issue(1, "Dashboard SSE disconnects under load"),
+            _dup_issue(2, "Dashboard SSE disconnects under load."),
+            _dup_issue(3, "Totally unrelated thing"),
+        ]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = _fake_list_result(issues)
+            matches = DuplicateFinder("souliane/teatree").find()
+
+        assert len(matches) == 1
+        pair = matches[0]
+        assert {pair.a_number, pair.b_number} == {1, 2}
+        assert pair.score >= 0.9
+
+    def test_finds_conventional_commit_variants(self) -> None:
+        issues = [
+            _dup_issue(10, "feat: add duplicate detection"),
+            _dup_issue(11, "Add duplicate detection"),
+            _dup_issue(12, "fix: something else entirely"),
+        ]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = _fake_list_result(issues)
+            matches = DuplicateFinder("souliane/teatree").find()
+
+        assert any({m.a_number, m.b_number} == {10, 11} for m in matches)
+
+    def test_ignores_low_similarity(self) -> None:
+        issues = [
+            _dup_issue(1, "Dashboard SSE disconnects under load"),
+            _dup_issue(2, "Switch CI from codecov to coveralls"),
+        ]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = _fake_list_result(issues)
+            matches = DuplicateFinder("souliane/teatree").find()
+
+        assert matches == []
+
+    def test_threshold_is_configurable(self) -> None:
+        issues = [
+            _dup_issue(1, "Refactor overlay loader"),
+            _dup_issue(2, "Refactor overlay module"),
+        ]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = _fake_list_result(issues)
+            strict = DuplicateFinder("souliane/teatree", threshold=0.99).find()
+            loose = DuplicateFinder("souliane/teatree", threshold=0.6).find()
+
+        assert strict == []
+        assert len(loose) >= 1
+
+    def test_each_pair_reported_once(self) -> None:
+        issues = [
+            _dup_issue(1, "Duplicate issue detection"),
+            _dup_issue(2, "Duplicate issue detection"),
+            _dup_issue(3, "Duplicate issue detection"),
+        ]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = _fake_list_result(issues)
+            matches = DuplicateFinder("souliane/teatree").find()
+
+        # With 3 identical titles we expect C(3, 2) = 3 unique pairs, no self-pairs, no duplicates.
+        pair_keys = {frozenset((m.a_number, m.b_number)) for m in matches}
+        assert len(pair_keys) == len(matches) == 3
+        assert all(m.a_number != m.b_number for m in matches)
+
+    def test_gh_failure_returns_empty(self) -> None:
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = SimpleNamespace(stdout="", stderr="gh: not found", returncode=1)
+            matches = DuplicateFinder("souliane/teatree").find()
+
+        assert matches == []


### PR DESCRIPTION
## Summary

Second slice of the smart ticket management idea in [#49](https://github.com/souliane/teatree/issues/49). Adds a duplicate-detection CLI that flags pairs of open issues with near-identical titles.

The first slice (auto-labeling via `t3 tool label-issues`) shipped in [#444](https://github.com/souliane/teatree/pull/444). The remaining triage slices (auto-close issues referencing merged PRs, priority inference, stale-issue sweeps) are separate work that can layer on top of the same `teatree.triage` module.

## How it works

- `normalize_title` strips noise before comparison: conventional-commit prefixes (`feat:`, `fix(cli):`, `docs(scope)!:`), trailing `(#NNN)` PR suffixes, leading bracket tags (`[WIP]`, `[RFC]`), non-alphanumeric punctuation, and collapses whitespace.
- `DuplicateFinder` pairs normalized titles via `difflib.SequenceMatcher.ratio()` and emits `DuplicateMatch` records sorted by descending score. Each pair is reported once (uses `itertools.combinations`).
- Default threshold `0.75` — strict enough to avoid false positives on the current teatree backlog (returns nothing today). Users can drop it with `--threshold 0.6` for a broader sweep.

## Usage

```bash
t3 tool find-duplicates souliane/teatree                   # default 0.75 threshold
t3 tool find-duplicates souliane/teatree --threshold 0.6   # broader sweep
```

Sample output at `--threshold 0.4` on today's teatree backlog (top matches):

```
  0.51  #377 feat(dashboard): button to run workspace clean-all on selected overlays...
         #376 feat(dashboard): button to run /ac-reviewing-codebase across teatree...
  0.46  #167 feat: dockerize t3 itself — run teatree in a container
         #16 Decouple t3-retro from teatree and distribute as a standalone skill
  ...
```

## Test plan

- [x] 12 new tests in `tests/test_triage.py` — `normalize_title` rules + `DuplicateFinder` flow with `gh` mocked at the `run_allowed_to_fail` boundary
- [x] Full suite: 2486 passed, 12 skipped, coverage 93.39% (threshold 93%)
- [x] `ruff check` + `ruff format` clean
- [x] Smoke-tested against `souliane/teatree` (default + lowered thresholds)
- [x] BLUEPRINT.md updated; `cli-reference.md` regenerated

Relates-to: [#49](https://github.com/souliane/teatree/issues/49)