### PR TITLE
docs(skills): rewrite teatree-bughunt + teatree-dogfood for loop era

### DIFF
--- a/skills/teatree-bughunt/SKILL.md
+++ b/skills/teatree-bughunt/SKILL.md
@@ -17,95 +17,119 @@ search_hints:
   - find and fix
 ---
 
-# TeaTree — Bug Hunt Mode (Self-QA on the Dashboard)
+# TeaTree — Bug Hunt Mode (Self-QA on the Loop and Statusline)
 
-A Quick Wins variant where, instead of picking tickets off the board, the agent dogfoods the dashboard, finds bugs, files them, and fixes them in the same session. The user no longer has to play QA.
+A Quick Wins variant where, instead of picking tickets off the board, the agent dogfoods the loop and the rendered statusline, finds bugs, files them, and fixes them in the same session. The user no longer has to play QA.
 
 Shares the Quick Wins family with `/teatree-batch`.
 
 ## Prerequisites
 
-Same as `/teatree-batch` (`ac-python`, `ac-django`, overlay skill loaded). Plus: `t3 dashboard` must boot cleanly from the main clone (no uncommitted in-progress edits blocking startup).
+Same as `/teatree-batch` (`ac-python`, `ac-django`, overlay skill loaded). Plus: at least one overlay registered with credentials that resolve (`t3 teatree loop tick --overlay <name>` must finish without `ImproperlyConfigured`); `~/.local/share/teatree/statusline.txt` writable (the renderer creates the directory if absent).
 
 ## Step 1 — Ask the scope
 
 Use `AskUserQuestion` with three options:
 
 - **Existing** — tackle open issues labelled `bug` from the board (no hunting).
