### PR TITLE
refactor(skills): drop session-narrative past-failure blocks + ship content-sibling sweep

### DIFF
--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -67,7 +67,7 @@ When a user reports "this worked yesterday" or "this just started happening," ch
 3. Plugin/package updates (check cache timestamps, lockfiles)
 4. Environment changes (new env vars, updated tools)
 
-This is faster than reading every file in detail and often pinpoints the cause immediately. (Source: retro 2026-04-02 — duplicate hooks from plugin migration found via file dates, not code reading.)
+This is faster than reading every file in detail and often pinpoints the cause immediately.
 
 ### Phase 1: Root Cause Investigation
 

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -43,7 +43,7 @@ Retro's behavior depends on these `~/.teatree` variables and on whether the curr
 - **Push behavior is mode-conditional — defer to `t3:rules § Publishing Actions Are Mode-Conditional`.** Resolve the effective mode in the prescribed order (`T3_MODE` env → active overlay config → global `[teatree]` table → per-repo memory overrides → default `interactive`).
   - **`auto`**: push immediately after the privacy scan passes — no prompt, no "your call", no deferral to `/t3:contribute`. Open the PR if one doesn't already exist.
   - **`interactive`**: commit locally and remind the user to run `/t3:contribute`.
-  - The legacy `T3_PUSH` / `T3_AUTO_PUSH_FORK` env vars are honored only when no `mode` is configured anywhere; the `mode` setting subsumes them and wins on conflict. **Do not gate retro pushes on `T3_PUSH` when `mode = "auto"` is set in `~/.teatree.toml`** — that was a 2026-04-25 retro lesson. A fork-vs-upstream split (origin ≠ `T3_UPSTREAM`) does not change the push decision; it only affects whether `/t3:contribute` opens an upstream issue afterward.
+  - The legacy `T3_PUSH` / `T3_AUTO_PUSH_FORK` env vars are honored only when no `mode` is configured anywhere; the `mode` setting subsumes them and wins on conflict. **Do not gate retro pushes on `T3_PUSH` when `mode = "auto"` is set in `~/.teatree.toml`.** A fork-vs-upstream split (origin ≠ `T3_UPSTREAM`) does not change the push decision; it only affects whether `/t3:contribute` opens an upstream issue afterward.
 - **`T3_UPSTREAM`** — upstream GitHub repo (e.g., `souliane/teatree`). Used by `/t3:contribute` to open issues upstream after pushing. When `origin` matches `T3_UPSTREAM`, pushes already land directly on upstream.
 - **`T3_PRIVACY`** — privacy check strictness: `strict` (default) or `relaxed`. See § Privacy Scan.
 - **`T3_REVIEW_SKILL`** — name of an external skill review tool (e.g., `ac-reviewing-codebase`). If set, retro recommends running it after skill improvements. If not set, retro suggests installing one during first run and storing the preference.
@@ -201,8 +201,6 @@ flowchart TD
 ### 1. Conversation Audit
 
 **Scope-match check first (Non-Negotiable).** Before auditing individual failures, re-open the ticket/issue body that framed this session and map every acceptance criterion, phase, or deliverable to what actually shipped. If ANY AC is unshipped and the session was declared complete (MR merged with `Closes/Fixes`, `/t3:next` run, ticket marked done), that is a **False completion** finding and it outranks every tactical finding below. Re-reading the issue body is not optional — scoping→implementation drift is invisible from the conversation alone.
