### PR TITLE
chore(skills): promote 13 Claude memories to skill rules

### DIFF
--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -90,6 +90,8 @@ When the active overlay has `require_ticket = True` in its configuration, a trac
 - **Removing or replacing a CLI parameter**: Ask the user what the replacement API should look like BEFORE writing code. Don't assume auto-detect-only — the user may want a human-readable argument (e.g., `--path` instead of a DB ID). Design the API first, then update source, then update tests. Running tests before committing is mandatory — don't rely on pre-commit hooks to catch failures.
 - **Extracting overlay code to core** (generalization, refactoring): Write the BLUEPRINT spec first, then have the user review it before coding. Existing overlay code evolved organically — extracting it as-is copies its shortcuts. Design the clean-slate API from the spec, not from the existing implementation.
 
+- **UI layout / multi-column structures**: Ask for the full desired layout (column order, which columns to show/hide) BEFORE writing any template code. Rewriting headers and cell blocks for repeated column-order changes wastes time.
+
 **How to decide:** If you would normally ask the user "is this approach okay?" before coding, that's a complex task — use plan mode.
 
 ### 2. TDD Cycle

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -110,6 +110,19 @@ After verifying repo rules, **check the full file** (not just changed lines) of 
 
 This step prevents architectural drift. Each diff looks fine in isolation — this check catches the cumulative effect by examining the full module.
 
