### PR TITLE
fix(loop): make t3 loop tick a machine-wide singleton (flock)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -544,6 +544,8 @@ Can be overridden via a markdown file at `references/skill-delegation.md` with `
 
 TeaTree drives the day from a single long-lived Claude Code session running a fat `/loop`. The loop fires on a fixed cadence (default 12 minutes, configured via `[teatree] loop_cadence_seconds`). The tick body is Python code (`teatree.loop.tick.run_tick`), not prose — so it is tested, typed, and version-controlled.
 
+**Tick is a machine-wide singleton.** Every open Claude Code session registers its own `CronCreate` for `t3 loop tick` via the session-start hook, so N concurrent sessions would otherwise fire N overlapping ticks racing on scanner state, the statusline file, and per-row dispatch dedup. The `loop_tick` management command wraps `run_tick` in `teatree.utils.singleton.singleton("loop-tick")` (the same flock-backed primitive used by `t3 <overlay> worker` and `t3 slack listen`). A second concurrent tick gets `AlreadyRunningError`, prints `SKIP`, and exits 0 — the holding tick's cron re-fires on the next cadence anyway.
+
 Each tick runs three stages:
 
 1. **Scan** — pure-Python scanners under `teatree.loop.scanners` collect signals from external sources in parallel. Scanners are deterministic, mockable, and fully covered by integration tests against stubbed backends. They never invoke Claude.
@@ -900,7 +902,7 @@ Each registered overlay gets a subcommand group (e.g., `t3 acme`). Commands dele
 - `t3 <overlay> full-status` — ticket/worktree/session summary
 - `t3 <overlay> agent [TASK]` — launch Claude Code with overlay context
 - `t3 <overlay> resetdb` — drop and recreate SQLite database
-- `t3 <overlay> worker` — start background task workers (singleton — refuses a second instance while one is alive; uses `teatree.utils.singleton` over `$XDG_DATA_HOME/teatree/teatree-worker.pid`)
+- `t3 <overlay> worker` — start background task workers (singleton — refuses a second instance while one is alive; uses `teatree.utils.singleton`, a non-blocking `flock` over `$XDG_DATA_HOME/teatree/teatree-worker.pid`)
 
 **Management command groups** (each exposed as a sub-typer):
 
@@ -1064,7 +1066,7 @@ e2e_dir = "e2e"  # subdirectory containing playwright.config.ts (default: "e2e")
 
 The walkthrough never writes a bot token to disk in plaintext; tokens always go via `pass`. Re-running `t3 setup slack-bot --overlay <name> --reset` rotates both tokens.
 
-**Socket Mode listener** (`t3 slack listen`): a global singleton process that opens one WebSocket per slack-enabled overlay. Events are written to `$XDG_DATA_HOME/teatree/slack-events.jsonl` in real time. `t3 slack status` checks if the listener is running. `t3 slack check` drains the queue and prints user messages as JSON (exit 0 = messages found, 1 = empty) — designed for a fast cron (30s–1min). The listener uses PID-file-based singleton detection — only one instance runs at a time. Start it as a background process or let the SessionStart hook manage its lifecycle.
+**Socket Mode listener** (`t3 slack listen`): a global singleton process that opens one WebSocket per slack-enabled overlay. Events are written to `$XDG_DATA_HOME/teatree/slack-events.jsonl` in real time. `t3 slack status` checks if the listener is running. `t3 slack check` drains the queue and prints user messages as JSON (exit 0 = messages found, 1 = empty) — designed for a fast cron (30s–1min). The listener uses the shared `teatree.utils.singleton` flock primitive (kernel-enforced, crash-safe) — only one instance runs at a time. Start it as a background process or let the SessionStart hook manage its lifecycle.
 
 **Operating mode (`teatree.mode`, env: `T3_MODE`)** — controls whether the agent
 pauses for confirmation on publishing actions (push, PR create, PR merge, messaging-backend

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1381,9 +1381,11 @@ Usage: t3 teatree worktree start [OPTIONS]
  Thin wrapper around ``Worktree.start_services()``: the FSM advances
  to SERVICES_UP and enqueues ``execute_worktree_start``; the runner
  also runs synchronously here so the operator sees immediate output.
- Allocates free host ports, refreshes the env cache, runs overlay
- pre-run steps, then ``docker compose up -d``. After the runner
- succeeds, runs the overlay's readiness probes — exits 1 if any fail.
+ Refreshes the env cache, runs overlay pre-run steps, then
+ ``docker compose up -d``. Docker auto-maps host ports; the actual
+ ports are then queried via ``docker compose port`` and stored on
+ ``Worktree.extra["ports"]``. After the runner succeeds, runs the
+ overlay's readiness probes — exits 1 if any fail.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
@@ -1581,10 +1583,12 @@ Usage: t3 teatree workspace start [OPTIONS]
 
  Start docker for every worktree in the current ticket workspace.
 
- Allocates one shared port set across the workspace, then fires
- ``Worktree.start_services()`` on each worktree (CLI runs the
- runner synchronously). After every worktree starts, runs each
- overlay's readiness probes — exits 1 if any probe fails.
+ Fires ``Worktree.start_services()`` on each worktree (CLI runs the
+ runner synchronously). Each runner brings up docker-compose, which
+ auto-maps host ports; the actual ports are then queried via
+ ``docker compose port`` and stored on ``Worktree.extra["ports"]``.
+ After every worktree starts, runs each overlay's readiness probes —
+ exits 1 if any probe fails.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --path        TEXT  Worktree path inside the workspace (auto-detects from    │
@@ -1770,7 +1774,7 @@ Usage: t3 teatree run services [OPTIONS]
 ```
 Usage: t3 teatree run backend [OPTIONS]
 
