### PR TITLE
fix(core): fall back to pk when issue_url ends in /0

### DIFF
--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -78,7 +78,9 @@ class Ticket(models.Model):
     @property
     def ticket_number(self) -> str:
         match = re.search(r"(\d+)$", self.issue_url)
-        return match.group(1) if match else str(self.pk)
+        if match and match.group(1) != "0":
+            return match.group(1)
+        return str(self.pk)
 
     @transition(field=state, source=State.NOT_STARTED, target=State.SCOPED)
     def scope(

--- a/tests/teatree_core/test_models.py
+++ b/tests/teatree_core/test_models.py
@@ -106,6 +106,31 @@ def _init_repo_with_branch(repo_dir: Path, *, branch: str, commits_ahead: int) -
         git("commit", "-m", f"add f{i}")
 
 
+class TestTicketNumber(TestCase):
+    """``Ticket.ticket_number`` derives a stable identifier from ``issue_url``.
+
+    The fallback to ``str(self.pk)`` covers issue URLs that do not end in a
+    valid issue number — empty, non-numeric suffix, or the placeholder ``/0``
+    that GitHub and GitLab never assign to a real issue (issue numbers start at 1).
+    """
+
+    def test_returns_trailing_number_when_url_is_well_formed(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/example/repo/issues/123")
+        assert ticket.ticket_number == "123"
+
+    def test_falls_back_to_pk_when_url_is_empty(self) -> None:
+        ticket = Ticket.objects.create()
+        assert ticket.ticket_number == str(ticket.pk)
+
+    def test_falls_back_to_pk_when_url_has_no_trailing_number(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://example.com/no-number")
+        assert ticket.ticket_number == str(ticket.pk)
+
+    def test_falls_back_to_pk_when_url_ends_in_zero(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/example/repo/issues/0")
+        assert ticket.ticket_number == str(ticket.pk)
+
+
 class TestTicketTransitions(TestCase):
     @pytest.fixture(autouse=True)
     def _inject_tmp_path(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`Ticket.ticket_number` previously returned the literal string `"0"` for issue URLs ending in `/0` (a placeholder GitHub and GitLab never assign to a real issue, since both number issues from 1). The value is used as a branch suffix, Compose project name, and worktree DB name, so collisions are possible if more than one such ticket exists; the dashboard also rendered broken `#0` links.

This PR treats `"0"` as an absent issue number and falls back to `str(self.pk)`, which is unique by construction. New tests cover the four input shapes:

- valid trailing number (`/issues/123`)
- empty `issue_url`
- non-numeric suffix
- `/issues/0` (the regression)

Closes #511

## Test plan

- [x] `uv run pytest --no-cov tests/teatree_core/test_models.py` — 68 passed
- [x] `uv run ruff check` — clean
- [x] Live verification on dashboard DB: tickets 144 and 183 now render with their PK rather than `#0`