### PR TITLE
feat(loop): group MRs under parent ticket via PullRequest FK + Closes/Fixes footer (https://github.com/souliane/teatree/issues/640)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -160,6 +160,7 @@ src/teatree/
     tick.py             # One tick: scan in parallel, dispatch to phase agents when needed, render statusline
     dispatch.py         # Signal → action mapping (statusline / agent / webhook)
     rendering.py        # Classify dispatched actions per overlay; render anchor / action / in-flight rows
+    pr_ticket_index.py  # Build mr_url → parent_ticket_number index (PullRequest FK + Closes/Fixes regex)
     statusline.py       # Statusline composition (zones, formatters) and file write
     scanners/           # Pure-Python signal collectors — one file each
       active_tickets.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,6 +257,7 @@ per_module_floors = [
   { path = "src/teatree/loop/persistence.py", floor = 80 },
   { path = "src/teatree/loop/rendering.py", floor = 80 },
   { path = "src/teatree/loop/dispatch.py", floor = 80 },
+  { path = "src/teatree/loop/pr_ticket_index.py", floor = 80 },
 ]
 
 [tool.uv.build-backend]

--- a/src/teatree/loop/pr_ticket_index.py
+++ b/src/teatree/loop/pr_ticket_index.py
@@ -20,9 +20,10 @@ from teatree.loop.dispatch import DispatchAction
 type Payload = Mapping[str, Any]
 
 # Matches ``Closes #123`` / ``Fixes: #456`` / ``Resolves #789`` (and the
-# plural/punctuation variants). Anchored at a word boundary so it doesn't
-# match ``preCloses#`` or similar. Same vocabulary as
-# ``teatree.core.runners.ship.sanitize_close_keywords`` to stay consistent.
+# plural/past-tense variants the platforms recognise — ``closed``, ``fixed``,
+# ``resolved``). Broader than ``sanitize_close_keywords`` in ship.py because
+# the parser must accept anything GitHub/GitLab auto-link, not just the
+# subset we emit. Anchored at a word boundary so ``preCloses#`` doesn't match.
 _CLOSE_KEYWORD_RE = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[\s:]*#(\d+)",
     re.IGNORECASE,

--- a/src/teatree/loop/pr_ticket_index.py
+++ b/src/teatree/loop/pr_ticket_index.py
@@ -1,0 +1,122 @@
+"""Build a ``mr_url → parent_ticket_number`` index for statusline grouping.
+
+Two sources, cheapest first:
+
+1.  ``PullRequest.ticket`` FK — authoritative when the row exists. Persisted
+    when the user runs ``ship``, so any MR that went through the standard
+    pipeline appears here.
+2.  ``Closes/Fixes #N`` footer parsed from the MR description carried on the
+    ``ScanSignal`` payload. Free fallback for PRs whose ``PullRequest`` row
+    never got created (manual MRs, MRs opened in a different overlay) so the
+    statusline still buckets them under the parent ticket they reference.
+"""
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from teatree.loop.dispatch import DispatchAction
+
+type Payload = Mapping[str, Any]
+
+# Matches ``Closes #123`` / ``Fixes: #456`` / ``Resolves #789`` (and the
+# plural/punctuation variants). Anchored at a word boundary so it doesn't
+# match ``preCloses#`` or similar. Same vocabulary as
+# ``teatree.core.runners.ship.sanitize_close_keywords`` to stay consistent.
+_CLOSE_KEYWORD_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[\s:]*#(\d+)",
+    re.IGNORECASE,
+)
+
+
+def _description_from_payload(payload: Payload) -> str:
+    raw = payload.get("raw")
+    if isinstance(raw, Mapping):
+        for key in ("description", "body"):
+            value = raw.get(key)
+            if isinstance(value, str):
+                return value
+    return ""
+
+
+def _parse_closes_ticket(description: str) -> str:
+    """Return the first ``#N`` mentioned after a Closes/Fixes/Resolves keyword.
+
+    Returns an empty string if no close-keyword is found.
+    """
+    match = _CLOSE_KEYWORD_RE.search(description)
+    return match.group(1) if match else ""
+
+
+def _mr_url_payloads(actions: Iterable[DispatchAction]) -> dict[str, Payload]:
+    """Collect ``url → payload`` for MR-bearing statusline actions."""
+    out: dict[str, Payload] = {}
+    for action in actions:
+        if action.kind != "statusline":
+            continue
+        if action.zone not in {"action_needed", "in_flight"}:
+            continue
+        payload = action.payload if isinstance(action.payload, Mapping) else {}
+        url = payload.get("url")
+        if isinstance(url, str) and url:
+            out[url] = payload
+    return out
+
+
+def _lookup_pr_tickets(urls: Iterable[str]) -> dict[str, str]:
+    """Return ``url → ticket_number`` for MRs persisted as ``PullRequest`` rows.
+
+    Falls back to an empty dict when Django isn't ready (e.g. unit tests that
+    didn't load the apps) — the parser path still works.
+    """
+    url_list = [u for u in urls if u]
+    if not url_list:
+        return {}
+    try:
+        from django.apps import apps  # noqa: PLC0415
+
+        pr_model = apps.get_model("core", "PullRequest")
+    except Exception:  # noqa: BLE001
+        return {}
+    result: dict[str, str] = {}
+    try:
+        rows = (
+            pr_model.objects.filter(url__in=url_list)
+            .select_related("ticket")
+            .only("url", "ticket__issue_url", "ticket__id")
+        )
+        for row in rows:
+            ticket = row.ticket
+            if ticket is None:
+                continue
+            number = ticket.ticket_number
+            if number:
+                result[row.url] = number
+    except Exception:  # noqa: BLE001
+        return {}
+    return result
+
+
+def build_ticket_index(actions: Iterable[DispatchAction]) -> dict[str, str]:
+    """Map every MR URL in *actions* to its parent ticket number.
+
+    Order of resolution per URL:
+
+    1.  ``PullRequest.ticket`` FK lookup (authoritative).
+    2.  ``Closes/Fixes #N`` footer parsed from the MR description carried on
+        the signal payload.
+
+    Missing entries simply aren't in the result — the caller treats them as
+    orphans and renders them at the tail of the overlay's PR group.
+    """
+    payloads = _mr_url_payloads(actions)
+    if not payloads:
+        return {}
+    index = _lookup_pr_tickets(payloads.keys())
+    for url, payload in payloads.items():
+        if url in index:
+            continue
+        ticket_number = _parse_closes_ticket(_description_from_payload(payload))
+        if ticket_number:
+            index[url] = ticket_number
+    return index

