### PR TITLE
feat(e2e): deterministic --target dev|local for dual-env specs

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -883,9 +883,10 @@ Typer-based, work without Django:
 - `t3 sessions` — list/resume Claude conversation sessions
 - `t3 docs` — serve mkdocs documentation (requires `docs` dependency group)
 - `t3 ci {cancel,divergence,fetch-errors,fetch-failed-tests,trigger-e2e,quality-check}` — CI helpers
-- `t3 <overlay> e2e run [<test-path>]` — run E2E tests; dispatches to the project runner (in-repo pytest-playwright) or the external runner (remote Playwright repo) based on the overlay's `get_e2e_config()` — same command across overlays
-- `t3 <overlay> e2e external [--repo <name>] [<test-path>]` — explicit external runner: Playwright from `T3_PRIVATE_TESTS` or a named `[e2e_repos.<name>]` git repo; skips port discovery when `BASE_URL` is already set (DEV/staging mode)
-- `t3 <overlay> e2e project [<test-path>] [--update-snapshots]` — explicit project runner: pytest-playwright in the overlay's own test dir, executed in the canonical Docker image by default
+- `t3 <overlay> e2e run [<test-path>] [--target dev|local]` — run E2E tests; dispatches to the project runner (in-repo pytest-playwright) or the external runner (remote Playwright repo) based on the overlay's `get_e2e_config()` — same command across overlays
+- `t3 <overlay> e2e external [--repo <name>] [--target dev|local] [<test-path>]` — explicit external runner: Playwright from `T3_PRIVATE_TESTS` or a named `[e2e_repos.<name>]` git repo; skips port discovery when `BASE_URL` is already set (DEV/staging mode)
+- `t3 <overlay> e2e project [<test-path>] [--target dev|local] [--update-snapshots]` — explicit project runner: pytest-playwright in the overlay's own test dir, executed in the canonical Docker image by default
+- `--target dev|local` — dual-env selector (omitted = back-compat inference from `BASE_URL`). Exported as `T3_E2E_TARGET`; a dual-mode spec branches on it rather than a `BASE_URL` host regex. `local` always discovers the local frontend so it can never silently hit a deployed env
 - `t3 review {post-draft-note,delete-draft-note,list-draft-notes,publish-draft-notes,update-note,reply-to-discussion,resolve-discussion}` — code-host draft notes (post/delete/list/publish), in-place edits of draft or published notes, plus immediate replies on existing discussion threads and resolve/unresolve toggle. Routes to GitHub or GitLab via the active overlay's `CodeHostBackend`.
 - `t3 review-request discover` — discover open PRs awaiting review
 - `t3 tool {privacy-scan,analyze-video,bump-deps,label-issues,find-duplicates,triage-issues,audit-memory}` — standalone utilities

--- a/skills/e2e/SKILL.md
+++ b/skills/e2e/SKILL.md
@@ -46,6 +46,24 @@ Always start dev servers via `t3 <overlay> worktree start` before running tests.
 
 **E2E for backend/API changes:** When backend or microservice changes affect data visible in the frontend (e.g., webhook payload fields, API serializer fields, new model fields exposed via API), E2E tests are still required even if there is no frontend PR. The frontend form already has the fields — E2E proves the end-to-end data flow. Do NOT skip E2E just because the change is "backend-only."
 
