### PR TITLE
fix(sync): close-MR + approvals-dismissed signals on the dashboard

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -103,7 +103,9 @@ src/teatree/
     github_sync.py      # GitHubSyncBackend — Projects v2 board + reviewer PR sync + auto-cleanup on board "Done"
     gitlab.py           # GitLab API client (httpx)
     gitlab_ci.py        # GitLab CI pipeline operations
-    gitlab_sync.py      # GitLabSyncBackend — MR upsert, assigned-issue upsert, labels, merged MR cleanup, Slack review permalinks
+    gitlab_sync.py             # GitLabSyncBackend — MR upsert, assigned-issue upsert, labels, Slack review permalinks
+    gitlab_sync_terminal.py    # Detect merged + closed MRs, advance ticket state on merge, rewrite cached state on close
+    gitlab_sync_approvals.py   # Detect "approvals dismissed by push" from MR system notes
     slack.py            # Slack notifications
     slack_reactions.py  # Emoji reactions on MR permalinks (ticket state transitions)
     notion.py           # Notion integration

--- a/src/teatree/backends/gitlab_api.py
+++ b/src/teatree/backends/gitlab_api.py
@@ -274,16 +274,39 @@ class GitLabAPI:
         *,
         updated_after: str | None = None,
         per_page: int = 100,
-    ) -> list[dict[str, object]]:
+    ) -> list[RawMR]:
         """Fetch recently merged MRs authored by *author*.
 
         When *updated_after* is provided, only returns MRs updated after that
         timestamp (ISO 8601).  Otherwise returns the most recent *per_page*.
         """
+        return self._list_terminal_mrs("merged", author, updated_after=updated_after, per_page=per_page)
+
+    def list_recently_closed_mrs(
+        self,
+        author: str,
+        *,
+        updated_after: str | None = None,
+        per_page: int = 100,
+    ) -> list[RawMR]:
+        """Fetch recently closed-without-merge MRs authored by *author*.
+
+        Mirrors :meth:`list_recently_merged_mrs` for the ``state=closed`` case.
+        """
+        return self._list_terminal_mrs("closed", author, updated_after=updated_after, per_page=per_page)
+
+    def _list_terminal_mrs(
+        self,
+        state: str,
+        author: str,
+        *,
+        updated_after: str | None,
+        per_page: int,
+    ) -> list[RawMR]:
         from urllib.parse import urlencode  # noqa: PLC0415
 
         query: dict[str, str | int] = {
-            "state": "merged",
+            "state": state,
             "author_username": author,
             "scope": "all",
             "per_page": per_page,

--- a/src/teatree/backends/gitlab_sync.py
+++ b/src/teatree/backends/gitlab_sync.py
@@ -3,15 +3,15 @@
 import logging
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast, override
+from typing import TYPE_CHECKING, override
 
 import httpx
 from django.core.cache import cache
 from django.utils import timezone
 
+from teatree.backends.gitlab_sync_terminal import detect_closed_mrs, detect_merged_mrs
 from teatree.backends.slack_review_sync import fetch_review_permalinks
-from teatree.core.cleanup import cleanup_worktree
-from teatree.core.models import Ticket, Worktree
+from teatree.core.models import Ticket
 from teatree.core.sync import (
     LAST_SYNC_CACHE_KEY,
     PENDING_REVIEWS_CACHE_KEY,
@@ -99,7 +99,8 @@ class GitLabSyncBackend(SyncBackend):
             Ticket.objects.in_flight().filter(overlay="").update(overlay=overlay_name)
 
         self._fetch_issue_labels(client, result)
-        self._detect_merged_mrs(client, username, result, last_sync)
+        detect_merged_mrs(client, username, result, last_sync)
+        detect_closed_mrs(client, username, result, last_sync)
         fetch_review_permalinks(result)
         self._sync_reviewer_mrs(client, username, result)
 
@@ -303,66 +304,6 @@ class GitLabSyncBackend(SyncBackend):
         ticket.save(update_fields=update_fields)
 
     @classmethod
-    def _scan_merged_mrs(
-        cls,
-        mrs: RawAPIDict,
-        merged_urls: set[str],
-        result: SyncResult,
-    ) -> tuple[bool, bool]:
-        changed = False
-        unmerged = False
-        for mr_url, mr_entry in mrs.items():
-            if not isinstance(mr_entry, dict):
-                continue
-            if mr_url not in merged_urls:
-                unmerged = True
-                continue
-            entry = cast("MREntryDict", mr_entry)
-            if entry.pop("discussions", None) is not None:
-                changed = True
-            if entry.get("state") != "merged":
-                entry["state"] = "merged"
-                changed = True
-            result.mrs_merged += 1
-        return changed, not unmerged
-
-    @classmethod
-    def _apply_merged_status(cls, ticket: Ticket, merged_urls: set[str], result: SyncResult) -> None:
-        extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-        mrs = extra.get("mrs", {})
-        if not isinstance(mrs, dict) or not mrs:
-            return
-
-        changed, all_merged = cls._scan_merged_mrs(mrs, merged_urls, result)
-
-        if not changed and not all_merged:
-            return
-
-        update_fields: list[str] = []
-        if changed:
-            extra["mrs"] = mrs
-            ticket.extra = extra
-            update_fields.append("extra")
-        if all_merged and _STATE_ORDER.index(Ticket.State.MERGED) > _STATE_ORDER.index(ticket.state):
-            ticket.state = Ticket.State.MERGED
-            update_fields.append("state")
-        if update_fields:
-            ticket.save(update_fields=update_fields)
-
-        if all_merged:
-            cls._cleanup_merged_worktrees(ticket, result)
-
-    @classmethod
-    def _cleanup_merged_worktrees(cls, ticket: Ticket, result: SyncResult) -> None:
-        for worktree in Worktree.objects.filter(ticket=ticket):
-            try:
-                cleanup_worktree(worktree)
-                result.worktrees_cleaned += 1
-            except Exception as exc:
-                logger.exception("Failed to clean worktree %s", worktree.repo_path)
-                result.errors.append(f"Worktree cleanup failed for {worktree.repo_path} ({worktree.branch}): {exc}")
-
-    @classmethod
     def _fetch_assigned_issues(
         cls,
         client: "GitLabAPI",
@@ -413,27 +354,6 @@ class GitLabSyncBackend(SyncBackend):
     def _extract_issue_repo_path(cls, issue_url: str) -> str:
         match = _ISSUE_PARTS_RE.search(issue_url)
         return match.group(1) if match else ""
-
-    @classmethod
-    def _detect_merged_mrs(
-        cls,
-        client: "GitLabAPI",
-        username: str,
-        result: SyncResult,
-        last_sync: str | None,
-    ) -> None:
-        try:
-            merged_mrs = client.list_recently_merged_mrs(username, updated_after=last_sync)
-        except Exception as exc:  # noqa: BLE001
-            result.errors.append(f"Merged MR fetch failed: {exc}")
-            return
-
-        if not merged_mrs:
-            return
-
-        merged_urls = {str(mr.get("web_url", "")) for mr in merged_mrs}
-        for ticket in Ticket.objects.in_flight():
-            cls._apply_merged_status(ticket, merged_urls, result)
 
     @classmethod
     def _resolve_issue(cls, client: "GitLabAPI", issue_url: str) -> tuple[dict, str, int] | None:
@@ -573,7 +493,7 @@ class GitLabSyncBackend(SyncBackend):
                     "author": author_name,
                     "draft": str(mr.get("draft", False)),
                     "updated_at": str(mr.get("updated_at", "")),
-                }
+                },
             )
 
         cache.set(PENDING_REVIEWS_CACHE_KEY, reviews, timeout=None)

