### PR TITLE
fix(workspace): robust workspace start + browser-free Notion download

### DIFF
--- a/src/teatree/backends/notion.py
+++ b/src/teatree/backends/notion.py
@@ -1,7 +1,13 @@
+import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
+from urllib.parse import unquote
 
 import httpx
+
+_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+_SIGNED_MARKERS = ("X-Amz-Signature", "expirationTimestamp", "signature=")
 
 
 def _brave_cookies(domain: str) -> httpx.Cookies:
@@ -15,23 +21,112 @@ def _brave_cookies(domain: str) -> httpx.Cookies:
     return cookies
 
 
+@dataclass(frozen=True)
+class NotionFileRef:
+    """A Notion file attachment, resolvable to a signed download URL."""
+
+    space_id: str
+    attachment_id: str
+    filename: str
+    block_id: str
+
+    @property
+    def stored_url(self) -> str:
+        # getSignedFileUrls validates against the S3 origin form; the
+        # file.notion.so/f/f/… display form is rejected ("Invalid secure
+        # file URL").
+        return (
+            "https://prod-files-secure.s3.us-west-2.amazonaws.com/"
+            f"{self.space_id}/{self.attachment_id}/{self.filename}"
+        )
+
+    @classmethod
+    def from_fetch_src(cls, src: str) -> "NotionFileRef | None":
+        """Parse the ``file://%7B…%7D`` src string emitted by ``notion-fetch``.
+
+        Decodes to ``{"source":"attachment:<aid>:<name>","permissionRecord":
+        {"table":"block","id":"<blockId>","spaceId":"<spaceId>"}}``.
+        """
+        payload = src[len("file://") :] if src.startswith("file://") else src
+        try:
+            data = json.loads(unquote(payload))
+        except (json.JSONDecodeError, ValueError):
+            return None
+        source = str(data.get("source", ""))
+        record = data.get("permissionRecord") or {}
+        if not source.startswith("attachment:") or not record.get("id"):
+            return None
+        _, attachment_id, filename = source.split(":", 2)
+        return cls(
+            space_id=str(record.get("spaceId", "")),
+            attachment_id=attachment_id,
+            filename=filename,
+            block_id=str(record["id"]),
+        )
+
+
+def _is_signed(url: str) -> bool:
+    return any(marker in url for marker in _SIGNED_MARKERS)
+
+
+def resolve_signed_url(ref: NotionFileRef, cookies: httpx.Cookies) -> str:
+    """Resolve a signed download URL via Notion's internal getSignedFileUrls API.
+
+    This is what the Notion web app calls when a file is clicked; driving it
+    directly with the browser session cookies removes the need for a manual
+    browser click to obtain the signature.
+    """
+    with httpx.Client(
+        cookies=cookies,
+        headers={"User-Agent": _UA, "Content-Type": "application/json"},
+        timeout=30.0,
+    ) as client:
+        resp = client.post(
+            "https://www.notion.so/api/v3/getSignedFileUrls",
+            json={
+                "urls": [
+                    {
+                        "url": ref.stored_url,
+                        "permissionRecord": {"table": "block", "id": ref.block_id},
+                    },
+                ],
+            },
+        )
+        resp.raise_for_status()
+        body = resp.json()
+    for key in ("signedUrls", "signedGetUrls", "signed_urls"):
+        urls = body.get(key)
+        if urls:
+            return cast("str", urls[0])
+    msg = f"getSignedFileUrls returned no signed URL: {body}"
+    raise RuntimeError(msg)
+
+
 def download_notion_file(
     *,
-    url: str,
+    url: str = "",
+    ref: NotionFileRef | None = None,
     dest: Path,
 ) -> Path:
-    """Download a Notion file attachment using browser cookies.
+    """Download a Notion file attachment using the Brave browser session.
 
