### PR TITLE
feat(slack): Socket Mode receiver + t3 slack listen CLI

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -186,6 +186,7 @@ src/teatree/
     gitlab_sync_approvals.py / gitlab_sync_terminal.py  # Approval and terminal-state sync helpers
     slack.py            # Slack API client (httpx wrapper for SlackBotBackend)
     slack_bot.py        # SlackBotBackend — Socket Mode messaging client (implements MessagingBackend)
+    slack_receiver.py   # Socket Mode receiver — writes inbound events to JSONL queue (t3 slack listen)
     slack_reactions.py  # Reaction helpers used by transition signals
     slack_review_sync.py # Review-thread → Slack post sync
     messaging_noop.py   # NoopMessagingBackend — default for overlays that opt out
@@ -775,15 +776,17 @@ The loop's PR-sweep scanners (§ 5.6) iterate registered overlays, instantiate e
 
 ### 7.3 Messaging Selection
 
-Per-overlay `messaging_backend` declaration follows the same pattern. Default is `"noop"` — overlays opt in. A single Slack workspace can serve multiple overlays (one bot, one token, distinct channel routing), or each overlay can declare its own bot via `slack_bot_token_ref` (a `pass` entry name; see § 10.1).
+Per-overlay `messaging_backend` declaration follows the same pattern. Default is `"noop"` — overlays opt in. A single Slack workspace can serve multiple overlays (one bot, one token, distinct channel routing), or each overlay can declare its own bot via `slack_token_ref` (a `pass` entry name prefix; see § 10.1).
+
+**Inbound events.** `t3 slack listen` runs a global singleton Socket Mode receiver that opens one WebSocket per slack-enabled overlay. Events (`app_mention`, `message.im`) are written to an append-only JSONL queue at `$XDG_DATA_HOME/teatree/slack-events.jsonl`. The fat loop tick drains the queue via `SlackMentionsScanner`. When the receiver is not running, `fetch_dms` falls back to `conversations.history` API polling. Install the optional `slack_sdk` dependency with `uv tool install --editable '.[slack]'`.
 
 ```python
 def get_messaging(overlay: OverlayBase) -> MessagingBackend:
     match overlay.config.messaging_backend:
         case "slack":
             return SlackBotBackend(
-                bot_token=pass_get(overlay.config.slack_bot_token_ref + "-bot"),
-                app_token=pass_get(overlay.config.slack_bot_token_ref + "-app"),
+                bot_token=pass_get(overlay.config.slack_token_ref + "-bot"),
+                app_token=pass_get(overlay.config.slack_token_ref + "-app"),
                 user_id=overlay.config.slack_user_id,
             )
         case "noop" | "":
@@ -1029,14 +1032,14 @@ agent_signature = false  # never append agent identity (Co-Authored-By, "Sent us
 path = "~/workspace/myproject"
 code_host = "github"                       # "github" | "gitlab"
 messaging_backend = "slack"                # "slack" | "noop" (default)
-slack_bot_token_ref = "teatree/slack/myproject"   # `pass` entry prefix; -bot and -app suffixes resolve the two tokens
+slack_token_ref = "teatree/slack/myproject"   # `pass` entry prefix; -bot and -app suffixes resolve the two tokens
 slack_user_id = "U01ABCD1234"              # my Slack user ID (used to filter mentions/DMs)
 
 [overlays.another-project]
 path = "~/workspace/another-project"
 code_host = "gitlab"
 messaging_backend = "slack"
-slack_bot_token_ref = "teatree/slack/another-project"
+slack_token_ref = "teatree/slack/another-project"
 slack_user_id = "U01ABCD1234"
 
 # External Playwright E2E repos — used by `t3 e2e external --repo <name>`
@@ -1051,7 +1054,7 @@ e2e_dir = "e2e"  # subdirectory containing playwright.config.ts (default: "e2e")
 **Slack bot setup** (`t3 setup slack-bot --overlay <name>`): an interactive walkthrough scaffolds the per-overlay Slack app and stores its tokens. Steps:
 
 1. Open the Slack-side "Create app from manifest" URL with a teatree-owned manifest pre-filled. The manifest declares Socket Mode (no public webhook needed), the standard scope set (`channels:history`, `channels:read`, `chat:write`, `groups:history`, `groups:read`, `im:history`, `im:read`, `im:write`, `mpim:history`, `mpim:read`, `reactions:read`, `reactions:write`, `users:read`, `users:read.email`), and bot events (`app_mention`, `message.im`).
-2. After the user installs the app to their workspace, capture the bot token (`xoxb-…`) and the app-level token (`xapp-…`) into `pass` entries `<slack_bot_token_ref>-bot` and `<slack_bot_token_ref>-app`.
+2. After the user installs the app to their workspace, capture the bot token (`xoxb-…`) and the app-level token (`xapp-…`) into `pass` entries `<slack_token_ref>-bot` and `<slack_token_ref>-app`.
 3. Capture the user's Slack ID (`U01ABCD1234`) and write it to `[overlays.<name>] slack_user_id` in `~/.teatree.toml`. The walkthrough mutates only the per-overlay block; nothing else in the file is touched.
 4. Smoke-test by sending a DM via the bot and waiting for the user to react with ✅ on the message.
 
@@ -1142,7 +1145,7 @@ Overlay-specific configuration lives on `overlay.config` (an `OverlayConfig` dat
 | Method / property | Return type | Default | Purpose |
 |---|---|---|---|
 | `messaging_backend` | `Literal["slack", "noop"]` | `"noop"` | Selects which `MessagingBackend` the loader returns |
-| `slack_bot_token_ref` | `str` | `""` | `pass` entry prefix; `<ref>-bot` and `<ref>-app` resolve the two tokens |
+| `slack_token_ref` | `str` | `""` | `pass` entry prefix; `<ref>-bot` and `<ref>-app` resolve the two tokens |
 | `slack_user_id` | `str` | `""` | The user's Slack ID (used to filter mentions/DMs) |
 | `get_review_channel()` | `tuple[str, str]` | `("", "")` | (channel name, channel ID) for review-request messages |
 | `get_transition_emojis()` | `dict[str, str]` | `DEFAULT_TRANSITION_EMOJIS` | Emoji reactions per ticket-state transition |

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -29,6 +29,7 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 │ overlay         Dev-mode overlay install/uninstall.                          │
 │ infra           Teatree-wide infrastructure services.                        │
 │ loop            Manage the long-lived fat loop.                              │
+│ slack           Slack integration commands.                                  │
 │ teatree         Commands for the t3-teatree overlay.                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -988,6 +989,52 @@ Usage: t3 loop start [OPTIONS]
 Usage: t3 loop stop [OPTIONS]
 
  Print the slot id to stop in the Claude Code session.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+### `t3 slack`
+
+```
+Usage: t3 slack [OPTIONS] COMMAND [ARGS]...
+
+ Slack integration commands.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ listen  Run the Socket Mode receiver for all (or one) slack-enabled          │
+│         overlays.                                                            │
+│ status  Check if the Socket Mode listener is running.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 slack listen`
+
+```
+Usage: t3 slack listen [OPTIONS]
+
+ Run the Socket Mode receiver for all (or one) slack-enabled overlays.
+
+ Maintains one WebSocket per overlay, writes events to a JSONL queue
+ file that the fat loop tick drains. Runs until SIGTERM or SIGINT.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --overlay           TEXT  Restrict to a single overlay (default: all).       │
+│ --queue-file        PATH  Override the event queue path (test hook).         │
+│ --help                    Show this message and exit.                        │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 slack status`
+
+```
+Usage: t3 slack status [OPTIONS]
+
+ Check if the Socket Mode listener is running.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "httpx>=0.27",
   "tomlkit>=0.13",
 ]
