### PR TITLE
fix(pr): include commit subject in ensure-pr description (#54)

### DIFF
--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -301,8 +301,12 @@ class Command(TyperCommand):
 
         commit_subject, commit_body = git.last_commit_message(repo=repo_path)
         title = commit_subject or f"WIP: {branch_name}"
-        description = commit_body or f"PR auto-created to track branch `{branch_name}`."
-        description = sanitize_close_keywords(description, close_ticket=get_overlay().config.mr_close_ticket)
+        raw_description = (
+            f"{commit_subject}\n\n{commit_body}"
+            if commit_subject and commit_body
+            else (commit_subject or commit_body or f"PR auto-created to track branch `{branch_name}`.")
+        )
+        description = sanitize_close_keywords(raw_description, close_ticket=get_overlay().config.mr_close_ticket)
 
         remote = git.remote_url(repo=repo_path)
         repo_slug = _slug_from_remote(remote)


### PR DESCRIPTION
## Summary
`ensure-pr` used only the commit body for the PR description. COMPANY's CI validator requires the first line to match the title (commit subject). Now constructs description as `subject + body`, matching `_ship_preview`.

Bug 1 from #54 (bare-repo 404) was already fixed in `4e0b8e0`.

Fixes #54

## Test plan
- [x] 2646 tests pass, 93.0% coverage