-- **New** — skip the board, dogfood the dashboard, file and fix whatever turns up.
+- **New** — skip the board, dogfood the loop, file and fix whatever turns up.
 - **Both** — existing first (they've already been triaged), then hunt for new ones.
 
 Never silently pick one. The choice changes the workload materially.
 
-## Step 2 — Launch the dashboard (New / Both)
+## Step 2 — Run a tick (New / Both)
 
 From the main clone — NOT a worktree. The goal is to QA the deployed state.
 
 ```bash
 cd "$T3_REPO"
-t3 dashboard &
-DASHBOARD_PID=$!
-# Wait for HTTP 200 before inspecting
-until curl -sf http://127.0.0.1:8000/ > /dev/null; do sleep 1; done
+
+# One ad-hoc multi-overlay tick. JSON output is the structured surface; the
+# rendered file is the user-visible surface. Inspect both.
+t3 teatree loop tick --json > /tmp/tick.json
+cat "${XDG_DATA_HOME:-$HOME/.local/share}/teatree/statusline.txt"
+
+# Single-overlay diagnosis when a multi-overlay tick reports errors:
+t3 teatree loop tick --overlay <name>
 ```
 
-Remember the PID — kill it at the end.
+`tick.json` has `signal_count`, `action_count`, `errors`, and `actions[]` — the structured contract. The statusline file is the formatted contract — three zones (anchors / action_needed / in_flight), ANSI-coloured, OSC 8 hyperlinks where signals carry a `url` payload.
 
-## Step 3 — Inspect every view
+## Step 3 — Inspect both surfaces
 
-**Preferred tool:** Chrome DevTools MCP (`mcp__chrome-devtools__*`) if loaded — it gives live DOM, JS console errors, network failures, and screenshots. Fall back to `WebFetch` per URL if the MCP is unavailable. Raw `curl` HTML is last resort because dynamic content won't render.
+Walk the output of the tick **and** the rendered statusline. The tick must agree with what the user actually sees at the bottom of their session.
 
-Walk every view in the dashboard IA. For each list page, also open 2–3 detail pages. Focus on:
+**Structured (`tick.json` / `t3 teatree loop status`):**
 
-- **Tickets list / detail** — counts match DB? `overlay`, `variant`, `status`, `repos` populated? Links work?
-- **Worktrees list / detail** — FSM `state` coherent with filesystem? Ports shown? No duplicates from stale rows?
-- **Sessions list / detail** — visited phases match the `Session` record? Repos modified/tested populated?
-- **Task queue** — PENDING + CLAIMED + DONE counts add up to total? No stuck leases (CLAIMED with stale heartbeat)?
-- **Review / PR views** — action buttons match item state? (e.g., a "request review" action must not appear for already-merged MRs; a "waiting for my review" list must offer a "start review" affordance).
-- **Followup views** — sync status fresh? No orphan tickets?
+- `errors` is empty. Any entry like `"my_prs[teatree]": "AuthError: ..."` is bug #1 — surface it before doing anything else.
+- `signal_count` and `action_count` are non-zero when the registered overlays have open work. A clean inbox is plausible; a 0/0 tick on an overlay you know has open PRs is a scanner bug.
+- Every scanner that should run on the active overlay shows up: `pending_tasks` (always, no overlay tag), `my_prs[<overlay>]`, `reviewer_prs[<overlay>]`, `assigned_issues[<overlay>]`, `slack_mentions[<overlay>]` if messaging is configured, `notion_view` if a Notion client is wired. A missing scanner with no error means the overlay declared it but the loop dropped it — file it.
+- Every signal kind in the JSON is one the dispatcher knows about (see § "Reference"). An unknown kind silently falls through to `in_flight` — that's a bug, not a feature.
+
+**Rendered (`statusline.txt`):**
+
+- Anchor line first, dim grey, with `tick @ <iso>`. Missing → renderer broken.
+- Action-needed lines bright red, in-flight bright cyan. If a `my_pr.failed` ends up cyan, the zone map drifted.
+- Lines with a `url` payload render as OSC 8 hyperlinks — the raw bytes are `\033]8;;<url>\033\\<text>\033]8;;\033\\`. A line with a URL in JSON but **no** OSC 8 in the file is a render bug. (Run `od -c ~/.local/share/teatree/statusline.txt | head` if your terminal hides escapes.)
+- Multi-overlay ticks prefix lines with `[<overlay>]`. A signal with `payload.overlay = "teatree"` and no `[teatree]` prefix is a `_zones_for` bug.
+- `NO_COLOR=1 t3 teatree loop tick --statusline-file /tmp/x.txt` — the file must contain no `\033` bytes and URLs must fall back to `text <url>`.
 
 ### What counts as a bug (file it)
 
-- **Missing items** that should appear (empty list when DB has rows).
-- **Extra items** that shouldn't appear (stale entries, soft-deleted rows leaking through).
-- **Corrupted / stale data** (timestamps in the wrong tz, nulls where the DB has a value, counts that don't match the underlying query).
-- **State / action mismatch** — action offered that can't apply to the item's current state (e.g. "post Slack review request" on a merged MR, "approve" on a draft), or expected action missing (e.g. no "start review" button on an MR assigned to the user).
-- **Broken links / 500s / 404s / JS console errors.**
-- **Layout glitches** that block interaction (button offscreen, modal can't close).
+- **Scanner error in `report.errors`** — anything other than transient network failures. Tag the scanner+overlay in the title.
+- **Missing signal** — open PR on the code host, ticket assigned to the user, fresh Slack mention, but the corresponding scanner emits nothing. Reproduce first, then file.
+- **Wrong zone** — `my_pr.failed` rendered in `in_flight`, `slack.mention` rendered in `anchors`, etc. Cross-reference `_STATUSLINE_ZONE_BY_KIND` in `src/teatree/loop/dispatch.py`.
+- **Broken hyperlink** — text URL where OSC 8 expected, OSC 8 wrapping the wrong text, hyperlink that points at the wrong PR.
+- **Stale or duplicated entries** — same PR rendered twice, a closed PR still in `in_flight`, a merged PR in `action_needed`.
+- **Multi-overlay leak** — a signal from one overlay rendered without (or with the wrong) `[overlay]` prefix; identical PRs from two overlays collapsed into one line.
+- **Anchor / counter mismatch** — `signal_count` in JSON differs from the number of zone entries; `errors` non-empty but no "scanner errors:" line in `action_needed`.
+- **Crash / non-zero exit** — `t3 teatree loop tick` raising a traceback to stderr is bug #1.
 
 ### What does NOT count (don't file)
 
-- Subjective UX preferences, cosmetic nits with no functional impact.
-- Feature requests (file separately with label `enhancement`, don't mix into the bug batch).
-- Flakes that don't reproduce on a second load — note them, re-check at the end.
+- Empty zones on a quiet day.
+- Subjective preferences about line phrasing or color choices (raise as enhancement, not bug).
+- Transient network flakes (retry once; if it doesn't reproduce after 2 ticks, drop).
+- Terminal-specific rendering quirks (some terminals don't honour OSC 8 — that's a terminal limitation, not a teatree bug, unless we're feeding it malformed escapes).
 
 ## Step 4 — Present findings before filing
 
-List every bug with: page URL, symptom (concrete: what you saw vs. what you expected), probable cause if you can tell from a quick code scan, severity (blocker / high / medium / low). Ask the user to confirm the list — this waives the standing "never create tickets without asking" rule **only for the confirmed batch**.
+List every bug with: source (`tick.json` field path, or statusline byte offset), symptom (what you saw vs. what you expected), probable cause if a quick `rg` makes it obvious, severity (blocker / high / medium / low). Ask the user to confirm the list — this waives the standing "never create tickets without asking" rule **only for the confirmed batch**.
 
-Dedupe aggressively: if three findings share one root cause, file one ticket with all three symptoms listed.
+Dedupe aggressively: if three findings share one root cause (one stale signal kind, one zone-map typo), file one ticket with all three symptoms listed.
 
 ## Step 5 — File and implement
 
 For each confirmed bug, in severity order:
 
-1. `gh issue create` with label `bug`, clear reproduction steps, severity.
+1. `gh issue create` with label `bug`, clear reproduction (paste the relevant `tick.json` excerpt and the rendered statusline line), severity, and the scanner / module to look at.
 2. Add to the project board.
-3. Implement per `/teatree-batch` rules (worktree via `t3 teatree workspace ticket`, TDD, `t3:reviewer` sub-agent, sequential merge).
+3. Implement per `/teatree-batch` rules (worktree via `t3 teatree workspace ticket`, TDD against the existing scanner/dispatch tests in `tests/teatree_loop/`, `t3:reviewer` sub-agent, sequential merge).
 4. Close the issue via the PR.
 
 ## Step 6 — Tear down
 
-```bash
-kill "$DASHBOARD_PID" 2>/dev/null
-pkill -f "uvicorn teatree.asgi" 2>/dev/null
-```
+Nothing to kill. Delete any temp files you wrote during inspection (`/tmp/tick.json`, `/tmp/x.txt`).
 
 Report: bugs found, filed, fixed, skipped (with reasons).
 
+## Reference — scanners, signal kinds, zones
+
+Verify against the source before quoting in a bug report — these can drift.
+
+- **Scanners** (`src/teatree/loop/scanners/`): `pending_tasks`, `my_prs`, `reviewer_prs`, `assigned_issues`, `slack_mentions`, `notion_view`. The first five run per-overlay when their backend is available; `pending_tasks` and `notion_view` run once.
+- **Signal kinds** → **default zone / agent** (see `src/teatree/loop/dispatch.py`):
+  - `my_pr.failed`, `my_pr.draft_notes` → `action_needed`
+  - `my_pr.open` → `in_flight`
+  - `slack.mention`, `slack.dm` → `action_needed` (also dispatched to `t3:reviewer` when the message body contains a PR URL)
+  - `reviewer_pr.new_sha`, `reviewer_pr.unreviewed` → agent `t3:reviewer`
+  - `pending_task`, `assigned_issue.ready` → agent `t3:orchestrator`
+  - `notion.unrouted` → webhook `n8n`
+  - Any unknown kind → `in_flight` (silent fallback — flag it)
+
 ## Rules
 
-- The dashboard runs from the main clone, but all **fixes** happen in worktrees — don't edit the main clone.
-- Bound the hunt: one pass through every top-level view. Don't spiral into exhaustive edge-case exploration — if a view looks fine on a first careful pass, move on.
-- If the dashboard won't boot, that's bug #1 — file and fix it before continuing.
-- Chrome DevTools MCP screenshots belong in the issue body when the bug is visual.
+- The tick runs from the main clone, but all **fixes** happen in worktrees — don't edit the main clone.
+- Bound the hunt: one pass through the JSON + rendered file. Don't loop the tick more than 2–3 times for the same scope — repeated ticks change `last_reviewed_sha` caches and other state.
+- If `t3 teatree loop tick` won't run, that's bug #1 — file and fix it before continuing.
+- Paste the relevant byte sequence in the issue body when the bug is render-shape (OSC 8, ANSI). `od -c` output is more useful than a screenshot here.

--- a/skills/teatree-dogfood/SKILL.md
+++ b/skills/teatree-dogfood/SKILL.md
@@ -8,31 +8,54 @@ triggers:
   priority: 85
   keywords:
     - '\b(dogfood|dogfooding)\b'
-    - '\b(cli change|dashboard change|server startup|manage\.py change)\b'
-  exclude: '\b(dogfood the dashboard|bug hunt|self[- ]qa)\b'
+    - '\b(cli change|loop change|statusline change|scanner change|manage\.py change)\b'
+  exclude: '\b(dogfood the loop|bug hunt|self[- ]qa)\b'
 search_hints:
   - dogfood
   - dogfooding
   - cli change
-  - dashboard change
-  - server startup
+  - loop change
+  - statusline change
+  - scanner change
   - validation checklist
 ---
 
-# TeaTree — Dogfooding Checklist (CLI/Server Changes)
+# TeaTree — Dogfooding Checklist (CLI / Loop / Statusline Changes)
 
-Apply this checklist whenever you modify CLI commands, dashboard views, or server startup. Unit tests alone are insufficient — teatree's failure modes are cwd-, process-, and install-sensitive.
+Apply this checklist whenever you modify CLI commands, loop scanners, dispatch logic, or statusline rendering. Unit tests alone are insufficient — teatree's failure modes are cwd-, process-, install-, and overlay-sensitive, and the statusline only hits the user's eyes once it has been rendered to disk.
 
-1. **Run the command yourself** — `t3 <command>` from a worktree (not the main clone) to catch cwd-dependent bugs.
-2. **Verify HTTP 200** — for dashboard/server changes: `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:<port>/` must return 200.
-3. **Run E2E tests** — dashboard changes require Playwright E2E tests in `e2e/test_dashboard.py`. **Pre-flight:** kill any zombie servers first (`pkill -9 -f "uvicorn teatree.asgi"; pkill -9 -f "chrome-headless"; pkill -9 -f "playwright/driver"`). Then: `DJANGO_SETTINGS_MODULE=e2e.settings uv run pytest e2e/ --ds e2e.settings --no-cov -v`. Each timed-out run leaves zombie processes — kill before retrying. For full-suite validation prefer CI (clean environment, ~seconds/test vs. 7+ min locally on a loaded machine).
-4. **Test the full flow** — if the change involves task execution, create a task and verify the worker picks it up. Don't declare "auto-start works" without observing a task transition from PENDING to CLAIMED.
-5. **Check overlay resolution from worktrees** — `discover_active_overlay()` uses cwd-based discovery. Worktree directory names don't match overlay names. Always test from a worktree path, not the main clone.
+## Run-it-yourself checklist
+
+1. **Run the CLI from a worktree** — `cd $T3_WORKSPACE_DIR/<branch>/teatree && t3 teatree <command>`. Worktree directory names don't match overlay names, so cwd-based discovery exercises the entry-point fallback (see § Pitfalls).
+2. **Tick the loop and read the file** — for any change touching `loop/`, `scanners/`, `dispatch/`, or `statusline/`:
+
+   ```bash
+   t3 teatree loop tick --statusline-file /tmp/sl.txt --json | jq .
+   cat /tmp/sl.txt          # what the user sees
+   od -c /tmp/sl.txt | head # what's actually in the bytes (ANSI / OSC 8)
+   ```
+
+   The JSON is the structured contract; the file is the rendered contract. Both must match the change you intended.
+3. **Exercise both color paths** — `NO_COLOR=1 t3 teatree loop tick --statusline-file /tmp/sl-nc.txt && grep -c $'\033' /tmp/sl-nc.txt` must return `0`. Without `NO_COLOR`, the file must contain `\033[2;37m` (anchors), `\033[1;31m` (action_needed), or `\033[1;36m` (in_flight) when the matching zone is non-empty.
+4. **Exercise both overlay paths** when you have more than one overlay registered:
+   - `t3 teatree loop tick` (no flag) → multi-overlay; rendered lines prefixed with `[<overlay>]`.
+   - `t3 teatree loop tick --overlay <name>` → single overlay; lines unprefixed.
+5. **Exercise the full task lifecycle** when the change touches task execution. Create a task, run a tick, verify the worker picks it up. Don't declare "auto-start works" without observing a task transition from PENDING → CLAIMED → DONE in the DB.
+6. **Verify the OSC 8 hyperlinks render** in your real terminal (iTerm2, Kitty, WezTerm, Ghostty), not just in the byte stream. A click-through that lands on the wrong URL is a render bug; a click-through that opens nothing is a terminal limitation worth noting.
+7. **Confirm the Claude Code statusline hook is wired** — `cat ~/.claude/settings.json | jq .statusLine.command` should point at `hooks/scripts/statusline.sh` (either via plugin or hand-wired). The hook is just a `cat` of `${XDG_DATA_HOME:-$HOME/.local/share}/teatree/statusline.txt` — if the bottom bar is blank, the hook is the first thing to check.
 
 ## Known Pitfalls
-
-**`discover_active_overlay()` returns the wrong name in worktrees.** The function walks cwd looking for `manage.py` and returns the directory name. In worktrees, this gives names like `move-dashboard-to-general-cli` instead of `t3-teatree`. The `_resolve_overlay_for_server()` function in `cli/__init__.py` works around this by preferring entry-point overlays.
 
 **`uv run` silently reverts uncommitted edits.** It rebuilds editable installs on every invocation. See `workspace/references/troubleshooting.md` § "uv run Silently Reverts Edits". Commit changes before running `uv run pytest`, or re-read the file after the run to verify content survived.
 
 **`git stash` + `git checkout <other-branch>` silently loses edits.** Stash pop can restore a stale file version that appears current (inode mtime doesn't change) but isn't. Symptom: edits look gone, or tests run against an in-memory version while disk has older content. Fix: always use separate worktrees, never `git stash`.
+
+**`discover_active_overlay()` returns the wrong name in worktrees.** The function walks cwd looking for `manage.py` and returns the directory name. In worktrees, this gives names like `ac-teatree-541-follow-up-...` instead of `teatree`. The `_resolve_overlay_for_server()` function in `cli/__init__.py` works around this by preferring entry-point overlays. Always test from a worktree path so this code path actually runs.
+
+**Single-overlay tick caches.** `code_host_from_overlay()` and `messaging_from_overlay()` are `lru_cache`d for the whole process. After swapping overlay credentials in tests or local config, call `reset_backend_caches()` (or restart the process) — otherwise the next tick reuses the stale client and you'll think your edit didn't take.
+
+**OSC 8 escapes hidden by terminals.** Some terminals (Terminal.app, basic xterm) honour the OSC 8 sequence by silently absorbing it without rendering it as a hyperlink — and `cat` always shows the underlying text. If you're checking that hyperlinks were emitted, use `od -c` on the file, not eyeball the rendered output.
+
+**`statusline.txt` is owner-readable only.** The renderer writes via `tempfile.mkstemp` + `Path.replace`, which leaves the file at the mkstemp default of `0o600`. If you copied the file to a shared path for inspection (don't), permissions will surprise you.
+
+**`T3_OVERLAY_NAME` env override**. The anchor line appends the env var when set. If you exported it once for a debugging session, every later tick will keep showing it — `unset T3_OVERLAY_NAME` before a multi-overlay tick or you'll think the multi-overlay path is broken.


### PR DESCRIPTION
## Summary

The descriptions of `teatree-bughunt` and `teatree-dogfood` got refreshed for the loop era in #552, but the skill bodies still walked through dashboard QA — boot `t3 dashboard`, `curl` HTTP 200, kill the uvicorn pid at the end, run Playwright against `e2e/test_dashboard.py`. None of that exists since #541. This PR rewrites both bodies so the loops actually exercise what teatree ships now.

**bughunt** — replaces the per-dashboard-view inspection list with a two-surface check: `t3 teatree loop tick --json` for the structured contract, and the rendered `statusline.txt` for the user-visible contract. New bug categories match the loop's actual failure modes (scanner error in `report.errors`, missing signal, wrong dispatch zone, broken OSC 8 hyperlink, multi-overlay leak, anchor / counter mismatch). Adds a reference table of scanners → signal kinds → zones/agents so the filer can sanity-check against `src/teatree/loop/dispatch.py`.

**dogfood** — replaces the HTTP-200 + Playwright-against-dashboard checklist with the run-it-yourself checks that actually catch loop and statusline regressions: tick from a worktree, read both the JSON and the rendered file (`od -c` for byte-level), exercise both color paths (`NO_COLOR=1` must yield zero `\033` bytes), exercise the multi-overlay vs `--overlay` paths, and confirm the Claude Code statusline hook points at `hooks/scripts/statusline.sh`. Pitfalls kept: `uv run` editable rebuild, `git stash`, `discover_active_overlay` worktree quirk. New ones added: `code_host_from_overlay` lru_cache bite, OSC 8 escapes silently absorbed by some terminals, `tempfile.mkstemp` 0o600 default, stale `T3_OVERLAY_NAME` env from prior debug sessions.

## Test plan

- [x] markdownlint clean (prek hook auto-formatted the markdown — committed)
- [x] Frontmatter unchanged from #552; only bodies edited
- [x] Cross-referenced every quoted command, signal kind, env var, and file path against current `src/teatree/loop/`:
  - scanners enumerated match `src/teatree/loop/scanners/*.py`
  - signal kinds match `kind=` literals in scanners + `_AGENT_BY_KIND` / `_STATUSLINE_ZONE_BY_KIND` in `dispatch.py`
  - statusline path matches `default_path()` in `loop/statusline.py` (no `TEATREE_STATUSLINE_FILE` — the env var doesn't exist; removed earlier draft that referenced it)
  - file mode 0o600 matches `tempfile.mkstemp` default; verified with `stat -f '%Sp' ~/.local/share/teatree/statusline.txt`

Relates-to #19 (local TODO — body half of the bughunt/dogfood pivot started in #552).