### PR TITLE
feat(setup): auto-repair editable installs missing declared deps (#548)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1063,7 +1063,7 @@ Three install paths, one source of truth:
 
 - **APM**: `apm install souliane/teatree` — deploys to any supported agent
 - **Claude Code plugin**: `/plugin install t3@souliane-teatree` — Claude-specific
-- **CLI-first**: `uv tool install teatree && t3 setup` — bootstraps from Python (runs APM install, syncs skill symlinks, and registers the Claude plugin in one step). `t3 setup` also auto-runs `uv tool install --editable <repo>` when the global `t3` binary is missing, so `uv run t3 setup` from a fresh checkout upgrades itself in-place.
+- **CLI-first**: `uv tool install teatree && t3 setup` — bootstraps from Python (runs APM install, syncs skill symlinks, and registers the Claude plugin in one step). `t3 setup` also auto-runs `uv tool install --editable <repo>` when the global `t3` binary is missing, so `uv run t3 setup` from a fresh checkout upgrades itself in-place. On every run it additionally reads `[project].dependencies` from the resolved main clone, compares against `importlib.metadata.distributions()`, and — when an editable install is missing a declared dep — re-runs `uv tool install --editable <source> --reinstall` and `execv`-restarts itself against the refreshed venv (see `teatree.utils.dep_drift` and `cli/setup.py:_repair_dep_drift`). Closes the catch-22 where adding a new top-level teatree dep used to break every existing editable install until the user manually reinstalled.
 
 The agent-facing hook layer (`hooks/scripts/hook_router.py`) blocks `uv run t3` Bash invocations and directs agents to call the globally installed `t3` instead.
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ t3 setup                       # installs skills globally, respects local symlin
 
 `uv tool install --editable .` produces the same global `~/.local/bin/t3` as the user flow — edits in this clone take effect on the next invocation, no `uv run` prefix. `t3 setup` runs [APM](https://github.com/microsoft/apm) to install companion dependencies (superpowers, ac-django, etc.), symlinks teatree skills to `~/.claude/skills/`, registers the Claude plugin, and — if `t3` isn't on `PATH` — re-runs `uv tool install --editable .` to self-install. Must be run from the main clone, not a worktree.
 
+`t3 setup` also self-heals when teatree adds a new dep: editable installs don't auto-resync their venv when `pyproject.toml` changes, so on every run `t3 setup` compares the declared `[project].dependencies` against the dists in the running interpreter and re-runs `uv tool install --editable . --reinstall` automatically when anything is missing. After the reinstall, setup re-execs itself against the refreshed venv. No manual `--reinstall` step is needed when pulling teatree updates.
+
 ## Skills
 
 Each skill teaches the agent one phase of development:

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1816,8 +1816,8 @@ Usage: t3 teatree pr create [OPTIONS] TICKET_ID
  ``ticket_id`` accepts the internal DB pk, the full issue URL, or the
  bare issue number (resolved against ``Ticket.issue_url``).
 
- ``--title`` overrides the MR title (default: last commit subject).
- Stored on ``ticket.extra['mr_title_override']`` so the worker reads it.
+ ``--title`` overrides the PR title (default: last commit subject).
+ Stored on ``ticket.extra['pr_title_override']`` so the worker reads it.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    ticket_id      TEXT  [required]                                         │

--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -1,12 +1,54 @@
 #!/usr/bin/env bash
-# Thin statusline hook: cat the file the loop has rendered.
-# The loop (`teatree.loop.statusline.render`) writes the file; this hook
-# only reads it. Decoupling render from read keeps the hook fast (<10ms)
-# regardless of how much work the tick does composing the content.
+# Claude Code statusline hook.
+#
+# Composes two info streams:
+#  1. The fat loop's pre-rendered zones file (anchors, action_needed, in_flight)
+#     written by `t3 loop tick` to ${TEATREE_STATUSLINE_FILE} or the default
+#     XDG path. Decoupling render from read keeps this hook fast (<10ms).
+#  2. Live per-session info from Claude's stdin JSON: model, context-window %,
+#     and skills loaded this session — the latter populated by hook_router.py
+#     / track-skill-usage.sh into ${state_dir}/<session_id>.skills.
 
 set -u
 
 target="${TEATREE_STATUSLINE_FILE:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/statusline.txt}"
+state_dir="${TEATREE_CLAUDE_STATUSLINE_STATE_DIR:-/tmp/claude-statusline}"
+
+session_id=""
+model=""
+ctx_pct=""
+if ! [ -t 0 ] && command -v jq >/dev/null 2>&1; then
+    input=$(cat)
+    if [ -n "$input" ]; then
+        session_id=$(printf '%s' "$input" | jq -r '.session_id // empty')
+        model=$(printf '%s' "$input" | jq -r '.model.display_name // empty')
+        ctx_pct=$(printf '%s' "$input" | jq -r '.context_window.used_percentage // empty' | cut -d. -f1)
+    fi
+fi
+
+skills=""
+if [ -n "$session_id" ]; then
+    skills_file="$state_dir/${session_id}.skills"
+    if [ -r "$skills_file" ]; then
+        skills=$(paste -sd ' ' "$skills_file")
+    fi
+fi
+
+header=""
+sep=""
+if [ -n "$model" ]; then
+    header="model=${model}"
+    sep=" | "
+fi
+if [ -n "$ctx_pct" ] && [ "$ctx_pct" != "empty" ]; then
+    header="${header}${sep}ctx=${ctx_pct}%"
+    sep=" | "
+fi
+if [ -n "$skills" ]; then
+    header="${header}${sep}skills: ${skills}"
+fi
+
+[ -n "$header" ] && printf '%s\n' "$header"
 
 if [[ -r "$target" ]]; then
     cat "$target"

--- a/settings.json
+++ b/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/statusline-command.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/statusline.sh"
           }
         ]
       }

