### PR TITLE
fix(plugin): namespace t3 skills via marketplace-style registration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "souliane",
+  "owner": {
+    "name": "souliane",
+    "url": "https://github.com/souliane"
+  },
+  "plugins": [
+    {
+      "name": "t3",
+      "description": "Personal code factory for multi-repo projects",
+      "version": "0.0.1",
+      "author": {
+        "name": "souliane"
+      },
+      "source": "./plugins/t3"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ htmlcov/
 *.map
 
 
+# Local plugin marketplace self-reference (created by t3 setup)
+plugins/
+
 # APM dependencies
 apm_modules/
 docs/plans/

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -143,29 +143,29 @@ class DoctorService:
     @staticmethod
     def find_installed_claude_plugin() -> dict[str, str] | None:
         """Return plugin version/installPath/scope, or None when not installed."""
+        plugins_json = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+        if plugins_json.is_file():
+            try:
+                data = json.loads(plugins_json.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                data = {}
+            entries = (data.get("plugins") or {}).get(_CLAUDE_PLUGIN_ID) or []
+            if entries:
+                first = entries[0]
+                return {
+                    "version": first.get("version", ""),
+                    "installPath": first.get("installPath", ""),
+                    "scope": first.get("scope", ""),
+                }
+        # Legacy: symlink in plugins dir (pre-marketplace registration).
         link = Path.home() / ".claude" / "plugins" / "t3"
         if link.is_symlink():
             return {
-                "version": "(local)",
+                "version": "(legacy-symlink)",
                 "installPath": str(link.resolve()),
                 "scope": "symlink",
             }
-        plugins_json = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
-        if not plugins_json.is_file():
-            return None
-        try:
-            data = json.loads(plugins_json.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            return None
-        entries = (data.get("plugins") or {}).get(_CLAUDE_PLUGIN_ID) or []
-        if not entries:
-            return None
-        first = entries[0]
-        return {
-            "version": first.get("version", ""),
-            "installPath": first.get("installPath", ""),
-            "scope": first.get("scope", ""),
-        }
+        return None
 
     @staticmethod
     def collect_overlay_skills() -> list[tuple[Path, str]]:
@@ -447,6 +447,107 @@ def _check_skills() -> bool:
     return ok
 
 
+def _read_json_safe(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _resolve_main_clone() -> Path | None:
+    env_path = os.environ.get("T3_REPO", "")
+    if env_path:
+        candidate = Path(env_path).expanduser()
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+    repo = DoctorService.find_teatree_repo()
+    if not repo:
+        return None
+    git = repo / ".git"
+    if git.is_file():
+        match = re.match(r"^gitdir:\s*(.+)$", git.read_text().strip())
+        if match:
+            main_git = Path(match.group(1)).parent.parent
+            if main_git.name == ".git" and main_git.is_dir():
+                return main_git.parent
+    return repo
+
+
+def _repair_marketplace_json(plugins_dir: Path, target: str, now: str) -> bool:
+    path = plugins_dir / "known_marketplaces.json"
+    data = _read_json_safe(path)
+    mp_name = _CLAUDE_PLUGIN_ID.split("@", 1)[1]
+    if data.get(mp_name, {}).get("installLocation") == target:
+        return False
+    data[mp_name] = {
+        "source": {"source": "directory", "path": target},
+        "installLocation": target,
+        "lastUpdated": now,
+    }
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+def _repair_installed_plugins(plugins_dir: Path, target: str, now: str) -> bool:
+    path = plugins_dir / "installed_plugins.json"
+    data = _read_json_safe(path)
+    plugins = data.setdefault("plugins", {})
+    entries = plugins.get(_CLAUDE_PLUGIN_ID, [])
+    if entries and entries[0].get("installPath") == target:
+        return False
+    data.setdefault("version", 2)
+    plugins[_CLAUDE_PLUGIN_ID] = [
+        {
+            "scope": "user",
+            "installPath": target,
+            "version": "local",
+            "installedAt": entries[0].get("installedAt", now) if entries else now,
+            "lastUpdated": now,
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+def _repair_enabled_plugins() -> bool:
+    settings_path = Path.home() / ".claude" / "settings.json"
+    resolved = settings_path.resolve() if settings_path.is_file() else settings_path
+    data = _read_json_safe(resolved)
+    enabled = data.setdefault("enabledPlugins", {})
+    if enabled.get(_CLAUDE_PLUGIN_ID) is True:
+        return False
+    enabled[_CLAUDE_PLUGIN_ID] = True
+    resolved.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+def _ensure_plugin_registered() -> bool:
+    """Verify and auto-repair t3 plugin registration.
+
+    Called at every ``t3 doctor check`` (and thus every Claude session start).
+    """
+    repo = _resolve_main_clone()
+    if not repo:
+        return True
+
+    from datetime import UTC, datetime  # noqa: PLC0415
+
+    target = str(repo.resolve())
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    plugins_dir = Path.home() / ".claude" / "plugins"
+
+    repaired = _repair_marketplace_json(plugins_dir, target, now)
+    repaired = _repair_installed_plugins(plugins_dir, target, now) or repaired
+    repaired = _repair_enabled_plugins() or repaired
+
+    if repaired:
+        typer.echo(f"OK    Auto-repaired {_CLAUDE_PLUGIN_ID} plugin → {target}")
+    return True
+
+
 @doctor_app.command()
 def check() -> bool:
     """Verify imports, required tools, and editable-install sanity."""
@@ -466,6 +567,7 @@ def check() -> bool:
 
     ok = _check_editable_sanity() and ok
     ok = _check_skills() and ok
+    _ensure_plugin_registered()
 
     if ok:
         typer.echo("All checks passed")

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -462,7 +462,10 @@ def _resolve_main_clone() -> Path | None:
         candidate = Path(env_path).expanduser()
         if (candidate / "pyproject.toml").is_file():
             return candidate
-    repo = DoctorService.find_teatree_repo()
+    try:
+        repo = DoctorService.find_teatree_repo()
+    except OSError:
+        return None
     if not repo:
         return None
     git = repo / ".git"
@@ -528,7 +531,15 @@ def _ensure_plugin_registered() -> bool:
     """Verify and auto-repair t3 plugin registration.
 
     Called at every ``t3 doctor check`` (and thus every Claude session start).
+    Best-effort — never fails the check if the repo or filesystem is unavailable.
     """
+    try:
+        return _do_ensure_plugin_registered()
+    except OSError:
+        return True
+
+
+def _do_ensure_plugin_registered() -> bool:
     repo = _resolve_main_clone()
     if not repo:
         return True

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import sys
 import tomllib
+from datetime import UTC, datetime
 from pathlib import Path
 
 import typer
@@ -104,62 +105,132 @@ def _run_captured(args: list[str], cwd: Path | None = None) -> CompletedProcess[
     return run_allowed_to_fail(args, cwd=cwd, expected_codes=None)
 
 
-def _uninstall_marketplace_plugin(claude_bin: str) -> None:
-    """Remove the marketplace-cached plugin if present (replaced by local symlink)."""
-    plugin_id = f"{_PLUGIN_NAME}@{_MARKETPLACE_NAME}"
-    result = _run_captured([claude_bin, "plugin", "uninstall", plugin_id])
-    if result.returncode == 0:
-        typer.echo(f"OK    Removed stale marketplace plugin {plugin_id}.")
+_PLUGIN_ID = f"{_PLUGIN_NAME}@{_MARKETPLACE_NAME}"
 
-    cache_root = Path.home() / ".claude" / "plugins" / "cache" / _MARKETPLACE_NAME / _PLUGIN_NAME
+
+def _read_json(path: Path) -> dict:
+    if path.is_file():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {}
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _settings_path() -> Path:
+    """Return the resolved settings.json path (follows symlinks)."""
+    path = Path.home() / ".claude" / "settings.json"
+    return path.resolve() if path.is_file() else path
+
+
+def _register_installed_plugin(repo: Path) -> None:
+    """Register t3 in installed_plugins.json with installPath pointing to the main clone."""
+    plugins_json = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+    data = _read_json(plugins_json)
+    data.setdefault("version", 2)
+    plugins = data.setdefault("plugins", {})
+
+    target = str(repo.resolve())
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    existing = plugins.get(_PLUGIN_ID, [])
+    if existing and existing[0].get("installPath") == target:
+        return
+
+    plugins[_PLUGIN_ID] = [
+        {
+            "scope": "user",
+            "installPath": target,
+            "version": "local",
+            "installedAt": existing[0].get("installedAt", now) if existing else now,
+            "lastUpdated": now,
+        },
+    ]
+    _write_json(plugins_json, data)
+
+
+def _enable_plugin() -> None:
+    """Ensure t3@souliane is enabled in settings.json."""
+    resolved = _settings_path()
+    data = _read_json(resolved)
+    plugins = data.setdefault("enabledPlugins", {})
+    if plugins.get(_PLUGIN_ID) is True:
+        return
+    plugins[_PLUGIN_ID] = True
+    _write_json(resolved, data)
+
+
+def _cleanup_legacy_plugin() -> None:
+    """Remove legacy symlink-based plugin setup from before marketplace-style registration."""
+    plugins_dir = Path.home() / ".claude" / "plugins"
+    link = plugins_dir / _PLUGIN_NAME
+    if link.is_symlink():
+        link.unlink()
+        typer.echo(f"OK    Removed legacy plugin symlink: {link}")
+
+    resolved = _settings_path()
+    data = _read_json(resolved)
+    enabled = data.get("enabledPlugins", {})
+    legacy_keys = [k for k in enabled if k.startswith("/") and k.endswith(f"/{_PLUGIN_NAME}")]
+    if legacy_keys:
+        for key in legacy_keys:
+            del enabled[key]
+        _write_json(resolved, data)
+        typer.echo(f"OK    Removed {len(legacy_keys)} legacy enabledPlugins path entry(ies).")
+
+    cache_root = plugins_dir / "cache" / _MARKETPLACE_NAME / _PLUGIN_NAME
     if cache_root.is_dir():
         shutil.rmtree(cache_root)
 
 
-def _enable_local_plugin(link: Path) -> None:
-    """Ensure the local plugin path is enabled in settings.json."""
-    settings_path = Path.home() / ".claude" / "settings.json"
-    resolved = settings_path.resolve() if settings_path.is_file() else settings_path
-    if resolved.is_file():
-        data = json.loads(resolved.read_text(encoding="utf-8"))
-    else:
-        resolved.parent.mkdir(parents=True, exist_ok=True)
-        data = {}
-    plugins = data.setdefault("enabledPlugins", {})
-    key = str(link)
-    if plugins.get(key) is True:
+def _ensure_marketplace_symlink(repo: Path) -> None:
+    """Create ``plugins/t3 -> ..`` inside the repo for marketplace source resolution."""
+    plugins_dir = repo / "plugins"
+    link = plugins_dir / _PLUGIN_NAME
+    if link.is_symlink():
         return
-    plugins[key] = True
-    resolved.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    plugins_dir.mkdir(exist_ok=True)
+    link.symlink_to("..")
+
+
+def _register_marketplace(repo: Path) -> None:
+    """Ensure the ``souliane`` marketplace is registered in known_marketplaces.json."""
+    _ensure_marketplace_symlink(repo)
+    marketplaces_json = Path.home() / ".claude" / "plugins" / "known_marketplaces.json"
+    data = _read_json(marketplaces_json)
+    target = str(repo.resolve())
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    existing = data.get(_MARKETPLACE_NAME, {})
+    if existing.get("installLocation") == target:
+        return
+
+    data[_MARKETPLACE_NAME] = {
+        "source": {"source": "directory", "path": target},
+        "installLocation": target,
+        "lastUpdated": now,
+    }
+    _write_json(marketplaces_json, data)
 
 
 def _install_claude_plugin(repo: Path) -> bool:
-    """Link the t3 plugin to the local checkout (always live, no cache)."""
-    plugins_dir = Path.home() / ".claude" / "plugins"
-    plugins_dir.mkdir(parents=True, exist_ok=True)
-    link = plugins_dir / _PLUGIN_NAME
+    """Register the t3 plugin pointing directly at the local main clone.
 
-    target = repo.resolve()
-    if link.is_symlink():
-        if link.resolve() == target:
-            typer.echo(f"OK    Plugin symlink already correct: {link} → {repo}")
-        else:
-            link.unlink()
-            link.symlink_to(target)
-            typer.echo(f"OK    Plugin symlink updated: {link} → {repo}")
-    elif link.exists():
-        typer.echo(f"WARN  {link} exists but is not a symlink — skipping plugin link.")
-        return False
-    else:
-        link.symlink_to(target)
-        typer.echo(f"OK    Plugin symlink created: {link} → {repo}")
-
-    _enable_local_plugin(link)
-
-    claude_bin = shutil.which("claude")
-    if claude_bin:
-        _uninstall_marketplace_plugin(claude_bin)
-
+    Uses the same ``installed_plugins.json`` format as marketplace-installed
+    plugins so Claude Code treats it identically (namespaced skills, visible
+    in ``claude plugin list``).  The ``installPath`` points directly at the
+    main clone — no cache copy, always live.
+    """
+    _cleanup_legacy_plugin()
+    _register_marketplace(repo)
+    _register_installed_plugin(repo)
+    _enable_plugin()
+    typer.echo(f"OK    Plugin {_PLUGIN_ID} registered (installPath: {repo.resolve()}).")
     return True
 
 
@@ -420,6 +491,7 @@ def _sync_skill_symlinks(
     created = 0
     fixed = 0
 
+    core_skill_names: set[str] = set()
     if sync_core:
         for skill in sorted(DEFAULT_SKILLS_DIR.iterdir()):
             if not (skill / "SKILL.md").is_file():
@@ -429,8 +501,11 @@ def _sync_skill_symlinks(
             fixed += f
     else:
         _remove_core_skill_links(runtime_skills, DEFAULT_SKILLS_DIR)
+        core_skill_names = {s.name for s in DEFAULT_SKILLS_DIR.iterdir() if (s / "SKILL.md").is_file()}
 
     for target, link_name in DoctorService.collect_overlay_skills():
+        if link_name in core_skill_names:
+            continue
         c, f = _ensure_skill_link(target, runtime_skills / link_name, workspace_dir)
         created += c
         fixed += f

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -13,11 +13,12 @@ import pytest
 from teatree.cli.setup import (
     CORE_EXCLUDED_SKILLS,
     _clean_broken_symlinks,
-    _enable_local_plugin,
+    _enable_plugin,
     _ensure_skill_link,
     _ensure_t3_installed,
     _find_main_clone,
     _install_claude_plugin,
+    _register_installed_plugin,
     _remove_excluded_skills,
     _repair_dep_drift,
     _run_apm_install,
@@ -117,57 +118,76 @@ class TestRunApmInstall:
             assert args[0][0] == ["/usr/bin/apm", "install", "-g", "--target", "claude"]
 
 
-class TestEnableLocalPlugin:
+class TestEnablePlugin:
     def test_adds_plugin_to_settings(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
         settings = claude_dir / "settings.json"
         settings.write_text(json.dumps({"key": "value"}))
-        link = tmp_path / "plugins" / "t3"
 
-        _enable_local_plugin(link)
+        _enable_plugin()
 
         data = json.loads(settings.read_text())
-        assert data["enabledPlugins"][str(link)] is True
+        assert data["enabledPlugins"]["t3@souliane"] is True
 
     def test_noop_when_already_enabled(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
-        link = tmp_path / "plugins" / "t3"
         settings = claude_dir / "settings.json"
-        settings.write_text(json.dumps({"enabledPlugins": {str(link): True}}))
+        settings.write_text(json.dumps({"enabledPlugins": {"t3@souliane": True}}))
         mtime_before = settings.stat().st_mtime
 
-        _enable_local_plugin(link)
+        _enable_plugin()
 
         assert settings.stat().st_mtime == mtime_before
 
-    def test_creates_settings_when_missing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+
+class TestRegisterInstalledPlugin:
+    def test_registers_plugin_in_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
-        link = tmp_path / "plugins" / "t3"
+        (tmp_path / ".claude" / "plugins").mkdir(parents=True)
+        repo = tmp_path / "teatree-clone"
+        repo.mkdir()
 
-        _enable_local_plugin(link)
+        _register_installed_plugin(repo)
 
-        settings = tmp_path / ".claude" / "settings.json"
-        assert settings.is_file()
-        data = json.loads(settings.read_text())
-        assert data["enabledPlugins"][str(link)] is True
+        data = json.loads((tmp_path / ".claude" / "plugins" / "installed_plugins.json").read_text())
+        entries = data["plugins"]["t3@souliane"]
+        assert len(entries) == 1
+        assert entries[0]["installPath"] == str(repo.resolve())
+        assert entries[0]["version"] == "local"
+
+    def test_noop_when_already_correct(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        plugins_dir = tmp_path / ".claude" / "plugins"
+        plugins_dir.mkdir(parents=True)
+        repo = tmp_path / "teatree-clone"
+        repo.mkdir()
+
+        _register_installed_plugin(repo)
+        mtime = (plugins_dir / "installed_plugins.json").stat().st_mtime
+
+        _register_installed_plugin(repo)
+        assert (plugins_dir / "installed_plugins.json").stat().st_mtime == mtime
 
 
 class TestInstallClaudePlugin:
-    def test_creates_symlink(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_registers_plugin_and_marketplace(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
         repo = tmp_path / "teatree-clone"
         repo.mkdir()
-        with patch("teatree.cli.setup.shutil.which", return_value=None):
-            assert _install_claude_plugin(repo) is True
-        link = tmp_path / ".claude" / "plugins" / "t3"
-        assert link.is_symlink()
-        assert link.resolve() == repo.resolve()
+        assert _install_claude_plugin(repo) is True
 
-    def test_updates_stale_symlink(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        data = json.loads((tmp_path / ".claude" / "plugins" / "installed_plugins.json").read_text())
+        assert "t3@souliane" in data["plugins"]
+        assert data["plugins"]["t3@souliane"][0]["installPath"] == str(repo.resolve())
+
+        settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+        assert settings["enabledPlugins"]["t3@souliane"] is True
+
+    def test_removes_legacy_symlink(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
         plugins_dir = tmp_path / ".claude" / "plugins"
         plugins_dir.mkdir(parents=True)
@@ -176,38 +196,26 @@ class TestInstallClaudePlugin:
         old_target.mkdir()
         link.symlink_to(old_target)
 
-        new_repo = tmp_path / "new-clone"
-        new_repo.mkdir()
-        with patch("teatree.cli.setup.shutil.which", return_value=None):
-            assert _install_claude_plugin(new_repo) is True
-        assert link.resolve() == new_repo.resolve()
-
-    def test_uninstalls_marketplace_version(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
         repo = tmp_path / "teatree-clone"
         repo.mkdir()
+        _install_claude_plugin(repo)
 
-        completed = SimpleNamespace(returncode=0, stdout="", stderr="")
-        with (
-            patch("teatree.cli.setup.shutil.which", return_value="/usr/bin/claude"),
-            patch("teatree.cli.setup._run_captured", return_value=completed) as mock_run,
-        ):
-            _install_claude_plugin(repo)
+        assert not link.exists()
 
-        uninstall_calls = [c for c in mock_run.call_args_list if "uninstall" in c.args[0]]
-        assert len(uninstall_calls) == 1
-        assert "t3@souliane" in uninstall_calls[0].args[0]
-
-    def test_returns_false_for_non_symlink_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_removes_legacy_enabled_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
-        plugins_dir = tmp_path / ".claude" / "plugins"
-        plugins_dir.mkdir(parents=True)
-        (plugins_dir / "t3").mkdir()  # regular dir, not symlink
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        settings = claude_dir / "settings.json"
+        settings.write_text(json.dumps({"enabledPlugins": {"/some/path/t3": True}}))
 
         repo = tmp_path / "teatree-clone"
         repo.mkdir()
-        with patch("teatree.cli.setup.shutil.which", return_value=None):
-            assert _install_claude_plugin(repo) is False
+        _install_claude_plugin(repo)
+
+        data = json.loads(settings.read_text())
+        assert "/some/path/t3" not in data["enabledPlugins"]
+        assert data["enabledPlugins"]["t3@souliane"] is True
 
 
 class TestStripApmHooks:


### PR DESCRIPTION
## Summary
- Register t3 plugin using marketplace-style `installed_plugins.json` format (`t3@souliane`) so Claude Code namespaces all core skills as `t3:code`, `t3:ship`, `t3:review`, etc.
- `installPath` points directly at the main clone — always live, no cache copy
- `t3 setup` handles full registration (marketplace + plugin + enabledPlugins) and legacy cleanup
- `t3 doctor check` auto-repairs plugin registration on every Claude session start
- Fixed `_sync_skill_symlinks` bug where `collect_overlay_skills()` re-added core skill symlinks after `_remove_core_skill_links` pruned them

## Test plan
- [x] `t3 setup` registers plugin, removes legacy symlink, cleans enabledPlugins
- [x] `claude plugin list` shows `t3@souliane` as enabled
- [x] Core skill symlinks removed from `~/.claude/skills/`
- [x] `t3 doctor check` auto-repairs if registration is missing
- [x] All 2766 tests pass
- [ ] Restart Claude Code and verify `t3:code` etc. appear in skill list