### PR TITLE
style: extract HealthCheck to core/health.py, strip overlay docstrings

### DIFF
--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -28,7 +28,7 @@ def get_code_host(overlay: "OverlayBase") -> CodeHostBackend | None:
     Selection follows ``overlay.config.code_host``; falls back to inspecting
     the available tokens when the field is unset.
     """
-    choice = getattr(overlay.config, "code_host", "")
+    choice = overlay.config.code_host
     github_token = overlay.config.get_github_token()
     gitlab_token = overlay.config.get_gitlab_token()
 
@@ -66,13 +66,13 @@ def get_messaging(overlay: "OverlayBase") -> MessagingBackend:
     Default is :class:`NoopMessagingBackend` so callers always get a
     Protocol-conforming object — no per-call ``is None`` guards.
     """
-    choice = getattr(overlay.config, "messaging_backend", "") or "noop"
+    choice = overlay.config.messaging_backend or "noop"
     if choice == "slack":
-        token_ref = getattr(overlay.config, "slack_token_ref", "")
+        token_ref = overlay.config.slack_token_ref
         return SlackBotBackend(
             bot_token=read_pass(f"{token_ref}-bot") if token_ref else overlay.config.get_slack_token(),
             app_token=read_pass(f"{token_ref}-app") if token_ref else "",
-            user_id=getattr(overlay.config, "slack_user_id", ""),
+            user_id=overlay.config.slack_user_id,
         )
     if choice == "noop":
         return NoopMessagingBackend()

--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -34,6 +34,7 @@ class SlackBotBackend:
         self._bot_token = bot_token
         self._app_token = app_token
         self._user_id = user_id
+        self._cached_bot_id: str | None = None
         # Inbound queues populated by the Phase 3.6 Socket Mode receiver. Each
         # tick the loop scanner drains them via ``fetch_mentions`` /
         # ``fetch_dms``; the receiver calls ``enqueue_mention`` / ``enqueue_dm``.
@@ -130,9 +131,9 @@ class SlackBotBackend:
         return result
 
     def _resolve_bot_id(self) -> str:
-        if not hasattr(self, "_cached_bot_id"):
+        if self._cached_bot_id is None:
             data = self._post("auth.test", {})
-            self._cached_bot_id = data.get("user_id", "") if data.get("ok") else ""
+            self._cached_bot_id = str(data.get("user_id", "")) if data.get("ok") else ""
         return self._cached_bot_id
 
     def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -417,29 +417,20 @@ class IntrospectionHelpers:
             return editable, url
 
 
-@doctor_app.command()
-def check() -> bool:
-    """Verify imports, required tools, and editable-install sanity."""
+def _check_editable_sanity() -> bool:
     ok = True
-
     try:
-        import django  # noqa: PLC0415, F401
-
-        import teatree.core  # noqa: PLC0415, F401
-    except ImportError as exc:
-        typer.echo(f"FAIL  Import check: {exc}")
-        return False
-
-    for tool in _REQUIRED_TOOLS:
-        if not shutil.which(tool):
-            typer.echo(f"FAIL  Required tool not found: {tool}")
+        for problem in DoctorService.check_editable_sanity():
+            typer.echo(f"WARN  {problem}")
             ok = False
-
-    for problem in DoctorService.check_editable_sanity():
-        typer.echo(f"WARN  {problem}")
+    except Exception as exc:  # noqa: BLE001 — overlay loading can fail in many ways
+        typer.echo(f"FAIL  Editable sanity check crashed: {exc.__class__.__name__}: {exc}")
         ok = False
+    return ok
 
-    # Validate SKILL.md frontmatter.
+
+def _check_skills() -> bool:
+    ok = True
     claude_skills = Path.home() / ".claude" / "skills"
     if claude_skills.is_dir():
         from teatree.skill_schema import validate_directory  # noqa: PLC0415
@@ -453,6 +444,28 @@ def check() -> bool:
         if not errors:
             skill_count = sum(1 for d in claude_skills.iterdir() if d.is_dir() and (d / "SKILL.md").is_file())
             typer.echo(f"OK    {skill_count} skill(s) validated")
+    return ok
+
+
+@doctor_app.command()
+def check() -> bool:
+    """Verify imports, required tools, and editable-install sanity."""
+    try:
+        import django  # noqa: PLC0415, F401
+
+        import teatree.core  # noqa: PLC0415, F401
+    except ImportError as exc:
+        typer.echo(f"FAIL  Import check: {exc}")
+        return False
+
+    ok = True
+    for tool in _REQUIRED_TOOLS:
+        if not shutil.which(tool):
+            typer.echo(f"FAIL  Required tool not found: {tool}")
+            ok = False
+
+    ok = _check_editable_sanity() and ok
+    ok = _check_skills() and ok
 
     if ok:
         typer.echo("All checks passed")

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -1,7 +1,9 @@
 """TeaTree configuration — overlay discovery from ~/.teatree.toml."""
 
 import importlib.util
+import json
 import os
+import time
 import tomllib
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
@@ -319,9 +321,6 @@ def check_for_updates(*, force: bool = False) -> str | None:
 
     Results are cached for 24 h in ``DATA_DIR / "update-check.json"``.
     """
-    import json  # noqa: PLC0415
-    import time  # noqa: PLC0415
-
     config = load_config()
     if not force and not config.user.check_updates:
         return None
@@ -367,9 +366,6 @@ def check_for_updates(*, force: bool = False) -> str | None:
 
 def _write_update_cache(cache_path: Path, message: str) -> None:
     """Persist the update-check result so we don't hit the network every invocation."""