--- a/src/teatree/backends/gitlab_sync.py
+++ b/src/teatree/backends/gitlab_sync.py
@@ -9,6 +9,7 @@ import httpx
 from django.core.cache import cache
 from django.utils import timezone
 
+from teatree.backends.gitlab_sync_approvals import detect_approval_dismissal
 from teatree.backends.gitlab_sync_terminal import detect_closed_mrs, detect_merged_mrs
 from teatree.backends.slack_review_sync import fetch_review_permalinks
 from teatree.core.models import Ticket
@@ -144,6 +145,14 @@ class GitLabSyncBackend(SyncBackend):
             e2e_url = cls._detect_e2e_evidence(discussions, web_url)
             if e2e_url:
                 mr_entry.e2e_test_plan_url = e2e_url
+
+            current_count = (
+                int(mr_entry.approvals.get("count", 0)) if isinstance(mr_entry.approvals, dict) else 0  # ty: ignore[invalid-argument-type]
+            )
+            dismissal = detect_approval_dismissal(discussions, current_approval_count=current_count)
+            if dismissal is not None:
+                mr_entry.approvals_dismissed_at = dismissal.at
+                mr_entry.dismissed_approvers = dismissal.approvers
 
             draft_count = ctx.client.get_draft_notes_count(ctx.project.project_id, mr_iid)
             mr_entry.draft_comments_pending = draft_count > 0

--- a/src/teatree/backends/gitlab_sync_approvals.py
+++ b/src/teatree/backends/gitlab_sync_approvals.py
@@ -1,0 +1,94 @@
+"""Detect "approvals dismissed by push" events from MR system notes.
+
+Sourced from system notes attached to MR discussions (already fetched). The
+note bodies that GitLab emits when the ``reset_approvals_on_push`` setting
+fires vary by version, so the dismissal pattern is intentionally permissive
+("removed all approvals"). The approver attribution is reconstructed by
+replaying ``approved`` / ``unapproved`` system notes in chronological order.
+
+The signal is suppressed whenever ``current_approval_count > 0`` — a positive
+current count means someone has re-approved after any dismissal, so the
+dashboard would only nag on stale state.
+"""
+
+import operator
+import re
+from dataclasses import dataclass
+
+from teatree.core.sync import RawAPIDict
+
+_DISMISSED_BODY_RE = re.compile(r"^removed all approvals", re.IGNORECASE)
+_APPROVED_BODY_RE = re.compile(r"^approved (this )?merge request", re.IGNORECASE)
+_UNAPPROVED_BODY_RE = re.compile(r"^unapproved (this )?merge request", re.IGNORECASE)
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalDismissal:
+    at: str
+    approvers: list[str]
+
+
+def detect_approval_dismissal(
+    discussions: list[RawAPIDict],
+    *,
+    current_approval_count: int,
+) -> ApprovalDismissal | None:
+    """Return the most recent push-triggered approval dismissal, or None.
+
+    Returns None when ``current_approval_count > 0`` — a re-approval supersedes
+    any earlier dismissal, so the dashboard signal would be stale.
+    """
+    if current_approval_count > 0:
+        return None
+
+    events = sorted(_iter_approval_events(discussions), key=operator.itemgetter(0))
+    if not events:
+        return None
+
+    approvers: list[str] = []
+    last_dismissal: ApprovalDismissal | None = None
+    for created_at, kind, username in events:
+        if kind == "approved":
+            if username and username not in approvers:
+                approvers.append(username)
+        elif kind == "unapproved":
+            if username in approvers:
+                approvers.remove(username)
+        elif kind == "dismissed":
+            if approvers:
+                last_dismissal = ApprovalDismissal(at=created_at, approvers=list(approvers))
+            approvers = []
+    return last_dismissal
+
+
+def _iter_approval_events(discussions: list[RawAPIDict]) -> list[tuple[str, str, str]]:
+    out: list[tuple[str, str, str]] = []
+    for disc in discussions:
+        if not isinstance(disc, dict):
+            continue
+        notes = disc.get("notes", [])
+        if not isinstance(notes, list):
+            continue
+        for note in notes:
+            event = _note_as_event(note)
+            if event is not None:
+                out.append(event)
+    return out
+
+
+def _note_as_event(note: object) -> tuple[str, str, str] | None:
+    if not isinstance(note, dict):
+        return None
+    if not note.get("system"):  # ty: ignore[invalid-argument-type]
+        return None
+    body = str(note.get("body", ""))  # ty: ignore[no-matching-overload]
+    created_at = str(note.get("created_at", ""))  # ty: ignore[no-matching-overload]
+    author = note.get("author", {})  # ty: ignore[no-matching-overload]
+    username = str(author.get("username", "")) if isinstance(author, dict) else ""
+    if _DISMISSED_BODY_RE.search(body):
+        return (created_at, "dismissed", username)
+    if _APPROVED_BODY_RE.search(body):
+        return (created_at, "approved", username)
+    if _UNAPPROVED_BODY_RE.search(body):
+        return (created_at, "unapproved", username)
+    return None

