### PR TITLE
fix(workspace): resolve namespaced clones (#491)

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from teatree.config import load_config
+from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_overlay
 from teatree.utils import git
@@ -264,7 +265,8 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False) -> str:
             logger.exception("cleanup step failed for %s: %s", worktree.repo_path, step.description)
             step_errors.append(f"{step.description}: {exc}")
 
-    step_errors.extend(_remove_git_worktree(workspace / worktree.repo_path, wt_path, worktree, force=force))
+    repo_main = resolve_clone_path(workspace, worktree) or workspace / worktree.repo_path
+    step_errors.extend(_remove_git_worktree(repo_main, wt_path, worktree, force=force))
 
     if worktree.db_name:
         drop_db(worktree.db_name)

--- a/src/teatree/core/clone_paths.py
+++ b/src/teatree/core/clone_paths.py
@@ -1,0 +1,64 @@
+"""Source-clone resolution shared by provisioning, cleanup, orphan-guard, reconcile.
+
+Lives in ``teatree.core`` rather than ``teatree.core.runners`` because importing
+``runners`` triggers ``runners.__init__`` which pulls in ``cleanup`` (via
+``teardown``) — a circular import the moment ``cleanup`` itself wants to
+resolve a clone.
+"""
+
+import logging
+from pathlib import Path
+
+from teatree.core.models import Worktree
+
+logger = logging.getLogger(__name__)
+
+
+def find_clone_path(workspace: Path, repo_name: str) -> Path | None:
+    """Resolve ``repo_name`` to an actual git clone under ``workspace``.
+
+    Tries the literal path first (``workspace / repo_name``) so explicit
+    ``souliane/teatree``-style entries keep working. If that's not a git
+    checkout, scans one level deep — ``workspace / */basename`` — so a bare
+    ``teatree`` from ``--repos teatree`` finds the namespaced clone at
+    ``workspace/souliane/teatree``. Returns ``None`` when no match exists.
+    Logs a warning when more than one match is found and picks the first
+    (alphabetic) so the operator can spot basename collisions in the logs.
+    """
+    literal = workspace / repo_name
+    if (literal / ".git").is_dir():
+        return literal
+
+    basename = Path(repo_name).name
+    matches: list[Path] = []
+    for entry in sorted(workspace.iterdir()):
+        if not entry.is_dir() or entry == literal:
+            continue
+        candidate = entry / basename
+        if (candidate / ".git").is_dir():
+            matches.append(candidate)
+
+    if not matches:
+        return None
+    if len(matches) > 1:
+        logger.warning(
+            "Multiple clones match %r under %s; picking %s. Pass --repos with the namespace prefix to disambiguate.",
+            repo_name,
+            workspace,
+            matches[0],
+        )
+    return matches[0]
+
+
+def resolve_clone_path(workspace: Path, worktree: Worktree) -> Path | None:
+    """Return the source clone path for *worktree*, with namespace fallback.
+
+    Prefers ``worktree.extra['clone_path']`` (set at provision time when the
+    namespace-aware lookup was used). Falls back to a fresh
+    :func:`find_clone_path` scan for legacy rows that pre-date the field.
+    Returns ``None`` when no clone exists anywhere.
+    """
+    stored = (worktree.extra or {}).get("clone_path", "")
+    if stored:
+        return Path(stored)
+    return find_clone_path(workspace, worktree.repo_path)

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -36,6 +36,7 @@ class TicketExtra(TypedDict, total=False):
 
 class WorktreeExtra(TypedDict, total=False):
     worktree_path: str
+    clone_path: str
     services: list[str]
     urls: dict[str, str]
     pids: dict[str, int]

--- a/src/teatree/core/orphan_guard.py
+++ b/src/teatree/core/orphan_guard.py
@@ -21,6 +21,7 @@ from enum import StrEnum
 
 from teatree.config import load_config
 from teatree.core.cleanup import _branch_tree_matches_squash, classify_branch_commits, probe_host_cli
+from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Worktree
 from teatree.utils import git
 
@@ -109,8 +110,8 @@ def find_orphans_in_workspace() -> list[BranchReport]:
     reports: list[BranchReport] = []
     seen: set[tuple[str, str]] = set()
     for wt in Worktree.objects.all():
-        repo_main = workspace / wt.repo_path
-        if not repo_main.is_dir():
+        repo_main = resolve_clone_path(workspace, wt)
+        if repo_main is None or not repo_main.is_dir():
             continue
         key = (str(repo_main), wt.branch)
         if key in seen:

--- a/src/teatree/core/reconcile.py
+++ b/src/teatree/core/reconcile.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from teatree.config import load_config
+from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Ticket, Worktree
 from teatree.core.worktree_env import detect_drift, render_env_cache
 from teatree.utils import git
@@ -193,7 +194,7 @@ def _collect_stale_worktree_dirs(drift: Drift, worktrees: list[Worktree], ticket
         if (wt.extra or {}).get("worktree_path")
     }
     for wt in worktrees:
-        repo_main = workspace / wt.repo_path
+        repo_main = resolve_clone_path(workspace, wt) or workspace / wt.repo_path
         for path_str in _find_worktree_paths_on_disk(repo_main):
             resolved = Path(path_str).resolve().as_posix()
             if resolved == str(repo_main.resolve()):

--- a/src/teatree/core/runners/provision.py
+++ b/src/teatree/core/runners/provision.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from teatree.config import workspace_dir as _workspace_dir
+from teatree.core.clone_paths import find_clone_path
 from teatree.core.models import Ticket, Worktree
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.utils import git
@@ -56,18 +57,19 @@ class WorktreeProvisioner(RunnerBase):
                 overlay=ticket.overlay,
             )
 
-            wt_path = self._create(workspace, repo_name, ticket_dir, branch)
-            if wt_path is None:
-                # actual failure — drop the row so subsequent runs can retry cleanly
+            created = self._create(workspace, repo_name, ticket_dir, branch)
+            if created is None:
                 worktree.delete()
                 failed.append(repo_name)
                 continue
-            if not wt_path:
-                # skipped (source repo missing) — keep the row without a path
-                continue
 
+            wt_path, clone_path = created
             worktree.branch = branch
-            worktree.extra = {**(worktree.extra or {}), "worktree_path": wt_path}
+            worktree.extra = {
+                **(worktree.extra or {}),
+                "worktree_path": wt_path,
+                "clone_path": str(clone_path),
+            }
             worktree.save(update_fields=["branch", "extra"])
             provisioned[repo_name] = wt_path
 
@@ -80,21 +82,27 @@ class WorktreeProvisioner(RunnerBase):
         return RunnerResult(ok=True, detail=f"provisioned {len(provisioned)} worktree(s)")
 
     @staticmethod
-    def _create(workspace: Path, repo_name: str, ticket_dir: Path, branch: str) -> str | None:
+    def _create(workspace: Path, repo_name: str, ticket_dir: Path, branch: str) -> tuple[str, Path] | None:
         """Run ``git worktree add`` for one repo.
 
-        Returns the worktree path on success, ``""`` when the source repo is
-        not a git checkout (skipped), or ``None`` on actual failure. Retries
-        without ``-b`` so partial-failure recovery picks up an existing branch.
+        Returns ``(worktree_path, clone_path)`` on success or ``None`` on
+        failure (no clone found, or ``git worktree add`` rejected the path).
+        Retries without ``-b`` so partial-failure recovery picks up an
+        existing branch.
         """
-        repo_path = workspace / repo_name
-        if not (repo_path / ".git").is_dir():
-            logger.info("Skipping %s: not a git repository under %s", repo_name, workspace)
-            return ""
+        repo_path = find_clone_path(workspace, repo_name)
+        if repo_path is None:
+            logger.warning(
+                "No git clone found for %s under %s (looked at %s and one-level subdirs)",
+                repo_name,
+                workspace,
+                workspace / repo_name,
+            )
+            return None
 
         wt_path = ticket_dir / Path(repo_name).name
         if wt_path.exists():
-            return str(wt_path)
+            return str(wt_path), repo_path
 
         git.pull_ff_only(str(repo_path))
 
@@ -111,4 +119,4 @@ class WorktreeProvisioner(RunnerBase):
             with suppress(OSError):
                 pv_dest.symlink_to(pv)
 
-        return str(wt_path)
+        return str(wt_path), repo_path

--- a/tests/teatree_core/test_cleanup.py
+++ b/tests/teatree_core/test_cleanup.py
@@ -561,3 +561,50 @@ class TestCleanupWorktreeRemovesOnDiskWorktree(TestCase):
         assert "errors" in label.lower() or "Cleaned: myrepo" in label
         # Worktree row deleted regardless so the operator can retry without DB cruft
         assert not Worktree.objects.filter(pk=wt.pk).exists()
