### PR TITLE
fix(loop): honour NO_COLOR in the statusline line builder (#721)

### DIFF
--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from teatree.loop.dispatch import DispatchAction
 from teatree.loop.pr_ticket_index import build_ticket_index
-from teatree.loop.statusline import StatuslineEntry, StatuslineZones, _hyperlink
+from teatree.loop.statusline import StatuslineEntry, StatuslineZones, _hyperlink, colorize_enabled, plain_link
 
 # DispatchAction payloads are `dict[str, Any]` by contract (see dispatch.py).
 # Renderer-side reads only ever look up scalar fields, so we narrow to
@@ -32,9 +32,9 @@ def _is_url(text: object) -> bool:
     return isinstance(text, str) and text.startswith(("http://", "https://"))
 
 
-def _link(text: str, url: object) -> str:
+def _link(text: str, url: object, *, colorize: bool) -> str:
     if isinstance(url, str) and url.startswith(("http://", "https://")):
-        return _hyperlink(text, url)
+        return _hyperlink(text, url) if colorize else plain_link(text, url)
     return text
 
 
@@ -49,6 +49,19 @@ class _PRRef:
 class _IssueRef:
     label: str
     url: str
+
+
+@dataclass(frozen=True, slots=True)
+class _OverlayActionRefs:
+    """One overlay's slice of classified refs for the action-needed row.
+
+    Bundling the three ref collections keeps ``_render_action_line``'s
+    signature small (composition over a long positional list).
+    """
+
+    pr_refs: list[_PRRef]
+    disposition_refs: dict[str, list[_IssueRef]]
+    ready_refs: list[_IssueRef]
 
 
 def _pr_ref(action: DispatchAction) -> _PRRef | None:
@@ -79,7 +92,13 @@ def _ticket_number_from_url(url: str) -> str:
     return match.group(1) if match else ""
 
 
-def _render_pr_group(overlay: str, refs: list[_PRRef], *, ticket_index: dict[str, str] | None = None) -> str:
+def _render_pr_group(
+    overlay: str,
+    refs: list[_PRRef],
+    *,
+    ticket_index: dict[str, str] | None = None,
+    colorize: bool,
+) -> str:
     """Render a flat list of PR refs, grouped per parent ticket when known."""
     prefix = f"[{overlay}] " if overlay else ""
     if not refs:
@@ -97,7 +116,7 @@ def _render_pr_group(overlay: str, refs: list[_PRRef], *, ticket_index: dict[str
         text = f"!{ref.iid}"
         if ref.annotation:
             text += f" ({ref.annotation})"
-        return _link(text, ref.url)
+        return _link(text, ref.url, colorize=colorize)
 
     chunks: list[str] = []
     for tnum in sorted(by_ticket):
@@ -226,6 +245,7 @@ def _render_ticket_line(
     pr_map: dict[str, list[_PRRef]],
     *,
     live_pr_urls: set[str] | None = None,
+    colorize: bool,
 ) -> str:
     prefix = f"[{overlay}] " if overlay else ""
     live = live_pr_urls or set()
@@ -235,10 +255,10 @@ def _render_ticket_line(
             continue
         if _is_pr_url(url) and url not in live:
             continue
-        ticket_text = _link(f"#{num}", url)
+        ticket_text = _link(f"#{num}", url, colorize=colorize)
         prs = pr_map.get(num, [])
         if prs:
-            pr_parts = [_link(f"!{r.iid}", r.url) for r in prs]
+            pr_parts = [_link(f"!{r.iid}", r.url, colorize=colorize) for r in prs]
             ticket_text += f" ({' '.join(pr_parts)})"
         by_state.setdefault(state, []).append(ticket_text)
     if not by_state:
@@ -256,43 +276,42 @@ def _render_ticket_line(
 
 def _render_action_line(
     overlay: str,
+    action_refs: _OverlayActionRefs,
     *,
-    pr_refs: list[_PRRef],
-    disposition_refs: dict[str, list[_IssueRef]],
-    ready_refs: list[_IssueRef],
     ticket_index: dict[str, str] | None = None,
+    colorize: bool,
 ) -> str:
     prefix = f"[{overlay}] " if overlay else ""
     prs_by_ticket: dict[str, list[_PRRef]] = {}
-    for ref in pr_refs:
+    for ref in action_refs.pr_refs:
         parent = (ticket_index or {}).get(ref.url, "")
         if parent and parent != str(ref.iid):
             prs_by_ticket.setdefault(parent, []).append(ref)
     consumed_pr_urls: set[str] = set()
 
     parts: list[str] = []
-    for reason, refs in disposition_refs.items():
+    for reason, refs in action_refs.disposition_refs.items():
         label = _DISPOSITION_LABELS.get(reason, reason)
-        items = " ".join(_link(r.label, r.url) for r in refs)
+        items = " ".join(_link(r.label, r.url, colorize=colorize) for r in refs)
         parts.append(f"{label}: {items}")
-    if ready_refs:
+    if action_refs.ready_refs:
         items: list[str] = []
-        for ref in ready_refs:
-            text = _link(ref.label, ref.url)
+        for ref in action_refs.ready_refs:
+            text = _link(ref.label, ref.url, colorize=colorize)
             number = ref.label.lstrip("#")
             prs = prs_by_ticket.get(number, [])
             if prs:
-                pr_parts = [_link(f"!{p.iid}", p.url) for p in prs]
+                pr_parts = [_link(f"!{p.iid}", p.url, colorize=colorize) for p in prs]
                 text += f" ({' '.join(pr_parts)})"
                 consumed_pr_urls.update(p.url for p in prs)
             items.append(text)
         parts.append(f"ready: {' '.join(items)}")
-    if pr_refs:
-        remaining = [r for r in pr_refs if r.url not in consumed_pr_urls]
+    if action_refs.pr_refs:
+        remaining = [r for r in action_refs.pr_refs if r.url not in consumed_pr_urls]
         if remaining:
             parts.insert(
                 0,
-                _render_pr_group(overlay, remaining, ticket_index=ticket_index).removeprefix(prefix),
+                _render_pr_group(overlay, remaining, ticket_index=ticket_index, colorize=colorize).removeprefix(prefix),
             )
     if not parts:
         return ""
@@ -327,6 +346,7 @@ def _populate_overlay_zones(
     c: _ClassifiedActions,
     *,
     ticket_index: dict[str, str],
+    colorize: bool,
 ) -> None:
     all_overlays = sorted({*c.active_tickets, *c.action_prs, *c.disposition_refs, *c.ready_refs, *c.inflight_prs})
 
@@ -349,30 +369,45 @@ def _populate_overlay_zones(
             c.active_tickets.get(overlay_key, []),
             pr_map,
             live_pr_urls=live_pr_urls_by_overlay.get(overlay_key, set()),
+            colorize=colorize,
         )
         if ticket_line:
             zones.anchors.append(ticket_line)
 
         action_line = _render_action_line(
             overlay_key,
-            pr_refs=c.action_prs.get(overlay_key, []),
-            disposition_refs=c.disposition_refs.get(overlay_key, {}),
-            ready_refs=c.ready_refs.get(overlay_key, []),
+            _OverlayActionRefs(
+                pr_refs=c.action_prs.get(overlay_key, []),
+                disposition_refs=c.disposition_refs.get(overlay_key, {}),
+                ready_refs=c.ready_refs.get(overlay_key, []),
+            ),
             ticket_index=ticket_index,
+            colorize=colorize,
         )
         if action_line:
             zones.action_needed.append(action_line)
 
         inflight_refs = c.inflight_prs.get(overlay_key, [])
         if inflight_refs:
-            zones.in_flight.append(_render_pr_group(overlay_key, inflight_refs, ticket_index=ticket_index))
+            zones.in_flight.append(
+                _render_pr_group(overlay_key, inflight_refs, ticket_index=ticket_index, colorize=colorize)
+            )
 
 
-def zones_for(actions: list[DispatchAction]) -> StatuslineZones:
+def zones_for(actions: list[DispatchAction], *, colorize: bool | None = None) -> StatuslineZones:
+    """Build statusline zones from dispatched actions.
+
+    *colorize* threads the OSC 8 vs. plain ``text <url>`` decision into the
+    line builder so ``NO_COLOR`` is honoured at the point links are formed
+    (#721). ``None`` resolves from the environment via
+    :func:`~teatree.loop.statusline.colorize_enabled`, matching
+    :func:`~teatree.loop.statusline.render`'s own default.
+    """
+    colorize = colorize_enabled(colorize=colorize)
     zones = StatuslineZones()
     c = _classify_actions(actions)
     ticket_index = build_ticket_index(actions)
-    _populate_overlay_zones(zones, c, ticket_index=ticket_index)
+    _populate_overlay_zones(zones, c, ticket_index=ticket_index, colorize=colorize)
 
     for zone_name, entry in c.other:
         zone_list = getattr(zones, zone_name, None)

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -58,9 +58,28 @@ def default_path() -> Path:
     return base / "teatree" / "statusline.txt"
 
 
+def colorize_enabled(*, colorize: bool | None = None) -> bool:
+    """Resolve the effective colour decision (single source of truth).
+
+    ``None`` resolves from the ``NO_COLOR`` standard (https://no-color.org/):
+    colour is on unless ``NO_COLOR`` is present in the environment. Both
+    :func:`render` and the line builder in :mod:`teatree.loop.rendering`
+    consult this so the OSC 8 / plain-``text <url>`` decision is made in
+    exactly one place (#721).
+    """
+    if colorize is not None:
+        return colorize
+    return "NO_COLOR" not in os.environ
+
+
 def _hyperlink(text: str, url: str) -> str:
     """Wrap *text* in an OSC 8 terminal hyperlink pointing at *url*."""
     return f"\033]8;;{url}\033\\{text}\033]8;;\033\\"
+
+
+def plain_link(text: str, url: str) -> str:
+    """The NO_COLOR fallback form — identical to ``_format_item``'s."""
+    return f"{text} <{url}>"
 
 
 def _format_item(item: ZoneItem, color: str, *, colorize: bool) -> str:
@@ -71,7 +90,7 @@ def _format_item(item: ZoneItem, color: str, *, colorize: bool) -> str:
             text = _hyperlink(text, url)
         return f"{color}{text}{_ANSI_RESET}"
     if url:
-        return f"{text} <{url}>"
+        return plain_link(text, url)
     return text
 
 
@@ -101,8 +120,7 @@ def render(zones: StatuslineZones, *, target: Path | None = None, colorize: bool
     """
     target = target or default_path()
     target.parent.mkdir(parents=True, exist_ok=True)
-    if colorize is None:
-        colorize = "NO_COLOR" not in os.environ
+    colorize = colorize_enabled(colorize=colorize)
 
     # Group every line by its [overlay] prefix, preserving insertion order.
     by_overlay: dict[str, dict[str, list[ZoneItem]]] = {}

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -259,7 +259,7 @@ def run_tick(
     _execute_mechanical(report)
     _persist_agent_dispatches(report)
 
-    zones = zones_for(report.actions)
+    zones = zones_for(report.actions, colorize=colorize)
     _write_tick_meta(started_at, target=statusline_path)
     if report.errors:
         zones.action_needed.append(f"scanner errors: {', '.join(report.errors)}")

--- a/tests/teatree_loop/test_rendering.py
+++ b/tests/teatree_loop/test_rendering.py
@@ -1,0 +1,79 @@
+"""Tests for teatree.loop.rendering — line builder under NO_COLOR (#721).
+
+The statusline module documents NO_COLOR (https://no-color.org/) support,
+but ``rendering._link`` baked OSC 8 hyperlink escapes into the line text
+*before* ``render()`` could honour ``colorize=False`` — so a NO_COLOR
+consumer (or anything parsing the file as plain text) got escape-byte
+garbage and no ``text <url>`` fallback. These drive the full
+``zones_for`` → ``_link`` → ``render`` pipeline under NO_COLOR.
+"""
+
+from pathlib import Path
+
+from teatree.loop.dispatch import DispatchAction
+from teatree.loop.rendering import zones_for
+from teatree.loop.statusline import render
+
+_ACTIONS = [
+    DispatchAction(
+        kind="statusline",
+        zone="action_needed",
+        detail="Ticket 55 — issue_closed",
+        payload={
+            "reason": "issue_closed",
+            "overlay": "teatree",
+            "url": "https://example.com/issues/55",
+        },
+    ),
+]
+
+
+class TestNoColorPipeline:
+    def test_zones_for_colorize_false_emits_no_escapes(self) -> None:
+        zones = zones_for(_ACTIONS, colorize=False)
+        blob = "".join(
+            item if isinstance(item, str) else item.text
+            for zone in (zones.anchors, zones.action_needed, zones.in_flight)
+            for item in zone
+        )
+        assert "\033" not in blob, repr(blob)
+        # The URL must still be present, as a plain `text <url>` fallback.
+        assert "https://example.com/issues/55" in blob
+
+    def test_zones_for_colorize_true_keeps_osc8(self) -> None:
+        zones = zones_for(_ACTIONS, colorize=True)
+        blob = "".join(
+            item if isinstance(item, str) else item.text
+            for zone in (zones.anchors, zones.action_needed, zones.in_flight)
+            for item in zone
+        )
+        assert "\033]8;;" in blob
+
+    def test_full_render_under_no_color_has_zero_escape_bytes(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("NO_COLOR", "1")
+        target = tmp_path / "statusline.txt"
+        zones = zones_for(_ACTIONS, colorize=False)
+        render(zones, target=target, colorize=False)
+        content = target.read_text(encoding="utf-8")
+        assert "\033" not in content, repr(content)
+        assert "https://example.com/issues/55" in content
+
+    def test_zones_for_defaults_to_env_when_colorize_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("NO_COLOR", "1")
+        zones = zones_for(_ACTIONS)  # colorize unset -> resolve from env
+        blob = "".join(
+            item if isinstance(item, str) else item.text
+            for zone in (zones.anchors, zones.action_needed, zones.in_flight)
+            for item in zone
+        )
+        assert "\033" not in blob, repr(blob)
+
+    def test_zones_for_default_colorizes_without_no_color(self, monkeypatch) -> None:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        zones = zones_for(_ACTIONS)
+        blob = "".join(
+            item if isinstance(item, str) else item.text
+            for zone in (zones.anchors, zones.action_needed, zones.in_flight)
+            for item in zone
+        )
+        assert "\033]8;;" in blob

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -605,7 +605,7 @@ def test_render_pr_group_buckets_under_parent_ticket() -> None:
         "https://gitlab.com/x/y/-/merge_requests/370": "855",
         "https://gitlab.com/x/y/-/merge_requests/399": "855",
     }
-    line = _render_pr_group("acme", refs, ticket_index=ticket_index)
+    line = _render_pr_group("acme", refs, ticket_index=ticket_index, colorize=True)
     assert "#855:" in line
     assert "!370" in line
     assert "!399" in line
@@ -615,13 +615,13 @@ def test_render_pr_group_lists_orphans_when_no_match() -> None:
     from teatree.loop.rendering import _PRRef, _render_pr_group  # noqa: PLC0415
 
     refs = [_PRRef(iid=42, url="https://example.com/mr/42", annotation="")]
-    line = _render_pr_group("t3-teatree", refs, ticket_index={})
+    line = _render_pr_group("t3-teatree", refs, ticket_index={}, colorize=True)
     assert "!42" in line
     assert "#" not in line  # no ticket prefix
 
 
 def test_render_action_line_inlines_mrs_after_ready_tickets() -> None:
-    from teatree.loop.rendering import _IssueRef, _PRRef, _render_action_line  # noqa: PLC0415
+    from teatree.loop.rendering import _IssueRef, _OverlayActionRefs, _PRRef, _render_action_line  # noqa: PLC0415
 
     pr_refs = [
         _PRRef(iid=370, url="https://gitlab.com/x/y/-/merge_requests/370", annotation=""),
@@ -638,10 +638,9 @@ def test_render_action_line_inlines_mrs_after_ready_tickets() -> None:
 
     line = _render_action_line(
         "acme",
-        pr_refs=pr_refs,
-        disposition_refs={},
-        ready_refs=ready_refs,
+        _OverlayActionRefs(pr_refs=pr_refs, disposition_refs={}, ready_refs=ready_refs),
         ticket_index=ticket_index,
+        colorize=True,
     )
 
     # !370 should appear inline after #855, !368 should remain in the standalone PR group.


### PR DESCRIPTION
Closes via review-loop. Implements [#721](https://github.com/souliane/teatree/issues/721).

## Problem

`src/teatree/loop/statusline.py` documents `NO_COLOR` (https://no-color.org/) support, but `rendering._link()` baked OSC 8 hyperlink escapes into the line **text** *before* `render()` ever saw it — so `colorize=False` had no effect on the escapes and there was no `text <url>` plain-text fallback. `NO_COLOR=1 t3 loop tick` still wrote `\033` bytes into the statusline file (contract violation).

## Fix

- **Single source of truth:** new `statusline.colorize_enabled(*, colorize=None)` resolves the `NO_COLOR` decision in one place; both `render()` and `zones_for()` consult it (no duplicated `"NO_COLOR" not in os.environ`).
- **Decision threaded into the line builder:** `_link()` now emits the plain `text <url>` form (identical to `_format_item`'s fallback, via shared `plain_link()`) when colour is off. `colorize` is passed down `zones_for → _populate_overlay_zones → _render_ticket_line / _render_action_line / _render_pr_group → _link`. `tick.py` passes its resolved `colorize` into `zones_for` so the file written under `NO_COLOR` has **zero** escape bytes.
- **Composition (no lint suppression):** the three per-overlay ref collections were bundled into a frozen `_OverlayActionRefs` so `_render_action_line` stays within the argument-count gate — the architecture was fixed, not the rule silenced.

## Test plan

- [x] New `tests/teatree_loop/test_rendering.py`: drives the full `zones_for → _link → render` pipeline under `NO_COLOR` and asserts no `\033` bytes + the URL survives as plain `text <url>`; plus `colorize=True` keeps OSC 8, and env-default resolution both ways. (The issue noted no integration test drove this pipeline — now it does.)
- [x] Existing `test_tick.py` direct `_render_*` callers updated to the new signatures (assertions unchanged — they test structure, not escapes).
- [x] Full `uv run pytest`: **3482 passed, 12 skipped**, coverage **93.30% ≥ 93.0%**.
- [x] `ruff check`/`ruff format`/`ty check` clean; `prek run --files <changed>` all green; privacy scan clean (0 findings) on diff + commit message.