### PR TITLE
test(slack): restore coverage to 93% + strip compat comments

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -129,6 +129,42 @@ t3 overlay uninstall <overlay-name>
 
 The main clone (detected via a real `.git` directory) refuses `install` — use this in worktrees only. Tracked overlays persist in `.t3.local.json` (gitignored).
 
+## Slack integration (optional)
+
+Each overlay can have its own Slack bot for bidirectional messaging
+(question mirroring, DM monitoring, mention scanning). Setup per overlay:
+
+```sh
+t3 setup slack-bot --overlay <name>
+```
+
+This walks through Slack app creation, generates a manifest, stores
+`xoxb-` (bot) and `xapp-` (app-level) tokens in `pass`, and writes the
+config to `~/.teatree.toml`. The bot needs Socket Mode enabled
+(`connections:write` scope on the app-level token).
+
+Start the event listener (runs in foreground, one WebSocket per overlay):
+
+```sh
+t3 slack listen                    # all slack-enabled overlays
+t3 slack listen --overlay <name>   # single overlay
+t3 slack status                    # check if the listener is running
+```
+
+The listener writes inbound events to a JSONL queue. The fat loop tick
+(`t3 loop tick`) drains the queue and surfaces mentions/DMs in the
+statusline. The Claude Code hook mirrors `AskUserQuestion` prompts to
+Slack DM so you can answer from your phone.
+
+Config lives in `~/.teatree.toml`:
+
+```toml
+[overlays.<name>]
+messaging_backend = "slack"
+slack_user_id = "U..."          # your Slack member ID
+slack_token_ref = "teatree/<name>/slack"  # pass entry prefix
+```
+
 ## Overlay discovery
 
 Overlays register via standard Python entry points in `pyproject.toml`:

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -87,7 +87,6 @@ Useful optional values:
 | `T3_PRIVATE_TESTS` | Private QA repo path | empty |
 | `T3_BRANCH_PREFIX` | Branch prefix for generated worktrees | derived from git user |
 | `T3_ISSUE_TRACKER` | `gitlab` or `github` | detected |
-| `T3_CHAT_PLATFORM` | `slack`, `teams`, or `none` | `none` |
 | `T3_SKILL_OWNERSHIP_FILE` | Ownership config for skill editing | `$HOME/.ac-reviewing-codebase` |
 
 Do not require `T3_OVERLAY`. The active overlay is discovered via entry points.
@@ -99,7 +98,6 @@ cat > ~/.teatree <<'EOF'
 T3_REPO="$HOME/workspace/teatree"
 T3_WORKSPACE_DIR="$HOME/workspace"
 T3_ISSUE_TRACKER="gitlab"
-T3_CHAT_PLATFORM="none"
 T3_CONTRIBUTE=false
 T3_PUSH=false
 T3_AUTO_PUSH_FORK=false
@@ -109,6 +107,19 @@ T3_PRIVATE_TESTS=""
 T3_BRANCH_PREFIX="ac"
 T3_SKILL_OWNERSHIP_FILE="$HOME/.ac-reviewing-codebase"
 EOF
