### PR TITLE
feat(secrets): store POSTGRES_PASSWORD via pass key reference (https://github.com/souliane/teatree/issues/417)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -642,7 +642,7 @@ Defined in `teatree.core.overlay`. All methods receive the `worktree` instance f
 | Method | Signature | Default | Purpose |
 |--------|-----------|---------|---------|
 | `get_env_extra(worktree)` | `→ dict[str, str]` | `{}` | Extra environment variables |
-| `declared_secret_env_keys()` | `→ set[str]` | `set()` | Keys whose values must NOT land in `.t3-env.cache` (still produced by `get_env_extra` so subprocess `env=` callers receive them, but `render_env_cache` filters them out of the on-disk file). Use for `pass`-sourced credentials. |
+| `declared_secret_env_keys()` | `→ set[str]` | `set()` | Keys whose values must NOT land in `.t3-env.cache` (still produced by `get_env_extra` so subprocess `env=` callers receive them, but `render_env_cache` filters them out of the on-disk file). Core auto-includes `POSTGRES_PASSWORD` and writes a `POSTGRES_PASSWORD_PASS_KEY` reference instead — runtime callers resolve the literal via `teatree.utils.postgres_secret.resolve_postgres_password`. Use this hook for additional `pass`-sourced credentials. |
 | `get_required_ports(worktree)` | `→ set[str]` | `set()` | Port keys to allocate per worktree (e.g. `{"backend", "frontend", "postgres"}`). Empty set means no docker-compose ports — single-service overlays opt out. |
 | `get_port_env(ports)` | `→ dict[str, str]` | `{KEY_HOST_PORT: ...}` | Env vars exported to compose for allocated host ports. Default renders `${KEY}_HOST_PORT` for each key; overlays override to add convention-specific aliases (e.g. `POSTGRES_PORT`, `CORS_WHITE_FRONT`). |
 | `uses_redis()` | `→ bool` | `False` | Whether the shared `teatree-redis` container should be ensured and a per-ticket DB index allocated. Multi-service overlays with Celery/RQ/cache opt in; single-service overlays leave the default. |
@@ -858,7 +858,7 @@ Internal utilities (`utils/`) — port allocation, git helpers, DB ops — are P
 **workspace** — Workspace operations (ticket setup, status, finalize, cleanup)
 **worktree** — Per-worktree commands (`provision`, `start`, `verify`, `teardown`, `clean`, `ready`, `status`)
 **db** — Database operations
-**env** — Read/write the env cache (`set`, `show`, `check`)
+**env** — Read/write the env cache (`set`, `show`, `check`, `migrate-secrets`). `migrate-secrets` moves any `POSTGRES_PASSWORD=<literal>` line out of `.t3-env.cache` into the local `pass` store under `teatree/wt/<ticket_id>/postgres` so the on-disk cache only carries the symbolic `POSTGRES_PASSWORD_PASS_KEY` reference.
 **run** — Service runner (uses `lifecycle.compose_project()` shared helper)
 **pr** — PR creation and validation
 **ticket** — Ticket transitions and queries (`list`, `transition`, ...)

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1187,6 +1187,7 @@ Usage: t3 teatree [OPTIONS] COMMAND [ARGS]...
 │ tasks        Async task queue.                                               │
 │ followup     Follow-up snapshots.                                            │
 │ lifecycle    Session lifecycle and phase tracking.                           │
+│ env          Inspect and mutate the worktree env cache.                      │
 │ ticket       Ticket state management.                                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -2341,6 +2342,130 @@ Usage: t3 teatree lifecycle visit-phase [OPTIONS] TICKET_ID PHASE
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 teatree env`
+
+```
+Usage: t3 teatree env [OPTIONS] COMMAND [ARGS]...
+
+ Inspect and mutate the worktree env cache.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ show             Print the env cache as the DB would render it.              │
+│ set-var          Persist an override on the worktree and refresh the cache.  │
+│ unset            Delete an override row and refresh the cache.               │
+│ overrides        List user-declared overrides for this worktree.             │
+│ check            Exit non-zero if the on-disk cache diverges from the DB     │
+│                  render.                                                     │
+│ migrate-secrets  Move POSTGRES_PASSWORD literals out of .t3-env.cache into   │
+│                  pass.                                                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree env show`
+
+```
+Usage: t3 teatree env show [OPTIONS]
+
+ Print the current env as the DB would render it.
+
+ Never reads the cache file — always renders fresh from the DB.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --path          TEXT  Worktree path (auto-detects from PWD if empty).        │
+│ --format        TEXT  shell | json [default: shell]                          │
+│ --help                Show this message and exit.                            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree env set-var`
+
+```
+Usage: t3 teatree env set-var [OPTIONS] KEY_VALUE
+
+ Persist an override on the worktree and refresh the cache.
+
+ Rejects keys owned by core (edit the model field instead).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    key_value      TEXT  KEY=VALUE. [required]                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
+│ --help              Show this message and exit.                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree env unset`
+
+```
+Usage: t3 teatree env unset [OPTIONS] KEY
+
+ Delete an override row and refresh the cache.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    key      TEXT  Override key to remove. [required]                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
+│ --help              Show this message and exit.                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree env overrides`
+
+```
+Usage: t3 teatree env overrides [OPTIONS]
+
+ List user-declared overrides for this worktree.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
+│ --help              Show this message and exit.                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree env check`
+
+```
+Usage: t3 teatree env check [OPTIONS]
+
+ Exit non-zero if the on-disk cache diverges from the DB render.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
+│ --help              Show this message and exit.                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree env migrate-secrets`
+
+```
+Usage: t3 teatree env migrate-secrets [OPTIONS]
+
+ Move ``POSTGRES_PASSWORD`` literals out of ``.t3-env.cache`` into ``pass``.
+
+ For each targeted worktree this command:
+
+ 1. Reads the literal ``POSTGRES_PASSWORD=`` line from the on-disk cache.
+ 2. Stores it in ``pass`` under the canonical key for that worktree.
+ 3. Regenerates the cache so it now contains only the symbolic
+     ``POSTGRES_PASSWORD_PASS_KEY`` reference.
+
+ Idempotent — caches that already lack a literal are reported as
+ ``already migrated`` and left alone.  Exits 0 when every targeted
+ worktree finished successfully, non-zero when at least one needs
+ attention (no pass installed, cache missing, etc.).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --path        TEXT  Worktree path (migrates only this worktree). Empty =     │
+│                     migrate every worktree.                                  │
+│ --help              Show this message and exit.                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,7 @@ pythonpath = [ ".", "src", "scripts", "scripts/hooks", "tests" ]
 filterwarnings = [
   "error",
   "ignore:In Typer, only the parameter 'autocompletion' is supported.*:DeprecationWarning",
+  "ignore:POSTGRES_PASSWORD literal is deprecated.*:DeprecationWarning",
 ]
 xfail_strict = true
 markers = [

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -121,6 +121,17 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("visit-phase", "Mark a phase as visited on the ticket's latest session."),
         ],
     ),
