### PR TITLE
fix(core): reply-dispatch reliability + leak-safe hardening (follow-up to #677-#681)

### DIFF
--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -86,7 +86,7 @@ class ReplyDispatchQuerySet(models.QuerySet):
             self.filter(status=ReplyDispatch.Status.FAILED)
             .exclude(action_name="dead_letter_alert")
             .filter(models.Q(next_retry_at__isnull=True) | models.Q(next_retry_at__lte=moment))
-            .order_by("dispatched_at", "pk")
+            .order_by("next_retry_at", "pk")
         )
 
 

--- a/src/teatree/core/reply_retry.py
+++ b/src/teatree/core/reply_retry.py
@@ -27,9 +27,10 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
-from teatree.core.models import ReplyDispatch
+from teatree.core.models import IncomingEvent, ReplyDispatch
 from teatree.core.reply_transport import Replier
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,16 @@ class RetrySweep:
             dispatch.status = ReplyDispatch.Status.SENT
             dispatch.error_message = ""
             dispatch.next_retry_at = None
-            dispatch.save(update_fields=["status", "error_message", "next_retry_at"])
+            try:
+                with transaction.atomic():
+                    dispatch.save(update_fields=["status", "error_message", "next_retry_at"])
+            except Exception:
+                logger.warning(
+                    "Dispatch %s redelivered but the success-status save could not be saved — "
+                    "the row stays FAILED and will be retried (bounded double-fire)",
+                    dispatch.pk,
+                    exc_info=True,
+                )
         return attempted
 
     def _handle_failure(self, dispatch: ReplyDispatch, replier: Replier, exc: Exception) -> None:
@@ -101,10 +111,42 @@ class RetrySweep:
                 event=event,
                 actor=event.actor,
                 body=body,
+                # The :deadletter suffix assumes a dispatch is dead-lettered
+                # at most once (the sweep flips status to DEAD_LETTER, which
+                # due_for_retry excludes, so the row is never re-swept).
                 idempotency_key=f"{dispatch.idempotency_key}:deadletter",
             )
-        except Exception:
+        except Exception as alert_exc:
             logger.exception("Dead-letter alert for dispatch %s could not be delivered", dispatch.pk)
+            RetrySweep._persist_failed_alert(dispatch, event, alert_exc)
+
+    @staticmethod
+    def _persist_failed_alert(dispatch: ReplyDispatch, event: IncomingEvent, exc: Exception) -> None:
+        """Record a terminal audit row when the dead-letter alert itself fails.
+
+        A permanently-broken DM channel would otherwise silently drop the
+        dead letter. The row uses a FAILED status (excluded from
+        ``due_for_retry`` via ``action_name="dead_letter_alert"``) so it
+        leaves an auditable trail without entering the retry storm. The
+        ``:deadletter-alert`` idempotency-key suffix and the
+        ``IntegrityError`` recovery make a repeated sweep a safe no-op.
+        """
+        try:
+            with transaction.atomic():
+                ReplyDispatch.objects.create(
+                    event=event,
+                    target_ref=event.actor,
+                    action_name="dead_letter_alert",
+                    idempotency_key=f"{dispatch.idempotency_key}:deadletter-alert",
+                    status=ReplyDispatch.Status.FAILED,
+                    body="dead-letter alert delivery failed",
+                    error_message=str(exc),
+                )
+        except IntegrityError:
+            logger.debug(
+                "Dead-letter alert audit row for dispatch %s already recorded — idempotent no-op",
+                dispatch.pk,
+            )
 
 
 def sweep_failed_dispatches(

--- a/src/teatree/core/reply_transport.py
+++ b/src/teatree/core/reply_transport.py
@@ -139,43 +139,54 @@ class _BaseReplier:
         )
 
     def _send(self, spec: ReplySpec) -> ReplyDispatch:
