### PR TITLE
fix(statusline): clickable tickets, dim color, TOML overlay backends

### DIFF
--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -75,13 +75,19 @@ def ci_service_from_overlay() -> CIService | None:
 
 
 def iter_overlay_backends() -> list[OverlayBackends]:
-    """Yield :class:`OverlayBackends` for every registered overlay.
+    """Build :class:`OverlayBackends` for every registered overlay.
 
     Overlays whose credentials don't resolve get ``host=None`` /
     ``messaging=None`` — the caller decides whether to skip them.
+
+    Also includes TOML-configured overlays that have credentials but no
+    Python class (project-directory-only overlays reached via subprocess).
     """
     out: list[OverlayBackends] = []
+    found_names: set[str] = set()
+
     for name, overlay in get_all_overlays().items():
+        found_names.add(name)
         try:
             host = get_code_host(overlay)
         except (ImproperlyConfigured, ValueError):
@@ -102,7 +108,73 @@ def iter_overlay_backends() -> list[OverlayBackends]:
                 max_concurrent_auto_starts=int(overlay.config.max_concurrent_auto_starts),
             ),
         )
+
+    out.extend(_backends_from_toml(found_names))
     return out
+
+
+def _backends_from_toml(already_found: set[str]) -> list[OverlayBackends]:
+    """Build backends for TOML overlays not discovered via entry points."""
+    from teatree.config import load_config  # noqa: PLC0415
+
+    result: list[OverlayBackends] = []
+    config = load_config()
+    for name, overlay_cfg in (config.raw.get("overlays") or {}).items():
+        if name in already_found or not isinstance(overlay_cfg, dict):
+            continue
+        host = _host_from_toml(overlay_cfg)
+        messaging = _messaging_from_toml(overlay_cfg)
+        if host is None and messaging is None:
+            continue
+        result.append(
+            OverlayBackends(
+                name=name,
+                host=host,
+                messaging=messaging,
+                ready_labels=tuple(overlay_cfg.get("ready_labels", ())),
+                exclude_labels=tuple(overlay_cfg.get("exclude_labels", ())),
+            ),
+        )
+    return result
+
+
+def _host_from_toml(cfg: dict) -> CodeHostBackend | None:
+    from teatree.utils.secrets import read_pass  # noqa: PLC0415
+
+    gitlab_token_ref = cfg.get("gitlab_token_ref", "")
+    github_token_ref = cfg.get("github_token_ref", "")
+    gitlab_url = cfg.get("gitlab_url", "https://gitlab.com")
+
+    if gitlab_token_ref:
+        token = read_pass(gitlab_token_ref)
+        if token:
+            from teatree.backends.gitlab import GitLabCodeHost  # noqa: PLC0415
+
+            return GitLabCodeHost(token=token, base_url=gitlab_url)
+    if github_token_ref:
+        token = read_pass(github_token_ref)
+        if token:
+            from teatree.backends.github import GitHubCodeHost  # noqa: PLC0415
+
+            return GitHubCodeHost(token=token)
+    return None
+
+
+def _messaging_from_toml(cfg: dict) -> MessagingBackend | None:
+    if cfg.get("messaging_backend") != "slack":
+        return None
+    from teatree.backends.slack_bot import SlackBotBackend  # noqa: PLC0415
+    from teatree.utils.secrets import read_pass  # noqa: PLC0415
+
+    token_ref = cfg.get("slack_token_ref", "")
+    if not token_ref:
+        return None
+    bot_token = read_pass(f"{token_ref}-bot")
+    app_token = read_pass(f"{token_ref}-app")
+    user_id = cfg.get("slack_user_id", "")
+    if bot_token:
+        return SlackBotBackend(bot_token=bot_token, app_token=app_token or "", user_id=user_id)
+    return None
 
 
 def reset_backend_caches() -> None:

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -15,7 +15,7 @@ _ANSI_CYAN = "\033[1;36m"
 _ANSI_BOLD = "\033[1m"
 
 _ZONE_COLORS: dict[str, str] = {
-    "anchors": _ANSI_CYAN,
+    "anchors": _ANSI_DIM,
     "action_needed": _ANSI_RED,
     "in_flight": _ANSI_CYAN,
 }

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -277,7 +277,16 @@ def _classify_actions(actions: list[DispatchAction]) -> _ClassifiedActions:
     return c
 
 
-_NOISE_STATES = frozenset({"not_started", "merged", "delivered"})
+_NOISE_STATES = frozenset(
+    {
+        "not_started",
+        "merged",
+        "delivered",
+        "shipped",
+        "in_review",
+        "retrospected",
+    }
+)
 _MAX_PER_STATE = 5
 
 
@@ -286,18 +295,29 @@ def _render_ticket_line(
     tickets: list[tuple[str, str, str]],
     pr_map: dict[str, list[_PRRef]],
 ) -> str:
-    """One compact line per overlay: ``[ov] started: #1 (!5) #2 · shipped: #3``."""
+    """One compact line per overlay with inline hyperlinks.
+
+    Format: ``[ov] started: #1 (!5) #2 · coded: #3``
+    Each ``#N`` is an OSC8 hyperlink when an issue URL is available.
+    """
     prefix = f"[{overlay}] " if overlay else ""
     by_state: dict[str, list[str]] = {}
-    for num, state, _url in tickets:
+    for num, state, url in tickets:
         if state in _NOISE_STATES:
             continue
-        ticket_label = f"#{num}"
+        ticket_text = f"#{num}"
+        if url:
+            ticket_text = _hyperlink(ticket_text, url)
         prs = pr_map.get(num, [])
         if prs:
-            pr_labels = " ".join(f"!{r.iid}" for r in prs)
-            ticket_label += f" ({pr_labels})"
-        by_state.setdefault(state, []).append(ticket_label)
+            pr_parts = []
+            for r in prs:
+                pr_text = f"!{r.iid}"
+                if r.url:
+                    pr_text = _hyperlink(pr_text, r.url)
+                pr_parts.append(pr_text)
+            ticket_text += f" ({' '.join(pr_parts)})"
+        by_state.setdefault(state, []).append(ticket_text)
     if not by_state:
         return ""
     groups: list[str] = []

--- a/tests/teatree_loop/test_statusline.py
+++ b/tests/teatree_loop/test_statusline.py
@@ -138,7 +138,7 @@ class TestStatuslineColors:
         render(zones, target=target, colorize=True)
         content = target.read_text()
 
-        assert "\033[1;36m" in content  # cyan for anchors
+        assert "\033[2;37m" in content  # dim for anchors
         assert "\033[1;31m" in content  # red for action_needed
         assert "\033[1;36m" in content  # cyan for in_flight
         assert "\033[0m" in content  # reset after each line


### PR DESCRIPTION
## Summary
- Inline OSC8 hyperlinks on ticket numbers and PR refs in anchors zone
- Restore dim color for anchors (cyan was too noisy)
- Filter shipped/in_review/retrospected from anchors (developer-done states)
- New `_backends_from_toml()`: TOML overlays without a Python class get PRs, Slack, and issues scanned
- Include `issue_url` in `ActiveTicketsScanner` payload

## Test plan
- [x] 2746 tests pass
- [x] `t3 loop tick` renders clickable tickets, dim anchors, t3-company Slack DMs visible