### PR TITLE
fix(cleanup): refuse worktree teardown that would destroy unpushed commits (#706)

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -24,7 +24,7 @@ from teatree.core.overlay_loader import get_overlay
 from teatree.utils import git
 from teatree.utils.db import drop_db
 from teatree.utils.postgres_secret import remove_postgres_pass_entry
-from teatree.utils.run import run_allowed_to_fail
+from teatree.utils.run import CommandFailedError, run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
 
@@ -232,8 +232,21 @@ def _raise_if_unpushed(repo_main: str, worktree: Worktree) -> None:
     here — the work survives on the remote. Only commits absent from every
     ``refs/remotes/*`` block teardown. The error names the branch, the count,
     and up to ``_SUBJECT_PREVIEW_LIMIT`` short SHAs so the loss is loud.
+
+    **Fails closed.** If the probe itself errors (invalid/missing branch,
+    corrupt repo, any ``git log`` failure) it raises ``CommandFailedError``;
+    we translate that into a refusal rather than proceeding, because an
+    inconclusive probe means we cannot prove the commits are pushed.
     """
-    unpushed = git.commits_absent_from_all_remotes(repo_main, worktree.branch)
+    try:
+        unpushed = git.commits_absent_from_all_remotes(repo_main, worktree.branch)
+    except CommandFailedError as exc:
+        msg = (
+            f"{worktree.repo_path} ({worktree.branch}): "
+            f"refused teardown — could not verify the branch is pushed "
+            f"(git probe failed: {exc}). Push the branch or pass force=True to discard."
+        )
+        raise RuntimeError(msg) from exc
     if not unpushed:
         return
     preview = unpushed[:_SUBJECT_PREVIEW_LIMIT]
@@ -280,10 +293,22 @@ def _remove_git_worktree(
     if not repo_main.is_dir():
         return [f"source repo missing at {repo_main}"]
     if not force:
-        # #706 — the data-loss guard runs first and is the single seam every
-        # teardown caller funnels through. It blocks removal of commits that
-        # exist on no remote at all (the bug that destroyed worktrees). It is
-        # never skipped except by an explicit force override.
+        # #706 — the data-loss guard runs first. It is the seam every
+        # Worktree-row-driven teardown caller funnels through (execute_teardown
+        # / WorktreeTeardown, WorktreeTeardownRunner, clean-merged, clean-all,
+        # sync-backend merge cleanup, abandon) and blocks removal of commits
+        # that exist on no remote at all (the bug that destroyed worktrees).
+        # It is never skipped except by an explicit force override.
+        #
+        # One narrower path is NOT routed here: _workspace_cleanup.
+        # prune_squash_merged() deletes a branch+worktree directly via
+        # git.worktree_remove/branch_delete, but only AFTER is_squash_merged()
+        # has confirmed the content is on a remote (merged PR or empty diff vs
+        # origin/<default>), so it is low risk. Routing it through this guard
+        # would require synthesising a Worktree row and would risk false-
+        # blocking legitimately squash-merged branches whose local SHAs differ
+        # from the squash commit. Unifying that path is tracked as follow-up
+        # (see #706 review) rather than forced here.
         _raise_if_unpushed(str(repo_main), worktree)
         # The squash-merge-aware origin/main hygiene gate is stricter: it also
         # blocks pushed-but-unmerged branches. Sync backends and interactive

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -218,6 +218,36 @@ def _raise_if_genuinely_ahead(repo_main: str, worktree: Worktree) -> None:
     raise RuntimeError(msg)
 
 
+def _raise_if_unpushed(repo_main: str, worktree: Worktree) -> None:
+    """Raise ``RuntimeError`` when the branch has commits on NO remote ref (#706).
+
+    The data-loss guard. The lifecycle FSM can read a teardown-eligible state
+    (MERGED / shipped) while the branch was never actually pushed — async ship
+    never drained (#707/#708). Removing the git worktree then destroys those
+    commits irrecoverably once refs are pruned or ``git gc`` runs.
+
+    This is intentionally distinct from :func:`_raise_if_genuinely_ahead`
+    (squash-merge-aware, ``origin/main``-relative cleanup hygiene). A branch
+    pushed to its own remote tracking ref but not yet merged to main is SAFE
+    here — the work survives on the remote. Only commits absent from every
+    ``refs/remotes/*`` block teardown. The error names the branch, the count,
+    and up to ``_SUBJECT_PREVIEW_LIMIT`` short SHAs so the loss is loud.
+    """
+    unpushed = git.commits_absent_from_all_remotes(repo_main, worktree.branch)
+    if not unpushed:
+        return
+    preview = unpushed[:_SUBJECT_PREVIEW_LIMIT]
+    shas = ", ".join(preview)
+    if len(unpushed) > _SUBJECT_PREVIEW_LIMIT:
+        shas += ", …"
+    msg = (
+        f"{worktree.repo_path} ({worktree.branch}): "
+        f"refused teardown — {len(unpushed)} commit(s) on NO remote (data loss): "
+        f"{shas}. Push the branch or pass force=True to discard."
+    )
+    raise RuntimeError(msg)
+
+
 def _resolve_worktree_path(workspace: Path, worktree: Worktree) -> str:
     """Return the on-disk worktree path, preferring extras and falling back to the canonical layout.
 
@@ -233,7 +263,14 @@ def _resolve_worktree_path(workspace: Path, worktree: Worktree) -> str:
     return str(workspace / worktree.branch / Path(worktree.repo_path).name)
 
 
-def _remove_git_worktree(repo_main: Path, wt_path: str, worktree: Worktree, *, force: bool) -> list[str]:
+def _remove_git_worktree(
+    repo_main: Path,
+    wt_path: str,
+    worktree: Worktree,
+    *,
+    force: bool,
+    strict_hygiene: bool,
+) -> list[str]:
     """Remove the git worktree + branch from the source repo, returning any error messages.
 
     Returns an empty list on success. The source repo missing, the git worktree
@@ -243,7 +280,18 @@ def _remove_git_worktree(repo_main: Path, wt_path: str, worktree: Worktree, *, f
     if not repo_main.is_dir():
         return [f"source repo missing at {repo_main}"]
     if not force:
-        _raise_if_genuinely_ahead(str(repo_main), worktree)
+        # #706 — the data-loss guard runs first and is the single seam every
+        # teardown caller funnels through. It blocks removal of commits that
+        # exist on no remote at all (the bug that destroyed worktrees). It is
+        # never skipped except by an explicit force override.
+        _raise_if_unpushed(str(repo_main), worktree)
+        # The squash-merge-aware origin/main hygiene gate is stricter: it also
+        # blocks pushed-but-unmerged branches. Sync backends and interactive
+        # clean-all want it (they clean only on detected merge / orphan reap);
+        # the automated FSM teardown path does not (the ticket is MERGED and
+        # the work is already preserved on the remote).
+        if strict_hygiene:
+            _raise_if_genuinely_ahead(str(repo_main), worktree)
     errors: list[str] = []
     if not git.worktree_remove(str(repo_main), wt_path):
         errors.append(f"git worktree remove failed for {wt_path}")
@@ -252,7 +300,7 @@ def _remove_git_worktree(repo_main: Path, wt_path: str, worktree: Worktree, *, f
     return errors
 
 
-def cleanup_worktree(worktree: Worktree, *, force: bool = False) -> str:
+def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> str:
     """Remove a single worktree: git worktree, branch, DB, overlay cleanup.
 
     Deletes the Worktree record from the database and returns a summary label.
@@ -260,10 +308,21 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False) -> str:
     still succeeds, but they are surfaced in the returned label so the caller
     can detect partial failures.
 
-    Raises ``RuntimeError`` when *force* is ``False`` and the branch has local
-    commits that are genuinely ahead of the default branch (i.e. not merge
-    commits and not squash-merged under a new SHA). Pass ``force=True`` only
-    from trusted callers (e.g. tests, programmatic API).
+    Two guards protect against losing work, both bypassed only by an explicit
+    ``force=True``.
+
+    Data-loss guard (#706, always on): raises ``RuntimeError`` when the branch
+    has commits on NO remote ref — removing the worktree would destroy them
+    irrecoverably.
+
+    Hygiene gate (``strict_hygiene``, default on): additionally raises when the
+    branch is genuinely ahead of ``origin/main`` and not squash-merged. Sync
+    backends and interactive ``clean-all`` keep this on; the automated FSM
+    teardown path passes ``strict_hygiene=False`` (the ticket is MERGED and the
+    branch is already on its remote).
+
+    Pass ``force=True`` only from trusted callers (explicit operator override,
+    tests, programmatic API).
     """
     workspace = load_config().user.workspace_dir
     wt_path = _resolve_worktree_path(workspace, worktree)
@@ -281,7 +340,7 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False) -> str:
             step_errors.append(f"{step.description}: {exc}")
 
     repo_main = resolve_clone_path(workspace, worktree) or workspace / worktree.repo_path
-    step_errors.extend(_remove_git_worktree(repo_main, wt_path, worktree, force=force))
+    step_errors.extend(_remove_git_worktree(repo_main, wt_path, worktree, force=force, strict_hygiene=strict_hygiene))
 
     if worktree.db_name:
         db_user = _read_env_cache_value(Path(wt_path), "POSTGRES_USER")

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -350,12 +350,18 @@ class Command(TyperCommand):
     def teardown(
         self,
         path: str = typer.Option("", help="Worktree path inside the workspace (auto-detects from PWD)."),
+        *,
+        force: bool = typer.Option(
+            default=False,
+            help="Tear down even when a branch has commits not on any remote (data loss).",
+        ),
     ) -> str:
         """Tear down every worktree in the current ticket workspace.
 
         Fires ``Worktree.teardown()`` on each worktree. Continues past
         per-worktree failures to maximise cleanup; surfaces them in the
-        final summary.
+        final summary. Refuses to remove a worktree whose branch carries
+        unpushed commits unless ``--force`` is passed.
         """
         ticket = _resolve_workspace_ticket(path)
 
@@ -372,6 +378,7 @@ class Command(TyperCommand):
                 wt.save()
             result = WorktreeTeardownRunner(
                 wt,
+                force=force,
                 snapshot_db_name=snapshot_db_name,
                 snapshot_extra=snapshot_extra,
             ).run()
@@ -447,7 +454,7 @@ class Command(TyperCommand):
                 continue
             for wt in worktrees:
                 try:
-                    cleaned.append(cleanup_worktree(wt, force=True))
+                    cleaned.append(cleanup_worktree(wt, strict_hygiene=False))
                 except RuntimeError as exc:
                     cleaned.append(f"FAILED {wt.repo_path} ({wt.branch}): {exc}")
         if not cleaned:

--- a/src/teatree/core/management/commands/worktree.py
+++ b/src/teatree/core/management/commands/worktree.py
@@ -257,6 +257,11 @@ class Command(TyperCommand):
     def teardown(
         self,
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
+        *,
+        force: bool = typer.Option(
+            default=False,
+            help="Tear down even when the branch has commits not on any remote (data loss).",
+        ),
     ) -> str:
         """Stop docker, drop DB, remove git worktree, delete row.
 
@@ -264,7 +269,8 @@ class Command(TyperCommand):
         CREATED and enqueues ``execute_worktree_teardown``; the runner
         also runs synchronously here so the operator sees immediate
         output. Folds the previous ``teardown`` + ``clean`` commands
-        into a single canonical path.
+        into a single canonical path. Refuses to remove a worktree whose
+        branch carries unpushed commits unless ``--force`` is passed.
         """
         worktree = resolve_worktree(path)
         repo_path = worktree.repo_path
@@ -276,6 +282,7 @@ class Command(TyperCommand):
             worktree.save()
         result = WorktreeTeardownRunner(
             worktree,
+            force=force,
             snapshot_db_name=snapshot_db_name,
             snapshot_extra=snapshot_extra,
         ).run()

--- a/src/teatree/core/runners/teardown.py
+++ b/src/teatree/core/runners/teardown.py
@@ -14,10 +14,20 @@ class WorktreeTeardown(RunnerBase):
     each one (git worktree removal, branch deletion, DB drop, overlay
     cleanup hooks). Errors on a single worktree are captured but do not
     abort the rest — the runner reports a combined success/failure label.
+
+    This is the *automated* teardown path: ``execute_teardown`` enqueues it
+    when the ticket FSM reaches MERGED. The FSM can read MERGED while the
+    branch was never actually pushed (async ship never drained — #707/#708),
+    so this path must NOT force-bypass ``cleanup_worktree``'s unsynced-commit
+    guard. ``force`` defaults to ``False`` (the guard fires); pass
+    ``force=True`` only from an explicit operator override (e.g.
+    ``--force``). #706 — forcing here physically destroyed worktrees with
+    unpushed work.
     """
 
-    def __init__(self, ticket: Ticket) -> None:
+    def __init__(self, ticket: Ticket, *, force: bool = False) -> None:
         self.ticket = ticket
+        self.force = force
 
     def run(self) -> RunnerResult:
         ticket = self.ticket
@@ -29,7 +39,7 @@ class WorktreeTeardown(RunnerBase):
         errors: list[str] = []
         for worktree in worktrees:
             try:
-                labels.append(cleanup_worktree(worktree, force=True))
+                labels.append(cleanup_worktree(worktree, force=self.force, strict_hygiene=False))
             except RuntimeError as exc:
                 logger.exception("teardown failed for %s", worktree.repo_path)
                 errors.append(f"{worktree.repo_path} ({worktree.branch}): {exc}")

--- a/src/teatree/core/runners/worktree_teardown.py
+++ b/src/teatree/core/runners/worktree_teardown.py
@@ -24,13 +24,19 @@ class WorktreeTeardownRunner(RunnerBase):
     satisfy the FSM CREATED contract, so the runner accepts a snapshot of
     those fields captured before the reset — restored on the row before the
     cleanup helpers read them.
+
+    ``force`` defaults to ``False`` so ``cleanup_worktree``'s unsynced-commit
+    guard fires: this runner backs the ``execute_worktree_teardown`` task and
+    the ``worktree``/``workspace teardown`` CLIs, and the FSM can reach a
+    teardown-eligible state while the branch was never pushed (#706/#707/#708).
+    Pass ``force=True`` only from an explicit operator override.
     """
 
     def __init__(
         self,
         worktree: Worktree,
         *,
-        force: bool = True,
+        force: bool = False,
         snapshot_db_name: str | None = None,
         snapshot_extra: WorktreeExtra | None = None,
     ) -> None:
@@ -48,7 +54,7 @@ class WorktreeTeardownRunner(RunnerBase):
         docker_compose_down(project)
 
         try:
-            label = cleanup_worktree(worktree, force=self.force)
+            label = cleanup_worktree(worktree, force=self.force, strict_hygiene=False)
         except RuntimeError as exc:
             logger.warning("teardown refused for %s: %s", worktree.repo_path, exc)
             return RunnerResult(ok=False, detail=str(exc))

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -49,8 +49,16 @@ def commits_absent_from_all_remotes(repo: str, branch: str) -> list[str]:
     non-empty result means these commits exist on NO remote: removing the
     worktree would destroy them irrecoverably. Returns ``"<sha> <subject>"``
     lines (newest first).
+
+    **Fails closed.** Uses :func:`run_strict` so a non-zero ``git log`` exit
+    (invalid/missing branch, corrupt repo, any git error) raises
+    ``CommandFailedError`` rather than yielding an empty list. For a data-loss
+    guard, "we couldn't determine whether the commits are pushed" must block
+    teardown, not allow it. The legitimate empty case (``git log`` exits 0 with
+    no output because the branch genuinely has nothing absent from remotes)
+    still returns ``[]`` and allows teardown.
     """
-    output = run(repo=repo, args=["log", branch, "--not", "--remotes", "--oneline"])
+    output = run_strict(repo=repo, args=["log", branch, "--not", "--remotes", "--oneline"])
     return [line for line in output.splitlines() if line.strip()]
 
 

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -38,6 +38,22 @@ def unsynced_commits(repo: str, branch: str, target: str = "origin/main") -> lis
     return [line for line in output.splitlines() if line.strip()]
 
 
+def commits_absent_from_all_remotes(repo: str, branch: str) -> list[str]:
+    """Return ``branch`` commits not reachable from ANY ``refs/remotes/*`` ref.
+
+    The data-loss guard for worktree teardown (#706). Unlike
+    :func:`unsynced_commits` (which compares against ``origin/main`` only and
+    therefore flags pushed-but-unmerged branches), ``--not --remotes`` is empty
+    whenever the branch tip was pushed anywhere — to its own remote tracking
+    ref, to main, or captured by a squash-merge that was itself pushed. A
+    non-empty result means these commits exist on NO remote: removing the
+    worktree would destroy them irrecoverably. Returns ``"<sha> <subject>"``
+    lines (newest first).
+    """
+    output = run(repo=repo, args=["log", branch, "--not", "--remotes", "--oneline"])
+    return [line for line in output.splitlines() if line.strip()]
+
+
 def status_porcelain(repo: str = ".") -> str:
     return run(repo=repo, args=["status", "--porcelain"])
 

--- a/tests/teatree_core/test_cleanup.py
+++ b/tests/teatree_core/test_cleanup.py
@@ -15,6 +15,17 @@ _patch_overlay = patch("teatree.core.cleanup.get_overlay")
 _patch_classify = patch("teatree.core.cleanup.classify_branch_commits")
 
 
+def _no_unpushed(mock_git: MagicMock) -> None:
+    """Default the #706 data-loss guard helper to "nothing unpushed".
+
+    Tests exercising unrelated cleanup behaviour share the wholesale ``git``
+    mock; without this the guard sees a truthy ``MagicMock`` and refuses
+    spuriously. Tests that target the guard override the return value after
+    calling this.
+    """
+    mock_git.commits_absent_from_all_remotes.return_value = []
+
+
 def _mock_workspace(mock_config: MagicMock) -> None:
     mock_config.return_value.user.workspace_dir.__truediv__ = lambda self, x: MagicMock(is_dir=lambda: True)
 
@@ -45,6 +56,7 @@ class TestCleanupWorktree(TestCase):
         mock_overlay: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = []
@@ -69,6 +81,7 @@ class TestCleanupWorktree(TestCase):
         mock_overlay: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
 
         wt = self._make_worktree(db_name="wt_99")
@@ -87,6 +100,7 @@ class TestCleanupWorktree(TestCase):
         mock_overlay: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         step_fn = MagicMock()
         mock_overlay.return_value.get_cleanup_steps.return_value = [MagicMock(callable=step_fn)]
 
@@ -105,6 +119,7 @@ class TestCleanupWorktree(TestCase):
         mock_overlay: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_overlay.return_value.config.teardown_removes_pass_entries = False
 
@@ -123,6 +138,7 @@ class TestCleanupWorktree(TestCase):
         mock_overlay: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_overlay.return_value.config.teardown_removes_pass_entries = True
 
@@ -142,6 +158,7 @@ class TestCleanupWorktree(TestCase):
         mock_overlay: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
 
         wt = self._make_worktree()
@@ -162,6 +179,7 @@ class TestCleanupWorktree(TestCase):
         mock_classify: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 chore: cve fix"]
@@ -199,6 +217,7 @@ class TestCleanupWorktree(TestCase):
         is already captured by the squash tree.
         """
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 retro: post-merge docs"]
@@ -227,6 +246,7 @@ class TestCleanupWorktree(TestCase):
     ) -> None:
         """Genuinely ahead commits whose tree differs from the squash carry real work."""
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 feat: new work"]
@@ -255,6 +275,7 @@ class TestCleanupWorktree(TestCase):
     ) -> None:
         """Branches whose only "unsynced" commits are squash-merged or merge commits are safe to clean."""
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 feat: squashed on main"]
@@ -280,6 +301,7 @@ class TestCleanupWorktree(TestCase):
         mock_overlay: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 chore: cve fix"]
@@ -293,6 +315,140 @@ class TestCleanupWorktree(TestCase):
     @_patch_overlay
     @_patch_git
     @_patch_config
+    def test_raises_when_commits_absent_from_all_remotes(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """#706 data-loss guard — branch with commits on no remote blocks teardown."""
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.commits_absent_from_all_remotes.return_value = [
+            "abc1234 feat: never pushed",
+            "def5678 fix: also local",
+        ]
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        with pytest.raises(RuntimeError, match=r"on NO remote \(data loss\)"):
+            cleanup_worktree(wt)
+
+        mock_git.worktree_remove.assert_not_called()
+        mock_git.branch_delete.assert_not_called()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_unpushed_guard_message_truncates_sha_preview(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """More than the preview limit of unpushed commits is summarised with an ellipsis."""
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.commits_absent_from_all_remotes.return_value = [f"sha{i} commit {i}" for i in range(5)]
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        with pytest.raises(RuntimeError, match=r"5 commit\(s\) on NO remote.*…") as excinfo:
+            cleanup_worktree(wt)
+        assert "sha0" in str(excinfo.value)
+        assert "sha4" not in str(excinfo.value)
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_force_bypasses_unpushed_guard(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """An explicit force override discards even commits on no remote."""
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.commits_absent_from_all_remotes.return_value = ["abc123 feat: unpushed"]
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        cleanup_worktree(wt, force=True)
+
+        mock_git.worktree_remove.assert_called_once()
+        mock_git.commits_absent_from_all_remotes.assert_not_called()
+
+    @_patch_classify
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_strict_hygiene_refuses_pushed_but_unmerged_branch(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+        mock_classify: MagicMock,
+    ) -> None:
+        """Pushed-but-unmerged branch is refused under strict hygiene (default).
+
+        The origin/main hygiene gate still blocks it — the sync-backend /
+        clean-all contract is unchanged.
+        """
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.commits_absent_from_all_remotes.return_value = []  # pushed → data-loss guard passes
+        mock_git.unsynced_commits.return_value = ["abc123 feat: pushed not merged"]
+        mock_classify.return_value = BranchClassification(
+            genuinely_ahead=[BranchCommit(sha="abc123", subject="feat: pushed not merged", is_merge=False)]
+        )
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        with (
+            patch("teatree.core.cleanup._pr_merge_commit_sha", return_value=""),
+            pytest.raises(RuntimeError, match="unsynced commit"),
+        ):
+            cleanup_worktree(wt, strict_hygiene=True)
+        mock_git.worktree_remove.assert_not_called()
+
+    @_patch_classify
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_non_strict_hygiene_allows_pushed_but_unmerged_branch(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+        mock_classify: MagicMock,
+    ) -> None:
+        """Pushed-but-unmerged branch is allowed when strict hygiene is off.
+
+        This is the automated FSM teardown contract — a branch pushed to its
+        own remote ref passes; only the data-loss guard still applies.
+        """
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.commits_absent_from_all_remotes.return_value = []  # pushed
+        mock_git.unsynced_commits.return_value = ["abc123 feat: pushed not merged"]
+        mock_classify.return_value = BranchClassification(
+            genuinely_ahead=[BranchCommit(sha="abc123", subject="feat: pushed not merged", is_merge=False)]
+        )
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        cleanup_worktree(wt, strict_hygiene=False)
+        mock_git.worktree_remove.assert_called_once()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
     def test_releases_redis_slot_when_last_worktree_removed(
         self,
         mock_config: MagicMock,
@@ -300,6 +456,7 @@ class TestCleanupWorktree(TestCase):
         mock_overlay: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = []
@@ -326,6 +483,7 @@ class TestCleanupWorktree(TestCase):
         mock_overlay: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = []
@@ -360,6 +518,7 @@ class TestCleanupWorktree(TestCase):
         mock_overlay: MagicMock,
     ) -> None:
         _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = []

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -746,6 +746,7 @@ class TestWorkspaceCleanAll(TestCase):
                 mock_overlay.return_value.get_cleanup_steps.return_value = []
                 mock_git.status_porcelain.return_value = ""
                 mock_git.unsynced_commits.return_value = []
+                mock_git.commits_absent_from_all_remotes.return_value = []
                 cleaned = cast("list[str]", call_command("workspace", "clean-all"))
 
             assert any("Cleaned: backend" in c for c in cleaned)
@@ -838,6 +839,7 @@ class TestWorkspaceCleanAll(TestCase):
             ):
                 mock_overlay.return_value.get_cleanup_steps.return_value = []
                 mock_git.status_porcelain.return_value = " M dirty_file.py"
+                mock_git.commits_absent_from_all_remotes.return_value = []
                 call_command("workspace", "clean-all")
 
             assert any("uncommitted changes" in msg for msg in logs.output)
@@ -998,6 +1000,10 @@ class TestWorkspaceCleanAll(TestCase):
                 mock_overlay.return_value.get_cleanup_steps.return_value = []
                 mock_git.status_porcelain.return_value = ""
                 mock_git.unsynced_commits.side_effect = _unsynced
+                # Both branches are pushed to their own remote ref, so the
+                # #706 data-loss guard passes; this test targets the stricter
+                # origin/main hygiene refusal on the frontend branch.
+                mock_git.commits_absent_from_all_remotes.return_value = []
                 cleaned = cast("list[str]", call_command("workspace", "clean-all"))
 
             assert any("Cleaned: backend" in c for c in cleaned)
@@ -1124,7 +1130,11 @@ class TestWorkspaceCleanMerged(TestCase):
 
         assert cleaned == ["Cleaned: repo (ac-repo-70)"]
         assert mock_cleanup.call_count == 1
-        assert mock_cleanup.call_args.kwargs.get("force") is True
+        # #706 — clean-merged must NOT force-bypass the data-loss guard. The
+        # ticket is MERGED so the origin/main hygiene gate is skipped, but
+        # commits absent from every remote still block teardown.
+        assert mock_cleanup.call_args.kwargs.get("force") is not True
+        assert mock_cleanup.call_args.kwargs.get("strict_hygiene") is False
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/teatree_core/test_runners_teardown.py
+++ b/tests/teatree_core/test_runners_teardown.py
@@ -214,3 +214,53 @@ class TestWorktreeTeardownUnpushedGuard(TestCase):
 
         assert result.ok is True, result.detail
         assert not self.wt_path.exists()
+
+    def test_fail_closed_when_branch_unknown_to_git(self) -> None:
+        """#706 fail-closed when the data-loss probe cannot run.
+
+        Here the Worktree row names a branch git doesn't know, so the probe
+        errors. Teardown must REFUSE — we cannot prove the commits are pushed,
+        so we must not destroy the worktree.
+        """
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/706",
+            state=Ticket.State.MERGED,
+        )
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="myrepo",
+            branch="branch-git-never-heard-of",
+            extra={"worktree_path": str(self.wt_path)},
+        )
+
+        result = self._teardown(ticket)
+
+        assert result.ok is False
+        assert self.wt_path.exists(), "worktree destroyed despite an inconclusive data-loss probe"
+        assert Worktree.objects.filter(branch="branch-git-never-heard-of").exists()
+
+    def test_force_still_overrides_when_probe_would_error(self) -> None:
+        """Force bypasses the probe entirely.
+
+        The explicit force escape hatch skips the data-loss probe, so an
+        unknown branch does not block a forced teardown.
+        """
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/706",
+            state=Ticket.State.MERGED,
+        )
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="myrepo",
+            branch="branch-git-never-heard-of",
+            extra={"worktree_path": str(self.wt_path)},
+        )
+
+        result = self._teardown(ticket, force=True)
+
+        assert result.ok is True, result.detail
+        assert not self.wt_path.exists()

--- a/tests/teatree_core/test_runners_teardown.py
+++ b/tests/teatree_core/test_runners_teardown.py
@@ -6,7 +6,10 @@ enqueues teardown I/O (worktree removal, branch deletion, DB drop) onto a
 the ticket is ready for ``retrospect()``.
 """
 
+import shutil
+import subprocess
 from collections.abc import Iterator
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -16,6 +19,8 @@ from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import reset_overlay_cache
 from teatree.core.runners import WorktreeTeardown
 from tests.teatree_core.conftest import CommandOverlay
+
+_GIT = shutil.which("git") or "git"
 
 
 @pytest.fixture(autouse=True)
@@ -55,8 +60,8 @@ class TestWorktreeTeardown(TestCase):
 
         cleaned: list[str] = []
 
-        def fake_cleanup(worktree: Worktree, *, force: bool = False) -> str:
-            del force
+        def fake_cleanup(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> str:
+            del force, strict_hygiene
             label = f"Cleaned: {worktree.repo_path}"
             cleaned.append(worktree.repo_path)
             worktree.delete()
@@ -75,8 +80,8 @@ class TestWorktreeTeardown(TestCase):
     def test_continues_on_individual_failure_and_reports_errors(self) -> None:
         ticket = self._ticket_with_worktrees(count=2)
 
-        def fake_cleanup(worktree: Worktree, *, force: bool = False) -> str:
-            del force
+        def fake_cleanup(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> str:
+            del force, strict_hygiene
             if worktree.repo_path == "repo-0":
                 msg = "branch ahead of main"
                 raise RuntimeError(msg)
@@ -94,3 +99,118 @@ class TestWorktreeTeardown(TestCase):
         assert "branch ahead of main" in result.detail
         # repo-1 cleaned even though repo-0 raised
         assert ticket.worktrees.filter(repo_path="repo-1").count() == 0
+
+
+def _run_git(*args: str, cwd: Path) -> None:
+    subprocess.run([_GIT, "-C", str(cwd), *args], check=True, capture_output=True)
+
+
+class TestWorktreeTeardownUnpushedGuard(TestCase):
+    """#706 — the automated teardown path must NOT destroy unpushed work.
+
+    ``execute_teardown`` (django-task) → ``WorktreeTeardown`` →
+    ``cleanup_worktree``. The FSM can read MERGED while the branch was never
+    actually pushed (async ship never drained). This exercises the *real*
+    git path that physically deleted two worktree dirs in the wild, with a
+    bare remote standing in for ``origin``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.workspace = tmp_path / "workspace"
+        self.workspace.mkdir()
+        # Bare repo acts as the shared remote (origin).
+        self.remote = tmp_path / "remote.git"
+        self.remote.mkdir()
+        _run_git("init", "-q", "--bare", "-b", "main", cwd=self.remote)
+
+        self.repo_main = self.workspace / "myrepo"
+        self.repo_main.mkdir()
+        _run_git("init", "-q", "-b", "main", cwd=self.repo_main)
+        _run_git("config", "user.email", "t@t", cwd=self.repo_main)
+        _run_git("config", "user.name", "t", cwd=self.repo_main)
+        _run_git("remote", "add", "origin", str(self.remote), cwd=self.repo_main)
+        _run_git("commit", "--allow-empty", "-q", "-m", "initial", cwd=self.repo_main)
+        _run_git("push", "-q", "origin", "main", cwd=self.repo_main)
+        _run_git("fetch", "-q", "origin", cwd=self.repo_main)
+
+        self.branch = "ac-myrepo-706-x"
+        self.wt_path = self.workspace / self.branch / "myrepo"
+        _run_git("worktree", "add", "-q", "-b", self.branch, str(self.wt_path), cwd=self.repo_main)
+
+    def _commit_in_worktree(self, message: str) -> None:
+        (self.wt_path / "file.txt").write_text(message, encoding="utf-8")
+        _run_git("add", "file.txt", cwd=self.wt_path)
+        _run_git("config", "user.email", "t@t", cwd=self.wt_path)
+        _run_git("config", "user.name", "t", cwd=self.wt_path)
+        _run_git("commit", "-q", "-m", message, cwd=self.wt_path)
+
+    def _ticket_with_worktree(self) -> Ticket:
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/706",
+            state=Ticket.State.MERGED,
+        )
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="myrepo",
+            branch=self.branch,
+            extra={"worktree_path": str(self.wt_path)},
+        )
+        return ticket
+
+    def _teardown(self, ticket: Ticket, **kwargs: bool) -> object:
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.cleanup.load_config") as mock_config,
+            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+        ):
+            mock_config.return_value.user.workspace_dir = self.workspace
+            mock_overlay.return_value.get_cleanup_steps.return_value = []
+            return WorktreeTeardown(ticket, **kwargs).run()
+
+    def test_refuses_to_remove_worktree_with_unpushed_commits(self) -> None:
+        """The session-destroying scenario: branch has commits on NO remote."""
+        ticket = self._ticket_with_worktree()
+        self._commit_in_worktree("unpushed work")
+
+        result = self._teardown(ticket)
+
+        assert result.ok is False
+        assert self.branch in result.detail
+        assert "on NO remote" in result.detail
+        assert "data loss" in result.detail
+        assert self.wt_path.exists(), "worktree with unpushed commits was destroyed"
+        assert Worktree.objects.filter(branch=self.branch).exists()
+
+    def test_proceeds_when_branch_fully_pushed(self) -> None:
+        """A branch whose HEAD is on a remote ref is safe to tear down."""
+        ticket = self._ticket_with_worktree()
+        self._commit_in_worktree("pushed work")
+        _run_git("push", "-q", "origin", self.branch, cwd=self.wt_path)
+        _run_git("fetch", "-q", "origin", cwd=self.repo_main)
+
+        result = self._teardown(ticket)
+
+        assert result.ok is True, result.detail
+        assert not self.wt_path.exists()
+
+    def test_force_overrides_the_guard(self) -> None:
+        """An explicit force escape hatch tears down even unpushed work."""
+        ticket = self._ticket_with_worktree()
+        self._commit_in_worktree("unpushed but force")
+
+        result = self._teardown(ticket, force=True)
+
+        assert result.ok is True, result.detail
+        assert not self.wt_path.exists()
+
+    def test_no_extra_commits_proceeds(self) -> None:
+        """A worktree with no commits beyond the pushed base is safe."""
+        ticket = self._ticket_with_worktree()
+
+        result = self._teardown(ticket)
+
+        assert result.ok is True, result.detail
+        assert not self.wt_path.exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1268,3 +1268,76 @@ class TestUnsyncedCommits:
         result = git.unsynced_commits(str(local), "feature")
         assert len(result) == 1
         assert "feature work" in result[0]
+
+
+class TestCommitsAbsentFromAllRemotes:
+    """#706 data-loss guard helper — commits reachable from no remote ref."""
+
+    def test_returns_empty_when_nothing_unpushed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            utils_run_mod.subprocess,
+            "run",
+            lambda *_a, **_k: CompletedProcess([], 0, stdout="", stderr=""),
+        )
+        assert git.commits_absent_from_all_remotes("/repo", "feature") == []
+
+    def test_returns_lines_and_filters_blanks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        output = "abc123 unpushed work\n\n   \ndef456 more local\n"
+        monkeypatch.setattr(
+            utils_run_mod.subprocess,
+            "run",
+            lambda *_a, **_k: CompletedProcess([], 0, stdout=output, stderr=""),
+        )
+        assert git.commits_absent_from_all_remotes("/repo", "feature") == [
+            "abc123 unpushed work",
+            "def456 more local",
+        ]
+
+    def test_pushed_branch_not_on_main_is_considered_safe(self, tmp_path: Path) -> None:
+        """A pushed-but-unmerged branch has nothing absent from all remotes.
+
+        The work survives on its own remote ref, so teardown is safe. This is
+        the inverse of ``unsynced_commits`` and the reason #706 needs a
+        distinct helper.
+        """
+        bare = tmp_path / "remote.git"
+        utils_run_mod.run_checked(["git", "init", "--bare", str(bare)])
+        local = tmp_path / "local"
+        utils_run_mod.run_checked(["git", "clone", str(bare), str(local)])
+        for k, v in {"user.email": "t@x", "user.name": "t", "commit.gpgsign": "false"}.items():
+            utils_run_mod.run_checked(["git", "-C", str(local), "config", k, v])
+        (local / "a").write_text("1\n")
+        utils_run_mod.run_checked(["git", "-C", str(local), "add", "a"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "commit", "-m", "main commit"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "branch", "-M", "main"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "push", "origin", "main"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "checkout", "-b", "feature"])
+        (local / "b").write_text("2\n")
+        utils_run_mod.run_checked(["git", "-C", str(local), "add", "b"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "commit", "-m", "feature work"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "push", "origin", "feature"])
+
+        # Pushed → reachable from refs/remotes/origin/feature → nothing absent.
+        assert git.commits_absent_from_all_remotes(str(local), "feature") == []
+
+    def test_local_only_commit_is_flagged(self, tmp_path: Path) -> None:
+        """A commit that was never pushed anywhere is reported (data loss risk)."""
+        bare = tmp_path / "remote.git"
+        utils_run_mod.run_checked(["git", "init", "--bare", str(bare)])
+        local = tmp_path / "local"
+        utils_run_mod.run_checked(["git", "clone", str(bare), str(local)])
+        for k, v in {"user.email": "t@x", "user.name": "t", "commit.gpgsign": "false"}.items():
+            utils_run_mod.run_checked(["git", "-C", str(local), "config", k, v])
+        (local / "a").write_text("1\n")
+        utils_run_mod.run_checked(["git", "-C", str(local), "add", "a"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "commit", "-m", "main commit"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "branch", "-M", "main"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "push", "origin", "main"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "checkout", "-b", "feature"])
+        (local / "b").write_text("2\n")
+        utils_run_mod.run_checked(["git", "-C", str(local), "add", "b"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "commit", "-m", "never pushed"])
+
+        result = git.commits_absent_from_all_remotes(str(local), "feature")
+        assert len(result) == 1
+        assert "never pushed" in result[0]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1341,3 +1341,34 @@ class TestCommitsAbsentFromAllRemotes:
         result = git.commits_absent_from_all_remotes(str(local), "feature")
         assert len(result) == 1
         assert "never pushed" in result[0]
+
+    def test_git_error_raises_instead_of_returning_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """#706 fail-closed on a non-zero git exit.
+
+        A git error must NOT be read as "nothing unpushed" — it raises so the
+        data-loss guard refuses teardown.
+        """
+        monkeypatch.setattr(
+            utils_run_mod.subprocess,
+            "run",
+            lambda *_a, **_k: CompletedProcess([], 128, stdout="", stderr="fatal: bad revision"),
+        )
+        with pytest.raises(utils_run_mod.CommandFailedError):
+            git.commits_absent_from_all_remotes("/repo", "feature")
+
+    def test_missing_branch_raises_not_silently_empty(self, tmp_path: Path) -> None:
+        """An unknown branch makes ``git log`` exit 128 → must raise, not return []."""
+        bare = tmp_path / "remote.git"
+        utils_run_mod.run_checked(["git", "init", "--bare", str(bare)])
+        local = tmp_path / "local"
+        utils_run_mod.run_checked(["git", "clone", str(bare), str(local)])
+        for k, v in {"user.email": "t@x", "user.name": "t", "commit.gpgsign": "false"}.items():
+            utils_run_mod.run_checked(["git", "-C", str(local), "config", k, v])
+        (local / "a").write_text("1\n")
+        utils_run_mod.run_checked(["git", "-C", str(local), "add", "a"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "commit", "-m", "main commit"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "branch", "-M", "main"])
+        utils_run_mod.run_checked(["git", "-C", str(local), "push", "origin", "main"])
+
+        with pytest.raises(utils_run_mod.CommandFailedError):
+            git.commits_absent_from_all_remotes(str(local), "does-not-exist")


### PR DESCRIPTION
## The bug

Worktree teardown deleted worktrees based on FSM state rather than git reality. A worktree carrying commits that existed on **no remote** could be physically removed, destroying unpushed work. This actually happened twice in one session: two worktrees with local-only commits were torn down and lost.

## The fix

- Single guarded seam `_remove_git_worktree` — all FSM-driven worktree removal now flows through it.
- New `commits_absent_from_all_remotes` probe (uses `run_strict`) checks git reality (`--not --remotes`) instead of trusting FSM state.
- `_raise_if_unpushed` fails **closed**: if the probe itself errors, teardown is refused rather than assumed safe.
- `force` / `--force` escape hatch for the deliberate-deletion case.
- The automated FSM path applies the data-loss guard only; strict origin/main hygiene is retained for sync backends and `clean-all`.

## Test evidence

- 3309 passed, 12 skipped
- `ruff`, `ty`, format: clean
- 100% coverage on new code
- Independently reviewed: SHIP WITH NITS — both nits fixed (fail-closed hardening + docstring/scope correction)

Fixes [#706](https://github.com/souliane/teatree/issues/706)
