### PR TITLE
chore(hooks): drop relax from blueprint-sync exempt prefixes

### DIFF
--- a/scripts/hooks/check_blueprint_sync.py
+++ b/scripts/hooks/check_blueprint_sync.py
@@ -2,7 +2,7 @@
 
 Exits non-zero when source code changes without a corresponding BLUEPRINT.md
 update, unless the commit type is one that typically doesn't require it
-(test, docs, style, chore, relax, ci).
+(test, docs, style, chore, ci, fix).
 
 See: souliane/teatree#8
 """
@@ -12,7 +12,7 @@ import subprocess
 import sys
 
 # Commit types that don't require BLUEPRINT updates.
-_EXEMPT_PREFIXES = ("test", "docs", "style", "chore", "relax", "ci", "fix")
+_EXEMPT_PREFIXES = ("test", "docs", "style", "chore", "ci", "fix")
 
 
 def _staged_files() -> list[str]:


### PR DESCRIPTION
Follow-up to [#526](https://github.com/souliane/teatree/pull/526) / [#525](https://github.com/souliane/teatree/issues/525).

PR [#526](https://github.com/souliane/teatree/pull/526) removed `relax` from the `conventional-pre-commit` allowed types, so any future `relax:` subject is rejected by commitlint before it can reach `check_blueprint_sync.py`. The `relax` entry in `_EXEMPT_PREFIXES` (and the corresponding mention in the docstring) is therefore dead code — dropping it for consistency with the rest of the bypass cleanup.

No behavior change: a `relax:` subject was already blocked at commit-message stage; this just removes the orphaned reference.

Relates to [#525](https://github.com/souliane/teatree/issues/525).