### PR TITLE
feat(hooks): add scoping gate warning when coding without prior scoping (#135)

### DIFF
--- a/hooks/scripts/ensure-skills-loaded.sh
+++ b/hooks/scripts/ensure-skills-loaded.sh
@@ -162,6 +162,9 @@ EOF
 
                 gate_warning=""
                 case "$target_phase" in
+                    coding)
+                        echo "$visited" | grep -q "scoping" || gate_warning="⚠ Coding without scoping first. For features, run /t3:ticket or /brainstorming to clarify intent before implementing."
+                        ;;
                     reviewing)
                         echo "$visited" | grep -q "testing" || gate_warning="⚠ Reviewing without testing first. Run /t3:test first, or use --force in t3 ship."
                         ;;


### PR DESCRIPTION
## Summary

- Add `coding)` case to the hook's gate-warning block — warns when coding intent is detected without the scoping phase visited first
- Suggests `/t3:ticket` or `/brainstorming` to clarify intent before implementing

The remaining ACs from #135 were already implemented in prior commits:
- `State.SCOPED` exists in the FSM with `scope()` transition
- `code/SKILL.md` already warns when scoping was skipped (lines 55-61)
- BLUEPRINT.md already includes `scoped` in the state sequence

## Test plan

- [x] 2668 passed, ruff clean
- [x] `bash -n` validates the hook script
- [x] All pre-commit hooks pass