### PR TITLE
refactor(slack): harmonize token ref + auto-detect user ID

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -775,15 +775,15 @@ The loop's PR-sweep scanners (§ 5.6) iterate registered overlays, instantiate e
 
 ### 7.3 Messaging Selection
 
-Per-overlay `messaging_backend` declaration follows the same pattern. Default is `"noop"` — overlays opt in. A single Slack workspace can serve multiple overlays (one bot, one token, distinct channel routing), or each overlay can declare its own bot via `slack_bot_token_ref` (a `pass` entry name; see § 10.1).
+Per-overlay `messaging_backend` declaration follows the same pattern. Default is `"noop"` — overlays opt in. A single Slack workspace can serve multiple overlays (one bot, one token, distinct channel routing), or each overlay can declare its own bot via `slack_token_ref` (a `pass` entry name; see § 10.1).
 
 ```python
 def get_messaging(overlay: OverlayBase) -> MessagingBackend:
     match overlay.config.messaging_backend:
         case "slack":
             return SlackBotBackend(
-                bot_token=pass_get(overlay.config.slack_bot_token_ref + "-bot"),
-                app_token=pass_get(overlay.config.slack_bot_token_ref + "-app"),
+                bot_token=pass_get(overlay.config.slack_token_ref + "-bot"),
+                app_token=pass_get(overlay.config.slack_token_ref + "-app"),
                 user_id=overlay.config.slack_user_id,
             )
         case "noop" | "":
@@ -1029,14 +1029,14 @@ agent_signature = false  # never append agent identity (Co-Authored-By, "Sent us
 path = "~/workspace/myproject"
 code_host = "github"                       # "github" | "gitlab"
 messaging_backend = "slack"                # "slack" | "noop" (default)
-slack_bot_token_ref = "teatree/slack/myproject"   # `pass` entry prefix; -bot and -app suffixes resolve the two tokens
+slack_token_ref = "teatree/slack/myproject"   # `pass` entry prefix; -bot and -app suffixes resolve the two tokens
 slack_user_id = "U01ABCD1234"              # my Slack user ID (used to filter mentions/DMs)
 
 [overlays.another-project]
 path = "~/workspace/another-project"
 code_host = "gitlab"
 messaging_backend = "slack"
-slack_bot_token_ref = "teatree/slack/another-project"
+slack_token_ref = "teatree/slack/another-project"
 slack_user_id = "U01ABCD1234"
 
 # External Playwright E2E repos — used by `t3 e2e external --repo <name>`
@@ -1051,7 +1051,7 @@ e2e_dir = "e2e"  # subdirectory containing playwright.config.ts (default: "e2e")
 **Slack bot setup** (`t3 setup slack-bot --overlay <name>`): an interactive walkthrough scaffolds the per-overlay Slack app and stores its tokens. Steps:
 
 1. Open the Slack-side "Create app from manifest" URL with a teatree-owned manifest pre-filled. The manifest declares Socket Mode (no public webhook needed), the standard scope set (`channels:history`, `channels:read`, `chat:write`, `groups:history`, `groups:read`, `im:history`, `im:read`, `im:write`, `mpim:history`, `mpim:read`, `reactions:read`, `reactions:write`, `users:read`, `users:read.email`), and bot events (`app_mention`, `message.im`).
-2. After the user installs the app to their workspace, capture the bot token (`xoxb-…`) and the app-level token (`xapp-…`) into `pass` entries `<slack_bot_token_ref>-bot` and `<slack_bot_token_ref>-app`.
+2. After the user installs the app to their workspace, capture the bot token (`xoxb-…`) and the app-level token (`xapp-…`) into `pass` entries `<slack_token_ref>-bot` and `<slack_token_ref>-app`.
 3. Capture the user's Slack ID (`U01ABCD1234`) and write it to `[overlays.<name>] slack_user_id` in `~/.teatree.toml`. The walkthrough mutates only the per-overlay block; nothing else in the file is touched.
 4. Smoke-test by sending a DM via the bot and waiting for the user to react with ✅ on the message.
 
@@ -1142,7 +1142,7 @@ Overlay-specific configuration lives on `overlay.config` (an `OverlayConfig` dat
 | Method / property | Return type | Default | Purpose |
 |---|---|---|---|
 | `messaging_backend` | `Literal["slack", "noop"]` | `"noop"` | Selects which `MessagingBackend` the loader returns |
-| `slack_bot_token_ref` | `str` | `""` | `pass` entry prefix; `<ref>-bot` and `<ref>-app` resolve the two tokens |
+| `slack_token_ref` | `str` | `""` | `pass` entry prefix; `<ref>-bot` and `<ref>-app` resolve the two tokens |
 | `slack_user_id` | `str` | `""` | The user's Slack ID (used to filter mentions/DMs) |
 | `get_review_channel()` | `tuple[str, str]` | `("", "")` | (channel name, channel ID) for review-request messages |
 | `get_transition_emojis()` | `dict[str, str]` | `DEFAULT_TRANSITION_EMOJIS` | Emoji reactions per ticket-state transition |

--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -69,7 +69,7 @@ def get_messaging(overlay: "OverlayBase") -> MessagingBackend:
     """
     choice = getattr(overlay.config, "messaging_backend", "") or "noop"
     if choice == "slack":
-        token_ref = getattr(overlay.config, "slack_bot_token_ref", "")
+        token_ref = getattr(overlay.config, "slack_token_ref", "")
         return SlackBotBackend(
             bot_token=read_pass(f"{token_ref}-bot") if token_ref else overlay.config.get_slack_token(),
             app_token=read_pass(f"{token_ref}-app") if token_ref else "",

--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -99,7 +99,7 @@ def write_overlay_settings(
     overlay_name: str,
     *,
     slack_user_id: str,
-    slack_bot_token_ref: str,
+    slack_token_ref: str,
     messaging_backend: str = "slack",
 ) -> None:
     """Persist Slack settings on the per-overlay block of *config_path*.
@@ -127,7 +127,7 @@ def write_overlay_settings(
 
     overlay_block["messaging_backend"] = messaging_backend
     overlay_block["slack_user_id"] = slack_user_id
-    overlay_block["slack_bot_token_ref"] = slack_bot_token_ref
+    overlay_block["slack_token_ref"] = slack_token_ref
 
     config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
 
@@ -238,9 +238,9 @@ def slack_bot_setup(
         config_path,
         overlay,
         slack_user_id=user_id,
-        slack_bot_token_ref=token_ref,
+        slack_token_ref=token_ref,
     )
-    typer.echo(f"OK    Wrote `[overlays.{overlay}]` slack_user_id and slack_bot_token_ref to {config_path}.")
+    typer.echo(f"OK    Wrote `[overlays.{overlay}]` slack_user_id and slack_token_ref to {config_path}.")
 
     typer.echo("Step 4/4 — Smoke test.")
     if skip_smoke_test:

--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -148,6 +148,19 @@ def _prompt_token(label: str, pattern: re.Pattern[str]) -> str:
         typer.echo(f"      Invalid {label} format — try again.")
 
 
+def _resolve_user_id(bot_token: str) -> str | None:
+    """Auto-detect the installing user's Slack ID via email lookup."""
+    from teatree.utils.run import run_allowed_to_fail  # noqa: PLC0415
+
+    result = run_allowed_to_fail(["git", "config", "user.email"], expected_codes=None, timeout=3)
+    email = result.stdout.strip() if result.returncode == 0 else ""
+    if not email:
+        return None
+    backend = SlackBotBackend(bot_token=bot_token, user_id="")
+    user_id = backend.resolve_user_id(email)
+    return user_id if _USER_ID_RE.match(user_id) else None
+
+
 def _prompt_user_id() -> str:
     while True:
         value = typer.prompt("Your Slack user id (e.g. U01ABCD1234)").strip()
@@ -210,7 +223,7 @@ def slack_bot_setup(
     if not reset:
         manifest = build_manifest(overlay_name=overlay)
         url = manifest_install_url(manifest)
-        typer.echo("Step 1/4 — Create the Slack app.")
+        typer.echo("Step 1/3 — Create the Slack app.")
         typer.echo("")
         typer.echo("      Opening https://api.slack.com/apps …")
         webbrowser.open(url)
@@ -225,15 +238,19 @@ def slack_bot_setup(
         typer.echo("      → Generate an App-Level Token (xapp-…) from Basic Information")
         typer.echo('        (scope: connections:write, name: "teatree")')
     else:
-        typer.echo("Step 1/4 — Reset mode: skipping manifest.")
+        typer.echo("Step 1/3 — Reset mode: skipping manifest.")
 
-    typer.echo("Step 2/4 — Paste the bot token (`xoxb-…`) and app-level token (`xapp-…`).")
+    typer.echo("Step 2/3 — Paste the bot token (`xoxb-…`) and app-level token (`xapp-…`).")
     bot_token = _prompt_token("bot token", _BOT_TOKEN_RE)
     app_token = _prompt_token("app-level token", _APP_TOKEN_RE)
     _store_tokens(token_ref, bot_token=bot_token, app_token=app_token)
 
-    typer.echo("Step 3/4 — Record your Slack user id so the bot knows who to talk to.")
-    user_id = _prompt_user_id()
+    user_id = _resolve_user_id(bot_token)
+    if user_id:
+        typer.echo(f"OK    Auto-detected Slack user id: {user_id}")
+    else:
+        typer.echo("      Could not auto-detect Slack user id from git email.")
+        user_id = _prompt_user_id()
     write_overlay_settings(
         config_path,
         overlay,
@@ -242,7 +259,7 @@ def slack_bot_setup(
     )
     typer.echo(f"OK    Wrote `[overlays.{overlay}]` slack_user_id and slack_token_ref to {config_path}.")
 
-    typer.echo("Step 4/4 — Smoke test.")
+    typer.echo("Step 3/3 — Smoke test.")
     if skip_smoke_test:
         typer.echo("      Skipped per `--skip-smoke-test`.")
         return

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -83,7 +83,7 @@ class OverlayConfig:
     """
     messaging_backend: str = "noop"
     """Selects the MessagingBackend implementation: ``"slack"`` or ``"noop"`` (default)."""
-    slack_bot_token_ref: str = ""
+    slack_token_ref: str = ""
     """``pass`` entry name prefix for Slack bot credentials.
 
     The loader reads ``<ref>-bot`` (xoxb token) and ``<ref>-app`` (xapp token).

--- a/tests/test_slack_setup.py
+++ b/tests/test_slack_setup.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import sys
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
@@ -196,6 +197,11 @@ def _stub_overlays() -> list[OverlayEntry]:
 
 
 class TestSlackBotCommand:
+    @pytest.fixture(autouse=True)
+    def _no_auto_resolve(self) -> Generator[None]:
+        with patch("teatree.cli.slack_setup._resolve_user_id", return_value=None):
+            yield
+
     def _invoke(self, tmp_path: Path, *, inputs: str, args: list[str]) -> "object":
         runner = CliRunner()
         config = tmp_path / "teatree.toml"

--- a/tests/test_slack_setup.py
+++ b/tests/test_slack_setup.py
@@ -116,11 +116,11 @@ class TestWriteOverlaySettings:
             config,
             "acme",
             slack_user_id="U01ABCD1234",
-            slack_bot_token_ref="teatree/acme/slack",
+            slack_token_ref="teatree/acme/slack",
         )
         document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
         assert document["overlays"]["acme"]["slack_user_id"] == "U01ABCD1234"
-        assert document["overlays"]["acme"]["slack_bot_token_ref"] == "teatree/acme/slack"
+        assert document["overlays"]["acme"]["slack_token_ref"] == "teatree/acme/slack"
         assert document["overlays"]["acme"]["messaging_backend"] == "slack"
 
     def test_preserves_unrelated_keys(self, tmp_path: Path) -> None:
@@ -135,7 +135,7 @@ class TestWriteOverlaySettings:
             config,
             "acme",
             slack_user_id="U01ABCD1234",
-            slack_bot_token_ref="teatree/acme/slack",
+            slack_token_ref="teatree/acme/slack",
         )
         document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
         assert document["teatree"]["workspace_dir"] == "~/work"
@@ -147,18 +147,18 @@ class TestWriteOverlaySettings:
     def test_overwrites_existing_slack_settings(self, tmp_path: Path) -> None:
         config = tmp_path / "teatree.toml"
         config.write_text(
-            '[overlays.acme]\nslack_user_id = "U_OLD"\nslack_bot_token_ref = "old-ref"\n',
+            '[overlays.acme]\nslack_user_id = "U_OLD"\nslack_token_ref = "old-ref"\n',
             encoding="utf-8",
         )
         write_overlay_settings(
             config,
             "acme",
             slack_user_id="U_NEW",
-            slack_bot_token_ref="new-ref",
+            slack_token_ref="new-ref",
         )
         document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
         assert document["overlays"]["acme"]["slack_user_id"] == "U_NEW"
-        assert document["overlays"]["acme"]["slack_bot_token_ref"] == "new-ref"
+        assert document["overlays"]["acme"]["slack_token_ref"] == "new-ref"
 
 
 class TestPatterns:
@@ -237,7 +237,7 @@ class TestSlackBotCommand:
         assert captured["teatree/acme/slack-app"] == "xapp-1-test"
         document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
         assert document["overlays"]["acme"]["slack_user_id"] == "U01ABCD1234"
-        assert document["overlays"]["acme"]["slack_bot_token_ref"] == "teatree/acme/slack"
+        assert document["overlays"]["acme"]["slack_token_ref"] == "teatree/acme/slack"
 
     def test_reset_skips_manifest_url(self, tmp_path: Path) -> None:
         opened: list[str] = []


### PR DESCRIPTION
## Summary

- Rename `slack_bot_token_ref` → `slack_token_ref` across codebase + BLUEPRINT
- Auto-detect Slack user ID from `git config user.email` via Slack API
- Streamline from 4 interactive steps to 2 (paste tokens + smoke test)

## Test plan

- [x] 34 slack setup tests pass
- [x] Full suite: 2693 passed, 12 skipped