### PR TITLE
fix(privacy-scan): surface findings to scripted/non-TTY callers (#696)

### DIFF
--- a/scripts/hooks/refuse-public-push-with-leak.sh
+++ b/scripts/hooks/refuse-public-push-with-leak.sh
@@ -89,7 +89,11 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   report=$(mktemp "${TMPDIR:-/tmp}/t3-privacy-gate.XXXXXX")
   if ! printf '%s\n' "${diff}" | ${scan_cmd} - >"${report}" 2>&1; then
     echo "✗ refuse: push to PUBLIC repo '${slug}' carries privacy findings on '${local_ref}'."
-    cat "${report}" 2>/dev/null || true
+    echo "  Findings (line / category / redacted match):"
+    # The scanner writes a deterministic plain-text summary to stdout
+    # (captured here via 2>&1), so the user sees exactly which line/
+    # category tripped the gate — not just a generic "carries findings".
+    sed 's/^/  /' "${report}" 2>/dev/null || cat "${report}" 2>/dev/null || true
     echo "  Scrub the diff (generic placeholders) before pushing to a public repo."
     echo "  (public-repo privacy gate — see /t3:rules § Verify Repo Visibility Before Filing External Issues)"
     blocked=1

--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -58,6 +58,24 @@ def _scan_line(line: str, banned_re: re.Pattern[str] | None) -> list[tuple[str, 
     return findings
 
 
+def _plain_summary(findings: list[dict[str, str | int]]) -> str:
+    """Deterministic plain-text findings summary for non-TTY callers.
+
+    Stable, greppable, line-oriented (one finding per line: line number,
+    category, redacted match). Consumed verbatim by the pre-push gate's
+    refusal message and by any scripted caller of ``t3 tool
+    privacy-scan``. The redaction of the match itself is already applied
+    upstream in ``_scan_line`` (api keys are truncated to a 20-char
+    prefix); other categories carry the raw match by design so the user
+    can locate the offending text.
+    """
+    if not findings:
+        return "Privacy scan: clean (0 findings)"
+    header = f"Privacy scan: {len(findings)} finding(s)"
+    rows = [f"  line {f['line']}: {f['category']}: {f['match']}" for f in findings]
+    return "\n".join([header, *rows])
+
+
 @app.command()
 def main(
     input_file: str = typer.Argument("-", help="File to scan (- for stdin, or a file path)"),
@@ -78,16 +96,24 @@ def main(
 
     if json_output:
         print(json.dumps(all_findings, indent=2))
-    elif all_findings:
-        table = Table(title="Privacy Scan Findings")
-        table.add_column("Line", style="dim", justify="right")
-        table.add_column("Category", style="bold")
-        table.add_column("Match")
-        for f in all_findings:
-            table.add_row(str(f["line"]), str(f["category"]), str(f["match"]))
-        console.print(table)
     else:
-        console.print("[green]Privacy scan: clean[/]")
+        # Always emit a deterministic, plain-text summary on **stdout**.
+        # This is the stream a piped/non-TTY caller reliably sees: the
+        # pre-push gate captures it with ``> report 2>&1`` and
+        # ``ToolRunner.run_script`` re-emits it. The rich table is a
+        # TTY-only nicety on stderr; it must never be the *only* output,
+        # or scripted callers get "exit 1, no diagnostics" (#696).
+        print(_plain_summary(all_findings))
+        if all_findings:
+            table = Table(title="Privacy Scan Findings")
+            table.add_column("Line", style="dim", justify="right")
+            table.add_column("Category", style="bold")
+            table.add_column("Match")
+            for f in all_findings:
+                table.add_row(str(f["line"]), str(f["category"]), str(f["match"]))
+            console.print(table)
+        else:
+            console.print("[green]Privacy scan: clean[/]")
 
     if all_findings and strict:
         raise SystemExit(1)

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -31,6 +31,14 @@ class ToolRunner:
             raise typer.Exit(code=1)
         cmd = [sys.executable, str(script), *args]
         result = run_allowed_to_fail(cmd, expected_codes=None)
+        # ``run_allowed_to_fail`` captures the child's streams. Re-emit
+        # them so scripted callers actually see the script's diagnostics
+        # — without this, ``t3 tool privacy-scan`` exits non-zero with no
+        # visible findings, defeating the gate it powers (#696).
+        if result.stdout:
+            sys.stdout.write(result.stdout)
+        if result.stderr:
+            sys.stderr.write(result.stderr)
         if result.returncode != 0:
             raise typer.Exit(code=result.returncode)
 

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -77,6 +78,55 @@ class TestToolCommands:
             result = runner.invoke(app, ["tool", "bump-deps"])
             assert result.exit_code == 0
             mock.assert_called_once_with("bump-pyproject-deps-from-lock-file")
+
+
+class TestPrivacyScanWrapperSurfacesFindings:
+    """``t3 tool privacy-scan`` must surface the scanner's findings (#696).
+
+    ``ToolRunner.run_script`` spawns the scanner via
+    ``run_allowed_to_fail`` which uses ``capture_output=True``. Before the
+    fix the captured stdout/stderr were discarded, so a piped caller saw
+    "exit 1, no output". The wrapper must re-emit what the scanner wrote so
+    the finding (line/category/redacted match) is caller-visible. The real
+    scanner subprocess is exercised here — nothing is mocked.
+    """
+
+    # ``ToolRunner.run_script`` spawns a fresh ``python`` child that reads
+    # the *real* stdin, so the only faithful reproduction of the
+    # ``printf ... | t3 tool privacy-scan -`` flow is a real subprocess
+    # that drives ``run_script`` with piped stdin. Monkeypatching
+    # ``sys.stdin`` in-process would not reach the grandchild scanner.
+    _DRIVER = (
+        "from teatree.cli.tools import ToolRunner\n"
+        "try:\n"
+        "    ToolRunner.run_script('privacy_scan', '-')\n"
+        "except SystemExit as e:\n"
+        "    raise\n"
+        "except Exception as e:\n"
+        "    import sys; sys.exit(getattr(e, 'exit_code', 3))\n"
+    )
+
+    def _invoke(self, stdin_text: str) -> tuple[int, str]:
+        proc = subprocess.run(
+            [sys.executable, "-c", self._DRIVER],
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(Path(__file__).resolve().parents[1]),
+        )
+        return proc.returncode, proc.stdout + proc.stderr
+
+    def test_planted_secret_finding_reaches_caller(self) -> None:
+        code, out = self._invoke("token = glpat-XXXXXXXXXXXXXXXX\n")  # privacy-scan:allow self-fixture
+        assert code == 1, out
+        assert "api_key" in out
+        assert "glpat-" in out
+
+    def test_clean_input_reaches_caller(self) -> None:
+        code, out = self._invoke("an ordinary line\n")
+        assert code == 0, out
+        assert "clean" in out.lower()
 
 
 class TestSonarCheck:

--- a/tests/test_privacy_scan_script.py
+++ b/tests/test_privacy_scan_script.py
@@ -42,6 +42,65 @@ class TestPrivacyScanScriptEntrypoint:
         assert result.returncode == 0, result.stdout + result.stderr
 
 
+class TestPrivacyScanCallerVisibleSummary:
+    """Findings must reach a piped/non-TTY caller without a manual rerun (#696).
+
+    The historical bug: findings were rendered only via a ``rich`` table on
+    ``Console(stderr=True)``, which is invisible to scripted callers (and is
+    captured-and-discarded by ``ToolRunner.run_script``). The scanner now
+    always writes a deterministic plain-text summary to **stdout** so a
+    piped caller reliably sees the offending line, category, and redacted
+    match. ``capture_output=True`` below is exactly how ``run_script`` and
+    the pre-push gate consume it — no TTY, no mocking of the scanner.
+    """
+
+    def test_planted_secret_summary_is_on_stdout_for_piped_caller(self) -> None:
+        result = _run("token = glpat-XXXXXXXXXXXXXXXX\n")  # privacy-scan:allow self-fixture
+        assert result.returncode == 1, result.stdout + result.stderr
+        # The caller (run_script / the gate) reads stdout — the finding
+        # detail must be there, not only in a stderr rich table.
+        assert "api_key" in result.stdout
+        assert "1" in result.stdout  # the offending line number
+        assert "glpat-" in result.stdout  # redacted match prefix
+
+    def test_internal_path_category_and_line_visible_on_stdout(self) -> None:
+        result = _run("ok\nsee /Users/someone/secret/path\n")  # privacy-scan:allow self-fixture
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "home_path" in result.stdout
+        assert "2" in result.stdout  # finding is on the second line
+
+    def test_clean_input_prints_clear_clean_line_on_stdout(self) -> None:
+        result = _run("a perfectly ordinary line of prose\n")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "clean" in result.stdout.lower()
+
+    def test_json_output_still_valid(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "-", "--json"],
+            input="token = glpat-XXXXXXXXXXXXXXXX\n",  # privacy-scan:allow self-fixture
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        import json  # noqa: PLC0415
+
+        parsed = json.loads(proc.stdout)
+        assert isinstance(parsed, list)
+        assert parsed[0]["category"] == "api_key"
+        assert parsed[0]["line"] == 1
+
+    def test_no_strict_warns_but_exits_zero_with_visible_summary(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "-", "--no-strict"],
+            input="token = glpat-XXXXXXXXXXXXXXXX\n",  # privacy-scan:allow self-fixture
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "api_key" in proc.stdout
+
+
 class TestPrivacyScanAllowAnnotation:
     """A line carrying the inline ``privacy-scan:allow`` annotation is exempt.
 

--- a/tests/test_refuse_public_push_with_leak.py
+++ b/tests/test_refuse_public_push_with_leak.py
@@ -135,6 +135,29 @@ class TestRefusePublicPushWithLeak:
         combined = (result.stdout + result.stderr).lower()
         assert "privacy" in combined
 
+    def test_refusal_message_includes_concrete_finding_detail(self, tmp_path: Path) -> None:
+        """The gate must show *which* file/line/category tripped it (#696).
+
+        Not just "carries privacy findings" — the scanner's plain-text
+        summary (category + redacted match + line) must be in the
+        caller-visible refusal output so the user can act without a
+        manual rerun.
+        """
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        (work / "leak.txt").write_text(
+            "token = glpat-XXXXXXXXXXXXXXXX\n",  # privacy-scan:allow test fixture
+            encoding="utf-8",
+        )
+        _git(work, "add", "leak.txt")
+        _git(work, "commit", "-m", "add config")
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        combined = result.stdout + result.stderr
+        assert "api_key" in combined, combined
+        assert "glpat-" in combined, combined
+
     def test_blocks_public_push_with_internal_path(self, tmp_path: Path) -> None:
         work, env = _clone_with_remote(tmp_path, "PUBLIC")
         planted = "see /Users/someone/secret/path\n"  # privacy-scan:allow test fixture


### PR DESCRIPTION
Closes #696. The findings table was rendered only via rich Console(stderr=True), and ToolRunner.run_script captured child output with capture_output=True and never re-emitted it — so `t3 tool privacy-scan` / the pre-push gate / CI / agents saw exit 1 with zero diagnostics. Now: the scanner always prints a deterministic plain-text summary (line / category / redacted match) to stdout; run_script re-emits captured stdout/stderr; the refuse-public-push gate indents the concrete summary under its refusal so the user sees which file/line tripped it. --json, _ALLOW_MARKER, _FALSE_POSITIVE_RE, exit semantics unchanged. 38 tests (incl. a real-subprocess piped-caller test), 20 no-regression; prek green.