### PR TITLE
fix(statusline): group dispositions, cap ready-to-start, add exclude_labels

### DIFF
--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -36,6 +36,7 @@ class OverlayBackends:
     host: CodeHostBackend | None
     messaging: MessagingBackend | None
     ready_labels: tuple[str, ...]
+    exclude_labels: tuple[str, ...] = ()
     overlay: OverlayBase | None = None
     auto_start_assigned_issues: bool = False
     max_concurrent_auto_starts: int = 1
@@ -101,6 +102,7 @@ def iter_overlay_backends() -> list[OverlayBackends]:
                 host=host,
                 messaging=messaging,
                 ready_labels=tuple(overlay.config.ready_labels),
+                exclude_labels=tuple(overlay.config.exclude_labels),
                 overlay=overlay,
                 auto_start_assigned_issues=bool(overlay.config.auto_start_assigned_issues),
                 max_concurrent_auto_starts=int(overlay.config.max_concurrent_auto_starts),

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -98,6 +98,12 @@ class OverlayConfig:
 
     Used by ``AssignedIssuesScanner``. Empty disables the filter (every
     open assigned issue is considered ready)."""
+    exclude_labels: list[str]
+    """Labels that exclude an assigned issue from the statusline.
+
+    Issues carrying any of these labels are skipped by ``AssignedIssuesScanner``
+    even if they match ``ready_labels``. Useful for workflow stages like
+    "DEV review" where the developer's work is done."""
     auto_start_assigned_issues: bool = False
     """When ``True``, the loop hands ready assigned issues to the orchestrator
     agent to drive end-to-end through PR creation. When ``False`` (default),
@@ -133,6 +139,7 @@ class OverlayConfig:
         self.workspace_repos = []
         self.protected_branches = []
         self.ready_labels = []
+        self.exclude_labels = []
         if settings_module:
             self._load_settings(settings_module)
         if overlay_name:

--- a/src/teatree/loop/scanners/assigned_issues.py
+++ b/src/teatree/loop/scanners/assigned_issues.py
@@ -82,6 +82,7 @@ class AssignedIssuesScanner:
 
     host: CodeHostBackend
     ready_labels: tuple[str, ...] = field(default_factory=tuple)
+    exclude_labels: tuple[str, ...] = field(default_factory=tuple)
     auto_start: bool = False
     max_concurrent: int = 1
     overlay_name: str = ""
@@ -103,6 +104,8 @@ class AssignedIssuesScanner:
         for issue in issues:
             labels = _issue_labels(issue)
             if self.ready_labels and not any(label in labels for label in self.ready_labels):
+                continue
+            if self.exclude_labels and any(label in labels for label in self.exclude_labels):
                 continue
             url = _issue_url(issue)
             if self.auto_start and url and url in tracked:

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -124,6 +124,7 @@ def build_default_jobs(
                             scanner=AssignedIssuesScanner(
                                 host=backend.host,
                                 ready_labels=backend.ready_labels,
+                                exclude_labels=backend.exclude_labels,
                                 auto_start=backend.auto_start_assigned_issues,
                                 max_concurrent=backend.max_concurrent_auto_starts,
                                 overlay_name=tag,
@@ -189,8 +190,20 @@ def build_default_scanners(
     ]
 
 
+_DISPOSITION_LABELS: dict[str, str] = {
+    "issue_closed": "closed issues",
+    "unassigned": "reassigned away",
+    "label_removed": "ready-label removed",
+}
+
+_MAX_READY_TO_START = 5
+
+
 def _zones_for(actions: list[DispatchAction]) -> StatuslineZones:
     zones = StatuslineZones()
+    disposition_counts: dict[str, dict[str, int]] = {}
+    ready_entries: list[StatuslineEntry] = []
+
     for action in actions:
         url = action.payload.get("url") if isinstance(action.payload, dict) else None
         url_str = url if isinstance(url, str) else ""
@@ -198,14 +211,38 @@ def _zones_for(actions: list[DispatchAction]) -> StatuslineZones:
         prefix = f"[{overlay}] " if isinstance(overlay, str) and overlay else ""
 
         if action.kind == "statusline":
+            reason = action.payload.get("reason") if isinstance(action.payload, dict) else None
+            if isinstance(reason, str):
+                key = overlay if isinstance(overlay, str) else ""
+                disposition_counts.setdefault(key, {}).setdefault(reason, 0)
+                disposition_counts[key][reason] += 1
+                continue
+
+            entry = StatuslineEntry(text=f"{prefix}{action.detail}", url=url_str)
+            if action.zone == "action_needed" and action.detail.startswith("Ready to start:"):
+                ready_entries.append(entry)
+                continue
+
             zone_list = getattr(zones, action.zone, None)
             if isinstance(zone_list, list):
-                zone_list.append(StatuslineEntry(text=f"{prefix}{action.detail}", url=url_str))
+                zone_list.append(entry)
         elif action.kind == "mechanical":
             zones.in_flight.append(StatuslineEntry(text=f"⚙ {prefix}{action.detail}", url=url_str))
-        else:  # "agent" or "webhook" — surface as in-flight progress
+        else:
             text = f"→ {action.zone}: {prefix}{action.detail}"
             zones.in_flight.append(StatuslineEntry(text=text, url=url_str))
+
+    for overlay_key, reasons in sorted(disposition_counts.items()):
+        prefix = f"[{overlay_key}] " if overlay_key else ""
+        parts = [f"{count} {_DISPOSITION_LABELS.get(r, r)}" for r, count in reasons.items()]
+        zones.action_needed.append(f"{prefix}Stale tickets: {', '.join(parts)}")
+
+    for entry in ready_entries[:_MAX_READY_TO_START]:
+        zones.action_needed.append(entry)
+    overflow = len(ready_entries) - _MAX_READY_TO_START
+    if overflow > 0:
+        zones.action_needed.append(f"… and {overflow} more ready to start")
+
     return zones
 
 

--- a/tests/teatree_loop/test_scanners.py
+++ b/tests/teatree_loop/test_scanners.py
@@ -402,3 +402,31 @@ class TestAssignedIssuesScanner:
         )
         notify = AssignedIssuesScanner(host=host, ready_labels=("ready",), auto_start=False).scan()
         assert notify[0].payload["auto_start"] is False
+
+    def test_exclude_labels_filters_out_matching_issues(self) -> None:
+        host = FakeCodeHost(
+            user="alice",
+            assigned_issues=[
+                {"web_url": "x", "title": "actionable", "labels": ["ready"]},
+                {"web_url": "y", "title": "in review", "labels": ["ready", "DEV review"]},
+                {"web_url": "z", "title": "also done", "labels": ["ready", "Process::Technical review"]},
+            ],
+        )
+        scanner = AssignedIssuesScanner(
+            host=host,
+            ready_labels=("ready",),
+            exclude_labels=("DEV review", "Process::Technical review"),
+        )
+        signals = scanner.scan()
+        assert [s.payload["url"] for s in signals] == ["x"]
+
+    def test_exclude_labels_empty_means_no_exclusion(self) -> None:
+        host = FakeCodeHost(
+            user="alice",
+            assigned_issues=[
+                {"web_url": "x", "title": "first", "labels": ["DEV review"]},
+            ],
+        )
+        scanner = AssignedIssuesScanner(host=host, ready_labels=(), exclude_labels=())
+        signals = scanner.scan()
+        assert [s.payload["url"] for s in signals] == ["x"]

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -176,6 +176,75 @@ def test_build_default_jobs_tags_per_overlay() -> None:
     assert len(pending) == 1  # singleton across overlays
 
 
+def test_zones_groups_disposition_candidates_by_reason(tmp_path: Path) -> None:
+    from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
+    from teatree.loop.tick import _zones_for  # noqa: PLC0415
+
+    actions = [
+        DispatchAction(
+            kind="statusline",
+            zone="action_needed",
+            detail="Ticket 55 — issue_closed",
+            payload={"reason": "issue_closed", "overlay": "teatree"},
+        ),
+        DispatchAction(
+            kind="statusline",
+            zone="action_needed",
+            detail="Ticket 114 — issue_closed",
+            payload={"reason": "issue_closed", "overlay": "teatree"},
+        ),
+        DispatchAction(
+            kind="statusline",
+            zone="action_needed",
+            detail="Ticket 12 — unassigned",
+            payload={"reason": "unassigned", "overlay": "teatree"},
+        ),
+    ]
+    zones = _zones_for(actions)
+    texts = [item if isinstance(item, str) else item.text for item in zones.action_needed]
+    assert len(texts) == 1
+    assert "2 closed issues" in texts[0]
+    assert "1 reassigned away" in texts[0]
+    assert "[teatree]" in texts[0]
+
+
+def test_zones_caps_ready_to_start_entries(tmp_path: Path) -> None:
+    from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
+    from teatree.loop.tick import _MAX_READY_TO_START, _zones_for  # noqa: PLC0415
+
+    actions = [
+        DispatchAction(
+            kind="statusline",
+            zone="action_needed",
+            detail=f"Ready to start: Issue #{i}",
+            payload={"url": f"https://example.com/issues/{i}"},
+        )
+        for i in range(12)
+    ]
+    zones = _zones_for(actions)
+    texts = [item if isinstance(item, str) else item.text for item in zones.action_needed]
+    assert len(texts) == _MAX_READY_TO_START + 1
+    assert "… and 7 more ready to start" in texts[-1]
+
+
+def test_zones_no_overflow_when_ready_under_cap() -> None:
+    from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
+    from teatree.loop.tick import _zones_for  # noqa: PLC0415
+
+    actions = [
+        DispatchAction(
+            kind="statusline",
+            zone="action_needed",
+            detail="Ready to start: Small backlog",
+            payload={"url": "https://example.com/issues/1"},
+        )
+    ]
+    zones = _zones_for(actions)
+    texts = [item if isinstance(item, str) else item.text for item in zones.action_needed]
+    assert len(texts) == 1
+    assert "more ready to start" not in texts[0]
+
+
 def test_tick_multi_overlay_prefixes_summary(tmp_path: Path) -> None:
     """Signals collected via the multi-overlay path get an ``[overlay]`` prefix in the rendered line."""
     from unittest.mock import MagicMock  # noqa: PLC0415


### PR DESCRIPTION
## Summary
- Group disposition candidates (issue_closed, unassigned, label_removed) into summary lines instead of one-per-ticket
- Cap "Ready to start" entries at 5 with "… and N more" overflow
- Add `exclude_labels` to `OverlayConfig` so overlays can filter out issues with workflow labels like "DEV review"

## Changes
- `tick.py` — `_zones_for()` groups dispositions by reason, caps ready-to-start
- `overlay.py` — new `exclude_labels: list[str]` field on `OverlayConfig`
- `backend_factory.py` — threads `exclude_labels` through `OverlayBackends`
- `assigned_issues.py` — `AssignedIssuesScanner` respects `exclude_labels`
- 5 new tests covering grouping, capping, overflow, and exclude filtering