+optional-dependencies.slack = [ "slack-sdk>=3.35" ]
 scripts = { t3 = "t3_bootstrap:main" }
 
 entry-points."teatree.overlays".t3-teatree = "teatree.contrib.t3_teatree.overlay:TeatreeOverlay"
@@ -44,6 +45,7 @@ dev = [
   "pytest-timeout>=2.4",
   "pytest-xdist>=3.5",
   "ruff>=0.14.2",
+  "slack-sdk>=3.35",
   "tach>=0.34",
   "ty>=0.0.18",
   "typer>=0.12",

--- a/src/teatree/backends/slack_receiver.py
+++ b/src/teatree/backends/slack_receiver.py
@@ -1,0 +1,147 @@
+"""Socket Mode receiver — writes inbound Slack events to a JSONL queue file.
+
+One global singleton process handles all slack-enabled overlays. Each overlay
+gets its own WebSocket connection (one per ``xapp-`` token). Events are written
+to a single append-only JSONL queue at ``$XDG_DATA_HOME/teatree/slack-events.jsonl``
+tagged with the overlay name. The fat loop tick drains the queue via
+:func:`drain_event_queue`.
+
+Start with ``t3 slack listen`` (all overlays) or ``t3 slack listen --overlay X``.
+"""
+
+import json
+import logging
+import os
+import signal
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_QUEUE_FILENAME = "slack-events.jsonl"
+_HANDLED_EVENT_TYPES = frozenset({"app_mention", "message"})
+
+
+def default_queue_path() -> Path:
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "share"
+    return base / "teatree" / _QUEUE_FILENAME
+
+
+def _enqueue(path: Path, overlay: str, event: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps({"overlay": overlay, "event": event}, separators=(",", ":"))
+    with path.open("a", encoding="utf-8") as f:
+        f.write(line + "\n")
+
+
+def drain_event_queue(path: Path | None = None) -> list[dict]:
+    path = path or default_queue_path()
+    if not path.is_file():
+        return []
+    tmp = path.with_suffix(".draining")
+    try:
+        path.rename(tmp)
+    except OSError:
+        return []
+    events = []
+    for line in tmp.read_text(encoding="utf-8").strip().splitlines():
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    tmp.unlink(missing_ok=True)
+    return events
+
+
+def _run_single_overlay(
+    *,
+    overlay_name: str,
+    app_token: str,
+    bot_token: str,
+    queue_path: Path,
+    stop_event: threading.Event,
+) -> None:
+    try:
+        from slack_sdk.socket_mode import SocketModeClient  # noqa: PLC0415
+        from slack_sdk.socket_mode.client import BaseSocketModeClient  # noqa: PLC0415
+        from slack_sdk.socket_mode.request import SocketModeRequest  # noqa: PLC0415
+        from slack_sdk.socket_mode.response import SocketModeResponse  # noqa: PLC0415
+        from slack_sdk.web import WebClient  # noqa: PLC0415
+    except ImportError:
+        logger.warning("slack_sdk not installed — reinstall with: uv tool install --editable '.[slack]'")
+        return
+
+    web_client = WebClient(token=bot_token)
+    client = SocketModeClient(app_token=app_token, web_client=web_client)
+
+    def _handle(_sm_client: BaseSocketModeClient, req: SocketModeRequest) -> None:
+        client.send_socket_mode_response(SocketModeResponse(envelope_id=req.envelope_id))
+        if req.type != "events_api":
+            return
+        event = (req.payload or {}).get("event", {})
+        event_type = event.get("type", "")
+        if event_type not in _HANDLED_EVENT_TYPES:
+            return
+        subtype = event.get("subtype", "")
+        if subtype in {"bot_message", "message_changed", "message_deleted"}:
+            return
+        _enqueue(queue_path, overlay_name, event)
+        logger.info("[%s] Queued %s event (ts=%s)", overlay_name, event_type, event.get("ts", "?"))
+
+    client.socket_mode_request_listeners.append(_handle)
+    client.connect()
+    logger.info("[%s] Socket Mode connected", overlay_name)
+
+    while not stop_event.is_set():
+        stop_event.wait(timeout=1.0)
+
+    client.close()
+    logger.info("[%s] Socket Mode disconnected", overlay_name)
+
+
+def run_listener(
+    overlays: list[tuple[str, str, str]],
+    *,
+    queue_path: Path | None = None,
+) -> None:
+    queue = queue_path or default_queue_path()
+    stop = threading.Event()
+
+    def _signal_handler(signum: int, frame: object) -> None:
+        _ = signum, frame
+        logger.info("Received signal, shutting down")
+        stop.set()
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+
+    threads: list[threading.Thread] = []
+    for overlay_name, app_token, bot_token in overlays:
+        t = threading.Thread(
+            target=_run_single_overlay,
+            kwargs={
+                "overlay_name": overlay_name,
+                "app_token": app_token,
+                "bot_token": bot_token,
+                "queue_path": queue,
+                "stop_event": stop,
+            },
+            daemon=True,
+            name=f"slack-{overlay_name}",
+        )
+        t.start()
+        threads.append(t)
+        logger.info("Started listener thread for %s", overlay_name)
+
+    if not threads:
+        logger.warning("No slack-enabled overlays found")
+        return
+
+    while not stop.is_set():
+        time.sleep(1.0)
+
+    for t in threads:
+        t.join(timeout=5.0)
+    logger.info("All listener threads stopped")

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -28,6 +28,7 @@ from teatree.cli.overlay_dev import overlay_dev_app
 from teatree.cli.review import review_app
 from teatree.cli.review_request import review_request_app
 from teatree.cli.setup import setup_app
+from teatree.cli.slack_listen import slack_app
 from teatree.cli.tools import tool_app
 
 logger = logging.getLogger(__name__)
@@ -91,6 +92,7 @@ app.add_typer(assess_app, name="assess")
 app.add_typer(overlay_dev_app, name="overlay")
 app.add_typer(infra_app, name="infra")
 app.add_typer(loop_app, name="loop")
+app.add_typer(slack_app, name="slack")
 
 
 # ── Django-dependent overlay command groups ───────────────────────────

--- a/src/teatree/cli/slack_listen.py
+++ b/src/teatree/cli/slack_listen.py
@@ -1,0 +1,112 @@
+"""``t3 slack listen`` — run the Socket Mode receiver for Slack events."""
+
+import logging
+import os
+from pathlib import Path
+
+import typer
+
+from teatree.backends.slack_receiver import default_queue_path, run_listener
+from teatree.utils.secrets import read_pass
+
+slack_app = typer.Typer(name="slack", help="Slack integration commands.", no_args_is_help=True)
+
+
+def _resolve_overlays(restrict: str) -> list[tuple[str, str, str]]:
+    import tomllib  # noqa: PLC0415
+
+    config_path = Path.home() / ".teatree.toml"
+    if not config_path.is_file():
+        return []
+    with config_path.open("rb") as f:
+        config = tomllib.load(f)
+    result: list[tuple[str, str, str]] = []
+    for name, overlay_cfg in (config.get("overlays") or {}).items():
+        if restrict and name != restrict:
+            continue
+        if overlay_cfg.get("messaging_backend") != "slack":
+            continue
+        token_ref = overlay_cfg.get("slack_token_ref", "")
+        if not token_ref:
+            continue
+        bot_token = read_pass(f"{token_ref}-bot")
+        app_token = read_pass(f"{token_ref}-app")
+        if bot_token and app_token:
+            result.append((name, app_token, bot_token))
+        else:
+            typer.echo(f"WARN  {name}: missing bot or app token in pass at {token_ref}")
+    return result
+
+
+@slack_app.command("listen")
+def listen_command(
+    *,
+    overlay: str = typer.Option("", "--overlay", help="Restrict to a single overlay (default: all)."),
+    queue_file: Path = typer.Option(
+        None,
+        "--queue-file",
+        help="Override the event queue path (test hook).",
+    ),
+) -> None:
+    """Run the Socket Mode receiver for all (or one) slack-enabled overlays.
+
+    Maintains one WebSocket per overlay, writes events to a JSONL queue
+    file that the fat loop tick drains. Runs until SIGTERM or SIGINT.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-5s %(name)s %(message)s",
+    )
+    pid_path = default_queue_path().with_name("slack-listener.pid")
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    if pid_path.is_file():
+        old_pid = pid_path.read_text(encoding="utf-8").strip()
+        if old_pid.isdigit() and _pid_alive(int(old_pid)):
+            typer.echo(f"WARN  Listener already running (PID {old_pid}). Use --overlay for a second instance.")
+            raise typer.Exit(code=1)
+    pid_path.write_text(str(os.getpid()) + "\n", encoding="utf-8")
+
+    overlays = _resolve_overlays(overlay)
+    if not overlays:
+        typer.echo("ERROR No slack-enabled overlays found in ~/.teatree.toml")
+        pid_path.unlink(missing_ok=True)
+        raise typer.Exit(code=1)
+
+    for name, _app, _bot in overlays:
+        typer.echo(f"OK    Listening on {name}")
+
+    try:
+        run_listener(overlays, queue_path=queue_file)
+    finally:
+        pid_path.unlink(missing_ok=True)
+
+
+@slack_app.command("status")
+def status_command() -> None:
+    """Check if the Socket Mode listener is running."""
+    pid_path = default_queue_path().with_name("slack-listener.pid")
+    if not pid_path.is_file():
+        typer.echo("Listener: not running (no PID file)")
+        raise typer.Exit(code=1)
+    pid_str = pid_path.read_text(encoding="utf-8").strip()
+    if not pid_str.isdigit():
+        typer.echo("Listener: stale PID file")
+        pid_path.unlink(missing_ok=True)
+        raise typer.Exit(code=1)
+    pid = int(pid_str)
+    if _pid_alive(pid):
+        typer.echo(f"Listener: running (PID {pid})")
+    else:
+        typer.echo(f"Listener: dead (PID {pid} not found)")
+        pid_path.unlink(missing_ok=True)
+        raise typer.Exit(code=1)
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True

--- a/src/teatree/loop/scanners/slack_mentions.py
+++ b/src/teatree/loop/scanners/slack_mentions.py
@@ -1,10 +1,11 @@
-"""Scan Slack mentions and DMs delivered by the active overlay's MessagingBackend."""
+"""Scan Slack mentions and DMs from the MessagingBackend and the Socket Mode queue."""
 
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from teatree.backends.protocols import MessagingBackend
+from teatree.backends.slack_receiver import drain_event_queue
 from teatree.loop.scanners.base import ScanSignal
 from teatree.paths import DATA_DIR
 from teatree.types import RawAPIDict
@@ -51,6 +52,17 @@ class SlackMentionsScanner:
         cursors = _read_cursors(self.cursor_path)
         mentions = self.backend.fetch_mentions(since=cursors.get("mentions", ""))
         dms = self.backend.fetch_dms(since=cursors.get("dms", ""))
+
+        for queued in drain_event_queue():
+            event = queued.get("event", {})
+            event_type = event.get("type", "")
+            if event_type == "app_mention":
+                mentions.append(event)
+            elif event_type == "message":
+                channel_type = event.get("channel_type", "")
+                if channel_type == "im":
+                    dms.append(event)
+
         signals: list[ScanSignal] = []
         for event in mentions:
             ts = _ts(event)

--- a/uv.lock
+++ b/uv.lock
@@ -1506,6 +1506,15 @@ wheels = [
 ]
 
 [[package]]
+name = "slack-sdk"
+version = "3.41.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/35/fc009118a13187dd9731657c60138e5a7c2dea88681a7f04dc406af5da7d/slack_sdk-3.41.0.tar.gz", hash = "sha256:eb61eb12a65bebeca9cb5d36b3f799e836ed2be21b456d15df2627cfe34076ca", size = 250568, upload-time = "2026-03-12T16:10:11.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/df/2e4be347ff98281b505cc0ccf141408cdd25eb5ca9f3830deb361b2472d3/slack_sdk-3.41.0-py2.py3-none-any.whl", hash = "sha256:bb18dcdfff1413ec448e759cf807ec3324090993d8ab9111c74081623b692a89", size = 313885, upload-time = "2026-03-12T16:10:09.811Z" },
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1580,6 +1589,11 @@ dependencies = [
     { name = "tomlkit" },
 ]
 
+[package.optional-dependencies]
+slack = [
+    { name = "slack-sdk" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "cyclonedx-bom" },
@@ -1594,6 +1608,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "slack-sdk" },
     { name = "tach" },
     { name = "ty" },
     { name = "typer" },
@@ -1612,8 +1627,10 @@ requires-dist = [
     { name = "django-tasks-db", specifier = ">=0.12" },
     { name = "django-typer", specifier = ">=3.3" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.35" },
     { name = "tomlkit", specifier = ">=0.13" },
 ]
+provides-extras = ["slack"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1629,6 +1646,7 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.4" },
     { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "ruff", specifier = ">=0.14.2" },
+    { name = "slack-sdk", specifier = ">=3.35" },
     { name = "tach", specifier = ">=0.34" },
     { name = "ty", specifier = ">=0.0.18" },
     { name = "typer", specifier = ">=0.12" },


### PR DESCRIPTION
## Summary

- `t3 slack listen` — global singleton Socket Mode receiver
- One WebSocket per slack-enabled overlay, events to JSONL queue
- `t3 slack status` — PID-based singleton check
- `SlackMentionsScanner` drains queue on each tick
- `slack_sdk` as optional runtime + dev dep (proper types)
- BLUEPRINT updated

## Test plan

- [x] 2693 passed, 12 skipped
- [x] ruff + ty-check clean