### PR TITLE
docs(rules): add Re-Derive the Minimal Blocker guardrail

### DIFF
--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -74,6 +74,7 @@ Use `Ctrl+F`/`grep` to jump to a rule. Sections are grouped below by theme; numb
 36. [Run Retro Before Ending Non-Trivial Sessions](#run-retro-before-ending-non-trivial-sessions)
 37. [Commit Before Declaring Done](#commit-before-declaring-done-non-negotiable)
 38. [Pre-Commit Hook Failures on Unrelated Tests](#pre-commit-hook-failures-on-unrelated-tests)
+38a. [Re-Derive the Minimal Blocker](#re-derive-the-minimal-blocker)
 
 **Design principles**
 
@@ -166,6 +167,10 @@ When the auto-mode classifier denies a tool call (Bash command rejected, MCP cal
 - Teatree (this skill, BLUEPRINT, plugin `settings.json`) defines the _protocol_. Teatree never relaxes permissions on the user's behalf.
 - The agent **attempts** the edit to `~/.claude/settings.json` (user scope) directly — that's the path with zero manual steps for the user. Many users have a standing authorization for this in their `autoMode.allow`. The agent only falls back to handing over a paste-ready snippet **after** the harness self-modification guardrail blocks the write — never as the default path. The snippet is the manual fallback, not the primary mechanism.
 - Plugin-distributed permissions (`plugins/t3/settings.json`, `CLAUDE.md` standing clauses) are **never** the right place to relax for a single workflow — that would grant the standing right to every user of the plugin. Refuse if asked to do this; explain that user-scope `settings.json` is the right knob.
+
+## Re-Derive the Minimal Blocker
+
+When an operation is blocked — a classifier denial, a failing gate, an external or human-gated wait — re-derive the **minimal** set of work that genuinely depends on that exact operation before declaring anything else blocked. A blocked merge does not block PR creation, implementation, review, or research; a blocked deploy does not block the next feature. Before reporting "nothing actionable", ask of each pending task: does it consume the blocked operation's output, or does it merely share a goal (or sit later in the same chain) reachable by a different, available path? Reporting "nothing actionable" for two or more cycles behind a single external block is itself the signal to audit for a non-blocked path rather than continue idling. This complements the Classifier Denial Protocol (which governs the denied operation itself); this rule governs not over-propagating that block to independent work.
 
 ## Context Transparency
 


### PR DESCRIPTION
## Summary

Adds one cross-cutting reasoning guardrail to the `t3:rules` core skill: **Re-Derive the Minimal Blocker**.

When an operation is blocked (classifier denial, failing gate, external/human-gated wait), re-derive the minimal set of work that genuinely depends on that exact operation before declaring anything else blocked. Prevents over-propagating a single block to independent work (PR creation, implementation, review, research). Complements the existing Classifier Denial Protocol.

## Changes

- New section `## Re-Derive the Minimal Blocker` in `skills/rules/SKILL.md`, placed adjacent to the Classifier Denial Protocol it complements.
- One navigational Index entry (`38a.`) under the "Workflow discipline" group, following the existing non-sequential-suffix convention.

## Test plan

- [x] `prek run --files skills/rules/SKILL.md` — all hooks pass, including skill-prose-ban (#140)
- [x] Privacy scan clean