### PR TITLE
fix(docs): update BLUEPRINT scanner count and directory tree after #560

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -6,7 +6,7 @@ If the entire `src/` and `tests/` tree were deleted, this document alone — plu
 
 **Change policy:** Every code change to teatree must be reflected here. Before modifying this file, always ask the user for approval — this is the source of truth and the user validates every change.
 
-**Status:** This BLUEPRINT is the **current** architecture under issue [#541](https://github.com/souliane/teatree/issues/541). All phases (0-8) have shipped on the active branch. The statusline file is the persistent UI surface; the HTML dashboard, ttyd web terminal, ASGI/uvicorn scaffolding, and platform autostart helpers are gone; the code-host + messaging Protocols are unified, with `SlackBotBackend`/`NoopMessagingBackend` selectable via overlay config; `t3 setup slack-bot --overlay <name>` walks the user through Slack app registration; the fat loop + 6 scanners + dispatcher are wired through `t3 loop tick` (review-channel scanning is folded into the dispatcher's PR-URL detection); the headless executor is the deliberately-slim `claude -p` swap point for a future Anthropic SDK runtime; and the no-overlay-leak gate keeps the platform tenant-agnostic.
+**Status:** This BLUEPRINT is the **current** architecture under issue [#541](https://github.com/souliane/teatree/issues/541). All phases (0-8) have shipped on the active branch. The statusline file is the persistent UI surface; the HTML dashboard, ttyd web terminal, ASGI/uvicorn scaffolding, and platform autostart helpers are gone; the code-host + messaging Protocols are unified, with `SlackBotBackend`/`NoopMessagingBackend` selectable via overlay config; `t3 setup slack-bot --overlay <name>` walks the user through Slack app registration; the fat loop + 7 scanners + dispatcher are wired through `t3 loop tick` (review-channel scanning is folded into the dispatcher's PR-URL detection); the headless executor is the deliberately-slim `claude -p` swap point for a future Anthropic SDK runtime; and the no-overlay-leak gate keeps the platform tenant-agnostic.
 
 ---
 
@@ -158,6 +158,7 @@ src/teatree/
       notion_view.py
       assigned_issues.py
       pending_tasks.py
+      ticket_dispositions.py
 
   backends/             # Pluggable external service integrations
     protocols.py        # Protocol classes (see §7)

--- a/tests/teatree_loop/test_assigned_issues_db.py
+++ b/tests/teatree_loop/test_assigned_issues_db.py
@@ -25,12 +25,12 @@ class _Host:
         return self.issues
 
     # The scanner never calls these but the Protocol requires them.
-    def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
-        _ = author
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
         return []
 
-    def list_review_requested_prs(self, *, reviewer: str) -> list[RawAPIDict]:
-        _ = reviewer
+    def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (reviewer, updated_after)
         return []
 
     def create_pr(self, spec: Any) -> RawAPIDict:

--- a/tests/teatree_loop/test_scanners.py
+++ b/tests/teatree_loop/test_scanners.py
@@ -26,12 +26,12 @@ class FakeCodeHost:
     def current_user(self) -> str:
         return self.user
 
-    def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
-        _ = author
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
         return self.my_prs
 
-    def list_review_requested_prs(self, *, reviewer: str) -> list[RawAPIDict]:
-        _ = reviewer
+    def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (reviewer, updated_after)
         return self.review_requested_prs
 
     def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:

--- a/tests/teatree_loop/test_ticket_dispositions.py
+++ b/tests/teatree_loop/test_ticket_dispositions.py
@@ -21,12 +21,12 @@ class _Host:
     def current_user(self) -> str:
         return self.user
 
-    def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
-        _ = author
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
         return []
 
-    def list_review_requested_prs(self, *, reviewer: str) -> list[RawAPIDict]:
-        _ = reviewer
+    def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (reviewer, updated_after)
         return []
 
     def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:


### PR DESCRIPTION
## Summary

Post-review fixes for [#541](https://github.com/souliane/teatree/issues/541) phase 7 landing (#560):

- BLUEPRINT status banner: "6 scanners" → "7 scanners"
- BLUEPRINT directory tree: add missing `ticket_dispositions.py` under `scanners/`
- Align test fakes (`test_scanners.py`, `test_assigned_issues_db.py`, `test_ticket_dispositions.py`) with `CodeHostBackend` Protocol's `updated_after: str | None = None` parameter

## Test plan

- [x] `uv run pytest tests/teatree_loop/ --no-cov -q` — 95 passed
- [x] Full prek matrix green