--- a/src/teatree/backends/gitlab_sync_terminal.py
+++ b/src/teatree/backends/gitlab_sync_terminal.py
@@ -1,0 +1,155 @@
+"""Terminal-state MR handling: detect merged and closed MRs, update cached extras.
+
+Split out of ``gitlab_sync.py`` to keep that module under the LOC budget enforced
+by ``hooks/check_module_health.py``. The two states share fetch + url-collection
+plumbing but diverge on side effects:
+
+- merged → advance the ticket FSM to ``MERGED`` and clean up worktrees
+- closed → only rewrite the cached MR state so the dashboard filter hides it
+"""
+
+import logging
+from typing import TYPE_CHECKING, cast
+
+import httpx
+
+from teatree.core.cleanup import cleanup_worktree
+from teatree.core.models import Ticket, Worktree
+from teatree.core.sync import MREntryDict, RawAPIDict, SyncResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from teatree.backends.gitlab_api import GitLabAPI
+
+logger = logging.getLogger(__name__)
+
+_STATE_ORDER = [s.value for s in Ticket.State]
+
+
+def detect_merged_mrs(client: "GitLabAPI", username: str, result: SyncResult, last_sync: str | None) -> None:
+    merged_urls = _fetch_terminal_mr_urls(
+        client.list_recently_merged_mrs,
+        username,
+        last_sync,
+        result,
+        label="Merged",
+    )
+    if merged_urls is None:
+        return
+    for ticket in Ticket.objects.in_flight():
+        apply_merged_status(ticket, merged_urls, result)
+
+
+def detect_closed_mrs(client: "GitLabAPI", username: str, result: SyncResult, last_sync: str | None) -> None:
+    closed_urls = _fetch_terminal_mr_urls(
+        client.list_recently_closed_mrs,
+        username,
+        last_sync,
+        result,
+        label="Closed",
+    )
+    if closed_urls is None:
+        return
+    for ticket in Ticket.objects.in_flight():
+        apply_closed_status(ticket, closed_urls, result)
+
+
+def apply_merged_status(ticket: Ticket, merged_urls: set[str], result: SyncResult) -> None:
+    extra = ticket.extra if isinstance(ticket.extra, dict) else {}
+    mrs = extra.get("mrs", {})
+    if not isinstance(mrs, dict) or not mrs:
+        return
+
+    changed, all_merged = _scan_merged_mrs(mrs, merged_urls, result)
+
+    if not changed and not all_merged:
+        return
+
+    update_fields: list[str] = []
+    if changed:
+        extra["mrs"] = mrs
+        ticket.extra = extra
+        update_fields.append("extra")
+    if all_merged and _STATE_ORDER.index(Ticket.State.MERGED) > _STATE_ORDER.index(ticket.state):
+        ticket.state = Ticket.State.MERGED
+        update_fields.append("state")
+    if update_fields:
+        ticket.save(update_fields=update_fields)
+
+    if all_merged:
+        _cleanup_merged_worktrees(ticket, result)
+
+
+def apply_closed_status(ticket: Ticket, closed_urls: set[str], result: SyncResult) -> None:
+    # Closed-without-merge has no FSM target and no worktree cleanup: the user may
+    # still reopen / push a new MR for the same ticket. Only the cached MR entry is
+    # rewritten so the dashboard's state-based filter stops rendering the row.
+    extra = ticket.extra if isinstance(ticket.extra, dict) else {}
+    mrs = extra.get("mrs", {})
+    if not isinstance(mrs, dict) or not mrs:
+        return
+
+    changed = False
+    for mr_url, mr_entry in mrs.items():
+        if not isinstance(mr_entry, dict) or mr_url not in closed_urls:
+            continue
+        entry = cast("MREntryDict", mr_entry)
+        if entry.pop("discussions", None) is not None:
+            changed = True
+        if entry.get("state") != "closed":
+            entry["state"] = "closed"
+            changed = True
+        result.mrs_closed += 1
+
+    if changed:
+        extra["mrs"] = mrs
+        ticket.extra = extra
+        ticket.save(update_fields=["extra"])
+
+
+def _scan_merged_mrs(mrs: RawAPIDict, merged_urls: set[str], result: SyncResult) -> tuple[bool, bool]:
+    changed = False
+    unmerged = False
+    for mr_url, mr_entry in mrs.items():
+        if not isinstance(mr_entry, dict):
+            continue
+        if mr_url not in merged_urls:
+            unmerged = True
+            continue
+        entry = cast("MREntryDict", mr_entry)
+        if entry.pop("discussions", None) is not None:
+            changed = True
+        if entry.get("state") != "merged":
+            entry["state"] = "merged"
+            changed = True
+        result.mrs_merged += 1
+    return changed, not unmerged
+
+
+def _cleanup_merged_worktrees(ticket: Ticket, result: SyncResult) -> None:
+    for worktree in Worktree.objects.filter(ticket=ticket):
+        try:
+            cleanup_worktree(worktree)
+            result.worktrees_cleaned += 1
+        except Exception as exc:
+            logger.exception("Failed to clean worktree %s", worktree.repo_path)
+            result.errors.append(f"Worktree cleanup failed for {worktree.repo_path} ({worktree.branch}): {exc}")
+
+
+def _fetch_terminal_mr_urls(
+    fetcher: "Callable[..., list[RawAPIDict]]",
+    username: str,
+    last_sync: str | None,
+    result: SyncResult,
+    *,
+    label: str,
+) -> set[str] | None:
+    try:
+        mrs = fetcher(username, updated_after=last_sync)
+    except httpx.HTTPError as exc:
+        result.errors.append(f"{label} MR fetch failed: {exc}")
+        return None
+    if not mrs:
+        return None
+    return {str(mr.get("web_url", "")) for mr in mrs}