- Start the backend via docker-compose.
+ Start the backend via docker-compose. Host port is auto-mapped.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
@@ -1783,16 +1787,7 @@ Usage: t3 teatree run backend [OPTIONS]
 ```
 Usage: t3 teatree run frontend [OPTIONS]
 
- Start the frontend dev server on the host.
-
- Angular's nx serve needs 6GB+ RAM which exceeds typical Docker memory
- limits. The frontend always runs on the host; backend/redis stay in Docker.
- In CI, use build-frontend + nginx instead (see docker-compose.e2e.yml).
-
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
-│ --help              Show this message and exit.                              │
-╰──────────────────────────────────────────────────────────────────────────────╯
+ Start the frontend dev server.
 ```
 
 ##### `t3 teatree run build-frontend`

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -436,7 +436,7 @@ def _check_singletons() -> bool:
     """Clean up stale pid files for known singleton processes."""
     from teatree.utils.singleton import default_pid_path, read_pid  # noqa: PLC0415
 
-    for name in ("teatree-worker", "slack-listener"):
+    for name in ("teatree-worker", "slack-listener", "loop-tick"):
         path = default_pid_path(name)
         had_file = path.is_file()
         if read_pid(path) is None and had_file:

--- a/src/teatree/core/management/commands/loop_tick.py
+++ b/src/teatree/core/management/commands/loop_tick.py
@@ -54,12 +54,22 @@ class Command(TyperCommand):
             messaging_from_overlay,
         )
         from teatree.loop.tick import TickRequest, run_tick  # noqa: PLC0415
+        from teatree.utils.singleton import AlreadyRunningError, singleton  # noqa: PLC0415
 
-        if overlay:
-            request = TickRequest(host=code_host_from_overlay(), messaging=messaging_from_overlay())
-        else:
-            request = TickRequest(backends=iter_overlay_backends())
-        report = run_tick(request, statusline_path=statusline_file)
+        try:
+            with singleton("loop-tick"):
+                if overlay:
+                    request = TickRequest(host=code_host_from_overlay(), messaging=messaging_from_overlay())
+                else:
+                    request = TickRequest(backends=iter_overlay_backends())
+                report = run_tick(request, statusline_path=statusline_file)
+        except AlreadyRunningError:
+            if json_output:
+                self.stdout.write(json.dumps({"skipped": "another tick is already running"}))
+            else:
+                self.stdout.write("SKIP  another tick is already running — singleton lock held.")
+            return
+
         result = _report_to_dict(report)
         if json_output:
             self.stdout.write(json.dumps(result, indent=2))

--- a/src/teatree/utils/singleton.py
+++ b/src/teatree/utils/singleton.py
@@ -1,13 +1,26 @@
-"""Pid-file singleton guards for long-running processes.
+"""Flock-backed singleton guards for long-running processes.
 