+## Dual-Env Testing (one spec, DEV or local)
+
+A single spec should run against either the deployed **dev** environment or the **local** stack, selected by one CLI argument. Determinism comes from code, never from a parsed file.
+
+**Target selection.** `t3 <overlay> e2e [run|external|project] --target dev|local`:
+
+- `dev` — keep the pre-set `BASE_URL` (deployed env); no local port scan.
+- `local` — always discover the local frontend, even if a stray `BASE_URL` is exported (so `--target local` can never silently hit a deployed env).
+- omitted — back-compat: infer `dev` if `BASE_URL` is set, else `local`.
+
+The resolved value is exported as **`T3_E2E_TARGET`**. The spec branches on it — `const IS_DEV = process.env.T3_E2E_TARGET === 'dev'` — and must not re-derive the target from a `BASE_URL` host regex. Prefer testing a deployed/merged change against `dev`; an unmerged change must still pass on `local`.
+
+**Recording DEV-vs-local discrepancies (typed sidecar, not prose).** When a spec must behave differently per target (different field labels in a regulated vs internal document, a DEV-only cross-check, a feature whose data only exists on one side), encode it in a **typed TypeScript sidecar the spec imports** (e.g. `<spec>.dualenv.ts` exporting a typed `DualEnvSpec`). `tsc` type-checks it; nothing parses Markdown/YAML to drive behavior. The sidecar is the durable, machine-enforced record of every known divergence and of any fixture provenance.
+
+**Replicating a DEV object to local.** To test a not-yet-deployed feature locally, anchor on a real reproducible DEV object (read it read-only — authorized) and ensure it exists in the local DB. The local DB must be a DEV dump (use DSLR; if the object is missing, ask the user for a fresh dump — agents must never set `T3_ALLOW_REMOTE_DUMP`). Provisioning is at most two `t3` CLI invocations (provision/refresh, then run); fold password reset and access seeding into the provision step (`t3 <overlay> db refresh` already resets passwords).
+
+**Documented limitation — some features are DEV-only on local.** DSLR snapshots legitimately lack certain data catalogs (e.g. the Excel-priced bandwidth product catalog). A feature that depends on such a catalog **cannot be reproduced on the local stack from DSLR**, regardless of snapshot age. This is not a bug to fix — record it in the spec's typed sidecar as a DEV-only divergence so the spec runs that feature against `dev` only and the limitation stays visible and enforced. Pin the run to the intended worktree's stack; cross-worktree container/DB drift causes silent mis-targeting.
+
 ## Writing Tests
 
 **Test depth:** Don't just verify "page loads with 200". Read the source code to understand what the feature does, then test specific behaviors: form fields, filters, CRUD operations, access control, edge cases.

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -103,19 +103,30 @@ def _discover_frontend_port(project: str, default: int = 4200) -> int | None:
     return None
 
 
-def _build_e2e_env(frontend_url: str | None = None, *, headed: bool) -> dict[str, str]:
+def _build_e2e_env(
+    frontend_url: str | None = None,
+    *,
+    headed: bool,
+    target: str,
+) -> dict[str, str]:
     """Build environment dict for Playwright: ``BASE_URL``, overlay extras, ``CI``.
 
     When *frontend_url* is given it overrides ``BASE_URL``.
     When it is ``None`` the existing ``BASE_URL`` env var is preserved (DEV / staging mode).
 
+    *target* is the resolved dual-env target (``"dev"`` or ``"local"``); it is
+    exported as ``T3_E2E_TARGET`` so a single dual-mode spec can branch on
+    ``process.env.T3_E2E_TARGET === 'dev'`` instead of re-deriving the target
+    from a ``BASE_URL`` host regex.
+
     Overlay-specific env vars (e.g. ``CUSTOMER``) come from
-    :meth:`OverlayBase.get_e2e_env_extras` — core only knows about ``BASE_URL``
-    and ``CI``.
+    :meth:`OverlayBase.get_e2e_env_extras` — core only knows about ``BASE_URL``,
+    ``T3_E2E_TARGET`` and ``CI``.
     """
     env = {**os.environ}
     if frontend_url is not None:
         env["BASE_URL"] = frontend_url
+    env["T3_E2E_TARGET"] = target
 
     envfile = _find_env_cache(_get_user_cwd())
     env_cache = _parse_env_file(envfile) if envfile is not None else {}
@@ -135,6 +146,7 @@ class Command(TyperCommand):
         self,
         test_path: str = "",
         *,
+        target: str = "",
         headed: bool = False,
         update_snapshots: bool = False,
         docker: bool = True,
@@ -147,6 +159,9 @@ class Command(TyperCommand):
         or ``"runner": "external"``; when absent, ``test_dir`` implies ``project``
         and ``project_path`` implies ``external`` for compatibility.
 
