### PR TITLE
fix(loop): clickable !N ref for dismissed-approval reviewer PRs

### DIFF
--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -27,6 +27,15 @@ _DISPOSITION_LABELS: dict[str, str] = {
     "label_removed": "label-removed",
 }
 
+# Summary prefixes the reviewer-prs scanner stamps on its signals (see
+# ``scanners/reviewer_prs.py``): ``Review needed:`` for
+# ``reviewer_pr.new_sha``/``unreviewed`` and ``Approval dismissed:`` for
+# ``reviewer_pr.approval_dismissed``. ``_pr_ref`` keys the URL-tail iid
+# derivation off these so every reviewer dual-dispatch renders as a
+# clickable ``!N`` ref, while non-reviewer PR-URL signals keep their
+# human-readable generic line.
+_REVIEWER_SUMMARY_PREFIXES: tuple[str, ...] = ("Review needed:", "Approval dismissed:")
+
 
 def _is_url(text: object) -> bool:
     return isinstance(text, str) and text.startswith(("http://", "https://"))
@@ -71,9 +80,12 @@ def _pr_ref(action: DispatchAction) -> _PRRef | None:
     if not isinstance(iid, int) or iid == 0:
         # Reviewer-pr signals don't ship `iid` in the payload but the MR URL
         # ends with the numeric ref — derive it so the row renders as `!N`
-        # under the right overlay. Other signal kinds still fall through
-        # without an iid (rendered as a generic line).
-        if action.detail.startswith("Review needed:") and isinstance(url, str):
+        # under the right overlay. Match every reviewer summary form (the
+        # scanner emits ``Review needed:`` for new_sha/unreviewed and
+        # ``Approval dismissed:`` for approval_dismissed) without hijacking
+        # other PR-URL-bearing signals (e.g. ``my_pr.open``), which keep
+        # their human-readable generic line.
+        if isinstance(url, str) and action.detail.startswith(_REVIEWER_SUMMARY_PREFIXES):
             tail = _ticket_number_from_url(url)
             if tail.isdigit():
                 return _PRRef(iid=int(tail), url=url, annotation="review")

--- a/tests/teatree_loop/test_rendering.py
+++ b/tests/teatree_loop/test_rendering.py
@@ -77,3 +77,47 @@ class TestNoColorPipeline:
             for item in zone
         )
         assert "\033]8;;" in blob
+
+
+def _statusline_action(*, detail: str, url: str) -> DispatchAction:
+    """Build a reviewer-pr dual-dispatch statusline action.
+
+    Mirrors what ``dispatch._dispatch_one`` produces: ``detail`` is the
+    scanner summary and the payload carries ``url``/``overlay`` but no
+    ``iid`` (reviewer scanners never ship an iid — see
+    ``scanners/reviewer_prs.py``).
+    """
+    return DispatchAction(
+        kind="statusline",
+        zone="action_needed",
+        detail=detail,
+        payload={"url": url, "overlay": "teatree"},
+    )
+
+
+class TestReviewerPrRefRendering:
+    """Reviewer-pr signals render as a clickable per-overlay ``!N`` ref.
+
+    They carry only ``url`` (no ``iid``); the renderer derives the iid
+    from the URL tail. ``approval_dismissed`` uses a different summary
+    ("Approval dismissed:") than new_sha/unreviewed ("Review needed:"),
+    so the derivation must cover both prefixes.
+    """
+
+    _PR_URL = "https://gitlab.example.com/g/p/-/merge_requests/123"
+
+    def test_review_needed_renders_clickable_pr_ref(self) -> None:
+        action = _statusline_action(detail=f"Review needed: {self._PR_URL}", url=self._PR_URL)
+        zones = zones_for([action], colorize=False)
+        action_blob = "".join(item if isinstance(item, str) else item.text for item in zones.action_needed)
+        assert "[teatree] !123" in action_blob, repr(action_blob)
+
+    def test_approval_dismissed_renders_clickable_pr_ref(self) -> None:
+        zones = zones_for(
+            [_statusline_action(detail=f"Approval dismissed: {self._PR_URL}", url=self._PR_URL)],
+            colorize=False,
+        )
+        action_blob = "".join(item if isinstance(item, str) else item.text for item in zones.action_needed)
+        # Before the fix this collapsed into a generic "Approval dismissed:
+        # <url>" line with no per-overlay `!N` grouping.
+        assert "[teatree] !123" in action_blob, repr(action_blob)

