### PR TITLE
fix(dashboard): surface backend sync failures instead of HTTP 500

### DIFF
--- a/src/teatree/core/sync.py
+++ b/src/teatree/core/sync.py
@@ -138,7 +138,13 @@ def sync_followup() -> SyncResult:
 
     for backend in backends:
         if backend.is_configured(overlay):
-            result = _merge_results(result, backend.sync(overlay))
+            try:
+                backend_result = backend.sync(overlay)
+            except Exception as exc:
+                backend_name = type(backend).__name__
+                logger.exception("%s sync failed", backend_name)
+                backend_result = SyncResult(errors=[f"{backend_name} sync failed: {exc}"])
+            result = _merge_results(result, backend_result)
             ran_any = True
 
     if not ran_any:

--- a/tests/teatree_core/test_sync.py
+++ b/tests/teatree_core/test_sync.py
@@ -987,6 +987,30 @@ class TestSyncFollowup(TestCase):
         assert len(result.errors) == 1
         assert "API timeout" in result.errors[0]
 
+    def test_unhandled_backend_exception_does_not_crash_sync(self) -> None:
+        """A backend raising an unhandled exception must surface as a SyncResult error.
+
+        Regression: ``httpx.ReadTimeout`` from a backend internal call escaped the
+        backend's own try/except and crashed ``sync_followup``, which surfaced as
+        an HTTP 500 on ``/dashboard/sync/``. The dashboard must receive a
+        SyncResult with errors instead.
+        """
+        failing_backend = MagicMock()
+        failing_backend.is_configured.return_value = True
+        failing_backend.sync.side_effect = httpx.ReadTimeout("upstream hung")
+        type(failing_backend).__name__ = "FailingBackend"
+
+        with (
+            patch("teatree.backends.gitlab_sync.GitLabSyncBackend", return_value=failing_backend),
+            patch("teatree.backends.github_sync.GitHubSyncBackend") as gh_backend_cls,
+        ):
+            gh_backend_cls.return_value.is_configured.return_value = False
+            result = sync_followup()
+
+        assert result.mrs_found == 0
+        assert any("upstream hung" in e for e in result.errors)
+        assert any("FailingBackend" in e for e in result.errors)
+
     def test_returns_error_when_username_missing(self) -> None:
         overlay = SyncOverlay(gitlab_username="")
         mock_client = MagicMock()


### PR DESCRIPTION
Surfaced during a dashboard dogfood session — clicking **UPDATE TEATREE** triggered an HTTP 500 from \`/dashboard/sync/\` because \`httpcore.ReadTimeout\` from a slow MR-discussions fetch escaped the GitLab backend's per-call try/except and crashed the whole \`sync_followup\` loop.

## Fix

Wrap each backend's \`sync(overlay)\` call in \`try / except Exception\` inside \`sync_followup\`. Unhandled exceptions become \`SyncResult.errors\` entries so the dashboard renders a partial result + error message instead of a 500.

## Test

\`tests/teatree_core/test_sync.py::TestSyncFollowup::test_unhandled_backend_exception_does_not_crash_sync\` injects a fake backend that raises \`httpx.ReadTimeout\` and asserts the error surfaces in \`result.errors\` (no exception escapes).

Full \`test_sync.py\` suite: 122 passed.