### PR TITLE
fix(privacy-scan): annotate self-test fixtures so the branch diff scans clean

### DIFF
--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -16,7 +16,17 @@ from rich.table import Table
 app = typer.Typer(add_completion=False)
 console = Console(stderr=True)
 
-_EMAIL_RE = re.compile(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z]{2,}", re.ASCII)
+# Require a plausible local part: it may contain ``.+-`` internally but
+# must *end* in an email-local char (alphanumeric/underscore) immediately
+# before ``@``. This drops the decorator/attribute class of false
+# positives — ``+@pytest.fixture`` (diff ``+`` as a fake local part),
+# ``@app.route``, ``@module.attr`` — where the char before ``@`` is a diff
+# marker, whitespace, or absent, while still matching genuine addresses
+# (``user@example.com``, ``t@e.st``) whose local part ends in a real char.
+_EMAIL_RE = re.compile(
+    r"[a-zA-Z0-9_]([a-zA-Z0-9_.+-]*[a-zA-Z0-9_])?@[a-zA-Z0-9-]+\.[a-zA-Z]{2,}",
+    re.ASCII,
+)
 _HOME_PATH_RE = re.compile(r"(?:/Users/|/home/)[a-zA-Z0-9_.-]+")
 _IP_RE = re.compile(r"\b(?:10|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}\b")
 _API_KEY_RE = re.compile(r"\b(?:glpat-|sk-|ghp_|gho_|github_pat_|xoxb-|xoxp-)[a-zA-Z0-9_-]{10,}")

--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -22,7 +22,7 @@ console = Console(stderr=True)
 # positives — ``+@pytest.fixture`` (diff ``+`` as a fake local part),
 # ``@app.route``, ``@module.attr`` — where the char before ``@`` is a diff
 # marker, whitespace, or absent, while still matching genuine addresses
-# (``user@example.com``, ``t@e.st``) whose local part ends in a real char.
+# whose local part ends in a real char (including a one-char local part).
 _EMAIL_RE = re.compile(
     r"[a-zA-Z0-9_]([a-zA-Z0-9_.+-]*[a-zA-Z0-9_])?@[a-zA-Z0-9-]+\.[a-zA-Z]{2,}",
     re.ASCII,

--- a/tests/test_privacy_scan_script.py
+++ b/tests/test_privacy_scan_script.py
@@ -163,9 +163,9 @@ class TestDecoratorIsNotAnEmail:
     @pytest.mark.parametrize(
         "line",
         [
-            "+contact me at someone@gmail.com please",
-            "real address: t@e.st in this diff",
-            "+    leak = 'someone@gmail.com'",
+            "+contact me at someone@gmail.com please",  # privacy-scan:allow (dummy example address, test input)
+            "real address: t@e.st in this diff",  # privacy-scan:allow (dummy example address, test input)
+            "+    leak = 'someone@gmail.com'",  # privacy-scan:allow (dummy example address, test input)
         ],
     )
     def test_real_email_still_caught(self, line: str) -> None:
@@ -181,7 +181,8 @@ class TestDecoratorIsNotAnEmail:
         assert "api_key" in result.stdout
 
     def test_real_email_on_same_line_as_decorator_still_flagged(self) -> None:
-        result = _run("@app.route  # owner someone@gmail.com\n")
+        line = "@app.route  # owner someone@gmail.com"  # privacy-scan:allow (dummy example address, test input)
+        result = _run(line + "\n")
         assert result.returncode == 1, result.stdout + result.stderr
         assert "email" in result.stdout
 

--- a/tests/test_privacy_scan_script.py
+++ b/tests/test_privacy_scan_script.py
@@ -129,5 +129,62 @@ class TestPrivacyScanAllowAnnotation:
         assert result.returncode == 1, result.stdout + result.stderr
 
 
+class TestDecoratorIsNotAnEmail:
+    """Python decorators / attribute access must not be flagged as emails (#701).
+
+    ``_EMAIL_RE`` historically matched ``<chars>@<domain>.<tld>`` loosely,
+    so a diff line ``+@pytest.fixture`` (diff ``+`` as a fake local part)
+    or ``@module.attr`` tripped the public-repo privacy gate. The fix
+    tightens the local part so a real address is required while the
+    decorator class of false positives is dropped — without weakening
+    detection of genuine emails (which the ``privacy-scan:allow``
+    convention still exempts when they are intentional fixtures).
+    """
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "+@pytest.fixture",
+            "    @pytest.fixture",
+            "@pytest.fixture",
+            "@app.route",
+            "+@app.route('/x')",
+            "@dataclass",
+            "@staticmethod",
+            "@property",
+            "@module.attr",
+            "+    @some.decorator.chain",
+        ],
+    )
+    def test_decorator_token_is_not_flagged(self, line: str) -> None:
+        result = _run(line + "\n")
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "+contact me at someone@gmail.com please",
+            "real address: t@e.st in this diff",
+            "+    leak = 'someone@gmail.com'",
+        ],
+    )
+    def test_real_email_still_caught(self, line: str) -> None:
+        result = _run(line + "\n")
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "email" in result.stdout
+
+    def test_real_secret_on_same_line_as_decorator_still_flagged(self) -> None:
+        # A decorator that is *not* an email must not mask a genuine
+        # secret sharing the line.
+        result = _run("@pytest.fixture  # token = glpat-XXXXXXXXXXXXXXXX\n")  # privacy-scan:allow self-fixture
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "api_key" in result.stdout
+
+    def test_real_email_on_same_line_as_decorator_still_flagged(self) -> None:
+        result = _run("@app.route  # owner someone@gmail.com\n")
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "email" in result.stdout
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
fix(privacy-scan): annotate self-test fixtures so the branch diff scans clean

The decorator-FP fix added test-input strings and a docstring that embed
dummy example addresses the scanner correctly detects. Scanning this
branch's own diff therefore tripped the public-repo gate on the repo's
own test data (the cry-wolf problem the gate exists to remove).

Mark each source line that intentionally embeds a detectable dummy
address with the per-line privacy-scan:allow marker (the #688 idiom;
_scan_line exempts the source line, runtime behaviour is unchanged
because the scanner scans the test's input string, not the comment).
Reword the _EMAIL_RE docstring to drop the literal example address
instead of a trailing marker, keeping the comment block prek-clean.

Delivers both commits for the ticket: edfcdd2 (tighten _EMAIL_RE so decorators are not emails) + da84be5 (self-test annotation).

Closes #701
