### PR TITLE
fix(setup): add missing app_mentions:read scope to Slack manifest

### DIFF
--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -27,6 +27,7 @@ from teatree.utils.secrets import write_pass
 type SlackManifest = dict[str, Any]
 
 _BOT_SCOPES = [
+    "app_mentions:read",
     "channels:history",
     "channels:read",
     "chat:write",


### PR DESCRIPTION
## Summary

- Add `app_mentions:read` to `_BOT_SCOPES` — required by the `app_mention` bot event
- Without it, Slack rejects the manifest at creation time

## Test plan

- [x] 34 slack setup tests pass
- [x] Verified error message: "App_mention event is missing scope(s): app_mentions:read"