### PR TITLE
feat(review): add `t3 review update-note` for in-place note edits

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -670,7 +670,7 @@ Typer-based, work without Django:
 - `t3 <overlay> e2e run [<test-path>]` — run E2E tests; dispatches to the project runner (in-repo pytest-playwright) or the external runner (remote Playwright repo) based on the overlay's `get_e2e_config()` — same command across overlays
 - `t3 <overlay> e2e external [--repo <name>] [<test-path>]` — explicit external runner: Playwright from `T3_PRIVATE_TESTS` or a named `[e2e_repos.<name>]` git repo; skips port discovery when `BASE_URL` is already set (DEV/staging mode)
 - `t3 <overlay> e2e project [<test-path>] [--update-snapshots]` — explicit project runner: pytest-playwright in the overlay's own test dir, executed in the canonical Docker image by default
-- `t3 review {post-draft-note,delete-draft-note,list-draft-notes,publish-draft-notes,reply-to-discussion,resolve-discussion}` — GitLab draft notes plus immediate replies on existing discussion threads and resolve/unresolve toggle
+- `t3 review {post-draft-note,delete-draft-note,list-draft-notes,publish-draft-notes,update-note,reply-to-discussion,resolve-discussion}` — GitLab draft notes (post/delete/list/publish), in-place edits of draft or published notes, plus immediate replies on existing discussion threads and resolve/unresolve toggle
 - `t3 review-request discover` — discover open MRs
 - `t3 tool {privacy-scan,analyze-video,bump-deps,label-issues,find-duplicates}` — standalone utilities
 - `t3 config write-skill-cache` — write overlay skill metadata to cache

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -362,6 +362,8 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 │ list-draft-notes     List draft notes on a GitLab MR.                        │
 │ reply-to-discussion  Reply to a GitLab MR discussion thread (immediate, not  │
 │                      draft).                                                 │
+│ update-note          Update a note on a GitLab MR — auto-detects draft vs    │
+│                      published.                                              │
 │ resolve-discussion   Mark a GitLab MR discussion thread resolved or          │
 │                      unresolved.                                             │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -451,6 +453,25 @@ Usage: t3 review reply-to-discussion [OPTIONS] REPO MR DISCUSSION_ID BODY
 │ *    mr                 INTEGER  Merge request IID [required]                │
 │ *    discussion_id      TEXT     Discussion (thread) ID [required]           │
 │ *    body               TEXT     Reply body (markdown) [required]            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 review update-note`
+
+```
+Usage: t3 review update-note [OPTIONS] REPO MR NOTE_ID BODY
+
+ Update a note on a GitLab MR — auto-detects draft vs published.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    repo         TEXT     GitLab project path (e.g., my-org/my-repo)        │
+│                            [required]                                        │
+│ *    mr           INTEGER  Merge request IID [required]                      │
+│ *    note_id      INTEGER  Note ID (draft or published) [required]           │
+│ *    body         TEXT     New comment body (markdown) [required]            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │

--- a/skills/platforms/references/gitlab.md
+++ b/skills/platforms/references/gitlab.md
@@ -220,6 +220,10 @@ t3 review list-draft-notes <REPO> <MR_IID>
 
 # Delete a draft note
 t3 review delete-draft-note <REPO> <MR_IID> <NOTE_ID>
