### PR TITLE
test(coverage): combine unit + e2e suites into single threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,23 +70,28 @@ jobs:
           tags: teatree-test-${{ matrix.python-version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      # --cov-fail-under=0 disables the per-run threshold here — the 93% gate
+      # runs on the combined unit+e2e report in the `coverage` job below.
       - run: >
           docker run --rm
           -v "$PWD":/app
           -e UV_PROJECT_ENVIRONMENT=/tmp/.venv
-          -e COVERAGE_FILE=/app/.coverage
+          -e COVERAGE_FILE=/app/.coverage.unit
           teatree-test-${{ matrix.python-version }}
           uv run -p ${{ matrix.python-version }} pytest --no-header -q
           -o cache_dir=/tmp/.pytest_cache
-          --cov-report=xml:/app/coverage.xml
+          --cov-fail-under=0
       - uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: coverage-${{ matrix.python-version }}
-          path: coverage.xml
+          name: coverage-data-unit
+          path: .coverage.unit*
+          include-hidden-files: true
 
   e2e:
     runs-on: ubuntu-latest
+    env:
+      COVERAGE_FILE: .coverage.e2e
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
@@ -107,3 +112,41 @@ jobs:
           path: e2e/snapshot_tests_failures/
           if-no-files-found: ignore
           retention-days: 14
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage-data-e2e
+          path: .coverage.e2e*
+          include-hidden-files: true
+          if-no-files-found: ignore
+
+  # Combine the .coverage.* artifacts produced by `test` and `e2e` into a
+  # single report. No test re-run — `coverage combine` merges the data files,
+  # then `report` enforces the threshold and `html` produces the browsable
+  # report. Mirrors what scripts/coverage.sh does locally.
+  coverage:
+    runs-on: ubuntu-latest
+    needs: [test, e2e]
+    if: always()
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: uv sync
+      - uses: actions/download-artifact@v6
+        with:
+          pattern: coverage-data-*
+          merge-multiple: true
+      - run: uv run coverage combine
+      - run: uv run coverage report --fail-under=93
+      - run: uv run coverage html
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage-html
+          path: htmlcov/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 .pytest_cache/
 e2e/snapshot_tests_failures/
 .coverage
+.coverage.*
 *.egg-info/
 dist/
 build/

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1039,7 +1039,18 @@ The design is **broad allow, narrow deny**:
 
 ### 13.1 Coverage Gate
 
-**>90% branch coverage, non-negotiable.** Enforced by pytest-cov with `fail_under = 93, branch = true`. Omits only migrations.
+**>90% branch coverage, non-negotiable.** Combines unit (`tests/`) and e2e (`e2e/`) suites — every line of `src/teatree` that either suite exercises counts. Threshold (`93`) enforced on the combined report only.
+
+**Why combined.** Many code paths are easier to exercise from the dashboard (HTMX panels, view rendering, JS-driven flows) than from a unit test. Combining lets us delete unit tests that duplicate what an e2e already covers without sacrificing the gate.
+
+**How it works:**
+
+- `[tool.coverage.run] patch = ["subprocess"], sigterm = true` — auto-instruments the uvicorn worker that Playwright drives, and flushes coverage on `proc.terminate()`.
+- Each pytest invocation gets a distinct `COVERAGE_FILE` (`.coverage.unit`, `.coverage.e2e`) so parallel writes don't race.
+- Individual jobs pass `--cov-fail-under=0` so the per-run check ignores the 93% target — that target is enforced only on the combined report.
+- `coverage combine` merges every `.coverage.*` file (including the per-PID partials `patch=["subprocess"]` leaves behind) into one `.coverage`.
+- Locally: `scripts/coverage.sh` runs both suites in parallel, combines, reports, and writes HTML to `htmlcov/`.
+- CI: the `test` and `e2e` jobs upload `.coverage.*` artifacts; a small `coverage` job downloads, combines, and enforces the threshold — no test re-runs.
 
 ### 13.2 Django Test Settings
 
@@ -1077,7 +1088,7 @@ Playwright tests in `e2e/` with separate settings (`e2e.settings`) using file-ba
 
 | Tool | What it checks | Config |
 |------|----------------|--------|
-| pytest + pytest-cov | >90% branch coverage (`fail_under = 93`) | `pyproject.toml [tool.coverage]` |
+| pytest + pytest-cov | >90% branch coverage on combined unit+e2e (threshold `93`) | `pyproject.toml [tool.coverage]` + `scripts/coverage.sh` |
 | ruff | ALL rules enabled, specific ignores justified | `pyproject.toml [tool.ruff]` |
 | ty | Static type checker with `error-on-warning = true` | `pyproject.toml [tool.ty]` |
 | import-linter | Dependency boundaries | `pyproject.toml [tool.importlinter]` |

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -73,6 +73,16 @@ def _disable_animations_init(page) -> None:
         "(document.head||document.documentElement).appendChild(s);})();"
     )
     page.add_init_script(script)
+    # Coverage instrumentation roughly doubles the uvicorn worker's response
+    # time, which makes Playwright's 5s `expect` and 30s action timeouts
+    # marginal. Bump them when COVERAGE_FILE is set so coverage runs don't
+    # introduce flakes; ad-hoc e2e runs keep the tighter defaults.
+    if os.environ.get("COVERAGE_FILE"):
+        from playwright.sync_api import expect as pw_expect
+
+        page.set_default_timeout(60_000)
+        page.set_default_navigation_timeout(60_000)
+        pw_expect.set_options(timeout=15_000)
 
 
 # pytest-playwright-visual's `assert_snapshot` hard-fails on any single-pixel

--- a/e2e/test_dashboard_buttons.py
+++ b/e2e/test_dashboard_buttons.py
@@ -124,6 +124,10 @@ def test_approval_button_expands_ticket_details(e2e_server: str, page: Page) -> 
 def test_hide_selected_fires_transition(e2e_server: str, page: Page) -> None:
     page.goto(e2e_server)
     page.locator("tr[data-mr-row]").first.wait_for(state="attached")
+    # Wait for HTMX to attach handlers — under coverage instrumentation the
+    # initial load completes before HTMX finishes wiring up, and clicking
+    # before then sends no transition POST.
+    page.wait_for_load_state("networkidle")
     page.locator("thead input[type='checkbox']").check()
     hide_btn = page.locator("#hide-selected-btn")
     expect(hide_btn).to_be_visible()
@@ -399,7 +403,10 @@ def test_mermaid_lifecycle_renders_svg(e2e_server: str, page: Page) -> None:
     page.locator("button[onclick^='toggleTicketDetails']").first.click()
     details = page.locator("tr[id^='ticket-details-']").first
     expect(details).to_be_visible()
-    details.locator(".mermaid svg").first.wait_for(state="attached", timeout=10000)
+    # No explicit timeout — uses the page default (bumped under coverage in
+    # e2e/conftest.py). Mermaid lazy-loads + parses + renders the SVG, which
+    # is meaningfully slower when the uvicorn worker is instrumented.
+    details.locator(".mermaid svg").first.wait_for(state="attached")
 
 
 def test_snapshot_sessions_filter_queued(e2e_server: str, page: Page, assert_snapshot: Callable) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,10 +245,31 @@ partial_branches = [
 
 [tool.coverage.run]
 branch = true
+# patch=["subprocess"] auto-instruments any Python subprocess (the uvicorn
+# worker Playwright drives during e2e) without an asgi.py shim. Implies
+# parallel mode: each process writes a distinct .coverage.* file that
+# `coverage combine` merges.
+# sigterm=true flushes coverage on SIGTERM — the e2e_server fixture stops
+# uvicorn with proc.terminate(), and without this the subprocess data is lost.
+# (sys.monitoring core would be ~5x faster but doesn't support branch=true
+# on coverage.py 7.13 — branch coverage matters more, so keep the default.)
+patch = [ "subprocess" ]
+sigterm = true
 source = [
   "src/teatree",
 ]
 omit = [ "src/teatree/core/migrations/*.py" ]
+
+[tool.coverage.paths]
+# Combine treats these as the same source tree. Required because the test job
+# runs in Docker (/app/src/teatree/...) and the e2e job on the host runner
+# (/home/runner/work/teatree/teatree/src/teatree/...). Local runs match the
+# first entry verbatim, so this is a no-op outside CI.
+source = [
+  "src/teatree",
+  "*/src/teatree",
+  "/app/src/teatree",
+]
 
 [tool.uv.build-backend]
 module-name = "teatree"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Combined unit + e2e coverage report.
+#
+# Runs the unit suite and the Playwright e2e suite **in parallel** (they're
+# fully isolated: tests use an in-memory SQLite, e2e uses its own per-worker
+# DB), captures coverage from both processes (pytest + the uvicorn subprocess
+# Playwright drives — auto-instrumented via `patch=["subprocess"]` in
+# pyproject.toml), combines the data files, and writes a terminal report
+# plus an HTML one to htmlcov/.
+#
+# Each pytest invocation gets its own COVERAGE_FILE so the parallel writes
+# don't race. `coverage combine` then merges every .coverage.* file (including
+# the per-PID files the patched subprocess leaves behind) into a single
+# .coverage that `report` and `html` consume.
+#
+# Local: ./scripts/coverage.sh
+# CI: the workflow uploads each job's .coverage.* artifacts and combines them
+#     in a small follow-up job — no test re-run.
+set -euo pipefail
+
+uv run coverage erase
+
+# --cov-fail-under=0 disables the per-run threshold — the 93% gate is enforced
+# on the combined report below.
+COVERAGE_FILE=.coverage.unit uv run pytest tests/ --cov --cov-report= --cov-fail-under=0 &
+unit_pid=$!
+# Match CI: `t3 teatree e2e project --no-docker` is the same entry point both
+# local and CI use. The e2e management command appends --cov when COVERAGE_FILE
+# is set (see src/teatree/core/management/commands/e2e.py).
+COVERAGE_FILE=.coverage.e2e t3 teatree e2e project --no-docker &
+e2e_pid=$!
+
+unit_rc=0
+e2e_rc=0
+wait "$unit_pid" || unit_rc=$?
+wait "$e2e_pid" || e2e_rc=$?
+
+if [[ $unit_rc -ne 0 || $e2e_rc -ne 0 ]]; then
+  echo "Test failure (unit=$unit_rc, e2e=$e2e_rc)" >&2
+  exit 1
+fi
+
+uv run coverage combine
+uv run coverage report --fail-under=93
+uv run coverage html
+echo "HTML report: htmlcov/index.html"

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -324,7 +324,16 @@ class Command(TyperCommand):
                 raise SystemExit(rc)
 
         cmd = ["uv", "run", "pytest", test_dir]
-        cmd.extend(["-o", f"DJANGO_SETTINGS_MODULE={settings_module}", "--no-cov", "-p", "no:tach", "-v"])
+        cmd.extend(["-o", f"DJANGO_SETTINGS_MODULE={settings_module}", "-p", "no:tach", "-v"])
+        # COVERAGE_FILE is set by scripts/coverage.sh (and CI) to capture coverage
+        # for the combined report. patch=["subprocess"] in pyproject auto-instruments
+        # the uvicorn worker. The 93% gate only applies to the combined unit+e2e
+        # report — disable the per-run threshold so the e2e-only data file isn't
+        # rejected as low coverage. Default to --no-cov so ad-hoc e2e runs stay fast.
+        if os.environ.get("COVERAGE_FILE"):
+            cmd.extend(["--cov", "--cov-report=", "--cov-fail-under=0"])
+        else:
+            cmd.append("--no-cov")
         if update_snapshots:
             cmd.append("--update-snapshots")
 


### PR DESCRIPTION
## Summary
- Combines `tests/` (unit) and `e2e/` (Playwright) coverage so every line of `src/teatree` either suite exercises counts toward the 93% gate. This unblocks deleting unit tests that duplicate dashboard flows already covered by Playwright.
- Replaces the manual `coverage.process_startup()` shim with `[tool.coverage.run] patch = ["subprocess"], sigterm = true` (coverage 7.10+) — auto-instruments the uvicorn worker Playwright drives, flushes on `proc.terminate()`.
- Each pytest invocation gets a distinct `COVERAGE_FILE` (`.coverage.unit`, `.coverage.e2e`) so parallel writes don't race; `coverage combine` merges the partials.
- Individual jobs pass `--cov-fail-under=0` — the 93% target is enforced only on the combined report.

## Local
```sh
./scripts/coverage.sh
```
Runs `pytest tests/` and `t3 teatree e2e project --no-docker` in parallel, combines, reports, writes `htmlcov/index.html`.

## CI
- `test` and `e2e` jobs upload `.coverage.*` artifacts.
- A small `coverage` job downloads, combines, reports — **no test re-runs**.

## Test plan
- [x] `uv run ruff check` clean
- [x] Unit suite alone produces `.coverage.unit` (93.41%)
- [x] E2E run produces `.coverage.e2e.<host>.<pid>.<rand>` partials (subprocess instrumentation working)
- [x] `coverage combine` merges multiple files into one
- [ ] CI green: `test`, `e2e`, `coverage` all pass; combined report > 93%

Closes #458