-        # Idempotency is enforced on the ReplyDispatch *record*. The
-        # platform side effect (the actual post) has a theoretical
-        # double-fire window between this SELECT and the INSERT — bounded
-        # in practice by the machine-wide `t3 loop tick` flock singleton
-        # (#676), which serialises the only caller.
-        existing = ReplyDispatch.objects.filter(idempotency_key=spec.idempotency_key).first()
-        if existing is not None:
-            logger.debug("Reply %s already recorded — idempotent no-op", spec.idempotency_key)
-            return existing
-        try:
-            self._deliver(spec)
-        except Exception as exc:  # noqa: BLE001 — any backend failure becomes a FAILED row
-            logger.warning("Reply %s delivery failed: %s", spec.idempotency_key, exc)
-            return self._record(spec, status=ReplyDispatch.Status.FAILED, error_message=str(exc))
-        return self._record(spec, status=ReplyDispatch.Status.SENT)
-
-    @staticmethod
-    def _record(
-        spec: ReplySpec,
-        *,
-        status: str,
-        error_message: str = "",
-    ) -> ReplyDispatch:
+        # Idempotency is intrinsic to the ReplyDispatch *record*: the
+        # idempotency key is atomically reserved with a PENDING row
+        # *before* the side effect, so a second caller racing on the same
+        # key (including a non-loop / cron caller without the machine-wide
+        # `t3 loop tick` flock #676) reuses the reserved row and never
+        # re-delivers. The IntegrityError recovery below remains as
+        # defense-in-depth for the create-vs-create race.
         try:
             with transaction.atomic():