-    import json  # noqa: PLC0415
-    import time  # noqa: PLC0415
-
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path.write_text(
         json.dumps({"ts": time.time(), "message": message}),

--- a/src/teatree/core/health.py
+++ b/src/teatree/core/health.py
@@ -1,0 +1,60 @@
+"""Post-provision health checks for worktree readiness."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from teatree.core.models import Worktree
+    from teatree.core.overlay import OverlayBase
+
+
+@dataclass(frozen=True, slots=True)
+class HealthCheck:
+    name: str
+    check: Callable[[], bool]
+    description: str = ""
+
+
+def _symlink_source_healthy(dest: Path, source: Path) -> bool:
+    if dest.is_symlink():
+        if not source.exists():
+            return False
+        if source.is_dir():
+            return any(source.iterdir())
+        return True
+    if not dest.exists():
+        return False
+    if dest.is_dir():
+        return any(dest.iterdir())
+    return True
+
+
+def default_health_checks(overlay: "OverlayBase", worktree: "Worktree") -> list[HealthCheck]:
+    checks: list[HealthCheck] = []
+    extra = worktree.extra or {}
+    wt_path = extra.get("worktree_path", "")
+
+    if wt_path:
+        checks.append(
+            HealthCheck(
+                name="worktree-exists",
+                check=lambda: Path(wt_path).is_dir(),
+                description=f"Worktree directory exists: {wt_path}",
+            ),
+        )
+
+        for spec in overlay.get_symlinks(worktree):
+            dest = Path(wt_path) / spec.get("path", "")
+            source = Path(spec.get("source", ""))
+            if spec.get("mode", "symlink") == "symlink" and source.exists():
+                checks.append(
+                    HealthCheck(
+                        name=f"symlink-{spec.get('path', '?')}",
+                        check=lambda d=dest, s=source: _symlink_source_healthy(d, s),
+                        description=f"Symlink target populated: {spec.get('path', '')}",
+                    ),
+                )
+
+    return checks

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from dataclasses import dataclass
 from importlib import import_module
-from pathlib import Path
 from typing import TYPE_CHECKING
 
+from teatree.core.health import HealthCheck
+from teatree.core.health import default_health_checks as _default_health_checks
 from teatree.types import (
     BaseImageConfig,
     DbImportStrategy,
@@ -28,6 +28,7 @@ __all__ = [
     "DEFAULT_TRANSITION_EMOJIS",
     "BaseImageConfig",
     "DbImportStrategy",
+    "HealthCheck",
     "OverlayBase",
     "OverlayConfig",
     "OverlayMetadata",
@@ -57,72 +58,22 @@ DEFAULT_TRANSITION_EMOJIS: dict[str, str] = {
 
 
 class OverlayConfig:
-    """Overlay-specific configuration — credentials, project settings, URLs.
-
-    Configure via an ``overlay_settings`` module (Django-style) referenced by
-    the overlay class, or by subclassing and setting attributes directly.
-
-    Settings modules use ``UPPER_CASE`` constants that map to ``lower_case``
-    attributes on this class.  Settings ending in ``_PASS_KEY`` become secret
-    readers: ``GITHUB_TOKEN_PASS_KEY = "github/token"`` makes
-    ``get_github_token()`` read from the ``pass`` password store.
-    """
-
     # ── Static settings (override via settings module or subclass) ───
 
     gitlab_url: str = "https://gitlab.com/api/v4"
     github_owner: str = ""
-    """GitHub user or org that owns the project board."""
     github_project_number: int = 0
-    """GitHub Projects v2 board number (0 = not configured)."""
     code_host: str = ""
-    """Selects the CodeHostBackend implementation: ``"github"``, ``"gitlab"``, or ``""``.
-
-    Empty falls back to whichever token the config exposes.
-    """
     messaging_backend: str = "noop"
-    """Selects the MessagingBackend implementation: ``"slack"`` or ``"noop"`` (default)."""
     slack_token_ref: str = ""
-    """``pass`` entry name prefix for Slack bot credentials.
-
-    The loader reads ``<ref>-bot`` (xoxb token) and ``<ref>-app`` (xapp token).
-    Empty falls back to ``get_slack_token()`` for one-shot webhook posts.
-    """
     slack_user_id: str = ""
-    """Slack user id of the human the bot speaks for; used to filter @mentions."""
     require_ticket: bool = False
-    """Whether to enforce a tracked issue before coding/shipping."""
     ready_labels: list[str]
-    """Labels that mark an assigned issue as ready for the loop to pick up.
-
-    Used by ``AssignedIssuesScanner``. Empty disables the filter (every
-    open assigned issue is considered ready)."""
     exclude_labels: list[str]
-    """Labels that exclude an assigned issue from the statusline.
-
-    Issues carrying any of these labels are skipped by ``AssignedIssuesScanner``
-    even if they match ``ready_labels``. Useful for workflow stages like
-    "DEV review" where the developer's work is done."""
     auto_start_assigned_issues: bool = False
-    """When ``True``, the loop hands ready assigned issues to the orchestrator
-    agent to drive end-to-end through PR creation. When ``False`` (default),
-    ready issues only surface in the statusline; the operator decides when to
-    start them. The PR-merge gate (``require_human_approval_to_merge``) is the
-    final stopping point regardless of this flag."""
     max_concurrent_auto_starts: int = 1
-    """Cap on auto-started tickets in flight. The scanner counts tickets in
-    states ``NOT_STARTED..SHIPPED`` whose ``extra.auto_started`` is ``True``
-    and emits at most ``max - in_flight`` new auto-start signals per tick.
-    Tickets in ``IN_REVIEW`` (PR open, awaiting human merge) and beyond no
-    longer occupy the auto-start budget."""
     notion_database_id: str = ""
-    """Notion database id powering ``NotionViewScanner``. Empty disables the scanner."""
     mr_close_ticket: bool = False
-    """Whether PR descriptions should use auto-closing keywords (Closes #N).
-
-    When ``False`` (default), close keywords are replaced with ``Relates to #N``
-    so merging the PR does not auto-close the linked issue.
-    """
     known_variants: list[str]
     pr_auto_labels: list[str]
     frontend_repos: list[str]
@@ -145,10 +96,6 @@ class OverlayConfig:
             self._load_toml_overrides(overlay_name)
 
     def _load_settings(self, module_path: str) -> None:
-        """Load UPPER_CASE constants from a settings module as attributes.
-
-        ``*_PASS_KEY`` settings register a secret reader via ``pass``.
-        """
         mod = import_module(module_path)
         for name in dir(mod):
             if not name.isupper() or name.startswith("_"):
@@ -162,11 +109,6 @@ class OverlayConfig:
                 setattr(self, name.lower(), value)
 
     def _load_toml_overrides(self, overlay_name: str) -> None:
-        """Load overlay-specific overrides from ``~/.teatree.toml``.
-
-        Reads ``[overlays.<name>]`` section. Keys ending in ``_pass_key``
-        register secret readers, others set attributes directly.
-        """
         from teatree.config import load_config  # noqa: PLC0415
 
         config = load_config()
@@ -181,7 +123,6 @@ class OverlayConfig:
                 setattr(self, key, value)
 
     def _register_secret(self, attr_name: str, pass_key: str) -> None:
-        """Create a ``get_<attr_name>()`` method that reads from ``pass``."""
 
         def _reader(_key: str = pass_key) -> str:
             from teatree.utils.secrets import read_pass  # noqa: PLC0415
@@ -210,16 +151,9 @@ class OverlayConfig:
     # ── Structured getters (need logic, can't be plain constants) ────
 
     def get_review_channel(self) -> tuple[str, str]:
-        """Return (channel_name, channel_id) for review notifications."""
         return ("", "")
 
     def get_transition_emojis(self) -> dict[str, str]:
-        """Map FSM transition names to Slack emoji reactions.
-
-        Override via the settings module (``TRANSITION_EMOJIS = {...}``) or
-        by subclassing. The override is *merged* on top of the defaults so
-        overlays only need to specify the keys they change.
-        """
         override = getattr(self, "transition_emojis", None)
         if isinstance(override, dict):
             return {**DEFAULT_TRANSITION_EMOJIS, **override}
@@ -230,12 +164,6 @@ class OverlayConfig:
 
 
 class OverlayMetadata:
-    """Project metadata, CI integration, PR validation, and skill registration.
-
-    Subclass and assign to ``OverlayBase.metadata`` for project-specific values.
-    Consumers access via ``overlay.metadata.get_skill_metadata()``.
-    """
-
     def validate_pr(self, title: str, description: str) -> ValidationResult:
         return {"errors": [], "warnings": []}
 
@@ -258,7 +186,6 @@ class OverlayMetadata:
         return []
 
     def get_issue_title(self, url: str) -> str:
-        """Fetch the title of an issue from its URL. Returns empty string on failure."""
         return ""
 
 
@@ -283,7 +210,6 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
     # ── Issue title resolution ────────────────────────────────────────
 
     def get_issue_title(self, url: str) -> str:
-        """Fetch the title of an issue from its URL via the code-host backend."""
         from teatree.backends.loader import get_code_host  # noqa: PLC0415
 
         try:
@@ -302,26 +228,9 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
         return {}
 
     def declared_env_keys(self) -> set[str]:
-        """Return every env key this overlay may contribute to the cache.
-
-        Used by ``tests/test_env_contract.py`` to assert that every
-        ``${VAR}`` reference in overlay compose templates has a declared
-        producer.  Default is the empty set — overlays that contribute
-        nothing extra need not override this.
-        """
         return set()
 
     def declared_secret_env_keys(self) -> set[str]:
-        """Return env keys whose values must NOT be persisted to ``.t3-env.cache``.
-
-        Keys returned here are still produced by ``get_env_extra()`` — callers
-        passing the dict as subprocess ``env=`` (e.g. ``t3 <overlay> run backend``,
-        ``worktree_start``) keep them — but ``render_env_cache`` filters them out
-        of the on-disk file. Use this for credentials read from ``pass`` or any
-        value that should live only in process memory.
-
-        Default empty: overlays that don't source secrets need not override.
-        """
         return set()
 
     def get_db_import_strategy(self, worktree: "Worktree") -> DbImportStrategy | None:
@@ -354,60 +263,26 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
         return {}
 
     def get_compose_file(self, worktree: "Worktree") -> str:
-        """Return the path to the docker-compose file for this worktree."""
         return ""
 
     def get_base_images(self, worktree: "Worktree") -> list[BaseImageConfig]:
-        """Return base images teatree builds once and shares across worktrees.
-
-        Each image is tagged ``{image_name}:deps-{sha256(lockfile)[:12]}``;
-        teatree skips the build when the tag already exists.  Code changes
-        reach containers through the worktree's volume mount — no rebuild.
-        Default: no base images (opt-in — overlays keep working until they
-        opt in).
-        """
         _ = worktree
         return []
 
     def get_docker_services(self, worktree: "Worktree") -> set[str]:
-        """Service names (as declared in ``get_services_config``) that MUST run in Docker.
-
-        Teatree rejects ``worktree provision`` if any name returned here is not
-        declared in ``get_services_config`` — prevents drift between the
-        enforcement list and the service specs.  Default: empty set (opt-in).
-        """
         _ = worktree
         return set()
 
     # ── Port hooks ───────────────────────────────────────────────────
 
     def get_required_ports(self, worktree: "Worktree") -> set[str]:
-        """Return the set of port keys this overlay needs allocated per worktree.
-
-        Default: empty set. Overlays opt in by declaring the keys they map in
-        their compose templates (e.g., ``{"backend", "frontend", "postgres"}``).
-        Pure-Python overlays without docker compose declare nothing here.
-        """
         _ = worktree
         return set()
 
     def get_port_env(self, ports: dict[str, int]) -> dict[str, str]:
-        """Return the env vars that publish allocated host *ports* to compose.
-
-        Default mapping is generic: each key ``X`` becomes ``X_HOST_PORT``
-        (uppercased). Overlays override to add convention-specific aliases
-        (e.g. ``POSTGRES_PORT`` for ``psql``, ``CORS_WHITE_FRONT`` for
-        Django CORS) without changing core.
-        """
         return {f"{key.upper()}_HOST_PORT": str(port) for key, port in ports.items()}
 
     def uses_redis(self) -> bool:
-        """Return True when this overlay needs the shared teatree-redis container.
-
-        Default ``False`` — single-service overlays (CLI tools, doc generators,
-        teatree itself) skip the redis-allocation step. Multi-service overlays
-        with Celery/RQ/cache override to ``True``.
-        """
         return False
 
     # ── Run hooks ────────────────────────────────────────────────────
@@ -422,182 +297,40 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
         return []
 
     def get_e2e_env_extras(self, env_cache: dict[str, str]) -> dict[str, str]:
-        """Return overlay-specific env vars to add to the Playwright environment.
-
-        Receives the parsed worktree env cache (``.t3-env.cache``). Use this to
-        derive overlay-specific vars Playwright tests need (e.g. ``CUSTOMER``
-        from ``WT_VARIANT``). Existing values in ``os.environ`` win — this hook
-        only fills in missing keys. Default: no extras.
-
-        Keeps overlay-specific naming conventions (variant→customer, tenant→client)
-        out of core; each overlay owns its own mapping.
-        """
         _ = env_cache
         return {}
 
     def get_e2e_preflight(self, *, customer: str | None, base_url: str | None) -> list[Callable[[], None]]:
-        """Return preflight checks to run before launching the external Playwright suite.
-
-        Each callable raises :class:`RuntimeError` on failure with a human-readable
-        message; the ``e2e external`` command will print the message and exit
-        non-zero before any test starts. Default: no checks.
-
-        Overlays use this to fail fast on environment problems they alone can detect
-        (auth chains, network reachability, vendor SSO availability) without leaking
-        overlay-specific knowledge into core.
-        """
         _ = customer, base_url
         return []
 
     def get_verify_endpoints(self, worktree: "Worktree") -> dict[str, str]:
-        """Return custom health-check paths per service.
-
-        Keys match ``worktree.ports`` entries (e.g. ``"backend"``, ``"frontend"``).
-        Values are URL paths (e.g. ``"/admin/login/"``).
-        Services not listed here fall back to ``/``.
-        """
         return {}
 
     def get_timeouts(self) -> dict[str, int]:
-        """Return overlay-specific timeout overrides (seconds).
-
-        Keys match ``teatree.timeouts`` operation names (e.g. ``"setup"``,
-        ``"db_import"``).  ``0`` disables the timeout for that operation.
-        Only return overrides — missing keys fall through to core defaults.
-        """
         return {}
 
     def get_cleanup_steps(self, worktree: "Worktree") -> list[ProvisionStep]:
-        """Return extra cleanup steps run before a worktree is removed.
-
-        Use for overlay-specific teardown (Docker containers, cache dirs, etc.).
-        """
         return []
 
     def get_health_checks(self, worktree: "Worktree") -> list["HealthCheck"]:
-        """Return post-provision health checks to verify the worktree is functional.
-
-        Overlays can override to add project-specific checks (e.g., verify
-        specific DB tables exist, check custom symlinks).  The default checks
-        verify: worktree path exists, symlinks are valid, and DB name is set.
-        """
         return _default_health_checks(self, worktree)
 
     def get_readiness_probes(self, worktree: "Worktree") -> list["Probe"]:
-        """Return runtime readiness probes for a started worktree.
-
-        Health checks (``get_health_checks``) verify post-provision invariants
-        (symlinks, db name set) — they answer "did setup do its job?". Probes
-        verify post-start runtime behaviour — they answer "is the env actually
-        serving?". Overlays declare HTTP endpoints, command checks, and custom
-        probes that an operator can trust as the truth-tellers for ready.
-
-        Default empty: an overlay with no probes makes no claim about ready.
-        """
         _ = worktree
         return []
 
     def get_workspace_repos(self) -> list[str]:
-        """Return repo paths relative to ``workspace_dir``.
-
-        Supports nested paths (e.g. ``souliane/teatree``).  Reads from
-        ``config.workspace_repos`` first; falls back to ``get_repos()``.
-        """
         if self.config.workspace_repos:
             return list(self.config.workspace_repos)
         return self.get_repos()
 
     def get_visual_qa_targets(self, changed_files: list[str]) -> list[str]:
-        """Return URL paths the pre-push browser sanity gate should load.
-
-        Each path is appended to the worktree base URL (e.g. ``"/"`` →
-        ``http://127.0.0.1:8000/``).  Return ``[]`` to skip the gate for
-        this diff.  Default: skip — overlays opt in by mapping diff paths
-        to the URLs they care about.
-
-        Called from the shipping gate as a side effect of PR creation;
-        results are recorded on ``Ticket.extra['visual_qa']``.
-        """
         _ = changed_files
         return []
 
     # ── Loop hooks ───────────────────────────────────────────────────
 
     def is_issue_done(self, issue_data: "RawAPIDict") -> bool:
-        """Return whether the upstream issue is fully done.
-
-        Called by ``TicketCompletionScanner`` to detect tickets whose upstream
-        issue indicates all work is complete — even across multiple repos/PRs.
-
-        Default (GitHub): ``state ∈ {closed, completed}``.
-        GitLab overlays override to check for a process label instead, since a
-        multi-repo ticket may have several MRs and the issue stays open until
-        the last one merges.
-        """
         state = issue_data.get("state")
         return isinstance(state, str) and state in {"closed", "completed"}
-
-
-# ── Health checks ───────────────────────────────────────────────────
-
-
-@dataclass(frozen=True, slots=True)
-class HealthCheck:
-    name: str
-    check: Callable[[], bool]
-    description: str = ""
-
-
-def _symlink_source_healthy(dest: Path, source: Path) -> bool:
-    """Return True when *dest* contains populated content.
-
-    Two valid end states: a symlink at *dest* pointing to a populated
-    *source*, or a real populated directory at *dest* (e.g. after
-    ``npm install`` ran in the worktree, replacing the symlink with a
-    real directory — see #480).
-    """
-    if dest.is_symlink():
-        if not source.exists():
-            return False
-        if source.is_dir():
-            return any(source.iterdir())
-        return True
-    if not dest.exists():
-        return False
-    if dest.is_dir():
-        return any(dest.iterdir())
-    return True
-
-
-def _default_health_checks(overlay: OverlayBase, worktree: "Worktree") -> list[HealthCheck]:
-    """Return standard post-provision checks applicable to any overlay."""
-    checks: list[HealthCheck] = []
-    extra = worktree.extra or {}
-    wt_path = extra.get("worktree_path", "")
-
-    if wt_path:
-        checks.append(
-            HealthCheck(
-                name="worktree-exists",
-                check=lambda: Path(wt_path).is_dir(),
-                description=f"Worktree directory exists: {wt_path}",
-            ),
-        )
-
-        # Verify symlinks point to valid, non-empty targets.
-        # An empty source directory (e.g. a pre-existing but never-populated
-        # `node_modules/`) previously passed the check and masked broken
-        # provisioning — see t3-o.#55.
-        for spec in overlay.get_symlinks(worktree):
-            dest = Path(wt_path) / spec.get("path", "")
-            source = Path(spec.get("source", ""))
-            if spec.get("mode", "symlink") == "symlink" and source.exists():
-                checks.append(
-                    HealthCheck(
-                        name=f"symlink-{spec.get('path', '?')}",
-                        check=lambda d=dest, s=source: _symlink_source_healthy(d, s),
-                        description=f"Symlink target populated: {spec.get('path', '')}",
-                    ),
-                )
-
-    return checks

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -109,7 +109,7 @@ def render(zones: StatuslineZones, *, target: Path | None = None, colorize: bool
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(body)
         Path(tmp_path).replace(target)
-    except Exception:
+    except BaseException:
         tmp_path.unlink(missing_ok=True)
         raise
 

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -6,8 +6,10 @@ testing lives here as plain Python.
 """
 
 import datetime as dt
+import json
 import logging
 import os
+import tomllib
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -475,10 +477,9 @@ def _ignore_disposed_ticket(payload: ActionPayload) -> None:
     if ticket_id is None:
         return
     ticket = ticket_model.objects.get(pk=ticket_id)
-    if hasattr(ticket, "ignore"):
-        ticket.ignore()
-        ticket.save()
-        logger.info("Auto-ignored ticket %s (reason: %s)", ticket_id, payload.get("reason", "?"))
+    ticket.ignore()
+    ticket.save()
+    logger.info("Auto-ignored ticket %s (reason: %s)", ticket_id, payload.get("reason", "?"))
 
 
 def _complete_ticket(payload: ActionPayload) -> None:
@@ -536,8 +537,6 @@ def _repo_freshness(repo_path: Path) -> dict[str, int | str] | None:
 
 
 def _collect_repo_freshness() -> dict[str, dict[str, int | str]]:
-    import tomllib  # noqa: PLC0415
-
     repos: dict[str, Path] = {}
     t3_repo = os.environ.get("T3_REPO")
     if t3_repo:
@@ -565,8 +564,6 @@ def _write_tick_meta(started_at: dt.datetime, *, target: Path | None = None) -> 
     meta_path = (target or default_path()).with_name("tick-meta.json")
     cadence = int(os.environ.get("T3_LOOP_CADENCE", "720") or "720")
     next_epoch = int(started_at.timestamp()) + cadence
-    import json  # noqa: PLC0415
-
     freshness = _collect_repo_freshness()
     meta_path.write_text(
         json.dumps({"next_epoch": next_epoch, "cadence": cadence, "freshness": freshness}) + "\n",

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -10,13 +10,13 @@ User-facing CLI output flows through ``self.stdout`` / ``self.stderr``
 on ``DjangoDbImporter`` (Django ``BaseCommand`` pattern), which keeps
 the source free of bare ``print`` calls and lets tests capture output
 by passing an ``io.StringIO``.
+
+DSLR snapshot helpers live in ``django_db_dslr``.
 """
 
 import enum
 import logging
 import os
-import re
-import shutil
 import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -24,25 +24,11 @@ from pathlib import Path
 from typing import TextIO
 
 from teatree.utils import bad_artifacts
+from teatree.utils import django_db_dslr as _dslr
+from teatree.utils.django_db_dslr import prune_dslr_snapshots
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class DjangoDbImportConfig:
-    ref_db_name: str
-    ticket_db_name: str
-    main_repo_path: str
-    dump_dir: str
-    dump_glob: str
-    ci_dump_glob: str
-    snapshot_tool: str = "dslr"
-    remote_db_url: str = ""
-    migrate_env_extra: dict[str, str] = field(default_factory=dict)
-    dump_timeout: int = 1800
-    dslr_snapshot: str = ""  # Force a specific DSLR snapshot name (skip auto-discovery)
-    dump_path: str = ""  # Force a specific .pgsql dump file (skip DSLR and dump discovery)
 
 
 # ---------------------------------------------------------------------------
@@ -97,98 +83,6 @@ def _terminate_connections(db_name: str, pg_host: str, pg_user: str, pg_env: dic
     )
 
 
-def _find_dslr_cmd(tool_name: str, _main_repo_path: str = "") -> list[str]:
-    """Return a command prefix for invoking dslr.
-
-    Uses ``uv run`` from the **host project** (where dslr + psycopg live as
-    hard dependencies), not from the target repo.  The *main_repo_path* arg
-    is accepted for backward compatibility but ignored — dslr must be in the
-    teatree host project's venv.
-
-    Honour ``DSLR_CMD`` env var as an explicit override.
-    """
-    dslr = os.environ.get("DSLR_CMD", "")
-    if dslr and shutil.which(dslr):
-        return [dslr]
-    if shutil.which("uv"):
-        return ["uv", "run", tool_name]
-    return []
-
-
-def _dslr_env(ref_db: str) -> dict[str, str]:
-    url = _local_db_url(ref_db)
-    return {**os.environ, "DATABASE_URL": url, "DSLR_DB_URL": url}
-
-
-def _dslr_snap_name(ref_db: str) -> str:
-    today = datetime.now(tz=UTC).strftime("%Y%m%d")
-    return f"{today}_{ref_db}"
-
-
-def _dslr_artifact_key(snap_name: str) -> str:
-    return f"dslr:{snap_name}"
-
-
-def _find_dslr_snapshots(dslr_cmd: list[str], env: dict[str, str], ref_db: str) -> list[str]:
-    """Return matching DSLR snapshots sorted newest-first, excluding bad artifacts."""
-    suffix = f"_{ref_db}"
-    result = run_allowed_to_fail([*dslr_cmd, "list"], env=env, expected_codes=None)
-    if result.returncode != 0:
-        return []
-    names: list[str] = []
-    for line in result.stdout.splitlines():
-        token = line.strip().split()[0] if line.strip() else ""
-        if token.endswith(suffix) and not bad_artifacts.is_bad(_dslr_artifact_key(token)):
-            names.append(token)
-    names.sort(reverse=True)
-    return names
-
-
-def _is_env_error(stderr: str) -> bool:
-    """Return True if the error is environmental (connection, auth), not data corruption."""
-    env_patterns = [
-        "connection refused",
-        "could not connect",
-        "password authentication failed",
-        "SSL",
-        "ssl",
-        "no pg_hba.conf entry",
-        "timeout expired",
-        "server closed the connection",
-    ]
-    lower = stderr.lower()
-    return any(p.lower() in lower for p in env_patterns)
-
-
-def _restore_ref_from_dslr(dslr_cmd: list[str], env: dict[str, str], snap_name: str) -> tuple[bool, bool, str]:
-    """Restore a DSLR snapshot. Returns (success, is_env_error, stderr)."""
-    result = run_allowed_to_fail([*dslr_cmd, "restore", snap_name], env=env, expected_codes=None)
-    if result.returncode == 0:
-        return True, False, ""
-    return False, _is_env_error(result.stderr), result.stderr.strip()
-
-
-def _extract_failing_migration(stdout: str) -> str | None:
-    match = re.search(r"Applying (\w+\.\w+)\.\.\.", stdout)
-    return match.group(1) if match else None
-
-
-def _parse_dslr_snapshots(stdout: str) -> dict[str, list[str]]:
-    """Parse ``dslr list`` output, group snapshot names by tenant (suffix after date)."""
-    by_tenant: dict[str, list[str]] = {}
-    for line in stdout.splitlines():
-        token = line.strip().split()[0] if line.strip() else ""
-        if not token:
-            continue
-        # Snapshot names: <date>_<tenant>  e.g. "20260401_development-acme"
-        if "_" in token:
-            tenant = token.split("_", maxsplit=1)[1]
-            by_tenant.setdefault(tenant, []).append(token)
-    for names in by_tenant.values():
-        names.sort(reverse=True)
-    return by_tenant
-
-
 def validate_dump(dump_path: Path) -> bool:
     if dump_path.stat().st_size == 0:
         return False
@@ -197,6 +91,22 @@ def validate_dump(dump_path: Path) -> bool:
         sys.stdout.write(f"  WARNING: Dump appears truncated: {dump_path.name} (delete and re-fetch)\n")
         return False
     return True
+
+
+@dataclass(frozen=True)
+class DjangoDbImportConfig:
+    ref_db_name: str
+    ticket_db_name: str
+    main_repo_path: str
+    dump_dir: str
+    dump_glob: str
+    ci_dump_glob: str
+    snapshot_tool: str = "dslr"
+    remote_db_url: str = ""
+    migrate_env_extra: dict[str, str] = field(default_factory=dict)
+    dump_timeout: int = 1800
+    dslr_snapshot: str = ""
+    dump_path: str = ""
 
 
 _MAX_MIGRATE_RETRIES = 20
@@ -236,8 +146,10 @@ class DjangoDbImporter:
         self.cfg = cfg
         self.stdout: TextIO = stdout if stdout is not None else sys.stdout
         self.stderr: TextIO = stderr if stderr is not None else sys.stderr
-        self.dslr_cmd: list[str] = _find_dslr_cmd(cfg.snapshot_tool, cfg.main_repo_path) if cfg.snapshot_tool else []
-        self.dslr_env: dict[str, str] = _dslr_env(cfg.ref_db_name) if self.dslr_cmd else {}
+        self.dslr_cmd: list[str] = (
+            _dslr.find_dslr_cmd(cfg.snapshot_tool, cfg.main_repo_path) if cfg.snapshot_tool else []
+        )
+        self.dslr_env: dict[str, str] = _dslr.dslr_env(cfg.ref_db_name) if self.dslr_cmd else {}
         pg_host, pg_user, pg_env = _pg_args()
         self.pg_host = pg_host
         self.pg_user = pg_user
@@ -272,7 +184,7 @@ class DjangoDbImporter:
         return True
 
     def _take_dslr_snapshot(self) -> None:
-        snap_name = _dslr_snap_name(self.cfg.ref_db_name)
+        snap_name = _dslr.dslr_snap_name(self.cfg.ref_db_name)
         self.stdout.write(f"  Taking DSLR snapshot: {snap_name}\n")
         run_allowed_to_fail([*self.dslr_cmd, "snapshot", "-y", snap_name], env=self.dslr_env, expected_codes=None)
 
@@ -321,7 +233,7 @@ class DjangoDbImporter:
         if "already exists" not in combined and "does not exist" not in combined:
             return "Cannot migrate reference DB (non-fakeable error), skipping."
 
-        failing = _extract_failing_migration(stdout)
+        failing = _dslr.extract_failing_migration(stdout)
         if not failing:
             return "Cannot identify failing migration, skipping reference migration."
 
@@ -401,13 +313,13 @@ class DjangoDbImporter:
     def _resolve_dslr_snapshots(self) -> list[str]:
         if self.cfg.dslr_snapshot:
             return [self.cfg.dslr_snapshot]
-        return _find_dslr_snapshots(self.dslr_cmd, self.dslr_env, self.cfg.ref_db_name)
+        return _dslr.find_dslr_snapshots(self.dslr_cmd, self.dslr_env, self.cfg.ref_db_name)
 
     def _log_dslr_restore_failure(self, snap_name: str, *, is_env: bool, stderr: str) -> None:
         if is_env:
             self.stdout.write(f"  WARNING: DSLR restore failed (environment error, not marking bad): {snap_name}\n")
         else:
-            bad_artifacts.mark_bad(_dslr_artifact_key(snap_name))
+            bad_artifacts.mark_bad(_dslr.dslr_artifact_key(snap_name))
             self.stdout.write(
                 f"  BAD ARTIFACT: DSLR snapshot '{snap_name}' marked bad (delete: dslr delete {snap_name})\n",
             )
@@ -428,7 +340,7 @@ class DjangoDbImporter:
             return False
         for snap_name in snapshots:
             self.stdout.write(f"  Restoring {self.cfg.ref_db_name} from DSLR snapshot: {snap_name}\n")
-            ok, is_env, stderr = _restore_ref_from_dslr(self.dslr_cmd, self.dslr_env, snap_name)
+            ok, is_env, stderr = _dslr.restore_ref_from_dslr(self.dslr_cmd, self.dslr_env, snap_name)
             if not ok:
                 self._log_dslr_restore_failure(snap_name, is_env=is_env, stderr=stderr)
                 continue
@@ -627,22 +539,10 @@ def django_db_import(
     )
 
 
-def prune_dslr_snapshots(*, keep: int = 1, snapshot_tool: str = "dslr", main_repo_path: str = "") -> list[str]:
-    """Delete old DSLR snapshots, keeping the *keep* newest per tenant.
-
-    Returns a list of deleted snapshot names.
-    """
-    dslr_cmd = _find_dslr_cmd(snapshot_tool, main_repo_path)
-    if not dslr_cmd:
-        return []
-    result = run_allowed_to_fail([*dslr_cmd, "list"], expected_codes=None)
-    if result.returncode != 0:
-        return []
-    by_tenant = _parse_dslr_snapshots(result.stdout)
-    deleted: list[str] = []
-    for tenant, names in by_tenant.items():
-        for old in names[keep:]:
-            sys.stdout.write(f"  Pruning DSLR snapshot: {old} (tenant={tenant})\n")
-            run_allowed_to_fail([*dslr_cmd, "delete", "-y", old], expected_codes=None)
-            deleted.append(old)
-    return deleted
+__all__ = [
+    "DjangoDbImportConfig",
+    "DjangoDbImporter",
+    "django_db_import",
+    "prune_dslr_snapshots",
+    "validate_dump",
+]

--- a/src/teatree/utils/django_db_dslr.py
+++ b/src/teatree/utils/django_db_dslr.py
@@ -1,0 +1,129 @@
+"""DSLR snapshot helpers for Django database provisioning.
+
+Handles discovery, restore, pruning, and environment setup for DSLR
+(Django Lightweight Snapshot Restore) snapshots used by the DB import
+engine in ``django_db.py``.
+"""
+
+import os
+import re
+import shutil
+import sys
+from datetime import UTC, datetime
+
+from teatree.utils import bad_artifacts
+from teatree.utils.run import run_allowed_to_fail
+
+
+def find_dslr_cmd(tool_name: str, _main_repo_path: str = "") -> list[str]:
+    """Return a command prefix for invoking dslr.
+
+    Uses ``uv run`` from the **host project** (where dslr + psycopg live as
+    hard dependencies), not from the target repo.  The *main_repo_path* arg
+    is accepted for backward compatibility but ignored — dslr must be in the
+    teatree host project's venv.
+
+    Honour ``DSLR_CMD`` env var as an explicit override.
+    """
+    dslr = os.environ.get("DSLR_CMD", "")
+    if dslr and shutil.which(dslr):
+        return [dslr]
+    if shutil.which("uv"):
+        return ["uv", "run", tool_name]
+    return []
+
+
+def dslr_env(ref_db: str) -> dict[str, str]:
+    from teatree.utils.django_db import _local_db_url as local_db_url  # noqa: PLC0415
+
+    url = local_db_url(ref_db)
+    return {**os.environ, "DATABASE_URL": url, "DSLR_DB_URL": url}
+
+
+def dslr_snap_name(ref_db: str) -> str:
+    today = datetime.now(tz=UTC).strftime("%Y%m%d")
+    return f"{today}_{ref_db}"
+
+
+def dslr_artifact_key(snap_name: str) -> str:
+    return f"dslr:{snap_name}"
+
+
+def find_dslr_snapshots(dslr_cmd: list[str], env: dict[str, str], ref_db: str) -> list[str]:
+    """Return matching DSLR snapshots sorted newest-first, excluding bad artifacts."""
+    suffix = f"_{ref_db}"
+    result = run_allowed_to_fail([*dslr_cmd, "list"], env=env, expected_codes=None)
+    if result.returncode != 0:
+        return []
+    names: list[str] = []
+    for line in result.stdout.splitlines():
+        token = line.strip().split()[0] if line.strip() else ""
+        if token.endswith(suffix) and not bad_artifacts.is_bad(dslr_artifact_key(token)):
+            names.append(token)
+    names.sort(reverse=True)
+    return names
+
+
+def is_env_error(stderr: str) -> bool:
+    """Return True if the error is environmental (connection, auth), not data corruption."""
+    env_patterns = [
+        "connection refused",
+        "could not connect",
+        "password authentication failed",
+        "SSL",
+        "ssl",
+        "no pg_hba.conf entry",
+        "timeout expired",
+        "server closed the connection",
+    ]
+    lower = stderr.lower()
+    return any(p.lower() in lower for p in env_patterns)
+
+
+def restore_ref_from_dslr(dslr_cmd: list[str], env: dict[str, str], snap_name: str) -> tuple[bool, bool, str]:
+    """Restore a DSLR snapshot. Returns (success, is_env_error, stderr)."""
+    result = run_allowed_to_fail([*dslr_cmd, "restore", snap_name], env=env, expected_codes=None)
+    if result.returncode == 0:
+        return True, False, ""
+    return False, is_env_error(result.stderr), result.stderr.strip()
+
+
+def extract_failing_migration(stdout: str) -> str | None:
+    match = re.search(r"Applying (\w+\.\w+)\.\.\.", stdout)
+    return match.group(1) if match else None
+
+
+def parse_dslr_snapshots(stdout: str) -> dict[str, list[str]]:
+    """Parse ``dslr list`` output, group snapshot names by tenant (suffix after date)."""
+    by_tenant: dict[str, list[str]] = {}
+    for line in stdout.splitlines():
+        token = line.strip().split()[0] if line.strip() else ""
+        if not token:
+            continue
+        if "_" in token:
+            tenant = token.split("_", maxsplit=1)[1]
+            by_tenant.setdefault(tenant, []).append(token)
+    for names in by_tenant.values():
+        names.sort(reverse=True)
+    return by_tenant
+
+
+def prune_dslr_snapshots(*, keep: int = 1, snapshot_tool: str = "dslr", main_repo_path: str = "") -> list[str]:
+    """Delete old DSLR snapshots, keeping the *keep* newest per tenant.
+
+    Returns a list of deleted snapshot names.
+    """
+    dslr_cmd = find_dslr_cmd(snapshot_tool, main_repo_path)
+    if not dslr_cmd:
+        return []
+    result = run_allowed_to_fail([*dslr_cmd, "list"], expected_codes=None)
+    if result.returncode != 0:
+        return []
+    by_tenant = parse_dslr_snapshots(result.stdout)
+    deleted: list[str] = []
+    for tenant, names in by_tenant.items():
+        for old in names[keep:]:
+            sys.stdout.write(f"  Pruning DSLR snapshot: {old} (tenant={tenant})\n")
+            run_allowed_to_fail([*dslr_cmd, "delete", "-y", old], expected_codes=None)
+            deleted.append(old)
+    return deleted

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -1,5 +1,7 @@
 from teatree.utils.run import CommandFailedError, run_allowed_to_fail, run_checked
 
+# ── Low-level runners ───────────────────────────────────────────────
+
 
 def run(*, repo: str = ".", args: list[str]) -> str:
     result = run_allowed_to_fail(["git", "-C", repo, *args], expected_codes=None)
@@ -32,14 +34,6 @@ def log_oneline(repo: str = ".", range_spec: str = "") -> str:
 
 
 def unsynced_commits(repo: str, branch: str, target: str = "origin/main") -> list[str]:
-    """Return one-line commit descriptions on *branch* not reachable from *target*.
-
-    An empty list means the branch is fully captured by ``target`` (default
-    ``origin/main``). Compared against the default branch — not against
-    every remote tracking ref — so a feature branch that has been pushed
-    to its own remote ref still surfaces commits that haven't landed on
-    main yet.
-    """
     output = run(repo=repo, args=["log", branch, "--not", target, "--oneline"])
     return [line for line in output.splitlines() if line.strip()]
 
@@ -104,7 +98,6 @@ def default_branch(repo: str = ".") -> str:
 
 
 def branch_merged(repo: str, branch: str, target: str = "origin/main") -> bool:
-    """Return True if *branch* has been merged into *target*."""
     output = run(repo=repo, args=["branch", "--merged", target])
     return any(line.strip() == branch for line in output.splitlines())
 
@@ -114,18 +107,10 @@ def current_branch(repo: str = ".") -> str:
 
 
 def remote_url(repo: str = ".", remote: str = "origin") -> str:
-    """Return the fetch URL for the given remote, or empty string if not found."""
     return run(repo=repo, args=["remote", "get-url", remote])
 
 
 def remote_slug(repo: str = ".", remote: str = "origin") -> str:
-    """Return ``owner/repo`` (or ``group/sub/.../proj``) for the given remote.
-
-    When ``repo`` is already a slug (no leading ``/``, no ``:`` or ``@``,
-    contains a ``/``), it is returned unchanged.  Otherwise the remote URL is
-    parsed.  Returns the empty string when no slug can be resolved so callers
-    can fall back to a default.
-    """
     if "/" in repo and not repo.startswith("/") and ":" not in repo and "@" not in repo:
         return repo
     url = remote_url(repo=repo, remote=remote)
@@ -134,10 +119,8 @@ def remote_slug(repo: str = ".", remote: str = "origin") -> str:
     cleaned = url.rstrip("/")
     cleaned = cleaned.removesuffix(".git")
     if "@" in cleaned and ":" in cleaned and "://" not in cleaned:
-        # scp-like form: git@github.com:owner/repo
         return cleaned.split(":", 1)[1]
     if "://" in cleaned:
-        # https://host/owner/repo or ssh://git@host/owner/repo
         host_and_path = cleaned.split("://", 1)[1].split("/", 1)
         if len(host_and_path) > 1:
             return host_and_path[1]
@@ -145,12 +128,10 @@ def remote_slug(repo: str = ".", remote: str = "origin") -> str:
 
 
 def config_value(repo: str = ".", key: str = "") -> str:
-    """Return a git config value, or empty string if not set."""
     return run(repo=repo, args=["config", key])
 
 
 def last_commit_message(repo: str = ".") -> tuple[str, str]:
-    """Return ``(subject, body)`` from the last git commit."""
     output = run(repo=repo, args=["log", "-1", "--format=%s%n%n%b"])
     lines = output.split("\n", 1)
     subject = lines[0].strip()
@@ -159,7 +140,6 @@ def last_commit_message(repo: str = ".") -> tuple[str, str]:
 
 
 def worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = True) -> bool:
-    """Add a git worktree. Returns True on success."""
     args = ["worktree", "add"]
     if create_branch:
         args.extend(["-b", branch])
@@ -171,3 +151,80 @@ def worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = Tru
     except CommandFailedError:
         return False
     return True
+
+
+# ── GitRepo class ────────────────────────────────────────────────────
+
+
+class GitRepo:
+    """OOP wrapper — encapsulates repo path, delegates to module-level functions.
+
+    Module-level functions remain the canonical implementation so that
+    ``patch.object(git_mod, "run", ...)`` in tests intercepts all call paths.
+    """
+
+    def __init__(self, path: str = ".") -> None:
+        self.path = path
+
+    def merge_base(self, target: str = "origin/main") -> str:
+        return merge_base(self.path, target)
+
+    def rev_count(self, range_spec: str = "") -> int:
+        return rev_count(self.path, range_spec)
+
+    def log_oneline(self, range_spec: str = "") -> str:
+        return log_oneline(self.path, range_spec)
+
+    def unsynced_commits(self, branch: str, target: str = "origin/main") -> list[str]:
+        return unsynced_commits(self.path, branch, target)
+
+    def status_porcelain(self) -> str:
+        return status_porcelain(self.path)
+
+    def soft_reset(self, target: str = "") -> None:
+        soft_reset(self.path, target)
+
+    def commit(self, message: str = "") -> None:
+        commit(self.path, message)
+
+    def fetch(self, remote: str = "origin", ref: str = "") -> None:
+        fetch(self.path, remote, ref)
+
+    def rebase(self, target: str = "") -> None:
+        rebase(self.path, target)
+
+    def worktree_remove(self, path: str = "") -> bool:
+        return worktree_remove(self.path, path)
+
+    def branch_delete(self, branch: str = "") -> bool:
+        return branch_delete(self.path, branch)
+
+    def pull_ff_only(self) -> bool:
+        return pull_ff_only(self.path)
+
+    def push(self, remote: str = "origin", branch: str = "") -> None:
+        push(self.path, remote, branch)
+
+    def default_branch(self) -> str:
+        return default_branch(self.path)
+
+    def branch_merged(self, branch: str, target: str = "origin/main") -> bool:
+        return branch_merged(self.path, branch, target)
+
+    def current_branch(self) -> str:
+        return current_branch(self.path)
+
+    def remote_url(self, remote: str = "origin") -> str:
+        return remote_url(self.path, remote)
+
+    def remote_slug(self, remote: str = "origin") -> str:
+        return remote_slug(self.path, remote)
+
+    def config_value(self, key: str = "") -> str:
+        return config_value(self.path, key)
+
+    def last_commit_message(self) -> tuple[str, str]:
+        return last_commit_message(self.path)
+
+    def worktree_add(self, path: str, branch: str, *, create_branch: bool = True) -> bool:
+        return worktree_add(self.path, path, branch, create_branch=create_branch)

--- a/src/teatree/visual_qa.py
+++ b/src/teatree/visual_qa.py
@@ -21,7 +21,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from teatree.core.models.types import VisualQAPageDetail, VisualQAPageError, VisualQASummary
 from teatree.core.overlay import OverlayBase
@@ -30,19 +30,13 @@ from teatree.utils import git
 if TYPE_CHECKING:
     from playwright.sync_api import BrowserContext
 
-# Playwright is imported lazily so ``pip install teatree`` does not require it.
-# When it is absent, ``run_check`` raises ``VisualQAUnavailableError`` and the
-# gate fails open with a clear message instead of blocking the push.
 PlaywrightError: type[BaseException] = Exception
-sync_playwright: Any = None
 try:
     from playwright.sync_api import Error as _PlaywrightError
-    from playwright.sync_api import sync_playwright as _sync_playwright
 except ImportError:
     pass
 else:
     PlaywrightError = _PlaywrightError
-    sync_playwright = _sync_playwright
 
 # Default file patterns that warrant a browser sanity check.
 # Overlays can override via ``OverlayBase.get_visual_qa_targets()``.
@@ -178,9 +172,11 @@ def run_check(targets: list[str], base_url: str, screenshot_dir: str = DEFAULT_S
     ``VisualQAUnavailableError`` when Playwright cannot start so callers
     can fail open with a clear message rather than blocking the push.
     """
-    if sync_playwright is None:
+    try:
+        from playwright.sync_api import sync_playwright  # noqa: PLC0415
+    except ImportError:
         msg = "playwright is not installed. Run: uv sync && playwright install chromium"
-        raise VisualQAUnavailableError(msg)
+        raise VisualQAUnavailableError(msg) from None
 
     out_dir = Path(screenshot_dir)
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_django_db.py
+++ b/tests/test_django_db.py
@@ -9,26 +9,27 @@ import pytest
 
 from teatree.utils import bad_artifacts
 from teatree.utils import django_db as mod
+from teatree.utils import django_db_dslr as dslr_mod
 from teatree.utils import run as run_mod
 from teatree.utils.django_db import (
     DjangoDbImportConfig,
     DjangoDbImporter,
-    _dslr_env,
-    _dslr_snap_name,
     _ensure_ref_db,
-    _extract_failing_migration,
-    _find_dslr_cmd,
-    _find_dslr_snapshots,
     _local_db_url,
     _MigrateResult,
-    _parse_dslr_snapshots,
     _pg_args,
-    _restore_ref_from_dslr,
     _terminate_connections,
     django_db_import,
     prune_dslr_snapshots,
     validate_dump,
 )
+from teatree.utils.django_db_dslr import dslr_env as _dslr_env
+from teatree.utils.django_db_dslr import dslr_snap_name as _dslr_snap_name
+from teatree.utils.django_db_dslr import extract_failing_migration as _extract_failing_migration
+from teatree.utils.django_db_dslr import find_dslr_cmd as _find_dslr_cmd
+from teatree.utils.django_db_dslr import find_dslr_snapshots as _find_dslr_snapshots
+from teatree.utils.django_db_dslr import parse_dslr_snapshots as _parse_dslr_snapshots
+from teatree.utils.django_db_dslr import restore_ref_from_dslr as _restore_ref_from_dslr
 
 
 @pytest.fixture(autouse=True)
@@ -130,29 +131,29 @@ class TestPgArgs:
 class TestFindDslrCmd:
     def test_uses_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DSLR_CMD", "/custom/dslr")
-        monkeypatch.setattr(mod.shutil, "which", lambda p: p)
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda p: p)
         assert _find_dslr_cmd("dslr") == ["/custom/dslr"]
 
     def test_prefers_uv_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without DSLR_CMD, always uses uv run (avoids broken pyenv shims)."""
         monkeypatch.delenv("DSLR_CMD", raising=False)
-        monkeypatch.setattr(mod.shutil, "which", lambda p: p)
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda p: p)
         assert _find_dslr_cmd("dslr") == ["uv", "run", "dslr"]
 
     def test_falls_back_to_uv_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("DSLR_CMD", raising=False)
-        monkeypatch.setattr(mod.shutil, "which", lambda p: "uv" if p == "uv" else None)
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda p: "uv" if p == "uv" else None)
         assert _find_dslr_cmd("dslr") == ["uv", "run", "dslr"]
 
     def test_returns_empty_when_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("DSLR_CMD", raising=False)