-One teatree instance shares one SQLite DB and one queue of background tasks.
-Two concurrent ``t3 <overlay> worker`` invocations would compete for the same
-rows and double-execute side effects; two concurrent ``t3 slack listen``
-processes would double-ack every Slack event. Both commands wrap their main
-loop with :func:`singleton` so a second invocation refuses to start while
-the first is alive.
+One teatree instance shares one SQLite DB and one queue of background
+tasks. Two concurrent ``t3 <overlay> worker`` invocations would compete
+for the same rows and double-execute side effects; two concurrent
+``t3 slack listen`` processes would double-ack every Slack event; and N
+concurrent ``t3 loop tick`` processes (one per open Claude Code session,
+each registered by the session-start hook's ``CronCreate``) would race
+on scanner state, the statusline file, and per-row dispatch dedup. Each
+of these wraps its main loop with :func:`singleton` so a second
+invocation refuses to start while the first is alive.
+
+The guard is a non-blocking ``fcntl.flock``. It is kernel-enforced:
+crash-safe (the lock releases when the holder's process dies, with no
+stale-pid window to steal), and free of the read-pid/write-pid TOCTOU
+race the previous pid-file implementation had. The lock file still
+records the holder's pid so ``t3 doctor`` and ``read_pid`` can report
+*who* holds it — but the pid is diagnostic only; the ``flock`` is the
+lock.
 """
 
+import contextlib
+import fcntl
 import os
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -43,8 +56,11 @@ def default_pid_path(name: str) -> Path:
 def read_pid(pid_path: Path) -> int | None:
     """Return the live pid recorded at ``pid_path``, or ``None``.
 
-    Returns ``None`` when the file is missing, malformed, or the pid is dead.
-    Removes the file in the malformed/dead cases so the caller can claim it.
+    Diagnostic helper (consumed by ``t3 doctor``). Returns ``None`` when
+    the file is missing, malformed, or the recorded pid is dead, and
+    removes the file in the malformed/dead cases. Safe alongside the
+    ``flock``: a live holder always keeps its own (live) pid in the
+    file, so this never unlinks an actively-held lock file.
     """
     if not pid_path.is_file():
         return None
@@ -59,20 +75,41 @@ def read_pid(pid_path: Path) -> int | None:
     return pid
 
 
+def _recorded_pid(path: Path) -> int:
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return 0
+    return int(raw) if raw.isdigit() else 0
+
+
 @contextmanager
 def singleton(name: str, *, pid_path: Path | None = None) -> Iterator[Path]:
     """Acquire a singleton lock named ``name`` for the lifetime of the block.
 
-    Raises :class:`AlreadyRunningError` if another live process owns the lock.
-    Writes the current pid on entry and clears it on exit (including crashes).
+    Raises :class:`AlreadyRunningError` if another live process owns the
+    lock. The kernel releases the lock on context exit OR on process
+    death — there is no stale state to clean up. The lock file is NOT
+    unlinked on exit (unlinking a path another opener may have already
+    ``open()``-ed reintroduces a double-acquire race); it is reused in
+    place by the next acquirer.
     """
     path = pid_path or default_pid_path(name)
     path.parent.mkdir(parents=True, exist_ok=True)
-    live_pid = read_pid(path)
-    if live_pid is not None:
-        raise AlreadyRunningError(name, live_pid, path)
-    path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o644)
     try:
-        yield path
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            holder = _recorded_pid(path)
+            os.close(fd)
+            raise AlreadyRunningError(name, holder, path) from exc
+        os.ftruncate(fd, 0)
+        os.write(fd, f"{os.getpid()}\n".encode())
+        try:
+            yield path
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
     finally:
-        path.unlink(missing_ok=True)
+        with contextlib.suppress(OSError):
+            os.close(fd)

--- a/tests/teatree_core/test_loop_tick_command.py
+++ b/tests/teatree_core/test_loop_tick_command.py
@@ -96,3 +96,34 @@ class TestLoopTickCommand(TestCase):
             call_command("loop_tick", "--overlay", "myoverlay", stdout=stdout)
 
         host_mock.assert_called_once()
+
+    def test_skips_tick_when_singleton_lock_held(self) -> None:
+        """Holding the real `loop-tick` lock makes the command skip the tick.
+
+        No mock of the lock itself — a genuine concurrent holder is
+        simulated by acquiring `singleton("loop-tick")` in this process
+        first, exercising the exact production refusal path.
+        """
+        from teatree.utils.singleton import singleton  # noqa: PLC0415
+
+        stdout = StringIO()
+        with (
+            singleton("loop-tick"),
+            patch("teatree.loop.tick.run_tick") as run_tick_mock,
+        ):
+            call_command("loop_tick", stdout=stdout)
+
+        run_tick_mock.assert_not_called()
+        output = stdout.getvalue()
+        assert "SKIP" in output
+        assert "another tick is already running" in output
+
+    def test_skip_emits_json_when_requested(self) -> None:
+        from teatree.utils.singleton import singleton  # noqa: PLC0415
+
+        stdout = StringIO()
+        with singleton("loop-tick"):
+            call_command("loop_tick", "--json", stdout=stdout)
+
+        payload = json.loads(stdout.getvalue())
+        assert payload == {"skipped": "another tick is already running"}

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,11 +1,22 @@
-"""Tests for ``teatree.utils.singleton`` pid-file locks."""
+"""Tests for ``teatree.utils.singleton`` flock-backed locks."""
 
+import multiprocessing
 import os
+import time
 from pathlib import Path
 
 import pytest
 
 from teatree.utils.singleton import AlreadyRunningError, default_pid_path, pid_alive, read_pid, singleton
+
+
+def _hold_lock(lock_path: str, ready_path: str, release_path: str) -> None:
+    """Helper: acquire the lock, signal ready, hold until told to release."""
+    with singleton("xproc", pid_path=Path(lock_path)):
+        Path(ready_path).write_text("acquired", encoding="utf-8")
+        deadline = time.time() + 10.0
+        while not Path(release_path).exists() and time.time() < deadline:
+            time.sleep(0.02)
 
 
 class TestPidAlive:
@@ -39,32 +50,65 @@ class TestReadPid:
 
 
 class TestSingleton:
-    def test_acquires_and_releases(self, tmp_path: Path) -> None:
+    def test_acquires_and_records_pid(self, tmp_path: Path) -> None:
+        path = tmp_path / "lock.pid"
+        with singleton("test", pid_path=path) as held:
+            assert held == path
+            assert path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+    def test_reacquirable_after_clean_exit(self, tmp_path: Path) -> None:
         path = tmp_path / "lock.pid"
         with singleton("test", pid_path=path):
-            assert path.read_text(encoding="utf-8").strip() == str(os.getpid())
-        assert not path.is_file()
+            pass
+        with singleton("test", pid_path=path) as held:
+            assert held == path
 
-    def test_releases_on_exception(self, tmp_path: Path) -> None:
+    def test_reacquirable_after_exception(self, tmp_path: Path) -> None:
         path = tmp_path / "lock.pid"
         msg = "boom"
-        with pytest.raises(RuntimeError), singleton("test", pid_path=path):
+        with pytest.raises(RuntimeError, match=msg), singleton("test", pid_path=path):
             raise RuntimeError(msg)
-        assert not path.is_file()
+        with singleton("test", pid_path=path) as held:
+            assert held == path
 
-    def test_refuses_second_instance(self, tmp_path: Path) -> None:
+    def test_nested_acquire_in_same_process_refuses(self, tmp_path: Path) -> None:
         path = tmp_path / "lock.pid"
-        path.write_text(f"{os.getpid()}\n", encoding="utf-8")
-        with pytest.raises(AlreadyRunningError) as exc, singleton("test", pid_path=path):
+        with (
+            singleton("test", pid_path=path),
+            pytest.raises(AlreadyRunningError) as exc,
+            singleton("test", pid_path=path),
+        ):
             pass
         assert exc.value.pid == os.getpid()
         assert exc.value.name == "test"
 
-    def test_steals_stale_pid(self, tmp_path: Path) -> None:
+    def test_ignores_dead_pid_in_lockfile(self, tmp_path: Path) -> None:
         path = tmp_path / "lock.pid"
         path.write_text("999999999\n", encoding="utf-8")
         with singleton("test", pid_path=path):
             assert path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+    def test_concurrent_process_is_refused(self, tmp_path: Path) -> None:
+        lock_path = tmp_path / "lock.pid"
+        ready_path = tmp_path / "ready"
+        release_path = tmp_path / "release"
+        proc = multiprocessing.Process(
+            target=_hold_lock,
+            args=(str(lock_path), str(ready_path), str(release_path)),
+        )
+        proc.start()
+        try:
+            deadline = time.time() + 5.0
+            while not ready_path.exists() and time.time() < deadline:
+                time.sleep(0.02)
+            assert ready_path.exists(), "helper never acquired the lock"
+
+            with pytest.raises(AlreadyRunningError) as exc, singleton("xproc", pid_path=lock_path):
+                pass
+            assert exc.value.pid == proc.pid
+        finally:
+            release_path.write_text("go", encoding="utf-8")
+            proc.join(timeout=5)
 
     def test_default_path_uses_data_dir(self) -> None:
         path = default_pid_path("worker")

--- a/tests/test_slack_listen.py
+++ b/tests/test_slack_listen.py
@@ -149,9 +149,13 @@ class TestListenCommand:
         assert "No slack-enabled overlays" in result.stdout
 
     def test_exits_when_already_running(self, tmp_path: Path) -> None:
+        from teatree.utils.singleton import singleton  # noqa: PLC0415
+
         pid_file = tmp_path / "slack-listener.pid"
-        pid_file.write_text(f"{os.getpid()}\n", encoding="utf-8")
-        with patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"):
+        with (
+            singleton("slack-listener", pid_path=pid_file),
+            patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"),
+        ):
             result = runner.invoke(slack_app, ["listen"])
 
         assert result.exit_code == 1
@@ -170,7 +174,16 @@ class TestListenCommand:
         assert result.exit_code == 0
         assert "Listening on ov" in result.stdout
 
-    def test_cleans_pid_file_after_run(self, tmp_path: Path) -> None:
+    def test_lock_released_after_run(self, tmp_path: Path) -> None:
+        """The flock releases on clean exit so the lock is re-acquirable.
+
+        The lock file itself persists by design (unlinking a path another
+        opener may already hold reintroduces a double-acquire race — see
+        ``teatree.utils.singleton``); release is proven by re-acquiring,
+        not by file absence.
+        """
+        from teatree.utils.singleton import singleton  # noqa: PLC0415
+
         with (
             patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"),
             patch("teatree.cli.slack_listen._resolve_overlays", return_value=[("ov", "xapp", "xoxb")]),
@@ -179,9 +192,12 @@ class TestListenCommand:
             runner.invoke(slack_app, ["listen"])
 
         pid_file = tmp_path / "slack-listener.pid"
-        assert not pid_file.is_file()
+        with singleton("slack-listener", pid_path=pid_file) as held:
+            assert held == pid_file
 
-    def test_cleans_pid_on_exception(self, tmp_path: Path) -> None:
+    def test_lock_released_on_exception(self, tmp_path: Path) -> None:
+        from teatree.utils.singleton import singleton  # noqa: PLC0415
+
         with (
             patch("teatree.cli.slack_listen.default_queue_path", return_value=tmp_path / "events.jsonl"),
             patch("teatree.cli.slack_listen._resolve_overlays", return_value=[("ov", "xapp", "xoxb")]),
@@ -189,6 +205,7 @@ class TestListenCommand:
         ):
             result = runner.invoke(slack_app, ["listen"])
 
-        pid_file = tmp_path / "slack-listener.pid"
-        assert not pid_file.is_file()
         assert result.exit_code != 0
+        pid_file = tmp_path / "slack-listener.pid"
+        with singleton("slack-listener", pid_path=pid_file) as held:
+            assert held == pid_file


### PR DESCRIPTION
## Summary

User reported the teatree loop is not a singleton. Root cause: the session-start hook registers a `CronCreate` for `t3 loop tick` per open Claude Code session, so N sessions fire N overlapping ticks every 12 min — racing on GitLab API quotas, the statusline file, scanner state, and `persist_agent_actions` (per-row dedup, not per-event).

## Resolution

User-approved decision: **consolidate, don't fork**. There was already a PID-file singleton in `teatree.utils.singleton` (used by `t3 worker` + `t3 slack listen`). Rather than add a second primitive, this rewrites that one to a non-blocking `fcntl.flock` and adds `t3 loop tick` as a third call site.

flock is kernel-enforced: crash-safe (released on process death, no stale-pid steal window) and free of the read-pid/write-pid TOCTOU race the old implementation had. The public API is unchanged, so worker + slack-listener call sites get the stronger primitive with no edits.

## Changes

- `teatree.utils.singleton`: PID-file → flock. No unlink on exit (avoids the double-acquire race when another opener already holds an fd to the path); kernel releases on close/death. `read_pid` retained as the `t3 doctor` diagnostic janitor.
- `loop_tick` command wraps `run_tick` in `singleton("loop-tick")`; refused tick prints `SKIP`, exits 0.
- `t3 doctor` `_check_singletons` also sweeps `loop-tick`.
- Tests rewritten to the flock contract (release proven by re-acquire; real held-lock refusal instead of mocks; two-phase cross-process handshake — no sleep flake).
- BLUEPRINT.md: new singleton paragraph in the loop section; worker + slack-listener descriptions updated PID-file → flock.

## Review

Pre-push `t3:reviewer` sub-agent. The duplicate-primitive MAJOR was escalated to the user (AskUserQuestion) → chose consolidation. BLUEPRINT MAJOR resolved. no-fsync / useful-yield / vacuous-test MINOR+NIT all applied. Cross-service: API preserved, worker + slack-listener call sites unchanged and green.

## Test plan

- [x] `uv run pytest tests/test_singleton.py` — 14 passed (incl. real cross-process refusal)
- [x] Full suite — 3128 passed, 93.14% coverage
- [x] `uv run ruff check` + `uv run ty check` — clean
- [x] worker + slack-listener + doctor call sites verified green under the new primitive