--- a/src/teatree/core/selectors/_types.py
+++ b/src/teatree/core/selectors/_types.py
@@ -54,6 +54,8 @@ class DashboardMRRow:
     e2e_test_plan_url: str
     is_frontend: bool
     needs_reply_count: int = 0
+    approvals_dismissed_at: str = ""
+    dismissed_approvers: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/teatree/core/selectors/dashboard.py
+++ b/src/teatree/core/selectors/dashboard.py
@@ -288,6 +288,8 @@ def _build_mr_rows(ticket: Ticket) -> list[DashboardMRRow]:
                 e2e_test_plan_url=str(mr.get("e2e_test_plan_url", "")),
                 is_frontend=str(mr.get("repo", "")) in frontend_repos,
                 needs_reply_count=_count_needs_reply(mr),
+                approvals_dismissed_at=str(mr.get("approvals_dismissed_at", "")),
+                dismissed_approvers=_list_of_str(mr.get("dismissed_approvers", [])),
             ),
         )
     return rows

--- a/src/teatree/core/sync.py
+++ b/src/teatree/core/sync.py
@@ -65,6 +65,8 @@ class MREntry:
     notion_url: str | None = None
     draft_comments_pending: bool | None = None
     draft_comments_count: int | None = None
+    approvals_dismissed_at: str | None = None
+    dismissed_approvers: list[str] | None = None
 
     def to_dict(self) -> MREntryDict:
         result: MREntryDict = {}

--- a/src/teatree/core/sync.py
+++ b/src/teatree/core/sync.py
@@ -27,6 +27,7 @@ class SyncResult:
     tickets_updated: int = 0
     labels_fetched: int = 0
     mrs_merged: int = 0
+    mrs_closed: int = 0
     reviews_synced: int = 0
     worktrees_cleaned: int = 0
     errors: list[str] = field(default_factory=list)
@@ -104,6 +105,7 @@ def _merge_results(a: SyncResult, b: SyncResult) -> SyncResult:
         tickets_updated=a.tickets_updated + b.tickets_updated,
         labels_fetched=a.labels_fetched + b.labels_fetched,
         mrs_merged=a.mrs_merged + b.mrs_merged,
+        mrs_closed=a.mrs_closed + b.mrs_closed,
         reviews_synced=a.reviews_synced + b.reviews_synced,
         worktrees_cleaned=a.worktrees_cleaned + b.worktrees_cleaned,
         errors=[*a.errors, *b.errors],

--- a/src/teatree/core/templates/teatree/partials/dashboard_tickets.html
+++ b/src/teatree/core/templates/teatree/partials/dashboard_tickets.html
@@ -174,6 +174,12 @@
                   onclick="toggleTicketDetails('{{ ticket.ticket_id }}')"
                 >{{ mr.approval_count }}/{{ mr.approval_required }}</button>
               {% endif %}
+              {% if mr.approvals_dismissed_at %}
+                <span
+                  class="pill pill-sm bg-orange-100 text-orange-800 ml-1 cursor-help"
+                  title="Approvals dismissed by push at {{ mr.approvals_dismissed_at }}{% if mr.dismissed_approvers %} — previously approved by: {{ mr.dismissed_approvers|join:', ' }}{% endif %}"
+                >&#x21BB; approvals lost</span>
+              {% endif %}
             </td>
             {% if forloop.first %}
               <td class="border-b border-bark/10 px-3 py-3 align-top" {% if mr_count > 1 %}rowspan="{{ mr_count }}"{% endif %}>

