### PR TITLE
feat(loop): inline MRs in parens after their parent ticket in ready zone (https://github.com/souliane/teatree/issues/647)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -159,7 +159,7 @@ src/teatree/
   loop/                 # /loop topology (see §5.6)
     tick.py             # One tick: scan in parallel, dispatch to phase agents when needed, render statusline
     dispatch.py         # Signal → action mapping (statusline / agent / webhook)
-    rendering.py        # Classify dispatched actions per overlay; render anchor / action / in-flight rows
+    rendering.py        # Classify dispatched actions per overlay; render anchor / action / in-flight rows. Ready zone inlines `(!iid)` after each ticket whose parent MR is known.
     pr_ticket_index.py  # Build mr_url → parent_ticket_number index (PullRequest FK + Closes/Fixes regex)
     statusline.py       # Statusline composition (zones, formatters) and file write
     scanners/           # Pure-Python signal collectors — one file each

--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -263,16 +263,37 @@ def _render_action_line(
     ticket_index: dict[str, str] | None = None,
 ) -> str:
     prefix = f"[{overlay}] " if overlay else ""
+    prs_by_ticket: dict[str, list[_PRRef]] = {}
+    for ref in pr_refs:
+        parent = (ticket_index or {}).get(ref.url, "")
+        if parent and parent != str(ref.iid):
+            prs_by_ticket.setdefault(parent, []).append(ref)
+    consumed_pr_urls: set[str] = set()
+
     parts: list[str] = []
-    if pr_refs:
-        parts.append(_render_pr_group(overlay, pr_refs, ticket_index=ticket_index).removeprefix(prefix))
     for reason, refs in disposition_refs.items():
         label = _DISPOSITION_LABELS.get(reason, reason)
         items = " ".join(_link(r.label, r.url) for r in refs)
         parts.append(f"{label}: {items}")
     if ready_refs:
-        items = " ".join(_link(r.label, r.url) for r in ready_refs)
-        parts.append(f"ready: {items}")
+        items: list[str] = []
+        for ref in ready_refs:
+            text = _link(ref.label, ref.url)
+            number = ref.label.lstrip("#")
+            prs = prs_by_ticket.get(number, [])
+            if prs:
+                pr_parts = [_link(f"!{p.iid}", p.url) for p in prs]
+                text += f" ({' '.join(pr_parts)})"
+                consumed_pr_urls.update(p.url for p in prs)
+            items.append(text)
+        parts.append(f"ready: {' '.join(items)}")
+    if pr_refs:
+        remaining = [r for r in pr_refs if r.url not in consumed_pr_urls]
+        if remaining:
+            parts.insert(
+                0,
+                _render_pr_group(overlay, remaining, ticket_index=ticket_index).removeprefix(prefix),
+            )
     if not parts:
         return ""
     return f"{prefix}{' · '.join(parts)}"

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -511,6 +511,42 @@ def test_render_pr_group_lists_orphans_when_no_match() -> None:
     assert "#" not in line  # no ticket prefix
 
 
+def test_render_action_line_inlines_mrs_after_ready_tickets() -> None:
+    from teatree.loop.rendering import _IssueRef, _PRRef, _render_action_line  # noqa: PLC0415
+
+    pr_refs = [
+        _PRRef(iid=370, url="https://gitlab.com/x/y/-/merge_requests/370", annotation=""),
+        _PRRef(iid=368, url="https://gitlab.com/x/y/-/merge_requests/368", annotation=""),
+    ]
+    ready_refs = [
+        _IssueRef(label="#855", url="https://gitlab.com/x/y/-/issues/855"),
+        _IssueRef(label="#854", url="https://gitlab.com/x/y/-/issues/854"),
+    ]
+    ticket_index = {
+        "https://gitlab.com/x/y/-/merge_requests/370": "855",
+        # !368 is an orphan — no parent ticket
+    }
+
+    line = _render_action_line(
+        "acme",
+        pr_refs=pr_refs,
+        disposition_refs={},
+        ready_refs=ready_refs,
+        ticket_index=ticket_index,
+    )
+
+    # !370 should appear inline after #855, !368 should remain in the standalone PR group.
+    assert "#855" in line
+    assert "!370" in line
+    assert "#854" in line
+    assert "!368" in line
+    pos_855 = line.index("#855")
+    pos_370 = line.index("!370")
+    assert pos_855 < pos_370, "!370 must follow #855"
+    # !370 should not also appear in the standalone PR-group section (de-dup).
+    assert line.count("!370") == 1
+
+
 def test_reviewer_pr_signal_surfaces_in_statusline() -> None:
     from teatree.loop.dispatch import dispatch  # noqa: PLC0415
     from teatree.loop.rendering import zones_for  # noqa: PLC0415


### PR DESCRIPTION
## Summary
- `_render_action_line` now consumes the `pr_refs → parent_ticket_number` index built by `pr_ticket_index.build_ticket_index`, inverts it locally, and appends `(!iid)` after each ready-zone ticket whose parent MR is known.
- Consumed MRs are removed from the trailing `[overlay] !x · !y` group so they aren't rendered twice.
- Example: `[t3-company] ready: #855 (!370) #854 #8452 (!7397) · !368 · !32` instead of two separate lines.

Closes #647