### PR TITLE
chore(overlay): rename mr_auto_labels → pr_auto_labels

### DIFF
--- a/docs/overlay-api.md
+++ b/docs/overlay-api.md
@@ -44,7 +44,7 @@ Set these as `UPPER_CASE` constants in a settings module, or as `lower_case` key
 | `github_project_number` | `0` | GitHub Projects v2 board number |
 | `require_ticket` | `False` | Whether to enforce a tracked issue before coding/shipping |
 | `known_variants` | `[]` | Tenant variant identifiers |
-| `mr_auto_labels` | `[]` | Labels auto-applied to merge requests |
+| `pr_auto_labels` | `[]` | Labels auto-applied to pull requests (GitLab MRs translated at the API edge) |
 | `frontend_repos` | `[]` | Frontend repo names (for build steps) |
 | `workspace_repos` | `[]` | Repo paths relative to `workspace_dir` (supports nested paths) |
 | `protected_branches` | `[]` | Branch names that should never be deleted during cleanup |

--- a/skills/workspace/references/extension-points.md
+++ b/skills/workspace/references/extension-points.md
@@ -37,7 +37,7 @@ Settings are defined in `overlay_settings.py` and overridden per-user in `~/.tea
 | `get_review_channel()` | `REVIEW_CHANNEL_ID/NAME` | Review request target |
 | `gitlab_url` | `GITLAB_URL` | GitLab instance base URL |
 | `known_variants` | `KNOWN_VARIANTS` | Multi-tenant variant list |
-| `mr_auto_labels` | `MR_AUTO_LABELS` | Labels applied to new MRs |
+| `pr_auto_labels` | `PR_AUTO_LABELS` | Labels applied to new PRs |
 | `frontend_repos` | `FRONTEND_REPOS` | Repos that need E2E tests |
 | `dev_env_url` | `DEV_ENV_URL` | Development environment URL |
 | `dashboard_logo` | `DASHBOARD_LOGO` | Custom dashboard branding |

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -106,7 +106,7 @@ class OverlayConfig:
     so merging the PR does not auto-close the linked issue.
     """
     known_variants: list[str]
-    mr_auto_labels: list[str]
+    pr_auto_labels: list[str]
     frontend_repos: list[str]
     workspace_repos: list[str]
     protected_branches: list[str]
@@ -115,7 +115,7 @@ class OverlayConfig:
     def __init__(self, settings_module: str = "", overlay_name: str = "") -> None:
         # Initialize mutable defaults per-instance
         self.known_variants = []
-        self.mr_auto_labels = []
+        self.pr_auto_labels = []
         self.frontend_repos = []
         self.workspace_repos = []
         self.protected_branches = []

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -30,7 +30,7 @@ def sanitize_close_keywords(description: str, *, close_ticket: bool) -> str:
 
 
 def overlay_pr_labels() -> list[str]:
-    raw = get_overlay().config.mr_auto_labels
+    raw = get_overlay().config.pr_auto_labels
     if isinstance(raw, str):
         values: Iterable[str] = raw.split(",")
     elif isinstance(raw, Iterable):

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -182,19 +182,19 @@ class TestSanitizeCloseKeywords:
         assert sanitize_close_keywords("Closes #123", close_ticket=True) == "Closes #123"
 
 
-class TestOverlayMrLabels:
+class TestOverlayPrLabels:
     def test_default_overlay_returns_empty(self) -> None:
         with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
             assert overlay_pr_labels() == []
 
     def test_overlay_with_string_labels(self) -> None:
         mock = MagicMock()
-        mock.config.mr_auto_labels = "label-a, label-b"
+        mock.config.pr_auto_labels = "label-a, label-b"
         with patch("teatree.core.overlay_loader._discover_overlays", return_value={"test": mock}):
             assert overlay_pr_labels() == ["label-a", "label-b"]
 
     def test_non_iterable_returns_empty(self) -> None:
         mock = MagicMock()
-        mock.config.mr_auto_labels = 42
+        mock.config.pr_auto_labels = 42
         with patch("teatree.core.overlay_loader._discover_overlays", return_value={"test": mock}):
             assert overlay_pr_labels() == []


### PR DESCRIPTION
## Summary

Bring the overlay-config field name in line with the rest of core: PR is canonical (BLUEPRINT § 5.6, § 7.1, § 8); GitLab MRs are translated at the Protocol edge. BLUEPRINT § 10.2.1 already documented \`pr_auto_labels\`; the code was lagging.

## Renamed together

- \`OverlayConfig.mr_auto_labels\` → \`pr_auto_labels\` (\`src/teatree/core/overlay.py\`)
- The runner that reads it (\`src/teatree/core/runners/ship.py\`)
- The upstream test class \`TestOverlayMrLabels\` → \`TestOverlayPrLabels\` and its mock attribute writes (\`tests/teatree_core/test_runners_ship.py\`)
- Workspace skill extension-point row: \`MR_AUTO_LABELS\` → \`PR_AUTO_LABELS\`, "applied to new MRs" → "applied to new PRs" (\`skills/workspace/references/extension-points.md\`)
- Overlay-API doc row (\`docs/overlay-api.md\`)

## Breaking change

Downstream overlays must rename their settings constant from \`MR_AUTO_LABELS\` to \`PR_AUTO_LABELS\` so \`OverlayConfig._load_settings()\` still populates the field. The first-party t3-company overlay gets a companion PR; third parties need the same one-line edit (the same line — \`MR_AUTO_LABELS = [...]\` becomes \`PR_AUTO_LABELS = [...]\`).

No backward-compat shim — per project policy of not carrying compat aliases (CLAUDE.md "No tech debt without explicit approval").

## Test plan

- [x] \`pytest tests/teatree_core/test_runners_ship.py\` — 20 passed locally.
- [x] Pre-commit hooks green (ruff, ty-check, banned-terms, blueprint-sync, conventional-commit).
- [x] Pre-push hooks green (Docker test matrix, ensure-PR-exists).
- [ ] CI green on the PR.