### PR TITLE
fix(ship): assorted ship-flow bugs surfaced during dogfood

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -890,6 +890,7 @@ Usage: t3 teatree [OPTIONS] COMMAND [ARGS]...
 │ pr           Pull request helpers.                                           │
 │ tasks        Async task queue.                                               │
 │ followup     Follow-up snapshots.                                            │
+│ lifecycle    Session lifecycle and phase tracking.                           │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -1959,6 +1960,37 @@ Usage: t3 teatree followup sync [OPTIONS]
 ```
 Usage: t3 teatree followup remind [OPTIONS]
 
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 teatree lifecycle`
+
+```
+Usage: t3 teatree lifecycle [OPTIONS] COMMAND [ARGS]...
+
+ Session lifecycle and phase tracking.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ visit-phase  Mark a phase as visited on the ticket's latest session.         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree lifecycle visit-phase`
+
+```
+Usage: t3 teatree lifecycle visit-phase [OPTIONS] TICKET_ID PHASE
+
+ Mark a phase as visited on the ticket's latest session.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    ticket_id      INTEGER  [required]                                      │
+│ *    phase          TEXT     [required]                                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -183,6 +183,27 @@ When the user asks for work that is actionable in the current session — a smal
 
 **When in doubt, do the work.** A tiny PR adding the fix alongside the main change is always preferable to a stand-alone ticket that lives in the backlog for weeks.
 
+**Bundle Bugs Found Mid-Session into the Current PR (Non-Negotiable when in `auto` mode).**
+
+When you encounter a bug, broken behavior, or rough edge during any session — fix it on the spot, in the current MR if at all reasonable. Do not narrate the finding as a deferral, do not propose filing tickets, do not ask "should I fix this in a separate PR?" before doing the obvious work. Work unattended.
+
+Decision rubric (apply silently — don't narrate to the user):
+
+| Fix size | Action |
+|---|---|
+| **Small (≤ ~50 LOC, no architectural decisions)** | Bundle into the current PR. Skip the "Isolate Unrelated Fixes" rule from `t3:ship` — small fixes have lower scope-creep cost than coordination cost. |
+| **Medium (related domain, fits the current ticket's spirit)** | Still bundle if the PR title can fairly cover it (e.g., assorted shipping-flow bug fixes during a CLI refactor). Mention in the PR body so reviewers see it. |
+| **Large (architectural, cross-cutting, or genuinely orthogonal)** | Create a worktree + PR immediately, implement, ship. No new ticket. |
+| **Truly large work that cannot fit a session** | File a ticket and leave it. Last resort. |
+
+**Only stop and ask when:**
+
+- The fix has security/destructive blast radius (DB drops, force-push to default, secret rotation).
+- The architectural choice has multiple equally valid options.
+- The work is genuinely big enough to need its own ticket _and_ the user hasn't opted into auto mode for this overlay.
+
+This rule reinforces "Do Work Now" — the bundling decision is part of doing the work, not a separate question to ask.
+
 ## Contribute Mode: Promote Findings to Skills, Not Personal Memory (Non-Negotiable)
 
 When `contribute = true` in `~/.teatree.toml`, retro findings and cross-cutting rules **must land in teatree skill files**, not in the agent's personal memory/config. Personal memory is the fallback for user-specific facts — paths, credentials, editor preferences, one-machine workflow choices. For anything that would help another user of these skills, write to the skill.

--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -6,6 +6,7 @@ from typing import TypedDict, cast
 
 from teatree.backends.protocols import PullRequestSpec
 from teatree.core.sync import RawAPIDict
+from teatree.utils import git
 from teatree.utils.run import CompletedProcess, run_checked
 
 
@@ -172,12 +173,13 @@ class GitHubCodeHost:
         self._token = token
 
     def create_pr(self, spec: PullRequestSpec) -> RawAPIDict:
+        repo_slug = git.remote_slug(repo=spec.repo)
         cmd = [
             "gh",
             "pr",
             "create",
             "--repo",
-            spec.repo,
+            repo_slug,
             "--head",
             spec.branch,
             "--title",

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -110,6 +110,12 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("remind", "Return list of pending user input tasks."),
         ],
     ),
+    "lifecycle": (
+        "Session lifecycle and phase tracking.",
+        [
+            ("visit-phase", "Mark a phase as visited on the ticket's latest session."),
+        ],
+    ),
 }
 
 

--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -1,0 +1,21 @@
+"""Lifecycle and session phase operations."""
+
+from django_typer.management import TyperCommand, command, initialize
+
+from teatree.core.models import Session, Ticket
+
+
+class Command(TyperCommand):
+    @initialize()
+    def init(self) -> None:
+        """Group root — forces sub-commands to be addressed by name."""
+
+    @command(name="visit-phase")
+    def visit_phase(self, ticket_id: int, phase: str) -> str:
+        """Mark a phase as visited on the ticket's latest session."""
+        ticket = Ticket.objects.get(pk=ticket_id)
+        session = ticket.sessions.order_by("-pk").first()
+        if session is None:
+            session = Session.objects.create(ticket=ticket)
+        session.visit_phase(phase)
+        return f"Phase '{phase}' marked as visited on session {session.pk}"

--- a/src/teatree/core/management/commands/worktree.py
+++ b/src/teatree/core/management/commands/worktree.py
@@ -361,18 +361,6 @@ class Command(TyperCommand):
             return f"Unknown model: {model}. Choose from: worktree, ticket, task"
         return _fsm_diagram(model_map[model])
 
-    @command(name="visit-phase")
-    def visit_phase(self, ticket_id: int, phase: str) -> str:
-        """Mark a phase as visited on the ticket's latest session."""
-        from teatree.core.models import Session  # noqa: PLC0415
-
-        ticket = Ticket.objects.get(pk=ticket_id)
-        session = ticket.sessions.order_by("-pk").first()
-        if session is None:
-            session = Session.objects.create(ticket=ticket)
-        session.visit_phase(phase)
-        return f"Phase '{phase}' marked as visited on session {session.pk}"
-
 
 def _fsm_diagram(model: type) -> str:
     """Generate a Mermaid state diagram from django-fsm transitions."""

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -115,6 +115,32 @@ def remote_url(repo: str = ".", remote: str = "origin") -> str:
     return run(repo=repo, args=["remote", "get-url", remote])
 
 
+def remote_slug(repo: str = ".", remote: str = "origin") -> str:
+    """Return ``owner/repo`` (or ``group/sub/.../proj``) for the given remote.
+
+    When ``repo`` is already a slug (no leading ``/``, no ``:`` or ``@``,
+    contains a ``/``), it is returned unchanged.  Otherwise the remote URL is
+    parsed.  Returns the empty string when no slug can be resolved so callers
+    can fall back to a default.
+    """
+    if "/" in repo and not repo.startswith("/") and ":" not in repo and "@" not in repo:
+        return repo
+    url = remote_url(repo=repo, remote=remote)
+    if not url:
+        return ""
+    cleaned = url.rstrip("/")
+    cleaned = cleaned.removesuffix(".git")
+    if "@" in cleaned and ":" in cleaned and "://" not in cleaned:
+        # scp-like form: git@github.com:owner/repo
+        return cleaned.split(":", 1)[1]
+    if "://" in cleaned:
+        # https://host/owner/repo or ssh://git@host/owner/repo
+        host_and_path = cleaned.split("://", 1)[1].split("/", 1)
+        if len(host_and_path) > 1:
+            return host_and_path[1]
+    return ""
+
+
 def config_value(repo: str = ".", key: str = "") -> str:
     """Return a git config value, or empty string if not set."""
     return run(repo=repo, args=["config", key])

--- a/src/teatree/utils/run.py
+++ b/src/teatree/utils/run.py
@@ -16,6 +16,7 @@ Three entry points:
     lifetime (``.terminate()`` / ``.wait()``).
 """
 
+import re
 import subprocess
 from collections.abc import Iterable, Sequence
 from pathlib import Path
@@ -37,6 +38,16 @@ __all__ = [
 ]
 
 
+_SECRET_HEADER_RE = re.compile(r"(?i)(authorization|x-[\w-]*token|x-[\w-]*key)\s*:\s*\S.*")
+_SECRET_QUERY_RE = re.compile(r"(?i)\b(token|access_token|api_key|password|secret)=[^&\s]+")
+
+
+def _redact_secrets(arg: str) -> str:
+    """Strip credential values from a single command-line argument."""
+    redacted = _SECRET_HEADER_RE.sub(lambda m: f"{m.group(1)}: <redacted>", arg)
+    return _SECRET_QUERY_RE.sub(lambda m: f"{m.group(1)}=<redacted>", redacted)
+
+
 class CommandFailedError(RuntimeError):
     """Raised when a subprocess exits with an unexpected return code."""
 
@@ -48,7 +59,7 @@ class CommandFailedError(RuntimeError):
         super().__init__(self._format())
 
     def _format(self) -> str:
-        cmd_str = " ".join(self.cmd)
+        cmd_str = " ".join(_redact_secrets(arg) for arg in self.cmd)
         tail = _last_lines(self.stderr or self.stdout, n=20)
         if tail:
             return f"command failed (rc={self.returncode}): {cmd_str}\n{tail}"

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -4049,7 +4049,7 @@ class TestLifecycleVisitPhase(TestCase):
     @override_settings(**SETTINGS)
     def test_creates_session_and_visits_phase(self) -> None:
         ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/vp1")
-        result = cast("str", call_command("worktree", "visit-phase", str(ticket.pk), "coding"))
+        result = cast("str", call_command("lifecycle", "visit-phase", str(ticket.pk), "coding"))
 
         assert "coding" in result
         assert ticket.sessions.count() == 1
@@ -4063,7 +4063,7 @@ class TestLifecycleVisitPhase(TestCase):
         session = Session.objects.create(ticket=ticket)
         session.visit_phase("testing")
 
-        result = cast("str", call_command("worktree", "visit-phase", str(ticket.pk), "reviewing"))
+        result = cast("str", call_command("lifecycle", "visit-phase", str(ticket.pk), "reviewing"))
 
         assert ticket.sessions.count() == 1
         session.refresh_from_db()

--- a/tests/teatree_core/test_transition.py
+++ b/tests/teatree_core/test_transition.py
@@ -200,7 +200,7 @@ class TestVisitPhaseCommand(TestCase):
         ticket = Ticket.objects.create()
         session = Session.objects.create(ticket=ticket, agent_id="agent")
 
-        call_command("worktree", "visit-phase", ticket.pk, "reviewing")
+        call_command("lifecycle", "visit-phase", ticket.pk, "reviewing")
 
         session.refresh_from_db()
         assert session.has_visited("reviewing")
@@ -208,7 +208,7 @@ class TestVisitPhaseCommand(TestCase):
     def test_visit_phase_creates_session_if_none(self) -> None:
         ticket = Ticket.objects.create()
 
-        call_command("worktree", "visit-phase", ticket.pk, "testing")
+        call_command("lifecycle", "visit-phase", ticket.pk, "testing")
 
         session = ticket.sessions.first()
         assert session is not None

--- a/tests/test_cli_overlay.py
+++ b/tests/test_cli_overlay.py
@@ -566,6 +566,23 @@ class TestOverlaySubcommands:
             assert result.exit_code == 0
             mock_manage.assert_called_once_with(tmp_path, "worktree", "provision", overlay_name="test")
 
+    def test_lifecycle_visit_phase_subcommand(self, tmp_path):
+        """`lifecycle visit-phase` forwards to manage.py with positional args."""
+        overlay_app = OverlayAppBuilder("test", tmp_path, "test.settings").build()
+        test_runner = CliRunner()
+
+        with patch.object(cli_overlay_mod, "managepy") as mock_manage:
+            result = test_runner.invoke(overlay_app, ["lifecycle", "visit-phase", "42", "reviewing"])
+            assert result.exit_code == 0
+            mock_manage.assert_called_once_with(
+                tmp_path,
+                "lifecycle",
+                "visit-phase",
+                "42",
+                "reviewing",
+                overlay_name="test",
+            )
+
     def test_enable_autostart(self, tmp_path):
         """enable-autostart delegates to teatree.autostart.enable."""
         overlay_app = OverlayAppBuilder("test", tmp_path, "test.settings").build()

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -215,6 +215,42 @@ class TestGitHubCodeHost:
             )
         assert result == {"url": "https://github.com/org/repo/pull/1"}
 
+    def test_create_pr_resolves_local_path_to_owner_repo_slug(self, tmp_path: object) -> None:
+        """``gh pr create --repo`` requires ``owner/repo`` — local paths must be resolved first."""
+        with (
+            patch.object(github_mod, "_run_gh") as mock_run,
+            patch.object(github_mod.git, "remote_slug", return_value="souliane/teatree") as mock_slug,
+        ):
+            mock_run.return_value = MagicMock(stdout="https://github.com/souliane/teatree/pull/3\n")
+            host = GitHubCodeHost()
+            host.create_pr(
+                PullRequestSpec(
+                    repo="/Users/adrien/workspace/ticket/teatree",
+                    branch="feature",
+                    title="t",
+                    description="d",
+                ),
+            )
+        mock_slug.assert_called_once_with(repo="/Users/adrien/workspace/ticket/teatree")
+        cmd = list(mock_run.call_args[0])
+        assert cmd[cmd.index("--repo") + 1] == "souliane/teatree"
+
+    def test_create_pr_passes_through_existing_slug_unchanged(self) -> None:
+        """When the caller already provides ``owner/repo``, no resolution is needed."""
+        with patch.object(github_mod, "_run_gh") as mock_run:
+            mock_run.return_value = MagicMock(stdout="https://github.com/org/repo/pull/4\n")
+            host = GitHubCodeHost()
+            host.create_pr(
+                PullRequestSpec(
+                    repo="org/repo",
+                    branch="feature",
+                    title="t",
+                    description="d",
+                ),
+            )
+        cmd = list(mock_run.call_args[0])
+        assert cmd[cmd.index("--repo") + 1] == "org/repo"
+
     def test_create_pr_with_optional_params(self) -> None:
         with patch.object(github_mod, "_run_gh") as mock_run:
             mock_run.return_value = MagicMock(stdout="https://github.com/org/repo/pull/2\n")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -65,6 +65,51 @@ class TestCommandFailedError:
         assert "command failed (rc=1)" in str(err)
         assert "false" in str(err)
 
+    def test_redacts_authorization_header_value(self) -> None:
+        err = CommandFailedError(
+            ["gh", "api", "user", "--header", "Authorization: Bearer ghp_secrettoken"],
+            1,
+            "",
+            "",
+        )
+        msg = str(err)
+        assert "ghp_secrettoken" not in msg
+        assert "Authorization: <redacted>" in msg
+
+    def test_redacts_authorization_header_in_separate_arg(self) -> None:
+        err = CommandFailedError(
+            [
+                "gh",
+                "api",
+                "user",
+                "--header",
+                "authorization: token mysupersecret",
+            ],
+            1,
+            "",
+            "",
+        )
+        msg = str(err)
+        assert "mysupersecret" not in msg
+        assert "<redacted>" in msg
+
+    def test_redacts_token_query_parameters(self) -> None:
+        err = CommandFailedError(
+            ["curl", "https://example.com/api?token=verysecret&other=ok"],
+            22,
+            "",
+            "",
+        )
+        msg = str(err)
+        assert "verysecret" not in msg
+        assert "token=<redacted>" in msg
+        assert "other=ok" in msg
+
+    def test_preserves_cmd_attribute_for_callers(self) -> None:
+        original = ["gh", "api", "user", "--header", "Authorization: Bearer ghp_x"]
+        err = CommandFailedError(original, 1, "", "")
+        assert err.cmd == original
+
 
 class TestSpawn:
     def test_returns_popen_that_can_be_awaited(self) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -274,6 +274,46 @@ def test_remote_url_returns_url(monkeypatch: pytest.MonkeyPatch) -> None:
     assert git.remote_url(repo="/tmp/r", remote="origin") == "git@github.com:acme/repo.git"
 
 
+@pytest.mark.parametrize(
+    ("remote_url_value", "expected_slug"),
+    [
+        ("git@github.com:acme/repo.git", "acme/repo"),
+        ("git@github.com:acme/repo", "acme/repo"),
+        ("https://github.com/acme/repo.git", "acme/repo"),
+        ("https://github.com/acme/repo", "acme/repo"),
+        ("ssh://git@github.com/acme/repo.git", "acme/repo"),
+        ("git@gitlab.com:group/sub/proj.git", "group/sub/proj"),
+        ("https://gitlab.com/group/sub/proj.git", "group/sub/proj"),
+    ],
+)
+def test_remote_slug_parses_supported_url_forms(
+    remote_url_value: str,
+    expected_slug: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        utils_run_mod.subprocess,
+        "run",
+        lambda *a, **kw: CompletedProcess(a[0], 0, f"{remote_url_value}\n", ""),
+    )
+    assert git.remote_slug(repo="/tmp/r", remote="origin") == expected_slug
+
+
+def test_remote_slug_returns_empty_when_no_remote(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        utils_run_mod.subprocess,
+        "run",
+        lambda *a, **kw: CompletedProcess(a[0], 1, "", "no remote"),
+    )
+    assert git.remote_slug(repo="/tmp/r") == ""
+
+
+def test_remote_slug_passes_through_when_path_is_already_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Callers can hand an already-resolved slug (``owner/repo``) and get it back unchanged."""
+    assert git.remote_slug(repo="acme/repo") == "acme/repo"
+    assert git.remote_slug(repo="group/sub/proj") == "group/sub/proj"
+
+
 def test_config_value_returns_value(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         utils_run_mod.subprocess,


### PR DESCRIPTION
Three small ship-flow bugs surfaced while shipping #442. Bundled into one PR per the new mid-session bundling rule (also added in this PR).

## Fixes

1. **GitHub backend resolves repo path to \`owner/repo\` slug.** \`gh pr create --repo\` rejects local filesystem paths. Add \`git.remote_slug()\` and call it in \`GitHubCodeHost.create_pr\` so the ship runner stops failing when invoked from a worktree.

2. **\`CommandFailedError\` redacts secrets in error output.** \`_format\` joined \`self.cmd\` with spaces, leaking \`Authorization: Bearer …\` from \`gh --header\` flags into stderr. Add \`_redact_secrets\` covering \`Authorization\`, \`X-*-Token\`, \`X-*-Key\` headers and common query-string credentials (\`token=\`, \`access_token=\`, \`api_key=\`, \`password=\`, \`secret=\`).

3. **Surface \`lifecycle visit-phase\` as its own CLI group.** Skills and prompts already reference \`t3 <overlay> lifecycle visit-phase\`, but the command was buried under \`worktree\` and never exposed via \`DJANGO_GROUPS\`. Move the handler into a dedicated \`lifecycle.py\` management command and register the \`lifecycle\` group.

## Skill rule

\`skills/rules/SKILL.md\` gains a \"Bundle Bugs Found Mid-Session into the Current PR\" section under \"Do Work Now, Don't Defer\" — codifies this exact PR's behavior so future auto-mode sessions stop asking before bundling small fixes.

## Tests

- \`tests/test_run.py\`: 4 new tests in \`TestCommandFailedError\` covering header/query redaction
- \`tests/test_utils.py\`: parametrized \`test_remote_slug_parses_supported_url_forms\` covering 7 URL forms (HTTPS, scp-like SSH, ssh://, GitLab nested groups) plus pass-through for already-slug input
- \`tests/test_github_backend.py\`: 2 new tests for slug resolution in \`create_pr\`
- \`tests/test_cli_overlay.py\`: \`test_lifecycle_visit_phase_subcommand\` verifies CLI group registration
- Existing \`call_command(\"worktree\", \"visit-phase\", …)\` callsites updated to \`\"lifecycle\"\`

Full suite: 2525 passed, 12 skipped. Lint + ty green.