### PR TITLE
feat(statusline): show 5h and 7d rate-limit usage with color coding

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -552,7 +552,7 @@ Each tick runs three stages:
 
 #### 5.6.1 Statusline rendering
 
-The statusline is the **only persistent UI surface**. It is written to a file by the loop and read by the statusline hook (`hooks/scripts/statusline.sh`) which is just a `cat`. This decouples render speed from content size.
+The statusline is the **only persistent UI surface**. It is written to a file by the loop and read by the statusline hook (`hooks/scripts/statusline.sh`). The hook composes a header line (model, context-window %, 5-hour and 7-day rate-limit usage with color-coded thresholds, loaded skills) from Claude's stdin JSON, then `cat`s the loop's pre-rendered zones file, then chains any extra statusline scripts listed in `[teatree] statusline_chain` (glob patterns resolved to the latest match, interpreter inferred from extension). This decouples render speed from content size.
 
 **Zones (three, fixed order):**
 
@@ -570,7 +570,7 @@ The render module lives at `src/teatree/loop/statusline.py` (`StatuslineZones` d
 
 The loop respects the active overlay's `mode` (§ 10.1, canonical default `interactive`). When an overlay opts into `mode = "auto"`, the training wheel `[teatree] require_human_approval_to_merge = true` (default) keeps merge gated even though push and PR creation run autonomously — merge requires a user reaction (👍 or `/merge`) on the statusline entry or the PR thread. The user flips the training wheel to `false` only when comfortable. In `interactive` overlays, every publishing action still prompts; the loop surfaces work but never publishes silently.
 
-`UserSettings.require_human_approval_to_merge` and `UserSettings.loop_cadence_seconds` (default 720) live in `src/teatree/config.py`; both are toml-overridable in `[teatree]` and per-overlay via `[overlays.<name>]` once registered in `OVERLAY_OVERRIDABLE_SETTINGS`.
+`UserSettings.require_human_approval_to_merge`, `UserSettings.loop_cadence_seconds` (default 720), and `UserSettings.statusline_chain` (default empty) live in `src/teatree/config.py`; the first two are toml-overridable in `[teatree]` and per-overlay via `[overlays.<name>]` once registered in `OVERLAY_OVERRIDABLE_SETTINGS`. `statusline_chain` is global-only (not per-overlay).
 
 ---
 

--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -43,16 +43,22 @@ if [ -n "$session_id" ]; then
     fi
 fi
 
-_DIM=$'\033[0;37m'
+_CYN=$'\033[1;36m'
+_GRN=$'\033[1;32m'
 _YLW=$'\033[1;33m'
 _RED=$'\033[1;31m'
+_BLU=$'\033[1;34m'
+_MAG=$'\033[1;35m'
+_DIM=$'\033[2m'
 _RST=$'\033[0m'
+_OSC8=$'\033]8;'
+_ST=$'\033\\'
 
 color_pct() {
     local pct="$1"
     if (( pct >= 95 )); then printf "${_RED}%s%%${_RST}" "$pct"
     elif (( pct >= 80 )); then printf "${_YLW}%s%%${_RST}" "$pct"
-    else printf "${_DIM}%s%%${_RST}" "$pct"
+    else printf "${_GRN}%s%%${_RST}" "$pct"
     fi
 }
 
@@ -67,29 +73,34 @@ format_reset_time() {
             reset_time=$(date -d "@$resets_at" "+%H:%M" 2>/dev/null)
         fi
     fi
-    [ -n "$reset_time" ] && printf ' →%s' "$reset_time"
+    [ -n "$reset_time" ] && printf " ${_DIM}(until %s)${_RST}" "$reset_time"
+}
+
+osc8_link() {
+    printf '%s' "${_OSC8};${1}${_ST}${2}${_OSC8};${_ST}"
 }
 
 header=""
-sep=""
+sep="${_DIM} | ${_RST}"
 if [ -n "$model" ]; then
-    header="model=${model}"
-    sep=" | "
+    header="${_DIM}model=${_RST}${_GRN}${model}${_RST}"
 fi
 if [ -n "$ctx_pct" ] && [ "$ctx_pct" != "empty" ]; then
-    header="${header}${sep}ctx=$(color_pct "$ctx_pct")"
-    sep=" | "
+    header="${header}${sep}${_DIM}ctx=${_RST}$(color_pct "$ctx_pct")"
 fi
 if [ -n "$five_hour_pct" ] && [ "$five_hour_pct" != "empty" ]; then
-    header="${header}${sep}5h=$(color_pct "$five_hour_pct")$(format_reset_time "$five_hour_resets_at")"
-    sep=" | "
+    header="${header}${sep}${_DIM}5h=${_RST}$(color_pct "$five_hour_pct")$(format_reset_time "$five_hour_resets_at")"
 fi
 if [ -n "$seven_day_pct" ] && [ "$seven_day_pct" != "empty" ]; then
-    header="${header}${sep}7d=$(color_pct "$seven_day_pct")"
-    sep=" | "
+    header="${header}${sep}${_DIM}7d=${_RST}$(color_pct "$seven_day_pct")"
 fi
 if [ -n "$skills" ]; then
-    header="${header}${sep}skills: ${skills}"
+    _colored_skills=""
+    for _s in $skills; do
+        [ -n "$_colored_skills" ] && _colored_skills="${_colored_skills} ${_DIM}|${_RST} "
+        _colored_skills="${_colored_skills}${_MAG}${_s}${_RST}"
+    done
+    header="${header}${sep}${_DIM}skills:${_RST} ${_colored_skills}"
 fi
 
 [ -n "$header" ] && printf '%s\n' "$header"
@@ -98,8 +109,28 @@ if [[ -r "$target" ]]; then
     cat "$target"
 fi
 
-# Chain context-mode plugin statusline (token savings line).
-ctx_statusline=$(ls -d "$HOME"/.claude/plugins/cache/context-mode/context-mode/*/bin/statusline.mjs 2>/dev/null | sort -V | tail -1)
-if [ -n "$ctx_statusline" ] && [ -n "${input:-}" ]; then
-    printf '%s' "$input" | node "$ctx_statusline"
+# Chain extra statusline scripts from [teatree] statusline_chain in
+# ~/.teatree.toml. Each entry is a glob pattern; the latest match
+# (sort -V) is run with the Claude stdin JSON piped in.
+if [ -n "${input:-}" ]; then
+    _toml="$HOME/.teatree.toml"
+    if [ -r "$_toml" ]; then
+        _in_chain=false
+        while IFS= read -r _line; do
+            if [[ "$_line" =~ ^statusline_chain ]]; then _in_chain=true; continue; fi
+            $_in_chain || continue
+            [[ "$_line" =~ ^\] ]] && break
+            [[ "$_line" =~ ^[[:space:]]*\" ]] || continue
+            _pat=$(printf '%s' "$_line" | sed 's/.*"\(.*\)".*/\1/')
+            _pat="${_pat/#\~/$HOME}"
+            _resolved=$(ls -d $_pat 2>/dev/null | sort -V | tail -1)
+            [ -z "$_resolved" ] && continue
+            case "$_resolved" in
+                *.mjs|*.js) _runner="node" ;;
+                *.py)       _runner="python3" ;;
+                *)          _runner="bash" ;;
+            esac
+            printf '%s' "$input" | "$_runner" "$_resolved" 2>/dev/null
+        done < "$_toml"
+    fi
 fi

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -175,6 +175,7 @@ class UserSettings:
     # `skills/rules/SKILL.md` § "No AI Signature on Posts Made on the User's
     # Behalf".
     agent_signature: bool = False
