### PR TITLE
fix(core): gate auto-shipping on actual commits ahead of base

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -165,7 +165,7 @@ The central entity. One ticket per unit of work (maps to an issue/task in the tr
 | `start()` | scoped → started | Enqueues `execute_provision` worker. Worker runs `WorktreeProvisioner` and calls `schedule_coding()` on success. |
 | `code()` | started → coded | Calls `schedule_testing()` |
 | `test(passed=True)` | coded → tested | Stores `tests_passed` in extra; calls `schedule_review()` |
-| `review()` | tested → reviewed | Condition: reviewing task completed. Calls `schedule_shipping()` |
+| `review()` | tested → reviewed | Condition: reviewing task completed. Calls `schedule_shipping()` only if `has_shippable_diff()` returns True (otherwise stamps `extra["shipping_skipped"]` for triage — guards meta-tickets from spurious shipping tasks). |
 | `ship()` | reviewed → shipped | Enqueues `execute_ship` worker. Worker runs `ShipExecutor` and calls `request_review()` on success. |
 | `request_review()` | shipped → in_review | — |
 | `mark_merged()` | in_review → merged | Enqueues `execute_teardown` worker. Worker runs `WorktreeTeardown` (best-effort cleanup of git worktrees, branches, per-worktree DBs, overlay hooks). Errors do NOT block the FSM — `retrospect()` can advance the ticket regardless. |
@@ -180,9 +180,11 @@ The central entity. One ticket per unit of work (maps to an issue/task in the tr
 - `start()` → enqueues provision → on success → headless coding task
 - `code()` → headless testing task
 - `test()` → headless reviewing task
-- `review()` → shipping task (execution target gated by `T3_AUTO_SHIP`)
+- `review()` → shipping task (execution target gated by `T3_AUTO_SHIP`), gated on `has_shippable_diff()`
 
 `schedule_shipping()` defaults to `ExecutionTarget.INTERACTIVE` so the user must explicitly approve the push. Set `T3_AUTO_SHIP=true` in the environment to make shipping headless.
+
+`Ticket.has_shippable_diff()` returns True iff at least one `Worktree` has commits ahead of its base branch (resolved via `origin/<default>` or local `main` fallback). When False, `review()` advances state but skips `schedule_shipping()` — typical for meta-tracker tickets whose work shipped via sibling PRs. Manual `schedule_shipping()` callers (CLI, dashboard, tests) remain permissive and bypass the gate.
 
 **`extra` structure:**
 

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -1,13 +1,18 @@
+import logging
 import os
 import re
 from typing import TYPE_CHECKING, ClassVar, cast
 
+from django.apps import apps
 from django.db import models, transaction
 from django_fsm import FSMField, TransitionNotAllowed, transition
 
 from teatree.config import Mode, get_effective_settings
 from teatree.core.managers import TicketManager
-from teatree.utils import redis_container
+from teatree.utils import git, redis_container
+from teatree.utils.run import CommandFailedError
+
+logger = logging.getLogger(__name__)
 
 
 def _auto_ship_enabled() -> bool:
@@ -29,6 +34,7 @@ if TYPE_CHECKING:
     from teatree.core.models.session import Session
     from teatree.core.models.task import Task
     from teatree.core.models.types import TicketExtra
+    from teatree.core.models.worktree import Worktree
 
 
 class Ticket(models.Model):
@@ -127,7 +133,27 @@ class Ticket(models.Model):
         conditions=[lambda t: t.tasks.filter(phase="reviewing", status="completed").exists()],
     )
     def review(self) -> None:
-        self.schedule_shipping()
+        if self.has_shippable_diff():
+            self.schedule_shipping()
+            return
+        logger.info(
+            "Ticket %s reviewed with no shippable diff; skipping auto-shipping (likely meta or already-shipped work)",
+            self.pk,
+        )
+        extra = self._extra()
+        extra["shipping_skipped"] = "no shippable diff — likely meta or already-shipped work"
+        self.extra = extra
+
+    def has_shippable_diff(self) -> bool:
+        """Return True iff at least one worktree has commits ahead of its base branch.
+
+        Used by ``review()`` to skip auto-scheduling shipping when there is
+        nothing to ship — typically meta-tracker tickets whose work already
+        landed via sibling PRs. Manual ``schedule_shipping()`` callers are not
+        gated.
+        """
+        worktree_model = apps.get_model("core", "Worktree")
+        return any(_worktree_has_commits_ahead(wt) for wt in worktree_model.objects.filter(ticket=self))
 
     def schedule_coding(self, *, parent_task: "Task | None" = None) -> "Task":
         """Create a fresh headless coding task after scoping completes."""
@@ -334,3 +360,27 @@ class Ticket(models.Model):
 
     def _extra(self) -> "TicketExtra":
         return cast("TicketExtra", self.extra or {})
+
+
+def _worktree_has_commits_ahead(worktree: "Worktree") -> bool:
+    repo_path = (worktree.extra or {}).get("worktree_path") or worktree.repo_path
+    branch = worktree.branch
+    if not repo_path or not branch:
+        return False
+    base = _resolve_base_branch(repo_path)
+    try:
+        return git.rev_count(repo=repo_path, range_spec=f"{base}..{branch}") > 0
+    except (CommandFailedError, ValueError, OSError):
+        # Missing path, missing branch, missing git remote — all mean no
+        # shippable diff. Fail closed so the auto-FSM stops at REVIEWED.
+        return False
+
+
+def _resolve_base_branch(repo_path: str) -> str:
+    try:
+        return f"origin/{git.default_branch(repo_path)}"
+    except (CommandFailedError, RuntimeError):
+        # No origin remote (fresh clones, tests under tmp_path) — fall back to
+        # the local default. ``RuntimeError`` covers ``default_branch``'s own
+        # "could not detect" path.
+        return "main"

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -31,6 +31,7 @@ class TicketExtra(TypedDict, total=False):
     branch: str
     description: str
     provision: dict[str, str]
+    shipping_skipped: str
 
 
 class WorktreeExtra(TypedDict, total=False):

--- a/tests/teatree_core/test_models.py
+++ b/tests/teatree_core/test_models.py
@@ -1,3 +1,5 @@
+import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -72,9 +74,46 @@ def _complete_phase_task(ticket: Ticket, phase: str) -> None:
     task.complete()
 
 
+def _attach_shippable_worktree(ticket: Ticket, tmp_path: Path, *, commits_ahead: int = 1) -> Worktree:
+    """Attach a git-backed worktree to *ticket* so ``has_shippable_diff`` returns True."""
+    repo_dir = tmp_path / f"repo-{ticket.pk}"
+    branch = f"feature-{ticket.pk}"
+    _init_repo_with_branch(repo_dir, branch=branch, commits_ahead=commits_ahead)
+    return Worktree.objects.create(ticket=ticket, repo_path=str(repo_dir), branch=branch)
+
+
+def _init_repo_with_branch(repo_dir: Path, *, branch: str, commits_ahead: int) -> None:
+    """Initialise a git repo at *repo_dir* with main + a feature branch.
+
+    The feature branch is named *branch* and contains *commits_ahead* commits
+    on top of the main tip. Use ``commits_ahead=0`` for the no-shippable-diff
+    case (branch points at the same SHA as main).
+    """
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", "-C", str(repo_dir), *args], check=True, env=env, capture_output=True)  # noqa: S607
+
+    git("init", "--initial-branch=main")
+    (repo_dir / "README.md").write_text("seed\n")
+    git("add", "README.md")
+    git("commit", "-m", "seed")
+    git("checkout", "-b", branch)
+    for i in range(commits_ahead):
+        (repo_dir / f"f{i}.txt").write_text(f"{i}\n")
+        git("add", f"f{i}.txt")
+        git("commit", "-m", f"add f{i}")
+
+
 class TestTicketTransitions(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject_tmp_path(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+
     def test_persist_delivery_state(self) -> None:
         ticket = Ticket.objects.create()
+        _attach_shippable_worktree(ticket, self._tmp_path)
 
         _advance_ticket_to_tested(ticket)
 
@@ -134,6 +173,7 @@ class TestTicketTransitions(TestCase):
 
     def test_reviewing_task_completion_advances_to_reviewed(self) -> None:
         ticket = Ticket.objects.create()
+        _attach_shippable_worktree(ticket, self._tmp_path)
         _advance_ticket_to_tested(ticket)
 
         _complete_phase_task(ticket, "reviewing")
@@ -249,8 +289,79 @@ class TestTicketTransitions(TestCase):
             ticket.review()
 
 
+class TestHasShippableDiff(TestCase):
+    """``Ticket.has_shippable_diff`` and the auto-shipping gate (issue #473)."""
+
+    @pytest.fixture(autouse=True)
+    def _inject_tmp_path(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+
+    def _make_ticket_with_worktree(self, *, commits_ahead: int) -> Ticket:
+        ticket = Ticket.objects.create()
+        repo_dir = self._tmp_path / f"repo-{commits_ahead}"
+        branch = "feature"
+        _init_repo_with_branch(repo_dir, branch=branch, commits_ahead=commits_ahead)
+        Worktree.objects.create(ticket=ticket, repo_path=str(repo_dir), branch=branch)
+        return ticket
+
+    def test_returns_false_when_no_worktrees(self) -> None:
+        ticket = Ticket.objects.create()
+
+        assert ticket.has_shippable_diff() is False
+
+    def test_returns_false_when_branch_has_no_commits_ahead(self) -> None:
+        ticket = self._make_ticket_with_worktree(commits_ahead=0)
+
+        assert ticket.has_shippable_diff() is False
+
+    def test_returns_true_when_branch_has_commits_ahead(self) -> None:
+        ticket = self._make_ticket_with_worktree(commits_ahead=2)
+
+        assert ticket.has_shippable_diff() is True
+
+    def test_review_skips_shipping_task_when_no_diff(self) -> None:
+        ticket = self._make_ticket_with_worktree(commits_ahead=0)
+        _advance_ticket_to_tested(ticket)
+
+        _complete_phase_task(ticket, "reviewing")
+        ticket.refresh_from_db()
+
+        assert ticket.state == Ticket.State.REVIEWED
+        assert not ticket.tasks.filter(phase="shipping").exists()
+        assert "no shippable diff" in ticket.extra.get("shipping_skipped", "")
+
+    def test_review_schedules_shipping_when_branch_has_commits(self) -> None:
+        ticket = self._make_ticket_with_worktree(commits_ahead=1)
+        _advance_ticket_to_tested(ticket)
+
+        _complete_phase_task(ticket, "reviewing")
+        ticket.refresh_from_db()
+
+        assert ticket.state == Ticket.State.REVIEWED
+        assert ticket.tasks.filter(phase="shipping", status=Task.Status.PENDING).exists()
+        assert "shipping_skipped" not in ticket.extra
+
+    def test_returns_false_when_worktree_missing_branch(self) -> None:
+        ticket = Ticket.objects.create()
+        Worktree.objects.create(ticket=ticket, repo_path=str(self._tmp_path), branch="")
+
+        assert ticket.has_shippable_diff() is False
+
+    def test_returns_false_when_repo_path_is_not_a_git_directory(self) -> None:
+        ticket = Ticket.objects.create()
+        not_a_repo = self._tmp_path / "not-a-repo"
+        not_a_repo.mkdir()
+        Worktree.objects.create(ticket=ticket, repo_path=str(not_a_repo), branch="feature")
+
+        assert ticket.has_shippable_diff() is False
+
+
 class TestPhaseAutoDispatch(TestCase):
     """Auto-dispatch of next-phase tasks at each phase boundary (issue #364)."""
+
+    @pytest.fixture(autouse=True)
+    def _inject_tmp_path(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
 
     def test_start_provisions_then_schedules_coding_task(self) -> None:
         ticket = Ticket.objects.create()
@@ -371,6 +482,7 @@ class TestPhaseAutoDispatch(TestCase):
 
     def test_shipping_task_completion_advances_to_shipped(self) -> None:
         ticket = Ticket.objects.create()
+        _attach_shippable_worktree(ticket, self._tmp_path)
         _advance_ticket_to_tested(ticket)
         _complete_phase_task(ticket, "reviewing")
         # reviewing completion → REVIEWED + shipping task (interactive by default)

--- a/tests/teatree_core/test_workflow_integration.py
+++ b/tests/teatree_core/test_workflow_integration.py
@@ -5,13 +5,37 @@ verifying that state transitions, task auto-scheduling, and quality gates all
 chain together correctly.
 """
 
+import subprocess
+from pathlib import Path
+
 import pytest
 from django.test import TestCase
 
 from teatree.core.models import QualityGateError, Session, Task, Ticket, Worktree
 
 
+def _make_repo_with_diff(repo_dir: Path, *, branch: str) -> None:
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+
+    def git(*args: str) -> None:
+        subprocess.run(["git", "-C", str(repo_dir), *args], check=True, env=env, capture_output=True)  # noqa: S607
+
+    git("init", "--initial-branch=main")
+    (repo_dir / "README.md").write_text("seed\n")
+    git("add", "README.md")
+    git("commit", "-m", "seed")
+    git("checkout", "-b", branch)
+    (repo_dir / "feature.txt").write_text("feature\n")
+    git("add", "feature.txt")
+    git("commit", "-m", "add feature")
+
+
 class TestTicketLifecycle(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject_tmp_path(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+
     def test_from_creation_to_tested(self) -> None:
         """Ticket flows from creation through testing with worktree provisioning."""
         ticket = Ticket.objects.create()
@@ -47,6 +71,10 @@ class TestTicketLifecycle(TestCase):
         ticket.code()
         ticket.test(passed=True)
         ticket.save()
+
+        repo_dir = self._tmp_path / "backend"
+        _make_repo_with_diff(repo_dir, branch="feat/42")
+        Worktree.objects.create(ticket=ticket, repo_path=str(repo_dir), branch="feat/42")
 
         session = Session.objects.create(ticket=ticket, agent_id="test-agent")
         session.visit_phase("coding")

--- a/tests/teatree_core/test_workflows.py
+++ b/tests/teatree_core/test_workflows.py
@@ -369,6 +369,10 @@ class TestOverlayFiltering(TestCase):
 
 
 class TestTaskWorkflow(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject_tmp_path(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+
     @override_settings(**WORKFLOW_SETTINGS)
     def test_claim_work_complete_advances_ticket(self) -> None:
         """Test the full task lifecycle: create -> claim -> complete -> ticket advances."""
@@ -384,6 +388,23 @@ class TestTaskWorkflow(TestCase):
         ticket.test(passed=True)
         ticket.save()
         assert ticket.state == Ticket.State.TESTED
+
+        repo_dir = self._tmp_path / "backend"
+        repo_dir.mkdir(parents=True)
+        env = {
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+        for cmd in (
+            ["git", "init", "--initial-branch=main"],
+            ["git", "commit", "--allow-empty", "-m", "seed"],
+            ["git", "checkout", "-b", "feature/99"],
+            ["git", "commit", "--allow-empty", "-m", "feature work"],
+        ):
+            subprocess.run(cmd, cwd=repo_dir, check=True, env=env, capture_output=True)
+        Worktree.objects.create(ticket=ticket, repo_path=str(repo_dir), branch="feature/99")
 
         # start()/code()/test() each auto-schedule a task; the worker picks them
         # up FIFO. Drain the coding + testing tasks (the "work" already happened


### PR DESCRIPTION
## Summary

- Add `Ticket.has_shippable_diff()` that returns True iff any of the ticket's worktrees has commits on its branch ahead of its base.
- Gate the auto-FSM body of `Ticket.review()` on it: when there is nothing to ship, log, stamp `extra["shipping_skipped"]` with a triage note, transition to REVIEWED, and skip task creation.
- Manual `schedule_shipping()` callers (CLI, dashboard, tests) remain permissive — only the auto cascade is gated.

## Why

Meta-tracker tickets (e.g. [#412](https://github.com/souliane/teatree/issues/412), which lists 9 sub-items each shipped through their own PR) were auto-routed through the full FSM cascade. Three headless agents reported "slice shipped via PR #..." and returned success envelopes, so the FSM advanced into an interactive shipping task that an operator picked up only to find nothing to ship.

`Ticket.review()` previously called `schedule_shipping()` unconditionally. With this gate, the cascade stops at REVIEWED for tickets with no shippable diff; an operator can `ignore()` or `rework()` from there.

## Test plan

- [x] `Ticket.has_shippable_diff()` returns False with no worktrees, False with zero commits ahead, True with commits ahead — covered in `TestHasShippableDiff` using a real git repo under `tmp_path`.
- [x] `review()` skips `schedule_shipping()` and writes `extra["shipping_skipped"]` when no shippable diff; ticket still transitions to REVIEWED.
- [x] `review()` schedules shipping as before when at least one worktree has commits ahead.
- [x] Existing `test_reviewing_task_completion_advances_to_reviewed` still passes (with a fixture worktree containing commits).
- [x] Full `tests/teatree_core/` suite green (997 passed, 12 skipped).

Closes #473