### PR TITLE
fix(overlay): apply TOML overrides to entry-point overlays (https://github.com/souliane/teatree/issues/645)

### DIFF
--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -93,7 +93,7 @@ class OverlayConfig:
         if settings_module:
             self._load_settings(settings_module)
         if overlay_name:
-            self._load_toml_overrides(overlay_name)
+            self.apply_toml_overrides(overlay_name)
 
     def _load_settings(self, module_path: str) -> None:
         mod = import_module(module_path)
@@ -108,7 +108,14 @@ class OverlayConfig:
             else:
                 setattr(self, name.lower(), value)
 
-    def _load_toml_overrides(self, overlay_name: str) -> None:
+    def apply_toml_overrides(self, overlay_name: str) -> None:
+        """Apply ``[overlays.<overlay_name>]`` overrides from ``~/.teatree.toml``.
+
+        Called automatically by ``__init__`` when an ``overlay_name`` is
+        supplied, and by ``overlay_loader._discover_overlays`` for every
+        entry-point overlay (so ``OverlayConfig`` subclasses don't have to
+        opt in by threading ``overlay_name`` through every ``super().__init__``).
+        """
         from teatree.config import load_config  # noqa: PLC0415
 
         config = load_config()

--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -81,7 +81,13 @@ def _discover_overlays() -> "dict[str, OverlayBase]":
         if not issubclass(cls, OverlayBase):
             msg = f"Entry point {ep.name!r} ({ep.value}) does not subclass OverlayBase"
             raise ImproperlyConfigured(msg)
-        result[ep.name] = cls()
+        overlay = cls()
+        # Apply [overlays.<name>] TOML overrides so entry-point overlays
+        # are configurable from ~/.teatree.toml on the same footing as
+        # TOML-only overlays. Without this, OverlayConfig subclasses
+        # would have to opt in by passing overlay_name to super().__init__.
+        overlay.config.apply_toml_overrides(ep.name)
+        result[ep.name] = overlay
 
     # 2. TOML-configured overlays (not already found via entry points)
     result.update(_discover_toml_overlays(OverlayBase, set(result)))

--- a/tests/teatree_core/test_overlay.py
+++ b/tests/teatree_core/test_overlay.py
@@ -222,6 +222,64 @@ class TestOverlayConfig(TestCase):
         with patch("teatree.utils.secrets.read_pass", return_value="secret-value"):
             assert config.get_github_token() == "secret-value"
 
+    def test_entry_point_overlays_receive_toml_overrides(self) -> None:
+        # _discover_overlays must call apply_toml_overrides on every
+        # entry-point overlay so [overlays.<name>] in ~/.teatree.toml wins
+        # over the overlay's settings module — same precedence as TOML-only
+        # overlays. Without this, every OverlayConfig subclass would have
+        # to opt in via super().__init__(overlay_name=...).
+        from teatree.core.overlay_loader import _discover_overlays  # noqa: PLC0415
+
+        # Use the existing DummyOverlay registered above as the entry-point target.
+        ep = MagicMock()
+        ep.name = "dummy-ep"
+        ep.value = "tests.teatree_core.test_overlay:DummyOverlay"
+        ep.load.return_value = DummyOverlay
+
+        mock_config = MagicMock()
+        mock_config.raw = {
+            "overlays": {
+                "dummy-ep": {
+                    "exclude_labels": ["Process::DEV review"],
+                },
+            },
+        }
+
+        reset_overlay_cache()
+        try:
+            with (
+                patch("importlib.metadata.entry_points", return_value=[ep]),
+                patch("teatree.config.load_config", return_value=mock_config),
+            ):
+                overlays = _discover_overlays()
+        finally:
+            reset_overlay_cache()
+
+        assert "dummy-ep" in overlays
+        assert overlays["dummy-ep"].config.exclude_labels == ["Process::DEV review"]
+
+    def test_apply_toml_overrides_after_init_overwrites_subclass_defaults(self) -> None:
+        # Subclasses that pass only ``settings_module`` (like OperConfig) miss
+        # TOML overrides unless apply_toml_overrides is called explicitly.
+        # Entry-point discovery uses that call site to keep overlay names
+        # honest, so the method must be callable after __init__ and must
+        # win against any subclass default.
+        config = OverlayConfig()
+        config.exclude_labels = ["from-subclass-default"]
+
+        mock_config = MagicMock()
+        mock_config.raw = {
+            "overlays": {
+                "test-overlay": {
+                    "exclude_labels": ["Process::DEV review", "Process::QA review"],
+                },
+            },
+        }
+        with patch("teatree.config.load_config", return_value=mock_config):
+            config.apply_toml_overrides("test-overlay")
+
+        assert config.exclude_labels == ["Process::DEV review", "Process::QA review"]
+
 
 class TestDefaultHealthChecks(TestCase):
     def test_includes_worktree_and_symlink_checks(self) -> None:


### PR DESCRIPTION
## Summary
- `[overlays.<name>]` TOML overrides were ignored for entry-point overlays because `OverlayConfig` subclasses (e.g. `OperConfig`) pass `settings_module` to `super().__init__` but not `overlay_name`. The result: `~/.teatree.toml` settings like `exclude_labels` silently did nothing on the production CLI.
- Fix: apply TOML overrides at the entry-point discovery layer (`_discover_overlays`) so every overlay gets the same precedence as TOML-only overlays — no subclass needs to opt in.
- Renamed `_load_toml_overrides` → `apply_toml_overrides` (public API now that it's called from outside the class).

## Repro before fix
- TOML has `exclude_labels = ["Process::DEV review", "Process::QA review"]`
- Statusline still includes tickets carrying those labels.

## After fix
- Statusline correctly filters tickets with the configured labels.

Closes #645