-        monkeypatch.setattr(mod.shutil, "which", lambda _: None)
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda _: None)
         assert _find_dslr_cmd("dslr") == []
 
     def test_ignores_main_repo_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Dslr runs from the host project venv, not the target repo."""
         monkeypatch.delenv("DSLR_CMD", raising=False)
-        monkeypatch.setattr(mod.shutil, "which", lambda p: p)
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda p: p)
         assert _find_dslr_cmd("dslr", "/repo/main") == ["uv", "run", "dslr"]
 
 
@@ -442,14 +443,14 @@ class TestTryRestoreFromDslr:
         assert importer._try_restore_from_dslr(skip_dslr=True) is False
 
     def test_skips_when_no_snapshots(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(mod, "_find_dslr_snapshots", lambda *a: [])
+        monkeypatch.setattr(dslr_mod, "find_dslr_snapshots", lambda *a: [])
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
         importer = _make_importer(tmp_path)
         assert importer._try_restore_from_dslr(skip_dslr=False) is False
 
     def test_succeeds_with_snapshot_and_runs_migrate(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(mod, "_find_dslr_snapshots", lambda *a: ["20260326_development-acme"])
-        monkeypatch.setattr(mod, "_restore_ref_from_dslr", lambda *a: (True, False, ""))
+        monkeypatch.setattr(dslr_mod, "find_dslr_snapshots", lambda *a: ["20260326_development-acme"])
+        monkeypatch.setattr(dslr_mod, "restore_ref_from_dslr", lambda *a: (True, False, ""))
         monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", lambda self: _MigrateResult.APPLIED)
         monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: None)
         monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: True)
@@ -459,8 +460,8 @@ class TestTryRestoreFromDslr:
 
     def test_skips_dslr_snapshot_when_already_migrated(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         snapshot_calls: list[str] = []
-        monkeypatch.setattr(mod, "_find_dslr_snapshots", lambda *a: ["20260326_development-acme"])
-        monkeypatch.setattr(mod, "_restore_ref_from_dslr", lambda *a: (True, False, ""))
+        monkeypatch.setattr(dslr_mod, "find_dslr_snapshots", lambda *a: ["20260326_development-acme"])
+        monkeypatch.setattr(dslr_mod, "restore_ref_from_dslr", lambda *a: (True, False, ""))
         monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", lambda self: _MigrateResult.ALREADY_MIGRATED)
         monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: snapshot_calls.append("called"))
         monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: True)
@@ -478,11 +479,11 @@ class TestTryRestoreFromDslr:
             return (ok, False, "" if ok else "mock restore error")
 
         monkeypatch.setattr(
-            mod,
-            "_find_dslr_snapshots",
+            dslr_mod,
+            "find_dslr_snapshots",
             lambda *a: ["20260326_development-acme", "20260320_development-acme"],
         )
-        monkeypatch.setattr(mod, "_restore_ref_from_dslr", fake_restore)
+        monkeypatch.setattr(dslr_mod, "restore_ref_from_dslr", fake_restore)
         monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", lambda self: _MigrateResult.APPLIED)
         monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: None)
         monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: True)
@@ -499,11 +500,11 @@ class TestTryRestoreFromDslr:
             return _MigrateResult.APPLIED if len(migrate_calls) == 2 else _MigrateResult.FAILED
 
         monkeypatch.setattr(
-            mod,
-            "_find_dslr_snapshots",
+            dslr_mod,
+            "find_dslr_snapshots",
             lambda *a: ["20260326_development-acme", "20260320_development-acme"],
         )
-        monkeypatch.setattr(mod, "_restore_ref_from_dslr", lambda *a: (True, False, ""))
+        monkeypatch.setattr(dslr_mod, "restore_ref_from_dslr", lambda *a: (True, False, ""))
         monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", fake_migrate)
         monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: None)
         monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: True)
@@ -514,11 +515,11 @@ class TestTryRestoreFromDslr:
 
     def test_falls_back_when_all_snapshots_fail(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
-            mod,
-            "_find_dslr_snapshots",
+            dslr_mod,
+            "find_dslr_snapshots",
             lambda *a: ["20260326_development-acme", "20260320_development-acme"],
         )
-        monkeypatch.setattr(mod, "_restore_ref_from_dslr", lambda *a: (False, False, "mock error"))
+        monkeypatch.setattr(dslr_mod, "restore_ref_from_dslr", lambda *a: (False, False, "mock error"))
         monkeypatch.setattr(run_mod.subprocess, "run", _ok_run)
         importer = _make_importer(tmp_path)
         assert importer._try_restore_from_dslr(skip_dslr=False) is False
@@ -528,8 +529,8 @@ class TestTryRestoreFromDslr:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setattr(mod, "_find_dslr_snapshots", lambda *a: ["20260326_development-acme"])
-        monkeypatch.setattr(mod, "_restore_ref_from_dslr", lambda *a: (True, False, ""))
+        monkeypatch.setattr(dslr_mod, "find_dslr_snapshots", lambda *a: ["20260326_development-acme"])
+        monkeypatch.setattr(dslr_mod, "restore_ref_from_dslr", lambda *a: (True, False, ""))
         monkeypatch.setattr(DjangoDbImporter, "_migrate_reference_db", lambda self: _MigrateResult.APPLIED)
         monkeypatch.setattr(DjangoDbImporter, "_take_dslr_snapshot", lambda self: None)
         monkeypatch.setattr(DjangoDbImporter, "_copy_ref_to_ticket", lambda self: False)
@@ -696,13 +697,13 @@ class TestTryRestoreFromCiDump:
 
 class TestDjangoDbImport:
     def test_succeeds_via_dslr(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: ["/bin/dslr"])
+        monkeypatch.setattr(dslr_mod, "find_dslr_cmd", lambda *a, **kw: ["/bin/dslr"])
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: True)
         cfg = _make_cfg(tmp_path)
         assert django_db_import(cfg) is True
 
     def test_falls_through_to_local_dump(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(dslr_mod, "find_dslr_cmd", lambda *a, **kw: [])
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: True)
         cfg = _make_cfg(tmp_path)
@@ -710,7 +711,7 @@ class TestDjangoDbImport:
 
     def test_blocks_fallback_without_slow_import(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Non-DSLR fallbacks require --slow-import."""
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(dslr_mod, "find_dslr_cmd", lambda *a, **kw: [])
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: True)
         cfg = _make_cfg(tmp_path)