+    statusline_chain: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -217,6 +218,7 @@ def load_config(path: Path | None = None) -> TeaTreeConfig:
         require_human_approval_to_merge=bool(teatree.get("require_human_approval_to_merge", True)),
         claude_chrome=bool(teatree.get("claude_chrome", True)),
         agent_signature=bool(teatree.get("agent_signature", False)),
+        statusline_chain=[str(s) for s in teatree.get("statusline_chain", [])],
     )
 
     return TeaTreeConfig(user=user, raw=raw)

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -17,6 +17,11 @@ pytestmark = pytest.mark.integration
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "hooks" / "scripts" / "statusline.sh"
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m|\x1b\]8;[^\x1b]*\x1b\\")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 def _run(payload: dict, *, state_dir: Path, statusline_file: Path | None = None) -> subprocess.CompletedProcess:
@@ -47,7 +52,7 @@ class TestStatuslineHook:
         )
 
         assert result.returncode == 0, result.stderr
-        assert "skills: t3:code t3:debug" in result.stdout
+        assert "skills: t3:code | t3:debug" in _strip_ansi(result.stdout)
 
     def test_omits_skills_when_session_file_absent(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"
@@ -59,7 +64,28 @@ class TestStatuslineHook:
         )
 
         assert result.returncode == 0, result.stderr
