### PR TITLE
feat(tool): t3 tool triage-issues — resolved-but-open + stale scan (#49)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -857,7 +857,7 @@ Typer-based, work without Django:
 - `t3 <overlay> e2e project [<test-path>] [--update-snapshots]` — explicit project runner: pytest-playwright in the overlay's own test dir, executed in the canonical Docker image by default
 - `t3 review {post-draft-note,delete-draft-note,list-draft-notes,publish-draft-notes,update-note,reply-to-discussion,resolve-discussion}` — code-host draft notes (post/delete/list/publish), in-place edits of draft or published notes, plus immediate replies on existing discussion threads and resolve/unresolve toggle. Routes to GitHub or GitLab via the active overlay's `CodeHostBackend`.
 - `t3 review-request discover` — discover open PRs awaiting review
-- `t3 tool {privacy-scan,analyze-video,bump-deps,label-issues,find-duplicates}` — standalone utilities
+- `t3 tool {privacy-scan,analyze-video,bump-deps,label-issues,find-duplicates,triage-issues}` — standalone utilities
 - `t3 config write-skill-cache` — write overlay skill metadata to cache
 - `t3 doctor {check,repair}` — health checks and symlink repair
 - `t3 setup slack-bot --overlay <name>` — interactive walkthrough to register a Slack bot for an overlay; opens the app-manifest URL, captures bot+app tokens, stores them via `pass`, writes `slack_user_id` into `~/.teatree.toml`, smoke-tests with a round-trip DM (see § 10.1 for the manifest template and scopes). Subcommands of `t3 setup` short-circuit the global skill-install callback so the walkthrough runs without requiring `T3_REPO`.

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -553,6 +553,7 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 │                  keyword-matching title and body.                            │
 │ find-duplicates  Flag pairs of open issues with near-identical titles.       │
 │ claude-handover  Show Claude handover telemetry and runtime recommendations. │
+│ triage-issues    Scan for resolved-but-open and stale issues.                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -672,6 +673,27 @@ Usage: t3 tool claude-handover [OPTIONS]
 │                                directory.                                    │
 │ --json                         Emit machine-readable JSON.                   │
 │ --help                         Show this message and exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 tool triage-issues`
+
+```
+Usage: t3 tool triage-issues [OPTIONS] REPO
+
+ Scan for resolved-but-open and stale issues.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    repo      TEXT  Repository in owner/name form (e.g. souliane/teatree)   │
+│                      [required]                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --stale-days            INTEGER  Inactivity threshold for stale-issue        │
+│                                  detection.                                  │
+│                                  [default: 30]                               │
+│ --close-resolved                 Close resolved-but-open issues (with        │
+│                                  comment linking the merged PR).             │
+│ --help                           Show this message and exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -168,3 +168,40 @@ def claude_handover(
         f"reset={reset_at}; "
         f"recommended={recommendation}",
     )
+
+
+@tool_app.command("triage-issues")
+def triage_issues(
+    repo: str = typer.Argument(..., help="Repository in owner/name form (e.g. souliane/teatree)"),
+    *,
+    stale_days: int = typer.Option(30, "--stale-days", help="Inactivity threshold for stale-issue detection."),
+    close_resolved: bool = typer.Option(
+        False, "--close-resolved", help="Close resolved-but-open issues (with comment linking the merged PR)."
+    ),
+) -> None:
+    """Scan for resolved-but-open and stale issues."""
+    from teatree.triage import TriageScanner  # noqa: PLC0415
+
+    scanner = TriageScanner(repo)
+
+    resolved = scanner.find_resolved()
+    if resolved:
+        typer.echo(f"\n{'=' * 60}\n Resolved-but-open ({len(resolved)} issue(s))\n{'=' * 60}")
+        for r in resolved:
+            typer.echo(f"  #{r.issue_number}  {r.issue_title}")
+            typer.echo(f"    ↳ merged PR #{r.pr_number}: {r.pr_title}  [{r.confidence}]")
+        if close_resolved:
+            scanner.close_resolved(resolved)
+            typer.echo(f"Closed {len(resolved)} resolved issue(s).")
+        else:
+            typer.echo("\nRe-run with --close-resolved to close these issues.")
+    else:
+        typer.echo("No resolved-but-open issues found.")
+
+    stale = scanner.find_stale(days=stale_days)
+    if stale:
+        typer.echo(f"\n{'=' * 60}\n Stale issues — unlabeled, inactive >{stale_days}d ({len(stale)})\n{'=' * 60}")
+        for s in stale:
+            typer.echo(f"  #{s.issue_number}  {s.issue_title}  ({s.days_inactive}d inactive)")
+    else:
+        typer.echo(f"No stale issues (unlabeled, inactive >{stale_days}d).")

--- a/src/teatree/triage.py
+++ b/src/teatree/triage.py
@@ -1,9 +1,10 @@
-"""Auto-labeling and duplicate detection for GitHub issues — triage tool (see #49)."""
+"""Auto-labeling, duplicate detection, and triage for GitHub issues (see #49)."""
 
 import json
 import re
 import sys
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from difflib import SequenceMatcher
 from itertools import combinations
 
@@ -166,3 +167,145 @@ class DuplicateFinder:
                 )
         matches.sort(key=lambda m: m.score, reverse=True)
         return matches
