### PR TITLE
fix(dashboard): repair Automation card links and drop orphan detail rows

### DIFF
--- a/src/teatree/core/templates/teatree/partials/dashboard_automation.html
+++ b/src/teatree/core/templates/teatree/partials/dashboard_automation.html
@@ -1,14 +1,14 @@
 {% if automation.running or automation.completed_24h %}
 <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-  <a href="#section-headless-queue" class="rounded-xl border border-bark/10 bg-gradient-to-b from-moss/10 to-white px-4 py-3 block hover:brightness-95 transition cursor-pointer" onclick="document.getElementById('section-headless-queue').open=true">
+  <a href="#section-sessions" class="rounded-xl border border-bark/10 bg-gradient-to-b from-moss/10 to-white px-4 py-3 block hover:brightness-95 transition cursor-pointer" onclick="document.getElementById('section-sessions').open=true">
     <span class="font-sans text-[10px] font-semibold uppercase tracking-[0.2em] text-bark/50">Running</span>
     <div class="mt-2 font-display text-3xl leading-none">{{ automation.running }}</div>
   </a>
-  <a href="#section-recent-activity" class="rounded-xl border border-bark/10 bg-gradient-to-b from-green-50 to-white px-4 py-3 block hover:brightness-95 transition cursor-pointer" onclick="document.getElementById('section-recent-activity').open=true">
+  <a href="#section-sessions" class="rounded-xl border border-bark/10 bg-gradient-to-b from-green-50 to-white px-4 py-3 block hover:brightness-95 transition cursor-pointer" onclick="document.getElementById('section-sessions').open=true">
     <span class="font-sans text-[10px] font-semibold uppercase tracking-[0.2em] text-bark/50">Succeeded (24h)</span>
     <div class="mt-2 font-display text-3xl leading-none text-green-700">{{ automation.succeeded_24h }}</div>
   </a>
-  <a href="#section-recent-activity" class="rounded-xl border border-bark/10 bg-gradient-to-b from-red-50 to-white px-4 py-3 block hover:brightness-95 transition cursor-pointer" onclick="document.getElementById('section-recent-activity').open=true">
+  <a href="#section-sessions" class="rounded-xl border border-bark/10 bg-gradient-to-b from-red-50 to-white px-4 py-3 block hover:brightness-95 transition cursor-pointer" onclick="document.getElementById('section-sessions').open=true">
     <span class="font-sans text-[10px] font-semibold uppercase tracking-[0.2em] text-bark/50">Failed (24h)</span>
     <div class="mt-2 font-display text-3xl leading-none {% if automation.failed_24h %}text-red-600{% else %}text-bark{% endif %}">{{ automation.failed_24h }}</div>
   </a>

--- a/src/teatree/core/templates/teatree/partials/dashboard_tickets.html
+++ b/src/teatree/core/templates/teatree/partials/dashboard_tickets.html
@@ -342,6 +342,7 @@
             </td>
           </tr>
         {% endfor %}
+        {% if ticket.mrs %}
         <!-- Combined task graph + lifecycle (toggled by approval count click) -->
         <tr id="ticket-details-{{ ticket.ticket_id }}" class="hidden" data-ticket-group="{{ ticket.ticket_id }}">
           <td colspan="10" class="border-b border-bark/10 bg-parchment/50 px-5 py-3">
@@ -361,6 +362,7 @@
             </div>
           </td>
         </tr>
+        {% endif %}
         {% endwith %}
       {% endfor %}
     </tbody>

--- a/tests/teatree_core/test_views.py
+++ b/tests/teatree_core/test_views.py
@@ -137,6 +137,16 @@ class TestDashboardPanelView(TestCase):
 
         assert response.status_code == 404
 
+    def test_tickets_panel_omits_detail_row_for_ticket_without_mrs(self) -> None:
+        ticket = Ticket.objects.create(
+            overlay="test", issue_url="https://example.com/issues/911", state=Ticket.State.STARTED
+        )
+
+        response = Client().get(reverse("teatree:dashboard-panel", args=["tickets"]), HTTP_HX_REQUEST="true")
+
+        assert response.status_code == 200
+        assert f"ticket-details-{ticket.pk}".encode() not in response.content
+
     def test_action_required(self) -> None:
         """Cover the 'action_required' branch of _panel_context (line 81)."""
         response = Client().get(reverse("teatree:dashboard-panel", args=["action_required"]), HTTP_HX_REQUEST="true")


### PR DESCRIPTION
## Bug-hunt findings

Two issues found while dogfooding the dashboard.

### 1. Automation card dead links

The "Running / Succeeded (24h) / Failed (24h)" cards in the Automation panel linked to `#section-headless-queue` and `#section-recent-activity`, both of which were removed when those panels were merged into the unified `Sessions` panel (#303). The click handlers called `document.getElementById(...).open=true` on missing elements (silent failure); the hash anchors went nowhere.

**Fix:** point all three cards at `#section-sessions` (the unified panel that does exist).

### 2. Orphan ticket-details rows

For a ticket without MRs, `dashboard_tickets.html` renders a `data-ticket-row` placeholder (no toggle button) but unconditionally also rendered a `<tr id="ticket-details-N">` row after the loop. On a real backlog (~150 in-flight tickets, ~80% with no MR) that's ~120 hidden detail rows in the DOM that no toggle could ever open — pushing the tickets panel response to ~1MB.

**Fix:** wrap the detail row in `{% if ticket.mrs %}`.

## Test

Added a regression test in `TestDashboardPanelView` that creates a ticket without MRs and asserts no `ticket-details-<pk>` is in the rendered tickets panel.

```bash
uv run pytest --no-cov -x -q tests/teatree_core/test_views.py::TestDashboardPanelView
# 14 passed
```

Verified the test correctly catches the regression: stashed the template fix → test failed; restored → test passed.

## Test plan

- [x] Lint clean (`uv run ruff check`)
- [x] Format clean (`uv run ruff format --check`)
- [x] Panel-view unit tests pass (14/14)
- [ ] CI E2E green