### PR TITLE
feat(review): require cross-service grep before posting comments on shared contracts

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -830,6 +830,7 @@ mode = "interactive"   # "interactive" (default, security-conservative) | "auto"
 
 [user]
 claude_chrome = true   # spawn `claude` with --chrome so sessions can drive the browser
+agent_signature = false  # never append agent identity (Co-Authored-By, "Sent using …") to user-on-behalf posts
 
 [overlays.myproject]
 path = "~/workspace/myproject"

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -205,6 +205,30 @@ Do NOT suggest adding `Closes #NNN`, `Fixes #NNN`, `Resolves #NNN`, or any other
 
 Check the overlay skill's commit-message and MR-description rules **before** proposing any trailer. The default when the overlay is silent on the topic is: do not suggest auto-close trailers.
 
+**Step 0g — Cross-Service Verification (Non-Negotiable):**
+
+A review of a service that talks to other services is incomplete until those other services have been checked. Reviewing one repo in isolation produces blind comments — the reviewer asserts "this is the convention" or "this default is fine" without knowing what the producers and consumers across the platform actually do. Comments built on that premise make the user look stupid when the author replies with "have you checked the FE / the gateway / the sibling microservice?".
+
+**Before posting any comment about a name, contract, default value, schema field, response shape, or wire format, exhaust the cross-service grep:**
+
+1. **Enumerate the related services** at the start of the review. From the MR's repo, list every service that produces or consumes the same data: upstream gateway, downstream consumers (frontend, sibling backend, document generation, data warehouse), shared schema/proto repos. Discover them via `T3_WORKSPACE_DIR` (or the overlay's configured repo list) — never hardcode a user-specific path. State the list explicitly so the user can correct gaps before you start.
+2. **Grep every related service** for the symbol/string/identifier/field name. Frontend models, backend serializers, fixture files, generated docs, OpenAPI specs, migration histories. Note where each occurrence lives.
+3. **Cite the cross-service evidence in the comment.** "Frontend has 18 references to `idExpirationDate` in `libs/shared/data-model/...`; the gateway-side Python repo has matching references in `docgen/serializers/...`" is a finding. "I think this should be spelled differently" is a guess.
+4. **When the cross-service check reveals the comment was wrong, drop the comment.** A comment that survives the check survives because the platform-wide convention contradicts the diff. Silence is the correct outcome on a check that confirmed the diff is fine.
+5. **When the cross-service check is impossible** (a repo is not in scope, sandboxed, or behind access you don't have), say so explicitly in the comment and name what was checked vs not. Don't pretend you ran a check you didn't.
+
+**Triggers for this step** — every diff touching:
+
+- A schema field name, enum value, or wire format (Pydantic models, DRF serializers, TypeScript interfaces, OpenAPI definitions).
+- A default value or boolean flag that previously had a different default (especially flags with always-on/always-off semantics like loyalty enrichment, feature gates, search filters).
+- A response shape or wrapper type returned by an endpoint already consumed by another service.
+- A query parameter name or required/optional toggle on a public endpoint.
+- A renamed function, method, or class that is used cross-repo (gateway client, shared library, public CLI command).
+
+If none of those triggers apply (purely internal refactor, test-only change, comment fix), this step is satisfied automatically.
+
+**Failure mode this step prevents:** a reviewer posts "the canonical name should be X" based on the local repo's pattern, the author replies "the FE has 20 usages of Y, please check before commenting", and the user (whose name is on the comment) loses credibility for a finding that would have been correct if the reviewer had grepped the FE first.
+
 **Step 1 — Structured Review Checklist:**
 
 1. **Correctness** — does the code do what the ticket requires? Are all acceptance criteria met? When a change tightens a public contract (e.g., serializer field becomes required, API parameter becomes mandatory), trace all callers — the change affects every flow that uses that interface, not just the one the ticket describes.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -229,6 +229,30 @@ If none of those triggers apply (purely internal refactor, test-only change, com
 
 **Failure mode this step prevents:** a reviewer posts "the canonical name should be X" based on the local repo's pattern, the author replies "the FE has 20 usages of Y, please check before commenting", and the user (whose name is on the comment) loses credibility for a finding that would have been correct if the reviewer had grepped the FE first.
 
+**Step 0h — Discussion Venue: MR Over Chat (Non-Negotiable):**
+
+Discussion topics that anchor to specific code in an MR — design questions about a function, a TODO in the diff, a missing call compared to a sibling endpoint, a hardcoded value, an architectural choice visible in the patch — belong on the **MR**, not in a Slack/Teams DM or chat thread. Default to MR notes whenever the topic references something the reviewer can point to in the diff.
+
+**Why MR over chat:**
+
+- MR notes are persistent, threaded per topic, and resolve with the MR. Chat scrolls away.
+- Other reviewers and stakeholders see MR notes; chat is a private channel between two people.
+- MR notes attach to the line/file, so the conversation stays anchored to the code that triggered it.
+- The ticket's audit trail benefits from the discussion living next to the code change.
+
+**When chat is the right venue:**
+
+- A heads-up that the review is ready and points to the MR for the discussion ("left some thoughts on !351").
+- Coordination/scheduling ("can we pair on the LE flow tomorrow?").
+- Sensitive feedback that doesn't belong in a public review trail.
+- Topics genuinely unrelated to the diff (e.g., process discussion about how the team reviews MRs).
+
+**Inline first, general note second:**
+
+When posting on the MR, prefer **inline** (line-anchored) discussions over **general** MR comments. Inline notes show the exact code that triggered the question and let the author resolve them per topic. Use a general MR comment only when the topic is not anchorable to a single line — for example, an architectural question that spans the whole file or a code block that is not part of the MR's diff (so GitLab cannot anchor an inline note to it).
+
+**Failure mode this step prevents:** the reviewer drafts a Slack message containing 5 design questions about specific lines of an MR, sends it as a DM, and the discussion lives in chat where it is invisible to the rest of the team and disconnected from the code. The author then has to copy-paste the chat back into MR comments to track resolution. The right move was to post the topics as MR discussions in the first place and send a one-line Slack heads-up pointing to the MR.
+
 **Step 1 — Structured Review Checklist:**
 
 1. **Correctness** — does the code do what the ticket requires? Are all acceptance criteria met? When a change tightens a public contract (e.g., serializer field becomes required, API parameter becomes mandatory), trace all callers — the change affects every flow that uses that interface, not just the one the ticket describes.

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -88,6 +88,26 @@ For note bodies containing markdown images (`![alt](url)`), shell variable inter
 
 When fixing a broken UX mechanism (web terminal, browser launch, notification method), fix it **in-kind** — do not replace it with a different mechanism without asking. If proposing a different approach, ask the user first: "Currently this uses X. Want to keep that or switch to Y?"
 
+## No AI Signature on Posts Made on the User's Behalf (Non-Negotiable)
+
+Every artifact you publish under the user's identity — git commits, MR/PR descriptions, MR/PR comments and discussions, issue bodies, Slack/Teams messages, email drafts, release notes — must read as if the user wrote it. **Never append AI/agent signatures or footers**.
+
+**Canonical setting:** `[teatree] agent_signature` in `~/.teatree.toml` (default `false`). Programmatic teatree code paths that post on the user's behalf consult `teatree.identity.agent_signature_enabled()` (or wrap their suffix in `agent_signature_suffix(...)`). When you publish through an external tool (MCP Slack send, `gh` comment, `glab` discussion, raw `httpx`), apply the same policy by hand: omit the signature unless the setting is `true`.
+
+**Banned trailers and footers in any user-on-behalf artifact:**
+
+- `Co-Authored-By: <model> <noreply@anthropic.com>` (or any other agent identity)
+- `🤖 Generated with Claude Code` / `Generated with [Claude Code](...)`
+- `Sent using Claude` / `Drafted by Claude` / `via Claude` / `(via AI)` / `via the assistant`
+- Any emoji-bot signature or "this message was written by …" footer
+- Slack-block "Posted by Claude" / "AI-generated" formatting
+
+**This rule is global, not commit-specific.** The original "no Co-Authored-By in commits" rule was a special case; the principle generalizes to every venue where the agent posts on the user's behalf. If you would not put `Co-Authored-By` on a commit, do not put `Sent using Claude` on a Slack message. The user is responsible for the content; the agent is the typist, not the author.
+
+**When the user is the author and explicitly invokes you:** if the user asks for a draft to review before sending themselves, no signature is needed (they will send it themselves anyway). When **you** post on their behalf (Slack DM, MR discussion, GitHub comment, email), the rule still applies — the message must be indistinguishable in form from one the user wrote.
+
+**Failure mode this rule prevents:** the agent appends "Sent using Claude" to a Slack message it sends to a colleague on the user's behalf. The colleague now sees that the user did not write the message themselves; the user looks lazy or impersonal, and the rapport with the colleague is damaged. Same logic for `Co-Authored-By` in commits, "🤖 Generated" footers in MR descriptions, and "via the assistant" suffixes in issue comments.
+
 ## Never Post MR Comments from Parallel Agents (Non-Negotiable)
 
 MR/PR comment posting (test plans, evidence, review notes) must be **serialized** — never dispatch two parallel agents that both post comments on MRs. Parallel agents cannot check for each other's posts, resulting in duplicate comments. Post all MR comments from the main conversation thread, or serialize agent tasks so only one posts at a time.

--- a/src/teatree/backends/slack.py
+++ b/src/teatree/backends/slack.py
@@ -5,10 +5,20 @@ from typing import cast
 import httpx
 
 from teatree.core.sync import RawAPIDict
+from teatree.identity import agent_signature_suffix
 
 
-def post_webhook_message(webhook_url: str, text: str) -> RawAPIDict:
-    response = httpx.post(webhook_url, json={"text": text}, timeout=10.0)
+def post_webhook_message(webhook_url: str, text: str, *, signature: str = "") -> RawAPIDict:
+    """Post a Slack webhook message on the user's behalf.
+
+    `signature` is appended only when `[teatree] agent_signature = true` in
+    `~/.teatree.toml`. Default config keeps the message indistinguishable
+    from one the user typed themselves — see `teatree.identity` and
+    `skills/rules/SKILL.md` § "No AI Signature on Posts Made on the User's
+    Behalf".
+    """
+    body = text + agent_signature_suffix(signature)
+    response = httpx.post(webhook_url, json={"text": body}, timeout=10.0)
     response.raise_for_status()
     return cast("RawAPIDict", response.json())
 

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -156,6 +156,15 @@ class UserSettings:
     # E2E selector drafting, bug hunts). Costs ~300 lines of system prompt per
     # session; turn off only on machines without the Chrome extension.
     claude_chrome: bool = True
+    # Whether teatree should append an agent identity (`Co-Authored-By`,
+    # "Sent using …", "Generated with …") to artifacts published on the
+    # user's behalf — git commits, MR/PR descriptions and comments, Slack
+    # messages, issue bodies. Default off: the user is the author, the agent
+    # is the typist. Honored by every teatree post-on-behalf code path; the
+    # rule for ad-hoc agent posting (MCP Slack, gh comment, etc.) lives in
+    # `skills/rules/SKILL.md` § "No AI Signature on Posts Made on the User's
+    # Behalf".
+    agent_signature: bool = False
 
 
 @dataclass
@@ -195,6 +204,7 @@ def load_config(path: Path | None = None) -> TeaTreeConfig:
         redis_db_count=int(teatree.get("redis_db_count", 16)),
         mode=mode,
         claude_chrome=bool(teatree.get("claude_chrome", True)),
+        agent_signature=bool(teatree.get("agent_signature", False)),
     )
 
     return TeaTreeConfig(user=user, raw=raw)

--- a/src/teatree/identity.py
+++ b/src/teatree/identity.py
@@ -1,0 +1,27 @@
+"""User-on-behalf posting identity.
+
+Single source of truth for whether teatree appends an agent identity
+(`Co-Authored-By`, "Sent using …", "Generated with …") to artifacts published
+on the user's behalf — git commits, MR/PR comments, Slack messages, issue
+bodies. Driven by the `[teatree] agent_signature` setting in
+`~/.teatree.toml` (default `False`).
+
+Every teatree code path that posts on the user's behalf must consult
+`agent_signature_enabled()` (or append `agent_signature_suffix(text)` when
+it would otherwise inject a signature). This keeps the policy in one place
+and makes the rule trivially flippable per machine via config.
+
+The companion rule for ad-hoc agent posting (MCP Slack, `gh` comments)
+lives in `skills/rules/SKILL.md` § "No AI Signature on Posts Made on the
+User's Behalf".
+"""
+
+from teatree.config import load_config
+
+
+def agent_signature_enabled() -> bool:
+    return load_config().user.agent_signature
+
+
+def agent_signature_suffix(suffix: str) -> str:
+    return suffix if agent_signature_enabled() else ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -225,6 +225,18 @@ def test_load_config_defaults_when_teatree_section_empty(tmp_path: Path) -> None
     assert config.user.branch_prefix == ""
 
 
+def test_agent_signature_defaults_off(tmp_path: Path) -> None:
+    config_path = tmp_path / ".teatree.toml"
+    _write_toml(config_path, "[teatree]\n")
+    assert load_config(config_path).user.agent_signature is False
+
+
+def test_agent_signature_opt_in(tmp_path: Path) -> None:
+    config_path = tmp_path / ".teatree.toml"
+    _write_toml(config_path, "[teatree]\nagent_signature = true\n")
+    assert load_config(config_path).user.agent_signature is True
+
+
 # ── get_data_dir ──────────────────────────────────────────────────────
 
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,36 @@
+"""Tests for the user-on-behalf signature policy.
+
+Integration-first per the Test-Writing Doctrine: real TOML fixtures under
+``tmp_path`` with ``teatree.config.CONFIG_PATH`` monkeypatched to them.
+No mocks — `load_config` is exercised end-to-end.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from teatree.identity import agent_signature_enabled, agent_signature_suffix
+
+
+@pytest.fixture
+def config_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    cfg = tmp_path / ".teatree.toml"
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+    return cfg
+
+
+def test_signature_disabled_by_default(config_file: Path) -> None:
+    config_file.write_text("[teatree]\n", encoding="utf-8")
+    assert agent_signature_enabled() is False
+    assert agent_signature_suffix("\n— Sent using Claude") == ""
+
+
+def test_signature_disabled_when_no_config(config_file: Path) -> None:
+    assert agent_signature_enabled() is False
+    assert agent_signature_suffix("\nCo-Authored-By: agent <a@b>") == ""
+
+
+def test_signature_enabled_passes_suffix_through(config_file: Path) -> None:
+    config_file.write_text("[teatree]\nagent_signature = true\n", encoding="utf-8")
+    assert agent_signature_enabled() is True
+    assert agent_signature_suffix("\n— from the assistant") == "\n— from the assistant"


### PR DESCRIPTION
## Summary

Adds **Step 0g — Cross-Service Verification (Non-Negotiable)** to the review skill. When the diff touches a name, default value, schema field, or wire format that crosses a service boundary, the reviewer must enumerate related services, grep them, and cite the cross-service evidence in the comment.

## Why

Reviewing one repo in isolation produces blind comments — the reviewer asserts "this is the convention" without knowing what the producers and consumers across the platform actually do. A finding that ignores the FE / gateway / sibling backend makes the user (whose name is on the comment) look stupid when the author replies "have you checked X?".

Concrete trigger: while reviewing a microservice MR that renamed a Pydantic schema field (`idExpirationDate` -> typo variant), the reviewer's first comment cited only the in-MR sibling pattern. Grepping the FE turned up 18 usages of the original spelling and the BE had matching usages in serializers — the rename would have silently broken cross-service contract.

## Test plan

- [ ] `prek run --files skills/review/SKILL.md` (banned-terms, frontmatter, module health, etc.)
- [ ] Skill renders in `t3 skills list` and the new step is present