--- a/tests/test_architecture_contract.py
+++ b/tests/test_architecture_contract.py
@@ -1,0 +1,36 @@
+"""The declared module graph must stay internally consistent.
+
+``tach.toml`` is the architecture contract: each ``[[modules]]`` entry
+declares what that package may import. A concurrent merge can land a new
+cross-package import without the matching ``depends_on`` edge — the
+pre-commit ``tach`` hook then blocks *every* commit touching that package
+until someone notices. This contract test fails the same way ``tach
+check`` does, so the boundary regression is caught by the test suite
+(CI / local ``pytest``) instead of only at commit time.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestArchitectureContract:
+    def test_tach_check_module_graph_is_clean(self) -> None:
+        # S607: trusted fixed argv (literal "uv run tach check", no user
+        # input) — the repo-wide convention for subprocess in tests.
+        result = subprocess.run(
+            ["uv", "run", "tach", "check"],  # noqa: S607
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            pytest.fail(
+                "tach check found a module-boundary violation — a package "
+                "imports something not in its tach.toml `depends_on`:\n"
+                f"{result.stdout}\n{result.stderr}",
+            )

--- a/tests/test_architecture_contract.py
+++ b/tests/test_architecture_contract.py
@@ -7,9 +7,16 @@ pre-commit ``tach`` hook then blocks *every* commit touching that package
 until someone notices. This contract test fails the same way ``tach
 check`` does, so the boundary regression is caught by the test suite
 (CI / local ``pytest``) instead of only at commit time.
+
+Invoked as ``{sys.executable} -m tach check`` rather than ``uv run
+tach``: ``sys.executable`` is always an executable interpreter path in
+every environment (local venv, the Docker test matrix), whereas a bare
+``uv``/``tach`` on ``PATH`` is not guaranteed and is non-executable in
+the Docker matrix.
 """
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -19,10 +26,10 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 class TestArchitectureContract:
     def test_tach_check_module_graph_is_clean(self) -> None:
-        # S607: trusted fixed argv (literal "uv run tach check", no user
-        # input) — the repo-wide convention for subprocess in tests.
+        # S603: trusted fixed argv — sys.executable plus literal flags, no
+        # user input. sys.executable is portable across every test env.
         result = subprocess.run(
-            ["uv", "run", "tach", "check"],  # noqa: S607
+            [sys.executable, "-m", "tach", "check"],
             cwd=_REPO_ROOT,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

Two self-QA-found defects in the factory's own loop machinery, both surfaced by the recent merge burst (#707/#708/#712/#714/#717/#721/#736):

- **`fix(tach)`** — A concurrent merge added `from teatree.config import get_effective_settings` to `teatree.loop.dispatch` (the `_dispatch_answering` autonomy lookup, #670/#712/#717) while the tach-module-graph guard (#714) landed separately. `teatree.loop`'s `depends_on` never gained the matching `teatree.config` edge, so `tach check` fails on a clean checkout and the pre-commit `tach` hook **blocks every commit that touches the loop package**. `teatree.config` is already a sanctioned dependency for several other modules; this adds the missing edge. A new `tests/test_architecture_contract.py` runs `tach check` so any future module-boundary merge seam is caught by the test suite, not only at commit time.

- **`fix(loop)`** — The reviewer-prs scanner stamps two summary forms (`Review needed:` for new_sha/unreviewed, `Approval dismissed:` for approval_dismissed) and ships no `iid` in the payload. `rendering._pr_ref` only derived the iid from the URL tail when the detail started with `Review needed:`, so a dual-dispatched `reviewer_pr.approval_dismissed` collapsed into a generic `Approval dismissed: <url>` line instead of a clickable `!N` ref grouped under its overlay in the action-needed zone — exactly the re-review signal a reviewer most needs to act on. Now matches both reviewer summary prefixes while non-reviewer PR-URL signals (e.g. `my_pr.open`) keep their human-readable line.

## Test plan

- [x] `pytest tests/` — 3506 passed, 12 skipped
- [x] New `test_rendering.py::TestReviewerPrRefRendering` — red before / green after the `_pr_ref` fix
- [x] New `test_architecture_contract.py` — red before / green after the tach.toml edge
- [x] `tach check` clean; pre-commit + Docker test-matrix push gates pass
- [x] Contract test invokes tach via `sys.executable -m tach` for Docker-matrix portability
- [x] ruff check + format clean on changed files