### PR TITLE
feat(ticket): add comment command to post issue/work-item comments

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -142,7 +142,7 @@ src/teatree/
       run.py            # Service runner
       followup.py       # PR sync (GitHub + GitLab via CodeHostBackend)
       pr.py             # PR creation and validation
-      ticket.py         # Ticket transitions and queries
+      ticket.py         # Ticket transitions, queries, and tracker comments
       tool.py           # Overlay-declared tool subcommands
       e2e.py            # `e2e run|external|project`
       loop_tick.py      # One tick of the fat loop (scan, dispatch, statusline)
@@ -865,7 +865,7 @@ Internal utilities (`utils/`) — port allocation, git helpers, DB ops — are P
 **env** — Read/write the env cache (`set`, `show`, `check`, `migrate-secrets`). `migrate-secrets` moves any `POSTGRES_PASSWORD=<literal>` line out of `.t3-env.cache` into the local `pass` store under `teatree/wt/<ticket_id>/postgres` so the on-disk cache only carries the symbolic `POSTGRES_PASSWORD_PASS_KEY` reference.
 **run** — Service runner (uses `lifecycle.compose_project()` shared helper)
 **pr** — PR creation and validation
-**ticket** — Ticket transitions and queries (`list`, `transition`, ...)
+**ticket** — Ticket transitions and queries (`list`, `transition`, `sync-completions`, `comment`). `comment <issue_url> --body/--body-file` posts a tracker comment via the per-URL `CodeHostBackend` (GitLab issues + work items, GitHub issues).
 **tool** — Overlay-declared tool subcommands (declared via `OverlayBase.get_tool_commands()`)
 **e2e** — `e2e run|external|project` (Playwright dispatcher)
 **overlay** — Overlay inspection (`config`, `info`)

--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -349,6 +349,25 @@ class GitHubCodeHost:
         data = _gh_api_get(endpoint, token=self._token)
         return cast("RawAPIDict", data) if isinstance(data, dict) else {"error": f"Issue not found: {issue_url}"}
 
+    def post_issue_comment(self, *, issue_url: str, body: str) -> RawAPIDict:
+        """Post a comment to a GitHub issue.
+
+        Supports ``https://github.com/<owner>/<repo>/issues/<number>``.
+        Returns ``{"error": ...}`` when the URL is not a recognised GitHub
+        issue URL.
+        """
+        path = urlparse(issue_url).path
+        match = _ISSUE_URL_RE.match(path)
+        if match is None:
+            return {"error": f"Not a GitHub issue URL: {issue_url}"}
+
+        data = _gh_api_post(
+            f"repos/{match['owner']}/{match['repo']}/issues/{match['number']}/comments",
+            {"body": body},
+            token=self._token,
+        )
+        return cast("RawAPIDict", data) if isinstance(data, dict) else {}
+
     def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState:
         """Return *reviewer*'s current review state on the PR at *pr_url*.
 

--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -10,6 +10,9 @@ from teatree.types import RawAPIDict
 
 _ISSUE_URL_RE = re.compile(r"^/(?P<path>.+?)/-/issues/(?P<iid>\d+)/?$")
 _MR_URL_RE = re.compile(r"^/(?P<path>.+?)/-/merge_requests/(?P<iid>\d+)/?$")
+# GitLab serves the same iid under both /-/issues/<iid> and /-/work_items/<iid>;
+# the notes API endpoint is identical for either.
+_ISSUE_OR_WORKITEM_URL_RE = re.compile(r"^/(?P<path>.+?)/-/(?:issues|work_items)/(?P<iid>\d+)/?$")
 
 
 class _GitLabUser(TypedDict, total=False):
@@ -180,6 +183,32 @@ class GitLabCodeHost:
 
         issue = self._client.get_issue(project.project_id, int(match["iid"]))
         return issue if isinstance(issue, dict) else {"error": f"Issue not found: {issue_url}"}
+
+    def post_issue_comment(self, *, issue_url: str, body: str) -> RawAPIDict:
+        """Post a comment to a GitLab issue or work item.
+
+        Accepts the canonical web formats
+        ``https://gitlab.example.com/<group>/<repo>/-/issues/<iid>`` and
+        ``…/-/work_items/<iid>`` (GitLab exposes the same iid under both).
+        Returns ``{"error": ...}`` when the URL is not a recognised GitLab
+        issue URL or when the project cannot be resolved.
+        """
+        path = urlparse(issue_url).path
+        match = _ISSUE_OR_WORKITEM_URL_RE.match(path)
+        if match is None:
+            return {"error": f"Not a GitLab issue URL: {issue_url}"}
+
+        project = self._client.resolve_project(match["path"])
+        if project is None:
+            return {"error": f"Could not resolve project: {match['path']}"}
+
+        return (
+            self._client.post_json(
+                f"projects/{project.project_id}/issues/{int(match['iid'])}/notes",
+                {"body": body},
+            )
+            or {}
+        )
 
     def _resolve_project(self, repo: str) -> ProjectInfo | None:
         """Resolve a GitLab project from a local path, ``namespace/repo`` slug, or bare name.

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -100,6 +100,8 @@ class CodeHostBackend(Protocol):
 
     def get_issue(self, issue_url: str) -> RawAPIDict: ...  # pragma: no branch
 
