### PR TITLE
docs(agents): retro guardrails — un-migrated-DB scanner safety + GIT_*-hermetic git tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,19 @@ hooks/                 Agent platform hooks (Claude Code hook_router, statusline
 - **Fields:** task (FK), execution_target, ended_at, exit_code, error, result (JSONField), launch_url
 - Enables cross-task failure querying and audit trail
 
+### New model queried on the always-run path (Non-Negotiable)
+
+When a new model is read by code that runs on every loop tick or at
+import/startup — loop scanners registered in `build_default_jobs`,
+signal handlers, statusline builders — that query MUST tolerate a
+missing table. A fresh or pre-migration install runs the code before
+`migrate` creates the table; an unguarded queryset turns into a
+per-tick error for *every* user until they migrate. Materialise the
+queryset inside `except (OperationalError, ProgrammingError): return
+<empty>` — narrow to the missing-relation classes so a genuine DB
+outage still surfaces via `_run_job`. Canonical exemplars:
+`IncomingEventsScanner.scan`, `_reap_stale_task_claims`.
+
 ## Three-Tier Command Split
 
 | Tier | Tool | Examples | Needs Django? |
@@ -263,7 +276,7 @@ New tests — added in this repo or in any overlay repo — must lean **integrat
 1. **Django test client** (`client.get(...)`, `client.post(...)`) for views and URL endpoints.
 3. **`call_command("name", ...)`** for management commands — exercises the full Typer + Django glue.
 4. **`subprocess.run(["t3", ...])`** (marked `@pytest.mark.integration`) when the bug would only surface through the real entry point.
-5. **Real filesystem + real `git` under `tmp_path`** for anything that provisions worktrees, writes env files, or runs `git worktree add`. No mocking `Path`, `subprocess`, or git output.
+5. **Real filesystem + real `git` under `tmp_path`** for anything that provisions worktrees, writes env files, or runs `git worktree add`. No mocking `Path`, `subprocess`, or git output. **Run those `git`/script subprocesses with a `GIT_*`-stripped env** (`{k: v for k, v in os.environ.items() if not k.startswith("GIT_")}`): the suite can run from the inline pre-commit `pytest` hook, where the outer `git commit` exports `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` — inherited, they hijack the tmp-repo git calls so the test mutates the real repo. A test that passes standalone but fails under `git commit` is this.
 6. **Real Django ORM against the test DB** — use factories or `Model.objects.create(...)`, not mocked querysets.
 
 **When a unit test is justified:**


### PR DESCRIPTION
## Summary

Two generalizable guardrails captured by `/t3:retro` on the autonomous-events session, written as rules in `AGENTS.md` (the canonical home — architectural/procedural, not skill prose):

1. **New model queried on the always-run path (Non-Negotiable).** A model read by loop scanners (`build_default_jobs`), signals, or the statusline must tolerate a missing table — `except (OperationalError, ProgrammingError)`. A pre-migration install otherwise errors every tick for every user. This shipped as a real regression this session (`IncomingEventsScanner`, #675→fixed #682); the rule prevents recurrence.
2. **Test-Writing Doctrine rule 5 addendum.** Real-git-under-`tmp_path` tests must run subprocesses with a `GIT_*`-stripped env, or they corrupt the outer repo when the suite runs from the inline pre-commit `pytest` hook (passes standalone, fails under `git commit`). Surfaced porting #638 to t3-company, fixed in both (#683/#110).

No code change. Generic, project-agnostic prose (public-repo safe; privacy scan clean).

## Test plan

- [x] `t3 tool privacy-scan` on the diff — clean
- [x] Conventional-commit + pre-commit hooks pass
- [x] No code touched (docs-only)