### PR TITLE
refactor(sync): rename MR→PR, route gitlab_sync through CodeHostBackend (#541 follow-up)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -6,7 +6,7 @@ If the entire `src/` and `tests/` tree were deleted, this document alone — plu
 
 **Change policy:** Every code change to teatree must be reflected here. Before modifying this file, always ask the user for approval — this is the source of truth and the user validates every change.
 
-**Status:** This BLUEPRINT is the **current** architecture under issue [#541](https://github.com/souliane/teatree/issues/541). All eight phases have shipped on the active branch — the statusline file is the persistent UI surface; the HTML dashboard, ttyd web terminal, ASGI/uvicorn scaffolding, and platform autostart helpers are gone; the code-host + messaging Protocols are unified, with `SlackBotBackend`/`NoopMessagingBackend` selectable via overlay config; `t3 setup slack-bot --overlay <name>` walks the user through Slack app registration; the fat loop + 7 scanners + dispatcher are wired through `t3 loop tick`; the headless executor is the deliberately-slim `claude -p` swap point for a future Anthropic SDK runtime; and the no-overlay-leak gate keeps the platform tenant-agnostic.
+**Status:** This BLUEPRINT is the **current** architecture under issue [#541](https://github.com/souliane/teatree/issues/541). Phases 0-6 and 8 have shipped on the active branch; phase 7 (ticket dispositions — close superseded issues/PRs) is deferred to a follow-up. The statusline file is the persistent UI surface; the HTML dashboard, ttyd web terminal, ASGI/uvicorn scaffolding, and platform autostart helpers are gone; the code-host + messaging Protocols are unified, with `SlackBotBackend`/`NoopMessagingBackend` selectable via overlay config; `t3 setup slack-bot --overlay <name>` walks the user through Slack app registration; the fat loop + 6 scanners + dispatcher are wired through `t3 loop tick` (review-channel scanning is folded into the dispatcher's PR-URL detection); the headless executor is the deliberately-slim `claude -p` swap point for a future Anthropic SDK runtime; and the no-overlay-leak gate keeps the platform tenant-agnostic.
 
 ---
 
@@ -458,7 +458,7 @@ Each tick runs three stages:
 
 1. **Scan** — pure-Python scanners under `teatree.loop.scanners` collect signals from external sources in parallel. Scanners are deterministic, mockable, and fully covered by integration tests against stubbed backends. They never invoke Claude.
 2. **Dispatch** — the tick decides what each signal means and either acts inline (mechanical fix-and-push, n8n webhook trigger, statusline note) or delegates to one of the seven phase agents shipped with the plugin (§ 11.2). Phase agents are invoked via the standard Task tool the same way `t3:orchestrator` invokes them today; the loop is just one more caller.
-3. **Render** — `teatree.loop.statusline.render` writes `~/.teatree/statusline.txt` with three zones (§ 5.6.1).
+3. **Render** — `teatree.loop.statusline.render` writes `${XDG_DATA_HOME:-$HOME/.local/share}/teatree/statusline.txt` (or `$TEATREE_STATUSLINE_FILE` when set) with three zones (§ 5.6.1).
 
 **Scanners (`teatree.loop.scanners.*`):**
 
@@ -952,7 +952,7 @@ privacy = "strict"
 | Setting | Type | Purpose |
 |---------|------|---------|
 | `TEATREE_HEADLESS_RUNTIME` | str | Runtime for headless tasks (default: "claude-code") |
-| `TEATREE_CLAUDE_STATUSLINE_STATE_DIR` | str | Directory for the loop's rendered statusline file (default: `~/.teatree/`) |
+| `TEATREE_CLAUDE_STATUSLINE_STATE_DIR` | str | Directory for Claude Code's per-session statusline state files used by `agents/handover.py` (default: `/tmp/claude-statusline`). Distinct from the loop's rendered statusline file — see env var `TEATREE_STATUSLINE_FILE` below. |
 | `TEATREE_EDITABLE` | bool | Declare teatree is editable (verified by `t3 doctor check`) |
 | `OVERLAY_EDITABLE` | bool | Declare overlay is editable (verified by `t3 doctor check`) |
 
@@ -1474,8 +1474,8 @@ Dev dependencies: ruff, pytest, pytest-cov, pytest-django, ty, import-linter, pr
 - **Port allocation is ephemeral (Non-Negotiable).** Ports are allocated at `worktree start` via `find_free_ports()` (file-locked in `teatree.utils.ports`), passed as env vars to `docker compose`, and discovered at runtime via `docker compose port`. Ports are **never** written to `.env.worktree`, the database, or any other persistent store. Docker services are discoverable via `docker compose port` (single source of truth). Host-process services (e.g. frontend dev servers) use the allocated port directly.
 - Coverage omits only migrations. Everything else must be covered.
 - `claude -p` is headless (exits immediately). The user's interactive session running `/loop` is the only persistent Claude Code session.
-- Statusline state is rendered to a file (`~/.teatree/statusline.txt`) by the loop and `cat`-ed by the hook — the hook itself does no DB or network I/O.
-- Overlay-specific names (customer, tenant, product) **must not appear** in `src/teatree/` or `docs/`. Phase 8 lands a CI grep gate to enforce this.
+- Statusline state is rendered to a file (`${XDG_DATA_HOME:-$HOME/.local/share}/teatree/statusline.txt`, override via `TEATREE_STATUSLINE_FILE`) by the loop and `cat`-ed by the hook — the hook itself does no DB or network I/O. The file lives under XDG data, not `~/.teatree` (which is the user's shell config file, not a directory).
+- Overlay-specific names (customer, tenant, product) **must not appear** in `src/teatree/` or `docs/`. The CI grep gate (`scripts/hooks/check_no_overlay_leak.py`) enforces this — forbidden terms are loaded at runtime from `$TEATREE_OVERLAY_LEAK_TERMS` or `~/.teatree.toml` `[overlay_leak].terms` so the public repo never holds tenant names.
 - E2E tests (when overlays declare them) use file-based SQLite (not `:memory:`) because Playwright spawns a separate server process.
 
 ## Module Dependency Graph

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -166,6 +166,18 @@ This gate exists because the CI `validate_mr_title_and_description` job fails on
 
 > **PreToolUse hook:** A `validate-mr-metadata.sh` hook automatically intercepts MR create/update commands in project repos. It validates the title and description first line against the release-notes format rules and **blocks** non-compliant calls with a clear error. Fix the reported issues and retry — no manual validation needed.
 
+### 5b. Multi-Phase PRs Must Name Every Phase in the Title (Non-Negotiable)
+
+When a PR ships work spanning more than one numbered phase of an issue (e.g. `phase 3` of an 8-phase rewrite), the title MUST list every phase the diff covers — not only the lead phase. A reviewer must be able to read the title and know exactly what scope to expect.
+
+- Single phase: `feat(scope): <subject> (#NNN phase 3)` — fine.
+- Bundled phases: `feat(scope): <subject> (#NNN phases 1-6 + 8)` — preferred range form.
+- Non-contiguous: `feat(scope): <subject> (#NNN phases 2, 3, 8)` — explicit list.
+
+**Why:** A title that says "phase 3" while the diff also demolishes the dashboard (phase 2), adds the statusline file (phase 1), introduces the loop scaffolding (phase 4), and lands the no-leak gate (phase 8) is misleading. Reviewers gate their attention by title; mis-titling forces them to discover scope from the diff, which is the slow path. Past failure: PR #543 advertised "phase 3" but bundled phases 1, 2, 3, 3.6, 4, 5, 6, 8.
+
+**How to apply:** before creating the PR, list the commits and decide which phase each commit belongs to. If the answer covers more than one phase, use the bundled form. The same rule applies when a description says "phase X" — the description's first line must match the title.
+
 ### 6. Monitor Pipeline
 
 - Background polling for pipeline status.

--- a/src/teatree/agents/prompt.py
+++ b/src/teatree/agents/prompt.py
@@ -105,17 +105,17 @@ def build_task_prompt(task: Task) -> str:
     if task.execution_reason:
         lines.append(f"Reason: {task.execution_reason}")
 
-    # MR context
-    mrs = extra.get("mrs", {})
-    if isinstance(mrs, dict) and mrs:
-        lines.extend(("", "Open merge requests:"))
-        for mr in mrs.values():
-            if not isinstance(mr, dict):
+    # PR context
+    prs = extra.get("prs", {})
+    if isinstance(prs, dict) and prs:
+        lines.extend(("", "Open pull requests:"))
+        for pr in prs.values():
+            if not isinstance(pr, dict):
                 continue
-            url = mr.get("url", "")
-            title = mr.get("title", "")
-            draft = " (draft)" if mr.get("draft") else ""
-            pipeline = mr.get("pipeline_status", "")
+            url = pr.get("url", "")
+            title = pr.get("title", "")
+            draft = " (draft)" if pr.get("draft") else ""
+            pipeline = pr.get("pipeline_status", "")
             pipeline_info = f" — pipeline: {pipeline}" if pipeline else ""
             lines.append(f"  - {url}{draft}{pipeline_info}")
             if title:
@@ -125,7 +125,7 @@ def build_task_prompt(task: Task) -> str:
         (
             "",
             "Instructions:",
-            "1. Check what has been done so far (git log, existing code, MR status)",
+            "1. Check what has been done so far (git log, existing code, PR status)",
             "2. Identify what remains to be done",
             "3. If you can proceed (code, test, fix) — do it",
             "4. If you need human input (design decision, access, clarification) — STOP immediately.",
@@ -219,26 +219,26 @@ def build_system_context(task: Task, *, skills: list[str], lifecycle_skill: str 
 
 
 type _TicketExtra = dict[str, object]
-type _MrDict = dict[str, object]
+type _PrDict = dict[str, object]
 
 
-def _format_mr_context(extra: _TicketExtra) -> list[str]:
-    mrs = extra.get("mrs", {})
-    if not isinstance(mrs, dict) or not mrs:
+def _format_pr_context(extra: _TicketExtra) -> list[str]:
+    prs = extra.get("prs", {})
+    if not isinstance(prs, dict) or not prs:
         return []
-    lines = ["", "Open merge requests:"]
-    for raw_mr in mrs.values():
-        if not isinstance(raw_mr, dict):
+    lines = ["", "Open pull requests:"]
+    for raw_pr in prs.values():
+        if not isinstance(raw_pr, dict):
             continue
-        mr = cast("_MrDict", raw_mr)
-        url = mr.get("url", "")
-        mr_title = mr.get("title", "")
-        draft = " (draft)" if mr.get("draft") else ""
-        pipeline = mr.get("pipeline_status", "")
+        pr = cast("_PrDict", raw_pr)
+        url = pr.get("url", "")
+        pr_title = pr.get("title", "")
+        draft = " (draft)" if pr.get("draft") else ""
+        pipeline = pr.get("pipeline_status", "")
         pipeline_info = f" — pipeline: {pipeline}" if pipeline else ""
         lines.append(f"  - {url}{draft}{pipeline_info}")
-        if mr_title:
-            lines.append(f"    {mr_title}")
+        if pr_title:
+            lines.append(f"    {pr_title}")
     return lines
 
 
@@ -272,7 +272,7 @@ def build_interactive_context(task: Task, *, skills: list[str]) -> str:
             ),
         )
 
-    lines.extend(_format_mr_context(extra))
+    lines.extend(_format_pr_context(extra))
 
     lines.extend(("", "This is an interactive session — the user is present."))
 

--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -215,8 +215,11 @@ class GitHubCodeHost:
         user = cast("_GitHubUser", data)
         return user.get("login", "")
 
-    def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
-        query = quote_plus(f"is:pr is:open author:{author}")
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        terms = [f"is:pr is:open author:{author}"]
+        if updated_after:
+            terms.append(f"updated:>={updated_after}")
+        query = quote_plus(" ".join(terms))
         data = _gh_api_get(f"search/issues?q={query}&per_page=100", token=self._token)
         if not isinstance(data, dict):
             return []
@@ -225,8 +228,16 @@ class GitHubCodeHost:
             return []
         return cast("list[RawAPIDict]", items)
 
-    def list_review_requested_prs(self, *, reviewer: str) -> list[RawAPIDict]:
-        query = quote_plus(f"is:pr is:open review-requested:{reviewer}")
+    def list_review_requested_prs(
+        self,
+        *,
+        reviewer: str,
+        updated_after: str | None = None,
+    ) -> list[RawAPIDict]:
+        terms = [f"is:pr is:open review-requested:{reviewer}"]
+        if updated_after:
+            terms.append(f"updated:>={updated_after}")
+        query = quote_plus(" ".join(terms))
         data = _gh_api_get(f"search/issues?q={query}&per_page=100", token=self._token)
         if not isinstance(data, dict):
             return []

--- a/src/teatree/backends/github_sync.py
+++ b/src/teatree/backends/github_sync.py
@@ -55,7 +55,7 @@ class GitHubSyncBackend(SyncBackend):
         }
 
         for item in items:
-            result.mrs_found += 1
+            result.prs_found += 1
             state = status_map.get(item.status, Ticket.State.NOT_STARTED)
             extra: RawAPIDict = {
                 "issue_title": item.title,

--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 from urllib.parse import urlparse
 
+from teatree.backends import gitlab_api as _gitlab_api
 from teatree.backends.gitlab_api import GitLabAPI, ProjectInfo
 from teatree.backends.protocols import PullRequestSpec
 from teatree.core.sync import RawAPIDict
@@ -13,8 +14,10 @@ def get_client(*, token: str = "", base_url: str = "") -> GitLabAPI:
     """Build a ``GitLabAPI`` from explicit credentials.
 
     When *token* is empty the ``GitLabAPI`` default (env-var fallback) is used.
+    Resolves ``GitLabAPI`` through the module attribute so test patches that
+    rebind ``teatree.backends.gitlab_api.GitLabAPI`` apply here too.
     """
-    return GitLabAPI(
+    return _gitlab_api.GitLabAPI(
         token=token,
         base_url=base_url or "https://gitlab.com/api/v4",
     )
@@ -29,6 +32,17 @@ class GitLabCodeHost:
         base_url: str = "",
     ) -> None:
         self._client = client or get_client(token=token, base_url=base_url)
+
+    @property
+    def client(self) -> GitLabAPI:
+        """Underlying ``GitLabAPI``.
+
+        Exposed for ``GitLabSyncBackend`` and other GitLab-specific consumers
+        that need calls outside the cross-host Protocol surface (pipeline
+        status, approvals, discussions, draft notes count, terminal-state PR
+        scans). Cross-host code paths must keep using the Protocol methods.
+        """
+        return self._client
 
     def create_pr(self, spec: PullRequestSpec) -> RawAPIDict:
         project = self._resolve_project(spec.repo)
@@ -54,11 +68,16 @@ class GitLabCodeHost:
         """Return the authenticated GitLab username."""
         return self._client.current_username()
 
-    def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
-        return self._client.list_all_open_mrs(author)
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        return self._client.list_all_open_mrs(author, updated_after=updated_after)
 
-    def list_review_requested_prs(self, *, reviewer: str) -> list[RawAPIDict]:
-        return self._client.list_open_mrs_as_reviewer(reviewer)
+    def list_review_requested_prs(
+        self,
+        *,
+        reviewer: str,
+        updated_after: str | None = None,
+    ) -> list[RawAPIDict]:
+        return self._client.list_open_mrs_as_reviewer(reviewer, updated_after=updated_after)
 
     def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:
         return self._client.list_open_issues_for_assignee(assignee)

--- a/src/teatree/backends/gitlab_api.py
+++ b/src/teatree/backends/gitlab_api.py
@@ -251,6 +251,7 @@ class GitLabAPI:
         reviewer: str,
         *,
         per_page: int = 100,
+        updated_after: str | None = None,
     ) -> list[RawMR]:
         """Fetch all open MRs where *reviewer* is assigned as reviewer (not author)."""
         from urllib.parse import urlencode  # noqa: PLC0415
@@ -262,6 +263,8 @@ class GitLabAPI:
             "per_page": per_page,
             "not[author_username]": reviewer,
         }
+        if updated_after:
+            query["updated_after"] = updated_after
         params = urlencode(query)
         data = self.get_json(f"merge_requests?{params}")
         if not isinstance(data, list):

--- a/src/teatree/backends/gitlab_sync.py
+++ b/src/teatree/backends/gitlab_sync.py
@@ -1,4 +1,24 @@
-"""GitLab sync backend — MR upsert, issue labels, merged MR cleanup, assigned issues."""
+"""GitLab sync backend — PR upsert, issue labels, merged PR cleanup, assigned issues.
+
+Translates between GitLab's "merge request" API surface and teatree's
+canonical "PR" data model: ``PREntry``, ``Ticket.extra["prs"]``,
+``SyncResult.prs_*``. GitLab API URLs and method names that hit
+``/merge_requests/...`` endpoints keep their GitLab-native naming because
+they describe the literal endpoint being called.
+
+The backend wraps a ``GitLabCodeHost`` and routes cross-host shaped calls
+(``list_my_prs``, ``list_assigned_issues``, ``list_review_requested_prs``)
+through the :class:`CodeHostBackend` Protocol. GitLab-specific operations
+(pipeline status, approvals, discussions, draft notes count, terminal-state
+PR scans, project resolution, work item status) are accessed via
+:attr:`GitLabCodeHost.client` because they have no GitHub parallel.
+
+The backend constructs its own ``GitLabCodeHost`` from the overlay's GitLab
+token rather than going through ``get_code_host(overlay)`` so dual sync
+(GitHub project board + GitLab MRs in the same overlay) keeps working: the
+loader picks one primary code host but each sync backend is platform-bound
+and needs its own client.
+"""
 
 import logging
 import re
@@ -10,16 +30,17 @@ import httpx
 from django.core.cache import cache
 from django.utils import timezone
 
+from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab_sync_approvals import detect_approval_dismissal
-from teatree.backends.gitlab_sync_terminal import detect_closed_mrs, detect_merged_mrs
+from teatree.backends.gitlab_sync_terminal import detect_closed_prs, detect_merged_prs
 from teatree.backends.slack_review_sync import fetch_review_permalinks
 from teatree.core.models import Ticket
 from teatree.core.sync import (
     LAST_SYNC_CACHE_KEY,
     PENDING_REVIEWS_CACHE_KEY,
     DiscussionSummary,
-    MREntry,
-    MREntryDict,
+    PREntry,
+    PREntryDict,
     RawAPIDict,
     SyncBackend,
     SyncResult,
@@ -43,8 +64,15 @@ _STATE_ORDER = [s.value for s in Ticket.State]
 
 
 @dataclass(frozen=True, slots=True)
-class _MRContext:
-    mr: RawAPIDict
+class _PRContext:
+    """A single GitLab MR being processed as a teatree PR.
+
+    The ``raw`` field holds the upstream GitLab API response (which uses
+    GitLab's MR vocabulary); the surrounding code maps it onto the teatree
+    canonical ``PREntry`` model.
+    """
+
+    raw: RawAPIDict
     repo_short: str
     client: "GitLabAPI"
     project: "ProjectInfo | None"
@@ -59,16 +87,17 @@ class GitLabSyncBackend(SyncBackend):
 
     @override
     def sync(self, overlay: object) -> SyncResult:
-        from teatree.backends.gitlab_api import GitLabAPI, ProjectInfo  # noqa: PLC0415
+        from teatree.backends.gitlab_api import ProjectInfo  # noqa: PLC0415
         from teatree.core.overlay import OverlayBase  # noqa: PLC0415
 
         if not isinstance(overlay, OverlayBase):
             return SyncResult(errors=["Invalid overlay"])
 
-        overlay_name = _overlay_name(overlay)
         token = overlay.config.get_gitlab_token()
-        client = GitLabAPI(token=token, base_url=overlay.config.gitlab_url)
-        username = overlay.config.get_gitlab_username() or client.current_username()
+        host = GitLabCodeHost(token=token, base_url=overlay.config.gitlab_url)
+        overlay_name = _overlay_name(overlay)
+        client = host.client
+        username = overlay.config.get_gitlab_username() or host.current_user()
         if not username:
             return SyncResult(errors=["GitLab username is not configured in overlay"])
         result = SyncResult()
@@ -77,116 +106,116 @@ class GitLabSyncBackend(SyncBackend):
         sync_started_at = timezone.now()
 
         try:
-            mrs = client.list_all_open_mrs(username, updated_after=last_sync)
+            raw_prs = host.list_my_prs(author=username, updated_after=last_sync)
         except Exception as exc:  # noqa: BLE001
-            return SyncResult(errors=[f"MR fetch failed: {exc}"])
+            return SyncResult(errors=[f"PR fetch failed: {exc}"])
 
-        for mr in mrs:
-            result.mrs_found += 1
-            repo_path = self._extract_repo_path(mr)
+        for raw in raw_prs:
+            result.prs_found += 1
+            repo_path = self._extract_repo_path(raw)
             repo_short = repo_path.rsplit("/", maxsplit=1)[-1]
-            project_id = int(mr.get("project_id", 0))  # type: ignore[arg-type]
+            project_id = int(raw.get("project_id", 0))  # type: ignore[arg-type]
             project = (
                 ProjectInfo(project_id=project_id, path_with_namespace=repo_path, short_name=repo_short)
                 if project_id
                 else None
             )
-            ctx = _MRContext(mr=mr, repo_short=repo_short, client=client, project=project)
-            self._upsert_ticket_from_mr(ctx, result, username=username, overlay_name=overlay_name)
+            ctx = _PRContext(raw=raw, repo_short=repo_short, client=client, project=project)
+            self._upsert_ticket_from_pr(ctx, result, username=username, overlay_name=overlay_name)
 
-        self._fetch_assigned_issues(client, username, result, overlay_name=overlay_name)
+        self._fetch_assigned_issues(host, username, result, overlay_name=overlay_name)
 
         # Backfill overlay on any in-flight tickets that still have it empty
         if overlay_name:
             Ticket.objects.in_flight().filter(overlay="").update(overlay=overlay_name)
 
         self._fetch_issue_labels(client, result)
-        detect_merged_mrs(client, username, result, last_sync)
-        detect_closed_mrs(client, username, result, last_sync)
+        detect_merged_prs(client, username, result, last_sync)
+        detect_closed_prs(client, username, result, last_sync)
         fetch_review_permalinks(result)
-        self._sync_reviewer_mrs(client, username, result)
+        self._sync_reviewer_prs(host, username, result)
 
         cache.set(LAST_SYNC_CACHE_KEY, sync_started_at.isoformat(), timeout=None)
 
         return result
 
     @classmethod
-    def _extract_repo_path(cls, mr: RawAPIDict) -> str:
-        web_url = str(mr.get("web_url", ""))
+    def _extract_repo_path(cls, raw: RawAPIDict) -> str:
+        web_url = str(raw.get("web_url", ""))
         match = _REPO_PATH_RE.search(web_url)
         return match.group(1) if match else ""
 
     @classmethod
-    def _build_mr_entry(cls, ctx: "_MRContext", *, username: str) -> MREntry:
-        """Build a fully enriched MREntry from a raw MR dict."""
-        mr = ctx.mr
-        web_url = str(mr.get("web_url", ""))
-        is_draft = bool(mr.get("draft"))
-        mr_iid = int(mr.get("iid", 0))  # type: ignore[arg-type]
+    def _build_pr_entry(cls, ctx: "_PRContext", *, username: str) -> PREntry:
+        """Build a fully enriched PREntry from a raw GitLab MR dict."""
+        raw = ctx.raw
+        web_url = str(raw.get("web_url", ""))
+        is_draft = bool(raw.get("draft"))
+        pr_iid = int(raw.get("iid", 0))  # type: ignore[arg-type]
 
-        mr_entry = MREntry(
+        pr_entry = PREntry(
             url=web_url,
-            title=str(mr.get("title", "")),
-            branch=str(mr.get("source_branch", "")),
+            title=str(raw.get("title", "")),
+            branch=str(raw.get("source_branch", "")),
             draft=is_draft,
             repo=ctx.repo_short,
-            iid=mr_iid,
-            updated_at=str(mr.get("updated_at", "")),
-            state=str(mr.get("state", "opened")),
+            iid=pr_iid,
+            updated_at=str(raw.get("updated_at", "")),
+            state=str(raw.get("state", "opened")),
         )
 
-        if not is_draft and ctx.project and mr_iid:
-            pipeline = ctx.client.get_mr_pipeline(ctx.project.project_id, mr_iid)
-            mr_entry.pipeline_status = pipeline["status"]
-            mr_entry.pipeline_url = pipeline["url"]
-            mr_entry.approvals = ctx.client.get_mr_approvals(ctx.project.project_id, mr_iid)
+        if not is_draft and ctx.project and pr_iid:
+            pipeline = ctx.client.get_mr_pipeline(ctx.project.project_id, pr_iid)
+            pr_entry.pipeline_status = pipeline["status"]
+            pr_entry.pipeline_url = pipeline["url"]
+            pr_entry.approvals = ctx.client.get_mr_approvals(ctx.project.project_id, pr_iid)
 
-            discussions = ctx.client.get_mr_discussions(ctx.project.project_id, mr_iid)
-            mr_entry.discussions = cls._classify_discussions(discussions, username)
+            discussions = ctx.client.get_mr_discussions(ctx.project.project_id, pr_iid)
+            pr_entry.discussions = cls._classify_discussions(discussions, username)
             e2e_url = cls._detect_e2e_evidence(discussions, web_url)
             if e2e_url:
-                mr_entry.e2e_test_plan_url = e2e_url
+                pr_entry.e2e_test_plan_url = e2e_url
 
             current_count = (
-                int(mr_entry.approvals.get("count", 0)) if isinstance(mr_entry.approvals, dict) else 0  # ty: ignore[invalid-argument-type]
+                int(pr_entry.approvals.get("count", 0)) if isinstance(pr_entry.approvals, dict) else 0  # ty: ignore[invalid-argument-type]
             )
             dismissal = detect_approval_dismissal(discussions, current_approval_count=current_count)
             if dismissal is not None:
-                mr_entry.approvals_dismissed_at = dismissal.at
-                mr_entry.dismissed_approvers = dismissal.approvers
+                pr_entry.approvals_dismissed_at = dismissal.at
+                pr_entry.dismissed_approvers = dismissal.approvers
 
-            draft_count = ctx.client.get_draft_notes_count(ctx.project.project_id, mr_iid)
-            mr_entry.draft_comments_pending = draft_count > 0
-            mr_entry.draft_comments_count = draft_count if draft_count > 0 else None
+            draft_count = ctx.client.get_draft_notes_count(ctx.project.project_id, pr_iid)
+            pr_entry.draft_comments_pending = draft_count > 0
+            pr_entry.draft_comments_count = draft_count if draft_count > 0 else None
 
-        reviewers = mr.get("reviewers", [])
+        reviewers = raw.get("reviewers", [])
         if isinstance(reviewers, list):
-            mr_entry.review_requested = bool(reviewers)
-            mr_entry.reviewer_names = [str(r.get("username", "")) for r in reviewers if isinstance(r, dict)]  # ty: ignore[no-matching-overload]
+            pr_entry.review_requested = bool(reviewers)
+            pr_entry.reviewer_names = [str(r.get("username", "")) for r in reviewers if isinstance(r, dict)]  # ty: ignore[no-matching-overload]
 
-        return mr_entry
+        return pr_entry
 
     @classmethod
-    def _upsert_ticket_from_mr(
+    def _upsert_ticket_from_pr(
         cls,
-        ctx: "_MRContext",
+        ctx: "_PRContext",
         result: SyncResult,
         *,
         username: str = "",
         overlay_name: str = "",
     ) -> None:
-        mr_entry = cls._build_mr_entry(ctx, username=username)
-        web_url = mr_entry.url
-        lookup_url = cls._extract_issue_url(ctx.mr) or web_url
-        mr_entry_dict = mr_entry.to_dict()
-        inferred_state = cls._infer_state_from_mrs({web_url: mr_entry_dict})
+        pr_entry = cls._build_pr_entry(ctx, username=username)
+        web_url = pr_entry.url
+        lookup_url = cls._extract_issue_url(ctx.raw) or web_url
+        pr_entry_dict = pr_entry.to_dict()
+        inferred_state = cls._infer_state_from_prs({web_url: pr_entry_dict})
 
         tickets = list(Ticket.objects.filter(issue_url=lookup_url).order_by("pk"))
         if not tickets:
             Ticket.objects.create(
                 issue_url=lookup_url,
                 repos=[ctx.repo_short],
-                extra={"mrs": {web_url: mr_entry_dict}},
+                extra={"prs": {web_url: pr_entry_dict}},
                 state=inferred_state,
                 overlay=overlay_name,
             )
@@ -199,7 +228,7 @@ class GitLabSyncBackend(SyncBackend):
             if overlay_name and not ticket.overlay:
                 ticket.overlay = overlay_name
                 ticket.save(update_fields=["overlay"])
-            cls._update_ticket(ticket, mr_entry_dict, web_url, ctx.repo_short, inferred_state)
+            cls._update_ticket(ticket, pr_entry_dict, web_url, ctx.repo_short, inferred_state)
             result.tickets_updated += 1
 
     @classmethod
@@ -234,7 +263,7 @@ class GitLabSyncBackend(SyncBackend):
         return result
 
     @classmethod
-    def _detect_e2e_evidence(cls, discussions: list[RawAPIDict], mr_url: str) -> str:
+    def _detect_e2e_evidence(cls, discussions: list[RawAPIDict], pr_url: str) -> str:
         for disc in discussions:
             if not isinstance(disc, dict):
                 continue
@@ -249,7 +278,7 @@ class GitLabSyncBackend(SyncBackend):
                 has_keyword = bool(_E2E_EVIDENCE_RE.search(body))
                 if has_keyword and has_image:
                     note_id = note.get("id")  # ty: ignore[invalid-argument-type]
-                    return f"{mr_url}#note_{note_id}" if note_id else mr_url
+                    return f"{pr_url}#note_{note_id}" if note_id else pr_url
         return ""
 
     @classmethod
@@ -257,13 +286,13 @@ class GitLabSyncBackend(SyncBackend):
         src_extra = source.extra if isinstance(source.extra, dict) else {}
         tgt_extra = target.extra if isinstance(target.extra, dict) else {}
 
-        src_mrs = src_extra.get("mrs", {})
-        tgt_mrs = tgt_extra.get("mrs", {})
-        if isinstance(src_mrs, dict) and isinstance(tgt_mrs, dict):
-            for url, entry in src_mrs.items():
-                if url not in tgt_mrs:
-                    tgt_mrs[url] = entry
-            tgt_extra["mrs"] = tgt_mrs
+        src_prs = src_extra.get("prs", {})
+        tgt_prs = tgt_extra.get("prs", {})
+        if isinstance(src_prs, dict) and isinstance(tgt_prs, dict):
+            for url, entry in src_prs.items():
+                if url not in tgt_prs:
+                    tgt_prs[url] = entry
+            tgt_extra["prs"] = tgt_prs
             target.extra = tgt_extra
 
         src_repos = source.repos if isinstance(source.repos, list) else []
@@ -278,25 +307,25 @@ class GitLabSyncBackend(SyncBackend):
     def _update_ticket(
         cls,
         ticket: Ticket,
-        mr_entry: MREntryDict,
-        mr_url: str,
+        pr_entry: PREntryDict,
+        pr_url: str,
         repo_short: str,
         inferred_state: str = "",
     ) -> None:
         extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-        mrs = extra.get("mrs", {})
-        if not isinstance(mrs, dict):
-            mrs = {}
+        prs = extra.get("prs", {})
+        if not isinstance(prs, dict):
+            prs = {}
 
         # Preserve fields written by skills (Slack data, E2E links) that sync can't fetch
-        prev = mrs.get(mr_url)
+        prev = prs.get(pr_url)
         if isinstance(prev, dict):
             for key in _SKILL_WRITTEN_FIELDS:
-                if key in prev and key not in mr_entry:
-                    mr_entry[key] = prev[key]
+                if key in prev and key not in pr_entry:
+                    pr_entry[key] = prev[key]
 
-        mrs[mr_url] = mr_entry
-        extra["mrs"] = mrs
+        prs[pr_url] = pr_entry
+        extra["prs"] = prs
 
         repos = ticket.repos if isinstance(ticket.repos, list) else []
         if repo_short not in repos:
@@ -316,19 +345,19 @@ class GitLabSyncBackend(SyncBackend):
     @classmethod
     def _fetch_assigned_issues(
         cls,
-        client: "GitLabAPI",
+        host: GitLabCodeHost,
         username: str,
         result: SyncResult,
         *,
         overlay_name: str = "",
     ) -> None:
-        """Upsert tickets for issues assigned to *username* that have no MR yet.
+        """Upsert tickets for issues assigned to *username* that have no PR yet.
 
-        Tickets keyed by the same ``issue_url`` are consolidated with MR-based
+        Tickets keyed by the same ``issue_url`` are consolidated with PR-based
         tickets so each ticket is represented by a single row.
         """
         try:
-            issues = client.list_open_issues_for_assignee(username)
+            issues = host.list_assigned_issues(assignee=username)
         except httpx.HTTPError as exc:
             result.errors.append(f"Assigned issues fetch failed: {exc}")
             return
@@ -472,28 +501,28 @@ class GitLabSyncBackend(SyncBackend):
         return None
 
     @classmethod
-    def _infer_state_from_mrs(cls, mrs_data: dict[str, MREntryDict]) -> str:
+    def _infer_state_from_prs(cls, prs_data: dict[str, PREntryDict]) -> str:
         best = Ticket.State.NOT_STARTED
-        for mr in mrs_data.values():
-            if not isinstance(mr, dict):
+        for pr in prs_data.values():
+            if not isinstance(pr, dict):
                 continue
-            is_draft = mr.get("draft", True)
+            is_draft = pr.get("draft", True)
             if is_draft:
                 candidate = Ticket.State.STARTED
             else:
-                approvals = mr.get("approvals")
+                approvals = pr.get("approvals")
                 has_approvals = isinstance(approvals, dict) and int(approvals.get("count", 0)) > 0  # ty: ignore[no-matching-overload]
-                review_requested = bool(mr.get("review_requested"))
+                review_requested = bool(pr.get("review_requested"))
                 candidate = Ticket.State.IN_REVIEW if (has_approvals or review_requested) else Ticket.State.SHIPPED
             if _STATE_ORDER.index(candidate) > _STATE_ORDER.index(best):
                 best = candidate
         return best
 
     @classmethod
-    def _extract_issue_url(cls, mr: RawAPIDict) -> str:
+    def _extract_issue_url(cls, raw: RawAPIDict) -> str:
         for text in [
-            str(mr.get("description", "") or "").split("\n", maxsplit=1)[0],
-            str(mr.get("title", "")),
+            str(raw.get("description", "") or "").split("\n", maxsplit=1)[0],
+            str(raw.get("title", "")),
         ]:
             match = _ISSUE_URL_RE.search(text)
             if match:
@@ -501,30 +530,30 @@ class GitLabSyncBackend(SyncBackend):
         return ""
 
     @classmethod
-    def _sync_reviewer_mrs(cls, client: "GitLabAPI", username: str, result: SyncResult) -> None:
+    def _sync_reviewer_prs(cls, host: GitLabCodeHost, username: str, result: SyncResult) -> None:
         try:
-            reviewer_mrs = client.list_open_mrs_as_reviewer(username)
+            reviewer_prs = host.list_review_requested_prs(reviewer=username)
         except Exception as exc:  # noqa: BLE001
-            result.errors.append(f"Reviewer MR fetch failed: {exc}")
+            result.errors.append(f"Reviewer PR fetch failed: {exc}")
             return
 
         reviews: list[dict[str, str]] = []
-        for mr in reviewer_mrs:
-            web_url = str(mr.get("web_url", ""))
-            author_info = mr.get("author", {})
+        for raw in reviewer_prs:
+            web_url = str(raw.get("web_url", ""))
+            author_info = raw.get("author", {})
             author_name = str(author_info.get("username", "")) if isinstance(author_info, dict) else ""  # ty: ignore[no-matching-overload]
-            repo_path = cls._extract_repo_path(mr)
+            repo_path = cls._extract_repo_path(raw)
             repo_short = repo_path.rsplit("/", maxsplit=1)[-1]
-            iid = str(mr.get("iid", ""))
+            iid = str(raw.get("iid", ""))
             reviews.append(
                 {
                     "url": web_url,
-                    "title": str(mr.get("title", "")),
+                    "title": str(raw.get("title", "")),
                     "repo": repo_short,
                     "iid": iid,
                     "author": author_name,
-                    "draft": str(mr.get("draft", False)),
-                    "updated_at": str(mr.get("updated_at", "")),
+                    "draft": str(raw.get("draft", False)),
+                    "updated_at": str(raw.get("updated_at", "")),
                 },
             )
 

--- a/src/teatree/backends/gitlab_sync_terminal.py
+++ b/src/teatree/backends/gitlab_sync_terminal.py
@@ -1,11 +1,14 @@
-"""Terminal-state MR handling: detect merged and closed MRs, update cached extras.
+"""Terminal-state PR handling: detect merged and closed PRs, update cached extras.
 
 Split out of ``gitlab_sync.py`` to keep that module under the LOC budget enforced
 by ``hooks/check_module_health.py``. The two states share fetch + url-collection
 plumbing but diverge on side effects:
 
 - merged → advance the ticket FSM to ``MERGED`` and clean up worktrees
-- closed → only rewrite the cached MR state so consumers filter the row out
+- closed → only rewrite the cached PR state so consumers filter the row out
+
+GitLab API method names that end in ``_mrs`` are kept (they describe the
+literal GitLab endpoint being called); teatree-canonical names use ``pr``.
 """
 
 import logging
@@ -15,7 +18,7 @@ import httpx
 
 from teatree.core.cleanup import cleanup_worktree
 from teatree.core.models import Ticket, Worktree
-from teatree.core.sync import MREntryDict, RawAPIDict, SyncResult
+from teatree.core.sync import PREntryDict, RawAPIDict, SyncResult
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -27,8 +30,8 @@ logger = logging.getLogger(__name__)
 _STATE_ORDER = [s.value for s in Ticket.State]
 
 
-def detect_merged_mrs(client: "GitLabAPI", username: str, result: SyncResult, last_sync: str | None) -> None:
-    merged_urls = _fetch_terminal_mr_urls(
+def detect_merged_prs(client: "GitLabAPI", username: str, result: SyncResult, last_sync: str | None) -> None:
+    merged_urls = _fetch_terminal_pr_urls(
         client.list_recently_merged_mrs,
         username,
         last_sync,
@@ -41,8 +44,8 @@ def detect_merged_mrs(client: "GitLabAPI", username: str, result: SyncResult, la
         apply_merged_status(ticket, merged_urls, result)
 
 
-def detect_closed_mrs(client: "GitLabAPI", username: str, result: SyncResult, last_sync: str | None) -> None:
-    closed_urls = _fetch_terminal_mr_urls(
+def detect_closed_prs(client: "GitLabAPI", username: str, result: SyncResult, last_sync: str | None) -> None:
+    closed_urls = _fetch_terminal_pr_urls(
         client.list_recently_closed_mrs,
         username,
         last_sync,
@@ -57,18 +60,18 @@ def detect_closed_mrs(client: "GitLabAPI", username: str, result: SyncResult, la
 
 def apply_merged_status(ticket: Ticket, merged_urls: set[str], result: SyncResult) -> None:
     extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-    mrs = extra.get("mrs", {})
-    if not isinstance(mrs, dict) or not mrs:
+    prs = extra.get("prs", {})
+    if not isinstance(prs, dict) or not prs:
         return
 
-    changed, all_merged = _scan_merged_mrs(mrs, merged_urls, result)
+    changed, all_merged = _scan_merged_prs(prs, merged_urls, result)
 
     if not changed and not all_merged:
         return
 
     update_fields: list[str] = []
     if changed:
-        extra["mrs"] = mrs
+        extra["prs"] = prs
         ticket.extra = extra
         update_fields.append("extra")
     if all_merged and _STATE_ORDER.index(Ticket.State.MERGED) > _STATE_ORDER.index(ticket.state):
@@ -83,47 +86,47 @@ def apply_merged_status(ticket: Ticket, merged_urls: set[str], result: SyncResul
 
 def apply_closed_status(ticket: Ticket, closed_urls: set[str], result: SyncResult) -> None:
     # Closed-without-merge has no FSM target and no worktree cleanup: the user may
-    # still reopen / push a new MR for the same ticket. Only the cached MR entry is
+    # still reopen / push a new PR for the same ticket. Only the cached PR entry is
     # rewritten so the cached state-based filter stops rendering the row.
     extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-    mrs = extra.get("mrs", {})
-    if not isinstance(mrs, dict) or not mrs:
+    prs = extra.get("prs", {})
+    if not isinstance(prs, dict) or not prs:
         return
 
     changed = False
-    for mr_url, mr_entry in mrs.items():
-        if not isinstance(mr_entry, dict) or mr_url not in closed_urls:
+    for pr_url, pr_entry in prs.items():
+        if not isinstance(pr_entry, dict) or pr_url not in closed_urls:
             continue
-        entry = cast("MREntryDict", mr_entry)
+        entry = cast("PREntryDict", pr_entry)
         if entry.pop("discussions", None) is not None:
             changed = True
         if entry.get("state") != "closed":
             entry["state"] = "closed"
             changed = True
-        result.mrs_closed += 1
+        result.prs_closed += 1
 
     if changed:
-        extra["mrs"] = mrs
+        extra["prs"] = prs
         ticket.extra = extra
         ticket.save(update_fields=["extra"])
 
 
-def _scan_merged_mrs(mrs: RawAPIDict, merged_urls: set[str], result: SyncResult) -> tuple[bool, bool]:
+def _scan_merged_prs(prs: RawAPIDict, merged_urls: set[str], result: SyncResult) -> tuple[bool, bool]:
     changed = False
     unmerged = False
-    for mr_url, mr_entry in mrs.items():
-        if not isinstance(mr_entry, dict):
+    for pr_url, pr_entry in prs.items():
+        if not isinstance(pr_entry, dict):
             continue
-        if mr_url not in merged_urls:
+        if pr_url not in merged_urls:
             unmerged = True
             continue
-        entry = cast("MREntryDict", mr_entry)
+        entry = cast("PREntryDict", pr_entry)
         if entry.pop("discussions", None) is not None:
             changed = True
         if entry.get("state") != "merged":
             entry["state"] = "merged"
             changed = True
-        result.mrs_merged += 1
+        result.prs_merged += 1
     return changed, not unmerged
 
 
@@ -137,7 +140,7 @@ def _cleanup_merged_worktrees(ticket: Ticket, result: SyncResult) -> None:
             result.errors.append(f"Worktree cleanup failed for {worktree.repo_path} ({worktree.branch}): {exc}")
 
 
-def _fetch_terminal_mr_urls(
+def _fetch_terminal_pr_urls(
     fetcher: "Callable[..., list[RawAPIDict]]",
     username: str,
     last_sync: str | None,
@@ -146,10 +149,10 @@ def _fetch_terminal_mr_urls(
     label: str,
 ) -> set[str] | None:
     try:
-        mrs = fetcher(username, updated_after=last_sync)
+        raw_prs = fetcher(username, updated_after=last_sync)
     except httpx.HTTPError as exc:
-        result.errors.append(f"{label} MR fetch failed: {exc}")
+        result.errors.append(f"{label} PR fetch failed: {exc}")
         return None
-    if not mrs:
+    if not raw_prs:
         return None
-    return {str(mr.get("web_url", "")) for mr in mrs}
+    return {str(raw.get("web_url", "")) for raw in raw_prs}

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -50,9 +50,19 @@ class CodeHostBackend(Protocol):
 
     def current_user(self) -> str: ...  # pragma: no branch
 
-    def list_my_prs(self, *, author: str) -> list[RawAPIDict]: ...  # pragma: no branch
+    def list_my_prs(
+        self,
+        *,
+        author: str,
+        updated_after: str | None = None,
+    ) -> list[RawAPIDict]: ...  # pragma: no branch
 
-    def list_review_requested_prs(self, *, reviewer: str) -> list[RawAPIDict]: ...  # pragma: no branch
+    def list_review_requested_prs(
+        self,
+        *,
+        reviewer: str,
+        updated_after: str | None = None,
+    ) -> list[RawAPIDict]: ...  # pragma: no branch
 
     def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict: ...  # pragma: no branch
 

--- a/src/teatree/backends/slack.py
+++ b/src/teatree/backends/slack.py
@@ -25,12 +25,12 @@ def post_webhook_message(webhook_url: str, text: str, *, signature: str = "") ->
 
 @dataclass(frozen=True, slots=True)
 class SlackReviewMatch:
-    mr_url: str
+    pr_url: str
     permalink: str
     channel: str
 
 
-_MR_URL_RE = re.compile(r"https://[^\s|>]+/merge_requests/\d+")
+_PR_URL_RE = re.compile(r"https://[^\s|>]+/(?:merge_requests|pull|pulls)/\d+")
 
 
 def _resolve_workspace_domain(client: httpx.Client) -> str:
@@ -50,7 +50,7 @@ class _ChannelContext:
 
 def _iter_review_matches(
     msg: RawAPIDict,
-    mr_url_set: set[str],
+    pr_url_set: set[str],
     seen: set[str],
     ctx: _ChannelContext,
 ) -> list[SlackReviewMatch]:
@@ -59,7 +59,7 @@ def _iter_review_matches(
     ts = str(msg.get("ts", ""))
     if not ts:
         return []
-    found_urls = _MR_URL_RE.findall(text)
+    found_urls = _PR_URL_RE.findall(text)
     if not found_urls:
         return []
 
@@ -67,9 +67,9 @@ def _iter_review_matches(
     matches: list[SlackReviewMatch] = []
     for url in found_urls:
         clean_url = url.rstrip("/").split("#")[0]
-        if clean_url in mr_url_set and clean_url not in seen:
+        if clean_url in pr_url_set and clean_url not in seen:
             seen.add(clean_url)
-            matches.append(SlackReviewMatch(mr_url=clean_url, permalink=permalink, channel=ctx.channel_name))
+            matches.append(SlackReviewMatch(pr_url=clean_url, permalink=permalink, channel=ctx.channel_name))
     return matches
 
 
@@ -93,21 +93,21 @@ class SlackReviewSearchRequest:
     token: str
     channel_id: str
     channel_name: str
-    mr_urls: list[str]
+    pr_urls: list[str]
     max_pages: int = 10
     workspace_domain: str = ""
 
 
 def search_review_permalinks(request: SlackReviewSearchRequest) -> list[SlackReviewMatch]:
-    """Read recent messages from a Slack channel and match MR URLs.
+    """Read recent messages from a Slack channel and match PR URLs.
 
     Uses conversations.history (no search:read scope needed).
-    Matching is deterministic: exact MR URL substring match, no AI.
+    Matching is deterministic: exact PR URL substring match, no AI.
     """
-    if not request.token or not request.channel_id or not request.mr_urls:
+    if not request.token or not request.channel_id or not request.pr_urls:
         return []
 
-    mr_url_set = set(request.mr_urls)
+    pr_url_set = set(request.pr_urls)
     matches: list[SlackReviewMatch] = []
     seen: set[str] = set()
 
@@ -126,9 +126,9 @@ def search_review_permalinks(request: SlackReviewSearchRequest) -> list[SlackRev
                 break
 
             for msg in data.get("messages", []):  # ty: ignore[not-iterable]
-                matches.extend(_iter_review_matches(msg, mr_url_set, seen, ctx))
+                matches.extend(_iter_review_matches(msg, pr_url_set, seen, ctx))
 
-            if seen == mr_url_set or not data.get("has_more"):
+            if seen == pr_url_set or not data.get("has_more"):
                 break
             meta = data.get("response_metadata", {})
             cursor = meta.get("next_cursor") if isinstance(meta, dict) else None  # ty: ignore[invalid-argument-type]

--- a/src/teatree/backends/slack_reactions.py
+++ b/src/teatree/backends/slack_reactions.py
@@ -3,7 +3,7 @@
 When a ticket transitions between FSM states, we want the corresponding
 Slack review-request message to get an emoji reaction so reviewers can see
 the state change at a glance (``:tada:`` on merge, ``:arrows_counterclockwise:``
-on rework, …).  The review permalink stored on each MR entry gives us the
+on rework, …).  The review permalink stored on each PR entry gives us the
 Slack ``channel`` and ``timestamp`` needed for ``reactions.add``.
 """
 
@@ -77,24 +77,24 @@ def add_reaction(token: str, channel_id: str, timestamp: str, emoji: str) -> boo
     return False
 
 
-def _iter_mr_permalinks(ticket: "Ticket") -> list[str]:
-    """Collect non-empty ``review_permalink`` values from the ticket's MRs."""
+def _iter_pr_permalinks(ticket: "Ticket") -> list[str]:
+    """Collect non-empty ``review_permalink`` values from the ticket's PRs."""
     extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-    mrs = extra.get("mrs", {})
-    if not isinstance(mrs, dict):
+    prs = extra.get("prs", {})
+    if not isinstance(prs, dict):
         return []
     permalinks: list[str] = []
-    for mr in mrs.values():
-        if not isinstance(mr, dict):
+    for pr in prs.values():
+        if not isinstance(pr, dict):
             continue
-        permalink = mr.get("review_permalink")
+        permalink = pr.get("review_permalink")
         if isinstance(permalink, str) and permalink:
             permalinks.append(permalink)
     return permalinks
 
 
 def add_reactions_for_transition(ticket: "Ticket", transition_name: str) -> int:
-    """Add the emoji mapped to *transition_name* to every MR permalink.
+    """Add the emoji mapped to *transition_name* to every PR permalink.
 
     Returns the number of successful reaction posts.  Missing credentials,
     missing permalinks, and unmapped transitions are all silent no-ops.
@@ -109,7 +109,7 @@ def add_reactions_for_transition(ticket: "Ticket", transition_name: str) -> int:
         return 0
 
     posted = 0
-    for permalink in _iter_mr_permalinks(ticket):
+    for permalink in _iter_pr_permalinks(ticket):
         parsed = parse_permalink(permalink)
         if not parsed:
             continue

--- a/src/teatree/backends/slack_review_sync.py
+++ b/src/teatree/backends/slack_review_sync.py
@@ -1,4 +1,4 @@
-"""Slack review-permalink sync — attach review channel links to in-flight MRs."""
+"""Slack review-permalink sync — attach review channel links to in-flight PRs."""
 
 import logging
 
@@ -12,34 +12,34 @@ from teatree.core.sync import SyncResult
 logger = logging.getLogger(__name__)
 
 
-def _collect_reviewable_mr_urls() -> tuple[list[str], dict[str, tuple[Ticket, str]]]:
-    mr_urls: list[str] = []
+def _collect_reviewable_pr_urls() -> tuple[list[str], dict[str, tuple[Ticket, str]]]:
+    pr_urls: list[str] = []
     url_to_ticket: dict[str, tuple[Ticket, str]] = {}
     for ticket in Ticket.objects.in_flight():
         extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-        mrs = extra.get("mrs", {})
-        if not isinstance(mrs, dict):
+        prs = extra.get("prs", {})
+        if not isinstance(prs, dict):
             continue
-        for mr_url, mr in mrs.items():
-            if not isinstance(mr, dict) or mr.get("draft") or mr.get("review_permalink"):
+        for pr_url, pr in prs.items():
+            if not isinstance(pr, dict) or pr.get("draft") or pr.get("review_permalink"):
                 continue
-            clean_url = mr_url.rstrip("/").split("#")[0]
-            mr_urls.append(clean_url)
-            url_to_ticket[clean_url] = (ticket, mr_url)
-    return mr_urls, url_to_ticket
+            clean_url = pr_url.rstrip("/").split("#")[0]
+            pr_urls.append(clean_url)
+            url_to_ticket[clean_url] = (ticket, pr_url)
+    return pr_urls, url_to_ticket
 
 
-def _apply_match(ticket: Ticket, mr_url: str, permalink: str, channel: str) -> bool:
+def _apply_match(ticket: Ticket, pr_url: str, permalink: str, channel: str) -> bool:
     extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-    mrs = extra.get("mrs", {})
-    if not isinstance(mrs, dict):
+    prs = extra.get("prs", {})
+    if not isinstance(prs, dict):
         return False
-    mr = mrs.get(mr_url)
-    if not isinstance(mr, dict):
+    pr = prs.get(pr_url)
+    if not isinstance(pr, dict):
         return False
-    mr["review_permalink"] = permalink
-    mr["review_channel"] = channel
-    extra["mrs"] = mrs
+    pr["review_permalink"] = permalink
+    pr["review_channel"] = channel
+    extra["prs"] = prs
     ticket.extra = extra
     ticket.save(update_fields=["extra"])
     return True
@@ -52,8 +52,8 @@ def fetch_review_permalinks(result: SyncResult) -> None:
     if not token or not channel_id:
         return
 
-    mr_urls, url_to_ticket = _collect_reviewable_mr_urls()
-    if not mr_urls:
+    pr_urls, url_to_ticket = _collect_reviewable_pr_urls()
+    if not pr_urls:
         return
 
     try:
@@ -62,7 +62,7 @@ def fetch_review_permalinks(result: SyncResult) -> None:
                 token=token,
                 channel_id=channel_id,
                 channel_name=channel_name,
-                mr_urls=mr_urls,
+                pr_urls=pr_urls,
             )
         )
     except (httpx.HTTPError, RuntimeError, ValueError) as exc:
@@ -70,6 +70,6 @@ def fetch_review_permalinks(result: SyncResult) -> None:
         return
 
     for match in matches:
-        ticket, mr_url = url_to_ticket[match.mr_url]
-        if _apply_match(ticket, mr_url, match.permalink, match.channel):
+        ticket, pr_url = url_to_ticket[match.pr_url]
+        if _apply_match(ticket, pr_url, match.permalink, match.channel):
             result.reviews_synced += 1

--- a/src/teatree/backends/types.py
+++ b/src/teatree/backends/types.py
@@ -8,7 +8,7 @@ protocol implementations.  They do NOT replace the Protocol signatures
 from typing import TypedDict
 
 
-class MergeRequestResponse(TypedDict, total=False):
+class PullRequestResponse(TypedDict, total=False):
     iid: int
     web_url: str
     title: str

--- a/src/teatree/core/admin.py
+++ b/src/teatree/core/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from teatree.core.models import MergeRequest, Session, Task, TaskAttempt, Ticket, Worktree
+from teatree.core.models import PullRequest, Session, Task, TaskAttempt, Ticket, Worktree
 
 
 @admin.register(Ticket)
@@ -28,6 +28,6 @@ class TaskAttemptAdmin(admin.ModelAdmin):
     list_display = ("id", "task", "execution_target", "exit_code", "ended_at")
 
 
-@admin.register(MergeRequest)
-class MergeRequestAdmin(admin.ModelAdmin):
+@admin.register(PullRequest)
+class PullRequestAdmin(admin.ModelAdmin):
     list_display = ("id", "ticket", "repo", "iid", "state")

--- a/src/teatree/core/management/commands/followup.py
+++ b/src/teatree/core/management/commands/followup.py
@@ -18,7 +18,7 @@ class Command(TyperCommand):
 
         result = sync_followup()
         return {
-            "mrs_found": result.mrs_found,
+            "prs_found": result.prs_found,
             "tickets_created": result.tickets_created,
             "tickets_updated": result.tickets_updated,
             "worktrees_cleaned": result.worktrees_cleaned,

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -232,8 +232,8 @@ class Command(TyperCommand):
         ``ticket_id`` accepts the internal DB pk, the full issue URL, or the
         bare issue number (resolved against ``Ticket.issue_url``).
 
-        ``--title`` overrides the MR title (default: last commit subject).
-        Stored on ``ticket.extra['mr_title_override']`` so the worker reads it.
+        ``--title`` overrides the PR title (default: last commit subject).
+        Stored on ``ticket.extra['pr_title_override']`` so the worker reads it.
         """
         ticket = _resolve_ticket(ticket_id)
         worktree = ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
@@ -257,7 +257,7 @@ class Command(TyperCommand):
         with transaction.atomic():
             if title:
                 extra = cast("TicketExtra", ticket.extra or {})
-                extra["mr_title_override"] = title
+                extra["pr_title_override"] = title
                 ticket.extra = extra
             ticket.ship()
             ticket.save()

--- a/src/teatree/core/migrations/0002_rename_merge_request_to_pull_request.py
+++ b/src/teatree/core/migrations/0002_rename_merge_request_to_pull_request.py
@@ -1,0 +1,65 @@
+"""Rename MergeRequest model to PullRequest, table and related_name to match.
+
+Phase 3 of issue #541 declared "PR" as the canonical term in core; this
+migration completes that rename at the schema layer. It also rewrites the
+``Ticket.extra["mrs"]`` JSONField key to ``Ticket.extra["prs"]`` so prompt
+templates and scanners can read the new key consistently.
+"""
+
+from django.db import migrations, models
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+
+def _rename_extra_mrs_to_prs(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    Ticket = apps.get_model("core", "Ticket")
+    for ticket in Ticket.objects.exclude(extra={}).iterator():
+        extra = ticket.extra or {}
+        if not isinstance(extra, dict) or "mrs" not in extra:
+            continue
+        extra["prs"] = extra.pop("mrs")
+        ticket.extra = extra
+        ticket.save(update_fields=["extra"])
+
+
+def _rename_extra_prs_to_mrs(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    Ticket = apps.get_model("core", "Ticket")
+    for ticket in Ticket.objects.exclude(extra={}).iterator():
+        extra = ticket.extra or {}
+        if not isinstance(extra, dict) or "prs" not in extra:
+            continue
+        extra["mrs"] = extra.pop("prs")
+        ticket.extra = extra
+        ticket.save(update_fields=["extra"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RenameModel(old_name="MergeRequest", new_name="PullRequest"),
+        migrations.AlterModelTable(
+            name="pullrequest",
+            table="teatree_pull_request",
+        ),
+        migrations.AlterField(
+            model_name="pullrequest",
+            name="ticket",
+            field=models.ForeignKey(
+                on_delete=models.deletion.CASCADE,
+                related_name="pull_requests",
+                to="core.ticket",
+            ),
+        ),
+        migrations.RemoveConstraint(
+            model_name="pullrequest",
+            name="unique_merge_request_url",
+        ),
+        migrations.AddConstraint(
+            model_name="pullrequest",
+            constraint=models.UniqueConstraint(fields=("url",), name="unique_pull_request_url"),
+        ),
+        migrations.RunPython(_rename_extra_mrs_to_prs, _rename_extra_prs_to_mrs),
+    ]

--- a/src/teatree/core/models/__init__.py
+++ b/src/teatree/core/models/__init__.py
@@ -1,5 +1,5 @@
 from teatree.core.models.errors import InvalidTransitionError, QualityGateError
-from teatree.core.models.merge_request import MergeRequest
+from teatree.core.models.pull_request import PullRequest
 from teatree.core.models.session import Session
 from teatree.core.models.task import Task, TaskAttempt
 from teatree.core.models.ticket import Ticket
@@ -9,8 +9,8 @@ from teatree.core.models.worktree import Worktree, WorktreeEnvOverride
 
 __all__ = [
     "InvalidTransitionError",
-    "MergeRequest",
     "Ports",
+    "PullRequest",
     "QualityGateError",
     "Session",
     "Task",

--- a/src/teatree/core/models/pull_request.py
+++ b/src/teatree/core/models/pull_request.py
@@ -5,14 +5,14 @@ from django.utils import timezone
 from django_fsm import FSMField, transition
 
 
-class MergeRequest(models.Model):
+class PullRequest(models.Model):
     class State(models.TextChoices):
         OPEN = "open", "Open"
         REVIEW_REQUESTED = "review_requested", "Review requested"
         APPROVED = "approved", "Approved"
         MERGED = "merged", "Merged"
 
-    ticket = models.ForeignKey("core.Ticket", on_delete=models.CASCADE, related_name="merge_requests")
+    ticket = models.ForeignKey("core.Ticket", on_delete=models.CASCADE, related_name="pull_requests")
     overlay = models.CharField(max_length=255, blank=True)
     url = models.URLField(max_length=500)
     repo = models.CharField(max_length=255)
@@ -22,11 +22,11 @@ class MergeRequest(models.Model):
     state = FSMField(max_length=32, choices=State.choices, default=State.OPEN)
 
     class Meta:
-        db_table = "teatree_merge_request"
+        db_table = "teatree_pull_request"
         constraints: ClassVar = [
             models.UniqueConstraint(
                 fields=["url"],
-                name="unique_merge_request_url",
+                name="unique_pull_request_url",
             ),
         ]
 

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -24,8 +24,8 @@ class VisualQASummary(TypedDict, total=False):
 
 class TicketExtra(TypedDict, total=False):
     tests_passed: bool
-    mr_urls: list[str]
-    mr_title_override: str
+    pr_urls: list[str]
+    pr_title_override: str
     ignored_from: str
     visual_qa: VisualQASummary
     branch: str

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -41,7 +41,7 @@ def overlay_mr_labels() -> list[str]:
 
 
 class ShipExecutor(RunnerBase):
-    """Push the worktree branch and open the merge request.
+    """Push the worktree branch and open the pull request.
 
     Runs inside ``execute_ship`` after the FSM advances to ``SHIPPED``. The
     worker calls ``request_review()`` on success to advance to ``IN_REVIEW``.
@@ -53,7 +53,7 @@ class ShipExecutor(RunnerBase):
     def run(self) -> RunnerResult:
         ticket = self.ticket
         extra = cast("TicketExtra", ticket.extra or {})
-        existing_urls = list(extra.get("mr_urls") or [])
+        existing_urls = list(extra.get("pr_urls") or [])
         if existing_urls:
             return RunnerResult(ok=True, detail=existing_urls[-1])
 
@@ -71,10 +71,10 @@ class ShipExecutor(RunnerBase):
         git.push(repo=repo_path, remote="origin", branch=branch)
 
         spec = self._build_pr_spec(ticket, host, repo_path, branch, extra)
-        mr = host.create_pr(spec)
-        url = str(mr.get("web_url") or mr.get("html_url") or "")
-        self._record_mr_url(ticket, extra, url)
-        logger.info("Ship executor pushed %s and opened MR %s", branch, url)
+        pr = host.create_pr(spec)
+        url = str(pr.get("web_url") or pr.get("html_url") or "")
+        self._record_pr_url(ticket, extra, url)
+        logger.info("Ship executor pushed %s and opened PR %s", branch, url)
         return RunnerResult(ok=True, detail=url)
 
     @staticmethod
@@ -85,7 +85,7 @@ class ShipExecutor(RunnerBase):
         branch: str,
         extra: "TicketExtra",
     ) -> PullRequestSpec:
-        title_override = str(extra.get("mr_title_override") or "")
+        title_override = str(extra.get("pr_title_override") or "")
         subject, body = git.last_commit_message(repo=repo_path)
         title = title_override or subject or f"Resolve {ticket.issue_url}"
         raw_description = f"{subject}\n\n{body}" if subject and body else (subject or body)
@@ -101,11 +101,11 @@ class ShipExecutor(RunnerBase):
         )
 
     @staticmethod
-    def _record_mr_url(ticket: "Ticket", extra: "TicketExtra", url: str) -> None:
-        urls = list(extra.get("mr_urls") or [])
+    def _record_pr_url(ticket: "Ticket", extra: "TicketExtra", url: str) -> None:
+        urls = list(extra.get("pr_urls") or [])
         if url and url not in urls:
             urls.append(url)
-        extra["mr_urls"] = urls
-        extra.pop("mr_title_override", None)
+        extra["pr_urls"] = urls
+        extra.pop("pr_title_override", None)
         ticket.extra = extra
         ticket.save(update_fields=["extra"])

--- a/src/teatree/core/selectors/__init__.py
+++ b/src/teatree/core/selectors/__init__.py
@@ -30,7 +30,7 @@ from ._types import (
     UnifiedSessionRow,
 )
 from .activity import build_active_sessions, build_recent_activity
-from .automation import _check_mr, build_action_required, build_automation_summary
+from .automation import _check_pr, build_action_required, build_automation_summary
 from .queues import (
     _last_result_for_tasks,
     build_headless_queue,
@@ -54,7 +54,7 @@ __all__ = [
     "TaskRelatedRow",
     "UnifiedSessionRow",
     "_cached",
-    "_check_mr",
+    "_check_pr",
     "_display_id",
     "_extra_str",
     "_humanize_duration",

--- a/src/teatree/core/selectors/automation.py
+++ b/src/teatree/core/selectors/automation.py
@@ -71,20 +71,20 @@ def build_action_required(overlay: str | None = None) -> list[ActionRequiredItem
         for task in task_qs
     ]
 
-    items.extend(_action_items_from_mrs(overlay))
+    items.extend(_action_items_from_prs(overlay))
     return items
 
 
-def _action_items_from_mrs(overlay: str | None = None) -> list[ActionRequiredItem]:
-    """Scan in-flight MRs for review/approval needs."""
+def _action_items_from_prs(overlay: str | None = None) -> list[ActionRequiredItem]:
+    """Scan in-flight PRs for review/approval needs."""
     items: list[ActionRequiredItem] = []
     for ticket in Ticket.objects.in_flight(overlay=overlay):
         extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-        mrs = extra.get("mrs", {})
-        if not isinstance(mrs, dict):
+        prs = extra.get("prs", {})
+        if not isinstance(prs, dict):
             continue
-        for mr in mrs.values():
-            items.extend(_check_mr(mr, ticket))
+        for pr in prs.values():
+            items.extend(_check_pr(pr, ticket))
     return items
 
 
@@ -95,35 +95,35 @@ _DISCUSSION_STATUS_DISPLAY = {
 }
 
 
-def _check_mr(mr: dict, ticket: "Ticket") -> list[ActionRequiredItem]:
-    """Return action items for a single MR dict."""
-    if not isinstance(mr, dict) or mr.get("draft") or mr.get("state") in {"merged", "closed"}:
+def _check_pr(pr: dict, ticket: "Ticket") -> list[ActionRequiredItem]:
+    """Return action items for a single PR dict."""
+    if not isinstance(pr, dict) or pr.get("draft") or pr.get("state") in {"merged", "closed"}:
         return []
-    repo = str(mr.get("repo", ""))
-    iid = str(mr.get("iid", ""))
-    mr_url = str(mr.get("url", ""))
-    mr_label = f"{repo} #{iid}"
-    pipeline = mr.get("pipeline_status")
-    slack_url = str(mr.get("review_permalink", ""))
-    approvals = mr.get("approvals", {})
+    repo = str(pr.get("repo", ""))
+    iid = str(pr.get("iid", ""))
+    pr_url = str(pr.get("url", ""))
+    pr_label = f"{repo} #{iid}"
+    pipeline = pr.get("pipeline_status")
+    slack_url = str(pr.get("review_permalink", ""))
+    approvals = pr.get("approvals", {})
     if not isinstance(approvals, dict):
         approvals = {}
     count = int(approvals.get("count", 0))
     required = int(approvals.get("required", 1))
     items: list[ActionRequiredItem] = []
 
-    if pipeline == "success" and not mr.get("review_permalink") and not mr.get("review_requested"):
+    if pipeline == "success" and not pr.get("review_permalink") and not pr.get("review_requested"):
         items.append(
             ActionRequiredItem(
                 kind="needs_review_request",
-                label=f"{mr_label} — ready for review request",
-                url=mr_url,
+                label=f"{pr_label} — ready for review request",
+                url=pr_url,
                 ticket_id=ticket.pk,
                 detail="CI green, no review posted yet",
             ),
         )
 
-    raw_discussions = mr.get("discussions", [])
+    raw_discussions = pr.get("discussions", [])
     discussions: list[DiscussionData] = (
         [d for d in raw_discussions if isinstance(d, dict)] if isinstance(raw_discussions, list) else []
     )
@@ -133,8 +133,8 @@ def _check_mr(mr: dict, ticket: "Ticket") -> list[ActionRequiredItem]:
         items.append(
             ActionRequiredItem(
                 kind="needs_reply",
-                label=f"{mr_label} — {needs_reply} comment{'s' if needs_reply > 1 else ''} need reply",
-                url=mr_url,
+                label=f"{pr_label} — {needs_reply} comment{'s' if needs_reply > 1 else ''} need reply",
+                url=pr_url,
                 ticket_id=ticket.pk,
                 detail="Review threads waiting for your response",
                 slack_url=slack_url,
@@ -142,25 +142,25 @@ def _check_mr(mr: dict, ticket: "Ticket") -> list[ActionRequiredItem]:
             ),
         )
 
-    if pipeline == "success" and mr.get("review_requested") and count < required:
+    if pipeline == "success" and pr.get("review_requested") and count < required:
         items.append(
             ActionRequiredItem(
                 kind="needs_approval",
-                label=f"{mr_label} — waiting for approval ({count}/{required})",
-                url=mr_url,
+                label=f"{pr_label} — waiting for approval ({count}/{required})",
+                url=pr_url,
                 ticket_id=ticket.pk,
                 detail="Review requested, approval pending",
                 slack_url=slack_url,
             ),
         )
 
-    draft_count = mr.get("draft_comments_count")
-    if mr.get("draft_comments_pending") and isinstance(draft_count, int) and draft_count > 0:
+    draft_count = pr.get("draft_comments_count")
+    if pr.get("draft_comments_pending") and isinstance(draft_count, int) and draft_count > 0:
         items.append(
             ActionRequiredItem(
                 kind="review_draft",
-                label=f"{mr_label} — agent posted review comments",
-                url=mr_url,
+                label=f"{pr_label} — agent posted review comments",
+                url=pr_url,
                 ticket_id=ticket.pk,
                 detail=f"{draft_count} draft comment{'s' if draft_count > 1 else ''}"
                 " need your review before publishing",
@@ -171,7 +171,7 @@ def _check_mr(mr: dict, ticket: "Ticket") -> list[ActionRequiredItem]:
 
 
 def _extract_review_comments(discussions: list[DiscussionData]) -> tuple[ReviewCommentDetail, ...]:
-    """Extract review comment details from MR discussion data."""
+    """Extract review comment details from PR discussion data."""
     comments: list[ReviewCommentDetail] = []
     for disc in discussions:
         status_key = str(disc.get("status", ""))

--- a/src/teatree/core/sync.py
+++ b/src/teatree/core/sync.py
@@ -1,7 +1,8 @@
-"""Sync external data (MRs/PRs, issues, project boards) into the local database.
+"""Sync external data (PRs, issues, project boards) into the local database.
 
 Dispatches to the appropriate backend (GitLab or GitHub) based on the
-active overlay's configuration.
+active overlay's configuration. "PR" is the canonical term in core; the
+GitLab backend translates to MR internally.
 """
 
 import logging
@@ -14,20 +15,20 @@ PENDING_REVIEWS_CACHE_KEY = "teatree_pending_reviews"
 # Type aliases for untyped external data (GitLab/GitHub API responses)
 # and serialized internal data stored in JSONFields.
 type RawAPIDict = dict[str, object]
-type MREntryDict = dict[str, object]
+type PREntryDict = dict[str, object]
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
 class SyncResult:
-    mrs_found: int = 0
+    prs_found: int = 0
     issues_found: int = 0
     tickets_created: int = 0
     tickets_updated: int = 0
     labels_fetched: int = 0
-    mrs_merged: int = 0
-    mrs_closed: int = 0
+    prs_merged: int = 0
+    prs_closed: int = 0
     reviews_synced: int = 0
     worktrees_cleaned: int = 0
     errors: list[str] = field(default_factory=list)
@@ -43,7 +44,7 @@ class DiscussionSummary:
 
 
 @dataclass(slots=True)
-class MREntry:
+class PREntry:
     url: str
     title: str
     branch: str
@@ -51,7 +52,7 @@ class MREntry:
     repo: str
     iid: int
     updated_at: str
-    state: str = "opened"  # opened | closed | merged | locked — from the upstream MR API
+    state: str = "opened"  # opened | closed | merged | locked — from the upstream PR API
     pipeline_status: str | None = None
     pipeline_url: str | None = None
     approvals: RawAPIDict | None = None
@@ -68,8 +69,8 @@ class MREntry:
     approvals_dismissed_at: str | None = None
     dismissed_approvers: list[str] | None = None
 
-    def to_dict(self) -> MREntryDict:
-        result: MREntryDict = {}
+    def to_dict(self) -> PREntryDict:
+        result: PREntryDict = {}
         for k in self.__slots__:
             v = getattr(self, k)
             if v is None:
@@ -101,13 +102,13 @@ class SyncBackend(ABC):
 def _merge_results(a: SyncResult, b: SyncResult) -> SyncResult:
     """Merge two SyncResult instances, summing counts and concatenating lists."""
     return SyncResult(
-        mrs_found=a.mrs_found + b.mrs_found,
+        prs_found=a.prs_found + b.prs_found,
         issues_found=a.issues_found + b.issues_found,
         tickets_created=a.tickets_created + b.tickets_created,
         tickets_updated=a.tickets_updated + b.tickets_updated,
         labels_fetched=a.labels_fetched + b.labels_fetched,
-        mrs_merged=a.mrs_merged + b.mrs_merged,
-        mrs_closed=a.mrs_closed + b.mrs_closed,
+        prs_merged=a.prs_merged + b.prs_merged,
+        prs_closed=a.prs_closed + b.prs_closed,
         reviews_synced=a.reviews_synced + b.reviews_synced,
         worktrees_cleaned=a.worktrees_cleaned + b.worktrees_cleaned,
         errors=[*a.errors, *b.errors],
@@ -127,7 +128,7 @@ def _overlay_name(overlay: object) -> str:
 def sync_followup() -> SyncResult:
     """Sync from all configured code host backends.
 
-    Runs GitHub project board sync and/or GitLab MR sync based on
+    Runs GitHub project board sync and/or GitLab PR sync based on
     which credentials are configured in the active overlay.  When both
     tokens are present, both syncs run and results are merged.
     """
@@ -176,8 +177,8 @@ __all__ = [
     "LAST_SYNC_CACHE_KEY",
     "PENDING_REVIEWS_CACHE_KEY",
     "DiscussionSummary",
-    "MREntry",
-    "MREntryDict",
+    "PREntry",
+    "PREntryDict",
     "RawAPIDict",
     "SyncBackend",
     "SyncResult",

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -64,7 +64,7 @@ def sync_followup() -> dict[str, int | list[str]]:
 
     result = _sync()
     return {
-        "mrs_found": result.mrs_found,
+        "prs_found": result.prs_found,
         "tickets_created": result.tickets_created,
         "tickets_updated": result.tickets_updated,
         "errors": result.errors,
@@ -175,7 +175,7 @@ def execute_provision(ticket_id: int) -> TransitionResult:
 
 @task()
 def execute_ship(ticket_id: int) -> TransitionResult:
-    """Push the worktree branch and open the merge request for a SHIPPED ticket.
+    """Push the worktree branch and open the pull request for a SHIPPED ticket.
 
     Idempotency: the worker takes a row lock and re-checks state before running.
     At-least-once delivery from django-tasks means this can fire more than once

--- a/tests/teatree_agents/test_prompt.py
+++ b/tests/teatree_agents/test_prompt.py
@@ -154,10 +154,10 @@ class TestBuildTaskPrompt(TestCase):
         assert "reviewing" in prompt
         assert "Auto-scheduled review" in prompt
 
-    def test_includes_mr_context(self) -> None:
+    def test_includes_pr_context(self) -> None:
         ticket = Ticket.objects.create(
             extra={
-                "mrs": {
+                "prs": {
                     "backend": {
                         "url": "https://gitlab.com/mr/1",
                         "title": "Backend changes",
@@ -176,9 +176,9 @@ class TestBuildTaskPrompt(TestCase):
         assert "pipeline: success" in prompt
         assert "Backend changes" in prompt
 
-    def test_skips_non_dict_mr_items(self) -> None:
+    def test_skips_non_dict_pr_items(self) -> None:
         ticket = Ticket.objects.create(
-            extra={"mrs": {"bad": "not-a-dict", "good": {"url": "https://x.com/mr/2"}}},
+            extra={"prs": {"bad": "not-a-dict", "good": {"url": "https://x.com/mr/2"}}},
         )
         session = Session.objects.create(ticket=ticket)
         task = Task.objects.create(ticket=ticket, session=session)
@@ -194,9 +194,9 @@ class TestBuildTaskPrompt(TestCase):
         prompt = build_task_prompt(task)
         assert "Work on ticket" in prompt
 
-    def test_mr_without_title_or_pipeline(self) -> None:
+    def test_pr_without_title_or_pipeline(self) -> None:
         ticket = Ticket.objects.create(
-            extra={"mrs": {"repo": {"url": "https://x.com/mr/3", "draft": False}}},
+            extra={"prs": {"repo": {"url": "https://x.com/mr/3", "draft": False}}},
         )
         session = Session.objects.create(ticket=ticket)
         task = Task.objects.create(ticket=ticket, session=session)
@@ -206,13 +206,13 @@ class TestBuildTaskPrompt(TestCase):
         assert "(draft)" not in prompt
         assert "pipeline:" not in prompt
 
-    def test_non_dict_mrs_ignored(self) -> None:
-        ticket = Ticket.objects.create(extra={"mrs": "not-a-dict"})
+    def test_non_dict_prs_ignored(self) -> None:
+        ticket = Ticket.objects.create(extra={"prs": "not-a-dict"})
         session = Session.objects.create(ticket=ticket)
         task = Task.objects.create(ticket=ticket, session=session)
 
         prompt = build_task_prompt(task)
-        assert "merge requests" not in prompt.lower()
+        assert "pull requests" not in prompt.lower()
 
 
 # --- build_system_context ---
@@ -389,10 +389,10 @@ class TestBuildInteractiveContext(TestCase):
         assert "/test" in ctx
         assert "REQUIRED" in ctx
 
-    def test_with_mrs(self) -> None:
+    def test_with_prs(self) -> None:
         ticket = Ticket.objects.create(
             extra={
-                "mrs": {
+                "prs": {
                     "repo": {
                         "url": "https://gitlab.com/mr/5",
                         "title": "MR Title",
@@ -411,9 +411,9 @@ class TestBuildInteractiveContext(TestCase):
         assert "pipeline: failed" in ctx
         assert "MR Title" in ctx
 
-    def test_skips_non_dict_mr(self) -> None:
+    def test_skips_non_dict_pr(self) -> None:
         ticket = Ticket.objects.create(
-            extra={"mrs": {"bad": 42, "ok": {"url": "https://x.com/mr/7"}}},
+            extra={"prs": {"bad": 42, "ok": {"url": "https://x.com/mr/7"}}},
         )
         session = Session.objects.create(ticket=ticket)
         task = Task.objects.create(ticket=ticket, session=session)
@@ -421,17 +421,17 @@ class TestBuildInteractiveContext(TestCase):
         ctx = build_interactive_context(task, skills=[])
         assert "https://x.com/mr/7" in ctx
 
-    def test_non_dict_mrs(self) -> None:
-        ticket = Ticket.objects.create(extra={"mrs": "not-a-dict"})
+    def test_non_dict_prs(self) -> None:
+        ticket = Ticket.objects.create(extra={"prs": "not-a-dict"})
         session = Session.objects.create(ticket=ticket)
         task = Task.objects.create(ticket=ticket, session=session)
 
         ctx = build_interactive_context(task, skills=[])
-        assert "merge requests" not in ctx.lower()
+        assert "pull requests" not in ctx.lower()
 
-    def test_mr_no_title_no_pipeline(self) -> None:
+    def test_pr_no_title_no_pipeline(self) -> None:
         ticket = Ticket.objects.create(
-            extra={"mrs": {"repo": {"url": "https://x.com/mr/8"}}},
+            extra={"prs": {"repo": {"url": "https://x.com/mr/8"}}},
         )
         session = Session.objects.create(ticket=ticket)
         task = Task.objects.create(ticket=ticket, session=session)

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -101,7 +101,7 @@ def test_list_my_prs_delegates_to_client_list_all_open_mrs() -> None:
 
     assert len(result) == 2
     assert result[0]["iid"] == 1
-    client.list_all_open_mrs.assert_called_once_with("adrien")
+    client.list_all_open_mrs.assert_called_once_with("adrien", updated_after=None)
 
 
 def test_list_my_prs_returns_empty_when_no_mrs() -> None:
@@ -120,7 +120,7 @@ def test_list_review_requested_prs_delegates_to_client() -> None:
     result = host.list_review_requested_prs(reviewer="adrien")
 
     assert result == [{"iid": 5, "title": "MR 5"}]
-    client.list_open_mrs_as_reviewer.assert_called_once_with("adrien")
+    client.list_open_mrs_as_reviewer.assert_called_once_with("adrien", updated_after=None)
 
 
 def test_list_assigned_issues_delegates_to_client() -> None:

--- a/tests/teatree_backends/test_slack.py
+++ b/tests/teatree_backends/test_slack.py
@@ -75,7 +75,7 @@ def test_search_review_permalinks_returns_empty_when_no_token() -> None:
             token="",
             channel_id="C123",
             channel_name="review",
-            mr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
+            pr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
         )
     )
     assert result == []
@@ -88,33 +88,33 @@ def test_search_review_permalinks_returns_empty_when_no_channel_id() -> None:
             token="xoxb-token",
             channel_id="",
             channel_name="review",
-            mr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
+            pr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
         )
     )
     assert result == []
 
 
-def test_search_review_permalinks_returns_empty_when_no_mr_urls() -> None:
-    """search_review_permalinks returns [] when mr_urls is empty (line 47)."""
+def test_search_review_permalinks_returns_empty_when_no_pr_urls() -> None:
+    """search_review_permalinks returns [] when pr_urls is empty (line 47)."""
     result = search_review_permalinks(
         SlackReviewSearchRequest(
             token="xoxb-token",
             channel_id="C123",
             channel_name="review",
-            mr_urls=[],
+            pr_urls=[],
         )
     )
     assert result == []
 
 
 def test_search_review_permalinks_finds_matching_mr(monkeypatch: pytest.MonkeyPatch) -> None:
-    """search_review_permalinks matches MR URL in message text (lines 46-111)."""
-    mr_url = "https://gitlab.com/org/repo/-/merge_requests/42"
+    """search_review_permalinks matches PR URL in message text (lines 46-111)."""
+    pr_url = "https://gitlab.com/org/repo/-/merge_requests/42"
     page = {
         "ok": True,
         "messages": [
             {
-                "text": f"Please review {mr_url}",
+                "text": f"Please review {pr_url}",
                 "ts": "1700000000.000100",
             },
         ],
@@ -128,24 +128,24 @@ def test_search_review_permalinks_finds_matching_mr(monkeypatch: pytest.MonkeyPa
             token="xoxb-token",
             channel_id="C123",
             channel_name="review-crew",
-            mr_urls=[mr_url],
+            pr_urls=[pr_url],
         )
     )
 
     assert len(result) == 1
     assert result[0] == SlackReviewMatch(
-        mr_url=mr_url,
+        pr_url=pr_url,
         permalink="https://team.slack.com/archives/C123/p1700000000000100",
         channel="review-crew",
     )
 
 
 def test_search_review_permalinks_stops_when_all_found(monkeypatch: pytest.MonkeyPatch) -> None:
-    """search_review_permalinks stops paging when all MR URLs are matched (line 102)."""
-    mr_url = "https://gitlab.com/org/repo/-/merge_requests/10"
+    """search_review_permalinks stops paging when all PR URLs are matched (line 102)."""
+    pr_url = "https://gitlab.com/org/repo/-/merge_requests/10"
     page1 = {
         "ok": True,
-        "messages": [{"text": f"Check {mr_url}", "ts": "1700000001.000200"}],
+        "messages": [{"text": f"Check {pr_url}", "ts": "1700000001.000200"}],
         "has_more": True,
         "response_metadata": {"next_cursor": "cursor2"},
     }
@@ -162,7 +162,7 @@ def test_search_review_permalinks_stops_when_all_found(monkeypatch: pytest.Monke
             token="xoxb-token",
             channel_id="C456",
             channel_name="reviews",
-            mr_urls=[mr_url],
+            pr_urls=[pr_url],
         )
     )
 
@@ -173,17 +173,17 @@ def test_search_review_permalinks_stops_when_all_found(monkeypatch: pytest.Monke
 
 def test_search_review_permalinks_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
     """search_review_permalinks follows pagination cursor (lines 63-64, 106-109)."""
-    mr_url1 = "https://gitlab.com/org/repo/-/merge_requests/1"
-    mr_url2 = "https://gitlab.com/org/repo/-/merge_requests/2"
+    pr_url1 = "https://gitlab.com/org/repo/-/merge_requests/1"
+    pr_url2 = "https://gitlab.com/org/repo/-/merge_requests/2"
     page1 = {
         "ok": True,
-        "messages": [{"text": f"Review {mr_url1}", "ts": "1700000001.000100"}],
+        "messages": [{"text": f"Review {pr_url1}", "ts": "1700000001.000100"}],
         "has_more": True,
         "response_metadata": {"next_cursor": "page2cursor"},
     }
     page2 = {
         "ok": True,
-        "messages": [{"text": f"Review {mr_url2}", "ts": "1700000002.000200"}],
+        "messages": [{"text": f"Review {pr_url2}", "ts": "1700000002.000200"}],
         "has_more": False,
     }
     fake_client = FakeClient(auth_url="https://ws.slack.com/", pages=[page1, page2])
@@ -194,12 +194,12 @@ def test_search_review_permalinks_paginates(monkeypatch: pytest.MonkeyPatch) -> 
             token="xoxb-token",
             channel_id="C789",
             channel_name="review",
-            mr_urls=[mr_url1, mr_url2],
+            pr_urls=[pr_url1, pr_url2],
         )
     )
 
     assert len(result) == 2
-    assert {m.mr_url for m in result} == {mr_url1, mr_url2}
+    assert {m.pr_url for m in result} == {pr_url1, pr_url2}
 
 
 def test_search_review_permalinks_stops_on_not_ok(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -213,7 +213,7 @@ def test_search_review_permalinks_stops_on_not_ok(monkeypatch: pytest.MonkeyPatc
             token="xoxb-token",
             channel_id="C999",
             channel_name="review",
-            mr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
+            pr_urls=["https://gitlab.com/org/repo/-/merge_requests/1"],
         )
     )
 
@@ -222,12 +222,12 @@ def test_search_review_permalinks_stops_on_not_ok(monkeypatch: pytest.MonkeyPatc
 
 def test_search_review_permalinks_skips_messages_without_ts(monkeypatch: pytest.MonkeyPatch) -> None:
     """search_review_permalinks skips messages with empty ts (line 79-80)."""
-    mr_url = "https://gitlab.com/org/repo/-/merge_requests/5"
+    pr_url = "https://gitlab.com/org/repo/-/merge_requests/5"
     page = {
         "ok": True,
         "messages": [
-            {"text": f"Review {mr_url}", "ts": ""},
-            {"text": f"Review {mr_url}", "ts": "1700000003.000100"},
+            {"text": f"Review {pr_url}", "ts": ""},
+            {"text": f"Review {pr_url}", "ts": "1700000003.000100"},
         ],
         "has_more": False,
     }
@@ -239,7 +239,7 @@ def test_search_review_permalinks_skips_messages_without_ts(monkeypatch: pytest.
             token="xoxb-token",
             channel_id="C111",
             channel_name="review",
-            mr_urls=[mr_url],
+            pr_urls=[pr_url],
         )
     )
 
@@ -249,10 +249,10 @@ def test_search_review_permalinks_skips_messages_without_ts(monkeypatch: pytest.
 
 def test_search_review_permalinks_uses_provided_workspace_domain(monkeypatch: pytest.MonkeyPatch) -> None:
     """search_review_permalinks uses workspace_domain param if provided (line 57-58)."""
-    mr_url = "https://gitlab.com/org/repo/-/merge_requests/7"
+    pr_url = "https://gitlab.com/org/repo/-/merge_requests/7"
     page = {
         "ok": True,
-        "messages": [{"text": f"Review {mr_url}", "ts": "1700000004.000100"}],
+        "messages": [{"text": f"Review {pr_url}", "ts": "1700000004.000100"}],
         "has_more": False,
     }
     fake_client = FakeClient(pages=[page])
@@ -263,7 +263,7 @@ def test_search_review_permalinks_uses_provided_workspace_domain(monkeypatch: py
             token="xoxb-token",
             channel_id="C222",
             channel_name="review",
-            mr_urls=[mr_url],
+            pr_urls=[pr_url],
             workspace_domain="custom.slack.com",
         )
     )
@@ -273,13 +273,13 @@ def test_search_review_permalinks_uses_provided_workspace_domain(monkeypatch: py
 
 
 def test_search_review_permalinks_deduplicates_same_mr(monkeypatch: pytest.MonkeyPatch) -> None:
-    """search_review_permalinks only returns first match for a given MR URL (line 92)."""
-    mr_url = "https://gitlab.com/org/repo/-/merge_requests/8"
+    """search_review_permalinks only returns first match for a given PR URL (line 92)."""
+    pr_url = "https://gitlab.com/org/repo/-/merge_requests/8"
     page = {
         "ok": True,
         "messages": [
-            {"text": f"Review {mr_url}", "ts": "1700000005.000100"},
-            {"text": f"Also {mr_url}", "ts": "1700000006.000200"},
+            {"text": f"Review {pr_url}", "ts": "1700000005.000100"},
+            {"text": f"Also {pr_url}", "ts": "1700000006.000200"},
         ],
         "has_more": False,
     }
@@ -291,7 +291,7 @@ def test_search_review_permalinks_deduplicates_same_mr(monkeypatch: pytest.Monke
             token="xoxb-token",
             channel_id="C333",
             channel_name="review",
-            mr_urls=[mr_url],
+            pr_urls=[pr_url],
         )
     )
 
@@ -302,7 +302,7 @@ def test_search_review_permalinks_stops_when_no_cursor(monkeypatch: pytest.Monke
     """search_review_permalinks stops when has_more but no cursor (line 108-109)."""
     page = {
         "ok": True,
-        "messages": [{"text": "No MR here", "ts": "1700000007.000100"}],
+        "messages": [{"text": "No PR here", "ts": "1700000007.000100"}],
         "has_more": True,
         "response_metadata": {},
     }
@@ -314,7 +314,7 @@ def test_search_review_permalinks_stops_when_no_cursor(monkeypatch: pytest.Monke
             token="xoxb-token",
             channel_id="C444",
             channel_name="review",
-            mr_urls=["https://gitlab.com/org/repo/-/merge_requests/99"],
+            pr_urls=["https://gitlab.com/org/repo/-/merge_requests/99"],
         )
     )
 

--- a/tests/teatree_backends/test_slack_reactions.py
+++ b/tests/teatree_backends/test_slack_reactions.py
@@ -8,7 +8,7 @@ import pytest
 
 from teatree.backends import slack_reactions
 from teatree.backends.slack_reactions import (
-    _iter_mr_permalinks,
+    _iter_pr_permalinks,
     add_reaction,
     add_reactions_for_transition,
     parse_permalink,
@@ -98,11 +98,11 @@ class TestAddReaction:
         assert add_reaction("xoxb", "C1", "1.0", "tada") is False
 
 
-class TestIterMrPermalinks:
+class TestIterPrPermalinks:
     def test_collects_only_non_empty_string_permalinks(self) -> None:
         ticket = SimpleNamespace(
             extra={
-                "mrs": {
+                "prs": {
                     "a": {"review_permalink": "https://team.slack.com/archives/C1/p1700000000000100"},
                     "b": {"review_permalink": ""},
                     "c": {},
@@ -111,12 +111,12 @@ class TestIterMrPermalinks:
                 }
             }
         )
-        assert _iter_mr_permalinks(ticket) == ["https://team.slack.com/archives/C1/p1700000000000100"]
+        assert _iter_pr_permalinks(ticket) == ["https://team.slack.com/archives/C1/p1700000000000100"]
 
-    def test_empty_when_no_mrs(self) -> None:
-        assert _iter_mr_permalinks(SimpleNamespace(extra={})) == []
-        assert _iter_mr_permalinks(SimpleNamespace(extra={"mrs": "garbage"})) == []
-        assert _iter_mr_permalinks(SimpleNamespace(extra=None)) == []
+    def test_empty_when_no_prs(self) -> None:
+        assert _iter_pr_permalinks(SimpleNamespace(extra={})) == []
+        assert _iter_pr_permalinks(SimpleNamespace(extra={"prs": "garbage"})) == []
+        assert _iter_pr_permalinks(SimpleNamespace(extra=None)) == []
 
 
 @dataclass
@@ -138,7 +138,7 @@ class _StubOverlay:
 
 class TestAddReactionsForTransition:
     def _ticket(self, permalinks: list[str]) -> SimpleNamespace:
-        return SimpleNamespace(extra={"mrs": {f"mr-{i}": {"review_permalink": p} for i, p in enumerate(permalinks)}})
+        return SimpleNamespace(extra={"prs": {f"pr-{i}": {"review_permalink": p} for i, p in enumerate(permalinks)}})
 
     def test_posts_one_reaction_per_permalink(self, monkeypatch: pytest.MonkeyPatch) -> None:
         overlay = _StubOverlay(_StubConfig(token="xoxb"))

--- a/tests/teatree_backends/test_types.py
+++ b/tests/teatree_backends/test_types.py
@@ -3,7 +3,7 @@ import teatree.backends.types as _types
 
 def test_typed_responses_importable() -> None:
     for name in (
-        "MergeRequestResponse",
+        "PullRequestResponse",
         "PipelineResponse",
         "QualityCheckResponse",
         "NoteResponse",

--- a/tests/teatree_core/test_models.py
+++ b/tests/teatree_core/test_models.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from teatree.core import admin as core_admin
 from teatree.core.models import (
     InvalidTransitionError,
-    MergeRequest,
+    PullRequest,
     QualityGateError,
     Session,
     Task,
@@ -1100,53 +1100,53 @@ class TestAdmin(TestCase):
         assert core_admin is not None
 
 
-class TestMergeRequestModel(TestCase):
+class TestPullRequestModel(TestCase):
     def test_str_representation(self) -> None:
         ticket = Ticket.objects.create(overlay="test")
-        mr = MergeRequest.objects.create(
+        pr = PullRequest.objects.create(
             ticket=ticket,
             url="https://example.com/repo/-/merge_requests/1",
             repo="my-repo",
             iid="42",
         )
-        assert str(mr) == "my-repo #42"
+        assert str(pr) == "my-repo #42"
 
     def test_request_review_transition(self) -> None:
         ticket = Ticket.objects.create(overlay="test")
-        mr = MergeRequest.objects.create(
+        pr = PullRequest.objects.create(
             ticket=ticket,
             url="https://example.com/repo/-/merge_requests/2",
             repo="my-repo",
             iid="43",
         )
-        mr.request_review(slack_url="https://slack.com/msg/123")
-        mr.save()
-        mr.refresh_from_db()
-        assert mr.state == MergeRequest.State.REVIEW_REQUESTED
-        assert mr.slack_url == "https://slack.com/msg/123"
-        assert mr.review_requested_at is not None
+        pr.request_review(slack_url="https://slack.com/msg/123")
+        pr.save()
+        pr.refresh_from_db()
+        assert pr.state == PullRequest.State.REVIEW_REQUESTED
+        assert pr.slack_url == "https://slack.com/msg/123"
+        assert pr.review_requested_at is not None
 
     def test_approve_transition(self) -> None:
         ticket = Ticket.objects.create(overlay="test")
-        mr = MergeRequest.objects.create(
+        pr = PullRequest.objects.create(
             ticket=ticket,
             url="https://example.com/repo/-/merge_requests/3",
             repo="my-repo",
             iid="44",
-            state=MergeRequest.State.REVIEW_REQUESTED,
+            state=PullRequest.State.REVIEW_REQUESTED,
         )
-        mr.approve()
-        mr.save()
-        assert mr.state == MergeRequest.State.APPROVED
+        pr.approve()
+        pr.save()
+        assert pr.state == PullRequest.State.APPROVED
 
     def test_mark_merged_transition(self) -> None:
         ticket = Ticket.objects.create(overlay="test")
-        mr = MergeRequest.objects.create(
+        pr = PullRequest.objects.create(
             ticket=ticket,
             url="https://example.com/repo/-/merge_requests/4",
             repo="my-repo",
             iid="45",
         )
-        mr.mark_merged()
-        mr.save()
-        assert mr.state == MergeRequest.State.MERGED
+        pr.mark_merged()
+        pr.save()
+        assert pr.state == PullRequest.State.MERGED

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -63,7 +63,7 @@ class TestShipExecutor(TestCase):
         assert spec.assignee == "souliane"
 
         ticket.refresh_from_db()
-        assert ticket.extra["mr_urls"] == ["https://example.com/mr/1"]
+        assert ticket.extra["pr_urls"] == ["https://example.com/mr/1"]
 
     def test_returns_failure_when_no_code_host(self) -> None:
         ticket = self._ticket_with_worktree()

--- a/tests/teatree_core/test_selectors.py
+++ b/tests/teatree_core/test_selectors.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from teatree.core.models import Session, Task, TaskAttempt, Ticket
 from teatree.core.selectors import (
     _cached,
-    _check_mr,
+    _check_pr,
     _humanize_duration,
     _last_result_for_tasks,
     _list_of_str,
@@ -639,27 +639,27 @@ class TestBuildTaskDetail(TestCase):
         assert detail.session_agent_id == "agent"
 
 
-class TestCheckMr(TestCase):
+class TestCheckPr(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         cls.ticket = Ticket.objects.create(state=Ticket.State.STARTED)
 
     def test_returns_empty_for_draft(self) -> None:
-        assert _check_mr({"draft": True}, self.ticket) == []
+        assert _check_pr({"draft": True}, self.ticket) == []
 
     def test_returns_empty_for_non_dict(self) -> None:
-        assert _check_mr("not-a-dict", self.ticket) == []
+        assert _check_pr("not-a-dict", self.ticket) == []
 
     def test_returns_empty_for_merged(self) -> None:
-        """Merged MRs must not surface as action items — bug hunt 2026-04-25 (#455 §2)."""
-        assert _check_mr(self._closed_state_mr("merged"), self.ticket) == []
+        """Merged PRs must not surface as action items — bug hunt 2026-04-25 (#455 §2)."""
+        assert _check_pr(self._closed_state_pr("merged"), self.ticket) == []
 
     def test_returns_empty_for_closed(self) -> None:
-        """Closed-without-merge MRs must not surface as action items either."""
-        assert _check_mr(self._closed_state_mr("closed"), self.ticket) == []
+        """Closed-without-merge PRs must not surface as action items either."""
+        assert _check_pr(self._closed_state_pr("closed"), self.ticket) == []
 
     @staticmethod
-    def _closed_state_mr(state: str) -> dict:
+    def _closed_state_pr(state: str) -> dict:
         return {
             "draft": False,
             "repo": "backend",
@@ -673,19 +673,19 @@ class TestCheckMr(TestCase):
         }
 
     def test_needs_review_request(self) -> None:
-        mr = {
+        pr = {
             "draft": False,
             "repo": "backend",
             "iid": 10,
             "url": "https://gitlab.com/org/backend/-/merge_requests/10",
             "pipeline_status": "success",
         }
-        items = _check_mr(mr, self.ticket)
+        items = _check_pr(pr, self.ticket)
         assert len(items) == 1
         assert items[0].kind == "needs_review_request"
 
     def test_needs_reply(self) -> None:
-        mr = {
+        pr = {
             "draft": False,
             "repo": "backend",
             "iid": 10,
@@ -696,24 +696,24 @@ class TestCheckMr(TestCase):
                 {"status": "needs_reply"},
             ],
         }
-        items = _check_mr(mr, self.ticket)
+        items = _check_pr(pr, self.ticket)
         assert any(item.kind == "needs_reply" for item in items)
         needs_reply_item = next(i for i in items if i.kind == "needs_reply")
         assert "2 comments" in needs_reply_item.label
 
     def test_needs_reply_singular(self) -> None:
-        mr = {
+        pr = {
             "draft": False,
             "repo": "backend",
             "iid": 10,
             "url": "https://gitlab.com/org/backend/-/merge_requests/10",
             "discussions": [{"status": "needs_reply"}],
         }
-        items = _check_mr(mr, self.ticket)
+        items = _check_pr(pr, self.ticket)
         assert any("1 comment need reply" in i.label for i in items)
 
     def test_needs_approval(self) -> None:
-        mr = {
+        pr = {
             "draft": False,
             "repo": "backend",
             "iid": 10,
@@ -723,12 +723,12 @@ class TestCheckMr(TestCase):
             "review_permalink": "https://slack.com/x",
             "approvals": {"count": 0, "required": 2},
         }
-        items = _check_mr(mr, self.ticket)
+        items = _check_pr(pr, self.ticket)
         assert any(item.kind == "needs_approval" for item in items)
 
     def test_non_dict_approvals(self) -> None:
         """Non-dict approvals should be treated as empty."""
-        mr = {
+        pr = {
             "draft": False,
             "repo": "backend",
             "iid": 10,
@@ -738,24 +738,24 @@ class TestCheckMr(TestCase):
             "review_permalink": "https://slack.com/x",
             "approvals": "not-a-dict",
         }
-        items = _check_mr(mr, self.ticket)
+        items = _check_pr(pr, self.ticket)
         assert any(item.kind == "needs_approval" for item in items)
 
     def test_non_list_discussions(self) -> None:
         """When discussions is not a list, the needs_reply check is skipped (branch 464->477)."""
-        mr = {
+        pr = {
             "draft": False,
             "repo": "backend",
             "iid": 10,
             "url": "https://gitlab.com/org/backend/-/merge_requests/10",
             "discussions": "not-a-list",
         }
-        items = _check_mr(mr, self.ticket)
+        items = _check_pr(pr, self.ticket)
         # No crash; no needs_reply item
         assert all(i.kind != "needs_reply" for i in items)
 
     def test_review_draft_pending(self) -> None:
-        mr = {
+        pr = {
             "draft": False,
             "repo": "backend",
             "iid": 10,
@@ -763,14 +763,14 @@ class TestCheckMr(TestCase):
             "draft_comments_pending": True,
             "draft_comments_count": 3,
         }
-        items = _check_mr(mr, self.ticket)
+        items = _check_pr(pr, self.ticket)
         assert any(item.kind == "review_draft" for item in items)
         draft_item = next(i for i in items if i.kind == "review_draft")
         assert "3 draft comments" in draft_item.detail
         assert "agent posted review comments" in draft_item.label
 
     def test_review_draft_singular(self) -> None:
-        mr = {
+        pr = {
             "draft": False,
             "repo": "backend",
             "iid": 10,
@@ -778,12 +778,12 @@ class TestCheckMr(TestCase):
             "draft_comments_pending": True,
             "draft_comments_count": 1,
         }
-        items = _check_mr(mr, self.ticket)
+        items = _check_pr(pr, self.ticket)
         draft_item = next(i for i in items if i.kind == "review_draft")
         assert "1 draft comment need" in draft_item.detail
 
     def test_review_draft_not_pending(self) -> None:
-        mr = {
+        pr = {
             "draft": False,
             "repo": "backend",
             "iid": 10,
@@ -791,40 +791,40 @@ class TestCheckMr(TestCase):
             "draft_comments_pending": False,
             "draft_comments_count": 0,
         }
-        items = _check_mr(mr, self.ticket)
+        items = _check_pr(pr, self.ticket)
         assert all(i.kind != "review_draft" for i in items)
 
     def test_review_draft_missing_count(self) -> None:
         """When draft_comments_pending is True but count is missing, no item."""
-        mr = {
+        pr = {
             "draft": False,
             "repo": "backend",
             "iid": 10,
             "url": "https://gitlab.com/org/backend/-/merge_requests/10",
             "draft_comments_pending": True,
         }
-        items = _check_mr(mr, self.ticket)
+        items = _check_pr(pr, self.ticket)
         assert all(i.kind != "review_draft" for i in items)
 
 
 class TestBuildActionRequired(TestCase):
-    def test_skips_non_dict_mrs(self) -> None:
-        """When mrs is not a dict, it should be skipped."""
+    def test_skips_non_dict_prs(self) -> None:
+        """When prs is not a dict, it should be skipped."""
         Ticket.objects.create(
             state=Ticket.State.STARTED,
-            extra={"mrs": "not-a-dict"},
+            extra={"prs": "not-a-dict"},
         )
 
         items = build_action_required()
 
         assert all(item.kind == "interactive_task" for item in items) or items == []
 
-    def test_includes_mr_action_items(self) -> None:
-        """build_action_required iterates MRs and calls _check_mr (covers line 432)."""
+    def test_includes_pr_action_items(self) -> None:
+        """build_action_required iterates PRs and calls _check_pr (covers line 432)."""
         Ticket.objects.create(
             state=Ticket.State.STARTED,
             extra={
-                "mrs": {
+                "prs": {
                     "url1": {
                         "draft": False,
                         "repo": "backend",
@@ -856,7 +856,7 @@ class TestReviewCommentsInActionRequired(TestCase):
         Ticket.objects.create(
             state=Ticket.State.STARTED,
             extra={
-                "mrs": {
+                "prs": {
                     "url1": {
                         "url": "https://gitlab.com/org/backend/-/merge_requests/10",
                         "repo": "backend",
@@ -882,7 +882,7 @@ class TestReviewCommentsInActionRequired(TestCase):
         Ticket.objects.create(
             state=Ticket.State.STARTED,
             extra={
-                "mrs": {
+                "prs": {
                     "url1": {
                         "url": "https://gitlab.com/org/backend/-/merge_requests/10",
                         "repo": "backend",
@@ -906,7 +906,7 @@ class TestReviewCommentsInActionRequired(TestCase):
         Ticket.objects.create(
             state=Ticket.State.STARTED,
             extra={
-                "mrs": {
+                "prs": {
                     "url1": {
                         "url": "https://gitlab.com/org/x/-/merge_requests/1",
                         "repo": "x",
@@ -925,7 +925,7 @@ class TestReviewCommentsInActionRequired(TestCase):
         Ticket.objects.create(
             state=Ticket.State.STARTED,
             extra={
-                "mrs": {
+                "prs": {
                     "url1": {
                         "url": "https://gitlab.com/org/x/-/merge_requests/1",
                         "repo": "x",

--- a/tests/teatree_core/test_sync.py
+++ b/tests/teatree_core/test_sync.py
@@ -18,8 +18,8 @@ from teatree.core.sync import (
     LAST_SYNC_CACHE_KEY,
     PENDING_REVIEWS_CACHE_KEY,
     DiscussionSummary,
-    MREntry,
-    MREntryDict,
+    PREntry,
+    PREntryDict,
     RawAPIDict,
     SyncResult,
     _merge_results,
@@ -197,9 +197,9 @@ class TestDiscussionSummary:
             ds.status = "needs_reply"  # type: ignore[misc]
 
 
-class TestMREntry:
+class TestPREntry:
     def test_required_fields(self) -> None:
-        entry = MREntry(
+        entry = PREntry(
             url="https://example.com/mr/1",
             title="feat: add feature",
             branch="feat/add-feature",
@@ -212,7 +212,7 @@ class TestMREntry:
         assert entry.iid == 42
 
     def test_optional_fields_default_to_none(self) -> None:
-        entry = MREntry(
+        entry = PREntry(
             url="u",
             title="t",
             branch="b",
@@ -227,7 +227,7 @@ class TestMREntry:
         assert entry.review_permalink is None
 
     def test_to_dict_omits_none_values(self) -> None:
-        entry = MREntry(
+        entry = PREntry(
             url="u",
             title="t",
             branch="b",
@@ -251,7 +251,7 @@ class TestMREntry:
         }
 
     def test_to_dict_includes_set_optional_fields(self) -> None:
-        entry = MREntry(
+        entry = PREntry(
             url="u",
             title="t",
             branch="b",
@@ -270,7 +270,7 @@ class TestMREntry:
         assert d["reviewer_names"] == ["alice"]
 
     def test_to_dict_serializes_discussions(self) -> None:
-        entry = MREntry(
+        entry = PREntry(
             url="u",
             title="t",
             branch="b",
@@ -290,7 +290,7 @@ class TestMREntry:
         ]
 
     def test_mutable(self) -> None:
-        entry = MREntry(
+        entry = PREntry(
             url="u",
             title="t",
             branch="b",
@@ -303,7 +303,7 @@ class TestMREntry:
         assert entry.pipeline_status == "success"
 
     def test_draft_comments_fields_default_to_none(self) -> None:
-        entry = MREntry(
+        entry = PREntry(
             url="u",
             title="t",
             branch="b",
@@ -316,7 +316,7 @@ class TestMREntry:
         assert entry.draft_comments_count is None
 
     def test_draft_comments_in_to_dict(self) -> None:
-        entry = MREntry(
+        entry = PREntry(
             url="u",
             title="t",
             branch="b",
@@ -365,35 +365,35 @@ class TestProcessLabel:
         assert GitLabSyncBackend._process_label([]) is None
 
 
-class TestInferStateFromMrs:
-    def test_empty_mrs(self) -> None:
-        assert GitLabSyncBackend._infer_state_from_mrs({}) == Ticket.State.NOT_STARTED
+class TestInferStateFromPrs:
+    def test_empty_prs(self) -> None:
+        assert GitLabSyncBackend._infer_state_from_prs({}) == Ticket.State.NOT_STARTED
 
     def test_corrupted_mrs(self) -> None:
-        assert GitLabSyncBackend._infer_state_from_mrs({"x": "not-a-dict"}) == Ticket.State.NOT_STARTED
+        assert GitLabSyncBackend._infer_state_from_prs({"x": "not-a-dict"}) == Ticket.State.NOT_STARTED
 
     def test_draft_mr(self) -> None:
         mrs = {"url1": {"draft": True}}
-        assert GitLabSyncBackend._infer_state_from_mrs(mrs) == Ticket.State.STARTED
+        assert GitLabSyncBackend._infer_state_from_prs(mrs) == Ticket.State.STARTED
 
     def test_non_draft_mr(self) -> None:
         mrs = {"url1": {"draft": False}}
-        assert GitLabSyncBackend._infer_state_from_mrs(mrs) == Ticket.State.SHIPPED
+        assert GitLabSyncBackend._infer_state_from_prs(mrs) == Ticket.State.SHIPPED
 
     def test_mr_with_approvals(self) -> None:
         mrs = {"url1": {"draft": False, "approvals": {"count": 1, "required": 1}}}
-        assert GitLabSyncBackend._infer_state_from_mrs(mrs) == Ticket.State.IN_REVIEW
+        assert GitLabSyncBackend._infer_state_from_prs(mrs) == Ticket.State.IN_REVIEW
 
     def test_mr_with_review_requested(self) -> None:
         mrs = {"url1": {"draft": False, "review_requested": True}}
-        assert GitLabSyncBackend._infer_state_from_mrs(mrs) == Ticket.State.IN_REVIEW
+        assert GitLabSyncBackend._infer_state_from_prs(mrs) == Ticket.State.IN_REVIEW
 
     def test_picks_highest_across_mrs(self) -> None:
         mrs = {
             "url1": {"draft": True},  # STARTED
             "url2": {"draft": False, "approvals": {"count": 1, "required": 1}},  # IN_REVIEW
         }
-        assert GitLabSyncBackend._infer_state_from_mrs(mrs) == Ticket.State.IN_REVIEW
+        assert GitLabSyncBackend._infer_state_from_prs(mrs) == Ticket.State.IN_REVIEW
 
     def test_second_mr_does_not_advance_when_lower(self) -> None:
         """When second MR infers a lower state than the first, best stays unchanged."""
@@ -402,7 +402,7 @@ class TestInferStateFromMrs:
             "url2": {"draft": True},  # STARTED (lower)
         }
         # Should pick the highest: IN_REVIEW
-        assert GitLabSyncBackend._infer_state_from_mrs(mrs) == Ticket.State.IN_REVIEW
+        assert GitLabSyncBackend._infer_state_from_prs(mrs) == Ticket.State.IN_REVIEW
 
 
 class TestClassifyDiscussions:
@@ -494,7 +494,7 @@ class TestUpdateTicket(TestCase):
             issue_url="https://gitlab.com/org/repo/-/issues/200",
             repos=["repo"],
             extra={
-                "mrs": {
+                "prs": {
                     "https://gitlab.com/org/repo/-/merge_requests/50": {
                         "url": "https://gitlab.com/org/repo/-/merge_requests/50",
                         "repo": "repo",
@@ -508,7 +508,7 @@ class TestUpdateTicket(TestCase):
         )
 
         # Simulate a sync update that doesn't include the skill-written fields
-        new_mr_entry: MREntryDict = {
+        new_mr_entry: PREntryDict = {
             "url": "https://gitlab.com/org/repo/-/merge_requests/50",
             "repo": "repo",
             "title": "feat: new title",
@@ -519,7 +519,7 @@ class TestUpdateTicket(TestCase):
         GitLabSyncBackend._update_ticket(ticket, new_mr_entry, mr_url, "repo")
 
         ticket.refresh_from_db()
-        mr = ticket.extra["mrs"]["https://gitlab.com/org/repo/-/merge_requests/50"]
+        mr = ticket.extra["prs"]["https://gitlab.com/org/repo/-/merge_requests/50"]
         assert mr["title"] == "feat: new title"
         assert mr["review_channel"] == "#backend-review"
         assert mr["review_permalink"] == "https://slack.com/archives/C123/p456"
@@ -533,35 +533,35 @@ class TestMergeTicketExtras(TestCase):
             overlay="test",
             issue_url="https://gitlab.com/org/repo/-/issues/900",
             repos=["repo-a"],
-            extra={"mrs": {"https://mr/1": {"title": "MR 1"}}},
+            extra={"prs": {"https://mr/1": {"title": "MR 1"}}},
         )
         source = Ticket.objects.create(
             overlay="test",
             issue_url="https://gitlab.com/org/repo/-/issues/901",
             repos=["repo-b"],
-            extra={"mrs": {"https://mr/2": {"title": "MR 2"}}},
+            extra={"prs": {"https://mr/2": {"title": "MR 2"}}},
         )
         GitLabSyncBackend._merge_ticket_extras(target, source)
         target.refresh_from_db()
 
-        assert "https://mr/1" in target.extra["mrs"]
-        assert "https://mr/2" in target.extra["mrs"]
+        assert "https://mr/1" in target.extra["prs"]
+        assert "https://mr/2" in target.extra["prs"]
         assert "repo-a" in target.repos
         assert "repo-b" in target.repos
 
     def test_handles_non_dict_mrs(self) -> None:
-        """Non-dict mrs in extras are treated as empty -- repos still merge."""
+        """Non-dict prs in extras are treated as empty -- repos still merge."""
         target = Ticket.objects.create(
             overlay="test",
             issue_url="https://gitlab.com/org/repo/-/issues/960",
             repos=["repo-a"],
-            extra={"mrs": "corrupt"},
+            extra={"prs": "corrupt"},
         )
         source = Ticket.objects.create(
             overlay="test",
             issue_url="https://gitlab.com/org/repo/-/issues/961",
             repos=["repo-b"],
-            extra={"mrs": ["also-corrupt"]},
+            extra={"prs": ["also-corrupt"]},
         )
         GitLabSyncBackend._merge_ticket_extras(target, source)
         target.refresh_from_db()
@@ -573,19 +573,19 @@ class TestMergeTicketExtras(TestCase):
             overlay="test",
             issue_url="https://gitlab.com/org/repo/-/issues/950",
             repos=["repo-a", "repo-b"],
-            extra={"mrs": {"https://mr/1": {"title": "MR 1"}}},
+            extra={"prs": {"https://mr/1": {"title": "MR 1"}}},
         )
         source = Ticket.objects.create(
             overlay="test",
             issue_url="https://gitlab.com/org/repo/-/issues/951",
             repos=["repo-b", "repo-c"],
-            extra={"mrs": {"https://mr/1": {"title": "MR 1 dup"}, "https://mr/3": {"title": "MR 3"}}},
+            extra={"prs": {"https://mr/1": {"title": "MR 1 dup"}, "https://mr/3": {"title": "MR 3"}}},
         )
         GitLabSyncBackend._merge_ticket_extras(target, source)
         target.refresh_from_db()
 
-        assert target.extra["mrs"]["https://mr/1"]["title"] == "MR 1"
-        assert "https://mr/3" in target.extra["mrs"]
+        assert target.extra["prs"]["https://mr/1"]["title"] == "MR 1"
+        assert "https://mr/3" in target.extra["prs"]
         assert target.repos == ["repo-a", "repo-b", "repo-c"]
 
 
@@ -616,7 +616,7 @@ class TestFetchReviewPermalinks(TestCase):
             repos=["repo"],
             state=Ticket.State.STARTED,
             extra={
-                "mrs": {
+                "prs": {
                     "https://gitlab.com/org/repo/-/merge_requests/50": {
                         "draft": True,
                         "url": "https://gitlab.com/org/repo/-/merge_requests/50",
@@ -639,7 +639,7 @@ class TestFetchReviewPermalinks(TestCase):
             repos=["repo"],
             state=Ticket.State.SHIPPED,
             extra={
-                "mrs": {
+                "prs": {
                     "https://gitlab.com/org/repo/-/merge_requests/51": {
                         "draft": False,
                         "review_permalink": "https://slack.com/existing",
@@ -668,7 +668,7 @@ class TestFetchReviewPermalinks(TestCase):
             repos=["repo"],
             state=Ticket.State.SHIPPED,
             extra={
-                "mrs": {
+                "prs": {
                     "https://gitlab.com/org/repo/-/merge_requests/52": {
                         "draft": False,
                     },
@@ -697,14 +697,14 @@ class TestFetchReviewPermalinks(TestCase):
             issue_url="https://gitlab.com/org/repo/-/issues/503",
             repos=["repo"],
             state=Ticket.State.SHIPPED,
-            extra={"mrs": {mr_url: {"draft": False}}},
+            extra={"prs": {mr_url: {"draft": False}}},
         )
 
         self._monkeypatch.setattr(
             "teatree.backends.slack_review_sync.search_review_permalinks",
             lambda _request: [
                 SlackReviewMatch(
-                    mr_url=mr_url,
+                    pr_url=mr_url,
                     permalink="https://team.slack.com/archives/C123/p170000",
                     channel="review-crew",
                 ),
@@ -717,7 +717,7 @@ class TestFetchReviewPermalinks(TestCase):
 
         assert result.reviews_synced == 1
         ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/503")
-        mr = ticket.extra["mrs"][mr_url]
+        mr = ticket.extra["prs"][mr_url]
         assert mr["review_permalink"] == "https://team.slack.com/archives/C123/p170000"
         assert mr["review_channel"] == "review-crew"
 
@@ -728,7 +728,7 @@ class TestFetchReviewPermalinks(TestCase):
             issue_url="https://gitlab.com/org/repo/-/issues/801",
             repos=["repo"],
             state=Ticket.State.SHIPPED,
-            extra={"mrs": "not-a-dict"},
+            extra={"prs": "not-a-dict"},
         )
         self._monkeypatch.setattr("teatree.backends.slack_review_sync.search_review_permalinks", lambda _request: [])
 
@@ -744,7 +744,7 @@ class TestFetchReviewPermalinks(TestCase):
             issue_url="https://gitlab.com/org/repo/-/issues/802",
             repos=["repo"],
             state=Ticket.State.SHIPPED,
-            extra={"mrs": {"https://gitlab.com/mr/1": "not-a-dict"}},
+            extra={"prs": {"https://gitlab.com/mr/1": "not-a-dict"}},
         )
         self._monkeypatch.setattr("teatree.backends.slack_review_sync.search_review_permalinks", lambda _request: [])
 
@@ -891,7 +891,7 @@ class TestApplyMergedStatusAllMerged(TestCase):
         ticket = Ticket.objects.create(
             issue_url="https://gitlab.com/org/repo/-/issues/1",
             state=Ticket.State.IN_REVIEW,
-            extra={"mrs": {"url1": {"title": "MR1"}, "url2": {"title": "MR2"}}},
+            extra={"prs": {"url1": {"title": "MR1"}, "url2": {"title": "MR2"}}},
         )
         result = SyncResult()
         apply_merged_status(ticket, {"url1", "url2"}, result)
@@ -902,7 +902,7 @@ class TestApplyMergedStatusAllMerged(TestCase):
         ticket = Ticket.objects.create(
             issue_url="https://gitlab.com/org/repo/-/issues/2",
             state=Ticket.State.IN_REVIEW,
-            extra={"mrs": {"url1": {"title": "MR1"}, "url2": {"title": "MR2"}}},
+            extra={"prs": {"url1": {"title": "MR1"}, "url2": {"title": "MR2"}}},
         )
         result = SyncResult()
         apply_merged_status(ticket, {"url1"}, result)
@@ -914,7 +914,7 @@ class TestApplyMergedStatusAllMerged(TestCase):
         ticket = Ticket.objects.create(
             issue_url="https://gitlab.com/org/repo/-/issues/3",
             state=Ticket.State.IN_REVIEW,
-            extra={"mrs": {"url1": {"title": "MR1"}}},
+            extra={"prs": {"url1": {"title": "MR1"}}},
         )
         Worktree.objects.create(
             overlay="test",
@@ -932,7 +932,7 @@ class TestApplyMergedStatusAllMerged(TestCase):
         ticket = Ticket.objects.create(
             issue_url="https://gitlab.com/org/repo/-/issues/4",
             state=Ticket.State.IN_REVIEW,
-            extra={"mrs": {"url1": {"title": "MR1"}}},
+            extra={"prs": {"url1": {"title": "MR1"}}},
         )
         Worktree.objects.create(
             overlay="test",
@@ -958,7 +958,7 @@ class TestApplyClosedStatus(TestCase):
             issue_url="https://gitlab.com/org/repo/-/issues/77",
             state=Ticket.State.IN_REVIEW,
             extra={
-                "mrs": {
+                "prs": {
                     "url1": {"title": "MR1", "state": "opened"},
                 },
             },
@@ -966,16 +966,16 @@ class TestApplyClosedStatus(TestCase):
         result = SyncResult()
         apply_closed_status(ticket, {"url1"}, result)
         ticket.refresh_from_db()
-        assert ticket.extra["mrs"]["url1"]["state"] == "closed"
+        assert ticket.extra["prs"]["url1"]["state"] == "closed"
         assert ticket.state == Ticket.State.IN_REVIEW
-        assert result.mrs_closed == 1
+        assert result.prs_closed == 1
 
     def test_does_not_change_ticket_state_when_all_closed(self) -> None:
         """Closing the only MR must NOT advance the ticket FSM (no FSM target for closed)."""
         ticket = Ticket.objects.create(
             issue_url="https://gitlab.com/org/repo/-/issues/78",
             state=Ticket.State.IN_REVIEW,
-            extra={"mrs": {"url1": {"title": "MR1", "state": "opened"}}},
+            extra={"prs": {"url1": {"title": "MR1", "state": "opened"}}},
         )
         result = SyncResult()
         apply_closed_status(ticket, {"url1"}, result)
@@ -987,7 +987,7 @@ class TestApplyClosedStatus(TestCase):
             issue_url="https://gitlab.com/org/repo/-/issues/79",
             state=Ticket.State.IN_REVIEW,
             extra={
-                "mrs": {
+                "prs": {
                     "url1": {
                         "title": "MR1",
                         "state": "opened",
@@ -999,14 +999,14 @@ class TestApplyClosedStatus(TestCase):
         result = SyncResult()
         apply_closed_status(ticket, {"url1"}, result)
         ticket.refresh_from_db()
-        assert "discussions" not in ticket.extra["mrs"]["url1"]
+        assert "discussions" not in ticket.extra["prs"]["url1"]
 
     def test_does_not_clean_worktrees(self) -> None:
         """Closed MRs leave worktrees alone — user may reopen with new MR."""
         ticket = Ticket.objects.create(
             issue_url="https://gitlab.com/org/repo/-/issues/80",
             state=Ticket.State.IN_REVIEW,
-            extra={"mrs": {"url1": {"title": "MR1", "state": "opened"}}},
+            extra={"prs": {"url1": {"title": "MR1", "state": "opened"}}},
         )
         Worktree.objects.create(
             overlay="test",
@@ -1036,21 +1036,21 @@ class TestSyncFollowup(TestCase):
 
         result = sync_followup()
 
-        assert result.mrs_found == 2
+        assert result.prs_found == 2
         assert result.tickets_created == 2
         assert result.errors == []
         assert Ticket.objects.count() == 2
 
         issue_ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/100")
         assert "repo" in issue_ticket.repos
-        assert "mrs" in issue_ticket.extra
+        assert "prs" in issue_ticket.extra
         # Non-draft MR should have pipeline data
-        mr_data = issue_ticket.extra["mrs"][_MR_WITH_ISSUE["web_url"]]
+        mr_data = issue_ticket.extra["prs"][_MR_WITH_ISSUE["web_url"]]
         assert mr_data["pipeline_status"] == "success"
         assert mr_data["approvals"] == {"count": 0, "required": 1}
 
         mr_ticket = Ticket.objects.get(issue_url=_MR_WITHOUT_ISSUE["web_url"])
-        assert mr_ticket.extra["mrs"][_MR_WITHOUT_ISSUE["web_url"]]["draft"] is True
+        assert mr_ticket.extra["prs"][_MR_WITHOUT_ISSUE["web_url"]]["draft"] is True
 
     def test_sync_sets_draft_comments_pending(self) -> None:
         mock_client = _make_mock_client([_MR_WITH_ISSUE])
@@ -1060,7 +1060,7 @@ class TestSyncFollowup(TestCase):
         sync_followup()
 
         ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/100")
-        mr_data = ticket.extra["mrs"][_MR_WITH_ISSUE["web_url"]]
+        mr_data = ticket.extra["prs"][_MR_WITH_ISSUE["web_url"]]
         assert mr_data["draft_comments_pending"] is True
         assert mr_data["draft_comments_count"] == 5
 
@@ -1072,7 +1072,7 @@ class TestSyncFollowup(TestCase):
         sync_followup()
 
         ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/100")
-        mr_data = ticket.extra["mrs"][_MR_WITH_ISSUE["web_url"]]
+        mr_data = ticket.extra["prs"][_MR_WITH_ISSUE["web_url"]]
         assert mr_data["draft_comments_pending"] is False
         assert "draft_comments_count" not in mr_data
 
@@ -1092,7 +1092,7 @@ class TestSyncFollowup(TestCase):
             overlay="test",
             issue_url="https://gitlab.com/org/repo/-/issues/100",
             repos=["old-repo"],
-            extra={"mrs": {}},
+            extra={"prs": {}},
         )
 
         mock_client = _make_mock_client([_MR_WITH_ISSUE])
@@ -1105,7 +1105,7 @@ class TestSyncFollowup(TestCase):
         ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/100")
         assert "repo" in ticket.repos
         assert "old-repo" in ticket.repos
-        assert _MR_WITH_ISSUE["web_url"] in ticket.extra["mrs"]
+        assert _MR_WITH_ISSUE["web_url"] in ticket.extra["prs"]
 
     def test_returns_error_when_token_missing(self) -> None:
         overlay = SyncOverlay(gitlab_token="")
@@ -1122,7 +1122,7 @@ class TestSyncFollowup(TestCase):
 
         result = sync_followup()
 
-        assert result.mrs_found == 0
+        assert result.prs_found == 0
         assert len(result.errors) == 1
         assert "API timeout" in result.errors[0]
 
@@ -1146,7 +1146,7 @@ class TestSyncFollowup(TestCase):
             gh_backend_cls.return_value.is_configured.return_value = False
             result = sync_followup()
 
-        assert result.mrs_found == 0
+        assert result.prs_found == 0
         assert any("upstream hung" in e for e in result.errors)
         assert any("FailingBackend" in e for e in result.errors)
 
@@ -1166,7 +1166,7 @@ class TestSyncFollowup(TestCase):
             overlay="test",
             issue_url=_MR_WITHOUT_ISSUE["web_url"],
             repos=["repo"],
-            extra={"mrs": {}},
+            extra={"prs": {}},
         )
 
         mock_client = _make_mock_client([_MR_WITHOUT_ISSUE])
@@ -1176,14 +1176,14 @@ class TestSyncFollowup(TestCase):
 
         assert result.tickets_updated == 1
         ticket = Ticket.objects.get(issue_url=_MR_WITHOUT_ISSUE["web_url"])
-        assert _MR_WITHOUT_ISSUE["web_url"] in ticket.extra["mrs"]
+        assert _MR_WITHOUT_ISSUE["web_url"] in ticket.extra["prs"]
 
     def test_handles_corrupted_extra_field(self) -> None:
         Ticket.objects.create(
             overlay="test",
             issue_url="https://gitlab.com/org/repo/-/issues/100",
             repos=["repo"],
-            extra={"mrs": "not-a-dict"},
+            extra={"prs": "not-a-dict"},
         )
 
         mock_client = _make_mock_client([_MR_WITH_ISSUE])
@@ -1193,7 +1193,7 @@ class TestSyncFollowup(TestCase):
 
         assert result.tickets_updated == 1
         ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/100")
-        assert isinstance(ticket.extra["mrs"], dict)
+        assert isinstance(ticket.extra["prs"], dict)
 
     def test_first_run_passes_no_updated_after(self) -> None:
         """First sync (no cached timestamp) should call list_open_mrs without updated_after."""
@@ -1260,7 +1260,7 @@ class TestSyncFollowup(TestCase):
             issue_url="https://gitlab.com/org/repo/-/issues/100",
             repos=["repo"],
             state=Ticket.State.NOT_STARTED,
-            extra={"mrs": {}},
+            extra={"prs": {}},
         )
         mock_client = _make_mock_client([_MR_WITH_ISSUE])
         self._monkeypatch.setattr("teatree.backends.gitlab_api.GitLabAPI", lambda **_kw: mock_client)
@@ -1277,7 +1277,7 @@ class TestSyncFollowup(TestCase):
             issue_url="https://gitlab.com/org/repo/-/issues/100",
             repos=["repo"],
             state=Ticket.State.IN_REVIEW,
-            extra={"mrs": {}},
+            extra={"prs": {}},
         )
         # MR with no approvals -> inferred SHIPPED, but ticket is already at IN_REVIEW
         mock_client = _make_mock_client([_MR_WITH_ISSUE])
@@ -1302,7 +1302,7 @@ class TestSyncFollowup(TestCase):
 
         assert result.tickets_created == 1
         ticket = Ticket.objects.get(issue_url=mr["web_url"])
-        mr_data = ticket.extra["mrs"][mr["web_url"]]
+        mr_data = ticket.extra["prs"][mr["web_url"]]
         assert "review_requested" not in mr_data
         assert "reviewer_names" not in mr_data
 
@@ -1312,14 +1312,14 @@ class TestSyncFollowup(TestCase):
             overlay="test",
             issue_url="https://gitlab.com/org/repo/-/issues/100",
             repos=["repo"],
-            extra={"mrs": {"https://mr/old": {"title": "old"}}},
+            extra={"prs": {"https://mr/old": {"title": "old"}}},
             state=Ticket.State.STARTED,
         )
         dup_b = Ticket.objects.create(
             overlay="test",
             issue_url="https://gitlab.com/org/repo/-/issues/101",
             repos=["other-repo"],
-            extra={"mrs": {"https://mr/dup": {"title": "dup"}}},
+            extra={"prs": {"https://mr/dup": {"title": "dup"}}},
         )
         dup_c = Ticket.objects.create(
             overlay="test",
@@ -1347,7 +1347,7 @@ class TestSyncFollowup(TestCase):
         assert not Ticket.objects.filter(pk=dup_b.pk).exists()
         assert not Ticket.objects.filter(pk=dup_c.pk).exists()
         ticket_a.refresh_from_db()
-        assert "https://mr/dup" in ticket_a.extra["mrs"]
+        assert "https://mr/dup" in ticket_a.extra["prs"]
         assert "other-repo" in ticket_a.repos
 
 
@@ -1387,7 +1387,7 @@ class TestSyncFollowupAssignedIssues(TestCase):
         assert ticket.repos == ["repo"]
         # issue_title starts from the list response then gets refreshed by _fetch_issue_labels
         assert ticket.extra["issue_title"]
-        assert "mrs" not in ticket.extra or ticket.extra["mrs"] == {}
+        assert "prs" not in ticket.extra or ticket.extra["prs"] == {}
 
     def test_skips_duplicate_when_mr_already_created_ticket(self) -> None:
         mock_client = _make_mock_client([_MR_WITH_ISSUE])
@@ -1404,7 +1404,7 @@ class TestSyncFollowupAssignedIssues(TestCase):
 
         tickets = Ticket.objects.filter(issue_url="https://gitlab.com/org/repo/-/issues/100")
         assert tickets.count() == 1
-        assert _MR_WITH_ISSUE["web_url"] in tickets.first().extra["mrs"]
+        assert _MR_WITH_ISSUE["web_url"] in tickets.first().extra["prs"]
 
     def test_captures_api_errors(self) -> None:
         mock_client = _make_mock_client([])
@@ -1505,7 +1505,7 @@ class TestSyncFollowupMergedMrs(TestCase):
             repos=["repo"],
             state=Ticket.State.IN_REVIEW,
             extra={
-                "mrs": {
+                "prs": {
                     "https://gitlab.com/org/repo/-/merge_requests/42": {
                         "url": "https://gitlab.com/org/repo/-/merge_requests/42",
                         "repo": "repo",
@@ -1524,12 +1524,12 @@ class TestSyncFollowupMergedMrs(TestCase):
 
         result = sync_followup()
 
-        assert result.mrs_merged == 1
+        assert result.prs_merged == 1
         ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/100")
-        mr = ticket.extra["mrs"]["https://gitlab.com/org/repo/-/merge_requests/42"]
+        mr = ticket.extra["prs"]["https://gitlab.com/org/repo/-/merge_requests/42"]
         assert "discussions" not in mr
 
-    def test_advances_ticket_to_merged_when_all_mrs_merged(self) -> None:
+    def test_advances_ticket_to_merged_when_all_prs_merged(self) -> None:
         """When all MRs for a ticket are merged, ticket state advances to MERGED."""
         Ticket.objects.create(
             overlay="test",
@@ -1537,7 +1537,7 @@ class TestSyncFollowupMergedMrs(TestCase):
             repos=["repo"],
             state=Ticket.State.IN_REVIEW,
             extra={
-                "mrs": {
+                "prs": {
                     "https://gitlab.com/org/repo/-/merge_requests/42": {
                         "url": "https://gitlab.com/org/repo/-/merge_requests/42",
                         "repo": "repo",
@@ -1564,7 +1564,7 @@ class TestSyncFollowupMergedMrs(TestCase):
             repos=["repo"],
             state=Ticket.State.IN_REVIEW,
             extra={
-                "mrs": {
+                "prs": {
                     "https://gitlab.com/org/repo/-/merge_requests/42": {
                         "url": "https://gitlab.com/org/repo/-/merge_requests/42",
                         "repo": "repo",
@@ -1590,8 +1590,8 @@ class TestSyncFollowupMergedMrs(TestCase):
         ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/100")
         assert ticket.state == Ticket.State.IN_REVIEW
         # Merged MR's discussions removed, open MR's discussions preserved
-        assert "discussions" not in ticket.extra["mrs"]["https://gitlab.com/org/repo/-/merge_requests/42"]
-        assert "discussions" in ticket.extra["mrs"]["https://gitlab.com/org/repo/-/merge_requests/99"]
+        assert "discussions" not in ticket.extra["prs"]["https://gitlab.com/org/repo/-/merge_requests/42"]
+        assert "discussions" in ticket.extra["prs"]["https://gitlab.com/org/repo/-/merge_requests/99"]
 
     def test_handles_merged_mr_fetch_failure(self) -> None:
         """When merged MR fetch fails, error is appended but sync continues."""
@@ -1601,7 +1601,7 @@ class TestSyncFollowupMergedMrs(TestCase):
 
         result = sync_followup()
 
-        assert any("Merged MR fetch failed" in e for e in result.errors)
+        assert any("Merged PR fetch failed" in e for e in result.errors)
 
     def test_skips_ticket_with_no_mrs(self) -> None:
         """Ticket with empty/missing mrs dict should be skipped in merged detection."""
@@ -1610,7 +1610,7 @@ class TestSyncFollowupMergedMrs(TestCase):
             issue_url="https://gitlab.com/org/repo/-/issues/300",
             repos=["repo"],
             state=Ticket.State.IN_REVIEW,
-            extra={"mrs": {}},
+            extra={"prs": {}},
         )
 
         mock_client = _make_merged_mock([_MERGED_MR])
@@ -1618,7 +1618,7 @@ class TestSyncFollowupMergedMrs(TestCase):
 
         result = sync_followup()
 
-        assert result.mrs_merged == 0
+        assert result.prs_merged == 0
 
     def test_skips_non_dict_mr_entry(self) -> None:
         """Non-dict mr_entry values should be skipped in merged detection."""
@@ -1628,7 +1628,7 @@ class TestSyncFollowupMergedMrs(TestCase):
             repos=["repo"],
             state=Ticket.State.IN_REVIEW,
             extra={
-                "mrs": {
+                "prs": {
                     "https://gitlab.com/org/repo/-/merge_requests/42": "not-a-dict",
                 },
             },
@@ -1640,7 +1640,7 @@ class TestSyncFollowupMergedMrs(TestCase):
         result = sync_followup()
 
         # Non-dict entries are skipped; no crash, no merge count
-        assert result.mrs_merged == 0
+        assert result.prs_merged == 0
 
     def test_followup_marks_closed_mr_so_dashboard_filters_it(self) -> None:
         """When user closes an MR without merging, sync must update the cached state to "closed".
@@ -1654,7 +1654,7 @@ class TestSyncFollowupMergedMrs(TestCase):
             repos=["repo"],
             state=Ticket.State.IN_REVIEW,
             extra={
-                "mrs": {
+                "prs": {
                     _CLOSED_MR["web_url"]: {
                         "url": _CLOSED_MR["web_url"],
                         "repo": "repo",
@@ -1670,9 +1670,9 @@ class TestSyncFollowupMergedMrs(TestCase):
 
         result = sync_followup()
 
-        assert result.mrs_closed == 1
+        assert result.prs_closed == 1
         ticket = Ticket.objects.get(issue_url="https://gitlab.com/org/repo/-/issues/77")
-        assert ticket.extra["mrs"][_CLOSED_MR["web_url"]]["state"] == "closed"
+        assert ticket.extra["prs"][_CLOSED_MR["web_url"]]["state"] == "closed"
 
     def test_handles_closed_mr_fetch_failure(self) -> None:
         """Closed-MR fetch failure logs an error but does not abort sync."""
@@ -1682,7 +1682,7 @@ class TestSyncFollowupMergedMrs(TestCase):
 
         result = sync_followup()
 
-        assert any("Closed MR fetch failed" in e for e in result.errors)
+        assert any("Closed PR fetch failed" in e for e in result.errors)
 
     def test_no_change_when_mr_has_no_discussions(self) -> None:
         """Merged MR without discussions causes no save (no changed flag)."""
@@ -1692,7 +1692,7 @@ class TestSyncFollowupMergedMrs(TestCase):
             repos=["repo"],
             state=Ticket.State.IN_REVIEW,
             extra={
-                "mrs": {
+                "prs": {
                     "https://gitlab.com/org/repo/-/merge_requests/42": {
                         "url": "https://gitlab.com/org/repo/-/merge_requests/42",
                         "repo": "repo",
@@ -1709,7 +1709,7 @@ class TestSyncFollowupMergedMrs(TestCase):
         result = sync_followup()
 
         # MR is counted as merged even without discussions
-        assert result.mrs_merged == 1
+        assert result.prs_merged == 1
 
 
 class TestSyncFollowupLabels(TestCase):
@@ -1851,17 +1851,17 @@ class TestSyncFollowupLabels(TestCase):
 
 class TestMergeResults:
     def test_sums_counts_and_concatenates_errors(self) -> None:
-        a = SyncResult(mrs_found=3, tickets_created=1, errors=["err-a"])
-        b = SyncResult(mrs_found=5, tickets_updated=2, errors=["err-b"])
+        a = SyncResult(prs_found=3, tickets_created=1, errors=["err-a"])
+        b = SyncResult(prs_found=5, tickets_updated=2, errors=["err-b"])
         merged = _merge_results(a, b)
-        assert merged.mrs_found == 8
+        assert merged.prs_found == 8
         assert merged.tickets_created == 1
         assert merged.tickets_updated == 2
         assert merged.errors == ["err-a", "err-b"]
 
     def test_merges_empty_results(self) -> None:
         merged = _merge_results(SyncResult(), SyncResult())
-        assert merged.mrs_found == 0
+        assert merged.prs_found == 0
         assert merged.errors == []
 
 
@@ -1903,7 +1903,7 @@ class TestDualSync(TestCase):
 
         result = sync_followup()
 
-        assert result.mrs_found == 2  # 1 GitHub + 1 GitLab
+        assert result.prs_found == 2  # 1 GitHub + 1 GitLab
         assert result.tickets_created == 2
         assert result.errors == []
         assert Ticket.objects.count() == 2
@@ -1916,7 +1916,7 @@ class TestDualSync(TestCase):
         with _patch_overlay(overlay):
             result = sync_followup()
 
-        assert result.mrs_found == 1
+        assert result.prs_found == 1
         assert result.tickets_created == 1
 
     def test_no_tokens_returns_error(self) -> None:
@@ -1930,6 +1930,8 @@ class TestDualSync(TestCase):
 
 class TestSyncReviewerMRs(TestCase):
     def test_caches_reviewer_mrs(self) -> None:
+        from teatree.backends.gitlab import GitLabCodeHost  # noqa: PLC0415
+
         mock_client = MagicMock()
         mock_client.list_open_mrs_as_reviewer.return_value = [
             {
@@ -1941,9 +1943,10 @@ class TestSyncReviewerMRs(TestCase):
                 "author": {"username": "alice"},
             },
         ]
+        host = GitLabCodeHost(client=mock_client)
         result = SyncResult()
 
-        GitLabSyncBackend._sync_reviewer_mrs(mock_client, "testuser", result)
+        GitLabSyncBackend._sync_reviewer_prs(host, "testuser", result)
 
         cached = cache.get(PENDING_REVIEWS_CACHE_KEY)
         assert cached is not None
@@ -1955,14 +1958,17 @@ class TestSyncReviewerMRs(TestCase):
         cache.delete(PENDING_REVIEWS_CACHE_KEY)
 
     def test_handles_api_failure_gracefully(self) -> None:
+        from teatree.backends.gitlab import GitLabCodeHost  # noqa: PLC0415
+
         mock_client = MagicMock()
         mock_client.list_open_mrs_as_reviewer.side_effect = RuntimeError("API down")
+        host = GitLabCodeHost(client=mock_client)
         result = SyncResult()
 
-        GitLabSyncBackend._sync_reviewer_mrs(mock_client, "testuser", result)
+        GitLabSyncBackend._sync_reviewer_prs(host, "testuser", result)
 
         assert len(result.errors) == 1
-        assert "Reviewer MR fetch failed" in result.errors[0]
+        assert "Reviewer PR fetch failed" in result.errors[0]
 
 
 # ── GitHub sync ──────────────────────────────────────────────────────
@@ -2002,7 +2008,7 @@ class TestSyncGitHub(TestCase):
             result = GitHubSyncBackend().sync(overlay)
 
         assert result.tickets_created == 1
-        assert result.mrs_found == 1
+        assert result.prs_found == 1
         ticket = Ticket.objects.get(issue_url="https://github.com/souliane/teatree/issues/42")
         assert ticket.state == Ticket.State.STARTED
         assert ticket.extra["issue_title"] == "Test issue"


### PR DESCRIPTION
## Summary

Phase 3 of #541 declared "PR" canonical in core but the rename only landed on the backend Protocol; the data model and sync surface kept GitLab's MR vocabulary. This makes the rename consistent across the codebase and folds in five small follow-up findings under one ticket.

Relates to #541.

## Changes

**Schema rename** (with `RunPython` data migration)
- `MergeRequest` model → `PullRequest` (`db_table=teatree_pull_request`, `related_name=pull_requests`, constraint `unique_pull_request_url`)
- `Ticket.extra["mrs"]` → `Ticket.extra["prs"]` (rewritten in migration; reverse path included)

**Type / data renames**
- `MREntry` / `MREntryDict` → `PREntry` / `PREntryDict` in `core.sync`
- `MergeRequestResponse` → `PullRequestResponse` in `backends.types`
- `SyncResult.mrs_*` counters → `prs_*`
- `ticket.extra["mr_urls"]` / `["mr_title_override"]` → `["pr_urls"]` / `["pr_title_override"]`

**User-visible strings**
- `agents/prompt.py` emits "Open pull requests:" and reads `extra["prs"]`
- Slack regex matches both `/merge_requests/` and `/pull/` permalinks; Slack sync helpers renamed (`_iter_pr_permalinks`, `pr_url`, etc.)

**Sync routing**
- `gitlab_sync.py` wraps `GitLabCodeHost` and routes `list_my_prs` / `list_assigned_issues` / `list_review_requested_prs` through the `CodeHostBackend` Protocol
- GitLab-specific calls (pipeline, approvals, discussions, draft notes, terminal-state scans) go through the newly exposed `GitLabCodeHost.client` property because they have no GitHub parallel
- Protocol gains `updated_after` on `list_my_prs` / `list_review_requested_prs`; GitHub host translates to the `updated:>=<since>` search qualifier

**Docs / process**
- `BLUEPRINT.md`: "All eight phases have shipped" → "Phases 0-6 and 8 have shipped on the active branch; phase 7 (ticket dispositions) is deferred"; scanner count 7 → 6 (review-channel scanning is folded into the dispatcher's PR-URL detection); statusline path documented as `${XDG_DATA_HOME:-$HOME/.local/share}/teatree/statusline.txt` (with `$TEATREE_STATUSLINE_FILE` override)
- `skills/ship/SKILL.md`: new section 5b — multi-phase PR titles must list every bundled phase (e.g. "phases 1-6 + 8") so reviewers can grep against the canonical phase list

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check` — 288 files already formatted
- [x] `uv run ty check src/` — clean
- [x] `uv run python manage.py makemigrations --check --dry-run` — "No changes detected"
- [x] `uv run pytest --no-cov -q` — 2522 passed, 12 skipped
- [ ] Run sync against a real GitLab overlay to confirm the renamed `extra["prs"]` key is written and the Protocol-routed `list_my_prs(updated_after=...)` carries the cursor