### PR TITLE
feat(overlay): pin teatree __overlay_api_version__

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,12 @@ An overlay is a lightweight Python package that customizes teatree. It:
 4. Registers via a `teatree.overlays` entry point in `pyproject.toml` (e.g., `my-overlay = "myapp.overlay:MyOverlay"`)
 5. Gets auto-discovered by the overlay loader from `importlib.metadata.entry_points(group="teatree.overlays")`
 
+### Overlay API version (`teatree.__overlay_api_version__`)
+
+Teatree exports `__overlay_api_version__` (a string) for overlays to assert against at import time. Bump it on every **breaking** change to the overlay-facing surface — `OverlayBase` method signatures, `Worktree`/`Ticket` fields overlays read, the entry-point contract, or runner protocols overlays may implement. Non-breaking additions (new optional hook, new helper) do not bump it.
+
+Overlays should hard-fail at import (no shim, no deprecation warning) when the runtime teatree exposes a different version than what they were built against. CI catches the rest before merge.
+
 ## Backend Architecture
 
 ### API Protocols (`backends/protocols.py`)

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -479,6 +479,8 @@ Everything else — DB provisioning strategies, migration runners, symlink manag
 
 Defined in `teatree.core.overlay`. All methods receive the `worktree` instance for context.
 
+**Overlay API version pin.** ``teatree.__overlay_api_version__`` (currently ``"1"``) is bumped on any **breaking** change to the overlay-facing API: ``OverlayBase`` method signatures, ``Worktree``/``Ticket`` fields overlays read, the ``teatree.overlays`` entry-point contract, or runner protocols overlays may implement. Overlays assert this at import to fail loudly when teatree diverges from what they were built against — no silent misbehavior, no shim, no deprecation warning. Non-breaking additions (new optional hook, new helper) leave the version alone.
+
 **Abstract methods (must implement):**
 
 | Method | Signature | Purpose |

--- a/src/teatree/__init__.py
+++ b/src/teatree/__init__.py
@@ -1,5 +1,6 @@
+from teatree._overlay_api import __overlay_api_version__
 from teatree.project import find_project_root
 
 __version__ = "0.0.1"
 
-__all__ = ["__version__", "find_project_root"]
+__all__ = ["__overlay_api_version__", "__version__", "find_project_root"]

--- a/src/teatree/_overlay_api.py
+++ b/src/teatree/_overlay_api.py
@@ -1,0 +1,11 @@
+"""Overlay API version pin (re-exported from ``teatree``).
+
+Bumped on any breaking change to the overlay-facing API: ``OverlayBase``
+method signatures, ``Worktree``/``Ticket`` fields overlays read, the
+``teatree.overlays`` entry-point contract, or the runner protocols an
+overlay may implement. Overlays assert this at import to fail loudly when
+teatree diverges from what they were built against — no silent
+misbehavior.
+"""
+
+__overlay_api_version__ = "1"

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -12,5 +12,6 @@ def test_teatree_apps_register() -> None:
     agents_config = apps.get_app_config("agents")
 
     assert teatree.__version__ == "0.0.1"
+    assert teatree.__overlay_api_version__ == "1"
     assert core_config.name == "teatree.core"
     assert agents_config.name == "teatree.agents"


### PR DESCRIPTION
## Summary
Expose ``teatree.__overlay_api_version__ = \"1\"`` so overlays can assert against it at import. Bump on **breaking** changes only — ``OverlayBase`` signatures, ``Worktree``/``Ticket`` overlay-visible fields, ``teatree.overlays`` entry-point contract, runner protocols. Non-breaking additions (new optional hook, helper) leave it alone.

Document the contract in:
- `AGENTS.md` § \"Overlay API version\" — short paragraph for overlay authors
- `BLUEPRINT.md` §6.1 (OverlayBase ABC) — bump policy and import-time-fail rule

## Companion overlay change
A follow-up MR on company-fork-org/t3-company will assert the version on `OperOverlay` import.

## Test plan
- [x] `uv run ruff check src/ tests/` → all checks passed
- [x] `uv run pytest --no-cov -x -q tests/test_package_smoke.py` → 1 passed (assertion on the pinned value)
- [x] Manual: `python -c \"import teatree; print(teatree.__overlay_api_version__)\"` → `1`