### PR TITLE
fix(hooks): post Slack DM synchronously on AskUserQuestion

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -38,7 +38,7 @@
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook_router.py --event PreToolUse",
-            "timeout": 3
+            "timeout": 6
           }
         ]
       }

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -938,64 +938,113 @@ def _format_question_text(questions: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _slack_post_dm(bot_token: str, user_id: str, text: str) -> None:
-    import contextlib  # noqa: PLC0415
+def _slack_dm_cache_path() -> Path:
+    base = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share")))
+    return base / "teatree" / "slack_dm_channels.json"
+
+
+def _read_dm_channel_cache(user_id: str) -> str:
+    path = _slack_dm_cache_path()
+    if not path.is_file():
+        return ""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    cached = data.get(user_id)
+    return cached if isinstance(cached, str) else ""
+
+
+def _write_dm_channel_cache(user_id: str, channel: str) -> None:
+    path = _slack_dm_cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        existing = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        existing = {}
+    if not isinstance(existing, dict):
+        existing = {}
+    existing[user_id] = channel
+    path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _slack_open_dm(bot_token: str, user_id: str, *, timeout: float) -> str:
     import urllib.request  # noqa: PLC0415
 
-    dm_payload = json.dumps({"users": user_id}).encode()
-    dm_req = urllib.request.Request(
+    payload = json.dumps({"users": user_id}).encode()
+    req = urllib.request.Request(
         "https://slack.com/api/conversations.open",
-        data=dm_payload,
+        data=payload,
         headers={"Authorization": f"Bearer {bot_token}", "Content-Type": "application/json"},
     )
     try:
-        dm_resp = json.loads(urllib.request.urlopen(dm_req, timeout=5).read())  # noqa: S310
+        resp = json.loads(urllib.request.urlopen(req, timeout=timeout).read())  # noqa: S310
     except Exception:  # noqa: BLE001
-        return
-    channel = dm_resp.get("channel", {}).get("id", "")
-    if not channel:
-        return
+        return ""
+    if not isinstance(resp, dict):
+        return ""
+    channel = resp.get("channel")
+    if not isinstance(channel, dict):
+        return ""
+    cid = channel.get("id")
+    return cid if isinstance(cid, str) else ""
 
-    msg_payload = json.dumps({"channel": channel, "text": text}).encode()
-    msg_req = urllib.request.Request(
+
+def _slack_post_message(bot_token: str, channel: str, text: str, *, timeout: float) -> bool:
+    """Post ``text`` to ``channel``. Return True iff Slack acknowledged success."""
+    import urllib.request  # noqa: PLC0415
+
+    payload = json.dumps({"channel": channel, "text": text}).encode()
+    req = urllib.request.Request(
         "https://slack.com/api/chat.postMessage",
-        data=msg_payload,
+        data=payload,
         headers={"Authorization": f"Bearer {bot_token}", "Content-Type": "application/json"},
     )
-    with contextlib.suppress(Exception):
-        urllib.request.urlopen(msg_req, timeout=5)  # noqa: S310
+    try:
+        resp = json.loads(urllib.request.urlopen(req, timeout=timeout).read())  # noqa: S310
+    except Exception:  # noqa: BLE001
+        return False
+    return bool(isinstance(resp, dict) and resp.get("ok") is True)
+
+
+def _slack_post_dm(bot_token: str, user_id: str, text: str, *, timeout: float = 2.0) -> None:
+    """Post ``text`` to ``user_id``'s DM. Resolves channel via cache when possible.
+
+    Cache hit → single ``chat.postMessage`` call (sub-second on a normal
+    connection, fits inside the 3s hook timeout). Cache miss or
+    ``channel_not_found`` → open the DM, cache the channel id, retry.
+    """
+    cached = _read_dm_channel_cache(user_id)
+    if cached and _slack_post_message(bot_token, cached, text, timeout=timeout):
+        return
+    channel = _slack_open_dm(bot_token, user_id, timeout=timeout)
+    if not channel:
+        return
+    if _slack_post_message(bot_token, channel, text, timeout=timeout):
+        _write_dm_channel_cache(user_id, channel)
 
 
 def _perform_slack_post(slack_cfg: tuple[str, str], questions: list[dict]) -> None:
+    """Resolve the bot token and post the question — runs synchronously.
+
+    Synchronous so the Slack DM lands **before** the AskUserQuestion prompt
+    renders in the terminal. The previous fork-and-detach variant caused
+    the message to arrive *after* the user had already answered.
+    """
     token_ref, user_id = slack_cfg
     result = subprocess.run(  # noqa: S603
         ["pass", "show", f"{token_ref}-bot"],  # noqa: S607
         capture_output=True,
         text=True,
-        timeout=5,
+        timeout=2,
         check=False,
     )
     bot_token = result.stdout.strip() if result.returncode == 0 else ""
     if not bot_token:
         return
     _slack_post_dm(bot_token, user_id, _format_question_text(questions))
-
-
-def _dispatch_slack_post_detached(slack_cfg: tuple[str, str], questions: list[dict]) -> None:
-    """Fork and post in the child so the agent's PreToolUse hook returns immediately.
-
-    The Slack HTTP round-trip (pass show + conversations.open + chat.postMessage) can
-    take seconds on a slow link; if we did it inline the agent's tool call would block
-    on the hook timeout before showing the user the prompt.
-    """
-    pid = os.fork()
-    if pid != 0:
-        return
-    os.setsid()  # pragma: no cover
-    try:  # pragma: no cover
-        _perform_slack_post(slack_cfg, questions)
-    finally:  # pragma: no cover
-        os._exit(0)
 
 
 def _post_question_to_slack(data: dict) -> None:
@@ -1005,7 +1054,7 @@ def _post_question_to_slack(data: dict) -> None:
     slack_cfg = _slack_config_from_toml()
     if slack_cfg is None:
         return
-    _dispatch_slack_post_detached(slack_cfg, questions)
+    _perform_slack_post(slack_cfg, questions)
 
 
 def handle_mirror_question_to_slack(data: dict) -> bool:

--- a/tests/test_slack_mirror_hook.py
+++ b/tests/test_slack_mirror_hook.py
@@ -1,4 +1,11 @@
-"""Slack mirror for AskUserQuestion fires on PreToolUse, non-blocking."""
+"""Slack mirror for AskUserQuestion fires on PreToolUse, synchronously.
+
+The mirror posts a DM to the user so they see the question on Slack
+**before** they answer in the terminal. The previous detached/forked
+implementation made the message land *after* the user had answered;
+this is now a synchronous call with a per-user channel cache so the
+post fits inside the hook timeout.
+"""
 
 import json
 from pathlib import Path
@@ -34,41 +41,99 @@ class TestMirrorHandler:
 
     def test_returns_false_so_chain_continues(self) -> None:
         with (
-            patch.object(router, "_dispatch_slack_post_detached") as mock_dispatch,
+            patch.object(router, "_perform_slack_post") as mock_post,
             patch.object(router, "_slack_config_from_toml", return_value=("tok/ref", "U1")),
         ):
-            mock_dispatch.return_value = None
+            mock_post.return_value = None
             result = router.handle_mirror_question_to_slack(self._question_payload())
         assert result is False
 
     def test_ignores_other_tools(self) -> None:
-        with patch.object(router, "_dispatch_slack_post_detached") as mock_dispatch:
+        with patch.object(router, "_perform_slack_post") as mock_post:
             router.handle_mirror_question_to_slack({"tool_name": "Bash", "tool_input": {"command": "ls"}})
-        mock_dispatch.assert_not_called()
+        mock_post.assert_not_called()
 
-    def test_dispatches_when_questions_present_and_slack_configured(self) -> None:
+    def test_dispatches_synchronously_when_questions_present(self) -> None:
         with (
-            patch.object(router, "_dispatch_slack_post_detached") as mock_dispatch,
+            patch.object(router, "_perform_slack_post") as mock_post,
             patch.object(router, "_slack_config_from_toml", return_value=("tok/ref", "U1")),
         ):
             router.handle_mirror_question_to_slack(self._question_payload())
-        mock_dispatch.assert_called_once()
-        slack_cfg, questions = mock_dispatch.call_args.args
+        mock_post.assert_called_once()
+        slack_cfg, questions = mock_post.call_args.args
         assert slack_cfg == ("tok/ref", "U1")
         assert questions[0]["question"] == "Ship it?"
 
     def test_no_dispatch_when_no_questions(self) -> None:
-        with patch.object(router, "_dispatch_slack_post_detached") as mock_dispatch:
+        with patch.object(router, "_perform_slack_post") as mock_post:
             router.handle_mirror_question_to_slack({"tool_name": "AskUserQuestion", "tool_input": {"questions": []}})
-        mock_dispatch.assert_not_called()
+        mock_post.assert_not_called()
 
     def test_no_dispatch_when_slack_not_configured(self) -> None:
         with (
             patch.object(router, "_slack_config_from_toml", return_value=None),
-            patch.object(router, "_dispatch_slack_post_detached") as mock_dispatch,
+            patch.object(router, "_perform_slack_post") as mock_post,
         ):
             router.handle_mirror_question_to_slack(self._question_payload())
-        mock_dispatch.assert_not_called()
+        mock_post.assert_not_called()
+
+
+class TestDmChannelCache:
+    def test_round_trip_through_cache_file(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        assert router._read_dm_channel_cache("U1") == ""
+        router._write_dm_channel_cache("U1", "D123")
+        assert router._read_dm_channel_cache("U1") == "D123"
+
+    def test_multiple_users_in_same_cache(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        router._write_dm_channel_cache("U1", "D1")
+        router._write_dm_channel_cache("U2", "D2")
+        assert router._read_dm_channel_cache("U1") == "D1"
+        assert router._read_dm_channel_cache("U2") == "D2"
+
+    def test_corrupt_cache_returns_empty(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        path = router._slack_dm_cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        assert router._read_dm_channel_cache("U1") == ""
+
+
+class TestSlackPostDm:
+    def test_cache_hit_skips_open_dm(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        router._write_dm_channel_cache("U1", "D-cached")
+        with (
+            patch.object(router, "_slack_open_dm") as mock_open,
+            patch.object(router, "_slack_post_message", return_value=True) as mock_post,
+        ):
+            router._slack_post_dm("xoxb-tok", "U1", "hello")
+        mock_open.assert_not_called()
+        mock_post.assert_called_once_with("xoxb-tok", "D-cached", "hello", timeout=2.0)
+
+    def test_cache_miss_opens_dm_and_caches(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        with (
+            patch.object(router, "_slack_open_dm", return_value="D-new") as mock_open,
+            patch.object(router, "_slack_post_message", return_value=True) as mock_post,
+        ):
+            router._slack_post_dm("xoxb-tok", "U1", "hello")
+        mock_open.assert_called_once()
+        mock_post.assert_called_once_with("xoxb-tok", "D-new", "hello", timeout=2.0)
+        assert router._read_dm_channel_cache("U1") == "D-new"
+
+    def test_stale_cache_falls_back_to_open(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        router._write_dm_channel_cache("U1", "D-stale")
+        with (
+            patch.object(router, "_slack_open_dm", return_value="D-fresh") as mock_open,
+            patch.object(router, "_slack_post_message", side_effect=[False, True]) as mock_post,
+        ):
+            router._slack_post_dm("xoxb-tok", "U1", "hello")
+        mock_open.assert_called_once()
+        assert mock_post.call_count == 2
+        assert router._read_dm_channel_cache("U1") == "D-fresh"
 
 
 class TestHooksJsonWiring:
@@ -79,3 +144,13 @@ class TestHooksJsonWiring:
         post_matchers = [entry.get("matcher", "") for entry in hooks_config["hooks"].get("PostToolUse", [])]
         assert "AskUserQuestion" in pre_matchers
         assert "AskUserQuestion" not in post_matchers
+
+    def test_askuserquestion_hook_timeout_allows_sync_post(self) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        hooks_config = json.loads((repo_root / "hooks" / "hooks.json").read_text(encoding="utf-8"))
+        ask_entry = next(
+            entry for entry in hooks_config["hooks"]["PreToolUse"] if entry.get("matcher") == "AskUserQuestion"
+        )
+        # Synchronous post needs to fit pass-show + (cache hit) chat.postMessage
+        # under the timeout. 3s was too tight; 5s+ keeps a safety margin.
+        assert ask_entry["hooks"][0]["timeout"] >= 5


### PR DESCRIPTION
## Summary

The Slack DM that mirrors an \`AskUserQuestion\` was reliably arriving **after** I had already answered in the terminal. Root cause: the previous implementation \`fork()\`ed and detached the HTTP round-trip (\`pass show\` + \`conversations.open\` + \`chat.postMessage\`) so the hook returned immediately, leaving the actual send to a background process. The send finished long after the prompt had been rendered and answered.

### Fix

- Run the Slack post **synchronously** inside the hook.
- Cache the per-user DM channel id in \`\$XDG_DATA_HOME/teatree/slack_dm_channels.json\` so warm-path calls skip \`conversations.open\` and only \`chat.postMessage\` runs inline (sub-second).
- Stale cache (channel_not_found) falls back to opening + caching, then retries.
- Bump the AskUserQuestion PreToolUse hook timeout from 3s to 6s to give the synchronous call breathing room on slow links.

### Tests

15 tests cover: handler registration, sync dispatch, cache round-trip, cache hit/miss/stale paths, hook timeout, and the existing \`AskUserQuestion\` PreToolUse wiring.

## Test plan

- [x] \`pytest\` clean (2965 passed)
- [x] \`ruff check\` / \`ruff format\` / \`ty check\` clean
- [ ] CI green
- [ ] Smoke test: the next \`AskUserQuestion\` shows up on Slack before I have time to answer