+        ``--target dev|local`` selects the dual-env target and is forwarded to
+        whichever runner handles the overlay (see ``external`` for semantics).
+
         Runner-specific flags (``--repo``, ``--playwright-args``) stay on the
         explicit ``external`` subcommand to keep this entry point overlay-agnostic.
         """
@@ -156,6 +171,7 @@ class Command(TyperCommand):
         if runner == "project":
             return self.project(
                 test_path=test_path,
+                target=target,
                 headed=headed,
                 docker=docker,
                 update_snapshots=update_snapshots,
@@ -163,6 +179,7 @@ class Command(TyperCommand):
         if runner == "external":
             return self.external(
                 test_path=test_path,
+                target=target,
                 headed=headed,
                 update_snapshots=update_snapshots,
             )
@@ -210,12 +227,29 @@ class Command(TyperCommand):
                 self.stderr.write(f"E2E preflight failed: {exc}")
                 raise SystemExit(1) from exc
 
+    def _resolve_target(self, target: str) -> str:
+        """Resolve the dual-env target deterministically.
+
+        ``dev`` / ``local`` are explicit. Empty means back-compat inference:
+        a pre-set ``BASE_URL`` env var means a remote target (``dev``),
+        otherwise ``local``. The result is exported verbatim as
+        ``T3_E2E_TARGET`` so the spec never re-derives it from a host regex.
+        """
+        normalized = target.strip().lower()
+        if normalized in {"dev", "local"}:
+            return normalized
+        if normalized:
+            self.stderr.write(f"--target must be 'dev' or 'local', got {target!r}.")
+            raise SystemExit(2)
+        return "dev" if os.environ.get("BASE_URL") else "local"
+
     @command()
-    def external(
+    def external(  # noqa: PLR0913
         self,
         test_path: str = "",
         *,
         repo: str = "",
+        target: str = "",
         headed: bool = False,
         update_snapshots: bool = False,
         playwright_args: str = "",
@@ -228,6 +262,19 @@ class Command(TyperCommand):
             ``~/.teatree.toml`` and use its ``e2e_dir`` subdirectory.
         - Default: resolve from ``T3_PRIVATE_TESTS`` env var or ``[teatree].private_tests``
             config key.
+
+        ``--target dev|local`` selects the dual-env target deterministically:
+
+        - ``dev``: keep the pre-set ``BASE_URL`` (deployed env), no port scan.
+        - ``local``: always discover the local frontend, even if a stray
+            ``BASE_URL`` is exported (``--target local`` never hits a
+            deployed env silently).
+        - empty: back-compat — infer ``dev`` if ``BASE_URL`` is set,
+            else ``local``.
+
+        The resolved value is exported as ``T3_E2E_TARGET`` so a dual-mode
+        spec branches on ``process.env.T3_E2E_TARGET === 'dev'`` rather than
+        re-deriving the target from a ``BASE_URL`` host regex.
 
         Discovers the frontend port from docker-compose (or local process)
         and reads the tenant variant from the env cache.
@@ -245,8 +292,15 @@ class Command(TyperCommand):
             if not private_tests_path:
                 return "private_tests not configured in ~/.teatree.toml / T3_PRIVATE_TESTS, or directory missing."
 
-        # When BASE_URL is already set (DEV / staging target), skip local port discovery.
-        if os.environ.get("BASE_URL"):
+        resolved_target = self._resolve_target(target)
+
+        # target=dev   → keep the pre-set BASE_URL (deployed env), no port scan.
+        # target=local → always discover the local frontend, even if a stray
+        #                 BASE_URL is exported, so `--target local` can never
+        #                 silently hit a deployed environment.
+        if resolved_target == "dev":
+            if not os.environ.get("BASE_URL"):
+                return "--target dev requires BASE_URL (the deployed environment URL) to be set."
             frontend_url = None  # preserve existing BASE_URL
         else:
             worktree = resolve_worktree()
@@ -266,9 +320,10 @@ class Command(TyperCommand):
             headed=headed,
             extra=extra,
         )
-        env = _build_e2e_env(frontend_url, headed=headed)
+        env = _build_e2e_env(frontend_url, headed=headed, target=resolved_target)
 
         self.stdout.write(f"  Running from: {private_tests_path}")
+        self.stdout.write(f"  Target: {resolved_target}")
         self.stdout.write(f"  BASE_URL: {env['BASE_URL']}")
         if env.get("CUSTOMER"):
             self.stdout.write(f"  CUSTOMER: {env['CUSTOMER']}")
@@ -287,17 +342,23 @@ class Command(TyperCommand):
         self,
         test_path: str = "",
         *,
+        target: str = "",
         headed: bool = False,
         docker: bool = True,
         update_snapshots: bool = False,
     ) -> str:
         """Run E2E tests from the project's own test directory.
 
