### PR TITLE
fix(cli): wire ticket command, FSM visit-phase, filter secrets, audit-memory tool

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -878,7 +878,7 @@ Typer-based, work without Django:
 - `t3 <overlay> e2e project [<test-path>] [--update-snapshots]` — explicit project runner: pytest-playwright in the overlay's own test dir, executed in the canonical Docker image by default
 - `t3 review {post-draft-note,delete-draft-note,list-draft-notes,publish-draft-notes,update-note,reply-to-discussion,resolve-discussion}` — code-host draft notes (post/delete/list/publish), in-place edits of draft or published notes, plus immediate replies on existing discussion threads and resolve/unresolve toggle. Routes to GitHub or GitLab via the active overlay's `CodeHostBackend`.
 - `t3 review-request discover` — discover open PRs awaiting review
-- `t3 tool {privacy-scan,analyze-video,bump-deps,label-issues,find-duplicates,triage-issues}` — standalone utilities
+- `t3 tool {privacy-scan,analyze-video,bump-deps,label-issues,find-duplicates,triage-issues,audit-memory}` — standalone utilities
 - `t3 config write-skill-cache` — write overlay skill metadata to cache
 - `t3 doctor {check,repair}` — health checks and symlink repair
 - `t3 setup slack-bot --overlay <name>` — interactive walkthrough to register a Slack bot for an overlay; opens the app-manifest URL, captures bot+app tokens, stores them via `pass`, writes `slack_user_id` into `~/.teatree.toml`, smoke-tests with a round-trip DM (see § 10.1 for the manifest template and scopes). Subcommands of `t3 setup` short-circuit the global skill-install callback so the walkthrough runs without requiring `T3_REPO`.

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -554,6 +554,8 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 │                  keyword-matching title and body.                            │
 │ find-duplicates  Flag pairs of open issues with near-identical titles.       │
 │ claude-handover  Show Claude handover telemetry and runtime recommendations. │
+│ audit-memory     Scan Claude memory files for entries that should be         │
+│                  promoted to skills.                                         │
 │ triage-issues    Scan for resolved-but-open and stale issues.                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -674,6 +676,19 @@ Usage: t3 tool claude-handover [OPTIONS]
 │                                directory.                                    │
 │ --json                         Emit machine-readable JSON.                   │
 │ --help                         Show this message and exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 tool audit-memory`
+
+```
+Usage: t3 tool audit-memory [OPTIONS]
+
+ Scan Claude memory files for entries that should be promoted to skills.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --verbose  -v        Show matched patterns for each entry.                   │
+│ --help               Show this message and exit.                             │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1089,6 +1089,7 @@ Usage: t3 teatree [OPTIONS] COMMAND [ARGS]...
 │ tasks        Async task queue.                                               │
 │ followup     Follow-up snapshots.                                            │
 │ lifecycle    Session lifecycle and phase tracking.                           │