-                return ReplyDispatch.objects.create(
-                    event=spec.event,
-                    target_ref=spec.target_ref,
-                    action_name=spec.action_name,
+                dispatch, created = ReplyDispatch.objects.get_or_create(
                     idempotency_key=spec.idempotency_key,
-                    status=status,
-                    body=spec.body,
-                    error_message=error_message,
+                    defaults={
+                        "event": spec.event,
+                        "target_ref": spec.target_ref,
+                        "action_name": spec.action_name,
+                        "status": ReplyDispatch.Status.PENDING,
+                        "body": spec.body,
+                    },
                 )
         except IntegrityError:
             logger.debug("Reply %s already recorded — idempotent no-op", spec.idempotency_key)
             return ReplyDispatch.objects.get(idempotency_key=spec.idempotency_key)
+        if not created:
+            logger.debug("Reply %s already recorded — idempotent no-op", spec.idempotency_key)
+            return dispatch
+        try:
+            # Savepoint so a DB-level error raised inside subclass
+            # `_deliver` (e.g. a create-vs-create race) does not poison
+            # the outer transaction and the FAILED finalize can still run.
+            with transaction.atomic():
+                self._deliver(spec)
+        except Exception as exc:  # noqa: BLE001 — any backend failure becomes a FAILED row
+            logger.warning("Reply %s delivery failed: %s", spec.idempotency_key, exc)
+            return self._finalize(dispatch, status=ReplyDispatch.Status.FAILED, error_message=str(exc))
+        return self._finalize(dispatch, status=ReplyDispatch.Status.SENT)
+
+    @staticmethod
+    def _finalize(
+        dispatch: ReplyDispatch,
+        *,
+        status: ReplyDispatch.Status,
+        error_message: str = "",
+    ) -> ReplyDispatch:
+        dispatch.status = status
+        dispatch.error_message = error_message
+        with transaction.atomic():
+            dispatch.save(update_fields=["status", "error_message"])
+        return dispatch
 
     def redeliver(self, dispatch: ReplyDispatch) -> None:
         """Re-attempt a previously-recorded dispatch (the retry-sweep path).

--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -177,7 +177,7 @@ def _workspace_owner_ticket(cwd_path: Path) -> Ticket | None:
     workspace-dir invariant; if violated the first match wins.
     """
     workspace_candidates = set(_candidate_paths(str(cwd_path.parent)))
-    for wt in Worktree.objects.exclude(extra__worktree_path__isnull=True):
+    for wt in Worktree.objects.exclude(extra__worktree_path__isnull=True).order_by("pk"):
         recorded = (wt.extra or {}).get("worktree_path", "")
         if not recorded:
             continue

--- a/src/teatree/core/views/_rate_limit.py
+++ b/src/teatree/core/views/_rate_limit.py
@@ -21,10 +21,13 @@ CPU/DoS guard (unauthenticated floods already 401 before any DB write
 and are intentionally not bucketed).
 """
 
+import logging
 import threading
 from collections.abc import Callable
 
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_CAPACITY = 60
 _DEFAULT_REFILL_PER_SECOND = 1.0
@@ -74,6 +77,14 @@ class WebhookRateLimiter:
         self._lock = threading.Lock()
 
     def allow(self, source: str) -> bool:
+        # An unknown source must not mint an unbounded bucket — a
+        # misconfigured/forged platform value would otherwise get an
+        # uncapped allowance. Treat it as rate-limited (rejected).
+        from teatree.core.models import IncomingEvent  # noqa: PLC0415
+
+        if source not in IncomingEvent.Source.values:
+            logger.warning("Rejecting webhook from unknown source %r — not creating a bucket", source)
+            return False
         with self._lock:
             bucket = self._buckets.get(source)
             if bucket is None:

--- a/tests/teatree_core/test_managers.py
+++ b/tests/teatree_core/test_managers.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 
-from teatree.core.models import Session, Task, Ticket, Worktree
+from teatree.core.models import IncomingEvent, ReplyDispatch, Session, Task, Ticket, Worktree
 
 
 class TestTicketQuerySet(TestCase):
@@ -94,3 +94,46 @@ class TestTaskQuerySet(TestCase):
 
         assert sdk_tasks == [sdk_ready, sdk_reclaimable]
         assert user_tasks == [user_ready]
+
+
+class TestReplyDispatchQuerySet(TestCase):
+    def test_due_for_retry_orders_by_oldest_due_first(self) -> None:
+        """``due_for_retry`` returns rows oldest-due-first by ``next_retry_at``.
+
+        Not oldest-dispatched-first — this matches the
+        ``Index(["status", "next_retry_at"])`` on the model.
+        """
+        event = IncomingEvent.objects.create(
+            source=IncomingEvent.Source.SLACK,
+            actor="U_ALICE",
+            channel_ref="C-eng",
+            thread_ref="t1",
+            body="orig",
+            idempotency_key="slack:e1",
+        )
+        now = timezone.now()
+        early_dispatch_late_retry = ReplyDispatch.objects.create(
+            event=event,
+            target_ref="C-eng",
+            action_name="post_in_thread",
+            idempotency_key="k-early-dispatch",
+            status=ReplyDispatch.Status.FAILED,
+            dispatched_at=now - timedelta(hours=5),
+            next_retry_at=now - timedelta(minutes=1),
+        )
+        late_dispatch_early_retry = ReplyDispatch.objects.create(
+            event=event,
+            target_ref="C-eng",
+            action_name="post_in_thread",
+            idempotency_key="k-late-dispatch",
+            status=ReplyDispatch.Status.FAILED,
+            dispatched_at=now - timedelta(hours=1),
+            next_retry_at=now - timedelta(minutes=30),
+        )
+
+        # Ordered by next_retry_at: the one due longest ago comes first,
+        # regardless of dispatched_at.
+        assert list(ReplyDispatch.objects.due_for_retry(now)) == [
+            late_dispatch_early_retry,
+            early_dispatch_late_retry,
+        ]

--- a/tests/teatree_core/test_reply_retry.py
+++ b/tests/teatree_core/test_reply_retry.py
@@ -1,7 +1,7 @@
 """Behaviour tests for the failed-ReplyDispatch retry sweep (#673 items 1+2)."""
 
 import datetime as dt
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 from django.utils import timezone
@@ -123,6 +123,68 @@ class TestSweepFailedDispatches(TestCase):
         d.refresh_from_db()
         assert d.status == ReplyDispatch.Status.DEAD_LETTER
         assert swept == 1
+
+    def test_dead_letter_alert_failure_persists_auditable_row(self) -> None:
+        """A permanently-broken DM channel leaves an auditable record.
+
+        Rather than silently dropping the dead letter.
+        """
+        event = _event()
+        d = _failed(event, key="k1", retry_count=4)
+        replier = MagicMock()
+        replier.redeliver.side_effect = RuntimeError("permanently down")
+        replier.post_dm.side_effect = RuntimeError("DM channel also broken")
+
+        sweep_failed_dispatches(resolver=lambda _src: replier, max_retries=5)
+
+        audit = ReplyDispatch.objects.get(idempotency_key=f"{d.idempotency_key}:deadletter-alert")
+        assert audit.status == ReplyDispatch.Status.FAILED
+        assert "DM channel also broken" in audit.error_message
+        # Excluded from the retry sweep — a broken DM channel must not storm.
+        assert audit not in list(ReplyDispatch.objects.due_for_retry())
+
+    def test_dead_letter_alert_audit_row_is_idempotent(self) -> None:
+        """Re-running the sweep must not crash on the unique idempotency key.
+
+        Holds when a dead-letter-alert audit row already exists.
+        """
+        event = _event()
+        d = _failed(event, key="k1", retry_count=4)
+        ReplyDispatch.objects.create(
+            event=event,
+            target_ref="U_ALICE",
+            action_name="dead_letter_alert",
+            idempotency_key=f"{d.idempotency_key}:deadletter-alert",
+            status=ReplyDispatch.Status.FAILED,
+            body="prior audit row",
+        )
+        replier = MagicMock()
+        replier.redeliver.side_effect = RuntimeError("permanently down")
+        replier.post_dm.side_effect = RuntimeError("DM channel also broken")
+
+        swept = sweep_failed_dispatches(resolver=lambda _src: replier, max_retries=5)
+
+        d.refresh_from_db()
+        assert d.status == ReplyDispatch.Status.DEAD_LETTER
+        assert swept == 1
+        assert ReplyDispatch.objects.filter(idempotency_key=f"{d.idempotency_key}:deadletter-alert").count() == 1
+
+    def test_post_success_save_failure_is_logged(self) -> None:
+        """A post-success / save-failure is logged explicitly.
+
+        Elevated from a docstring caveat to a logged WARNING.
+        """
+        event = _event()
+        _failed(event, key="k1")
+        replier = MagicMock()
+
+        with (
+            patch.object(ReplyDispatch, "save", side_effect=RuntimeError("db gone")),
+            self.assertLogs("teatree.core.reply_retry", level="WARNING") as logs,
+        ):
+            sweep_failed_dispatches(resolver=lambda _src: replier)
+
+        assert any("db gone" in m or "could not be saved" in m for m in logs.output)
 
     def test_no_replier_leaves_dispatch_untouched(self) -> None:
         event = _event()

--- a/tests/teatree_core/test_reply_transport_production.py
+++ b/tests/teatree_core/test_reply_transport_production.py
@@ -212,6 +212,43 @@ class TestRecordRaceRecovery(TestCase):
         assert ReplyDispatch.objects.filter(idempotency_key="slack:race:d").count() == 1
 
 
+class TestIntrinsicIdempotency(TestCase):
+    def test_concurrent_caller_with_same_key_does_not_double_deliver(self) -> None:
+        """The idempotency guarantee is intrinsic to the key reservation.
+
+        Not dependent on an external flock: a second caller racing on the
+        same key reuses the reserved row and never calls ``_deliver``
+        twice.
+        """
+        event = _event(IncomingEvent.Source.SLACK, key="slack:intrinsic")
+        deliveries: list[str] = []
+
+        class CountingReplier(NoopReplier):
+            def _deliver(self, spec: ReplySpec) -> None:
+                deliveries.append(spec.idempotency_key)
+
+        replier = CountingReplier()
+        first = replier.post_dm(event=event, actor="U", body="x", idempotency_key="slack:intr:d")
+        second = replier.post_dm(event=event, actor="U", body="x", idempotency_key="slack:intr:d")
+
+        assert first.pk == second.pk
+        assert deliveries == ["slack:intr:d"]
+        assert ReplyDispatch.objects.filter(idempotency_key="slack:intr:d").count() == 1
+
+    def test_failed_delivery_still_recorded_once(self) -> None:
+        event = _event(IncomingEvent.Source.SLACK, key="slack:intrinsic-fail")
+        bot = MagicMock()
+        bot.open_dm.return_value = "D-1"
+        bot.post_message.side_effect = RuntimeError("backend down")
+        replier = SlackReplier(bot=bot)
+
+        dispatch = replier.post_dm(event=event, actor="U", body="x", idempotency_key="slack:intr:f")
+
+        assert dispatch.status == ReplyDispatch.Status.FAILED
+        assert "backend down" in dispatch.error_message
+        assert ReplyDispatch.objects.filter(idempotency_key="slack:intr:f").count() == 1
+
+
 class TestReplierFactory(TestCase):
     def test_returns_slack_replier_for_slack_source(self) -> None:
         assert isinstance(replier_for(IncomingEvent.Source.SLACK, bot=MagicMock()), SlackReplier)

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -14,6 +14,7 @@ from teatree.core.resolve import (
     _match_worktree_by_path,
     _parse_env_file,
     _warn_cwd_mismatch,
+    _workspace_owner_ticket,
     resolve_worktree,
 )
 
@@ -500,3 +501,45 @@ class TestAutoRegisterReusesExistingWorktree(TestCase):
 
         assert result is not None
         assert result.ticket.issue_url == "auto:feat/solo"
+
+
+class TestWorkspaceOwnerTicketIsDeterministic(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+
+    def test_lowest_pk_wins_when_multiple_siblings_share_workspace(self) -> None:
+        """Resolution stays deterministic if the invariant is violated.
+
+        The one-ticket-per-workspace invariant being violated, the
+        lowest-``pk`` worktree's ticket wins. Without ``.order_by("pk")``
+        the "first match wins" comment is a lie — the unordered queryset's
+        iteration order is backend-dependent.
+        """
+        repo_a = self._tmp_path / "repo-a"
+        repo_b = self._tmp_path / "repo-b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+
+        first_ticket = Ticket.objects.create(issue_url="https://gitlab.com/org/repo/-/issues/1")
+        second_ticket = Ticket.objects.create(issue_url="https://gitlab.com/org/repo/-/issues/2")
+        first_wt = Worktree.objects.create(
+            ticket=first_ticket,
+            repo_path="repo-a",
+            branch="ac/first",
+            extra={"worktree_path": str(repo_a)},
+        )
+        Worktree.objects.create(
+            ticket=second_ticket,
+            repo_path="repo-b",
+            branch="ac/second",
+            extra={"worktree_path": str(repo_b)},
+        )
+
+        # Resolving a third sibling under the same workspace dir: cwd's
+        # parent is tmp_path, matching both stored worktree_path parents.
+        owner = _workspace_owner_ticket((self._tmp_path / "repo-c").resolve())
+
+        assert owner is not None
+        assert owner.pk == first_ticket.pk
+        assert owner.pk == first_wt.ticket.pk

--- a/tests/teatree_core/test_webhook_rate_limit.py
+++ b/tests/teatree_core/test_webhook_rate_limit.py
@@ -47,6 +47,25 @@ class TestWebhookRateLimiter:
         # gitlab has its own bucket — unaffected by slack exhaustion
         assert limiter.allow("gitlab") is True
 
+    def test_unknown_source_is_rejected_without_creating_a_bucket(self, caplog) -> None:
+        clock = [0.0]
+        limiter = WebhookRateLimiter(capacity=10, refill_per_second=0.0, now=lambda: clock[0])
+
+        with caplog.at_level("WARNING", logger="teatree.core.views._rate_limit"):
+            assert limiter.allow("bogus-source") is False
+            assert limiter.allow("bogus-source") is False
+
+        # No unbounded bucket was created for the unknown source.
+        assert "bogus-source" not in limiter._buckets
+        assert any("bogus-source" in r.message for r in caplog.records)
+
+    def test_every_known_source_value_is_allowed(self) -> None:
+        clock = [0.0]
+        limiter = WebhookRateLimiter(capacity=1, refill_per_second=0.0, now=lambda: clock[0])
+
+        for source in IncomingEvent.Source.values:
+            assert limiter.allow(source) is True
+
 
 SIGNING_SECRET = "test-signing-secret"
 


### PR DESCRIPTION
Follow-up hardening from an architectural review of the reply-dispatch / repliers / webhook rate-limiting cluster (#677, #678, #679, #680, #681). Each item is a concrete reliability or maintainability gap found while reading the merged code; no behaviour change beyond the fix described.

- **resolve:** `_workspace_owner_ticket` had no `order_by`, so "first match wins" was nondeterministic across runs. Now ordered by `pk`.
- **managers:** `due_for_retry` sorted by `dispatched_at`; switched to `next_retry_at, pk` — semantically "oldest-due-first" and aligned with the existing `(status, next_retry_at)` index. No migration.
- **reply-retry:** a failing dead-letter alert was only logged, leaving dead letters unauditable on a broken DM channel. It now persists a terminal `:deadletter-alert` row. The success-status save is wrapped in `transaction.atomic()` and a save failure is logged explicitly rather than left as a docstring caveat.
- **reply-transport:** `_send` idempotency relied on an external flock; reworked to `get_or_create` so the guarantee is intrinsic for any caller. `NoopReplier` behaviour is byte-for-byte unchanged.
- **rate-limit:** `WebhookRateLimiter` now rejects unknown `source` values instead of creating an unbounded bucket per unknown key.

Tests: integration-style per the Test-Writing Doctrine (real ORM rows, fake clocks, only network backends mocked). `tests/teatree_core` green (1078 passed, 12 skipped). Privacy scan clean.