+    def post_issue_comment(self, *, issue_url: str, body: str) -> RawAPIDict: ...  # pragma: no branch
+
     def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]: ...  # pragma: no branch
 
 

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -19,6 +19,12 @@ class CompletionResult(TypedDict, total=False):
     action: str
 
 
+class CommentResult(TypedDict, total=False):
+    issue_url: str
+    comment_id: int
+    error: str
+
+
 logger = logging.getLogger(__name__)
 
 _ALLOWED_TRANSITIONS = {
@@ -66,6 +72,48 @@ class Command(TyperCommand):
             }
 
         return {"ticket_id": int(ticket.pk), "state": ticket.state}
+
+    @command()
+    def comment(
+        self,
+        issue_url: str,
+        *,
+        body: Annotated[str, typer.Option(help="Comment body text.")] = "",
+        body_file: Annotated[str, typer.Option(help="Path to a file containing the comment body.")] = "",
+    ) -> CommentResult:
+        """Post a comment to an issue or work item by its URL.
+
+        Resolves the code host per-URL across all registered overlays, so it
+        works for any tracker an overlay is configured for (GitLab issues and
+        work items, GitHub issues). Pass the body inline with ``--body`` or
+        from a file with ``--body-file``.
+        """
+        from pathlib import Path  # noqa: PLC0415
+
+        from teatree.backends.loader import get_code_host_for_url  # noqa: PLC0415
+        from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+
+        text = Path(body_file).read_text(encoding="utf-8") if body_file else body
+        if not text:
+            return {"error": "No comment body: pass --body or --body-file"}
+
+        for overlay in get_all_overlays().values():
+            host = get_code_host_for_url(overlay, issue_url)
+            if host is None:
+                continue
+            raw = host.post_issue_comment(issue_url=issue_url, body=text)
+            error = raw.get("error") if isinstance(raw, dict) else None
+            if error:
+                self.stdout.write(f"  failed: {error}")
+                return {"error": str(error)}
+            comment_id = raw.get("id") if isinstance(raw, dict) else None
+            self.stdout.write(f"  commented on {issue_url}")
+            return {
+                "issue_url": issue_url,
+                "comment_id": comment_id if isinstance(comment_id, int) else 0,
+            }
+
+        return {"error": f"No code host could be resolved for {issue_url}"}
 
     @command(name="list")
     def list_tickets(self, state: str = "", overlay: str = "") -> list[dict[str, object]]:

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -354,3 +354,84 @@ def test_get_review_state_returns_none_when_reviewer_empty() -> None:
         == ReviewState.NONE
     )
     client.resolve_project.assert_not_called()
