### PR TITLE
fix(review): reject broken anchors upfront, add post-comment fallback

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -363,6 +363,7 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ post-draft-note      Post a draft note on a GitLab MR (inline or general).   │
+│ post-comment         Post an immediate (non-draft) comment on a GitLab MR.   │
 │ delete-draft-note    Delete a draft note from a GitLab MR.                   │
 │ publish-draft-notes  Publish all draft notes on a GitLab MR (bulk submit).   │
 │ list-draft-notes     List draft notes on a GitLab MR.                        │
@@ -381,6 +382,31 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
 
  Post a draft note on a GitLab MR (inline or general).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
+│                         [required]                                           │
+│ *    mr        INTEGER  Merge request IID [required]                         │
+│ *    note      TEXT     Comment text (markdown) [required]                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --file        TEXT     File path for inline comment (omit for general note)  │
+│ --line        INTEGER  Line number in the new file (must be an added line)   │
+│                        [default: 0]                                          │
+│ --help                 Show this message and exit.                           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 review post-comment`
+
+```
+Usage: t3 review post-comment [OPTIONS] REPO MR NOTE
+
+ Post an immediate (non-draft) comment on a GitLab MR.
+
+ Useful when `post-draft-note` fails to anchor inline because the file's
+ diff is collapsed (large files). This bypasses the draft workflow and
+ posts straight to a discussion, where GitLab's anchoring works.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -350,15 +350,27 @@ This prevents noise from multiple review passes or multiple reviewers covering t
 
 When reviewing an external MR/PR, **always post comments inline on the correct file and line** in the diff view. For comments that aren't tied to a specific line (e.g., description feedback), post a general note without position data.
 
-**Extend the CLI, never inline API recipes.** If a `t3 review` operation is missing, implement it in `src/teatree/cli/review.py` — do NOT document a raw API snippet or inline script here. Skills describe what command to run, not how to replicate missing CLI functionality. Current subcommands: `post-draft-note`, `delete-draft-note`, `publish-draft-notes`, `list-draft-notes`, `update-note`, `reply-to-discussion`, `resolve-discussion`.
+**Extend the CLI, never inline API recipes.** If a `t3 review` operation is missing, implement it in `src/teatree/cli/review.py` — do NOT document a raw API snippet or inline script here. Skills describe what command to run, not how to replicate missing CLI functionality. Current subcommands: `post-draft-note`, `post-comment`, `delete-draft-note`, `publish-draft-notes`, `list-draft-notes`, `update-note`, `reply-to-discussion`, `resolve-discussion`.
 
-**Use `t3 review post-draft-note` (Mandatory).** It handles token extraction, diff refs, position serialization, and added-line validation. Never use raw API calls.
+**Use `t3 review post-draft-note` (Mandatory).** It handles token extraction, diff refs, position validation, and post-flight anchor verification. Never use raw API calls.
 
 ```bash
 t3 review post-draft-note <REPO> <MR_IID> "Comment text" --file <path/to/file> --line <line_number>
 ```
 
-**Pre-flight: verify target line is an added line.** Before posting each inline note, confirm the target `new_line` corresponds to an added (`+`) or modified line in the diff — never a context (unchanged) line. Targeting a context line causes GitLab to render the comment in **every hunk** that references that line, creating duplicates. When the finding is about an unchanged line, target the nearest added line and reference the unchanged line in the comment text instead.
+The CLI validates the target line is an added (`+`) line in the MR diff before posting, and verifies the response anchored correctly (non-null `line_code`). When something goes wrong it refuses upfront — common rejected cases:
+
+- **Context line:** the target is unchanged in the diff. CLI rejects and lists the nearby added lines so you can pick one.
+- **File not in diff:** the file path isn't part of the MR. CLI rejects with the list of changed files.
+- **Collapsed-diff file:** GitLab's draft-note anchoring fails on large files whose diff was collapsed server-side. CLI detects the null `line_code` after posting, deletes the broken draft, and suggests `post-comment` (below).
+
+**Workaround for collapsed-diff files — `t3 review post-comment`.** When the file is too large for GitLab to anchor a draft, post an immediate (non-draft) inline discussion via the `/discussions` endpoint, which anchors fine even on collapsed diffs:
+
+```bash
+t3 review post-comment <REPO> <MR_IID> "Comment text" --file <path/to/file> --line <line_number>
+```
+
+The comment posts immediately rather than batching with a review. Reserve this for the cases where `post-draft-note` explicitly errors with the collapsed-diff message.
 
 **Pre-flight: the file you anchor on MUST be the file the body discusses.** If the comment body describes code in `foo.py` (e.g., "`foo.py`'s `bar()` is missing X that the sibling `baz.py` got"), anchor the comment on `foo.py` — not on `baz.py`, even if `baz.py` has more added lines in the diff. Two defensible patterns when `foo.py` has no added lines:
 
