### PR TITLE
fix(cli): set T3_OVERLAY_NAME on overlay callback (#558)

### DIFF
--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -168,10 +168,17 @@ class OverlayAppBuilder:
         self.overlay_name = overlay_name
         self.project_path = project_path
         self.settings_module = settings_module
+
         self.overlay_app = typer.Typer(no_args_is_help=True, help=f"Commands for the {overlay_name} overlay.")
 
     def build(self) -> typer.Typer:
         """Build and return the fully-configured overlay Typer app."""
+        overlay_name = self.overlay_name
+
+        @self.overlay_app.callback(invoke_without_command=True)
+        def _activate() -> None:
+            os.environ["T3_OVERLAY_NAME"] = overlay_name
+
         self._register_resetdb_command()
         self._register_worker_command()
         self._register_shortcut_commands()


### PR DESCRIPTION
## Summary
Multi-overlay installs crashed with `Multiple overlays found` because `T3_OVERLAY_NAME` was only set for subprocesses via `managepy()`, not in the current process. Direct `get_overlay()` calls in `review.py`, `ci.py`, `agent.py` all failed.

Fix: add a typer callback on each overlay app that sets `os.environ["T3_OVERLAY_NAME"]` when the subcommand is invoked.

Closes #558

## Test plan
- [x] 2646 tests pass, 93.0% coverage