### PR TITLE
feat(core): autonomous-directive policy, batch singleton sub-agent, code-enforced public-repo privacy gate (#685)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,14 @@ repos:
         always_run: true
         stages: [commit]
 
+      - id: refuse-public-push-with-leak
+        name: Refuse pushing a privacy-leaking diff to a PUBLIC repo (#685)
+        language: system
+        entry: scripts/hooks/refuse-public-push-with-leak.sh
+        pass_filenames: false
+        always_run: true
+        stages: [push]
+
   # Phase 1 - Init
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 5ab6bd930e86ba0e929eedcee2be458f6b8e4936  # 0.8.16

--- a/scripts/hooks/refuse-public-push-with-leak.sh
+++ b/scripts/hooks/refuse-public-push-with-leak.sh
@@ -38,9 +38,11 @@ if [ -z "${remote_url}" ]; then
 fi
 [ -n "${remote_url}" ] || exit 0  # no remote URL — nothing to gate
 
-# Extract owner/repo from common GitHub URL shapes:
+# Extract owner/repo from common GitHub URL shapes (the ssh-shape
+# example below carries the inline allow-annotation so this hook's own
+# header does not self-trip the privacy gate it powers):
 #   https://github.com/owner/repo(.git)
-#   git@github.com:owner/repo(.git)
+#   git@github.com:owner/repo(.git)  # privacy-scan:allow doc example
 slug=$(printf '%s' "${remote_url}" \
   | sed -E 's#^[^:]+://[^/]+/##; s#^git@[^:]+:##; s#\.git$##')
 case "${slug}" in

--- a/scripts/hooks/refuse-public-push-with-leak.sh
+++ b/scripts/hooks/refuse-public-push-with-leak.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Pre-push hook: public-repo privacy gate (#685).
+#
+# Refuses `git push` when the `origin` remote resolves to a PUBLIC
+# repository and the branch-vs-base diff fails `t3 tool privacy-scan`
+# (a planted secret, an internal `/Users/`-`/home/` path, a private IP,
+# an API token, an internal hostname, or a T3_BANNED_TERM). Pushes to a
+# private remote, and clean pushes to a public remote, pass through.
+#
+# This is the deterministic enforcement home for the contribute-mode
+# rule "no customer/internal identifier reaches a public repo": the
+# skill prose states the policy, this hook blocks the action.
+#
+# Git invokes a pre-push hook as:  hook <remote-name> <remote-url>
+# and feeds ref updates on stdin, one per line:
+#   <local-ref> <local-sha> <remote-ref> <remote-sha>
+# A deleted ref has local-sha all-zeros (skip it). For a new remote ref
+# the remote-sha is all-zeros, so the gate falls back to the merge-base
+# with the remote's default branch as the comparison base.
+#
+# Visibility is resolved via `gh repo view <owner>/<repo> --json
+# visibility`. When `gh` is unavailable or the visibility cannot be
+# determined, the gate fails OPEN (passes through) — it is a safety net
+# layered on top of the privacy scan in retro/contribute, not the only
+# line of defence, and blocking every push on a gh-less machine would
+# break the workflow.
+#
+# Wired via prek in `.pre-commit-config.yaml` (stages: [push]) so it
+# ships with the repo and needs no per-machine bootstrap.
+set -euo pipefail
+
+ZERO="0000000000000000000000000000000000000000"
+remote_name="${1:-origin}"
+remote_url="${2:-}"
+
+if [ -z "${remote_url}" ]; then
+  remote_url=$(git remote get-url "${remote_name}" 2>/dev/null || true)
+fi
+[ -n "${remote_url}" ] || exit 0  # no remote URL — nothing to gate
+
+# Extract owner/repo from common GitHub URL shapes:
+#   https://github.com/owner/repo(.git)
+#   git@github.com:owner/repo(.git)
+slug=$(printf '%s' "${remote_url}" \
+  | sed -E 's#^[^:]+://[^/]+/##; s#^git@[^:]+:##; s#\.git$##')
+case "${slug}" in
+  */*) : ;;
+  *) exit 0 ;;  # not an owner/repo shape — cannot ask gh, fail open
+esac
+
+command -v gh >/dev/null 2>&1 || exit 0  # no gh — fail open
+
+visibility=$(gh repo view "${slug}" --json visibility \
+  --jq '.visibility' 2>/dev/null || true)
+# Normalise (gh emits PUBLIC/PRIVATE/INTERNAL).
+visibility=$(printf '%s' "${visibility}" | tr '[:lower:]' '[:upper:]')
+[ "${visibility}" = "PUBLIC" ] || exit 0  # private/internal/unknown → pass
+
+scan_cmd=${T3_PRIVACY_SCAN_CMD:-t3 tool privacy-scan}
+
+default_ref=$(git symbolic-ref --short refs/remotes/"${remote_name}"/HEAD 2>/dev/null || true)
+default_branch=${default_ref#"${remote_name}"/}
+default_branch=${default_branch:-main}
+
+blocked=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -n "${local_sha:-}" ] || continue
+  [ "${local_sha}" != "${ZERO}" ] || continue  # branch deletion — skip
+
+  if [ "${remote_sha}" != "${ZERO}" ] && [ -n "${remote_sha}" ]; then
+    base="${remote_sha}"
+  else
+    base=$(git merge-base "${local_sha}" \
+      "refs/remotes/${remote_name}/${default_branch}" 2>/dev/null || true)
+  fi
+
+  if [ -n "${base}" ]; then
+    diff=$(git diff "${base}" "${local_sha}" 2>/dev/null || true)
+  else
+    # No comparison point (brand-new repo / unknown base): scan the
+    # whole tree at the pushed sha rather than skipping the gate.
+    diff=$(git show "${local_sha}" 2>/dev/null || true)
+  fi
+
+  [ -n "${diff}" ] || continue
+
+  report=$(mktemp "${TMPDIR:-/tmp}/t3-privacy-gate.XXXXXX")
+  if ! printf '%s\n' "${diff}" | ${scan_cmd} - >"${report}" 2>&1; then
+    echo "✗ refuse: push to PUBLIC repo '${slug}' carries privacy findings on '${local_ref}'."
+    cat "${report}" 2>/dev/null || true
+    echo "  Scrub the diff (generic placeholders) before pushing to a public repo."
+    echo "  (public-repo privacy gate — see /t3:rules § Verify Repo Visibility Before Filing External Issues)"
+    blocked=1
+  fi
+  rm -f "${report}"
+done
+
+exit "${blocked}"

--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -81,3 +81,7 @@ def main(
 
     if all_findings and strict:
         raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -23,6 +23,14 @@ _API_KEY_RE = re.compile(r"\b(?:glpat-|sk-|ghp_|gho_|github_pat_|xoxb-|xoxp-)[a-
 _HOSTNAME_RE = re.compile(r"\b[a-z0-9-]+\.internal\.[a-z]+\b|\b[a-z0-9-]+\.corp\.[a-z]+\b")
 _FALSE_POSITIVE_RE = re.compile(r"example\.com|user@example|jane|bob|placeholder")
 
+# Inline allow-annotation, mirroring gitleaks' ``gitleaks:allow`` idiom.
+# A line carrying this literal marker is exempt from all findings — used
+# so a repo's own privacy-scanner test fixtures and the gate's own
+# documentation examples do not self-block the public-repo privacy gate.
+# It exempts only the line it appears on; a real leak on any other line
+# is still reported.
+_ALLOW_MARKER = "privacy-scan:allow"
+
 
 def _build_banned_re(banned_terms: str) -> re.Pattern[str] | None:
     terms = [t.strip() for t in banned_terms.split(",") if t.strip()]
@@ -34,6 +42,8 @@ def _build_banned_re(banned_terms: str) -> re.Pattern[str] | None:
 
 def _scan_line(line: str, banned_re: re.Pattern[str] | None) -> list[tuple[str, str]]:
     findings: list[tuple[str, str]] = []
+    if _ALLOW_MARKER in line:
+        return findings
     findings.extend(("email", m.group()) for m in _EMAIL_RE.finditer(line) if not _FALSE_POSITIVE_RE.search(m.group()))
     findings.extend(("home_path", m.group()) for m in _HOME_PATH_RE.finditer(line))
     findings.extend(("private_ip", m.group()) for m in _IP_RE.finditer(line))

--- a/skills/followup/SKILL.md
+++ b/skills/followup/SKILL.md
@@ -17,7 +17,7 @@ metadata:
 
 # Follow-Up — Daily Routine & Batch Processing
 
-Fetch all "Not started" issues assigned to the current user, then implement each one sequentially in the main conversation using the full delivery cycle (code, test, push, PR). See § Rules for the sequential-only constraint.
+Fetch all "Not started" issues assigned to the current user, then implement each one sequentially using the full delivery cycle (code, test, push, PR) — the cycle itself is the single one documented in [`../teatree-batch/SKILL.md`](../teatree-batch/SKILL.md) § Workflow. Interactive followup runs that cycle in the main conversation; see § Rules for the sequential-only constraint and how it relates to the batch-mode singleton sub-agent exception.
 
 ## Periodic Mode
 
@@ -113,12 +113,7 @@ If the project uses an external tracker (e.g., Notion), update the ticket status
 
 If not found in the external tracker, log a warning but continue — not all tickets have an entry.
 
-**b. Run the full lifecycle** using the loaded skills — each phase uses the corresponding lifecycle skill:
-
-1. **Intake** (`/t3:ticket`): Fetch issue, create worktree (`t3 <overlay> workspace ticket`), run `t3 <overlay> worktree provision`, verify environment.
-2. **Implementation** (`/t3:code`): Implement with TDD. Check ALL repos in scope.
-3. **Testing** (`/t3:test`): Run tests, fix failures, ensure lint passes.
-4. **Delivery** (`/t3:ship`): Commit, push, create PRs for ALL repos with changes.
+**b. Run the full per-ticket delivery cycle.** The delivery cycle (intake → implementation → testing → delivery) is documented once in [`../teatree-batch/SKILL.md`](../teatree-batch/SKILL.md) § Workflow and is not restated here — followup runs the same cycle. The two skills differ only in how the cycle is hosted: batch mode delegates each ticket to a singleton delivery sub-agent (its § Rules "Singleton delivery sub-agent" exception), whereas interactive followup runs the cycle in the main conversation per the constraint in § Rules below.
 
 **c. Report result** before moving to the next ticket:
 
@@ -266,7 +261,7 @@ See [`references/followup-schema.md`](references/followup-schema.md) for the ful
 
 ### Interactive mode (default)
 
-- **Sequential only.** Never use sub-agents for ticket implementation. See [`../rules/SKILL.md`](../rules/SKILL.md) § "Sub-Agent Limitations".
+- **Sequential only.** Interactive followup runs each ticket's delivery cycle in the main conversation and does not delegate ticket implementation to sub-agents — the [`../rules/SKILL.md`](../rules/SKILL.md) § "Sub-Agent Limitations" default applies here. The batch-mode singleton delivery sub-agent (the explicit exception documented in that same section and in [`../teatree-batch/SKILL.md`](../teatree-batch/SKILL.md) § Rules) is the deliberate carve-out for unattended batch runs, not for interactive followup; the two are not in conflict because they apply to different hosting modes.
 - **Never start without user approval.** Always show the confirmation table first.
 - **Always pre-fetch external context.** Read all specs before starting implementation.
 - **Always run scope analysis.** The issue tracker project ≠ the implementation repo.

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -288,6 +288,8 @@ Sub-agents (Agent tool) **lose all loaded skills, MCP access, and shell function
 
 **Exception:** Skills with `subagent_safe: true` in their YAML frontmatter are pure methodology/guidelines that work without shell functions, MCP tools, or cross-skill state.
 
+**Exception (batch mode):** `/teatree-batch` deliberately delegates each ticket's full delivery to a single **singleton** sub-agent, run one at a time. That sub-agent loads the skills it needs via the Skill tool itself, so the "loses all loaded skills" caveat does not apply. This keeps the batch orchestrator's context lean across a long backlog. See `/teatree-batch` § Rules "Singleton delivery sub-agent" — that is the canonical statement; do not generalize it to non-batch sessions.
+
 **Before delegating platform API work:** Read the relevant platform reference (`t3:platforms`) before writing sub-agent prompts that involve API calls (draft notes, discussions, PR operations). Sub-agents can't read skills themselves — copy the exact API recipe into the agent prompt.
 
 **After a sub-agent completes, re-read any files it modified.** Sub-agents get a forked copy of your file state — their edits don't update your cache. Writing to a file without re-reading first will silently overwrite their changes.
@@ -393,6 +395,16 @@ When `contribute = true` in `~/.teatree.toml`, retro findings and cross-cutting 
 4. Is it a user preference (tone, formatting) or environment fact (path, credential)? → personal memory is legitimate.
 
 **Promote means edit an existing skill.** Pick the best-fit existing skill (`/t3:rules`, `/t3:next`, `/t3:ship`, etc.) and insert the rule there. Do not invent a new skill for a single rule — that fragments the skill graph.
+
+## Autonomous Directive Adoption
+
+This is the meta-policy that gives the "promote findings" rule above its trigger. It has no clean code home — it describes how to read the user's intent, which is methodology, not a deterministic gate — so it lives here as prose.
+
+In contribute mode (`contribute = true` in `~/.teatree.toml`), a user statement of the form "it should…" / "you should…" / "the agent shouldn't…" about agent behaviour is read as a request to adopt that behaviour into teatree itself — a skill edit where the behaviour is methodology, a code change (hook deny, FSM condition, CLI rejection) where a deterministic home exists. It is not a one-off instruction to satisfy for the current task and forget. The expected response is to make the teatree change in the same session, the same way change 1 of any retro finding lands: act on it, rather than asking "should I make a ticket or just fix it?".
+
+The session default in contribute mode is full autonomy. The agent carries the work to completion — implement, test, commit — without pausing to ask permission for in-scope work that the "Do Work Now" rule already covers. A clarifying question via `AskUserQuestion` is reserved for the case where the agent is genuinely unsure: a debatable architectural choice with several equally reasonable options, an ambiguous destination, or a directive whose scope the agent cannot infer from context. Uncertainty is the signal to interrupt; the absence of uncertainty is the signal to proceed. Treating every "should" as a question to bounce back is the failure this policy names — it converts a standing behaviour change into conversational acknowledgement that evaporates with the session.
+
+When the directive is genuinely ambiguous about _where_ it belongs (skill prose vs. code, which skill, which overlay), that ambiguity is itself the trigger for one `AskUserQuestion` — not for deferral, and not for a silent guess.
 
 ## Ask About Auth Before External Service Integrations
 
@@ -516,7 +528,7 @@ When a pre-commit hook runs the full test suite and fails on tests **unrelated t
 
 ## Worktree-First Work (Non-Negotiable)
 
-**All development work MUST happen in a worktree**, never on the main clone. Use `t3 <overlay> workspace ticket` or the `using-git-worktrees` skill to create one before writing any code.
+**All development work MUST happen in a worktree**, never on the main clone. Use `t3 <overlay> workspace ticket` or the `using-git-worktrees` skill to create one before writing any code. The worktree exists _before the first file change_ — the failure mode this forecloses is editing the main clone first and "moving it into a worktree later", which loses uncommitted work and pollutes shared state. Enforced deterministically by the `refuse-main-clone-commit` pre-commit hook and the `protect-default-branch` PreToolUse deny.
 
 **Pre-edit check — before editing ANY project file:** If the file path lives directly under `$T3_WORKSPACE_DIR/<repo>/` (not under a ticket subdirectory like `$T3_WORKSPACE_DIR/<ticket>/<repo>/`), **stop** — you are in the main clone. Find or create the correct worktree first via `t3 <overlay> workspace ticket`. The main clone may happen to be on the PR branch (from a previous checkout) — editing there "works" but pollutes the shared clone, risks merge conflicts for other worktrees, and violates isolation.
 

--- a/skills/teatree-batch/SKILL.md
+++ b/skills/teatree-batch/SKILL.md
@@ -28,14 +28,12 @@ Load `ac-python` and `ac-django` — all code must follow their review checklist
 
 1. **Run a codebase health audit** (load `ac-reviewing-codebase` in a sub-agent). Scope: all repos in the user's workspace directories. This finds actionable items beyond the issue tracker: god-modules, broken CI gates, missing coverage, stale branches.
 2. **Fetch the prioritized board** (see `/teatree-plan` § 6) and sort by effort (quick wins first).
-3. **For each ticket**, in order:
-   - Read the issue. If it requires design decisions or user input, **skip it** and move to the next.
-   - Create a worktree via `t3 teatree workspace ticket <ticket_url>` (uses `$T3_WORKSPACE_DIR`).
-   - Implement following `ac-python`/`ac-django` standards. When a teatree change affects the overlay API, make the corresponding overlay fix in the same session.
-   - Run tests + lint, self-review with a `t3:reviewer` sub-agent.
-   - Push, create PR, wait for CI, merge.
-   - Clean up worktree, update main.
-   - **Merge each PR before starting the next** (sequential, not parallel).
+3. **For each ticket**, in order. The main conversation acts as the **orchestrator only** — it queues tickets, spawns one delivery sub-agent per ticket, records the structured result, and moves on. It holds no per-ticket implementation context (see § Rules "Singleton delivery sub-agent"):
+   - The orchestrator reads only enough of the issue to decide routing. A ticket that needs design decisions or user input is skipped and the next one starts.
+   - One delivery sub-agent owns the ticket's full cycle: it creates a worktree via `t3 teatree workspace ticket <ticket_url>` (uses `$T3_WORKSPACE_DIR`), implements to `ac-python`/`ac-django` standards (when a teatree change affects the overlay API, the corresponding overlay fix lands in the same session), runs tests + lint, and self-reviews with a `t3:reviewer` sub-agent.
+   - **Privacy gate.** A push to a PUBLIC repo is gated by the `refuse-public-push-with-leak` pre-push hook: it runs `t3 tool privacy-scan` on the branch-vs-base diff and the push is refused on any finding. The delivery sub-agent treats a clean scan as a precondition for the push, not an afterthought — see [`../rules/SKILL.md`](../rules/SKILL.md) § "Verify Repo Visibility Before Filing External Issues".
+   - The sub-agent pushes, creates the PR, waits for CI, merges, cleans up the worktree, and updates main, then returns a structured result the orchestrator records before starting the next ticket.
+   - Delivery is sequential — each PR merges before the next ticket's sub-agent is spawned, never in parallel.
 4. **Close stale issues** that are already resolved in the codebase.
 5. **Report** what was done and what was skipped (with reasons) at the end.
 
@@ -50,9 +48,11 @@ During batch/quickwin sessions, the user may send new requests (bug reports, fea
 
 ## Rules
 
-- Never edit the main clone — always use worktrees.
-- Never create issues/PRs without implementing them.
-- Skip tickets needing architectural decisions — collect them for the user.
-- Self-review every PR before merging.
-- Commit progressively at stable states.
-- Fix overlays together with core changes — don't leave them broken.
+- **Singleton delivery sub-agent.** Each ticket's full delivery cycle belongs to one dedicated sub-agent, spawned by the orchestrator and run one at a time — parallel delivery sub-agents are out of scope for batch mode. The orchestrator carries no per-ticket implementation context; it queues tickets, spawns the delivery sub-agent, and records its structured result, which keeps its context lean across a long backlog. This is the explicit batch-mode exception to [`../rules/SKILL.md`](../rules/SKILL.md) § "Sub-Agent Limitations": the delivery sub-agent loads the skills it needs via the Skill tool itself, so the "loses all loaded skills" caveat does not apply to it. The exception is scoped to batch mode and does not generalize to ordinary sessions.
+- **Public-repo privacy gate.** A merge to a PUBLIC repo is preceded by a clean `t3 tool privacy-scan` on the branch-vs-base diff so no customer or internal identifier reaches a public repo. The `refuse-public-push-with-leak` pre-push hook is the deterministic enforcement; the canonical statement is [`../rules/SKILL.md`](../rules/SKILL.md) § "Verify Repo Visibility Before Filing External Issues".
+- The main clone is read-only for batch work — every change happens in a worktree.
+- Issues and PRs are created only when they are also implemented in the same session.
+- Tickets that need architectural decisions are collected for the user rather than guessed at.
+- Every PR is self-reviewed before it merges.
+- Commits land progressively at stable states.
+- Overlay fixes ship together with the core change they depend on rather than being left broken.

--- a/tests/test_privacy_scan_script.py
+++ b/tests/test_privacy_scan_script.py
@@ -1,0 +1,46 @@
+"""Integration tests for ``scripts/privacy_scan.py`` as a subprocess.
+
+``t3 tool privacy-scan`` runs this script via
+``ToolRunner.run_script`` → ``[sys.executable, script, *args]``. Without
+an ``if __name__ == "__main__"`` guard the typer ``app`` is never
+invoked and the script is a silent no-op (exit 0 on a planted secret),
+which makes the retro/contribute privacy scan worthless. These tests
+invoke the script the same way ``run_script`` does so the entrypoint is
+exercised, not mocked.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "privacy_scan.py"
+
+
+def _run(stdin: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "-"],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestPrivacyScanScriptEntrypoint:
+    def test_planted_api_key_exits_nonzero(self) -> None:
+        result = _run("token = glpat-XXXXXXXXXXXXXXXX\n")
+        assert result.returncode == 1, result.stdout + result.stderr
+
+    def test_internal_home_path_exits_nonzero(self) -> None:
+        result = _run("see /Users/someone/secret/path\n")
+        assert result.returncode == 1, result.stdout + result.stderr
+
+    def test_clean_text_exits_zero(self) -> None:
+        result = _run("a perfectly ordinary line of prose\n")
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_privacy_scan_script.py
+++ b/tests/test_privacy_scan_script.py
@@ -30,16 +30,44 @@ def _run(stdin: str) -> subprocess.CompletedProcess[str]:
 
 class TestPrivacyScanScriptEntrypoint:
     def test_planted_api_key_exits_nonzero(self) -> None:
-        result = _run("token = glpat-XXXXXXXXXXXXXXXX\n")
+        result = _run("token = glpat-XXXXXXXXXXXXXXXX\n")  # privacy-scan:allow self-fixture
         assert result.returncode == 1, result.stdout + result.stderr
 
     def test_internal_home_path_exits_nonzero(self) -> None:
-        result = _run("see /Users/someone/secret/path\n")
+        result = _run("see /Users/someone/secret/path\n")  # privacy-scan:allow self-fixture
         assert result.returncode == 1, result.stdout + result.stderr
 
     def test_clean_text_exits_zero(self) -> None:
         result = _run("a perfectly ordinary line of prose\n")
         assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestPrivacyScanAllowAnnotation:
+    """A line carrying the inline ``privacy-scan:allow`` annotation is exempt.
+
+    Same idiom as gitleaks' ``gitleaks:allow``. Used so a repo's own
+    privacy-scanner fixtures and the gate's own documentation examples do
+    not self-block the gate, while a real leak on any line *without* the
+    annotation is still caught.
+    """
+
+    def test_annotated_line_is_exempt(self) -> None:
+        result = _run("token = glpat-XXXXXXXXXXXXXXXX  # privacy-scan:allow planted fixture\n")
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_annotated_line_does_not_exempt_other_lines(self) -> None:
+        text = (
+            "token = glpat-XXXXXXXXXXXXXXXX  # privacy-scan:allow fixture\n"
+            "real = glpat-YYYYYYYYYYYYYYYY\n"  # privacy-scan:allow self-fixture
+        )
+        result = _run(text)
+        assert result.returncode == 1, result.stdout + result.stderr
+
+    def test_annotation_only_exempts_its_own_line_not_a_substring_match(self) -> None:
+        # The annotation must be the literal marker, not any line that
+        # merely mentions the word "allow".
+        result = _run("token = glpat-XXXXXXXXXXXXXXXX  # allow this please\n")  # privacy-scan:allow self-fixture
+        assert result.returncode == 1, result.stdout + result.stderr
 
 
 if __name__ == "__main__":

--- a/tests/test_refuse_public_push_with_leak.py
+++ b/tests/test_refuse_public_push_with_leak.py
@@ -41,7 +41,7 @@ def _git(cwd: Path, *args: str) -> None:
 def _make_repo(path: Path, branch: str = "main") -> None:
     path.mkdir(parents=True)
     _git(path, "init", "-b", branch)
-    _git(path, "config", "user.email", "t@e.st")
+    _git(path, "config", "user.email", "t@e.st")  # privacy-scan:allow test fixture
     _git(path, "config", "user.name", "Tester")
     (path / "README.md").write_text("hello\n", encoding="utf-8")
     _git(path, "add", "README.md")
@@ -78,7 +78,7 @@ def _clone_with_remote(tmp_path: Path, gh_visibility: str) -> tuple[Path, dict[s
     _make_repo(origin)
     work = tmp_path / "work"
     _git(tmp_path, "clone", str(origin), str(work))
-    _git(work, "config", "user.email", "t@e.st")
+    _git(work, "config", "user.email", "t@e.st")  # privacy-scan:allow test fixture
     _git(work, "config", "user.name", "Tester")
     # The origin URL is a local path; rewrite it to a github.com-looking
     # URL so the gate has an owner/repo to ask gh about.
@@ -123,7 +123,7 @@ class TestRefusePublicPushWithLeak:
     def test_blocks_public_push_with_planted_secret(self, tmp_path: Path) -> None:
         work, env = _clone_with_remote(tmp_path, "PUBLIC")
         (work / "leak.txt").write_text(
-            "token = glpat-XXXXXXXXXXXXXXXX\n",
+            "token = glpat-XXXXXXXXXXXXXXXX\n",  # privacy-scan:allow test fixture
             encoding="utf-8",
         )
         _git(work, "add", "leak.txt")
@@ -137,7 +137,8 @@ class TestRefusePublicPushWithLeak:
 
     def test_blocks_public_push_with_internal_path(self, tmp_path: Path) -> None:
         work, env = _clone_with_remote(tmp_path, "PUBLIC")
-        (work / "notes.txt").write_text("see /Users/someone/secret/path\n", encoding="utf-8")
+        planted = "see /Users/someone/secret/path\n"  # privacy-scan:allow test fixture
+        (work / "notes.txt").write_text(planted, encoding="utf-8")
         _git(work, "add", "notes.txt")
         _git(work, "commit", "-m", "add notes")
 
@@ -158,7 +159,7 @@ class TestRefusePublicPushWithLeak:
     def test_allows_private_repo_push_even_with_secret(self, tmp_path: Path) -> None:
         work, env = _clone_with_remote(tmp_path, "PRIVATE")
         (work / "leak.txt").write_text(
-            "token = glpat-XXXXXXXXXXXXXXXX\n",
+            "token = glpat-XXXXXXXXXXXXXXXX\n",  # privacy-scan:allow test fixture
             encoding="utf-8",
         )
         _git(work, "add", "leak.txt")
@@ -179,7 +180,7 @@ class TestRefusePublicPushWithLeak:
         # is genuinely unavailable.
         env["PATH"] = "/usr/bin:/bin"
         (work / "leak.txt").write_text(
-            "token = glpat-XXXXXXXXXXXXXXXX\n",
+            "token = glpat-XXXXXXXXXXXXXXXX\n",  # privacy-scan:allow test fixture
             encoding="utf-8",
         )
         _git(work, "add", "leak.txt")
@@ -187,6 +188,55 @@ class TestRefusePublicPushWithLeak:
 
         result = _run_hook(work, env, _push_stdin(work))
 
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_annotated_fixture_does_not_block_but_real_leak_in_same_diff_does(self, tmp_path: Path) -> None:
+        """The allow-annotation is line-scoped, not a file-level exclusion.
+
+        An inline-allowed fixture line passes the gate, but a real
+        un-annotated secret elsewhere in the same branch still blocks the
+        push — proving the gate stays honest.
+        """
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        # A scanner-fixture-shaped file: the secret carries the marker.
+        fixture = work / "scanner_fixture.py"
+        fixture.write_text(
+            'SECRET = "glpat-ZZZZZZZZZZZZZZZZ"  # privacy-scan:allow fixture\n',
+            encoding="utf-8",
+        )
+        _git(work, "add", "scanner_fixture.py")
+        _git(work, "commit", "-m", "add scanner fixture")
+
+        clean = _run_hook(work, env, _push_stdin(work))
+        assert clean.returncode == 0, "annotated fixture must not block: " + clean.stdout + clean.stderr
+
+        # Now a genuinely leaking, un-annotated file in a later commit.
+        leaking = 'API = "glpat-ZZZZZZZZZZZZZZZZ"\n'  # privacy-scan:allow test fixture
+        (work / "config.py").write_text(leaking, encoding="utf-8")
+        _git(work, "add", "config.py")
+        _git(work, "commit", "-m", "add config")
+
+        blocked = _run_hook(work, env, _push_stdin(work))
+        assert blocked.returncode == 1, "real leak must still block: " + blocked.stdout + blocked.stderr
+
+    def test_gate_passes_a_diff_whose_only_secrets_are_annotated(self, tmp_path: Path) -> None:
+        """A diff whose secret-shaped strings are all inline-allowed is clean.
+
+        This is the end-to-end analogue of "scan this branch's own diff":
+        the scanner's own fixtures and the hook's doc examples carry the
+        marker, so the gate does not self-block.
+        """
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        body = (
+            'def a(): assert scan("glpat-AAAAAAAAAAAAAAAA")  # privacy-scan:allow fixture\n'
+            'def b(): assert scan("see /Users/dev/x")  # privacy-scan:allow fixture\n'
+            "#   git@github.com:owner/repo  # privacy-scan:allow doc example\n"
+        )
+        (work / "test_scanner.py").write_text(body, encoding="utf-8")
+        _git(work, "add", "test_scanner.py")
+        _git(work, "commit", "-m", "add scanner tests")
+
+        result = _run_hook(work, env, _push_stdin(work))
         assert result.returncode == 0, result.stdout + result.stderr
 
     def test_hook_is_executable(self) -> None:

--- a/tests/test_refuse_public_push_with_leak.py
+++ b/tests/test_refuse_public_push_with_leak.py
@@ -1,0 +1,197 @@
+"""Integration tests for the public-repo privacy pre-push gate (#685).
+
+The gate refuses ``git push`` when the ``origin`` remote resolves to a
+PUBLIC repository and the branch-vs-base diff fails ``t3 tool
+privacy-scan`` (a planted secret, an internal path, a banned term).
+A clean diff to a public remote, and any push to a private remote, are
+allowed through.
+
+These are integration tests in the spirit of the Test-Writing Doctrine:
+a real ``git init`` repo under ``tmp_path``, a real second repo acting as
+the ``origin`` remote, and a real ``gh`` shim on ``PATH`` that returns a
+fixed visibility. Nothing about git or the filesystem is mocked.
+"""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).resolve().parents[1] / "scripts" / "hooks" / "refuse-public-push-with-leak.sh"
+SCAN = Path(__file__).resolve().parents[1] / "scripts" / "privacy_scan.py"
+
+
+def _hermetic_env() -> dict[str, str]:
+    """Env with all GIT_* vars stripped so tmp-repo git calls are hermetic."""
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],  # noqa: S607
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        env=_hermetic_env(),
+    )
+
+
+def _make_repo(path: Path, branch: str = "main") -> None:
+    path.mkdir(parents=True)
+    _git(path, "init", "-b", branch)
+    _git(path, "config", "user.email", "t@e.st")
+    _git(path, "config", "user.name", "Tester")
+    (path / "README.md").write_text("hello\n", encoding="utf-8")
+    _git(path, "add", "README.md")
+    _git(path, "commit", "-m", "init")
+
+
+def _make_gh_shim(bin_dir: Path, visibility: str) -> None:
+    """Write a fake ``gh`` that answers ``repo view --json visibility``."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "gh"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "$*" == *"repo view"* && "$*" == *"visibility"* ]]; then\n'
+        '  if [[ "$*" == *"--jq"* ]]; then\n'
+        f'    echo "{visibility}"\n'
+        "  else\n"
+        f'    echo \'{{"visibility":"{visibility}"}}\'\n'
+        "  fi\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _clone_with_remote(tmp_path: Path, gh_visibility: str) -> tuple[Path, dict[str, str]]:
+    """Create an origin repo, a working clone, and a gh shim PATH.
+
+    Returns the working clone path and the env (PATH-prefixed with the
+    gh shim, GIT_* scrubbed) to run the hook with.
+    """
+    origin = tmp_path / "origin"
+    _make_repo(origin)
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", str(origin), str(work))
+    _git(work, "config", "user.email", "t@e.st")
+    _git(work, "config", "user.name", "Tester")
+    # The origin URL is a local path; rewrite it to a github.com-looking
+    # URL so the gate has an owner/repo to ask gh about.
+    _git(work, "remote", "set-url", "origin", "https://github.com/acme/widget.git")
+
+    bin_dir = tmp_path / "bin"
+    _make_gh_shim(bin_dir, gh_visibility)
+    env = _hermetic_env()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    # Point the hook at the real privacy_scan script via a known env knob
+    # so it does not depend on a globally-installed `t3`.
+    env["T3_PRIVACY_SCAN_CMD"] = f"python3 {SCAN}"
+    return work, env
+
+
+def _run_hook(cwd: Path, env: dict[str, str], stdin: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(HOOK), "origin", "https://github.com/acme/widget.git"],  # noqa: S607
+        cwd=cwd,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def _push_stdin(work: Path) -> str:
+    """Build the git pre-push stdin line for the current branch HEAD."""
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],  # noqa: S607
+        cwd=work,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_hermetic_env(),
+    ).stdout.strip()
+    return f"refs/heads/main {sha} refs/heads/main 0000000000000000000000000000000000000000\n"
+
+
+class TestRefusePublicPushWithLeak:
+    def test_blocks_public_push_with_planted_secret(self, tmp_path: Path) -> None:
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        (work / "leak.txt").write_text(
+            "token = glpat-XXXXXXXXXXXXXXXX\n",
+            encoding="utf-8",
+        )
+        _git(work, "add", "leak.txt")
+        _git(work, "commit", "-m", "add config")
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        combined = (result.stdout + result.stderr).lower()
+        assert "privacy" in combined
+
+    def test_blocks_public_push_with_internal_path(self, tmp_path: Path) -> None:
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        (work / "notes.txt").write_text("see /Users/someone/secret/path\n", encoding="utf-8")
+        _git(work, "add", "notes.txt")
+        _git(work, "commit", "-m", "add notes")
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 1, result.stdout + result.stderr
+
+    def test_allows_public_push_with_clean_diff(self, tmp_path: Path) -> None:
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        (work / "feature.txt").write_text("a clean new feature line\n", encoding="utf-8")
+        _git(work, "add", "feature.txt")
+        _git(work, "commit", "-m", "add feature")
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_allows_private_repo_push_even_with_secret(self, tmp_path: Path) -> None:
+        work, env = _clone_with_remote(tmp_path, "PRIVATE")
+        (work / "leak.txt").write_text(
+            "token = glpat-XXXXXXXXXXXXXXXX\n",
+            encoding="utf-8",
+        )
+        _git(work, "add", "leak.txt")
+        _git(work, "commit", "-m", "add config")
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_passthrough_when_gh_unavailable(self, tmp_path: Path) -> None:
+        """No gh on PATH → visibility unknown → fail open (do not block).
+
+        The gate is a safety net, not the only line of defence; blocking
+        every push on a machine without gh would break the workflow.
+        """
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        # Keep system bins (bash/git) but drop the gh shim dir so `gh`
+        # is genuinely unavailable.
+        env["PATH"] = "/usr/bin:/bin"
+        (work / "leak.txt").write_text(
+            "token = glpat-XXXXXXXXXXXXXXXX\n",
+            encoding="utf-8",
+        )
+        _git(work, "add", "leak.txt")
+        _git(work, "commit", "-m", "add config")
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_hook_is_executable(self) -> None:
+        assert os.access(HOOK, os.X_OK), f"{HOOK} must be chmod +x"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Closes #685.

Adopts agent-behaviour directives into teatree itself rather than conversation-only acknowledgement.

- **rules:** new non-imperative `Autonomous Directive Adoption` section + Sub-Agent Limitations batch-mode exception + worktree-first reinforcement.
- **teatree-batch:** per-ticket delivery runs in one orchestrator-spawned singleton sub-agent, sequential; orchestrator holds no per-ticket context.
- **privacy gate (enforcement code):** new `refuse-public-push-with-leak` pre-push hook — blocks pushing a branch whose remote is a PUBLIC repo when `t3 tool privacy-scan` on the branch-vs-base diff finds anything; fails open without `gh`. Wired via prek `stages: [push]`.
- **bug fix:** `scripts/privacy_scan.py` had no `__main__` guard — `t3 tool privacy-scan` was a silent no-op (the retro/contribute scan did nothing). Added guard + subprocess-level test.
- **self-block fix:** inline `privacy-scan:allow` annotation (mirrors `gitleaks:allow` precedent) so the scanner's own fixtures/doc examples don't block their own push, line-scoped so real leaks elsewhere still block.
- **followup dedup:** `followup` references `/teatree-batch` as the single source of truth for the delivery cycle; reconciled the conflicting 'never use sub-agents' line.

Integration-tested (real git repos under tmp_path, gh shim, no git/fs mocks). prek green incl. skill-prose-ban + banned-terms. Privacy scan of this branch's own diff: clean.