@@ -373,8 +385,6 @@ A comment anchored on the wrong file is worse than a general note — the author
 ```bash
 t3 review publish-draft-notes <REPO> <MR_IID>
 ```
-
-**`WARNING: inline position was not accepted`** means GitLab did not store the `position` data — the note will render as a general comment, not inline on the diff. Check that `--file` matches a path in the PR diff and `--line` is within the changed range.
 
 **If `t3 review delete-draft-note` returns 404** — the draft was already submitted (published to regular notes) by the user from the GitLab UI. Use `DELETE projects/{encoded_repo}/merge_requests/{iid}/notes/{note_id}` via the regular notes endpoint instead.
 

--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -1,13 +1,59 @@
 """Review CLI commands — GitLab draft note operations."""
 
+import re
 from http import HTTPStatus
+from typing import TypedDict
 
 import typer
 
 from teatree.utils.run import run_allowed_to_fail
 
+
+class InlinePosition(TypedDict):
+    """GitLab inline-note position payload (text diff anchoring)."""
+
+    position_type: str
+    base_sha: str
+    head_sha: str
+    start_sha: str
+    old_path: str
+    new_path: str
+    new_line: int
+
+
 review_app = typer.Typer(no_args_is_help=True, help="Code review helpers.")
 _TOKEN_PARTS_COUNT = 2
+_HUNK_HEADER = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+_NEARBY_LINE_RANGE = 5
+
+
+def _find_added_line(diff_text: str, target_line: int) -> tuple[bool, list[int]]:
+    """Scan a unified-diff hunk text for ``target_line`` in the new file.
+
+    Returns ``(is_added, nearby_added_lines)`` — ``is_added`` is True when the
+    target line corresponds to an added (``+``) line in any hunk; the second
+    element lists added line numbers within ±5 of the target for error hints.
+    """
+    is_added = False
+    nearby: list[int] = []
+    nl: int | None = None
+    for line in diff_text.splitlines():
+        m = _HUNK_HEADER.match(line)
+        if m:
+            nl = int(m.group(1))
+            continue
+        if nl is None:
+            continue
+        sign = line[:1] if line else " "
+        if sign == "-":
+            continue
+        if sign == "+":
+            if nl == target_line:
+                is_added = True
+            if abs(nl - target_line) <= _NEARBY_LINE_RANGE:
+                nearby.append(nl)
+        nl += 1
+    return is_added, sorted(set(nearby))
 
 
 class ReviewService:
@@ -49,54 +95,165 @@ class ReviewService:
         except Exception:  # noqa: BLE001
             return os.environ.get("GITLAB_URL", "https://gitlab.com/api/v4")
 
