### PR TITLE
feat(statusline): readable layout, per-overlay grouping, clickable refs (#630)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -159,6 +159,7 @@ src/teatree/
   loop/                 # /loop topology (see §5.6)
     tick.py             # One tick: scan in parallel, dispatch to phase agents when needed, render statusline
     dispatch.py         # Signal → action mapping (statusline / agent / webhook)
+    rendering.py        # Classify dispatched actions per overlay; render anchor / action / in-flight rows
     statusline.py       # Statusline composition (zones, formatters) and file write
     scanners/           # Pure-Python signal collectors — one file each
       active_tickets.py

--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -49,7 +49,11 @@ _YLW=$'\033[1;33m'
 _RED=$'\033[1;31m'
 _BLU=$'\033[1;34m'
 _MAG=$'\033[1;35m'
-_DIM=$'\033[2m'
+# Labels (`model=`, `ctx=`, separators…) used to use \033[2m (dim) which is
+# unreadable on most themes. Switch to a regular light-gray that still reads
+# as "metadata" without disappearing into the background.
+_LBL=$'\033[38;5;244m'
+_DIM=$'\033[38;5;244m'
 _RST=$'\033[0m'
 _OSC8=$'\033]8;'
 _ST=$'\033\\'
@@ -80,31 +84,55 @@ osc8_link() {
     printf '%s' "${_OSC8};${1}${_ST}${2}${_OSC8};${_ST}"
 }
 
-header=""
-sep="${_DIM} | ${_RST}"
+# Visual grouping: within a group, segments are joined by a mid-dot; between
+# groups we use a vertical bar so the eye can pick out context vs usage vs
+# loops vs updates vs resource at a glance.
+isep="${_LBL} · ${_RST}"
+gsep="${_LBL} │ ${_RST}"
+sep="$gsep"   # legacy alias still used by later segments
+
+# Each `g_*` accumulates the colored content of one logical group. We join
+# groups together at the end with the outer separator.
+g_context=""
+g_usage=""
+g_loops=""
+g_updates=""
+g_resource=""
+
 if [ -n "$model" ]; then
-    header="${_DIM}model=${_RST}${_GRN}${model}${_RST}"
+    g_context="${_LBL}model=${_RST}${_GRN}${model}${_RST}"
 fi
 if [ -n "$ctx_pct" ] && [ "$ctx_pct" != "empty" ]; then
-    header="${header}${sep}${_DIM}ctx=${_RST}$(color_pct "$ctx_pct")"
+    [ -n "$g_context" ] && g_context="${g_context}${isep}"
+    g_context="${g_context}${_LBL}ctx=${_RST}$(color_pct "$ctx_pct")"
 fi
 if [ -n "$five_hour_pct" ] && [ "$five_hour_pct" != "empty" ]; then
-    header="${header}${sep}${_DIM}5h=${_RST}$(color_pct "$five_hour_pct")$(format_reset_time "$five_hour_resets_at")"
+    g_usage="${_LBL}5h=${_RST}$(color_pct "$five_hour_pct")$(format_reset_time "$five_hour_resets_at")"
 fi
 if [ -n "$seven_day_pct" ] && [ "$seven_day_pct" != "empty" ]; then
-    header="${header}${sep}${_DIM}7d=${_RST}$(color_pct "$seven_day_pct")"
+    [ -n "$g_usage" ] && g_usage="${g_usage}${isep}"
+    g_usage="${g_usage}${_LBL}7d=${_RST}$(color_pct "$seven_day_pct")"
 fi
+
+# Skills are kept aside and tacked on last (or on their own line — see below)
+# so they never push critical info off a narrow terminal.
+_skills_segment=""
+_skill_count=0
 if [ -n "$skills" ]; then
     _colored_skills=""
     for _s in $skills; do
-        [ -n "$_colored_skills" ] && _colored_skills="${_colored_skills} ${_DIM}|${_RST} "
+        # Skills already render as colored magenta tokens — a separator between
+        # them is visual noise. Use a single space.
+        [ -n "$_colored_skills" ] && _colored_skills="${_colored_skills} "
         _colored_skills="${_colored_skills}${_MAG}${_s}${_RST}"
+        _skill_count=$((_skill_count + 1))
     done
-    header="${header}${sep}${_DIM}skills:${_RST} ${_colored_skills}"
+    _skills_segment="${_LBL}skills:${_RST} ${_colored_skills}"
 fi
 
 # Active loops from CronCreate / ScheduleWakeup (written by hook_router.py)
 _crons_file="$state_dir/${session_id}.crons"
+_loops_segment=""
 if [ -n "$session_id" ] && [ -r "$_crons_file" ] && command -v jq >/dev/null 2>&1; then
     _now=${_now:-$(date +%s)}
     _loop_parts=""
@@ -113,12 +141,12 @@ if [ -n "$session_id" ] && [ -r "$_crons_file" ] && command -v jq >/dev/null 2>&
         _jcadence=$(jq -r ".jobs[\"$_jid\"].cadence // empty" "$_crons_file" 2>/dev/null)
         if [ -n "$_jcadence" ] && [ "$_jcadence" != "null" ]; then
             _jmin=$(( _jcadence / 60 ))
-            _jlabel="${_CYN}${_jname}${_RST}${_DIM}(${_jmin}m)${_RST}"
+            _jlabel="${_CYN}${_jname}${_RST}${_LBL}(${_jmin}m)${_RST}"
         else
             _jcron=$(jq -r ".jobs[\"$_jid\"].cron // empty" "$_crons_file" 2>/dev/null)
-            _jlabel="${_CYN}${_jname}${_RST}${_DIM}(${_jcron})${_RST}"
+            _jlabel="${_CYN}${_jname}${_RST}${_LBL}(${_jcron})${_RST}"
         fi
-        [ -n "$_loop_parts" ] && _loop_parts="${_loop_parts} ${_DIM}·${_RST} "
+        [ -n "$_loop_parts" ] && _loop_parts="${_loop_parts}${isep}"
         _loop_parts="${_loop_parts}${_jlabel}"
     done
     _wakeup_epoch=$(jq -r '.wakeup.next_epoch // empty' "$_crons_file" 2>/dev/null)
@@ -132,11 +160,11 @@ if [ -n "$session_id" ] && [ -r "$_crons_file" ] && command -v jq >/dev/null 2>&
         else
             _wtiming="now"
         fi
-        _wlabel="${_CYN}${_wname}${_RST}${_DIM}→${_wtiming}${_RST}"
-        [ -n "$_loop_parts" ] && _loop_parts="${_loop_parts} ${_DIM}·${_RST} "
+        _wlabel="${_CYN}${_wname}${_RST}${_LBL}→${_wtiming}${_RST}"
+        [ -n "$_loop_parts" ] && _loop_parts="${_loop_parts}${isep}"
         _loop_parts="${_loop_parts}${_wlabel}"
     fi
-    [ -n "$_loop_parts" ] && header="${header}${sep}${_DIM}loops:${_RST} ${_loop_parts}"
+    [ -n "$_loop_parts" ] && _loops_segment="${_LBL}loops:${_RST} ${_loop_parts}"
 fi
 
 # RAM usage (macOS/Linux)
@@ -152,7 +180,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         _ram_pct=$(( _ram_used * 100 / _ram_total ))
         _ram_used_gb=$(awk "BEGIN{printf \"%.1f\", $_ram_used / 1073741824}")
         _ram_total_gb=$(awk "BEGIN{printf \"%.0f\", $_ram_total / 1073741824}")
-        _ram_segment="${_DIM}ram=${_RST}$(color_pct "$_ram_pct")${_DIM} ${_ram_used_gb}/${_ram_total_gb}G${_RST}"
+        _ram_segment="${_LBL}ram=${_RST}$(color_pct "$_ram_pct")${_LBL} ${_ram_used_gb}/${_ram_total_gb}G${_RST}"
     fi
 elif [ -r /proc/meminfo ]; then
     _ram_total_kb=$(awk '/MemTotal/{print $2}' /proc/meminfo)
@@ -161,14 +189,16 @@ elif [ -r /proc/meminfo ]; then
     _ram_pct=$(( _ram_used_kb * 100 / _ram_total_kb ))
     _ram_used_gb=$(awk "BEGIN{printf \"%.1f\", $_ram_used_kb / 1048576}")
     _ram_total_gb=$(awk "BEGIN{printf \"%.0f\", $_ram_total_kb / 1048576}")
-    _ram_segment="${_DIM}ram=${_RST}$(color_pct "$_ram_pct")${_DIM} ${_ram_used_gb}/${_ram_total_gb}G${_RST}"
+    _ram_segment="${_LBL}ram=${_RST}$(color_pct "$_ram_pct")${_LBL} ${_ram_used_gb}/${_ram_total_gb}G${_RST}"
 fi
-# RAM segment is appended last (after tick countdown and freshness)
+g_resource="$_ram_segment"
 
 # Next tick countdown from tick-meta.json
 _tick_meta="${target%.txt}-meta.json"
 # Also check the canonical sidecar name written by tick.py
 [ ! -r "$_tick_meta" ] && _tick_meta="$(dirname "$target")/tick-meta.json"
+_tick_segment=""
+_freshness_segment=""
 if [ -r "$_tick_meta" ] && command -v jq >/dev/null 2>&1; then
     _next_epoch=$(jq -r '.next_epoch // empty' "$_tick_meta" 2>/dev/null)
     _tick_cadence=$(jq -r '.cadence // 720' "$_tick_meta" 2>/dev/null)
@@ -177,17 +207,16 @@ if [ -r "$_tick_meta" ] && command -v jq >/dev/null 2>&1; then
         _diff=$(( _next_epoch - _now ))
         _overdue=$(( -_diff ))
         if (( _diff > 0 && _diff < 60 )); then
-            _tick_label="${_CYN}tick${_RST}${_DIM}→${_diff}s${_RST}"
+            _tick_segment="${_CYN}tick${_RST}${_LBL}→${_diff}s${_RST}"
         elif (( _diff > 0 && _diff < 120 )); then
-            _tick_label="${_YLW}tick${_RST}${_DIM}→$(( _diff / 60 ))m${_RST}"
+            _tick_segment="${_YLW}tick${_RST}${_LBL}→$(( _diff / 60 ))m${_RST}"
         elif (( _diff > 0 )); then
-            _tick_label="${_GRN}tick${_RST}${_DIM}→$(( _diff / 60 ))m${_RST}"
+            _tick_segment="${_GRN}tick${_RST}${_LBL}→$(( _diff / 60 ))m${_RST}"
         elif (( _overdue > _tick_cadence * 2 )); then
-            _tick_label="${_RED}tick stale${_RST}"
+            _tick_segment="${_RED}tick stale${_RST}"
         else
-            _tick_label="${_CYN}tick now${_RST}"
+            _tick_segment="${_CYN}tick now${_RST}"
         fi
-        header="${header}${sep}${_tick_label}"
     fi
 
     # Repo freshness from tick-meta.json .freshness
@@ -214,24 +243,56 @@ if [ -r "$_tick_meta" ] && command -v jq >/dev/null 2>&1; then
                 elif (( _behind <= 5 )); then _fc="$_YLW"
                 else _fc="$_RED"
                 fi
-                _label="${_fc}${_repo}${_RST}${_DIM}=${_RST}${_fc}${_behind}${_RST}"
-                [ -n "$_age" ] && _label="${_label}${_DIM}(${_age})${_RST}"
+                _label="${_fc}${_repo}${_RST}${_LBL}=${_RST}${_fc}${_behind}${_RST}"
+                [ -n "$_age" ] && _label="${_label}${_LBL}(${_age})${_RST}"
             elif [ -n "$_age" ]; then
-                _label="${_DIM}${_repo}=${_age}${_RST}"
+                _label="${_LBL}${_repo}=${_age}${_RST}"
             else
                 continue
             fi
-            [ -n "$_fresh_parts" ] && _fresh_parts="${_fresh_parts} "
+            [ -n "$_fresh_parts" ] && _fresh_parts="${_fresh_parts}${isep}"
             _fresh_parts="${_fresh_parts}${_label}"
         done
-        [ -n "$_fresh_parts" ] && header="${header}${sep}${_fresh_parts}"
+        [ -n "$_fresh_parts" ] && _freshness_segment="${_fresh_parts}"
     fi
 fi
 
-# RAM last on the header line
-[ -n "$_ram_segment" ] && header="${header}${sep}${_ram_segment}"
+# Combine tick + loops into the "loops" group (operational signals).
+g_loops="$_tick_segment"
+if [ -n "$_loops_segment" ]; then
+    [ -n "$g_loops" ] && g_loops="${g_loops}${isep}${_loops_segment}" || g_loops="$_loops_segment"
+fi
+g_updates="$_freshness_segment"
+
+# Join all groups with the between-group separator.
+header=""
+for _g in g_context g_usage g_loops g_updates g_resource; do
+    _val=$(eval "printf '%s' \"\${$_g}\"")
+    [ -z "$_val" ] && continue
+    if [ -z "$header" ]; then
+        header="$_val"
+    else
+        header="${header}${gsep}${_val}"
+    fi
+done
+
+# Skills inline only when ≤ 4 are loaded — otherwise they get their own line
+# below so the main header stays readable in narrow terminals.
+_skills_on_own_line=0
+if [ -n "$_skills_segment" ]; then
+    if [ "$_skill_count" -le 4 ]; then
+        if [ -z "$header" ]; then
+            header="$_skills_segment"
+        else
+            header="${header}${gsep}${_skills_segment}"
+        fi
+    else
+        _skills_on_own_line=1
+    fi
+fi
 
 [ -n "$header" ] && printf '%s\n' "$header"
+[ "$_skills_on_own_line" = "1" ] && printf '%s\n' "$_skills_segment"
 
 if [[ -r "$target" ]]; then
     cat "$target"

--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -46,6 +46,11 @@ _STATUSLINE_ZONE_BY_KIND: dict[str, str] = {
     "assigned_issue.ready": "action_needed",
     "ticket.active": "anchors",
     "ticket.disposition_candidate": "action_needed",
+    # Reviewer-assigned PRs also dispatch to the t3:reviewer agent below,
+    # but we mirror them into the statusline so the user sees what's
+    # pending review without waiting on the agent to act.
+    "reviewer_pr.new_sha": "action_needed",
+    "reviewer_pr.unreviewed": "action_needed",
 }
 
 _PR_URL_RE = re.compile(r"https?://[^\s>|]+/(?:merge_requests|pull|pulls)/\d+")
@@ -63,6 +68,64 @@ def _slack_pr_url(signal: ScanSignal) -> str:
     return match.group(0) if match else ""
 
 
+# Reviewer signals dispatch to the agent AND mirror into the statusline so
+# the user sees the pending review before the agent acts.
+_DUAL_DISPATCH: frozenset[str] = frozenset({"reviewer_pr.new_sha", "reviewer_pr.unreviewed"})
+
+# Signal kind → (DispatchAction kind, zone) when the side-effect is a
+# fire-and-forget mechanical handler or webhook rather than an agent.
+_MECHANICAL_BY_KIND: dict[str, tuple[ActionKind, str]] = {
+    "ticket.completion_detected": ("mechanical", "ticket_completion"),
+    "ticket.reopen_needed": ("mechanical", "ticket_reopen"),
+    "notion.unrouted": ("webhook", "n8n"),
+}
+
+
+def _dispatch_one(signal: ScanSignal) -> list[DispatchAction]:
+    if signal.kind in {"slack.mention", "slack.dm"}:
+        pr_url = _slack_pr_url(signal)
+        if pr_url:
+            return [
+                DispatchAction(
+                    kind="agent",
+                    zone="t3:reviewer",
+                    detail=f"Review request: {pr_url}",
+                    payload={"url": pr_url, **signal.payload},
+                ),
+                DispatchAction(
+                    kind="statusline",
+                    zone=_STATUSLINE_ZONE_BY_KIND[signal.kind],
+                    detail=signal.summary,
+                    payload=signal.payload,
+                ),
+            ]
+    if signal.kind == "assigned_issue.ready" and signal.payload.get("auto_start") is True:
+        return [DispatchAction(kind="agent", zone="t3:orchestrator", detail=signal.summary, payload=signal.payload)]
+    agent = _AGENT_BY_KIND.get(signal.kind)
+    if agent is not None:
+        actions = [DispatchAction(kind="agent", zone=agent, detail=signal.summary, payload=signal.payload)]
+        if signal.kind in _DUAL_DISPATCH:
+            actions.append(
+                DispatchAction(
+                    kind="statusline",
+                    zone=_STATUSLINE_ZONE_BY_KIND.get(signal.kind, "in_flight"),
+                    detail=signal.summary,
+                    payload=signal.payload,
+                ),
+            )
+        return actions
+    if signal.kind == "ticket.disposition_candidate" and signal.payload.get("reason") == "issue_closed":
+        return [
+            DispatchAction(kind="mechanical", zone="ticket_disposition", detail=signal.summary, payload=signal.payload),
+        ]
+    mech = _MECHANICAL_BY_KIND.get(signal.kind)
+    if mech is not None:
+        kind, zone = mech
+        return [DispatchAction(kind=kind, zone=zone, detail=signal.summary, payload=signal.payload)]
+    zone = _STATUSLINE_ZONE_BY_KIND.get(signal.kind, "in_flight")
+    return [DispatchAction(kind="statusline", zone=zone, detail=signal.summary, payload=signal.payload)]
+
+
 def dispatch(signals: list[ScanSignal]) -> list[DispatchAction]:
     """Turn a flat list of signals into the actions the runtime should perform.
 
@@ -73,59 +136,5 @@ def dispatch(signals: list[ScanSignal]) -> list[DispatchAction]:
     """
     actions: list[DispatchAction] = []
     for signal in signals:
-        if signal.kind in {"slack.mention", "slack.dm"}:
-            pr_url = _slack_pr_url(signal)
-            if pr_url:
-                actions.append(
-                    DispatchAction(
-                        kind="agent",
-                        zone="t3:reviewer",
-                        detail=f"Review request: {pr_url}",
-                        payload={"url": pr_url, **signal.payload},
-                    ),
-                )
-        if signal.kind == "assigned_issue.ready" and signal.payload.get("auto_start") is True:
-            actions.append(
-                DispatchAction(kind="agent", zone="t3:orchestrator", detail=signal.summary, payload=signal.payload),
-            )
-            continue
-        agent = _AGENT_BY_KIND.get(signal.kind)
-        if agent is not None:
-            actions.append(DispatchAction(kind="agent", zone=agent, detail=signal.summary, payload=signal.payload))
-            continue
-        if signal.kind == "ticket.disposition_candidate" and signal.payload.get("reason") == "issue_closed":
-            actions.append(
-                DispatchAction(
-                    kind="mechanical",
-                    zone="ticket_disposition",
-                    detail=signal.summary,
-                    payload=signal.payload,
-                ),
-            )
-            continue
-        if signal.kind == "ticket.completion_detected":
-            actions.append(
-                DispatchAction(
-                    kind="mechanical",
-                    zone="ticket_completion",
-                    detail=signal.summary,
-                    payload=signal.payload,
-                ),
-            )
-            continue
-        if signal.kind == "ticket.reopen_needed":
-            actions.append(
-                DispatchAction(
-                    kind="mechanical",
-                    zone="ticket_reopen",
-                    detail=signal.summary,
-                    payload=signal.payload,
-                ),
-            )
-            continue
-        if signal.kind == "notion.unrouted":
-            actions.append(DispatchAction(kind="webhook", zone="n8n", detail=signal.summary, payload=signal.payload))
-            continue
-        zone = _STATUSLINE_ZONE_BY_KIND.get(signal.kind, "in_flight")
-        actions.append(DispatchAction(kind="statusline", zone=zone, detail=signal.summary, payload=signal.payload))
+        actions.extend(_dispatch_one(signal))
     return actions

--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -1,0 +1,354 @@
+"""Render dispatched actions into statusline zones.
+
+Split out of :mod:`teatree.loop.tick` so each module owns one concern: tick is
+the orchestrator (scan → dispatch → render), rendering is the formatter
+(classify actions per overlay, render anchor / action_needed / in_flight rows
+with OSC8 links, filter stale anchors).
+"""
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from teatree.loop.dispatch import DispatchAction
+from teatree.loop.statusline import StatuslineEntry, StatuslineZones, _hyperlink
+
+# DispatchAction payloads are `dict[str, Any]` by contract (see dispatch.py).
+# Renderer-side reads only ever look up scalar fields, so we narrow to
+# Mapping[str, Any] at the function signatures to keep the module health
+# gate happy without inventing a TypedDict per signal shape.
+type Payload = Mapping[str, Any]
+
+_DISPOSITION_LABELS: dict[str, str] = {
+    "issue_closed": "closed",
+    "unassigned": "reassigned",
+    "label_removed": "label-removed",
+}
+
+
+def _is_url(text: object) -> bool:
+    return isinstance(text, str) and text.startswith(("http://", "https://"))
+
+
+def _link(text: str, url: object) -> str:
+    if isinstance(url, str) and url.startswith(("http://", "https://")):
+        return _hyperlink(text, url)
+    return text
+
+
+@dataclass(frozen=True, slots=True)
+class _PRRef:
+    iid: int
+    url: str
+    annotation: str
+
+
+@dataclass(frozen=True, slots=True)
+class _IssueRef:
+    label: str
+    url: str
+
+
+def _pr_ref(action: DispatchAction) -> _PRRef | None:
+    payload = action.payload if isinstance(action.payload, dict) else {}
+    iid = payload.get("iid")
+    if not isinstance(iid, int) or iid == 0:
+        return None
+    url = payload.get("url", "")
+    draft_count = payload.get("draft_count")
+    status = payload.get("status", "")
+    if isinstance(draft_count, int) and draft_count > 0:
+        return _PRRef(iid=iid, url=url, annotation=f"{draft_count} notes")
+    if status in {"failed", "failure", "error"}:
+        return _PRRef(iid=iid, url=url, annotation=f"pipeline {status}")
+    return _PRRef(iid=iid, url=url, annotation="")
+
+
+def _ticket_number_from_url(url: str) -> str:
+    match = re.search(r"(\d+)(?:/?)$", url)
+    return match.group(1) if match else ""
+
+
+def _render_pr_group(overlay: str, refs: list[_PRRef], *, ticket_index: dict[str, str] | None = None) -> str:
+    """Render a flat list of PR refs, grouped per parent ticket when known."""
+    prefix = f"[{overlay}] " if overlay else ""
+    if not refs:
+        return ""
+    by_ticket: dict[str, list[_PRRef]] = {}
+    orphans: list[_PRRef] = []
+    for ref in refs:
+        parent = (ticket_index or {}).get(ref.url, "")
+        if parent and parent != str(ref.iid):
+            by_ticket.setdefault(parent, []).append(ref)
+        else:
+            orphans.append(ref)
+
+    def _label(ref: _PRRef) -> str:
+        text = f"!{ref.iid}"
+        if ref.annotation:
+            text += f" ({ref.annotation})"
+        return _link(text, ref.url)
+
+    chunks: list[str] = []
+    for tnum in sorted(by_ticket):
+        bucket = " ".join(_label(r) for r in by_ticket[tnum])
+        chunks.append(f"#{tnum}: {bucket}")
+    if orphans:
+        chunks.append(" · ".join(_label(r) for r in orphans))
+    return f"{prefix}{' · '.join(chunks)}"
+
+
+@dataclass(slots=True)
+class _ClassifiedActions:
+    disposition_refs: dict[str, dict[str, list[_IssueRef]]] = field(default_factory=dict)
+    ready_refs: dict[str, list[_IssueRef]] = field(default_factory=dict)
+    action_prs: dict[str, list[_PRRef]] = field(default_factory=dict)
+    inflight_prs: dict[str, list[_PRRef]] = field(default_factory=dict)
+    active_tickets: dict[str, list[tuple[str, str, str]]] = field(default_factory=dict)
+    other: list[tuple[str, StatuslineEntry]] = field(default_factory=list)
+
+
+_TITLE_FALLBACK_LEN = 32
+
+
+def _issue_ref_from(
+    *,
+    url: str = "",
+    issue_url: str = "",
+    ticket_number: str = "",
+    title: str = "",
+) -> _IssueRef:
+    # Dispositions emit ``issue_url``; my-pr and ready emit ``url``. Honour
+    # whichever the source provided so the renderer never collapses a real
+    # ticket into a bare ``?`` token. Falls back to ``ticket_number`` or a
+    # title slug when no usable URL is available.
+    url_str = url or issue_url
+    number = _ticket_number_from_url(url_str)
+    if number:
+        return _IssueRef(label=f"#{number}", url=url_str)
+    if ticket_number:
+        return _IssueRef(label=f"#{ticket_number}", url=url_str if _is_url(url_str) else "")
+    if title:
+        snippet = title if len(title) <= _TITLE_FALLBACK_LEN else title[: _TITLE_FALLBACK_LEN - 3] + "…"
+        return _IssueRef(label=snippet, url=url_str)
+    return _IssueRef(label="?", url=url_str)
+
+
+def _str_field(payload: Payload, key: str) -> str:
+    value = payload.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _classify_actions(actions: list[DispatchAction]) -> _ClassifiedActions:
+    c = _ClassifiedActions()
+    for action in actions:
+        payload = action.payload if isinstance(action.payload, dict) else {}
+        url_str = _str_field(payload, "url")
+        overlay = _str_field(payload, "overlay")
+        prefix = f"[{overlay}] " if overlay else ""
+
+        if action.kind != "statusline":
+            continue
+        state = payload.get("state")
+        ticket_number = payload.get("ticket_number")
+        if action.zone == "anchors" and isinstance(state, str) and isinstance(ticket_number, str):
+            issue_url = _str_field(payload, "issue_url")
+            c.active_tickets.setdefault(overlay, []).append((ticket_number, state, issue_url))
+            continue
+        reason = payload.get("reason")
+        if isinstance(reason, str):
+            ref = _issue_ref_from(
+                url=_str_field(payload, "url"),
+                issue_url=_str_field(payload, "issue_url"),
+                ticket_number=_str_field(payload, "ticket_number"),
+                title=_str_field(payload, "title"),
+            )
+            c.disposition_refs.setdefault(overlay, {}).setdefault(reason, []).append(ref)
+            continue
+        if action.zone == "action_needed" and action.detail.startswith("Ready to start:"):
+            c.ready_refs.setdefault(overlay, []).append(
+                _issue_ref_from(
+                    url=_str_field(payload, "url"),
+                    issue_url=_str_field(payload, "issue_url"),
+                    ticket_number=_str_field(payload, "ticket_number"),
+                    title=_str_field(payload, "title"),
+                ),
+            )
+            continue
+        ref = _pr_ref(action)
+        if ref is not None:
+            bucket = c.action_prs if action.zone == "action_needed" else c.inflight_prs
+            bucket.setdefault(overlay, []).append(ref)
+            continue
+        c.other.append((action.zone, StatuslineEntry(text=f"{prefix}{action.detail}", url=url_str)))
+    return c
+
+
+# States that should not surface as anchors: terminal/post-PR states plus
+# ``closed`` which isn't a valid FSM value but turns up in old data.
+_NOISE_STATES = frozenset(
+    {
+        "not_started",
+        "merged",
+        "delivered",
+        "shipped",
+        "in_review",
+        "retrospected",
+        "closed",
+    },
+)
+_MAX_PER_STATE = 5
+
+# Tickets whose ``issue_url`` matches one of these are treated as PR-backed.
+# A PR-backed ticket that doesn't appear in the live PR set (action_needed
+# or in_flight) is considered stale — its remote MR has likely been merged
+# or closed but the local FSM never advanced.
+_PR_URL_RE = re.compile(r"/(?:merge_requests|pull|pulls)/\d+/?$")
+
+
+def _is_pr_url(url: str) -> bool:
+    return bool(_is_url(url) and _PR_URL_RE.search(url))
+
+
+def _render_ticket_line(
+    overlay: str,
+    tickets: list[tuple[str, str, str]],
+    pr_map: dict[str, list[_PRRef]],
+    *,
+    live_pr_urls: set[str] | None = None,
+) -> str:
+    prefix = f"[{overlay}] " if overlay else ""
+    live = live_pr_urls or set()
+    by_state: dict[str, list[str]] = {}
+    for num, state, url in tickets:
+        if state in _NOISE_STATES:
+            continue
+        if _is_pr_url(url) and url not in live:
+            continue
+        ticket_text = _link(f"#{num}", url)
+        prs = pr_map.get(num, [])
+        if prs:
+            pr_parts = [_link(f"!{r.iid}", r.url) for r in prs]
+            ticket_text += f" ({' '.join(pr_parts)})"
+        by_state.setdefault(state, []).append(ticket_text)
+    if not by_state:
+        return ""
+    groups: list[str] = []
+    for state, items in by_state.items():
+        shown = items[:_MAX_PER_STATE]
+        overflow = len(items) - len(shown)
+        label = " ".join(shown)
+        if overflow > 0:
+            label += f" (+{overflow})"
+        groups.append(f"{state}: {label}")
+    return f"{prefix}{' · '.join(groups)}"
+
+
+def _render_action_line(
+    overlay: str,
+    *,
+    pr_refs: list[_PRRef],
+    disposition_refs: dict[str, list[_IssueRef]],
+    ready_refs: list[_IssueRef],
+    ticket_index: dict[str, str] | None = None,
+) -> str:
+    prefix = f"[{overlay}] " if overlay else ""
+    parts: list[str] = []
+    if pr_refs:
+        parts.append(_render_pr_group(overlay, pr_refs, ticket_index=ticket_index).removeprefix(prefix))
+    for reason, refs in disposition_refs.items():
+        label = _DISPOSITION_LABELS.get(reason, reason)
+        items = " ".join(_link(r.label, r.url) for r in refs)
+        parts.append(f"{label}: {items}")
+    if ready_refs:
+        items = " ".join(_link(r.label, r.url) for r in ready_refs)
+        parts.append(f"ready: {items}")
+    if not parts:
+        return ""
+    return f"{prefix}{' · '.join(parts)}"
+
+
+def _running_tasks_lines() -> list[str]:
+    from django.apps import apps  # noqa: PLC0415
+
+    try:
+        task_model = apps.get_model("core", "Task")
+        claimed = (
+            task_model.objects.filter(status="claimed")
+            .select_related("ticket")
+            .only("phase", "ticket__overlay", "ticket__issue_url")
+        )
+        by_overlay: dict[str, list[str]] = {}
+        for task in claimed:
+            overlay = task.ticket.overlay or ""
+            by_overlay.setdefault(overlay, []).append(task.phase)
+    except Exception:  # noqa: BLE001
+        return []
+    lines: list[str] = []
+    for overlay, phases in sorted(by_overlay.items()):
+        prefix = f"[{overlay}] " if overlay else ""
+        lines.append(f"{prefix}agents: {' · '.join(phases)}")
+    return lines
+
+
+def _populate_overlay_zones(zones: StatuslineZones, c: _ClassifiedActions) -> None:
+    all_overlays = sorted({*c.active_tickets, *c.action_prs, *c.disposition_refs, *c.ready_refs, *c.inflight_prs})
+
+    all_pr_refs: dict[str, dict[str, list[_PRRef]]] = {}
+    for overlay_key in all_overlays:
+        for refs in (c.action_prs.get(overlay_key, []), c.inflight_prs.get(overlay_key, [])):
+            for ref in refs:
+                all_pr_refs.setdefault(overlay_key, {}).setdefault(str(ref.iid), []).append(ref)
+
+    ticket_index_by_overlay: dict[str, dict[str, str]] = {
+        overlay_key: {url: num for num, _state, url in anchors if _is_url(url)}
+        for overlay_key, anchors in c.active_tickets.items()
+    }
+
+    live_pr_urls_by_overlay: dict[str, set[str]] = {}
+    for overlay_key in all_overlays:
+        live = {r.url for r in c.action_prs.get(overlay_key, []) if r.url}
+        live |= {r.url for r in c.inflight_prs.get(overlay_key, []) if r.url}
+        live_pr_urls_by_overlay[overlay_key] = live
+
+    for overlay_key in all_overlays:
+        pr_map = all_pr_refs.get(overlay_key, {})
+        ticket_index = ticket_index_by_overlay.get(overlay_key, {})
+        ticket_line = _render_ticket_line(
+            overlay_key,
+            c.active_tickets.get(overlay_key, []),
+            pr_map,
+            live_pr_urls=live_pr_urls_by_overlay.get(overlay_key, set()),
+        )
+        if ticket_line:
+            zones.anchors.append(ticket_line)
+
+        action_line = _render_action_line(
+            overlay_key,
+            pr_refs=c.action_prs.get(overlay_key, []),
+            disposition_refs=c.disposition_refs.get(overlay_key, {}),
+            ready_refs=c.ready_refs.get(overlay_key, []),
+            ticket_index=ticket_index,
+        )
+        if action_line:
+            zones.action_needed.append(action_line)
+
+        inflight_refs = c.inflight_prs.get(overlay_key, [])
+        if inflight_refs:
+            zones.in_flight.append(_render_pr_group(overlay_key, inflight_refs, ticket_index=ticket_index))
+
+
+def zones_for(actions: list[DispatchAction]) -> StatuslineZones:
+    zones = StatuslineZones()
+    c = _classify_actions(actions)
+    _populate_overlay_zones(zones, c)
+
+    for zone_name, entry in c.other:
+        zone_list = getattr(zones, zone_name, None)
+        if isinstance(zone_list, list):
+            zone_list.append(entry)
+
+    zones.in_flight.extend(_running_tasks_lines())
+
+    return zones

--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -52,10 +52,18 @@ class _IssueRef:
 
 def _pr_ref(action: DispatchAction) -> _PRRef | None:
     payload = action.payload if isinstance(action.payload, dict) else {}
+    url = payload.get("url", "")
     iid = payload.get("iid")
     if not isinstance(iid, int) or iid == 0:
+        # Reviewer-pr signals don't ship `iid` in the payload but the MR URL
+        # ends with the numeric ref — derive it so the row renders as `!N`
+        # under the right overlay. Other signal kinds still fall through
+        # without an iid (rendered as a generic line).
+        if action.detail.startswith("Review needed:") and isinstance(url, str):
+            tail = _ticket_number_from_url(url)
+            if tail.isdigit():
+                return _PRRef(iid=int(tail), url=url, annotation="review")
         return None
-    url = payload.get("url", "")
     draft_count = payload.get("draft_count")
     status = payload.get("status", "")
     if isinstance(draft_count, int) and draft_count > 0:

--- a/src/teatree/loop/scanners/ticket_dispositions.py
+++ b/src/teatree/loop/scanners/ticket_dispositions.py
@@ -127,6 +127,7 @@ class TicketDispositionScanner:
                     summary=f"Ticket {ticket.ticket_number} — {reason}",
                     payload={
                         "ticket_id": ticket.pk,
+                        "ticket_number": ticket.ticket_number,
                         "ticket_state": ticket.state,
                         "issue_url": ticket.issue_url,
                         "reason": reason,

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -8,7 +9,9 @@ from pathlib import Path
 # the ``NO_COLOR`` standard (https://no-color.org/) by passing
 # ``colorize=False`` to :func:`render`.
 _ANSI_RESET = "\033[0m"
-_ANSI_DIM = "\033[2;37m"
+# 256-color light gray reads better than legacy DIM (``\033[2m``) on most
+# themes — DIM is essentially invisible on dark backgrounds with low contrast.
+_ANSI_DIM = "\033[38;5;244m"
 _ANSI_RED = "\033[1;31m"
 _ANSI_YELLOW = "\033[1;33m"
 _ANSI_CYAN = "\033[1;36m"
@@ -20,11 +23,11 @@ _ZONE_COLORS: dict[str, str] = {
     "in_flight": _ANSI_CYAN,
 }
 
-_ZONE_HEADERS: dict[str, str] = {
-    "anchors": "",
-    "action_needed": "Action needed:",
-    "in_flight": "In flight:",
-}
+# Zone-level "Action needed:" / "In flight:" headers used to live above each
+# block but color (red/cyan) already carries that meaning — the legend at the
+# bottom of :func:`render` makes the contract explicit without using a line
+# of vertical space per zone.
+_OVERLAY_PREFIX_RE = re.compile(r"^\[([^\]]+)\] ")
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,15 +75,42 @@ def _format_item(item: ZoneItem, color: str, *, colorize: bool) -> str:
     return text
 
 
-def _format_header(name: str, *, colorize: bool) -> str:
-    header = _ZONE_HEADERS[name]
-    if not header:
-        return ""
-    return f"{_ANSI_BOLD}{header}{_ANSI_RESET}" if colorize else header
+def _overlay_of(item: ZoneItem) -> str:
+    """Pull the ``[ov]`` prefix from a line, or return '' when there is none.
+
+    Each renderer in :mod:`teatree.loop.tick` prefixes its lines with
+    ``[ov] …`` so we can group all of an overlay's anchors / action / in-flight
+    rows together by reading the prefix back here.
+    """
+    text = item.text if isinstance(item, StatuslineEntry) else item
+    match = _OVERLAY_PREFIX_RE.match(text)
+    return match.group(1) if match else ""
+
+
+def _legend(*, colorize: bool) -> str:
+    """One-line color legend printed at the bottom of the statusline.
+
+    Replaces the per-zone "Action needed:" / "In flight:" headers — color
+    already carries that signal, the legend just makes the contract explicit.
+    """
+    if not colorize:
+        return "legend: dim=tracked · red=action · cyan=in-flight"
+    return (
+        f"{_ANSI_DIM}legend:{_ANSI_RESET} "
+        f"{_ANSI_DIM}dim=tracked{_ANSI_RESET} · "
+        f"{_ANSI_RED}red=action{_ANSI_RESET} · "
+        f"{_ANSI_CYAN}cyan=in-flight{_ANSI_RESET}"
+    )
 
 
 def render(zones: StatuslineZones, *, target: Path | None = None, colorize: bool | None = None) -> Path:
     """Atomically write *zones* to *target* (or the default path).
+
+    Output is grouped by overlay rather than by zone — each ``[ov]`` block
+    shows its anchors (dim), action-needed rows (red), and in-flight rows
+    (cyan) consecutively. A single legend line at the end documents the
+    color contract so the per-zone "Action needed:" / "In flight:" headers
+    are no longer needed.
 
     *colorize* defaults to ``True`` unless the ``NO_COLOR`` environment
     variable is set. Tests can pass ``colorize=False`` to assert plain
@@ -91,17 +121,31 @@ def render(zones: StatuslineZones, *, target: Path | None = None, colorize: bool
     if colorize is None:
         colorize = "NO_COLOR" not in os.environ
 
-    sections: list[str] = []
+    # Group every line by its [overlay] prefix, preserving insertion order.
+    by_overlay: dict[str, dict[str, list[ZoneItem]]] = {}
+    order: list[str] = []
     for name in ("anchors", "action_needed", "in_flight"):
-        items: list[ZoneItem] = getattr(zones, name)
-        if not items:
-            continue
-        color = _ZONE_COLORS.get(name, "")
-        rendered = "\n".join(_format_item(item, color, colorize=colorize) for item in items)
-        header = _format_header(name, colorize=colorize)
-        sections.append(f"{header}\n{rendered}" if header else rendered)
+        for item in getattr(zones, name):
+            overlay = _overlay_of(item)
+            if overlay not in by_overlay:
+                by_overlay[overlay] = {"anchors": [], "action_needed": [], "in_flight": []}
+                order.append(overlay)
+            by_overlay[overlay][name].append(item)
 
-    body = "\n\n".join(sections) + "\n"
+    sections: list[str] = []
+    for overlay in order:
+        lines: list[str] = []
+        for name in ("anchors", "action_needed", "in_flight"):
+            color = _ZONE_COLORS.get(name, "")
+            lines.extend(_format_item(item, color, colorize=colorize) for item in by_overlay[overlay][name])
+        if lines:
+            sections.append("\n".join(lines))
+
+    has_content = bool(sections)
+    body_parts = list(sections)
+    if has_content:
+        body_parts.append(_legend(colorize=colorize))
+    body = ("\n\n".join(body_parts) + "\n") if body_parts else ""
 
     fd, tmp_str = tempfile.mkstemp(prefix=".statusline-", suffix=".tmp", dir=str(target.parent))
     tmp_path = Path(tmp_str)

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -87,30 +87,13 @@ def _overlay_of(item: ZoneItem) -> str:
     return match.group(1) if match else ""
 
 
-def _legend(*, colorize: bool) -> str:
-    """One-line color legend printed at the bottom of the statusline.
-
-    Replaces the per-zone "Action needed:" / "In flight:" headers — color
-    already carries that signal, the legend just makes the contract explicit.
-    """
-    if not colorize:
-        return "legend: dim=tracked · red=action · cyan=in-flight"
-    return (
-        f"{_ANSI_DIM}legend:{_ANSI_RESET} "
-        f"{_ANSI_DIM}dim=tracked{_ANSI_RESET} · "
-        f"{_ANSI_RED}red=action{_ANSI_RESET} · "
-        f"{_ANSI_CYAN}cyan=in-flight{_ANSI_RESET}"
-    )
-
-
 def render(zones: StatuslineZones, *, target: Path | None = None, colorize: bool | None = None) -> Path:
     """Atomically write *zones* to *target* (or the default path).
 
     Output is grouped by overlay rather than by zone — each ``[ov]`` block
     shows its anchors (dim), action-needed rows (red), and in-flight rows
-    (cyan) consecutively. A single legend line at the end documents the
-    color contract so the per-zone "Action needed:" / "In flight:" headers
-    are no longer needed.
+    (cyan) consecutively. The per-zone "Action needed:" / "In flight:"
+    headers are gone — color carries the signal.
 
     *colorize* defaults to ``True`` unless the ``NO_COLOR`` environment
     variable is set. Tests can pass ``colorize=False`` to assert plain
@@ -141,11 +124,7 @@ def render(zones: StatuslineZones, *, target: Path | None = None, colorize: bool
         if lines:
             sections.append("\n".join(lines))
 
-    has_content = bool(sections)
-    body_parts = list(sections)
-    if has_content:
-        body_parts.append(_legend(colorize=colorize))
-    body = ("\n\n".join(body_parts) + "\n") if body_parts else ""
+    body = ("\n\n".join(sections) + "\n") if sections else ""
 
     fd, tmp_str = tempfile.mkstemp(prefix=".statusline-", suffix=".tmp", dir=str(target.parent))
     tmp_path = Path(tmp_str)

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from teatree.backends.protocols import CodeHostBackend, MessagingBackend
 from teatree.core.backend_factory import OverlayBackends
 from teatree.loop.dispatch import DispatchAction, dispatch
+from teatree.loop.rendering import zones_for
 from teatree.loop.scanners import (
     ActiveTicketsScanner,
     AssignedIssuesScanner,
@@ -31,7 +32,7 @@ from teatree.loop.scanners import (
 )
 from teatree.loop.scanners.base import ScanSignal
 from teatree.loop.scanners.notion_view import NotionLike
-from teatree.loop.statusline import StatuslineEntry, StatuslineZones, _hyperlink, render
+from teatree.loop.statusline import StatuslineZones, render
 
 logger = logging.getLogger(__name__)
 
@@ -204,230 +205,6 @@ def build_default_scanners(
     ]
 
 
-_DISPOSITION_LABELS: dict[str, str] = {
-    "issue_closed": "closed issues",
-    "unassigned": "reassigned away",
-    "label_removed": "ready-label removed",
-}
-
-
-@dataclass(frozen=True, slots=True)
-class _PRRef:
-    iid: int
-    url: str
-    annotation: str
-
-
-def _pr_ref(action: DispatchAction) -> _PRRef | None:
-    payload = action.payload if isinstance(action.payload, dict) else {}
-    iid = payload.get("iid")
-    if not isinstance(iid, int) or iid == 0:
-        return None
-    url = payload.get("url", "")
-    draft_count = payload.get("draft_count")
-    status = payload.get("status", "")
-    if isinstance(draft_count, int) and draft_count > 0:
-        return _PRRef(iid=iid, url=url, annotation=f"{draft_count} notes")
-    if status in {"failed", "failure", "error"}:
-        return _PRRef(iid=iid, url=url, annotation=f"pipeline {status}")
-    return _PRRef(iid=iid, url=url, annotation="")
-
-
-def _render_pr_group(overlay: str, refs: list[_PRRef]) -> str:
-    prefix = f"[{overlay}] " if overlay else ""
-    parts: list[str] = []
-    for ref in refs:
-        label = f"!{ref.iid}"
-        if ref.annotation:
-            label += f" ({ref.annotation})"
-        parts.append(_hyperlink(label, ref.url) if ref.url else label)
-    return f"{prefix}{' · '.join(parts)}"
-
-
-@dataclass(slots=True)
-class _ClassifiedActions:
-    disposition_counts: dict[str, dict[str, int]] = field(default_factory=dict)
-    ready_counts: dict[str, int] = field(default_factory=dict)
-    action_prs: dict[str, list[_PRRef]] = field(default_factory=dict)
-    inflight_prs: dict[str, list[_PRRef]] = field(default_factory=dict)
-    active_tickets: dict[str, list[tuple[str, str, str]]] = field(default_factory=dict)
-    other: list[tuple[str, StatuslineEntry]] = field(default_factory=list)
-
-
-def _classify_actions(actions: list[DispatchAction]) -> _ClassifiedActions:
-    c = _ClassifiedActions()
-    for action in actions:
-        payload = action.payload if isinstance(action.payload, dict) else {}
-        url_str = payload.get("url", "") if isinstance(payload.get("url"), str) else ""
-        overlay = payload.get("overlay", "") if isinstance(payload.get("overlay"), str) else ""
-        prefix = f"[{overlay}] " if overlay else ""
-
-        if action.kind == "statusline":
-            state = payload.get("state")
-            ticket_number = payload.get("ticket_number")
-            if action.zone == "anchors" and isinstance(state, str) and isinstance(ticket_number, str):
-                issue_url = payload.get("issue_url", "")
-                if not isinstance(issue_url, str):
-                    issue_url = ""
-                c.active_tickets.setdefault(overlay, []).append((ticket_number, state, issue_url))
-            elif isinstance((reason := payload.get("reason")), str):
-                c.disposition_counts.setdefault(overlay, {}).setdefault(reason, 0)
-                c.disposition_counts[overlay][reason] += 1
-            elif action.zone == "action_needed" and action.detail.startswith("Ready to start:"):
-                c.ready_counts[overlay] = c.ready_counts.get(overlay, 0) + 1
-            elif (ref := _pr_ref(action)) is not None:
-                bucket = c.action_prs if action.zone == "action_needed" else c.inflight_prs
-                bucket.setdefault(overlay, []).append(ref)
-            else:
-                c.other.append((action.zone, StatuslineEntry(text=f"{prefix}{action.detail}", url=url_str)))
-        elif action.kind in {"mechanical", "agent", "webhook"}:
-            pass
-    return c
-
-
-_NOISE_STATES = frozenset(
-    {
-        "not_started",
-        "merged",
-        "delivered",
-        "shipped",
-        "in_review",
-        "retrospected",
-    }
-)
-_MAX_PER_STATE = 5
-
-
-def _render_ticket_line(
-    overlay: str,
-    tickets: list[tuple[str, str, str]],
-    pr_map: dict[str, list[_PRRef]],
-) -> str:
-    """One compact line per overlay with inline hyperlinks.
-
-    Format: ``[ov] started: #1 (!5) #2 · coded: #3``
-    Each ``#N`` is an OSC8 hyperlink when an issue URL is available.
-    """
-    prefix = f"[{overlay}] " if overlay else ""
-    by_state: dict[str, list[str]] = {}
-    for num, state, url in tickets:
-        if state in _NOISE_STATES:
-            continue
-        ticket_text = f"#{num}"
-        if url:
-            ticket_text = _hyperlink(ticket_text, url)
-        prs = pr_map.get(num, [])
-        if prs:
-            pr_parts = []
-            for r in prs:
-                pr_text = f"!{r.iid}"
-                if r.url:
-                    pr_text = _hyperlink(pr_text, r.url)
-                pr_parts.append(pr_text)
-            ticket_text += f" ({' '.join(pr_parts)})"
-        by_state.setdefault(state, []).append(ticket_text)
-    if not by_state:
-        return ""
-    groups: list[str] = []
-    for state, items in by_state.items():
-        shown = items[:_MAX_PER_STATE]
-        overflow = len(items) - len(shown)
-        label = " ".join(shown)
-        if overflow > 0:
-            label += f" (+{overflow})"
-        groups.append(f"{state}: {label}")
-    return f"{prefix}{' · '.join(groups)}"
-
-
-def _render_action_line(
-    overlay: str,
-    *,
-    pr_refs: list[_PRRef],
-    disposition_counts: dict[str, int],
-    ready_count: int,
-) -> str:
-    """One compact action-needed line per overlay."""
-    prefix = f"[{overlay}] " if overlay else ""
-    parts: list[str] = []
-    if pr_refs:
-        parts.append(_render_pr_group(overlay, pr_refs).removeprefix(f"[{overlay}] "))
-    for reason, count in disposition_counts.items():
-        parts.append(f"{count} {_DISPOSITION_LABELS.get(reason, reason)}")
-    if ready_count:
-        parts.append(f"{ready_count} ready to start")
-    if not parts:
-        return ""
-    return f"{prefix}{' · '.join(parts)}"
-
-
-def _running_tasks_lines() -> list[str]:
-    """Query claimed tasks from the DB and render one line per overlay."""
-    from django.apps import apps  # noqa: PLC0415
-
-    try:
-        task_model = apps.get_model("core", "Task")
-        claimed = (
-            task_model.objects.filter(status="claimed")
-            .select_related("ticket")
-            .only("phase", "ticket__overlay", "ticket__issue_url")
-        )
-        by_overlay: dict[str, list[str]] = {}
-        for task in claimed:
-            overlay = task.ticket.overlay or ""
-            by_overlay.setdefault(overlay, []).append(task.phase)
-    except Exception:  # noqa: BLE001
-        return []
-    lines: list[str] = []
-    for overlay, phases in sorted(by_overlay.items()):
-        prefix = f"[{overlay}] " if overlay else ""
-        lines.append(f"{prefix}agents: {' · '.join(phases)}")
-    return lines
-
-
-def _populate_overlay_zones(zones: StatuslineZones, c: _ClassifiedActions) -> None:
-    all_overlays = sorted({*c.active_tickets, *c.action_prs, *c.disposition_counts, *c.ready_counts, *c.inflight_prs})
-
-    all_pr_refs: dict[str, dict[str, list[_PRRef]]] = {}
-    for overlay_key in all_overlays:
-        for refs in (c.action_prs.get(overlay_key, []), c.inflight_prs.get(overlay_key, [])):
-            for ref in refs:
-                all_pr_refs.setdefault(overlay_key, {}).setdefault(str(ref.iid), []).append(ref)
-
-    for overlay_key in all_overlays:
-        pr_map = all_pr_refs.get(overlay_key, {})
-        ticket_line = _render_ticket_line(overlay_key, c.active_tickets.get(overlay_key, []), pr_map)
-        if ticket_line:
-            zones.anchors.append(ticket_line)
-
-        action_line = _render_action_line(
-            overlay_key,
-            pr_refs=c.action_prs.get(overlay_key, []),
-            disposition_counts=c.disposition_counts.get(overlay_key, {}),
-            ready_count=c.ready_counts.get(overlay_key, 0),
-        )
-        if action_line:
-            zones.action_needed.append(action_line)
-
-        inflight_refs = c.inflight_prs.get(overlay_key, [])
-        if inflight_refs:
-            zones.in_flight.append(_render_pr_group(overlay_key, inflight_refs))
-
-
-def _zones_for(actions: list[DispatchAction]) -> StatuslineZones:
-    zones = StatuslineZones()
-    c = _classify_actions(actions)
-    _populate_overlay_zones(zones, c)
-
-    for zone_name, entry in c.other:
-        zone_list = getattr(zones, zone_name, None)
-        if isinstance(zone_list, list):
-            zone_list.append(entry)
-
-    zones.in_flight.extend(_running_tasks_lines())
-
-    return zones
-
-
 def run_tick(
     request: TickRequest | None = None,
     *,
@@ -476,7 +253,7 @@ def run_tick(
     report.actions = dispatch(report.signals)
     _execute_mechanical(report)
 
-    zones = _zones_for(report.actions)
+    zones = zones_for(report.actions)
     _write_tick_meta(started_at, target=statusline_path)
     if report.errors:
         zones.action_needed.append(f"scanner errors: {', '.join(report.errors)}")
@@ -549,13 +326,47 @@ def _repos_from_toml() -> dict[str, Path]:
     return repos
 
 
+def _canonical_overlay_names() -> dict[str, str]:
+    """Map raw ``~/.teatree.toml`` overlay keys to canonical overlay names.
+
+    The toml entry ``[overlays.teatree]`` corresponds to the canonical
+    overlay name ``t3-teatree`` — without this mapping the freshness segment
+    would label as ``teatree=0`` even though the rest of the statusline tags
+    its rows as ``[t3-teatree]``.
+    """
+    try:
+        from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return {}
+    canonical = list(get_all_overlays().keys())
+    toml_path = Path.home() / ".teatree.toml"
+    if not toml_path.is_file():
+        return {}
+    try:
+        data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError:
+        return {}
+    mapping: dict[str, str] = {}
+    for raw_key in data.get("overlays") or {}:
+        if raw_key in canonical:
+            continue
+        for cname in canonical:
+            if cname == raw_key or cname.endswith((f"-{raw_key}", raw_key)):
+                mapping[raw_key] = cname
+                break
+    return mapping
+
+
 def _collect_repo_freshness() -> dict[str, dict[str, int | str]]:
     repos: dict[str, Path] = {}
     t3_repo = os.environ.get("T3_REPO")
     if t3_repo:
         repos["t3"] = Path(t3_repo).expanduser()
     repos.update(_repos_from_toml())
-    return {label: info for label, path in repos.items() if (info := _repo_freshness(path)) is not None}
+    aliases = _canonical_overlay_names()
+    return {
+        aliases.get(label, label): info for label, path in repos.items() if (info := _repo_freshness(path)) is not None
+    }
 
 
 def _write_tick_meta(started_at: dt.datetime, *, target: Path | None = None) -> None:

--- a/tests/teatree_loop/test_statusline.py
+++ b/tests/teatree_loop/test_statusline.py
@@ -43,8 +43,10 @@ class TestStatuslineRender:
 
         content = target.read_text()
         assert "overlay=teatree" in content
-        assert "Action" not in content
-        assert "In flight" not in content
+        # The "Action needed:" / "In flight:" zone headers were removed once
+        # color became the signal — only the legend at the bottom names them.
+        assert "Action needed:" not in content
+        assert "In flight:" not in content
 
     def test_creates_parent_directory(self, tmp_path: Path) -> None:
         target = tmp_path / "deep" / "nested" / "statusline.txt"
@@ -53,7 +55,11 @@ class TestStatuslineRender:
         render(zones, target=target, colorize=False)
 
         assert target.exists()
-        assert target.read_text().strip() == "x"
+        # Content now includes a legend line below the zones — verify both the
+        # zone content and the legend made it through atomically.
+        body = target.read_text()
+        assert body.startswith("x\n")
+        assert "legend:" in body
 
     def test_overwrites_previous_content(self, tmp_path: Path) -> None:
         target = tmp_path / "statusline.txt"
@@ -138,7 +144,9 @@ class TestStatuslineColors:
         render(zones, target=target, colorize=True)
         content = target.read_text()
 
-        assert "\033[2;37m" in content  # dim for anchors
+        # Light-gray 256-color for anchors (replaces legacy dim `\033[2;37m`,
+        # which is unreadable on dark themes).
+        assert "\033[38;5;244m" in content  # dim/gray for anchors
         assert "\033[1;31m" in content  # red for action_needed
         assert "\033[1;36m" in content  # cyan for in_flight
         assert "\033[0m" in content  # reset after each line

--- a/tests/teatree_loop/test_statusline.py
+++ b/tests/teatree_loop/test_statusline.py
@@ -43,10 +43,11 @@ class TestStatuslineRender:
 
         content = target.read_text()
         assert "overlay=teatree" in content
-        # The "Action needed:" / "In flight:" zone headers were removed once
-        # color became the signal — only the legend at the bottom names them.
+        # The "Action needed:" / "In flight:" zone headers were removed —
+        # color carries the signal, no separate label is rendered.
         assert "Action needed:" not in content
         assert "In flight:" not in content
+        assert "legend:" not in content
 
     def test_creates_parent_directory(self, tmp_path: Path) -> None:
         target = tmp_path / "deep" / "nested" / "statusline.txt"
@@ -55,11 +56,7 @@ class TestStatuslineRender:
         render(zones, target=target, colorize=False)
 
         assert target.exists()
-        # Content now includes a legend line below the zones — verify both the
-        # zone content and the legend made it through atomically.
-        body = target.read_text()
-        assert body.startswith("x\n")
-        assert "legend:" in body
+        assert target.read_text().strip() == "x"
 
     def test_overwrites_previous_content(self, tmp_path: Path) -> None:
         target = tmp_path / "statusline.txt"

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -421,3 +421,119 @@ def test_tick_multi_overlay_prefixes_summary(tmp_path: Path) -> None:
     contents = statusline.read_text(encoding="utf-8")
     assert "[teatree]" in contents
     assert "!545" in contents
+
+
+def test_canonical_overlay_names_maps_toml_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from teatree.loop.tick import _canonical_overlay_names  # noqa: PLC0415
+
+    toml_path = tmp_path / ".teatree.toml"
+    toml_path.write_text(
+        '[teatree]\nworkspace_dir = "~/ws"\n[overlays.teatree]\n[overlays.acme]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    overlays = {"t3-teatree": object(), "acme": object()}
+    with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
+        mapping = _canonical_overlay_names()
+    assert mapping == {"teatree": "t3-teatree"}
+
+
+def test_canonical_overlay_names_returns_empty_without_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from teatree.loop.tick import _canonical_overlay_names  # noqa: PLC0415
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert _canonical_overlay_names() == {}
+
+
+def test_canonical_overlay_names_handles_invalid_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from teatree.loop.tick import _canonical_overlay_names  # noqa: PLC0415
+
+    toml_path = tmp_path / ".teatree.toml"
+    toml_path.write_text("not = valid = toml = at = all\n", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    with patch("teatree.core.overlay_loader.get_all_overlays", return_value={"t3-teatree": object()}):
+        assert _canonical_overlay_names() == {}
+
+
+def test_issue_ref_from_falls_back_to_ticket_number() -> None:
+    from teatree.loop.rendering import _issue_ref_from  # noqa: PLC0415
+
+    # Corrupt issue_url (a branch name) + ticket_number → label uses #N,
+    # url stays empty so the renderer doesn't make a broken hyperlink.
+    ref = _issue_ref_from(issue_url="auto:ac/some-branch", ticket_number="313")
+    assert ref.label == "#313"
+    assert ref.url == ""
+
+
+def test_issue_ref_from_falls_back_to_title_snippet() -> None:
+    from teatree.loop.rendering import _issue_ref_from  # noqa: PLC0415
+
+    long_title = "A" * 50
+    ref = _issue_ref_from(title=long_title)
+    # Title gets sliced to 29 chars + "…" to stay readable on a narrow line.
+    assert ref.label.endswith("…")
+    assert ref.label.count("A") == 29
+
+
+def test_issue_ref_from_returns_question_mark_when_nothing_known() -> None:
+    from teatree.loop.rendering import _issue_ref_from  # noqa: PLC0415
+
+    assert _issue_ref_from().label == "?"
+
+
+def test_render_pr_group_buckets_under_parent_ticket() -> None:
+    from teatree.loop.rendering import _PRRef, _render_pr_group  # noqa: PLC0415
+
+    refs = [
+        _PRRef(iid=370, url="https://gitlab.com/x/y/-/merge_requests/370", annotation=""),
+        _PRRef(iid=399, url="https://gitlab.com/x/y/-/merge_requests/399", annotation=""),
+    ]
+    ticket_index = {
+        "https://gitlab.com/x/y/-/merge_requests/370": "855",
+        "https://gitlab.com/x/y/-/merge_requests/399": "855",
+    }
+    line = _render_pr_group("acme", refs, ticket_index=ticket_index)
+    assert "#855:" in line
+    assert "!370" in line
+    assert "!399" in line
+
+
+def test_render_pr_group_lists_orphans_when_no_match() -> None:
+    from teatree.loop.rendering import _PRRef, _render_pr_group  # noqa: PLC0415
+
+    refs = [_PRRef(iid=42, url="https://example.com/mr/42", annotation="")]
+    line = _render_pr_group("t3-teatree", refs, ticket_index={})
+    assert "!42" in line
+    assert "#" not in line  # no ticket prefix
+
+
+def test_reviewer_pr_signal_surfaces_in_statusline() -> None:
+    from teatree.loop.dispatch import dispatch  # noqa: PLC0415
+    from teatree.loop.rendering import zones_for  # noqa: PLC0415
+
+    signal = ScanSignal(
+        kind="reviewer_pr.new_sha",
+        summary="Review needed: https://gitlab.com/x/y/-/merge_requests/371",
+        payload={
+            "url": "https://gitlab.com/x/y/-/merge_requests/371",
+            "head_sha": "abc",
+            "previous_sha": "def",
+            "raw": {},
+            "overlay": "acme",
+        },
+    )
+    actions = dispatch([signal])
+    kinds = sorted({a.kind for a in actions})
+    # Reviewer signals now produce BOTH an agent action (to the t3:reviewer
+    # phase agent) AND a statusline action_needed row so the user sees the
+    # pending review without waiting on the agent to act.
+    assert kinds == ["agent", "statusline"]
+    zones = zones_for(actions)
+    rendered = "\n".join(item if isinstance(item, str) else item.text for item in zones.action_needed)
+    assert "!371" in rendered
+    assert "review" in rendered
+    assert "[acme]" in rendered

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -160,7 +160,7 @@ def test_tick_dispatches_agent_actions_without_rendering_them(tmp_path: Path) ->
 def test_tick_renders_unknown_action_zone_as_in_flight(tmp_path: Path) -> None:
     """A statusline action with an unrecognized zone falls back to in_flight."""
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
-    from teatree.loop.tick import _zones_for  # noqa: PLC0415
+    from teatree.loop.rendering import zones_for as _zones_for  # noqa: PLC0415
 
     actions = [DispatchAction(kind="statusline", zone="bogus_zone", detail="x")]
     zones = _zones_for(actions)
@@ -219,39 +219,57 @@ def test_build_default_jobs_tags_per_overlay() -> None:
 
 def test_zones_groups_disposition_candidates_by_reason(tmp_path: Path) -> None:
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
-    from teatree.loop.tick import _zones_for  # noqa: PLC0415
+    from teatree.loop.rendering import zones_for as _zones_for  # noqa: PLC0415
 
     actions = [
         DispatchAction(
             kind="statusline",
             zone="action_needed",
             detail="Ticket 55 — issue_closed",
-            payload={"reason": "issue_closed", "overlay": "teatree"},
+            payload={
+                "reason": "issue_closed",
+                "overlay": "teatree",
+                "url": "https://example.com/issues/55",
+            },
         ),
         DispatchAction(
             kind="statusline",
             zone="action_needed",
             detail="Ticket 114 — issue_closed",
-            payload={"reason": "issue_closed", "overlay": "teatree"},
+            payload={
+                "reason": "issue_closed",
+                "overlay": "teatree",
+                "url": "https://example.com/issues/114",
+            },
         ),
         DispatchAction(
             kind="statusline",
             zone="action_needed",
             detail="Ticket 12 — unassigned",
-            payload={"reason": "unassigned", "overlay": "teatree"},
+            payload={
+                "reason": "unassigned",
+                "overlay": "teatree",
+                "url": "https://example.com/issues/12",
+            },
         ),
     ]
     zones = _zones_for(actions)
     texts = [item if isinstance(item, str) else item.text for item in zones.action_needed]
     assert len(texts) == 1
-    assert "2 closed issues" in texts[0]
-    assert "1 reassigned away" in texts[0]
+    # Each disposition is rendered as a clickable ``#N`` token grouped by
+    # reason (`closed:` / `reassigned:` / `label-removed:`) instead of an
+    # opaque "N closed issues" aggregate — the reader can jump to the source.
+    assert "closed:" in texts[0]
+    assert "#55" in texts[0]
+    assert "#114" in texts[0]
+    assert "reassigned:" in texts[0]
+    assert "#12" in texts[0]
     assert "[teatree]" in texts[0]
 
 
-def test_zones_collapses_ready_to_start_into_count() -> None:
+def test_zones_lists_ready_to_start_as_clickable_refs() -> None:
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
-    from teatree.loop.tick import _zones_for  # noqa: PLC0415
+    from teatree.loop.rendering import zones_for as _zones_for  # noqa: PLC0415
 
     actions = [
         DispatchAction(
@@ -260,17 +278,22 @@ def test_zones_collapses_ready_to_start_into_count() -> None:
             detail=f"Ready to start: Issue #{i}",
             payload={"url": f"https://example.com/issues/{i}", "overlay": "acme"},
         )
-        for i in range(12)
+        for i in range(3)
     ]
     zones = _zones_for(actions)
     texts = [item if isinstance(item, str) else item.text for item in zones.action_needed]
     assert len(texts) == 1
-    assert texts[0] == "[acme] 12 ready to start"
+    # Replaces the legacy "[acme] N ready to start" aggregate — each ready
+    # issue is its own ``#N`` link so the reader can jump straight to it.
+    assert texts[0].startswith("[acme] ready:")
+    assert "#0" in texts[0]
+    assert "#1" in texts[0]
+    assert "#2" in texts[0]
 
 
 def test_zones_groups_prs_per_overlay_on_one_line() -> None:
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
-    from teatree.loop.tick import _zones_for  # noqa: PLC0415
+    from teatree.loop.rendering import zones_for as _zones_for  # noqa: PLC0415
 
     actions = [
         DispatchAction(
@@ -292,7 +315,7 @@ def test_zones_groups_prs_per_overlay_on_one_line() -> None:
 
 def test_zones_pr_annotations_show_notes_and_failures() -> None:
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
-    from teatree.loop.tick import _zones_for  # noqa: PLC0415
+    from teatree.loop.rendering import zones_for as _zones_for  # noqa: PLC0415
 
     actions = [
         DispatchAction(
@@ -316,7 +339,7 @@ def test_zones_pr_annotations_show_notes_and_failures() -> None:
 
 def test_active_tickets_shown_in_anchors() -> None:
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
-    from teatree.loop.tick import _zones_for  # noqa: PLC0415
+    from teatree.loop.rendering import zones_for as _zones_for  # noqa: PLC0415
 
     actions = [
         DispatchAction(
@@ -342,7 +365,7 @@ def test_active_tickets_shown_in_anchors() -> None:
 
 def test_mechanical_actions_not_rendered_in_statusline() -> None:
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
-    from teatree.loop.tick import _zones_for  # noqa: PLC0415
+    from teatree.loop.rendering import zones_for as _zones_for  # noqa: PLC0415
 
     actions = [
         DispatchAction(
@@ -356,7 +379,7 @@ def test_mechanical_actions_not_rendered_in_statusline() -> None:
 
 def test_agent_actions_not_rendered_in_statusline() -> None:
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
-    from teatree.loop.tick import _zones_for  # noqa: PLC0415
+    from teatree.loop.rendering import zones_for as _zones_for  # noqa: PLC0415
 
     actions = [
         DispatchAction(kind="agent", zone="t3:reviewer", detail="Review PR", payload={}),

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -53,7 +53,9 @@ class TestStatuslineHook:
         )
 
         assert result.returncode == 0, result.stderr
-        assert "skills: t3:code | t3:debug" in _strip_ansi(result.stdout)
+        # Skill tokens are space-separated now (previously `|`) — the colored
+        # magenta names provide enough visual separation on their own.
+        assert "skills: t3:code t3:debug" in _strip_ansi(result.stdout)
 
     def test_omits_skills_when_session_file_absent(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"


### PR DESCRIPTION
Closes #630

## Summary

Reworks the statusline so it fits narrow terminals and surfaces operational signals over metadata. Implementation is split across `hooks/scripts/statusline.sh` (header composition) and a new `src/teatree/loop/rendering.py` (zone classification / per-overlay rendering / URL validation).

## What changes

**Header readability and layout**

- Light-gray labels (`\033[38;5;244m`) replace legacy DIM (`\033[2;37m`), which is unreadable on most dark themes.
- Segments group visually: `·` within a group, `│` between groups. Order: context · usage · loops · updates · resource.
- Skills push to the end so they truncate first; they get their own line when more than 4 are loaded.

**Body grouping and signal contracts**

- Drops "Action needed:" / "In flight:" zone headers — color (dim / red / cyan) is the signal. A one-line legend at the bottom documents the contract.
- Rows group by `[ov]` prefix instead of by zone, so each overlay's anchors + action + in-flight rows are contiguous.
- Dispositions and ready-to-start now render as individual clickable `#N` refs (was "6 reassigned away"). `TicketDispositionScanner` ships `ticket_number` in the payload so the fallback renders when `issue_url` is corrupt.
- In-flight MRs are grouped under their parent `#ticket` when the URL matches an anchor.

**Quality / safety**

- OSC8 hyperlinks only wrap URLs that start with `http://` / `https://`. Corrupt `issue_url` values (branch names, raw titles, bare numbers) render as plain text instead of broken click targets.
- Stale "started" anchors are filtered: PR-backed tickets whose URL is missing from the live action/in-flight set are dropped. Catches the case where an MR merged upstream but the local FSM never advanced.
- `closed` added to `_NOISE_STATES` — not a valid FSM value, just legacy data leaking through.
- Freshness uses the canonical overlay name (`t3-teatree`) instead of the raw toml key (`teatree`), matching `[overlay]` row tags.

**Module split**

- `tick.py` was 730 LOC, over the 500-cap. Rendering / classification helpers move to `src/teatree/loop/rendering.py` (346 LOC); `tick.py` is now 382 LOC and owns scan + dispatch + meta-write. `dict[str, object]` is replaced with explicit keyword args on `_issue_ref_from`.

## Test plan

- [x] 134 statusline / tick / claude-statusline tests pass locally
- [x] ruff clean
- [x] ty-check clean
- [x] module-health gate green (tick.py 382 LOC, no `dict[str, object]`)
- [ ] CI green