### PR TITLE
feat(hooks): refuse commits in the main clone on a non-default branch (#638)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,14 @@ repos:
         always_run: true
         stages: [commit]
 
+      - id: refuse-main-clone-commit
+        name: Refuse commits in the main clone on a non-default branch (worktree-first)
+        language: system
+        entry: scripts/hooks/refuse-main-clone-commit.sh
+        pass_filenames: false
+        always_run: true
+        stages: [commit]
+
   # Phase 1 - Init
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 5ab6bd930e86ba0e929eedcee2be458f6b8e4936  # 0.8.16

--- a/scripts/hooks/refuse-main-clone-commit.sh
+++ b/scripts/hooks/refuse-main-clone-commit.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Pre-commit hook: enforce worktree-first (#638).
+#
+# Refuses a commit when it is attempted from a *main clone* (a checkout
+# whose ``.git`` is a directory) while on a non-default branch. Feature
+# work belongs in a worktree, never in the shared main clone — branches
+# and commits landing there pollute shared state and risk committing to
+# the wrong place. Worktrees (``.git`` is a file) are always allowed.
+#
+# The default branch is detected from ``origin/HEAD`` so this works for
+# teatree (``main``) and overlays whose default is ``development``
+# without any per-repo configuration; it falls back to ``main`` when
+# ``origin/HEAD`` is unset.
+#
+# Wired via prek in ``.pre-commit-config.yaml`` so it ships with the
+# repo and needs no per-machine bootstrap.
+set -euo pipefail
+
+git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
+
+# Worktrees have ``.git`` as a *file*; ``git rev-parse --git-dir`` in a
+# worktree resolves to ``…/.git/worktrees/<name>``. Only a main clone
+# has a top-level ``.git`` directory. If the resolved git dir is exactly
+# ``<toplevel>/.git`` and that is a directory, this is the main clone.
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+if [ ! -d "${toplevel}/.git" ] || [ "$(cd "${git_dir}" && pwd)" != "$(cd "${toplevel}/.git" && pwd)" ]; then
+  exit 0  # a worktree (or detached/odd layout) — not the main clone
+fi
+
+current=$(git symbolic-ref --short HEAD 2>/dev/null) || exit 0  # detached HEAD: let other hooks decide
+
+default_ref=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)
+default_branch=${default_ref#origin/}
+default_branch=${default_branch:-main}
+
+if [ "${current}" != "${default_branch}" ]; then
+  echo "✗ refuse: main clone is on '${current}' (default is '${default_branch}') — develop in a worktree."
+  echo "  Run: t3 teatree workspace ticket <issue_url>"
+  echo "  (worktree-first is non-negotiable — see /t3:rules § Worktree-First Work)"
+  exit 1
+fi
+
+exit 0

--- a/scripts/hooks/refuse-main-clone-commit.sh
+++ b/scripts/hooks/refuse-main-clone-commit.sh
@@ -35,7 +35,7 @@ default_branch=${default_branch:-main}
 
 if [ "${current}" != "${default_branch}" ]; then
   echo "✗ refuse: main clone is on '${current}' (default is '${default_branch}') — develop in a worktree."
-  echo "  Run: t3 teatree workspace ticket <issue_url>"
+  echo "  Run: t3 <overlay> workspace ticket <issue_url>"
   echo "  (worktree-first is non-negotiable — see /t3:rules § Worktree-First Work)"
   exit 1
 fi

--- a/tests/test_refuse_main_clone_commit.py
+++ b/tests/test_refuse_main_clone_commit.py
@@ -1,0 +1,114 @@
+"""Tests for the worktree-first pre-commit guard (#638).
+
+The hook refuses a commit when it runs in a *main clone* (``.git`` is a
+directory) on a non-default branch — pushing developers into a worktree
+instead of polluting the shared clone.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).resolve().parents[1] / "scripts" / "hooks" / "refuse-main-clone-commit.sh"
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)  # noqa: S607
+
+
+def _make_main_clone(tmp_path: Path) -> Path:
+    repo = tmp_path / "teatree"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "t@e.st")
+    _git(repo, "config", "user.name", "Tester")
+    (repo / "f.txt").write_text("x", encoding="utf-8")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", "init")
+    # Give it an origin/HEAD so default-branch detection has something to read.
+    _git(repo, "remote", "add", "origin", str(repo))
+    _git(repo, "fetch", "origin")
+    _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+    return repo
+
+
+def _run_hook(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(HOOK)],  # noqa: S607
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestRefuseMainCloneCommit:
+    def test_allows_commit_on_default_branch(self, tmp_path: Path) -> None:
+        repo = _make_main_clone(tmp_path)
+        result = _run_hook(repo)
+        assert result.returncode == 0, result.stderr
+
+    def test_refuses_commit_on_feature_branch_in_main_clone(self, tmp_path: Path) -> None:
+        repo = _make_main_clone(tmp_path)
+        _git(repo, "checkout", "-b", "ac/some-feature")
+
+        result = _run_hook(repo)
+
+        assert result.returncode == 1
+        combined = result.stdout + result.stderr
+        assert "worktree" in combined.lower()
+        assert "t3" in combined
+
+    def test_allows_commit_in_a_worktree_on_feature_branch(self, tmp_path: Path) -> None:
+        repo = _make_main_clone(tmp_path)
+        wt = tmp_path / "wt"
+        _git(repo, "worktree", "add", "-b", "ac/feature", str(wt))
+
+        result = _run_hook(wt)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_detects_development_default_branch(self, tmp_path: Path) -> None:
+        """An overlay whose default branch is `development` is honoured."""
+        repo = tmp_path / "overlay"
+        repo.mkdir()
+        _git(repo, "init", "-b", "development")
+        _git(repo, "config", "user.email", "t@e.st")
+        _git(repo, "config", "user.name", "Tester")
+        (repo / "f.txt").write_text("x", encoding="utf-8")
+        _git(repo, "add", "f.txt")
+        _git(repo, "commit", "-m", "init")
+        _git(repo, "remote", "add", "origin", str(repo))
+        _git(repo, "fetch", "origin")
+        _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/development")
+
+        on_default = _run_hook(repo)
+        assert on_default.returncode == 0, on_default.stderr
+
+        _git(repo, "checkout", "-b", "ac/x")
+        on_feature = _run_hook(repo)
+        assert on_feature.returncode == 1
+
+    def test_falls_back_to_main_when_no_origin_head(self, tmp_path: Path) -> None:
+        repo = tmp_path / "noorigin"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "t@e.st")
+        _git(repo, "config", "user.name", "Tester")
+        (repo / "f.txt").write_text("x", encoding="utf-8")
+        _git(repo, "add", "f.txt")
+        _git(repo, "commit", "-m", "init")
+
+        assert _run_hook(repo).returncode == 0
+        _git(repo, "checkout", "-b", "feature")
+        assert _run_hook(repo).returncode == 1
+
+    def test_hook_is_executable(self) -> None:
+        import os  # noqa: PLC0415
+
+        assert os.access(HOOK, os.X_OK), f"{HOOK} must be chmod +x"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_refuse_main_clone_commit.py
+++ b/tests/test_refuse_main_clone_commit.py
@@ -60,6 +60,23 @@ class TestRefuseMainCloneCommit:
         assert "worktree" in combined.lower()
         assert "t3" in combined
 
+    def test_refuses_from_a_subdirectory_of_the_main_clone(self, tmp_path: Path) -> None:
+        """Refuse from a subdirectory of the main clone.
+
+        The load-bearing case: cwd is a subdir, so `git rev-parse
+        --git-dir` returns an *absolute* path and the cd-resolution must
+        still equate it with `<toplevel>/.git`.
+        """
+        repo = _make_main_clone(tmp_path)
+        _git(repo, "checkout", "-b", "ac/sub")
+        subdir = repo / "scripts"
+        subdir.mkdir()
+
+        result = _run_hook(subdir)
+
+        assert result.returncode == 1
+        assert "worktree" in (result.stdout + result.stderr).lower()
+
     def test_allows_commit_in_a_worktree_on_feature_branch(self, tmp_path: Path) -> None:
         repo = _make_main_clone(tmp_path)
         wt = tmp_path / "wt"


### PR DESCRIPTION
## Summary

Closes #638. The worktree-first rule was skill-enforced only and kept being violated — feature branches/commits landing in the shared main clone. You caught the main clone left on `fix/review-anchor-validation`; the reflog confirms prior sessions ran `git checkout`+`commit` directly there (HEAD@{6} `commit: fix(review)...`). No machine guard existed, so it recurred. This adds one.

## Changes

- `scripts/hooks/refuse-main-clone-commit.sh` — pre-commit hook. Refuses a commit when the checkout is a **main clone** (`.git` is a directory AND resolved `git rev-parse --git-dir` == `<toplevel>/.git`) **and** HEAD ≠ the default branch. Worktrees (`.git` is a file) and detached HEAD pass (exit 0).
- Default branch detected from `origin/HEAD` → handles teatree (`main`) and overlays whose default is `development` with zero per-repo config; falls back to `main` when unset. (Resolves the issue's "configurable default?" open question without an env var.)
- Wired into `.pre-commit-config.yaml` next to `no-commit-on-merged-branch` → ships with the repo; a fresh clone + `prek install` gets it (issue success criterion, no per-machine bootstrap).
- 7 behaviour tests, real `git` under `tmp_path`: default-branch allow, feature-branch refuse, **subdirectory** refuse (the load-bearing relative-git-dir path), worktree allow, `development`-default detection, no-`origin/HEAD` fallback, executable bit.

## Review

`t3:reviewer` sub-agent — **APPROVE**, no blockers/majors. Verified the script against real git repos for subdir/submodule/`$GIT_DIR`/detached/bare/macOS-`/private` edge cases (all correct), confirmed `stages: [commit]` matches the repo's prek convention, and the integration-first test shape per AGENTS.md. Both NITs folded in: message generalized to `t3 <overlay>`, subdirectory regression test added.

No CI duplication: main-clone-local developer discipline; a no-op on CI PR branches.

## Test plan

- [x] `uv run pytest tests/test_refuse_main_clone_commit.py` — 7 passed
- [x] `uv run ruff check` — clean
- [x] Hook is a verified no-op in worktrees (this PR's own commits passed through it)

Closes #638.