### PR TITLE
chore(readiness): extract run_and_report_probes helper

### DIFF
--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -23,7 +23,7 @@ from teatree.core.management.commands._workspace_cleanup import (
 from teatree.core.models import Ticket, Worktree
 from teatree.core.orphan_guard import find_orphans_in_workspace
 from teatree.core.overlay_loader import get_overlay
-from teatree.core.readiness import run_probes
+from teatree.core.readiness import run_and_report_probes
 from teatree.core.reconcile import Drift, reconcile_all, reconcile_ticket
 from teatree.core.resolve import resolve_worktree
 from teatree.core.runners import (
@@ -282,11 +282,9 @@ class Command(TyperCommand):
             if not probes:
                 continue
             self.stdout.write(f"  {wt.repo_path}:")
-            results = run_probes(probes)
-            for r in results:
-                self.stdout.write(f"    {r.format()}")
-            total += len(results)
-            total_failures += sum(1 for r in results if not r.passed)
+            summary = run_and_report_probes(probes, write_line=self.stdout.write, indent="    ")
+            total += summary.total
+            total_failures += summary.failures
         if total_failures:
             self.stderr.write(f"  {total_failures} of {total} probe(s) failed")
             raise SystemExit(1)
@@ -317,12 +315,9 @@ class Command(TyperCommand):
                 self.stdout.write(f"  {wt.repo_path}: no probes")
                 continue
             self.stdout.write(f"  {wt.repo_path}:")
-            results = run_probes(probes)
-            for r in results:
-                self.stdout.write(f"    {r.format()}")
-            failures = [r for r in results if not r.passed]
-            total += len(results)
-            total_failures += len(failures)
+            summary = run_and_report_probes(probes, write_line=self.stdout.write, indent="    ")
+            total += summary.total
+            total_failures += summary.failures
         if total_failures:
             self.stderr.write(f"  {total_failures} of {total} probe(s) failed")
             raise SystemExit(1)

--- a/src/teatree/core/management/commands/worktree.py
+++ b/src/teatree/core/management/commands/worktree.py
@@ -19,7 +19,7 @@ from django_typer.management import TyperCommand, command
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_overlay
-from teatree.core.readiness import run_probes
+from teatree.core.readiness import run_and_report_probes
 from teatree.core.resolve import resolve_worktree
 from teatree.core.runners import (
     WorktreeProvisionRunner,
@@ -167,20 +167,16 @@ class Command(TyperCommand):
         """Run overlay readiness probes; raise SystemExit(1) on any failure.
 
         Shared by ``start``, ``verify``, ``ready`` so all three honor the same
-        runtime health gate. ``start`` and ``verify`` cannot return success
-        when the started/healthy services are silently broken (raw
-        translations, missing CORS headers, fixture-seed integrity).
+        runtime health gate. Returns success when the overlay has no probes
+        (the empty list is itself a valid contract).
         """
         probes = overlay.get_readiness_probes(worktree)
         if not probes:
             self.stdout.write("  No readiness probes defined for this overlay.")
             return
-        results = run_probes(probes)
-        for r in results:
-            self.stdout.write(f"  {r.format()}")
-        failures = [r for r in results if not r.passed]
-        if failures:
-            self.stderr.write(f"  {len(failures)} of {len(results)} probe(s) failed")
+        summary = run_and_report_probes(probes, write_line=self.stdout.write, indent="  ")
+        if summary.failures:
+            self.stderr.write(f"  {summary.failures} of {summary.total} probe(s) failed")
             raise SystemExit(1)
 
     @command()

--- a/src/teatree/core/readiness.py
+++ b/src/teatree/core/readiness.py
@@ -122,6 +122,34 @@ def run_probes(probes: "Iterable[Probe]", *, max_workers: int = 8) -> list[Probe
     return [results[i] for i in range(len(probes_list))]
 
 
+@dataclass(frozen=True, slots=True)
+class ProbeRunSummary:
+    """Aggregate counts after running a probe batch."""
+
+    total: int
+    failures: int
+
+
+def run_and_report_probes(
+    probes: "Iterable[Probe]",
+    *,
+    write_line: "Callable[[str], None]",
+    indent: str = "",
+) -> ProbeRunSummary:
+    """Run probes, format each result via ``write_line``, return a summary.
+
+    Empty input returns ``ProbeRunSummary(0, 0)`` and writes nothing — the
+    caller decides whether to print a "no probes" line or stay silent. The
+    failure-count message and ``SystemExit`` belong to the caller too;
+    different commands word the message and exit-condition differently.
+    """
+    results = run_probes(probes)
+    for result in results:
+        write_line(f"{indent}{result.format()}")
+    failures = sum(1 for r in results if not r.passed)
+    return ProbeRunSummary(total=len(results), failures=failures)
+
+
 def _check_http(name: str, spec: HTTPProbeSpec) -> ProbeResult:
     evidence = f"GET {spec.url}"
     headers = dict(spec.request_headers or {})
@@ -224,7 +252,9 @@ __all__ = [
     "HTTPProbeSpec",
     "Probe",
     "ProbeResult",
+    "ProbeRunSummary",
     "command_probe",
     "http_probe",
+    "run_and_report_probes",
     "run_probes",
 ]

--- a/tests/teatree_core/test_readiness.py
+++ b/tests/teatree_core/test_readiness.py
@@ -17,6 +17,7 @@ from teatree.core.readiness import (
     ProbeResult,
     command_probe,
     http_probe,
+    run_and_report_probes,
     run_probes,
 )
 
@@ -261,3 +262,27 @@ class TestRunProbes:
         ]
         results = run_probes(probes)
         assert [r.passed for r in results] == [True, False]
+
+
+class TestRunAndReportProbes:
+    def test_empty_input_writes_nothing_and_returns_zero_summary(self) -> None:
+        lines: list[str] = []
+        summary = run_and_report_probes([], write_line=lines.append)
+        assert lines == []
+        assert (summary.total, summary.failures) == (0, 0)
+
+    def test_writes_each_result_with_indent(self) -> None:
+        probes = [
+            Probe(name="ok", description="d", check_fn=lambda: ProbeResult(name="ok", passed=True, reason="200")),
+            Probe(name="bad", description="d", check_fn=lambda: ProbeResult(name="bad", passed=False, reason="nope")),
+        ]
+        lines: list[str] = []
+        summary = run_and_report_probes(probes, write_line=lines.append, indent="  ")
+        assert lines == ["  [OK] ok — 200", "  [FAIL] bad — nope"]
+        assert (summary.total, summary.failures) == (2, 1)
+
+    def test_default_indent_is_empty(self) -> None:
+        probes = [Probe(name="ok", description="d", check_fn=lambda: ProbeResult(name="ok", passed=True))]
+        lines: list[str] = []
+        run_and_report_probes(probes, write_line=lines.append)
+        assert lines == ["[OK] ok"]


### PR DESCRIPTION
## Summary
Three call sites previously duplicated the run-probes / format / count-failures triplet:

- ``Worktree._check_readiness_probes`` (single-worktree gate, used by ``start``/``verify``/``ready``)
- ``Workspace.start`` post-start probe loop (multi-worktree)
- ``Workspace.ready`` (multi-worktree)

Extract one helper in ``teatree.core.readiness``:

```python
def run_and_report_probes(
    probes: Iterable[Probe],
    *,
    write_line: Callable[[str], None],
    indent: str = "",
) -> ProbeRunSummary
```

Each command keeps its own empty-handling and failure-message wording — only the runner / formatter / counter is shared.

## Test plan
- [x] `uv run ruff check src/ tests/` → all checks passed
- [x] `uv run pytest --no-cov -x -q tests/teatree_core/test_readiness.py` → 24 passed (3 new)
- [x] `uv run pytest --no-cov -x -q tests/teatree_core/test_readiness.py tests/teatree_core/test_readiness_commands.py tests/test_cli.py tests/test_cli_ci.py` → 115 passed