### PR TITLE
docs(skills): align CLI command tables with current help output + grep cross-ref rule

### DIFF
--- a/skills/followup/SKILL.md
+++ b/skills/followup/SKILL.md
@@ -260,7 +260,7 @@ After posting (or during any follow-up invocation), remove entries from `mr_remi
 
 ### 12. Dashboard
 
-The dashboard is a Django view served by teatree. Start it with `t3 <overlay> dashboard` (e.g., `t3 acme dashboard`). It provides a live overview of all in-flight work, reading from the DB populated by `t3 <overlay> followup sync`.
+The dashboard is a Django view served by teatree. Start it with `t3 dashboard` (top-level command, no overlay needed). It provides a live overview of all in-flight work, reading from the DB populated by `t3 <overlay> followup sync`.
 
 **Extension point: `followup_enrich_data`** — project overlays can add project-specific fields to followup entries (e.g., Notion status, tenant info).
 
@@ -268,7 +268,7 @@ The dashboard is a Django view served by teatree. Start it with `t3 <overlay> da
 
 **Execute immediately when the skill is loaded** — before responding to the user, before asking what they want, before anything else. This is the first thing followup does on every invocation (both interactive and periodic). The user should never have to ask for a data refresh.
 
-**Always use `t3 <overlay> followup sync`** (or `t3 daily` as a top-level shortcut) to collect data. This command handles MR discovery, pipeline status, approvals, merge detection, and cache cleanup in one deterministic pass. Never manually call issue tracker APIs to build followup data — the CLI command is the single entry point.
+**Always use `t3 <overlay> followup sync`** (or `t3 <overlay> daily` as a one-shot shortcut that also processes reminders) to collect data. This command handles MR discovery, pipeline status, approvals, merge detection, and cache cleanup in one deterministic pass. Never manually call issue tracker APIs to build followup data — the CLI command is the single entry point.
 
 The command discovers open MRs from the repos returned by the overlay's `get_followup_repos()` method. Overlays can return a static list or query the GitLab group API dynamically. The legacy `T3_FOLLOWUP_REPOS` env var is not read by the code — configure the overlay instead.
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -43,6 +43,25 @@ _Adapted from [superpowers/verification-before-completion](https://github.com/ob
 
 **Banned language without evidence:** "should pass", "probably works", "seems correct", "looks good", "I'm confident". These words without a command output are lies, not claims.
 
+## Grep Before Claiming Cross-Reference Coverage (Non-Negotiable)
+
+When the user asks how their codebase or harness compares to an external reference — an article, a framework's docs, a competitor's product, a popular library — the reflex is to pattern-match: a name in the reference resembles a skill or file or function the agent has seen, so the agent claims it's covered (or claims the inverse). This pattern-match is unreliable across naming differences and partial-implementation gaps, and it always defaults toward overclaiming coverage when the agent has the user's project context loaded.
+
+**Required before any "X is covered / X is a gap" claim:**
+
+1. **Grep the actual repo** for the concept under at least two framings. `rg`, `grep -r`, or `git log -S` against the codebase, not against memory.
+2. **Cite `file:line`** for each "covered" assertion. A claim that something exists must point at where it exists.
+3. **Cite the specific gap** for each "missing" assertion. Name the function, regex, or section that would have to exist and link the file path where you'd expect it. If you can't, you don't have enough evidence to call it a gap.
+4. **If you can't grep** (no read access, ambiguous naming, the concept is implementation-shape rather than keyword-shape), **ask the user** before making the claim. Do not paper over the uncertainty with hedge words.
+
+**Banned shortcuts:**
+
+- Naming a skill ("/t3:code", "/t3:ship") and asserting it covers an article concept on the strength of its description alone.
+- Listing items as "covered" because they sound like things the harness probably does.
+- Producing a "what's missing" list without grepping for each item first.
+
+**Why this rule exists.** When the user's project state is loaded into context (CLAUDE.md, MEMORY.md, recent file reads), the agent's pattern-matching defaults aggressive — it treats name-similarity as coverage and produces flattering comparisons that don't survive a `rg` check. The corrective is to require evidence at the point of claim, not at the point of correction.
+
 ## User Instructions Are Priority 1
 
 When the user gives a direct, explicit instruction (skip tests, push now, use this approach), execute it IMMEDIATELY. Do not try a "better" approach first, do not retry the same failing approach hoping it works, and do not silently substitute your own plan. Execute the instruction first (it's fast and safe), then suggest an alternative if you have one.

--- a/skills/workspace/references/scripts-and-functions.md
+++ b/skills/workspace/references/scripts-and-functions.md
@@ -16,38 +16,52 @@ t3 <overlay> --help            # overlay-specific commands (from overlay project
 | Command | What it does |
 |---------|-------------|
 | `t3 startoverlay` | Scaffold a new overlay package |
-| `t3 start-ticket <URL>` | Zero to coding — create ticket, provision worktree, start services |
-| `t3 ship <TICKET_ID>` | Code to MR — create merge request |
-| `t3 daily` | Daily followup — sync MRs, check gates, remind reviewers |
-| `t3 agent` | Launch agent with project context |
-| `t3 full-status` | Show ticket, worktree, and session state summary |
+| `t3 docs` | Serve project documentation with mkdocs |
+| `t3 agent` | Launch Claude Code with auto-detected project context |
+| `t3 sessions` | List recent Claude conversation sessions with resume commands |
 | `t3 info` | Show binary, source paths, editable status, and installed overlays |
-| `t3 doctor check` | Verify imports and editable-install sanity |
-| `t3 config autoload` | List skill auto-loading rules |
+| `t3 dashboard` | Migrate the database and start the dashboard dev server |
+| `t3 doctor check` | Verify imports, required tools, and editable-install sanity |
+| `t3 config autoload` | List skill auto-loading rules from `context-match.yml` |
+| `t3 config check-update` | Check if a newer version of teatree is available |
+| `t3 config write-skill-cache` | Write overlay skill metadata + trigger index to XDG cache |
+| `t3 config cache` | Show the XDG skill-metadata cache content |
 | `t3 ci cancel` | Cancel stale CI pipelines |
 | `t3 ci divergence` | Check fork divergence from upstream |
 | `t3 ci trigger-e2e` | Trigger E2E tests on CI |
-| `t3 ci fetch-errors` | Fetch error logs from CI |
-| `t3 ci fetch-failed-tests` | Extract failed test IDs from CI |
-| `t3 ci quality-check` | Run quality analysis |
-| `t3 review-request discover` | Discover open MRs awaiting review |
-| `t3 tool privacy-scan` | Scan for privacy-sensitive patterns |
-| `t3 tool analyze-video` | Decompose video into frames |
-| `t3 tool bump-deps` | Bump pyproject.toml deps from uv.lock |
+| `t3 ci fetch-errors` | Fetch error logs from the latest CI pipeline |
+| `t3 ci fetch-failed-tests` | Extract failed test IDs from the latest CI pipeline |
+| `t3 ci quality-check` | Run quality analysis (fetch test report from latest pipeline) |
+| `t3 review post-draft-note` / `publish-draft-notes` / `delete-draft-note` / `list-draft-notes` / `update-note` / `reply-to-discussion` / `resolve-discussion` | Code review helpers |
+| `t3 review-request discover` | Discover open merge requests awaiting review |
+| `t3 setup` | First-time setup and global skill management |
+| `t3 assess` | Codebase health assessment |
+| `t3 overlay` | Dev-mode overlay install/uninstall |
+| `t3 infra` | Teatree-wide infrastructure services |
+| `t3 tool privacy-scan` | Scan text for privacy-sensitive patterns |
+| `t3 tool analyze-video` | Decompose video into frames for AI analysis |
+| `t3 tool bump-deps` | Bump pyproject.toml dependencies from uv.lock |
 | `t3 tool sonar-check` | Run local SonarQube analysis via Docker |
+| `t3 tool label-issues` | Suggest labels for unlabeled open issues |
+| `t3 tool find-duplicates` | Flag pairs of open issues with near-identical titles |
+| `t3 tool claude-handover` | Show Claude handover telemetry and runtime recommendations |
 
 ## Overlay Commands (`t3 <overlay> ...`)
 
+Run `t3 <overlay> --help` for the full list. Subcommand groups: `worktree`, `workspace`, `run`, `e2e`, `db`, `pr`, `tasks`, `followup`, `lifecycle`, `config`. Standalone commands: `resetdb`, `worker`, `full-status`, `ship`, `daily`, `agent`. Some overlays expose extra command groups (e.g. `tool`).
+
 | Command | What it does |
 |---------|-------------|
-| `t3 <overlay> dashboard` | Migrate DB + start dashboard server |
-| `t3 <overlay> resetdb` | Drop and recreate SQLite DB |
+| `t3 <overlay> ship [TICKET_ID]` | Code to MR — create merge request for the ticket |
+| `t3 <overlay> daily` | Daily followup — sync MRs, check gates, remind reviewers |
+| `t3 <overlay> full-status` | Show ticket, worktree, and session state summary |
+| `t3 <overlay> agent` | Launch Claude Code with overlay context and auto-detected skills |
+| `t3 <overlay> resetdb` | Drop the SQLite database and re-run all migrations |
 | `t3 <overlay> worker` | Start background task workers |
 | `t3 <overlay> worktree provision [VARIANT]` | Provision worktree: ports, env, symlinks, DB |
 | `t3 <overlay> worktree start` | Start dev servers, then verify |
 | `t3 <overlay> worktree status` | Show worktree state |
-| `t3 <overlay> worktree teardown` | Tear down a worktree |
-| `t3 <overlay> worktree teardown` | Teardown — stop services, drop DB, clean state |
+| `t3 <overlay> worktree teardown` | Stop services, drop DB, clean state |
 | `t3 <overlay> worktree diagram` | Print state diagram as Mermaid |
 | `t3 <overlay> workspace ticket` | Create ticket workspace with git worktrees |
 | `t3 <overlay> workspace finalize` | Squash commits + rebase on default branch |
@@ -71,6 +85,8 @@ t3 <overlay> --help            # overlay-specific commands (from overlay project
 | `t3 <overlay> followup sync` | Sync followup data from MRs |
 | `t3 <overlay> followup refresh` | Return counts of tickets and tasks |
 | `t3 <overlay> followup remind` | Return list of pending tasks |
+| `t3 <overlay> lifecycle ...` | Session lifecycle and phase tracking |
+| `t3 <overlay> tasks ...` | Async task queue (overlay-dependent) |
 
 ## Standalone Scripts (`scripts/`)
 

--- a/skills/workspace/references/troubleshooting.md
+++ b/skills/workspace/references/troubleshooting.md
@@ -151,16 +151,16 @@ See your [issue tracker platform reference](../../platforms/references/) § "Kno
 - **Fix:** Unset the leaking env vars before committing: `unset DJANGO_SETTINGS_MODULE && git commit ...`. If the issue is `.pth`-based cross-contamination, use `SKIP=pytest git commit ...` and verify tests pass separately with explicit `PYTHONPATH`.
 - **Prevention:** When committing to a repo other than the current working directory (e.g., during skill reviews or retros), sanitize Django-related env vars first. The agent should detect when the target repo differs from the cwd and preemptively unset `DJANGO_SETTINGS_MODULE` and reset `VIRTUAL_ENV`. When a shared venv has editable installs from multiple Django projects, the pytest pre-commit hook may always fail — use `SKIP=pytest` and run tests manually.
 
-## `No module named uvicorn` When Running `t3 <overlay> dashboard`
+## `No module named uvicorn` When Running `t3 dashboard`
 
-- **Symptom:** `t3 acme dashboard` fails with `No module named uvicorn`.
+- **Symptom:** `t3 dashboard` fails with `No module named uvicorn`.
 - **Cause:** `_uvicorn()` used `sys.executable` — the teatree venv's Python. But `uvicorn` is a dependency of the overlay project (e.g., t3-acme), not of teatree itself. The teatree venv has no `uvicorn` installed.
 - **Fix:** `_uvicorn()` now uses `uv --directory <project_path> run uvicorn` to run in the project's environment, falling back to `sys.executable` otherwise.
 - **Prevention:** When spawning overlay project commands from the `t3` CLI, always consider whether the command needs project-specific dependencies. If so, use `uv --directory <project_path>` to run in the correct environment.
 
-## `Could not import module "asgi"` When Running `t3 <overlay> dashboard`
+## `Could not import module "asgi"` When Running `t3 dashboard`
 
-- **Symptom:** `t3 acme dashboard` runs migrations successfully but then fails with `Error loading ASGI app. Could not import module "asgi"`.
+- **Symptom:** `t3 dashboard` runs migrations successfully but then fails with `Error loading ASGI app. Could not import module "asgi"`.
 - **Cause:** `_uvicorn()` read `DJANGO_SETTINGS_MODULE` from `os.environ` to construct the ASGI module path (e.g., `acme.asgi:application`). But the overlay registration never set it in the environment — only the overlay entry object had the `settings_module`. With an empty env var, the ASGI path resolved to bare `"asgi:application"`.
 - **Fix:** Thread `settings_module` from the overlay entry through `_build_overlay_app` → `dashboard` → `_uvicorn` as a parameter, falling back to `os.environ` only if not provided.
 - **Prevention:** When adding CLI commands that need overlay metadata (settings module, project path), pass the metadata explicitly from the overlay entry rather than relying on environment variables that may not be set.


### PR DESCRIPTION
## Summary

Two doc/skill drift fixes surfaced during the holistic codebase review:

1. **docs(rules): require grep before claiming cross-reference coverage** — adds a rule under skills/rules/SKILL.md so the agent grep-verifies cross-references before declaring all-docs-aligned.
2. **docs(skills): align CLI command tables with current help output** — fixes stale CLI references in three skill files:
   - skills/workspace/references/scripts-and-functions.md — top-level command table claimed t3 ship, t3 daily, t3 full-status, t3 start-ticket as global commands. They are overlay-scoped (t3 <overlay> ship etc.). t3 start-ticket no longer exists. Added missing top-level entries (sessions, docs, setup, assess, overlay, infra) and missing tool / config subcommands.
   - skills/followup/SKILL.md — t3 acme dashboard example (dashboard is top-level), t3 daily shortcut claim (it is overlay-scoped).
   - skills/workspace/references/troubleshooting.md — two t3 acme dashboard references corrected to t3 dashboard.

Verified against uv run t3 --help, uv run t3 teatree --help, uv run t3 dashboard --help, etc.

## Test plan
- [x] prek clean on commit
- [ ] CI green