### PR TITLE
fix(tach): allow teatree.loop → teatree.config (post-#714 stale-merge graph breakage)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1721,6 +1721,7 @@ graph TD
     teatree.loop --> teatree.types
     teatree.loop --> teatree.paths
     teatree.loop --> teatree.utils
+    teatree.loop --> teatree.config
     teatree.loop --> teatree.core
     teatree.loop --> teatree.backends
     teatree.docker --> teatree.types

--- a/tach.toml
+++ b/tach.toml
@@ -118,6 +118,7 @@ depends_on = [
   "teatree.types",
   "teatree.paths",
   "teatree.utils",
+  "teatree.config",
   "teatree.core",
   "teatree.backends"
 ]


### PR DESCRIPTION
**P0 — `main` is RED. This unblocks every merge (incl. #737).** Route to t3-review-loop fast-track.

## Root cause

#714 merged ~8 commits stale-behind-main and broke `main` (merge commit `c7589de`, lint job FAILS at the `tach` hook):

```
src/teatree/loop/dispatch.py:18: Cannot use 'teatree.config.get_effective_settings'.
Module 'teatree.loop' cannot depend on 'teatree.config'.
```

#714's stricter `tach.toml` declared `teatree.loop` with an explicit `depends_on` that predated the NO_COLOR/effective-settings statusline work. A post-#714 merge added `from teatree.config import get_effective_settings` to `loop/dispatch.py:18`. Pre-#714 `teatree.loop` was undeclared so tach didn't constrain it (green); post-merge the stricter graph rejects the edge.

## Fix (surgical)

Add `"teatree.config"` to `teatree.loop`'s `depends_on`. `teatree.config` is a deliberately low-level shared module (`depends_on=["teatree.paths","teatree.utils"]`) that `teatree.core`, `teatree.timeouts`, and `teatree.contrib` already depend on — `loop → config` is consistent with the established layering, not a new architectural smell. Same "declaring a module exposed a real edge" pattern #714 itself handled; #714's author couldn't see this edge because the import didn't exist at #714-branch time. `BLUEPRINT.md` tach-graph regenerated by the prek hook (docs stay aligned).

## Verification

- [x] `PYENV_VERSION=3.13.11 uv run tach check` → **All modules validated** (was FAIL).
- [x] Full `uv run pytest`: **3503 passed, 12 skipped**, coverage **93.33%** — confirms the stale #714 merge broke *only* the tach graph, nothing else regressed.
- [x] `prek run --files tach.toml` clean; privacy scan clean (0 findings) on diff + commit message; souliane-noreply identity, content byte-identical (tree+diff hashes verified unchanged).