### PR TITLE
fix(hooks): model-friendly loop enforcement, Django-free doctor check

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -267,12 +267,20 @@ def _session_has_loop(session_id: str) -> bool:
         return False
 
 
+def _cleanup_stale_pending(session_id: str) -> None:
+    """Remove loop-pending files from old sessions."""
+    for f in STATE_DIR.glob("*.loop-pending"):
+        if f.stem != session_id:
+            f.unlink(missing_ok=True)
+
+
 def handle_enforce_loop_on_prompt(data: dict) -> None:
     """On first prompt, check if the fat loop needs registration."""
     session_id = data.get("session_id", "")
     if not session_id:
         return
     _ensure_state_dir()
+    _cleanup_stale_pending(session_id)
     pending = _state_file(session_id, "loop-pending")
     if _session_has_loop(session_id):
         pending.unlink(missing_ok=True)
@@ -283,14 +291,14 @@ def handle_enforce_loop_on_prompt(data: dict) -> None:
     minutes = max(1, cadence // 60)
     pending.write_text("1", encoding="utf-8")
     print(  # noqa: T201
-        f"MANDATORY: Register the fat loop NOW. Call CronCreate with "
-        f'cron="*/{minutes} * * * *", prompt="{_LOOP_PROMPT}", recurring=true. '
-        f"Do this BEFORE any other work."
+        f"Session setup: the teatree background loop is not registered yet. "
+        f"Please call CronCreate with "
+        f'cron="*/{minutes} * * * *", prompt="{_LOOP_PROMPT}", recurring=true.'
     )
 
 
 def handle_enforce_loop_registration(data: dict) -> bool:
-    """Block tools until the fat loop cron is registered."""
+    """Block Bash/Edit/Write until the background loop cron is registered."""
     tool_name = data.get("tool_name", "")
     if tool_name in {"CronCreate", "CronDelete", "CronList", "ScheduleWakeup", "Skill", "ToolSearch"}:
         return False
@@ -306,9 +314,9 @@ def handle_enforce_loop_registration(data: dict) -> bool:
     cadence = int(os.environ.get("T3_LOOP_CADENCE", _LOOP_CADENCE_DEFAULT) or _LOOP_CADENCE_DEFAULT)
     minutes = max(1, cadence // 60)
     reason = (
-        f"LOOP REGISTRATION REQUIRED: Call CronCreate with "
-        f'cron="*/{minutes} * * * *", prompt="{_LOOP_PROMPT}", recurring=true '
-        f"BEFORE calling any other tool."
+        f"The teatree background loop is not registered yet. "
+        f"Please call CronCreate with "
+        f'cron="*/{minutes} * * * *", prompt="{_LOOP_PROMPT}", recurring=true.'
     )
     json.dump({"permissionDecision": "deny", "permissionDecisionReason": reason}, sys.stdout)
     return True

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -5,7 +5,7 @@ import os
 import re
 import shutil
 import sys
-from importlib.metadata import PackageNotFoundError, distribution, packages_distributions
+from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 
 import typer
@@ -25,17 +25,6 @@ AGENT_SKILL_RUNTIMES: tuple[str, ...] = ("claude", "codex")
 def agent_skill_dirs() -> list[tuple[str, Path]]:
     """Return (runtime_label, skills_dir) pairs, resolved against the current HOME."""
     return [(name, Path.home() / f".{name}" / "skills") for name in AGENT_SKILL_RUNTIMES]
-
-
-def _resolve_overlay_dists(overlays: dict) -> list[str]:
-    """Map overlay instances to their distribution package names."""
-    dist_map = packages_distributions()
-    result: list[str] = []
-    for overlay_inst in overlays.values():
-        top_package = type(overlay_inst).__module__.split(".", maxsplit=1)[0]
-        dist_names = dist_map.get(top_package, [top_package])
-        result.append(dist_names[0] if dist_names else top_package)
-    return result
 
 
 _DEV_SOURCES_FILE = ".t3-dev-sources"
@@ -243,10 +232,12 @@ class DoctorService:
                     "Fix: set T3_REPO env var or run `uv pip install -e <teatree-path>`",
                 )
 
-        # Overlays — resolve dist names once, check both directions
-        from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+        # Overlays — resolve dist names from entry points metadata (no Django needed).
+        import importlib.metadata  # noqa: PLC0415
 
-        overlay_dists = _resolve_overlay_dists(get_all_overlays())
+        overlay_dists = [
+            ep.dist.name if ep.dist else ep.name for ep in importlib.metadata.entry_points(group="teatree.overlays")
+        ]
 
         for overlay_dist in overlay_dists:
             overlay_is_editable, _ = IntrospectionHelpers.editable_info(overlay_dist)
@@ -294,8 +285,18 @@ class DoctorService:
         """Find the overlay repo in the workspace directory."""
         from teatree.config import load_config  # noqa: PLC0415
 
-        workspace = Path(load_config().user.workspace_dir).expanduser()
-        # Try common layouts: workspace/<dist>, workspace/*/<dist>
+        config = load_config()
+        workspace = Path(config.user.workspace_dir).expanduser()
+
+        # Check TOML overlay paths first — they're explicit and authoritative.
+        for overlay_cfg in (config.raw.get("overlays") or {}).values():
+            path_str = overlay_cfg.get("path", "")
+            if path_str:
+                candidate = Path(path_str).expanduser()
+                if (candidate / "pyproject.toml").is_file():
+                    return candidate
+
+        # Fallback: scan workspace for dist_name directory.
         for candidate in [workspace / dist_name, *workspace.glob(f"*/{dist_name}")]:
             if (candidate / "pyproject.toml").is_file():
                 return candidate
@@ -345,7 +346,9 @@ class DoctorService:
             else:
                 typer.echo(f"FAIL  uv sync failed after patching sources: {result.stderr.strip()}")
         else:
-            typer.echo(f"FAIL  Could not patch [tool.uv.sources] for {package}")
+            typer.echo(
+                f"WARN  {package} is not in host pyproject.toml sources. Fix: `uv tool install --editable {repo_path}`"
+            )
 
     @staticmethod
     def restore_sources(project_root: Path) -> None:

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -59,14 +59,10 @@ def _stage_home(tmp_path: Path, monkeypatch) -> Path:
     return tmp_path
 
 
-def _stub_overlay_instance(module: str = "my_overlay.overlay") -> object:
-    """Return an instance whose ``type(inst).__module__`` is *module*.
-
-    ``_resolve_overlay_dists`` inspects the instance's class module, not the
-    instance module. A plain ``MagicMock`` would report ``unittest.mock``.
-    """
-    cls = type("_OverlayStub", (), {"__module__": module})
-    return cls()
+def _fake_entry_point(dist_name: str = "my-overlay") -> object:
+    """Return a fake ``importlib.metadata.EntryPoint`` with ``dist.name``."""
+    dist = type("_FakeDist", (), {"name": dist_name})()
+    return type("_FakeEP", (), {"name": f"t3-{dist_name}", "dist": dist})()
 
 
 def _editable_map(**dists: tuple[bool, str]):
@@ -436,7 +432,7 @@ class TestRepairSymlinks:
 class TestCheckEditableSanity:
     """End-to-end sanity check wired to a real ``~/.teatree.toml``.
 
-    ``editable_info`` and ``get_all_overlays`` are the two external boundaries
+    ``editable_info`` and ``entry_points`` are the two external boundaries
     we cannot make real without installing actual packages, so they stay as
     mocks. Everything else (config loading, repo discovery) runs live.
     """
@@ -445,20 +441,14 @@ class TestCheckEditableSanity:
         _stage_home(tmp_path, monkeypatch)
         _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = false\n")
 
-        with (
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
-        ):
+        with patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")):
             assert DoctorService.check_editable_sanity() == []
 
     def test_empty_when_contribute_true_and_all_editable(self, tmp_path, monkeypatch):
         _stage_home(tmp_path, monkeypatch)
         _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = true\n")
 
-        with (
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
-        ):
+        with patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")):
             assert DoctorService.check_editable_sanity() == []
 
     def test_auto_fixes_teatree_when_contribute_true(self, tmp_path, monkeypatch):
@@ -472,7 +462,6 @@ class TestCheckEditableSanity:
 
         with (
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
             patch.object(DoctorService, "make_editable") as mock_fix,
         ):
             problems = DoctorService.check_editable_sanity()
@@ -488,7 +477,6 @@ class TestCheckEditableSanity:
 
         with (
             patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
             patch("teatree.find_project_root", return_value=None),
         ):
             problems = DoctorService.check_editable_sanity()
@@ -499,10 +487,7 @@ class TestCheckEditableSanity:
         _stage_home(tmp_path, monkeypatch)
         _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = false\n")
 
-        with (
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")),
-            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
-        ):
+        with patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")):
             problems = DoctorService.check_editable_sanity()
 
         assert any("contribute=false" in p for p in problems)
@@ -516,22 +501,16 @@ class TestCheckEditableSanity:
         overlay_repo = tmp_path / "my-overlay"
         overlay_repo.mkdir()
         (overlay_repo / "pyproject.toml").write_text('[project]\nname = "my-overlay"\n')
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda **_kw: [_fake_entry_point("my-overlay")],
+        )
 
         with (
             patch.object(
                 IntrospectionHelpers,
                 "editable_info",
                 side_effect=_editable_map(teatree=(True, ""), **{"my-overlay": (False, "")}),
-            ),
-            patch.object(
-                teatree_overlay_loader,
-                "get_all_overlays",
-                return_value={"test": _stub_overlay_instance()},
-            ),
-            patch.object(
-                teatree_cli_doctor,
-                "packages_distributions",
-                return_value={"my_overlay": ["my-overlay"]},
             ),
             patch.object(DoctorService, "make_editable") as mock_fix,
         ):