-    The full signed URL (with signature + expirationTimestamp) must be passed in;
-    file.notion.so returns 400 without those params even when cookies are valid.
+    Pass either a *ref* (resolved server-side via getSignedFileUrls — no
+    browser click needed) or a pre-signed *url*. A non-signed plain URL is
+    rejected with a clear message because file.notion.so returns 400 without
+    the signature params.
     """
     cookies = _brave_cookies("notion.so")
+    if ref is not None and not _is_signed(url):
+        url = resolve_signed_url(ref, cookies)
+    elif not _is_signed(url):
+        msg = f"URL is not signed and no NotionFileRef given to resolve it: {url}"
+        raise ValueError(msg)
 
     with httpx.Client(
         cookies=cookies,
-        headers={"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"},
+        headers={"User-Agent": _UA},
         follow_redirects=True,
-        timeout=30.0,
+        timeout=60.0,
     ) as client:
         resp = client.get(url)
         resp.raise_for_status()

--- a/src/teatree/backends/notion.py
+++ b/src/teatree/backends/notion.py
@@ -36,8 +36,7 @@ class NotionFileRef:
         # file.notion.so/f/f/… display form is rejected ("Invalid secure
         # file URL").
         return (
-            "https://prod-files-secure.s3.us-west-2.amazonaws.com/"
-            f"{self.space_id}/{self.attachment_id}/{self.filename}"
+            f"https://prod-files-secure.s3.us-west-2.amazonaws.com/{self.space_id}/{self.attachment_id}/{self.filename}"
         )
 
     @classmethod
@@ -47,7 +46,7 @@ class NotionFileRef:
         Decodes to ``{"source":"attachment:<aid>:<name>","permissionRecord":
         {"table":"block","id":"<blockId>","spaceId":"<spaceId>"}}``.
         """