+│ ticket       Ticket state management.                                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -2231,7 +2232,7 @@ Usage: t3 teatree lifecycle [OPTIONS] COMMAND [ARGS]...
 ```
 Usage: t3 teatree lifecycle visit-phase [OPTIONS] TICKET_ID PHASE
 
- Mark a phase as visited on the ticket's latest session.
+ Mark a phase as visited and advance the ticket FSM if applicable.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    ticket_id      INTEGER  [required]                                      │
@@ -2239,5 +2240,74 @@ Usage: t3 teatree lifecycle visit-phase [OPTIONS] TICKET_ID PHASE
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 teatree ticket`
+
+```
+Usage: t3 teatree ticket [OPTIONS] COMMAND [ARGS]...
+
+ Ticket state management.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ transition        Transition a ticket to a new state.                        │
+│ list              List tickets, optionally filtered by state and/or overlay. │
+│ sync-completions  Check post-ship tickets against upstream issues and        │
+│                   advance completed ones.                                    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree ticket transition`
+
+```
+Usage: t3 teatree ticket transition [OPTIONS] TICKET_ID TRANSITION_NAME
+
+ Transition a ticket to a new state.
+
+ Accepts any of the allowed transition names: scope, start, code, test,
+ review, ship, request_review, mark_merged, retrospect, mark_delivered, rework.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    ticket_id            INTEGER  [required]                                │
+│ *    transition_name      TEXT     [required]                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree ticket list`
+
+```
+Usage: t3 teatree ticket list [OPTIONS]
+
+ List tickets, optionally filtered by state and/or overlay.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --state          TEXT                                                        │
+│ --overlay        TEXT                                                        │
+│ --help                 Show this message and exit.                           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree ticket sync-completions`
+
+```
+Usage: t3 teatree ticket sync-completions [OPTIONS]
+
+ Check post-ship tickets against upstream issues and advance completed ones.
+
+ Walks tickets in shipped/in_review/merged states, calls the overlay's
+ ``is_issue_done()`` for each, and transitions completed tickets toward
+ delivered. Use ``--dry-run`` to preview without touching state.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --dry-run    --no-dry-run      Show what would transition without acting.    │
+│                                [default: no-dry-run]                         │
+│ --help                         Show this message and exit.                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -120,6 +120,14 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("visit-phase", "Mark a phase as visited on the ticket's latest session."),
         ],
     ),
+    "ticket": (
+        "Ticket state management.",
+        [
+            ("transition", "Transition a ticket to a new state."),
+            ("list", "List tickets, optionally filtered by state and/or overlay."),
+            ("sync-completions", "Check post-ship tickets against upstream issues and advance completed ones."),
+        ],
+    ),
 }
 
 

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -170,6 +170,33 @@ def claude_handover(
     )
 
 
+@tool_app.command("audit-memory")
+def audit_memory(
+    *,
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show matched patterns for each entry."),
+) -> None:
+    """Scan Claude memory files for entries that should be promoted to skills."""
+    from teatree.memory_audit import scan_all  # noqa: PLC0415
+
+    entries = scan_all()
+    if not entries:
+        typer.echo("No promotable memory entries found.")
+        return
+
+    by_skill: dict[str, list] = {}
+    for entry in entries:
+        by_skill.setdefault(entry.suggested_skill, []).append(entry)
+
+    typer.echo(f"Found {len(entries)} promotable memory entries:\n")
+    for skill, skill_entries in sorted(by_skill.items()):
+        typer.echo(f"  → t3:{skill} ({len(skill_entries)} entries)")
+        for entry in skill_entries:
+            typer.echo(f"    {entry.name}  [{entry.entry_type}]  {entry.path}")
+            if verbose:
+                for pattern in entry.matched_patterns:
+                    typer.echo(f"      matched: {pattern}")
+
+
 @tool_app.command("triage-issues")
 def triage_issues(
     repo: str = typer.Argument(..., help="Repository in owner/name form (e.g. souliane/teatree)"),

--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -1,8 +1,24 @@
 """Lifecycle and session phase operations."""
 
+import logging
+
+from django.db import transaction
+from django_fsm import TransitionNotAllowed
 from django_typer.management import TyperCommand, command, initialize
 
 from teatree.core.models import Session, Ticket
+
+logger = logging.getLogger(__name__)
+
+_PHASE_TO_TRANSITION: dict[str, str] = {
+    "scoping": "scope",
+    "coding": "start",
+    "testing": "test",
+    "reviewing": "review",
+    "shipping": "ship",
+    "requesting_review": "request_review",
+    "retrospecting": "retrospect",
+}
 
 
 class Command(TyperCommand):
@@ -12,10 +28,32 @@ class Command(TyperCommand):
 
     @command(name="visit-phase")
     def visit_phase(self, ticket_id: int, phase: str) -> str:
-        """Mark a phase as visited on the ticket's latest session."""
+        """Mark a phase as visited and advance the ticket FSM if applicable."""
         ticket = Ticket.objects.get(pk=ticket_id)
         session = ticket.sessions.order_by("-pk").first()
         if session is None:
             session = Session.objects.create(ticket=ticket)
         session.visit_phase(phase)
-        return f"Phase '{phase}' marked as visited on session {session.pk}"
+
+        transition_name = _PHASE_TO_TRANSITION.get(phase)
+        if transition_name:
+            _try_advance(ticket, transition_name)
+
+        return f"Phase '{phase}' marked as visited on session {session.pk} (ticket state: {ticket.state})"
+
+
+def _try_advance(ticket: Ticket, transition_name: str) -> None:
+    method = getattr(ticket, transition_name, None)
+    if method is None:
+        return
+    try:
+        with transaction.atomic():
+            method()
+            ticket.save()
+    except TransitionNotAllowed:
+        logger.debug(
+            "Transition '%s' not valid from state '%s' for ticket %s — FSM unchanged",
+            transition_name,
+            ticket.state,
+            ticket.pk,
+        )

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -230,8 +230,10 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
     def declared_env_keys(self) -> set[str]:
         return set()
 
+    _CORE_SECRET_KEYS: frozenset[str] = frozenset({"POSTGRES_PASSWORD"})
+
     def declared_secret_env_keys(self) -> set[str]:
-        return set()
+        return set(self._CORE_SECRET_KEYS)
 
     def get_db_import_strategy(self, worktree: "Worktree") -> DbImportStrategy | None:
         return None

--- a/src/teatree/memory_audit.py
+++ b/src/teatree/memory_audit.py
@@ -1,0 +1,118 @@
+"""Scan Claude memory files for entries that should be promoted to skills."""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+_GUARDRAIL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bNEVER\b", re.IGNORECASE),
+    re.compile(r"\bALWAYS\b", re.IGNORECASE),
+    re.compile(r"\bMUST\b", re.IGNORECASE),
+    re.compile(r"\bdo NOT\b", re.IGNORECASE),
+    re.compile(r"\bbefore .{3,30} (do|run|check)\b", re.IGNORECASE),
+    re.compile(r"\bafter .{3,30} (do|run|check)\b", re.IGNORECASE),
+    re.compile(r"\bwhen .{3,30} (always|never|must)\b", re.IGNORECASE),
+    re.compile(r"\bnon-negotiable\b", re.IGNORECASE),
+)
+
+_SKILL_HINT_MAP: dict[str, str] = {
+    "commit": "ship",
+    "push": "ship",
+    "mr": "ship",
+    "pr": "ship",
+    "merge": "ship",
+    "review": "review",
+    "test": "test",
+    "e2e": "e2e",
+    "playwright": "e2e",
+    "debug": "debug",
+    "worktree": "workspace",
+    "workspace": "workspace",
+    "db": "workspace",
+    "docker": "workspace",
+    "retro": "retro",
+    "ticket": "ticket",
+    "skill": "rules",
+    "import": "code",
+    "lint": "code",
+    "ruff": "code",
+    "type": "code",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryEntry:
+    path: Path
+    name: str
+    entry_type: str
+    body: str
+    matched_patterns: tuple[str, ...]
+    suggested_skill: str
+
+
+def discover_memory_dirs() -> list[Path]:
+    claude_dir = Path.home() / ".claude" / "projects"
+    if not claude_dir.is_dir():
+        return []
+    return sorted(d for project in claude_dir.iterdir() if project.is_dir() for d in [project / "memory"] if d.is_dir())
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    if not text.startswith("---"):
+        return {}, text
+    end = text.find("---", 3)
+    if end == -1:
+        return {}, text
+    frontmatter_text = text[3:end].strip()
+    body = text[end + 3 :].strip()
+    fields: dict[str, str] = {}
+    for line in frontmatter_text.splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    return fields, body
+
+
+def _detect_guardrail_patterns(body: str) -> tuple[str, ...]:
+    return tuple(pattern.pattern for pattern in _GUARDRAIL_PATTERNS if pattern.search(body))
+
+
+def _suggest_skill(body: str) -> str:
+    lowered = body.lower()
+    for keyword, skill in _SKILL_HINT_MAP.items():
+        if keyword in lowered:
+            return skill
+    return "rules"
+
+
+def scan_memory_dir(memory_dir: Path) -> list[MemoryEntry]:
+    entries: list[MemoryEntry] = []
+    for md_file in sorted(memory_dir.glob("*.md")):
+        if md_file.name == "MEMORY.md":
+            continue
+        text = md_file.read_text(encoding="utf-8")
+        fields, body = _parse_frontmatter(text)
+        entry_type = fields.get("type", fields.get("metadata", {}) if isinstance(fields.get("metadata"), dict) else "")
+        if isinstance(entry_type, dict):
+            entry_type = entry_type.get("type", "")
+        matched = _detect_guardrail_patterns(body)
+        if not matched:
+            continue
+        entries.append(
+            MemoryEntry(
+                path=md_file,
+                name=fields.get("name", md_file.stem),
+                entry_type=str(entry_type),
+                body=body,
+                matched_patterns=matched,
+                suggested_skill=_suggest_skill(body),
+            )
+        )
+    return entries
+
+
+def scan_all() -> list[MemoryEntry]:
+    results: list[MemoryEntry] = []
+    for memory_dir in discover_memory_dirs():
+        results.extend(scan_memory_dir(memory_dir))
+    return results

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -4154,6 +4154,30 @@ class TestLifecycleVisitPhase(TestCase):
         assert "reviewing" in session.visited_phases
         assert str(session.pk) in result
 
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_advances_fsm_alongside_session_visit(self) -> None:
+        ticket = Ticket.objects.create(
+            overlay="test", issue_url="https://example.com/issues/vp3", state=Ticket.State.NOT_STARTED
+        )
+        cast("str", call_command("lifecycle", "visit-phase", str(ticket.pk), "scoping"))
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SCOPED
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_fsm_mismatch_does_not_block_phase_visit(self) -> None:
+        ticket = Ticket.objects.create(
+            overlay="test", issue_url="https://example.com/issues/vp4", state=Ticket.State.NOT_STARTED
+        )
+        cast("str", call_command("lifecycle", "visit-phase", str(ticket.pk), "reviewing"))
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.NOT_STARTED
+        session = ticket.sessions.first()
+        assert "reviewing" in session.visited_phases
+
 
 class TestRunHealthChecks(TestCase):
     @_patch_overlays(FULL_OVERLAY)

--- a/tests/teatree_core/test_worktree_env.py
+++ b/tests/teatree_core/test_worktree_env.py
@@ -82,6 +82,22 @@ class ExtraOnlyOverlay(OverlayBase):
         return {"EXTRA_KEY"}
 
 
+class PostgresPasswordOverlay(OverlayBase):
+    """Overlay that returns POSTGRES_PASSWORD without declaring it secret."""
+
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        return []
+
+    def get_env_extra(self, worktree: Worktree) -> dict[str, str]:
+        return {"POSTGRES_PASSWORD": "s3cr3t-pw", "EXTRA_KEY": "extra_value"}
+
+    def declared_env_keys(self) -> set[str]:
+        return {"POSTGRES_PASSWORD", "EXTRA_KEY"}
+
+
 class SecretOverlay(OverlayBase):
     """Overlay whose get_env_extra includes both public and secret keys."""
 
@@ -134,6 +150,7 @@ _SHARED_PG = {"test": SharedPostgresOverlay()}
 _ENV_EXTRA_COLLIDES = {"test": EnvExtraOverrideOverlay()}
 _EXTRA_ONLY = {"test": ExtraOnlyOverlay()}
 _SECRET = {"test": SecretOverlay()}
+_POSTGRES_PW = {"test": PostgresPasswordOverlay()}
 _COMMAND = {"test": CommandOverlay()}
 
 
@@ -195,6 +212,16 @@ class TestRenderEnvCache(TestCase):
             assert "PUBLIC_KEY" in spec.keys
             assert "SECRET_PASSWORD" not in spec.keys
             assert "DATABASE_URL" not in spec.keys
+
+    def test_core_filters_postgres_password_without_overlay_declaring_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt, _ = _make_worktree(tmp, ticket_name="tp", ticket_url="https://ex.com/2", variant="acme")
+            with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_POSTGRES_PW):
+                spec = render_env_cache(wt)
+            assert spec is not None
+            assert "EXTRA_KEY=extra_value" in spec.content
+            assert "POSTGRES_PASSWORD" not in spec.content
+            assert "s3cr3t-pw" not in spec.content
 
 
 class TestWriteEnvCache(TestCase):

--- a/tests/test_memory_audit.py
+++ b/tests/test_memory_audit.py
@@ -1,0 +1,78 @@
+"""Tests for teatree.memory_audit — scan memory files for promotable entries."""
+
+from pathlib import Path
+
+import pytest
+
+from teatree.memory_audit import _detect_guardrail_patterns, _parse_frontmatter, _suggest_skill, scan_memory_dir
+
+
+class TestParseFrontmatter:
+    def test_parses_yaml_frontmatter(self) -> None:
+        text = "---\nname: my-rule\ntype: feedback\n---\nBody here."
+        fields, body = _parse_frontmatter(text)
+        assert fields["name"] == "my-rule"
+        assert fields["type"] == "feedback"
+        assert body == "Body here."
+
+    def test_returns_empty_when_no_frontmatter(self) -> None:
+        text = "Just a body with no frontmatter."
+        fields, body = _parse_frontmatter(text)
+        assert fields == {}
+        assert body == text
+
+
+class TestDetectGuardrailPatterns:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "NEVER run this command directly.",
+            "You must ALWAYS check first.",
+            "This is non-negotiable.",
+            "Do NOT use pip on local.",
+        ],
+    )
+    def test_detects_guardrail_language(self, text: str) -> None:
+        assert len(_detect_guardrail_patterns(text)) > 0
+
+    def test_returns_empty_for_neutral_text(self) -> None:
+        assert _detect_guardrail_patterns("The user prefers Emacs.") == ()
+
+
+class TestSuggestSkill:
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            ("Never push without explicit approval", "ship"),
+            ("Always run the test suite first", "test"),
+            ("When reviewing code, check for N+1", "review"),
+            ("Worktree must be isolated", "workspace"),
+            ("Generic guardrail about something", "rules"),
+        ],
+    )
+    def test_maps_keywords_to_skills(self, body: str, expected: str) -> None:
+        assert _suggest_skill(body) == expected
+
+
+class TestScanMemoryDir:
+    def test_scans_and_flags_promotable_entries(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        (memory_dir / "MEMORY.md").write_text("# Index\n")
+        (memory_dir / "feedback_push.md").write_text(
+            "---\nname: push-rules\ntype: feedback\n---\nNEVER push without explicit approval from the user."
+        )
+        (memory_dir / "user_editor.md").write_text("---\nname: editor\ntype: user\n---\nUser prefers Emacs.")
+
+        entries = scan_memory_dir(memory_dir)
+        assert len(entries) == 1
+        assert entries[0].name == "push-rules"
+        assert entries[0].suggested_skill == "ship"
+
+    def test_skips_memory_index(self, tmp_path: Path) -> None:
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        (memory_dir / "MEMORY.md").write_text("NEVER skip this.\n")
+
+        entries = scan_memory_dir(memory_dir)
+        assert entries == []


### PR DESCRIPTION
## Summary
- **#571**: Register `ticket` management command (transition, list, sync-completions) in the overlay CLI
- **#546**: `lifecycle visit-phase` now also advances the ticket FSM via the corresponding transition
- **#417**: Core declares `POSTGRES_PASSWORD` as a secret env key, filtering it from `.t3-env.cache` regardless of overlay declaration
- **#565**: New `t3 tool audit-memory` — scans Claude memory files for guardrail entries that should be promoted to skills

## Test plan
- [x] `t3 <overlay> ticket list/transition/sync-completions` accessible from CLI
- [x] `visit-phase scoping` on a NOT_STARTED ticket advances FSM to SCOPED
- [x] `visit-phase` with invalid FSM transition still records the phase visit
- [x] `POSTGRES_PASSWORD` filtered from env cache even without overlay declaring it
- [x] `audit-memory` scans memory dirs, detects guardrail patterns, suggests skills
- [x] All pre-commit hooks pass (ruff, ty-check, tach, codespell, blueprint-sync)

Closes #571, closes #546, closes #565, partially addresses #417