--- a/tests/teatree_backends/test_gitlab_sync_approvals.py
+++ b/tests/teatree_backends/test_gitlab_sync_approvals.py
@@ -1,0 +1,142 @@
+"""Tests for detect_approval_dismissal in gitlab_sync_approvals."""
+
+from teatree.backends.gitlab_sync_approvals import ApprovalDismissal, detect_approval_dismissal
+
+
+def _disc(notes: list[dict]) -> dict:
+    return {"notes": notes, "individual_note": len(notes) == 1}
+
+
+def _system_note(body: str, *, username: str = "system", created_at: str) -> dict:
+    return {
+        "system": True,
+        "body": body,
+        "created_at": created_at,
+        "author": {"username": username},
+    }
+
+
+def _user_note(body: str, *, username: str, created_at: str) -> dict:
+    return {
+        "system": False,
+        "body": body,
+        "created_at": created_at,
+        "author": {"username": username},
+    }
+
+
+class TestDetectApprovalDismissal:
+    def test_returns_none_when_currently_approved(self) -> None:
+        """If current approval count > 0, no dismissal signal — re-approved already."""
+        discussions = [
+            _disc([_system_note("approved this merge request", username="alice", created_at="2026-05-01T10:00:00Z")]),
+            _disc(
+                [
+                    _system_note(
+                        "removed all approvals when new commits are added to the source branch",
+                        created_at="2026-05-01T11:00:00Z",
+                    ),
+                ],
+            ),
+            _disc([_system_note("approved this merge request", username="bob", created_at="2026-05-01T12:00:00Z")]),
+        ]
+        assert detect_approval_dismissal(discussions, current_approval_count=1) is None
+
+    def test_returns_none_when_no_dismissal_note(self) -> None:
+        discussions = [
+            _disc([_system_note("approved this merge request", username="alice", created_at="2026-05-01T10:00:00Z")]),
+            _disc([_user_note("LGTM", username="alice", created_at="2026-05-01T10:30:00Z")]),
+        ]
+        assert detect_approval_dismissal(discussions, current_approval_count=0) is None
+
+    def test_returns_none_when_no_prior_approval(self) -> None:
+        """Spurious 'removed all approvals' without any prior approval is meaningless."""
+        discussions = [
+            _disc(
+                [
+                    _system_note(
+                        "removed all approvals when new commits are added to the source branch",
+                        created_at="2026-05-01T11:00:00Z",
+                    ),
+                ],
+            ),
+        ]
+        assert detect_approval_dismissal(discussions, current_approval_count=0) is None
+
+    def test_detects_push_reset_with_approver_attribution(self) -> None:
+        discussions = [
+            _disc([_system_note("approved this merge request", username="alice", created_at="2026-05-01T10:00:00Z")]),
+            _disc([_system_note("approved this merge request", username="bob", created_at="2026-05-01T10:30:00Z")]),
+            _disc(
+                [
+                    _system_note(
+                        "removed all approvals when new commits are added to the source branch",
+                        created_at="2026-05-01T11:00:00Z",
+                    ),
+                ],
+            ),
+        ]
+        result = detect_approval_dismissal(discussions, current_approval_count=0)
+        assert result == ApprovalDismissal(at="2026-05-01T11:00:00Z", approvers=["alice", "bob"])
+
+    def test_handles_manual_unapproval_then_push_reset(self) -> None:
+        """Manual unapproval before the push reset removes that user from the dismissed list."""
+        discussions = [
+            _disc([_system_note("approved this merge request", username="alice", created_at="2026-05-01T10:00:00Z")]),
+            _disc([_system_note("approved this merge request", username="bob", created_at="2026-05-01T10:30:00Z")]),
+            _disc(
+                [_system_note("unapproved this merge request", username="alice", created_at="2026-05-01T10:45:00Z")],
+            ),
+            _disc(
+                [
+                    _system_note(
+                        "removed all approvals because the merge request was updated",
+                        created_at="2026-05-01T11:00:00Z",
+                    ),
+                ],
+            ),
+        ]
+        result = detect_approval_dismissal(discussions, current_approval_count=0)
+        assert result is not None
+        assert result.approvers == ["bob"]
+
+    def test_uses_most_recent_dismissal(self) -> None:
+        """Two dismissal cycles: only the most recent matters."""
+        discussions = [
+            _disc([_system_note("approved this merge request", username="alice", created_at="2026-05-01T10:00:00Z")]),
+            _disc(
+                [
+                    _system_note(
+                        "removed all approvals when new commits are added to the source branch",
+                        created_at="2026-05-01T11:00:00Z",
+                    ),
+                ],
+            ),
+            _disc([_system_note("approved this merge request", username="bob", created_at="2026-05-01T12:00:00Z")]),
+            _disc(
+                [
+                    _system_note(
+                        "removed all approvals when new commits are added to the source branch",
+                        created_at="2026-05-01T13:00:00Z",
+                    ),
+                ],
+            ),
+        ]
+        result = detect_approval_dismissal(discussions, current_approval_count=0)
+        assert result == ApprovalDismissal(at="2026-05-01T13:00:00Z", approvers=["bob"])
+
+    def test_ignores_user_notes(self) -> None:
+        """Non-system notes with similar text must not trigger detection."""
+        discussions = [
+            _disc([_system_note("approved this merge request", username="alice", created_at="2026-05-01T10:00:00Z")]),
+            _disc(
+                [
+                    _user_note(
+                        "I removed all approvals because the bot was wrong",
+                        username="bob",
+                        created_at="2026-05-01T11:00:00Z",
+                    ),
+                ],
+            ),
+        ]
+        assert detect_approval_dismissal(discussions, current_approval_count=0) is None

--- a/tests/teatree_core/test_selectors.py
+++ b/tests/teatree_core/test_selectors.py
@@ -1279,6 +1279,50 @@ class TestBuildMrRows(TestCase):
         rows = _build_mr_rows(ticket)
         assert [r.iid for r in rows] == ["11"]
 
