### PR TITLE
fix(slack): complete token ref rename + BLUEPRINT docs

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1053,12 +1053,15 @@ e2e_dir = "e2e"  # subdirectory containing playwright.config.ts (default: "e2e")
 
 **Slack bot setup** (`t3 setup slack-bot --overlay <name>`): an interactive walkthrough scaffolds the per-overlay Slack app and stores its tokens. Steps:
 
-1. Open the Slack-side "Create app from manifest" URL with a teatree-owned manifest pre-filled. The manifest declares Socket Mode (no public webhook needed), the standard scope set (`channels:history`, `channels:read`, `chat:write`, `groups:history`, `groups:read`, `im:history`, `im:read`, `im:write`, `mpim:history`, `mpim:read`, `reactions:read`, `reactions:write`, `users:read`, `users:read.email`), and bot events (`app_mention`, `message.im`).
-2. After the user installs the app to their workspace, capture the bot token (`xoxb-…`) and the app-level token (`xapp-…`) into `pass` entries `<slack_token_ref>-bot` and `<slack_token_ref>-app`.
-3. Capture the user's Slack ID (`U01ABCD1234`) and write it to `[overlays.<name>] slack_user_id` in `~/.teatree.toml`. The walkthrough mutates only the per-overlay block; nothing else in the file is touched.
-4. Smoke-test by sending a DM via the bot and waiting for the user to react with ✅ on the message.
+1. Print the manifest JSON (with `messages_tab_enabled`, `app_mentions:read` scope, Socket Mode, bot events `app_mention` + `message.im`) and open the Slack app creation page. The user pastes the manifest, creates the app, installs it to the workspace, and generates an app-level token with `connections:write` scope.
+2. Capture the bot token (`xoxb-…`) and app-level token (`xapp-…`) into `pass` entries `<slack_token_ref>-bot` and `<slack_token_ref>-app`.
+3. Auto-detect the user's Slack ID from `git config user.email` via the Slack API. Falls back to a manual prompt when detection fails.
+4. Write `messaging_backend`, `slack_user_id`, and `slack_token_ref` to `[overlays.<name>]` in `~/.teatree.toml`.
+5. Smoke-test by sending a DM via the bot and waiting for the user to react with ✅.
 
 The walkthrough never writes a bot token to disk in plaintext; tokens always go via `pass`. Re-running `t3 setup slack-bot --overlay <name> --reset` rotates both tokens.