+
+
+_ISSUE_REF_IN_TITLE = re.compile(r"\(#(\d+)\)")
+
+
+@dataclass(frozen=True)
+class ResolvedIssue:
+    issue_number: int
+    issue_title: str
+    pr_number: int
+    pr_title: str
+
+    @property
+    def confidence(self) -> str:
+        return "high" if f"#{self.issue_number})" in self.pr_title else "medium"
+
+
+@dataclass(frozen=True)
+class StaleIssue:
+    issue_number: int
+    issue_title: str
+    days_inactive: int
+
+
+class TriageScanner:
+    """Find resolved-but-open issues and stale issues."""
+
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+
+    def _fetch_open_issues(self) -> list[dict]:
+        result = run_allowed_to_fail(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                self.repo,
+                "--state",
+                "open",
+                "--limit",
+                "200",
+                "--json",
+                "number,title,body,labels,updatedAt",
+            ],
+            expected_codes=None,
+        )
+        if result.returncode != 0:
+            sys.stderr.write(f"gh issue list failed: {result.stderr.strip()}\n")
+            return []
+        return json.loads(result.stdout or "[]")
+
+    def _fetch_merged_prs(self) -> list[dict]:
+        result = run_allowed_to_fail(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                self.repo,
+                "--state",
+                "merged",
+                "--limit",
+                "200",
+                "--json",
+                "number,title,mergedAt",
+            ],
+            expected_codes=None,
+        )
+        if result.returncode != 0:
+            return []
+        return json.loads(result.stdout or "[]")
+
+    def find_resolved(self) -> list[ResolvedIssue]:
+        issues = self._fetch_open_issues()
+        if not issues:
+            return []
+        prs = self._fetch_merged_prs()
+        if not prs:
+            return []
+
+        issue_numbers = {i["number"] for i in issues}
+        issue_by_number = {i["number"]: i for i in issues}
+
+        resolved: list[ResolvedIssue] = []
+        for pr in prs:
+            for match in _ISSUE_REF_IN_TITLE.finditer(pr["title"]):
+                ref_number = int(match.group(1))
+                if ref_number in issue_numbers:
+                    issue = issue_by_number[ref_number]
+                    resolved.append(
+                        ResolvedIssue(
+                            issue_number=ref_number,
+                            issue_title=issue["title"],
+                            pr_number=pr["number"],
+                            pr_title=pr["title"],
+                        )
+                    )
+        resolved.sort(key=lambda r: r.issue_number)
+        return resolved
+
+    def close_resolved(self, resolved: list[ResolvedIssue]) -> None:
+        for r in resolved:
+            run_allowed_to_fail(
+                [
+                    "gh",
+                    "issue",
+                    "close",
+                    str(r.issue_number),
+                    "--repo",
+                    self.repo,
+                    "--comment",
+                    f"Auto-closed: resolved by #{r.pr_number} ({r.pr_title}).",
+                ],
+                expected_codes=None,
+            )
+
+    def find_stale(self, *, days: int = 30) -> list[StaleIssue]:
+        issues = self._fetch_open_issues()
+        if not issues:
+            return []
+
+        now = datetime.now(tz=UTC)
+        stale: list[StaleIssue] = []
+        for issue in issues:
+            if issue.get("labels"):
+                continue
+            updated_str = issue.get("updatedAt", "")
+            if not updated_str:
+                continue
+            updated = datetime.fromisoformat(updated_str)
+            inactive_days = (now - updated).days
+            if inactive_days >= days:
+                stale.append(
+                    StaleIssue(
+                        issue_number=issue["number"],
+                        issue_title=issue["title"],
+                        days_inactive=inactive_days,
+                    )
+                )
+        stale.sort(key=lambda s: s.days_inactive, reverse=True)
+        return stale

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,10 +1,14 @@
 """Tests for teatree.triage — label inference and duplicate detection for GitHub issues."""
 
 import json
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from teatree.triage import LABEL_KEYWORDS, DuplicateFinder, LabelSuggester, infer_labels, normalize_title
+from typer.testing import CliRunner
+
+from teatree.cli.tools import tool_app
+from teatree.triage import LABEL_KEYWORDS, DuplicateFinder, LabelSuggester, TriageScanner, infer_labels, normalize_title
 
 
 def _issue_fixture() -> list[dict]:
@@ -205,5 +209,143 @@ class TestDuplicateFinder:
         with patch("teatree.triage.run_allowed_to_fail") as mock_run:
             mock_run.return_value = SimpleNamespace(stdout="", stderr="gh: not found", returncode=1)
             matches = DuplicateFinder("souliane/teatree").find()
-
         assert matches == []
+
+
+def _pr_fixture(number: int, title: str) -> dict:
+    return {"number": number, "title": title, "mergedAt": "2026-05-01T00:00:00Z"}
+
+
+def _issue_with_age(number: int, title: str, *, labels: list[dict] | None = None, days_ago: int = 0) -> dict:
+    updated = (datetime.now(tz=UTC) - timedelta(days=days_ago)).isoformat()
+    return {"number": number, "title": title, "body": "", "labels": labels or [], "updatedAt": updated}
+
+
+class TestTriageScanner:
+    def test_finds_resolved_issues_by_title_reference(self) -> None:
+        issues = [_issue_with_age(42, "feat: add triage tool")]
+        prs = [_pr_fixture(100, "feat: add triage tool (#42)")]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.side_effect = [
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(prs), stderr="", returncode=0),
+            ]
+            scanner = TriageScanner("souliane/teatree")
+            resolved = scanner.find_resolved()
+        assert len(resolved) == 1
+        assert resolved[0].issue_number == 42
+        assert resolved[0].pr_number == 100
+
+    def test_ignores_issues_without_merged_pr(self) -> None:
+        issues = [_issue_with_age(42, "feat: add triage tool")]
+        prs: list[dict] = []
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.side_effect = [
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(prs), stderr="", returncode=0),
+            ]
+            resolved = TriageScanner("souliane/teatree").find_resolved()
+        assert resolved == []
+
+    def test_finds_stale_issues(self) -> None:
+        issues = [
+            _issue_with_age(1, "Old issue", days_ago=60),
+            _issue_with_age(2, "Recent issue", days_ago=5),
+            _issue_with_age(3, "Another old one", days_ago=45),
+        ]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0)
+            stale = TriageScanner("souliane/teatree").find_stale(days=30)
+        assert len(stale) == 2
+        assert {s.issue_number for s in stale} == {1, 3}
+
+    def test_stale_excludes_labeled_issues(self) -> None:
+        issues = [
+            _issue_with_age(1, "Old but labeled", labels=[{"name": "enhancement"}], days_ago=60),
+            _issue_with_age(2, "Old and unlabeled", days_ago=60),
+        ]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0)
+            stale = TriageScanner("souliane/teatree").find_stale(days=30)
+        assert len(stale) == 1
+        assert stale[0].issue_number == 2
+
+    def test_find_resolved_gh_pr_failure_returns_empty(self) -> None:
+        issues = [_issue_with_age(42, "feat: thing")]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.side_effect = [
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+                SimpleNamespace(stdout="", stderr="error", returncode=1),
+            ]
+            assert TriageScanner("souliane/teatree").find_resolved() == []
+
+    def test_stale_skips_empty_updated_at(self) -> None:
+        issues = [{"number": 1, "title": "No date", "body": "", "labels": [], "updatedAt": ""}]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0)
+            assert TriageScanner("souliane/teatree").find_stale(days=1) == []
+
+    def test_confidence_property(self) -> None:
+        issues = [_issue_with_age(42, "feat: triage")]
+        prs = [_pr_fixture(100, "feat: triage (#42)")]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.side_effect = [
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(prs), stderr="", returncode=0),
+            ]
+            resolved = TriageScanner("souliane/teatree").find_resolved()
+        assert resolved[0].confidence == "high"
+
+    def test_gh_failure_returns_empty(self) -> None:
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.return_value = SimpleNamespace(stdout="", stderr="error", returncode=1)
+            assert TriageScanner("souliane/teatree").find_resolved() == []
+            assert TriageScanner("souliane/teatree").find_stale() == []
+
+
+runner = CliRunner()
+
+
+class TestTriageIssuesCLI:
+    def test_shows_resolved_and_stale(self) -> None:
+        issues = [_issue_with_age(42, "feat: add triage tool", days_ago=60)]
+        prs = [_pr_fixture(100, "feat: add triage tool (#42)")]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.side_effect = [
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(prs), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+            ]
+            result = runner.invoke(tool_app, ["triage-issues", "souliane/teatree", "--stale-days", "30"])
+        assert result.exit_code == 0
+        assert "#42" in result.output
+        assert "merged PR #100" in result.output
+        assert "60d inactive" in result.output
+
+    def test_no_findings(self) -> None:
+        issues = [_issue_with_age(1, "Recent labeled", labels=[{"name": "bug"}], days_ago=1)]
+        prs: list[dict] = []
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.side_effect = [
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(prs), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+            ]
+            result = runner.invoke(tool_app, ["triage-issues", "souliane/teatree"])
+        assert result.exit_code == 0
+        assert "No resolved-but-open" in result.output
+        assert "No stale" in result.output
+
+    def test_close_resolved_flag(self) -> None:
+        issues = [_issue_with_age(42, "feat: add triage tool")]
+        prs = [_pr_fixture(100, "feat: add triage tool (#42)")]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.side_effect = [
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(prs), stderr="", returncode=0),
+                SimpleNamespace(stdout="", stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+            ]
+            result = runner.invoke(tool_app, ["triage-issues", "souliane/teatree", "--close-resolved"])
+        assert result.exit_code == 0
+        assert "Closed 1" in result.output


### PR DESCRIPTION
## Summary

Third slice of [#49](https://github.com/souliane/teatree/issues/49): adds `TriageScanner` with two scans:

1. **Resolved-but-open**: finds open issues referenced by merged PRs via `(#N)` in the PR title. Preview by default; `--close-resolved` to close with a comment.
2. **Stale issues**: unlabeled issues with no activity for >N days (default 30). Preview only.

## Test plan

- [x] 38 triage tests pass (business logic + CLI)
- [x] Full suite 2679 passed, 93.06% coverage
- [x] All pre-commit hooks + Docker test matrix pass