### PR TITLE
fix(ship): add pr create --sync so interactive ship runs inline (#708)

### DIFF
--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -54,6 +54,16 @@ class WorktreeMissingError(TypedDict):
 class ShipEnqueued(TypedDict):
     ticket_id: int
     state: str
+    queued: bool
+    warning: str
+
+
+class ShipExecuted(TypedDict):
+    ticket_id: int
+    state: str
+    synced: bool
+    ok: bool
+    detail: str
 
 
 class ShippingGateFailure(TypedDict):
@@ -180,14 +190,15 @@ def _check_shipping_gate(ticket: Ticket) -> ShippingGateFailure | None:
     return None
 
 
-def _enqueue_ship(ticket: Ticket, title: str) -> ShipEnqueued | ShippingGateFailure:
-    """Run the ``ship()`` transition, converting an illegal hop to JSON.
+def _do_ship_transition(ticket: Ticket, title: str) -> ShippingGateFailure | None:
+    """Run the ``ship()`` FSM transition; return a gate failure or ``None``.
 
     Invariant (#694): ``pr create`` never raises a raw
     ``TransitionNotAllowed`` — even on the ``--skip-validation`` path, where
     the gate reconcile is bypassed and ``ship()`` may be illegal from the
     current (non-REVIEWED) state. The failure is reported as the same
-    structured shape the gate-fail path returns.
+    structured shape the gate-fail path returns. ``ship()`` schedules
+    ``execute_ship.enqueue`` via ``transaction.on_commit``.
     """
     try:
         with transaction.atomic():
@@ -204,7 +215,59 @@ def _enqueue_ship(ticket: Ticket, title: str) -> ShipEnqueued | ShippingGateFail
             missing=[],
             hint="Drop --skip-validation so the gate can reconcile the FSM, or record the missing phases.",
         )
-    return ShipEnqueued(ticket_id=int(ticket.pk), state=str(ticket.state))
+    return None
+
+
+def _enqueue_ship(ticket: Ticket, title: str) -> ShipEnqueued | ShippingGateFailure:
+    """Async ship: enqueue ``execute_ship`` and warn it needs a worker.
+
+    The push + PR are NOT performed here — they run in ``execute_ship``,
+    which only fires when a worker drains the django-tasks queue. In a
+    no-worker context (e.g. an interactive ``uv run`` invocation) the ship
+    silently never completes; the explicit ``warning`` makes that visible
+    instead of looking like a successful ship (#708). Use ``--sync`` to
+    push + open the PR inline in this process.
+    """
+    failure = _do_ship_transition(ticket, title)
+    if failure is not None:
+        return failure
+    return ShipEnqueued(
+        ticket_id=int(ticket.pk),
+        state=str(ticket.state),
+        queued=True,
+        warning=(
+            "Ship was QUEUED, not performed. The branch push and PR creation "
+            "run in the `execute_ship` task and will NOT complete until a "
+            "worker drains the queue (`t3 <overlay> tasks work-next-sdk`). "
+            "Re-run with `--sync` to push and open the PR inline now."
+        ),
+    )
+
+
+def _ship_sync(ticket: Ticket, title: str) -> ShipExecuted | ShippingGateFailure:
+    """Synchronous ship: run ``execute_ship`` inline in this process (#708).
+
+    After the FSM transition commits, invoke the ship task synchronously
+    via django-tasks' ``.call()`` so the push + PR happen before the
+    command returns — no queue worker required. ``execute_ship`` is
+    idempotent (re-checks state under ``select_for_update``), so the
+    ``on_commit`` enqueue scheduled by ``ship()`` is a safe no-op if a
+    worker later picks it up (state is no longer SHIPPED).
+    """
+    from teatree.core.tasks import execute_ship  # noqa: PLC0415
+
+    failure = _do_ship_transition(ticket, title)
+    if failure is not None:
+        return failure
+    result = execute_ship.call(int(ticket.pk))
+    ticket.refresh_from_db()
+    return ShipExecuted(
+        ticket_id=int(ticket.pk),
+        state=str(ticket.state),
+        synced=True,
+        ok=bool(result.get("ok", False)),
+        detail=str(result.get("detail", "")),
+    )
 
 
 def _resolve_base_url(worktree: Worktree | None) -> str:
@@ -255,6 +318,26 @@ def _run_visual_qa_gate(ticket: Ticket, *, skip_reason: str = "") -> VisualQAGat
     )
 
 
+def _run_ship_gates(
+    ticket: Ticket,
+    worktree: Worktree,
+    *,
+    skip_visual_qa: str = "",
+) -> ShippingGateFailure | VisualQAGateFailure | PrValidationError | None:
+    """Run the pre-ship gates in order; return the first failure or ``None``.
+
+    Composed out of ``create`` so the command stays within the
+    return-count gate and the gate sequence is independently testable.
+    """
+    gate_error = _check_shipping_gate(ticket)
+    if gate_error is not None:
+        return gate_error
+    visual_qa_error = _run_visual_qa_gate(ticket, skip_reason=skip_visual_qa)
+    if visual_qa_error is not None:
+        return visual_qa_error
+    return _validate_pr_metadata(ticket, worktree)
+
+
 def _resolve_ticket(ref: str) -> Ticket:
     """Resolve a ticket by pk / issue number / issue URL.
 
@@ -267,7 +350,12 @@ def _resolve_ticket(ref: str) -> Ticket:
 
 class Command(TyperCommand):
     @command()
-    def create(
+    # PLR0913: this signature IS the CLI contract — django-typer derives
+    # --title/--dry-run/--skip-validation/--skip-visual-qa/--sync by
+    # introspecting these kwargs; bundling them into a dataclass would delete
+    # the flags. Same targeted-noqa-for-framework-reality pattern as the
+    # repo's PLC0415 (import-in-function) and SLF001 (framework internals).
+    def create(  # noqa: PLR0913
         self,
         ticket_id: str,
         *,
@@ -275,20 +363,33 @@ class Command(TyperCommand):
         dry_run: bool = False,
         skip_validation: bool = False,
         skip_visual_qa: str = "",
+        sync: bool = False,
     ) -> (
-        ShipEnqueued | ShipDryRun | PrValidationError | VisualQAGateFailure | ShippingGateFailure | WorktreeMissingError
+        ShipEnqueued
+        | ShipExecuted
+        | ShipDryRun
+        | PrValidationError
+        | VisualQAGateFailure
+        | ShippingGateFailure
+        | WorktreeMissingError
     ):
         """Validate ship gates and trigger the ship transition.
 
-        On success the ``execute_ship`` worker pushes the branch, opens the PR,
-        and advances ``SHIPPED → IN_REVIEW``. The return value reports the PR
-        URL once the worker completes (synchronous in interactive mode).
+        Default (async): the ship is *queued* — ``execute_ship`` pushes the
+        branch and opens the PR only when a worker drains the django-tasks
+        queue. The result carries an explicit ``warning`` so a no-worker
+        context does not look like a completed ship (#708).
+
+        ``--sync``: run ``execute_ship`` inline in this process so the push
+        and PR happen before the command returns — no worker required. Use
+        this for interactive / ``uv run`` invocations where nothing is
+        draining the queue.
 
         ``ticket_id`` accepts the internal DB pk, the full issue URL, or the
         bare issue number (resolved against ``Ticket.issue_url``).
 
         ``--title`` overrides the PR title (default: last commit subject).
-        Stored on ``ticket.extra['pr_title_override']`` so the worker reads it.
+        Stored on ``ticket.extra['pr_title_override']`` so the ship reads it.
         """
         ticket = _resolve_ticket(ticket_id)
         worktree = ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
@@ -296,19 +397,14 @@ class Command(TyperCommand):
             return WorktreeMissingError(error="ticket has no worktree")
 
         if not skip_validation:
-            gate_error = _check_shipping_gate(ticket)
-            if gate_error:
-                return gate_error
-            visual_qa_error = _run_visual_qa_gate(ticket, skip_reason=skip_visual_qa)
-            if visual_qa_error:
-                return visual_qa_error
-            validation_error = _validate_pr_metadata(ticket, worktree)
-            if validation_error:
-                return validation_error
+            gate_failure = _run_ship_gates(ticket, worktree, skip_visual_qa=skip_visual_qa)
+            if gate_failure is not None:
+                return gate_failure
 
         if dry_run:
             return _ship_dry_run(ticket, worktree)
-
+        if sync:
+            return _ship_sync(ticket, title)
         return _enqueue_ship(ticket, title)
 
     @command(name="ensure-pr")

--- a/tests/teatree_core/test_lifecycle_fsm_enforcement.py
+++ b/tests/teatree_core/test_lifecycle_fsm_enforcement.py
@@ -254,7 +254,10 @@ class TestPrCreateNeverRaisesTransitionNotAllowed(TestCase):
 
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.SHIPPED
-        assert result == {"ticket_id": ticket.pk, "state": Ticket.State.SHIPPED}
+        assert result["ticket_id"] == ticket.pk
+        assert result["state"] == Ticket.State.SHIPPED
+        assert result["queued"] is True
+        assert "QUEUED, not performed" in result["warning"]
 
     def test_pr_create_title_override_is_persisted_on_ship(self) -> None:
         # The --title override path (now in _enqueue_ship) records
@@ -288,7 +291,10 @@ class TestPrCreateNeverRaisesTransitionNotAllowed(TestCase):
 
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.SHIPPED
-        assert result == {"ticket_id": ticket.pk, "state": Ticket.State.SHIPPED}
+        assert result["ticket_id"] == ticket.pk
+        assert result["state"] == Ticket.State.SHIPPED
+        assert result["queued"] is True
+        assert "QUEUED, not performed" in result["warning"]
         assert ticket.extra["pr_title_override"] == "Custom PR title"
 
 

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -1877,7 +1877,11 @@ class TestPrCreate(TestCase):
 
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.SHIPPED
-        assert result == {"ticket_id": ticket.pk, "state": Ticket.State.SHIPPED}
+        # Default (async) path is queued with an explicit no-worker warning (#708).
+        assert result["ticket_id"] == ticket.pk
+        assert result["state"] == Ticket.State.SHIPPED
+        assert result["queued"] is True
+        assert "QUEUED, not performed" in result["warning"]
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -67,7 +67,12 @@ class TestPrCreateThinWrapper(TestCase):
 
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.SHIPPED
-        assert result == {"ticket_id": ticket.pk, "state": Ticket.State.SHIPPED}
+        # Default (async) path: queued, with an explicit no-worker warning (#708).
+        assert result["ticket_id"] == ticket.pk
+        assert result["state"] == Ticket.State.SHIPPED
+        assert result["queued"] is True
+        assert "QUEUED, not performed" in result["warning"]
+        assert "--sync" in result["warning"]
 
     def test_returns_error_when_no_worktree(self) -> None:
         ticket = Ticket.objects.create(overlay="test", state=Ticket.State.REVIEWED)
@@ -133,6 +138,94 @@ class TestPrCreateThinWrapper(TestCase):
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.REVIEWED  # not advanced
         assert result["allowed"] is False
+
+
+class TestPrCreateSyncShip(TestCase):
+    """`pr create --sync` runs the ship inline; async warns it is queued (#708)."""
+
+    @pytest.fixture(autouse=True)
+    def _inject(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._monkeypatch = monkeypatch
+
+    def test_sync_runs_execute_ship_inline(self) -> None:
+        ticket = _shippable_ticket()
+        ship_mock = MagicMock()
+        ship_mock.call.return_value = {"ticket_id": ticket.pk, "ok": True, "detail": "PR opened"}
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command, "_run_visual_qa_gate", return_value=None),
+            patch.object(pr_command, "_validate_pr_metadata", return_value=None),
+            patch("teatree.core.tasks.execute_ship", ship_mock),
+        ):
+            result = cast(
+                "dict[str, object]",
+                call_command("pr", "create", str(ticket.id), sync=True),
+            )
+
+        ship_mock.call.assert_called_once_with(ticket.pk)
+        assert result["synced"] is True
+        assert result["ok"] is True
+        assert result["detail"] == "PR opened"
+        assert result["ticket_id"] == ticket.pk
+
+    def test_sync_reports_ship_failure_without_raising(self) -> None:
+        ticket = _shippable_ticket()
+        ship_mock = MagicMock()
+        ship_mock.call.return_value = {"ticket_id": ticket.pk, "ok": False, "detail": "push rejected"}
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command, "_run_visual_qa_gate", return_value=None),
+            patch.object(pr_command, "_validate_pr_metadata", return_value=None),
+            patch("teatree.core.tasks.execute_ship", ship_mock),
+        ):
+            result = cast(
+                "dict[str, object]",
+                call_command("pr", "create", str(ticket.id), sync=True),
+            )
+
+        assert result["synced"] is True
+        assert result["ok"] is False
+        assert result["detail"] == "push rejected"
+
+    def test_async_default_does_not_call_execute_ship_inline(self) -> None:
+        ticket = _shippable_ticket()
+        ship_mock = MagicMock()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command, "_run_visual_qa_gate", return_value=None),
+            patch.object(pr_command, "_validate_pr_metadata", return_value=None),
+            patch("teatree.core.tasks.execute_ship", ship_mock),
+        ):
+            result = cast(
+                "dict[str, object]",
+                call_command("pr", "create", str(ticket.id)),
+            )
+
+        ship_mock.call.assert_not_called()
+        assert result["queued"] is True
+        assert "QUEUED, not performed" in result["warning"]
+
+    def test_sync_illegal_transition_returns_gate_failure(self) -> None:
+        # Not REVIEWED and validation skipped -> ship() illegal -> structured
+        # failure, never a raw TransitionNotAllowed, even on the sync path (#694).
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.STARTED)
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/backend",
+            branch="feature-branch",
+            extra={"worktree_path": "/tmp/backend"},
+        )
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast(
+                "dict[str, object]",
+                call_command("pr", "create", str(ticket.id), sync=True, skip_validation=True),
+            )
+        assert result["allowed"] is False
+        assert "Cannot ship from state" in result["error"]
 
 
 class TestShipPreviewTitleDescriptionInvariant(TestCase):


