### PR TITLE
test(e2e): cover all dashboard panels + flows, capture server logs and videos (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ htmlcov/
 apm_modules/
 docs/plans/
 .t3.local.json
+
+# E2E artifacts: server stdout/stderr capture + Playwright video recordings.
+# Mounted writable into the e2e Docker container; useful when triaging CI failures.
+e2e/.logs/
+e2e/.videos/

--- a/README.md
+++ b/README.md
@@ -340,6 +340,22 @@ uv run pytest               # >90% coverage required
 prek run --all-files         # ruff, pytest, codespell, banned-terms
 ```
 
+### E2E Tests
+
+Dashboard E2E tests live under `e2e/` and run inside Docker for snapshot stability ([#275](https://github.com/souliane/teatree/issues/275)):
+
+```bash
+t3 teatree e2e project              # run full suite (CI default)
+t3 teatree e2e project --headed     # interactive mode for debugging
+```
+
+**Failure triage artifacts** (git-ignored, mounted writable into the e2e container):
+
+- `e2e/.logs/server-<ISO>-<worker>.log` — captured stdout/stderr from the live ASGI server. Path is printed on every test failure via `pytest_runtest_makereport`.
+- `e2e/.videos/<test-name>/<rand>.webm` — Playwright video recording. Only retained for **failing** tests (passing tests delete their video on teardown to keep CI artifact size small).
+
+In CI, attach the `e2e/.logs/` and `e2e/.videos/` directories as job artifacts and link them from the failed run summary so reviewers can replay the failure without rerunning the suite.
+
 ## Security Considerations
 
 Skills are prompt instructions — they control what your AI agent does. This makes the supply chain a security surface.

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -34,6 +34,9 @@ services:
     volumes:
       - ..:/app:ro
       - ../e2e/snapshots:/app/e2e/snapshots
+      # Writable mounts for failure triage — host paths are git-ignored.
+      - ../e2e/.logs:/app/e2e/.logs
+      - ../e2e/.videos:/app/e2e/.videos
     build:
       context: ..
       dockerfile: dev/Dockerfile.e2e

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -8,11 +8,13 @@ Run with:
 """
 
 import os
+import shutil
 import subprocess
 import sys
 import time
 from collections.abc import Iterator
-from datetime import UTC
+from datetime import UTC, datetime
+from pathlib import Path
 
 import httpx
 import patchy
@@ -31,10 +33,19 @@ os.environ["TEATREE_PANEL_CACHE_TTL"] = "0"
 os.environ["TEATREE_E2E_GIT_SHA"] = "abc1234"
 os.environ["TEATREE_E2E_GIT_BRANCH"] = "e2e-branch"
 
+# Repo-root-relative artifact dirs — mounted writable into the e2e Docker
+# container (see ``dev/docker-compose.yml``). Created lazily so a developer
+# running ``uv run pytest`` outside Docker also gets a populated folder.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LOGS_DIR = _REPO_ROOT / "e2e" / ".logs"
+_VIDEOS_DIR = _REPO_ROOT / "e2e" / ".videos"
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Override DJANGO_SETTINGS_MODULE before pytest-django initializes Django."""
     os.environ["DJANGO_SETTINGS_MODULE"] = "e2e.settings"
+    _LOGS_DIR.mkdir(parents=True, exist_ok=True)
+    _VIDEOS_DIR.mkdir(parents=True, exist_ok=True)
 
 
 _DISABLE_ANIMATIONS_CSS = (
@@ -48,7 +59,7 @@ _DISABLE_ANIMATIONS_CSS = (
 
 @pytest.fixture(scope="session")
 def browser_context_args(browser_context_args: dict[str, object]) -> dict[str, object]:
-    """Fix viewport (1280x720 for README rendering) and reduce motion.
+    """Fix viewport (1280x720 for README rendering), reduce motion, record video.
 
     Pixel-stable screenshots require both a fixed viewport and aggressive
     animation suppression — per-call ``animations="disabled"`` only catches
@@ -56,11 +67,17 @@ def browser_context_args(browser_context_args: dict[str, object]) -> dict[str, o
     hover/loading states. See [#275](https://github.com/souliane/teatree/issues/275)
     (credits @m13v). The ``_disable_animations_init`` fixture below injects a
     global stylesheet on every navigation to cover the rest.
+
+    ``record_video_dir`` enables Playwright video recording for every test;
+    the ``_video_retain_on_failure`` fixture deletes the video for passing
+    tests so artifact size only grows with failures.
     """
     return {
         **browser_context_args,
         "viewport": {"width": 1280, "height": 720},
         "reduced_motion": "reduce",
+        "record_video_dir": str(_VIDEOS_DIR),
+        "record_video_size": {"width": 1280, "height": 720},
     }
 
 
@@ -73,6 +90,31 @@ def _disable_animations_init(page) -> None:
         "(document.head||document.documentElement).appendChild(s);})();"
     )
     page.add_init_script(script)
+
+
+@pytest.fixture(autouse=True)
+def _video_retain_on_failure(request: pytest.FixtureRequest, page) -> Iterator[None]:
+    """Mimic Playwright's ``--video=retain-on-failure`` mode.
+
+    pytest-playwright doesn't expose an equivalent CLI flag, and recording
+    every video would balloon CI artifact size. Strategy: always record (via
+    ``browser_context_args``), then on test exit delete the video iff the
+    test passed. Test outcome is stashed by ``pytest_runtest_makereport``.
+    """
+    yield
+    rep = getattr(request.node, "rep_call", None)
+    video_path: Path | None = None
+    try:
+        video = page.video
+        if video is not None:
+            page.context.close()  # flush video to disk
+            raw = video.path()
+            if raw:
+                video_path = Path(raw)
+    except Exception:  # noqa: BLE001 — best-effort cleanup
+        video_path = None
+    if rep is not None and rep.passed and video_path is not None and video_path.exists():
+        video_path.unlink(missing_ok=True)
 
 
 # pytest-playwright-visual's `assert_snapshot` hard-fails on any single-pixel
@@ -124,6 +166,21 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         item.add_marker(mark)
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> Iterator[None]:
+    """Surface the server log path on failure + stash outcome for video fixture."""
+    outcome = yield
+    rep = outcome.get_result()
+    if rep.when == "call":
+        item.rep_call = rep  # ty: ignore[unresolved-attribute]
+    if rep.failed:
+        log_path = getattr(item.session, "_e2e_server_log_path", None)
+        if log_path:
+            sys.stderr.write(
+                f"\n[E2E] Server log for failure ({item.nodeid}, {rep.when}): {log_path}\n",
+            )
+
+
 @pytest.fixture(scope="session")
 def django_db_modify_db_settings():
     """Prevent pytest-django from renaming the DB to a test_ prefix."""
@@ -154,12 +211,16 @@ def django_db_setup(django_db_modify_db_settings, django_db_blocker):
 
 
 @pytest.fixture(scope="session")
-def e2e_server(django_db_setup) -> Iterator[str]:
+def e2e_server(django_db_setup, request: pytest.FixtureRequest) -> Iterator[str]:
     """Start ASGI server (uvicorn) on a free port, yield URL.
 
     Using ASGI instead of WSGI (runserver) so SSE streaming connections
     are handled properly — async generators are cancelled on client
     disconnect instead of leaking threads.
+
+    Server stdout+stderr are tee'd to ``e2e/.logs/server-<ISO>.log`` rather
+    than discarded — failures in CI are otherwise opaque. The path is
+    surfaced via ``pytest_runtest_makereport`` whenever a test fails.
     """
     port = _find_free_port()
     url = f"http://127.0.0.1:{port}"
@@ -177,6 +238,12 @@ def e2e_server(django_db_setup) -> Iterator[str]:
         "DJANGO_SETTINGS_MODULE": "e2e.settings",
         "TEATREE_E2E_DB_DIR": str(_DB_DIR),
     }
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    log_path = _LOGS_DIR / f"server-{timestamp}-{worker}.log"
+    request.session._e2e_server_log_path = log_path  # noqa: SLF001  # ty: ignore[unresolved-attribute]
+    sys.stderr.write(f"E2E server log: {log_path}\n")
+    log_handle = log_path.open("wb")
     proc = subprocess.Popen(  # noqa: S603
         [
             sys.executable,
@@ -190,27 +257,36 @@ def e2e_server(django_db_setup) -> Iterator[str]:
             "--log-level",
             "warning",
         ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
         env=env,
     )
 
-    _wait_for_server(url)
+    try:
+        _wait_for_server(url)
+    except TimeoutError:
+        log_handle.close()
+        proc.kill()
+        proc.wait(timeout=3)
+        sys.stderr.write(f"\n[E2E] Server failed to start. Log: {log_path}\n")
+        raise
     yield url
     proc.terminate()
     try:
-        _, stderr = proc.communicate(timeout=5)
+        proc.wait(timeout=5)
     except subprocess.TimeoutExpired:
         proc.kill()
-        _, stderr = proc.communicate(timeout=3)
-    if stderr:
-        sys.stderr.write(f"E2E server stderr:\n{stderr.decode()[-1000:]}\n")
+        proc.wait(timeout=3)
+    log_handle.close()
 
 
 @pytest.fixture(autouse=True)
 def _seed_data(e2e_server: str, django_db_blocker) -> Iterator[None]:
     """Seed DB before each test, flush after."""
+    from django.core.cache import cache
+
     from teatree.core.models import Session, Task, Ticket, Worktree
+    from teatree.core.sync import PENDING_REVIEWS_CACHE_KEY
 
     with django_db_blocker.unblock():
         # Ticket with MR data
@@ -252,6 +328,13 @@ def _seed_data(e2e_server: str, django_db_blocker) -> Iterator[None]:
             state="provisioned",
             db_name="wt_42_demo",
         )
+        Worktree.objects.create(
+            ticket=ticket,
+            repo_path="/tmp/demo-frontend",
+            branch="feat-42-fe",
+            state="ready",
+            db_name="wt_42_demo_fe",
+        )
         session = Session.objects.create(ticket=ticket, agent_id="e2e-agent")
         Task.objects.create(
             ticket=ticket,
@@ -280,17 +363,58 @@ def _seed_data(e2e_server: str, django_db_blocker) -> Iterator[None]:
         # The headless task above triggers the immediate-backend signal which
         # creates a TaskAttempt with `ended_at=now()` — that microsecond-precision
         # timestamp is rendered in the Sessions panel and would change every run.
-        from datetime import datetime
-
         from teatree.core.models import TaskAttempt
 
         frozen = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
         TaskAttempt.objects.update(started_at=frozen, ended_at=frozen)
 
+        # Seed pending_reviews via the Django cache the panel builder reads.
+        # Using FileBasedCache (see ``e2e/settings.py``) so the live ASGI
+        # subprocess sees the same payload as the test process.
+        cache.set(
+            PENDING_REVIEWS_CACHE_KEY,
+            [
+                {
+                    "url": "https://gitlab.example.com/org/backend/-/merge_requests/505",
+                    "title": "feat(reports): nightly export pipeline",
+                    "repo": "backend",
+                    "iid": "505",
+                    "author": "alice",
+                    "draft": "false",
+                    "updated_at": "2026-01-01T08:00:00Z",
+                },
+                {
+                    "url": "https://gitlab.example.com/org/frontend/-/merge_requests/612",
+                    "title": "fix(login): handle SSO redirect race",
+                    "repo": "frontend",
+                    "iid": "612",
+                    "author": "bob",
+                    "draft": "true",
+                    "updated_at": "2026-01-02T09:30:00Z",
+                },
+            ],
+            timeout=None,
+        )
+
     yield
 
     with django_db_blocker.unblock():
         Ticket.objects.all().delete()
+        cache.clear()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _purge_logs_videos_on_session_end() -> Iterator[None]:
+    """Drop empty log/video dirs at the end of a clean session.
+
+    Failed runs leave the artifacts in place — ``_video_retain_on_failure``
+    already deletes per-test videos for passing tests, so anything still on
+    disk after a green run is empty boilerplate.
+    """
+    yield
+    for path in (_LOGS_DIR, _VIDEOS_DIR):
+        if path.is_dir() and not any(path.iterdir()):
+            shutil.rmtree(path, ignore_errors=True)
 
 
 def _find_free_port() -> int:

--- a/e2e/settings.py
+++ b/e2e/settings.py
@@ -77,6 +77,16 @@ TASKS = {
     },
 }
 
+# File-based cache shared across the test process and the live ASGI subprocess.
+# The default LocMemCache is per-process, so seeding ``PENDING_REVIEWS_CACHE_KEY``
+# from conftest would never reach the server's panel builder.
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+        "LOCATION": str(_DB_DIR / "cache"),
+    },
+}
+
 # Disable the dashboard auto-sync POST in e2e mode. The auto-sync's
 # ``hx-on::after-request="refreshPanels"`` triggers a second wave of panel
 # reloads after the initial HTMX panel loads have already settled, which can

--- a/e2e/test_dashboard.py
+++ b/e2e/test_dashboard.py
@@ -83,7 +83,10 @@ def test_tickets_pipeline_and_approvals(e2e_server: str, page: Page) -> None:
     page.goto(e2e_server)
     expect(page.locator("body")).to_contain_text("\u2705")  # ✅
     expect(page.locator("body")).to_contain_text("\u274c")  # ❌
-    expect(page.locator("span", has_text="Draft")).to_be_visible()
+    # Draft pill rendered for the frontend!200 MR. ``.first`` because the
+    # Pending Reviews panel also seeds a draft entry — both spans share the
+    # same Tailwind class so a bare locator is ambiguous.
+    expect(page.locator("span", has_text="Draft").first).to_be_visible()
     expect(page.locator("body")).to_contain_text("1/1")
     expect(page.locator("body")).to_contain_text("0/1")
 
@@ -212,19 +215,8 @@ def test_htmx_panels_present(e2e_server: str, page: Page) -> None:
 
 
 # ── Additional panels ──────────────────────────────────────────────
-
-
-@pytest.mark.skip(reason="snapshot platform-sensitive, see #378 follow-up")
-def test_action_required_panel(e2e_server: str, page: Page, assert_snapshot: Callable) -> None:
-    page.goto(e2e_server)
-    expect(page.locator("h2", has_text="Action Required")).to_be_visible()
-
-    action_section = page.locator("h2", has_text="Action Required").locator("..")
-    assert_snapshot(
-        action_section.screenshot(animations="disabled"),
-        name="action-required.png",
-        threshold=_SNAPSHOT_THRESHOLD,
-    )
+# Functional coverage for the rest of the panel surface lives in
+# ``test_dashboard_panels.py`` (functional asserts, not snapshots — see #19).
 
 
 def test_sessions_panel_visible(e2e_server: str, page: Page) -> None:
@@ -237,13 +229,10 @@ def test_automation_panel(e2e_server: str, page: Page) -> None:
     expect(page.locator("h2", has_text="Automation")).to_be_visible()
 
 
-def test_task_detail_modal(e2e_server: str, page: Page) -> None:
-    page.goto(e2e_server)
-    task_link = page.locator("[hx-get*='/tasks/'][hx-get*='/detail/']").first
-    if task_link.is_visible():
-        task_link.click()
-        page.wait_for_timeout(500)
-        expect(page.locator("#task-modal-body")).to_be_visible()
+# Task detail modal coverage moved to ``test_dashboard_flows.py``
+# (``test_task_detail_modal_opens``) — that version drops the
+# ``if visible:`` skip guard and asserts modal contents on a guaranteed-
+# visible seeded task.
 
 
 # ── Git Pull (CONTRIBUTE mode) ─────────────────────────────────────

--- a/e2e/test_dashboard_flows.py
+++ b/e2e/test_dashboard_flows.py
@@ -1,0 +1,156 @@
+"""E2E coverage for dashboard flows: modal, history endpoint, SSE, launches.
+
+The pre-existing flow coverage in ``test_dashboard.py`` was either
+gated on ``if visible`` (effectively a no-op) or stopped at the click
+boundary without asserting downstream state. These tests close those
+gaps. See [#19](https://github.com/souliane/teatree/issues/19).
+"""
+
+import json
+from urllib.parse import quote
+
+import httpx
+from playwright.sync_api import Page, Route, expect
+
+
+def test_task_detail_modal_opens(e2e_server: str, page: Page, django_db_blocker) -> None:
+    """Click a Task button in the unified-sessions panel; modal populates with task fields.
+
+    Replaces ``test_task_detail_modal`` which was gated on
+    ``if task_link.is_visible():`` and therefore became a silent no-op.
+    """
+    from teatree.core.models import Task
+
+    page.goto(e2e_server)
+    # Wait for the unified sessions HTMX panel to load (renders Task buttons).
+    page.locator("#unified-sessions-grid").wait_for(state="visible")
+
+    with django_db_blocker.unblock():
+        task = Task.objects.filter(execution_target="interactive").first()
+    assert task is not None, "seed should provide an interactive task"
+
+    page.get_by_role("button", name=f"Task {task.pk}").first.click()
+
+    modal_body = page.locator("#task-modal-body")
+    expect(modal_body).to_be_visible()
+    # Task fields rendered in ``task_detail_popup.html``: task_id, status,
+    # execution_target, execution_reason. We verify the seed-specific
+    # reason ("Needs manual verification") to prove the right task loaded.
+    expect(modal_body).to_contain_text(f"Task {task.pk}")
+    expect(modal_body).to_contain_text("Needs manual verification")
+    expect(modal_body).to_contain_text("Interactive")
+
+
+def test_session_history_endpoint(e2e_server: str) -> None:
+    """``/sessions/<id>/history/?cwd=<path>`` returns 200 and a rendered partial.
+
+    Direct-hit test (no Playwright) — the view doesn't require an HTMX
+    header; it just renders the transcript template. Missing/invalid
+    ``cwd`` gives 404 (regex guard).
+    """
+    cwd = quote("/tmp/demo-backend", safe="")
+    # Use a session_id short enough to survive the template's
+    # ``truncatechars:14`` filter on "Session " + id.
+    session_id = "sess-42"
+    response = httpx.get(
+        f"{e2e_server}/sessions/{session_id}/history/?cwd={cwd}",
+        timeout=5.0,
+    )
+    assert response.status_code == 200, response.text[:200]  # noqa: PLR2004
+    body = response.text
+    assert session_id in body
+    # No transcript file exists for this synthetic session — the template
+    # branches to the empty-state message.
+    assert "No messages found." in body
+
+    # Sanity: missing ``cwd`` 404s — guards against regressions in the
+    # path validator.
+    bad = httpx.get(f"{e2e_server}/sessions/abc-1234-session/history/", timeout=5.0)
+    assert bad.status_code == 404  # noqa: PLR2004
+
+
+def test_sse_connection(e2e_server: str) -> None:
+    """SSE endpoint streams an initial ``connected`` event on subscribe.
+
+    ``DashboardSSEView`` always emits ``event: connected`` as its first
+    frame so HTMX clients can confirm the channel is alive. We read raw
+    bytes with httpx and assert the framing is well-formed within a
+    timeout. Cancelled by closing the response — the async generator
+    catches ``CancelledError`` and returns cleanly.
+    """
+    timeout = httpx.Timeout(connect=5.0, read=10.0, write=5.0, pool=5.0)
+    with httpx.stream("GET", f"{e2e_server}/dashboard/events/", timeout=timeout) as response:
+        assert response.status_code == 200  # noqa: PLR2004
+        assert "text/event-stream" in response.headers["content-type"]
+        # Read just enough to confirm the first event arrived.
+        buffer = ""
+        for chunk in response.iter_text():
+            buffer += chunk
+            if "event: connected" in buffer:
+                break
+        assert "event: connected" in buffer, f"first chunk: {buffer[:200]}"
+        assert '"status": "ok"' in buffer
+
+
+def test_launch_terminal_flow(e2e_server: str, page: Page) -> None:
+    """Clicking the Terminal button POSTs to ``/dashboard/launch-terminal/``.
+
+    We never want to actually spawn ttyd in CI. Intercept the request via
+    ``page.route`` and return a deterministic ``launch_url`` payload, then
+    verify the dashboard's ``handleActionResponse`` handler tries to open
+    that URL via ``window.open`` (which we shim to record the target).
+    """
+    fake_url = "http://terminal.example.test/abc"
+    captured: dict[str, str] = {}
+
+    def handle_launch(route: Route) -> None:
+        captured["request"] = route.request.url
+        route.fulfill(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({"launch_url": fake_url}),
+        )
+
+    page.route("**/dashboard/launch-terminal/", handle_launch)
+    page.goto(e2e_server)
+    # Capture window.open calls — handleActionResponse opens the URL in a
+    # new tab on success. Returning ``null`` keeps Playwright from waiting
+    # on a popup that we don't actually need.
+    page.add_init_script(
+        "window.__opens = []; window.open = (u, t) => { window.__opens.push(u); return null; };",
+    )
+    page.reload()  # re-run init script after route is set
+    page.locator("button.split-main", has_text="Terminal").first.click()
+    # Wait for the captured POST to land.
+    page.wait_for_function("window.__opens && window.__opens.length > 0", timeout=5000)
+    opens = page.evaluate("window.__opens")
+    assert fake_url in opens, f"expected window.open({fake_url!r}); got {opens!r}"
+    assert "/dashboard/launch-terminal/" in captured.get("request", "")
+
+
+def test_launch_agent_headless(e2e_server: str, page: Page, django_db_blocker) -> None:
+    """Clicking Headless creates a Task and a TaskAttempt under ImmediateBackend.
+
+    Extends the original ``test_create_headless_task`` (which only
+    asserted that the panel re-rendered) with downstream assertions:
+    the new Task exists in the DB and has at least one TaskAttempt
+    (because ``e2e.settings`` configures ImmediateBackend).
+    """
+    from teatree.core.models import Task, TaskAttempt
+
+    with django_db_blocker.unblock():
+        before_tasks = Task.objects.filter(execution_target="headless").count()
+        before_attempts = TaskAttempt.objects.count()
+
+    page.goto(e2e_server)
+    page.on("dialog", lambda dialog: dialog.accept())
+    page.locator("button", has_text="Headless").first.click()
+    # Give the synchronous task backend time to record the attempt.
+    page.wait_for_timeout(1500)
+
+    with django_db_blocker.unblock():
+        after_tasks = Task.objects.filter(execution_target="headless").count()
+        after_attempts = TaskAttempt.objects.count()
+
+    assert after_tasks > before_tasks, "click should have created a new headless Task"
+    assert after_attempts > before_attempts, "ImmediateBackend should have recorded a TaskAttempt for the new task"

--- a/e2e/test_dashboard_panels.py
+++ b/e2e/test_dashboard_panels.py
@@ -1,0 +1,98 @@
+"""E2E coverage for dashboard panels not previously asserted.
+
+Functional asserts (text/elements present), no snapshot diffing — see
+[#19](https://github.com/souliane/teatree/issues/19) for context. Snapshot
+tests against these panels are platform-sensitive and were the reason the
+original ``test_action_required_panel`` was skipped on every run.
+
+Worktrees and Activity panels aren't rendered as standalone ``<details>``
+blocks on the dashboard home page (only Automation, Action Required,
+Sessions, In-Flight Tickets, Pending Reviews are). For those we drive the
+HTMX endpoint directly with the ``HX-Request`` header — that's the
+contract real HTMX clients hit at runtime.
+"""
+
+from playwright.sync_api import APIResponse, Page, expect
+
+
+def _fetch_panel(page: Page, e2e_server: str, panel: str) -> APIResponse:
+    """GET ``/dashboard/panels/<panel>/`` with HTMX header. Returns Playwright APIResponse."""
+    return page.request.get(
+        f"{e2e_server}/dashboard/panels/{panel}/",
+        headers={"HX-Request": "true"},
+    )
+
+
+def test_action_required_panel(e2e_server: str, page: Page) -> None:
+    """Section renders and surfaces the seeded interactive task as an action item.
+
+    Replaces the platform-sensitive snapshot test that was skipped on every
+    run. The seeded ticket has one ``execution_target=interactive`` Task in
+    ``PENDING`` status — ``build_action_required`` turns that into an
+    ``"interactive_task"`` row labeled with the ticket number + reason.
+    """
+    page.goto(e2e_server)
+    expect(page.locator("h2", has_text="Action Required")).to_be_visible()
+    # The seeded interactive task carries this exact ``execution_reason``.
+    # Rendered as the right-hand "detail" span on the action item card.
+    expect(page.locator("body")).to_contain_text("Needs manual verification")
+    expect(page.locator("span.pill", has_text="Interactive").first).to_be_visible()
+
+
+def test_worktrees_panel(e2e_server: str, page: Page) -> None:
+    """Worktrees panel returns 200 and renders the seeded worktree rows.
+
+    The panel isn't on the home dashboard (only consumed via HTMX); we hit
+    the endpoint directly and parse the response body.
+    """
+    response = _fetch_panel(page, e2e_server, "worktrees")
+    assert response.status == 200, f"got {response.status}: {response.text()[:200]}"  # noqa: PLR2004
+    body = response.text()
+    # Section column headers from ``dashboard_worktrees.html``.
+    assert "Ticket" in body
+    assert "Branch" in body
+    assert "Database" in body
+    # Both seeded worktrees are visible (one provisioned, one ready).
+    assert "feat-42" in body
+    assert "wt_42_demo" in body
+    assert "wt_42_demo_fe" in body
+
+
+def test_pending_reviews_panel(e2e_server: str, page: Page) -> None:
+    """Pending Reviews section renders the seeded cache rows.
+
+    Issue #19 calls this panel ``review_comments``; the actual builder key
+    (and template) is ``pending_reviews``. ``conftest._seed_data`` primes
+    the ``PENDING_REVIEWS_CACHE_KEY`` Django cache the builder reads from
+    — using FileBasedCache so the test process's writes reach the live
+    ASGI subprocess.
+    """
+    page.goto(e2e_server)
+    expect(page.locator("h2", has_text="Pending Reviews")).to_be_visible()
+    # Two seeded entries: one non-draft, one draft.
+    expect(page.locator("body")).to_contain_text("backend\xa0#505")
+    expect(page.locator("body")).to_contain_text("frontend\xa0#612")
+    expect(page.locator("body")).to_contain_text("nightly export pipeline")
+    # Draft pill on the second row.
+    expect(page.locator("span.pill", has_text="Draft").first).to_be_visible()
+
+
+def test_activity_panel(e2e_server: str, page: Page) -> None:
+    """Activity panel returns 200 and renders the seeded TaskAttempt row.
+
+    The headless task seeded in conftest runs synchronously under
+    ImmediateBackend, producing a TaskAttempt that ``build_recent_activity``
+    surfaces as an activity card. Real attempts fail in CI (no ``claude``
+    binary) — we accept any of the rendered exit_code branches.
+    """
+    response = _fetch_panel(page, e2e_server, "activity")
+    assert response.status == 200, f"got {response.status}: {response.text()[:200]}"  # noqa: PLR2004
+    body = response.text()
+    # The seeded ticket renders as ``#42`` (Ticket._display_id).
+    assert "#42" in body
+    # Headless task phase from seed data.
+    assert "reviewing" in body
+    # Any of the three exit_code badges from ``dashboard_activity.html``.
+    assert any(badge in body for badge in ("Success", "Failed", "Unknown")), (
+        f"expected an exit-code badge in the rendered card; got body[:400]={body[:400]!r}"
+    )


### PR DESCRIPTION
test(e2e): cover all dashboard panels + flows, capture server logs and videos (#19)

Adds functional E2E coverage for the panels and flows that were skipped or
gated to no-ops:

- Panels: action_required (replaces skipped snapshot test), worktrees,
  pending_reviews, activity. Worktrees + activity hit the HTMX panel
  endpoint directly since they aren't rendered as standalone sections on
  the dashboard home.
- Flows: task_detail_modal_opens (drops the stale ``if visible`` guard),
  session_history_endpoint, sse_connection, launch_terminal_flow (mocks
  the launcher via page.route — never spawns ttyd in CI),
  launch_agent_headless (asserts a TaskAttempt was recorded under
  ImmediateBackend).
- Conftest: server stdout+stderr captured to
  ``e2e/.logs/server-<ISO>-<worker>.log``; ``pytest_runtest_makereport``
  prints the path on every failure. Playwright video via
  ``record_video_dir``; ``_video_retain_on_failure`` deletes per-test
  videos for passing runs to keep CI artifact size bounded. Seed data
  extended with a second worktree, two pending-review cache entries, and
  the ``cache.clear()`` flush.
- ``e2e/settings.py`` switches the Django cache to ``FileBasedCache``
  (location under ``_DB_DIR``) so the test process and the live ASGI
  subprocess share the cache the panel builders read from.
- ``dev/docker-compose.yml`` mounts ``e2e/.logs`` and ``e2e/.videos``
  writable into the e2e container (the rest of the repo stays ``:ro``).
- README adds an E2E section documenting the new artifacts.

Verified via ``t3 teatree e2e project``: 109 passed, 5 skipped (5:14).