### PR TITLE
fix(statusline): recompute behind inline after FETCH_HEAD updates

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -227,6 +227,23 @@ if [ -r "$_tick_meta" ] && command -v jq >/dev/null 2>&1; then
         for _repo in $(echo "$_freshness" | jq -r 'keys[]' 2>/dev/null); do
             _behind=$(echo "$_freshness" | jq -r ".\"$_repo\".behind // -1" 2>/dev/null)
             _fetch_ep=$(echo "$_freshness" | jq -r ".\"$_repo\".fetch_epoch // 0" 2>/dev/null)
+            _path=$(echo "$_freshness" | jq -r ".\"$_repo\".path // empty" 2>/dev/null)
+            # Recompute behind inline when FETCH_HEAD has been touched since the
+            # tick wrote this entry (e.g. a manual `git pull` in another terminal).
+            # Cheap: one local `git rev-list` per repo, no network.
+            if [ -n "$_path" ] && [ -f "$_path/.git/FETCH_HEAD" ]; then
+                # Linux stat (-c) first, BSD/macOS (-f) fallback. The reverse
+                # order silently produces wrong output on Linux because
+                # `stat -f` exists there too with a different meaning.
+                _disk_ep=$(stat -c %Y "$_path/.git/FETCH_HEAD" 2>/dev/null || stat -f %m "$_path/.git/FETCH_HEAD" 2>/dev/null || echo 0)
+                if [ "$_disk_ep" -gt "$_fetch_ep" ] 2>/dev/null; then
+                    _fresh_behind=$(git -C "$_path" rev-list HEAD..origin/main --count 2>/dev/null)
+                    if [ -n "$_fresh_behind" ]; then
+                        _behind="$_fresh_behind"
+                        _fetch_ep="$_disk_ep"
+                    fi
+                fi
+            fi
             _age=""
             if [ "$_fetch_ep" -gt 0 ] 2>/dev/null; then
                 _age_s=$(( _now - _fetch_ep ))

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -307,6 +307,12 @@ def _execute_mechanical(report: TickReport) -> None:
 
 
 def _repo_freshness(repo_path: Path) -> dict[str, int | str] | None:
+    """Snapshot a repo's freshness for the statusline header.
+
+    The ``path`` field is included so the statusline hook can recompute
+    ``behind`` inline after a ``git pull`` — otherwise the cached value
+    stays stale until the next tick (~12 min later).
+    """
     from teatree.utils.run import run_allowed_to_fail  # noqa: PLC0415
 
     git_dir = repo_path / ".git"
@@ -324,7 +330,7 @@ def _repo_freshness(repo_path: Path) -> dict[str, int | str] | None:
         behind = -1
     fetch_head = git_dir / "FETCH_HEAD"
     fetch_epoch = int(fetch_head.stat().st_mtime) if fetch_head.is_file() else 0
-    return {"behind": behind, "fetch_epoch": fetch_epoch}
+    return {"behind": behind, "fetch_epoch": fetch_epoch, "path": str(repo_path)}
 
 
 def _repos_from_toml() -> dict[str, Path]:

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -209,3 +209,104 @@ class TestStatuslineHook:
         plain = _strip_ansi(result.stdout)
         assert "skills:" not in plain
         assert "rogue" not in plain
