### PR TITLE
fix(core): skip db_import when worktree has no db_name

### DIFF
--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -69,7 +69,7 @@ class WorktreeProvisionRunner(RunnerBase):
         wt_path = (worktree.extra or {}).get("worktree_path", "")
         _setup_worktree_dir(wt_path, worktree, overlay)
 
-        if overlay.get_db_import_strategy(worktree) is not None:
+        if worktree.db_name and overlay.get_db_import_strategy(worktree) is not None:
             self._run_db_import()
 
         report = run_provision_steps(overlay.get_provision_steps(worktree))

--- a/tests/teatree_core/test_runner_db_import.py
+++ b/tests/teatree_core/test_runner_db_import.py
@@ -1,0 +1,98 @@
+"""Tests for ``WorktreeProvisionRunner._run_db_import`` skip semantics.
+
+Regression guard for #484: when a worktree has no associated database (the
+common case for frontend-only repos), the runner used to call
+``overlay.db_import()`` anyway and log a misleading
+``WARNING ... DB import failed for <repo> — continuing``. The runner now
+skips ``_run_db_import`` entirely when ``worktree.db_name`` is empty.
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay import DbImportStrategy, OverlayBase, ProvisionStep
+from teatree.core.overlay_loader import reset_overlay_cache
+from teatree.core.runners import WorktreeProvisionRunner
+
+
+class _RecordingOverlay(OverlayBase):
+    """Overlay that records db_import calls and always returns a strategy."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.db_import_calls: int = 0
+
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        return []
+
+    def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy | None:
+        return {
+            "kind": "fallback-chain",
+            "source_database": "dev",
+            "shared_postgres": True,
+            "snapshot_tool": "dslr",
+            "restore_order": [],
+            "notes": [],
+            "worktree_repo_path": worktree.repo_path,
+        }
+
+    def db_import(self, worktree: Worktree, **kwargs: Any) -> bool:
+        self.db_import_calls += 1
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _clear_overlay_cache() -> Iterator[None]:
+    reset_overlay_cache()
+    yield
+    reset_overlay_cache()
+
+
+class TestRunnerSkipsDbImportWhenNoDbName(TestCase):
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.wt_path = tmp_path / "worktree"
+        self.wt_path.mkdir()
+
+    def _make_worktree(self, *, db_name: str) -> Worktree:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/i/484")
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="frontend",
+            branch="feature",
+            db_name=db_name,
+            extra={"worktree_path": str(self.wt_path)},
+        )
+
+    def test_skips_db_import_when_db_name_empty(self) -> None:
+        """Frontend-style worktree (no DB) must not trigger overlay.db_import()."""
+        worktree = self._make_worktree(db_name="")
+        overlay = _RecordingOverlay()
+
+        with patch("teatree.core.runners.worktree_provision._setup_worktree_dir"):
+            WorktreeProvisionRunner(worktree, overlay=overlay).run()
+
+        assert overlay.db_import_calls == 0
+
+    def test_runs_db_import_when_db_name_set(self) -> None:
+        """Backend-style worktree (with DB) still drives overlay.db_import()."""
+        worktree = self._make_worktree(db_name="wt_484")
+        overlay = _RecordingOverlay()
+
+        with (
+            patch("teatree.core.runners.worktree_provision._setup_worktree_dir"),
+            patch("teatree.utils.db.db_exists", return_value=False),
+        ):
+            WorktreeProvisionRunner(worktree, overlay=overlay).run()
+
+        assert overlay.db_import_calls == 1


### PR DESCRIPTION
## Summary

Worktree provision used to emit `DB import failed for <repo> — continuing` for repos with no associated database (typically frontend-only repos in multi-repo overlays). The runner gated `db_import` only on `overlay.get_db_import_strategy(worktree) is not None`, but some overlays (e.g. t3-company) return a strategy at the overlay level regardless of whether the current worktree's repo owns a database. The runner then called `overlay.db_import(worktree)` which inevitably returned False, producing a misleading warning that obscured real failures.

This change adds `worktree.db_name` as the runner-level signal: an empty `db_name` means this worktree has nothing to import. Backend worktrees still drive `db_import` as before.

## Test plan

- New `test_skips_db_import_when_db_name_empty` — frontend-style worktree (no DB) → `overlay.db_import()` not called.
- New `test_runs_db_import_when_db_name_set` — backend-style worktree (with DB) → `overlay.db_import()` called once.
- Full `tests/teatree_core/` (1008 tests) still green.

Closes #484