### PR TITLE
feat(hooks): inject retro directive before context compaction

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -80,6 +80,17 @@
         ]
       }
     ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook_router.py --event PreCompact",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
     "PostCompact": [
       {
         "hooks": [

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -527,6 +527,37 @@ def handle_read_dedup(data: dict) -> None:
     )
 
 
+# ── PreCompact: retro-before-compact ──────────────────────────────
+
+
+def handle_pre_compact(data: dict) -> None:
+    """Inject retro directive before compaction destroys session knowledge."""
+    session_id = data.get("session_id", "")
+    if not session_id:
+        return
+
+    skills_file = _state_file(session_id, "skills")
+    loaded: set[str] = set()
+    if skills_file.is_file():
+        loaded = {line.strip() for line in skills_file.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+    lifecycle_skills = {"t3:code", "t3:debug", "t3:test", "t3:ship", "t3:review", "t3:ticket"}
+    if not (loaded & lifecycle_skills):
+        return
+
+    json.dump(
+        {
+            "additionalContext": (
+                "COMPACTION IMMINENT — lifecycle skills were active this session "
+                f"({', '.join(sorted(loaded & lifecycle_skills))}). "
+                "Run /t3:retro NOW to persist session learnings to memory before "
+                "context is compressed. After retro completes, compaction will proceed."
+            ),
+        },
+        sys.stdout,
+    )
+
+
 # ── PostCompact: recover-temp-files ───────────────────────────────
 
 
@@ -803,6 +834,7 @@ _HANDLERS: dict[str, list] = {
         handle_read_dedup,
     ],
     "InstructionsLoaded": [handle_track_skill_usage],
+    "PreCompact": [handle_pre_compact],
     "PostCompact": [handle_post_compact],
     "SessionEnd": [handle_session_end],
 }


### PR DESCRIPTION
## Summary
- Adds `PreCompact` hook that checks if lifecycle skills were loaded during the session
- When active, injects an `additionalContext` directive telling the agent to run `/t3:retro` before context is compressed
- Preserves session learnings (debug findings, design decisions, test patterns) that would otherwise be lost during compaction

## Context
Claude Code autocompaction on 1M context models has a known bug ([anthropics/claude-code#52390](https://github.com/anthropics/claude-code/issues/52390)) where the trigger metric uses uncached `input_tokens` instead of cumulative context. When compaction does fire, this hook ensures retro runs first.

## Test plan
- [x] Smoke-tested handler with lifecycle skill loaded → directive injected
- [x] Verified no output when no lifecycle skills loaded
- [x] Pre-commit hooks pass (ruff, ty, tach, codespell)