### PR TITLE
feat(lifecycle): chain start/verify into readiness probes (#479)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -238,6 +238,8 @@ One worktree per repository per ticket.
 | `db_refresh()` | provisioned/services_up/ready → provisioned | Stores timestamp |
 | `teardown()` | * → created | Clears db_name, extra |
 
+**Readiness gate:** ``worktree start``, ``worktree verify``, ``worktree ready``, and ``workspace start`` all run the overlay's ``get_readiness_probes(worktree)`` after their primary work and exit 1 if any probe fails. Probes verify the running services are actually serving (HTTP, CORS round-trip, fixture-seed integrity) — they answer questions ``verify`` cannot. See ``teatree.core.readiness``.
+
 **Port allocation (Non-Negotiable — see §17):** Ports are NEVER stored in the database or in the `.t3-env.cache` file. They are allocated fresh at `worktree start` time via `find_free_ports()` and passed as environment variables to `docker compose`. Discovery uses `docker compose port` at runtime — the running containers are the single source of truth.
 
 - Backend: 8001+

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -246,7 +246,8 @@ class Command(TyperCommand):
 
         Allocates one shared port set across the workspace, then fires
         ``Worktree.start_services()`` on each worktree (CLI runs the
-        runner synchronously).
+        runner synchronously). After every worktree starts, runs each
+        overlay's readiness probes — exits 1 if any probe fails.
         """
         anchor = resolve_worktree(path)
         ticket = Ticket.objects.get(pk=anchor.ticket.pk)
@@ -270,6 +271,22 @@ class Command(TyperCommand):
         if failures:
             self.stderr.write(f"  Failed: {', '.join(failures)}")
             return "error"
+
+        total = 0
+        total_failures = 0
+        for wt in worktrees:
+            probes = overlay.get_readiness_probes(wt)
+            if not probes:
+                continue
+            self.stdout.write(f"  {wt.repo_path}:")
+            results = run_probes(probes)
+            for r in results:
+                self.stdout.write(f"    {r.format()}")
+            total += len(results)
+            total_failures += sum(1 for r in results if not r.passed)
+        if total_failures:
+            self.stderr.write(f"  {total_failures} of {total} probe(s) failed")
+            raise SystemExit(1)
         return f"started {len(worktrees)} worktree(s)"
 
     @command()

--- a/src/teatree/core/management/commands/worktree.py
+++ b/src/teatree/core/management/commands/worktree.py
@@ -163,6 +163,26 @@ class Command(TyperCommand):
             raise SystemExit(1)
         return int(worktree.pk)
 
+    def _check_readiness_probes(self, worktree: Worktree, overlay: OverlayBase) -> None:
+        """Run overlay readiness probes; raise SystemExit(1) on any failure.
+
+        Shared by ``start``, ``verify``, ``ready`` so all three honor the same
+        runtime health gate. ``start`` and ``verify`` cannot return success
+        when the started/healthy services are silently broken (raw
+        translations, missing CORS headers, fixture-seed integrity).
+        """
+        probes = overlay.get_readiness_probes(worktree)
+        if not probes:
+            self.stdout.write("  No readiness probes defined for this overlay.")
+            return
+        results = run_probes(probes)
+        for r in results:
+            self.stdout.write(f"  {r.format()}")
+        failures = [r for r in results if not r.passed]
+        if failures:
+            self.stderr.write(f"  {len(failures)} of {len(results)} probe(s) failed")
+            raise SystemExit(1)
+
     @command()
     def start(
         self,
@@ -174,7 +194,8 @@ class Command(TyperCommand):
         to SERVICES_UP and enqueues ``execute_worktree_start``; the runner
         also runs synchronously here so the operator sees immediate output.
         Allocates free host ports, refreshes the env cache, runs overlay
-        pre-run steps, then ``docker compose up -d``.
+        pre-run steps, then ``docker compose up -d``. After the runner
+        succeeds, runs the overlay's readiness probes — exits 1 if any fail.
         """
         worktree = resolve_worktree(path)
         resolved_overlay = get_overlay()
@@ -195,6 +216,7 @@ class Command(TyperCommand):
         if not result.ok:
             self.stderr.write(f"  Start failed for {worktree.repo_path}")
             raise SystemExit(1)
+        self._check_readiness_probes(worktree, resolved_overlay)
         return worktree.state
 
     @command()