-
-**Past failure (#97):** Scoping session focused on Phase 5 (of 5). Implementation shipped Phase 5 only, but the PR used `Closes #97`, auto-closing the issue. Retro ran and found tactical workspace-troubleshooting nuggets while never noticing that 4/5 phases of the issue body were unshipped. The user had to manually call it out. Prevention: this step.
 
 **Check dashboard server logs next.** Inspect the teatree dashboard log for errors that may not have surfaced in the conversation:
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -300,8 +300,6 @@ When `contribute = true` in `~/.teatree.toml`, retro findings and cross-cutting 
 
 **Promote means edit an existing skill.** Pick the best-fit existing skill (`/t3:rules`, `/t3:next`, `/t3:ship`, etc.) and insert the rule there. Do not invent a new skill for a single rule — that fragments the skill graph.
 
-**Past failure (2026-04-24):** Retro saved a scoping-phase auto-enqueue rule to `~/.claude/.../memory/feedback_scoping_auto_enqueue_coding.md` when `contribute = true` and the correct home was `skills/next/SKILL.md`. The user had to explicitly call out the deferral and push for the promotion. Prevention: this checklist.
-
 ## Ask About Auth Before External Service Integrations
 
 When implementing features that require an external service (Notion, Slack, CI, etc.), ask "how do you authenticate with this service?" BEFORE writing any code. The answer (direct API token, CLI auth, MCP tool, OAuth, etc.) determines the entire architecture. Skipping this question leads to multiple implementation pivots.
@@ -428,8 +426,6 @@ When a pre-commit hook runs the full test suite and fails on tests **unrelated t
 2. `git branch <branch> HEAD` (snapshots the current staged + working state to the new branch).
 3. If staged-but-not-committed: `git stash push --staged`, `git worktree add ~/workspace/<branch>/<repo> -b <branch>`, `cd` into the worktree, `git stash pop`, then commit there.
 4. If already-committed-on-main: `git branch <branch> HEAD`, `git reset --hard origin/main` (or `git reset --hard <previous-HEAD>`), then `git worktree add ~/workspace/<branch>/<repo> <branch>` and continue from the worktree.
-
-**Past failure (2026-05-05):** Resuming after compaction with skill edits already applied directly in the main clones of `souliane/teatree` and `souliane/skills`, I committed those edits on `main` rather than recovering them onto worktree branches first. The user reset main and called `/retro`. Prevention: this pre-commit check.
 
 **Collision detection — check on EVERY file write or git operation:**
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -148,8 +148,6 @@ Before writing `Closes #N` or `Fixes #N` in a PR body, re-read the linked issue 
 - List the unshipped phases/AC in the PR body under a "Remaining scope" heading so the next agent sees the gap.
 - Do NOT rely on "I'll do the rest later" memory. The issue body is the contract; a partial PR that auto-closes the issue silently discards the rest of the contract.
 
-**Past failure (#97, PR #423):** Issue #97 defined 5 phases (`Phase 1` teardown cleanup through `Phase 5` teatree core hooks). PR #423 shipped only Phase 5 but used `Closes #97`, auto-closing the issue when 4/5 phases remained. The user had to reopen the issue manually. Prevention: the phase-by-phase ✅/❌ matrix in the PR body would have forced the correct verb (`Relates-to`).
-
 **STOP — resolve the ticket URL before typing the glab command.**
 
 Before composing any `glab mr create` or `glab mr update` call, answer these three questions:
@@ -234,8 +232,6 @@ If a sibling is open, **do not open a second MR targeting the default branch** �
 
 **Never open two MRs on the same ticket targeting the default branch in parallel.** The only exception is when the two MRs touch genuinely disjoint files (different repos, different modules with no shared imports, no overlapping generated docs) — and even then, the second MR's description must name the sibling PR it races with.
 
-**Past failure (#140 / PRs #427 + #436):** Both PRs touched `README.md`, `BLUEPRINT.md`, `src/teatree/core/*` and ran in parallel against `main`. When #427 squash-merged first, #436 inherited an unsynced merge base and required a full 3-way conflict resolution. Opening #436 as a stacked PR with `--base ac/teatree-#140-initial-ship` would have avoided every conflict.
-
 ### Also sweep by content for ticketless PRs (Non-Negotiable)
 
 The ticket-ref query above misses **retro fixes, skill edits, and other PRs without a ticket reference**. Before opening any such PR, also run a content sweep against open and recently-merged PRs on the same repo and look for overlap on title keywords or touched files:
@@ -254,8 +250,6 @@ Match against:
 - **Touched files** that overlap with `git diff --name-only origin/main..HEAD` on the local branch — for skill PRs especially, multiple agents/users converge on the same `skills/<topic>/SKILL.md` file.
 
 Treat a hit on either signal as a sibling and apply the same options (wait, stack, or bundle per `## Bundle Into an Existing Open PR` below). If the hit is in the recently-merged list, run `git fetch origin main && git log origin/main..HEAD` — if the local diff is now empty, abandon the branch instead of pushing an empty PR.
-
-**Past failure (2026-05-05, PR [#509](https://github.com/souliane/teatree/pull/509)):** Agent opened #509 with two retro findings (grep cross-ref rule + pre-commit worktree check) without sweeping. The user had merged the same two findings via [#507](https://github.com/souliane/teatree/pull/507) and [#508](https://github.com/souliane/teatree/pull/508) in parallel, minutes before #509 landed. #509 squash-merged as an empty diff — wasted CI on lint/test/e2e jobs and added an empty merge commit to history.
 
 ## Bundle Into an Existing Open PR
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -236,6 +236,27 @@ If a sibling is open, **do not open a second MR targeting the default branch** �
 
 **Past failure (#140 / PRs #427 + #436):** Both PRs touched `README.md`, `BLUEPRINT.md`, `src/teatree/core/*` and ran in parallel against `main`. When #427 squash-merged first, #436 inherited an unsynced merge base and required a full 3-way conflict resolution. Opening #436 as a stacked PR with `--base ac/teatree-#140-initial-ship` would have avoided every conflict.
 
+### Also sweep by content for ticketless PRs (Non-Negotiable)
+
+The ticket-ref query above misses **retro fixes, skill edits, and other PRs without a ticket reference**. Before opening any such PR, also run a content sweep against open and recently-merged PRs on the same repo and look for overlap on title keywords or touched files:
+
+```bash
+# Open PRs (parallel work in flight)
+gh pr list --repo <repo> --state open --json number,title,headRefName
+
+# Recently-merged PRs (work that landed minutes ago — same risk)
+gh pr list --repo <repo> --state merged --limit 10 --json number,title,mergedAt
+```
+
+Match against:
+
+- **Title keywords** that overlap with the about-to-be-pushed PR's title (e.g., "rules", "worktree", "anti-fabrication"). Synonyms count.
+- **Touched files** that overlap with `git diff --name-only origin/main..HEAD` on the local branch — for skill PRs especially, multiple agents/users converge on the same `skills/<topic>/SKILL.md` file.
+
+Treat a hit on either signal as a sibling and apply the same options (wait, stack, or bundle per `## Bundle Into an Existing Open PR` below). If the hit is in the recently-merged list, run `git fetch origin main && git log origin/main..HEAD` — if the local diff is now empty, abandon the branch instead of pushing an empty PR.
+
+**Past failure (2026-05-05, PR [#509](https://github.com/souliane/teatree/pull/509)):** Agent opened #509 with two retro findings (grep cross-ref rule + pre-commit worktree check) without sweeping. The user had merged the same two findings via [#507](https://github.com/souliane/teatree/pull/507) and [#508](https://github.com/souliane/teatree/pull/508) in parallel, minutes before #509 landed. #509 squash-merged as an empty diff — wasted CI on lint/test/e2e jobs and added an empty merge commit to history.
+
 ## Bundle Into an Existing Open PR
 
 When a session uncovers a small unique commit on a now-stale branch (typical during cleanup or retro), and opening a dedicated PR for that one commit would be more ceremony than the change deserves, **bundle it into a sibling open PR** instead. This trades a little PR-scope discipline for delivery speed.

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -83,9 +83,7 @@ The `SkillLoadingPolicy` class resolves which skills to load based on intent, ov
 
 ## Plugin Hooks Architecture
 
-Hooks are registered in `hooks/hooks.json` (shipped with the plugin). This is the **sole source** for hook registrations — do NOT duplicate hooks in the user's `~/.claude/settings.json`. When adding or changing hooks, only modify `hooks.json` in this repo.
-
-**Known failure (2026-04-02):** PR #109 moved hooks from `settings.json` to plugin `hooks.json` but didn't remove the old ones. This caused double hook execution on every tool call, accelerating context consumption and triggering aggressive microcompaction. Prevention: when migrating hooks to the plugin, always remove the `settings.json` equivalents in the same change.
+Hooks are registered in `hooks/hooks.json` (shipped with the plugin). This is the **sole source** for hook registrations — do NOT duplicate hooks in the user's `~/.claude/settings.json`. When migrating hooks to the plugin, remove the `settings.json` equivalents in the same change to avoid double execution.
 
 ## Management Command Patterns
 
@@ -96,8 +94,7 @@ Teatree's CLI groups (`t3 <overlay> <group> <sub>`) are django-typer `TyperComma
 - Canonical example: `src/teatree/core/management/commands/tasks.py:19` — `raise SystemExit(1)` after `self.stderr.write(...)`.
 - Tests: `with pytest.raises(SystemExit) as exc_info: call_command(...)` then assert `exc_info.value.code == N`. `pytest.raises(typer.Exit)` reports `DID NOT RAISE` even though the source did raise — call_command eats it before pytest sees it.
 - `typer.Exit` is still correct in `src/teatree/cli/*.py` files that go through the typer runner directly (different call site).
-
-**Known failure (2026-04-22):** `e2e` management command returned `"E2E failed (exit 1)."` as a string instead of raising. CI jobs running `t3 teatree e2e *` reported success on Playwright/pytest failures. Fixed in [#370](https://github.com/souliane/teatree/pull/370) by raising `SystemExit(result.returncode)` after `self.stderr.write(...)`.
+- Anti-pattern: returning an error string from a management command instead of raising. The CLI exits 0 and CI reports green on real failures.
 
 ### Annotated typer options must have defaults for `call_command`
 


### PR DESCRIPTION
Two retro findings. Both are skill-only — no code changes.

## refactor(skills): drop session-narrative past-failure blocks

`Past failure` / `Known failure` paragraphs across the skills repo carry agent-session narrative (specific dates, PR numbers, 'the user did X', 'I committed Y'). That kind of content belongs in personal memory, not in the open-sourced skills repo. The surrounding rules stand on their own without the incident citation. Removed across `debug`, `retro`, `rules`, `ship`, `teatree` skills.

One incident citation in `teatree/SKILL.md` was rewritten as a one-line anti-pattern bullet (returning an error string from a management command instead of raising) — useful as guidance, no narrative.

## docs(ship): sweep open + recently-merged PRs by content for ticketless retros

The existing `One Open MR Per Ticket` rule keys on a ticket reference, which retro/skill PRs don't have. When a parallel retro PR lands mid-session, the agent's PR can be redundant or empty. Adds a content sweep against open AND recently-merged PRs by title-keyword and touched-file overlap. If the local diff has gone empty against fresh `origin/main`, abandon the branch instead of pushing.

## Test plan

- [x] prek passes locally on both commits
- [x] Privacy scan clean
- [ ] CI green