+    def _fetch_diff_refs(self, encoded_repo: str, mr: int) -> tuple[dict[str, str] | None, str]:
+        """Return the MR's diff_refs (base/head/start SHAs) or an error message."""
+        api = self._get_api()
+        mr_data = api.get_json(f"projects/{encoded_repo}/merge_requests/{mr}")
+        if not isinstance(mr_data, dict):
+            return None, f"Could not fetch MR !{mr}"
+        diff_refs_raw = mr_data.get("diff_refs", {})
+        if not isinstance(diff_refs_raw, dict):
+            return None, "MR has no diff_refs"
+        return {str(k): str(v) for k, v in diff_refs_raw.items()}, ""
+
+    def _fetch_file_diff(self, encoded_repo: str, mr: int, file: str) -> tuple[str | None, str]:
+        """Return the raw unified diff for ``file`` in the MR, or an error message.
+
+        Uses ``access_raw_diffs=true`` so large files collapsed by the default
+        ``/diffs`` endpoint still surface their full hunks.
+        """
+        api = self._get_api()
+        changes = api.get_json(f"projects/{encoded_repo}/merge_requests/{mr}/changes?access_raw_diffs=true")
+        if not isinstance(changes, dict):
+            return None, "Could not fetch MR changes to validate inline target"
+        files = changes.get("changes")
+        if not isinstance(files, list):
+            return None, "MR changes response had no `changes` array"
+        match = next(
+            (f for f in files if isinstance(f, dict) and (f.get("new_path") == file or f.get("old_path") == file)),
+            None,
+        )
+        if match is None:
+            paths = [str(f.get("new_path")) for f in files if isinstance(f, dict)]
+            return None, f"File {file!r} is not changed in MR !{mr}. Changed files: {paths}"
+        diff_text = str(match.get("diff") or "")
+        if not diff_text:
+            return None, (
+                f"File {file!r} has no diff content in the MR API response (likely a collapsed large diff). "
+                "draft_notes cannot anchor on collapsed files — use `t3 review post-comment` instead, "
+                "or pick a smaller file."
+            )
+        return diff_text, ""
+
+    def _resolve_inline_position(
+        self,
+        encoded_repo: str,
+        mr: int,
+        file: str,
+        line: int,
+    ) -> tuple[InlinePosition | None, str]:
+        """Build a GitLab inline-note ``position`` dict, or return an error message.
+
+        Validates that ``file:line`` is an added (``+``) line in the MR diff.
+        """
+        diff_refs, refs_error = self._fetch_diff_refs(encoded_repo, mr)
+        if diff_refs is None:
+            return None, refs_error
+        diff_text, diff_error = self._fetch_file_diff(encoded_repo, mr, file)
+        if diff_text is None:
+            return None, diff_error
+        is_added, nearby = _find_added_line(diff_text, line)
+        if not is_added:
+            hint = f" Nearby added lines in this file: {nearby}." if nearby else ""
+            return None, (
+                f"Line {line} in {file} is not an added (`+`) line in the MR diff — "
+                f"inline notes only anchor on added lines.{hint}"
+            )
+        position: InlinePosition = {
+            "position_type": "text",
+            "base_sha": diff_refs["base_sha"],
+            "head_sha": diff_refs["head_sha"],
+            "start_sha": diff_refs["start_sha"],
+            "old_path": file,
+            "new_path": file,
+            "new_line": line,
+        }
+        return position, ""
+
     def post_draft_note(self, repo: str, mr: int, note: str, *, file: str = "", line: int = 0) -> tuple[str, int]:
-        """Post a draft note. Returns (message, exit_code)."""
+        """Post a draft note. Returns (message, exit_code).
+
+        For inline notes (file+line), validates that the target line is an added
+        (``+``) line in the MR diff, then verifies after posting that GitLab
+        actually anchored the draft (``line_code`` non-null). Broken drafts
+        (anchor refused, usually because the file diff is collapsed) are
+        deleted and surfaced as an error so they cannot be published silently.
+        """
+        api = self._get_api()
+        encoded = repo.replace("/", "%2F")
+        endpoint = f"projects/{encoded}/merge_requests/{mr}/draft_notes"
+
+        if not (file and line):
+            result = api.post_json(endpoint, {"note": note})
+            if not result:
+                return "Failed to post draft note", 1
+            return f"OK draft_note_id={dict(result).get('id')}", 0
+
+        position, error = self._resolve_inline_position(encoded, mr, file, line)
+        if position is None:
+            return error, 1
+
+        result = api.post_json(endpoint, {"note": note, "position": position})
+        if not result:
+            return "Failed to post draft note", 1
+        result_dict = dict(result) if isinstance(result, dict) else {}
+        note_id = result_dict.get("id")
+        line_code = result_dict.get("line_code")
+        if line_code:
+            return f"OK draft_note_id={note_id}\nline_code={line_code}", 0
+
+        if isinstance(note_id, int):
+            api.delete(f"{endpoint}/{note_id}")
+        return (
+            f"GitLab refused to anchor the draft on {file}:{line} (line_code came back null). "
+            "This usually means the file diff is collapsed because of its size; the draft_notes "
+            "API cannot anchor on collapsed-diff files. Workaround: "
+            f"`t3 review post-comment {repo} {mr} ... --file {file} --line {line}` "
+            "(creates an immediate non-draft inline discussion)."
+        ), 1
+
+    def post_comment(
+        self,
+        repo: str,
+        mr: int,
+        note: str,
+        *,
+        file: str = "",
+        line: int = 0,
+    ) -> tuple[str, int]:
+        """Post an immediate (non-draft) MR comment via ``/discussions``.
+
+        Use when ``post_draft_note`` fails because the file diff is collapsed
+        — the discussions endpoint anchors inline notes even on large files,
+        but the comment posts immediately instead of batching with a review.
+        """
         api = self._get_api()
         encoded = repo.replace("/", "%2F")
 