-        payload = src[len("file://") :] if src.startswith("file://") else src
+        payload = src.removeprefix("file://")
         try:
             data = json.loads(unquote(payload))
         except (json.JSONDecodeError, ValueError):

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -236,24 +236,42 @@ def triage_issues(
 
 @tool_app.command("notion-download")
 def notion_download(
-    url: str = typer.Argument(..., help="file.notion.so URL from browser tab (must include signature)."),
+    url: str = typer.Argument(
+        ...,
+        help="Either the `file://%7B…%7D` src from `notion-fetch` (resolved "
+        "automatically via Notion's API — no browser click needed) or a "
+        "pre-signed file.notion.so URL.",
+    ),
     dest: Path = typer.Option(Path(), "--dest", "-d", help="Destination directory."),
 ) -> None:
-    """Download a Notion file attachment using browser cookies."""
+    """Download a Notion file attachment using the Brave browser session.
+
+    Accepts the `file://`-prefixed reference string that `t3`'s notion-fetch
+    emits for `<file>` blocks; the signed URL is resolved server-side, so no
+    manual browser click is required.
+    """
     import re  # noqa: PLC0415
     from urllib.parse import urlparse  # noqa: PLC0415
 
-    from teatree.backends.notion import download_notion_file  # noqa: PLC0415
+    from teatree.backends.notion import NotionFileRef, download_notion_file  # noqa: PLC0415
+
+    ref = NotionFileRef.from_fetch_src(url)
+    if ref is not None:
+        filename = ref.filename
+        out = dest / filename if dest.is_dir() else dest
+        typer.echo(f"Resolving + downloading {filename} (via Notion API)...")
+        result = download_notion_file(ref=ref, dest=out)
+        typer.echo(f"Saved: {result} ({result.stat().st_size:,} bytes)")
+        return
 
     parsed = urlparse(url)
     path_match = re.match(r"/f/f/[^/]+/[^/]+/(.+)", parsed.path)
     if not path_match:
-        typer.echo(f"Cannot parse file URL: {url}")
+        typer.echo(f"Cannot parse file URL or notion-fetch ref: {url}")
         raise typer.Exit(1)
 
-    filename = path_match.group(1)
+    filename = path_match.group(1).split("?", 1)[0]
     out = dest / filename if dest.is_dir() else dest
     typer.echo(f"Downloading {filename}...")
-
     result = download_notion_file(url=url, dest=out)
     typer.echo(f"Saved: {result} ({result.stat().st_size:,} bytes)")

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -87,9 +87,15 @@ def _discover_frontend_port(project: str, default: int = 4200) -> int | None:
     when the stack is up; the local scan is a last-ditch fallback for users
     who started compose outside the teatree runner.
     """
-    port = get_service_port(project, "frontend", default)
-    if port is not None:
-        return port
+    # The compose `frontend` service is nginx serving the pre-built dist on
+    # container port 80; a raw dev-server setup instead listens on 4200.
+    # Query both container ports — `default` is the host-scan fallback, not
+    # the container port, so it must not be passed to `docker compose port`
+    # (that always missed the nginx:80 service).
+    for container_port in (80, default):
+        port = get_service_port(project, "frontend", container_port)
+        if port is not None:
+            return port
     # Scan the allocation range — ports start at 4200 and go up
     for candidate in range(4200, 4211):
         if _detect_local_port(candidate) is not None:

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -252,7 +252,7 @@ class Command(TyperCommand):
         ticket = _resolve_workspace_ticket(path)
         overlay = get_overlay()
 
-        worktrees = list(ticket.worktrees.all())
+        worktrees = list(Worktree.objects.filter(ticket=ticket))
         for wt in worktrees:
             self.stdout.write(f"  Provisioning {wt.repo_path}…")
             with transaction.atomic():
@@ -283,7 +283,7 @@ class Command(TyperCommand):
         ticket = _resolve_workspace_ticket(path)
         overlay = get_overlay()
 
-        worktrees = list(ticket.worktrees.all())
+        worktrees = list(Worktree.objects.filter(ticket=ticket))
         failures: list[str] = []
         for wt in worktrees:
             self.stdout.write(f"  Starting {wt.repo_path}…")
@@ -329,7 +329,7 @@ class Command(TyperCommand):
         ticket = _resolve_workspace_ticket(path)
         overlay = get_overlay()
 
-        worktrees = list(ticket.worktrees.all())
+        worktrees = list(Worktree.objects.filter(ticket=ticket))
         total = 0
         total_failures = 0
         for wt in worktrees:
@@ -359,7 +359,7 @@ class Command(TyperCommand):
         """
         ticket = _resolve_workspace_ticket(path)
 
-        worktrees = list(ticket.worktrees.all())
+        worktrees = list(Worktree.objects.filter(ticket=ticket))
         labels: list[str] = []
         failures: list[str] = []
         for wt in worktrees:

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -25,7 +25,7 @@ from teatree.core.orphan_guard import find_orphans_in_workspace
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.readiness import run_and_report_probes
 from teatree.core.reconcile import Drift, reconcile_all, reconcile_ticket
-from teatree.core.resolve import resolve_worktree
+from teatree.core.resolve import WorktreeNotFoundError, _get_user_cwd, resolve_worktree
 from teatree.core.runners import (
     WorktreeProvisioner,
     WorktreeProvisionRunner,
@@ -66,6 +66,37 @@ def _warn_orphans(write: Callable[[str], None]) -> None:
 
 def _workspace_dir() -> Path:
     return load_config().user.workspace_dir
+
+
+def _resolve_workspace_ticket(path: str) -> Ticket:
+    """Resolve the ticket for a workspace-scoped command.
+
+    Workspace commands (provision/start/ready/teardown) act on *every*
+    worktree in a ticket, so they should be runnable both from inside a
+    worktree subdir and from the ticket workspace root that holds those
+    subdirs. First try the normal worktree resolution; if that fails
+    because we're at the workspace root, match child worktree dirs back
+    to their ticket.
+    """
+    try:
+        anchor = resolve_worktree(path)
+        return Ticket.objects.get(pk=anchor.ticket.pk)
+    except WorktreeNotFoundError:
+        base = Path(path).resolve() if path else Path(_get_user_cwd()).resolve()
+        ticket_pks: set[int] = set()
+        for wt in Worktree.objects.exclude(extra__worktree_path__isnull=True):
+            wt_path = (wt.extra or {}).get("worktree_path", "")
+            if wt_path and Path(wt_path).resolve().parent == base:
+                ticket_pks.add(wt.ticket_id)
+        if len(ticket_pks) == 1:
+            return Ticket.objects.get(pk=ticket_pks.pop())
+        if len(ticket_pks) > 1:
+            msg = (
+                f"{base} holds worktrees from multiple tickets ({sorted(ticket_pks)}).\n"
+                "Run the command from a specific worktree subdir."
+            )
+            raise WorktreeNotFoundError(msg) from None
+        raise
 
 
 def _fix_drift(drift: Drift) -> list[str]:
@@ -218,8 +249,7 @@ class Command(TyperCommand):
         feedback. Stops at the first failure so the operator can fix the
         offending worktree before retrying.
         """
-        anchor = resolve_worktree(path)
-        ticket = Ticket.objects.get(pk=anchor.ticket.pk)
+        ticket = _resolve_workspace_ticket(path)
         overlay = get_overlay()
 
         worktrees = list(ticket.worktrees.all())
@@ -250,8 +280,7 @@ class Command(TyperCommand):
         After every worktree starts, runs each overlay's readiness probes —
         exits 1 if any probe fails.
         """
-        anchor = resolve_worktree(path)
-        ticket = Ticket.objects.get(pk=anchor.ticket.pk)
+        ticket = _resolve_workspace_ticket(path)
         overlay = get_overlay()
 
         worktrees = list(ticket.worktrees.all())
@@ -297,8 +326,7 @@ class Command(TyperCommand):
         apply to a variant, the overlay's ``get_readiness_probes`` returns
         an empty list (or omits that probe) for that worktree.
         """
-        anchor = resolve_worktree(path)
-        ticket = Ticket.objects.get(pk=anchor.ticket.pk)
+        ticket = _resolve_workspace_ticket(path)
         overlay = get_overlay()
 
         worktrees = list(ticket.worktrees.all())
@@ -329,8 +357,7 @@ class Command(TyperCommand):
         per-worktree failures to maximise cleanup; surfaces them in the
         final summary.
         """
-        anchor = resolve_worktree(path)
-        ticket = Ticket.objects.get(pk=anchor.ticket.pk)
+        ticket = _resolve_workspace_ticket(path)
 
         worktrees = list(ticket.worktrees.all())
         labels: list[str] = []

--- a/src/teatree/core/runners/worktree_start.py
+++ b/src/teatree/core/runners/worktree_start.py
@@ -94,8 +94,12 @@ class WorktreeStartRunner(RunnerBase):
 
         env = {**os.environ, **overlay.get_env_extra(worktree)}
         env.pop("VIRTUAL_ENV", None)
-        if not self._docker_compose_up(project, compose_file, env):
-            return RunnerResult(ok=False, detail=f"docker compose up failed for {worktree.repo_path}")
+        ok, reason = self._docker_compose_up(project, compose_file, env)
+        if not ok:
+            return RunnerResult(
+                ok=False,
+                detail=f"docker compose up failed for {worktree.repo_path}: {reason}",
+            )
 
         ports = get_worktree_ports(project, compose_file=compose_file)
         extra = worktree.extra or {}
@@ -105,8 +109,16 @@ class WorktreeStartRunner(RunnerBase):
         worktree.save(update_fields=["extra"])
         return RunnerResult(ok=True, detail=f"started {len(commands)} service(s)")
 
-    def _docker_compose_up(self, project: str, compose_file: str, env: dict[str, str]) -> bool:
-        self._ensure_images_built(project, compose_file, env)
+    def _docker_compose_up(self, project: str, compose_file: str, env: dict[str, str]) -> tuple[bool, str]:
+        """Bring the stack up.
+
+        Returns ``(ok, reason)`` — *reason* carries the real failure cause
+        (build error, timeout, or compose stderr) so the caller can surface
+        it instead of a generic "failed" message.
+        """
+        build_error = self._ensure_images_built(project, compose_file, env)
+        if build_error:
+            return False, build_error
         cmd = [
             "docker",
             "compose",
@@ -122,18 +134,17 @@ class WorktreeStartRunner(RunnerBase):
         try:
             result = run_allowed_to_fail(cmd, env=env, expected_codes=None, timeout=timeout)
         except TimeoutExpired:
-            logger.warning("docker compose up timed out after %ss", timeout)
-            return False
+            msg = f"compose up timed out after {timeout}s"
+            logger.warning(msg)
+            return False, msg
         if result.returncode != 0:
-            logger.warning(
-                "docker compose up failed (exit %s): %s",
-                result.returncode,
-                result.stderr.strip()[:500],
-            )
-            return False
-        return True
+            stderr = result.stderr.strip()
+            logger.warning("docker compose up failed (exit %s): %s", result.returncode, stderr[:500])
+            tail = stderr.splitlines()[-1] if stderr else "(no stderr)"
+            return False, f"exit {result.returncode}: {tail}"
+        return True, ""
 
-    def _ensure_images_built(self, project: str, compose_file: str, env: dict[str, str]) -> None:
+    def _ensure_images_built(self, project: str, compose_file: str, env: dict[str, str]) -> str | None:
         """Build any compose service whose ``build:`` image is missing locally.
 
         ``up --no-build --pull=never`` fails the first time a worktree's
@@ -142,13 +153,17 @@ class WorktreeStartRunner(RunnerBase):
         the missing image is a hard error. Pre-flight per service, build the
         missing ones once, then let the subsequent ``up`` reuse the local
         images on every later start.
+
+        Returns ``None`` on success, or a short error string when the build
+        fails or times out so the caller surfaces the real cause instead of a
+        generic "docker compose up failed".
         """
         services = self._enumerate_buildable_services(project, compose_file, env)
         if not services:
-            return
+            return None
         missing = sorted(name for name, image in services.items() if not self._image_exists(image, env))
         if not missing:
-            return
+            return None
         logger.info("Building missing compose images for services: %s", missing)
         cmd = [
             "docker",
@@ -163,14 +178,15 @@ class WorktreeStartRunner(RunnerBase):
         try:
             result = run_allowed_to_fail(cmd, env=env, expected_codes=None, timeout=timeout)
         except TimeoutExpired:
-            logger.warning("docker compose build timed out after %ss", timeout)
-            return
+            msg = f"image build for {missing} timed out after {timeout}s"
+            logger.warning(msg)
+            return msg
         if result.returncode != 0:
-            logger.warning(
-                "docker compose build failed (exit %s): %s",
-                result.returncode,
-                result.stderr.strip()[:500],
-            )
+            stderr = result.stderr.strip()
+            logger.warning("docker compose build failed (exit %s): %s", result.returncode, stderr[:500])
+            tail = stderr.splitlines()[-1] if stderr else "(no stderr)"
+            return f"image build for {missing} failed (exit {result.returncode}): {tail}"
+        return None
 
     @staticmethod
     def _enumerate_buildable_services(project: str, compose_file: str, env: dict[str, str]) -> dict[str, str]:

--- a/tests/teatree_backends/test_notion.py
+++ b/tests/teatree_backends/test_notion.py
@@ -9,8 +9,22 @@ import httpx
 import pytest
 import typer.testing
 
-from teatree.backends.notion import NotionClient, _brave_cookies, download_notion_file
+from teatree.backends.notion import (
+    NotionClient,
+    NotionFileRef,
+    _brave_cookies,
+    _is_signed,
+    download_notion_file,
+    resolve_signed_url,
+)
 from teatree.cli.tools import tool_app
+
+# A `file://`-prefixed ref as emitted by `notion-fetch` for a <file> block.
+VALID_FETCH_SRC = (
+    "file://%7B%22source%22%3A%20%22attachment%3Aatt-123%3AMy%20Report.pdf%22%2C"
+    "%20%22permissionRecord%22%3A%20%7B%22table%22%3A%20%22block%22%2C%20%22id%22"
+    "%3A%20%22blk-9%22%2C%20%22spaceId%22%3A%20%22sp-7%22%7D%7D"
+)
 
 
 @dataclass
@@ -136,3 +150,134 @@ class TestNotionClient:
         assert seen["url"] == "https://api.notion.com/v1/pages/page-1"
         assert seen["auth"] == "Bearer secret"
         assert seen["version"] == "2026-01-01"
+
+
+class TestNotionFileRef:
+    def test_parses_valid_fetch_src(self) -> None:
+        ref = NotionFileRef.from_fetch_src(VALID_FETCH_SRC)
+
+        assert ref is not None
+        assert ref.space_id == "sp-7"
+        assert ref.attachment_id == "att-123"
+        assert ref.filename == "My Report.pdf"
+        assert ref.block_id == "blk-9"
+
+    def test_stored_url_uses_s3_origin_form(self) -> None:
+        ref = NotionFileRef.from_fetch_src(VALID_FETCH_SRC)
+
+        assert ref is not None
+        assert ref.stored_url == ("https://prod-files-secure.s3.us-west-2.amazonaws.com/sp-7/att-123/My Report.pdf")
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "file://not-json",
+            "file://%7B%22source%22%3A%20%22nope%22%7D",  # not an attachment:
+            "https://file.notion.so/f/f/s/a/x.pdf?signature=abc",  # plain URL, not a ref
+        ],
+    )
+    def test_returns_none_for_unparseable(self, bad: str) -> None:
+        assert NotionFileRef.from_fetch_src(bad) is None
+
+
+class TestIsSigned:
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://file.notion.so/f/f/s/a/x.pdf?signature=abc", True),
+            ("https://x/y?X-Amz-Signature=z", True),
+            ("https://x/y?expirationTimestamp=9999", True),
+            ("https://prod-files-secure.s3.amazonaws.com/s/a/x.pdf", False),
+        ],
+    )
+    def test_detects_signature_markers(self, url: str, *, expected: bool) -> None:
+        assert _is_signed(url) is expected
+
+
+class TestResolveSignedUrl:
+    def _patch(self, monkeypatch: pytest.MonkeyPatch, handler: Any) -> dict[str, Any]:
+        original = httpx.Client.__init__
+
+        def patched(self: httpx.Client, **kwargs: Any) -> None:
+            kwargs["transport"] = httpx.MockTransport(handler)
+            original(self, **kwargs)
+
+        monkeypatch.setattr(httpx.Client, "__init__", patched)
+        return {}
+
+    def test_posts_stored_url_and_returns_signed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["url"] = str(request.url)
+            seen["body"] = request.content.decode()
+            return httpx.Response(200, json={"signedUrls": ["https://signed.example/x.pdf?sig=1"]})
+
+        self._patch(monkeypatch, handler)
+        ref = NotionFileRef.from_fetch_src(VALID_FETCH_SRC)
+        assert ref is not None
+
+        signed = resolve_signed_url(ref, httpx.Cookies())
+
+        assert signed == "https://signed.example/x.pdf?sig=1"
+        assert seen["url"] == "https://www.notion.so/api/v3/getSignedFileUrls"
+        assert "prod-files-secure.s3" in seen["body"]
+        assert "blk-9" in seen["body"]
+
+    def test_raises_when_no_signed_url_in_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch(monkeypatch, lambda _: httpx.Response(200, json={"other": []}))
+        ref = NotionFileRef.from_fetch_src(VALID_FETCH_SRC)
+        assert ref is not None
+
+        with pytest.raises(RuntimeError, match="no signed URL"):
+            resolve_signed_url(ref, httpx.Cookies())
+
+
+class TestDownloadViaRef:
+    def test_resolves_ref_then_downloads(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("teatree.backends.notion._brave_cookies", lambda _: httpx.Cookies())
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/api/v3/getSignedFileUrls":
+                return httpx.Response(200, json={"signedUrls": ["https://signed/x.pdf?signature=ok"]})
+            return httpx.Response(200, content=b"REF-BYTES")
+
+        original = httpx.Client.__init__
+
+        def patched(self: httpx.Client, **kwargs: Any) -> None:
+            kwargs["transport"] = httpx.MockTransport(handler)
+            original(self, **kwargs)
+
+        monkeypatch.setattr(httpx.Client, "__init__", patched)
+        ref = NotionFileRef.from_fetch_src(VALID_FETCH_SRC)
+
+        dest = download_notion_file(ref=ref, dest=tmp_path / "out.pdf")
+
+        assert dest.read_bytes() == b"REF-BYTES"
+
+    def test_rejects_unsigned_url_without_ref(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("teatree.backends.notion._brave_cookies", lambda _: httpx.Cookies())
+
+        with pytest.raises(ValueError, match="not signed"):
+            download_notion_file(url="https://plain.example/x.pdf", dest=tmp_path / "x.pdf")
+
+
+class TestNotionDownloadCLIRef:
+    def test_detects_fetch_ref_and_resolves(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_download(*, ref: Any = None, url: str = "", dest: Path) -> Path:
+            captured["ref"] = ref
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"PDF")
+            return dest
+
+        monkeypatch.setattr("teatree.backends.notion.download_notion_file", fake_download)
+
+        result = typer.testing.CliRunner().invoke(
+            tool_app, ["notion-download", VALID_FETCH_SRC, "--dest", str(tmp_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["ref"].filename == "My Report.pdf"
+        assert (tmp_path / "My Report.pdf").read_bytes() == b"PDF"


### PR DESCRIPTION
## Summary

Makes `t3 <overlay> workspace start` work reliably from a fresh provisioned workspace, and lets `t3 tool notion-download` resolve Notion signed file URLs without a manual browser click.

### `fix(workspace)` — start works from the ticket root
- `_resolve_workspace_ticket(path)` so `workspace provision/start/ready/teardown` work when invoked from the ticket directory, not just the repo root.
- `_docker_compose_up` / `_ensure_images_built` now return and surface the real docker error instead of a generic "docker compose up failed".
- `_discover_frontend_port` probes container ports `(80, default)` so nginx-served frontends (port 80) are found, not only dev-server 4200.

### `feat(tools)` — browser-free Notion downloads
- `NotionFileRef.from_fetch_src()` parses the `file://%7B…%7D` ref that `notion-fetch` emits for `<file>` blocks.
- `resolve_signed_url()` POSTs to Notion's internal `getSignedFileUrls` with the browser session cookies — the same call the web app makes on click — so no manual browser click is needed.
- `notion-download` auto-detects a `file://` ref vs a pre-signed URL.

## Test plan
- `pytest tests/ -k "notion or workspace or worktree_start or e2e or runner"` → 206 passed.
- Dogfooded: a full local COMPANY stack (web/celery/doc-service/nginx-frontend) comes up via `workspace start`; all four TICKET-1151 reference PDFs downloaded via `notion-download` with no browser interaction.
