### PR TITLE
relax(django_db): introduce DjangoDbImporter class to drop 50 T201 noqas

### DIFF
--- a/src/teatree/skill_schema.py
+++ b/src/teatree/skill_schema.py
@@ -154,7 +154,7 @@ def main() -> None:
     """CLI entry point for pre-commit and manual validation."""
     paths = [Path(p) for p in sys.argv[1:]]
     if not paths:
-        print("Usage: python -m teatree.skill_schema <SKILL.md ...>")  # noqa: T201
+        sys.stdout.write("Usage: python -m teatree.skill_schema <SKILL.md ...>\n")
         sys.exit(1)
 
     all_errors: list[str] = []
@@ -169,15 +169,15 @@ def main() -> None:
         all_warnings.extend(warns)
 
     for warning in all_warnings:
-        print(f"WARN: {warning}")  # noqa: T201
+        sys.stdout.write(f"WARN: {warning}\n")
     for error in all_errors:
-        print(f"ERROR: {error}")  # noqa: T201
+        sys.stdout.write(f"ERROR: {error}\n")
 
     if all_errors:
-        print(f"\nFAIL — {len(all_errors)} error(s)")  # noqa: T201
+        sys.stdout.write(f"\nFAIL — {len(all_errors)} error(s)\n")
         sys.exit(1)
     else:
-        print("PASS")  # noqa: T201
+        sys.stdout.write("PASS\n")
 
 
 if __name__ == "__main__":

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -5,6 +5,11 @@ fallback chain: DSLR snapshot → local dump → remote dump → CI dump.
 
 Overlays configure the engine via ``DjangoDbImportConfig``; the engine
 does the rest.  No Django imports — shells out to ``manage.py``.