-        if file and line:
-            mr_data = api.get_json(f"projects/{encoded}/merge_requests/{mr}")
-            if not isinstance(mr_data, dict):
-                return f"Could not fetch MR !{mr} from {repo}", 1
+        if not (file and line):
+            result = api.post_json(f"projects/{encoded}/merge_requests/{mr}/notes", {"body": note})
+            if not result:
+                return "Failed to post comment", 1
+            return f"OK note_id={dict(result).get('id')}", 0
 
-            diff_refs_raw = mr_data.get("diff_refs", {})
-            if not isinstance(diff_refs_raw, dict):
-                return "MR has no diff_refs", 1
-            diff_refs: dict[str, str] = {str(k): str(v) for k, v in diff_refs_raw.items()}
+        position, error = self._resolve_inline_position(encoded, mr, file, line)
+        if position is None:
+            return error, 1
 
-            payload: dict[str, object] = {
-                "note": note,
-                "position": {
-                    "position_type": "text",
-                    "base_sha": diff_refs["base_sha"],
-                    "head_sha": diff_refs["head_sha"],
-                    "start_sha": diff_refs["start_sha"],
-                    "old_path": file,
-                    "new_path": file,
-                    "new_line": line,
-                },
-            }
-        else:
-            payload = {"note": note}
-
-        result = api.post_json(f"projects/{encoded}/merge_requests/{mr}/draft_notes", payload)
+        result = api.post_json(
+            f"projects/{encoded}/merge_requests/{mr}/discussions",
+            {"body": note, "position": position},
+        )
         if not result:
-            return "Failed to post draft note", 1
-
+            return "Failed to post comment", 1
         result_dict = dict(result) if isinstance(result, dict) else {}
-        note_id = result_dict.get("id")
-        position_raw = result_dict.get("position")
-        position = dict(position_raw) if isinstance(position_raw, dict) else {}
-        line_code = position.get("line_code")
-
-        parts = [f"OK draft_note_id={note_id}"]
-        if line_code:
-            parts.append(f"line_code={line_code}")
-        position_stored = bool(position.get("new_path"))
-        if file and line and not position_stored:
-            parts.insert(0, f"WARNING: inline position was not accepted by GitLab (line {line} in {file}).")
-
-        return "\n".join(parts), 0
+        discussion_id = result_dict.get("id")
+        notes = result_dict.get("notes")
+        first_note = notes[0] if isinstance(notes, list) and notes else {}
+        note_type = first_note.get("type") if isinstance(first_note, dict) else None
+        if note_type != "DiffNote":
+            return f"Comment posted but not anchored inline (type={note_type!r}). discussion_id={discussion_id}", 1
+        return f"OK discussion_id={discussion_id} (inline DiffNote)", 0
 
     def delete_draft_note(self, repo: str, mr: int, note_id: int) -> tuple[str, int]:
         """Delete a draft note. Returns (message, exit_code)."""
