### PR TITLE
fix(hooks): derive a readable loop name for the canonical loop prompt (#691)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -843,19 +843,52 @@ def handle_session_end(data: dict) -> None:
 # ── PostToolUse: track-cron-jobs ──────────────────────────────────────
 
 
+_LOOP_NAME_MAX = 20
+
+
+def _clean_token(token: str) -> str:
+    """Strip surrounding/trailing punctuation and backticks from a token."""
+    return token.strip("`").strip(".,;:!?\"'()[]{}/").strip("`")
+
+
 def _derive_loop_name(prompt: str) -> str:
-    """Derive a short display name from a cron/loop prompt."""
+    """Derive a short display name from a cron/loop prompt.
+
+    - The canonical teatree loop prompt maps to a stable readable name.
+    - Slash-command prompts use the command token.
+    - Otherwise a short label is taken from the first meaningful word.
+
+    Surrounding punctuation and backticks are always stripped.
+    """
     prompt = prompt.strip()
+
+    # 1. Canonical teatree loop prompt → stable name (it runs `t3 loop tick`).
+    if prompt == _LOOP_PROMPT or prompt.startswith(_LOOP_PROMPT):
+        return "tick"
+
     if prompt.startswith("!"):
         prompt = prompt[1:].strip()
-    if prompt.startswith("/"):
-        prompt = prompt[1:].strip()
+
     parts = prompt.split()
     if not parts:
         return "loop"
-    cmd = parts[-1] if len(parts) > 1 else parts[0]
-    cmd = cmd.split("/")[-1]
-    return cmd[:20]
+
+    # `t3 loop <subcommand>` shell form → the subcommand (e.g. `tick`).
+    if parts[:2] == ["t3", "loop"] and len(parts) > 2:  # noqa: PLR2004
+        return _clean_token(parts[2])[:_LOOP_NAME_MAX] or "loop"
+
+    # 2. Slash-command form: a leading `/foo` or an embedded `/foo` token.
+    #    `/loop 5m /babysit-prs` wraps the real command — use the last token.
+    slash_tokens = [p for p in parts if p.startswith("/") and len(p) > 1]
+    if slash_tokens:
+        return _clean_token(slash_tokens[-1].split("/")[-1])[:_LOOP_NAME_MAX] or "loop"
+
+    # 3. Prose: first meaningful word, punctuation/backticks stripped.
+    for part in parts:
+        cleaned = _clean_token(part)
+        if cleaned:
+            return cleaned[:_LOOP_NAME_MAX]
+    return "loop"
 
 
 def _load_crons(path: Path) -> dict:

--- a/tests/test_cron_tracking_hook.py
+++ b/tests/test_cron_tracking_hook.py
@@ -122,16 +122,50 @@ class TestDeriveLoopName:
     @pytest.mark.parametrize(
         ("prompt", "expected"),
         [
+            # Canonical teatree loop prompt → stable readable name.
+            (router._LOOP_PROMPT, "tick"),
+            (router._LOOP_PROMPT + " extra trailing words", "tick"),
             ("!t3 loop tick", "tick"),
+            # Slash-command forms (leading or embedded token).
             ("/followup", "followup"),
             ("/t3-followup", "t3-followup"),
-            ("check the deploy status", "status"),
+            ("!/foo", "foo"),
+            ("/foo", "foo"),
+            ("/loop 5m /babysit-prs", "babysit-prs"),
+            # Prose prompt → short label from the first meaningful word,
+            # with surrounding punctuation/backticks stripped.
+            ("check the deploy status", "check"),
+            ("`backtick-word` then more", "backtick-word"),
+            ("Deploy.", "Deploy"),
+            # Degenerate inputs fall back to a stable label.
             ("!", "loop"),
+            ("/", "loop"),
             ("", "loop"),
         ],
     )
     def test_name_derivation(self, prompt: str, expected: str) -> None:
         assert router._derive_loop_name(prompt) == expected
+
+    def test_no_trailing_punctuation_or_backtick(self) -> None:
+        name = router._derive_loop_name(router._LOOP_PROMPT)
+        assert not name.endswith(".")
+        assert "`" not in name
+
+    def test_canonical_prompt_persisted_name_via_handler(self) -> None:
+        """Integration: the canonical loop prompt persists a readable job name."""
+        handle_track_cron_jobs(
+            {
+                "session_id": "loop-s",
+                "tool_name": "CronCreate",
+                "tool_input": {"cron": "*/12 * * * *", "prompt": router._LOOP_PROMPT},
+                "tool_result": {"id": "job-loop"},
+            }
+        )
+
+        crons_file = router.STATE_DIR / "loop-s.crons"
+        assert crons_file.is_file()
+        state = json.loads(crons_file.read_text(encoding="utf-8"))
+        assert state["jobs"]["job-loop"]["name"] == "tick"
 
 
 class TestCronCadenceSeconds:


### PR DESCRIPTION
Closes #691. The statusline showed `loops: summary.` because `_derive_loop_name` took the last whitespace token of the cron prompt — for the canonical loop prompt that is `summary.`. Now: canonical loop prompt → `tick`; `t3 loop <sub>` → the subcommand; slash-command prompts keep their command token (`/loop 5m /babysit-prs` → `babysit-prs`); otherwise first meaningful word with all surrounding/trailing punctuation, slashes and backticks stripped. 27 tests pass incl. an integration test through handle_track_cron_jobs; prek green.