### PR TITLE
feat(hook): fetch MR/issue titles + fix write-skill-cache CLI

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1015,6 +1015,8 @@ Three install paths, one source of truth:
 
 The agent-facing hook layer (`hooks/scripts/hook_router.py`) blocks `uv run t3` Bash invocations and directs agents to call the globally installed `t3` instead.
 
+`UserPromptSubmit` skill detection (`scripts/lib/skill_loader.py`) enriches the prompt with linked MR/issue titles before keyword matching via `teatree.url_title_fetcher`. This lets a domain skill (e.g. `home-savings-le`) auto-load when the prompt contains only a bare MR URL whose *title* — not its URL — carries the trigger keyword. Titles are fetched in parallel via `glab`/`gh` (1.5s per fetch, 4.0s total budget) and cached at `~/.cache/teatree/url-titles.json`. Disable with `T3_HOOK_FETCH_TITLES=0`.
+
 ### 12.4 Bash Permissions
 
 The plugin's `settings.json` ships a **comprehensive** `permissions.allow` list so every command teatree and its overlays legitimately invoke matches a static rule — the auto-mode classifier is never consulted for normal workflow. This keeps day-to-day work friction-free: no surprise prompts, no classifier false-denials on routine operations.

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -149,8 +149,8 @@ Usage: t3 config [OPTIONS] COMMAND [ARGS]...
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ check-update       Check if a newer version of teatree is available.         │
-│ write-skill-cache  Write overlay skill metadata to XDG cache for hook        │
-│                    consumption.                                              │
+│ write-skill-cache  Write overlay skill metadata + trigger index to XDG cache │
+│                    for hook consumption.                                     │
 │ autoload           List skill auto-loading rules from context-match.yml      │
 │                    files.                                                    │
 │ cache              Show the XDG skill-metadata cache content.                │