@@ -718,7 +719,7 @@ class TestDjangoDbImport:
 
     def test_falls_through_to_remote_fetch_then_local(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         local_calls: list[int] = []
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(dslr_mod, "find_dslr_cmd", lambda *a, **kw: [])
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
 
         def local_dump(_self):
@@ -733,7 +734,7 @@ class TestDjangoDbImport:
 
     def test_skips_remote_when_not_allowed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         remote_called: list[int] = []
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(dslr_mod, "find_dslr_cmd", lambda *a, **kw: [])
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: remote_called.append(1) or True)
@@ -743,7 +744,7 @@ class TestDjangoDbImport:
         assert remote_called == []
 
     def test_falls_through_to_ci(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(dslr_mod, "find_dslr_cmd", lambda *a, **kw: [])
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: False)
@@ -752,7 +753,7 @@ class TestDjangoDbImport:
         assert django_db_import(cfg, slow_import=True) is True
 
     def test_fails_when_all_strategies_fail(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(dslr_mod, "find_dslr_cmd", lambda *a, **kw: [])
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: False)
@@ -766,7 +767,7 @@ class TestDjangoDbImport:
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(dslr_mod, "find_dslr_cmd", lambda *a, **kw: [])
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: False)
@@ -781,7 +782,7 @@ class TestDjangoDbImport:
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture,
     ) -> None:
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: [])
+        monkeypatch.setattr(dslr_mod, "find_dslr_cmd", lambda *a, **kw: [])
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_dslr", lambda self, *, skip_dslr: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_local_dump", lambda self: False)
         monkeypatch.setattr(DjangoDbImporter, "_try_fetch_remote_dump", lambda self: False)