+
+User-facing CLI output flows through ``self.stdout`` / ``self.stderr``
+on ``DjangoDbImporter`` (Django ``BaseCommand`` pattern), which keeps
+the source free of bare ``print`` calls and lets tests capture output
+by passing an ``io.StringIO``.
 """
 
 import enum
@@ -16,6 +21,7 @@ import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TextIO
 
 from teatree.utils import bad_artifacts
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
@@ -39,18 +45,8 @@ class DjangoDbImportConfig:
     dump_path: str = ""  # Force a specific .pgsql dump file (skip DSLR and dump discovery)
 
 
-@dataclass(frozen=True)
-class _RestoreContext:
-    cfg: DjangoDbImportConfig
-    dslr_cmd: list[str]
-    dslr_env: dict[str, str]
-    pg_host: str
-    pg_user: str
-    pg_env: dict[str, str]
-
-
 # ---------------------------------------------------------------------------
-# Low-level Postgres helpers
+# Stateless helpers (no I/O on stdout, no global state)
 # ---------------------------------------------------------------------------
 
 
@@ -99,37 +95,6 @@ def _terminate_connections(db_name: str, pg_host: str, pg_user: str, pg_env: dic
         env=pg_env,
         expected_codes=None,
     )
-
-
-def _copy_ref_to_ticket(ctx: _RestoreContext) -> bool:
-    cfg = ctx.cfg
-    # `dropdb --force` (PG 13+) terminates active connections atomically before
-    # dropping — otherwise reconnecting services (backend containers attached
-    # to the ticket DB) race with pg_terminate_backend and the DB stays up,
-    # causing the subsequent createdb to fail with "database already exists".
-    drop_result = run_allowed_to_fail(
-        ["dropdb", "-h", ctx.pg_host, "-U", ctx.pg_user, "--if-exists", "--force", cfg.ticket_db_name],
-        env=ctx.pg_env,
-        expected_codes=None,
-    )
-    if drop_result.returncode != 0:
-        print(f"  WARNING: dropdb failed: {drop_result.stderr.strip()}", file=sys.stderr)  # noqa: T201
-        return False
-    _terminate_connections(cfg.ref_db_name, ctx.pg_host, ctx.pg_user, ctx.pg_env)
-    result = run_allowed_to_fail(
-        ["createdb", "-h", ctx.pg_host, "-U", ctx.pg_user, cfg.ticket_db_name, "-T", cfg.ref_db_name],
-        env=ctx.pg_env,
-        expected_codes=None,
-    )
-    if result.returncode != 0:
-        print(f"  WARNING: Template copy failed: {result.stderr.strip()}", file=sys.stderr)  # noqa: T201
-        return False
-    return True
-
-
-# ---------------------------------------------------------------------------
-# DSLR helpers
-# ---------------------------------------------------------------------------
 
 
 def _find_dslr_cmd(tool_name: str, _main_repo_path: str = "") -> list[str]:
@@ -203,316 +168,9 @@ def _restore_ref_from_dslr(dslr_cmd: list[str], env: dict[str, str], snap_name: 
     return False, _is_env_error(result.stderr), result.stderr.strip()
 
 
-def _take_dslr_snapshot(dslr_cmd: list[str], env: dict[str, str], ref_db: str) -> None:
-    snap_name = _dslr_snap_name(ref_db)
-    print(f"  Taking DSLR snapshot: {snap_name}")  # noqa: T201
-    run_allowed_to_fail([*dslr_cmd, "snapshot", "-y", snap_name], env=env, expected_codes=None)
-
-
-# ---------------------------------------------------------------------------
-# Dump validation
-# ---------------------------------------------------------------------------
-
-
-def validate_dump(dump_path: Path) -> bool:
-    if dump_path.stat().st_size == 0:
-        return False
-    result = run_allowed_to_fail(["pg_restore", "-l", str(dump_path)], expected_codes=None)
-    if "could not read" in (result.stderr or ""):
-        print(f"  WARNING: Dump appears truncated: {dump_path.name} (delete and re-fetch)")  # noqa: T201
-        return False
-    return True
-
-
-# ---------------------------------------------------------------------------
-# Migration with selective faking
-# ---------------------------------------------------------------------------
-
-_MAX_MIGRATE_RETRIES = 20
-
-
-class _MigrateResult(enum.Enum):
-    APPLIED = "applied"
-    ALREADY_MIGRATED = "already_migrated"
-    FAILED = "failed"
-
-
 def _extract_failing_migration(stdout: str) -> str | None:
     match = re.search(r"Applying (\w+\.\w+)\.\.\.", stdout)
     return match.group(1) if match else None
-
-
-def _migrate_reference_db(main_repo: str, ref_db: str, extra_env: dict[str, str]) -> _MigrateResult:
-    """Migrate the reference database.
-
-    Returns APPLIED when migrations ran, ALREADY_MIGRATED when the DB was
-    already up to date (callers skip the post-migrate DSLR snapshot), or
-    FAILED when migration cannot proceed.
-    """
-    manage_py = Path(main_repo) / "manage.py"
-    if not manage_py.is_file():
-        print(f"  Skipping reference DB migration (no manage.py in {main_repo})")  # noqa: T201
-        return _MigrateResult.ALREADY_MIGRATED
-
-    ref_db_url = _local_db_url(ref_db)
-    run_env = {**os.environ, "DATABASE_URL": ref_db_url, "DISABLE_DATABASE_SSL": "True", **extra_env}
-
-    print(f"  Migrating reference DB ({ref_db}) using main repo...")  # noqa: T201
-    migrate_cmd = ["uv", "--directory", main_repo, "run", "python", "manage.py", "migrate", "--no-input"]
-    for _attempt in range(_MAX_MIGRATE_RETRIES):
-        result = run_allowed_to_fail(migrate_cmd, cwd=main_repo, env=run_env, expected_codes=None)
-        if result.returncode == 0:
-            if "No migrations to apply" in result.stdout:
-                print("  Reference DB already up to date (no migrations applied).")  # noqa: T201
-                return _MigrateResult.ALREADY_MIGRATED
-            print("  Reference DB migrated.")  # noqa: T201
-            return _MigrateResult.APPLIED
-
-        combined = f"{result.stdout}\n{result.stderr}"
-        failure_reason = _try_fake_failing_migration(combined, result.stdout, main_repo, run_env)
-        if failure_reason:
-            print(f"  WARNING: {failure_reason}")  # noqa: T201
-            return _MigrateResult.FAILED
-
-    print("  WARNING: Reference DB migration exhausted retries, skipping.")  # noqa: T201
-    return _MigrateResult.FAILED
-
-
-def _try_fake_failing_migration(combined: str, stdout: str, main_repo: str, run_env: dict[str, str]) -> str:
-    """Try to fake a failing migration. Returns empty string on success, error message on failure."""
-    config_markers = ("ModuleNotFoundError", "ImproperlyConfigured", "DJANGO_SETTINGS_MODULE", "No module named")
-    if any(m in combined for m in config_markers):
-        return "Cannot migrate reference DB (config error), skipping."
-
-    if "already exists" not in combined and "does not exist" not in combined:
-        return "Cannot migrate reference DB (non-fakeable error), skipping."
-
-    failing = _extract_failing_migration(stdout)
-    if not failing:
-        return "Cannot identify failing migration, skipping reference migration."
-
-    app_label, migration_name = failing.split(".", 1)
-    reason = "schema already exists" if "already exists" in combined else "table absent from dump"
-    print(f"  Faking {failing} on reference DB ({reason})...")  # noqa: T201
-    run_allowed_to_fail(
-        ["uv", "--directory", main_repo, "run", "python", "manage.py", "migrate", app_label, migration_name, "--fake"],
-        cwd=main_repo,
-        env=run_env,
-        expected_codes=None,
-    )
-    return ""
-
-
-# ---------------------------------------------------------------------------
-# Restore-and-copy pipeline
-# ---------------------------------------------------------------------------
-
-
-def _restore_ref_and_copy(ctx: _RestoreContext, dump_path: str, label: str) -> bool:
-    from teatree.utils.db import db_restore  # noqa: PLC0415
-
-    cfg = ctx.cfg
-    try:
-        db_restore(cfg.ref_db_name, dump_path)
-    except (RuntimeError, CommandFailedError) as exc:
-        bad_artifacts.mark_bad(dump_path)
-        print(f"  BAD ARTIFACT: {label} marked bad (delete: rm {dump_path})")  # noqa: T201
-        print(f"    Restore error: {exc}", file=sys.stderr)  # noqa: T201
-        return False
-    migrate_result = _migrate_reference_db(cfg.main_repo_path, cfg.ref_db_name, cfg.migrate_env_extra)
-    if migrate_result is _MigrateResult.FAILED:
-        bad_artifacts.mark_bad(dump_path)
-        print(f"  BAD ARTIFACT: {label} marked bad (delete: rm {dump_path})")  # noqa: T201
-        return False
-    if ctx.dslr_cmd and migrate_result is _MigrateResult.APPLIED:
-        _take_dslr_snapshot(ctx.dslr_cmd, ctx.dslr_env, cfg.ref_db_name)
-    if _copy_ref_to_ticket(ctx):
-        print(f"  Created {cfg.ticket_db_name} from {label}.")  # noqa: T201
-        return True
-    return False
-
-
-# ---------------------------------------------------------------------------
-# Strategy implementations
-# ---------------------------------------------------------------------------
-
-# Prevent retrying remote dump in the same process after a failure.
-_remote_dump_failed: bool = False
-
-
-def _try_restore_from_dump_path(ctx: _RestoreContext) -> bool:
-    """Restore from an explicit dump file path (skip all auto-discovery)."""
-    from teatree.utils.db import db_restore  # noqa: PLC0415
-
-    dump = Path(ctx.cfg.dump_path)
-    if not dump.is_file():
-        print(f"  ERROR: Dump file not found: {dump}")  # noqa: T201
-        return False
-    print(f"  Restoring from explicit dump: {dump}")  # noqa: T201
-    _ensure_ref_db(ctx.cfg.ref_db_name, ctx.pg_host, ctx.pg_user, ctx.pg_env)
-    try:
-        db_restore(ctx.cfg.ref_db_name, str(dump))
-    except (RuntimeError, CommandFailedError):
-        logger.exception("Restore failed for dump %s", dump)
-        return False
-    migrate_result = _migrate_reference_db(ctx.cfg.main_repo_path, ctx.cfg.ref_db_name, ctx.cfg.migrate_env_extra)
-    if migrate_result is _MigrateResult.FAILED:
-        return False
-    if ctx.dslr_cmd and migrate_result is _MigrateResult.APPLIED:
-        _take_dslr_snapshot(ctx.dslr_cmd, ctx.dslr_env, ctx.cfg.ref_db_name)
-    return _copy_ref_to_ticket(ctx)
-
-
-def _resolve_dslr_snapshots(ctx: _RestoreContext) -> list[str]:
-    if ctx.cfg.dslr_snapshot:
-        return [ctx.cfg.dslr_snapshot]
-    return _find_dslr_snapshots(ctx.dslr_cmd, ctx.dslr_env, ctx.cfg.ref_db_name)
-
-
-def _log_dslr_restore_failure(snap_name: str, *, is_env: bool, stderr: str) -> None:
-    if is_env:
-        print(f"  WARNING: DSLR restore failed (environment error, not marking bad): {snap_name}")  # noqa: T201
-    else:
-        bad_artifacts.mark_bad(_dslr_artifact_key(snap_name))
-        print(f"  BAD ARTIFACT: DSLR snapshot '{snap_name}' marked bad (delete: dslr delete {snap_name})")  # noqa: T201
-    if stderr:
-        logger.warning("DSLR restore stderr for %s: %s", snap_name, stderr)
-        print(f"    Restore error: {stderr[:200]}")  # noqa: T201
-
-
-def _try_restore_from_dslr(ctx: _RestoreContext, *, skip_dslr: bool) -> bool:
-    if skip_dslr:
-        logger.info("DSLR restore skipped (skip_dslr=True)")
-        return False
-    if not ctx.dslr_cmd:
-        logger.info("DSLR restore skipped (no snapshot tool configured)")
-        return False
-    _ensure_ref_db(ctx.cfg.ref_db_name, ctx.pg_host, ctx.pg_user, ctx.pg_env)
-    snapshots = _resolve_dslr_snapshots(ctx)
-    if not snapshots:
-        return False
-    for snap_name in snapshots:
-        print(f"  Restoring {ctx.cfg.ref_db_name} from DSLR snapshot: {snap_name}")  # noqa: T201
-        ok, is_env, stderr = _restore_ref_from_dslr(ctx.dslr_cmd, ctx.dslr_env, snap_name)
-        if not ok:
-            _log_dslr_restore_failure(snap_name, is_env=is_env, stderr=stderr)
-            continue
-        migrate_result = _migrate_reference_db(ctx.cfg.main_repo_path, ctx.cfg.ref_db_name, ctx.cfg.migrate_env_extra)
-        if migrate_result is _MigrateResult.FAILED:
-            print(f"  WARNING: Migration failed after DSLR restore of {snap_name} (not marking snapshot bad)")  # noqa: T201
-            continue
-        if migrate_result is _MigrateResult.APPLIED:
-            _take_dslr_snapshot(ctx.dslr_cmd, ctx.dslr_env, ctx.cfg.ref_db_name)
-        else:
-            print("  Skipping DSLR snapshot (DB already migrated, snapshot is up to date).")  # noqa: T201
-        if _copy_ref_to_ticket(ctx):
-            print(f"  Created {ctx.cfg.ticket_db_name} from DSLR snapshot.")  # noqa: T201
-            return True
-        print(f"  WARNING: Template copy after DSLR {snap_name} failed, trying older...")  # noqa: T201
-    logger.warning("All DSLR snapshots failed for %s", ctx.cfg.ref_db_name)
-    print("  WARNING: All DSLR snapshots failed. Trying local dump fallback...")  # noqa: T201
-    return False
-
-
-def _try_restore_from_local_dump(ctx: _RestoreContext) -> bool:
-    dump_dir = Path(ctx.cfg.dump_dir)
-    if not dump_dir.is_dir():
-        logger.info("Local dump dir %s does not exist", dump_dir)
-        return False
-    dumps = sorted(
-        (p for p in dump_dir.glob(ctx.cfg.dump_glob) if validate_dump(p) and not bad_artifacts.is_bad(str(p))),
-        key=lambda p: p.name,
-        reverse=True,
-    )
-    if not dumps:
-        for zd in dump_dir.glob(ctx.cfg.dump_glob):
-            if zd.stat().st_size == 0:
-                print(f"  WARNING: Skipping 0-byte dump: {zd.name} (delete it)")  # noqa: T201
-        return False
-    for dump in dumps:
-        print(f"  Restoring from local dump: {dump.name}")  # noqa: T201
-        if _restore_ref_and_copy(ctx, str(dump), f"local dump ({dump.name})"):
-            return True
-        print(f"  WARNING: Local dump {dump.name} failed, trying older...")  # noqa: T201
-    logger.warning("All local dumps failed for %s", ctx.cfg.ref_db_name)
-    print("  WARNING: All local dumps failed. Trying remote dump...")  # noqa: T201
-    return False
-
-
-def _try_fetch_remote_dump(ctx: _RestoreContext) -> bool:
-    """Fetch a fresh dump from the remote DB into dump_dir.
-
-    Final safety gate: even when the caller passes ``allow_remote_dump=True``,
-    the environment variable ``T3_ALLOW_REMOTE_DUMP=1`` must also be set.
-    Prevents agent-triggered paths from auto-downloading gigabytes over VPN.
-    """
-    global _remote_dump_failed  # noqa: PLW0603
-    cfg = ctx.cfg
-    if os.environ.get("T3_ALLOW_REMOTE_DUMP") != "1":
-        logger.warning(
-            "Remote pg_dump blocked for %s: set T3_ALLOW_REMOTE_DUMP=1 to allow "
-            "remote dump fallback. Agents must never set this env var.",
-            cfg.ref_db_name,
-        )
-        return False
-    if not cfg.remote_db_url:
-        logger.info("Remote dump skipped (no remote_db_url configured)")
-        return False
-    if _remote_dump_failed:
-        print("  Skipping remote dump (already failed in this run).")  # noqa: T201
-        return False
-    dump_dir = Path(cfg.dump_dir)
-    try:
-        today = datetime.now(tz=UTC).strftime("%Y%m%d")
-        dump_path = dump_dir / f"{today}_{cfg.ref_db_name}.pgsql"
-        print(f"  Dumping from remote DB ({cfg.ref_db_name})...")  # noqa: T201
-        dump_dir.mkdir(parents=True, exist_ok=True)
-        result = run_allowed_to_fail(
-            ["pg_dump", "-Fc", "-f", str(dump_path), cfg.remote_db_url],
-            timeout=cfg.dump_timeout,
-            expected_codes=None,
-        )
-    except TimeoutExpired:
-        _remote_dump_failed = True
-        print(f"  WARNING: pg_dump timed out after {cfg.dump_timeout}s.")  # noqa: T201
-        return False
-    if result.returncode == 0:
-        size_mb = dump_path.stat().st_size / 1_000_000 if dump_path.exists() else 0
-        print(f"  Saved {dump_path.name} ({size_mb:.0f}MB)")  # noqa: T201
-        return True
-    _remote_dump_failed = True
-    stderr_text = (result.stderr or "").strip()
-    logger.warning("pg_dump failed (rc=%d) for %s: %s", result.returncode, cfg.ref_db_name, stderr_text)
-    print(f"  WARNING: pg_dump failed: {stderr_text}")  # noqa: T201
-    return False
-
-
-def _try_restore_from_ci_dump(ctx: _RestoreContext) -> bool:
-    ci_dumps = sorted(
-        Path(ctx.cfg.main_repo_path).glob(ctx.cfg.ci_dump_glob),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
-    if not ci_dumps:
-        return False
-    ci_dump = ci_dumps[0]
-    print(f"  Restoring from CI dump (last resort): {ci_dump.name}")  # noqa: T201
-    if _restore_ref_and_copy(ctx, str(ci_dump), f"CI dump ({ci_dump.name})"):
-        return True
-    logger.warning("CI dump restore failed for %s", ctx.cfg.ref_db_name)
-    print("  WARNING: CI dump restore failed.")  # noqa: T201
-    return False
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
-
-def reset_remote_dump_state() -> None:
-    """Reset the remote dump failure flag (for testing)."""
-    global _remote_dump_failed  # noqa: PLW0603
-    _remote_dump_failed = False
 
 
 def _parse_dslr_snapshots(stdout: str) -> dict[str, list[str]]:
@@ -531,31 +189,419 @@ def _parse_dslr_snapshots(stdout: str) -> dict[str, list[str]]:
     return by_tenant
 
 
-def prune_dslr_snapshots(*, keep: int = 1, snapshot_tool: str = "dslr", main_repo_path: str = "") -> list[str]:
-    """Delete old DSLR snapshots, keeping the *keep* newest per tenant.
+def validate_dump(dump_path: Path) -> bool:
+    if dump_path.stat().st_size == 0:
+        return False
+    result = run_allowed_to_fail(["pg_restore", "-l", str(dump_path)], expected_codes=None)
+    if "could not read" in (result.stderr or ""):
+        sys.stdout.write(f"  WARNING: Dump appears truncated: {dump_path.name} (delete and re-fetch)\n")
+        return False
+    return True
 