+#### Read BLUEPRINT.md Before Designing (Non-Negotiable)
+
+Before proposing a design that changes how existing code is structured, read `BLUEPRINT.md` and any architectural-invariants doc FIRST, not last. Inventory existing patterns touching the same subsystem before proposing new ones. If the proposed design reverses a BLUEPRINT invariant, surface that to the user BEFORE designing around it — the user decides whether to overturn the invariant; if yes, update BLUEPRINT.md in the same change.
+
+#### Architecture Refactor Blast-Radius Checklist
+
+After any architectural refactor, before declaring done:
+
+1. **Grep all file types** for old API names — not just `.py` but `.md`, `.toml`, skill files, mermaid diagrams, comments.
+2. **Lint rules are architectural guardrails** — never suppress; fix the design instead.
+3. **Cross-repo consumers** must be updated in the same session.
+4. **Documentation drift is invisible to tests** — re-read every doc/skill file that references the changed subsystem. 100% test coverage does not catch stale docs.
+
 #### New-Test Shape Check (Non-Negotiable)
 
 When the diff adds or modifies test files, verify the new tests follow the repo's test-writing doctrine (see the repo's `AGENTS.md` § "Test-Writing Doctrine" — teatree and every overlay repo carry the same rule):

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -74,6 +74,13 @@ Use `Ctrl+F`/`grep` to jump to a rule. Sections are grouped below by theme; numb
 37. [Commit Before Declaring Done](#commit-before-declaring-done-non-negotiable)
 38. [Pre-Commit Hook Failures on Unrelated Tests](#pre-commit-hook-failures-on-unrelated-tests)
 
+**Design principles**
+
+39. [Prefer Standard Over Clever](#prefer-standard-over-clever)
+40. [Never Slim Skills](#never-slim-skills)
+41. [Session Scope Management](#session-scope-management)
+42. [Skill Auto-Loading Must Work](#skill-auto-loading-must-work)
+
 ## Invoke Skills Before ANY Response
 
 _Adapted from [superpowers/using-superpowers](https://github.com/obra/superpowers)._
@@ -527,3 +534,19 @@ When removing a function, class, flag, or CLI argument: delete it completely. De
 ## GitLab Inline Comments
 
 When posting inline PR comments, target **added lines only** — not context or unchanged lines.
+
+## Prefer Standard Over Clever
+
+When choosing between a clever in-process approach and the framework's standard approach, choose the standard. Prefer explicit/standard/boring over clever/implicit. If you're uncertain which is better, that uncertainty is the signal to go standard. Django's `setup()` is designed to be called once per process — subprocess via `__main__.py` beats in-process `call_command()` for entry-point overlays.
+
+## Never Slim Skills
+
+Never extract SKILL.md content into `references/` files to save tokens. Agents don't reliably load reference files on demand, so critical instructions get ignored. When optimizing context consumption, focus on phase-scoped loading (only embed the skills needed for the task), not on shrinking individual skills.
+
+## Session Scope Management
+
+Don't let sessions grow unbounded. After completing 3–4 distinct features in one session, proactively suggest: "This is a good stopping point — want to run /t3-next and start fresh for the remaining items?" The user should not have to explicitly say "stop accepting new requests."
+
+## Skill Auto-Loading Must Work
+
+The user should never have to manually call a teatree or overlay skill. Skills must either auto-load or be explicitly called by the teatree mechanism. When reviewing teatree, check that the hook/autoloading mechanism covers all cases: Django projects auto-load `ac-django`, overlay projects auto-load their overlay skill, lifecycle skills chain-load companions. Fix gaps in the autoloading mechanism rather than documenting manual workarounds.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -351,6 +351,8 @@ When a session uncovers a small unique commit on a now-stale branch (typical dur
 - **Cancel running pipelines when closing an MR/PR.** When a PR is closed (abandoned, superseded, or replaced), cancel any running or pending pipelines for that branch immediately — they waste CI resources on code that will never be merged.
 - **Clickable references:** Every PR, ticket, or note reference must be a markdown link — see [`../rules/SKILL.md`](../rules/SKILL.md) § "Clickable References".
 - **Commit early, commit often.** Never accumulate more than 1-2 tickets of uncommitted changes. Commit after completing each ticket or logical unit of work. Squash later with `t3 <overlay> workspace finalize`.
+- **Prefer `git commit -a`** when committing changes that touch files the linter might reformat. Pre-commit hooks (ruff-format, end-of-file-fixer) modify files and re-stage them. If you stage specific files, the hook may modify OTHER files that remain unstaged. The pre-push hook then stashes these unstaged changes and fails to restore the patch. Use selective staging only when you specifically need to exclude files.
+- **Verify static asset URLs** after any change to `<script src>` or `<link href>` in templates: (1) check the URL resolves (`curl -sI <url>`), (2) if vendoring locally, verify file size > 1KB (a 45-byte file is an error page), (3) Playwright screenshot + console error check.
 - **Publishing actions are mode-conditional.** Canonical rule: see [`../rules/SKILL.md`](../rules/SKILL.md) § "Publishing Actions Are Mode-Conditional". In `interactive` mode (default) every push/PR/merge/remote-delete needs separate explicit approval. In `auto` mode (`t3.mode = "auto"` or `T3_MODE=auto`) the agent ships end-to-end without confirm prompts; only the always-gated list (force-push to defaults, history rewrites on shared defaults, destructive shared-state ops, unauthorised external writes, `--no-verify`) remains confirm-gated.
 - **Commit trailer preferences** (`Co-Authored-By`) live in the user's global agent config — check it before committing; when in doubt, omit the trailer.
 
@@ -359,3 +361,5 @@ When a session uncovers a small unique commit on a now-stale branch (typical dur
 When rewriting commit messages, use `filter-branch --msg-filter` (matches by full hash). Do NOT use `git rebase -i` with `GIT_SEQUENCE_EDITOR="sed"` — the short hash may differ from `git log --oneline`, causing a silent no-op.
 
 **Post-rewrite verification (Non-Negotiable):** After ANY rebase or filter-branch, verify the hash changed. Same hash = no-op.
+
+**Rebase todo shorthand:** When automating `git rebase -i` with `GIT_SEQUENCE_EDITOR`, the todo list uses single-letter shorthand (`p` not `pick`, `f` not `fixup`). Match on `^p` not `^pick`. Use `sed -e '/^p <hash>/s/^p/f/'` for fixup squashing.

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -119,6 +119,10 @@ T3_AUTO_SHIP=false                           # when true, shipping tasks are hea
 T3_PRIVACY=strict                            # block commits with PII
 ```
 
+## Interactive vs Headless Output
+
+The `{"summary":..., "files_modified":...}` JSON result block from `/t3:next` is consumed by the headless pipeline. In interactive sessions it's noise — skip it and only show the text summary.
+
 ## Related Skills
 
 This skill holds the core. Load the mode-specific skill for the task in hand — none `require:` this one, to keep per-invocation context small.

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -83,6 +83,16 @@ See [`../e2e/SKILL.md`](../e2e/SKILL.md) (`/t3:e2e`) for the full E2E workflow: 
 - Background polling for pipeline status.
 - Costs no tokens while waiting.
 
+### Docker Coverage Before Push
+
+When the repo's pre-push hook uses `--no-cov` but CI enforces a coverage threshold, run the exact CI command locally before pushing:
+
+```bash
+docker run --rm -v "$PWD":/app:ro -e UV_PROJECT_ENVIRONMENT=/tmp/.venv -e COVERAGE_FILE=/tmp/.coverage teatree-test uv run -p 3.13 pytest --no-header -q -o cache_dir=/tmp/.pytest_cache
+```
+
+If the total is below the CI threshold, add tests before pushing.
+
 ### Green Means Root Cause
 
 "Make the pipeline green" means fix the root cause — not skip, xfail, or `pragma: no cover` the test. Urgency means being faster at diagnosing, not cutting corners. A test that fails on the default branch is pre-existing and reported as such, not silenced.

--- a/skills/workspace/SKILL.md
+++ b/skills/workspace/SKILL.md
@@ -196,6 +196,10 @@ After importing a database or downloading an artifact, always validate it:
 
 Setup tools enforce ordering: **data store → migrations → application server**. Starting the application before migrations causes "relation does not exist" errors. Always use the orchestration functions (`t3 <overlay> worktree start`) rather than starting services individually.
 
+### Agent Worktree Commits (Non-Negotiable)
+
+When using `isolation: "worktree"` for parallel agents, the worktree is cleaned up automatically if the agent makes no git commits. Agents that only edit files lose all work. Before launching parallel agents for code changes: (1) verify the current state first (grep for the pattern — it may already be fixed), (2) instruct agents to commit before finishing, (3) run the full test suite without `--exitfirst` (`-x`) when assessing migration scope to see ALL failures, not just the first.
+
 ### Never Delegate Skill-Dependent Work to Sub-Agents
 
 See [`../rules/SKILL.md`](../rules/SKILL.md) § "Sub-Agent Limitations". If parallelism is needed, pass the **full skill file contents** in the sub-agent prompt — but prefer sequential main-conversation execution.


### PR DESCRIPTION
## Summary

Consolidate behavioral rules scattered across per-project Claude memory
files into their canonical teatree skill files.

- **47 memory files purged** across 7 project directories (stale, duplicate, safety-net pointers)
- **13 rules promoted** from memories to 7 SKILL.md files
- All affected MEMORY.md indices updated

### Promotions by target skill

| Skill | Rules added |
|-------|------------|
| `rules` | prefer-standard-over-clever, never-slim-skills, session-scope-management, skill-auto-loading |
| `ship` | git-commit-a, verify-static-assets, rebase-p-shorthand |
| `review` | blueprint-before-designing, architecture-refactor-blast-radius |
| `test` | docker-coverage-before-push |
| `workspace` | agent-worktree-commits |
| `code` | ask-layout-upfront |
| `teatree` | interactive-vs-headless-output |

## Test plan

- [x] All pre-commit hooks pass (markdownlint, banned-terms, skill frontmatter validation, module health)
- [x] All pre-push hooks pass (Docker test matrix, PR exists check)
- [ ] Verify skill loading still works after content additions