### PR TITLE
fix(loop): statusline loop display, ticket reopen, single DB, agent visibility

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -67,6 +67,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "CronCreate|CronDelete|ScheduleWakeup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook_router.py --event PostToolUse",
+            "timeout": 3
+          }
+        ]
       }
     ],
     "InstructionsLoaded": [

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -682,6 +682,98 @@ def handle_session_end(data: dict) -> None:
     json.dump({"additionalContext": "\n\n".join(parts)}, sys.stdout)
 
 
+# ── PostToolUse: track-cron-jobs ──────────────────────────────────────
+
+
+def _derive_loop_name(prompt: str) -> str:
+    """Derive a short display name from a cron/loop prompt."""
+    prompt = prompt.strip()
+    if prompt.startswith("!"):
+        prompt = prompt[1:].strip()
+    if prompt.startswith("/"):
+        prompt = prompt[1:].strip()
+    parts = prompt.split()
+    if not parts:
+        return "loop"
+    cmd = parts[-1] if len(parts) > 1 else parts[0]
+    cmd = cmd.split("/")[-1]
+    return cmd[:20]
+
+
+def _load_crons(path: Path) -> dict:
+    if not path.is_file():
+        return {"jobs": {}, "wakeup": None}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {"jobs": {}, "wakeup": None}
+
+
+def _save_crons(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data) + "\n", encoding="utf-8")
+
+
+def handle_track_cron_jobs(data: dict) -> None:
+    """Track CronCreate/CronDelete/ScheduleWakeup for statusline display."""
+    tool_name = data.get("tool_name", "")
+    if tool_name not in {"CronCreate", "CronDelete", "ScheduleWakeup"}:
+        return
+
+    session_id = data.get("session_id", "")
+    if not session_id:
+        return
+
+    _ensure_state_dir()
+    crons_file = _state_file(session_id, "crons")
+    state = _load_crons(crons_file)
+    if "jobs" not in state:
+        state["jobs"] = {}
+
+    import time  # noqa: PLC0415
+
+    now = int(time.time())
+    tool_input = data.get("tool_input", {})
+
+    if tool_name == "CronCreate":
+        prompt = tool_input.get("prompt", "")
+        cron_expr = tool_input.get("cron", "")
+        name = _derive_loop_name(prompt)
+        job_id = data.get("tool_result", {}).get("id", "") or f"job-{now}"
+        cadence = _cron_cadence_seconds(cron_expr)
+        state["jobs"][job_id] = {
+            "name": name,
+            "cron": cron_expr,
+            "cadence": cadence,
+            "created_at": now,
+        }
+    elif tool_name == "CronDelete":
+        job_id = tool_input.get("id", "")
+        state["jobs"].pop(job_id, None)
+    elif tool_name == "ScheduleWakeup":
+        delay = int(tool_input.get("delaySeconds", 0))
+        reason = tool_input.get("reason", "")
+        state["wakeup"] = {
+            "name": reason[:30] if reason else "loop",
+            "next_epoch": now + delay,
+        }
+
+    _save_crons(crons_file, state)
+
+
+def _cron_cadence_seconds(cron_expr: str) -> int | None:
+    """Extract cadence in seconds from simple */N minute patterns."""
+    parts = cron_expr.strip().split()
+    if len(parts) != 5:  # noqa: PLR2004
+        return None
+    minute = parts[0]
+    if minute.startswith("*/") and all(p == "*" for p in parts[1:]):
+        try:
+            return int(minute[2:]) * 60
+        except ValueError:
+            return None
+    return None
+
+
 # ── PreToolUse: block-direct-commands ────────────────────────────────
 
 
@@ -831,6 +923,7 @@ _HANDLERS: dict[str, list] = {
         handle_mirror_question_to_slack,
         handle_track_active_repo,
         handle_track_skill_usage,
+        handle_track_cron_jobs,
         handle_read_dedup,
     ],
     "InstructionsLoaded": [handle_track_skill_usage],

--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -103,6 +103,42 @@ if [ -n "$skills" ]; then
     header="${header}${sep}${_DIM}skills:${_RST} ${_colored_skills}"
 fi
 