-    Returns a list of deleted snapshot names.
+
+_MAX_MIGRATE_RETRIES = 20
+
+
+class _MigrateResult(enum.Enum):
+    APPLIED = "applied"
+    ALREADY_MIGRATED = "already_migrated"
+    FAILED = "failed"
+
+
+# ---------------------------------------------------------------------------
+# Importer — owns per-run state and all CLI output streams.
+# ---------------------------------------------------------------------------
+
+
+class DjangoDbImporter:
+    """Provision a Django DB by building a ref DB then template-copying it.
+
+    Mirrors Django's ``BaseCommand`` pattern: instances own ``stdout`` and
+    ``stderr`` streams, so all user-facing progress flows through
+    ``self.stdout.write(...)`` / ``self.stderr.write(...)`` instead of
+    bare ``print()``.  Tests pass ``io.StringIO`` to capture output.
+
+    Strategy chain (newest first): DSLR snapshot → local dump → remote
+    dump → CI dump.  Non-DSLR fallbacks are gated behind ``slow_import``
+    because each takes minutes instead of seconds.
     """
-    dslr_cmd = _find_dslr_cmd(snapshot_tool, main_repo_path)
-    if not dslr_cmd:
-        return []
-    result = run_allowed_to_fail([*dslr_cmd, "list"], expected_codes=None)
-    if result.returncode != 0:
-        return []
-    by_tenant = _parse_dslr_snapshots(result.stdout)
-    deleted: list[str] = []
-    for tenant, names in by_tenant.items():
-        for old in names[keep:]:
-            print(f"  Pruning DSLR snapshot: {old} (tenant={tenant})")  # noqa: T201
-            run_allowed_to_fail([*dslr_cmd, "delete", "-y", old], expected_codes=None)
-            deleted.append(old)
-    return deleted
+
+    def __init__(
+        self,
+        cfg: DjangoDbImportConfig,
+        *,
+        stdout: TextIO | None = None,
+        stderr: TextIO | None = None,
+    ) -> None:
+        self.cfg = cfg
+        self.stdout: TextIO = stdout if stdout is not None else sys.stdout
+        self.stderr: TextIO = stderr if stderr is not None else sys.stderr
+        self.dslr_cmd: list[str] = _find_dslr_cmd(cfg.snapshot_tool, cfg.main_repo_path) if cfg.snapshot_tool else []
+        self.dslr_env: dict[str, str] = _dslr_env(cfg.ref_db_name) if self.dslr_cmd else {}
+        pg_host, pg_user, pg_env = _pg_args()
+        self.pg_host = pg_host
+        self.pg_user = pg_user
+        self.pg_env = pg_env
+        self._remote_dump_failed = False
+
+    # ------- low-level template copy / migration --------------------------
+
+    def _copy_ref_to_ticket(self) -> bool:
+        cfg = self.cfg
+        # `dropdb --force` (PG 13+) terminates active connections atomically before
+        # dropping — otherwise reconnecting services (backend containers attached
+        # to the ticket DB) race with pg_terminate_backend and the DB stays up,
+        # causing the subsequent createdb to fail with "database already exists".
+        drop_result = run_allowed_to_fail(
+            ["dropdb", "-h", self.pg_host, "-U", self.pg_user, "--if-exists", "--force", cfg.ticket_db_name],
+            env=self.pg_env,
+            expected_codes=None,
+        )
+        if drop_result.returncode != 0:
+            self.stderr.write(f"  WARNING: dropdb failed: {drop_result.stderr.strip()}\n")
+            return False
+        _terminate_connections(cfg.ref_db_name, self.pg_host, self.pg_user, self.pg_env)
+        result = run_allowed_to_fail(
+            ["createdb", "-h", self.pg_host, "-U", self.pg_user, cfg.ticket_db_name, "-T", cfg.ref_db_name],
+            env=self.pg_env,
+            expected_codes=None,
+        )
+        if result.returncode != 0:
+            self.stderr.write(f"  WARNING: Template copy failed: {result.stderr.strip()}\n")
+            return False
+        return True
+
+    def _take_dslr_snapshot(self) -> None:
+        snap_name = _dslr_snap_name(self.cfg.ref_db_name)
+        self.stdout.write(f"  Taking DSLR snapshot: {snap_name}\n")
+        run_allowed_to_fail([*self.dslr_cmd, "snapshot", "-y", snap_name], env=self.dslr_env, expected_codes=None)
+
+    def _migrate_reference_db(self) -> _MigrateResult:
+        """Migrate the reference database.
+
+        Returns APPLIED when migrations ran, ALREADY_MIGRATED when the DB was
+        already up to date (callers skip the post-migrate DSLR snapshot), or
+        FAILED when migration cannot proceed.
+        """
+        cfg = self.cfg
+        manage_py = Path(cfg.main_repo_path) / "manage.py"
+        if not manage_py.is_file():
+            self.stdout.write(f"  Skipping reference DB migration (no manage.py in {cfg.main_repo_path})\n")
+            return _MigrateResult.ALREADY_MIGRATED
+
+        ref_db_url = _local_db_url(cfg.ref_db_name)
+        run_env = {**os.environ, "DATABASE_URL": ref_db_url, "DISABLE_DATABASE_SSL": "True", **cfg.migrate_env_extra}
+
+        self.stdout.write(f"  Migrating reference DB ({cfg.ref_db_name}) using main repo...\n")
+        migrate_cmd = ["uv", "--directory", cfg.main_repo_path, "run", "python", "manage.py", "migrate", "--no-input"]
+        for _attempt in range(_MAX_MIGRATE_RETRIES):
+            result = run_allowed_to_fail(migrate_cmd, cwd=cfg.main_repo_path, env=run_env, expected_codes=None)
+            if result.returncode == 0:
+                if "No migrations to apply" in result.stdout:
+                    self.stdout.write("  Reference DB already up to date (no migrations applied).\n")
+                    return _MigrateResult.ALREADY_MIGRATED
+                self.stdout.write("  Reference DB migrated.\n")
+                return _MigrateResult.APPLIED
+
+            combined = f"{result.stdout}\n{result.stderr}"
+            failure_reason = self._try_fake_failing_migration(combined, result.stdout, run_env)
+            if failure_reason:
+                self.stdout.write(f"  WARNING: {failure_reason}\n")
+                return _MigrateResult.FAILED
+
+        self.stdout.write("  WARNING: Reference DB migration exhausted retries, skipping.\n")
+        return _MigrateResult.FAILED
+
+    def _try_fake_failing_migration(self, combined: str, stdout: str, run_env: dict[str, str]) -> str:
+        """Try to fake a failing migration. Returns empty string on success, error message on failure."""
+        config_markers = ("ModuleNotFoundError", "ImproperlyConfigured", "DJANGO_SETTINGS_MODULE", "No module named")
+        if any(m in combined for m in config_markers):
+            return "Cannot migrate reference DB (config error), skipping."
+
+        if "already exists" not in combined and "does not exist" not in combined:
+            return "Cannot migrate reference DB (non-fakeable error), skipping."
+
+        failing = _extract_failing_migration(stdout)
+        if not failing:
+            return "Cannot identify failing migration, skipping reference migration."
+
+        app_label, migration_name = failing.split(".", 1)
+        reason = "schema already exists" if "already exists" in combined else "table absent from dump"
+        self.stdout.write(f"  Faking {failing} on reference DB ({reason})...\n")
+        run_allowed_to_fail(
+            [
+                "uv",
+                "--directory",
+                self.cfg.main_repo_path,
+                "run",
+                "python",
+                "manage.py",
+                "migrate",
+                app_label,
+                migration_name,
+                "--fake",
+            ],
+            cwd=self.cfg.main_repo_path,
+            env=run_env,
+            expected_codes=None,
+        )
+        return ""
+
+    # ------- restore + clone pipeline -------------------------------------
+
+    def _restore_ref_and_copy(self, dump_path: str, label: str) -> bool:
+        from teatree.utils.db import db_restore  # noqa: PLC0415
+
+        cfg = self.cfg
+        try:
+            db_restore(cfg.ref_db_name, dump_path)
+        except (RuntimeError, CommandFailedError) as exc:
+            bad_artifacts.mark_bad(dump_path)
+            self.stdout.write(f"  BAD ARTIFACT: {label} marked bad (delete: rm {dump_path})\n")
+            self.stderr.write(f"    Restore error: {exc}\n")
+            return False
+        migrate_result = self._migrate_reference_db()
+        if migrate_result is _MigrateResult.FAILED:
+            bad_artifacts.mark_bad(dump_path)
+            self.stdout.write(f"  BAD ARTIFACT: {label} marked bad (delete: rm {dump_path})\n")
+            return False
+        if self.dslr_cmd and migrate_result is _MigrateResult.APPLIED:
+            self._take_dslr_snapshot()
+        if self._copy_ref_to_ticket():
+            self.stdout.write(f"  Created {cfg.ticket_db_name} from {label}.\n")
+            return True
+        return False
+
+    # ------- strategy 1: explicit dump path -------------------------------
+
+    def _try_restore_from_dump_path(self) -> bool:
+        """Restore from an explicit dump file path (skip all auto-discovery)."""
+        from teatree.utils.db import db_restore  # noqa: PLC0415
+
+        dump = Path(self.cfg.dump_path)
+        if not dump.is_file():
+            self.stdout.write(f"  ERROR: Dump file not found: {dump}\n")
+            return False
+        self.stdout.write(f"  Restoring from explicit dump: {dump}\n")
+        _ensure_ref_db(self.cfg.ref_db_name, self.pg_host, self.pg_user, self.pg_env)
+        try:
+            db_restore(self.cfg.ref_db_name, str(dump))
+        except (RuntimeError, CommandFailedError):
+            logger.exception("Restore failed for dump %s", dump)
+            return False
+        migrate_result = self._migrate_reference_db()
+        if migrate_result is _MigrateResult.FAILED:
+            return False
+        if self.dslr_cmd and migrate_result is _MigrateResult.APPLIED:
+            self._take_dslr_snapshot()
+        return self._copy_ref_to_ticket()
+
+    # ------- strategy 2: DSLR snapshot ------------------------------------
+
+    def _resolve_dslr_snapshots(self) -> list[str]:
+        if self.cfg.dslr_snapshot:
+            return [self.cfg.dslr_snapshot]
+        return _find_dslr_snapshots(self.dslr_cmd, self.dslr_env, self.cfg.ref_db_name)
+
+    def _log_dslr_restore_failure(self, snap_name: str, *, is_env: bool, stderr: str) -> None:
+        if is_env:
+            self.stdout.write(f"  WARNING: DSLR restore failed (environment error, not marking bad): {snap_name}\n")
+        else:
+            bad_artifacts.mark_bad(_dslr_artifact_key(snap_name))
+            self.stdout.write(
+                f"  BAD ARTIFACT: DSLR snapshot '{snap_name}' marked bad (delete: dslr delete {snap_name})\n",
+            )
+        if stderr:
+            logger.warning("DSLR restore stderr for %s: %s", snap_name, stderr)
+            self.stdout.write(f"    Restore error: {stderr[:200]}\n")
+
+    def _try_restore_from_dslr(self, *, skip_dslr: bool) -> bool:
+        if skip_dslr:
+            logger.info("DSLR restore skipped (skip_dslr=True)")
+            return False
+        if not self.dslr_cmd:
+            logger.info("DSLR restore skipped (no snapshot tool configured)")
+            return False
+        _ensure_ref_db(self.cfg.ref_db_name, self.pg_host, self.pg_user, self.pg_env)
+        snapshots = self._resolve_dslr_snapshots()
+        if not snapshots:
+            return False
+        for snap_name in snapshots:
+            self.stdout.write(f"  Restoring {self.cfg.ref_db_name} from DSLR snapshot: {snap_name}\n")
+            ok, is_env, stderr = _restore_ref_from_dslr(self.dslr_cmd, self.dslr_env, snap_name)
+            if not ok:
+                self._log_dslr_restore_failure(snap_name, is_env=is_env, stderr=stderr)
+                continue
+            migrate_result = self._migrate_reference_db()
+            if migrate_result is _MigrateResult.FAILED:
+                self.stdout.write(
+                    f"  WARNING: Migration failed after DSLR restore of {snap_name} (not marking snapshot bad)\n",
+                )
+                continue
+            if migrate_result is _MigrateResult.APPLIED:
+                self._take_dslr_snapshot()
+            else:
+                self.stdout.write("  Skipping DSLR snapshot (DB already migrated, snapshot is up to date).\n")
+            if self._copy_ref_to_ticket():
+                self.stdout.write(f"  Created {self.cfg.ticket_db_name} from DSLR snapshot.\n")
+                return True
+            self.stdout.write(f"  WARNING: Template copy after DSLR {snap_name} failed, trying older...\n")
+        logger.warning("All DSLR snapshots failed for %s", self.cfg.ref_db_name)
+        self.stdout.write("  WARNING: All DSLR snapshots failed. Trying local dump fallback...\n")
+        return False
+
+    # ------- strategy 3: local dump file ----------------------------------
+
+    def _try_restore_from_local_dump(self) -> bool:
+        cfg = self.cfg
+        dump_dir = Path(cfg.dump_dir)
+        if not dump_dir.is_dir():
+            logger.info("Local dump dir %s does not exist", dump_dir)
+            return False
+        dumps = sorted(
+            (p for p in dump_dir.glob(cfg.dump_glob) if validate_dump(p) and not bad_artifacts.is_bad(str(p))),
+            key=lambda p: p.name,
+            reverse=True,
+        )
+        if not dumps:
+            for zd in dump_dir.glob(cfg.dump_glob):
+                if zd.stat().st_size == 0:
+                    self.stdout.write(f"  WARNING: Skipping 0-byte dump: {zd.name} (delete it)\n")
+            return False
+        for dump in dumps:
+            self.stdout.write(f"  Restoring from local dump: {dump.name}\n")
+            if self._restore_ref_and_copy(str(dump), f"local dump ({dump.name})"):
+                return True
+            self.stdout.write(f"  WARNING: Local dump {dump.name} failed, trying older...\n")
+        logger.warning("All local dumps failed for %s", cfg.ref_db_name)
+        self.stdout.write("  WARNING: All local dumps failed. Trying remote dump...\n")
+        return False
+
+    # ------- strategy 4: remote pg_dump -----------------------------------
+
+    def _try_fetch_remote_dump(self) -> bool:
+        """Fetch a fresh dump from the remote DB into dump_dir.
+
+        Final safety gate: even when the caller passes ``allow_remote_dump=True``,
+        the environment variable ``T3_ALLOW_REMOTE_DUMP=1`` must also be set.
+        Prevents agent-triggered paths from auto-downloading gigabytes over VPN.
+        """
+        cfg = self.cfg
+        if os.environ.get("T3_ALLOW_REMOTE_DUMP") != "1":
+            logger.warning(
+                "Remote pg_dump blocked for %s: set T3_ALLOW_REMOTE_DUMP=1 to allow "
+                "remote dump fallback. Agents must never set this env var.",
+                cfg.ref_db_name,
+            )
+            return False
+        if not cfg.remote_db_url:
+            logger.info("Remote dump skipped (no remote_db_url configured)")
+            return False
+        if self._remote_dump_failed:
+            self.stdout.write("  Skipping remote dump (already failed in this run).\n")
+            return False
+        dump_dir = Path(cfg.dump_dir)
+        try:
+            today = datetime.now(tz=UTC).strftime("%Y%m%d")
+            dump_path = dump_dir / f"{today}_{cfg.ref_db_name}.pgsql"
+            self.stdout.write(f"  Dumping from remote DB ({cfg.ref_db_name})...\n")
+            dump_dir.mkdir(parents=True, exist_ok=True)
+            result = run_allowed_to_fail(
+                ["pg_dump", "-Fc", "-f", str(dump_path), cfg.remote_db_url],
+                timeout=cfg.dump_timeout,
+                expected_codes=None,
+            )
+        except TimeoutExpired:
+            self._remote_dump_failed = True
+            self.stdout.write(f"  WARNING: pg_dump timed out after {cfg.dump_timeout}s.\n")
+            return False
+        if result.returncode == 0:
+            size_mb = dump_path.stat().st_size / 1_000_000 if dump_path.exists() else 0
+            self.stdout.write(f"  Saved {dump_path.name} ({size_mb:.0f}MB)\n")
+            return True
+        self._remote_dump_failed = True
+        stderr_text = (result.stderr or "").strip()
+        logger.warning("pg_dump failed (rc=%d) for %s: %s", result.returncode, cfg.ref_db_name, stderr_text)
+        self.stdout.write(f"  WARNING: pg_dump failed: {stderr_text}\n")
+        return False
+
+    # ------- strategy 5: CI dump ------------------------------------------
+
+    def _try_restore_from_ci_dump(self) -> bool:
+        cfg = self.cfg
+        ci_dumps = sorted(
+            Path(cfg.main_repo_path).glob(cfg.ci_dump_glob),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if not ci_dumps:
+            return False
+        ci_dump = ci_dumps[0]
+        self.stdout.write(f"  Restoring from CI dump (last resort): {ci_dump.name}\n")
+        if self._restore_ref_and_copy(str(ci_dump), f"CI dump ({ci_dump.name})"):
+            return True
+        logger.warning("CI dump restore failed for %s", cfg.ref_db_name)
+        self.stdout.write("  WARNING: CI dump restore failed.\n")
+        return False
+
+    # ------- orchestration ------------------------------------------------
+
+    def _warn_slow_path(self, label: str) -> None:
+        """Warn prominently when a non-DSLR (slow) restore path executes."""
+        self.stderr.write(f"  WARNING [SLOW PATH]: {label}\n")
+        self.stderr.write("  DSLR snapshots are the expected fast path. This operation is significantly slower.\n")
+
+    def run(
+        self,
+        *,
+        skip_dslr: bool = False,
+        slow_import: bool = False,
+        allow_remote_dump: bool = False,
+    ) -> bool:
+        """Execute the import.  Returns True on success, False if no source was available."""
+        cfg = self.cfg
+        if (cfg.dump_path and self._try_restore_from_dump_path()) or (
+            not cfg.dump_path and self._try_restore_from_dslr(skip_dslr=skip_dslr)
+        ):
+            return True
+
+        if not slow_import:
+            self.stderr.write(
+                "\n  DSLR restore failed or unavailable. Non-DSLR fallbacks are disabled by default.\n"
+                "  Non-DSLR paths (pg_restore, remote dump) take minutes instead of seconds.\n"
+                "  To allow slow fallback paths, re-run with: --slow-import\n",
+            )
+            return False
+
+        self._warn_slow_path("Falling back to pg_restore from local dump file.")
+        if self._try_restore_from_local_dump():
+            return True
+
+        if allow_remote_dump:
+            self._warn_slow_path("Downloading fresh dump from remote database (pg_dump over network).")
+            if self._try_fetch_remote_dump() and self._try_restore_from_local_dump():
+                return True
+
+        self._warn_slow_path("Trying CI dump as last resort (pg_restore).")
+        if self._try_restore_from_ci_dump():
+            return True
+
+        dump_dir = Path(cfg.dump_dir)
+        self.stdout.write(f"  ERROR: No database source available for '{cfg.ref_db_name}'.\n")
+        self.stdout.write(f"  - No local DSLR snapshot for {cfg.ref_db_name}\n")
+        self.stdout.write(f"  - No dump in {dump_dir}/\n")
+        self.stdout.write(f"  - No CI dump matching {cfg.ci_dump_glob} in {cfg.main_repo_path}\n")
+        self.stdout.write("\n")
+        if cfg.remote_db_url:
+            self.stdout.write("  To fetch a fresh dump from the remote DB, re-run with --slow-import.\n")
+        else:
+            self.stdout.write("  Configure remote_db_url in DjangoDbImportConfig to enable remote dump fetching.\n")
+        return False
 
 
-def _warn_slow_path(label: str) -> None:
-    """Print a prominent warning when a non-DSLR (slow) restore path executes."""
-    print(f"  WARNING [SLOW PATH]: {label}", file=sys.stderr)  # noqa: T201
-    print("  DSLR snapshots are the expected fast path. This operation is significantly slower.", file=sys.stderr)  # noqa: T201
+# ---------------------------------------------------------------------------
+# Public API — module-level functions delegating to DjangoDbImporter.
+# ---------------------------------------------------------------------------
 
 
 def django_db_import(
@@ -573,57 +619,30 @@ def django_db_import(
     multi-minute operations.  Pass ``--slow-import`` on the CLI to enable.
 
     Remote dumps additionally require *allow_remote_dump=True*.
-
-    Returns True on success, False if no source was available.
     """
-    dslr_cmd = _find_dslr_cmd(cfg.snapshot_tool, cfg.main_repo_path) if cfg.snapshot_tool else []
-    pg_host, pg_user, pg_env = _pg_args()
-    dslr_e = _dslr_env(cfg.ref_db_name) if dslr_cmd else {}
-    ctx = _RestoreContext(
-        cfg=cfg,
-        dslr_cmd=dslr_cmd,
-        dslr_env=dslr_e,
-        pg_host=pg_host,
-        pg_user=pg_user,
-        pg_env=pg_env,
+    return DjangoDbImporter(cfg).run(
+        skip_dslr=skip_dslr,
+        slow_import=slow_import,
+        allow_remote_dump=allow_remote_dump,
     )
 
-    if (cfg.dump_path and _try_restore_from_dump_path(ctx)) or (
-        not cfg.dump_path and _try_restore_from_dslr(ctx, skip_dslr=skip_dslr)
-    ):
-        return True
 
-    # --- Non-DSLR fallbacks (slow) — gated behind --slow-import --------
-    if not slow_import:
-        print(  # noqa: T201
-            "\n  DSLR restore failed or unavailable. Non-DSLR fallbacks are disabled by default.\n"
-            "  Non-DSLR paths (pg_restore, remote dump) take minutes instead of seconds.\n"
-            "  To allow slow fallback paths, re-run with: --slow-import\n",
-            file=sys.stderr,
-        )
-        return False
+def prune_dslr_snapshots(*, keep: int = 1, snapshot_tool: str = "dslr", main_repo_path: str = "") -> list[str]:
+    """Delete old DSLR snapshots, keeping the *keep* newest per tenant.
 
-    _warn_slow_path("Falling back to pg_restore from local dump file.")
-    if _try_restore_from_local_dump(ctx):
-        return True
-
-    if allow_remote_dump:
-        _warn_slow_path("Downloading fresh dump from remote database (pg_dump over network).")
-        if _try_fetch_remote_dump(ctx) and _try_restore_from_local_dump(ctx):
-            return True
-
-    _warn_slow_path("Trying CI dump as last resort (pg_restore).")
-    if _try_restore_from_ci_dump(ctx):
-        return True
-
-    dump_dir = Path(cfg.dump_dir)
-    print(f"  ERROR: No database source available for '{cfg.ref_db_name}'.")  # noqa: T201
-    print(f"  - No local DSLR snapshot for {cfg.ref_db_name}")  # noqa: T201
-    print(f"  - No dump in {dump_dir}/")  # noqa: T201
-    print(f"  - No CI dump matching {cfg.ci_dump_glob} in {cfg.main_repo_path}")  # noqa: T201
-    print()  # noqa: T201
-    if cfg.remote_db_url:
-        print("  To fetch a fresh dump from the remote DB, re-run with --slow-import.")  # noqa: T201
-    else:
-        print("  Configure remote_db_url in DjangoDbImportConfig to enable remote dump fetching.")  # noqa: T201
-    return False
+    Returns a list of deleted snapshot names.
+    """
+    dslr_cmd = _find_dslr_cmd(snapshot_tool, main_repo_path)
+    if not dslr_cmd:
+        return []
+    result = run_allowed_to_fail([*dslr_cmd, "list"], expected_codes=None)
+    if result.returncode != 0:
+        return []
+    by_tenant = _parse_dslr_snapshots(result.stdout)
+    deleted: list[str] = []
+    for tenant, names in by_tenant.items():
+        for old in names[keep:]:
+            sys.stdout.write(f"  Pruning DSLR snapshot: {old} (tenant={tenant})\n")
+            run_allowed_to_fail([*dslr_cmd, "delete", "-y", old], expected_codes=None)
+            deleted.append(old)
+    return deleted

--- a/tests/test_django_db.py
+++ b/tests/test_django_db.py
@@ -1,5 +1,6 @@
 """Tests for teatree.utils.django_db — generic Django DB import engine."""
 
+import io
 import subprocess
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -11,7 +12,7 @@ from teatree.utils import django_db as mod
 from teatree.utils import run as run_mod
 from teatree.utils.django_db import (
     DjangoDbImportConfig,
-    _copy_ref_to_ticket,
+    DjangoDbImporter,
     _dslr_env,
     _dslr_snap_name,
     _ensure_ref_db,
@@ -19,22 +20,13 @@ from teatree.utils.django_db import (
     _find_dslr_cmd,
     _find_dslr_snapshots,
     _local_db_url,
-    _migrate_reference_db,
     _MigrateResult,
     _parse_dslr_snapshots,
     _pg_args,
-    _restore_ref_and_copy,
     _restore_ref_from_dslr,
-    _RestoreContext,
-    _take_dslr_snapshot,
     _terminate_connections,
-    _try_fetch_remote_dump,
-    _try_restore_from_ci_dump,
-    _try_restore_from_dslr,
-    _try_restore_from_local_dump,
     django_db_import,
     prune_dslr_snapshots,
-    reset_remote_dump_state,
     validate_dump,
 )
 
@@ -57,22 +49,15 @@ def _make_cfg(tmp_path: Path, **overrides: str) -> DjangoDbImportConfig:
     return DjangoDbImportConfig(**defaults)
 
 
-def _stub_dslr_cmd(cmd: list[str] | None = None):
-    """Return a stub for ``_find_dslr_cmd`` that always returns *cmd*."""
-    result = cmd if cmd is not None else []
-    return lambda tool, main_repo="": result
-
-
-def _make_ctx(tmp_path: Path, *, dslr_cmd: str = "/usr/bin/dslr") -> _RestoreContext:
-    cfg = _make_cfg(tmp_path)
-    return _RestoreContext(
-        cfg=cfg,
-        dslr_cmd=dslr_cmd,
-        dslr_env={"DATABASE_URL": "postgres://u:p@localhost/dev"},
-        pg_host="localhost",
-        pg_user="local_superuser",
-        pg_env={"PGPASSWORD": "pw"},
-    )
+def _make_importer(tmp_path: Path, *, dslr_cmd: list[str] | None = None, **cfg_overrides: str) -> DjangoDbImporter:
+    """Build an importer with stubbed stdout/stderr and a controllable dslr command."""
+    importer = DjangoDbImporter(_make_cfg(tmp_path, **cfg_overrides), stdout=io.StringIO(), stderr=io.StringIO())
+    importer.dslr_cmd = dslr_cmd if dslr_cmd is not None else ["/usr/bin/dslr"]
+    importer.dslr_env = {"DATABASE_URL": "postgres://u:p@localhost/dev"} if importer.dslr_cmd else {}
+    importer.pg_host = "localhost"
+    importer.pg_user = "local_superuser"
+    importer.pg_env = {"PGPASSWORD": "pw"}
+    return importer
 
 
 def _ok_run(*_args, **_kwargs) -> CompletedProcess:
@@ -226,14 +211,15 @@ class TestRestoreRefFromDslr:
 
 
 class TestTakeDslrSnapshot:
-    def test_calls_dslr_snapshot(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_calls_dslr_snapshot(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         commands: list = []
         monkeypatch.setattr(
             run_mod.subprocess,
             "run",
             lambda args, **kw: commands.append(args) or _ok_run(),
         )
-        _take_dslr_snapshot(["/bin/dslr"], {}, "development-acme")
+        importer = _make_importer(tmp_path, dslr_cmd=["/bin/dslr"])
+        importer._take_dslr_snapshot()
         assert commands[0][0] == "/bin/dslr"
         assert commands[0][1] == "snapshot"
 
@@ -271,8 +257,8 @@ class TestTerminateConnections:
 class TestCopyRefToTicket:
     def test_success(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
-        ctx = _make_ctx(tmp_path)
-        assert _copy_ref_to_ticket(ctx) is True
+        importer = _make_importer(tmp_path)
+        assert importer._copy_ref_to_ticket() is True
 
     def test_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
@@ -280,8 +266,8 @@ class TestCopyRefToTicket:
             "run",
             lambda *a, **kw: CompletedProcess(a, 1, "", "template copy error"),
         )
-        ctx = _make_ctx(tmp_path)
-        assert _copy_ref_to_ticket(ctx) is False
+        importer = _make_importer(tmp_path)
+        assert importer._copy_ref_to_ticket() is False
 
 
 # ---------------------------------------------------------------------------
@@ -321,7 +307,7 @@ class TestMigrateReferenceDb:
     def test_succeeds_on_first_try(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         (tmp_path / "manage.py").write_text("", encoding="utf-8")
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
-        assert _migrate_reference_db(str(tmp_path), "development-acme", {}) is _MigrateResult.APPLIED
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.APPLIED
 
     def test_returns_already_migrated_when_no_migrations(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         (tmp_path / "manage.py").write_text("", encoding="utf-8")
@@ -330,7 +316,7 @@ class TestMigrateReferenceDb:
             "run",
             lambda *a, **kw: CompletedProcess(a, 0, "No migrations to apply.\n", ""),
         )
-        assert _migrate_reference_db(str(tmp_path), "development-acme", {}) is _MigrateResult.ALREADY_MIGRATED
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.ALREADY_MIGRATED
 
     def test_fakes_already_exists(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         (tmp_path / "manage.py").write_text("", encoding="utf-8")
@@ -346,7 +332,7 @@ class TestMigrateReferenceDb:
             return CompletedProcess(args, 0, "", "")
 
         monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
-        assert _migrate_reference_db(str(tmp_path), "development-acme", {}) is _MigrateResult.APPLIED
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.APPLIED
         assert "--fake" in calls[1]
 
     def test_skips_on_config_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -356,7 +342,7 @@ class TestMigrateReferenceDb:
             "run",
             lambda *a, **kw: CompletedProcess(a, 1, "", "ModuleNotFoundError: No module named 'foo'"),
         )
-        assert _migrate_reference_db(str(tmp_path), "development-acme", {}) is _MigrateResult.FAILED
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.FAILED
 
     def test_skips_on_non_fakeable_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         (tmp_path / "manage.py").write_text("", encoding="utf-8")
@@ -365,10 +351,10 @@ class TestMigrateReferenceDb:
             "run",
             lambda *a, **kw: CompletedProcess(a, 1, "", "unexpected error"),
         )
-        assert _migrate_reference_db(str(tmp_path), "development-acme", {}) is _MigrateResult.FAILED
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.FAILED
 
     def test_skips_when_no_manage_py(self, tmp_path: Path) -> None:
-        assert _migrate_reference_db(str(tmp_path), "development-acme", {}) is _MigrateResult.ALREADY_MIGRATED
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.ALREADY_MIGRATED
 
     def test_skips_when_failing_migration_not_parseable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         (tmp_path / "manage.py").write_text("", encoding="utf-8")
@@ -377,7 +363,7 @@ class TestMigrateReferenceDb:
             "run",
             lambda *a, **kw: CompletedProcess(a, 1, "Running migrate...\n", "already exists"),
         )
-        assert _migrate_reference_db(str(tmp_path), "development-acme", {}) is _MigrateResult.FAILED
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.FAILED
 
     def test_exhausts_retries(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         (tmp_path / "manage.py").write_text("", encoding="utf-8")
@@ -386,7 +372,7 @@ class TestMigrateReferenceDb:
             "run",
             lambda *a, **kw: CompletedProcess(a, 1, "Applying myapp.0001_init...\n", "already exists"),
         )
-        assert _migrate_reference_db(str(tmp_path), "development-acme", {}) is _MigrateResult.FAILED
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.FAILED
 
     def test_fakes_does_not_exist(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         (tmp_path / "manage.py").write_text("", encoding="utf-8")
@@ -402,7 +388,7 @@ class TestMigrateReferenceDb:
             return CompletedProcess(args, 0, "", "")
 
         monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
-        assert _migrate_reference_db(str(tmp_path), "development-acme", {}) is _MigrateResult.APPLIED
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.APPLIED
 
 
 # ---------------------------------------------------------------------------
@@ -415,72 +401,72 @@ class TestRestoreRefAndCopy:
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
         monkeypatch.setattr("teatree.utils.db.db_restore", lambda *a, **kw: None)
         (tmp_path / "manage.py").write_text("", encoding="utf-8")
-        ctx = _make_ctx(tmp_path)
-        assert _restore_ref_and_copy(ctx, "/tmp/dump.pgsql", "test") is True
+        importer = _make_importer(tmp_path)
+        assert importer._restore_ref_and_copy("/tmp/dump.pgsql", "test") is True
 
     def test_failure_on_restore(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("teatree.utils.db.db_restore", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("boom")))
-        ctx = _make_ctx(tmp_path)
-        assert _restore_ref_and_copy(ctx, "/tmp/dump.pgsql", "test") is False
+        importer = _make_importer(tmp_path)
+        assert importer._restore_ref_and_copy("/tmp/dump.pgsql", "test") is False
 
     def test_success_without_dslr(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
         monkeypatch.setattr("teatree.utils.db.db_restore", lambda *a, **kw: None)
         (tmp_path / "manage.py").write_text("", encoding="utf-8")
-        ctx = _make_ctx(tmp_path, dslr_cmd="")
-        assert _restore_ref_and_copy(ctx, "/tmp/dump.pgsql", "test") is True
+        importer = _make_importer(tmp_path, dslr_cmd=[])
+        assert importer._restore_ref_and_copy("/tmp/dump.pgsql", "test") is True
 
     def test_returns_false_when_migration_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("teatree.utils.db.db_restore", lambda *a, **kw: None)
-        monkeypatch.setattr(mod, "_migrate_reference_db", lambda *a: _MigrateResult.FAILED)
-        ctx = _make_ctx(tmp_path)
-        assert _restore_ref_and_copy(ctx, "/tmp/dump.pgsql", "test") is False
+        monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", lambda self: _MigrateResult.FAILED)
+        importer = _make_importer(tmp_path)
+        assert importer._restore_ref_and_copy("/tmp/dump.pgsql", "test") is False
 
     def test_returns_false_when_template_copy_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("teatree.utils.db.db_restore", lambda *a, **kw: None)
         (tmp_path / "manage.py").write_text("", encoding="utf-8")
-        monkeypatch.setattr(mod, "_migrate_reference_db", lambda *a: _MigrateResult.APPLIED)
-        monkeypatch.setattr(mod, "_take_dslr_snapshot", lambda *a: None)
-        monkeypatch.setattr(mod, "_copy_ref_to_ticket", lambda ctx: False)
-        ctx = _make_ctx(tmp_path)
-        assert _restore_ref_and_copy(ctx, "/tmp/dump.pgsql", "test") is False
+        monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", lambda self: _MigrateResult.APPLIED)
+        monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: None)
+        monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: False)
+        importer = _make_importer(tmp_path)
+        assert importer._restore_ref_and_copy("/tmp/dump.pgsql", "test") is False
 
 
 class TestTryRestoreFromDslr:
     def test_skips_when_no_dslr(self, tmp_path: Path) -> None:
-        ctx = _make_ctx(tmp_path, dslr_cmd="")
-        assert _try_restore_from_dslr(ctx, skip_dslr=False) is False
+        importer = _make_importer(tmp_path, dslr_cmd=[])
+        assert importer._try_restore_from_dslr(skip_dslr=False) is False
 
     def test_skips_when_skip_flag(self, tmp_path: Path) -> None:
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_dslr(ctx, skip_dslr=True) is False
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_dslr(skip_dslr=True) is False
 
     def test_skips_when_no_snapshots(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(mod, "_find_dslr_snapshots", lambda *a: [])
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_dslr(ctx, skip_dslr=False) is False
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_dslr(skip_dslr=False) is False
 
     def test_succeeds_with_snapshot_and_runs_migrate(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(mod, "_find_dslr_snapshots", lambda *a: ["20260326_development-acme"])
         monkeypatch.setattr(mod, "_restore_ref_from_dslr", lambda *a: (True, False, ""))
-        monkeypatch.setattr(mod, "_migrate_reference_db", lambda *a: _MigrateResult.APPLIED)
-        monkeypatch.setattr(mod, "_take_dslr_snapshot", lambda *a: None)
-        monkeypatch.setattr(mod, "_copy_ref_to_ticket", lambda ctx: True)
+        monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", lambda self: _MigrateResult.APPLIED)
+        monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: None)
+        monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: True)
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_dslr(ctx, skip_dslr=False) is True
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_dslr(skip_dslr=False) is True
 
     def test_skips_dslr_snapshot_when_already_migrated(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         snapshot_calls: list[str] = []
         monkeypatch.setattr(mod, "_find_dslr_snapshots", lambda *a: ["20260326_development-acme"])
         monkeypatch.setattr(mod, "_restore_ref_from_dslr", lambda *a: (True, False, ""))
-        monkeypatch.setattr(mod, "_migrate_reference_db", lambda *a: _MigrateResult.ALREADY_MIGRATED)
-        monkeypatch.setattr(mod, "_take_dslr_snapshot", lambda *a: snapshot_calls.append("called"))
-        monkeypatch.setattr(mod, "_copy_ref_to_ticket", lambda ctx: True)
+        monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", lambda self: _MigrateResult.ALREADY_MIGRATED)
+        monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: snapshot_calls.append("called"))
+        monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: True)
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_dslr(ctx, skip_dslr=False) is True
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_dslr(skip_dslr=False) is True
         assert snapshot_calls == [], "DSLR snapshot should be skipped when DB is already migrated"
 
     def test_tries_older_snapshot_when_first_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -495,31 +481,31 @@ class TestTryRestoreFromDslr:
             mod, "_find_dslr_snapshots", lambda *a: ["20260326_development-acme", "20260320_development-acme"]
         )
         monkeypatch.setattr(mod, "_restore_ref_from_dslr", fake_restore)
-        monkeypatch.setattr(mod, "_migrate_reference_db", lambda *a: _MigrateResult.APPLIED)
-        monkeypatch.setattr(mod, "_take_dslr_snapshot", lambda *a: None)
-        monkeypatch.setattr(mod, "_copy_ref_to_ticket", lambda ctx: True)
+        monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", lambda self: _MigrateResult.APPLIED)
+        monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: None)
+        monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: True)
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_dslr(ctx, skip_dslr=False) is True
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_dslr(skip_dslr=False) is True
         assert attempts == ["20260326_development-acme", "20260320_development-acme"]
 
     def test_tries_older_snapshot_when_migration_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        migrate_calls: list[str] = []
+        migrate_calls: list[None] = []
 
-        def fake_migrate(repo, ref_db, extra):
-            migrate_calls.append(ref_db)
+        def fake_migrate(_self):
+            migrate_calls.append(None)
             return _MigrateResult.APPLIED if len(migrate_calls) == 2 else _MigrateResult.FAILED
 
         monkeypatch.setattr(
             mod, "_find_dslr_snapshots", lambda *a: ["20260326_development-acme", "20260320_development-acme"]
         )
         monkeypatch.setattr(mod, "_restore_ref_from_dslr", lambda *a: (True, False, ""))
-        monkeypatch.setattr(mod, "_migrate_reference_db", fake_migrate)
-        monkeypatch.setattr(mod, "_take_dslr_snapshot", lambda *a: None)
-        monkeypatch.setattr(mod, "_copy_ref_to_ticket", lambda ctx: True)
+        monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", fake_migrate)
+        monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: None)
+        monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: True)
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_dslr(ctx, skip_dslr=False) is True
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_dslr(skip_dslr=False) is True
         assert len(migrate_calls) == 2
 
     def test_falls_back_when_all_snapshots_fail(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -528,20 +514,20 @@ class TestTryRestoreFromDslr:
         )
         monkeypatch.setattr(mod, "_restore_ref_from_dslr", lambda *a: (False, False, "mock error"))
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_dslr(ctx, skip_dslr=False) is False
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_dslr(skip_dslr=False) is False
 
     def test_falls_back_when_template_copy_fails_after_restore(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(mod, "_find_dslr_snapshots", lambda *a: ["20260326_development-acme"])
         monkeypatch.setattr(mod, "_restore_ref_from_dslr", lambda *a: (True, False, ""))
-        monkeypatch.setattr(mod, "_migrate_reference_db", lambda *a: _MigrateResult.APPLIED)
-        monkeypatch.setattr(mod, "_take_dslr_snapshot", lambda *a: None)
-        monkeypatch.setattr(mod, "_copy_ref_to_ticket", lambda ctx: False)
+        monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", lambda self: _MigrateResult.APPLIED)
+        monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: None)
+        monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: False)
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_dslr(ctx, skip_dslr=False) is False
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_dslr(skip_dslr=False) is False
 
 
 # ---------------------------------------------------------------------------
@@ -551,36 +537,34 @@ class TestTryRestoreFromDslr:
 
 class TestTryRestoreFromLocalDump:
     def test_skips_when_no_dump_dir(self, tmp_path: Path) -> None:
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_local_dump(ctx) is False
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_local_dump() is False
 
     def test_skips_when_no_matching_dumps(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         (tmp_path / ".data").mkdir()
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_local_dump(ctx) is False
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_local_dump() is False
 
-    def test_warns_about_zero_byte_dumps(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_warns_about_zero_byte_dumps(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_dir = tmp_path / ".data"
         data_dir.mkdir()
         (data_dir / "20260101_development-acme.pgsql").write_bytes(b"")
         # Also add a non-zero but truncated dump (filtered by validate_dump)
         (data_dir / "20260102_development-acme.pgsql").write_bytes(b"truncated")
         monkeypatch.setattr(mod, "validate_dump", lambda p: False)
-        ctx = _make_ctx(tmp_path)
-        _try_restore_from_local_dump(ctx)
-        assert "0-byte" in capsys.readouterr().out
+        importer = _make_importer(tmp_path)
+        importer._try_restore_from_local_dump()
+        assert "0-byte" in importer.stdout.getvalue()
 
     def test_succeeds_with_valid_dump(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_dir = tmp_path / ".data"
         data_dir.mkdir()
         (data_dir / "20260301_development-acme.pgsql").write_bytes(b"PGDMP")
         monkeypatch.setattr(mod, "validate_dump", lambda p: True)
-        monkeypatch.setattr(mod, "_restore_ref_and_copy", lambda ctx, path, label: True)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_local_dump(ctx) is True
+        monkeypatch.setattr(DjangoDbImporter, "_restore_ref_and_copy", lambda self, path, label: True)
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_local_dump() is True
 
     def test_tries_older_dump_when_first_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         data_dir = tmp_path / ".data"
@@ -589,14 +573,14 @@ class TestTryRestoreFromLocalDump:
         (data_dir / "20260215_development-acme.pgsql").write_bytes(b"PGDMP")
         attempted: list[str] = []
 
-        def fake_restore(ctx, path, label):
+        def fake_restore(_self, path, _label):
             attempted.append(Path(path).name)
             return "20260215" in path
 
         monkeypatch.setattr(mod, "validate_dump", lambda p: True)
-        monkeypatch.setattr(mod, "_restore_ref_and_copy", fake_restore)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_local_dump(ctx) is True
+        monkeypatch.setattr(DjangoDbImporter, "_restore_ref_and_copy", fake_restore)
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_local_dump() is True
         assert len(attempted) == 2
 
     def test_falls_back_when_all_dumps_fail(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -604,9 +588,9 @@ class TestTryRestoreFromLocalDump:
         data_dir.mkdir()
         (data_dir / "20260301_development-acme.pgsql").write_bytes(b"PGDMP")
         monkeypatch.setattr(mod, "validate_dump", lambda p: True)
-        monkeypatch.setattr(mod, "_restore_ref_and_copy", lambda ctx, path, label: False)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_local_dump(ctx) is False
+        monkeypatch.setattr(DjangoDbImporter, "_restore_ref_and_copy", lambda self, path, label: False)
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_local_dump() is False
 
 
 # ---------------------------------------------------------------------------
@@ -622,54 +606,43 @@ class TestTryFetchRemoteDump:
         dumps over VPN. The env gate is the final safety net.
         """
         monkeypatch.delenv("T3_ALLOW_REMOTE_DUMP", raising=False)
-        cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
-        ctx = _RestoreContext(cfg=cfg, dslr_cmd="", dslr_env={}, pg_host="h", pg_user="u", pg_env={})
-        assert _try_fetch_remote_dump(ctx) is False
+        importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
+        assert importer._try_fetch_remote_dump() is False
 
     def test_skips_when_no_remote_url(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
-        ctx = _make_ctx(tmp_path)
-        assert _try_fetch_remote_dump(ctx) is False
+        importer = _make_importer(tmp_path)
+        assert importer._try_fetch_remote_dump() is False
 
     def test_skips_when_already_failed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
-        mod._remote_dump_failed = True
-        cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
-        ctx = _RestoreContext(cfg=cfg, dslr_cmd="", dslr_env={}, pg_host="h", pg_user="u", pg_env={})
-        assert _try_fetch_remote_dump(ctx) is False
-        reset_remote_dump_state()
+        importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
+        importer._remote_dump_failed = True
+        assert importer._try_fetch_remote_dump() is False
 
     def test_handles_timeout(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
-        reset_remote_dump_state()
         (tmp_path / ".data").mkdir()
-        cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
-        ctx = _RestoreContext(cfg=cfg, dslr_cmd="", dslr_env={}, pg_host="h", pg_user="u", pg_env={})
+        importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
         monkeypatch.setattr(
             run_mod.subprocess,
             "run",
             lambda *a, **kw: (_ for _ in ()).throw(subprocess.TimeoutExpired("pg_dump", 1800)),
         )
-        assert _try_fetch_remote_dump(ctx) is False
-        reset_remote_dump_state()
+        assert importer._try_fetch_remote_dump() is False
 
     def test_handles_pg_dump_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
-        reset_remote_dump_state()
         (tmp_path / ".data").mkdir()
-        cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
-        ctx = _RestoreContext(cfg=cfg, dslr_cmd="", dslr_env={}, pg_host="h", pg_user="u", pg_env={})
+        importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
         monkeypatch.setattr(run_mod.subprocess, "run", _fail_run)
-        assert _try_fetch_remote_dump(ctx) is False
-        reset_remote_dump_state()
+        assert importer._try_fetch_remote_dump() is False
 
     def test_returns_true_after_successful_fetch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
-        reset_remote_dump_state()
         data_dir = tmp_path / ".data"
         data_dir.mkdir()
-        cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
-        ctx = _RestoreContext(cfg=cfg, dslr_cmd="", dslr_env={}, pg_host="h", pg_user="u", pg_env={})
+        importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
 
         def fake_run(args, **kw):
             if isinstance(args, list) and args[0] == "pg_dump":
@@ -678,8 +651,7 @@ class TestTryFetchRemoteDump:
             return _ok_run()
 
         monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
-        assert _try_fetch_remote_dump(ctx) is True
-        reset_remote_dump_state()
+        assert importer._try_fetch_remote_dump() is True
 
 
 # ---------------------------------------------------------------------------
@@ -689,24 +661,24 @@ class TestTryFetchRemoteDump:
 
 class TestTryRestoreFromCiDump:
     def test_skips_when_no_ci_dumps(self, tmp_path: Path) -> None:
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_ci_dump(ctx) is False
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_ci_dump() is False
 
     def test_succeeds_with_ci_dump(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         ci_dir = tmp_path / ".gitlab"
         ci_dir.mkdir()
         (ci_dir / "dump_after_migration.20260301.sql.gz").write_bytes(b"data")
-        monkeypatch.setattr(mod, "_restore_ref_and_copy", lambda ctx, path, label: True)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_ci_dump(ctx) is True
+        monkeypatch.setattr(DjangoDbImporter, "_restore_ref_and_copy", lambda self, path, label: True)
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_ci_dump() is True
 
     def test_falls_back_when_restore_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         ci_dir = tmp_path / ".gitlab"
         ci_dir.mkdir()
         (ci_dir / "dump_after_migration.20260301.sql.gz").write_bytes(b"data")
-        monkeypatch.setattr(mod, "_restore_ref_and_copy", lambda ctx, path, label: False)
-        ctx = _make_ctx(tmp_path)
-        assert _try_restore_from_ci_dump(ctx) is False
+        monkeypatch.setattr(DjangoDbImporter, "_restore_ref_and_copy", lambda self, path, label: False)
+        importer = _make_importer(tmp_path)
+        assert importer._try_restore_from_ci_dump() is False
 
 
 # ---------------------------------------------------------------------------
@@ -716,86 +688,78 @@ class TestTryRestoreFromCiDump:
 
 class TestDjangoDbImport:
     def test_succeeds_via_dslr(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", _stub_dslr_cmd([["/bin/dslr"]]))
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: True)
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: ["/bin/dslr"])
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: True)
         cfg = _make_cfg(tmp_path)
         assert django_db_import(cfg) is True
 
     def test_falls_through_to_local_dump(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", _stub_dslr_cmd())
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
-        monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: True)
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: True)
         cfg = _make_cfg(tmp_path)
         assert django_db_import(cfg, slow_import=True) is True
 
     def test_blocks_fallback_without_slow_import(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Non-DSLR fallbacks require --slow-import."""
-        reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", _stub_dslr_cmd())
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
-        monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: True)
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: True)
         cfg = _make_cfg(tmp_path)
         assert django_db_import(cfg) is False
 
     def test_falls_through_to_remote_fetch_then_local(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        reset_remote_dump_state()
         local_calls: list[int] = []
-        monkeypatch.setattr(mod, "_find_dslr_cmd", _stub_dslr_cmd())
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
 
-        def local_dump(ctx):
+        def local_dump(_self):
             local_calls.append(1)
             return len(local_calls) == 2  # fail first, succeed after remote fetch
 
-        monkeypatch.setattr(mod, "_try_restore_from_local_dump", local_dump)
-        monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: True)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", local_dump)
+        monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: True)
         cfg = _make_cfg(tmp_path)
         assert django_db_import(cfg, slow_import=True, allow_remote_dump=True) is True
         assert len(local_calls) == 2  # called twice: before and after remote fetch
 
     def test_skips_remote_when_not_allowed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        reset_remote_dump_state()
         remote_called: list[int] = []
-        monkeypatch.setattr(mod, "_find_dslr_cmd", _stub_dslr_cmd())
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
-        monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: False)
-        monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: remote_called.append(1) or True)
-        monkeypatch.setattr(mod, "_try_restore_from_ci_dump", lambda ctx: True)
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: remote_called.append(1) or True)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_ci_dump", lambda self: True)
         cfg = _make_cfg(tmp_path)
         assert django_db_import(cfg, slow_import=True, allow_remote_dump=False) is True
         assert remote_called == []
 
     def test_falls_through_to_ci(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", _stub_dslr_cmd())
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
-        monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: False)
-        monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
-        monkeypatch.setattr(mod, "_try_restore_from_ci_dump", lambda ctx: True)
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_ci_dump", lambda self: True)
         cfg = _make_cfg(tmp_path)
         assert django_db_import(cfg, slow_import=True) is True
 
     def test_fails_when_all_strategies_fail(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", _stub_dslr_cmd())
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
-        monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: False)
-        monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
-        monkeypatch.setattr(mod, "_try_restore_from_ci_dump", lambda ctx: False)
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_ci_dump", lambda self: False)
         cfg = _make_cfg(tmp_path)
         assert django_db_import(cfg, slow_import=True) is False
 
     def test_failure_message_with_remote_url(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
     ) -> None:
-        reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", _stub_dslr_cmd())
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
-        monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: False)
-        monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
-        monkeypatch.setattr(mod, "_try_restore_from_ci_dump", lambda ctx: False)
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_ci_dump", lambda self: False)
         cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
         django_db_import(cfg, slow_import=True)
         assert "--slow-import" in capsys.readouterr().out
@@ -803,34 +767,31 @@ class TestDjangoDbImport:
     def test_failure_message_without_remote_url(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
     ) -> None:
-        reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_find_dslr_cmd", _stub_dslr_cmd())
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
-        monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: False)
-        monkeypatch.setattr(mod, "_try_fetch_remote_dump", lambda ctx: False)
-        monkeypatch.setattr(mod, "_try_restore_from_ci_dump", lambda ctx: False)
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_ci_dump", lambda self: False)
         cfg = _make_cfg(tmp_path)
         django_db_import(cfg, slow_import=True)
         assert "Configure remote_db_url" in capsys.readouterr().out
 
     def test_skip_dslr_passed_through(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        reset_remote_dump_state()
         captured_skip: list[bool] = []
-        monkeypatch.setattr(mod, "_find_dslr_cmd", _stub_dslr_cmd([["/bin/dslr"]]))
+        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: ["/bin/dslr"])
 
-        def capture_dslr(ctx, *, skip_dslr):
+        def capture_dslr(_self, *, skip_dslr):
             captured_skip.append(skip_dslr)
             return True
 
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", capture_dslr)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", capture_dslr)
         cfg = _make_cfg(tmp_path)
         django_db_import(cfg, skip_dslr=True)
         assert captured_skip == [True]
 
     def test_no_snapshot_tool_skips_dslr_setup(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        reset_remote_dump_state()
-        monkeypatch.setattr(mod, "_try_restore_from_dslr", lambda ctx, *, skip_dslr: False)
-        monkeypatch.setattr(mod, "_try_restore_from_local_dump", lambda ctx: True)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
+        monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: True)
         cfg = DjangoDbImportConfig(
             ref_db_name="development-acme",
             ticket_db_name="wt_42_acme",

--- a/uv.lock
+++ b/uv.lock
@@ -447,14 +447,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Refactor \`src/teatree/utils/django_db.py\` from a 636-LOC god-module (32 module-level functions, 55 noqa suppressions, a per-process global flag) into a \`DjangoDbImporter\` class that mirrors Django's \`BaseCommand\` pattern.

### Why the rewrite

The original file had:
- 48 \`# noqa: T201\` suppressions on bare \`print()\` calls
- 5 \`# noqa: PLC0415\` lazy imports
- 2 \`# noqa: PLW0603\` global mutations of \`_remote_dump_failed\`
- A \`_RestoreContext\` dataclass passed as the first arg to almost every \`_try_*\` function — i.e. a class trying to escape its function shell
- A test-only helper (\`reset_remote_dump_state\`) that existed solely to undo the \`_remote_dump_failed\` module global between tests

A first attempt added \`_print\`/\`_print_err\` helper functions next to the existing \`logger\` to satisfy ruff. That just hid the smell — the file already violated the project's "no module with >10 module-level functions / 500 LOC" rule, and adding helpers made it worse.

### What this PR does

- Introduces \`DjangoDbImporter\` — instances own \`cfg\`, the per-run state (\`dslr_cmd\`, \`pg_host\`, etc.), the failure flag (\`self._remote_dump_failed\`), and \`stdout\`/\`stderr\` streams. All \`print(...)\` and \`print(..., file=sys.stderr)\` become \`self.stdout.write(...)\` / \`self.stderr.write(...)\`.
- \`_RestoreContext\` deleted (its fields became \`self.X\`).
- \`reset_remote_dump_state\` deleted (no global to reset — each test creates a fresh importer).
- Public API preserved: \`django_db_import(cfg, ...)\` and \`prune_dslr_snapshots(...)\` stay as module-level entry points; \`validate_dump\` and the pure parsers (\`_parse_dslr_snapshots\`, \`_extract_failing_migration\`, \`_dslr_snap_name\`, \`_local_db_url\`, \`_pg_args\`, \`_find_dslr_cmd\`, \`_dslr_env\`, \`_find_dslr_snapshots\`, \`_is_env_error\`, \`_restore_ref_from_dslr\`) remain module-level — they have no state and no I/O.
- Tests rewritten to instantiate \`DjangoDbImporter\` with \`io.StringIO\` for output capture; method monkey-patches use the class instead of the module.
- The two \`PLC0415\` sites the \`quality-gates\` hook flags as "new" are pre-existing imports — they only shifted line numbers due to the restructure.

### Stats

|                              | before | after |
|------------------------------|------:|------:|
| \`# noqa\` in django_db.py     | 55    | 5     |
| Module-level functions       | 32    | 16    |
| Global state                 | 1     | 0     |
| LOC                          | 636   | 640   |

For \`skill_schema.py\`: 5 \`# noqa: T201\` dropped by inlining \`sys.stdout.write(...)\` (single \`main()\` function, no class needed).

## Test plan

- [x] \`uv run ruff check src/teatree/utils/django_db.py src/teatree/skill_schema.py tests/test_django_db.py\` — clean
- [x] \`uv run pytest --no-cov -q tests/test_django_db.py tests/test_skill_schema.py\` — 96 passed
- [x] \`prek\` pre-commit chain (ruff, ty, tach, quality-gates, conventional commit) — all green