### PR TITLE
fix(core): reuse computed inference in backfill; ASCII fallback label (#743)

### DIFF
--- a/skills/teatree-bughunt/SKILL.md
+++ b/skills/teatree-bughunt/SKILL.md
@@ -25,7 +25,7 @@ Shares the Quick Wins family with `/teatree-batch`.
 
 ## Prerequisites
 
-Same as `/teatree-batch` (`ac-python`, `ac-django`, overlay skill loaded). Plus: at least one overlay registered with credentials that resolve (`t3 teatree loop tick --overlay <name>` must finish without `ImproperlyConfigured`); `~/.local/share/teatree/statusline.txt` writable (the renderer creates the directory if absent).
+Same as `/teatree-batch` (`ac-python`, `ac-django`, overlay skill loaded). Plus: at least one overlay registered with credentials that resolve (`t3 loop tick --overlay <name>` must finish without `ImproperlyConfigured`); `~/.local/share/teatree/statusline.txt` writable (the renderer creates the directory if absent).
 
 ## Step 1 — Ask the scope
 
@@ -46,11 +46,11 @@ cd "$T3_REPO"
 
 # One ad-hoc multi-overlay tick. JSON output is the structured surface; the
 # rendered file is the user-visible surface. Inspect both.
-t3 teatree loop tick --json > /tmp/tick.json
+t3 loop tick --json > /tmp/tick.json
 cat "${XDG_DATA_HOME:-$HOME/.local/share}/teatree/statusline.txt"
 
 # Single-overlay diagnosis when a multi-overlay tick reports errors:
-t3 teatree loop tick --overlay <name>
+t3 loop tick --overlay <name>
 ```
 
 `tick.json` has `signal_count`, `action_count`, `errors`, and `actions[]` — the structured contract. The statusline file is the formatted contract — three zones (anchors / action_needed / in_flight), ANSI-coloured, OSC 8 hyperlinks where signals carry a `url` payload.
@@ -59,7 +59,7 @@ t3 teatree loop tick --overlay <name>
 
 Walk the output of the tick **and** the rendered statusline. The tick must agree with what the user actually sees at the bottom of their session.
 
-**Structured (`tick.json` / `t3 teatree loop status`):**
+**Structured (`tick.json` / `t3 loop status`):**
 
 - `errors` is empty. Any entry like `"my_prs[teatree]": "AuthError: ..."` is bug #1 — surface it before doing anything else.
 - `signal_count` and `action_count` are non-zero when the registered overlays have open work. A clean inbox is plausible; a 0/0 tick on an overlay you know has open PRs is a scanner bug.
@@ -72,7 +72,7 @@ Walk the output of the tick **and** the rendered statusline. The tick must agree
 - Action-needed lines bright red, in-flight bright cyan. If a `my_pr.failed` ends up cyan, the zone map drifted.
 - Lines with a `url` payload render as OSC 8 hyperlinks — the raw bytes are `\033]8;;<url>\033\\<text>\033]8;;\033\\`. A line with a URL in JSON but **no** OSC 8 in the file is a render bug. (Run `od -c ~/.local/share/teatree/statusline.txt | head` if your terminal hides escapes.)
 - Multi-overlay ticks prefix lines with `[<overlay>]`. A signal with `payload.overlay = "teatree"` and no `[teatree]` prefix is a `_zones_for` bug.
-- `NO_COLOR=1 t3 teatree loop tick --statusline-file /tmp/x.txt` — the file must contain no `\033` bytes and URLs must fall back to `text <url>`.
+- `NO_COLOR=1 t3 loop tick --statusline-file /tmp/x.txt` — the file must contain no `\033` bytes and URLs must fall back to `text <url>`.
 
 ### What counts as a bug (file it)
 
@@ -83,7 +83,7 @@ Walk the output of the tick **and** the rendered statusline. The tick must agree
 - **Stale or duplicated entries** — same PR rendered twice, a closed PR still in `in_flight`, a merged PR in `action_needed`.
 - **Multi-overlay leak** — a signal from one overlay rendered without (or with the wrong) `[overlay]` prefix; identical PRs from two overlays collapsed into one line.
 - **Anchor / counter mismatch** — `signal_count` in JSON differs from the number of zone entries; `errors` non-empty but no "scanner errors:" line in `action_needed`.
-- **Crash / non-zero exit** — `t3 teatree loop tick` raising a traceback to stderr is bug #1.
+- **Crash / non-zero exit** — `t3 loop tick` raising a traceback to stderr is bug #1.
 
 ### What does NOT count (don't file)
 
@@ -131,5 +131,5 @@ Verify against the source before quoting in a bug report — these can drift.
 
 - The tick runs from the main clone, but all **fixes** happen in worktrees — don't edit the main clone.
 - Bound the hunt: one pass through the JSON + rendered file. Don't loop the tick more than 2–3 times for the same scope — repeated ticks change `last_reviewed_sha` caches and other state.
-- If `t3 teatree loop tick` won't run, that's bug #1 — file and fix it before continuing.
+- If `t3 loop tick` won't run, that's bug #1 — file and fix it before continuing.
 - Paste the relevant byte sequence in the issue body when the bug is render-shape (OSC 8, ANSI). `od -c` output is more useful than a screenshot here.

--- a/skills/teatree-dogfood/SKILL.md
+++ b/skills/teatree-dogfood/SKILL.md
@@ -30,16 +30,16 @@ Apply this checklist whenever you modify CLI commands, loop scanners, dispatch l
 2. **Tick the loop and read the file** — for any change touching `loop/`, `scanners/`, `dispatch/`, or `statusline/`:
 
    ```bash
