### PR TITLE
fix(privacy): scan commit messages in the public-push gate, not only diffs

### DIFF
--- a/scripts/hooks/refuse-public-push-with-leak.sh
+++ b/scripts/hooks/refuse-public-push-with-leak.sh
@@ -2,10 +2,13 @@
 # Pre-push hook: public-repo privacy gate (#685).
 #
 # Refuses `git push` when the `origin` remote resolves to a PUBLIC
-# repository and the branch-vs-base diff fails `t3 tool privacy-scan`
-# (a planted secret, an internal `/Users/`-`/home/` path, a private IP,
-# an API token, an internal hostname, or a T3_BANNED_TERM). Pushes to a
-# private remote, and clean pushes to a public remote, pass through.
+# repository and the branch-vs-base diff OR the commit messages in the
+# push range fail `t3 tool privacy-scan` (a planted secret, an internal
+# `/Users/`-`/home/` path, a private IP, an API token, an internal
+# hostname, or a T3_BANNED_TERM). Commit messages and trailers reach
+# public history just like file content, so they are scanned too (#703).
+# Pushes to a private remote, and clean pushes to a public remote, pass
+# through.
 #
 # This is the deterministic enforcement home for the contribute-mode
 # rule "no customer/internal identifier reaches a public repo": the
@@ -78,16 +81,22 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 
   if [ -n "${base}" ]; then
     diff=$(git diff "${base}" "${local_sha}" 2>/dev/null || true)
+    msgs=$(git log --format='%B' "${base}..${local_sha}" 2>/dev/null || true)
   else
     # No comparison point (brand-new repo / unknown base): scan the
     # whole tree at the pushed sha rather than skipping the gate.
     diff=$(git show "${local_sha}" 2>/dev/null || true)
+    msgs=$(git log --format='%B' "${local_sha}" 2>/dev/null || true)
   fi
 
-  [ -n "${diff}" ] || continue
+  # Commit messages and trailers reach public history exactly like file
+  # content does (a `Co-authored-by:` line carrying an internal/customer
+  # address is the canonical case). `git diff` excludes them, so scan the
+  # range's message bodies alongside the diff (#703).
+  [ -n "${diff}${msgs}" ] || continue
 
   report=$(mktemp "${TMPDIR:-/tmp}/t3-privacy-gate.XXXXXX")
-  if ! printf '%s\n' "${diff}" | ${scan_cmd} - >"${report}" 2>&1; then
+  if ! { printf '%s\n' "${diff}"; printf '%s\n' "${msgs}"; } | ${scan_cmd} - >"${report}" 2>&1; then
     echo "✗ refuse: push to PUBLIC repo '${slug}' carries privacy findings on '${local_ref}'."
     echo "  Findings (line / category / redacted match):"
     # The scanner writes a deterministic plain-text summary to stdout

--- a/tests/test_refuse_public_push_with_leak.py
+++ b/tests/test_refuse_public_push_with_leak.py
@@ -262,6 +262,55 @@ class TestRefusePublicPushWithLeak:
         result = _run_hook(work, env, _push_stdin(work))
         assert result.returncode == 0, result.stdout + result.stderr
 
+    def test_blocks_public_push_when_only_the_commit_message_leaks(self, tmp_path: Path) -> None:
+        """Commit messages reach public history too (#703).
+
+        The file diff is clean, but the message body carries a
+        secret-shaped token. The gate must scan ``git log`` bodies in the
+        push range, not only ``git diff`` — a ``Co-authored-by:`` trailer
+        with an internal/customer-domain address is the real-world case
+        that motivated this.
+        """
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        (work / "feature.txt").write_text("a perfectly clean feature line\n", encoding="utf-8")
+        _git(work, "add", "feature.txt")
+        _git(
+            work,
+            "commit",
+            "-m",
+            "add feature",
+            "-m",
+            "token = glpat-XXXXXXXXXXXXXXXX",  # privacy-scan:allow test fixture
+        )
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        combined = (result.stdout + result.stderr).lower()
+        assert "privacy" in combined
+
+    def test_allows_public_push_with_clean_multiline_commit_message(self, tmp_path: Path) -> None:
+        """Message scanning must not become a blanket block on trailers.
+
+        A clean diff plus a clean multi-paragraph message (including a
+        benign example-domain ``Co-authored-by`` trailer) still passes.
+        """
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        (work / "feature.txt").write_text("another clean feature line\n", encoding="utf-8")
+        _git(work, "add", "feature.txt")
+        _git(
+            work,
+            "commit",
+            "-m",
+            "add feature",
+            "-m",
+            "Longer body explaining the change in plain prose.\n\nCo-authored-by: A Dev <dev@example.com>",
+        )
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
     def test_hook_is_executable(self) -> None:
         assert os.access(HOOK, os.X_OK), f"{HOOK} must be chmod +x"
 


### PR DESCRIPTION
## Problem

The public-repo privacy pre-push gate (`scripts/hooks/refuse-public-push-with-leak.sh`, #685/#688) scans `git diff <base> <local_sha>` — **file content only**. Commit messages and trailers in the push range are never scanned, so a `Co-authored-by:` trailer (or message body) carrying an internal/customer-domain address reaches public history unchallenged. Found by the autonomous review loop while reviewing #697, whose squash-merge trailer embedded a customer-domain email on `main`.

## Fix

Collect the push range's commit-message bodies (`git log --format=%B <base>..<local_sha>`, or `git log --format=%B <local_sha>` when there is no base) and feed them through `privacy-scan` alongside the diff. Detection logic is unchanged — only the scanned surface widens from "diff" to "diff + commit messages". Header docstring updated to match.

## Tests

Integration tests under `tmp_path` with real `git` (Test-Writing Doctrine):

- `test_blocks_public_push_when_only_the_commit_message_leaks` — clean diff, secret-shaped token only in the message body → **blocked** (was red before the fix).
- `test_allows_public_push_with_clean_multiline_commit_message` — clean diff + clean multi-paragraph message with a benign `example.com` `Co-authored-by` trailer → **passes** (message scanning is not a blanket trailer block).
- All 9 pre-existing gate tests still pass (private-remote, gh-less fail-open, annotated-fixture, etc.).

11/11 pass. The new gate validated its own push (this branch's diff + commit message scanned clean).

Note: this prevents *future* message-borne leaks. The already-merged #697 trailer is existing public history; rewriting `main` to scrub it is disproportionate (breaks every clone/SHA) and is left as the repo owner's call.

Closes #703