+
+
+class TestFreshnessInlineRefresh:
+    """statusline.sh recomputes ``behind`` inline when FETCH_HEAD is newer than the tick."""
+
+    def _make_repo_behind_main(self, repo: Path, *, behind_by: int) -> int:
+        """Create a tiny git repo with ``behind_by`` commits on origin/main not on HEAD.
+
+        Returns the FETCH_HEAD mtime so the test can choose to mark it
+        newer or older than the cached ``fetch_epoch``.
+        """
+        repo.mkdir(parents=True, exist_ok=True)
+        env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
+        run = lambda *args: subprocess.run(args, cwd=repo, env=env, check=True, capture_output=True)  # noqa: E731
+        run("git", "init", "-q", "-b", "main")
+        run("git", "config", "user.email", "a@b.c")
+        run("git", "config", "user.name", "t")
+        (repo / "README").write_text("x")
+        run("git", "add", "README")
+        run("git", "commit", "-q", "-m", "base")
+        # Build "origin/main" as a remote-tracking ref ahead of HEAD by N commits.
+        bare = repo.parent / "origin.git"
+        run("git", "clone", "-q", "--bare", str(repo), str(bare))
+        run("git", "remote", "add", "origin", str(bare))
+        for i in range(behind_by):
+            wt = repo.parent / "pusher"
+            if not wt.exists():
+                subprocess.run(["git", "clone", "-q", str(bare), str(wt)], env=env, check=True, capture_output=True)  # noqa: S607
+                subprocess.run(["git", "config", "user.email", "a@b.c"], cwd=wt, check=True)  # noqa: S607
+                subprocess.run(["git", "config", "user.name", "t"], cwd=wt, check=True)  # noqa: S607
+            (wt / f"f{i}").write_text("y")
+            subprocess.run(["git", "add", f"f{i}"], cwd=wt, env=env, check=True)  # noqa: S607
+            subprocess.run(["git", "commit", "-q", "-m", f"c{i}"], cwd=wt, env=env, check=True)  # noqa: S607
+            subprocess.run(["git", "push", "-q", "origin", "main"], cwd=wt, env=env, check=True)  # noqa: S607
+        run("git", "fetch", "-q", "origin", "main")
+        fetch_head = repo / ".git" / "FETCH_HEAD"
+        return int(fetch_head.stat().st_mtime)
+
+    def test_uses_cached_value_when_fetch_head_not_newer(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        fetch_epoch = self._make_repo_behind_main(repo, behind_by=2)
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        sl = tmp_path / "statusline.txt"
+        sl.write_text("anchors\n")
+        # tick-meta says behind=99 (stale-but-cached value) with a fetch_epoch
+        # at or after the on-disk FETCH_HEAD mtime → script must NOT recompute.
+        meta = sl.with_name("tick-meta.json")
+        meta.write_text(
+            json.dumps(
+                {
+                    "freshness": {
+                        "repo": {"behind": 99, "fetch_epoch": fetch_epoch + 60, "path": str(repo)},
+                    },
+                },
+            ),
+        )
+
+        result = _run({"model": {"display_name": "Claude Opus"}}, state_dir=state_dir, statusline_file=sl)
+        plain = _strip_ansi(result.stdout)
+        assert "repo=99" in plain
+
+    def test_recomputes_when_fetch_head_is_newer(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        fetch_epoch_now = self._make_repo_behind_main(repo, behind_by=2)
+        # Simulate a pre-pull tick that recorded behind=99 with an older fetch_epoch.
+        # On-disk FETCH_HEAD is newer → script must refresh and show 2.
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        sl = tmp_path / "statusline.txt"
+        sl.write_text("anchors\n")
+        meta = sl.with_name("tick-meta.json")
+        meta.write_text(
+            json.dumps(
+                {
+                    "freshness": {
+                        "repo": {"behind": 99, "fetch_epoch": fetch_epoch_now - 3600, "path": str(repo)},
+                    },
+                },
+            ),
+        )
+
+        result = _run({"model": {"display_name": "Claude Opus"}}, state_dir=state_dir, statusline_file=sl)
+        plain = _strip_ansi(result.stdout)
+        assert "repo=2" in plain
+        assert "repo=99" not in plain
+
+    def test_no_path_field_falls_back_to_cached_behind(self, tmp_path: Path) -> None:
+        # Older tick-meta.json without `path` should still render (no crash).
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        sl = tmp_path / "statusline.txt"
+        sl.write_text("anchors\n")
+        meta = sl.with_name("tick-meta.json")
+        meta.write_text(
+            json.dumps({"freshness": {"old": {"behind": 5, "fetch_epoch": int(time.time())}}}),
+        )
+
+        result = _run({"model": {"display_name": "Claude Opus"}}, state_dir=state_dir, statusline_file=sl)
+        plain = _strip_ansi(result.stdout)
+        assert "old=5" in plain


### PR DESCRIPTION
Freshness segment showed stale \`behind\` until the next tick (~12 min). Now the statusline.sh hook compares the on-disk FETCH_HEAD mtime to the cached \`fetch_epoch\`; if newer (e.g. after a manual \`git pull\`), it re-runs \`git rev-list HEAD..origin/main --count\` locally — one cheap call, no network — and renders the fresh count immediately.

- Tick metadata now includes \`path\` per repo so the hook knows where to run git.
- Backwards-compatible: tick-meta entries without \`path\` fall back to the cached value.
- Linux/macOS stat portability: try \`stat -c %Y\` first, fall back to \`stat -f %m\`.

3 integration tests cover: cached-when-fresh, recompute-when-newer, missing-path fallback. All 2961 tests pass.