-   t3 teatree loop tick --statusline-file /tmp/sl.txt --json | jq .
+   t3 loop tick --statusline-file /tmp/sl.txt --json | jq .
    cat /tmp/sl.txt          # what the user sees
    od -c /tmp/sl.txt | head # what's actually in the bytes (ANSI / OSC 8)
    ```
 
    The JSON is the structured contract; the file is the rendered contract. Both must match the change you intended.
-3. **Exercise both color paths** — `NO_COLOR=1 t3 teatree loop tick --statusline-file /tmp/sl-nc.txt && grep -c $'\033' /tmp/sl-nc.txt` must return `0`. Without `NO_COLOR`, the file must contain `\033[2;37m` (anchors), `\033[1;31m` (action_needed), or `\033[1;36m` (in_flight) when the matching zone is non-empty.
+3. **Exercise both color paths** — `NO_COLOR=1 t3 loop tick --statusline-file /tmp/sl-nc.txt && grep -c $'\033' /tmp/sl-nc.txt` must return `0`. Without `NO_COLOR`, the file must contain `\033[2;37m` (anchors), `\033[1;31m` (action_needed), or `\033[1;36m` (in_flight) when the matching zone is non-empty.
 4. **Exercise both overlay paths** when you have more than one overlay registered:
-   - `t3 teatree loop tick` (no flag) → multi-overlay; rendered lines prefixed with `[<overlay>]`.
-   - `t3 teatree loop tick --overlay <name>` → single overlay; lines unprefixed.
+   - `t3 loop tick` (no flag) → multi-overlay; rendered lines prefixed with `[<overlay>]`.
+   - `t3 loop tick --overlay <name>` → single overlay; lines unprefixed.
 5. **Exercise the full task lifecycle** when the change touches task execution. Create a task, run a tick, verify the worker picks it up. Don't declare "auto-start works" without observing a task transition from PENDING → CLAIMED → DONE in the DB.
 6. **Verify the OSC 8 hyperlinks render** in your real terminal (iTerm2, Kitty, WezTerm, Ghostty), not just in the byte stream. A click-through that lands on the wrong URL is a render bug; a click-through that opens nothing is a terminal limitation worth noting.
 7. **Confirm the Claude Code statusline hook is wired** — `cat ~/.claude/settings.json | jq .statusLine.command` should point at `hooks/scripts/statusline.sh` (either via plugin or hand-wired). The hook is just a `cat` of `${XDG_DATA_HOME:-$HOME/.local/share}/teatree/statusline.txt` — if the bottom bar is blank, the hook is the first thing to check.

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -25,6 +25,14 @@ class CommentResult(TypedDict, total=False):
     error: str
 
 
+class ReattributeResult(TypedDict, total=False):
+    ticket_id: int
+    issue_url: str
+    from_overlay: str
+    to_overlay: str
+    action: str
+
+
 logger = logging.getLogger(__name__)
 
 _ALLOWED_TRANSITIONS = {
@@ -200,6 +208,59 @@ class Command(TyperCommand):
             self.stdout.write("No tickets to advance.")
         else:
             self.stdout.write(f"\n{len(results)} ticket(s) {'would be' if dry_run else ''} advanced.")
+        return results
+
+    @command()
+    def reconcile_overlay(
+        self,
+        *,
+        dry_run: Annotated[bool, typer.Option(help="Show what would change without persisting.")] = False,
+    ) -> list[ReattributeResult]:
+        """Backfill ``overlay`` for rows whose attribution disagrees with inference.
+
+        Walks every ticket with an ``issue_url`` and re-runs overlay
+        inference (now routed through ``get_workspace_repos()``). Rows whose
+        stored overlay differs from a *conclusive* inference are corrected;
+        an inconclusive (empty) inference never blanks an existing value.
+        Use ``--dry-run`` to preview.
+        """
+        results: list[ReattributeResult] = []
+
+        for ticket in Ticket.objects.exclude(issue_url="").order_by("pk"):
+            inferred = ticket._infer_overlay()  # noqa: SLF001 — backfill owns this model concern.
+            if not inferred or inferred == ticket.overlay:
+                continue
+
+            from_overlay = ticket.overlay
+            if dry_run:
+                results.append(
+                    ReattributeResult(
+                        ticket_id=int(ticket.pk),
+                        issue_url=ticket.issue_url,
+                        from_overlay=from_overlay,
+                        to_overlay=inferred,
+                        action="would_reattribute",
+                    )
+                )
+                self.stdout.write(f"  [dry-run] #{ticket.pk}: {from_overlay or '∅'} → {inferred}: {ticket.issue_url}")
+            else:
+                ticket.reconcile_overlay()
+                results.append(
+                    ReattributeResult(
+                        ticket_id=int(ticket.pk),
+                        issue_url=ticket.issue_url,
+                        from_overlay=from_overlay,
+                        to_overlay=ticket.overlay,
+                        action="reattributed",
+                    )
+                )
+                self.stdout.write(f"  #{ticket.pk}: {from_overlay or '∅'} → {ticket.overlay}: {ticket.issue_url}")
+
+        if not results:
+            self.stdout.write("All ticket overlays already consistent with inference.")
+        else:
+            verb = "would be" if dry_run else "were"
+            self.stdout.write(f"\n{len(results)} ticket(s) {verb} re-attributed.")
         return results
 
 

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -232,6 +232,7 @@ class Command(TyperCommand):
                 continue
 
             from_overlay = ticket.overlay
+            from_label = from_overlay or "(none)"
             if dry_run:
                 results.append(
                     ReattributeResult(
@@ -242,9 +243,9 @@ class Command(TyperCommand):
                         action="would_reattribute",
                     )
                 )
-                self.stdout.write(f"  [dry-run] #{ticket.pk}: {from_overlay or '∅'} → {inferred}: {ticket.issue_url}")
+                self.stdout.write(f"  [dry-run] #{ticket.pk}: {from_label} → {inferred}: {ticket.issue_url}")
             else:
-                ticket.reconcile_overlay()
+                ticket.apply_inferred_overlay(inferred)
                 results.append(
                     ReattributeResult(
                         ticket_id=int(ticket.pk),
@@ -254,7 +255,7 @@ class Command(TyperCommand):
                         action="reattributed",
                     )
                 )
-                self.stdout.write(f"  #{ticket.pk}: {from_overlay or '∅'} → {ticket.overlay}: {ticket.issue_url}")
+                self.stdout.write(f"  #{ticket.pk}: {from_label} → {ticket.overlay}: {ticket.issue_url}")
 
         if not results:
             self.stdout.write("All ticket overlays already consistent with inference.")

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -79,18 +79,24 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         super().save(*args, **kwargs)  # type: ignore[arg-type]
 
     def _infer_overlay(self) -> str:
-        """Derive overlay name from issue_url by matching workspace_repos in config."""
-        from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+        """Derive overlay name from ``issue_url`` (see ``infer_overlay_for_url``)."""
+        from teatree.core.overlay_loader import infer_overlay_for_url  # noqa: PLC0415
 
-        url = self.issue_url
-        for name, overlay in get_all_overlays().items():
-            config = getattr(overlay, "config", None)
-            if config is None:
-                continue
-            for repo_slug in getattr(config, "workspace_repos", []):
-                if isinstance(repo_slug, str) and repo_slug in url:
-                    return name
-        return ""
+        return infer_overlay_for_url(self.issue_url)
+
+    def reconcile_overlay(self) -> bool:
+        """Re-infer ``overlay`` from ``issue_url`` and persist a correction.
+
+        Returns ``True`` when the row's overlay was changed. An inconclusive
+        (empty) inference leaves the existing value untouched — a blank result
+        must never blank out a manually-set or previously-correct attribution.
+        """
+        inferred = self._infer_overlay()
+        if not inferred or inferred == self.overlay:
+            return False
+        self.overlay = inferred
+        Ticket.objects.filter(pk=self.pk).update(overlay=inferred)
+        return True
 
     @property
     def ticket_number(self) -> str:

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -84,19 +84,24 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
 
         return infer_overlay_for_url(self.issue_url)
 
-    def reconcile_overlay(self) -> bool:
-        """Re-infer ``overlay`` from ``issue_url`` and persist a correction.
+    def apply_inferred_overlay(self, inferred: str) -> bool:
+        """Persist ``inferred`` as the overlay when it is a conclusive change.
 
         Returns ``True`` when the row's overlay was changed. An inconclusive
         (empty) inference leaves the existing value untouched — a blank result
         must never blank out a manually-set or previously-correct attribution.
+        Callers that already computed the inference reuse it here rather than
+        re-walking the overlay registry.
         """
-        inferred = self._infer_overlay()
         if not inferred or inferred == self.overlay:
             return False
         self.overlay = inferred
         Ticket.objects.filter(pk=self.pk).update(overlay=inferred)
         return True
+
+    def reconcile_overlay(self) -> bool:
+        """Re-infer ``overlay`` from ``issue_url`` and persist a correction."""
+        return self.apply_inferred_overlay(self._infer_overlay())
 
     @property
     def ticket_number(self) -> str:

--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -66,6 +66,33 @@ def get_all_overlay_names() -> list[str]:
     return sorted(names)
 
 
+def infer_overlay_for_url(url: str) -> str:
+    """Return the overlay whose workspace repos own ``url``, or ``""``.
+
+    Routes through ``overlay.get_workspace_repos()`` rather than the raw
+    ``config.workspace_repos`` attribute: overlays that compute their repo
+    list dynamically leave the attribute empty, so reading it directly
+    mis-attributes every one of their tickets. A registered entry that is
+    not a full overlay, or whose hook raises, is skipped so one broken
+    overlay can't poison inference for the others.
+    """
+    if not url:
+        return ""
+    for name, overlay in get_all_overlays().items():
+        getter = getattr(overlay, "get_workspace_repos", None)
+        if not callable(getter):
+            continue
+        try:
+            repo_slugs = getter()
+        except Exception:
+            logger.warning("Overlay %r get_workspace_repos() failed during inference", name, exc_info=True)
+            continue
+        for repo_slug in repo_slugs or []:
+            if isinstance(repo_slug, str) and repo_slug in url:
+                return name
+    return ""
+
+
 @lru_cache(maxsize=1)
 def _discover_overlays() -> "dict[str, OverlayBase]":
     import importlib.metadata  # noqa: PLC0415

--- a/tests/teatree_core/test_ci_only_branches.py
+++ b/tests/teatree_core/test_ci_only_branches.py
@@ -12,7 +12,6 @@ the test suite at all.
 from operator import itemgetter
 from pathlib import Path
 from subprocess import CompletedProcess
-from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -46,20 +45,20 @@ class TestRegisterOverlayCommandsAllowlistFilter:
 
 
 class TestInferOverlayFromIssueUrl:
-    """``Ticket._infer_overlay`` walks ``workspace_repos`` to map URL → overlay.
+    """``Ticket._infer_overlay`` maps URL → overlay via ``get_workspace_repos()``.
 
-    The match-and-return branch on line 86 needs an overlay whose
-    ``config.workspace_repos`` contains a substring of ``issue_url``.
+    The match-and-return branch needs an overlay whose
+    ``get_workspace_repos()`` result contains a substring of ``issue_url``.
     """
 
     def test_returns_overlay_name_when_repo_slug_matches_url(self) -> None:
         from teatree.core.models.ticket import Ticket  # noqa: PLC0415
 
-        class _Cfg:
-            workspace_repos: ClassVar[list[str]] = ["example/widgets"]
-
         class _Overlay:
-            config = _Cfg()
+            config = None
+
+            def get_workspace_repos(self) -> list[str]:
+                return ["example/widgets"]
 
         ticket = Ticket(issue_url="https://github.com/example/widgets/issues/3")
         with patch("teatree.core.overlay_loader.get_all_overlays", return_value={"widgets": _Overlay()}):
@@ -68,11 +67,11 @@ class TestInferOverlayFromIssueUrl:
     def test_returns_empty_when_no_repo_slug_matches(self) -> None:
         from teatree.core.models.ticket import Ticket  # noqa: PLC0415
 
-        class _Cfg:
-            workspace_repos: ClassVar[list[str]] = ["acme/other"]
-
         class _Overlay:
-            config = _Cfg()
+            config = None
+
+            def get_workspace_repos(self) -> list[str]:
+                return ["acme/other"]
 
         ticket = Ticket(issue_url="https://github.com/example/widgets/issues/3")
         with patch("teatree.core.overlay_loader.get_all_overlays", return_value={"x": _Overlay()}):

--- a/tests/teatree_core/test_ticket_overlay_inference.py
+++ b/tests/teatree_core/test_ticket_overlay_inference.py
@@ -1,0 +1,193 @@
+"""Overlay attribution for tickets must follow the overlay's own repo list.
+
+``Ticket._infer_overlay`` previously read ``config.workspace_repos``
+directly. Overlays that compute their workspace repos dynamically (the
+GitLab overlay derives them from ``get_repos()``) leave that attribute
+empty, so inference could never attribute a ticket to them — every such
+ticket leaked into the first overlay whose static slug happened to match
+(or none, ending up mis-tagged). The fix routes inference through
+``overlay.get_workspace_repos()`` and adds a reconcile path so rows
+already persisted with the wrong overlay can be corrected.
+"""
+
+from contextlib import AbstractContextManager
+from typing import ClassVar, cast
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.models import Ticket
+
+type _Reattribute = dict[str, object]
+
+
+class _DynamicRepoOverlay:
+    """An overlay whose repos come from the method, not config.workspace_repos."""
+
+    def __init__(self, repos: list[str]) -> None:
+        self._repos = repos
+
+        class _Cfg:
+            workspace_repos: ClassVar[list[str]] = []
+
+        self.config = _Cfg()
+
+    def get_workspace_repos(self) -> list[str]:
+        return self._repos
+
+
+class TestInferOverlayUsesGetWorkspaceRepos(TestCase):
+    """Inference must consult ``get_workspace_repos()``, not the raw attribute."""
+
+    def test_matches_overlay_whose_repos_are_method_computed(self) -> None:
+        ticket = Ticket(issue_url="https://gitlab.com/acme/widgets/-/issues/42")
+        overlay = _DynamicRepoOverlay(["acme/widgets"])
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"gitlab-overlay": overlay},
+        ):
+            assert ticket._infer_overlay() == "gitlab-overlay"
+
+    def test_no_match_returns_empty(self) -> None:
+        ticket = Ticket(issue_url="https://gitlab.com/acme/widgets/-/issues/42")
+        overlay = _DynamicRepoOverlay(["other/repo"])
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"x": overlay},
+        ):
+            assert ticket._infer_overlay() == ""
+
+    def test_overlay_without_get_workspace_repos_is_skipped(self) -> None:
+        """A registered entry that is not a full overlay must not crash inference."""
+
+        class _Bare:
+            config = None
+
+        ticket = Ticket(issue_url="https://github.com/example/widgets/issues/3")
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"bare": _Bare()},
+        ):
+            assert ticket._infer_overlay() == ""
+
+    def test_method_raising_does_not_break_other_overlays(self) -> None:
+        class _Broken:
+            config = None
+
+            def get_workspace_repos(self) -> list[str]:
+                msg = "overlay config unavailable"
+                raise RuntimeError(msg)
+
+        good = _DynamicRepoOverlay(["acme/widgets"])
+        ticket = Ticket(issue_url="https://gitlab.com/acme/widgets/-/issues/42")
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"broken": _Broken(), "good": good},
+        ):
+            assert ticket._infer_overlay() == "good"
+
+
+class TestReconcileOverlay(TestCase):
+    """``Ticket.reconcile_overlay`` re-infers and persists a corrected overlay."""
+
+    def _patch_overlays(self, overlay: object) -> AbstractContextManager[object]:
+        return patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"gitlab-overlay": overlay},
+        )
+
+    def test_corrects_a_mis_attributed_row(self) -> None:
+        overlay = _DynamicRepoOverlay(["acme/widgets"])
+        with self._patch_overlays(overlay):
+            ticket = Ticket.objects.create(
+                overlay="wrong-overlay",
+                issue_url="https://gitlab.com/acme/widgets/-/issues/42",
+            )
+            changed = ticket.reconcile_overlay()
+        assert changed is True
+        assert ticket.overlay == "gitlab-overlay"
+        ticket.refresh_from_db()
+        assert ticket.overlay == "gitlab-overlay"
+
+    def test_leaves_correct_row_untouched(self) -> None:
+        overlay = _DynamicRepoOverlay(["acme/widgets"])
+        with self._patch_overlays(overlay):
+            ticket = Ticket.objects.create(
+                overlay="gitlab-overlay",
+                issue_url="https://gitlab.com/acme/widgets/-/issues/42",
+            )
+            changed = ticket.reconcile_overlay()
+        assert changed is False
+        assert ticket.overlay == "gitlab-overlay"
+
+    def test_keeps_existing_overlay_when_inference_is_inconclusive(self) -> None:
+        """An empty inference must not blank out a row's existing overlay."""
+        overlay = _DynamicRepoOverlay(["unrelated/repo"])
+        with self._patch_overlays(overlay):
+            ticket = Ticket.objects.create(
+                overlay="manually-set",
+                issue_url="https://gitlab.com/acme/widgets/-/issues/42",
+            )
+            changed = ticket.reconcile_overlay()
+        assert changed is False
+        assert ticket.overlay == "manually-set"
+
+    def test_no_issue_url_is_a_noop(self) -> None:
+        overlay = _DynamicRepoOverlay(["acme/widgets"])
+        with self._patch_overlays(overlay):
+            ticket = Ticket.objects.create(overlay="manual", issue_url="")
+            changed = ticket.reconcile_overlay()
+        assert changed is False
+        assert ticket.overlay == "manual"
+
+
+class TestReconcileOverlayCommand(TestCase):
+    """``manage.py ticket reconcile-overlay`` backfills mis-attributed rows."""
+
+    def _patch(self, overlay: object) -> AbstractContextManager[object]:
+        return patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"gitlab-overlay": overlay},
+        )
+
+    def test_dry_run_reports_without_persisting(self) -> None:
+        overlay = _DynamicRepoOverlay(["acme/widgets"])
+        with self._patch(overlay):
+            wrong = Ticket.objects.create(
+                overlay="wrong",
+                issue_url="https://gitlab.com/acme/widgets/-/issues/1",
+            )
+            results = cast("list[_Reattribute]", call_command("ticket", "reconcile-overlay", "--dry-run"))
+        assert any(r["ticket_id"] == wrong.pk and r["action"] == "would_reattribute" for r in results)
+        wrong.refresh_from_db()
+        assert wrong.overlay == "wrong"
+
+    def test_reports_nothing_when_all_rows_already_consistent(self) -> None:
+        overlay = _DynamicRepoOverlay(["acme/widgets"])
+        with self._patch(overlay):
+            Ticket.objects.create(
+                overlay="gitlab-overlay",
+                issue_url="https://gitlab.com/acme/widgets/-/issues/9",
+            )
+            results = cast("list[_Reattribute]", call_command("ticket", "reconcile-overlay"))
+        assert results == []
+
+    def test_persists_corrected_overlay(self) -> None:
+        overlay = _DynamicRepoOverlay(["acme/widgets"])
+        with self._patch(overlay):
+            wrong = Ticket.objects.create(
+                overlay="wrong",
+                issue_url="https://gitlab.com/acme/widgets/-/issues/1",
+            )
+            right = Ticket.objects.create(
+                overlay="gitlab-overlay",
+                issue_url="https://gitlab.com/acme/widgets/-/issues/2",
+            )
+            results = cast("list[_Reattribute]", call_command("ticket", "reconcile-overlay"))
+        wrong.refresh_from_db()
+        right.refresh_from_db()
+        assert wrong.overlay == "gitlab-overlay"
+        assert right.overlay == "gitlab-overlay"
+        reattributed = [r for r in results if r["action"] == "reattributed"]
+        assert [r["ticket_id"] for r in reattributed] == [wrong.pk]

--- a/tests/test_overlay_loader.py
+++ b/tests/test_overlay_loader.py
@@ -1,11 +1,12 @@
 """Tests for teatree.core.overlay_loader — TOML-based overlay discovery."""
 
+from typing import ClassVar
 from unittest.mock import patch
 
 import teatree.config as config_mod
 from teatree.config import TeaTreeConfig
 from teatree.core.overlay import OverlayBase
-from teatree.core.overlay_loader import _discover_toml_overlays
+from teatree.core.overlay_loader import _discover_toml_overlays, infer_overlay_for_url
 
 
 def _make_config(overlays: dict) -> TeaTreeConfig:
@@ -80,6 +81,62 @@ class TestDiscoverTomlOverlaysImportError:
             result = _discover_toml_overlays(OverlayBase, set())
         assert result == {}
         assert "failed to load class" in caplog.text
+
+
+class TestInferOverlayForUrl:
+    """``infer_overlay_for_url`` maps a URL to the owning overlay (#743)."""
+
+    def _overlay(self, repos: list[str]):
+        class _Cfg:
+            workspace_repos: ClassVar[list[str]] = []
+
+        class _Overlay:
+            config = _Cfg()
+
+            def get_workspace_repos(self) -> list[str]:
+                return repos
+
+        return _Overlay()
+
+    def test_empty_url_returns_empty(self):
+        assert infer_overlay_for_url("") == ""
+
+    def test_matches_via_get_workspace_repos(self):
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"gl": self._overlay(["acme/widgets"])},
+        ):
+            assert infer_overlay_for_url("https://gitlab.com/acme/widgets/-/issues/7") == "gl"
+
+    def test_no_match_returns_empty(self):
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"gl": self._overlay(["other/repo"])},
+        ):
+            assert infer_overlay_for_url("https://gitlab.com/acme/widgets/-/issues/7") == ""
+
+    def test_non_overlay_entry_is_skipped(self):
+        class _Bare:
+            config = None
+
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"bare": _Bare()},
+        ):
+            assert infer_overlay_for_url("https://example.com/x/issues/1") == ""
+
+    def test_raising_overlay_does_not_block_others(self, caplog):
+        class _Broken:
+            def get_workspace_repos(self) -> list[str]:
+                msg = "boom"
+                raise RuntimeError(msg)
+
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"broken": _Broken(), "ok": self._overlay(["acme/widgets"])},
+        ):
+            assert infer_overlay_for_url("https://gitlab.com/acme/widgets/-/issues/7") == "ok"
+        assert "failed during inference" in caplog.text
 
 
 # ── Test helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
fix(core): reuse computed inference in backfill; ASCII fallback label (#743)

Review nits: the reconcile-overlay backfill computed _infer_overlay()
then reconcile_overlay() recomputed it — extract Ticket.apply_inferred_
overlay(inferred) so the command reuses the value it already has and the
heavy overlay walk runs once per row. Replace the non-ASCII U+2205 glyph
in the backfill output with "(none)" so it renders on CI/terminals like
the sibling commands.