### PR TITLE
fix(loop): harden tick against multi-overlay crash and scanner 404s

### DIFF
--- a/src/teatree/backends/slack_reactions.py
+++ b/src/teatree/backends/slack_reactions.py
@@ -99,7 +99,7 @@ def add_reactions_for_transition(ticket: "Ticket", transition_name: str) -> int:
     Returns the number of successful reaction posts.  Missing credentials,
     missing permalinks, and unmapped transitions are all silent no-ops.
     """
-    overlay = get_overlay()
+    overlay = get_overlay(name=ticket.overlay or None)
     emoji = overlay.config.get_transition_emojis().get(transition_name)
     if not emoji:
         return 0

--- a/src/teatree/loop/scanners/ticket_dispositions.py
+++ b/src/teatree/loop/scanners/ticket_dispositions.py
@@ -17,6 +17,7 @@ Tickets past ``REVIEWED`` are skipped: once the PR exists, the disposition
 concept no longer applies — ``MyPrsScanner`` already covers post-PR state.
 """
 
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
@@ -29,6 +30,8 @@ from teatree.loop.scanners.base import ScanSignal
 
 if TYPE_CHECKING:
     from teatree.core.models.ticket import Ticket
+
+logger = logging.getLogger(__name__)
 
 # States in which disposition checks make sense — pre-PR work the operator can
 # still cancel without tearing down published artifacts.
@@ -104,7 +107,11 @@ class TicketDispositionScanner:
         author = self.host.current_user()
         signals: list[ScanSignal] = []
         for ticket in self._candidate_tickets():
-            issue = self.host.get_issue(ticket.issue_url)
+            try:
+                issue = self.host.get_issue(ticket.issue_url)
+            except Exception:  # noqa: BLE001
+                logger.warning("Failed to fetch issue for ticket %s (%s), skipping", ticket.pk, ticket.issue_url)
+                continue
             snap = _snapshot(issue)
             if snap is None:
                 continue

--- a/tests/teatree_backends/test_slack_reactions.py
+++ b/tests/teatree_backends/test_slack_reactions.py
@@ -137,14 +137,17 @@ class _StubOverlay:
 
 
 class TestAddReactionsForTransition:
-    def _ticket(self, permalinks: list[str]) -> SimpleNamespace:
-        return SimpleNamespace(extra={"prs": {f"pr-{i}": {"review_permalink": p} for i, p in enumerate(permalinks)}})
+    def _ticket(self, permalinks: list[str], overlay: str = "") -> SimpleNamespace:
+        return SimpleNamespace(
+            extra={"prs": {f"pr-{i}": {"review_permalink": p} for i, p in enumerate(permalinks)}},
+            overlay=overlay,
+        )
 
     def test_posts_one_reaction_per_permalink(self, monkeypatch: pytest.MonkeyPatch) -> None:
         overlay = _StubOverlay(_StubConfig(token="xoxb"))
         monkeypatch.setattr(
             "teatree.backends.slack_reactions.get_overlay",
-            lambda: overlay,
+            lambda name=None: overlay,
         )
         calls: list[tuple[str, str, str, str]] = []
 
@@ -168,7 +171,7 @@ class TestAddReactionsForTransition:
 
     def test_skips_unparseable_permalinks(self, monkeypatch: pytest.MonkeyPatch) -> None:
         overlay = _StubOverlay(_StubConfig(token="xoxb"))
-        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda: overlay)
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda name=None: overlay)
         monkeypatch.setattr(slack_reactions, "add_reaction", lambda *a, **kw: True)
 
         ticket = self._ticket(["not-a-permalink", "https://team.slack.com/archives/C1/p1700000000000100"])
@@ -176,7 +179,7 @@ class TestAddReactionsForTransition:
 
     def test_no_op_when_transition_unmapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         overlay = _StubOverlay(_StubConfig(token="xoxb"))
-        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda: overlay)
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda name=None: overlay)
         called = []
         monkeypatch.setattr(slack_reactions, "add_reaction", lambda *a, **kw: called.append(a) or True)
 
@@ -186,7 +189,7 @@ class TestAddReactionsForTransition:
 
     def test_no_op_when_no_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         overlay = _StubOverlay(_StubConfig(token=""))
-        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda: overlay)
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda name=None: overlay)
         called = []
         monkeypatch.setattr(slack_reactions, "add_reaction", lambda *a, **kw: called.append(a) or True)
 
@@ -196,7 +199,7 @@ class TestAddReactionsForTransition:
 
     def test_counts_only_successful_reactions(self, monkeypatch: pytest.MonkeyPatch) -> None:
         overlay = _StubOverlay(_StubConfig(token="xoxb"))
-        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda: overlay)
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda name=None: overlay)
         results = iter([True, False, True])
         monkeypatch.setattr(slack_reactions, "add_reaction", lambda *a, **kw: next(results))
 
@@ -211,7 +214,7 @@ class TestAddReactionsForTransition:
 
     def test_overlay_override_takes_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
         overlay = _StubOverlay(_StubConfig(token="xoxb", emojis={"mark_merged": "rocket"}))
-        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda: overlay)
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda name=None: overlay)
         recorded: list[str] = []
         monkeypatch.setattr(slack_reactions, "add_reaction", lambda _t, _c, _ts, emoji: recorded.append(emoji) or True)
 


### PR DESCRIPTION
## Summary
- `slack_reactions.add_reactions_for_transition()` called `get_overlay()` without the ticket's overlay name — crashes with `ImproperlyConfigured` when multiple overlays are registered. Now passes `name=ticket.overlay`.
- `TicketDispositionScanner.scan()` let a single `get_issue()` 404 kill the entire scanner iteration for all remaining tickets. Now wraps per-ticket in try/except with warning log.

## Test plan
- [x] Existing slack_reactions tests updated and passing (33 tests)
- [x] Disposition scanner tests passing
- [x] All pre-commit hooks pass

Relates-to: #568