@@ -205,6 +362,27 @@ def post_draft_note(
     """Post a draft note on a GitLab MR (inline or general)."""
     service = _require_token()
     msg, code = service.post_draft_note(repo, mr, note, file=file, line=line)
+    typer.echo(msg)
+    if code:
+        raise typer.Exit(code=code)
+
+
+@review_app.command(name="post-comment")
+def post_comment(
+    repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
+    mr: int = typer.Argument(help="Merge request IID"),
+    note: str = typer.Argument(help="Comment text (markdown)"),
+    file: str = typer.Option("", help="File path for inline comment (omit for general note)"),
+    line: int = typer.Option(0, help="Line number in the new file (must be an added line)"),
+) -> None:
+    """Post an immediate (non-draft) comment on a GitLab MR.
+
+    Useful when `post-draft-note` fails to anchor inline because the file's
+    diff is collapsed (large files). This bypasses the draft workflow and
+    posts straight to a discussion, where GitLab's anchoring works.
+    """
+    service = _require_token()
+    msg, code = service.post_comment(repo, mr, note, file=file, line=line)
     typer.echo(msg)
     if code:
         raise typer.Exit(code=code)

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -5,9 +5,59 @@ from typer.testing import CliRunner
 import teatree.backends.gitlab_api as gitlab_api_mod
 import teatree.utils.run as utils_run_mod
 from teatree.cli import app
-from teatree.cli.review import ReviewService
+from teatree.cli.review import ReviewService, _find_added_line
 
 runner = CliRunner()
+
+
+def _inline_api(changes_diff: str, post_result: dict[str, object] | None = None) -> MagicMock:
+    """Build a mock GitLabAPI whose get_json returns MR data + a one-file changes diff."""
+    api = MagicMock()
+    mr_data = {"diff_refs": {"base_sha": "a", "head_sha": "b", "start_sha": "c"}}
+    changes = {
+        "changes": [
+            {"new_path": "a.py", "old_path": "a.py", "diff": changes_diff},
+        ],
+    }
+    api.get_json.side_effect = lambda endpoint: changes if "/changes" in endpoint else mr_data
+    api.post_json.return_value = post_result or {"id": 99, "line_code": "h_0_1"}
+    api.delete.return_value = 204
+    return api
+
+
+# -- _find_added_line --------------------------------------------------------
+
+
+class TestFindAddedLine:
+    def test_added_line_recognised(self):
+        diff = "@@ -1,1 +1,2 @@\n unchanged\n+new line\n"
+        is_added, nearby = _find_added_line(diff, 2)
+        assert is_added
+        assert nearby == [2]
+
+    def test_context_line_rejected(self):
+        diff = "@@ -1,2 +1,2 @@\n line one\n line two\n+added\n"
+        is_added, _ = _find_added_line(diff, 1)
+        assert not is_added
+
+    def test_deleted_line_not_in_new_file(self):
+        diff = "@@ -1,2 +1,1 @@\n keep\n-removed\n"
+        is_added, _ = _find_added_line(diff, 2)
+        assert not is_added
+
+    def test_nearby_added_lines_collected(self):
+        diff = "@@ -1,0 +1,5 @@\n+l1\n+l2\n+l3\n+l4\n+l5\n"
+        _, nearby = _find_added_line(diff, 3)
+        assert nearby == [1, 2, 3, 4, 5]
+
+    def test_multi_hunk_offset_tracking(self):
+        diff = "@@ -1,0 +1,1 @@\n+first\n@@ -10,0 +20,1 @@\n+second\n"
+        is_added_first, _ = _find_added_line(diff, 1)
+        is_added_second, _ = _find_added_line(diff, 20)
+        is_added_gap, _ = _find_added_line(diff, 5)
+        assert is_added_first
+        assert is_added_second
+        assert not is_added_gap
 
 
 # -- GitLab token resolution --------------------------------------------------
@@ -59,65 +109,84 @@ class TestReviewService:
             assert result.exit_code == 0
             assert "OK draft_note_id=42" in result.output
 
-    def test_post_inline(self, monkeypatch):
-        """post-draft-note posts an inline note with file and line."""
+    def test_post_inline_added_line_succeeds(self, monkeypatch):
+        """Inline draft note succeeds when target is an added line and GitLab returns a line_code."""
         monkeypatch.setenv("GITLAB_TOKEN", "test-token")
-        mock_api = MagicMock()
-        mock_api.get_json.return_value = {
-            "diff_refs": {
-                "base_sha": "abc",
-                "head_sha": "def",
-                "start_sha": "ghi",
-            },
-        }
-        mock_api.post_json.return_value = {
-            "id": 99,
-            "position": {"line_code": "abc_1_1"},
-        }
-
+        diff = "@@ -0,0 +5,1 @@\n+added content\n"
+        mock_api = _inline_api(diff, post_result={"id": 99, "line_code": "abc_0_5"})
         with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
             result = runner.invoke(
                 app,
-                ["review", "post-draft-note", "org/repo", "1", "fix this", "--file", "src/main.py", "--line", "10"],
+                ["review", "post-draft-note", "org/repo", "1", "fix this", "--file", "a.py", "--line", "5"],
             )
             assert result.exit_code == 0
             assert "OK draft_note_id=99" in result.output
-            assert "line_code=abc_1_1" in result.output
+            assert "line_code=abc_0_5" in result.output
 
-    def test_post_inline_position_accepted_without_line_code(self, monkeypatch):
-        """post-draft-note succeeds without warning when position has new_path."""
+    def test_post_inline_context_line_rejected_upfront(self, monkeypatch):
+        """Targeting a context (unchanged) line is rejected before posting."""
         monkeypatch.setenv("GITLAB_TOKEN", "test-token")
-        mock_api = MagicMock()
-        mock_api.get_json.return_value = {
-            "diff_refs": {"base_sha": "a", "head_sha": "b", "start_sha": "c"},
-        }
-        mock_api.post_json.return_value = {"id": 100, "position": {"new_path": "a.py", "new_line": "5"}}
-
+        diff = "@@ -1,2 +1,2 @@\n keep one\n keep two\n+added\n"
+        mock_api = _inline_api(diff)
         with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
             result = runner.invoke(
                 app,
-                ["review", "post-draft-note", "org/repo", "1", "fix this", "--file", "a.py", "--line", "5"],
+                ["review", "post-draft-note", "org/repo", "1", "msg", "--file", "a.py", "--line", "1"],
             )
-            assert result.exit_code == 0
-            assert "OK draft_note_id=100" in result.output
-            assert "WARNING" not in result.output
+            assert result.exit_code == 1
+            assert "not an added" in result.output
+            mock_api.post_json.assert_not_called()
 
-    def test_post_inline_position_not_accepted(self, monkeypatch):
-        """post-draft-note warns when GitLab returns empty position (inline placement rejected)."""
+    def test_post_inline_file_not_in_diff(self, monkeypatch):
+        """Targeting a file not in the MR diff is rejected before posting."""
         monkeypatch.setenv("GITLAB_TOKEN", "test-token")
         mock_api = MagicMock()
-        mock_api.get_json.return_value = {
-            "diff_refs": {"base_sha": "a", "head_sha": "b", "start_sha": "c"},
-        }
-        mock_api.post_json.return_value = {"id": 100, "position": {}}
-
+        mock_api.get_json.side_effect = lambda endpoint: (
+            {"changes": [{"new_path": "other.py", "old_path": "other.py", "diff": "@@ -0,0 +1,1 @@\n+x\n"}]}
+            if "/changes" in endpoint
+            else {"diff_refs": {"base_sha": "a", "head_sha": "b", "start_sha": "c"}}
+        )
         with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
             result = runner.invoke(
                 app,
-                ["review", "post-draft-note", "org/repo", "1", "fix this", "--file", "a.py", "--line", "5"],
+                ["review", "post-draft-note", "org/repo", "1", "msg", "--file", "a.py", "--line", "1"],
             )
-            assert result.exit_code == 0
-            assert "WARNING: inline position was not accepted" in result.output
+            assert result.exit_code == 1
+            assert "not changed in MR" in result.output
+            mock_api.post_json.assert_not_called()
+
+    def test_post_inline_collapsed_diff_rejected_with_workaround(self, monkeypatch):
+        """When the file diff is empty (collapsed), the draft is rejected with a workaround hint."""
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        mock_api = MagicMock()
+        mock_api.get_json.side_effect = lambda endpoint: (
+            {"changes": [{"new_path": "a.py", "old_path": "a.py", "diff": ""}]}
+            if "/changes" in endpoint
+            else {"diff_refs": {"base_sha": "a", "head_sha": "b", "start_sha": "c"}}
+        )
+        with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
+            result = runner.invoke(
+                app,
+                ["review", "post-draft-note", "org/repo", "1", "msg", "--file", "a.py", "--line", "5"],
+            )
+            assert result.exit_code == 1
+            assert "no diff content" in result.output
+            mock_api.post_json.assert_not_called()
+
+    def test_post_inline_anchor_refused_deletes_broken_draft(self, monkeypatch):
+        """When GitLab returns line_code=None, the broken draft is deleted and an error is surfaced."""
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        diff = "@@ -0,0 +5,1 @@\n+added\n"
+        mock_api = _inline_api(diff, post_result={"id": 42, "line_code": None})
+        with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
+            result = runner.invoke(
+                app,
+                ["review", "post-draft-note", "org/repo", "1", "msg", "--file", "a.py", "--line", "5"],
+            )
+            assert result.exit_code == 1
+            assert "refused to anchor" in result.output
+            assert "post-comment" in result.output
+            mock_api.delete.assert_called_once()
 
     def test_post_mr_fetch_fails(self, monkeypatch):
         """post-draft-note fails when MR data cannot be fetched."""
@@ -146,6 +215,66 @@ class TestReviewService:
             )
             assert result.exit_code == 1
             assert "no diff_refs" in result.output
