### PR TITLE
fix(post_compact_hook): isolate _find_temp_files from real /tmp in tests

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -19,6 +19,7 @@ import os
 import re
 import subprocess  # noqa: S404
 import sys
+import tempfile
 from pathlib import Path
 
 STATE_DIR = Path(
@@ -514,19 +515,18 @@ def handle_read_dedup(data: dict) -> None:
 
 
 _T3_TEMP_PREFIX = "t3-snapshot-"
+_TMP_DIR = Path(tempfile.gettempdir())
 
 
 def _find_temp_files(session_id: str) -> list[Path]:
-    """Find t3 temp files for this session in STATE_DIR and /tmp."""
+    """Find t3 temp files for this session in STATE_DIR and _TMP_DIR."""
     results: list[Path] = []
     session_glob = f"{_T3_TEMP_PREFIX}{session_id}-*.md"
-    for search_dir in (STATE_DIR, Path("/tmp")):  # noqa: S108
+    for search_dir in (STATE_DIR, _TMP_DIR):
         if search_dir.is_dir():
             results.extend(sorted(search_dir.glob(session_glob)))
-    # Also pick up any sessionless t3-snapshot files in /tmp (legacy retro pattern)
-    tmp = Path("/tmp")  # noqa: S108
-    if tmp.is_dir():
-        for f in sorted(tmp.glob(f"{_T3_TEMP_PREFIX}*.md")):
+    if _TMP_DIR.is_dir():
+        for f in sorted(_TMP_DIR.glob(f"{_T3_TEMP_PREFIX}*.md")):
             if f not in results:
                 results.append(f)
     return results

--- a/tests/test_post_compact_hook.py
+++ b/tests/test_post_compact_hook.py
@@ -9,20 +9,17 @@ import hooks.scripts.hook_router as router
 from hooks.scripts.hook_router import _T3_TEMP_PREFIX, _find_temp_files, handle_post_compact
 
 
-@pytest.fixture
-def snapshot_dir(tmp_path: Path) -> Path:
-    """Create a temporary directory to act as /tmp."""
-    return tmp_path / "tmp"
-
-
 @pytest.fixture(autouse=True)
-def _isolate_state_dir(tmp_path: Path):
-    """Point STATE_DIR at a temp directory so tests don't pollute /tmp."""
-    original = router.STATE_DIR
+def _isolate_filesystem(tmp_path: Path):
+    """Point STATE_DIR and _TMP_DIR at temp directories so tests don't see real /tmp."""
+    original_state, original_tmp = router.STATE_DIR, router._TMP_DIR
     router.STATE_DIR = tmp_path / "state"
+    router._TMP_DIR = tmp_path / "tmp"
     router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    router._TMP_DIR.mkdir(parents=True, exist_ok=True)
     yield
-    router.STATE_DIR = original
+    router.STATE_DIR = original_state
+    router._TMP_DIR = original_tmp
 
 
 class TestFindTempFiles:
@@ -37,15 +34,13 @@ class TestFindTempFiles:
         assert len(result) == 1
         assert result[0].name == f.name
 
-    def test_finds_legacy_files_in_tmp(self, snapshot_dir: Path) -> None:
-        snapshot_dir.mkdir(parents=True, exist_ok=True)
-        f = snapshot_dir / f"{_T3_TEMP_PREFIX}other-session-20260403-1200.md"
+    def test_finds_legacy_files_in_tmp(self) -> None:
+        f = router._TMP_DIR / f"{_T3_TEMP_PREFIX}other-session-20260403-1200.md"
         f.write_text("old findings", encoding="utf-8")
 
-        # Direct test: put a file in STATE_DIR with no session match
         result = _find_temp_files("sess-123")
-        # Won't find it in snapshot_dir (it's not /tmp), validates STATE_DIR path works
-        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].name == f.name
 
 
 class TestHandlePostCompact:


### PR DESCRIPTION
## Summary

`_find_temp_files` scanned a hardcoded `/tmp` for legacy snapshot files, so the test suite picked up stale `/tmp/t3-snapshot-*.md` left over from prior agent sessions. `test_no_files_returns_empty` failed locally any time such a file existed.

Promote the temp directory to a module-level `_TMP_DIR` constant (`Path(tempfile.gettempdir())` — same default, no `# noqa: S108`), then have the autouse fixture redirect both `STATE_DIR` and `_TMP_DIR` at `tmp_path`. `test_finds_legacy_files_in_tmp` becomes meaningful again — it now writes into the patched `_TMP_DIR` and asserts the file is found, instead of just asserting "result is a list".

## Test plan

- [x] `pytest tests/test_post_compact_hook.py` passes (7/7) on a host with stale `/tmp/t3-snapshot-*.md` files present
- [x] `ruff check` and `ty check` clean on touched files
- [x] No `# noqa` introduced; quality-gate hook clean