+
+
+class TestCleanupWorktreeNamespacedClone(TestCase):
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.workspace = tmp_path / "workspace"
+        self.workspace.mkdir()
+        self.repo_main = self.workspace / "souliane" / "teatree"
+        self.repo_main.mkdir(parents=True)
+        _run_git("init", "-q", "-b", "main", cwd=self.repo_main)
+        _run_git("config", "user.email", "t@t", cwd=self.repo_main)
+        _run_git("config", "user.name", "t", cwd=self.repo_main)
+        _run_git("commit", "--allow-empty", "-q", "-m", "initial", cwd=self.repo_main)
+        self.branch = "ac-teatree-491-x"
+        self.wt_path = self.workspace / self.branch / "teatree"
+        _run_git("worktree", "add", "-q", "-b", self.branch, str(self.wt_path), cwd=self.repo_main)
+
+    def test_resolves_namespaced_clone_via_extra(self) -> None:
+        ticket = Ticket.objects.create(
+            issue_url="https://example.com/issues/491",
+            state=Ticket.State.IN_REVIEW,
+        )
+        wt = Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="teatree",
+            branch=self.branch,
+            extra={"worktree_path": str(self.wt_path), "clone_path": str(self.repo_main)},
+        )
+
+        with (
+            patch("teatree.core.cleanup.load_config") as mock_config,
+            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+        ):
+            mock_config.return_value.user.workspace_dir = self.workspace
+            mock_overlay.return_value.get_cleanup_steps.return_value = []
+            label = cleanup_worktree(wt, force=True)
+
+        assert not self.wt_path.exists()
+        registry = subprocess.run(
+            [_GIT, "-C", str(self.repo_main), "worktree", "list"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert str(self.wt_path) not in registry
+        assert "errors" not in label.lower()

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -295,6 +295,12 @@ class TestWorkspaceTicket(TestCase):
         self.enterContext(
             patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
         )
+        # Seed the host-style clones the provisioner expects under HOME/workspace.
+        # Tests that override T3_WORKSPACE_DIR ignore these and create their own.
+        workspace = Path(os.environ["HOME"]) / "workspace"
+        workspace.mkdir(parents=True, exist_ok=True)
+        for repo in ("backend", "frontend", "api", "web"):
+            (workspace / repo / ".git").mkdir(parents=True, exist_ok=True)
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -427,16 +433,13 @@ class TestWorkspaceTicket(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS, T3_WORKSPACE_DIR="/tmp/ws-test")
-    def test_skips_non_git_repo(self) -> None:
-        """Repos without .git directory are skipped."""
+    def test_partial_failure_when_one_repo_has_no_clone(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
 
             workspace = tmp_path / "workspace"
             workspace.mkdir()
-            # Only backend has .git; frontend doesn't
-            (workspace / "backend").mkdir()
-            (workspace / "backend" / ".git").mkdir()
+            (workspace / "backend" / ".git").mkdir(parents=True)
             (workspace / "frontend").mkdir()
 
             mock_result = MagicMock()
@@ -450,8 +453,8 @@ class TestWorkspaceTicket(TestCase):
                 ticket_id = cast("int", call_command("workspace", "ticket", "https://example.com/issues/81"))
 
             ticket = Ticket.objects.get(pk=ticket_id)
-            # Both worktrees are created in DB; one was skipped during git worktree add
-            assert ticket.worktrees.count() == 2
+            assert ticket.worktrees.count() == 1
+            assert ticket.worktrees.get().repo_path == "backend"
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS, T3_WORKSPACE_DIR="/tmp/ws-test")

--- a/tests/teatree_core/test_runners_provision.py
+++ b/tests/teatree_core/test_runners_provision.py
@@ -137,7 +137,7 @@ class TestWorktreeProvisioner(TestCase):
         assert "repo-a" in result.detail
         assert Worktree.objects.filter(ticket=ticket, repo_path="repo-a").count() == 0
 
-    def test_skips_repo_without_git_directory(self) -> None:
+    def test_returns_failure_when_no_clone_found_anywhere(self) -> None:
         not_a_repo = self.workspace / "no-git"
         not_a_repo.mkdir()
         ticket = self._scoped_ticket(repos=["no-git"], branch="ac-no-git-77-x")
@@ -149,12 +149,69 @@ class TestWorktreeProvisioner(TestCase):
         ):
             result = WorktreeProvisioner(ticket).run()
 
-        assert result.ok is True
+        assert result.ok is False
+        assert "no-git" in result.detail
         worktree_add.assert_not_called()
-        # Skipped repo keeps its DB row so the ticket still tracks it; the row
-        # has no worktree_path until a real source repo appears.
-        wt = Worktree.objects.get(ticket=ticket, repo_path="no-git")
-        assert (wt.extra or {}).get("worktree_path") is None
+        assert Worktree.objects.filter(ticket=ticket, repo_path="no-git").count() == 0
+
+    def test_finds_clone_under_namespaced_subdir(self) -> None:
+        namespaced = self.workspace / "souliane" / "teatree"
+        namespaced.mkdir(parents=True)
+        (namespaced / ".git").mkdir()
+        ticket = self._scoped_ticket(repos=["teatree"], branch="ac-teatree-491-x")
+
+        captured: dict[str, str] = {}
+
+        def fake_worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = True) -> bool:
+            del branch, create_branch
+            captured["source"] = repo
+            captured["dest"] = path
+            Path(path).mkdir(parents=True, exist_ok=True)
+            return True
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+            patch("teatree.core.runners.provision.git.worktree_add", side_effect=fake_worktree_add),
+            patch("teatree.core.runners.provision.git.pull_ff_only", return_value=True),
+        ):
+            result = WorktreeProvisioner(ticket).run()
+
+        assert result.ok is True
+        assert captured["source"] == str(namespaced)
+        assert captured["dest"] == str(self.workspace / "ac-teatree-491-x" / "teatree")
+        wt = Worktree.objects.get(ticket=ticket, repo_path="teatree")
+        assert (wt.extra or {}).get("worktree_path") == captured["dest"]
+        assert (wt.extra or {}).get("clone_path") == str(namespaced)
+
+    def test_warns_when_multiple_clones_match_basename(self) -> None:
+        first = self.workspace / "alpha" / "teatree"
+        second = self.workspace / "zeta" / "teatree"
+        for clone in (first, second):
+            clone.mkdir(parents=True)
+            (clone / ".git").mkdir()
+        ticket = self._scoped_ticket(repos=["teatree"], branch="ac-teatree-491-multi")
+
+        captured: dict[str, str] = {}
+
+        def fake_worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = True) -> bool:
+            del branch, create_branch
+            captured["source"] = repo
+            Path(path).mkdir(parents=True, exist_ok=True)
+            return True
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+            patch("teatree.core.runners.provision.git.worktree_add", side_effect=fake_worktree_add),
+            patch("teatree.core.runners.provision.git.pull_ff_only", return_value=True),
+            self.assertLogs("teatree.core.clone_paths", level="WARNING") as cm,
+        ):
+            result = WorktreeProvisioner(ticket).run()
+
+        assert result.ok is True
+        assert captured["source"] == str(first)
+        assert any("Multiple clones match" in msg for msg in cm.output)
 
     def test_returns_failure_when_branch_missing_from_extra(self) -> None:
         ticket = Ticket.objects.create(


### PR DESCRIPTION
## Summary

Closes #491. The provisioner used to silently skip a repo when the literal `<workspace>/<repo_name>/.git` lookup failed — the user got an empty ticket dir, a "Skipping..." INFO log, and a success exit. With clones under a namespace subdir (`~/workspace/souliane/teatree`) and `--repos teatree`, this hit every time.

The fix:

- **Namespace-aware lookup.** New `core/clone_paths.find_clone_path()` tries the literal path first, then scans `<workspace>/*/<basename>` one level deep. Warns when more than one match exists so basename collisions show up in the logs.
- **Persist the resolved clone.** `WorktreeProvisioner` writes the resolved path to `Worktree.extra["clone_path"]` so cleanup, `orphan_guard`, and `reconcile` (which all derived `<workspace>/<repo_path>` directly) keep working for namespaced rows. The new `resolve_clone_path()` helper reads the stored path with a fresh scan as fallback.
- **Fail loud, not silent.** A missing clone now returns `RunnerResult(ok=False)` and the CLI prints `"Provisioning failed"`. `_create()` no longer has the silent-skip return-empty-string path. The CLI still tolerates partial success (only deletes the ticket if zero worktrees materialised).

## Test plan

- [x] `uv run pytest --no-cov` — 2616 passed, 12 skipped
- [x] `uv run ruff check` — clean
- [x] New `test_finds_clone_under_namespaced_subdir` covers the #491 case
- [x] New `test_warns_when_multiple_clones_match_basename` covers the basename-collision warning
- [x] New `test_resolves_namespaced_clone_via_extra` (real-git integration) covers cleanup of a namespaced row
- [x] Existing skip tests rewritten to assert the new fail-loud semantics