### PR TITLE
refactor(arch): move sync types from core.sync to teatree.types

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1672,6 +1672,7 @@ graph TD
     teatree.agents --> teatree.core
     teatree.agents --> teatree.skill_loading
     teatree.agents --> teatree.utils
+    teatree.backends --> teatree.types
     teatree.backends --> teatree.utils
     teatree.backends --> teatree.core
     teatree.contrib --> teatree.types

--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -8,7 +8,7 @@ from typing import TypedDict, cast
 from urllib.parse import quote_plus, urlparse
 
 from teatree.backends.protocols import PullRequestSpec
-from teatree.core.sync import RawAPIDict
+from teatree.types import RawAPIDict
 from teatree.utils import git
 from teatree.utils.run import CompletedProcess, run_checked
 

--- a/src/teatree/backends/github_sync.py
+++ b/src/teatree/backends/github_sync.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, override
 from django.core.cache import cache
 
 from teatree.core.cleanup import cleanup_worktree
-from teatree.core.sync import PENDING_REVIEWS_CACHE_KEY, RawAPIDict, SyncBackend, SyncResult
+from teatree.types import PENDING_REVIEWS_CACHE_KEY, RawAPIDict, SyncBackend, SyncResult
 from teatree.utils.run import run_allowed_to_fail
 
 if TYPE_CHECKING:

--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 from teatree.backends import gitlab_api as _gitlab_api
 from teatree.backends.gitlab_api import GitLabAPI, ProjectInfo
 from teatree.backends.protocols import PullRequestSpec
-from teatree.core.sync import RawAPIDict
+from teatree.types import RawAPIDict
 
 _ISSUE_URL_RE = re.compile(r"^/(?P<path>.+?)/-/issues/(?P<iid>\d+)/?$")
 

--- a/src/teatree/backends/gitlab_sync.py
+++ b/src/teatree/backends/gitlab_sync.py
@@ -21,7 +21,8 @@ from teatree.backends.gitlab_sync_prs import _PRContext, extract_repo_path, upse
 from teatree.backends.gitlab_sync_terminal import detect_closed_prs, detect_merged_prs
 from teatree.backends.slack_review_sync import fetch_review_permalinks
 from teatree.core.models import Ticket
-from teatree.core.sync import LAST_SYNC_CACHE_KEY, PENDING_REVIEWS_CACHE_KEY, SyncBackend, SyncResult, _overlay_name
+from teatree.core.sync import _overlay_name
+from teatree.types import LAST_SYNC_CACHE_KEY, PENDING_REVIEWS_CACHE_KEY, SyncBackend, SyncResult
 
 logger = logging.getLogger(__name__)
 

--- a/src/teatree/backends/gitlab_sync_approvals.py
+++ b/src/teatree/backends/gitlab_sync_approvals.py
@@ -15,7 +15,7 @@ import operator
 import re
 from dataclasses import dataclass
 
-from teatree.core.sync import RawAPIDict
+from teatree.types import RawAPIDict
 
 _DISMISSED_BODY_RE = re.compile(r"^removed all approvals", re.IGNORECASE)
 _APPROVED_BODY_RE = re.compile(r"^approved (this )?merge request", re.IGNORECASE)

--- a/src/teatree/backends/gitlab_sync_issues.py
+++ b/src/teatree/backends/gitlab_sync_issues.py
@@ -13,7 +13,7 @@ import httpx
 
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.core.models import Ticket
-from teatree.core.sync import SyncResult
+from teatree.types import SyncResult
 
 if TYPE_CHECKING:
     from teatree.backends.gitlab_api import GitLabAPI

--- a/src/teatree/backends/gitlab_sync_prs.py
+++ b/src/teatree/backends/gitlab_sync_prs.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, SupportsInt, cast
 
 from teatree.backends.gitlab_sync_approvals import detect_approval_dismissal
 from teatree.core.models import Ticket
