### PR TITLE
feat(overlay): add get_e2e_env_extras hook for overlay-specific Playwright env

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -628,6 +628,7 @@ Defined in `teatree.core.overlay`. All methods receive the `worktree` instance f
 | `get_workspace_repos()` | `→ list[str]` | `get_repos()` | Repos for workspace ticket creation |
 | `get_tool_commands()` | `→ list[ToolCommand]` | `[]` | Overlay-specific CLI tools |
 | `get_visual_qa_targets(changed_files)` | `→ list[str]` | `[]` | URL paths the pre-push browser sanity gate should load |
+| `get_e2e_env_extras(env_cache)` | `→ dict[str, str]` | `{}` | Overlay-specific env vars merged into the Playwright environment (e.g. `WT_VARIANT`→`CUSTOMER`) |
 | `get_e2e_preflight(customer, base_url)` | `→ list[Callable[[], None]]` | `[]` | Pre-Playwright gates; each callable raises `RuntimeError` on failure |
 
 ### 6.2 Supporting TypedDicts

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -74,6 +74,8 @@ Overlays subclass `OverlayBase` and override methods:
 - `get_db_import_strategy(worktree)` — DSLR/dump import config
 - `get_services_config(worktree)` — Docker services
 - `get_visual_qa_targets(changed_files)` — URL paths the pre-push browser sanity gate should load (default: `[]` — opt in by mapping diff paths to URLs)
+- `get_e2e_env_extras(env_cache)` — overlay-specific env vars merged into the Playwright environment (e.g. map `WT_VARIANT` → `CUSTOMER`); default `{}`
+- `get_e2e_preflight(customer, base_url)` — pre-Playwright gates that fail fast on auth/SSO/network issues; default `[]`
 
 ## Skill Loading
 

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -122,21 +122,23 @@ def _discover_frontend_port(project: str, default: int = 4200) -> int | None:
 
 
 def _build_e2e_env(frontend_url: str | None = None, *, headed: bool) -> dict[str, str]:
-    """Build environment dict for Playwright: BASE_URL, CUSTOMER, CI.
+    """Build environment dict for Playwright: ``BASE_URL``, overlay extras, ``CI``.
 
     When *frontend_url* is given it overrides ``BASE_URL``.
     When it is ``None`` the existing ``BASE_URL`` env var is preserved (DEV / staging mode).
+
+    Overlay-specific env vars (e.g. ``CUSTOMER``) come from
+    :meth:`OverlayBase.get_e2e_env_extras` — core only knows about ``BASE_URL``
+    and ``CI``.
     """
     env = {**os.environ}
     if frontend_url is not None:
         env["BASE_URL"] = frontend_url
 
-    if "CUSTOMER" not in env:
-        envfile = _find_env_cache(_get_user_cwd())
-        if envfile is not None:
-            variant = _parse_env_file(envfile).get("WT_VARIANT", "")
-            if variant:
-                env["CUSTOMER"] = variant
+    envfile = _find_env_cache(_get_user_cwd())
+    env_cache = _parse_env_file(envfile) if envfile is not None else {}
+    for key, value in get_overlay().get_e2e_env_extras(env_cache).items():
+        env.setdefault(key, value)
 
     if headed:
         env.pop("CI", None)

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -386,6 +386,20 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
     def get_test_command(self, worktree: "Worktree") -> list[str] | RunCommand:
         return []
 
+    def get_e2e_env_extras(self, env_cache: dict[str, str]) -> dict[str, str]:
+        """Return overlay-specific env vars to add to the Playwright environment.
+
+        Receives the parsed worktree env cache (``.t3-env.cache``). Use this to
+        derive overlay-specific vars Playwright tests need (e.g. ``CUSTOMER``
+        from ``WT_VARIANT``). Existing values in ``os.environ`` win — this hook
+        only fills in missing keys. Default: no extras.
+
+        Keeps overlay-specific naming conventions (variant→customer, tenant→client)
+        out of core; each overlay owns its own mapping.
+        """
+        _ = env_cache
+        return {}
+
     def get_e2e_preflight(self, *, customer: str | None, base_url: str | None) -> list[Callable[[], None]]:
         """Return preflight checks to run before launching the external Playwright suite.
 

--- a/tests/teatree_core/conftest.py
+++ b/tests/teatree_core/conftest.py
@@ -45,6 +45,10 @@ class CommandOverlay(OverlayBase):
 
         return [ProvisionStep(name=f"pre-run-{service}", callable=remember_pre_run)]
 
+    def get_e2e_env_extras(self, env_cache: dict[str, str]) -> dict[str, str]:
+        variant = env_cache.get("WT_VARIANT", "")
+        return {"CUSTOMER": variant} if variant else {}
+
 
 COMMAND_OVERLAY = "tests.teatree_core.conftest.CommandOverlay"
 

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -132,6 +132,10 @@ class FullOverlay(OverlayBase):
     def get_compose_file(self, worktree: Worktree) -> str:
         return "/fake/docker-compose.yml"
 
+    def get_e2e_env_extras(self, env_cache: dict[str, str]) -> dict[str, str]:
+        variant = env_cache.get("WT_VARIANT", "")
+        return {"CUSTOMER": variant} if variant else {}
+
 
 class ServicesOverlay(FullOverlay):
     """Overlay with services config — used to test _start_services."""

--- a/tests/teatree_core/test_run_command.py
+++ b/tests/teatree_core/test_run_command.py
@@ -234,6 +234,7 @@ class TestE2eExternalCommand(TestCase):
                         "T3_ORIG_CWD": str(worktree_dir),
                     },
                 ),
+                patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
                 patch.object(e2e_mod, "get_service_port", return_value=4299),
                 patch.object(utils_run_mod.subprocess, "run", side_effect=fake_run),
             ):

--- a/tests/test_overlay_base.py
+++ b/tests/test_overlay_base.py
@@ -49,6 +49,12 @@ def test_get_e2e_preflight_returns_empty_list_by_default():
     assert overlay.get_e2e_preflight(customer=None, base_url=None) == []
 
 
+def test_get_e2e_env_extras_returns_empty_dict_by_default():
+    overlay = _MinimalOverlay()
+    assert overlay.get_e2e_env_extras({}) == {}
+    assert overlay.get_e2e_env_extras({"WT_VARIANT": "acme"}) == {}
+
+
 def test_get_db_import_strategy_returns_none():
     overlay = _MinimalOverlay()
     assert overlay.get_db_import_strategy(_make_worktree()) is None


### PR DESCRIPTION
## Summary
- Add new `OverlayBase.get_e2e_env_extras(env_cache: dict[str, str]) -> dict[str, str]` extension point so overlays own their naming conventions (variant→customer, tenant→client) instead of leaking them into core.
- `core/e2e.py:_build_e2e_env` now reads the worktree env cache, passes it to `overlay.get_e2e_env_extras(env_cache)`, and merges the result with `setdefault` (existing values in `os.environ` win).
- Removes the COMPANY-specific `WT_VARIANT → CUSTOMER` mapping from core; t3-company companion PR (company-fork-org/t3-company) overrides the new hook.
- BLUEPRINT.md § 6.1 and `skills/teatree/SKILL.md` updated; new default-behaviour test in `tests/test_overlay_base.py`; existing fixtures (`FullOverlay`, `CommandOverlay`) override the hook so the existing assertions still validate the wiring.

## Test plan
- [x] `uv run pytest tests/test_overlay_base.py tests/teatree_core/test_new_management_commands.py tests/teatree_core/test_run_command.py --no-cov` (full local pass)
- [x] Pre-push docker matrix (`prek`)

Closes part of #530's Phase 8 cleanup.