@@ -543,23 +522,15 @@ class TestCheckEditableSanity:
     def test_warns_when_overlay_editable_but_contribute_false(self, tmp_path, monkeypatch):
         _stage_home(tmp_path, monkeypatch)
         _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = false\n")
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda **_kw: [_fake_entry_point("my-overlay")],
+        )
 
-        with (
-            patch.object(
-                IntrospectionHelpers,
-                "editable_info",
-                side_effect=_editable_map(teatree=(False, ""), **{"my-overlay": (True, "file:///src")}),
-            ),
-            patch.object(
-                teatree_overlay_loader,
-                "get_all_overlays",
-                return_value={"test": _stub_overlay_instance()},
-            ),
-            patch.object(
-                teatree_cli_doctor,
-                "packages_distributions",
-                return_value={"my_overlay": ["my-overlay"]},
-            ),
+        with patch.object(
+            IntrospectionHelpers,
+            "editable_info",
+            side_effect=_editable_map(teatree=(False, ""), **{"my-overlay": (True, "file:///src")}),
         ):
             problems = DoctorService.check_editable_sanity()
 
@@ -568,20 +539,12 @@ class TestCheckEditableSanity:
     def test_empty_when_all_states_align_with_contribute_false(self, tmp_path, monkeypatch):
         _stage_home(tmp_path, monkeypatch)
         _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = false\n")
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda **_kw: [_fake_entry_point("my-overlay")],
+        )
 