-from teatree.core.sync import DiscussionSummary, PREntry, PREntryDict, RawAPIDict, SyncResult
+from teatree.types import DiscussionSummary, PREntry, PREntryDict, RawAPIDict, SyncResult
 
 if TYPE_CHECKING:
     from teatree.backends.gitlab_api import GitLabAPI, ProjectInfo

--- a/src/teatree/backends/gitlab_sync_terminal.py
+++ b/src/teatree/backends/gitlab_sync_terminal.py
@@ -18,7 +18,7 @@ import httpx
 
 from teatree.core.cleanup import cleanup_worktree
 from teatree.core.models import Ticket, Worktree
-from teatree.core.sync import PREntryDict, RawAPIDict, SyncResult
+from teatree.types import PREntryDict, RawAPIDict, SyncResult
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/src/teatree/backends/messaging_noop.py
+++ b/src/teatree/backends/messaging_noop.py
@@ -1,6 +1,6 @@
 """``NoopMessagingBackend`` — default for overlays that don't declare a chat backend."""
 
-from teatree.core.sync import RawAPIDict
+from teatree.types import RawAPIDict
 
 
 class NoopMessagingBackend:

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -11,7 +11,7 @@ multiple concerns (e.g. GitLab provides code hosting and CI in one client).
 from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
 
-from teatree.core.sync import RawAPIDict
+from teatree.types import RawAPIDict
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/teatree/backends/slack.py
+++ b/src/teatree/backends/slack.py
@@ -4,8 +4,8 @@ from typing import cast
 
 import httpx
 
-from teatree.core.sync import RawAPIDict
 from teatree.identity import agent_signature_suffix
+from teatree.types import RawAPIDict
 
 
 def post_webhook_message(webhook_url: str, text: str, *, signature: str = "") -> RawAPIDict:

--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -14,7 +14,7 @@ from typing import cast
 
 import httpx
 
-from teatree.core.sync import RawAPIDict
+from teatree.types import RawAPIDict
 
 type SlackPayload = dict[str, object]
 

--- a/src/teatree/backends/slack_review_sync.py
+++ b/src/teatree/backends/slack_review_sync.py
@@ -7,7 +7,7 @@ import httpx
 from teatree.backends.slack import SlackReviewSearchRequest, search_review_permalinks
 from teatree.core.models import Ticket
 from teatree.core.overlay_loader import get_overlay
