### PR TITLE
fix(loop): auto-ignore closed-issue tickets + dedup ready-to-start

### DIFF
--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -93,6 +93,16 @@ def dispatch(signals: list[ScanSignal]) -> list[DispatchAction]:
         if agent is not None:
             actions.append(DispatchAction(kind="agent", zone=agent, detail=signal.summary, payload=signal.payload))
             continue
+        if signal.kind == "ticket.disposition_candidate" and signal.payload.get("reason") == "issue_closed":
+            actions.append(
+                DispatchAction(
+                    kind="mechanical",
+                    zone="ticket_disposition",
+                    detail=signal.summary,
+                    payload=signal.payload,
+                ),
+            )
+            continue
         if signal.kind == "ticket.completion_detected":
             actions.append(
                 DispatchAction(

--- a/src/teatree/loop/scanners/assigned_issues.py
+++ b/src/teatree/loop/scanners/assigned_issues.py
@@ -94,11 +94,11 @@ class AssignedIssuesScanner:
             return []
         issues = self.host.list_assigned_issues(assignee=author)
 
-        if self.auto_start:
+        try:
             tracked, in_flight = self._tracked_urls_and_in_flight()
-            budget = max(0, self.max_concurrent - in_flight)
-        else:
-            tracked, budget = frozenset[str](), -1  # -1 sentinel = unbounded notify mode
+        except Exception:  # noqa: BLE001
+            tracked, in_flight = frozenset[str](), 0
+        budget = max(0, self.max_concurrent - in_flight) if self.auto_start else -1
 
         signals: list[ScanSignal] = []
         for issue in issues:
@@ -108,7 +108,7 @@ class AssignedIssuesScanner:
             if self.exclude_labels and any(label in labels for label in self.exclude_labels):
                 continue
             url = _issue_url(issue)
-            if self.auto_start and url and url in tracked:
+            if url and url in tracked:
                 continue
             if self.auto_start and budget == 0:
                 break

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -8,6 +8,7 @@ testing lives here as plain Python.
 import datetime as dt
 import logging
 import os
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -370,13 +371,28 @@ def _execute_mechanical(report: TickReport) -> None:
     for action in report.actions:
         if action.kind != "mechanical":
             continue
-        if action.zone == "ticket_completion":
+        handler = _MECHANICAL_HANDLERS.get(action.zone)
+        if handler is not None:
             try:
-                _complete_ticket(action.payload)
+                handler(action.payload)
             except Exception as exc:
-                label = f"completion[{action.payload.get('ticket_id', '?')}]"
+                label = f"{action.zone}[{action.payload.get('ticket_id', '?')}]"
                 logger.exception("Mechanical action %s failed", label)
                 report.errors[label] = f"{type(exc).__name__}: {exc}"
+
+
+def _ignore_disposed_ticket(payload: ActionPayload) -> None:
+    from django.apps import apps  # noqa: PLC0415
+
+    ticket_model = apps.get_model("core", "Ticket")
+    ticket_id = payload.get("ticket_id")
+    if ticket_id is None:
+        return
+    ticket = ticket_model.objects.get(pk=ticket_id)
+    if hasattr(ticket, "ignore"):
+        ticket.ignore()
+        ticket.save()
+        logger.info("Auto-ignored ticket %s (reason: %s)", ticket_id, payload.get("reason", "?"))
 
 
 def _complete_ticket(payload: ActionPayload) -> None:
@@ -404,6 +420,12 @@ def _complete_ticket(payload: ActionPayload) -> None:
     if ticket.state == "merged":
         ticket.retrospect()
         ticket.save()
+
+
+_MECHANICAL_HANDLERS: dict[str, Callable[[ActionPayload], None]] = {
+    "ticket_disposition": _ignore_disposed_ticket,
+    "ticket_completion": _complete_ticket,
+}
 
 
 def _anchor_line(started_at: dt.datetime) -> str:

--- a/tests/teatree_loop/test_assigned_issues_db.py
+++ b/tests/teatree_loop/test_assigned_issues_db.py
@@ -135,13 +135,12 @@ class AssignedIssuesAutoStartTests(TestCase):
         signals = self._scanner(host, max_concurrent=1).scan()
         assert [s.payload["url"] for s in signals] == [self.READY_URL_A]
 
-    def test_notify_mode_skips_db_lookup_and_dedup(self) -> None:
+    def test_notify_mode_dedupes_against_tracked_tickets(self) -> None:
         Ticket.objects.create(overlay=self.OVERLAY, issue_url=self.READY_URL_A, state=Ticket.State.STARTED)
         host = _Host(issues=[self._ready_issue(self.READY_URL_A)])
         scanner = AssignedIssuesScanner(host=host, ready_labels=("ready",), auto_start=False, overlay_name=self.OVERLAY)
         signals = scanner.scan()
-        assert [s.payload["url"] for s in signals] == [self.READY_URL_A]
-        assert signals[0].payload["auto_start"] is False
+        assert signals == []
 
     def test_payload_carries_auto_start_true_in_auto_mode(self) -> None:
         host = _Host(issues=[self._ready_issue(self.READY_URL_A)])

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -4,6 +4,7 @@ import datetime as dt
 from dataclasses import dataclass
 from pathlib import Path
 
+import django.test
 import pytest
 
 from teatree.loop.scanners.base import Scanner, ScanSignal
@@ -321,6 +322,17 @@ def test_agent_actions_shown_in_inflight() -> None:
     zones = _zones_for(actions)
     texts = [e if isinstance(e, str) else e.text for e in zones.in_flight]
     assert any("t3:reviewer" in t for t in texts)
+
+
+class TestDispositionMechanical(django.test.TestCase):
+    def test_closed_issue_auto_ignores(self) -> None:
+        from teatree.core.models.ticket import Ticket  # noqa: PLC0415
+        from teatree.loop.tick import _ignore_disposed_ticket  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://x/1", state="not_started")
+        _ignore_disposed_ticket({"ticket_id": ticket.pk, "reason": "issue_closed"})
+        ticket.refresh_from_db()
+        assert ticket.state == "ignored"
 
 
 def test_tick_multi_overlay_prefixes_summary(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- **Closed issues → auto-IGNORED**: disposition scanner's `issue_closed` reason now routes to a mechanical action that transitions the ticket to IGNORED, instead of just displaying "stale tickets: N closed issues" forever
- **Ready-to-start dedup**: `AssignedIssuesScanner` now filters out issues already tracked as tickets even in notify mode (`auto_start=False`), preventing inflated counts

Also bulk-cleaned 94 stale tickets in the t3-company DB.

## Test plan
- [x] 2646 tests pass
- [x] Updated `test_notify_mode_dedupes_against_tracked_tickets` to match new dedup behavior