### PR TITLE
feat(dashboard): hard-reload after Update TeaTree pulls real changes

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -733,7 +733,7 @@ Selector-backed views with django-htmx. **No domain logic in views** — all dat
 | `GET /dashboard/events/` | SSE | Server-Sent Events stream for real-time updates |
 | `GET /dashboard/panels/<panel>/` | HTMX | Panel refresh (requires HX-Request header) |
 | `POST /dashboard/sync/` | — | Trigger followup sync |
-| `POST /dashboard/git-pull/` | — | Pull teatree + all overlay repos; aborts on conflict, auto-switches stale branches |
+| `POST /dashboard/git-pull/` | — | Pull teatree + all overlay repos; aborts on conflict, auto-switches stale branches; per-repo `changed` flag triggers a client-side hard reload |
 | `GET /dashboard/switch-branch/` | JSON | List local branches + current branch |
 | `POST /dashboard/switch-branch/` | JSON | Switch teatree repo to specified branch (uvicorn auto-reloads) |
 | `POST /dashboard/launch-terminal/` | — | Open a terminal session |

--- a/src/teatree/core/templates/teatree/dashboard.html
+++ b/src/teatree/core/templates/teatree/dashboard.html
@@ -310,13 +310,38 @@
         } else {
           var results = data.results || {};
           var parts = [];
+          var anyChanged = false;
           for (var repo in results) {
             var out = results[repo].output || 'up to date';
             parts.push(repo + ': ' + out);
+            if (results[repo].changed) anyChanged = true;
           }
           showToast(parts.join('\n') || 'Update complete', 'success');
+          if (anyChanged) hardReloadDashboard();
         }
       } catch(e) { showToast('Update failed', 'error'); }
+    }
+
+    // Hard reload bypassing service workers and Cache Storage so the freshly
+    // pulled dashboard assets actually load. Delays briefly so the success
+    // toast is visible before the page swaps.
+    function hardReloadDashboard() {
+      setTimeout(function() {
+        var done = function() { location.reload(); };
+        var clearCaches = function() {
+          if (!('caches' in window)) return Promise.resolve();
+          return caches.keys().then(function(keys) {
+            return Promise.all(keys.map(function(k) { return caches.delete(k); }));
+          });
+        };
+        var unregisterSWs = function() {
+          if (!('serviceWorker' in navigator)) return Promise.resolve();
+          return navigator.serviceWorker.getRegistrations().then(function(regs) {
+            return Promise.all(regs.map(function(r) { return r.unregister(); }));
+          });
+        };
+        Promise.all([unregisterSWs(), clearCaches()]).then(done, done);
+      }, 1500);
     }
 
     // E2E sync signal: body[data-htmx-idle="1"] iff every panel-rendering

--- a/src/teatree/core/views/actions.py
+++ b/src/teatree/core/views/actions.py
@@ -174,6 +174,7 @@ class _PullResult(TypedDict, total=False):
     output: str
     error: str
     conflict: bool
+    changed: bool
 
 
 def _get_t3_repo() -> Path | None:
@@ -209,9 +210,11 @@ def _find_overlay_repo_dirs() -> list[tuple[str, Path]]:
     return repos
 
 
-_GIT_ENV = {**os.environ, "GIT_EDITOR": "true", "GIT_SEQUENCE_EDITOR": "true"}
+_GIT_ENV = {**os.environ, "GIT_EDITOR": "true", "GIT_SEQUENCE_EDITOR": "true", "LC_ALL": "C"}
 
 _TIMEOUT = 30
+
+_PULL_NOOP_PREFIXES = ("Already up to date", "Already up-to-date")
 
 
 def _git_pull_repo(repo_dir: Path) -> _PullResult:
@@ -233,7 +236,8 @@ def _git_pull_repo(repo_dir: Path) -> _PullResult:
 
     if result.returncode == 0:
         output = result.stdout.strip()
