### PR TITLE
fix(skill_schema): recognise companions as a teatree-native field

### DIFF
--- a/src/teatree/skill_schema.py
+++ b/src/teatree/skill_schema.py
@@ -5,7 +5,7 @@ Can be used as a CLI tool: ``uv run python -m teatree.skill_schema <paths>``.
 
 Teatree frontmatter is a superset of APM's SKILL.md format:
 - APM requires: ``name``, ``description``
-- Teatree adds: ``triggers``, ``search_hints``, ``requires``, ``metadata``, ``compatibility``
+- Teatree adds: ``triggers``, ``search_hints``, ``requires``, ``companions``, ``metadata``, ``compatibility``
 
 Unknown fields produce warnings (not errors) to preserve APM compatibility —
 APM or other tools may add fields teatree doesn't know about.
@@ -23,6 +23,7 @@ _KNOWN_TOP_LEVEL = frozenset(
         "triggers",
         "search_hints",
         "requires",
+        "companions",
         "metadata",
         "compatibility",
     }

--- a/tests/test_skill_schema.py
+++ b/tests/test_skill_schema.py
@@ -43,6 +43,13 @@ class TestValidateSkillMd:
         assert errors == []
         assert any("unknown field 'custom_field'" in w for w in warnings)
 
+    def test_companions_field_is_recognised(self, tmp_path: Path):
+        skill_md = tmp_path / "SKILL.md"
+        skill_md.write_text("---\nname: test\ndescription: d\ncompanions:\n  - other-skill\n---\n")
+        errors, warnings = validate_skill_md(skill_md)
+        assert errors == []
+        assert not any("'companions'" in w for w in warnings)
+
     def test_invalid_regex_in_keywords(self, tmp_path: Path):
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text("---\nname: test\ndescription: d\ntriggers:\n  keywords:\n    - '[invalid'\n---\n")


### PR DESCRIPTION
## Summary

The validator was warning `unknown field 'companions' (APM extension?)` on every dashboard startup for teatree skills that declare a `companions:` block. `companions` is consumed by `teatree.skill_deps.resolve_companions` and is a teatree-native field, not an APM extension.

This PR adds `"companions"` to `_KNOWN_TOP_LEVEL` and updates the module docstring to list it alongside the other teatree-added fields.

Closes #513

## Test plan

- [x] New unit test asserts that a SKILL.md with a `companions:` block produces no `'companions'` warning
- [x] `uv run pytest --no-cov tests/test_skill_schema.py` — 16 passed
- [x] `uv run ruff check` — clean