### PR TITLE
fix(tasks): reap stale claims from CLI list and loop tick (#655)

### DIFF
--- a/src/teatree/core/management/commands/tasks.py
+++ b/src/teatree/core/management/commands/tasks.py
@@ -116,6 +116,7 @@ class Command(TyperCommand):
         status: Annotated[str | None, typer.Option(help="Filter by status")] = None,
         execution_target: Annotated[str | None, typer.Option(help="Filter by execution target")] = None,
     ) -> list[TaskRow]:
+        Task.objects.reap_stale_claims()
         qs = Task.objects.all().order_by("pk")
         if status:
             qs = qs.filter(status=status)

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -223,6 +223,7 @@ def run_tick(
     """
     request = request or TickRequest()
     started_at = now or dt.datetime.now(dt.UTC)
+    _reap_stale_task_claims()
     if request.scanners is not None:
         jobs = [_ScannerJob(scanner=s, overlay="") for s in request.scanners]
     else:
@@ -260,6 +261,20 @@ def run_tick(
         zones.action_needed.append(f"scanner errors: {', '.join(report.errors)}")
     report.statusline_path = render(zones, target=statusline_path, colorize=colorize)
     return report
+
+
+def _reap_stale_task_claims() -> None:
+    """Sweep CLAIMED tasks whose lease has expired so the statusline reflects fresh state.
+
+    Best-effort: if the test harness blocks DB access (pytest-django without
+    a ``db`` marker), the loop tick should still render scanners and signals.
+    """
+    import contextlib  # noqa: PLC0415
+
+    from teatree.core.models import Task  # noqa: PLC0415
+
+    with contextlib.suppress(RuntimeError):
+        Task.objects.reap_stale_claims()
 
 
 def _persist_agent_dispatches(report: TickReport) -> None:

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -625,6 +625,30 @@ class TestTasksListCommand(TestCase):
         assert len(result) == 1
         assert result[0]["execution_target"] == "interactive"
 
+    def test_list_reaps_stale_claims_before_returning_rows(self) -> None:
+        from datetime import timedelta  # noqa: PLC0415
+
+        from django.utils import timezone  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="test")
+        session = Session.objects.create(ticket=ticket, overlay="test")
+        stale = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            status=Task.Status.CLAIMED,
+            claimed_by="dead-worker",
+            lease_expires_at=timezone.now() - timedelta(minutes=5),
+        )
+
+        result = cast("list[dict[str, object]]", call_command("tasks", "list"))
+
+        stale.refresh_from_db()
+        assert stale.status == Task.Status.FAILED
+        statuses = [row["status"] for row in result]
+        assert "claimed" not in statuses
+        assert "failed" in statuses
+
     def test_render_tasks_table_formats_rows(self) -> None:
         from io import StringIO  # noqa: PLC0415
 

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -400,6 +400,33 @@ class TestDispositionMechanical(django.test.TestCase):
         assert ticket.state == "ignored"
 
 
+class TestTickReapsStaleClaims(django.test.TestCase):
+    def test_run_tick_reaps_claims_with_expired_lease(self) -> None:
+        import tempfile  # noqa: PLC0415
+        from datetime import timedelta  # noqa: PLC0415
+
+        from django.utils import timezone  # noqa: PLC0415
+
+        from teatree.core.models import Session, Task, Ticket  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(state=Ticket.State.STARTED)
+        session = Session.objects.create(ticket=ticket, agent_id="agent")
+        stale = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            status=Task.Status.CLAIMED,
+            claimed_by="dead-worker",
+            lease_expires_at=timezone.now() - timedelta(minutes=5),
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_tick(TickRequest(scanners=[]), statusline_path=Path(tmp) / "statusline.txt")
+
+        stale.refresh_from_db()
+        assert stale.status == Task.Status.FAILED
+
+
 def test_tick_multi_overlay_prefixes_summary(tmp_path: Path) -> None:
     """Signals collected via the multi-overlay path get an ``[overlay]`` prefix in the rendered line."""
     from unittest.mock import MagicMock  # noqa: PLC0415

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -427,6 +427,52 @@ class TestTickReapsStaleClaims(django.test.TestCase):
         assert stale.status == Task.Status.FAILED
 
 
+def test_tick_captures_mechanical_handler_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising mechanical handler must not abort the tick — it lands in ``report.errors``."""
+    from teatree.loop import mechanical  # noqa: PLC0415
+
+    def boom(_payload: dict) -> None:
+        msg = "handler exploded"
+        raise RuntimeError(msg)
+
+    monkeypatch.setitem(mechanical.HANDLERS, "ticket_completion", boom)
+
+    signal = ScanSignal(
+        kind="ticket.completion_detected",
+        summary="ticket 42 ready",
+        payload={"ticket_id": 42},
+    )
+    scanner = _FixedScanner(name="completion", out=[signal])
+    statusline = tmp_path / "statusline.txt"
+    report = run_tick(TickRequest(scanners=[scanner]), statusline_path=statusline)
+
+    assert any("ticket_completion" in label for label in report.errors)
+    assert any("handler exploded" in msg for msg in report.errors.values())
+
+
+def test_tick_captures_persist_agent_dispatches_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``persist_agent_actions`` raises, the tick records it instead of crashing."""
+
+    def boom(_actions: object) -> None:
+        msg = "persistence down"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("teatree.loop.persistence.persist_agent_actions", boom)
+
+    scanner = _FixedScanner(name="ok", out=[ScanSignal(kind="my_pr.open", summary="x")])
+    statusline = tmp_path / "statusline.txt"
+    report = run_tick(TickRequest(scanners=[scanner]), statusline_path=statusline)
+
+    assert "dispatch_persist" in report.errors
+    assert "persistence down" in report.errors["dispatch_persist"]
+
+
 def test_tick_multi_overlay_prefixes_summary(tmp_path: Path) -> None:
     """Signals collected via the multi-overlay path get an ``[overlay]`` prefix in the rendered line."""
     from unittest.mock import MagicMock  # noqa: PLC0415
@@ -448,6 +494,42 @@ def test_tick_multi_overlay_prefixes_summary(tmp_path: Path) -> None:
     contents = statusline.read_text(encoding="utf-8")
     assert "[teatree]" in contents
     assert "!545" in contents
+
+
+def test_repos_from_toml_extracts_path_and_workspace_repos(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from teatree.loop.tick import _repos_from_toml  # noqa: PLC0415
+
+    toml_path = tmp_path / ".teatree.toml"
+    toml_path.write_text(
+        '[teatree]\nworkspace_dir = "~/ws"\n'
+        '[overlays.acme]\npath = "~/code/acme"\nworkspace_repos = ["acme/api", "acme/web"]\n'
+        "[overlays.broken]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    repos = _repos_from_toml()
+
+    assert repos["acme"] == Path.home() / "code" / "acme"
+    assert repos["api"].name == "api"
+    assert repos["web"].name == "web"
+
+
+def test_repos_from_toml_returns_empty_on_invalid_toml(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from teatree.loop.tick import _repos_from_toml  # noqa: PLC0415
+
+    toml_path = tmp_path / ".teatree.toml"
+    toml_path.write_text("not = valid = toml = at = all", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert _repos_from_toml() == {}
 
 
 def test_canonical_overlay_names_maps_toml_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #655 (partial — covers fix (a) of the umbrella issue).

## What

`Task.objects.reap_stale_claims()` failed CLAIMED tasks whose `lease_expires_at` had passed, but it only ran from the dashboard queue builder (`src/teatree/core/selectors/queues.py`). Operators using `t3 <overlay> tasks list` saw stale "claimed by worker" rows long after the worker had died, even though `claimable_for_headless()` correctly treated the slot as free.

## Changes

- `Task.objects.reap_stale_claims()` is now called from:
  - `tasks list` (CLI) before building the rendered rows.
  - `run_tick` so the mechanical loop reaps on every tick — keeps the dashboard / statusline in sync.
- New helper `_reap_stale_task_claims` in `teatree.loop.tick` wraps the call in `contextlib.suppress(RuntimeError)` so the test harness can still render scanners without a DB marker (production always has DB).
- Tests:
  - `TestTasksListCommand.test_list_reaps_stale_claims_before_returning_rows` — drives the management command and asserts the stale row is failed and removed from the response.
  - `TestTickReapsStaleClaims.test_run_tick_reaps_claims_with_expired_lease` — drives `run_tick` end-to-end through `django.test.TestCase` so the DB is available.

## Out of scope

Fixes (b) and (c) of #655 are overlay-specific (default test command flags, post-DB test DB cloning) and live in the downstream overlay.