+# Active loops from CronCreate / ScheduleWakeup (written by hook_router.py)
+_crons_file="$state_dir/${session_id}.crons"
+if [ -n "$session_id" ] && [ -r "$_crons_file" ] && command -v jq >/dev/null 2>&1; then
+    _now=${_now:-$(date +%s)}
+    _loop_parts=""
+    for _jid in $(jq -r '.jobs // {} | keys[]' "$_crons_file" 2>/dev/null); do
+        _jname=$(jq -r ".jobs[\"$_jid\"].name // \"loop\"" "$_crons_file" 2>/dev/null)
+        _jcadence=$(jq -r ".jobs[\"$_jid\"].cadence // empty" "$_crons_file" 2>/dev/null)
+        if [ -n "$_jcadence" ] && [ "$_jcadence" != "null" ]; then
+            _jmin=$(( _jcadence / 60 ))
+            _jlabel="${_CYN}${_jname}${_RST}${_DIM}(${_jmin}m)${_RST}"
+        else
+            _jcron=$(jq -r ".jobs[\"$_jid\"].cron // empty" "$_crons_file" 2>/dev/null)
+            _jlabel="${_CYN}${_jname}${_RST}${_DIM}(${_jcron})${_RST}"
+        fi
+        [ -n "$_loop_parts" ] && _loop_parts="${_loop_parts} ${_DIM}·${_RST} "
+        _loop_parts="${_loop_parts}${_jlabel}"
+    done
+    _wakeup_epoch=$(jq -r '.wakeup.next_epoch // empty' "$_crons_file" 2>/dev/null)
+    if [ -n "$_wakeup_epoch" ] && [ "$_wakeup_epoch" != "null" ]; then
+        _wname=$(jq -r '.wakeup.name // "loop"' "$_crons_file" 2>/dev/null)
+        _wdiff=$(( _wakeup_epoch - _now ))
+        if (( _wdiff > 60 )); then
+            _wtiming="$(( _wdiff / 60 ))m"
+        elif (( _wdiff > 0 )); then
+            _wtiming="${_wdiff}s"
+        else
+            _wtiming="now"
+        fi
+        _wlabel="${_CYN}${_wname}${_RST}${_DIM}→${_wtiming}${_RST}"
+        [ -n "$_loop_parts" ] && _loop_parts="${_loop_parts} ${_DIM}·${_RST} "
+        _loop_parts="${_loop_parts}${_wlabel}"
+    fi
+    [ -n "$_loop_parts" ] && header="${header}${sep}${_DIM}loops:${_RST} ${_loop_parts}"
+fi
+
 # RAM usage (macOS/Linux)
 _ram_segment=""
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -177,13 +177,15 @@ if [ -r "$_tick_meta" ] && command -v jq >/dev/null 2>&1; then
         _diff=$(( _next_epoch - _now ))
         _overdue=$(( -_diff ))
         if (( _diff > 0 && _diff < 60 )); then
-            _tick_label="${_DIM}tick in ${_diff}s${_RST}"
+            _tick_label="${_CYN}tick${_RST}${_DIM}→${_diff}s${_RST}"
+        elif (( _diff > 0 && _diff < 120 )); then
+            _tick_label="${_YLW}tick${_RST}${_DIM}→$(( _diff / 60 ))m${_RST}"
         elif (( _diff > 0 )); then
-            _tick_label="${_DIM}tick in $(( _diff / 60 ))m${_RST}"
+            _tick_label="${_GRN}tick${_RST}${_DIM}→$(( _diff / 60 ))m${_RST}"
         elif (( _overdue > _tick_cadence * 2 )); then
-            _tick_label="${_RED}loop stale${_RST}"
+            _tick_label="${_RED}tick stale${_RST}"
         else
-            _tick_label="${_DIM}tick now${_RST}"
+            _tick_label="${_CYN}tick now${_RST}"
         fi
         header="${header}${sep}${_tick_label}"
     fi

--- a/src/teatree/backends/github_sync.py
+++ b/src/teatree/backends/github_sync.py
@@ -19,6 +19,15 @@ logger = logging.getLogger(__name__)
 
 
 class GitHubSyncBackend(SyncBackend):
+    @staticmethod
+    def _overlay_name(overlay: object) -> str:
+        from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+
+        for name, ov in get_all_overlays().items():
+            if ov is overlay:
+                return name
+        return ""
+
     @override
     def is_configured(self, overlay: object) -> bool:
         from teatree.core.overlay import OverlayBase  # noqa: PLC0415
@@ -72,6 +81,7 @@ class GitHubSyncBackend(SyncBackend):
                     repos=[owner.split("/")[-1]],
                     state=state,
                     extra=extra,
+                    overlay=self._overlay_name(overlay),
                 )
                 result.tickets_created += 1
             else:

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -202,9 +202,9 @@ class OverlayAppBuilder:
         @overlay_app.command()
         def resetdb() -> None:
             """Drop the SQLite database and re-run all migrations."""
-            from teatree.paths import get_data_dir  # noqa: PLC0415
+            from teatree.paths import DATA_DIR  # noqa: PLC0415
 
-            db_path = get_data_dir(overlay_name) / "db.sqlite3"
+            db_path = DATA_DIR / "db.sqlite3"
             if db_path.exists():
                 db_path.unlink()
                 typer.echo(f"Deleted {db_path}")

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -67,6 +67,25 @@ class Ticket(models.Model):
     def __str__(self) -> str:
         return str(self.issue_url or f"ticket-{self.pk}")
 