+
+**Socket Mode listener** (`t3 slack listen`): a global singleton process that opens one WebSocket per slack-enabled overlay. Events are written to `$XDG_DATA_HOME/teatree/slack-events.jsonl` in real time. `t3 slack status` checks if the listener is running. The listener uses PID-file-based singleton detection — only one instance runs at a time. Start it as a background process or let the SessionStart hook manage its lifecycle.
 
 **Operating mode (`teatree.mode`, env: `T3_MODE`)** — controls whether the agent
 pauses for confirmation on publishing actions (push, PR create, PR merge, messaging-backend

--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -69,7 +69,7 @@ def get_messaging(overlay: "OverlayBase") -> MessagingBackend:
     """
     choice = getattr(overlay.config, "messaging_backend", "") or "noop"
     if choice == "slack":
-        token_ref = getattr(overlay.config, "slack_bot_token_ref", "")
+        token_ref = getattr(overlay.config, "slack_token_ref", "")
         return SlackBotBackend(
             bot_token=read_pass(f"{token_ref}-bot") if token_ref else overlay.config.get_slack_token(),
             app_token=read_pass(f"{token_ref}-app") if token_ref else "",

--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -104,7 +104,7 @@ def write_overlay_settings(
     overlay_name: str,
     *,
     slack_user_id: str,
-    slack_bot_token_ref: str,
+    slack_token_ref: str,
     messaging_backend: str = "slack",
 ) -> None:
     """Persist Slack settings on the per-overlay block of *config_path*.
@@ -132,7 +132,7 @@ def write_overlay_settings(
 
     overlay_block["messaging_backend"] = messaging_backend
     overlay_block["slack_user_id"] = slack_user_id
-    overlay_block["slack_bot_token_ref"] = slack_bot_token_ref
+    overlay_block["slack_token_ref"] = slack_token_ref
 
     config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
 
@@ -243,9 +243,9 @@ def slack_bot_setup(
         config_path,
         overlay,
         slack_user_id=user_id,
-        slack_bot_token_ref=token_ref,
+        slack_token_ref=token_ref,
     )
-    typer.echo(f"OK    Wrote `[overlays.{overlay}]` slack_user_id and slack_bot_token_ref to {config_path}.")
+    typer.echo(f"OK    Wrote `[overlays.{overlay}]` slack_user_id and slack_token_ref to {config_path}.")
 
     typer.echo("Step 4/4 — Smoke test.")
     if skip_smoke_test:

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -83,7 +83,7 @@ class OverlayConfig:
     """
     messaging_backend: str = "noop"
     """Selects the MessagingBackend implementation: ``"slack"`` or ``"noop"`` (default)."""
-    slack_bot_token_ref: str = ""
+    slack_token_ref: str = ""
     """``pass`` entry name prefix for Slack bot credentials.
 
     The loader reads ``<ref>-bot`` (xoxb token) and ``<ref>-app`` (xapp token).

--- a/tests/test_slack_setup.py
+++ b/tests/test_slack_setup.py
@@ -116,11 +116,11 @@ class TestWriteOverlaySettings:
             config,
             "acme",
             slack_user_id="U01ABCD1234",
-            slack_bot_token_ref="teatree/acme/slack",
+            slack_token_ref="teatree/acme/slack",
         )
         document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
         assert document["overlays"]["acme"]["slack_user_id"] == "U01ABCD1234"
-        assert document["overlays"]["acme"]["slack_bot_token_ref"] == "teatree/acme/slack"
+        assert document["overlays"]["acme"]["slack_token_ref"] == "teatree/acme/slack"
         assert document["overlays"]["acme"]["messaging_backend"] == "slack"
 
     def test_preserves_unrelated_keys(self, tmp_path: Path) -> None:
@@ -135,7 +135,7 @@ class TestWriteOverlaySettings:
             config,
             "acme",
             slack_user_id="U01ABCD1234",
-            slack_bot_token_ref="teatree/acme/slack",
+            slack_token_ref="teatree/acme/slack",
         )
         document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
         assert document["teatree"]["workspace_dir"] == "~/work"
@@ -147,18 +147,18 @@ class TestWriteOverlaySettings:
     def test_overwrites_existing_slack_settings(self, tmp_path: Path) -> None:
         config = tmp_path / "teatree.toml"
         config.write_text(
-            '[overlays.acme]\nslack_user_id = "U_OLD"\nslack_bot_token_ref = "old-ref"\n',
+            '[overlays.acme]\nslack_user_id = "U_OLD"\nslack_token_ref = "old-ref"\n',
             encoding="utf-8",
         )
         write_overlay_settings(
             config,
             "acme",
             slack_user_id="U_NEW",
-            slack_bot_token_ref="new-ref",
+            slack_token_ref="new-ref",
         )
         document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
         assert document["overlays"]["acme"]["slack_user_id"] == "U_NEW"
-        assert document["overlays"]["acme"]["slack_bot_token_ref"] == "new-ref"
+        assert document["overlays"]["acme"]["slack_token_ref"] == "new-ref"
 
 
 class TestPatterns:
@@ -237,7 +237,7 @@ class TestSlackBotCommand:
         assert captured["teatree/acme/slack-app"] == "xapp-1-test"
         document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
         assert document["overlays"]["acme"]["slack_user_id"] == "U01ABCD1234"
-        assert document["overlays"]["acme"]["slack_bot_token_ref"] == "teatree/acme/slack"
+        assert document["overlays"]["acme"]["slack_token_ref"] == "teatree/acme/slack"
 
     def test_reset_skips_manifest_url(self, tmp_path: Path) -> None:
         opened: list[str] = []


### PR DESCRIPTION
## Summary

- Complete `slack_bot_token_ref` → `slack_token_ref` rename missed by PR #597
- Update BLUEPRINT with Socket Mode listener, messages tab, app_mentions:read docs

## Test plan

- [x] 2693 passed, 12 skipped