### PR TITLE
refactor(arch): break config ↔ utils circular dependency

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -60,6 +60,7 @@ src/teatree/
   __init__.py
   __main__.py
   _overlay_api.py       # __overlay_api_version__ pin + import-time guard for overlays
+  paths.py              # XDG-compliant DATA_DIR + get_data_dir (leaf module, no deps)
   config.py             # ~/.teatree.toml parsing, overlay discovery, UserSettings
   settings.py           # Django settings — auto-discovers overlay apps from entry points
   identity.py           # User identity + agent_signature suffix policy
@@ -1628,12 +1629,14 @@ Dev dependencies: ruff, pytest, pytest-cov, pytest-django, ty, import-linter, pr
 
 ```mermaid
 graph TD
+    teatree.config --> teatree.paths
     teatree.config --> teatree.utils
-    teatree.utils --> teatree.config
+    teatree.utils --> teatree.paths
     teatree.timeouts --> teatree.config
     teatree.skill_loading --> teatree.types
     teatree.skill_loading --> teatree.utils
     teatree.core --> teatree.types
+    teatree.core --> teatree.paths
     teatree.core --> teatree.config
     teatree.core --> teatree.utils
     teatree.core --> teatree.timeouts
@@ -1650,6 +1653,7 @@ graph TD
     teatree.contrib --> teatree.core
     teatree.contrib --> teatree.config
     teatree.contrib --> teatree.utils
+    teatree.cli --> teatree.paths
     teatree.cli --> teatree.config
     teatree.cli --> teatree.core
     teatree.cli --> teatree.agents
@@ -1659,6 +1663,7 @@ graph TD
     teatree.cli --> teatree.claude_sessions
     teatree.cli --> teatree.overlay_init
     teatree.cli --> teatree.utils
+    teatree.paths
     teatree.types
     teatree.templates
     teatree.claude_sessions

--- a/src/teatree/cli/config.py
+++ b/src/teatree/cli/config.py
@@ -23,7 +23,8 @@ def write_skill_cache() -> None:
     """Write overlay skill metadata + trigger index to XDG cache for hook consumption."""
     import django  # noqa: PLC0415
 
-    from teatree.config import DATA_DIR, discover_active_overlay  # noqa: PLC0415
+    from teatree.config import discover_active_overlay  # noqa: PLC0415
+    from teatree.paths import DATA_DIR  # noqa: PLC0415
 
     discover_active_overlay()
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
@@ -63,7 +64,7 @@ def cache() -> None:
     """Show the XDG skill-metadata cache content."""
     import json as _json  # noqa: PLC0415
 
-    from teatree.config import DATA_DIR  # noqa: PLC0415
+    from teatree.paths import DATA_DIR  # noqa: PLC0415
 
     cache_path = DATA_DIR / "skill-metadata.json"
     if not cache_path.is_file():
@@ -81,7 +82,7 @@ def deps(skill: str) -> None:
     """Show resolved dependency chain for a skill."""
     import json as _json  # noqa: PLC0415
 
-    from teatree.config import DATA_DIR  # noqa: PLC0415
+    from teatree.paths import DATA_DIR  # noqa: PLC0415
     from teatree.skill_deps import resolve_all  # noqa: PLC0415
 
     cache_path = DATA_DIR / "skill-metadata.json"
@@ -109,7 +110,7 @@ def test_trigger(prompt: str) -> None:
     import json as _json  # noqa: PLC0415
 
     from teatree import find_project_root as _find_root  # noqa: PLC0415
-    from teatree.config import DATA_DIR  # noqa: PLC0415
+    from teatree.paths import DATA_DIR  # noqa: PLC0415
 
     root = _find_root()
     scripts_lib = root / "scripts" / "lib" if root else Path(__file__).resolve().parent

--- a/src/teatree/cli/infra.py
+++ b/src/teatree/cli/infra.py
@@ -2,6 +2,7 @@
 
 import typer
 
+from teatree.config import load_config
 from teatree.utils import redis_container
 
 infra_app = typer.Typer(no_args_is_help=True, help="Teatree-wide infrastructure services.")
@@ -13,7 +14,7 @@ infra_app.add_typer(redis_app, name="redis")
 @redis_app.command(name="up")
 def redis_up() -> None:
     """Start the shared Redis container (idempotent)."""
-    redis_container.ensure_running()
+    redis_container.ensure_running(db_count=load_config().user.redis_db_count)
     typer.echo(f"{redis_container.CONTAINER_NAME}: {redis_container.status()}")
 
 

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -202,7 +202,7 @@ class OverlayAppBuilder:
         @overlay_app.command()
         def resetdb() -> None:
             """Drop the SQLite database and re-run all migrations."""
-            from teatree.config import get_data_dir  # noqa: PLC0415
+            from teatree.paths import get_data_dir  # noqa: PLC0415
 
             db_path = get_data_dir(overlay_name) / "db.sqlite3"
             if db_path.exists():

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -9,10 +9,10 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from teatree.paths import DATA_DIR, get_data_dir
 from teatree.utils.run import TimeoutExpired, run_allowed_to_fail
 
 CONFIG_PATH = Path.home() / ".teatree.toml"
-DATA_DIR = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))) / "teatree"
 
 
 class Mode(StrEnum):
@@ -45,13 +45,6 @@ class Mode(StrEnum):
             valid = ", ".join(m.value for m in cls)
             msg = f"Invalid t3 mode {value!r}; valid values: {valid}"
             raise ValueError(msg) from exc
-
-
-def get_data_dir(namespace: str) -> Path:
-    """Return the data directory for a given namespace, creating it if needed."""
-    data_dir = DATA_DIR / namespace
-    data_dir.mkdir(parents=True, exist_ok=True)
-    return data_dir
 
 
 def default_logging(namespace: str) -> dict:

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -8,10 +8,11 @@ from pathlib import Path
 
 from django_typer.management import TyperCommand, command
 
-from teatree.config import E2ERepo, get_data_dir, load_e2e_repos
+from teatree.config import E2ERepo, load_e2e_repos
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import _find_env_cache, _get_user_cwd, _parse_env_file, resolve_worktree
 from teatree.core.runners.worktree_start import compose_project
+from teatree.paths import get_data_dir
 from teatree.utils.ports import get_service_port
 from teatree.utils.run import run_allowed_to_fail, run_checked, run_streamed
 

--- a/src/teatree/core/management/commands/worktree.py
+++ b/src/teatree/core/management/commands/worktree.py
@@ -16,6 +16,7 @@ import typer
 from django.db import transaction
 from django_typer.management import TyperCommand, command
 
+from teatree.config import load_config
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_overlay
@@ -146,7 +147,7 @@ class Command(TyperCommand):
         _update_ticket_variant(ticket, variant)
         resolved_overlay = get_overlay()
         if resolved_overlay.uses_redis():
-            redis_container.ensure_running()
+            redis_container.ensure_running(db_count=load_config().user.redis_db_count)
             Ticket.objects.allocate_redis_slot(ticket)
         validate_docker_service_contract(resolved_overlay, worktree)
         _build_base_images(resolved_overlay, worktree, writer=self.stdout.write)

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -4,8 +4,8 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 
+from teatree.config import load_config
 from teatree.core.models.errors import RedisSlotsExhaustedError
-from teatree.utils.redis_container import redis_db_count
 
 if TYPE_CHECKING:
     from teatree.core.models.ticket import Ticket
@@ -38,7 +38,7 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
         """
         if ticket.redis_db_index is not None:
             return int(ticket.redis_db_index)
-        count = redis_db_count()
+        count = load_config().user.redis_db_count
         taken = set(self.filter(redis_db_index__isnull=False).values_list("redis_db_index", flat=True))
         for index in range(count):
             if index not in taken:

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -7,7 +7,7 @@ from django.apps import apps
 from django.db import models, transaction
 from django_fsm import FSMField, TransitionNotAllowed, transition
 
-from teatree.config import Mode, get_effective_settings
+from teatree.config import Mode, get_effective_settings, load_config
 from teatree.core.managers import TicketManager
 from teatree.utils import git, redis_container
 from teatree.utils.run import CommandFailedError
@@ -353,7 +353,7 @@ class Ticket(models.Model):
         if self.redis_db_index is None:
             return
         index = self.redis_db_index
-        redis_container.flushdb(index)
+        redis_container.flushdb(index, db_count=load_config().user.redis_db_count)
         self.redis_db_index = None
         self.save(update_fields=["redis_db_index"])
 

--- a/src/teatree/core/skill_cache.py
+++ b/src/teatree/core/skill_cache.py
@@ -16,8 +16,8 @@ import operator
 from pathlib import Path
 
 import teatree
-from teatree.config import DATA_DIR
 from teatree.core.overlay_loader import get_overlay
+from teatree.paths import DATA_DIR
 from teatree.skill_deps import resolve_all
 from teatree.skill_schema import validate_skill_md
 from teatree.trigger_parser import parse_triggers as _parse_triggers

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import cast
 
 from teatree.backends.protocols import CodeHostBackend
-from teatree.config import DATA_DIR
 from teatree.core.sync import RawAPIDict
 from teatree.loop.scanners.base import ScanSignal
+from teatree.paths import DATA_DIR
 
 
 def _default_cache_path() -> Path:

--- a/src/teatree/loop/scanners/slack_mentions.py
+++ b/src/teatree/loop/scanners/slack_mentions.py
@@ -5,9 +5,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from teatree.backends.protocols import MessagingBackend
-from teatree.config import DATA_DIR
 from teatree.core.sync import RawAPIDict
 from teatree.loop.scanners.base import ScanSignal
+from teatree.paths import DATA_DIR
 
 
 def _default_cursor_path() -> Path:

--- a/src/teatree/paths.py
+++ b/src/teatree/paths.py
@@ -1,0 +1,12 @@
+"""XDG-compliant data paths — leaf module with no teatree dependencies."""
+
+import os
+from pathlib import Path
+
+DATA_DIR = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))) / "teatree"
+
+
+def get_data_dir(namespace: str) -> Path:
+    data_dir = DATA_DIR / namespace
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -4,7 +4,8 @@ Used when teatree is the Django project (the standard case).
 Auto-discovers overlay Django apps via entry points and adds them to INSTALLED_APPS.
 """
 
-from teatree.config import default_logging, get_data_dir
+from teatree.config import default_logging
+from teatree.paths import get_data_dir
 
 _DATA_DIR = get_data_dir("teatree")
 

--- a/src/teatree/utils/bad_artifacts.py
+++ b/src/teatree/utils/bad_artifacts.py
@@ -7,7 +7,7 @@ fail restore or migration.
 
 import json
 
-from teatree.config import DATA_DIR
+from teatree.paths import DATA_DIR
 
 _CACHE_FILE = DATA_DIR / "bad_artifacts.json"
 

--- a/src/teatree/utils/redis_container.py
+++ b/src/teatree/utils/redis_container.py
@@ -11,7 +11,6 @@ import logging
 import shutil
 from subprocess import CompletedProcess
 
-from teatree.config import load_config
 from teatree.utils.run import run_allowed_to_fail, run_checked
 
 logger = logging.getLogger(__name__)
@@ -21,9 +20,7 @@ IMAGE = "redis:7-alpine"
 HOST_PORT = 6379
 
 
-def redis_db_count() -> int:
-    """Return the number of Redis DB slots (``~/.teatree.toml``, default 16)."""
-    return load_config().user.redis_db_count
+DEFAULT_DB_COUNT = 16
 
 
 def _docker() -> str:
@@ -50,7 +47,7 @@ def status() -> str:
     return result.stdout.strip() or "missing"
 
 
-def ensure_running() -> None:
+def ensure_running(db_count: int = DEFAULT_DB_COUNT) -> None:
     """Start the shared Redis container if not already running."""
     current = status()
     if current == "running":
@@ -69,7 +66,7 @@ def ensure_running() -> None:
             IMAGE,
             "redis-server",
             "--databases",
-            str(redis_db_count()),
+            str(db_count),
         )
         return
     logger.info("Starting existing %s container (status=%s)", CONTAINER_NAME, current)
@@ -83,13 +80,13 @@ def stop() -> None:
     _docker_tolerant("stop", CONTAINER_NAME)
 
 
-def flushdb(index: int) -> None:
+def flushdb(index: int, db_count: int = DEFAULT_DB_COUNT) -> None:
     """FLUSHDB on the given Redis DB index.
 
     Called when a ticket releases its slot so the next ticket to grab the
     slot starts with a clean cache/queue.
     """
-    count = redis_db_count()
+    count = db_count
     if not 0 <= index < count:
         msg = f"redis db index {index} out of range 0..{count - 1}"
         raise ValueError(msg)

--- a/tach.toml
+++ b/tach.toml
@@ -9,12 +9,16 @@ exclude = [
 source_roots = ["tests", "src", "e2e"]
 
 [[modules]]
+path = "teatree.paths"
+depends_on = []
+
+[[modules]]
 path = "teatree.types"
 depends_on = []
 
 [[modules]]
 path = "teatree.config"
-depends_on = ["teatree.utils"]
+depends_on = ["teatree.paths", "teatree.utils"]
 
 [[modules]]
 path = "teatree.templates"
@@ -30,7 +34,7 @@ depends_on = []
 
 [[modules]]
 path = "teatree.utils"
-depends_on = ["teatree.config"]
+depends_on = ["teatree.paths"]
 
 [[modules]]
 path = "teatree.timeouts"
@@ -48,6 +52,7 @@ depends_on = []
 path = "teatree.core"
 depends_on = [
   "teatree.types",
+  "teatree.paths",
   "teatree.config",
   "teatree.utils",
   "teatree.timeouts",
@@ -79,6 +84,7 @@ depends_on = ["teatree.types", "teatree.core", "teatree.config", "teatree.utils"
 [[modules]]
 path = "teatree.cli"
 depends_on = [
+  "teatree.paths",
   "teatree.config",
   "teatree.core",
   "teatree.agents",

--- a/tests/teatree_core/test_cleanup.py
+++ b/tests/teatree_core/test_cleanup.py
@@ -1,7 +1,7 @@
 import shutil
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from django.test import TestCase
@@ -275,7 +275,7 @@ class TestCleanupWorktree(TestCase):
         with patch("teatree.utils.redis_container.flushdb") as mock_flush:
             cleanup_worktree(wt)
 
-        mock_flush.assert_called_once_with(3)
+        mock_flush.assert_called_once_with(3, db_count=ANY)
         ticket.refresh_from_db()
         assert ticket.redis_db_index is None
 

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from django.core.management import call_command
@@ -97,7 +97,7 @@ class TestLifecycleCommands(TestCase):
                 mock_sp.run.return_value = MagicMock(returncode=0)
                 call_command("worktree", "provision")
 
-            mock_ensure.assert_called_once_with()
+            mock_ensure.assert_called_once_with(db_count=ANY)
             ticket.refresh_from_db()
             assert ticket.redis_db_index == 0
 

--- a/tests/teatree_core/test_redis_slots.py
+++ b/tests/teatree_core/test_redis_slots.py
@@ -7,16 +7,16 @@ across tickets. Slot count is configurable via ``teatree.redis_db_count`` in
 RedisSlotsExhaustedError. Slots are released on ticket cleanup (FLUSHDB + clear field).
 """
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from django.test import TestCase
 
+from teatree.config import load_config
 from teatree.core.models import Ticket
 from teatree.core.models.errors import RedisSlotsExhaustedError
-from teatree.utils.redis_container import redis_db_count
 
-REDIS_DB_COUNT = redis_db_count()
+REDIS_DB_COUNT = load_config().user.redis_db_count
 
 
 class TestAllocateRedisSlot(TestCase):
@@ -58,7 +58,12 @@ class TestAllocateRedisSlot(TestCase):
             Ticket.objects.allocate_redis_slot(overflow)
 
     def test_slot_count_is_configurable(self) -> None:
-        with patch("teatree.core.managers.redis_db_count", return_value=2):
+        cfg = load_config()
+        from dataclasses import replace as _replace  # noqa: PLC0415
+
+        patched_user = _replace(cfg.user, redis_db_count=2)
+        patched_cfg = _replace(cfg, user=patched_user)
+        with patch("teatree.core.managers.load_config", return_value=patched_cfg):
             a = Ticket.objects.create()
             b = Ticket.objects.create()
             Ticket.objects.allocate_redis_slot(a)
@@ -74,7 +79,7 @@ class TestReleaseRedisSlot(TestCase):
         index = Ticket.objects.allocate_redis_slot(ticket)
         with patch("teatree.utils.redis_container.flushdb") as mock_flush:
             ticket.release_redis_slot()
-        mock_flush.assert_called_once_with(index)
+        mock_flush.assert_called_once_with(index, db_count=ANY)
         ticket.refresh_from_db()
         assert ticket.redis_db_index is None
 

--- a/tests/teatree_core/test_redis_slots.py
+++ b/tests/teatree_core/test_redis_slots.py
@@ -7,6 +7,7 @@ across tickets. Slot count is configurable via ``teatree.redis_db_count`` in
 RedisSlotsExhaustedError. Slots are released on ticket cleanup (FLUSHDB + clear field).
 """
 
+from dataclasses import replace as _replace
 from unittest.mock import ANY, patch
 
 import pytest
@@ -59,8 +60,6 @@ class TestAllocateRedisSlot(TestCase):
 
     def test_slot_count_is_configurable(self) -> None:
         cfg = load_config()
-        from dataclasses import replace as _replace  # noqa: PLC0415
-
         patched_user = _replace(cfg.user, redis_db_count=2)
         patched_cfg = _replace(cfg, user=patched_user)
         with patch("teatree.core.managers.load_config", return_value=patched_cfg):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -385,7 +385,7 @@ class TestConfigCommands:
 
     def test_cache_shows_content(self, tmp_path, monkeypatch):
         """Config cache displays skill-metadata.json content."""
-        monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path)
+        monkeypatch.setattr("teatree.paths.DATA_DIR", tmp_path)
         cache_path = tmp_path / "skill-metadata.json"
         cache_path.write_text('{"skill_path": "skills/test/SKILL.md"}\n')
 
@@ -395,7 +395,7 @@ class TestConfigCommands:
 
     def test_cache_no_file(self, tmp_path, monkeypatch):
         """Config cache fails when no cache file exists."""
-        monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path)
+        monkeypatch.setattr("teatree.paths.DATA_DIR", tmp_path)
 
         result = runner.invoke(app, ["config", "cache"])
         assert result.exit_code == 1
@@ -403,7 +403,7 @@ class TestConfigCommands:
 
     def test_deps_shows_chain(self, tmp_path, monkeypatch):
         """Config deps shows resolved dependency chain from cache."""
-        monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path)
+        monkeypatch.setattr("teatree.paths.DATA_DIR", tmp_path)
         cache = tmp_path / "skill-metadata.json"
         cache.write_text(
             json.dumps(
@@ -427,14 +427,14 @@ class TestConfigCommands:
 
     def test_deps_no_cache(self, tmp_path, monkeypatch):
         """Config deps fails when no cache exists."""
-        monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path)
+        monkeypatch.setattr("teatree.paths.DATA_DIR", tmp_path)
         result = runner.invoke(app, ["config", "deps", "test"])
         assert result.exit_code == 1
         assert "No cache found" in result.output
 
     def test_deps_computes_when_not_precomputed(self, tmp_path, monkeypatch):
         """Config deps computes deps on the fly if resolved_requires is missing."""
-        monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path)
+        monkeypatch.setattr("teatree.paths.DATA_DIR", tmp_path)
         cache = tmp_path / "skill-metadata.json"
         cache.write_text(
             json.dumps(
@@ -454,7 +454,7 @@ class TestConfigCommands:
         """Config test-trigger shows matching skill and pattern."""
         import sys  # noqa: PLC0415
 
-        monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path)
+        monkeypatch.setattr("teatree.paths.DATA_DIR", tmp_path)
         cache = tmp_path / "skill-metadata.json"
         cache.write_text(
             json.dumps(
@@ -485,7 +485,7 @@ class TestConfigCommands:
         """Config test-trigger shows no match for unrelated prompt."""
         import sys  # noqa: PLC0415
 
-        monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path)
+        monkeypatch.setattr("teatree.paths.DATA_DIR", tmp_path)
         cache = tmp_path / "skill-metadata.json"
         cache.write_text(json.dumps({"trigger_index": []}))
         scripts_dir = str(Path(__file__).resolve().parent.parent / "scripts")

--- a/tests/test_cli_infra.py
+++ b/tests/test_cli_infra.py
@@ -1,6 +1,6 @@
 """Tests for `t3 infra redis {up,down,status}` CLI."""
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -29,7 +29,7 @@ class TestInfraRedisUp:
         ):
             result = runner.invoke(infra_app, ["redis", "up"])
         assert result.exit_code == 0
-        mock_up.assert_called_once_with()
+        mock_up.assert_called_once_with(db_count=ANY)
 
 
 class TestInfraRedisDown:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -265,7 +265,7 @@ def test_loop_cadence_seconds_override(tmp_path: Path) -> None:
 
 
 def test_get_data_dir_creates_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path / "data")
+    monkeypatch.setattr("teatree.paths.DATA_DIR", tmp_path / "data")
     result = get_data_dir("test-namespace")
     assert result == tmp_path / "data" / "test-namespace"
     assert result.is_dir()
@@ -275,7 +275,7 @@ def test_get_data_dir_creates_directory(tmp_path: Path, monkeypatch: pytest.Monk
 
 
 def test_default_logging_returns_dict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("teatree.config.DATA_DIR", tmp_path / "data")
+    monkeypatch.setattr("teatree.paths.DATA_DIR", tmp_path / "data")
     config = default_logging("test-ns")
     assert config["version"] == 1
     assert "file" in config["handlers"]


### PR DESCRIPTION
## Summary

- Extract `DATA_DIR` and `get_data_dir` to new leaf module `teatree.paths` (no dependencies)
- Update all consumers (13 files) to import from `teatree.paths` directly
- `redis_container`: remove `redis_db_count()` — callers now pass `db_count` from config, keeping `utils` free of config imports
- `tach.toml`: `utils` no longer depends on `config`; `paths` added as leaf module

## Why

The `config ↔ utils` cycle was declared-and-allowed in tach but architecturally unclean. `utils.bad_artifacts` imported `DATA_DIR` from `config`, and `utils.redis_container` imported `load_config` from `config`. Both directions are now broken:

- `DATA_DIR` lives in the new `teatree.paths` leaf module
- `redis_container.ensure_running()` and `flushdb()` accept `db_count` as a parameter instead of reading config internally

## Test plan

- [x] `tach check` passes with `utils → config` edge removed
- [x] 2680 tests pass
- [x] `ruff check` + `ty check` clean