--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from teatree.loop.dispatch import DispatchAction
+from teatree.loop.pr_ticket_index import build_ticket_index
 from teatree.loop.statusline import StatuslineEntry, StatuslineZones, _hyperlink
 
 # DispatchAction payloads are `dict[str, Any]` by contract (see dispatch.py).
@@ -300,7 +301,12 @@ def _running_tasks_lines() -> list[str]:
     return lines
 
 
-def _populate_overlay_zones(zones: StatuslineZones, c: _ClassifiedActions) -> None:
+def _populate_overlay_zones(
+    zones: StatuslineZones,
+    c: _ClassifiedActions,
+    *,
+    ticket_index: dict[str, str],
+) -> None:
     all_overlays = sorted({*c.active_tickets, *c.action_prs, *c.disposition_refs, *c.ready_refs, *c.inflight_prs})
 
     all_pr_refs: dict[str, dict[str, list[_PRRef]]] = {}
@@ -308,11 +314,6 @@ def _populate_overlay_zones(zones: StatuslineZones, c: _ClassifiedActions) -> No
         for refs in (c.action_prs.get(overlay_key, []), c.inflight_prs.get(overlay_key, [])):
             for ref in refs:
                 all_pr_refs.setdefault(overlay_key, {}).setdefault(str(ref.iid), []).append(ref)