+    def save(self, *args: object, **kwargs: object) -> None:
+        if not self.overlay and self.issue_url:
+            self.overlay = self._infer_overlay()
+        super().save(*args, **kwargs)  # type: ignore[arg-type]
+
+    def _infer_overlay(self) -> str:
+        """Derive overlay name from issue_url by matching workspace_repos in config."""
+        from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+
+        url = self.issue_url
+        for name, overlay in get_all_overlays().items():
+            config = getattr(overlay, "config", None)
+            if config is None:
+                continue
+            for repo_slug in getattr(config, "workspace_repos", []):
+                if isinstance(repo_slug, str) and repo_slug in url:
+                    return name
+        return ""
+
     @property
     def ticket_number(self) -> str:
         match = re.search(r"(\d+)$", self.issue_url)

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -312,6 +312,23 @@ class Ticket(models.Model):
 
     @transition(
         field=state,
+        source=[State.SHIPPED, State.IN_REVIEW, State.MERGED, State.RETROSPECTED],
+        target=State.STARTED,
+    )
+    def reopen(self) -> None:
+        """Reopen a post-ship ticket back to STARTED.
+
+        Triggered when new draft MRs appear after the ticket was shipped,
+        indicating additional work is needed.
+        """
+        extra = self._extra()
+        extra.pop("tests_passed", None)
+        extra["reopened_from"] = self.state
+        self.extra = extra
+        self._cancel_pending_tasks()
+
+    @transition(
+        field=state,
         source=[
             State.NOT_STARTED,
             State.SCOPED,

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -43,6 +43,7 @@ class TicketExtra(TypedDict, total=False):
     prs: dict[str, PREntrySerialized]
     pr_title_override: str
     ignored_from: str
+    reopened_from: str
     visual_qa: VisualQASummary
     branch: str
     description: str

--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -113,6 +113,16 @@ def dispatch(signals: list[ScanSignal]) -> list[DispatchAction]:
                 ),
             )
             continue
+        if signal.kind == "ticket.reopen_needed":
+            actions.append(
+                DispatchAction(
+                    kind="mechanical",
+                    zone="ticket_reopen",
+                    detail=signal.summary,
+                    payload=signal.payload,
+                ),
+            )
+            continue
         if signal.kind == "notion.unrouted":
             actions.append(DispatchAction(kind="webhook", zone="n8n", detail=signal.summary, payload=signal.payload))
             continue

--- a/src/teatree/loop/mechanical.py
+++ b/src/teatree/loop/mechanical.py
@@ -1,0 +1,69 @@
+"""Mechanical action handlers — inline ticket transitions executed during a tick.
+
+Each handler receives an ``ActionPayload`` dict and mutates the DB directly.
+Called by ``tick._execute_mechanical`` after dispatch, before statusline render.
+"""
+
+import logging
+from collections.abc import Callable
+
+from teatree.loop.dispatch import ActionPayload
+
+logger = logging.getLogger(__name__)
+
+
+def ignore_disposed_ticket(payload: ActionPayload) -> None:
+    from django.apps import apps  # noqa: PLC0415
+
+    ticket_model = apps.get_model("core", "Ticket")
+    ticket_id = payload.get("ticket_id")
+    if ticket_id is None:
+        return
+    ticket = ticket_model.objects.get(pk=ticket_id)
+    ticket.ignore()
+    ticket.save()
+    logger.info("Auto-ignored ticket %s (reason: %s)", ticket_id, payload.get("reason", "?"))
+
+
+def complete_ticket(payload: ActionPayload) -> None:
+    """Transition a ticket from its current post-ship state toward delivered.
+
+    FSM path: shipped → request_review → mark_merged → retrospect.
+    """
+    from django.apps import apps  # noqa: PLC0415
+
+    ticket_model = apps.get_model("core", "Ticket")
+    ticket_id = payload.get("ticket_id")
+    if ticket_id is None:
+        return
+    ticket = ticket_model.objects.get(pk=ticket_id)
+
+    if ticket.state == "shipped":
+        ticket.request_review()
+        ticket.save()
+    if ticket.state == "in_review":
+        ticket.mark_merged()
+        ticket.save()
+    if ticket.state == "merged":
+        ticket.retrospect()
+        ticket.save()
+
+
+def reopen_ticket(payload: ActionPayload) -> None:
+    from django.apps import apps  # noqa: PLC0415
+
+    ticket_model = apps.get_model("core", "Ticket")
+    ticket_id = payload.get("ticket_id")
+    if ticket_id is None:
+        return
+    ticket = ticket_model.objects.get(pk=ticket_id)
+    ticket.reopen()
+    ticket.save()
+    logger.info("Auto-reopened ticket %s (was %s, draft MRs detected)", ticket_id, payload.get("ticket_state", "?"))
+
+
+HANDLERS: dict[str, Callable[[ActionPayload], None]] = {
+    "ticket_disposition": ignore_disposed_ticket,
+    "ticket_completion": complete_ticket,
+    "ticket_reopen": reopen_ticket,
+}