-from teatree.core.sync import SyncResult
+from teatree.types import SyncResult
 
 logger = logging.getLogger(__name__)
 

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -20,7 +20,7 @@ from teatree.core.models.types import TicketExtra, VisualQASummary
 from teatree.core.orphan_guard import BranchStatus, classify_branch
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.runners.ship import overlay_pr_labels, sanitize_close_keywords
-from teatree.core.sync import RawAPIDict
+from teatree.types import RawAPIDict
 from teatree.utils import git
 
 

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -21,7 +21,7 @@ from teatree.types import (
 if TYPE_CHECKING:
     from teatree.core.models import Worktree
     from teatree.core.readiness import Probe
-    from teatree.core.sync import RawAPIDict
+    from teatree.types import RawAPIDict
 
 # Re-export all types so existing ``from teatree.core.overlay import X`` still works.
 __all__ = [

--- a/src/teatree/core/sync.py
+++ b/src/teatree/core/sync.py
@@ -6,97 +6,10 @@ GitLab backend translates to MR internally.
 """
 
 import logging
-from abc import ABC, abstractmethod
-from dataclasses import asdict, dataclass, field
 
-LAST_SYNC_CACHE_KEY = "teatree_followup_last_sync"
-PENDING_REVIEWS_CACHE_KEY = "teatree_pending_reviews"
-
-# Type aliases for untyped external data (GitLab/GitHub API responses)
-# and serialized internal data stored in JSONFields.
-type RawAPIDict = dict[str, object]
-type PREntryDict = dict[str, object]
+from teatree.types import SyncBackend, SyncResult
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(slots=True)
-class SyncResult:
-    prs_found: int = 0
-    issues_found: int = 0
-    tickets_created: int = 0
-    tickets_updated: int = 0
-    labels_fetched: int = 0
-    prs_merged: int = 0
-    prs_closed: int = 0
-    reviews_synced: int = 0
-    worktrees_cleaned: int = 0
-    errors: list[str] = field(default_factory=list)
-
-
-@dataclass(frozen=True, slots=True)
-class DiscussionSummary:
-    status: str
-    detail: str
-
-    def to_dict(self) -> dict[str, str]:
-        return asdict(self)
-
-
-@dataclass(slots=True)
-class PREntry:
-    url: str
-    title: str
-    branch: str
-    draft: bool
-    repo: str
-    iid: int
-    updated_at: str
-    state: str = "opened"  # opened | closed | merged | locked — from the upstream PR API
-    pipeline_status: str | None = None
-    pipeline_url: str | None = None
-    approvals: RawAPIDict | None = None
-    discussions: list[DiscussionSummary] | None = None
-    e2e_test_plan_url: str | None = None
-    review_requested: bool | None = None
-    reviewer_names: list[str] | None = None
-    review_permalink: str | None = None
-    review_channel: str | None = None
-    notion_status: str | None = None
-    notion_url: str | None = None
-    draft_comments_pending: bool | None = None
-    draft_comments_count: int | None = None
-    approvals_dismissed_at: str | None = None
-    dismissed_approvers: list[str] | None = None
-
-    def to_dict(self) -> PREntryDict:
-        result: PREntryDict = {}
-        for k in self.__slots__:
-            v = getattr(self, k)
-            if v is None:
-                continue
-            if k == "discussions":
-                result[k] = [d.to_dict() for d in v]
-            else:
-                result[k] = v
-        return result
-
-
-class SyncBackend(ABC):
-    """Abstract base for code host sync backends.
-
-    Implementations live in ``teatree.backends.*_sync`` and are iterated by
-    ``sync_followup()``.  A single backend is responsible for one code host
-    (GitHub, GitLab, …).
-    """
-
-    @abstractmethod
-    def is_configured(self, overlay: object) -> bool:
-        """Return True if this backend has valid credentials in *overlay*."""
-
-    @abstractmethod
-    def sync(self, overlay: object) -> SyncResult:
-        """Sync from this code host into the local database."""
 
 
 def _merge_results(a: SyncResult, b: SyncResult) -> SyncResult:
@@ -171,19 +84,3 @@ def fetch_notion_statuses() -> None:
         "to populate ticket.extra['notion_status']."
     )
     raise NotImplementedError(msg)
-
-
-__all__ = [
-    "LAST_SYNC_CACHE_KEY",
-    "PENDING_REVIEWS_CACHE_KEY",
-    "DiscussionSummary",
-    "PREntry",
-    "PREntryDict",
-    "RawAPIDict",
-    "SyncBackend",
-    "SyncResult",
-    "_merge_results",
-    "_overlay_name",
-    "fetch_notion_statuses",
-    "sync_followup",
-]

--- a/src/teatree/loop/scanners/assigned_issues.py
+++ b/src/teatree/loop/scanners/assigned_issues.py
@@ -11,8 +11,8 @@ from typing import TYPE_CHECKING, cast
 from django.apps import apps
 
 from teatree.backends.protocols import CodeHostBackend
-from teatree.core.sync import RawAPIDict
 from teatree.loop.scanners.base import ScanSignal
+from teatree.types import RawAPIDict
 
 if TYPE_CHECKING:
     from teatree.core.models.ticket import Ticket

--- a/src/teatree/loop/scanners/my_prs.py
+++ b/src/teatree/loop/scanners/my_prs.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 from typing import cast
 
 from teatree.backends.protocols import CodeHostBackend
-from teatree.core.sync import RawAPIDict
 from teatree.loop.scanners.base import ScanSignal, SignalPayload
+from teatree.types import RawAPIDict
 
 
 def _str_field(data: RawAPIDict, *names: str) -> str:

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import cast
 
 from teatree.backends.protocols import CodeHostBackend
-from teatree.core.sync import RawAPIDict
 from teatree.loop.scanners.base import ScanSignal
 from teatree.paths import DATA_DIR
+from teatree.types import RawAPIDict
 
 
 def _default_cache_path() -> Path:

--- a/src/teatree/loop/scanners/slack_mentions.py
+++ b/src/teatree/loop/scanners/slack_mentions.py
@@ -5,9 +5,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from teatree.backends.protocols import MessagingBackend
-from teatree.core.sync import RawAPIDict
 from teatree.loop.scanners.base import ScanSignal
 from teatree.paths import DATA_DIR
+from teatree.types import RawAPIDict
 
 
 def _default_cursor_path() -> Path:

--- a/src/teatree/loop/scanners/ticket_dispositions.py
+++ b/src/teatree/loop/scanners/ticket_dispositions.py
@@ -27,8 +27,8 @@ from django.apps import apps
 from teatree.backends.loader import get_code_host_for_url
 from teatree.backends.protocols import CodeHostBackend
 from teatree.core.overlay import OverlayBase
-from teatree.core.sync import RawAPIDict
 from teatree.loop.scanners.base import ScanSignal
+from teatree.types import RawAPIDict
 
 if TYPE_CHECKING:
     from teatree.core.models.ticket import Ticket

--- a/src/teatree/types.py
+++ b/src/teatree/types.py
@@ -4,8 +4,9 @@ These types have no Django dependencies and no imports from ``teatree.core``,
 so they can be used by any layer without introducing cycles.
 """
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TypedDict
 
@@ -109,3 +110,82 @@ class ProvisionStep:
     callable: Callable[[], None]
     required: bool = True
     description: str = ""
+
+
+# ── Sync types (shared vocabulary between core and backends) ─────────
+
+LAST_SYNC_CACHE_KEY = "teatree_followup_last_sync"
+PENDING_REVIEWS_CACHE_KEY = "teatree_pending_reviews"
+
+type RawAPIDict = dict[str, object]
+type PREntryDict = dict[str, object]
+
+
+@dataclass(slots=True)
+class SyncResult:
+    prs_found: int = 0
+    issues_found: int = 0
+    tickets_created: int = 0
+    tickets_updated: int = 0
+    labels_fetched: int = 0
+    prs_merged: int = 0
+    prs_closed: int = 0
+    reviews_synced: int = 0
+    worktrees_cleaned: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class DiscussionSummary:
+    status: str
+    detail: str
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class PREntry:
+    url: str
+    title: str
+    branch: str
+    draft: bool
+    repo: str
+    iid: int
+    updated_at: str
+    state: str = "opened"
+    pipeline_status: str | None = None
+    pipeline_url: str | None = None
+    approvals: RawAPIDict | None = None
+    discussions: list[DiscussionSummary] | None = None
+    e2e_test_plan_url: str | None = None
+    review_requested: bool | None = None
+    reviewer_names: list[str] | None = None
+    review_permalink: str | None = None
+    review_channel: str | None = None
+    notion_status: str | None = None
+    notion_url: str | None = None
+    draft_comments_pending: bool | None = None
+    draft_comments_count: int | None = None
+    approvals_dismissed_at: str | None = None
+    dismissed_approvers: list[str] | None = None
+
+    def to_dict(self) -> PREntryDict:
+        result: PREntryDict = {}
+        for k in self.__slots__:
+            v = getattr(self, k)
+            if v is None:
+                continue
+            if k == "discussions":
+                result[k] = [d.to_dict() for d in v]
+            else:
+                result[k] = v
+        return result
+
+
+class SyncBackend(ABC):
+    @abstractmethod
+    def is_configured(self, overlay: object) -> bool: ...
+
+    @abstractmethod
+    def sync(self, overlay: object) -> SyncResult: ...

--- a/tach.toml
+++ b/tach.toml
@@ -73,6 +73,7 @@ depends_on = [
 [[modules]]
 path = "teatree.backends"
 depends_on = [
+  "teatree.types",
   "teatree.utils",
   "teatree.core"
 ]

--- a/tests/teatree_core/test_sync.py
+++ b/tests/teatree_core/test_sync.py
@@ -23,7 +23,8 @@ from teatree.backends.slack_review_sync import fetch_review_permalinks
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase, OverlayConfig, ProvisionStep
 from teatree.core.overlay_loader import reset_overlay_cache
-from teatree.core.sync import (
+from teatree.core.sync import _merge_results, _overlay_name, fetch_notion_statuses, sync_followup
+from teatree.types import (
     LAST_SYNC_CACHE_KEY,
     PENDING_REVIEWS_CACHE_KEY,
     DiscussionSummary,
@@ -31,10 +32,6 @@ from teatree.core.sync import (
     PREntryDict,
     RawAPIDict,
     SyncResult,
-    _merge_results,
-    _overlay_name,
-    fetch_notion_statuses,
-    sync_followup,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/teatree_loop/test_assigned_issues_db.py
+++ b/tests/teatree_loop/test_assigned_issues_db.py
@@ -6,8 +6,8 @@ from typing import Any
 from django.test import TestCase
 
 from teatree.core.models.ticket import Ticket
-from teatree.core.sync import RawAPIDict
 from teatree.loop.scanners.assigned_issues import AssignedIssuesScanner
+from teatree.types import RawAPIDict
 
 
 @dataclass

--- a/tests/teatree_loop/test_scanners.py
+++ b/tests/teatree_loop/test_scanners.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-from teatree.core.sync import RawAPIDict
 from teatree.loop.scanners.assigned_issues import AssignedIssuesScanner
 from teatree.loop.scanners.my_prs import MyPrsScanner
 from teatree.loop.scanners.notion_view import NotionViewScanner
 from teatree.loop.scanners.reviewer_prs import ReviewerPrsScanner
 from teatree.loop.scanners.slack_mentions import SlackMentionsScanner
+from teatree.types import RawAPIDict
 
 
 @dataclass

--- a/tests/teatree_loop/test_ticket_completion.py
+++ b/tests/teatree_loop/test_ticket_completion.py
@@ -8,10 +8,10 @@ from django.test import TestCase
 
 from teatree.core.models.ticket import Ticket
 from teatree.core.overlay import OverlayBase
-from teatree.core.sync import RawAPIDict
 from teatree.loop.dispatch import dispatch
 from teatree.loop.scanners.base import ScanSignal
 from teatree.loop.scanners.ticket_completion import TicketCompletionScanner
+from teatree.types import RawAPIDict
 
 
 @dataclass

--- a/tests/teatree_loop/test_ticket_dispositions.py
+++ b/tests/teatree_loop/test_ticket_dispositions.py
@@ -6,8 +6,8 @@ from typing import Any
 from django.test import TestCase
 
 from teatree.core.models.ticket import Ticket
-from teatree.core.sync import RawAPIDict
 from teatree.loop.scanners.ticket_dispositions import TicketDispositionScanner
+from teatree.types import RawAPIDict
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Move `SyncResult`, `PREntry`, `DiscussionSummary`, `SyncBackend`, `RawAPIDict`, `PREntryDict`, and cache key constants from `core/sync.py` to `teatree/types.py`
- Update 22 source files and 6 test files to import from `teatree.types`
- `core/sync.py` retains orchestration functions only (`sync_followup`, `_merge_results`, `_overlay_name`)
- `tach.toml`: add `teatree.types` to `backends` deps

## Why

Reduces the `backends → core` coupling. Backend modules that only need type definitions (protocols, response shapes, sync data classes) no longer pull in the full `core.sync` module. The remaining `backends → core` edge is for genuine model access (Ticket, Worktree) and cleanup functions — structural, not type-level.

## Test plan

- [x] `tach check` passes
- [x] 2680 tests pass
- [x] `ruff check` + `ty check` clean