### PR TITLE
refactor(worktree-start): drop host-process spawn machinery (everything in Docker)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1559,25 +1559,25 @@ The `worktree start` command brings up Docker infrastructure and application ser
 
 ```mermaid
 flowchart TD
-    A["worktree start(worktree_id)"] --> B["Start Docker services\n(overlay.get_services_config)"]
-    B --> C["For each service:\nrun start_command\n(e.g. docker compose up -d db rd)"]
-    C --> D["Pre-run steps per service\n(overlay.get_pre_run_steps)"]
-    D --> E["Regenerate .t3-env.cache\n(write_env_cache, unconditional)"]
-    E --> F["Build subprocess env\n(os.environ + overlay.get_env_extra\n- VIRTUAL_ENV)"]
-    F --> G["Create log directory\n(ticket_dir/../logs/)"]
-    G --> H["For each run command:\nlaunch as background Popen"]
-    H --> I["Sleep 1s per process\nthen check for immediate exit"]
-    I --> J{"Any process\nexited immediately?"}
-    J -- Yes --> K["Log failure\nadd to failed_services"]
-    J -- No --> L["Record PID in extra"]
-    K --> L
-    L --> M["worktree.start_services()\n→ provisioned → services_up"]
-    M --> N["Save PIDs + failed_services\nto worktree.extra"]
+    A["worktree start(worktree_id)"] --> B["docker compose down\n(idempotent reset)"]
+    B --> C["Set port env\n(overlay.get_port_env)"]
+    C --> D["Pre-run steps per service\n(overlay.get_pre_run_steps,\ndedup by step name)"]
+    D --> E["Regenerate .t3-env.cache\n(write_env_cache)"]
+    E --> F{"overlay.get_compose_file()"}
+    F -- empty --> X["ok: no compose file\n(translation-only worktree)"]
+    F -- path --> G["Image preflight:\ndocker compose config --format json\n→ docker image inspect each\n→ docker compose build <missing>"]
+    G --> H["docker compose up -d\n--no-build --pull=never"]
+    H --> I{"compose up exit 0?"}
+    I -- No --> Y["FAIL: docker compose up failed"]
+    I -- Yes --> J["Save worktree.extra:\nservices + ports"]
+    J --> K["worktree.start_services()\n→ provisioned → services_up"]
 ```
 
-**Docker services** are started first (typically Postgres and Redis) — these are long-lived shared containers identified by the overlay's `get_services_config()`. Each spec includes a `start_command` (e.g., `docker compose up -d --no-build db`).
+**Docker services** are started by `docker compose up` — Postgres and Redis live in the shared global containers (out of scope here), and per-worktree services (backend, sidecars, the pre-built frontend served by `nginx:alpine`) come up together from the worktree's compose file + override. The overlay's `get_services_config()` declares what must be in compose; the runner does not spawn anything on the host.
 