-
-    ticket_index_by_overlay: dict[str, dict[str, str]] = {
-        overlay_key: {url: num for num, _state, url in anchors if _is_url(url)}
-        for overlay_key, anchors in c.active_tickets.items()
-    }
 
     live_pr_urls_by_overlay: dict[str, set[str]] = {}
     for overlay_key in all_overlays:
@@ -322,7 +323,6 @@ def _populate_overlay_zones(zones: StatuslineZones, c: _ClassifiedActions) -> No
 
     for overlay_key in all_overlays:
         pr_map = all_pr_refs.get(overlay_key, {})
-        ticket_index = ticket_index_by_overlay.get(overlay_key, {})
         ticket_line = _render_ticket_line(
             overlay_key,
             c.active_tickets.get(overlay_key, []),
@@ -350,7 +350,8 @@ def _populate_overlay_zones(zones: StatuslineZones, c: _ClassifiedActions) -> No
 def zones_for(actions: list[DispatchAction]) -> StatuslineZones:
     zones = StatuslineZones()
     c = _classify_actions(actions)
-    _populate_overlay_zones(zones, c)
+    ticket_index = build_ticket_index(actions)
+    _populate_overlay_zones(zones, c, ticket_index=ticket_index)
 
     for zone_name, entry in c.other:
         zone_list = getattr(zones, zone_name, None)

--- a/tests/teatree_loop/test_pr_ticket_index.py
+++ b/tests/teatree_loop/test_pr_ticket_index.py
@@ -1,0 +1,277 @@
+"""Tests for ``teatree.loop.pr_ticket_index``."""
+
+from django.test import TestCase
+
+from teatree.core.models.pull_request import PullRequest
+from teatree.core.models.ticket import Ticket
+from teatree.loop.dispatch import DispatchAction
+from teatree.loop.pr_ticket_index import _parse_closes_ticket, build_ticket_index
+
+
+class TestParseClosesTicket:
+    def test_matches_closes_hash_n(self) -> None:
+        assert _parse_closes_ticket("Closes #855") == "855"
+
+    def test_matches_fixes_hash_n(self) -> None:
+        assert _parse_closes_ticket("Fixes #856 — broken thing") == "856"
+
+    def test_matches_resolves_hash_n(self) -> None:
+        assert _parse_closes_ticket("This MR resolves #99") == "99"
+
+    def test_matches_case_insensitive(self) -> None:
+        assert _parse_closes_ticket("CLOSES #1") == "1"
+
+    def test_matches_with_colon(self) -> None:
+        assert _parse_closes_ticket("Closes: #42") == "42"
+
+    def test_returns_empty_when_no_keyword(self) -> None:
+        assert _parse_closes_ticket("Related to #99") == ""
+
+    def test_returns_empty_when_no_hash(self) -> None:
+        assert _parse_closes_ticket("Closes nothing in particular") == ""
+
+    def test_returns_first_match_only(self) -> None:
+        assert _parse_closes_ticket("Closes #1\nFixes #2") == "1"
+
+    def test_returns_empty_on_empty_description(self) -> None:
+        assert _parse_closes_ticket("") == ""
+
+
+class TestBuildTicketIndexFromFooter:
+    """Parser-only path — no DB rows. Index falls back to description scan."""
+
+    def test_uses_closes_footer_when_no_pr_row(self) -> None:
+        url = "https://gitlab.com/x/y/-/merge_requests/370"
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="in_flight",
+                detail="PR #370 open",
+                payload={
+                    "url": url,
+                    "iid": 370,
+                    "raw": {"description": "feat(thing): does stuff\n\nCloses #855"},
+                },
+            ),
+        ]
+        assert build_ticket_index(actions) == {url: "855"}
+
+    def test_skips_actions_outside_action_needed_inflight(self) -> None:
+        url = "https://gitlab.com/x/y/-/merge_requests/370"
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="anchors",
+                detail="anchor",
+                payload={"url": url, "raw": {"description": "Closes #855"}},
+            ),
+        ]
+        assert build_ticket_index(actions) == {}
+
+    def test_skips_non_statusline_actions(self) -> None:
+        url = "https://gitlab.com/x/y/-/merge_requests/370"
+        actions = [
+            DispatchAction(
+                kind="agent",
+                zone="t3:reviewer",
+                detail="Review",
+                payload={"url": url, "raw": {"description": "Closes #855"}},
+            ),
+        ]
+        assert build_ticket_index(actions) == {}
+
+    def test_orphan_when_description_has_no_close_keyword(self) -> None:
+        url = "https://gitlab.com/x/y/-/merge_requests/371"
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="in_flight",
+                detail="PR #371 open",
+                payload={"url": url, "raw": {"description": "Related to #999"}},
+            ),
+        ]
+        assert build_ticket_index(actions) == {}
+
+    def test_supports_github_body_field(self) -> None:
+        url = "https://github.com/owner/repo/pull/42"
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="action_needed",
+                detail="PR #42 has notes",
+                payload={"url": url, "raw": {"body": "Fixes #500"}},
+            ),
+        ]
+        assert build_ticket_index(actions) == {url: "500"}
+
+    def test_handles_missing_raw_payload(self) -> None:
+        url = "https://example.com/mr/42"
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="in_flight",
+                detail="PR #42",
+                payload={"url": url, "iid": 42},
+            ),
+        ]
+        assert build_ticket_index(actions) == {}
+
+    def test_returns_empty_for_no_actions(self) -> None:
+        assert build_ticket_index([]) == {}
+
+
+class TestBuildTicketIndexFromDB(TestCase):
+    """DB-backed path — ``PullRequest.ticket`` FK is the authoritative source."""
+
+    def test_uses_pull_request_ticket_fk(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://x/issues/855", state="started")
+        url = "https://gitlab.com/x/y/-/merge_requests/370"
+        PullRequest.objects.create(
+            ticket=ticket,
+            overlay="acme",
+            url=url,
+            repo="x/y",
+            iid="370",
+        )
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="in_flight",
+                detail="PR #370 open",
+                payload={"url": url, "iid": 370, "raw": {}},
+            ),
+        ]
+        assert build_ticket_index(actions) == {url: "855"}
+
+    def test_fk_takes_precedence_over_footer_parse(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://x/issues/855", state="started")
+        url = "https://gitlab.com/x/y/-/merge_requests/370"
+        PullRequest.objects.create(
+            ticket=ticket,
+            overlay="acme",
+            url=url,
+            repo="x/y",
+            iid="370",
+        )
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="in_flight",
+                detail="PR #370 open",
+                payload={
+                    "url": url,
+                    "iid": 370,
+                    "raw": {"description": "Closes #9999"},
+                },
+            ),
+        ]
+        # DB wins — should be 855, not the 9999 from the footer.
+        assert build_ticket_index(actions) == {url: "855"}
+
+    def test_mixes_fk_and_footer_per_url(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://x/issues/855", state="started")
+        url_db = "https://gitlab.com/x/y/-/merge_requests/370"
+        url_parse = "https://gitlab.com/x/y/-/merge_requests/371"
+        PullRequest.objects.create(
+            ticket=ticket,
+            overlay="acme",
+            url=url_db,
+            repo="x/y",
+            iid="370",
+        )
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="in_flight",
+                detail="PR #370",
+                payload={"url": url_db, "iid": 370, "raw": {}},
+            ),
+            DispatchAction(
+                kind="statusline",
+                zone="in_flight",
+                detail="PR #371",
+                payload={
+                    "url": url_parse,
+                    "iid": 371,
+                    "raw": {"description": "Fixes #856"},
+                },
+            ),
+        ]
+        assert build_ticket_index(actions) == {url_db: "855", url_parse: "856"}
+
+
+class TestZonesForGroupsByParentTicket(TestCase):
+    """End-to-end: ``zones_for`` buckets MRs under parent tickets via FK + footer."""
+
+    def test_in_flight_prs_grouped_under_parent_via_db(self) -> None:
+        from teatree.loop.rendering import zones_for  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://x/issues/855", state="started")
+        url_a = "https://gitlab.com/x/y/-/merge_requests/370"
+        url_b = "https://gitlab.com/x/y/-/merge_requests/399"
+        for iid, url in [("370", url_a), ("399", url_b)]:
+            PullRequest.objects.create(ticket=ticket, overlay="acme", url=url, repo="x/y", iid=iid)
+
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="in_flight",
+                detail="PR #370 open",
+                payload={"url": url_a, "iid": 370, "overlay": "acme", "raw": {}},
+            ),
+            DispatchAction(
+                kind="statusline",
+                zone="in_flight",
+                detail="PR #399 open",
+                payload={"url": url_b, "iid": 399, "overlay": "acme", "raw": {}},
+            ),
+        ]
+        zones = zones_for(actions)
+        text = zones.in_flight[0] if isinstance(zones.in_flight[0], str) else zones.in_flight[0].text
+        assert "[acme]" in text
+        assert "#855:" in text
+        assert "!370" in text
+        assert "!399" in text
+
+    def test_action_needed_prs_grouped_via_footer_fallback(self) -> None:
+        from teatree.loop.rendering import zones_for  # noqa: PLC0415
+
+        # No PullRequest row — description footer is the only source.
+        url = "https://gitlab.com/x/y/-/merge_requests/370"
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="action_needed",
+                detail="PR #370 has 3 notes",
+                payload={
+                    "url": url,
+                    "iid": 370,
+                    "draft_count": 3,
+                    "overlay": "acme",
+                    "raw": {"description": "feat(thing): wip\n\nCloses #855"},
+                },
+            ),
+        ]
+        zones = zones_for(actions)
+        text = zones.action_needed[0] if isinstance(zones.action_needed[0], str) else zones.action_needed[0].text
+        assert "#855:" in text
+        assert "!370 (3 notes)" in text
+
+    def test_orphan_pr_renders_under_overlay_without_ticket_prefix(self) -> None:
+        from teatree.loop.rendering import zones_for  # noqa: PLC0415
+
+        url = "https://example.com/pr/999"
+        actions = [
+            DispatchAction(
+                kind="statusline",
+                zone="in_flight",
+                detail="PR #999 open",
+                payload={"url": url, "iid": 999, "overlay": "acme", "raw": {}},
+            ),
+        ]
+        zones = zones_for(actions)
+        text = zones.in_flight[0] if isinstance(zones.in_flight[0], str) else zones.in_flight[0].text
+        assert "[acme]" in text
+        assert "!999" in text
+        # No parent ticket — should not carry a "#N:" prefix in the bucket.
+        assert "#" not in text.replace("[acme]", "")


### PR DESCRIPTION
feat(loop): group MRs under parent ticket via PullRequest FK + Closes/Fixes footer (https://github.com/souliane/teatree/issues/640)

## Summary
- New `teatree.loop.pr_ticket_index` builds `mr_url → parent_ticket_number` index. Two sources, cheapest first: `PullRequest.ticket` FK lookup, then `Closes/Fixes/Resolves #N` regex on the MR description payload.
- Renderer threads the new flat index through `_populate_overlay_zones` / `_render_action_line` / `_render_pr_group`. The old per-overlay `ticket_index_by_overlay` was keyed by ticket URL but consumed with MR URLs — never matched. Replaced.
- 22 new tests (regex parser unit + FK lookup integration via `TestCase` + `zones_for` end-to-end).
- BLUEPRINT.md updated. Per-module coverage floor declared at 80%.

Closes #640