--- a/src/teatree/loop/scanners/ticket_completion.py
+++ b/src/teatree/loop/scanners/ticket_completion.py
@@ -29,6 +29,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _has_draft_mrs(ticket: "Ticket") -> bool:
+    """Return True if any MR in the ticket's extra is still a draft."""
+    extra = ticket.extra if isinstance(ticket.extra, dict) else {}
+    mrs = extra.get("mrs", {})
+    if not isinstance(mrs, dict):
+        return False
+    return any(isinstance(mr, dict) and mr.get("draft") for mr in mrs.values())
+
+
 _COMPLETABLE_STATES: frozenset[str] = frozenset({"shipped", "in_review", "merged"})
 
 
@@ -43,6 +53,20 @@ class TicketCompletionScanner:
     def scan(self) -> list[ScanSignal]:
         signals: list[ScanSignal] = []
         for ticket in self._candidate_tickets():
+            if _has_draft_mrs(ticket):
+                signals.append(
+                    ScanSignal(
+                        kind="ticket.reopen_needed",
+                        summary=f"Ticket {ticket.ticket_number} — draft MRs exist, reopening",
+                        payload={
+                            "ticket_id": ticket.pk,
+                            "ticket_state": ticket.state,
+                            "issue_url": ticket.issue_url,
+                        },
+                    ),
+                )
+                continue
+
             host = get_code_host_for_url(self.overlay, ticket.issue_url)
             if host is None:
                 continue

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -282,9 +282,6 @@ def _classify_actions(actions: list[DispatchAction]) -> _ClassifiedActions:
                 c.other.append((action.zone, StatuslineEntry(text=f"{prefix}{action.detail}", url=url_str)))
         elif action.kind == "mechanical":
             c.other.append(("in_flight", StatuslineEntry(text=f"⚙ {prefix}{action.detail}", url=url_str)))
-        else:
-            text = f"→ {action.zone}: {prefix}{action.detail}"
-            c.other.append(("in_flight", StatuslineEntry(text=text, url=url_str)))
     return c
 
 