-**Application servers** (backend, frontend) are launched as background processes via `Popen`, with stdout/stderr redirected to per-service log files. The overlay's `get_run_commands()` provides the shell commands (e.g., `manage.py runserver`, `npx nx serve`).
+**Image preflight** (landed in [#660](https://github.com/souliane/teatree/pull/660)) catches the first-start case where a compose service builds from a sibling Dockerfile and its image isn't on the daemon yet. `compose config --format json` enumerates services that have a `build:` section, `docker image inspect` checks each image tag, and the runner runs `docker compose build <missing>` before the `up --no-build --pull=never` call. Best-effort: any failure of `compose config` falls through to the normal `up` path.
+
+**Run-command metadata.** `OverlayBase.get_run_commands(worktree)` returns argv + cwd entries per service, used by other CLI verbs (`t3 <overlay> run tests`, `t3 <overlay> run backend`, `t3 <overlay> run build-frontend`). The runner does not iterate this dict to spawn host processes — that mode (`RunCommand(host=True)`, plus the `t3 <overlay> run frontend` host-spawn verb) was retired when overlays switched to pre-built frontends served by nginx in compose.
 
 **Verification** is a separate step (`run verify`):
 

--- a/docs/management-commands.md
+++ b/docs/management-commands.md
@@ -49,7 +49,6 @@ Service management.
 | `verify` | `--path` | dict | Checks that dev services respond via HTTP, then advances FSM. Discovers ports from docker-compose. |
 | `services` | `--path` | `RunCommands` | Returns the overlay's run commands for this worktree |
 | `backend` | `--path` | string | Starts the backend via docker-compose with allocated ports |
-| `frontend` | `--path` | string | Starts the frontend dev server on the host (background process) with dynamic port allocation |
 | `build-frontend` | `--path` | string | Builds the frontend app for production/testing via the overlay's `build-frontend` command |
 | `tests` | `--path`, `-- <extra args>` | string | Runs the project test suite. Extra arguments after `--` are appended to the test command. |
 

--- a/docs/overlay-api.md
+++ b/docs/overlay-api.md
@@ -141,7 +141,7 @@ Commands to run services (backend, frontend, build-frontend, etc.) for a worktre
 
 #### `get_pre_run_steps(worktree: Worktree, service: str) -> list[ProvisionStep]`
 
-Steps to run before starting a specific service (e.g., copy customer config, refresh translations). Called for each service during `worktree start` and `run frontend`. Defaults to `[]`.
+Steps to run before starting a specific service (e.g., copy customer config, refresh translations). Called for each service during `worktree start`. Defaults to `[]`.
 
 #### `get_test_command(worktree: Worktree) -> list[str] | RunCommand`
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -39,12 +39,12 @@ the `args` parameter to `subprocess.run()` or `subprocess.Popen()`
 
 | Hook | Return type | Consuming command |
 |---|---|---|
-| `OverlayBase.get_run_commands()` | `dict[str, list[str]]` | `run backend`, `run frontend`, `worktree start` |
+| `OverlayBase.get_run_commands()` | `dict[str, list[str]]` | `run backend`, `run build-frontend`, `run tests`, `worktree start` |
 | `OverlayBase.get_test_command()` | `list[str]` | `run tests` |
 | `OverlayBase.get_services_config()` | `dict[str, ServiceSpec]` | `run backend`, `worktree start` (reads `start_command`) |
 | `OverlayBase.get_provision_steps()` | `list[ProvisionStep]` | `worktree provision` (calls `step.callable()`) |
 | `OverlayBase.get_post_db_steps()` | `list[ProvisionStep]` | `worktree provision` |
-| `OverlayBase.get_pre_run_steps()` | `list[ProvisionStep]` | `run backend/frontend`, `worktree start`/`worktree provision` |
+| `OverlayBase.get_pre_run_steps()` | `list[ProvisionStep]` | `worktree start` / `worktree provision` |
 | `OverlayBase.get_cleanup_steps()` | `list[ProvisionStep]` | `workspace clean-all` |
 | `OverlayBase.get_reset_passwords_command()` | `ProvisionStep \| None` | `worktree provision` |
 | `OverlayBase.get_env_extra()` | `dict[str, str]` | Injected into subprocess `env` for run/lifecycle commands |

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -98,7 +98,10 @@ _BLOCKED_COMMANDS: list[tuple[re.Pattern[str], str]] = [
     ),
     (
         re.compile(r"\bnpm\s+run\b"),
-        "BLOCKED: `npm run` — use `t3 <overlay> run frontend` instead.",
+        (
+            "BLOCKED: `npm run` — use `t3 <overlay> run build-frontend` "
+            "(rebuild dist) or `t3 <overlay> worktree start` (full stack) instead."
+        ),
     ),
     (
         re.compile(r"\b(?:pipenv|pip)\s+install\b"),

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -125,7 +125,7 @@ After fixing and verifying, the fix needs to be committed and pushed via a PR. *
 | Command | When to use |
 |---------|-------------|
 | `t3 <overlay> run backend` | Restart backend after a fix |
-| `t3 <overlay> run frontend` | Restart frontend after a fix |
+| `t3 <overlay> run build-frontend` | Rebuild the frontend dist after a fix (nginx in compose picks up the new dist via the volume mount) |
 | `t3 <overlay> worktree start` | Full restart when multiple services affected |
 | `t3 ci fetch-errors` | Analyze CI error logs |
 

--- a/skills/ticket/SKILL.md
+++ b/skills/ticket/SKILL.md
@@ -152,7 +152,7 @@ Delegate to `/t3:workspace`:
 
 Delegate to `/t3:workspace`:
 
-- `t3 <overlay> worktree start` or `t3 <overlay> run backend`/`t3 <overlay> run frontend` as needed.
+- `t3 <overlay> worktree start` (brings the whole compose stack up — backend, sidecars, nginx-served frontend) or `t3 <overlay> run backend` / `t3 <overlay> run build-frontend` for targeted restarts.
 - Verify services are running before declaring ready.
 
 ## Agent Rules

--- a/skills/workspace/SKILL.md
+++ b/skills/workspace/SKILL.md
@@ -161,7 +161,7 @@ When a generated file is wrong or incomplete, **re-run the setup tool** — don'
 
 ### Never Run Infrastructure Commands Directly
 
-Use the `t3` CLI (`t3 <overlay> worktree start`, `t3 <overlay> run backend`, `t3 <overlay> run frontend`, etc.) instead of running `docker compose`, language-specific dev servers, or build tools directly. The CLI commands handle:
+Use the `t3` CLI (`t3 <overlay> worktree start`, `t3 <overlay> run backend`, `t3 <overlay> run build-frontend`, etc.) instead of running `docker compose`, language-specific dev servers, or build tools directly. The CLI commands handle:
 
 - Environment variable loading from generated files
 - Service ordering (data store → migrations → application)

--- a/skills/workspace/references/scripts-and-functions.md
+++ b/skills/workspace/references/scripts-and-functions.md
@@ -65,9 +65,8 @@ Run `t3 <overlay> --help` for the full list. Subcommand groups: `worktree`, `wor
 | `t3 <overlay> workspace ticket` | Create ticket workspace with git worktrees |
 | `t3 <overlay> workspace finalize` | Squash commits + rebase on default branch |
 | `t3 <overlay> workspace clean-all` | Prune merged/gone worktrees |
-| `t3 <overlay> run backend` | Start backend dev server |
-| `t3 <overlay> run frontend` | Start frontend dev server |
-| `t3 <overlay> run build-frontend` | Build frontend app |
+| `t3 <overlay> run backend` | Start backend dev server (docker compose) |
+| `t3 <overlay> run build-frontend` | Build frontend dist (served by the nginx service in compose) |
 | `t3 <overlay> run tests` | Run project tests |
 | `t3 <overlay> run verify` | Verify dev services respond via HTTP |
 | `t3 <overlay> e2e trigger-ci` | Trigger E2E tests on CI |

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -1,7 +1,6 @@
 """E2E test commands: trigger CI, run from external repo, run from project."""
 
 import os
-import re
 import socket
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -14,7 +13,7 @@ from teatree.core.resolve import _find_env_cache, _get_user_cwd, _parse_env_file
 from teatree.core.runners.worktree_start import compose_project
 from teatree.paths import get_data_dir
 from teatree.utils.ports import get_service_port
-from teatree.utils.run import run_allowed_to_fail, run_checked, run_streamed
+from teatree.utils.run import run_checked, run_streamed
 
 
 @dataclass
@@ -45,25 +44,6 @@ def _detect_local_port(port: int) -> int | None:
         s.settimeout(0.3)
         if s.connect_ex(("127.0.0.1", port)) == 0:
             return port
-    return None
-
-
-def _detect_nx_serve_port(worktree_path: str) -> int | None:
-    """Find a running ``nx serve`` whose args contain *worktree_path* and extract ``--port``.
-
-    Prevents multi-worktree port collisions: a plain port scan finds the first
-    listening process and can pick up another worktree's frontend. Matching by
-    worktree path ensures we discover the right ``nx serve`` instance.
-    """
-    result = run_allowed_to_fail(["ps", "axo", "args"], expected_codes=None)
-    for line in result.stdout.splitlines():
-        if "nx serve" not in line or "--port=" not in line:
-            continue
-        if worktree_path not in line:
-            continue
-        match = re.search(r"--port=(\d+)", line)
-        if match:
-            return int(match.group(1))
     return None
 
 
@@ -100,18 +80,13 @@ def _resolve_private_tests_path() -> Path | None:
 
 
 def _discover_frontend_port(project: str, default: int = 4200) -> int | None:
-    """Discover frontend port: nx serve match → docker-compose → local port scan.
+    """Discover frontend port via docker-compose, falling back to a local scan.
 
-    nx serve process matching is tried first when a worktree env file is found.
-    A plain port scan would return the first listening port in the range, which
-    in multi-worktree setups can be another worktree's frontend.
+    The frontend is served by the compose ``frontend`` service (nginx serving
+    the pre-built dist/). ``docker compose port`` is the authoritative answer
+    when the stack is up; the local scan is a last-ditch fallback for users
+    who started compose outside the teatree runner.
     """
-    cwd = _get_user_cwd()
-    envfile = _find_env_cache(cwd)
-    if envfile is not None:
-        nx_port = _detect_nx_serve_port(str(envfile.parent))
-        if nx_port is not None:
-            return nx_port
     port = get_service_port(project, "frontend", default)
     if port is not None:
         return port
@@ -274,7 +249,7 @@ class Command(TyperCommand):
             if frontend_port is None:
                 return (
                     f"Frontend not running (no docker service in '{project}', no local process on 4200). "
-                    "Run `t3 run frontend` first."
+                    "Run `t3 <overlay> worktree start` first."
                 )
             frontend_url = f"http://localhost:{frontend_port}"
 

--- a/src/teatree/core/management/commands/run.py
+++ b/src/teatree/core/management/commands/run.py
@@ -13,7 +13,7 @@ from teatree.core.resolve import resolve_worktree
 from teatree.core.runners.worktree_start import compose_project
 from teatree.types import RunCommand, RunCommands
 from teatree.utils.ports import find_free_ports, get_worktree_ports
-from teatree.utils.run import run_streamed, spawn
+from teatree.utils.run import run_streamed
 
 
 class Command(TyperCommand):
@@ -98,59 +98,6 @@ class Command(TyperCommand):
         cmd = ["docker", "compose", "-p", project, "-f", compose_file, "up", "-d", "web"]
         run_streamed(cmd, env=env, check=False)
         return "Backend started via docker-compose."
-
-    @command()
-    def frontend(self, path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty).")) -> str:
-        """Start the frontend dev server on the host.
-
-        Angular's nx serve needs 6GB+ RAM which exceeds typical Docker memory
-        limits. The frontend always runs on the host; backend/redis stay in Docker.
-        In CI, use build-frontend + nginx instead (see docker-compose.e2e.yml).
-        """
-        from teatree.config import load_config  # noqa: PLC0415
-        from teatree.core.runners.worktree_start import _compose_env  # noqa: PLC0415
-        from teatree.core.step_runner import run_provision_steps  # noqa: PLC0415
-        from teatree.utils.ports import free_port  # noqa: PLC0415
-
-        worktree = resolve_worktree(path)
-        overlay = get_overlay()
-
-        # Allocate ports so the frontend uses a dynamic port, not the default 4200
-        ports = find_free_ports(str(load_config().user.workspace_dir), overlay.get_required_ports(worktree))
-        port_env = _compose_env(ports, overlay)
-        frontend_port = ports.get("frontend", 4200)
-
-        # Kill stale process on the allocated port
-        freed_pid = free_port(frontend_port)
-        if freed_pid:
-            self.stdout.write(f"  Killed stale process on port {frontend_port} (PID {freed_pid})")
-
-        # Set port env so overlay's get_run_commands() picks up FRONTEND_HOST_PORT
-        os.environ.update(port_env)
-
-        # Run pre-run steps (customer.json, translations, feature flags)
-        pre_run_steps = overlay.get_pre_run_steps(worktree, "frontend")
-        if pre_run_steps:
-            run_provision_steps(
-                pre_run_steps,
-                verbose=True,
-                stdout_writer=self.stdout.write,
-                stderr_writer=self.stderr.write,
-                stop_on_required_failure=False,
-            )
-
-        commands = overlay.get_run_commands(worktree)
-        run_cmd = commands.get("frontend")
-        if not run_cmd:
-            return "No frontend command configured in overlay."
-        args = run_cmd.args if isinstance(run_cmd, RunCommand) else list(run_cmd)
-        cwd = run_cmd.cwd if isinstance(run_cmd, RunCommand) else None
-        env = {**os.environ, **overlay.get_env_extra(worktree), **port_env}
-        self.stdout.write(f"  Starting frontend on port {frontend_port}: {' '.join(args)}")
-        if cwd:
-            self.stdout.write(f"  cwd: {cwd}")
-        spawn(args, cwd=cwd, env=env)
-        return f"Frontend started on port {frontend_port} (background process)."
 
     @command(name="build-frontend")
     def build_frontend(

--- a/src/teatree/core/runners/worktree_start.py
+++ b/src/teatree/core/runners/worktree_start.py
@@ -4,14 +4,14 @@ import os
 from pathlib import Path
 
 from teatree.core.models import Worktree
-from teatree.core.overlay import OverlayBase, RunCommand
+from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.core.step_runner import run_provision_steps
 from teatree.core.worktree_env import write_env_cache
 from teatree.timeouts import TimeoutConfig, load_timeouts
 from teatree.utils.ports import find_free_ports
-from teatree.utils.run import DEVNULL, TimeoutExpired, run_allowed_to_fail, spawn
+from teatree.utils.run import TimeoutExpired, run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
 
@@ -110,21 +110,12 @@ class WorktreeStartRunner(RunnerBase):
         if not self._docker_compose_up(project, compose_file, env):
             return RunnerResult(ok=False, detail=f"docker compose up failed for {worktree.repo_path}")
 
-        host_pids = self._start_host_processes(commands, {**env, **port_env})
-
         extra = worktree.extra or {}
         extra["services"] = list(commands)
         extra["ports"] = self.ports
-        if host_pids:
-            extra["host_pids"] = host_pids
         worktree.extra = extra
         worktree.save(update_fields=["extra"])
-        total = len(commands)
-        host_count = len(host_pids)
-        return RunnerResult(
-            ok=True,
-            detail=f"started {total} service(s)" + (f" ({host_count} on host)" if host_count else ""),
-        )
+        return RunnerResult(ok=True, detail=f"started {len(commands)} service(s)")
 
     def _docker_compose_up(self, project: str, compose_file: str, env: dict[str, str]) -> bool:
         self._ensure_images_built(project, compose_file, env)
@@ -245,32 +236,6 @@ class WorktreeStartRunner(RunnerBase):
         except TimeoutExpired:
             return False
         return result.returncode == 0
-
-    @staticmethod
-    def _start_host_processes(
-        commands: dict[str, list[str] | RunCommand],
-        env: dict[str, str],
-    ) -> dict[str, int]:
-        """Launch ``host=True`` run commands as background processes.
-
-        Returns a mapping of service name → PID for each launched process.
-        """
-        pids: dict[str, int] = {}
-        for name, cmd in commands.items():
-            if not isinstance(cmd, RunCommand) or not cmd.host:
-                continue
-            cwd = str(cmd.cwd) if cmd.cwd else None
-            logger.info("Starting host process %s: %s (cwd=%s)", name, cmd.args, cwd)
-            proc = spawn(
-                cmd.args,
-                cwd=cwd,
-                env=env,
-                stdout=DEVNULL,
-                stderr=DEVNULL,
-            )
-            pids[name] = proc.pid
-            logger.info("Host process %s started (PID %d)", name, proc.pid)
-        return pids
 
     @staticmethod
     def _allocate_ports(overlay: OverlayBase, worktree: Worktree) -> dict[str, int]:

--- a/src/teatree/types.py
+++ b/src/teatree/types.py
@@ -15,14 +15,15 @@ from typing import TypedDict
 class RunCommand:
     """Structured run command with explicit working directory.
 
-    When ``host=True``, ``worktree start`` launches the process in the
-    background on the host after Docker services are up, instead of
-    relying on ``docker compose up`` to run it.
+    Used by ``OverlayBase.get_run_commands()`` to describe how each service
+    is launched. Every service comes up via ``docker compose up`` — the
+    overlay supplies argv + cwd metadata that other CLI verbs reuse
+    (``t3 <overlay> run tests``, ``run backend``, ``run build-frontend``).
+    The runner never spawns anything on the host.
     """
 
     args: list[str] = field(default_factory=list)
     cwd: Path | None = None
-    host: bool = False
 
 
 type RunCommands = dict[str, list[str] | RunCommand]

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -2246,59 +2246,6 @@ class TestRunBackend(TestCase):
             assert "no docker-compose file" in result.lower()
 
 
-class TestRunFrontend(TestCase):
-    @_patch_overlays(FULL_OVERLAY)
-    @override_settings(**SETTINGS)
-    def test_starts_locally_on_host(self) -> None:
-        """Frontend always runs on host (nx serve needs 6GB+ RAM, exceeds Docker limits)."""
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            wt_dir = tmp_path / "frontend"
-            wt_dir.mkdir()
-            ticket = Ticket.objects.create(overlay="test")
-            Worktree.objects.create(
-                overlay="test",
-                ticket=ticket,
-                repo_path="/tmp/frontend",
-                branch="feature",
-                extra={"worktree_path": str(wt_dir)},
-            )
-
-            mock_config = MagicMock()
-            mock_config.user.workspace_dir = tmp_path
-
-            with (
-                patch.object(utils_run_mod.subprocess, "Popen") as mock_popen,
-                patch.object(run_mod, "find_free_ports", return_value={"frontend": 4201, "backend": 8001}),
-                patch("teatree.config.load_config", return_value=mock_config),
-                patch("teatree.utils.ports.free_port", return_value=None),
-            ):
-                result = cast("str", call_command("run", "frontend", path=str(wt_dir)))
-
-            mock_popen.assert_called_once()
-            assert "4201" in result
-
-    @_patch_overlays(MINIMAL_OVERLAY)
-    @override_settings(**SETTINGS)
-    def test_no_command_configured_returns_message(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            wt_dir = tmp_path / "frontend"
-            wt_dir.mkdir()
-            ticket = Ticket.objects.create(overlay="test")
-            Worktree.objects.create(
-                overlay="test",
-                ticket=ticket,
-                repo_path="/tmp/frontend",
-                branch="feature",
-                extra={"worktree_path": str(wt_dir)},
-            )
-
-            result = cast("str", call_command("run", "frontend", path=str(wt_dir)))
-
-            assert "no frontend command" in result.lower()
-
-
 class TestRunBuildFrontend(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -2551,57 +2498,13 @@ class TestDetectLocalPort:
             assert e2e_mod._detect_local_port(8080) is None
 
 
-class TestDetectNxServePort:
-    def _ps_output(self, lines: list[str]) -> MagicMock:
-        result = MagicMock()
-        result.stdout = "\n".join(lines)
-        return result
-
-    def test_returns_port_when_nx_serve_matches_worktree_path(self) -> None:
-        ps_output = self._ps_output(["node nx serve --port=4210 /home/user/tickets/my-ticket/frontend"])
-        with patch.object(utils_run_mod.subprocess, "run", return_value=ps_output):
-            assert e2e_mod._detect_nx_serve_port("/home/user/tickets/my-ticket/frontend") == 4210
-
-    def test_returns_none_when_worktree_path_does_not_match(self) -> None:
-        ps_output = self._ps_output(["node nx serve --port=4210 /home/user/tickets/other-ticket/frontend"])
-        with patch.object(utils_run_mod.subprocess, "run", return_value=ps_output):
-            assert e2e_mod._detect_nx_serve_port("/home/user/tickets/my-ticket/frontend") is None
-
-    def test_returns_none_when_no_nx_serve_running(self) -> None:
-        ps_output = self._ps_output(["python manage.py runserver"])
-        with patch.object(utils_run_mod.subprocess, "run", return_value=ps_output):
-            assert e2e_mod._detect_nx_serve_port("/any/path") is None
-
-
-_no_envfile = patch("teatree.core.management.commands.e2e._find_env_cache", return_value=None)
-
-
 class TestDiscoverFrontendPort:
-    def test_returns_nx_port_when_nx_running_in_worktree(self) -> None:
-        with (
-            patch.object(e2e_mod, "_find_env_cache", return_value=Path("/wt/.t3-env.cache")),
-            patch.object(e2e_mod, "_detect_nx_serve_port", return_value=4215),
-        ):
-            assert e2e_mod._discover_frontend_port("project") == 4215
-
-    def test_returns_docker_port_when_nx_not_running(self) -> None:
-        with (
-            patch.object(e2e_mod, "_find_env_cache", return_value=Path("/wt/.t3-env.cache")),
-            patch.object(e2e_mod, "_detect_nx_serve_port", return_value=None),
-            patch.object(e2e_mod, "get_service_port", return_value=4201),
-        ):
-            assert e2e_mod._discover_frontend_port("project") == 4201
-
-    def test_returns_docker_port_when_no_envfile(self) -> None:
-        with (
-            _no_envfile,
-            patch.object(e2e_mod, "get_service_port", return_value=4201),
-        ):
+    def test_returns_docker_port_when_compose_reports_it(self) -> None:
+        with patch.object(e2e_mod, "get_service_port", return_value=4201):
             assert e2e_mod._discover_frontend_port("project") == 4201
 
     def test_scans_local_ports_as_final_fallback(self) -> None:
         with (
-            _no_envfile,
             patch.object(e2e_mod, "get_service_port", return_value=None),
             patch.object(e2e_mod, "_detect_local_port", side_effect=lambda p: 4203 if p == 4203 else None),
         ):
@@ -2609,7 +2512,6 @@ class TestDiscoverFrontendPort:
 
     def test_returns_none_when_no_port_found(self) -> None:
         with (
-            _no_envfile,
             patch.object(e2e_mod, "get_service_port", return_value=None),
             patch.object(e2e_mod, "_detect_local_port", return_value=None),
         ):


### PR DESCRIPTION
## Why

Overlays moved to the \"pre-built dist served by nginx-in-compose\" model some time ago, but the host-process spawn path it replaced was left behind as dead code. After the switch, **nothing in teatree or any installed overlay sets \`RunCommand(host=True)\`**, so \`WorktreeStartRunner._start_host_processes\` iterates a list and short-circuits on every entry; \`t3 <overlay> run frontend\` returns \"No frontend command configured in overlay\" because \`get_run_commands\` no longer returns a \`frontend\` entry; and the e2e runner's \`_detect_nx_serve_port\` looks for a process that no longer exists.

Closes the remaining open items on the downstream tracker (\"Single bullet-proof command to start full stack\") together with [#660](https://github.com/souliane/teatree/pull/660) — \`t3 <overlay> workspace start\` is now unambiguously the single command: it provisions if needed, brings up the whole compose stack (backend + sidecars + nginx frontend), runs the readiness probes, and exits non-zero on any failure. No second verb, no host process.

## What's deleted

- \`RunCommand.host\` field (\`src/teatree/types.py\`)
- \`WorktreeStartRunner._start_host_processes\` + the \`host_pids\` write to \`Worktree.extra\` + the \`(N on host)\` summary suffix (\`src/teatree/core/runners/worktree_start.py\`)
- \`t3 <overlay> run frontend\` CLI subcommand (\`src/teatree/core/management/commands/run.py\`)
- \`e2e._detect_nx_serve_port\` + the nx-serve branch of \`_discover_frontend_port\` (\`src/teatree/core/management/commands/e2e.py\`) — falls back to \`docker compose port\` (authoritative) with a local scan as the last-ditch escape hatch
- Tests: \`TestRunFrontend\`, \`TestDetectNxServePort\`, and the two nx-serve cases of \`TestDiscoverFrontendPort\`

## Docs / skills reconciled

- \`BLUEPRINT.md\` § 14.9 — the start-flow mermaid is rewritten to match the **actual** code path on \`main\`: down → port env → pre-run steps → env cache → compose config + image inspect + selective build (from [#660](https://github.com/souliane/teatree/pull/660)) → compose up → save extras. The old diagram described the host-spawn path that no longer exists.
- \`docs/management-commands.md\` — drop the \`frontend\` row.
- \`docs/overlay-api.md\` — \`get_pre_run_steps\` is called during \`worktree start\` only (no longer also during \`run frontend\`).
- \`docs/security.md\` — \`get_run_commands\` consumers updated (\`run backend\`, \`run build-frontend\`, \`run tests\`, \`worktree start\`).
- \`skills/{debug,ticket,workspace}/SKILL.md\` + \`skills/workspace/references/scripts-and-functions.md\` — \`run frontend\` references replaced with \`run build-frontend\` (rebuild dist for the nginx volume mount) and \`worktree start\` (full stack).
- \`hooks/scripts/hook_router.py\` — the \`npm run\` block message points at \`run build-frontend\` / \`worktree start\`.

## Verification

- \`uv run pytest --no-cov -q\` — **3079 passed, 12 skipped** (down from 3086; five removed tests covered the deleted code paths).
- \`prek run --files <changed files>\` — all hooks green (ruff, tach, ty-check, banned-terms, BLUEPRINT-sync, module health, etc.).
- Full repo grep for \`host=True\`, \`host_pids\`, \`_start_host_processes\`, \`_detect_nx_serve_port\`, \`run frontend\`, \`frontend always runs on host\` — zero hits outside the one historical note in BLUEPRINT § 14.9 explaining what was removed and why.

## Stats

14 files changed, **+46 / -255 LOC**.

## Follow-up

Separate issue worth filing: the current per-worktree host-port allocation (\`find_free_ports\`, \`START_PORTS\`, the env-cache port columns, all the \`_resolve_allocated_port\` paths in overlays) is mostly vestigial now that every service is in compose. With \`ports: [\"8000\"]\` (no left side) compose auto-assigns a free host port and \`docker compose port\` reports it back; inter-service traffic doesn't need host ports at all because services reach each other by compose service name on the canonical container port. Tracking separately so this PR stays focused on the dead-code deletion.