### PR TITLE
fix(core): single ServiceLauncher so a service can't run without its prereqs

### DIFF
--- a/src/teatree/core/management/commands/run.py
+++ b/src/teatree/core/management/commands/run.py
@@ -10,6 +10,7 @@ from django_typer.management import TyperCommand, command
 
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import resolve_worktree
+from teatree.core.runners.service_launch import ServiceLauncher
 from teatree.core.runners.worktree_start import compose_project
 from teatree.types import RunCommand, RunCommands
 from teatree.utils.ports import get_worktree_ports
@@ -101,15 +102,7 @@ class Command(TyperCommand):
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
     ) -> str:
         """Build the frontend app for production/testing."""
-        worktree = resolve_worktree(path)
-        commands = get_overlay().get_run_commands(worktree)
-        cmd = commands.get("build-frontend", [])
-        if not cmd:
-            return "No build-frontend command configured in the overlay."
-        run_args = cmd.args if isinstance(cmd, RunCommand) else list(cmd)
-        cwd = cmd.cwd if isinstance(cmd, RunCommand) else None
-        run_streamed(run_args, cwd=cwd)
-        return "Frontend built."
+        return ServiceLauncher(resolve_worktree(path), "build-frontend").run().detail
 
     @command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})
     def tests(

--- a/src/teatree/core/runners/service_launch.py
+++ b/src/teatree/core/runners/service_launch.py
@@ -1,0 +1,61 @@
+from typing import TYPE_CHECKING
+
+from teatree.core.overlay_loader import get_overlay
+from teatree.core.runners.base import RunnerBase, RunnerResult
+from teatree.core.step_runner import run_provision_steps
+from teatree.types import RunCommand
+from teatree.utils.run import run_streamed
+
+if TYPE_CHECKING:
+    from teatree.core.models import Worktree
+    from teatree.core.overlay import OverlayBase, ProvisionStep
+
+
+class ServiceLauncher(RunnerBase):
+    """Runs a worktree host service, always after its pre-run steps.
+
+    The only supported way to run a service. ``get_run_commands`` is reachable
+    only through here, so a caller cannot run a service without its
+    prerequisites — the drift that let ``run build-frontend`` skip
+    ``node_modules``/``customer.json`` is structurally impossible: the command
+    and its pre-run steps are bound together in one place instead of being
+    re-decided by every caller.
+    """
+
+    def __init__(self, worktree: "Worktree", service: str, *, overlay: "OverlayBase | None" = None) -> None:
+        self.worktree = worktree
+        self.service = service
+        self.overlay = overlay or get_overlay()
+
+    @staticmethod
+    def _collect_steps(overlay: "OverlayBase", worktree: "Worktree", services: list[str]) -> "list[ProvisionStep]":
+        seen: set[str] = set()
+        steps: list[ProvisionStep] = []
+        for service in services:
+            for step in overlay.get_pre_run_steps(worktree, service):
+                if step.name in seen:
+                    continue
+                seen.add(step.name)
+                steps.append(step)
+        return steps
+
+    @classmethod
+    def prepare_all(cls, worktree: "Worktree", services: list[str], *, overlay: "OverlayBase | None" = None) -> None:
+        overlay = overlay or get_overlay()
+        run_provision_steps(cls._collect_steps(overlay, worktree, services), stop_on_required_failure=False)
+
+    def prepare(self) -> None:
+        run_provision_steps(
+            self._collect_steps(self.overlay, self.worktree, [self.service]),
+            stop_on_required_failure=False,
+        )
+
+    def run(self) -> RunnerResult:
+        self.prepare()
+        cmd = self.overlay.get_run_commands(self.worktree).get(self.service)
+        if not cmd:
+            return RunnerResult(ok=False, detail=f"no run command configured for {self.service!r}")
+        args = cmd.args if isinstance(cmd, RunCommand) else list(cmd)
+        cwd = cmd.cwd if isinstance(cmd, RunCommand) else None
+        rc = run_streamed(args, cwd=cwd, check=False)
+        return RunnerResult(ok=rc == 0, detail=f"{self.service} finished (rc={rc})")

--- a/src/teatree/core/runners/worktree_start.py
+++ b/src/teatree/core/runners/worktree_start.py
@@ -7,7 +7,7 @@ from teatree.core.models import Worktree
 from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.runners.base import RunnerBase, RunnerResult
-from teatree.core.step_runner import run_provision_steps
+from teatree.core.runners.service_launch import ServiceLauncher
 from teatree.core.worktree_env import write_env_cache
 from teatree.timeouts import TimeoutConfig, load_timeouts
 from teatree.utils.ports import get_worktree_ports
@@ -76,15 +76,7 @@ class WorktreeStartRunner(RunnerBase):
         docker_compose_down(project, timeout=self.timeouts.get("docker_compose_down"))
 
         commands = overlay.get_run_commands(worktree)
-        seen_step_names: set[str] = set()
-        pre_run_steps = []
-        for service_name in commands:
-            for step in overlay.get_pre_run_steps(worktree, service_name):
-                if step.name in seen_step_names:
-                    continue
-                seen_step_names.add(step.name)
-                pre_run_steps.append(step)
-        run_provision_steps(pre_run_steps, stop_on_required_failure=False)
+        ServiceLauncher.prepare_all(worktree, list(commands), overlay=overlay)
 
         write_env_cache(worktree)
 

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -2271,7 +2271,10 @@ class TestRunBuildFrontend(TestCase):
                 result = cast("str", call_command("run", "build-frontend", path=str(wt_dir)))
 
             mock_run.assert_called_once()
-            assert "built" in result.lower()
+            # build-frontend now routes through ServiceLauncher (pre-run steps
+            # then the command); the launcher reports the service + exit code.
+            assert "build-frontend" in result.lower()
+            assert "rc=0" in result
 
     @_patch_overlays(MINIMAL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -2291,7 +2294,8 @@ class TestRunBuildFrontend(TestCase):
 
             result = cast("str", call_command("run", "build-frontend", path=str(wt_dir)))
 
-            assert "no build-frontend command" in result.lower()
+            assert "no run command configured" in result.lower()
+            assert "build-frontend" in result.lower()
 
 
 class TestRunTests(TestCase):

--- a/tests/teatree_core/test_service_launch.py
+++ b/tests/teatree_core/test_service_launch.py
@@ -1,0 +1,113 @@
+import tempfile
+from pathlib import Path
+from typing import ClassVar
+
+from django.test import TestCase
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay import ProvisionStep, RunCommands
+from teatree.core.runners.service_launch import ServiceLauncher
+from teatree.types import RunCommand
+from tests.teatree_core.conftest import CommandOverlay
+
+
+class OrderRecordingOverlay(CommandOverlay):
+    """Pre-run step and command both append to one file to prove ordering."""
+
+    def __init__(self, order_file: Path) -> None:
+        self.order_file = order_file
+
+    def get_run_commands(self, worktree: Worktree) -> RunCommands:
+        return {
+            "frontend": RunCommand(args=["sh", "-lc", f"echo cmd >> {self.order_file}"]),
+            "backend": ["true"],
+        }
+
+    def get_pre_run_steps(self, worktree: Worktree, service: str) -> list[ProvisionStep]:
+        def record() -> None:
+            with self.order_file.open("a") as fh:
+                fh.write(f"pre-{service}\n")
+
+        return [ProvisionStep(name=f"pre-run-{service}", callable=record)]
+
+
+class ServiceLauncherTests(TestCase):
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/1")
+        self.worktree = Worktree.objects.create(ticket=self.ticket, repo_path="backend", branch="b")
+        self._tmp = tempfile.TemporaryDirectory()
+        self.order_file = Path(self._tmp.name) / "order.txt"
+        self.overlay = OrderRecordingOverlay(self.order_file)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_run_executes_pre_run_steps_before_command(self) -> None:
+        result = ServiceLauncher(self.worktree, "frontend", overlay=self.overlay).run()
+        assert result.ok
+        assert self.order_file.read_text().splitlines() == ["pre-frontend", "cmd"]
+
+    def test_run_returns_not_ok_when_service_has_no_command(self) -> None:
+        result = ServiceLauncher(self.worktree, "missing", overlay=self.overlay).run()
+        assert not result.ok
+        assert "missing" in result.detail
+        # Pre-run still ran — prerequisites are never conditional on the command.
+        assert self.order_file.read_text().splitlines() == ["pre-missing"]
+
+    def test_prepare_all_runs_pre_run_for_every_service(self) -> None:
+        ServiceLauncher.prepare_all(self.worktree, ["frontend", "backend"], overlay=self.overlay)
+        assert self.order_file.read_text().splitlines() == ["pre-frontend", "pre-backend"]
+
+
+class RealisticStackOverlay(CommandOverlay):
+    """Generic realistic stack: a django backend, a fastapi microservice, a frontend."""
+
+    PREREQS: ClassVar[dict[str, list[str]]] = {
+        "backend": ["migrate"],
+        "microservice": ["uvicorn-deps"],
+        "frontend": ["npm-install", "link-node-modules"],
+    }
+
+    def __init__(self, order_file: Path) -> None:
+        self.order_file = order_file
+
+    def get_run_commands(self, worktree: Worktree) -> RunCommands:
+        return {svc: RunCommand(args=["sh", "-lc", f"echo run-{svc} >> {self.order_file}"]) for svc in self.PREREQS}
+
+    def get_pre_run_steps(self, worktree: Worktree, service: str) -> list[ProvisionStep]:
+        def make(step_name: str) -> ProvisionStep:
+            def record() -> None:
+                with self.order_file.open("a") as fh:
+                    fh.write(f"{step_name}\n")
+
+            return ProvisionStep(name=f"{service}-{step_name}", callable=record)
+
+        return [make(name) for name in self.PREREQS.get(service, [])]
+
+
+class RealisticStackWorkflowTests(TestCase):
+    """Drift-net: prereqs-then-command holds for every service shape, both entry points."""
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/2")
+        self.worktree = Worktree.objects.create(ticket=self.ticket, repo_path="backend", branch="b")
+        self._tmp = tempfile.TemporaryDirectory()
+        self.order_file = Path(self._tmp.name) / "order.txt"
+        self.overlay = RealisticStackOverlay(self.order_file)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_run_each_service_runs_its_prereqs_before_its_command(self) -> None:
+        for svc, prereqs in RealisticStackOverlay.PREREQS.items():
+            self.order_file.write_text("")
+            result = ServiceLauncher(self.worktree, svc, overlay=self.overlay).run()
+            assert result.ok, svc
+            assert self.order_file.read_text().splitlines() == [*prereqs, f"run-{svc}"], svc
+
+    def test_worktree_start_path_prepares_every_service(self) -> None:
+        ServiceLauncher.prepare_all(self.worktree, list(RealisticStackOverlay.PREREQS), overlay=self.overlay)
+        ran = set(self.order_file.read_text().splitlines())
+        assert ran == {"migrate", "uvicorn-deps", "npm-install", "link-node-modules"}
+        # No run-* markers — prepare_all wires prerequisites, never commands.
+        assert not any(line.startswith("run-") for line in self.order_file.read_text().splitlines())


### PR DESCRIPTION
## Root cause (the recurring provisioning drift)

The invariant *"running a service = its pre-run steps **then** its RunCommand"* lived in **caller convention**, not in core. `WorktreeStartRunner` honored it; `run <service>` (build-frontend) did not — it fetched `get_run_commands()[service]` and executed it directly, so a frontend service ran without its prerequisites (deps/symlink/config). Any new caller could silently reintroduce the same skip. Every per-overlay 'frontend not built' bug was a symptom of this one core gap.

## Fix

`core/runners/service_launch.ServiceLauncher(RunnerBase)` — the **only** supported way to run a host service. `get_run_commands` is reachable only through it, and it always runs the service's pre-run steps first.

- `worktree_start` → `ServiceLauncher.prepare_all(...)` (its inline pre-run loop deleted — one definition)
- `run.py` build-frontend → `ServiceLauncher(...).run()`

One definition, all entry points. A caller physically cannot run a service without its prerequisites — the drift is structurally impossible, not just fixed once.

## Tests (the drift-net)

- Invariant locked: pre-run executes before the command, for every entry point; prerequisites are never conditional on the command.
- **Generic realistic-stack regression net**: a fake 3-runtime stack (a django backend, a fastapi microservice, a frontend) with zero overlay specifics, asserting the invariant holds uniformly across all service shapes through both entry points. This is the test that would have caught the drift in core CI instead of in a downstream overlay against a live environment.

497 affected-area tests pass (`teatree_core` start/run/step/service/provision/worktree/management).