### PR TITLE
feat(hooks): mirror AskUserQuestion to Slack DM

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -27,6 +27,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook_router.py --event PreToolUse",
+            "timeout": 8
+          }
+        ]
+      },
+      {
         "matcher": "Bash|Edit|Write",
         "hooks": [
           {

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -694,6 +694,98 @@ def handle_block_direct_commands(data: dict) -> bool:
     return True
 
 
+# ── PreToolUse: mirror-question-to-slack ─────────────────────────────
+
+
+def _slack_config_from_toml() -> tuple[str, str] | None:
+    """Return (bot_token_ref, user_id) from the first slack-enabled overlay."""
+    import tomllib  # noqa: PLC0415
+
+    config_path = Path.home() / ".teatree.toml"
+    if not config_path.is_file():
+        return None
+    try:
+        with config_path.open("rb") as f:
+            config = tomllib.load(f)
+    except Exception:  # noqa: BLE001
+        return None
+    for overlay_cfg in (config.get("overlays") or {}).values():
+        if overlay_cfg.get("messaging_backend") == "slack":
+            ref = overlay_cfg.get("slack_token_ref", "")
+            uid = overlay_cfg.get("slack_user_id", "")
+            if ref and uid:
+                return ref, uid
+    return None
+
+
+def _format_question_text(questions: list[dict]) -> str:
+    lines: list[str] = []
+    for q in questions:
+        lines.append(f"*{q.get('question', '')}*")
+        for i, opt in enumerate(q.get("options", []), 1):
+            label = opt.get("label", "")
+            desc = opt.get("description", "")
+            lines.append(f"  {i}. {label}" + (f" — {desc}" if desc else ""))
+    lines.append("\n_Reply with the number (e.g. `1`) or type your answer._")
+    return "\n".join(lines)
+
+
+def _slack_post_dm(bot_token: str, user_id: str, text: str) -> None:
+    import contextlib  # noqa: PLC0415
+    import urllib.request  # noqa: PLC0415
+
+    dm_payload = json.dumps({"users": user_id}).encode()
+    dm_req = urllib.request.Request(
+        "https://slack.com/api/conversations.open",
+        data=dm_payload,
+        headers={"Authorization": f"Bearer {bot_token}", "Content-Type": "application/json"},
+    )
+    try:
+        dm_resp = json.loads(urllib.request.urlopen(dm_req, timeout=5).read())  # noqa: S310
+    except Exception:  # noqa: BLE001
+        return
+    channel = dm_resp.get("channel", {}).get("id", "")
+    if not channel:
+        return
+
+    msg_payload = json.dumps({"channel": channel, "text": text}).encode()
+    msg_req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=msg_payload,
+        headers={"Authorization": f"Bearer {bot_token}", "Content-Type": "application/json"},
+    )
+    with contextlib.suppress(Exception):
+        urllib.request.urlopen(msg_req, timeout=5)  # noqa: S310
+
+
+def _post_question_to_slack(data: dict) -> None:
+    questions = data.get("tool_input", {}).get("questions", [])
+    if not questions:
+        return
+    slack_cfg = _slack_config_from_toml()
+    if slack_cfg is None:
+        return
+    token_ref, user_id = slack_cfg
+    result = subprocess.run(  # noqa: S603
+        ["pass", "show", f"{token_ref}-bot"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    bot_token = result.stdout.strip() if result.returncode == 0 else ""
+    if not bot_token:
+        return
+    _slack_post_dm(bot_token, user_id, _format_question_text(questions))
+
+
+def handle_mirror_question_to_slack(data: dict) -> bool:
+    if data.get("tool_name") != "AskUserQuestion":
+        return False
+    _post_question_to_slack(data)
+    return False
+
+
 # ── Router ──────────────────────────────────────────────────────────
 
 _HANDLERS: dict[str, list] = {
@@ -703,6 +795,7 @@ _HANDLERS: dict[str, list] = {
         handle_enforce_skill_loading,
         handle_block_direct_commands,
         handle_validate_mr_metadata,
+        handle_mirror_question_to_slack,
     ],
     "PostToolUse": [handle_track_active_repo, handle_track_skill_usage, handle_read_dedup],
     "InstructionsLoaded": [handle_track_skill_usage],

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -414,6 +414,8 @@ This rule does NOT override `User Instructions Are Priority 1` — explicit corr
 
 **Never ask questions inline in text responses.** Always use the `AskUserQuestion` tool — it gives the user a structured UI to respond and prevents questions from being buried in output. One question at a time; wait for the answer before asking the next.
 
+**Why this matters beyond UX:** when Slack is configured, the `PreToolUse` hook automatically mirrors every `AskUserQuestion` call to the user's Slack DM. The user can see pending questions on their phone even when away from the terminal. Plain-text questions bypass this mirror and are invisible on Slack.
+
 ## Publishing Actions Are Mode-Conditional (Non-Negotiable)
 
 The setting `teatree.mode` in `~/.teatree.toml` (or the `T3_MODE` env var) picks between two doctrines for publishing actions — push, PR create, PR merge, PR approve/unapprove, remote branch deletion, Slack posts, any write that leaves the local machine. The default is `interactive` (security-conservative). `auto` opts into full autonomy.


### PR DESCRIPTION
## Summary

- New PreToolUse hook mirrors every `AskUserQuestion` call to the user's Slack DM
- Numbered choices format: user can reply with just the number
- Reads Slack config from `~/.teatree.toml`, bot token from `pass`
- Fails silently when Slack is not configured (no-op for non-Slack users)
- Rules skill updated: explains the Slack mirror as motivation for always using `AskUserQuestion`

## Test plan

- [x] Full suite: 2693 passed, 12 skipped
- [x] Lint clean
- [ ] Live test: trigger an AskUserQuestion and verify Slack DM delivery