-        assert "skills:" not in result.stdout
+        assert "skills:" not in _strip_ansi(result.stdout)
+
+    def test_renders_rate_limits_from_stdin(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        result = _run(
+            {
+                "session_id": "s1",
+                "model": {"display_name": "Claude Opus"},
+                "rate_limits": {
+                    "five_hour": {"used_percentage": 42, "resets_at": "1747047000"},
+                    "seven_day": {"used_percentage": 85},
+                },
+            },
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "5h=42%" in plain
+        assert "7d=85%" in plain
 
     def test_renders_model_and_context_window_from_stdin(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"
@@ -75,7 +101,7 @@ class TestStatuslineHook:
         )
 
         assert result.returncode == 0, result.stderr
-        plain = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout)
+        plain = _strip_ansi(result.stdout)
         assert "model=Claude Sonnet" in plain
         assert "ctx=41%" in plain
 
@@ -92,7 +118,8 @@ class TestStatuslineHook:
         )
 
         assert result.returncode == 0, result.stderr
-        assert "model=Claude Opus" in result.stdout
+        plain = _strip_ansi(result.stdout)
+        assert "model=Claude Opus" in plain
         assert "tick @ 2026-05-07T12:00:00" in result.stdout
         assert "→ statusline: x" in result.stdout
 
@@ -108,7 +135,7 @@ class TestStatuslineHook:
         )
 
         assert result.returncode == 0, result.stderr
-        assert "model=Claude Opus" in result.stdout
+        assert "model=Claude Opus" in _strip_ansi(result.stdout)
 
     def test_no_session_id_emits_no_skills_section(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"
@@ -122,5 +149,6 @@ class TestStatuslineHook:
         )
 
         assert result.returncode == 0, result.stderr
-        assert "skills:" not in result.stdout
-        assert "rogue" not in result.stdout
+        plain = _strip_ansi(result.stdout)
+        assert "skills:" not in plain
+        assert "rogue" not in plain


### PR DESCRIPTION
## Summary

- Read `.rate_limits.five_hour` and `.rate_limits.seven_day` from Claude's statusline stdin JSON
- Color-coded thresholds: green < 80%, yellow 80-95%, red >= 95%
- 5h reset time displayed as `(until HH:MM)`
- Green model name, dim labels/separators, magenta skills with `|` delimiters
- New `statusline_chain` UserSettings field — glob patterns in `~/.teatree.toml` for chaining extra statusline scripts (e.g. context-mode plugin), replacing the hardcoded combiner
- BLUEPRINT updated for the new setting and hook behavior
- Test assertions updated to strip ANSI + new rate-limit test

## Test plan

- [x] `tests/test_claude_statusline.py` — 7 tests pass (skills, model, ctx, rate limits, zones, edge cases)
- [x] Manual smoke: `echo '{"session_id":"test",...}' | bash statusline.sh` renders colors + chains context-mode from toml