### PR TITLE
fix(launcher): surface missing-binary errors as HTTP 500 with install hints

### DIFF
--- a/src/teatree/agents/terminal_launcher.py
+++ b/src/teatree/agents/terminal_launcher.py
@@ -23,11 +23,19 @@ from teatree.utils.run import DEVNULL, PIPE, spawn
 logger = logging.getLogger(__name__)
 
 
+_TTYD_INSTALL_HINT = "ttyd not found on PATH — install with `brew install ttyd` (macOS) or `apt install ttyd` (Linux)"
+_LINUX_TERMINAL_HINT = (
+    "No terminal emulator found on PATH — install one of "
+    "gnome-terminal, konsole, xfce4-terminal, kitty, alacritty, or xterm"
+)
+
+
 @dataclass(frozen=True, slots=True)
 class LaunchResult:
     launch_url: str = ""
     pid: int = 0
     mode: str = ""
+    error: str = ""
 
 
 def launch(command: list[str], *, mode: str = "ttyd", cwd: str = "", app: str = "") -> LaunchResult:
@@ -42,8 +50,8 @@ def launch(command: list[str], *, mode: str = "ttyd", cwd: str = "", app: str = 
 def _launch_ttyd(command: list[str], *, cwd: str = "") -> LaunchResult:
     ttyd_bin = shutil.which("ttyd")
     if not ttyd_bin:
-        logger.error("ttyd not found on PATH")
-        return LaunchResult(mode="ttyd")
+        logger.error(_TTYD_INSTALL_HINT)
+        return LaunchResult(mode="ttyd", error=_TTYD_INSTALL_HINT)
 
     port = find_free_port()
     proc = spawn(
@@ -179,8 +187,8 @@ def _launch_linux_window(cmd_str: str, *, cwd: str = "", app: str = "") -> Launc
     if not terminal:
         terminal = _detect_linux_terminal()
     if not terminal:
-        logger.error("No terminal emulator found on PATH")
-        return LaunchResult(mode="new-window")
+        logger.error(_LINUX_TERMINAL_HINT)
+        return LaunchResult(mode="new-window", error=_LINUX_TERMINAL_HINT)
 
     name = Path(terminal).name
     if name in {"gnome-terminal", "xfce4-terminal"}:

--- a/src/teatree/core/views/launch.py
+++ b/src/teatree/core/views/launch.py
@@ -80,6 +80,8 @@ class LaunchTerminalView(View):
         shell = os.environ.get("SHELL", "/bin/zsh")
         result = terminal_launch([shell, "-l"], mode=mode, app=app)
 
+        if result.error:
+            return JsonResponse({"error": result.error}, status=500)
         if result.launch_url:
             return JsonResponse({"launch_url": result.launch_url})
         return JsonResponse({"launched": True, "mode": result.mode})
@@ -112,6 +114,8 @@ class LaunchInteractiveAgentView(View):
         app = request.POST.get("terminal_app", "")
         result = terminal_launch(_claude_argv(claude_bin), mode=mode, app=app)
 
+        if result.error:
+            return JsonResponse({"error": result.error}, status=500)
         if result.launch_url:
             return JsonResponse({"launch_url": result.launch_url})
         return JsonResponse({"launched": True, "mode": result.mode})

--- a/tests/teatree_core/test_launch_view.py
+++ b/tests/teatree_core/test_launch_view.py
@@ -198,6 +198,21 @@ class TestLaunchTerminalView:
         assert response.status_code == 200
         assert data["launched"] is True
 
+    def test_returns_500_when_launcher_reports_error(self, monkeypatch: "pytest.MonkeyPatch") -> None:
+        from teatree.agents.terminal_launcher import LaunchResult  # noqa: PLC0415
+
+        mock_result = LaunchResult(mode="ttyd", error="ttyd not found on PATH — install with `brew install ttyd`")
+        monkeypatch.setattr(
+            "teatree.agents.terminal_launcher.launch",
+            lambda command, mode="ttyd", cwd="", app="": mock_result,
+        )
+
+        response = Client().post("/dashboard/launch-terminal/")
+        data = json.loads(response.content)
+
+        assert response.status_code == 500
+        assert "ttyd not found" in data["error"]
+
 
 class TestFindFreePort:
     def test_returns_valid_port(self) -> None:
@@ -265,6 +280,22 @@ class TestLaunchInteractiveAgentView:
 
         assert response.status_code == 500
         assert "claude CLI not found" in data["error"]
+
+    def test_returns_500_when_launcher_reports_error(self, monkeypatch: "pytest.MonkeyPatch") -> None:
+        from teatree.agents.terminal_launcher import LaunchResult  # noqa: PLC0415
+
+        mock_result = LaunchResult(mode="ttyd", error="ttyd not found on PATH — install with `brew install ttyd`")
+        monkeypatch.setattr("teatree.core.views.launch.shutil.which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(
+            "teatree.agents.terminal_launcher.launch",
+            lambda command, mode="ttyd", cwd="", app="": mock_result,
+        )
+
+        response = Client().post("/dashboard/launch-agent/")
+        data = json.loads(response.content)
+
+        assert response.status_code == 500
+        assert "ttyd not found" in data["error"]
 
 
 class TestClaudeArgv:

--- a/tests/test_terminal_launcher.py
+++ b/tests/test_terminal_launcher.py
@@ -38,6 +38,8 @@ class TestLaunchTtyd:
         assert result.mode == "ttyd"
         assert result.launch_url == ""
         assert result.pid == 0
+        assert "ttyd not found" in result.error
+        assert "brew install ttyd" in result.error
 
     def test_launches_ttyd_process(self) -> None:
         mock_proc = MagicMock(pid=12345)
@@ -165,6 +167,7 @@ class TestLaunchLinuxWindow:
             result = launcher_mod._launch_linux_window("echo hi")
         assert result.mode == "new-window"
         assert result.pid == 0
+        assert "No terminal emulator found" in result.error
 
     def test_uses_gnome_terminal(self) -> None:
         mock_proc = MagicMock(pid=55)


### PR DESCRIPTION
## Summary

When `ttyd` was missing from `PATH`, the launcher returned an empty `LaunchResult` and the dashboard view replied with `HTTP 200 {"launched": true}`, leaving the user with a blank tab and no clue what went wrong. Same pattern on Linux when no terminal emulator was found.

This PR adds an `error` field to `LaunchResult` and populates it with an install hint:

- `ttyd not found on PATH — install with `brew install ttyd` (macOS) or `apt install ttyd` (Linux)`
- `No terminal emulator found on PATH — install one of gnome-terminal, konsole, xfce4-terminal, kitty, alacritty, or xterm`

`LaunchTerminalView` and `LaunchInteractiveAgentView` now translate a populated `error` into `HTTP 500`. The existing `handleActionResponse` JS handler renders the message as an error toast.

Closes #515

## Test plan

- [x] `tests/test_terminal_launcher.py` — assert `result.error` populated when ttyd / Linux terminal missing
- [x] `tests/teatree_core/test_launch_view.py` — new test cases for `LaunchTerminalView` and `LaunchInteractiveAgentView` returning 500
- [x] `uv run pytest --no-cov tests/test_terminal_launcher.py tests/teatree_core/test_launch_view.py` — 44 passed
- [x] `uv run ruff check` — clean