### PR DESCRIPTION
Implements [#708](https://github.com/souliane/teatree/issues/708). Routed to t3-review-loop for independent maker≠checker review.

## Problem

`pr create` always enqueued `execute_ship`; the documented synchronous ship path never engaged. Under an interactive `uv run` worktree with no worker draining the django-tasks queue, the FSM advanced to `SHIPPED` but the git push + PR never happened — and the command looked successful (no indication the ship was deferred).

## Fix

- **`--sync`**: after the `ship()` transition commits, run `execute_ship` inline via django-tasks' `.call()` so the push + PR complete before the command returns — no worker required. `execute_ship` is idempotent (re-checks state under `select_for_update`), so the `on_commit` enqueue scheduled by `ship()` is a safe no-op if a worker later picks it up.
- **Async default**: now returns `queued=true` + an explicit `warning` that the ship is queued and won't complete until a worker drains the queue, so a no-worker context no longer looks like a successful ship.
- **Composition**: extracted `_do_ship_transition` (shared by both paths — preserves the #694 no-raw-`TransitionNotAllowed` invariant) and `_run_ship_gates` (gate sequence; keeps `create` within the return-count gate).
- **Approved targeted suppression**: `create()` carries a rationale-commented `# noqa: PLR0913` — its signature *is* the django-typer CLI contract (flags derived by introspection); bundling kwargs into a dataclass would delete the CLI flags. Coordinator-approved (CLAUDE.md "no suppression without approval"); mirrors the repo's existing targeted-noqa-for-framework-reality pattern (PLC0415, SLF001). The noqa is scoped to PLR0913 only — not broadened.

## Test plan

- [x] TDD red→green. New `TestPrCreateSyncShip`: sync runs `execute_ship` inline; sync reports ship failure without raising; async default does not call inline; sync illegal transition → structured gate failure (not raw `TransitionNotAllowed`, #694).
- [x] Old exact-dict `ShipEnqueued` assertions updated to the new `queued`+`warning` shape across 3 test files (the #708 behaviour change).
- [x] Full `uv run pytest`: **3503 passed, 12 skipped**, coverage **93.34% ≥ 93.0%**.
- [x] `ruff check`/`ruff format`/`ty check` clean; `prek run --files <changed>` all green; privacy scan clean (0 findings) on diff + commit message.