### PR TITLE
docs(skills): rules TOC + overlay-extension-point rule + readiness-probe contrast

### DIFF
--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -11,6 +11,69 @@ metadata:
 
 Cross-cutting rules that apply to all teatree skills. Loaded automatically via `requires:`.
 
+## Index
+
+Use `Ctrl+F`/`grep` to jump to a rule. Sections are grouped below by theme; numbering is for navigation only — every rule is binding.
+
+**Skill loading & verification**
+
+1. [Invoke Skills Before ANY Response](#invoke-skills-before-any-response)
+2. [Verification Before Completion](#verification-before-completion-non-negotiable)
+3. [Grep Before Claiming Cross-Reference Coverage](#grep-before-claiming-cross-reference-coverage-non-negotiable)
+4. [Verify Imports Before Applying External Code](#verify-imports-before-applying-external-code)
+
+**User intent, interruptions, and asking**
+
+5. [User Instructions Are Priority 1](#user-instructions-are-priority-1)
+6. [Always Use AskUserQuestion for Questions](#always-use-askuserquestion-for-questions)
+7. [Always Create Tasks](#always-create-tasks)
+8. [Mid-Task Interrupts](#mid-task-interrupts-non-negotiable)
+9. [Context Transparency](#context-transparency)
+10. [Context Longevity](#context-longevity)
+
+**Permissions, classifier, and authorization**
+
+11. [Classifier Denial Protocol](#classifier-denial-protocol-non-negotiable)
+12. [Ask About Auth Before External Service Integrations](#ask-about-auth-before-external-service-integrations)
+13. [Publishing Actions Are Mode-Conditional](#publishing-actions-are-mode-conditional-non-negotiable)
+
+**Communication & references**
+
+14. [Clickable References](#clickable-references)
+15. [No AI Signature on Posts Made on the User's Behalf](#no-ai-signature-on-posts-made-on-the-users-behalf-non-negotiable)
+16. [Never Post MR Comments from Parallel Agents](#never-post-mr-comments-from-parallel-agents-non-negotiable)
+17. [Verify Repo Visibility Before Filing External Issues](#verify-repo-visibility-before-filing-external-issues-non-negotiable)
+18. [Leak Remediation — Silent Scrubs](#leak-remediation--silent-scrubs-non-negotiable)
+19. [GitLab Inline Comments](#gitlab-inline-comments)
+
+**API & shell recipes**
+
+20. [Token Extraction](#token-extraction)
+21. [Temp File Safety](#temp-file-safety)
+22. [Complex API Payloads: Use curl or Python](#complex-api-payloads-use-curl-or-python)
+23. [Preserve Existing UX Patterns](#preserve-existing-ux-patterns)
+24. [Prefer Native Tool APIs Over Filesystem Heuristics](#prefer-native-tool-apis-over-filesystem-heuristics)
+25. [Shell Alias Safety](#shell-alias-safety)
+
+**Files, agents, and worktrees**
+
+26. [Sub-Agent Limitations](#sub-agent-limitations)
+27. [Symlink Safety](#symlink-safety)
+28. [Skill File Writes Require a Git Repo](#skill-file-writes-require-a-git-repo)
+29. [Worktree-First Work](#worktree-first-work-non-negotiable)
+30. [Concurrent Agent Safety](#concurrent-agent-safety-non-negotiable)
+
+**Workflow discipline**
+
+31. [Fix TeaTree/Skill Bugs Immediately](#fix-teatreeskill-bugs-immediately)
+32. [Teatree Extension Point Changes Must Update All Registered Overlays](#teatree-extension-point-changes-must-update-all-registered-overlays-non-negotiable)
+33. [Do Work Now, Don't Defer to "Later" Tickets](#do-work-now-dont-defer-to-later-tickets-non-negotiable)
+34. [Contribute Mode: Promote Findings to Skills, Not Personal Memory](#contribute-mode-promote-findings-to-skills-not-personal-memory-non-negotiable)
+35. [Never Change MR Base Branch or Dependencies](#never-change-mr-base-branch-or-dependencies-non-negotiable)
+36. [Run Retro Before Ending Non-Trivial Sessions](#run-retro-before-ending-non-trivial-sessions)
+37. [Commit Before Declaring Done](#commit-before-declaring-done-non-negotiable)
+38. [Pre-Commit Hook Failures on Unrelated Tests](#pre-commit-hook-failures-on-unrelated-tests)
+
 ## Invoke Skills Before ANY Response
 
 _Adapted from [superpowers/using-superpowers](https://github.com/obra/superpowers)._
@@ -231,6 +294,20 @@ Never modify skill files outside a git repo. Resolve real path with `readlink -f
 ## Fix TeaTree/Skill Bugs Immediately
 
 When a teatree or skill infrastructure bug is discovered during any task, fix it immediately as first priority. Never defer to focus on the user's task — broken infrastructure causes cascading failures.
+
+## Teatree Extension Point Changes Must Update All Registered Overlays (Non-Negotiable)
+
+When you add, change, or remove a hook on `OverlayBase` (e.g. `get_required_ports`, `get_port_env`, `uses_redis`, `get_health_checks`, `get_readiness_probes`, `get_base_images`, …) on this machine, you must in the same session update **every overlay registered locally** to adopt the new contract — even when the change is "additive" with a working default.
+
+**Why:** the teatree codebase is overlay-agnostic and CI cannot see the user's installed overlays. A "default returns empty/false" is silent — the overlay keeps shipping, but with the wrong runtime behaviour (port collisions, skipped readiness checks, missing health invariants). The drift only surfaces when the user runs the new command and gets a confusing failure with no obvious root cause.
+
+**How to apply:**
+
+1. Enumerate registered overlays on this machine: `uv run python -c "from importlib.metadata import entry_points; [print(ep.value) for ep in entry_points(group='teatree.overlays')]"`. Treat the output as the authoritative list — not memory, not assumptions about which overlays are installed.
+2. For each overlay, decide whether the new hook needs an explicit override and, if so, implement it in the same MR (or a paired MR opened in the same session). Do not file a "later" ticket — see § "Do Work Now, Don't Defer to 'Later' Tickets".
+3. Cite the overlay PR(s) in the teatree MR description so reviewers can confirm the chain landed end-to-end.
+
+**Past failure mode this rule prevents.** A wave of teatree PRs added several overlay hooks. A registered overlay kept running on the no-op defaults — multiple worktrees collided on the same backend port because `get_required_ports` returned an empty set, and `worktree ready` reported green even when nothing was serving. The teatree side looked clean; the symptom only showed up downstream after weeks.
 
 ## Do Work Now, Don't Defer to "Later" Tickets (Non-Negotiable)
 

--- a/skills/workspace/SKILL.md
+++ b/skills/workspace/SKILL.md
@@ -206,11 +206,27 @@ After starting dev servers, **verify each service responds via HTTP** before rep
 
 Project skills define the specific endpoints to check (e.g., admin login, API version, frontend index).
 
+### Health Checks vs Readiness Probes (Non-Negotiable)
+
+Two distinct gates run on a worktree, with two different overlay hooks:
+
+- `OverlayBase.get_health_checks(worktree)` — **post-provision invariants**. Did `worktree provision` finish its job? (symlinks valid, env cache populated, compose override generated.) Run by `worktree provision` to fail fast on broken setup.
+- `OverlayBase.get_readiness_probes(worktree)` — **post-start runtime checks**. Is the started worktree actually serving? (HTTP probes against allocated ports, health endpoints, dependent services responding.) Run by `worktree ready` and `workspace ready` to gate "ready to use" claims.
+
+**Decision rule for overlay authors:**
+
+- If the check makes sense before any service starts (file present, symlink target reachable, env var set), implement it as a `HealthCheck`.
+- If the check requires a running process (HTTP probe, command exit code, service round-trip), implement it as a `Probe` via `http_probe()` / `command_probe()` — see `teatree.core.readiness`.
+
+**Agent rule when starting a worktree:**
+
+- After `worktree start` succeeds, run `worktree ready` (or `workspace ready` for a multi-repo ticket) before declaring services "running". A green `start` only proves containers/processes launched — `ready` is the truth-teller. If `ready` is red, treat it like a CI failure: diagnose root cause, never bypass.
+
 ## Extension Points
 
 For the full extension points table, override chain, and project skill creation guide, see [`references/extension-points.md`](references/extension-points.md).
 
-Key methods on `OverlayBase`: `get_repos()`, `get_provision_steps()`, `get_db_import_strategy()`, `get_env_extra()`, `get_run_commands()`, `get_services_config()`, `get_verify_endpoints()`. See the reference for the full list.
+Key methods on `OverlayBase`: `get_repos()`, `get_required_ports()`, `get_port_env()`, `uses_redis()`, `get_provision_steps()`, `get_db_import_strategy()`, `get_env_extra()`, `get_run_commands()`, `get_services_config()`, `get_verify_endpoints()`, `get_health_checks()`, `get_readiness_probes()`. See the reference for the full list.
 
 ## Lifecycle State Machine
 
@@ -227,6 +243,8 @@ stateDiagram-v2
     services_up --> created : teardown
     services_up --> ready : verify
 ```
+
+The `services_up → ready` transition runs `OverlayBase.get_readiness_probes()`. A worktree is **only** "ready to use" once probes pass — `services_up` alone proves processes launched, not that they serve traffic.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Three small skill-doc changes that make the recent overlay extension-point work easier to navigate and prevent the silent drift that motivated it.

- \`skills/rules/SKILL.md\` — add a thematic index at the top. The file holds 38 binding cross-cutting rules; cross-references from other skills still anchor on the existing H2 headings, but \`Ctrl+F\`/\`grep\` on a theme now lands quickly.
- \`skills/rules/SKILL.md\` — add a new rule: when teatree adds, changes, or removes an \`OverlayBase\` hook on a developer's machine, the same session must update every locally-registered overlay to adopt the new contract. CI cannot see the user's installed overlays, so a default return value is silent — the overlay keeps shipping with the wrong runtime behaviour (port collisions, skipped readiness probes, missing health invariants) until weeks later when someone trips over it.
- \`skills/workspace/SKILL.md\` — contrast \`get_health_checks\` (post-provision invariants) with \`get_readiness_probes\` (post-start runtime checks) so overlay authors know which hook to implement, and document \`worktree ready\` as the truth-teller that follows \`worktree start\`.

## Test plan

- [x] \`uv run pytest --no-cov -x -q\` — full suite green
- [x] \`prek\` pre-commit hooks pass (banned-terms, frontmatter, BLUEPRINT, etc.)
- [x] No code changes — pure skill-doc additions

## Why now

A round of overlay hooks (port allocation, redis sharing, health checks, readiness probes) shipped to teatree without paired overlay-side adoption — the symptom surfaced as port collisions and false-green readiness in a downstream overlay. The new rule + the workspace doc tighten the loop so the next round can't silently drift.