+
+
+def test_post_issue_comment_posts_to_issue_notes_endpoint() -> None:
+    """post_issue_comment posts the body to the issue notes endpoint."""
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.post_json.return_value = {"id": 555}
+    host = GitLabCodeHost(client=client)
+
+    result = host.post_issue_comment(
+        issue_url="https://gitlab.com/org/repo/-/issues/7",
+        body="A clarifying question",
+    )
+
+    assert result == {"id": 555}
+    client.resolve_project.assert_called_once_with("org/repo")
+    client.post_json.assert_called_once_with(
+        "projects/42/issues/7/notes",
+        {"body": "A clarifying question"},
+    )
+
+
+def test_post_issue_comment_supports_work_items_url() -> None:
+    """GitLab serves the same iid under /-/work_items/<iid>; it must work too."""
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.post_json.return_value = {"id": 1}
+    host = GitLabCodeHost(client=client)
+
+    result = host.post_issue_comment(
+        issue_url="https://gitlab.com/group/sub/repo/-/work_items/469",
+        body="note",
+    )
+
+    assert result == {"id": 1}
+    client.resolve_project.assert_called_once_with("group/sub/repo")
+    client.post_json.assert_called_once_with(
+        "projects/42/issues/469/notes",
+        {"body": "note"},
+    )
+
+
+def test_post_issue_comment_rejects_non_issue_url() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    host = GitLabCodeHost(client=client)
+
+    result = host.post_issue_comment(
+        issue_url="https://gitlab.com/org/repo/-/merge_requests/12",
+        body="note",
+    )
+
+    assert result == {"error": "Not a GitLab issue URL: https://gitlab.com/org/repo/-/merge_requests/12"}
+    client.post_json.assert_not_called()
+
+
+def test_post_issue_comment_returns_error_when_project_not_resolved() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = None
+    host = GitLabCodeHost(client=client)
+
+    result = host.post_issue_comment(
+        issue_url="https://gitlab.com/org/repo/-/issues/7",
+        body="note",
+    )
+
+    assert result == {"error": "Could not resolve project: org/repo"}
+    client.post_json.assert_not_called()
+
+
+def test_post_issue_comment_returns_empty_dict_when_post_returns_none() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.post_json.return_value = None
+    host = GitLabCodeHost(client=client)
+
+    result = host.post_issue_comment(
+        issue_url="https://gitlab.com/org/repo/-/issues/7",
+        body="note",
+    )
+
+    assert result == {}

--- a/tests/teatree_backends/test_protocols.py
+++ b/tests/teatree_backends/test_protocols.py
@@ -78,6 +78,10 @@ class _FakeCodeHost:
         _ = issue_url
         return {}
 
+    def post_issue_comment(self, *, issue_url: str, body: str) -> dict[str, object]:
+        _ = (issue_url, body)
+        return {}
+
     def list_assigned_issues(self, *, assignee: str) -> list[dict[str, object]]:
         _ = assignee
         return []