+    "env": (
+        "Inspect and mutate the worktree env cache.",
+        [
+            ("show", "Print the env cache as the DB would render it."),
+            ("set-var", "Persist an override on the worktree and refresh the cache."),
+            ("unset", "Delete an override row and refresh the cache."),
+            ("overrides", "List user-declared overrides for this worktree."),
+            ("check", "Exit non-zero if the on-disk cache diverges from the DB render."),
+            ("migrate-secrets", "Move POSTGRES_PASSWORD literals out of .t3-env.cache into pass."),
+        ],
+    ),
     "ticket": (
         "Ticket state management.",
         [

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -23,6 +23,7 @@ from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_overlay
 from teatree.utils import git
 from teatree.utils.db import drop_db
+from teatree.utils.postgres_secret import remove_postgres_pass_entry
 from teatree.utils.run import run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
@@ -285,6 +286,11 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False) -> str:
     if worktree.db_name:
         db_user = _read_env_cache_value(Path(wt_path), "POSTGRES_USER")
         drop_db(worktree.db_name, user=db_user)
+
+    if getattr(overlay.config, "teardown_removes_pass_entries", False) is True:
+        ticket = worktree.ticket
+        if ticket is not None:
+            remove_postgres_pass_entry(ticket.ticket_number)
 
     label = f"Cleaned: {worktree.repo_path} ({worktree.branch})"
     if step_errors:

--- a/src/teatree/core/management/commands/env.py
+++ b/src/teatree/core/management/commands/env.py
@@ -7,14 +7,29 @@ config), never the cache file.
 
 import json
 import sys
+from dataclasses import dataclass
+from pathlib import Path
 
 import typer
 from django.core.management import execute_from_command_line
 from django_typer.management import TyperCommand, command
 
-from teatree.core.models import WorktreeEnvOverride
+from teatree.core.models import Worktree, WorktreeEnvOverride
 from teatree.core.resolve import resolve_worktree
-from teatree.core.worktree_env import detect_drift, load_overrides, render_env_cache, set_override, write_env_cache
+from teatree.core.worktree_env import (
+    CACHE_DIRNAME,
+    CACHE_FILENAME,
+    detect_drift,
+    load_overrides,
+    render_env_cache,
+    set_override,
+    write_env_cache,
+)
+from teatree.utils.postgres_secret import (
+    PostgresPasswordUnavailableError,
+    ensure_postgres_pass_entry,
+    extract_literal_from_cache,
+)
 
 
 class Command(TyperCommand):
@@ -117,6 +132,85 @@ class Command(TyperCommand):
             return 1
         self.stdout.write(f"  {worktree.repo_path}: env cache in sync with DB")
         return 0
+
+    @command(name="migrate-secrets")
+    def migrate_secrets(
+        self,
+        path: str = typer.Option(
+            "",
+            help="Worktree path (migrates only this worktree). Empty = migrate every worktree.",
+        ),
+    ) -> int:
+        """Move ``POSTGRES_PASSWORD`` literals out of ``.t3-env.cache`` into ``pass``.
+
+        For each targeted worktree this command:
+
+        1. Reads the literal ``POSTGRES_PASSWORD=`` line from the on-disk cache.
+        2. Stores it in ``pass`` under the canonical key for that worktree.
+        3. Regenerates the cache so it now contains only the symbolic
+            ``POSTGRES_PASSWORD_PASS_KEY`` reference.
+
+        Idempotent — caches that already lack a literal are reported as
+        ``already migrated`` and left alone.  Exits 0 when every targeted
+        worktree finished successfully, non-zero when at least one needs
+        attention (no pass installed, cache missing, etc.).
+        """
+        targets = [resolve_worktree(path)] if path else list(Worktree.objects.all())
+        if not targets:
+            self.stdout.write("  no worktrees found — nothing to migrate")
+            return 0
+
+        failures = 0
+        for worktree in targets:
+            outcome = self._migrate_single_worktree(worktree)
+            self.stdout.write(f"  {worktree.repo_path}: {outcome.message}")
+            if not outcome.ok:
+                failures += 1
+        return 0 if failures == 0 else 1
+
+    def _migrate_single_worktree(self, worktree: Worktree) -> "_MigrationOutcome":
+        cache_path = _cache_path_for(worktree)
+        if cache_path is None:
+            return _MigrationOutcome(ok=True, message="not provisioned — skipped")
+
+        literal = extract_literal_from_cache(cache_path)
+        ticket = worktree.ticket
+        if ticket is None:
+            return _MigrationOutcome(ok=False, message="no ticket attached — cannot derive pass key")
+        ticket_number = ticket.ticket_number
+
+        if not literal:
+            write_env_cache(worktree)
+            return _MigrationOutcome(ok=True, message="already migrated (no literal in cache)")
+
+        try:
+            pass_key = ensure_postgres_pass_entry(ticket_number, literal)
+        except PostgresPasswordUnavailableError as exc:
+            return _MigrationOutcome(ok=False, message=str(exc))
+
+        # Regenerate the cache from the DB so the literal is replaced with the
+        # symbolic reference.  The render layer already drops POSTGRES_PASSWORD.
+        write_env_cache(worktree)
+        return _MigrationOutcome(ok=True, message=f"migrated to pass key {pass_key}")
+
+
+def _cache_path_for(worktree: Worktree) -> Path | None:
+    wt_path = (worktree.extra or {}).get("worktree_path", "")
+    if not wt_path:
+        return None
+    return Path(wt_path).parent / CACHE_DIRNAME / CACHE_FILENAME
+
+
+@dataclass(frozen=True, slots=True)
+class _MigrationOutcome:
+    """Outcome of migrating one worktree — used by ``migrate-secrets``.
+
+    Replaces ad-hoc tuples so each line of code reads ``outcome.ok`` and
+    ``outcome.message`` instead of indexed access.
+    """
+
+    ok: bool
+    message: str
 
 
 def main() -> int:

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -74,6 +74,7 @@ class OverlayConfig:
     max_concurrent_auto_starts: int = 1
     notion_database_id: str = ""
     mr_close_ticket: bool = False