+        ``--target dev|local`` is exported as ``T3_E2E_TARGET`` for the in-repo
+        suite (same contract as the ``external`` runner); empty falls back to
+        ``BASE_URL``-based inference.
+
         Pass ``--update-snapshots`` to regenerate ``pytest-playwright-visual``
         baselines. Always do this inside the Docker image (the default) — the
         CI runner's Chromium renders fonts at different heights than macOS, so
         locally-generated baselines mismatch in CI.
         """
+        resolved_target = self._resolve_target(target)
         try:
             worktree = resolve_worktree()
             wt_path = (worktree.extra or {}).get("worktree_path", ".") if worktree else "."
@@ -311,7 +372,18 @@ class Command(TyperCommand):
         if docker and not Path("/.dockerenv").exists():
             compose_file = Path(wt_path) / "dev" / "docker-compose.yml"
             if compose_file.is_file():
-                cmd = ["docker", "compose", "-f", str(compose_file), "run", "--rm", "e2e", test_dir]
+                cmd = [
+                    "docker",
+                    "compose",
+                    "-f",
+                    str(compose_file),
+                    "run",
+                    "--rm",
+                    "-e",
+                    f"T3_E2E_TARGET={resolved_target}",
+                    "e2e",
+                    test_dir,
+                ]
                 if update_snapshots:
                     cmd.append("--update-snapshots")
                 rc = run_streamed(cmd, cwd=wt_path, check=False)
@@ -325,7 +397,7 @@ class Command(TyperCommand):
         if update_snapshots:
             cmd.append("--update-snapshots")
 
-        env = {**os.environ, "DJANGO_SETTINGS_MODULE": settings_module}
+        env = {**os.environ, "DJANGO_SETTINGS_MODULE": settings_module, "T3_E2E_TARGET": resolved_target}
         if headed:
             env.pop("CI", None)
         else:

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -4653,3 +4653,36 @@ class TestE2eExternalRepo(TestCase):
             pytest.raises(subprocess.CalledProcessError),
         ):
             call_command("e2e", "external", repo="demo-svc")
+
+
+class TestE2EResolveTarget(TestCase):
+    """`--target` resolution is deterministic and drives `T3_E2E_TARGET`."""
+
+    def test_explicit_values_are_normalized(self) -> None:
+        cmd = e2e_mod.Command()
+        for raw, expected in [("dev", "dev"), ("local", "local"), ("DEV", "dev"), (" Local ", "local")]:
+            with self.subTest(raw=raw):
+                assert cmd._resolve_target(raw) == expected
+
+    def test_invalid_value_exits(self) -> None:
+        with pytest.raises(SystemExit):
+            e2e_mod.Command()._resolve_target("staging")
+
+    def test_empty_infers_from_base_url(self) -> None:
+        cmd = e2e_mod.Command()
+        with patch.dict(os.environ, {"BASE_URL": "https://app-development.example.com"}, clear=False):
+            assert cmd._resolve_target("") == "dev"
+        env_no_base = {k: v for k, v in os.environ.items() if k != "BASE_URL"}
+        with patch.dict(os.environ, env_no_base, clear=True):
+            assert cmd._resolve_target("") == "local"
+
+    def test_build_env_exports_t3_e2e_target(self) -> None:
+        with (
+            patch.object(e2e_mod, "get_overlay") as get_overlay,
+            patch.object(e2e_mod, "_find_env_cache", return_value=None),
+        ):
+            get_overlay.return_value.get_e2e_env_extras.return_value = {}
+            env = e2e_mod._build_e2e_env("http://localhost:4200", headed=False, target="local")
+        assert env["T3_E2E_TARGET"] == "local"
+        assert env["BASE_URL"] == "http://localhost:4200"
+        assert env["CI"] == "1"

--- a/tests/teatree_core/test_provisioning_contract.py
+++ b/tests/teatree_core/test_provisioning_contract.py
@@ -367,7 +367,7 @@ class E2eEnvMergeContractTests(TestCase):
             patch("teatree.core.management.commands.e2e.get_overlay", return_value=_FixedExtrasOverlay()),
             patch("teatree.core.management.commands.e2e._find_env_cache", return_value=None),
         ):
-            return _build_e2e_env(None, headed=False)
+            return _build_e2e_env(None, headed=False, target="local")
 
     def test_explicit_env_wins_over_overlay_extra(self) -> None:
         with patch.dict(os.environ, {"E2E_CONTRACT_KEY": "from-env"}, clear=False):


### PR DESCRIPTION
## Summary

One E2E spec, run against the deployed **dev** environment or the **local** stack, selected by a single deterministic CLI argument.

- `t3 <ov> e2e run|external|project --target dev|local` — resolved deterministically by the CLI (`dev`|`local`, or back-compat inference from `BASE_URL`), exported as `T3_E2E_TARGET`. The spec branches on the env var; nothing parses a file to decide behavior.
- `--target local` always discovers the local frontend even if a stray `BASE_URL` is exported — it can never silently hit a deployed env.
- `--target dev` requires `BASE_URL` (the deployed URL) and skips the port scan.

## Skills

- `rules/SKILL.md`: scoped E2E-on-dev exception to the remote-DB rule (test may use its **own** dev objects without per-action approval; never hijack foreign objects; nothing destructive; dev only).
- `e2e/SKILL.md`: new **Dual-Env Testing** section — the `--target`/`T3_E2E_TARGET` contract, a **typed-TS-sidecar** convention for recording DEV-vs-local discrepancies (type-checked, no markdown/YAML parsing), DEV-object replication, and the documented DSLR limitation (some data catalogs are absent from snapshots, so those features stay dev-only on local).

## Tests

`TestE2EResolveTarget` (resolution + `T3_E2E_TARGET` export); existing `_build_e2e_env` consumer updated for the new required arg. Full `test_new_management_commands` + `test_provisioning_contract` modules green (204 passed). BLUEPRINT CLI surface updated.
