### PR TITLE
feat(cli): add t3 update — sync core + overlays ff-only, never clobber (#693)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -103,6 +103,7 @@ src/teatree/
     sessions.py         # `t3 sessions`
     setup.py            # `t3 setup ...`
     slack_setup.py      # `t3 setup slack-bot` walkthrough
+    update.py           # `t3 update` (sync core + overlays ff-only)
     tools.py            # `t3 tool ...`
 
   core/                 # Django app: the heart of teatree
@@ -885,6 +886,7 @@ Typer-based, work without Django:
 - `t3 tool {privacy-scan,analyze-video,bump-deps,label-issues,find-duplicates,triage-issues,audit-memory}` — standalone utilities
 - `t3 config write-skill-cache` — write overlay skill metadata to cache
 - `t3 doctor {check,repair}` — health checks and symlink repair
+- `t3 update` — fetch + fast-forward (ff-only) teatree core and every registered overlay repo to its default branch, reinstall advanced editable installs, then re-run the idempotent `t3 setup`. A dirty tree, a non-default-branch checkout, or a missing upstream is skipped with a reason (never stashed/reset/clobbered); exit is non-zero only on a hard fetch/pull failure, not a skip. Kept separate from `t3 setup` so routine bootstrap can never silently jump the running code to newer `main`.
 - `t3 setup slack-bot --overlay <name>` — interactive walkthrough to register a Slack bot for an overlay; opens the app-manifest URL, captures bot+app tokens, stores them via `pass`, writes `slack_user_id` into `~/.teatree.toml`, smoke-tests with a round-trip DM (see § 10.1 for the manifest template and scopes). Subcommands of `t3 setup` short-circuit the global skill-install callback so the walkthrough runs without requiring `T3_REPO`.
 - `t3 assess` — codebase health check (ruff, coverage, complexity, dependency staleness)
 - `t3 infra` — infrastructure helpers (e.g. shared docker container management)

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ graph LR
 | `teatree-plan` | Backlog prioritization with the GitHub Projects v2 board as single source of truth. Syncs repo issues to the board, walks the user through prioritization one question at a time, and reorders/updates board columns |
 | `test` | Testing, QA, and CI — running tests, analyzing failures, quality checks, CI interaction, test plans, and posting testing evidence |
 | `ticket` | Ticket intake and kickoff — from zero to ready-to-code |
+| `update` | WHEN to bring teatree core and registered overlays up to date with their default branch, and the safety guarantees of doing so |
 | `workspace` | Environment and workspace lifecycle — worktree creation, setup, DB provisioning, dev servers, cleanup |
 <!-- END SKILLS -->
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -25,6 +25,8 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 │ doctor          Smoke-test hooks, imports, services.                         │
 │ tool            Standalone utilities.                                        │
 │ setup           First-time setup and global skill management.                │
+│ update          Sync teatree core and registered overlays to their default   │
+│                 branch.                                                      │
 │ assess          Codebase health assessment.                                  │
 │ overlay         Dev-mode overlay install/uninstall.                          │
 │ infra           Teatree-wide infrastructure services.                        │
@@ -816,6 +818,18 @@ Usage: t3 setup slack-bot [OPTIONS]
 │                                   ~/.teatree.toml).                          │
 │                                   [default: /Users/adrien/.teatree.toml]     │
 │    --help                         Show this message and exit.                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+### `t3 update`
