### PR TITLE
feat(statusline): loop health — tick countdown + stale warning

### DIFF
--- a/hooks/scripts/completeness-loop.sh
+++ b/hooks/scripts/completeness-loop.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
-# SessionStart hook: ensure a durable teatree fat loop exists.
-#
-# Checks ~/.claude/scheduled_tasks.json for an existing "t3 loop tick"
-# entry. If found, stays silent (singleton). If absent, injects an
-# additionalContext directive telling the agent to create one via
-# CronCreate with durable: true.
+# SessionStart hook: register the teatree fat loop via CronCreate.
 #
 # The fat loop tick combines:
 #  - Scanner dispatch and statusline render (t3 loop tick)
 #  - Task completeness checks (TaskList, deferred-work scan)
+#
+# Singleton: if tick-meta.json was written within 2x the cadence,
+# the loop is already registered in this or a recent session — skip.
 
-_tasks_file="$HOME/.claude/scheduled_tasks.json"
-_marker="t3 loop tick"
+_meta="${XDG_DATA_HOME:-$HOME/.local/share}/teatree/tick-meta.json"
 
-if [ -f "$_tasks_file" ] && grep -q "$_marker" "$_tasks_file" 2>/dev/null; then
-    exit 0
+if [ -f "$_meta" ]; then
+    _cadence="${T3_LOOP_CADENCE:-720}"
+    _meta_mtime=$(stat -f %m "$_meta" 2>/dev/null || stat -c %Y "$_meta" 2>/dev/null || echo 0)
+    _age=$(( $(date +%s) - _meta_mtime ))
+    [ "$_age" -lt $(( _cadence * 2 )) ] && exit 0
 fi
 
 _cadence="${T3_LOOP_CADENCE:-720}"
@@ -23,6 +23,6 @@ _cron_minutes=$(( _cadence / 60 ))
 
 cat <<JSON
 {
-  "additionalContext": "MANDATORY SESSION SETUP (from teatree SessionStart hook): A durable teatree fat loop is NOT yet registered. Create one NOW by calling the CronCreate tool with these exact parameters: cron=\"*/${_cron_minutes} * * * *\", durable=true, recurring=true, prompt=\"Run \`t3 loop tick\` in Bash. Then call TaskList — flag any task in_progress >15 min without a commit, and scan the conversation for deferred work ('for another session', 'out of scope', 'TODO', 'later'). Create TaskCreate entries for any discovered skipped items. Report briefly.\". Do NOT skip this step — it is required for session health monitoring."
+  "additionalContext": "MANDATORY SESSION SETUP (from teatree SessionStart hook): Create a recurring fat loop NOW by calling the CronCreate tool with these exact parameters: cron=\"*/${_cron_minutes} * * * *\", recurring=true, prompt=\"Run \`t3 loop tick\` in Bash. Then call TaskList — flag any task in_progress >15 min without a commit, scan for deferred work. Report briefly.\". Do NOT skip this step — it is required for session health monitoring."
 }
 JSON

--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -135,17 +135,21 @@ _tick_meta="${target%.txt}-meta.json"
 [ ! -r "$_tick_meta" ] && _tick_meta="$(dirname "$target")/tick-meta.json"
 if [ -r "$_tick_meta" ] && command -v jq >/dev/null 2>&1; then
     _next_epoch=$(jq -r '.next_epoch // empty' "$_tick_meta" 2>/dev/null)
+    _tick_cadence=$(jq -r '.cadence // 720' "$_tick_meta" 2>/dev/null)
     if [ -n "$_next_epoch" ]; then
         _now=$(date +%s)
         _diff=$(( _next_epoch - _now ))
-        if (( _diff <= 0 )); then
-            _tick_label="tick now"
-        elif (( _diff < 60 )); then
-            _tick_label="tick in ${_diff}s"
+        _overdue=$(( -_diff ))
+        if (( _diff > 0 && _diff < 60 )); then
+            _tick_label="${_DIM}tick in ${_diff}s${_RST}"
+        elif (( _diff > 0 )); then
+            _tick_label="${_DIM}tick in $(( _diff / 60 ))m${_RST}"
+        elif (( _overdue > _tick_cadence * 2 )); then
+            _tick_label="${_RED}loop stale${_RST}"
         else
-            _tick_label="tick in $(( _diff / 60 ))m"
+            _tick_label="${_DIM}tick now${_RST}"
         fi
-        header="${header}${sep}${_DIM}${_tick_label}${_RST}"
+        header="${header}${sep}${_tick_label}"
     fi
 
     # Repo freshness from tick-meta.json .freshness


### PR DESCRIPTION
## Summary

- Tick countdown now shows **"loop stale"** in red when tick-meta is overdue by >2x cadence
- SessionStart singleton check uses `tick-meta.json` mtime (the `scheduled_tasks.json` approach didn't work — `CronCreate durable` is not persisted by Claude Code)
- Removed `durable=true` from the CronCreate directive; crons are session-scoped and re-registered each session via the hook

## Test plan

- [x] Manual: "tick in 7m" (normal), "tick now" (just due), "loop stale" (>2x overdue)
- [x] Full suite: 2693 passed, 12 skipped
- [x] Hook syntax check: `bash -n` passes