@@ -205,7 +227,8 @@ class Command(TyperCommand):
         """Run overlay health checks for one worktree.
 
         Thin wrapper around ``Worktree.verify()``: SERVICES_UP → READY +
-        runner records URLs and reports failed checks. Best-effort.
+        runner records URLs and reports failed checks. After the runner,
+        runs the overlay's readiness probes — exits 1 if any fail.
         """
         worktree = resolve_worktree(path)
         resolved_overlay = get_overlay()
@@ -214,6 +237,8 @@ class Command(TyperCommand):
             worktree.save()
         result = WorktreeVerifyRunner(worktree, overlay=resolved_overlay).run()
         self.stdout.write(f"  {result.detail}")
+        worktree.refresh_from_db()
+        self._check_readiness_probes(worktree, resolved_overlay)
         return worktree.state
 
     @command()
@@ -230,17 +255,7 @@ class Command(TyperCommand):
         """
         worktree = resolve_worktree(path)
         resolved_overlay = get_overlay()
-        probes = resolved_overlay.get_readiness_probes(worktree)
-        if not probes:
-            self.stdout.write("  No readiness probes defined for this overlay.")
-            return "ok"
-        results = run_probes(probes)
-        for r in results:
-            self.stdout.write(f"  {r.format()}")
-        failures = [r for r in results if not r.passed]
-        if failures:
-            self.stderr.write(f"  {len(failures)} of {len(results)} probe(s) failed")
-            raise SystemExit(1)
+        self._check_readiness_probes(worktree, resolved_overlay)
         return "ok"
 
     @command()

--- a/tests/teatree_core/test_lifecycle_probe_chaining.py
+++ b/tests/teatree_core/test_lifecycle_probe_chaining.py
@@ -1,0 +1,310 @@
+"""``worktree start``/``verify`` and ``workspace start`` chain into readiness probes.
+
+Issue #479 MR2: starting (or verifying) a worktree without checking readiness
+probes lets a silently broken environment look healthy. The lifecycle commands
+must exit 1 when any probe fails — same gate as ``ready``.
+"""
+
+import io
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+import teatree.core.management.commands.workspace as workspace_mod
+import teatree.core.management.commands.worktree as worktree_mod
+from teatree.core.models import Ticket, Worktree
+from teatree.core.readiness import Probe, ProbeResult
+from teatree.core.runners.base import RunnerResult
+
+SETTINGS = {
+    "TEATREE_OVERLAY_NAMES": ["test"],
+}
+
+
+def _passing_probe(name: str = "p1") -> Probe:
+    return Probe(
+        name=name,
+        description="d",
+        check_fn=lambda: ProbeResult(name=name, passed=True, reason="ok"),
+    )
+
+
+def _failing_probe(name: str = "p1", reason: str = "nope") -> Probe:
+    return Probe(
+        name=name,
+        description="d",
+        check_fn=lambda: ProbeResult(name=name, passed=False, reason=reason),
+    )
+
+
+def _build_worktree(wt_path: Path, *, repo_path: str = "backend") -> Worktree:
+    ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/479")
+    return Worktree.objects.create(
+        overlay="test",
+        ticket=ticket,
+        repo_path=repo_path,
+        branch="feature",
+        db_name="test_db",
+        extra={"worktree_path": str(wt_path)},
+        state=Worktree.State.PROVISIONED,
+    )
+
+
+@override_settings(**SETTINGS)
+class TestWorktreeStartChainsProbes(TestCase):
+    def test_start_exits_1_when_probe_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_path = Path(tmp) / "worktree"
+            wt_path.mkdir()
+            wt = _build_worktree(wt_path)
+
+            mock_overlay = MagicMock()
+            mock_overlay.get_run_commands.return_value = {}
+            mock_overlay.get_readiness_probes.return_value = [
+                _failing_probe("translations-loaded", reason="raw key visible"),
+            ]
+
+            mock_runner = MagicMock()
+            mock_runner.run.return_value = RunnerResult(ok=True, detail="started")
+
+            mock_config = MagicMock()
+            mock_config.user.workspace_dir = Path(tmp)
+
+            with (
+                patch.object(worktree_mod, "resolve_worktree", return_value=wt),
+                patch.object(worktree_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(worktree_mod, "WorktreeStartRunner", return_value=mock_runner),
+                patch.object(worktree_mod, "find_free_ports", return_value={"backend": 8001}),
+                patch("teatree.config.load_config", return_value=mock_config),
+                pytest.raises(SystemExit) as exc,
+            ):
+                call_command("worktree", "start", path=str(wt_path))
+            assert exc.value.code == 1
+
+    def test_start_returns_state_when_all_probes_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_path = Path(tmp) / "worktree"
+            wt_path.mkdir()
+            wt = _build_worktree(wt_path)
+
+            mock_overlay = MagicMock()
+            mock_overlay.get_run_commands.return_value = {}
+            mock_overlay.get_readiness_probes.return_value = [_passing_probe("backend-up")]
+
+            mock_runner = MagicMock()
+            mock_runner.run.return_value = RunnerResult(ok=True, detail="started")
+
+            mock_config = MagicMock()
+            mock_config.user.workspace_dir = Path(tmp)
+
+            with (
+                patch.object(worktree_mod, "resolve_worktree", return_value=wt),
+                patch.object(worktree_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(worktree_mod, "WorktreeStartRunner", return_value=mock_runner),
+                patch.object(worktree_mod, "find_free_ports", return_value={"backend": 8001}),
+                patch("teatree.config.load_config", return_value=mock_config),
+            ):
+                result = call_command("worktree", "start", path=str(wt_path))
+            assert result == Worktree.State.SERVICES_UP
+
+    def test_start_returns_state_when_no_probes_defined(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_path = Path(tmp) / "worktree"
+            wt_path.mkdir()
+            wt = _build_worktree(wt_path)
+
+            mock_overlay = MagicMock()
+            mock_overlay.get_run_commands.return_value = {}
+            mock_overlay.get_readiness_probes.return_value = []
+
+            mock_runner = MagicMock()
+            mock_runner.run.return_value = RunnerResult(ok=True, detail="started")
+
+            mock_config = MagicMock()
+            mock_config.user.workspace_dir = Path(tmp)
+
+            with (
+                patch.object(worktree_mod, "resolve_worktree", return_value=wt),
+                patch.object(worktree_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(worktree_mod, "WorktreeStartRunner", return_value=mock_runner),
+                patch.object(worktree_mod, "find_free_ports", return_value={"backend": 8001}),
+                patch("teatree.config.load_config", return_value=mock_config),
+            ):
+                result = call_command("worktree", "start", path=str(wt_path))
+            assert result == Worktree.State.SERVICES_UP
+
+
+@override_settings(**SETTINGS)
+class TestWorktreeVerifyChainsProbes(TestCase):
+    def test_verify_exits_1_when_probe_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_path = Path(tmp) / "worktree"
+            wt_path.mkdir()
+            wt = _build_worktree(wt_path)
+            wt.state = Worktree.State.SERVICES_UP
+            wt.save(update_fields=["state"])
+
+            mock_overlay = MagicMock()
+            mock_overlay.get_readiness_probes.return_value = [
+                _failing_probe("cors", reason="missing Access-Control-Allow-Origin"),
+            ]
+
+            mock_runner = MagicMock()
+            mock_runner.run.return_value = RunnerResult(ok=True, detail="verified")
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with (
+                patch.object(worktree_mod, "resolve_worktree", return_value=wt),
+                patch.object(worktree_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(worktree_mod, "WorktreeVerifyRunner", return_value=mock_runner),
+                pytest.raises(SystemExit) as exc,
+            ):
+                call_command("worktree", "verify", path=str(wt_path), stdout=stdout, stderr=stderr)
+            assert exc.value.code == 1
+            assert "cors" in stdout.getvalue() + stderr.getvalue()
+
+    def test_verify_returns_state_when_all_probes_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_path = Path(tmp) / "worktree"
+            wt_path.mkdir()
+            wt = _build_worktree(wt_path)
+            wt.state = Worktree.State.SERVICES_UP
+            wt.save(update_fields=["state"])
+
+            mock_overlay = MagicMock()
+            mock_overlay.get_readiness_probes.return_value = [_passing_probe("api-up")]
+
+            mock_runner = MagicMock()
+            mock_runner.run.return_value = RunnerResult(ok=True, detail="verified")
+
+            with (
+                patch.object(worktree_mod, "resolve_worktree", return_value=wt),
+                patch.object(worktree_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(worktree_mod, "WorktreeVerifyRunner", return_value=mock_runner),
+            ):
+                result = call_command("worktree", "verify", path=str(wt_path))
+            assert result == Worktree.State.READY
+
+
+@override_settings(**SETTINGS)
+class TestWorkspaceStartChainsProbes(TestCase):
+    def test_start_exits_1_when_any_worktree_probe_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_a = tmp_path / "a"
+            wt_a.mkdir()
+            wt_b = tmp_path / "b"
+            wt_b.mkdir()
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/479")
+            anchor = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature",
+                db_name="db_a",
+                extra={"worktree_path": str(wt_a)},
+                state=Worktree.State.PROVISIONED,
+            )
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="frontend",
+                branch="feature",
+                db_name="db_b",
+                extra={"worktree_path": str(wt_b)},
+                state=Worktree.State.PROVISIONED,
+            )
+
+            def probes_for(wt: Worktree) -> list[Probe]:
+                if wt.repo_path == "frontend":
+                    return [_failing_probe("frontend-up", "503")]
+                return [_passing_probe("backend-up")]
+
+            mock_overlay = MagicMock()
+            mock_overlay.get_run_commands.return_value = {}
+            mock_overlay.get_readiness_probes.side_effect = probes_for
+
+            mock_runner = MagicMock()
+            mock_runner.run.return_value = RunnerResult(ok=True, detail="started")
+
+            with (
+                patch.object(workspace_mod, "resolve_worktree", return_value=anchor),
+                patch.object(workspace_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(workspace_mod, "WorktreeStartRunner", return_value=mock_runner),
+                patch.object(workspace_mod, "find_free_ports", return_value={"backend": 8001}),
+                pytest.raises(SystemExit) as exc,
+            ):
+                call_command("workspace", "start", path=str(wt_a))
+            assert exc.value.code == 1
+
+    def test_start_returns_summary_when_all_probes_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_a = tmp_path / "a"
+            wt_a.mkdir()
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/479")
+            anchor = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature",
+                db_name="db_a",
+                extra={"worktree_path": str(wt_a)},
+                state=Worktree.State.PROVISIONED,
+            )
+
+            mock_overlay = MagicMock()
+            mock_overlay.get_run_commands.return_value = {}
+            mock_overlay.get_readiness_probes.return_value = [_passing_probe("backend-up")]
+
+            mock_runner = MagicMock()
+            mock_runner.run.return_value = RunnerResult(ok=True, detail="started")
+
+            with (
+                patch.object(workspace_mod, "resolve_worktree", return_value=anchor),
+                patch.object(workspace_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(workspace_mod, "WorktreeStartRunner", return_value=mock_runner),
+                patch.object(workspace_mod, "find_free_ports", return_value={"backend": 8001}),
+            ):
+                result = call_command("workspace", "start", path=str(wt_a))
+            assert "started" in result
+
+    def test_start_returns_summary_when_no_probes_anywhere(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_a = tmp_path / "a"
+            wt_a.mkdir()
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/479")
+            anchor = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature",
+                db_name="db_a",
+                extra={"worktree_path": str(wt_a)},
+                state=Worktree.State.PROVISIONED,
+            )
+
+            mock_overlay = MagicMock()
+            mock_overlay.get_run_commands.return_value = {}
+            mock_overlay.get_readiness_probes.return_value = []
+
+            mock_runner = MagicMock()
+            mock_runner.run.return_value = RunnerResult(ok=True, detail="started")
+
+            with (
+                patch.object(workspace_mod, "resolve_worktree", return_value=anchor),
+                patch.object(workspace_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(workspace_mod, "WorktreeStartRunner", return_value=mock_runner),
+                patch.object(workspace_mod, "find_free_ports", return_value={"backend": 8001}),
+            ):
+                result = call_command("workspace", "start", path=str(wt_a))
+            assert "started" in result


### PR DESCRIPTION
## Summary

Extends the readiness gate added in #481 so the lifecycle subcommands also fail when probes fail.

- ``t3 worktree start`` runs ``get_readiness_probes`` after the start runner; exits 1 on any failure.
- ``t3 worktree verify`` does the same after the verify runner.
- ``t3 workspace start`` runs probes for every worktree in the ticket and exits 1 if any fail.
- Extracts a single ``_check_readiness_probes`` helper on the worktree command class so ``start``, ``verify``, and ``ready`` share the same output and exit contract.

Without this, a started/verified worktree could look healthy while serving raw translation keys, missing CORS headers, or a broken fixture seed — exactly the silent-failure modes the readiness probes were designed to catch.

## Test plan

- [x] New file ``tests/teatree_core/test_lifecycle_probe_chaining.py`` covers all three commands × {failing probe → exit 1, passing probe → ok, no probes → ok}.
- [x] Full suite green (2612 passed, 12 skipped).
- [x] ``ruff check`` / ``ruff format --check`` / ``ty check`` clean.
- [x] BLUEPRINT.md describes the readiness gate.