+    def test_passes_approvals_dismissed_metadata(self) -> None:
+        """When sync has flagged a push-reset dismissal, the dashboard row carries it through."""
+        ticket = Ticket.objects.create(
+            state=Ticket.State.STARTED,
+            extra={
+                "mrs": {
+                    "url1": {
+                        "url": "https://gitlab.com/org/backend/-/merge_requests/10",
+                        "title": "feat",
+                        "repo": "backend",
+                        "iid": "10",
+                        "branch": "feat/x",
+                        "draft": False,
+                        "approvals_dismissed_at": "2026-05-01T11:00:00Z",
+                        "dismissed_approvers": ["alice", "bob"],
+                    },
+                },
+            },
+        )
+        rows = _build_mr_rows(ticket)
+        assert len(rows) == 1
+        assert rows[0].approvals_dismissed_at == "2026-05-01T11:00:00Z"
+        assert rows[0].dismissed_approvers == ["alice", "bob"]
+
+    def test_approvals_dismissed_defaults_when_absent(self) -> None:
+        ticket = Ticket.objects.create(
+            state=Ticket.State.STARTED,
+            extra={
+                "mrs": {
+                    "url1": {
+                        "url": "https://gitlab.com/org/backend/-/merge_requests/10",
+                        "title": "feat",
+                        "repo": "backend",
+                        "iid": "10",
+                        "branch": "feat/x",
+                        "draft": False,
+                    },
+                },
+            },
+        )
+        rows = _build_mr_rows(ticket)
+        assert rows[0].approvals_dismissed_at == ""
+        assert rows[0].dismissed_approvers == []
+
     def test_non_dict_approvals(self) -> None:
         ticket = Ticket.objects.create(
             state=Ticket.State.STARTED,

--- a/tests/teatree_core/test_sync.py
+++ b/tests/teatree_core/test_sync.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.backends.gitlab_api import ProjectInfo
 from teatree.backends.gitlab_sync import GitLabSyncBackend
+from teatree.backends.gitlab_sync_terminal import apply_closed_status, apply_merged_status
 from teatree.backends.slack_review_sync import fetch_review_permalinks
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase, OverlayConfig, ProvisionStep
@@ -142,6 +143,12 @@ _MERGED_MR = {
     "project_id": 123,
 }
 
+_CLOSED_MR = {
+    "web_url": "https://gitlab.com/org/repo/-/merge_requests/77",
+    "iid": 77,
+    "project_id": 123,
+}
+
 
 def _make_mock_client(mrs: list[dict]) -> MagicMock:
     mock = MagicMock()
@@ -149,6 +156,7 @@ def _make_mock_client(mrs: list[dict]) -> MagicMock:
     mock.list_all_open_mrs.return_value = mrs
     mock.list_open_issues_for_assignee.return_value = []
     mock.list_recently_merged_mrs.return_value = []
+    mock.list_recently_closed_mrs.return_value = []
     mock.resolve_project.return_value = _PROJECT
     mock.get_mr_pipeline.return_value = {"status": "success", "url": "https://gitlab.com/pipelines/1"}
     mock.get_mr_approvals.return_value = {"count": 0, "required": 1}
@@ -161,6 +169,13 @@ def _make_merged_mock(merged_mrs: list[dict]) -> MagicMock:
     """Mock client with no open MRs and some merged MRs."""
     mock = _make_mock_client([])
     mock.list_recently_merged_mrs.return_value = merged_mrs
+    return mock
+
+
+def _make_closed_mock(closed_mrs: list[dict]) -> MagicMock:
+    """Mock client with no open MRs and some closed-without-merge MRs."""
+    mock = _make_mock_client([])
+    mock.list_recently_closed_mrs.return_value = closed_mrs
     return mock
 
 
@@ -817,7 +832,7 @@ class TestDetectE2EEvidence:
 
 
 class TestApplyMergedStatusAllMerged(TestCase):
-    @patch("teatree.backends.gitlab_sync.cleanup_worktree")
+    @patch("teatree.backends.gitlab_sync_terminal.cleanup_worktree")
     def test_advances_state_when_all_merged_no_discussions(self, mock_cleanup: MagicMock) -> None:
         """All MRs merged but none have discussions — state should still advance."""
         ticket = Ticket.objects.create(
@@ -826,7 +841,7 @@ class TestApplyMergedStatusAllMerged(TestCase):
             extra={"mrs": {"url1": {"title": "MR1"}, "url2": {"title": "MR2"}}},
         )
         result = SyncResult()
-        GitLabSyncBackend._apply_merged_status(ticket, {"url1", "url2"}, result)
+        apply_merged_status(ticket, {"url1", "url2"}, result)
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.MERGED
 
@@ -837,11 +852,11 @@ class TestApplyMergedStatusAllMerged(TestCase):
             extra={"mrs": {"url1": {"title": "MR1"}, "url2": {"title": "MR2"}}},
         )
         result = SyncResult()
-        GitLabSyncBackend._apply_merged_status(ticket, {"url1"}, result)
+        apply_merged_status(ticket, {"url1"}, result)
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.IN_REVIEW
 
-    @patch("teatree.backends.gitlab_sync.cleanup_worktree")
+    @patch("teatree.backends.gitlab_sync_terminal.cleanup_worktree")
     def test_auto_cleans_worktrees_on_merge(self, mock_cleanup: MagicMock) -> None:
         ticket = Ticket.objects.create(
             issue_url="https://gitlab.com/org/repo/-/issues/3",
@@ -855,11 +870,11 @@ class TestApplyMergedStatusAllMerged(TestCase):
             branch="fix-3",
         )
         result = SyncResult()