-        return {"ok": True, "output": output or "Already up to date."}
+        changed = bool(output) and not output.startswith(_PULL_NOOP_PREFIXES)
+        return {"ok": True, "output": output or "Already up to date.", "changed": changed}
 
     stderr = (result.stderr or result.stdout).strip()
 
@@ -294,7 +298,7 @@ def _switch_to_main_and_pull(repo_dir: Path) -> _PullResult | None:
                     timeout=10,
                 )
                 msg += f", deleted stale branch '{stale_branch}'"
-            return {"ok": True, "output": f"{msg}. {output}".strip()}
+            return {"ok": True, "output": f"{msg}. {output}".strip(), "changed": True}
     return None
 
 

--- a/tests/teatree_core/test_views.py
+++ b/tests/teatree_core/test_views.py
@@ -935,6 +935,17 @@ class TestGitPullRepo:
 
         assert result["ok"] is True
         assert "Already up to date" in str(result["output"])
+        assert result["changed"] is False
+
+    def test_changed_true_when_pull_updates(self, tmp_path: Path) -> None:
+        pull = subprocess_mod.CompletedProcess([], 0, "Updating abc..def\n 1 file changed\n", "")
+        with patch("teatree.utils.run.subprocess") as mock_sub:
+            mock_sub.run.return_value = pull
+            mock_sub.TimeoutExpired = subprocess_mod.TimeoutExpired
+            result = actions_views._git_pull_repo(tmp_path)
+
+        assert result["ok"] is True
+        assert result["changed"] is True
 
     def test_timeout(self, tmp_path: Path) -> None:
         with patch("teatree.utils.run.subprocess") as mock_sub:
@@ -1000,6 +1011,21 @@ class TestGitPullView(TestCase):
         data = response.json()
         assert data["ok"] is True
         assert "teatree" in data["results"]
+
+    def test_response_passes_changed_flag(self) -> None:
+        with (
+            patch.object(actions_views, "_get_t3_repo", return_value=self.tmp_path),
+            patch.object(actions_views, "_find_overlay_repo_dirs", return_value=[]),
+            patch.object(
+                actions_views,
+                "_git_pull_repo",
+                return_value={"ok": True, "output": "Updating abc..def", "changed": True},
+            ),
+        ):
+            response = Client().post(reverse("teatree:dashboard-git-pull"))
+
+        assert response.status_code == 200
+        assert response.json()["results"]["teatree"]["changed"] is True
 
     def test_pulls_overlay_repos(self) -> None:
         overlay_dir = self.tmp_path / "overlay"


### PR DESCRIPTION
## Summary

After hitting **Update TeaTree** in the dashboard, the freshly pulled templates/assets weren't actually loaded until a manual hard reload — the page itself kept running with the previously loaded code. This change makes the reload automatic, but only when the pull actually brought in new commits (no-op pulls just show the toast).

## Mechanism

- `_git_pull_repo` returns a per-repo `changed: bool` based on whether `git pull` output is an `"Already up to date."` no-op. The stale-branch-switch path is treated as `changed=True`. `_GIT_ENV` now pins `LC_ALL=C` so that detection is locale-stable.
- The flag passes straight through `GitPullView`'s JSON response.
- `handleGitPullResponse` shows the success toast as before, then if any repo reports `changed`, runs `hardReloadDashboard()` after a 1.5s delay: unregister service workers → clear Cache Storage → `location.reload()`.
- `BLUEPRINT.md` endpoint table notes the new flag.

## Test plan

- [x] `uv run pytest tests/teatree_core/test_views.py --no-cov` (96 passed)
- [x] New unit tests for `changed` (true on actual pull output, false on "Already up to date") + view round-trip test
- [x] `uv run prek run` clean (incl. ty, tach, blueprint-sync)
- [ ] Manual: click **Update TeaTree** with no remote change → toast, no reload. Pull a real commit → toast, then auto hard-reload.