--- a/tests/teatree_core/test_ticket_comment_command.py
+++ b/tests/teatree_core/test_ticket_comment_command.py
@@ -1,0 +1,104 @@
+"""`t3 ticket comment` — post a comment to an issue/work-item from the CLI."""
+
+from collections.abc import Iterator
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.backends import loader as loader_mod
+from teatree.core import overlay_loader as overlay_loader_mod
+from teatree.core.overlay_loader import reset_overlay_cache
+from tests.teatree_core.conftest import CommandOverlay
+
+
+@pytest.fixture(autouse=True)
+def clear_overlay_cache() -> Iterator[None]:
+    reset_overlay_cache()
+    yield
+    reset_overlay_cache()
+
+
+_MOCK_OVERLAY = {"test": CommandOverlay()}
+_ISSUE_URL = "https://gitlab.com/org/repo/-/work_items/469"
+
+
+class TicketCommentCommandTest(TestCase):
+    def test_posts_body_via_resolved_code_host(self) -> None:
+        host = MagicMock()
+        host.post_issue_comment.return_value = {"id": 4242}
+
+        with (
+            patch.object(overlay_loader_mod, "get_all_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(loader_mod, "get_code_host_for_url", return_value=host),
+        ):
+            result = cast(
+                "dict[str, object]",
+                call_command("ticket", "comment", _ISSUE_URL, body="A clarifying question"),
+            )
+
+        assert result == {"issue_url": _ISSUE_URL, "comment_id": 4242}
+        host.post_issue_comment.assert_called_once_with(
+            issue_url=_ISSUE_URL,
+            body="A clarifying question",
+        )
+
+
+class TicketCommentBodyFileTest(TestCase):
+    def test_reads_body_from_file(self) -> None:
+        import tempfile  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
+
+        host = MagicMock()
+        host.post_issue_comment.return_value = {"id": 1}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            body_path = Path(tmp) / "comment.md"
+            body_path.write_text("From a file\n", encoding="utf-8")
+
+            with (
+                patch.object(overlay_loader_mod, "get_all_overlays", return_value=_MOCK_OVERLAY),
+                patch.object(loader_mod, "get_code_host_for_url", return_value=host),
+            ):
+                call_command("ticket", "comment", _ISSUE_URL, body_file=str(body_path))
+
+        host.post_issue_comment.assert_called_once_with(
+            issue_url=_ISSUE_URL,
+            body="From a file\n",
+        )
+
+
+class TicketCommentErrorTest(TestCase):
+    def test_errors_when_no_body_supplied(self) -> None:
+        with patch.object(overlay_loader_mod, "get_all_overlays", return_value=_MOCK_OVERLAY):
+            result = cast(
+                "dict[str, object]",
+                call_command("ticket", "comment", _ISSUE_URL),
+            )
+        assert result == {"error": "No comment body: pass --body or --body-file"}
+
+    def test_errors_when_no_code_host_resolves(self) -> None:
+        with (
+            patch.object(overlay_loader_mod, "get_all_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(loader_mod, "get_code_host_for_url", return_value=None),
+        ):
+            result = cast(
+                "dict[str, object]",
+                call_command("ticket", "comment", _ISSUE_URL, body="hi"),
+            )
+        assert result == {"error": f"No code host could be resolved for {_ISSUE_URL}"}
+
+    def test_propagates_code_host_error(self) -> None:
+        host = MagicMock()
+        host.post_issue_comment.return_value = {"error": "Could not resolve project: org/repo"}
+        with (
+            patch.object(overlay_loader_mod, "get_all_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(loader_mod, "get_code_host_for_url", return_value=host),
+        ):
+            result = cast(
+                "dict[str, object]",
+                call_command("ticket", "comment", _ISSUE_URL, body="hi"),
+            )
+        assert result == {"error": "Could not resolve project: org/repo"}


### PR DESCRIPTION
## Summary

Adds a `t3 ticket comment <issue_url> --body/--body-file` CLI command so agents can post tracker comments through the CLI instead of shelling out to `glab`/`gh`.

- New `CodeHost.post_issue_comment(*, issue_url, body)` protocol method.
- GitLab implementation accepts both `/-/issues/<iid>` and `/-/work_items/<iid>` URLs (same underlying notes endpoint).
- GitHub implementation posts to `repos/<owner>/<repo>/issues/<n>/comments`.
- The command resolves the code host per-URL across all registered overlays (same pattern as `sync-completions`), reads the body inline or from a file, and returns a typed `CommentResult`.

## Tests

TDD throughout. New: GitLab host (5), GitHub parity via protocol, ticket command (5 incl. body-file + error paths), protocol conformance updated. `tests/teatree_backends/ + ticket command + management commands`: **451 passed, 12 skipped**. Lint + format clean. BLUEPRINT.md updated.

## Motivation

While debugging an external GitLab work item I needed to post a clarification comment from the CLI; no command existed. This fills that gap.