@@ -363,10 +360,28 @@ def _render_action_line(
     return f"{prefix}{' · '.join(parts)}"
 
 
-def _zones_for(actions: list[DispatchAction]) -> StatuslineZones:
-    zones = StatuslineZones()
-    c = _classify_actions(actions)
+def _running_tasks_lines() -> list[str]:
+    """Query claimed tasks from the DB and render one line per overlay."""
+    from django.apps import apps  # noqa: PLC0415
 
+    task_model = apps.get_model("core", "Task")
+    claimed = (
+        task_model.objects.filter(status="claimed")
+        .select_related("ticket")
+        .only("phase", "ticket__overlay", "ticket__issue_url")
+    )
+    by_overlay: dict[str, list[str]] = {}
+    for task in claimed:
+        overlay = task.ticket.overlay or ""
+        by_overlay.setdefault(overlay, []).append(task.phase)
+    lines: list[str] = []
+    for overlay, phases in sorted(by_overlay.items()):
+        prefix = f"[{overlay}] " if overlay else ""
+        lines.append(f"{prefix}agents: {' · '.join(phases)}")
+    return lines
+
+
+def _populate_overlay_zones(zones: StatuslineZones, c: _ClassifiedActions) -> None:
     all_overlays = sorted({*c.active_tickets, *c.action_prs, *c.disposition_counts, *c.ready_counts, *c.inflight_prs})
 
     all_pr_refs: dict[str, dict[str, list[_PRRef]]] = {}
@@ -394,10 +409,18 @@ def _zones_for(actions: list[DispatchAction]) -> StatuslineZones:
         if inflight_refs:
             zones.in_flight.append(_render_pr_group(overlay_key, inflight_refs))
 
+
+def _zones_for(actions: list[DispatchAction]) -> StatuslineZones:
+    zones = StatuslineZones()
+    c = _classify_actions(actions)
+    _populate_overlay_zones(zones, c)
+
     for zone_name, entry in c.other:
         zone_list = getattr(zones, zone_name, None)
         if isinstance(zone_list, list):
             zone_list.append(entry)
+
+    zones.in_flight.extend(_running_tasks_lines())
 
     return zones
 

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -280,8 +280,8 @@ def _classify_actions(actions: list[DispatchAction]) -> _ClassifiedActions:
                 bucket.setdefault(overlay, []).append(ref)
             else:
                 c.other.append((action.zone, StatuslineEntry(text=f"{prefix}{action.detail}", url=url_str)))
-        elif action.kind == "mechanical":
-            c.other.append(("in_flight", StatuslineEntry(text=f"⚙ {prefix}{action.detail}", url=url_str)))
+        elif action.kind in {"mechanical", "agent", "webhook"}:
+            pass
     return c
 
 
@@ -527,26 +527,35 @@ def _repo_freshness(repo_path: Path) -> dict[str, int | str] | None:
     return {"behind": behind, "fetch_epoch": fetch_epoch}
 
 
+def _repos_from_toml() -> dict[str, Path]:
+    """Extract repo paths from ~/.teatree.toml overlays."""
+    toml_path = Path.home() / ".teatree.toml"
+    if not toml_path.is_file():
+        return {}
+    try:
+        data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError:
+        return {}
+    workspace_dir = Path(str(data.get("teatree", {}).get("workspace_dir", "~/workspace"))).expanduser()
+    repos: dict[str, Path] = {}
+    for name, overlay in (data.get("overlays") or {}).items():
+        if not isinstance(overlay, dict):
+            continue
+        if "path" in overlay:
+            repos[name] = Path(str(overlay["path"])).expanduser()
+        for repo_slug in overlay.get("workspace_repos", []):
+            if isinstance(repo_slug, str):
+                repos[repo_slug.split("/")[-1]] = workspace_dir / repo_slug
+    return repos
+
+
 def _collect_repo_freshness() -> dict[str, dict[str, int | str]]:
     repos: dict[str, Path] = {}
     t3_repo = os.environ.get("T3_REPO")
     if t3_repo:
         repos["t3"] = Path(t3_repo).expanduser()
-    toml_path = Path.home() / ".teatree.toml"
-    if toml_path.is_file():
-        try:
-            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
-        except tomllib.TOMLDecodeError:
-            data = {}
-        for name, overlay in (data.get("overlays") or {}).items():
-            if isinstance(overlay, dict) and "path" in overlay:
-                repos[name] = Path(str(overlay["path"])).expanduser()
-    result: dict[str, dict[str, int | str]] = {}
-    for label, path in repos.items():
-        info = _repo_freshness(path)
-        if info is not None:
-            result[label] = info
-    return result
+    repos.update(_repos_from_toml())
+    return {label: info for label, path in repos.items() if (info := _repo_freshness(path)) is not None}
 
 
 def _write_tick_meta(started_at: dt.datetime, *, target: Path | None = None) -> None:

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -10,14 +10,13 @@ import json
 import logging
 import os
 import tomllib
-from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from teatree.backends.protocols import CodeHostBackend, MessagingBackend
 from teatree.core.backend_factory import OverlayBackends
-from teatree.loop.dispatch import ActionPayload, DispatchAction, dispatch
+from teatree.loop.dispatch import DispatchAction, dispatch
 from teatree.loop.scanners import (
     ActiveTicketsScanner,
     AssignedIssuesScanner,
@@ -466,10 +465,12 @@ def _execute_mechanical(report: TickReport) -> None:
     reflects the post-transition state. Errors are captured in
     ``report.errors`` — they never abort the tick.
     """
+    from teatree.loop.mechanical import HANDLERS  # noqa: PLC0415
+
     for action in report.actions:
         if action.kind != "mechanical":
             continue
-        handler = _MECHANICAL_HANDLERS.get(action.zone)
+        handler = HANDLERS.get(action.zone)
         if handler is not None:
             try:
                 handler(action.payload)
@@ -477,52 +478,6 @@ def _execute_mechanical(report: TickReport) -> None:
                 label = f"{action.zone}[{action.payload.get('ticket_id', '?')}]"
                 logger.exception("Mechanical action %s failed", label)
                 report.errors[label] = f"{type(exc).__name__}: {exc}"
-
-
-def _ignore_disposed_ticket(payload: ActionPayload) -> None:
-    from django.apps import apps  # noqa: PLC0415
-
-    ticket_model = apps.get_model("core", "Ticket")
-    ticket_id = payload.get("ticket_id")
-    if ticket_id is None:
-        return
-    ticket = ticket_model.objects.get(pk=ticket_id)
-    ticket.ignore()
-    ticket.save()
-    logger.info("Auto-ignored ticket %s (reason: %s)", ticket_id, payload.get("reason", "?"))
-
-
-def _complete_ticket(payload: ActionPayload) -> None:
-    """Transition a ticket from its current post-ship state toward delivered.
-
-    FSM path: shipped → request_review → mark_merged → retrospect.
-    Each step advances the ticket one state; ``mark_merged`` and
-    ``retrospect`` enqueue workers via ``on_commit`` for teardown and
-    retro I/O respectively.
-    """
-    from django.apps import apps  # noqa: PLC0415
-
-    ticket_model = apps.get_model("core", "Ticket")
-    ticket_id = payload.get("ticket_id")
-    if ticket_id is None:
-        return
-    ticket = ticket_model.objects.get(pk=ticket_id)
-
-    if ticket.state == "shipped":
-        ticket.request_review()
-        ticket.save()
-    if ticket.state == "in_review":
-        ticket.mark_merged()
-        ticket.save()
-    if ticket.state == "merged":
-        ticket.retrospect()
-        ticket.save()
-
-
-_MECHANICAL_HANDLERS: dict[str, Callable[[ActionPayload], None]] = {
-    "ticket_disposition": _ignore_disposed_ticket,
-    "ticket_completion": _complete_ticket,
-}
 
 
 def _repo_freshness(repo_path: Path) -> dict[str, int | str] | None:

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -364,16 +364,19 @@ def _running_tasks_lines() -> list[str]:
     """Query claimed tasks from the DB and render one line per overlay."""
     from django.apps import apps  # noqa: PLC0415
 
-    task_model = apps.get_model("core", "Task")
-    claimed = (
-        task_model.objects.filter(status="claimed")
-        .select_related("ticket")
-        .only("phase", "ticket__overlay", "ticket__issue_url")
-    )
-    by_overlay: dict[str, list[str]] = {}
-    for task in claimed:
-        overlay = task.ticket.overlay or ""
-        by_overlay.setdefault(overlay, []).append(task.phase)
+    try:
+        task_model = apps.get_model("core", "Task")
+        claimed = (
+            task_model.objects.filter(status="claimed")
+            .select_related("ticket")
+            .only("phase", "ticket__overlay", "ticket__issue_url")
+        )
+        by_overlay: dict[str, list[str]] = {}
+        for task in claimed:
+            overlay = task.ticket.overlay or ""
+            by_overlay.setdefault(overlay, []).append(task.phase)
+    except Exception:  # noqa: BLE001
+        return []
     lines: list[str] = []
     for overlay, phases in sorted(by_overlay.items()):
         prefix = f"[{overlay}] " if overlay else ""

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -5,9 +5,10 @@ Auto-discovers overlay Django apps via entry points and adds them to INSTALLED_A
 """
 
 from teatree.config import default_logging
-from teatree.paths import get_data_dir
+from teatree.paths import DATA_DIR
 
-_DATA_DIR = get_data_dir("teatree")
+_DATA_DIR = DATA_DIR
+_DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _discover_overlay_apps() -> list[str]:

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -4,11 +4,22 @@ Used when teatree is the Django project (the standard case).
 Auto-discovers overlay Django apps via entry points and adds them to INSTALLED_APPS.
 """
 
+import warnings
+
 from teatree.config import default_logging
 from teatree.paths import DATA_DIR
 
 _DATA_DIR = DATA_DIR
 _DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+_CANONICAL_DB = _DATA_DIR / "db.sqlite3"
+_STALE_PATHS = [_DATA_DIR / "teatree" / "db.sqlite3", _DATA_DIR / "dev" / "db.sqlite3"]
+for _stale in _STALE_PATHS:
+    if _stale.is_file():
+        warnings.warn(
+            f"Stale DB found at {_stale} — canonical DB is {_CANONICAL_DB}. Remove {_stale} to silence this warning.",
+            stacklevel=1,
+        )
 
 
 def _discover_overlay_apps() -> list[str]:

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -340,7 +340,7 @@ def test_active_tickets_shown_in_anchors() -> None:
     assert "[acme]" in anchor_texts[0]
 
 
-def test_mechanical_actions_shown_in_inflight() -> None:
+def test_mechanical_actions_not_rendered_in_statusline() -> None:
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
     from teatree.loop.tick import _zones_for  # noqa: PLC0415
 
@@ -351,7 +351,7 @@ def test_mechanical_actions_shown_in_inflight() -> None:
     ]
     zones = _zones_for(actions)
     texts = [e if isinstance(e, str) else e.text for e in zones.in_flight]
-    assert any("⚙" in t and "Ticket 42 done" in t for t in texts)
+    assert not any("Ticket 42 done" in t for t in texts)
 
 
 def test_agent_actions_not_rendered_in_statusline() -> None:

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -369,10 +369,10 @@ def test_agent_actions_shown_in_inflight() -> None:
 class TestDispositionMechanical(django.test.TestCase):
     def test_closed_issue_auto_ignores(self) -> None:
         from teatree.core.models.ticket import Ticket  # noqa: PLC0415
-        from teatree.loop.tick import _ignore_disposed_ticket  # noqa: PLC0415
+        from teatree.loop.mechanical import ignore_disposed_ticket  # noqa: PLC0415
 
         ticket = Ticket.objects.create(overlay="acme", issue_url="https://x/1", state="not_started")
-        _ignore_disposed_ticket({"ticket_id": ticket.pk, "reason": "issue_closed"})
+        ignore_disposed_ticket({"ticket_id": ticket.pk, "reason": "issue_closed"})
         ticket.refresh_from_db()
         assert ticket.state == "ignored"
 

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -144,8 +144,8 @@ def test_build_default_scanners_adds_messaging_and_notion_scanners() -> None:
     assert "notion_view" in names
 
 
-def test_tick_renders_agent_actions_in_in_flight_zone(tmp_path: Path) -> None:
-    """Non-statusline actions surface as in_flight progress lines."""
+def test_tick_dispatches_agent_actions_without_rendering_them(tmp_path: Path) -> None:
+    """Agent actions are dispatched but not rendered in the statusline."""
     scanner = _FixedScanner(
         name="reviewer_prs",
         out=[ScanSignal(kind="reviewer_pr.new_sha", summary="MR review")],
@@ -153,7 +153,7 @@ def test_tick_renders_agent_actions_in_in_flight_zone(tmp_path: Path) -> None:
     statusline = tmp_path / "statusline.txt"
     report = run_tick(TickRequest(scanners=[scanner]), statusline_path=statusline)
     contents = statusline.read_text(encoding="utf-8")
-    assert "→ t3:reviewer" in contents
+    assert "→ t3:reviewer" not in contents
     assert any(a.kind == "agent" for a in report.actions)
 
 

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -354,7 +354,7 @@ def test_mechanical_actions_shown_in_inflight() -> None:
     assert any("⚙" in t and "Ticket 42 done" in t for t in texts)
 
 
-def test_agent_actions_shown_in_inflight() -> None:
+def test_agent_actions_not_rendered_in_statusline() -> None:
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
     from teatree.loop.tick import _zones_for  # noqa: PLC0415
 
@@ -363,7 +363,7 @@ def test_agent_actions_shown_in_inflight() -> None:
     ]
     zones = _zones_for(actions)
     texts = [e if isinstance(e, str) else e.text for e in zones.in_flight]
-    assert any("t3:reviewer" in t for t in texts)
+    assert not any("t3:reviewer" in t for t in texts)
 
 
 class TestDispositionMechanical(django.test.TestCase):

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -136,6 +137,60 @@ class TestStatuslineHook:
 
         assert result.returncode == 0, result.stderr
         assert "model=Claude Opus" in _strip_ansi(result.stdout)
+
+    def test_renders_cron_jobs_from_state_file(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        crons = {
+            "jobs": {
+                "job-1": {"name": "tick", "cron": "*/12 * * * *", "cadence": 720, "created_at": 0},
+                "job-2": {"name": "followup", "cron": "*/5 * * * *", "cadence": 300, "created_at": 0},
+            },
+            "wakeup": None,
+        }
+        (state_dir / "s-cron.crons").write_text(json.dumps(crons), encoding="utf-8")
+
+        result = _run(
+            {"session_id": "s-cron", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "loops:" in plain
+        assert "tick(12m)" in plain
+        assert "followup(5m)" in plain
+
+    def test_renders_schedule_wakeup_countdown(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        crons = {
+            "jobs": {},
+            "wakeup": {"name": "checking build", "next_epoch": int(time.time()) + 180},
+        }
+        (state_dir / "s-wake.crons").write_text(json.dumps(crons), encoding="utf-8")
+
+        result = _run(
+            {"session_id": "s-wake", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "loops:" in plain
+        assert "checking build" in plain
+
+    def test_omits_loops_when_no_crons_file(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        result = _run(
+            {"session_id": "s-none", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "loops:" not in _strip_ansi(result.stdout)
 
     def test_no_session_id_emits_no_skills_section(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"

--- a/tests/test_cron_tracking_hook.py
+++ b/tests/test_cron_tracking_hook.py
@@ -1,0 +1,149 @@
+"""Tests for CronCreate/CronDelete/ScheduleWakeup tracking in the hook router."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import handle_track_cron_jobs
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state_dir(tmp_path: Path):
+    original = router.STATE_DIR
+    router.STATE_DIR = tmp_path / "state"
+    router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    yield
+    router.STATE_DIR = original
+
+
+class TestTrackCronJobs:
+    def test_cron_create_writes_state_file(self) -> None:
+        handle_track_cron_jobs(
+            {
+                "session_id": "s1",
+                "tool_name": "CronCreate",
+                "tool_input": {"cron": "*/12 * * * *", "prompt": "!t3 loop tick"},
+                "tool_result": {"id": "job-abc"},
+            }
+        )
+
+        crons_file = router.STATE_DIR / "s1.crons"
+        assert crons_file.is_file()
+        state = json.loads(crons_file.read_text(encoding="utf-8"))
+        assert "job-abc" in state["jobs"]
+        assert state["jobs"]["job-abc"]["name"] == "tick"
+        assert state["jobs"]["job-abc"]["cadence"] == 720
+        assert state["jobs"]["job-abc"]["cron"] == "*/12 * * * *"
+
+    def test_cron_delete_removes_job(self) -> None:
+        handle_track_cron_jobs(
+            {
+                "session_id": "s1",
+                "tool_name": "CronCreate",
+                "tool_input": {"cron": "*/5 * * * *", "prompt": "/followup"},
+                "tool_result": {"id": "job-xyz"},
+            }
+        )
+        handle_track_cron_jobs(
+            {
+                "session_id": "s1",
+                "tool_name": "CronDelete",
+                "tool_input": {"id": "job-xyz"},
+            }
+        )
+
+        state = json.loads((router.STATE_DIR / "s1.crons").read_text(encoding="utf-8"))
+        assert "job-xyz" not in state["jobs"]
+
+    def test_schedule_wakeup_writes_wakeup_state(self) -> None:
+        handle_track_cron_jobs(
+            {
+                "session_id": "s1",
+                "tool_name": "ScheduleWakeup",
+                "tool_input": {"delaySeconds": 270, "reason": "checking build", "prompt": "/foo"},
+            }
+        )
+
+        state = json.loads((router.STATE_DIR / "s1.crons").read_text(encoding="utf-8"))
+        assert state["wakeup"] is not None
+        assert state["wakeup"]["name"] == "checking build"
+        assert state["wakeup"]["next_epoch"] > 0
+
+    def test_multiple_cron_jobs_coexist(self) -> None:
+        handle_track_cron_jobs(
+            {
+                "session_id": "s1",
+                "tool_name": "CronCreate",
+                "tool_input": {"cron": "*/12 * * * *", "prompt": "!t3 loop tick"},
+                "tool_result": {"id": "job-1"},
+            }
+        )
+        handle_track_cron_jobs(
+            {
+                "session_id": "s1",
+                "tool_name": "CronCreate",
+                "tool_input": {"cron": "*/5 * * * *", "prompt": "/followup"},
+                "tool_result": {"id": "job-2"},
+            }
+        )
+
+        state = json.loads((router.STATE_DIR / "s1.crons").read_text(encoding="utf-8"))
+        assert len(state["jobs"]) == 2
+        assert state["jobs"]["job-1"]["name"] == "tick"
+        assert state["jobs"]["job-2"]["name"] == "followup"
+
+    def test_ignores_unrelated_tools(self) -> None:
+        handle_track_cron_jobs(
+            {
+                "session_id": "s1",
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls"},
+            }
+        )
+
+        crons_file = router.STATE_DIR / "s1.crons"
+        assert not crons_file.is_file()
+
+    def test_ignores_missing_session_id(self) -> None:
+        handle_track_cron_jobs(
+            {
+                "tool_name": "CronCreate",
+                "tool_input": {"cron": "*/5 * * * *", "prompt": "test"},
+                "tool_result": {"id": "job-1"},
+            }
+        )
+
+        assert not list(router.STATE_DIR.glob("*.crons"))
+
+
+class TestDeriveLoopName:
+    @pytest.mark.parametrize(
+        ("prompt", "expected"),
+        [
+            ("!t3 loop tick", "tick"),
+            ("/followup", "followup"),
+            ("/t3-followup", "t3-followup"),
+            ("check the deploy status", "status"),
+            ("!", "loop"),
+            ("", "loop"),
+        ],
+    )
+    def test_name_derivation(self, prompt: str, expected: str) -> None:
+        assert router._derive_loop_name(prompt) == expected
+
+
+class TestCronCadenceSeconds:
+    @pytest.mark.parametrize(
+        ("expr", "expected"),
+        [
+            ("*/5 * * * *", 300),
+            ("*/12 * * * *", 720),
+            ("0 9 * * 1-5", None),
+            ("0 * * * *", None),
+            ("bad", None),
+        ],
+    )
+    def test_cadence_extraction(self, expr: str, expected: int | None) -> None:
+        assert router._cron_cadence_seconds(expr) == expected


### PR DESCRIPTION
## Summary
- Show active `/loop` cron jobs in statusline header (name + cadence/countdown)
- Add `Ticket.reopen()` FSM transition — post-ship tickets reopen when draft MRs detected
- Consolidate to single canonical DB at `~/.local/share/teatree/db.sqlite3`
- Show running agents from DB (claimed tasks), not dispatch intent
- Fix GitHub sync: set overlay name on ticket creation
- Add PostToolUse hook matcher for CronCreate/CronDelete/ScheduleWakeup

Closes #613, closes #614, closes #615

## Test plan
- [x] 17 new tests in `test_cron_tracking_hook.py`
- [x] 3 new statusline tests for loop display
- [x] Updated agent action tests (dispatch without render)
- [x] Full suite: 2766 passed, 12 skipped