--- a/src/teatree/cli/loop.py
+++ b/src/teatree/cli/loop.py
@@ -8,10 +8,12 @@ of this module fill in once a Claude-side loop binding exists.
 """
 
 import json
+import os
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
+import django
 import typer
 
 from teatree.core.backend_factory import code_host_from_overlay, messaging_from_overlay
@@ -19,6 +21,12 @@ from teatree.loop.statusline import default_path
 from teatree.loop.tick import TickReport, run_tick
 
 loop_app = typer.Typer(name="loop", help="Manage the long-lived fat loop.", no_args_is_help=True)
+
+
+def _ensure_django_ready() -> None:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+    django.setup()
+
 
 type ReportDict = dict[str, Any]
 
@@ -43,6 +51,7 @@ def tick_command(
     json_output: bool = typer.Option(False, "--json", help="Emit the tick report as JSON."),
 ) -> None:
     """Run one tick: scan in parallel, dispatch, render statusline."""
+    _ensure_django_ready()
     host = code_host_from_overlay()
     messaging = messaging_from_overlay()
     report = run_tick(host=host, messaging=messaging, statusline_path=statusline_file)

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 import tomllib
 from pathlib import Path
 
@@ -12,6 +13,7 @@ import typer
 
 from teatree.cli.doctor import AGENT_SKILL_RUNTIMES, DoctorService, agent_skill_dirs
 from teatree.cli.slack_setup import slack_bot_setup
+from teatree.utils.dep_drift import editable_source_path, find_missing_dependencies
 from teatree.utils.run import CompletedProcess, run_allowed_to_fail
 
 # Re-exported here so external callers and tests see a single import path for
@@ -142,6 +144,60 @@ def _print_path_hint(bin_dir: Path | None) -> None:
     target = bin_dir or Path.home() / ".local" / "bin"
     typer.echo(f"NOTE  `{target}` is not on your PATH.")
     typer.echo(f'      Add to your shell rc (~/.zshrc or ~/.bashrc): export PATH="{target}:$PATH"')
+
+
+def _repair_dep_drift(repo: Path) -> bool:
+    """Reinstall the editable teatree if its venv is missing declared deps.
+
+    When teatree adds a new top-level dependency to ``pyproject.toml``, every
+    existing editable install (``uv tool install --editable .``) breaks until
+    the user re-runs the install — the venv's pinned deps don't auto-resync
+    when the source's ``pyproject.toml`` changes.  This was the catch-22 that
+    killed ``t3 setup`` when ``tomlkit`` was first added: the very command
+    that would repair the install was the one the missing dep took out.
+
+    Returns ``True`` and ``execvp``-replaces the process when a repair was
+    triggered (so this never actually returns ``True`` from the caller's
+    perspective).  Returns ``False`` when no drift is detected, when the
+    install is non-editable (PyPI/wheel), or when ``uv`` is unavailable.
+    """
+    pyproject = repo / "pyproject.toml"
+    if not pyproject.is_file():
+        return False
+    missing = find_missing_dependencies(pyproject)
+    if not missing:
+        return False
+
+    source = editable_source_path()
+    if source is None:
+        typer.echo(
+            f"WARN  Teatree is missing declared deps: {', '.join(missing)}\n"
+            "      Reinstall: `uv tool upgrade teatree --reinstall` "
+            "(or `pip install --upgrade teatree`).",
+        )
+        return False
+
+    uv_bin = shutil.which("uv")
+    if not uv_bin:
+        typer.echo(
+            f"WARN  Editable install missing deps ({', '.join(missing)}) but `uv` "
+            "is not on PATH — install uv and re-run `t3 setup`.",
+        )
+        return False
+
+    typer.echo(
+        f"NOTE  Editable install missing deps: {', '.join(missing)}.  Re-running "
+        f"`uv tool install --editable {source} --reinstall` …",
+    )
+    result = _run_captured([uv_bin, "tool", "install", "--editable", str(source), "--reinstall"])
+    if result.returncode != 0:
+        typer.echo(f"WARN  Reinstall failed: {result.stderr.strip()}")
+        return False
+
+    typer.echo("OK    Reinstalled — restarting `t3 setup` against the refreshed venv.")
+    t3_bin = shutil.which("t3") or sys.argv[0]
+    os.execv(t3_bin, [t3_bin, *sys.argv[1:]])  # noqa: S606
+    return True  # unreachable — execv replaces the process; here for the type-checker
 
 
 def _ensure_t3_installed(repo: Path) -> bool:
@@ -374,6 +430,7 @@ def run(
     repo = _validate_repo(_find_main_clone())
     typer.echo(f"Teatree repo: {repo}")
 
+    _repair_dep_drift(repo)
     _ensure_t3_installed(repo)
 
     _run_apm_install(repo)

--- a/src/teatree/utils/dep_drift.py
+++ b/src/teatree/utils/dep_drift.py
@@ -1,0 +1,75 @@
+"""Detect when an editable teatree install has drifted from ``pyproject.toml``.
+
+Reads ``[project].dependencies`` from teatree's source tree and compares
+against the dists installed in the running interpreter.  ``t3 setup`` uses
+this to auto-repair stale editable installs — the catch-22 that broke
+``t3 setup`` when ``tomlkit`` was first added, since the very command that
+would fix the install was the one the missing dep killed.
+
+The check intentionally has zero non-stdlib deps (``tomllib``,
+``importlib.metadata``, ``json``, ``re``) so it remains usable even when
+teatree's declared deps are partially missing from the venv.
+"""
+
+import json
+import re
+import tomllib
+from importlib.metadata import PackageNotFoundError, distribution, distributions
+from pathlib import Path
+
+_NORMALIZE_RE = re.compile(r"[-_.]+")
+_SPEC_TERMINATORS_RE = re.compile(r"[<>=!~\s\[]")
+
+
+def normalize(name: str) -> str:
+    """Normalise a distribution name per PEP 503."""
+    return _NORMALIZE_RE.sub("-", name).lower()
+
+
+def _name_from_spec(spec: str) -> str:
+    spec = spec.split(";", 1)[0].strip()
+    return _SPEC_TERMINATORS_RE.split(spec, maxsplit=1)[0].strip()
+
+
+def declared_dependency_names(pyproject_path: Path) -> set[str]:
+    """Return the normalized names from ``[project].dependencies``."""
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    deps = data.get("project", {}).get("dependencies", []) or []
+    return {normalize(_name_from_spec(spec)) for spec in deps if spec.strip()}
+
+
+def installed_distribution_names() -> set[str]:
+    """Return the set of normalized dist names visible to this interpreter."""
+    return {normalize(dist.name) for dist in distributions()}
+
+
+def find_missing_dependencies(pyproject_path: Path) -> list[str]:
+    """Return declared deps not installed in this interpreter, sorted."""
+    return sorted(declared_dependency_names(pyproject_path) - installed_distribution_names())
+
+
+def editable_source_path() -> Path | None:
+    """Return the editable source path of the running teatree, or ``None``.
+
+    Reads PEP 660 ``direct_url.json`` from teatree's dist-info.  Returns
+    ``None`` when teatree is installed non-editable (PyPI/wheel), when the
+    metadata is missing/unparsable, or when the recorded URL is not a
+    ``file://`` URL.
+    """
+    try:
+        dist = distribution("teatree")
+    except PackageNotFoundError:
+        return None
+    direct_url = dist.read_text("direct_url.json")
+    if not direct_url:
+        return None
+    try:
+        data = json.loads(direct_url)
+    except json.JSONDecodeError:
+        return None
+    if not data.get("dir_info", {}).get("editable"):
+        return None
+    url = data.get("url", "")
+    if not url.startswith("file://"):
+        return None
+    return Path(url.removeprefix("file://"))

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -1,0 +1,124 @@
+"""Tests for ``hooks/scripts/statusline.sh`` — the Claude Code statusline hook.
+
+The hook composes two info streams: the loop's pre-rendered zones file (anchors,
+action_needed, in_flight) and live per-session info from Claude's stdin JSON
+(model, ctx %, loaded skills).
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "hooks" / "scripts" / "statusline.sh"
+
+
+def _run(payload: dict, *, state_dir: Path, statusline_file: Path | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["TEATREE_CLAUDE_STATUSLINE_STATE_DIR"] = str(state_dir)
+    if statusline_file is not None:
+        env["TEATREE_STATUSLINE_FILE"] = str(statusline_file)
+    return subprocess.run(
+        [str(SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+
+
+class TestStatuslineHook:
+    def test_displays_loaded_skills_from_session_file(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        (state_dir / "session-skills.skills").write_text("t3:code\nt3:debug\n", encoding="utf-8")
+
+        result = _run(
+            {"session_id": "session-skills", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "skills: t3:code t3:debug" in result.stdout
+
+    def test_omits_skills_when_session_file_absent(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        result = _run(
+            {"session_id": "no-skills", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "skills:" not in result.stdout
+
+    def test_renders_model_and_context_window_from_stdin(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        result = _run(
+            {
+                "session_id": "s1",
+                "model": {"display_name": "Claude Sonnet"},
+                "context_window": {"used_percentage": 41.8},
+            },
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "model=Claude Sonnet" in result.stdout
+        assert "ctx=41%" in result.stdout
+
+    def test_appends_pre_rendered_loop_zones_file(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        statusline_file = tmp_path / "statusline.txt"
+        statusline_file.write_text("tick @ 2026-05-07T12:00:00\nIn flight:\n→ statusline: x\n", encoding="utf-8")
+
+        result = _run(
+            {"session_id": "s1", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            statusline_file=statusline_file,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "model=Claude Opus" in result.stdout
+        assert "tick @ 2026-05-07T12:00:00" in result.stdout
+        assert "→ statusline: x" in result.stdout
+
+    def test_handles_missing_loop_file_gracefully(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        missing = tmp_path / "nope.txt"
+
+        result = _run(
+            {"session_id": "s1", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            statusline_file=missing,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "model=Claude Opus" in result.stdout
+
+    def test_no_session_id_emits_no_skills_section(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        # A skills file exists but the payload has no session_id — must not pick it up
+        (state_dir / ".skills").write_text("rogue\n", encoding="utf-8")
+
+        result = _run(
+            {"model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "skills:" not in result.stdout
+        assert "rogue" not in result.stdout

--- a/tests/test_cli_loop.py
+++ b/tests/test_cli_loop.py
@@ -62,6 +62,20 @@ class TestTickCommand:
         assert "statusline" in result.stdout
         run_tick_mock.assert_called_once()
 
+    def test_calls_django_setup_before_scanning(self, tmp_path: Path) -> None:
+        """Regression: scanners hit Django ORM, so django.setup() must run first."""
+        report = _build_report(statusline_path=tmp_path / "sl.txt")
+        with (
+            patch("teatree.cli.loop.django.setup") as setup_mock,
+            patch("teatree.cli.loop.code_host_from_overlay", return_value=None),
+            patch("teatree.cli.loop.messaging_from_overlay", return_value=None),
+            patch("teatree.cli.loop.run_tick", return_value=report),
+        ):
+            result = runner.invoke(loop_app, ["tick"])
+
+        assert result.exit_code == 0
+        setup_mock.assert_called_once()
+
     def test_text_output_includes_scanner_errors(self, tmp_path: Path) -> None:
         report = _build_report(errors={"my_prs": "RuntimeError: x"})
         with (

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -19,6 +19,7 @@ from teatree.cli.setup import (
     _install_claude_plugin,
     _register_claude_marketplace,
     _remove_excluded_skills,
+    _repair_dep_drift,
     _run_apm_install,
     _strip_apm_hooks,
     _sync_skill_symlinks,
@@ -785,3 +786,116 @@ class TestEnsureT3Installed:
         assert str(bin_dir) in out
         assert "is not on your PATH" in out
         assert 'export PATH="' in out
+
+
+def _write_pyproject(repo: Path, deps: list[str]) -> Path:
+    """Build a minimal ``pyproject.toml`` declaring *deps* under ``[project]``."""
+    repo.mkdir(parents=True, exist_ok=True)
+    pyproject = repo / "pyproject.toml"
+    quoted = ", ".join(f'"{d}"' for d in deps)
+    pyproject.write_text(
+        f'[project]\nname = "teatree"\nversion = "0"\ndependencies = [{quoted}]\n',
+        encoding="utf-8",
+    )
+    return pyproject
+
+
+class TestRepairDepDrift:
+    """``_repair_dep_drift`` — auto-reinstall when an editable venv is stale."""
+
+    def test_returns_false_when_no_drift(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _write_pyproject(repo, ["django", "httpx"])
+        with patch("teatree.cli.setup.find_missing_dependencies", return_value=[]):
+            assert _repair_dep_drift(repo) is False
+
+    def test_returns_false_when_pyproject_absent(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        assert _repair_dep_drift(repo) is False
+
+    def test_warns_and_returns_false_on_non_editable_install(
+        self,
+        tmp_path: Path,
+        capsys: "pytest.CaptureFixture[str]",
+    ) -> None:
+        repo = tmp_path / "repo"
+        _write_pyproject(repo, ["tomlkit"])
+        with (
+            patch("teatree.cli.setup.find_missing_dependencies", return_value=["tomlkit"]),
+            patch("teatree.cli.setup.editable_source_path", return_value=None),
+        ):
+            assert _repair_dep_drift(repo) is False
+        out = capsys.readouterr().out
+        assert "tomlkit" in out
+        assert "uv tool upgrade teatree --reinstall" in out
+
+    def test_warns_and_returns_false_when_uv_missing(
+        self,
+        tmp_path: Path,
+        capsys: "pytest.CaptureFixture[str]",
+    ) -> None:
+        repo = tmp_path / "repo"
+        _write_pyproject(repo, ["tomlkit"])
+        source = tmp_path / "main-clone"
+        with (
+            patch("teatree.cli.setup.find_missing_dependencies", return_value=["tomlkit"]),
+            patch("teatree.cli.setup.editable_source_path", return_value=source),
+            patch("teatree.cli.setup.shutil.which", return_value=None),
+        ):
+            assert _repair_dep_drift(repo) is False
+        assert "uv` is not on PATH" in capsys.readouterr().out
+
+    def test_reinstalls_and_re_execs_on_editable_drift(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _write_pyproject(repo, ["tomlkit"])
+        source = tmp_path / "main-clone"
+        captured: dict[str, object] = {}
+
+        def fake_execv(path: str, argv: list[str]) -> None:
+            captured["path"] = path
+            captured["argv"] = argv
+            raise SystemExit(0)  # don't actually replace the test process
+
+        completed = SimpleNamespace(returncode=0, stdout="", stderr="")
+        with (
+            patch("teatree.cli.setup.find_missing_dependencies", return_value=["tomlkit"]),
+            patch("teatree.cli.setup.editable_source_path", return_value=source),
+            patch("teatree.cli.setup.shutil.which") as mock_which,
+            patch("teatree.cli.setup._run_captured", return_value=completed) as mock_run,
+            patch("teatree.cli.setup.os.execv", side_effect=fake_execv),
+            patch("teatree.cli.setup.sys.argv", ["/usr/local/bin/t3", "setup"]),
+        ):
+            bins = {"uv": "/usr/bin/uv", "t3": "/usr/local/bin/t3"}
+            mock_which.side_effect = bins.get
+            with pytest.raises(SystemExit):
+                _repair_dep_drift(repo)
+
+        # Reinstall command must target the editable source and pass --reinstall.
+        install_cmd = mock_run.call_args.args[0]
+        assert install_cmd[:3] == ["/usr/bin/uv", "tool", "install"]
+        assert "--editable" in install_cmd
+        assert str(source) in install_cmd
+        assert "--reinstall" in install_cmd
+        # Re-exec preserves the original argv (so subcommands and flags survive).
+        assert captured["argv"] == ["/usr/local/bin/t3", "setup"]
+
+    def test_returns_false_when_reinstall_fails(
+        self,
+        tmp_path: Path,
+        capsys: "pytest.CaptureFixture[str]",
+    ) -> None:
+        repo = tmp_path / "repo"
+        _write_pyproject(repo, ["tomlkit"])
+        source = tmp_path / "main-clone"
+        completed = SimpleNamespace(returncode=1, stdout="", stderr="boom")
+        with (
+            patch("teatree.cli.setup.find_missing_dependencies", return_value=["tomlkit"]),
+            patch("teatree.cli.setup.editable_source_path", return_value=source),
+            patch("teatree.cli.setup.shutil.which", return_value="/usr/bin/uv"),
+            patch("teatree.cli.setup._run_captured", return_value=completed),
+            patch("teatree.cli.setup.os.execv") as mock_execv,
+        ):
+            assert _repair_dep_drift(repo) is False
+            mock_execv.assert_not_called()
+        assert "Reinstall failed" in capsys.readouterr().out

--- a/tests/test_dep_drift.py
+++ b/tests/test_dep_drift.py
@@ -1,0 +1,150 @@
+"""Tests for ``teatree.utils.dep_drift`` — editable-install drift detection.
+
+The module powers ``t3 setup``'s self-healing path: when teatree's
+``pyproject.toml`` adds a new dep, every existing editable install hits
+``ModuleNotFoundError`` until the user re-runs
+``uv tool install --editable . --reinstall``.  ``dep_drift`` detects the
+condition; the wiring in ``cli/setup.py`` repairs it automatically.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from teatree.utils.dep_drift import (
+    declared_dependency_names,
+    editable_source_path,
+    find_missing_dependencies,
+    normalize,
+)
+
+
+class TestNormalize:
+    """PEP 503 distribution-name normalization."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("Django", "django"),
+            ("django_typer", "django-typer"),
+            ("django.typer", "django-typer"),
+            ("DJANGO__TYPER", "django-typer"),
+            ("django-tasks-db", "django-tasks-db"),
+            ("PyYAML", "pyyaml"),
+        ],
+    )
+    def test_normalises_to_pep503(self, raw: str, expected: str) -> None:
+        assert normalize(raw) == expected
+
+
+class TestDeclaredDependencyNames:
+    """Parsing ``[project].dependencies`` from ``pyproject.toml``."""
+
+    def test_extracts_plain_names(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            'dependencies = ["django>=5.2,<6.1", "httpx>=0.27", "tomlkit>=0.13"]\n',
+            encoding="utf-8",
+        )
+        assert declared_dependency_names(pyproject) == {"django", "httpx", "tomlkit"}
+
+    def test_normalises_names(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\ndependencies = ["Django_Typer>=3", "Django.Tasks.DB"]\n',
+            encoding="utf-8",
+        )
+        assert declared_dependency_names(pyproject) == {"django-typer", "django-tasks-db"}
+
+    def test_strips_extras_and_markers(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\n'
+            'dependencies = ["foo[extra]>=1", "bar; python_version < \'4\'", "baz==1.0"]\n',
+            encoding="utf-8",
+        )
+        assert declared_dependency_names(pyproject) == {"foo", "bar", "baz"}
+
+    def test_empty_when_section_missing(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nname = "x"\nversion = "0"\n', encoding="utf-8")
+        assert declared_dependency_names(pyproject) == set()
+
+
+class TestFindMissingDependencies:
+    """Drift detection: declared but not installed."""
+
+    def test_returns_missing_subset(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\ndependencies = ["django", "httpx", "tomlkit"]\n',
+            encoding="utf-8",
+        )
+        with patch(
+            "teatree.utils.dep_drift.installed_distribution_names",
+            return_value={"django", "httpx"},
+        ):
+            assert find_missing_dependencies(pyproject) == ["tomlkit"]
+
+    def test_empty_when_in_sync(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "x"\nversion = "0"\ndependencies = ["django", "httpx"]\n',
+            encoding="utf-8",
+        )
+        with patch(
+            "teatree.utils.dep_drift.installed_distribution_names",
+            return_value={"django", "httpx", "extra"},
+        ):
+            assert find_missing_dependencies(pyproject) == []
+
+
+class TestEditableSourcePath:
+    """Detecting the editable source via PEP 660 ``direct_url.json``."""
+
+    def test_returns_path_when_editable(self, tmp_path: Path) -> None:
+        direct_url = json.dumps(
+            {"url": f"file://{tmp_path}/clone", "dir_info": {"editable": True}},
+        )
+        fake_dist = _FakeDist({"direct_url.json": direct_url})
+        with patch("teatree.utils.dep_drift.distribution", return_value=fake_dist):
+            assert editable_source_path() == Path(f"{tmp_path}/clone")
+
+    def test_returns_none_when_not_editable(self, tmp_path: Path) -> None:
+        direct_url = json.dumps(
+            {"url": f"file://{tmp_path}/clone", "dir_info": {"editable": False}},
+        )
+        fake_dist = _FakeDist({"direct_url.json": direct_url})
+        with patch("teatree.utils.dep_drift.distribution", return_value=fake_dist):
+            assert editable_source_path() is None
+
+    def test_returns_none_when_direct_url_absent(self) -> None:
+        fake_dist = _FakeDist({})
+        with patch("teatree.utils.dep_drift.distribution", return_value=fake_dist):
+            assert editable_source_path() is None
+
+    def test_returns_none_when_direct_url_unparsable(self) -> None:
+        fake_dist = _FakeDist({"direct_url.json": "not json {{{"})
+        with patch("teatree.utils.dep_drift.distribution", return_value=fake_dist):
+            assert editable_source_path() is None
+
+    def test_returns_none_when_url_not_file_scheme(self) -> None:
+        direct_url = json.dumps(
+            {"url": "https://example.com/wheel", "dir_info": {"editable": True}},
+        )
+        fake_dist = _FakeDist({"direct_url.json": direct_url})
+        with patch("teatree.utils.dep_drift.distribution", return_value=fake_dist):
+            assert editable_source_path() is None
+
+
+class _FakeDist:
+    """Stand-in for ``importlib.metadata.Distribution`` exposing ``read_text``."""
+
+    def __init__(self, files: dict[str, str]) -> None:
+        self._files = files
+
+    def read_text(self, name: str) -> str | None:
+        return self._files.get(name)


### PR DESCRIPTION
## Summary

Closes #548. Closes the catch-22 that broke `t3 setup` whenever teatree added a new top-level dep, plus three follow-up fixes the user surfaced during testing.

**Drift detection (the original ticket):**
- `t3 setup` now reads `[project].dependencies` from the resolved main clone, compares against the dists in the running interpreter, and — when an editable install is missing a declared dep — re-runs `uv tool install --editable <source> --reinstall` and `execv`-restarts itself against the refreshed venv.
- Non-editable installs (PyPI/wheel) get a one-line reinstall hint and exit cleanly.
- Detection helpers in `teatree.utils.dep_drift` use only stdlib so the check itself stays usable when teatree's declared deps are partially missing.
- Builds on #547's lazy-import fix: that made `t3 setup` itself loadable; this commit closes the loop so the user never has to know the drift exists.

**Bundled follow-ups:**
- `t3 loop tick` raised `AppRegistryNotReady: Models aren't loaded yet` from `loop/scanners/pending_tasks.py`. Root cause: `cli/loop.py:tick_command` is a plain Typer command but its scanners reach the Django ORM. Fix: call `django.setup()` at the top of `tick_command`, mirroring `cli/config.py:30` and `cli/ci.py:41`.
- `settings.json` `statusLine` hook still pointed at the deleted `statusline-command.sh`; the file was renamed to `statusline.sh` in #543 but the registration wasn't updated. Re-point at the new filename.
- Restore loaded-skills info in the new statusline (lost during the #543 statusline rewrite). The thin `statusline.sh` was ignoring stdin entirely; now it reads `session_id` / `model` / `context_window` from Claude's stdin JSON, looks up loaded skills from `${state_dir}/<session_id>.skills` (still populated by `track-skill-usage.sh` / `hook_router.py`), prepends a single header line, then `cat`s the loop's pre-rendered zones file.

## Test plan

- [x] `tests/test_dep_drift.py` — 17 tests for the detection module
- [x] `tests/test_cli_setup.py::TestRepairDepDrift` — 6 tests for the wiring
- [x] `tests/test_cli_loop.py::TestTickCommand::test_calls_django_setup_before_scanning` — regression
- [x] `tests/test_claude_statusline.py` — 6 integration tests for the hook composition
- [x] Live smoke: `uv run t3 setup` end-to-end on a synced install — happy-path no-op
- [x] Live smoke: `uv run t3 loop tick` — completes without `AppRegistryNotReady`
- [x] Live smoke: `statusline.sh <<< '{"session_id":"abc","model":{...},"context_window":{"used_percentage":34.5}}'` renders model + ctx + skills + loop zones
- [x] README + BLUEPRINT updated