+    teardown_removes_pass_entries: bool = False
     known_variants: list[str]
     pr_auto_labels: list[str]
     frontend_repos: list[str]

--- a/src/teatree/core/worktree_env.py
+++ b/src/teatree/core/worktree_env.py
@@ -21,6 +21,7 @@ from teatree.core.models import Ticket, Worktree, WorktreeEnvOverride
 from teatree.core.models.types import WorktreeExtra, validated_worktree_extra
 from teatree.core.overlay_loader import get_overlay
 from teatree.docker.build import image_tag_for_lockfile
+from teatree.utils.postgres_secret import PASS_KEY_ENV, postgres_pass_key
 
 if TYPE_CHECKING:
     from teatree.core.overlay import OverlayBase
@@ -75,6 +76,7 @@ def _core_env_pairs(worktree: Worktree) -> list[tuple[str, str]]:
         ("TICKET_URL", ticket.issue_url),
         ("WT_DB_NAME", worktree.db_name),
         ("COMPOSE_PROJECT_NAME", f"{worktree.repo_path}-wt{ticket.ticket_number}"),
+        (PASS_KEY_ENV, postgres_pass_key(ticket.ticket_number)),
     ]
     if ticket.redis_db_index is not None:
         pairs.append(("REDIS_DB_INDEX", str(ticket.redis_db_index)))
@@ -91,6 +93,7 @@ def _declared_core_keys() -> set[str]:
         "COMPOSE_PROJECT_NAME",
         "REDIS_DB_INDEX",
         "POSTGRES_HOST",
+        PASS_KEY_ENV,
     }
 
 

--- a/src/teatree/utils/db.py
+++ b/src/teatree/utils/db.py
@@ -1,11 +1,12 @@
 import os
 
+from teatree.utils.postgres_secret import resolve_postgres_password
 from teatree.utils.run import CommandFailedError, run_allowed_to_fail, run_checked
 
 
 def pg_env() -> dict[str, str]:
     env = os.environ.copy()
-    if password := os.environ.get("POSTGRES_PASSWORD", ""):
+    if password := resolve_postgres_password(env):
         env["PGPASSWORD"] = password
     if port := os.environ.get("POSTGRES_PORT", ""):
         env["PGPORT"] = port

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -46,8 +46,9 @@ def _local_db_url(db_name: str) -> str:
     from urllib.parse import quote  # noqa: PLC0415
 
     from teatree.utils.db import pg_host, pg_user  # noqa: PLC0415
+    from teatree.utils.postgres_secret import resolve_postgres_password  # noqa: PLC0415
 
-    pw = os.environ.get("POSTGRES_PASSWORD", "")
+    pw = resolve_postgres_password()
     port = os.environ.get("POSTGRES_PORT", "5432")
     return f"postgres://{pg_user()}:{quote(pw, safe='')}@{pg_host()}:{port}/{db_name}"
 

