### PR TITLE
feat: launch host processes after docker compose in worktree start

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -6,7 +6,7 @@ If the entire `src/` and `tests/` tree were deleted, this document alone — plu
 
 **Change policy:** Every code change to teatree must be reflected here. Before modifying this file, always ask the user for approval — this is the source of truth and the user validates every change.
 
-**Status:** This BLUEPRINT is the **current** architecture under issue [#541](https://github.com/souliane/teatree/issues/541). All phases (0-8) have shipped on the active branch. The statusline file is the persistent UI surface; the HTML dashboard, ttyd web terminal, ASGI/uvicorn scaffolding, and platform autostart helpers are gone; the code-host + messaging Protocols are unified, with `SlackBotBackend`/`NoopMessagingBackend` selectable via overlay config; `t3 setup slack-bot --overlay <name>` walks the user through Slack app registration; the fat loop + 6 scanners + dispatcher are wired through `t3 loop tick` (review-channel scanning is folded into the dispatcher's PR-URL detection); the headless executor is the deliberately-slim `claude -p` swap point for a future Anthropic SDK runtime; and the no-overlay-leak gate keeps the platform tenant-agnostic.
+**Status:** This BLUEPRINT is the **current** architecture under issue [#541](https://github.com/souliane/teatree/issues/541). All phases (0-8) have shipped on the active branch. The statusline file is the persistent UI surface; the HTML dashboard, ttyd web terminal, ASGI/uvicorn scaffolding, and platform autostart helpers are gone; the code-host + messaging Protocols are unified, with `SlackBotBackend`/`NoopMessagingBackend` selectable via overlay config; `t3 setup slack-bot --overlay <name>` walks the user through Slack app registration; the fat loop + 7 scanners + dispatcher are wired through `t3 loop tick` (review-channel scanning is folded into the dispatcher's PR-URL detection); the headless executor is the deliberately-slim `claude -p` swap point for a future Anthropic SDK runtime; and the no-overlay-leak gate keeps the platform tenant-agnostic.
 
 ---
 
@@ -158,6 +158,7 @@ src/teatree/
       notion_view.py
       assigned_issues.py
       pending_tasks.py
+      ticket_dispositions.py
 
   backends/             # Pluggable external service integrations
     protocols.py        # Protocol classes (see §7)

--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -6,8 +6,9 @@
 #     written by `t3 loop tick` to ${TEATREE_STATUSLINE_FILE} or the default
 #     XDG path. Decoupling render from read keeps this hook fast (<10ms).
 #  2. Live per-session info from Claude's stdin JSON: model, context-window %,
-#     and skills loaded this session — the latter populated by hook_router.py
-#     / track-skill-usage.sh into ${state_dir}/<session_id>.skills.
+#     5-hour and 7-day rate-limit usage, and skills loaded this session —
+#     the latter populated by hook_router.py / track-skill-usage.sh into
+#     ${state_dir}/<session_id>.skills.
 
 set -u
 
@@ -17,12 +18,20 @@ state_dir="${TEATREE_CLAUDE_STATUSLINE_STATE_DIR:-/tmp/claude-statusline}"
 session_id=""
 model=""
 ctx_pct=""
+five_hour_pct=""
+five_hour_resets_at=""
+seven_day_pct=""
+seven_day_resets_at=""
 if ! [ -t 0 ] && command -v jq >/dev/null 2>&1; then
     input=$(cat)
     if [ -n "$input" ]; then
         session_id=$(printf '%s' "$input" | jq -r '.session_id // empty')
         model=$(printf '%s' "$input" | jq -r '.model.display_name // empty')
         ctx_pct=$(printf '%s' "$input" | jq -r '.context_window.used_percentage // empty' | cut -d. -f1)
+        five_hour_pct=$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty' | cut -d. -f1)
+        five_hour_resets_at=$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+        seven_day_pct=$(printf '%s' "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty' | cut -d. -f1)
+        seven_day_resets_at=$(printf '%s' "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
     fi
 fi
 
@@ -34,6 +43,33 @@ if [ -n "$session_id" ]; then
     fi
 fi
 
+_DIM=$'\033[0;37m'
+_YLW=$'\033[1;33m'
+_RED=$'\033[1;31m'
+_RST=$'\033[0m'
+
+color_pct() {
+    local pct="$1"
+    if (( pct >= 95 )); then printf "${_RED}%s%%${_RST}" "$pct"
+    elif (( pct >= 80 )); then printf "${_YLW}%s%%${_RST}" "$pct"
+    else printf "${_DIM}%s%%${_RST}" "$pct"
+    fi
+}
+
+format_reset_time() {
+    local resets_at="$1"
+    [ -z "$resets_at" ] || [ "$resets_at" = "empty" ] && return
+    local reset_time=""
+    if [[ "$resets_at" =~ ^[0-9]+$ ]]; then
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            reset_time=$(date -j -r "$resets_at" "+%H:%M" 2>/dev/null)
+        else
+            reset_time=$(date -d "@$resets_at" "+%H:%M" 2>/dev/null)
+        fi
+    fi
+    [ -n "$reset_time" ] && printf ' →%s' "$reset_time"
+}
+
 header=""
 sep=""
 if [ -n "$model" ]; then
@@ -41,7 +77,15 @@ if [ -n "$model" ]; then
     sep=" | "
 fi
 if [ -n "$ctx_pct" ] && [ "$ctx_pct" != "empty" ]; then
-    header="${header}${sep}ctx=${ctx_pct}%"
+    header="${header}${sep}ctx=$(color_pct "$ctx_pct")"
+    sep=" | "
+fi
+if [ -n "$five_hour_pct" ] && [ "$five_hour_pct" != "empty" ]; then
+    header="${header}${sep}5h=$(color_pct "$five_hour_pct")$(format_reset_time "$five_hour_resets_at")"
+    sep=" | "
+fi
+if [ -n "$seven_day_pct" ] && [ "$seven_day_pct" != "empty" ]; then
+    header="${header}${sep}7d=$(color_pct "$seven_day_pct")"
     sep=" | "
 fi
 if [ -n "$skills" ]; then
@@ -52,4 +96,10 @@ fi
 
 if [[ -r "$target" ]]; then
     cat "$target"
+fi
+
+# Chain context-mode plugin statusline (token savings line).
+ctx_statusline=$(ls -d "$HOME"/.claude/plugins/cache/context-mode/context-mode/*/bin/statusline.mjs 2>/dev/null | sort -V | tail -1)
+if [ -n "$ctx_statusline" ] && [ -n "${input:-}" ]; then
+    printf '%s' "$input" | node "$ctx_statusline"
 fi

--- a/sbom.json
+++ b/sbom.json
@@ -92,7 +92,7 @@
     },
     {
       "bom-ref": "requirements-L19",
-      "description": "requirements line 19: django==6.0.4",
+      "description": "requirements line 19: django==6.0.5",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -101,9 +101,9 @@
         }
       ],
       "name": "django",
-      "purl": "pkg:pypi/django@6.0.4",
+      "purl": "pkg:pypi/django@6.0.5",
       "type": "library",
-      "version": "6.0.4"
+      "version": "6.0.5"
     },
     {
       "bom-ref": "requirements-L28",

--- a/src/teatree/core/runners/worktree_start.py
+++ b/src/teatree/core/runners/worktree_start.py
@@ -3,14 +3,14 @@ import os
 from pathlib import Path
 
 from teatree.core.models import Worktree
-from teatree.core.overlay import OverlayBase
+from teatree.core.overlay import OverlayBase, RunCommand
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.core.step_runner import run_provision_steps
 from teatree.core.worktree_env import write_env_cache
 from teatree.timeouts import TimeoutConfig, load_timeouts
 from teatree.utils.ports import find_free_ports
-from teatree.utils.run import TimeoutExpired, run_allowed_to_fail
+from teatree.utils.run import DEVNULL, TimeoutExpired, run_allowed_to_fail, spawn
 
 logger = logging.getLogger(__name__)
 
@@ -106,12 +106,21 @@ class WorktreeStartRunner(RunnerBase):
         if not self._docker_compose_up(project, compose_file, env):
             return RunnerResult(ok=False, detail=f"docker compose up failed for {worktree.repo_path}")
 
+        host_pids = self._start_host_processes(commands, {**env, **port_env})
+
         extra = worktree.extra or {}
         extra["services"] = list(commands)
         extra["ports"] = self.ports
+        if host_pids:
+            extra["host_pids"] = host_pids
         worktree.extra = extra
         worktree.save(update_fields=["extra"])
-        return RunnerResult(ok=True, detail=f"started {len(commands)} service(s)")
+        total = len(commands)
+        host_count = len(host_pids)
+        return RunnerResult(
+            ok=True,
+            detail=f"started {total} service(s)" + (f" ({host_count} on host)" if host_count else ""),
+        )
 
     def _docker_compose_up(self, project: str, compose_file: str, env: dict[str, str]) -> bool:
         cmd = [
@@ -139,6 +148,32 @@ class WorktreeStartRunner(RunnerBase):
             )
             return False
         return True
+
+    @staticmethod
+    def _start_host_processes(
+        commands: dict[str, list[str] | RunCommand],
+        env: dict[str, str],
+    ) -> dict[str, int]:
+        """Launch ``host=True`` run commands as background processes.
+
+        Returns a mapping of service name → PID for each launched process.
+        """
+        pids: dict[str, int] = {}
+        for name, cmd in commands.items():
+            if not isinstance(cmd, RunCommand) or not cmd.host:
+                continue
+            cwd = str(cmd.cwd) if cmd.cwd else None
+            logger.info("Starting host process %s: %s (cwd=%s)", name, cmd.args, cwd)
+            proc = spawn(
+                cmd.args,
+                cwd=cwd,
+                env=env,
+                stdout=DEVNULL,
+                stderr=DEVNULL,
+            )
+            pids[name] = proc.pid
+            logger.info("Host process %s started (PID %d)", name, proc.pid)
+        return pids
 
     @staticmethod
     def _allocate_ports(overlay: OverlayBase, worktree: Worktree) -> dict[str, int]:

--- a/src/teatree/types.py
+++ b/src/teatree/types.py
@@ -12,10 +12,16 @@ from typing import TypedDict
 
 @dataclass(frozen=True)
 class RunCommand:
-    """Structured run command with explicit working directory."""
+    """Structured run command with explicit working directory.
+
+    When ``host=True``, ``worktree start`` launches the process in the
+    background on the host after Docker services are up, instead of
+    relying on ``docker compose up`` to run it.
+    """
 
     args: list[str] = field(default_factory=list)
     cwd: Path | None = None
+    host: bool = False
 
 
 type RunCommands = dict[str, list[str] | RunCommand]

--- a/tests/teatree_loop/test_assigned_issues_db.py
+++ b/tests/teatree_loop/test_assigned_issues_db.py
@@ -25,12 +25,12 @@ class _Host:
         return self.issues
 
     # The scanner never calls these but the Protocol requires them.
-    def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
-        _ = author
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
         return []
 
-    def list_review_requested_prs(self, *, reviewer: str) -> list[RawAPIDict]:
-        _ = reviewer
+    def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (reviewer, updated_after)
         return []
 
     def create_pr(self, spec: Any) -> RawAPIDict:

--- a/tests/teatree_loop/test_scanners.py
+++ b/tests/teatree_loop/test_scanners.py
@@ -26,12 +26,12 @@ class FakeCodeHost:
     def current_user(self) -> str:
         return self.user
 
-    def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
-        _ = author
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
         return self.my_prs
 
-    def list_review_requested_prs(self, *, reviewer: str) -> list[RawAPIDict]:
-        _ = reviewer
+    def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (reviewer, updated_after)
         return self.review_requested_prs
 
     def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:

--- a/tests/teatree_loop/test_ticket_dispositions.py
+++ b/tests/teatree_loop/test_ticket_dispositions.py
@@ -21,12 +21,12 @@ class _Host:
     def current_user(self) -> str:
         return self.user
 
-    def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
-        _ = author
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
         return []
 
-    def list_review_requested_prs(self, *, reviewer: str) -> list[RawAPIDict]:
-        _ = reviewer
+    def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (reviewer, updated_after)
         return []
 
     def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -7,6 +7,7 @@ action_needed, in_flight) and live per-session info from Claude's stdin JSON
 
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -74,8 +75,9 @@ class TestStatuslineHook:
         )
 
         assert result.returncode == 0, result.stderr
-        assert "model=Claude Sonnet" in result.stdout
-        assert "ctx=41%" in result.stdout
+        plain = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+        assert "model=Claude Sonnet" in plain
+        assert "ctx=41%" in plain
 
     def test_appends_pre_rendered_loop_zones_file(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"

--- a/uv.lock
+++ b/uv.lock
@@ -284,16 +284,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.4"
+version = "6.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/b9/4155091ad1788b38563bd77a7258c0834e8c12a7f56f6975deaf54f8b61d/django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac", size = 10907407, upload-time = "2026-04-07T13:55:44.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f1/bf85f0d29ef76abf901f193fe8fef4769d3da7794197832bc30151c071d8/django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269", size = 10924131, upload-time = "2026-05-05T13:54:39.329Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/47/3d61d611609764aa71a37f7037b870e7bfb22937366974c4fd46cada7bab/django-6.0.4-py3-none-any.whl", hash = "sha256:14359c809fc16e8f81fd2b59d7d348e4d2d799da6840b10522b6edf7b8afc1da", size = 8368342, upload-time = "2026-04-07T13:55:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5b/1328f8b84fce040c404f76822bf8c57d254e368e8cbd8bd67ec2b26d75f5/django-6.0.5-py3-none-any.whl", hash = "sha256:9d58a7cb49244e74c8e161d5e403a46d6209f1009ba40f5a66d6aa0d0786a8f0", size = 8368680, upload-time = "2026-05-05T13:54:33.532Z" },
 ]
 
 [[package]]
@@ -434,14 +434,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.49"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `host` flag to `RunCommand` dataclass
- `WorktreeStartRunner` spawns `host=True` commands as background processes after Docker services are up
- PIDs persisted in `worktree.extra["host_pids"]` for cleanup

## Motivation
Overlays define frontend dev servers (Angular, Vite, etc.) that must run on the host (too much RAM for Docker). Currently these need a separate `run frontend` command. With this change, `worktree start` launches them automatically.

## Test plan
- [x] 1467 tests pass, 12 skipped
- [x] Statusline test updated for ANSI color output