+
+```
+Usage: t3 update [OPTIONS] COMMAND [ARGS]...
+
+ Sync teatree core and registered overlays to their default branch.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: update
+description: WHEN to bring teatree core and registered overlays up to date with their default branch, and the safety guarantees of doing so. Use when the user wants to "sync teatree", "update teatree", "pull latest teatree", or after merging PRs that change framework/overlay code.
+compatibility: macOS/Linux, git, python3.13+, uv.
+triggers:
+  priority: 75
+  keywords:
+    - '\b(update teatree|sync teatree|upgrade teatree|pull latest teatree|t3 update)\b'
+search_hints:
+  - update teatree
+  - sync core and overlays
+metadata:
+  version: 0.0.1
+  subagent_safe: false
+---
+
+# Teatree Update
+
+The mechanism for syncing teatree core and every registered overlay to their
+default branch is the deterministic CLI command `t3 update` — it is not
+reproduced here. Run `t3 update`.
+
+## Dependencies
+
+- **setup** — `t3 update` reuses the idempotent setup/reinstall step at the
+  end. The reverse never holds: `t3 setup` is pure bootstrap and never
+  mutates checkouts or jumps the running code to newer `main`.
+
+## When This Applies
+
+Updating is a *mutating, network, version-changing* operation, deliberately
+separate from the idempotent `t3 setup` bootstrap. It is relevant after
+merging PRs that change framework or overlay code, or whenever the local
+teatree core / overlay clones have drifted behind their default branch and
+the running `t3` should reflect the latest code.
+
+It is *not* part of routine setup: folding update into setup would let a
+routine bootstrap silently jump the running code to newer `main` with
+breaking changes.
+
+## Safety Guarantee (Skips, Never Clobbers)
+
+`t3 update` only fast-forwards a clean clone that is on its default branch
+with a tracking upstream. A dirty working tree, a feature-branch checkout, or
+a missing upstream is reported as a skip with a reason — work in progress is
+never stashed, reset, merged, or rebased away. A skip is a normal outcome,
+not a failure; the process exits non-zero only when a fetch or fast-forward
+hard-fails.
+
+## Core ↔ Overlay Version Coupling
+
+An overlay can pin (or assume) a particular teatree core version. After core
+advances, an overlay that was in sync may now diverge from the core it
+expects. Re-running after the core update lets the overlay reach its own
+default branch and re-anchors editable installs, keeping the pair coherent.

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -30,6 +30,7 @@ from teatree.cli.review_request import review_request_app
 from teatree.cli.setup import setup_app
 from teatree.cli.slack_listen import slack_app
 from teatree.cli.tools import tool_app
+from teatree.cli.update import update_app
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,7 @@ app.add_typer(review_request_app, name="review-request")
 app.add_typer(doctor_app, name="doctor")
 app.add_typer(tool_app, name="tool")
 app.add_typer(setup_app, name="setup")
+app.add_typer(update_app, name="update")
 app.add_typer(assess_app, name="assess")
 app.add_typer(overlay_dev_app, name="overlay")
 app.add_typer(infra_app, name="infra")

--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -1,0 +1,314 @@
+"""t3 update — sync teatree core + registered overlays to their default branch.
+
+Updating is a *mutating, network, version-changing* operation, deliberately
+kept separate from the idempotent ``t3 setup`` bootstrap.  ``t3 update`` reuses
+the setup/reinstall step at the end; ``t3 setup`` never reaches into ``update``.
+
+For teatree core (``$T3_REPO``) and every registered overlay repo, this:
+
+1. ``git fetch`` the origin.
+2. Resolves the default branch from ``origin/HEAD``.
+3. Skips (never clobbers) a dirty, non-default-branch, or no-upstream checkout.
+4. Otherwise ``git pull --ff-only`` — fast-forward only, never merge/rebase.
+5. Reinstalls advanced editable installs, then runs the idempotent ``t3 setup``.
+6. Prints a per-repo summary; exits non-zero only on a hard failure (not a skip).
+
+This module is a top-level Typer group reached through the typer runner
+directly (sibling of ``t3 setup`` / ``t3 doctor``), so it raises
+``typer.Exit(code=N)`` — *not* ``SystemExit`` (which is for ``TyperCommand``
+groups reached via Django ``call_command``; see ``skills/teatree`` § "CLI exit
+codes").  Precedent: ``cli/setup.py`` ``_validate_repo`` → ``raise typer.Exit``.
+"""
+
+import enum
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+
+from teatree.utils.run import CompletedProcess, run_allowed_to_fail
+
+update_app = typer.Typer(
+    help="Sync teatree core and registered overlays to their default branch.",
+    invoke_without_command=True,
+)
+
+
+class UpdateStatus(enum.Enum):
+    """Outcome of attempting to update a single repo."""
+
+    UPDATED = "updated"
+    UP_TO_DATE = "up-to-date"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+@dataclass
+class RepoUpdate:
+    """The result of attempting to update one repo.
+
+    ``is_error`` is the single source of truth for the process exit code: only
+    a hard :class:`UpdateStatus.FAILED` is an error — a deliberate skip is not.
+    """
+
+    name: str
+    status: UpdateStatus
+    old_sha: str = ""
+    new_sha: str = ""
+    reason: str = ""
+
+    @property
+    def is_error(self) -> bool:
+        return self.status is UpdateStatus.FAILED
+
+    @property
+    def summary_line(self) -> str:
+        if self.status is UpdateStatus.UPDATED:
+            return f"OK    {self.name}: updated {self.old_sha} -> {self.new_sha}"
+        if self.status is UpdateStatus.UP_TO_DATE:
+            return f"OK    {self.name}: up-to-date"
+        if self.status is UpdateStatus.SKIPPED:
+            return f"SKIP  {self.name}: skipped ({self.reason})"
+        return f"FAIL  {self.name}: {self.reason}"
+
+
+def _git(repo: Path, *args: str, expected_codes: tuple[int, ...] | None = (0,)) -> CompletedProcess[str]:
+    """Run ``git`` in *repo* via the audited subprocess wrapper.
+
+    ``expected_codes=None`` accepts any exit code so the caller can branch on
+    it instead of catching an exception.
+    """
+    return run_allowed_to_fail(["git", *args], cwd=repo, expected_codes=expected_codes)
+
+
+def _short_sha(repo: Path) -> str:
+    return _git(repo, "rev-parse", "--short", "HEAD").stdout.strip()
+
+
+def _current_branch(repo: Path) -> str:
+    return _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+
+
+def _default_branch(repo: Path) -> str | None:
+    """Resolve the default branch from ``origin/HEAD`` (e.g. ``main``).
+
+    Returns ``None`` when ``origin/HEAD`` is unset — the repo has no
+    discoverable default branch and must be skipped.
+    """
+    result = _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", expected_codes=None)
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    # "refs/remotes/origin/main" -> "main"
+    return result.stdout.strip().rsplit("/", 1)[-1]
+
+
+def _has_origin_remote(repo: Path) -> bool:
+    result = _git(repo, "remote", expected_codes=None)
+    return "origin" in result.stdout.split()
+
+
+def _is_dirty(repo: Path) -> bool:
+    return bool(_git(repo, "status", "--porcelain").stdout.strip())
+
+
+def _has_upstream(repo: Path) -> bool:
+    result = _git(
+        repo,
+        "rev-parse",
+        "--abbrev-ref",
+        "--symbolic-full-name",
+        "@{upstream}",
+        expected_codes=None,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _check_origin(name: str, repo: Path) -> RepoUpdate | None:
+    if _has_origin_remote(repo):
+        return None
+    return RepoUpdate(name, UpdateStatus.SKIPPED, reason="no 'origin' remote configured")
+
+
+def _check_fetch(name: str, repo: Path) -> RepoUpdate | None:
+    fetch = _git(repo, "fetch", "origin", expected_codes=None)
+    if fetch.returncode == 0:
+        return None
+    return RepoUpdate(name, UpdateStatus.FAILED, reason=f"git fetch failed: {fetch.stderr.strip()}")
+
+
+def _check_default_branch(name: str, repo: Path) -> RepoUpdate | None:
+    default_branch = _default_branch(repo)
+    if default_branch is None:
+        return RepoUpdate(name, UpdateStatus.SKIPPED, reason="no origin/HEAD (no remote / no upstream)")
+    if not _has_upstream(repo):
+        return RepoUpdate(name, UpdateStatus.SKIPPED, reason="no upstream tracking branch")
+    current = _current_branch(repo)
+    if current != default_branch:
+        return RepoUpdate(
+            name,
+            UpdateStatus.SKIPPED,
+            reason=f"on branch {current!r}, not default {default_branch!r}",
+        )
+    return None
+
+
+def _check_clean(name: str, repo: Path) -> RepoUpdate | None:
+    if not _is_dirty(repo):
+        return None
+    return RepoUpdate(name, UpdateStatus.SKIPPED, reason="dirty working tree (uncommitted changes)")
+
+
+# Ordered safety gate: origin must exist before fetch, fetch before branch
+# resolution (which needs origin/HEAD), branch before the dirty check.  Each
+# guard *skips* (never clobbers) with a reason; only a failed fetch is a hard
+# failure.  The order is load-bearing — do not reorder.
+_PRECONDITIONS = (_check_origin, _check_fetch, _check_default_branch, _check_clean)
+
+
+def _precondition_block(name: str, repo: Path) -> RepoUpdate | None:
+    """Return the first terminal skip/fail outcome, or ``None`` if all clear."""
+    for guard in _PRECONDITIONS:
+        blocked = guard(name, repo)
+        if blocked is not None:
+            return blocked
+    return None
+
+
+def update_repo(name: str, repo: Path) -> RepoUpdate:
+    """Fetch and fast-forward *repo* to its default branch, or skip safely.
+
+    Never stashes, resets, or clobbers: a dirty tree, a non-default branch, or
+    a missing upstream each yield :class:`UpdateStatus.SKIPPED` with a reason.
+    A failed ``git fetch`` / ``git pull`` yields :class:`UpdateStatus.FAILED`.
+    """
+    blocked = _precondition_block(name, repo)
+    if blocked is not None:
+        return blocked
+
+    old_sha = _short_sha(repo)
+    pull = _git(repo, "pull", "--ff-only", expected_codes=None)
+    if pull.returncode != 0:
+        return RepoUpdate(name, UpdateStatus.FAILED, reason=f"git pull --ff-only failed: {pull.stderr.strip()}")
+
+    new_sha = _short_sha(repo)
+    if new_sha == old_sha:
+        return RepoUpdate(name, UpdateStatus.UP_TO_DATE)
+    return RepoUpdate(name, UpdateStatus.UPDATED, old_sha=old_sha, new_sha=new_sha)
+
+
+def _collect_repos() -> list[tuple[str, Path]]:
+    """Discover teatree core and every registered overlay repo.
+
+    Core is resolved via the same ``T3_REPO``/cwd logic ``t3 setup`` uses.
+    Overlays come from ``discover_overlays()`` (the ``teatree.overlays`` entry
+    points merged with ``[overlays.*]`` TOML config); each entry's
+    ``project_path`` is walked up to its containing git work tree.
+    """
+    from teatree.cli.setup import _find_main_clone  # noqa: PLC0415
+    from teatree.config import discover_overlays  # noqa: PLC0415
+
+    repos: list[tuple[str, Path]] = []
+    seen: set[Path] = set()
+
+    core = _find_main_clone()
+    if core is not None:
+        resolved = core.resolve()
+        repos.append(("teatree", resolved))
+        seen.add(resolved)
+
+    for entry in discover_overlays():
+        if entry.project_path is None:
+            continue
+        repo = _git_toplevel(entry.project_path.expanduser())
+        if repo is None or repo in seen:
+            continue
+        seen.add(repo)
+        repos.append((entry.name, repo))
+
+    return repos
+
+
+def _git_toplevel(path: Path) -> Path | None:
+    """Return the git work-tree root containing *path*, or None if not a repo."""
+    if not path.is_dir():
+        return None
+    result = _git(path, "rev-parse", "--show-toplevel", expected_codes=None)
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return Path(result.stdout.strip()).resolve()
+
+
+def _reinstall_and_resetup(updated: list[RepoUpdate]) -> None:
+    """Reinstall editable installs whose source advanced, then re-run setup.
+
+    Reinstalling re-anchors the running ``t3`` (and overlay code) on the new
+    sources; ``t3 setup`` afterwards re-syncs skill symlinks/config.  Both run
+    through the audited subprocess wrapper; failures are surfaced but do not by
+    themselves fail the run — the per-repo git outcome already did its job.
+    """
+    if not any(r.status is UpdateStatus.UPDATED for r in updated):
+        typer.echo("No repo advanced — skipping reinstall + setup.")
+        return
+
+    uv_bin = shutil.which("uv")
+    if uv_bin:
+        from teatree.cli.setup import _current_editable_source  # noqa: PLC0415
+
+        source = _current_editable_source(uv_bin)
+        if source is not None and source.is_dir():
+            typer.echo(f"Reinstalling editable teatree from {source} ...")
+            result = run_allowed_to_fail(
+                [uv_bin, "tool", "install", "--editable", str(source), "--reinstall"],
+                expected_codes=None,
+            )
+            if result.returncode != 0:
+                typer.echo(f"WARN  Reinstall failed: {result.stderr.strip()}")
+            else:
+                typer.echo("OK    Reinstalled teatree.")
+    else:
+        typer.echo("WARN  `uv` not on PATH — skipping editable reinstall.")
+
+    t3_bin = shutil.which("t3") or sys.argv[0]
+    typer.echo("Re-running `t3 setup` ...")
+    result = run_allowed_to_fail([t3_bin, "setup"], expected_codes=None)
+    typer.echo(result.stdout.rstrip() if result.stdout.strip() else "")
+    if result.returncode != 0:
+        typer.echo(f"WARN  `t3 setup` reported a problem: {result.stderr.strip()}")
+
+
+@update_app.callback()
+def run(ctx: typer.Context) -> None:
+    """Update teatree core + registered overlays (ff-only) and re-run setup.
+
+    Idempotent and safe to re-run.  Skips (never clobbers) a dirty tree, a
+    feature-branch checkout, or a missing upstream.  Exits non-zero only when
+    a repo update hard-fails — not when one is skipped.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+    _run_update()
+
+
+def _run_update() -> None:
+    """The actual update flow, factored out so the callback stays a thin shell."""
+    repos = _collect_repos()
+    if not repos:
+        typer.echo("ERROR No teatree core or overlay repos found to update.")
+        raise typer.Exit(code=1)
+
+    results: list[RepoUpdate] = []
+    for name, path in repos:
+        typer.echo(f"Updating {name} ({path}) ...")
+        results.append(update_repo(name, path))
+
+    _reinstall_and_resetup(results)
+
+    typer.echo("")
+    typer.echo("Summary:")
+    for result in results:
+        typer.echo(f"  {result.summary_line}")
+
+    if any(result.is_error for result in results):
+        raise typer.Exit(code=1)

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,0 +1,188 @@
+"""Integration tests for ``t3 update``.
+
+Real ``git init`` repos with fake (local) remotes under ``tmp_path`` — no
+mocking of ``git``, ``subprocess``, or the filesystem (Test-Writing Doctrine).
+
+The only externals stubbed are the *reinstall* and *re-run setup* side
+effects: those shell out to ``uv tool install`` / ``t3 setup`` against the
+host machine and are out of scope for the git-sync behaviour under test.
+The stubs are recording callables, not ``Mock()`` assertions on call_args.
+"""
+
+import subprocess
+from pathlib import Path
+
+import click
+import pytest
+
+from teatree.cli import update as update_mod
+from teatree.cli.update import RepoUpdate, UpdateStatus, update_repo
+
+
+def _git(cwd: Path, *args: str) -> str:
+    # Trusted fixed argv (literal "git" + test-controlled flags). GIT_* env
+    # is stripped session-wide by conftest so the tmp repo is isolated.
+    result = subprocess.run(
+        ["git", *args],  # noqa: S607
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _make_remote(tmp_path: Path, name: str = "remote") -> Path:
+    """Create a bare remote with one commit on ``main``."""
+    seed = tmp_path / f"{name}-seed"
+    seed.mkdir()
+    _git(seed, "init", "-b", "main")
+    _git(seed, "config", "user.email", "t@e.st")
+    _git(seed, "config", "user.name", "Tester")
+    (seed / "f.txt").write_text("v1\n")
+    _git(seed, "add", "f.txt")
+    _git(seed, "commit", "-m", "initial")
+
+    bare = tmp_path / f"{name}.git"
+    _git(tmp_path, "clone", "--bare", str(seed), str(bare))
+    return bare
+
+
+def _clone(tmp_path: Path, bare: Path, name: str = "clone") -> Path:
+    clone = tmp_path / name
+    _git(tmp_path, "clone", str(bare), str(clone))
+    _git(clone, "config", "user.email", "t@e.st")
+    _git(clone, "config", "user.name", "Tester")
+    return clone
+
+
+def _advance_remote(tmp_path: Path, bare: Path) -> str:
+    """Push a new commit to the bare remote; return its short sha."""
+    work = tmp_path / "advance"
+    _git(tmp_path, "clone", str(bare), str(work))
+    _git(work, "config", "user.email", "t@e.st")
+    _git(work, "config", "user.name", "Tester")
+    (work / "f.txt").write_text("v2\n")
+    _git(work, "add", "f.txt")
+    _git(work, "commit", "-m", "second")
+    _git(work, "push", "origin", "main")
+    return _git(work, "rev-parse", "--short", "HEAD")
+
+
+class TestUpdateRepoCleanFastForward:
+    def test_clean_on_default_branch_fast_forwards(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        old_sha = _git(clone, "rev-parse", "--short", "HEAD")
+        new_sha = _advance_remote(tmp_path, bare)
+
+        result = update_repo("clone", clone)
+
+        assert result.status is UpdateStatus.UPDATED
+        assert result.old_sha == old_sha
+        assert result.new_sha == new_sha
+        assert _git(clone, "rev-parse", "--short", "HEAD") == new_sha
+
+
+class TestUpdateRepoUpToDate:
+    def test_already_up_to_date_is_not_an_error(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+
+        result = update_repo("clone", clone)
+
+        assert result.status is UpdateStatus.UP_TO_DATE
+        assert result.is_error is False
+
+
+class TestUpdateRepoSkips:
+    def test_dirty_checkout_skips_without_clobbering(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _advance_remote(tmp_path, bare)
+        (clone / "f.txt").write_text("local uncommitted work\n")
+
+        result = update_repo("clone", clone)
+
+        assert result.status is UpdateStatus.SKIPPED
+        assert "dirty" in result.reason.lower()
+        assert result.is_error is False
+        # Never clobbered — the local edit survives.
+        assert (clone / "f.txt").read_text() == "local uncommitted work\n"
+
+    def test_feature_branch_checkout_skips(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _git(clone, "checkout", "-b", "feature/wip")
+
+        result = update_repo("clone", clone)
+
+        assert result.status is UpdateStatus.SKIPPED
+        assert "branch" in result.reason.lower()
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "feature/wip"
+
+    def test_no_upstream_skips(self, tmp_path: Path) -> None:
+        seed = tmp_path / "no-remote"
+        seed.mkdir()
+        _git(seed, "init", "-b", "main")
+        _git(seed, "config", "user.email", "t@e.st")
+        _git(seed, "config", "user.name", "Tester")
+        (seed / "f.txt").write_text("v1\n")
+        _git(seed, "add", "f.txt")
+        _git(seed, "commit", "-m", "initial")
+
+        result = update_repo("no-remote", seed)
+
+        assert result.status is UpdateStatus.SKIPPED
+        assert result.is_error is False
+
+
+class TestRepoUpdateSummary:
+    def test_summary_line_shapes(self) -> None:
+        updated = RepoUpdate("core", UpdateStatus.UPDATED, old_sha="aaaaaaa", new_sha="bbbbbbb")
+        up = RepoUpdate("ovl", UpdateStatus.UP_TO_DATE)
+        skipped = RepoUpdate("ovl2", UpdateStatus.SKIPPED, reason="dirty working tree")
+
+        assert "aaaaaaa" in updated.summary_line
+        assert "bbbbbbb" in updated.summary_line
+        assert "up-to-date" in up.summary_line
+        assert "skipped" in skipped.summary_line
+        assert "dirty working tree" in skipped.summary_line
+        assert updated.is_error is False
+        assert RepoUpdate("x", UpdateStatus.FAILED, reason="boom").is_error is True
+
+
+class TestUpdateCommandExitCode:
+    """The typer command exits non-zero only on a hard failure, not a skip."""
+
+    def _run(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, results: list[RepoUpdate]) -> int:
+        monkeypatch.setattr(update_mod, "_collect_repos", lambda: [("core", tmp_path)])
+        monkeypatch.setattr(update_mod, "update_repo", lambda name, path: results.pop(0))
+        monkeypatch.setattr(update_mod, "_reinstall_and_resetup", lambda repos: None)
+
+        try:
+            update_mod._run_update()
+        except (SystemExit, click.exceptions.Exit) as exc:
+            code = exc.code if isinstance(exc, SystemExit) else exc.exit_code
+            return int(code or 0)
+        return 0
+
+    def test_skip_only_exits_zero(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        code = self._run(
+            tmp_path,
+            monkeypatch,
+            [RepoUpdate("core", UpdateStatus.SKIPPED, reason="dirty working tree")],
+        )
+        assert code == 0
+
+    def test_hard_failure_exits_nonzero(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        code = self._run(
+            tmp_path,
+            monkeypatch,
+            [RepoUpdate("core", UpdateStatus.FAILED, reason="git fetch failed")],
+        )
+        assert code != 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -37,7 +37,7 @@ def _make_remote(tmp_path: Path, name: str = "remote") -> Path:
     seed = tmp_path / f"{name}-seed"
     seed.mkdir()
     _git(seed, "init", "-b", "main")
-    _git(seed, "config", "user.email", "t@e.st")
+    _git(seed, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
     _git(seed, "config", "user.name", "Tester")
     (seed / "f.txt").write_text("v1\n")
     _git(seed, "add", "f.txt")
@@ -51,7 +51,7 @@ def _make_remote(tmp_path: Path, name: str = "remote") -> Path:
 def _clone(tmp_path: Path, bare: Path, name: str = "clone") -> Path:
     clone = tmp_path / name
     _git(tmp_path, "clone", str(bare), str(clone))
-    _git(clone, "config", "user.email", "t@e.st")
+    _git(clone, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
     _git(clone, "config", "user.name", "Tester")
     return clone
 
@@ -60,7 +60,7 @@ def _advance_remote(tmp_path: Path, bare: Path) -> str:
     """Push a new commit to the bare remote; return its short sha."""
     work = tmp_path / "advance"
     _git(tmp_path, "clone", str(bare), str(work))
-    _git(work, "config", "user.email", "t@e.st")
+    _git(work, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
     _git(work, "config", "user.name", "Tester")
     (work / "f.txt").write_text("v2\n")
     _git(work, "add", "f.txt")
@@ -125,7 +125,7 @@ class TestUpdateRepoSkips:
         seed = tmp_path / "no-remote"
         seed.mkdir()
         _git(seed, "init", "-b", "main")
-        _git(seed, "config", "user.email", "t@e.st")
+        _git(seed, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
         _git(seed, "config", "user.name", "Tester")
         (seed / "f.txt").write_text("v1\n")
         _git(seed, "add", "f.txt")

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -10,13 +10,24 @@ The stubs are recording callables, not ``Mock()`` assertions on call_args.
 """
 
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
 import pytest
+import typer
 
+import teatree.cli.setup as setup_mod
+import teatree.config as config_mod
 from teatree.cli import update as update_mod
-from teatree.cli.update import RepoUpdate, UpdateStatus, update_repo
+from teatree.cli.update import (
+    RepoUpdate,
+    UpdateStatus,
+    _collect_repos,
+    _git_toplevel,
+    _reinstall_and_resetup,
+    update_repo,
+)
 
 
 def _git(cwd: Path, *args: str) -> str:
@@ -67,6 +78,27 @@ def _advance_remote(tmp_path: Path, bare: Path) -> str:
     _git(work, "commit", "-m", "second")
     _git(work, "push", "origin", "main")
     return _git(work, "rev-parse", "--short", "HEAD")
+
+
+@dataclass
+class _Result:
+    """Recording stand-in for a discover_overlays() entry (real git, no mock)."""
+
+    name: str
+    project_path: Path | None
+
+
+@dataclass
+class _Proc:
+    """Stand-in CompletedProcess for the host-machine `uv`/`t3` shell-outs.
+
+    Only those externals are replaced (per the module docstring); real
+    subprocess + real git drive every git-sync assertion.
+    """
+
+    returncode: int
+    stdout: str
+    stderr: str
 
 
 class TestUpdateRepoCleanFastForward:
@@ -120,6 +152,22 @@ class TestUpdateRepoSkips:
         assert result.status is UpdateStatus.SKIPPED
         assert "branch" in result.reason.lower()
         assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "feature/wip"
+
+    def test_non_default_branch_with_upstream_skips(self, tmp_path: Path) -> None:
+        # The clone is on a tracked feature branch (real upstream), not the
+        # default branch — this exercises the branch-mismatch skip *after*
+        # the upstream check passes.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _git(clone, "checkout", "-b", "feature/tracked")
+        _git(clone, "push", "-u", "origin", "feature/tracked")
+
+        result = update_repo("clone", clone)
+
+        assert result.status is UpdateStatus.SKIPPED
+        assert "not default" in result.reason.lower()
+        assert "feature/tracked" in result.reason
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "feature/tracked"
 
     def test_no_upstream_skips(self, tmp_path: Path) -> None:
         seed = tmp_path / "no-remote"
@@ -182,6 +230,236 @@ class TestUpdateCommandExitCode:
             [RepoUpdate("core", UpdateStatus.FAILED, reason="git fetch failed")],
         )
         assert code != 0
+
+
+class TestUpdateRepoHardFailures:
+    def test_fetch_failure_is_a_hard_failure_not_a_skip(self, tmp_path: Path) -> None:
+        # origin remote configured but its URL points nowhere → real `git
+        # fetch` fails with a non-zero exit; that is FAILED, not SKIPPED.
+        repo = tmp_path / "broken-origin"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
+        _git(repo, "config", "user.name", "Tester")
+        (repo / "f.txt").write_text("v1\n")
+        _git(repo, "add", "f.txt")
+        _git(repo, "commit", "-m", "initial")
+        _git(repo, "remote", "add", "origin", str(tmp_path / "does-not-exist.git"))
+
+        result = update_repo("broken", repo)
+
+        assert result.status is UpdateStatus.FAILED
+        assert result.is_error is True
+        assert "fetch" in result.reason.lower()
+
+    def test_no_origin_head_skips_with_reason(self, tmp_path: Path) -> None:
+        # A clone whose remote exists and fetches fine, but origin/HEAD was
+        # deleted — the default branch cannot be resolved → SKIPPED.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        # A real git config a user can have: don't let fetch (re)create
+        # origin/HEAD. With it removed, the default branch is unresolvable.
+        _git(clone, "config", "remote.origin.followRemoteHEAD", "never")
+        _git(clone, "remote", "set-head", "origin", "--delete")
+
+        result = update_repo("clone", clone)
+
+        assert result.status is UpdateStatus.SKIPPED
+        assert "origin/head" in result.reason.lower()
+        assert result.is_error is False
+
+    def test_non_fast_forward_pull_is_a_hard_failure(self, tmp_path: Path) -> None:
+        # Local default branch has a committed divergence from the remote, so
+        # `git pull --ff-only` cannot fast-forward → FAILED (never rebased).
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _advance_remote(tmp_path, bare)
+        (clone / "f.txt").write_text("divergent local commit\n")
+        _git(clone, "add", "f.txt")
+        _git(clone, "commit", "-m", "local divergence")
+
+        result = update_repo("clone", clone)
+
+        assert result.status is UpdateStatus.FAILED
+        assert result.is_error is True
+        assert "ff-only" in result.reason.lower()
+
+
+class TestGitToplevel:
+    def test_returns_none_for_non_directory(self, tmp_path: Path) -> None:
+        assert _git_toplevel(tmp_path / "missing") is None
+
+    def test_returns_none_for_non_git_directory(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert _git_toplevel(plain) is None
+
+    def test_resolves_subdir_to_work_tree_root(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        sub = clone / "nested" / "deep"
+        sub.mkdir(parents=True)
+
+        assert _git_toplevel(sub) == clone.resolve()
+
+
+class TestCollectRepos:
+    def test_collects_core_and_overlay_dedups(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        core_bare = _make_remote(tmp_path, "core")
+        core = _clone(tmp_path, core_bare, "core-clone")
+        ovl_bare = _make_remote(tmp_path, "ovl")
+        ovl = _clone(tmp_path, ovl_bare, "ovl-clone")
+
+        monkeypatch.setattr(setup_mod, "_find_main_clone", lambda: core)
+        monkeypatch.setattr(
+            config_mod,
+            "discover_overlays",
+            lambda: [
+                _Result("ovl", ovl),
+                _Result("dup-core", core),  # same repo as core → deduped
+                _Result("no-path", None),  # entry without a project path
+            ],
+        )
+
+        repos = _collect_repos()
+
+        assert ("teatree", core.resolve()) in repos
+        assert ("ovl", ovl.resolve()) in repos
+        names = [n for n, _ in repos]
+        assert "dup-core" not in names
+        assert "no-path" not in names
+
+    def test_handles_missing_core(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        ovl_bare = _make_remote(tmp_path, "ovl")
+        ovl = _clone(tmp_path, ovl_bare, "ovl-clone")
+
+        monkeypatch.setattr(setup_mod, "_find_main_clone", lambda: None)
+        monkeypatch.setattr(config_mod, "discover_overlays", lambda: [_Result("ovl", ovl)])
+
+        repos = _collect_repos()
+
+        assert repos == [("ovl", ovl.resolve())]
+
+
+class TestReinstallAndResetup:
+    def test_noop_when_nothing_advanced(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _reinstall_and_resetup([RepoUpdate("core", UpdateStatus.UP_TO_DATE)])
+
+        assert "skipping reinstall + setup" in capsys.readouterr().out
+
+    def test_warns_when_uv_missing(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        # uv absent, t3 absent → falls back to sys.argv[0]; both echo a path.
+        monkeypatch.setattr(update_mod.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(0, "setup ran", ""))
+
+        _reinstall_and_resetup([RepoUpdate("core", UpdateStatus.UPDATED, old_sha="a", new_sha="b")])
+
+        out = capsys.readouterr().out
+        assert "uv` not on PATH" in out
+        assert "Re-running `t3 setup`" in out
+
+    def test_reinstall_and_setup_run_when_advanced(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        source = tmp_path / "editable-src"
+        source.mkdir()
+        calls: list[list[str]] = []
+
+        def _which(name: str) -> str | None:
+            return f"/usr/bin/{name}" if name in {"uv", "t3"} else None
+
+        def _run(cmd: list[str], **_kw: object) -> _Proc:
+            calls.append(cmd)
+            return _Proc(0, "ok", "")
+
+        monkeypatch.setattr(update_mod.shutil, "which", _which)
+        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: source)
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
+
+        _reinstall_and_resetup([RepoUpdate("core", UpdateStatus.UPDATED, old_sha="a", new_sha="b")])
+
+        out = capsys.readouterr().out
+        assert "Reinstalled teatree." in out
+        assert any("tool" in c and "install" in c for c in calls)
+        assert any(c[-1] == "setup" for c in calls)
+
+    def test_skips_reinstall_for_non_editable_install_still_runs_setup(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # `uv` present but teatree is a non-editable install (no recorded
+        # source) → reinstall is skipped, but `t3 setup` still runs.
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: None)
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(0, "setup ran", ""))
+
+        _reinstall_and_resetup([RepoUpdate("core", UpdateStatus.UPDATED, old_sha="a", new_sha="b")])
+
+        out = capsys.readouterr().out
+        assert "Reinstalling editable teatree" not in out
+        assert "Re-running `t3 setup`" in out
+
+    def test_warns_when_reinstall_and_setup_fail(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        source = tmp_path / "editable-src"
+        source.mkdir()
+
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: source)
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(1, "", "boom"))
+
+        _reinstall_and_resetup([RepoUpdate("core", UpdateStatus.UPDATED, old_sha="a", new_sha="b")])
+
+        out = capsys.readouterr().out
+        assert "Reinstall failed" in out
+        assert "`t3 setup` reported a problem" in out
+
+
+class TestRunCallback:
+    def test_callback_returns_early_for_subcommand(self) -> None:
+        ctx = typer.Context(click.Command("update"))
+        ctx.invoked_subcommand = "slack-bot"
+        # Should not raise / not run the flow.
+        update_mod.run(ctx)
+
+    def test_callback_runs_flow_when_no_subcommand(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ran: list[bool] = []
+        monkeypatch.setattr(update_mod, "_run_update", lambda: ran.append(True))
+        ctx = typer.Context(click.Command("update"))
+        ctx.invoked_subcommand = None
+
+        update_mod.run(ctx)
+
+        assert ran == [True]
+
+
+class TestRunUpdateEndToEnd:
+    def test_no_repos_exits_nonzero(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        monkeypatch.setattr(update_mod, "_collect_repos", list)
+
+        with pytest.raises((SystemExit, click.exceptions.Exit)):
+            update_mod._run_update()
+
+        assert "No teatree core or overlay repos found" in capsys.readouterr().out
+
+    def test_real_repo_summary_and_zero_exit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        old_sha = _git(clone, "rev-parse", "--short", "HEAD")
+        new_sha = _advance_remote(tmp_path, bare)
+
+        monkeypatch.setattr(update_mod, "_collect_repos", lambda: [("clone", clone)])
+        monkeypatch.setattr(update_mod, "_reinstall_and_resetup", lambda _r: None)
+
+        update_mod._run_update()  # no exception → exit 0
+
+        out = capsys.readouterr().out
+        assert "Summary:" in out
+        assert old_sha in out
+        assert new_sha in out
+        assert _git(clone, "rev-parse", "--short", "HEAD") == new_sha
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #693. New top-level `t3 update`: for teatree core + every registered overlay — git fetch, resolve default branch, ff-only pull, reinstall editable installs, then run the idempotent `t3 setup`; dirty / wrong-branch / no-remote repos are **skipped with a reason, never clobbered**; per-repo summary; non-zero exit only on hard failure. Thin non-imperative `/t3:update` skill (WHEN + dirty guardrail + core↔overlay version-coupling caveat; no CLI steps). `t3 setup` scope unchanged. 8 integration tests over real git repos + fake remotes (no git/subprocess mocks); prek green (skill-prose-ban, banned-terms, gitleaks); privacy scan + real pre-push gate clean.