-        GitLabSyncBackend._apply_merged_status(ticket, {"url1"}, result)
+        apply_merged_status(ticket, {"url1"}, result)
         mock_cleanup.assert_called_once()
         assert result.worktrees_cleaned == 1
 
-    @patch("teatree.backends.gitlab_sync.cleanup_worktree", side_effect=RuntimeError("cleanup failed"))
+    @patch("teatree.backends.gitlab_sync_terminal.cleanup_worktree", side_effect=RuntimeError("cleanup failed"))
     def test_cleanup_failure_does_not_block_merge(self, mock_cleanup: MagicMock) -> None:
         ticket = Ticket.objects.create(
             issue_url="https://gitlab.com/org/repo/-/issues/4",
@@ -873,13 +888,84 @@ class TestApplyMergedStatusAllMerged(TestCase):
             branch="fix-4",
         )
         result = SyncResult()
-        GitLabSyncBackend._apply_merged_status(ticket, {"url1"}, result)
+        apply_merged_status(ticket, {"url1"}, result)
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.MERGED
         assert result.worktrees_cleaned == 0
         assert any("cleanup failed" in e for e in result.errors)
         # Error must carry the repo + branch so the dashboard can point at the stuck worktree.
         assert any("org/repo" in e and "fix-4" in e for e in result.errors)
+
+
+class TestApplyClosedStatus(TestCase):
+    """Closed-without-merge MRs: drop discussions, mark state=closed, never advance ticket FSM."""
+
+    def test_marks_cached_state_closed(self) -> None:
+        ticket = Ticket.objects.create(
+            issue_url="https://gitlab.com/org/repo/-/issues/77",
+            state=Ticket.State.IN_REVIEW,
+            extra={
+                "mrs": {
+                    "url1": {"title": "MR1", "state": "opened"},
+                },
+            },
+        )
+        result = SyncResult()
+        apply_closed_status(ticket, {"url1"}, result)
+        ticket.refresh_from_db()
+        assert ticket.extra["mrs"]["url1"]["state"] == "closed"
+        assert ticket.state == Ticket.State.IN_REVIEW
+        assert result.mrs_closed == 1
+
+    def test_does_not_change_ticket_state_when_all_closed(self) -> None:
+        """Closing the only MR must NOT advance the ticket FSM (no FSM target for closed)."""
+        ticket = Ticket.objects.create(
+            issue_url="https://gitlab.com/org/repo/-/issues/78",
+            state=Ticket.State.IN_REVIEW,
+            extra={"mrs": {"url1": {"title": "MR1", "state": "opened"}}},
+        )
+        result = SyncResult()
+        apply_closed_status(ticket, {"url1"}, result)
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.IN_REVIEW
+
+    def test_drops_discussions_from_closed_mr(self) -> None:
+        ticket = Ticket.objects.create(
+            issue_url="https://gitlab.com/org/repo/-/issues/79",
+            state=Ticket.State.IN_REVIEW,
+            extra={
+                "mrs": {
+                    "url1": {
+                        "title": "MR1",
+                        "state": "opened",
+                        "discussions": [{"status": "needs_reply", "detail": "fix"}],
+                    },
+                },
+            },
+        )
+        result = SyncResult()
+        apply_closed_status(ticket, {"url1"}, result)
+        ticket.refresh_from_db()
+        assert "discussions" not in ticket.extra["mrs"]["url1"]
+
+    def test_does_not_clean_worktrees(self) -> None:
+        """Closed MRs leave worktrees alone — user may reopen with new MR."""
+        ticket = Ticket.objects.create(
+            issue_url="https://gitlab.com/org/repo/-/issues/80",
+            state=Ticket.State.IN_REVIEW,
+            extra={"mrs": {"url1": {"title": "MR1", "state": "opened"}}},
+        )
+        Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="org/repo",
+            branch="fix-80",
+        )
+        result = SyncResult()
+        with patch("teatree.backends.gitlab_sync_terminal.cleanup_worktree") as mock_cleanup:
+            apply_closed_status(ticket, {"url1"}, result)
+        mock_cleanup.assert_not_called()
+        assert result.worktrees_cleaned == 0
 
 
 class TestSyncFollowup(TestCase):
@@ -1457,7 +1543,7 @@ class TestSyncFollowupMergedMrs(TestCase):
     def test_handles_merged_mr_fetch_failure(self) -> None:
         """When merged MR fetch fails, error is appended but sync continues."""
         mock_client = _make_mock_client([])
-        mock_client.list_recently_merged_mrs.side_effect = RuntimeError("timeout")
+        mock_client.list_recently_merged_mrs.side_effect = httpx.ConnectError("timeout")
         self._monkeypatch.setattr("teatree.backends.gitlab_api.GitLabAPI", lambda **_kw: mock_client)
 
         result = sync_followup()
@@ -1502,6 +1588,48 @@ class TestSyncFollowupMergedMrs(TestCase):
 
         # Non-dict entries are skipped; no crash, no merge count
         assert result.mrs_merged == 0