+```
+
+### Slack integration (per-overlay)
+
+Messaging is configured per overlay in `~/.teatree.toml`, not via `T3_CHAT_PLATFORM`.
+Run `t3 setup slack-bot --overlay <name>` to register a Slack app and store tokens.
+Then start `t3 slack listen` for real-time event delivery via Socket Mode.
+
+```toml
+[overlays.<name>]
+messaging_backend = "slack"
+slack_user_id = "U..."
+slack_token_ref = "teatree/<name>/slack"
 ```
 
 ## Step 3: Install Skills

--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -26,8 +26,7 @@ def get_code_host(overlay: "OverlayBase") -> CodeHostBackend | None:
     """Return the configured CodeHostBackend for *overlay*, or ``None``.
 
     Selection follows ``overlay.config.code_host``; falls back to inspecting
-    the available tokens when the field is unset (legacy behaviour kept so
-    older overlays that haven't migrated still work).
+    the available tokens when the field is unset.
     """
     choice = getattr(overlay.config, "code_host", "")
     github_token = overlay.config.get_github_token()

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -397,10 +397,8 @@ def discover_overlays(config_path: Path | None = None) -> list[OverlayEntry]:
         path_str = overlay_cfg.get("path", "")
         project_path = Path(path_str).expanduser() if path_str else None
         if not overlay_class and project_path:
-            # Backward compat: derive settings module from manage.py for TOML overlays
             manage_py = project_path / "manage.py"
             settings_module = _extract_settings_module(manage_py) if manage_py.is_file() else ""
-            # Store settings module as overlay_class fallback so callers can still use it
             overlay_class = settings_module
         overrides: dict[str, Any] = {}
         for key, parser in OVERLAY_OVERRIDABLE_SETTINGS.items():

--- a/src/teatree/core/clone_paths.py
+++ b/src/teatree/core/clone_paths.py
@@ -53,9 +53,8 @@ def find_clone_path(workspace: Path, repo_name: str) -> Path | None:
 def resolve_clone_path(workspace: Path, worktree: Worktree) -> Path | None:
     """Return the source clone path for *worktree*, with namespace fallback.
 
-    Prefers ``worktree.extra['clone_path']`` (set at provision time when the
-    namespace-aware lookup was used). Falls back to a fresh
-    :func:`find_clone_path` scan for legacy rows that pre-date the field.
+    Prefers ``worktree.extra['clone_path']`` (set at provision time). Falls
+    back to a fresh :func:`find_clone_path` scan for rows without the field.
     Returns ``None`` when no clone exists anywhere.
     """
     stored = (worktree.extra or {}).get("clone_path", "")

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -78,8 +78,7 @@ class OverlayConfig:
     code_host: str = ""
     """Selects the CodeHostBackend implementation: ``"github"``, ``"gitlab"``, or ``""``.
 
-    Empty falls back to whichever token the config exposes — legacy behaviour
-    preserved for overlays that predate the explicit field.
+    Empty falls back to whichever token the config exposes.
     """
     messaging_backend: str = "noop"
     """Selects the MessagingBackend implementation: ``"slack"`` or ``"noop"`` (default)."""

--- a/src/teatree/core/step_runner.py
+++ b/src/teatree/core/step_runner.py
@@ -127,14 +127,12 @@ def run_step(  # noqa: PLR0913
 def run_callable_step(name: str, fn: Callable[[], object]) -> StepResult:
     """Execute a Python callable and return a structured result.
 
-    Wraps arbitrary callables (including legacy ``partial(subprocess.run, ...)``
-    patterns) with timing and error capture.
+    Wraps arbitrary callables with timing and error capture.
     """
     start = time.monotonic()
     try:
         result = fn()
         duration = time.monotonic() - start
-        # Handle legacy subprocess.run return values
         if isinstance(result, subprocess.CompletedProcess):
             stdout = result.stdout if isinstance(result.stdout, str) else ""
             stderr = result.stderr if isinstance(result.stderr, str) else ""

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -67,7 +67,7 @@ class TickRequest:
     """What to scan in one tick — overlays, backends, or an explicit scanner list.
 
     Pass *backends* to scan many overlays in one tick. Pass *host*/*messaging*
-    for the legacy single-overlay path. Pass *scanners* to bypass default
+    for the single-overlay path. Pass *scanners* to bypass default
     scanner construction entirely (mostly used by tests).
     """
 
@@ -109,7 +109,7 @@ def build_default_jobs(
     """Build the default scanner jobs from one or more overlays.
 
     Pass *backends* to scan multiple overlays in one tick (each gets its
-    own host/messaging credentials). The legacy *host*/*messaging* shape
+    own host/messaging credentials). The *host*/*messaging* shape
     is preserved for callers that resolve a single overlay themselves.
     """
     jobs: list[_ScannerJob] = [_ScannerJob(scanner=PendingTasksScanner(), overlay="")]

--- a/tests/teatree_backends/test_messaging.py
+++ b/tests/teatree_backends/test_messaging.py
@@ -396,6 +396,53 @@ def test_slack_fetch_dms_returns_empty_when_api_fails(monkeypatch: pytest.Monkey
     assert backend.fetch_dms() == []
 
 
+def test_slack_resolve_bot_id_caches_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    call_count = 0
+
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        nonlocal call_count
+        if "conversations.open" in url:
+            return httpx.Response(200, json={"ok": True, "channel": {"id": "D1"}}, request=httpx.Request("POST", url))
+        if "auth.test" in url:
+            call_count += 1
+            return httpx.Response(200, json={"ok": True, "user_id": "UBOT"}, request=httpx.Request("POST", url))
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True, "messages": []}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="U1")
+
+    backend.fetch_dms()
+    backend.fetch_dms()
+    assert call_count == 1
+
+
+def test_slack_resolve_bot_id_returns_empty_on_api_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        if "conversations.open" in url:
+            return httpx.Response(200, json={"ok": True, "channel": {"id": "D1"}}, request=httpx.Request("POST", url))
+        if "auth.test" in url:
+            return httpx.Response(200, json={"ok": False}, request=httpx.Request("POST", url))
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"ok": True, "messages": [{"user": "UHUMAN", "text": "x", "ts": "1.0"}]},
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="U1")
+
+    dms = backend.fetch_dms()
+    assert len(dms) == 1
+
+
 def test_slack_post_reply_includes_thread_ts(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/teatree_backends/test_messaging.py
+++ b/tests/teatree_backends/test_messaging.py
@@ -291,6 +291,111 @@ def test_slack_get_reactions_returns_empty_when_get_fails(monkeypatch: pytest.Mo
     assert backend.get_reactions(channel="C1", ts="123") == []
 
 
+def test_slack_fetch_dms_polls_conversations_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    call_log: list[str] = []
+
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        call_log.append(url)
+        if "conversations.open" in url:
+            return httpx.Response(200, json={"ok": True, "channel": {"id": "D99"}}, request=httpx.Request("POST", url))
+        if "auth.test" in url:
+            return httpx.Response(200, json={"ok": True, "user_id": "UBOT"}, request=httpx.Request("POST", url))
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        call_log.append(url)
+        return httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "messages": [
+                    {"user": "UHUMAN", "text": "hello", "ts": "1.0"},
+                    {"user": "UBOT", "text": "bot reply", "ts": "2.0"},
+                ],
+            },
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="UHUMAN")
+
+    dms = backend.fetch_dms(since="0.5")
+
+    assert len(dms) == 1
+    assert dms[0]["user"] == "UHUMAN"
+
+
+def test_slack_fetch_dms_returns_empty_when_no_user_id() -> None:
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="")
+    assert backend.fetch_dms() == []
+
+
+def test_slack_fetch_dms_returns_empty_when_dm_channel_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(200, json={"ok": False}, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="U1")
+
+    assert backend.fetch_dms() == []
+
+
+def test_slack_fetch_dms_filters_non_dict_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        if "conversations.open" in url:
+            return httpx.Response(200, json={"ok": True, "channel": {"id": "D1"}}, request=httpx.Request("POST", url))
+        if "auth.test" in url:
+            return httpx.Response(200, json={"ok": True, "user_id": "UBOT"}, request=httpx.Request("POST", url))
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"ok": True, "messages": ["not-a-dict", {"user": "UHUMAN", "text": "ok", "ts": "1.0"}]},
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="UHUMAN")
+
+    dms = backend.fetch_dms()
+    assert len(dms) == 1
+
+
+def test_slack_fetch_dms_returns_empty_when_messages_not_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        if "conversations.open" in url:
+            return httpx.Response(200, json={"ok": True, "channel": {"id": "D1"}}, request=httpx.Request("POST", url))
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True, "messages": "not-a-list"}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="U1")
+
+    assert backend.fetch_dms() == []
+
+
+def test_slack_fetch_dms_returns_empty_when_api_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        if "conversations.open" in url:
+            return httpx.Response(200, json={"ok": True, "channel": {"id": "D99"}}, request=httpx.Request("POST", url))
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(200, json={"ok": False}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="U1")
+
+    assert backend.fetch_dms() == []
+
+
 def test_slack_post_reply_includes_thread_ts(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 

--- a/tests/teatree_backends/test_slack_mentions.py
+++ b/tests/teatree_backends/test_slack_mentions.py
@@ -1,0 +1,88 @@
+"""Tests for the SlackMentionsScanner (Socket Mode queue + API merge)."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from teatree.loop.scanners.slack_mentions import SlackMentionsScanner
+
+
+class TestSlackMentionsScanner:
+    def _make_backend(self, *, mentions: list | None = None, dms: list | None = None) -> MagicMock:
+        backend = MagicMock()
+        backend.fetch_mentions.return_value = mentions or []
+        backend.fetch_dms.return_value = dms or []
+        return backend
+
+    def test_surfaces_api_mentions(self, tmp_path: Path) -> None:
+        backend = self._make_backend(mentions=[{"ts": "1.0", "text": "hey @bot"}])
+        scanner = SlackMentionsScanner(backend=backend, cursor_path=tmp_path / "cursor.json")
+
+        signals = scanner.scan()
+
+        assert len(signals) == 1
+        assert signals[0].kind == "slack.mention"
+        assert "hey @bot" in signals[0].summary
+
+    def test_surfaces_api_dms(self, tmp_path: Path) -> None:
+        backend = self._make_backend(dms=[{"ts": "2.0", "text": "dm text"}])
+        scanner = SlackMentionsScanner(backend=backend, cursor_path=tmp_path / "cursor.json")
+
+        signals = scanner.scan()
+
+        assert len(signals) == 1
+        assert signals[0].kind == "slack.dm"
+
+    def test_merges_socket_mode_queue_events(self, tmp_path: Path) -> None:
+        backend = self._make_backend()
+        scanner = SlackMentionsScanner(backend=backend, cursor_path=tmp_path / "cursor.json")
+        queued_events = [
+            {"event": {"type": "app_mention", "ts": "3.0", "text": "queued mention"}},
+            {"event": {"type": "message", "channel_type": "im", "ts": "4.0", "text": "queued dm"}},
+        ]
+        with patch("teatree.loop.scanners.slack_mentions.drain_event_queue", return_value=queued_events):
+            signals = scanner.scan()
+
+        assert len(signals) == 2
+        kinds = {s.kind for s in signals}
+        assert kinds == {"slack.mention", "slack.dm"}
+
+    def test_ignores_non_im_queued_messages(self, tmp_path: Path) -> None:
+        backend = self._make_backend()
+        scanner = SlackMentionsScanner(backend=backend, cursor_path=tmp_path / "cursor.json")
+        queued = [{"event": {"type": "message", "channel_type": "channel", "ts": "5.0", "text": "not im"}}]
+        with patch("teatree.loop.scanners.slack_mentions.drain_event_queue", return_value=queued):
+            signals = scanner.scan()
+
+        assert len(signals) == 0
+
+    def test_updates_cursors_on_success(self, tmp_path: Path) -> None:
+        backend = self._make_backend(mentions=[{"ts": "10.0", "text": "x"}])
+        cursor_path = tmp_path / "cursor.json"
+        scanner = SlackMentionsScanner(backend=backend, cursor_path=cursor_path)
+
+        scanner.scan()
+
+        data = json.loads(cursor_path.read_text(encoding="utf-8"))
+        assert data["mentions"] == "10.0"
+
+    def test_empty_scan_does_not_write_cursors(self, tmp_path: Path) -> None:
+        backend = self._make_backend()
+        cursor_path = tmp_path / "cursor.json"
+        scanner = SlackMentionsScanner(backend=backend, cursor_path=cursor_path)
+
+        with patch("teatree.loop.scanners.slack_mentions.drain_event_queue", return_value=[]):
+            scanner.scan()
+
+        assert not cursor_path.is_file()
+
+    def test_reads_existing_cursors(self, tmp_path: Path) -> None:
+        backend = self._make_backend()
+        cursor_path = tmp_path / "cursor.json"
+        cursor_path.write_text('{"mentions": "5.0", "dms": "3.0"}', encoding="utf-8")
+        scanner = SlackMentionsScanner(backend=backend, cursor_path=cursor_path)
+
+        scanner.scan()
+
+        backend.fetch_mentions.assert_called_once_with(since="5.0")
+        backend.fetch_dms.assert_called_once_with(since="3.0")

--- a/tests/teatree_backends/test_slack_receiver.py
+++ b/tests/teatree_backends/test_slack_receiver.py
@@ -1,0 +1,262 @@
+"""Tests for the Slack Socket Mode event queue (no real WebSocket connections)."""
+
+import json
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from teatree.backends.slack_receiver import (
+    _enqueue,
+    _run_single_overlay,
+    default_queue_path,
+    drain_event_queue,
+    run_listener,
+)
+
+
+class TestDefaultQueuePath:
+    def test_uses_xdg_data_home(self, monkeypatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", "/custom/data")
+        assert default_queue_path() == Path("/custom/data/teatree/slack-events.jsonl")
+
+    def test_falls_back_to_home(self, monkeypatch) -> None:
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        result = default_queue_path()
+        assert result.name == "slack-events.jsonl"
+        assert "teatree" in str(result)
+
+
+class TestEnqueue:
+    def test_writes_json_line(self, tmp_path: Path) -> None:
+        queue = tmp_path / "events.jsonl"
+        _enqueue(queue, "myoverlay", {"type": "message", "text": "hello"})
+
+        lines = queue.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["overlay"] == "myoverlay"
+        assert data["event"]["text"] == "hello"
+
+    def test_appends_multiple_events(self, tmp_path: Path) -> None:
+        queue = tmp_path / "events.jsonl"
+        _enqueue(queue, "a", {"type": "message", "text": "first"})
+        _enqueue(queue, "b", {"type": "app_mention", "text": "second"})
+
+        lines = queue.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        queue = tmp_path / "deep" / "nested" / "events.jsonl"
+        _enqueue(queue, "x", {"type": "message"})
+        assert queue.is_file()
+
+
+class TestDrainEventQueue:
+    def test_returns_empty_when_no_file(self, tmp_path: Path) -> None:
+        assert drain_event_queue(tmp_path / "missing.jsonl") == []
+
+    def test_drains_and_removes_file(self, tmp_path: Path) -> None:
+        queue = tmp_path / "events.jsonl"
+        _enqueue(queue, "ov1", {"type": "message", "text": "hi"})
+        _enqueue(queue, "ov2", {"type": "app_mention", "text": "hey"})
+
+        events = drain_event_queue(queue)
+
+        assert len(events) == 2
+        assert events[0]["overlay"] == "ov1"
+        assert events[1]["overlay"] == "ov2"
+        assert not queue.is_file()
+
+    def test_skips_malformed_lines(self, tmp_path: Path) -> None:
+        queue = tmp_path / "events.jsonl"
+        queue.write_text('{"overlay":"a","event":{}}\nNOT_JSON\n{"overlay":"b","event":{}}\n', encoding="utf-8")
+
+        events = drain_event_queue(queue)
+
+        assert len(events) == 2
+
+    def test_handles_rename_failure_gracefully(self, tmp_path: Path) -> None:
+        queue = tmp_path / "events.jsonl"
+        queue.write_text("{}\n", encoding="utf-8")
+        draining = queue.with_suffix(".draining")
+        draining.mkdir()
+
+        events = drain_event_queue(queue)
+        assert events == []
+
+
+class TestRunSingleOverlay:
+    def test_returns_immediately_when_slack_sdk_missing(self, tmp_path: Path) -> None:
+        stop = threading.Event()
+        stop.set()
+        with patch.dict("sys.modules", {"slack_sdk": None, "slack_sdk.socket_mode": None}):
+            _run_single_overlay(
+                overlay_name="test",
+                app_token="xapp-test",
+                bot_token="xoxb-test",
+                queue_path=tmp_path / "events.jsonl",
+                stop_event=stop,
+            )
+
+    def test_connects_and_stops_on_event(self, tmp_path: Path) -> None:
+        import slack_sdk.socket_mode  # noqa: PLC0415
+        import slack_sdk.web  # noqa: PLC0415
+
+        mock_client = MagicMock()
+        mock_client.socket_mode_request_listeners = []
+        stop = threading.Event()
+
+        def fake_connect() -> None:
+            stop.set()
+
+        mock_client.connect = fake_connect
+
+        with (
+            patch.object(slack_sdk.socket_mode, "SocketModeClient", return_value=mock_client),
+            patch.object(slack_sdk.web, "WebClient"),
+        ):
+            _run_single_overlay(
+                overlay_name="ov",
+                app_token="xapp",
+                bot_token="xoxb",
+                queue_path=tmp_path / "events.jsonl",
+                stop_event=stop,
+            )
+
+        mock_client.close.assert_called_once()
+        assert len(mock_client.socket_mode_request_listeners) == 1
+
+    def test_handler_enqueues_mention_events(self, tmp_path: Path) -> None:
+        import slack_sdk.socket_mode  # noqa: PLC0415
+        import slack_sdk.web  # noqa: PLC0415
+        from slack_sdk.socket_mode.request import SocketModeRequest  # noqa: PLC0415
+
+        mock_client = MagicMock()
+        mock_client.socket_mode_request_listeners = []
+        stop = threading.Event()
+        queue = tmp_path / "events.jsonl"
+        handler_ref: list = []
+
+        def fake_connect() -> None:
+            handler_ref.extend(mock_client.socket_mode_request_listeners)
+            req = SocketModeRequest(
+                type="events_api",
+                envelope_id="e1",
+                payload={"event": {"type": "app_mention", "text": "hello", "ts": "1.0"}},
+            )
+            handler_ref[0](mock_client, req)
+            stop.set()
+
+        mock_client.connect = fake_connect
+
+        with (
+            patch.object(slack_sdk.socket_mode, "SocketModeClient", return_value=mock_client),
+            patch.object(slack_sdk.web, "WebClient"),
+        ):
+            _run_single_overlay(
+                overlay_name="ov",
+                app_token="xapp",
+                bot_token="xoxb",
+                queue_path=queue,
+                stop_event=stop,
+            )
+
+        events = drain_event_queue(queue)
+        assert len(events) == 1
+        assert events[0]["event"]["type"] == "app_mention"
+
+    def test_handler_filters_bot_messages(self, tmp_path: Path) -> None:
+        import slack_sdk.socket_mode  # noqa: PLC0415
+        import slack_sdk.web  # noqa: PLC0415
+        from slack_sdk.socket_mode.request import SocketModeRequest  # noqa: PLC0415
+
+        mock_client = MagicMock()
+        mock_client.socket_mode_request_listeners = []
+        stop = threading.Event()
+        queue = tmp_path / "events.jsonl"
+        handler_ref: list = []
+
+        def fake_connect() -> None:
+            handler_ref.extend(mock_client.socket_mode_request_listeners)
+            for subtype in ("bot_message", "message_changed", "message_deleted"):
+                req = SocketModeRequest(
+                    type="events_api",
+                    envelope_id=f"e-{subtype}",
+                    payload={"event": {"type": "message", "subtype": subtype, "ts": "1.0"}},
+                )
+                handler_ref[0](mock_client, req)
+            stop.set()
+
+        mock_client.connect = fake_connect
+
+        with (
+            patch.object(slack_sdk.socket_mode, "SocketModeClient", return_value=mock_client),
+            patch.object(slack_sdk.web, "WebClient"),
+        ):
+            _run_single_overlay(
+                overlay_name="ov",
+                app_token="xapp",
+                bot_token="xoxb",
+                queue_path=queue,
+                stop_event=stop,
+            )
+
+        events = drain_event_queue(queue)
+        assert events == []
+
+    def test_handler_ignores_non_events_api(self, tmp_path: Path) -> None:
+        import slack_sdk.socket_mode  # noqa: PLC0415
+        import slack_sdk.web  # noqa: PLC0415
+        from slack_sdk.socket_mode.request import SocketModeRequest  # noqa: PLC0415
+
+        mock_client = MagicMock()
+        mock_client.socket_mode_request_listeners = []
+        stop = threading.Event()
+        queue = tmp_path / "events.jsonl"
+
+        def fake_connect() -> None:
+            handler = mock_client.socket_mode_request_listeners[0]
+            req = SocketModeRequest(type="slash_commands", envelope_id="e1", payload={})
+            handler(mock_client, req)
+            stop.set()
+
+        mock_client.connect = fake_connect
+
+        with (
+            patch.object(slack_sdk.socket_mode, "SocketModeClient", return_value=mock_client),
+            patch.object(slack_sdk.web, "WebClient"),
+        ):
+            _run_single_overlay(
+                overlay_name="ov",
+                app_token="xapp",
+                bot_token="xoxb",
+                queue_path=queue,
+                stop_event=stop,
+            )
+
+        assert not queue.is_file()
+
+
+class TestRunListener:
+    def test_returns_when_no_overlay_threads(self, tmp_path: Path) -> None:
+        run_listener([], queue_path=tmp_path / "events.jsonl")
+
+    def test_starts_threads_and_stops_on_signal(self, tmp_path: Path) -> None:
+        import signal as sig  # noqa: PLC0415
+
+        started = threading.Event()
+
+        def fake_overlay(**kwargs: object) -> None:
+            started.set()
+            stop_event = kwargs["stop_event"]
+            stop_event.wait(timeout=5.0)
+
+        def run_and_signal() -> None:
+            started.wait(timeout=2.0)
+            sig.raise_signal(sig.SIGINT)
+
+        with patch("teatree.backends.slack_receiver._run_single_overlay", side_effect=fake_overlay):
+            trigger = threading.Thread(target=run_and_signal, daemon=True)
+            trigger.start()
+            run_listener([("ov", "xapp", "xoxb")], queue_path=tmp_path / "events.jsonl")
+            trigger.join(timeout=2.0)

--- a/tests/test_slack_listen.py
+++ b/tests/test_slack_listen.py
@@ -1,0 +1,167 @@
+"""Tests for ``t3 slack listen`` and ``t3 slack status`` CLI commands."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from teatree.cli.slack_listen import _pid_alive, _resolve_overlays, slack_app
+
+runner = CliRunner()
+
+
+class TestPidAlive:
+    def test_current_process_is_alive(self) -> None:
+        assert _pid_alive(os.getpid()) is True
+
+    def test_nonexistent_pid_is_dead(self) -> None:
+        assert _pid_alive(999999999) is False
+
+
+class TestResolveOverlays:
+    def test_returns_empty_when_no_config(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr("teatree.cli.slack_listen.Path.home", lambda: tmp_path)
+        assert _resolve_overlays("") == []
+
+    def test_reads_overlays_from_toml(self, tmp_path: Path, monkeypatch) -> None:
+        config = tmp_path / ".teatree.toml"
+        config.write_text(
+            '[overlays.myapp]\nmessaging_backend = "slack"\nslack_token_ref = "test/ref"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("teatree.cli.slack_listen.Path.home", lambda: tmp_path)
+        with patch("teatree.cli.slack_listen.read_pass", side_effect=["xoxb-bot", "xapp-app"]):
+            result = _resolve_overlays("")
+
+        assert len(result) == 1
+        assert result[0][0] == "myapp"
+
+    def test_skips_non_slack_overlays(self, tmp_path: Path, monkeypatch) -> None:
+        config = tmp_path / ".teatree.toml"
+        config.write_text(
+            '[overlays.myapp]\nmessaging_backend = "email"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("teatree.cli.slack_listen.Path.home", lambda: tmp_path)
+        assert _resolve_overlays("") == []
+
+    def test_warns_when_tokens_missing(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        config = tmp_path / ".teatree.toml"
+        config.write_text(
+            '[overlays.broken]\nmessaging_backend = "slack"\nslack_token_ref = "broken/ref"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("teatree.cli.slack_listen.Path.home", lambda: tmp_path)
+        with patch("teatree.cli.slack_listen.read_pass", return_value=""):
+            result = _resolve_overlays("")
+
+        assert result == []
+
+    def test_restricts_to_named_overlay(self, tmp_path: Path, monkeypatch) -> None:
+        config = tmp_path / ".teatree.toml"
+        config.write_text(
+            '[overlays.a]\nmessaging_backend = "slack"\nslack_token_ref = "a/ref"\n'
+            '[overlays.b]\nmessaging_backend = "slack"\nslack_token_ref = "b/ref"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("teatree.cli.slack_listen.Path.home", lambda: tmp_path)
+        with patch("teatree.cli.slack_listen.read_pass", side_effect=["xoxb-bot", "xapp-app"]):
+            result = _resolve_overlays("a")
+
+        assert len(result) == 1
+        assert result[0][0] == "a"
+
+
+class TestStatusCommand:
+    def test_no_pid_file(self, tmp_path: Path) -> None:
+        with patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"):
+            result = runner.invoke(slack_app, ["status"])
+
+        assert result.exit_code == 1
+        assert "not running" in result.stdout
+
+    def test_stale_pid_file(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "slack-listener.pid"
+        pid_file.write_text("999999999\n", encoding="utf-8")
+        with patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"):
+            result = runner.invoke(slack_app, ["status"])
+
+        assert result.exit_code == 1
+        assert "dead" in result.stdout
+
+    def test_garbled_pid_file(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "slack-listener.pid"
+        pid_file.write_text("not-a-number\n", encoding="utf-8")
+        with patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"):
+            result = runner.invoke(slack_app, ["status"])
+
+        assert result.exit_code == 1
+        assert "stale" in result.stdout
+        assert not pid_file.is_file()
+
+    def test_running_pid(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "slack-listener.pid"
+        pid_file.write_text(f"{os.getpid()}\n", encoding="utf-8")
+        with patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"):
+            result = runner.invoke(slack_app, ["status"])
+
+        assert result.exit_code == 0
+        assert "running" in result.stdout
+
+
+class TestListenCommand:
+    def test_exits_when_no_overlays(self, tmp_path: Path) -> None:
+        with (
+            patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"),
+            patch("teatree.cli.slack_listen._resolve_overlays", return_value=[]),
+        ):
+            result = runner.invoke(slack_app, ["listen"])
+
+        assert result.exit_code == 1
+        assert "No slack-enabled overlays" in result.stdout
+
+    def test_exits_when_already_running(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "slack-listener.pid"
+        pid_file.write_text(f"{os.getpid()}\n", encoding="utf-8")
+        with patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"):
+            result = runner.invoke(slack_app, ["listen"])
+
+        assert result.exit_code == 1
+        assert "already running" in result.stdout
+
+    def test_replaces_stale_pid_and_proceeds(self, tmp_path: Path) -> None:
+        pid_file = tmp_path / "slack-listener.pid"
+        pid_file.write_text("999999999\n", encoding="utf-8")
+        with (
+            patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"),
+            patch("teatree.cli.slack_listen._resolve_overlays", return_value=[("ov", "xapp", "xoxb")]),
+            patch("teatree.cli.slack_listen.run_listener"),
+        ):
+            result = runner.invoke(slack_app, ["listen"])
+
+        assert result.exit_code == 0
+        assert "Listening on ov" in result.stdout
+
+    def test_cleans_pid_file_after_run(self, tmp_path: Path) -> None:
+        with (
+            patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"),
+            patch("teatree.cli.slack_listen._resolve_overlays", return_value=[("ov", "xapp", "xoxb")]),
+            patch("teatree.cli.slack_listen.run_listener"),
+        ):
+            runner.invoke(slack_app, ["listen"])
+
+        pid_file = tmp_path / "slack-listener.pid"
+        assert not pid_file.is_file()
+
+    def test_cleans_pid_on_exception(self, tmp_path: Path) -> None:
+        with (
+            patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"),
+            patch("teatree.cli.slack_listen._resolve_overlays", return_value=[("ov", "xapp", "xoxb")]),
+            patch("teatree.cli.slack_listen.run_listener", side_effect=RuntimeError("boom")),
+        ):
+            result = runner.invoke(slack_app, ["listen"])
+
+        pid_file = tmp_path / "slack-listener.pid"
+        assert not pid_file.is_file()
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- Add test coverage for Slack receiver, listener CLI, mentions scanner, and DM polling
- Strip misleading "backward compat" / "legacy" comments from config.py, overlay.py, loader.py, step_runner.py, clone_paths.py, tick.py — the code is correct and current, only the framing was wrong
- Coverage: 91.6% → 93.0%

## Test plan
- [x] 2741 tests pass, 93.02% coverage
- [x] New test files: test_slack_receiver.py, test_slack_listen.py, test_slack_mentions.py
- [x] Extended: test_messaging.py (fetch_dms polling path)