### PR TITLE
fix(core): accept real populated dest dir in symlink health check

### DIFF
--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -388,13 +388,23 @@ class HealthCheck:
 
 
 def _symlink_source_healthy(dest: Path, source: Path) -> bool:
-    """Return True when *dest* resolves and *source* is populated (non-empty if a dir)."""
-    if not (dest.exists() or dest.is_symlink()):
+    """Return True when *dest* contains populated content.
+
+    Two valid end states: a symlink at *dest* pointing to a populated
+    *source*, or a real populated directory at *dest* (e.g. after
+    ``npm install`` ran in the worktree, replacing the symlink with a
+    real directory — see #480).
+    """
+    if dest.is_symlink():
+        if not source.exists():
+            return False
+        if source.is_dir():
+            return any(source.iterdir())
+        return True
+    if not dest.exists():
         return False
-    if not source.exists():
-        return False
-    if source.is_dir():
-        return any(source.iterdir())
+    if dest.is_dir():
+        return any(dest.iterdir())
     return True
 
 

--- a/tests/teatree_core/test_overlay.py
+++ b/tests/teatree_core/test_overlay.py
@@ -317,3 +317,77 @@ class TestDefaultHealthChecks(TestCase):
                 checks = overlay.get_health_checks(worktree)
             symlink_check = next(c for c in checks if c.name == "symlink-node_modules")
             assert symlink_check.check() is True
+
+    def test_symlink_check_passes_when_dest_is_real_populated_directory(self) -> None:
+        """A real populated directory at *dest* must pass even if *source* is empty.
+
+        Regression guard for #480: when ``npm install`` ran directly in the
+        worktree (replacing the symlink with a real ``node_modules`` directory)
+        and the main-clone source is empty, provision used to fail the health
+        check even though packages are installed and the worktree is usable.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_path = Path(tmp) / "worktree"
+            wt_path.mkdir()
+            empty_source = Path(tmp) / "empty_source"
+            empty_source.mkdir()
+
+            real_dest = wt_path / "node_modules"
+            real_dest.mkdir()
+            (real_dest / "some-package").mkdir()
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/4")
+            worktree = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature",
+                db_name="test_db",
+                extra={"worktree_path": str(wt_path)},
+            )
+
+            overlay = DummyOverlay()
+            with patch.object(
+                overlay,
+                "get_symlinks",
+                return_value=[
+                    {"path": "node_modules", "source": str(empty_source), "mode": "symlink"},
+                ],
+            ):
+                checks = overlay.get_health_checks(worktree)
+            symlink_check = next(c for c in checks if c.name == "symlink-node_modules")
+            assert symlink_check.check() is True
+
+    def test_symlink_check_fails_when_dest_is_real_empty_directory(self) -> None:
+        """A real but empty directory at *dest* must fail the health check."""
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_path = Path(tmp) / "worktree"
+            wt_path.mkdir()
+            populated_source = Path(tmp) / "populated_source"
+            populated_source.mkdir()
+            (populated_source / "some-package").mkdir()
+
+            real_dest = wt_path / "node_modules"
+            real_dest.mkdir()
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/5")
+            worktree = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature",
+                db_name="test_db",
+                extra={"worktree_path": str(wt_path)},
+            )
+
+            overlay = DummyOverlay()
+            with patch.object(
+                overlay,
+                "get_symlinks",
+                return_value=[
+                    {"path": "node_modules", "source": str(populated_source), "mode": "symlink"},
+                ],
+            ):
+                checks = overlay.get_health_checks(worktree)
+            symlink_check = next(c for c in checks if c.name == "symlink-node_modules")
+            assert symlink_check.check() is False


### PR DESCRIPTION
## Summary

Worktree provision used to fail with `Symlink target populated: node_modules` when the worktree's `node_modules` was a real populated directory (e.g., after `npm install` ran directly in the worktree, replacing the symlink with a real dir) and the main-clone source was empty. Provision was unrecoverable without manually deleting `node_modules` first.

Treat a real populated directory at `dest` as a healthy end state — the packages are installed, which is what the check is ultimately verifying. The empty-source/empty-symlink failure modes still fail as before.

## Test plan

- New test `test_symlink_check_passes_when_dest_is_real_populated_directory` — real populated dir at dest with empty source → passes.
- New test `test_symlink_check_fails_when_dest_is_real_empty_directory` — real empty dir at dest → fails.
- Existing regression guards (`fails_when_source_directory_is_empty`, `passes_when_source_directory_is_populated`) still pass — symlink semantics unchanged.

Closes #480