+
+# Edit a note in place — works for drafts AND published notes; auto-detects which.
+# The draft endpoint is tried first; on 404 it falls back to the published-notes endpoint.
+t3 review update-note <REPO> <MR_IID> <NOTE_ID> "New comment body"
 ```
 
 ### Key Differences from `/discussions`

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -306,7 +306,7 @@ This prevents noise from multiple review passes or multiple reviewers covering t
 
 When reviewing an external MR/PR, **always post comments inline on the correct file and line** in the diff view. For comments that aren't tied to a specific line (e.g., description feedback), post a general note without position data.
 
-**Extend the CLI, never inline API recipes.** If a `t3 review` operation is missing, implement it in `src/teatree/cli/review.py` — do NOT document a raw API snippet or inline script here. Skills describe what command to run, not how to replicate missing CLI functionality. Current subcommands: `post-draft-note`, `delete-draft-note`, `publish-draft-notes`, `list-draft-notes`, `reply-to-discussion`, `resolve-discussion`.
+**Extend the CLI, never inline API recipes.** If a `t3 review` operation is missing, implement it in `src/teatree/cli/review.py` — do NOT document a raw API snippet or inline script here. Skills describe what command to run, not how to replicate missing CLI functionality. Current subcommands: `post-draft-note`, `delete-draft-note`, `publish-draft-notes`, `list-draft-notes`, `update-note`, `reply-to-discussion`, `resolve-discussion`.
 
 **Use `t3 review post-draft-note` (Mandatory).** It handles token extraction, diff refs, position serialization, and added-line validation. Never use raw API calls.
 

--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -152,6 +152,37 @@ class ReviewService:
             return f"OK resolved={resolved}", 0
         return f"Failed: HTTP {response.status_code}", 1
 
+    def update_note(self, repo: str, mr: int, note_id: int, body: str) -> tuple[str, int]:
+        """Update a note (draft or published) on an MR. Returns (message, exit_code).
+
+        Tries the draft-notes endpoint first; on 404 falls back to the published-notes
+        endpoint. The two endpoints use different payload keys (``note`` vs ``body``).
+        """
+        api = self._get_api()
+        encoded = repo.replace("/", "%2F")
+        headers = {"PRIVATE-TOKEN": self.token}
+
+        draft_response = httpx.put(
+            f"{api.base_url}/projects/{encoded}/merge_requests/{mr}/draft_notes/{note_id}",
+            headers=headers,
+            json={"note": body},
+            timeout=10.0,
+        )
+        if draft_response.status_code == HTTPStatus.OK:
+            return f"OK updated draft_note_id={note_id}", 0
+        if draft_response.status_code != HTTPStatus.NOT_FOUND:
+            return f"Failed (draft): HTTP {draft_response.status_code}", 1
+
+        published_response = httpx.put(
+            f"{api.base_url}/projects/{encoded}/merge_requests/{mr}/notes/{note_id}",
+            headers=headers,
+            json={"body": body},
+            timeout=10.0,
+        )
+        if published_response.status_code == HTTPStatus.OK:
+            return f"OK updated note_id={note_id}", 0
+        return f"Failed: HTTP {published_response.status_code}", 1
+
     def list_draft_notes(self, repo: str, mr: int) -> tuple[str, int]:
         """List draft notes. Returns (message, exit_code)."""
         api = self._get_api()
@@ -247,6 +278,21 @@ def reply_to_discussion(
     """Reply to a GitLab MR discussion thread (immediate, not draft)."""
     service = _require_token()
     msg, code = service.reply_to_discussion(repo, mr, discussion_id, body)
+    typer.echo(msg)
+    if code:
+        raise typer.Exit(code=code)
+
+
+@review_app.command(name="update-note")
+def update_note(
+    repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
+    mr: int = typer.Argument(help="Merge request IID"),
+    note_id: int = typer.Argument(help="Note ID (draft or published)"),
+    body: str = typer.Argument(help="New comment body (markdown)"),
+) -> None:
+    """Update a note on a GitLab MR — auto-detects draft vs published."""
+    service = _require_token()
+    msg, code = service.update_note(repo, mr, note_id, body)
     typer.echo(msg)
     if code:
         raise typer.Exit(code=code)

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -279,6 +279,51 @@ class TestReviewService:
             assert result.exit_code == 1
             assert "Failed: HTTP 403" in result.output
 
+    def test_update_note_draft_success(self, monkeypatch):
+        """update-note PATCHes a draft note when the draft endpoint returns 200."""
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        mock_response = MagicMock(status_code=200)
+        with patch.object(httpx, "put", return_value=mock_response) as mock_put:
+            result = runner.invoke(app, ["review", "update-note", "org/repo", "1", "42", "new body"])
+            assert result.exit_code == 0
+            assert "OK updated draft_note_id=42" in result.output
+            assert "draft_notes/42" in mock_put.call_args.args[0]
+            assert mock_put.call_args.kwargs["json"] == {"note": "new body"}
+
+    def test_update_note_falls_back_to_published(self, monkeypatch):
+        """update-note falls back to the published-notes endpoint on draft 404."""
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        responses = [MagicMock(status_code=404), MagicMock(status_code=200)]
+        with patch.object(httpx, "put", side_effect=responses) as mock_put:
+            result = runner.invoke(app, ["review", "update-note", "org/repo", "1", "42", "new body"])
+            assert result.exit_code == 0
+            assert "OK updated note_id=42" in result.output
+            assert mock_put.call_count == 2
+            first_url = mock_put.call_args_list[0].args[0]
+            second_url = mock_put.call_args_list[1].args[0]
+            assert "draft_notes/42" in first_url
+            assert second_url.endswith("/notes/42")
+            assert mock_put.call_args_list[1].kwargs["json"] == {"body": "new body"}
+
+    def test_update_note_published_failure(self, monkeypatch):
+        """update-note returns failure when both endpoints reject the request."""
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        responses = [MagicMock(status_code=404), MagicMock(status_code=403)]
+        with patch.object(httpx, "put", side_effect=responses):
+            result = runner.invoke(app, ["review", "update-note", "org/repo", "1", "42", "new body"])
+            assert result.exit_code == 1
+            assert "Failed: HTTP 403" in result.output
+
+    def test_update_note_draft_unexpected_status(self, monkeypatch):
+        """update-note does NOT fall back when the draft endpoint returns a non-404 error."""
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        mock_response = MagicMock(status_code=403)
+        with patch.object(httpx, "put", return_value=mock_response) as mock_put:
+            result = runner.invoke(app, ["review", "update-note", "org/repo", "1", "42", "new body"])
+            assert result.exit_code == 1
+            assert "Failed (draft): HTTP 403" in result.output
+            assert mock_put.call_count == 1
+
 
 # -- _require_token helper -----------------------------------------------------
 
@@ -332,5 +377,13 @@ class TestRequireToken:
         with patch.object(utils_run_mod.subprocess, "run") as mock_run:
             mock_run.return_value = MagicMock(stderr="", returncode=1)
             result = runner.invoke(app, ["review", "resolve-discussion", "org/repo", "1", "abc"])
+            assert result.exit_code == 1
+            assert "No GitLab token" in result.output
+
+    def test_update_note_rejected(self, monkeypatch):
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        with patch.object(utils_run_mod.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(stderr="", returncode=1)
+            result = runner.invoke(app, ["review", "update-note", "org/repo", "1", "42", "body"])
             assert result.exit_code == 1
             assert "No GitLab token" in result.output


### PR DESCRIPTION
## Summary

- New `t3 review update-note <REPO> <MR_IID> <NOTE_ID> "<body>"` subcommand that PUTs new body text to a note on a GitLab MR — works for **drafts and published notes** transparently
- The draft-notes endpoint is tried first; on 404 the command falls back to the published-notes endpoint, which uses a different payload key (`note` vs `body`)
- Non-404 errors on the draft endpoint do NOT trigger the fallback (avoids masking real failures like 401/403)

## Motivation

Until now there was no clean way to fix a mistake in an already-posted MR comment. Deleting + reposting works for drafts but loses the discussion ID and notification trail on published notes (and the `never DELETE — only PATCH` rule says don't do that anyway). This makes "downgrade severity, fix a clash claim, expand evidence" follow-ups a single CLI call.

Caught real-world today: a review draft claimed an NgRx action-id clash that a follow-up grep showed wasn't a clash; needed to drop severity and correct the wording without re-publishing — currently no CLI for it.

## Test plan

- [x] `tests/test_cli_review.py` — 5 new tests cover: draft 200, draft 404 → published 200, draft 404 → published 403, draft 403 (no fallback), missing token
- [x] `uv run pytest tests/test_cli_review.py --no-cov -q` — 33 passed
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run ty check src/teatree/cli/review.py` — clean
- [x] `BLUEPRINT.md`, `docs/generated/cli-reference.md`, `skills/review/SKILL.md`, `skills/platforms/references/gitlab.md` updated to list the new subcommand