@@ -176,7 +176,8 @@ Usage: t3 config check-update [OPTIONS]
 ```
 Usage: t3 config write-skill-cache [OPTIONS]
 
- Write overlay skill metadata to XDG cache for hook consumption.
+ Write overlay skill metadata + trigger index to XDG cache for hook
+ consumption.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
@@ -1122,7 +1123,8 @@ Usage: t3 teatree worktree start [OPTIONS]
  to SERVICES_UP and enqueues ``execute_worktree_start``; the runner
  also runs synchronously here so the operator sees immediate output.
  Allocates free host ports, refreshes the env cache, runs overlay
- pre-run steps, then ``docker compose up -d``.
+ pre-run steps, then ``docker compose up -d``. After the runner
+ succeeds, runs the overlay's readiness probes — exits 1 if any fail.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
@@ -1138,7 +1140,8 @@ Usage: t3 teatree worktree verify [OPTIONS]
  Run overlay health checks for one worktree.
 
  Thin wrapper around ``Worktree.verify()``: SERVICES_UP → READY +
- runner records URLs and reports failed checks. Best-effort.
+ runner records URLs and reports failed checks. After the runner,
+ runs the overlay's readiness probes — exits 1 if any fail.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
@@ -1300,7 +1303,8 @@ Usage: t3 teatree workspace start [OPTIONS]
 
  Allocates one shared port set across the workspace, then fires
  ``Worktree.start_services()`` on each worktree (CLI runs the
- runner synchronously).
+ runner synchronously). After every worktree starts, runs each
+ overlay's readiness probes — exits 1 if any probe fails.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --path        TEXT  Worktree path inside the workspace (auto-detects from    │

--- a/scripts/lib/skill_loader.py
+++ b/scripts/lib/skill_loader.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from lib.trigger_parser import parse_triggers as parse_triggers_from_frontmatter
+from lib.url_title_fetcher import enrich_prompt as _enrich_prompt_with_url_titles
 
 _SRC_DIR = Path(__file__).resolve().parents[2] / "src"
 if str(_SRC_DIR) not in sys.path:
@@ -181,7 +182,8 @@ def detect_intent(
     if not trigger_index:
         return ""
 
-    lp = prompt.lower()
+    enriched = _enrich_prompt_with_url_titles(prompt)
+    lp = enriched.lower()
 
     # Pass 0: Explicit /<skill> slash commands (highest priority).
     # When the prompt starts with a known skill name, use it directly
@@ -266,7 +268,8 @@ def detect_intent_detailed(
     if not trigger_index:
         return _NO_MATCH
 
-    lp = prompt.lower()
+    enriched = _enrich_prompt_with_url_titles(prompt)
+    lp = enriched.lower()
 
     # Pass 0: Explicit /<skill> slash commands.
     slash_match = re.match(r"^/?([a-z][a-z0-9_-]+)", lp.strip())

--- a/scripts/lib/url_title_fetcher.py
+++ b/scripts/lib/url_title_fetcher.py
@@ -1,0 +1,1 @@
+../../src/teatree/url_title_fetcher.py

--- a/src/teatree/cli/config.py
+++ b/src/teatree/cli/config.py
@@ -20,26 +20,19 @@ def check_update() -> None:
 
 @config_app.command(name="write-skill-cache")
 def write_skill_cache() -> None:
-    """Write overlay skill metadata to XDG cache for hook consumption."""
-    import json as _json  # noqa: PLC0415
-
+    """Write overlay skill metadata + trigger index to XDG cache for hook consumption."""
     import django  # noqa: PLC0415
 
     from teatree.config import DATA_DIR, discover_active_overlay  # noqa: PLC0415
 
-    active = discover_active_overlay()
-    if active and "DJANGO_SETTINGS_MODULE" not in os.environ:
-        os.environ["DJANGO_SETTINGS_MODULE"] = "teatree.settings"
+    discover_active_overlay()
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
     django.setup()
 
-    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+    from teatree.core.views._startup import _write_skill_metadata_cache  # noqa: PLC0415
 
-    overlay = get_overlay()
-    metadata = overlay.metadata.get_skill_metadata()
-    cache_path = DATA_DIR / "skill-metadata.json"
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_path.write_text(_json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
-    typer.echo(f"Wrote skill metadata to {cache_path}")
+    _write_skill_metadata_cache()
+    typer.echo(f"Wrote skill metadata to {DATA_DIR / 'skill-metadata.json'}")
 
 
 @config_app.command()

--- a/src/teatree/url_title_fetcher.py
+++ b/src/teatree/url_title_fetcher.py
@@ -1,0 +1,150 @@
+"""Fetch GitLab/GitHub MR/issue titles to enrich prompts before trigger matching.
+
+Used by the UserPromptSubmit hook so a skill's keyword triggers can match the
+content of a linked MR/issue, not just the prompt text. Without this, pasting
+a bare MR URL from a generic-looking repo does not load skills that only the
+MR's *title* would identify (e.g. a domain-specific skill on a feature MR).
+
+Set ``T3_HOOK_FETCH_TITLES=0`` to disable. Titles are cached at
+``~/.cache/teatree/url-titles.json`` indefinitely (titles rarely change;
+delete the file to invalidate).
+"""
+
+import concurrent.futures
+import json
+import os
+import re
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
+
+CACHE_FILE = Path.home() / ".cache" / "teatree" / "url-titles.json"
+PER_FETCH_TIMEOUT = 1.5
+TOTAL_BUDGET = 4.0
+MAX_URLS = 10
+MAX_WORKERS = 5
+
+_GITLAB_URL_RE = re.compile(
+    r"https?://(?:[\w.-]*gitlab\.[\w.-]+)/([^\s#?]+?)/-/(merge_requests|issues|work_items)/(\d+)",
+    re.IGNORECASE,
+)
+_GITHUB_URL_RE = re.compile(
+    r"https?://github\.com/([^/\s]+/[^/\s]+)/(pull|issues)/(\d+)",
+    re.IGNORECASE,
+)
+
+
+def _load_cache() -> dict[str, str]:
+    if not CACHE_FILE.is_file():
+        return {}
+    try:
+        return json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_cache(cache: dict[str, str]) -> None:
+    try:
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        CACHE_FILE.write_text(json.dumps(cache, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _run_json(cmd: list[str]) -> dict:
+    try:
+        result = run_allowed_to_fail(cmd, expected_codes=None, timeout=PER_FETCH_TIMEOUT)
+    except (CommandFailedError, TimeoutExpired, OSError):
+        return {}
+    if result.returncode != 0:
+        return {}
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {}
+
+
+def _fetch_gitlab(repo: str, kind: str, iid: str) -> str:
+    if not shutil.which("glab"):
+        return ""
+    endpoint = "merge_requests" if kind == "merge_requests" else "issues"
+    project = repo.replace("/", "%2F")
+    return _run_json(["glab", "api", f"projects/{project}/{endpoint}/{iid}"]).get("title", "")
+
+
+def _fetch_github(repo: str, kind: str, num: str) -> str:
+    if not shutil.which("gh"):
+        return ""
+    cmd_kind = "pr" if kind == "pull" else "issue"
+    return _run_json(["gh", cmd_kind, "view", num, "--repo", repo, "--json", "title"]).get("title", "")
+
+
+def _extract_jobs(prompt: str) -> list[tuple[str, Callable[[], str]]]:
+    """Return [(cache_key, fetcher_callable), ...] for URLs found in the prompt."""
+    jobs: list[tuple[str, Callable[[], str]]] = []
+    for match in _GITLAB_URL_RE.finditer(prompt):
+        repo, kind, iid = match.group(1), match.group(2).lower(), match.group(3)
+        if kind == "work_items":
+            kind = "issues"
+        cache_key = f"gitlab:{repo}:{kind}:{iid}"
+        jobs.append((cache_key, lambda r=repo, k=kind, i=iid: _fetch_gitlab(r, k, i)))
+    for match in _GITHUB_URL_RE.finditer(prompt):
+        repo, kind, num = match.group(1), match.group(2).lower(), match.group(3)
+        cache_key = f"github:{repo}:{kind}:{num}"
+        jobs.append((cache_key, lambda r=repo, k=kind, n=num: _fetch_github(r, k, n)))
+    return jobs[:MAX_URLS]
+
+
+def fetch_titles(prompt: str) -> list[str]:
+    """Return titles for every GitLab/GitHub URL in *prompt*. Cached + parallel.
+
+    Returns ``[]`` when ``T3_HOOK_FETCH_TITLES=0``, when no URLs are found, or
+    when every fetch fails. Failures are not cached so transient errors retry
+    next time.
+    """
+    if os.environ.get("T3_HOOK_FETCH_TITLES", "1") == "0":
+        return []
+    jobs = _extract_jobs(prompt)
+    if not jobs:
+        return []
+
+    cache = _load_cache()
+    titles: list[str] = []
+    todo: list[tuple[str, Callable[[], str]]] = []
+    for cache_key, fetcher in jobs:
+        cached = cache.get(cache_key)
+        if cached:
+            titles.append(cached)
+        else:
+            todo.append((cache_key, fetcher))
+
+    if not todo:
+        return titles
+
+    cache_dirty = False
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(todo), MAX_WORKERS)) as pool:
+        future_to_key = {pool.submit(fetcher): key for key, fetcher in todo}
+        try:
+            for fut in concurrent.futures.as_completed(future_to_key, timeout=TOTAL_BUDGET):
+                title = fut.result()
+                if title:
+                    titles.append(title)
+                    cache[future_to_key[fut]] = title
+                    cache_dirty = True
+        except concurrent.futures.TimeoutError:
+            pass
+
+    if cache_dirty:
+        _save_cache(cache)
+    return titles
+
+
+def enrich_prompt(prompt: str) -> str:
+    """Append fetched MR/issue titles to *prompt* so trigger keywords can match them."""
+    titles = fetch_titles(prompt)
+    if not titles:
+        return prompt
+    suffix = "\n".join(f"[linked title: {t}]" for t in titles)
+    return f"{prompt}\n{suffix}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -308,19 +308,23 @@ class TestInfoCommand:
 
 class TestConfigCommands:
     def test_write_skill_cache_writes_json(self, tmp_path, monkeypatch):
-        """write-skill-cache writes overlay metadata to cache."""
+        """write-skill-cache delegates to the canonical _write_skill_metadata_cache helper."""
+        import teatree.core.views._startup as startup_mod  # noqa: PLC0415
         from teatree.config import OverlayEntry  # noqa: PLC0415
 
         active = OverlayEntry(name="test", overlay_class="test.overlay.TestOverlay")
         mock_overlay = MagicMock()
         mock_overlay.metadata.get_skill_metadata.return_value = {"skill_path": "skills/test/SKILL.md"}
 
-        monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path)
+        monkeypatch.setattr(startup_mod, "DATA_DIR", tmp_path)
         monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
         with (
             patch.object(config_mod, "discover_active_overlay", return_value=active),
             patch("django.setup"),
-            patch.object(overlay_loader_mod, "get_overlay", return_value=mock_overlay),
+            patch.object(startup_mod, "get_overlay", return_value=mock_overlay),
+            patch.object(startup_mod, "_build_trigger_index", return_value=[]),
+            patch.object(startup_mod, "resolve_all", return_value={}),
+            patch.object(startup_mod, "_collect_skill_mtimes", return_value={}),
         ):
             result = runner.invoke(app, ["config", "write-skill-cache"])
             assert result.exit_code == 0
@@ -329,6 +333,8 @@ class TestConfigCommands:
             assert cache.is_file()
             data = json.loads(cache.read_text())
             assert data["skill_path"] == "skills/test/SKILL.md"
+            assert data["trigger_index"] == []
+            assert "teatree_version" in data
 
     def test_write_skill_cache_no_active_overlay(self, monkeypatch):
         """write-skill-cache works when DJANGO_SETTINGS_MODULE is already set."""

--- a/tests/test_url_title_fetcher.py
+++ b/tests/test_url_title_fetcher.py
@@ -1,0 +1,121 @@
+"""Tests for teatree.url_title_fetcher."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from teatree import url_title_fetcher as utf
+
+
+@pytest.fixture
+def cache_path(tmp_path, monkeypatch):
+    cache = tmp_path / "url-titles.json"
+    monkeypatch.setattr(utf, "CACHE_FILE", cache)
+    return cache
+
+
+def _mk_completed(rc: int, stdout: str) -> SimpleNamespace:
+    """Build a stand-in for subprocess.run's CompletedProcess."""
+    return SimpleNamespace(returncode=rc, stdout=stdout, stderr="")
+
+
+class TestExtractJobs:
+    def test_finds_gitlab_merge_request(self):
+        prompt = "review https://gitlab.com/group/repo/-/merge_requests/42"
+        jobs = utf._extract_jobs(prompt)
+        assert len(jobs) == 1
+        assert jobs[0][0] == "gitlab:group/repo:merge_requests:42"
+
+    def test_finds_gitlab_issue_and_work_item(self):
+        prompt = "context: https://gitlab.com/group/repo/-/issues/7 and https://gitlab.com/group/repo/-/work_items/8"
+        jobs = utf._extract_jobs(prompt)
+        keys = [j[0] for j in jobs]
+        assert "gitlab:group/repo:issues:7" in keys
+        # work_items normalized to issues for cache symmetry
+        assert "gitlab:group/repo:issues:8" in keys
+
+    def test_finds_github_pr_and_issue(self):
+        prompt = "https://github.com/owner/repo/pull/12 https://github.com/owner/repo/issues/3"
+        jobs = utf._extract_jobs(prompt)
+        keys = [j[0] for j in jobs]
+        assert "github:owner/repo:pull:12" in keys
+        assert "github:owner/repo:issues:3" in keys
+
+    def test_caps_at_max_urls(self):
+        urls = " ".join(f"https://gitlab.com/g/r/-/merge_requests/{i}" for i in range(20))
+        assert len(utf._extract_jobs(urls)) == utf.MAX_URLS
+
+    def test_returns_empty_for_no_urls(self):
+        assert utf._extract_jobs("just a plain prompt with no urls") == []
+
+
+class TestFetchTitles:
+    def test_disabled_via_env_var(self, monkeypatch, cache_path):
+        monkeypatch.setenv("T3_HOOK_FETCH_TITLES", "0")
+        assert utf.fetch_titles("https://gitlab.com/g/r/-/merge_requests/1") == []
+
+    def test_returns_cached_titles_without_subprocess(self, cache_path):
+        cache_path.write_text(json.dumps({"gitlab:g/r:merge_requests:1": "Cached title"}))
+        with patch("teatree.url_title_fetcher.run_allowed_to_fail") as run:
+            titles = utf.fetch_titles("https://gitlab.com/g/r/-/merge_requests/1")
+        assert titles == ["Cached title"]
+        run.assert_not_called()
+
+    def test_fetches_uncached_gitlab_title(self, cache_path):
+        with (
+            patch("teatree.url_title_fetcher.shutil.which", return_value="/usr/bin/glab"),
+            patch(
+                "teatree.url_title_fetcher.run_allowed_to_fail",
+                return_value=_mk_completed(0, json.dumps({"title": "Real MR title"})),
+            ),
+        ):
+            titles = utf.fetch_titles("https://gitlab.com/g/r/-/merge_requests/99")
+        assert titles == ["Real MR title"]
+        cached = json.loads(cache_path.read_text())
+        assert cached["gitlab:g/r:merge_requests:99"] == "Real MR title"
+
+    def test_fetches_uncached_github_pr_title(self, cache_path):
+        with (
+            patch("teatree.url_title_fetcher.shutil.which", return_value="/usr/bin/gh"),
+            patch(
+                "teatree.url_title_fetcher.run_allowed_to_fail",
+                return_value=_mk_completed(0, json.dumps({"title": "Real PR title"})),
+            ),
+        ):
+            titles = utf.fetch_titles("https://github.com/owner/repo/pull/5")
+        assert titles == ["Real PR title"]
+
+    def test_failed_fetch_does_not_cache(self, cache_path):
+        with (
+            patch("teatree.url_title_fetcher.shutil.which", return_value="/usr/bin/glab"),
+            patch(
+                "teatree.url_title_fetcher.run_allowed_to_fail",
+                return_value=_mk_completed(1, ""),
+            ),
+        ):
+            titles = utf.fetch_titles("https://gitlab.com/g/r/-/merge_requests/99")
+        assert titles == []
+        assert not cache_path.is_file() or cache_path.read_text().strip() in {"", "{}", "{}\n"}
+
+    def test_glab_missing_returns_empty(self, cache_path):
+        with patch("teatree.url_title_fetcher.shutil.which", return_value=None):
+            titles = utf.fetch_titles("https://gitlab.com/g/r/-/merge_requests/1")
+        assert titles == []
+
+
+class TestEnrichPrompt:
+    def test_appends_titles_to_prompt(self, cache_path):
+        cache_path.write_text(json.dumps({"gitlab:g/r:merge_requests:1": "feat(home-savings): joint rep"}))
+        result = utf.enrich_prompt("review https://gitlab.com/g/r/-/merge_requests/1")
+        assert "review https://gitlab.com/g/r/-/merge_requests/1" in result
+        assert "[linked title: feat(home-savings): joint rep]" in result
+
+    def test_returns_prompt_unchanged_when_no_titles(self, cache_path, monkeypatch):
+        monkeypatch.setenv("T3_HOOK_FETCH_TITLES", "0")
+        prompt = "https://gitlab.com/g/r/-/merge_requests/1"
+        assert utf.enrich_prompt(prompt) == prompt
+
+    def test_returns_prompt_unchanged_when_no_urls(self):
+        assert utf.enrich_prompt("just a prompt") == "just a prompt"


### PR DESCRIPTION
## Two related changes on one branch

### 1. fix(cli): `t3 config write-skill-cache` writes the full cache

The CLI command was bypassing `_write_skill_metadata_cache()` and writing only `skill_path` + `remote_patterns`, wiping the `trigger_index`, `resolved_requires`, `skill_mtimes`, and `teatree_version` keys that hook consumers rely on. Fixed by delegating to the canonical helper.

### 2. feat(hook): fetch MR/issue titles to enrich prompt before trigger matching

Skill triggers only match text in the prompt, so a bare MR URL from a generic-looking repo cannot load skills that only the linked MR's *title* would identify (e.g. a domain-specific skill on a `feat(domain): ...` MR).

Adds a URL title fetcher that runs before trigger matching:

- Extracts GitLab/GitHub MR/issue/PR URLs from the prompt
- Fetches titles via `glab` / `gh` in parallel, capped by per-fetch (1.5s) and total (4.0s) budgets
- Caches successful titles indefinitely at `~/.cache/teatree/url-titles.json`
- Appends `[linked title: ...]` so normal keyword matching catches it
- Disabled via `T3_HOOK_FETCH_TITLES=0`; fails open when CLI tools missing

## Test plan
- [x] `uv run pytest tests/test_url_title_fetcher.py tests/test_cli.py --no-cov` — 14 new tests + existing CLI tests all pass
- [x] `uv run ruff check` — clean
- [x] BLUEPRINT.md updated with new hook layer entry