+
+
+# -- post-comment (immediate, non-draft) ---------------------------------------
+
+
+class TestPostComment:
+    def test_general_comment(self, monkeypatch):
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        mock_api = MagicMock()
+        mock_api.post_json.return_value = {"id": 555}
+        with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
+            result = runner.invoke(app, ["review", "post-comment", "org/repo", "1", "general body"])
+            assert result.exit_code == 0
+            assert "OK note_id=555" in result.output
+
+    def test_inline_diff_note(self, monkeypatch):
+        """post-comment anchors inline by posting via /discussions and verifying DiffNote."""
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        diff = "@@ -0,0 +5,1 @@\n+added\n"
+        mock_api = _inline_api(
+            diff,
+            post_result={"id": "disc-abc", "notes": [{"type": "DiffNote", "id": 1}]},
+        )
+        with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
+            result = runner.invoke(
+                app,
+                ["review", "post-comment", "org/repo", "1", "msg", "--file", "a.py", "--line", "5"],
+            )
+            assert result.exit_code == 0
+            assert "discussion_id=disc-abc" in result.output
+            assert "inline DiffNote" in result.output
+
+    def test_inline_anchor_falls_back_to_discussion_note(self, monkeypatch):
+        """If GitLab posts a non-DiffNote (anchor lost), the command reports failure."""
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        diff = "@@ -0,0 +5,1 @@\n+added\n"
+        mock_api = _inline_api(
+            diff,
+            post_result={"id": "disc-xyz", "notes": [{"type": "DiscussionNote", "id": 2}]},
+        )
+        with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
+            result = runner.invoke(
+                app,
+                ["review", "post-comment", "org/repo", "1", "msg", "--file", "a.py", "--line", "5"],
+            )
+            assert result.exit_code == 1
+            assert "not anchored inline" in result.output
+
+    def test_inline_context_line_rejected(self, monkeypatch):
+        monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        diff = "@@ -1,1 +1,1 @@\n unchanged\n"
+        mock_api = _inline_api(diff)
+        with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
+            result = runner.invoke(
+                app,
+                ["review", "post-comment", "org/repo", "1", "msg", "--file", "a.py", "--line", "1"],
+            )
+            assert result.exit_code == 1
+            assert "not an added" in result.output
+            mock_api.post_json.assert_not_called()
 
     def test_post_fails(self, monkeypatch):
         """post-draft-note fails when the POST returns empty."""
