### PR TITLE
fix(worktree-start): build missing compose images before docker compose up

### DIFF
--- a/src/teatree/core/runners/worktree_start.py
+++ b/src/teatree/core/runners/worktree_start.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from pathlib import Path
@@ -13,6 +14,9 @@ from teatree.utils.ports import find_free_ports
 from teatree.utils.run import DEVNULL, TimeoutExpired, run_allowed_to_fail, spawn
 
 logger = logging.getLogger(__name__)
+
+# Build can take minutes on first start — much longer than the 60s default for `up`.
+DOCKER_COMPOSE_BUILD_TIMEOUT = 600
 
 
 def compose_project(worktree: Worktree) -> str:
@@ -123,6 +127,7 @@ class WorktreeStartRunner(RunnerBase):
         )
 
     def _docker_compose_up(self, project: str, compose_file: str, env: dict[str, str]) -> bool:
+        self._ensure_images_built(project, compose_file, env)
         cmd = [
             "docker",
             "compose",
@@ -148,6 +153,98 @@ class WorktreeStartRunner(RunnerBase):
             )
             return False
         return True
+
+    def _ensure_images_built(self, project: str, compose_file: str, env: dict[str, str]) -> None:
+        """Build any compose service whose ``build:`` image is missing locally.
+
+        ``up --no-build --pull=never`` fails the first time a worktree's
+        compose override references a service that builds from a Dockerfile
+        (e.g. an overlay's docgen sidecar) — neither pull nor build runs, so
+        the missing image is a hard error. Pre-flight per service, build the
+        missing ones once, then let the subsequent ``up`` reuse the local
+        images on every later start.
+        """
+        services = self._enumerate_buildable_services(project, compose_file, env)
+        if not services:
+            return
+        missing = sorted(name for name, image in services.items() if not self._image_exists(image, env))
+        if not missing:
+            return
+        logger.info("Building missing compose images for services: %s", missing)
+        cmd = [
+            "docker",
+            "compose",
+            "-p",
+            project,
+            *_compose_files(compose_file),
+            "build",
+            *missing,
+        ]
+        timeout = self.timeouts.get("docker_compose_build") or DOCKER_COMPOSE_BUILD_TIMEOUT
+        try:
+            result = run_allowed_to_fail(cmd, env=env, expected_codes=None, timeout=timeout)
+        except TimeoutExpired:
+            logger.warning("docker compose build timed out after %ss", timeout)
+            return
+        if result.returncode != 0:
+            logger.warning(
+                "docker compose build failed (exit %s): %s",
+                result.returncode,
+                result.stderr.strip()[:500],
+            )
+
+    @staticmethod
+    def _enumerate_buildable_services(project: str, compose_file: str, env: dict[str, str]) -> dict[str, str]:
+        """Return ``{service_name: resolved_image_tag}`` for services with a ``build:`` section.
+
+        Returns an empty dict on any failure — older compose versions without
+        ``--format json``, unreachable daemons, malformed configs. The caller
+        treats an empty dict as "nothing to preflight" and lets ``up`` proceed
+        naturally; if ``up`` then fails on a missing image, the existing
+        warning path surfaces the cause.
+        """
+        cmd = [
+            "docker",
+            "compose",
+            "-p",
+            project,
+            *_compose_files(compose_file),
+            "config",
+            "--format",
+            "json",
+        ]
+        try:
+            result = run_allowed_to_fail(cmd, env=env, expected_codes=None, timeout=30)
+        except TimeoutExpired:
+            logger.warning("docker compose config timed out — skipping image preflight")
+            return {}
+        if result.returncode != 0:
+            logger.info(
+                "docker compose config failed (exit %s) — skipping image preflight",
+                result.returncode,
+            )
+            return {}
+        try:
+            config = json.loads(result.stdout)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            logger.info("docker compose config returned non-JSON — skipping image preflight")
+            return {}
+        if not isinstance(config, dict):
+            return {}
+        services: dict[str, str] = {}
+        for name, spec in (config.get("services") or {}).items():
+            if isinstance(spec, dict) and "build" in spec and isinstance(spec.get("image"), str):
+                services[name] = spec["image"]
+        return services
+
+    @staticmethod
+    def _image_exists(image: str, env: dict[str, str]) -> bool:
+        cmd = ["docker", "image", "inspect", image]
+        try:
+            result = run_allowed_to_fail(cmd, env=env, expected_codes=None, timeout=10)
+        except TimeoutExpired:
+            return False
+        return result.returncode == 0
 
     @staticmethod
     def _start_host_processes(

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -3808,6 +3808,205 @@ class TestLifecycleStart(TestCase):
                     call_command("worktree", "start", path=str(wt_path))
 
 
+class TestImagePreflight(TestCase):
+    """`worktree start` auto-builds compose service images that are missing locally.
+
+    Background: `docker compose up --no-build --pull=never` fails hard on the
+    first start of a worktree whose compose override declares a `build:`-only
+    service (e.g. an overlay's PDF-renderer sidecar). The fix is a preflight: ask
+    compose for each service's resolved image, `docker image inspect` it, and
+    `docker compose build` any that are missing before the `up` call. Once
+    built, subsequent `up --no-build` calls reuse the local image — code
+    changes still rely on volume-mounted source for hot reload.
+
+    Tests assert the call sequence on the patched subprocess so we don't need
+    a real Docker daemon.
+    """
+
+    def _setup(self, tmp_path: Path) -> tuple[Path, "MagicMock", "MagicMock"]:
+        wt_path = tmp_path / "worktree"
+        wt_path.mkdir()
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/483",
+            variant="acme",
+        )
+        Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="/tmp/backend",
+            branch="feature",
+            extra={"worktree_path": str(wt_path)},
+            db_name="wt_483_acme",
+            state=Worktree.State.PROVISIONED,
+        )
+
+        mock_overlay = MagicMock()
+        mock_overlay.get_run_commands.return_value = {"backend": "run-backend"}
+        mock_overlay.get_pre_run_steps.return_value = []
+        mock_overlay.get_env_extra.return_value = {}
+        mock_overlay.get_envrc_lines.return_value = []
+        mock_overlay.get_db_import_strategy.return_value = None
+        mock_overlay.get_provision_steps.return_value = []
+        mock_overlay.get_post_db_steps.return_value = []
+        mock_overlay.get_health_checks.return_value = []
+        mock_overlay.get_reset_passwords_command.return_value = None
+        mock_overlay.get_compose_file.return_value = "/fake/docker-compose.yml"
+
+        mock_config = MagicMock()
+        mock_config.user.workspace_dir = tmp_path
+        return wt_path, mock_overlay, mock_config
+
+    @staticmethod
+    def _docker_subcommand(cmd: list[str]) -> tuple[str, ...]:
+        """Identify the docker subcommand from a recorded argv list.
+
+        Examples: ``docker compose -p x -f y config --format json`` → ``("compose", "config")``;
+        ``docker image inspect img:tag`` → ``("image", "inspect")``;
+        ``docker compose -p x build svc`` → ``("compose", "build")``.
+        """
+        if not isinstance(cmd, list) or len(cmd) < 2 or cmd[0] != "docker":
+            return ()
+        if cmd[1] == "image":
+            return ("image", cmd[2]) if len(cmd) >= 3 else ("image",)
+        if cmd[1] == "compose":
+            i = 2
+            while i < len(cmd) and cmd[i] in {"-p", "-f", "--project-name", "--file"}:
+                i += 2
+            return ("compose", cmd[i]) if i < len(cmd) else ("compose",)
+        return (cmd[1],) if len(cmd) >= 2 else ()
+
+    @staticmethod
+    def _recorded_subcommands(mock_sp) -> list[tuple[str, ...]]:
+        recorded: list[tuple[str, ...]] = []
+        for call_args in mock_sp.run.call_args_list:
+            cmd = call_args.args[0] if call_args.args else call_args.kwargs.get("args", [])
+            shape = TestImagePreflight._docker_subcommand(cmd)
+            if shape:
+                recorded.append(shape)
+        return recorded
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_builds_missing_image_before_up(self) -> None:
+        """When compose config declares a build: service whose image is absent, build it first."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_path, mock_overlay, mock_config = self._setup(tmp_path)
+
+            compose_config_json = (
+                '{"services": {"sidecar": {"image": "myapp-wt483-sidecar:latest", '
+                '"build": {"context": "../sidecar"}}, "web": {"image": "myapp-web:cached"}}}'
+            )
+
+            def _mock_run(cmd, **kwargs):
+                shape = TestImagePreflight._docker_subcommand(cmd)
+                if shape == ("compose", "config"):
+                    return MagicMock(returncode=0, stdout=compose_config_json, stderr="")
+                if shape == ("image", "inspect"):
+                    # web image present, sidecar image missing
+                    missing = "sidecar" in cmd[-1]
+                    return MagicMock(returncode=1 if missing else 0, stdout="", stderr="")
+                return MagicMock(returncode=0, stdout="", stderr="")
+
+            with (
+                patch.object(worktree_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(utils_run_mod, "subprocess") as mock_sp,
+                patch.object(
+                    worktree_mod,
+                    "find_free_ports",
+                    return_value={"backend": 8001, "frontend": 4201, "postgres": 5432, "redis": 6379},
+                ),
+                patch("teatree.config.load_config", return_value=mock_config),
+            ):
+                mock_sp.run.side_effect = _mock_run
+                call_command("worktree", "start", path=str(wt_path))
+
+            recorded = TestImagePreflight._recorded_subcommands(mock_sp)
+            # The preflight must run before up: config → image inspect → build → up.
+            assert ("compose", "config") in recorded
+            assert ("image", "inspect") in recorded
+            assert ("compose", "build") in recorded
+            assert ("compose", "up") in recorded
+            assert recorded.index(("compose", "build")) < recorded.index(("compose", "up"))
+            # And `build` must come AFTER we discovered the missing image.
+            assert recorded.index(("image", "inspect")) < recorded.index(("compose", "build"))
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_skips_build_when_all_images_present(self) -> None:
+        """When every buildable service's image already exists, no `compose build` call is made."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_path, mock_overlay, mock_config = self._setup(tmp_path)
+
+            compose_config_json = (
+                '{"services": {"sidecar": {"image": "myapp-wt483-sidecar:latest", "build": {"context": "../sidecar"}}}}'
+            )
+
+            def _mock_run(cmd, **kwargs):
+                shape = TestImagePreflight._docker_subcommand(cmd)
+                if shape == ("compose", "config"):
+                    return MagicMock(returncode=0, stdout=compose_config_json, stderr="")
+                if shape == ("image", "inspect"):
+                    return MagicMock(returncode=0, stdout="[]", stderr="")  # present
+                return MagicMock(returncode=0, stdout="", stderr="")
+
+            with (
+                patch.object(worktree_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(utils_run_mod, "subprocess") as mock_sp,
+                patch.object(
+                    worktree_mod,
+                    "find_free_ports",
+                    return_value={"backend": 8001, "frontend": 4201, "postgres": 5432, "redis": 6379},
+                ),
+                patch("teatree.config.load_config", return_value=mock_config),
+            ):
+                mock_sp.run.side_effect = _mock_run
+                call_command("worktree", "start", path=str(wt_path))
+
+            recorded = TestImagePreflight._recorded_subcommands(mock_sp)
+            assert ("compose", "build") not in recorded
+            assert ("compose", "up") in recorded
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_falls_through_when_config_fails(self) -> None:
+        """If `docker compose config` errors, fall through to `up` rather than aborting.
+
+        Compose versions without `--format json`, malformed compose files, or
+        permission issues should not prevent `worktree start` from attempting
+        `up`. The user's existing flow (build manually or accept the natural
+        `up` failure) stays available.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_path, mock_overlay, mock_config = self._setup(tmp_path)
+
+            def _mock_run(cmd, **kwargs):
+                shape = TestImagePreflight._docker_subcommand(cmd)
+                if shape == ("compose", "config"):
+                    return MagicMock(returncode=1, stdout="", stderr="unknown flag: --format")
+                return MagicMock(returncode=0, stdout="", stderr="")
+
+            with (
+                patch.object(worktree_mod, "get_overlay", return_value=mock_overlay),
+                patch.object(utils_run_mod, "subprocess") as mock_sp,
+                patch.object(
+                    worktree_mod,
+                    "find_free_ports",
+                    return_value={"backend": 8001, "frontend": 4201, "postgres": 5432, "redis": 6379},
+                ),
+                patch("teatree.config.load_config", return_value=mock_config),
+            ):
+                mock_sp.run.side_effect = _mock_run
+                call_command("worktree", "start", path=str(wt_path))
+
+            recorded = TestImagePreflight._recorded_subcommands(mock_sp)
+            assert ("compose", "build") not in recorded
+            assert ("compose", "up") in recorded
+
+
 class TestLifecycleClean(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)


### PR DESCRIPTION
## Why

\`docker compose up --no-build --pull=never\` fails the first time a worktree's compose override declares a \`build:\`-only service (typical example: an overlay's PDF-renderer sidecar built from a sibling repo's Dockerfile). Neither pull nor build is attempted, so the missing image becomes a confusing red wall on first start. Reported in [company-fork-org/t3-company#83](https://github.com/company-fork-org/t3-company/issues/83) § Bug 1 — \"\`worktree start\` does not auto-build missing images\".

## What changed

In \`WorktreeStartRunner._docker_compose_up\`, before the existing \`up\` call:

1. \`docker compose config --format json\` enumerates services.
2. For each service with a \`build:\` section, \`docker image inspect <resolved-image>\` is run.
3. Any service whose image is missing locally is built via \`docker compose build <name>\`.
4. The existing \`up --no-build --pull=never\` then proceeds; subsequent starts on the same worktree skip the build because the images now exist locally.

The preflight is **best-effort**: older compose without \`--format json\`, malformed config, a timeout, or any other \`config\` failure all fall through to the previous behaviour (warn, attempt \`up\`, surface the natural error). The change does not alter the \`up\` flags themselves — code is still volume-mounted, so subsequent runs do not rebuild on code changes.

## Tests

\`tests/teatree_core/test_new_management_commands.py::TestImagePreflight\` — three integration cases via \`call_command(\"worktree\", \"start\", ...)\` with patched subprocess:

- **\`test_builds_missing_image_before_up\`** — when \`compose config\` reports a \`build:\` service whose \`docker image inspect\` returns non-zero, the runner calls \`docker compose build <service>\` strictly before \`docker compose up\`.
- **\`test_skips_build_when_all_images_present\`** — when every buildable service's image already exists locally, no \`compose build\` call is made.
- **\`test_falls_through_when_config_fails\`** — when \`compose config\` errors (old compose, malformed file), the preflight skips and \`up\` proceeds as before.

Full teatree suite: **3086 passed, 12 skipped**.

## Tracking

This closes the teatree-side of [company-fork-org/t3-company#83](https://github.com/company-fork-org/t3-company/issues/83). § Bugs 2, 3 already landed in [company-fork-org/t3-company#105](https://github.com/company-fork-org/t3-company/pull/105). § Bug 4 (\`t3 company run all\` aggregator) follows as a separate PR on the overlay.