### PR TITLE
fix(core): resolve() matches a bare-number issue_url (#707)

### DIFF
--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -27,7 +27,8 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
         Accepts a numeric pk (``"314"`` — direct DB lookup), a full issue URL
         (``"https://github.com/owner/repo/issues/466"`` — exact match on
         ``issue_url``), or a bare issue number when no pk exists (``"466"`` —
-        falls back to ``issue_url`` ending in ``/466``). Shared by
+        matches an ``issue_url`` ending in ``/466`` *or* one stored as the
+        bare string ``"466"``, #707). Shared by
         ``pr create`` and ``lifecycle visit-phase`` so both accept the same
         identifier set (#694) — callers naturally pass the forge issue number
         and must not silently hit ``DoesNotExist``.
@@ -38,7 +39,10 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
             try:
                 return self.get(pk=int(ref))
             except Ticket.DoesNotExist:
-                ticket = self.filter(issue_url__endswith=f"/{ref}").first()
+                # No such pk — fall back to issue_url. Match either a forge
+                # URL ending in /<ref> or a bare-number issue_url stored as
+                # just the issue number (#707), keeping the match exact.
+                ticket = self.filter(Q(issue_url__endswith=f"/{ref}") | Q(issue_url=ref)).first()
                 if ticket is not None:
                     return ticket
                 raise

--- a/tests/teatree_core/test_ticket_resolve.py
+++ b/tests/teatree_core/test_ticket_resolve.py
@@ -37,6 +37,20 @@ class TestTicketResolve(TestCase):
         )
         assert Ticket.objects.resolve(str(first.pk)).pk == first.pk
 
+    def test_resolves_bare_number_issue_url(self) -> None:
+        # #707: issue_url stored as the bare string "694" (not a forge URL).
+        # `pr create 694` must resolve, not raise DoesNotExist.
+        ticket = Ticket.objects.create(overlay="test", issue_url="694")
+        resolved = Ticket.objects.resolve("694")
+        assert resolved.pk == ticket.pk
+
+    def test_pk_precedence_over_bare_number_issue_url(self) -> None:
+        # A ticket whose issue_url is the bare string equal to another
+        # ticket's pk must not shadow the pk lookup.
+        by_pk = Ticket.objects.create(overlay="test")
+        Ticket.objects.create(overlay="test", issue_url=str(by_pk.pk))
+        assert Ticket.objects.resolve(str(by_pk.pk)).pk == by_pk.pk
+
     def test_raises_does_not_exist_for_unknown_ref(self) -> None:
         with pytest.raises(Ticket.DoesNotExist):
             Ticket.objects.resolve("https://github.com/souliane/teatree/issues/12345")


### PR DESCRIPTION
Implements [#707](https://github.com/souliane/teatree/issues/707). Closed via review-loop.

## Problem

`Ticket.objects.resolve("694")` raised `DoesNotExist` when the ticket's `issue_url` was stored as the bare string `"694"` (not a forge URL). The digit branch tried `pk`, then `issue_url__endswith="/694"` — neither matches a bare `"694"`. So `pr create 694` (the natural identifier a user knows) was unusable for any command routed through `resolve()`, even though `694` uniquely identifies the ticket.

## Fix

In the no-such-pk fallback, match `Q(issue_url__endswith="/<ref>") | Q(issue_url=ref)` — adding an **exact** bare-number `issue_url` alternative alongside the existing trailing-segment match. pk precedence is unchanged: the `get(pk=...)` lookup still runs first and only falls back on `DoesNotExist`; the `issue_url` match stays exact. Docstring updated to match.

## Test plan

- [x] TDD: `test_resolves_bare_number_issue_url` (red before, green after) + `test_pk_precedence_over_bare_number_issue_url` (pk still wins over a bare-number `issue_url` equal to another ticket's pk). Existing resolve tests unchanged and green.
- [x] Full `uv run pytest`: **3490 passed, 12 skipped**, coverage **93.30% ≥ 93.0%**.
- [x] `ruff check`/`ruff format`/`ty check` clean; `prek run --files <changed>` all green; privacy scan clean (0 findings) on diff + commit message.