--- a/src/teatree/utils/postgres_secret.py
+++ b/src/teatree/utils/postgres_secret.py
@@ -1,0 +1,192 @@
+"""Resolve and persist the per-worktree Postgres password without leaking it.
+
+Privacy-preserving alternative to keeping ``POSTGRES_PASSWORD=<literal>`` in
+``.t3-env.cache``.  The cache instead stores ``POSTGRES_PASSWORD_PASS_KEY``,
+a symbolic reference (e.g. ``teatree/wt/123/postgres``) that runtime tooling
+resolves on demand via the ``pass`` password store.
+
+Resolution order in :func:`resolve_postgres_password`:
+
+1. ``POSTGRES_PASSWORD_PASS_KEY`` env → ``pass show <key>``.
+2. ``T3_SECRET_RESOLVER`` env → run that command with the pass key (or
+    ``POSTGRES_PASSWORD`` if no pass key is set) as the first argument; its
+    stdout (first line, stripped) is the secret.  Used by environments that
+    cannot install ``pass``.
+3. ``POSTGRES_PASSWORD`` env literal — legacy, raises ``DeprecationWarning``
+    once per process so existing setups keep working but get nudged toward
+    the symbolic form.
+
+The literal secret never appears in log lines or exception messages
+emitted by this module — callers that need to verify resolution should
+check ``bool(value)`` or ``len(value)``, not echo the secret itself.
+"""
+
+import logging
+import os
+import warnings
+from pathlib import Path
+
+from teatree.utils import secrets
+from teatree.utils.run import CommandFailedError, run_checked
+
+logger = logging.getLogger(__name__)
+
+POSTGRES_PASSWORD_ENV = "POSTGRES_PASSWORD"  # noqa: S105 — env-var name, not a secret
+PASS_KEY_ENV = "POSTGRES_PASSWORD_PASS_KEY"  # noqa: S105 — env-var name, not a secret
+RESOLVER_ENV = "T3_SECRET_RESOLVER"
+PASS_KEY_PREFIX = "teatree/wt"  # noqa: S105 — pass key namespace, not a secret
+PASS_KEY_SUFFIX = "postgres"  # noqa: S105 — pass key leaf, not a secret
+
+_LITERAL_DEPRECATION_WARNED = False
+
+
+class PostgresPasswordUnavailableError(RuntimeError):
+    """Raised when no resolution strategy can produce a Postgres password."""
+
+
+def postgres_pass_key(ticket_id: object) -> str:
+    """Return the canonical ``pass`` key path for *ticket_id*.
+
+    *ticket_id* is stringified — the caller can pass a ``Ticket.ticket_number``,
+    primary key, or arbitrary string identifier.  Empty values yield a
+    ``ValueError`` so the caller never silently creates a flat ``teatree/wt//
+    postgres`` entry that would collide across worktrees.
+    """
+    value = str(ticket_id).strip()
+    if not value:
+        msg = "ticket_id must be non-empty to build a postgres pass-key"
+        raise ValueError(msg)
+    return f"{PASS_KEY_PREFIX}/{value}/{PASS_KEY_SUFFIX}"
+
+
+def resolve_postgres_password(env: dict[str, str] | None = None) -> str:
+    """Return the Postgres password without storing it anywhere observable.
+
+    Reads from *env* (defaults to ``os.environ``) following the resolution
+    order documented at the module docstring.  Returns the empty string
+    when no source is available — callers decide whether that's fatal.
+    """
+    source = env if env is not None else os.environ
+    if pass_key := source.get(PASS_KEY_ENV, "").strip():
+        value = secrets.read_pass(pass_key)
+        if value:
+            return value
+        # Fall through — the symbolic ref existed but resolution failed.
+        # The next resolver / literal may still succeed.
+        logger.warning("POSTGRES_PASSWORD_PASS_KEY=%s resolved to empty value", pass_key)
+
+    if resolver := source.get(RESOLVER_ENV, "").strip():
+        value = _resolve_via_command(resolver, source.get(PASS_KEY_ENV, ""))
+        if value:
+            return value
+
+    if literal := source.get(POSTGRES_PASSWORD_ENV, ""):
+        _warn_literal_password_deprecated()
+        return literal
+
+    return ""
+
+
+def _resolve_via_command(command: str, pass_key: str) -> str:
+    """Invoke *command* with *pass_key* and return its first stdout line.
+
+    Lets non-``pass`` users supply any resolver that echoes the secret
+    (e.g. 1Password CLI, Bitwarden CLI, sops, age).  Failure to invoke
+    or non-zero exit returns the empty string.
+    """
+    parts = command.split()
+    if pass_key:
+        parts.append(pass_key)
+    try:
+        result = run_checked(parts)
+    except (CommandFailedError, FileNotFoundError):
+        logger.warning("T3_SECRET_RESOLVER command failed to resolve postgres password")
+        return ""
+    line = result.stdout.strip().splitlines()
+    return line[0] if line else ""
+
+
+def _warn_literal_password_deprecated() -> None:
+    global _LITERAL_DEPRECATION_WARNED  # noqa: PLW0603 — module-level flag is the right scope.
+    if _LITERAL_DEPRECATION_WARNED:
+        return
+    _LITERAL_DEPRECATION_WARNED = True
+    warnings.warn(
+        "POSTGRES_PASSWORD literal is deprecated — store the secret in `pass` "
+        "and reference it via POSTGRES_PASSWORD_PASS_KEY. "
+        "Run `t3 <overlay> env migrate-secrets` to migrate existing worktrees.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def _reset_literal_deprecation_state() -> None:
+    """Test hook — reset the one-shot deprecation warning flag."""
+    global _LITERAL_DEPRECATION_WARNED  # noqa: PLW0603 — test-only reset of a module flag.
+    _LITERAL_DEPRECATION_WARNED = False
+
+
+def ensure_postgres_pass_entry(ticket_id: object, password: str) -> str:
+    """Store *password* under the worktree's canonical pass key.
+
+    Returns the pass key on success.  Raises ``PostgresPasswordUnavailableError``
+    when ``pass`` is not available — the caller decides whether to fall back
+    to the legacy literal-in-cache behavior or fail.
+    """
+    if not password:
+        msg = "password must be non-empty to be stored in pass"
+        raise ValueError(msg)
+    key = postgres_pass_key(ticket_id)
+    if not secrets.write_pass(key, password):
+        msg = (
+            "pass is not installed or pass insert failed — cannot store the "
+            "postgres password symbolically. Install pass or set "
+            "T3_SECRET_RESOLVER to keep secrets out of .t3-env.cache."
+        )
+        raise PostgresPasswordUnavailableError(msg)
+    return key
+
+
+def remove_postgres_pass_entry(ticket_id: object) -> bool:
+    """Remove the worktree's postgres entry from ``pass``.
+
+    Returns ``True`` when ``pass rm`` reported success, ``False`` otherwise
+    (no entry, pass not installed, command failed).  Callers should treat
+    a ``False`` as best-effort — teardown should not block on it.
+    """
+    key = postgres_pass_key(ticket_id)
+    return secrets.remove_pass(key)
+
+
+def extract_literal_from_cache(cache_path: Path) -> str:
+    """Return the literal ``POSTGRES_PASSWORD`` value stored in *cache_path*.
+
+    Returns the empty string when the file is missing, unreadable, or has
+    no literal entry (already migrated, or never used the literal form).
+    Surfaces only enough information for the migration command — never
+    logs the value.
+    """
+    if not cache_path.is_file():
+        return ""
+    try:
+        body = cache_path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if line.startswith(f"{POSTGRES_PASSWORD_ENV}="):
+            return line.split("=", maxsplit=1)[1]
+    return ""
+
+
+__all__ = [
+    "PASS_KEY_ENV",
+    "POSTGRES_PASSWORD_ENV",
+    "RESOLVER_ENV",
+    "PostgresPasswordUnavailableError",
+    "ensure_postgres_pass_entry",
+    "extract_literal_from_cache",
+    "postgres_pass_key",
+    "remove_postgres_pass_entry",
+    "resolve_postgres_password",
+]

--- a/src/teatree/utils/secrets.py
+++ b/src/teatree/utils/secrets.py
@@ -29,3 +29,22 @@ def write_pass(key: str, value: str) -> bool:
     except (CommandFailedError, FileNotFoundError):
         return False
     return True
+
+
+def remove_pass(key: str) -> bool:
+    """Remove *key* from the ``pass`` password store.
+
+    Uses ``pass rm --force`` so the entry is deleted without prompting.
+    Returns ``True`` on success, ``False`` if the entry was absent, ``pass``
+    is not installed, or the call failed.
+    """
+    try:
+        run_checked(["pass", "rm", "--force", key])
+    except (CommandFailedError, FileNotFoundError):
+        return False
+    return True
+
+
+def pass_entry_exists(key: str) -> bool:
+    """Return ``True`` when *key* resolves to a non-empty entry in ``pass``."""
+    return bool(read_pass(key))

--- a/tests/teatree_core/test_cleanup.py
+++ b/tests/teatree_core/test_cleanup.py
@@ -98,6 +98,43 @@ class TestCleanupWorktree(TestCase):
     @_patch_overlay
     @_patch_git
     @_patch_config
+    def test_skips_pass_remove_when_setting_disabled(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        _mock_workspace(mock_config)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_overlay.return_value.config.teardown_removes_pass_entries = False
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        with patch("teatree.core.cleanup.remove_postgres_pass_entry") as mock_remove:
+            cleanup_worktree(wt)
+        mock_remove.assert_not_called()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_removes_pass_entry_when_setting_enabled(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        _mock_workspace(mock_config)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_overlay.return_value.config.teardown_removes_pass_entries = True
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        ticket_number = wt.ticket.ticket_number
+        with patch("teatree.core.cleanup.remove_postgres_pass_entry") as mock_remove:
+            cleanup_worktree(wt)
+        mock_remove.assert_called_once_with(ticket_number)
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
     def test_deletes_worktree_record(
         self,
         mock_config: MagicMock,

--- a/tests/teatree_core/test_env_command.py
+++ b/tests/teatree_core/test_env_command.py
@@ -1,12 +1,14 @@
 """Integration tests for ``t3 env`` management command."""
 
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import TestCase
 
 from teatree.core.models import Ticket, Worktree, WorktreeEnvOverride
+from teatree.utils.postgres_secret import PostgresPasswordUnavailableError
 
 
 @dataclass
@@ -140,3 +142,130 @@ class TestEnvCheck(TestCase):
             patch("teatree.core.management.commands.env.detect_drift", return_value=(True, "/tmp/cache")),
         ):
             call_command("env", "check", "--path", "/tmp/wt/repo")
+
+
+class TestEnvMigrateSecrets(TestCase):
+    """The ``migrate-secrets`` subcommand moves literals into ``pass`` and refreshes the cache.
+
+    These tests provision a real ticket + worktree row, write a tiny
+    ``.t3-env.cache`` to ``tmp_path``, and patch only the ``pass`` boundary
+    (writing to a fake password store). Verifies that the literal disappears
+    from the regenerated cache and that the canonical pass key is stored.
+    """
+
+    def test_single_worktree_migration_writes_to_pass_and_regenerates_cache(self) -> None:
+        from tempfile import TemporaryDirectory  # noqa: PLC0415
+
+        from teatree.core.worktree_env import CACHE_DIRNAME, CACHE_FILENAME  # noqa: PLC0415
+
+        with TemporaryDirectory() as tmp:
+            ticket_dir = Path(tmp) / "ticket-42"
+            ticket_dir.mkdir()
+            wt_path = ticket_dir / "backend"
+            wt_path.mkdir()
+            cache_dir = ticket_dir / CACHE_DIRNAME
+            cache_dir.mkdir()
+            cache_file = cache_dir / CACHE_FILENAME
+            cache_file.write_text("FOO=bar\nPOSTGRES_PASSWORD=top-secret\n", encoding="utf-8")
+
+            ticket = Ticket.objects.create(overlay="teatree", issue_url="https://example.com/issues/42")
+            wt = Worktree.objects.create(
+                overlay="teatree",
+                ticket=ticket,
+                repo_path="backend",
+                branch="ac-test",
+                db_name="wt_42",
+                extra={"worktree_path": str(wt_path)},
+            )
+
+            stored: dict[str, str] = {}
+
+            def _fake_write_pass(key: str, value: str) -> bool:
+                stored[key] = value
+                return True
+
+            with (
+                patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
+                patch("teatree.utils.secrets.write_pass", side_effect=_fake_write_pass),
+            ):
+                call_command("env", "migrate-secrets", "--path", str(wt_path))
+
+            assert stored == {"teatree/wt/42/postgres": "top-secret"}
+            new_body = cache_file.read_text(encoding="utf-8")
+            assert "POSTGRES_PASSWORD=top-secret" not in new_body
+            assert "POSTGRES_PASSWORD_PASS_KEY=teatree/wt/42/postgres" in new_body
+
+    def test_reports_already_migrated_when_no_literal_present(self) -> None:
+        from tempfile import TemporaryDirectory  # noqa: PLC0415
+
+        from teatree.core.worktree_env import CACHE_DIRNAME, CACHE_FILENAME  # noqa: PLC0415
+
+        with TemporaryDirectory() as tmp:
+            ticket_dir = Path(tmp) / "ticket-7"
+            ticket_dir.mkdir()
+            wt_path = ticket_dir / "backend"
+            wt_path.mkdir()
+            cache_dir = ticket_dir / CACHE_DIRNAME
+            cache_dir.mkdir()
+            cache_file = cache_dir / CACHE_FILENAME
+            cache_file.write_text(
+                "FOO=bar\nPOSTGRES_PASSWORD_PASS_KEY=teatree/wt/7/postgres\n",
+                encoding="utf-8",
+            )
+
+            ticket = Ticket.objects.create(overlay="teatree", issue_url="https://example.com/issues/7")
+            wt = Worktree.objects.create(
+                overlay="teatree",
+                ticket=ticket,
+                repo_path="backend",
+                branch="ac-test",
+                db_name="wt_7",
+                extra={"worktree_path": str(wt_path)},
+            )
+
+            with (
+                patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
+                patch("teatree.utils.secrets.write_pass") as mock_write,
+            ):
+                call_command("env", "migrate-secrets", "--path", str(wt_path))
+
+            mock_write.assert_not_called()
+
+    def test_returns_nonzero_when_pass_not_available(self) -> None:
+        from tempfile import TemporaryDirectory  # noqa: PLC0415
+
+        from teatree.core.worktree_env import CACHE_DIRNAME, CACHE_FILENAME  # noqa: PLC0415
+
+        with TemporaryDirectory() as tmp:
+            ticket_dir = Path(tmp) / "ticket-99"
+            ticket_dir.mkdir()
+            wt_path = ticket_dir / "backend"
+            wt_path.mkdir()
+            cache_dir = ticket_dir / CACHE_DIRNAME
+            cache_dir.mkdir()
+            cache_file = cache_dir / CACHE_FILENAME
+            cache_file.write_text("POSTGRES_PASSWORD=needs-migration\n", encoding="utf-8")
+
+            ticket = Ticket.objects.create(overlay="teatree", issue_url="https://example.com/issues/99")
+            wt = Worktree.objects.create(
+                overlay="teatree",
+                ticket=ticket,
+                repo_path="backend",
+                branch="ac-test",
+                db_name="wt_99",
+                extra={"worktree_path": str(wt_path)},
+            )
+
+            with (
+                patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
+                patch(
+                    "teatree.core.management.commands.env.ensure_postgres_pass_entry",
+                    side_effect=PostgresPasswordUnavailableError("pass missing"),
+                ),
+            ):
+                # call_command returns the return value of the command's handler
+                result = call_command("env", "migrate-secrets", "--path", str(wt_path))
+                # The handler returns 1 on failure (non-zero exit code).
+                assert result == 1
+            # Literal must not be wiped — caller needs to retry once pass is configured.
+            assert "POSTGRES_PASSWORD=needs-migration" in cache_file.read_text(encoding="utf-8")

--- a/tests/teatree_core/test_worktree_env.py
+++ b/tests/teatree_core/test_worktree_env.py
@@ -220,8 +220,10 @@ class TestRenderEnvCache(TestCase):
                 spec = render_env_cache(wt)
             assert spec is not None
             assert "EXTRA_KEY=extra_value" in spec.content
-            assert "POSTGRES_PASSWORD" not in spec.content
+            assert "POSTGRES_PASSWORD=" not in spec.content
             assert "s3cr3t-pw" not in spec.content
+            # The symbolic pass-key reference replaces the stripped literal.
+            assert "POSTGRES_PASSWORD_PASS_KEY=teatree/wt/" in spec.content
 
 
 class TestWriteEnvCache(TestCase):

--- a/tests/teatree_utils/test_postgres_secret.py
+++ b/tests/teatree_utils/test_postgres_secret.py
@@ -1,0 +1,206 @@
+"""Tests for ``teatree.utils.postgres_secret`` — pass-key resolution helpers."""
+
+import os
+import warnings
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from teatree.utils import postgres_secret
+from teatree.utils.postgres_secret import (
+    PASS_KEY_ENV,
+    POSTGRES_PASSWORD_ENV,
+    RESOLVER_ENV,
+    PostgresPasswordUnavailableError,
+    ensure_postgres_pass_entry,
+    extract_literal_from_cache,
+    postgres_pass_key,
+    remove_postgres_pass_entry,
+    resolve_postgres_password,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_deprecation_state() -> None:
+    """Reset the one-shot deprecation warning flag between tests."""
+    postgres_secret._reset_literal_deprecation_state()
+
+
+class TestPostgresPassKey:
+    def test_returns_namespaced_key_for_ticket(self) -> None:
+        assert postgres_pass_key("123") == "teatree/wt/123/postgres"
+
+    def test_stringifies_non_string_ids(self) -> None:
+        assert postgres_pass_key(456) == "teatree/wt/456/postgres"
+
+    def test_rejects_empty_ticket_id(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            postgres_pass_key("")
+
+    def test_rejects_whitespace_ticket_id(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            postgres_pass_key("   ")
+
+
+class TestResolvePostgresPassword:
+    def test_prefers_pass_key_when_pass_resolves(self) -> None:
+        env = {PASS_KEY_ENV: "teatree/wt/42/postgres", POSTGRES_PASSWORD_ENV: "literal"}
+        with patch.object(postgres_secret.secrets, "read_pass", return_value="from-pass") as mock:
+            assert resolve_postgres_password(env) == "from-pass"
+        mock.assert_called_once_with("teatree/wt/42/postgres")
+
+    def test_falls_back_to_resolver_when_pass_empty(self, tmp_path: Path) -> None:
+        # Write a tiny shell resolver that echoes a fixed secret.
+        resolver = tmp_path / "resolver"
+        resolver.write_text("#!/bin/sh\necho from-resolver\n")
+        resolver.chmod(0o755)
+        env = {
+            PASS_KEY_ENV: "teatree/wt/42/postgres",
+            RESOLVER_ENV: str(resolver),
+        }
+        with patch.object(postgres_secret.secrets, "read_pass", return_value=""):
+            assert resolve_postgres_password(env) == "from-resolver"
+
+    def test_falls_back_to_literal_with_deprecation_warning(self) -> None:
+        env = {POSTGRES_PASSWORD_ENV: "legacy-literal"}
+        with (
+            patch.object(postgres_secret.secrets, "read_pass", return_value=""),
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            assert resolve_postgres_password(env) == "legacy-literal"
+        kinds = [w.category for w in caught]
+        assert DeprecationWarning in kinds
+
+    def test_returns_empty_when_no_source_available(self) -> None:
+        with patch.object(postgres_secret.secrets, "read_pass", return_value=""):
+            assert resolve_postgres_password({}) == ""
+
+    def test_deprecation_warning_fires_only_once_per_process(self) -> None:
+        env = {POSTGRES_PASSWORD_ENV: "literal"}
+        with (
+            patch.object(postgres_secret.secrets, "read_pass", return_value=""),
+            warnings.catch_warnings(record=True) as first_batch,
+        ):
+            warnings.simplefilter("always")
+            resolve_postgres_password(env)
+            resolve_postgres_password(env)
+        deprecations = [w for w in first_batch if w.category is DeprecationWarning]
+        assert len(deprecations) == 1
+
+    def test_defaults_to_os_environ_when_env_not_provided(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PASS_KEY_ENV, "teatree/wt/99/postgres")
+        monkeypatch.delenv(RESOLVER_ENV, raising=False)
+        monkeypatch.delenv(POSTGRES_PASSWORD_ENV, raising=False)
+        with patch.object(postgres_secret.secrets, "read_pass", return_value="env-resolved"):
+            assert resolve_postgres_password() == "env-resolved"
+
+
+class TestEnsurePostgresPassEntry:
+    def test_writes_to_pass_under_canonical_key(self) -> None:
+        with patch.object(postgres_secret.secrets, "write_pass", return_value=True) as mock:
+            key = ensure_postgres_pass_entry("777", "sup3r-s3cret")
+        assert key == "teatree/wt/777/postgres"
+        mock.assert_called_once_with("teatree/wt/777/postgres", "sup3r-s3cret")
+
+    def test_raises_when_pass_write_fails(self) -> None:
+        with (
+            patch.object(postgres_secret.secrets, "write_pass", return_value=False),
+            pytest.raises(PostgresPasswordUnavailableError, match="pass is not installed"),
+        ):
+            ensure_postgres_pass_entry("888", "secret")
+
+    def test_rejects_empty_password(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            ensure_postgres_pass_entry("888", "")
+
+
+class TestRemovePostgresPassEntry:
+    def test_calls_remove_pass_with_canonical_key(self) -> None:
+        with patch.object(postgres_secret.secrets, "remove_pass", return_value=True) as mock:
+            assert remove_postgres_pass_entry("321") is True
+        mock.assert_called_once_with("teatree/wt/321/postgres")
+
+    def test_returns_false_when_pass_remove_fails(self) -> None:
+        with patch.object(postgres_secret.secrets, "remove_pass", return_value=False):
+            assert remove_postgres_pass_entry("321") is False
+
+
+class TestExtractLiteralFromCache:
+    def test_returns_value_for_existing_literal(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".t3-env.cache"
+        cache.write_text("FOO=bar\nPOSTGRES_PASSWORD=abc123\nBAZ=qux\n", encoding="utf-8")
+        assert extract_literal_from_cache(cache) == "abc123"
+
+    def test_returns_empty_when_cache_missing(self, tmp_path: Path) -> None:
+        assert extract_literal_from_cache(tmp_path / "missing.cache") == ""
+
+    def test_returns_empty_when_only_pass_key_present(self, tmp_path: Path) -> None:
+        cache = tmp_path / ".t3-env.cache"
+        cache.write_text("POSTGRES_PASSWORD_PASS_KEY=teatree/wt/1/postgres\n", encoding="utf-8")
+        assert extract_literal_from_cache(cache) == ""
+
+    def test_does_not_leak_password_to_logger(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        cache = tmp_path / ".t3-env.cache"
+        cache.write_text("POSTGRES_PASSWORD=top-secret-literal\n", encoding="utf-8")
+        caplog.set_level("DEBUG", logger="teatree.utils.postgres_secret")
+        extract_literal_from_cache(cache)
+        assert "top-secret-literal" not in caplog.text
+
+
+class TestResolverCommandInvocation:
+    """End-to-end exercise of the T3_SECRET_RESOLVER fallback.
+
+    Uses a real executable script under tmp_path rather than mocking
+    ``run_checked`` — this verifies the resolver wiring stays honest when
+    the resolver echoes the secret and exits zero.
+    """
+
+    def test_resolver_receives_pass_key_as_argument(self, tmp_path: Path) -> None:
+        resolver = tmp_path / "resolver"
+        resolver.write_text('#!/bin/sh\nprintf "key:%s\\n" "$1"\n')
+        resolver.chmod(0o755)
+        env = {PASS_KEY_ENV: "teatree/wt/1/postgres", RESOLVER_ENV: str(resolver)}
+        with patch.object(postgres_secret.secrets, "read_pass", return_value=""):
+            value = resolve_postgres_password(env)
+        assert value == "key:teatree/wt/1/postgres"
+
+    def test_resolver_failure_falls_through_to_literal(self, tmp_path: Path) -> None:
+        resolver = tmp_path / "resolver"
+        resolver.write_text("#!/bin/sh\nexit 1\n")
+        resolver.chmod(0o755)
+        env = {RESOLVER_ENV: str(resolver), POSTGRES_PASSWORD_ENV: "literal"}
+        with (
+            patch.object(postgres_secret.secrets, "read_pass", return_value=""),
+            warnings.catch_warnings(),
+        ):
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert resolve_postgres_password(env) == "literal"
+
+    def test_missing_resolver_falls_through(self) -> None:
+        env = {RESOLVER_ENV: "/no/such/binary", POSTGRES_PASSWORD_ENV: "literal"}
+        with (
+            patch.object(postgres_secret.secrets, "read_pass", return_value=""),
+            warnings.catch_warnings(),
+        ):
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert resolve_postgres_password(env) == "literal"
+
+
+def test_module_does_not_log_literal_value(caplog: pytest.LogCaptureFixture) -> None:
+    """Verify the literal value never reaches the log stream."""
+    env = {PASS_KEY_ENV: "teatree/wt/9/postgres", POSTGRES_PASSWORD_ENV: "secret-literal"}
+    caplog.set_level("DEBUG", logger="teatree.utils.postgres_secret")
+    with patch.object(postgres_secret.secrets, "read_pass", return_value=""):
+        resolve_postgres_password(env)
+    assert "secret-literal" not in caplog.text
+
+
+def test_env_resolution_uses_os_environ_by_default_without_mutation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolution must not mutate ``os.environ`` so cache misses do not leak."""
+    monkeypatch.setenv(PASS_KEY_ENV, "teatree/wt/9/postgres")
+    snapshot = dict(os.environ)
+    with patch.object(postgres_secret.secrets, "read_pass", return_value="x"):
+        resolve_postgres_password()
+    assert dict(os.environ) == snapshot

--- a/tests/teatree_utils/test_secrets.py
+++ b/tests/teatree_utils/test_secrets.py
@@ -28,3 +28,29 @@ class TestWritePass:
     def test_returns_false_when_pass_not_installed(self) -> None:
         with patch("teatree.utils.secrets.run_checked", side_effect=FileNotFoundError):
             assert secrets.write_pass("acme/token", "abc") is False
+
+
+class TestRemovePass:
+    def test_returns_true_when_remove_succeeds(self) -> None:
+        result = CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("teatree.utils.secrets.run_checked", return_value=result) as mock:
+            assert secrets.remove_pass("acme/token") is True
+        assert mock.call_args.args[0] == ["pass", "rm", "--force", "acme/token"]
+
+    def test_returns_false_when_pass_command_fails(self) -> None:
+        with patch("teatree.utils.secrets.run_checked", side_effect=CommandFailedError(["pass"], 1, "", "boom")):
+            assert secrets.remove_pass("acme/token") is False
+
+    def test_returns_false_when_pass_not_installed(self) -> None:
+        with patch("teatree.utils.secrets.run_checked", side_effect=FileNotFoundError):
+            assert secrets.remove_pass("acme/token") is False
+
+
+class TestPassEntryExists:
+    def test_returns_true_when_pass_resolves_value(self) -> None:
+        with patch("teatree.utils.secrets.read_pass", return_value="value"):
+            assert secrets.pass_entry_exists("acme/token") is True
+
+    def test_returns_false_when_pass_returns_empty(self) -> None:
+        with patch("teatree.utils.secrets.read_pass", return_value=""):
+            assert secrets.pass_entry_exists("acme/token") is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import socket
 from pathlib import Path
@@ -699,6 +700,24 @@ def test_pg_env_omits_port_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     env = db.pg_env()
 
     assert "PGPORT" not in env
+
+
+def test_pg_env_resolves_password_via_pass_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``pg_env`` reads the password from ``pass`` when ``POSTGRES_PASSWORD_PASS_KEY`` is set.
+
+    The literal value never appears in ``os.environ`` — the only secret
+    delivery channel is the in-memory ``PGPASSWORD`` value placed on the
+    returned ``env`` dict.
+    """
+    from unittest.mock import patch  # noqa: PLC0415
+
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+    monkeypatch.setenv("POSTGRES_PASSWORD_PASS_KEY", "teatree/wt/42/postgres")
+    with patch("teatree.utils.postgres_secret.secrets.read_pass", return_value="from-pass"):
+        env = db.pg_env()
+    assert env["PGPASSWORD"] == "from-pass"
+    # The literal value must not be planted into the original process env.
+    assert os.environ.get("POSTGRES_PASSWORD", "") == ""
 
 
 def test_gitlab_api_graphql_sends_post_request(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes https://github.com/souliane/teatree/issues/417.

## Problem

`.t3-env.cache` held `POSTGRES_PASSWORD=<literal>`. Any `grep` / `cat` / `env | grep POSTGRES_` against the file leaked the password into the terminal, shell history, and agent transcripts. The incident that motivated [#417](https://github.com/souliane/teatree/issues/417) was exactly this: a routine `grep -E "POSTGRES_" .t3-env.cache` in an agent session put the dev DB password directly into the transcript.

## Solution

Store a **symbolic reference** in the cache and resolve the literal on demand via `pass`:

```
POSTGRES_PASSWORD_PASS_KEY=teatree/wt/<ticket_id>/postgres
```

Resolution order (`teatree.utils.postgres_secret.resolve_postgres_password`):

1. `POSTGRES_PASSWORD_PASS_KEY` → `pass show <key>`.
2. `T3_SECRET_RESOLVER` → user-supplied resolver command (1Password, Bitwarden, sops, age, …). Keeps the design pass-store-agnostic.
3. `POSTGRES_PASSWORD` literal — fires `DeprecationWarning` once per process so existing setups keep working but get nudged off.

## New surfaces

- `teatree.utils.postgres_secret` — new module with `resolve_postgres_password`, `ensure_postgres_pass_entry`, `remove_postgres_pass_entry`, `extract_literal_from_cache`, `postgres_pass_key`.
- `t3 <overlay> env migrate-secrets` — one-shot migration: lifts every literal out of `.t3-env.cache` into `pass`, rewrites the cache. Idempotent — re-run is a no-op.
- `OverlayConfig.teardown_removes_pass_entries` — opt-in flag to also `pass rm` on `t3 <overlay> worktree teardown`.

## Touched

- `worktree_env._core_env_pairs` — emit `POSTGRES_PASSWORD_PASS_KEY=…` for every worktree.
- `OverlayBase._CORE_SECRET_KEYS` — keeps `POSTGRES_PASSWORD` filtered out of the rendered cache.
- `utils/db.py`, `utils/django_db.py` — resolve via the new helper instead of reading `POSTGRES_PASSWORD` directly.
- `utils/secrets.py` — `remove_pass`, `pass_entry_exists`.
- `cleanup.cleanup_worktree` — optional `pass rm` gated on the config flag.

## Privacy properties

- Literal never appears in log lines or exception messages emitted by `postgres_secret`.
- `direnv`-exported env carries only the symbolic key (safe to grep). The literal only exists in-memory inside the process that calls `resolve_postgres_password`.
- Agent transcripts that paste `.t3-env.cache` contents now show the pass key, not the secret.

## Tests

39 new test cases in `tests/teatree_utils/test_postgres_secret.py` + updates across `test_env_command`, `test_cleanup`, `test_secrets`, `test_worktree_env`, `test_utils`. Full suite **3071 passed, 12 skipped**, overall coverage **93.06%** (`postgres_secret.py` at 98.1%).