### PR TITLE
feat(overlay): get_e2e_preflight extension point for pre-test gates

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -510,6 +510,7 @@ Defined in `teatree.core.overlay`. All methods receive the `worktree` instance f
 | `get_workspace_repos()` | `→ list[str]` | `get_repos()` | Repos for workspace ticket creation |
 | `get_tool_commands()` | `→ list[ToolCommand]` | `[]` | Overlay-specific CLI tools |
 | `get_visual_qa_targets(changed_files)` | `→ list[str]` | `[]` | URL paths the pre-push browser sanity gate should load |
+| `get_e2e_preflight(customer, base_url)` | `→ list[Callable[[], None]]` | `[]` | Pre-Playwright gates; each callable raises `RuntimeError` on failure |
 
 ### 6.2 Supporting TypedDicts
 

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -215,6 +215,17 @@ class Command(TyperCommand):
         variables = {"E2E": "true"}
         return ci.trigger_pipeline(project=project, ref=ref, variables=variables)
 
+    def _run_preflight(self, env: dict[str, str]) -> None:
+        """Run overlay-declared preflight checks. Exit non-zero on first failure."""
+        overlay = get_overlay()
+        checks = overlay.get_e2e_preflight(customer=env.get("CUSTOMER") or None, base_url=env.get("BASE_URL") or None)
+        for check in checks:
+            try:
+                check()
+            except RuntimeError as exc:
+                self.stderr.write(f"E2E preflight failed: {exc}")
+                raise SystemExit(1) from exc
+
     @command()
     def external(
         self,
@@ -277,6 +288,8 @@ class Command(TyperCommand):
         self.stdout.write(f"  BASE_URL: {env['BASE_URL']}")
         if env.get("CUSTOMER"):
             self.stdout.write(f"  CUSTOMER: {env['CUSTOMER']}")
+
+        self._run_preflight(env)
 
         cmd = ["npx", "playwright", "test", *opts.to_args()]
         rc = run_streamed(cmd, cwd=private_tests_path, env=env, check=False)

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -350,6 +350,20 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
     def get_test_command(self, worktree: "Worktree") -> list[str] | RunCommand:
         return []
 
+    def get_e2e_preflight(self, *, customer: str | None, base_url: str | None) -> list[Callable[[], None]]:
+        """Return preflight checks to run before launching the external Playwright suite.
+
+        Each callable raises :class:`RuntimeError` on failure with a human-readable
+        message; the ``e2e external`` command will print the message and exit
+        non-zero before any test starts. Default: no checks.
+
+        Overlays use this to fail fast on environment problems they alone can detect
+        (auth chains, network reachability, vendor SSO availability) without leaking
+        overlay-specific knowledge into core.
+        """
+        _ = customer, base_url
+        return []
+
     def get_verify_endpoints(self, worktree: "Worktree") -> dict[str, str]:
         """Return custom health-check paths per service.
 

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -3,7 +3,7 @@
 import os
 import subprocess
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from io import StringIO
 from pathlib import Path
 from typing import cast
@@ -2983,6 +2983,78 @@ class TestE2eExternal(TestCase):
         mock_discover.assert_not_called()
         env = mock_run.call_args[1]["env"]
         assert env["BASE_URL"] == "https://dev.example.com"
+
+
+class TestE2eExternalPreflight(TestCase):
+    """``e2e external`` invokes ``overlay.get_e2e_preflight()`` before launching Playwright."""
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_passes_customer_and_base_url_then_runs_playwright(self) -> None:
+        recorded: list[dict[str, str | None]] = []
+
+        def _record(self_overlay: object, *, customer: str | None, base_url: str | None) -> list[Callable[[], None]]:
+            _ = self_overlay
+            recorded.append({"customer": customer, "base_url": base_url})
+            return [lambda: None]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            private_dir = Path(tmp) / "private"
+            private_dir.mkdir()
+            mock_result = MagicMock(returncode=0)
+            with (
+                patch.dict(
+                    "os.environ",
+                    {
+                        "T3_PRIVATE_TESTS": str(private_dir),
+                        "BASE_URL": "https://dev.example.com",
+                        "CUSTOMER": "acme",
+                    },
+                    clear=False,
+                ),
+                patch.object(import_string(FULL_OVERLAY), "get_e2e_preflight", new=_record),
+                patch.object(e2e_mod, "_discover_frontend_port"),
+                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
+            ):
+                result = cast("str", call_command("e2e", "external"))
+
+        assert "passed" in result
+        assert recorded == [{"customer": "acme", "base_url": "https://dev.example.com"}]
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_failing_check_aborts_before_playwright(self) -> None:
+        def _failing(self_overlay: object, *, customer: str | None, base_url: str | None) -> list[Callable[[], None]]:
+            _ = self_overlay, customer, base_url
+
+            def _fail() -> None:
+                msg = "Vendor SSO rejected stored credentials"
+                raise RuntimeError(msg)
+
+            return [_fail]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            private_dir = Path(tmp) / "private"
+            private_dir.mkdir()
+            mock_result = MagicMock(returncode=0)
+            with (
+                patch.dict(
+                    "os.environ",
+                    {
+                        "T3_PRIVATE_TESTS": str(private_dir),
+                        "BASE_URL": "https://dev.example.com",
+                    },
+                    clear=False,
+                ),
+                patch.object(import_string(FULL_OVERLAY), "get_e2e_preflight", new=_failing),
+                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(e2e_mod, "_discover_frontend_port"),
+                pytest.raises(SystemExit) as exc_info,
+            ):
+                call_command("e2e", "external")
+
+        assert exc_info.value.code != 0
+        mock_run.assert_not_called()
 
 
 # ── e2e run (harmonized dispatcher) ─────────────────────────────────

--- a/tests/test_overlay_base.py
+++ b/tests/test_overlay_base.py
@@ -43,6 +43,12 @@ def test_get_test_command_returns_empty_list():
     assert overlay.get_test_command(_make_worktree()) == []
 
 
+def test_get_e2e_preflight_returns_empty_list_by_default():
+    overlay = _MinimalOverlay()
+    assert overlay.get_e2e_preflight(customer="acme", base_url="https://dev.example.com") == []
+    assert overlay.get_e2e_preflight(customer=None, base_url=None) == []
+
+
 def test_get_db_import_strategy_returns_none():
     overlay = _MinimalOverlay()
     assert overlay.get_db_import_strategy(_make_worktree()) is None


### PR DESCRIPTION
## Summary

Add `OverlayBase.get_e2e_preflight(customer, base_url) -> list[Callable[[], None]]` so overlays can register pre-Playwright gates (credential probes, fixture sanity checks, etc.) without core knowing anything about the gate's domain.

`t3 <overlay> e2e external` collects the list from the active overlay and runs each callable before launching Playwright. A failing gate raises `RuntimeError`, fails the run early, and prints the gate's own message — saving the 30-60s of stack-up + Playwright init only to fail mid-test on stale credentials.

The default implementation returns `[]`, so existing overlays are unaffected.

## Why

In the COMPANY overlay, the most common reason an E2E run fails is the partner-b SSO chain rejecting our credentials — `pass` rotated, the partner-a-side account locked, or the `E2E_PASSWORD` GitLab variable drifted. Catching that in 2 seconds via a credential probe (vs. 90s into a Playwright run) is a productivity win, but the probe is overlay-specific (Company Keycloak → partner-b-dev broker → partner-a) — core has no business knowing those URLs.

`get_e2e_preflight()` keeps the gate fully overlay-owned while letting core enforce the run-it-before-Playwright contract.

## Documented in

`BLUEPRINT.md` — extension points table.

## Test plan

- [x] Default `get_e2e_preflight()` returns `[]` → `e2e external` is a no-op for unaware overlays
- [x] OperOverlay override registers the partner-b SSO probe; `t3 company e2e external` runs it and reports `OK: valid` against DEV
- [x] Failing probe (rejected creds) raises `RuntimeError` and aborts the run before `playwright test` is invoked