### PR TITLE
fix(resolve): reuse workspace-owner ticket instead of forking auto: dup (#641)

### DIFF
--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -140,9 +140,12 @@ def _auto_register_from_git(cwd: str) -> Worktree | None:
             existing.save(update_fields=["extra"])
         return existing
 
-    ticket, _created = Ticket.objects.get_or_create(
-        issue_url=f"auto:{branch}",
-        defaults={"variant": "", "repos": [repo_name]},
+    ticket = (
+        _workspace_owner_ticket(cwd_path)
+        or Ticket.objects.get_or_create(
+            issue_url=f"auto:{branch}",
+            defaults={"variant": "", "repos": [repo_name]},
+        )[0]
     )
     wt, _wt_created = Worktree.objects.get_or_create(
         ticket=ticket,
@@ -153,6 +156,24 @@ def _auto_register_from_git(cwd: str) -> Worktree | None:
         },
     )
     return wt
+
+
+def _workspace_owner_ticket(cwd_path: Path) -> Ticket | None:
+    """Return the ticket that already owns *cwd_path*'s workspace dir, if any.
+
+    A per-ticket workspace dir holds one repo worktree per affected repo
+    (e.g. ``<workspace>/<ticket>/<repoA>``, ``…/<repoB>``). When a sibling
+    worktree under the same parent directory is already registered, its
+    ticket owns the workspace — a different branch/repo resolved from the
+    same workspace must attach to that ticket rather than fork a fresh
+    ``auto:<branch>`` ticket (#641).
+    """
+    workspace_dir = str(cwd_path.parent)
+    for wt in Worktree.objects.exclude(extra__worktree_path__isnull=True):
+        recorded = (wt.extra or {}).get("worktree_path", "")
+        if recorded and str(Path(recorded).parent) == workspace_dir:
+            return wt.ticket
+    return None
 
 
 def _is_main_clone(path: str) -> bool:

--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -167,11 +167,21 @@ def _workspace_owner_ticket(cwd_path: Path) -> Ticket | None:
     ticket owns the workspace — a different branch/repo resolved from the
     same workspace must attach to that ticket rather than fork a fresh
     ``auto:<branch>`` ticket (#641).
+
+    Stored ``worktree_path`` values are written unresolved (provision uses
+    ``config.workspace_dir()`` verbatim) while ``cwd_path`` here is
+    ``.resolve()``-d, so a symlinked workspace root (macOS ``/tmp`` →
+    ``/private/tmp``) would otherwise miss. Comparison goes through
+    ``_candidate_paths`` — the same symlink-variant set
+    ``_match_worktree_by_path`` uses. Relies on the one-ticket-per-
+    workspace-dir invariant; if violated the first match wins.
     """
-    workspace_dir = str(cwd_path.parent)
+    workspace_candidates = set(_candidate_paths(str(cwd_path.parent)))
     for wt in Worktree.objects.exclude(extra__worktree_path__isnull=True):
         recorded = (wt.extra or {}).get("worktree_path", "")
-        if recorded and str(Path(recorded).parent) == workspace_dir:
+        if not recorded:
+            continue
+        if set(_candidate_paths(str(Path(recorded).parent))) & workspace_candidates:
             return wt.ticket
     return None
 

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -462,6 +462,35 @@ class TestAutoRegisterReusesExistingWorktree(TestCase):
         assert not Ticket.objects.filter(issue_url="auto:docgen/other").exists()
         assert Ticket.objects.count() == 1
 
+    def test_reuses_workspace_owner_when_stored_path_is_symlink_unresolved(self) -> None:
+        """Owner is found even when the stored path is the unresolved (symlinked) form.
+
+        Provision records ``worktree_path`` verbatim from
+        ``config.workspace_dir()`` (no ``.resolve()``), while resolution
+        ``.resolve()``-s cwd. On a symlinked workspace root (macOS
+        ``/tmp`` → ``/private/tmp``) the two forms differ; the match must
+        still succeed via ``_candidate_paths``.
+        """
+        owner_ticket = Ticket.objects.create(issue_url="https://gitlab.com/org/repo/-/issues/94")
+        repo_a = self._make_git_worktree("repo-a")
+        # Simulate the unresolved stored form by de-privatising the path
+        # the way an unresolved macOS workspace root would be recorded.
+        stored = str(repo_a).replace("/private/", "/", 1) if str(repo_a).startswith("/private/") else str(repo_a)
+        Worktree.objects.create(
+            ticket=owner_ticket,
+            repo_path="repo-a",
+            branch="ac/real-work",
+            extra={"worktree_path": stored},
+        )
+        repo_b = self._make_git_worktree("repo-b")
+
+        with patch("teatree.core.resolve.git.current_branch", return_value="docgen/other"):
+            result = _auto_register_from_git(str(repo_b))
+
+        assert result is not None
+        assert result.ticket_id == owner_ticket.pk
+        assert not Ticket.objects.filter(issue_url="auto:docgen/other").exists()
+
     def test_no_workspace_owner_still_creates_auto_ticket(self) -> None:
         """When no sibling worktree shares the workspace dir, the auto: path stands."""
         wt_dir = self._make_git_worktree("lonely-repo")

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -434,3 +434,40 @@ class TestAutoRegisterReusesExistingWorktree(TestCase):
         assert result.repo_path == "my-repo"
         assert result.ticket.issue_url == "auto:feat/branch"
         assert Worktree.objects.count() == 2
+
+    def test_reuses_workspace_owner_ticket_for_sibling_branch(self) -> None:
+        """A sibling worktree under the same workspace dir reuses its ticket (#641).
+
+        Workspace ``ticket <real_url>`` owns repoA on branch A. Resolving a
+        *different* repo/branch under the SAME workspace dir must attach to
+        that ticket, not fork a new ``auto:<branch>`` ticket.
+        """
+        owner_ticket = Ticket.objects.create(issue_url="https://gitlab.com/org/repo/-/issues/94")
+        repo_a = self._make_git_worktree("repo-a")
+        Worktree.objects.create(
+            ticket=owner_ticket,
+            repo_path="repo-a",
+            branch="ac/real-work",
+            extra={"worktree_path": str(repo_a)},
+        )
+        repo_b = self._make_git_worktree("repo-b")  # sibling under the same tmp_path
+
+        with patch("teatree.core.resolve.git.current_branch", return_value="docgen/other"):
+            result = _auto_register_from_git(str(repo_b))
+
+        assert result is not None
+        assert result.ticket_id == owner_ticket.pk
+        assert result.repo_path == "repo-b"
+        assert result.branch == "docgen/other"
+        assert not Ticket.objects.filter(issue_url="auto:docgen/other").exists()
+        assert Ticket.objects.count() == 1
+
+    def test_no_workspace_owner_still_creates_auto_ticket(self) -> None:
+        """When no sibling worktree shares the workspace dir, the auto: path stands."""
+        wt_dir = self._make_git_worktree("lonely-repo")
+
+        with patch("teatree.core.resolve.git.current_branch", return_value="feat/solo"):
+            result = _auto_register_from_git(str(wt_dir))
+
+        assert result is not None
+        assert result.ticket.issue_url == "auto:feat/solo"


### PR DESCRIPTION
## Summary

Closes #641. `_auto_register_from_git` matched only `(branch, repo_path)`. When a workspace dir already owned a real ticket (repoA/branchA) and a `t3` command resolved a *different* repo/branch under the same workspace dir (sibling worktree / doc-service sub-worktree), the lookup missed and forked a duplicate `auto:<branch>` ticket — which then corrupted `.t3-cache` DB-name resolution and crashed the backend. Hit during TICKET-1151 demo prep (#94 → spawned #96).

## Fix

`_workspace_owner_ticket(cwd_path)`: before the `auto:` fallthrough, find a registered Worktree whose recorded `worktree_path` is a sibling under the same workspace dir (cwd parent); attach the new branch/repo Worktree to that owning ticket. Comparison goes through the module's existing `_candidate_paths` so a symlinked workspace root (macOS `/tmp`→`/private/tmp`) still matches. No sibling → `auto:` path unchanged.

## Review

`t3:reviewer` sub-agent. Caught a MAJOR — the first cut compared a resolved cwd parent against the *unresolved* stored `worktree_path` (provision records it verbatim), which would silently re-introduce the dup on symlinked-workspace macOS setups. Fixed by routing through `_candidate_paths` + added a regression test with the de-privatised stored form. MINOR (invariant doc) applied; N+1 concern assessed acceptable (step-3-only, bounded table).

## Test plan

- [x] `uv run pytest tests/teatree_core/test_resolve.py` — 33 passed (30 pre-existing unchanged + 3 new: sibling reuse, symlink-unresolved reuse, lone-repo still `auto:`)
- [x] Full suite — 3167 passed, 93.17% coverage
- [x] `uv run ruff check` + `uv run ty check` — clean

Refs #641.