@@ -792,7 +793,7 @@ class TestDjangoDbImport:
 
     def test_skip_dslr_passed_through(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         captured_skip: list[bool] = []
-        monkeypatch.setattr(mod, "_find_dslr_cmd", lambda *a, **kw: ["/bin/dslr"])
+        monkeypatch.setattr(dslr_mod, "find_dslr_cmd", lambda *a, **kw: ["/bin/dslr"])
 
         def capture_dslr(_self, *, skip_dslr):
             captured_skip.append(skip_dslr)
@@ -863,7 +864,7 @@ class TestPruneDslrSnapshots:
             return CompletedProcess(cmd, 0, stdout=dslr_output, stderr="")
 
         monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
-        monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/bin/uv")
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda _: "/usr/bin/uv")
         result = prune_dslr_snapshots(keep=1)
 
         assert result == ["20260401_development-acme", "20260320_development-acme"]
@@ -879,17 +880,17 @@ class TestPruneDslrSnapshots:
             return CompletedProcess(cmd, 0, stdout=dslr_output, stderr="")
 
         monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
-        monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/bin/uv")
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda _: "/usr/bin/uv")
         result = prune_dslr_snapshots(keep=2)
 
         assert result == ["20260401_dev-a"]
 
     def test_returns_empty_when_no_dslr(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(mod.shutil, "which", lambda _: None)
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda _: None)
         monkeypatch.delenv("DSLR_CMD", raising=False)
         assert prune_dslr_snapshots() == []
 
     def test_returns_empty_when_dslr_list_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(run_mod.subprocess, "run", lambda *a, **kw: CompletedProcess(a, 1, stdout="", stderr=""))
-        monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/bin/uv")
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda _: "/usr/bin/uv")
         assert prune_dslr_snapshots() == []


### PR DESCRIPTION
style: extract HealthCheck to core/health.py, strip overlay docstrings

- Extract HealthCheck, default_health_checks to core/health.py (no lint suppression needed)
- Strip inline docstrings from overlay.py (names are the docs per ac-python)
- overlay.py: 603 → 339 LOC