+
+    def test_followup_marks_closed_mr_so_dashboard_filters_it(self) -> None:
+        """When user closes an MR without merging, sync must update the cached state to "closed".
+
+        Regression: previously sync only fetched opened+merged states, so closed MRs kept
+        cached state="opened" forever and the dashboard kept rendering them.
+        """
+        Ticket.objects.create(
+            overlay="test",
+            issue_url="https://gitlab.com/org/repo/-/issues/77",
+            repos=["repo"],
+            state=Ticket.State.IN_REVIEW,
+            extra={
+                "mrs": {
+                    _CLOSED_MR["web_url"]: {
+                        "url": _CLOSED_MR["web_url"],
+                        "repo": "repo",
+                        "iid": 77,
+                        "state": "opened",
+                    },
+                },
+            },
+        )
+
+        mock_client = _make_closed_mock([_CLOSED_MR])
+        self._monkeypatch.setattr("teatree.backends.gitlab_api.GitLabAPI", lambda **_kw: mock_client)
+
+        result = sync_followup()
+
+        assert result.mrs_closed == 1
+        ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/77")
+        assert ticket.extra["mrs"][_CLOSED_MR["web_url"]]["state"] == "closed"
+
+    def test_handles_closed_mr_fetch_failure(self) -> None:
+        """Closed-MR fetch failure logs an error but does not abort sync."""
+        mock_client = _make_mock_client([])
+        mock_client.list_recently_closed_mrs.side_effect = httpx.ConnectError("timeout")
+        self._monkeypatch.setattr("teatree.backends.gitlab_api.GitLabAPI", lambda **_kw: mock_client)
+
+        result = sync_followup()
+
+        assert any("Closed MR fetch failed" in e for e in result.errors)
 
     def test_no_change_when_mr_has_no_discussions(self) -> None:
         """Merged MR without discussions causes no save (no changed flag)."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -946,6 +946,31 @@ def test_list_recently_merged_mrs_returns_empty_when_not_a_list(monkeypatch: pyt
     assert result == []
 
 
+def test_list_recently_closed_mrs_queries_state_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = gitlab_api.GitLabAPI(token="test-token")
+    captured: list[str] = []
+
+    def capture_get_json(endpoint: str) -> list[dict[str, object]]:
+        captured.append(endpoint)
+        return [{"iid": 77, "state": "closed"}]
+
+    monkeypatch.setattr(client, "get_json", capture_get_json)
+
+    result = client.list_recently_closed_mrs("adrien", updated_after="2024-06-01T00:00:00Z")
+
+    assert result == [{"iid": 77, "state": "closed"}]
+    assert "state=closed" in captured[0]
+    assert "author_username=adrien" in captured[0]
+    assert "updated_after" in captured[0]
+
+
+def test_list_recently_closed_mrs_returns_empty_when_not_a_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = gitlab_api.GitLabAPI(token="test-token")
+    monkeypatch.setattr(client, "get_json", lambda _endpoint: {"error": "bad"})
+
+    assert client.list_recently_closed_mrs("adrien") == []
+
+
 def test_get_mr_pipeline_returns_status_and_url(monkeypatch: pytest.MonkeyPatch) -> None:
     client = gitlab_api.GitLabAPI(token="test-token")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Two related dashboard staleness bugs caught while reviewing why a closed MR kept showing on the followup page.

### 1. Closed-without-merge MRs never disappeared
`GitLabSyncBackend.sync` only fetched `state=opened` and `state=merged` MRs. When you closed an MR without merging, its cached `extra["mrs"][...]["state"]` stayed `"opened"` forever, so the dashboard MR-row filter (which already drops `state in {merged, closed}`) never had a chance to hide it.

Adds `list_recently_closed_mrs` on the GitLab client plus a parallel `detect_closed_mrs` / `apply_closed_status` path. Closed-without-merge does not advance the ticket FSM and does not clean up worktrees — closing one MR is not a signal the work is abandoned, only `ignore()` is.

### 2. Approvals dismissed by push were invisible
When GitLab's `reset_approvals_on_push` fires, every prior approval is silently dropped and the MR row reverts to `0/N` — easy to miss, easy to forget to re-request review.

Sync now scans the system notes already returned by `get_mr_discussions` for the dismissal pattern, replays `approved` / `unapproved` events to attribute who lost their approval, and stores `approvals_dismissed_at` / `dismissed_approvers` on the `MREntry`. The signal self-clears as soon as someone re-approves (current count > 0). Dashboard renders an orange ↻ "approvals lost" pill next to the approval count with the dismissed approvers in the tooltip.

### Scaffolding
Detection lives in two new sibling modules (`gitlab_sync_terminal.py`, `gitlab_sync_approvals.py`) so `gitlab_sync.py` stays under the 500 LOC budget enforced by `check_module_health.py`. BLUEPRINT.md updated to reflect the split.

## Notes for the existing dashboard
Sync uses `updated_after = last_sync` for both terminal-state queries. MRs whose state changed before the deploy but after the last sync will be caught automatically. Older stale entries (closed long before deploy) need a manual prod for now — clearing the `teatree_followup_last_sync` cache key forces a full re-fetch.

## Test plan
- [x] `tests/teatree_backends/test_gitlab_sync_approvals.py` — 7 unit tests on the detector
- [x] `tests/teatree_core/test_sync.py::TestApplyClosedStatus` — 4 unit tests on the close path
- [x] `tests/teatree_core/test_sync.py::TestSyncFollowupMergedMrs::test_followup_marks_closed_mr_so_dashboard_filters_it`
- [x] `tests/teatree_core/test_sync.py::TestSyncFollowupMergedMrs::test_handles_closed_mr_fetch_failure`
- [x] `tests/teatree_core/test_selectors.py::test_passes_approvals_dismissed_metadata` + defaults
- [x] `tests/test_utils.py::test_list_recently_closed_mrs_*` (2 endpoint shape tests)
- [x] `uv run pytest tests/teatree_core tests/teatree_backends tests/test_utils.py --no-cov` — 452 passed
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` — clean