### PR TITLE
fix(e2e): gate mermaid SVG wait on HTMX idle (#490)

### DIFF
--- a/e2e/test_dashboard_buttons.py
+++ b/e2e/test_dashboard_buttons.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 import pytest
 from playwright.sync_api import Page, expect
 
-from e2e._dashboard_helpers import wait_for_sessions, wait_for_tickets
+from e2e._dashboard_helpers import wait_for_dashboard_idle, wait_for_sessions, wait_for_tickets
 
 _SNAPSHOT_THRESHOLD = 0.1
 
@@ -386,7 +386,9 @@ def test_snapshot_ticket_details_expanded(e2e_server: str, page: Page, assert_sn
     expect(details).to_be_visible()
     # Wait for the mermaid lifecycle SVG to render. Mermaid is vendored locally
     # (``teatree/js/mermaid-11.min.js``) so this works in sealed CI / Docker.
-    details.locator(".mermaid svg").first.wait_for(state="attached", timeout=5000)
+    wait_for_dashboard_idle(page)
+    details.locator(".mermaid").first.wait_for(state="attached")
+    details.locator(".mermaid svg").first.wait_for(state="attached", timeout=15000)
     assert_snapshot(
         details.screenshot(animations="disabled"),
         name="ticket-details-expanded.png",
@@ -401,7 +403,9 @@ def test_mermaid_lifecycle_renders_svg(e2e_server: str, page: Page) -> None:
     page.locator("button[onclick^='toggleTicketDetails']").first.click()
     details = page.locator("tr[id^='ticket-details-']").first
     expect(details).to_be_visible()
-    details.locator(".mermaid svg").first.wait_for(state="attached", timeout=10000)
+    wait_for_dashboard_idle(page)
+    details.locator(".mermaid").first.wait_for(state="attached")
+    details.locator(".mermaid svg").first.wait_for(state="attached", timeout=15000)
 
 
 def test_snapshot_sessions_filter_queued(e2e_server: str, page: Page, assert_snapshot: Callable) -> None:


### PR DESCRIPTION
## Summary

`test_mermaid_lifecycle_renders_svg` and `test_snapshot_ticket_details_expanded` flake on the first CI run with `TimeoutError` waiting for `.mermaid svg` to attach. The toggle button fires an HTMX swap; the test was racing the swap.

This PR:
- Gates the SVG wait on `body[data-htmx-idle="1"]` (existing helper) after the toggle click.
- Waits for the `.mermaid` `<pre>` to attach before waiting for its SVG child — separates the swap-arrival check from the Mermaid-rendering check.
- Bumps the SVG timeout to 15s for cold-Chromium CI runs.

Closes #490

## Test plan

- [x] Lint clean (`uv run ruff check`)
- [ ] CI E2E green on first run (no rerun needed)