-        with (
-            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
-            patch.object(
-                teatree_overlay_loader,
-                "get_all_overlays",
-                return_value={"test": _stub_overlay_instance()},
-            ),
-            patch.object(
-                teatree_cli_doctor,
-                "packages_distributions",
-                return_value={"my_overlay": ["my-overlay"]},
-            ),
-        ):
+        with patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")):
             assert DoctorService.check_editable_sanity() == []
 
     def test_warns_when_overlay_repo_not_found(self, tmp_path, monkeypatch):
@@ -591,23 +554,15 @@ class TestCheckEditableSanity:
             f'[teatree]\ncontribute = true\nworkspace_dir = "{tmp_path}"\n',
         )
         # No ``my-overlay`` directory under workspace_dir.
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda **_kw: [_fake_entry_point("my-overlay")],
+        )
 
-        with (
-            patch.object(
-                IntrospectionHelpers,
-                "editable_info",
-                side_effect=_editable_map(teatree=(True, ""), **{"my-overlay": (False, "")}),
-            ),
-            patch.object(
-                teatree_overlay_loader,
-                "get_all_overlays",
-                return_value={"test": _stub_overlay_instance()},
-            ),
-            patch.object(
-                teatree_cli_doctor,
-                "packages_distributions",
-                return_value={"my_overlay": ["my-overlay"]},
-            ),
+        with patch.object(
+            IntrospectionHelpers,
+            "editable_info",
+            side_effect=_editable_map(teatree=(True, ""), **{"my-overlay": (False, "")}),
         ):
             problems = DoctorService.check_editable_sanity()
 
@@ -712,7 +667,7 @@ class TestMakeEditable:
 
         assert "ephemeral" in capsys.readouterr().out
 
-    def test_reports_fail_when_pyproject_has_no_source_entry(self, tmp_path, capsys):
+    def test_reports_warn_when_pyproject_has_no_source_entry(self, tmp_path, capsys):
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text('[project]\nname = "myproject"\n')
         (tmp_path / "manage.py").write_text("")
@@ -720,7 +675,7 @@ class TestMakeEditable:
         with patch("teatree.cli.doctor._find_host_project_root", return_value=tmp_path):
             DoctorService.make_editable("teatree", Path("/tmp/teatree"))
 
-        assert "FAIL" in capsys.readouterr().out
+        assert "uv tool install" in capsys.readouterr().out
 
     def test_reports_fail_without_host_project_when_install_fails(self, tmp_path):
         failure = subprocess.CompletedProcess([], 1, "", "install failed")


### PR DESCRIPTION
## Summary
- Replace MANDATORY injection-like loop registration message with neutral language that Opus 4.6 follows
- Add zombie loop-pending cleanup on session start
- Resolve overlay dist names via entry-point metadata instead of `get_all_overlays()` — doctor check needs no Django setup
- `find_overlay_repo` checks TOML overlay paths first (finds t3-company)
- `make_editable` fallback suggests `uv tool install` instead of `uv pip install -e`
- Remove dead `_resolve_overlay_dists` helper

## Test plan
- [x] `t3 doctor check` passes without Django setup
- [x] `t3 loop tick` runs clean — 0 warnings
- [x] All 2783 tests pass
- [x] ruff check + format clean