@@ -377,5 +506,13 @@ class TestRequireToken:
         with patch.object(utils_run_mod.subprocess, "run") as mock_run:
             mock_run.return_value = MagicMock(stderr="", returncode=1)
             result = runner.invoke(app, ["review", "update-note", "org/repo", "1", "42", "body"])
+            assert result.exit_code == 1
+            assert "No GitLab token" in result.output
+
+    def test_post_comment_rejected(self, monkeypatch):
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        with patch.object(utils_run_mod.subprocess, "run") as mock_run:
+            mock_run.return_value = MagicMock(stderr="", returncode=1)
+            result = runner.invoke(app, ["review", "post-comment", "org/repo", "1", "body"])
             assert result.exit_code == 1
             assert "No GitLab token" in result.output


### PR DESCRIPTION
## Summary
- `t3 review post-draft-note` silently produced unpublishable drafts in two cases: context-line targets, and added-line targets in large files whose diff GitLab collapses server-side (line_code = null).
- Validate the target line against `/changes?access_raw_diffs=true` before posting, verify the response anchored, delete the draft on refusal.
- New `t3 review post-comment` subcommand for collapsed-diff files: posts immediate inline discussion via `/discussions` (the only way to anchor on a collapsed-diff file today).

## Test plan
- [x] `uv run pytest tests/test_cli_review.py` — 45/45 pass (added: context-line rejection, file-not-in-diff, collapsed-diff rejection with workaround hint, anchor-refused cleanup, plus the new `post-comment` command path).
- [x] End-to-end on a real MR: existing broken drafts deleted, new drafts posted with non-null `line_code`, lint + ty-check + module-health hooks green.