### PR TITLE
fix(privacy): block non-noreply commit author on public souliane/* push (#730)

### DIFF
--- a/scripts/hooks/refuse-public-push-with-leak.sh
+++ b/scripts/hooks/refuse-public-push-with-leak.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pre-push hook: public-repo privacy gate (#685).
+# Pre-push hook: public-repo privacy gate (#685, #730).
 #
 # Refuses `git push` when the `origin` remote resolves to a PUBLIC
 # repository and the branch-vs-base diff OR the commit messages in the
@@ -7,6 +7,17 @@
 # `/Users/`-`/home/` path, a private IP, an API token, an internal
 # hostname, or a T3_BANNED_TERM). Commit messages and trailers reach
 # public history just like file content, so they are scanned too (#703).
+#
+# It ALSO refuses (#730) when any commit in the push range has an author
+# OR committer email that is not a GitHub noreply address. A real /
+# deliverable address (e.g. a customer/personal-domain address
+# inherited from local git config) in PUBLIC history is a permanent PII
+# leak that GitHub's own "block pushes that expose my email" does not
+# catch for third-party domains. The accepted shape is the GitHub
+# noreply pattern `([0-9]+\+)?<login>@users.noreply.github.com`, which
+# covers every GitHub identity (souliane and any other login)
+# without hardcoding one specific login.
+#
 # Pushes to a private remote, and clean pushes to a public remote, pass
 # through.
 #
@@ -87,6 +98,32 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     # whole tree at the pushed sha rather than skipping the gate.
     diff=$(git show "${local_sha}" 2>/dev/null || true)
     msgs=$(git log --format='%B' "${local_sha}" 2>/dev/null || true)
+  fi
+
+  # Author / committer email is metadata `git diff` and `%B` never show,
+  # yet it lands in public history forever. On a PUBLIC remote every
+  # commit's author AND committer email must be a GitHub noreply address
+  # (`([0-9]+\+)?<login>@users.noreply.github.com`); anything else — a
+  # real/deliverable address such as a customer-domain email inherited
+  # from local git config — is blocked (#730).
+  if [ -n "${base}" ]; then
+    author_range="${base}..${local_sha}"
+  else
+    author_range="${local_sha}"
+  fi
+  noreply_re='^([0-9]+\+)?[A-Za-z0-9-]+@users\.noreply\.github\.com$'
+  bad_idents=$(git log --format='%ae%n%ce' "${author_range}" 2>/dev/null \
+    | grep -v -E "${noreply_re}" | sort -u || true)
+  if [ -n "${bad_idents}" ]; then
+    echo "✗ refuse: push to PUBLIC repo '${slug}' has a non-noreply commit identity on '${local_ref}'."
+    echo "  A real/deliverable email in public git history is a permanent PII leak."
+    echo "  Offending author/committer email(s):"
+    printf '%s\n' "${bad_idents}" | sed 's/^/    /'
+    echo "  Allowed shape: <id>+<login>@users.noreply.github.com (GitHub noreply)."
+    echo "  Rewrite the range's author/committer to the repo's GitHub noreply identity, then re-push:"
+    echo "    git filter-branch --env-filter '...' -- ${author_range}"
+    echo "  (public-repo privacy gate #730 — see /t3:rules § public-repo commit author identity)"
+    blocked=1
   fi
 
   # Commit messages and trailers reach public history exactly like file

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -48,7 +48,8 @@ Use `Ctrl+F`/`grep` to jump to a rule. Sections are grouped below by theme; numb
 17a. [Evidence Comes From the Deployed Environment](#evidence-comes-from-the-deployed-environment-non-negotiable)
 17. [Verify Repo Visibility Before Filing External Issues](#verify-repo-visibility-before-filing-external-issues-non-negotiable)
 18. [Leak Remediation — Silent Scrubs](#leak-remediation--silent-scrubs-non-negotiable)
-19. [GitLab Inline Comments](#gitlab-inline-comments)
+19. [Public-Repo Commit Author Identity](#public-repo-commit-author-identity-non-negotiable)
+20. [GitLab Inline Comments](#gitlab-inline-comments)
 
 **API & shell recipes**
 
@@ -284,6 +285,10 @@ If the target is **PUBLIC**, the body must not contain internal identifiers: cus
 ## Leak Remediation — Silent Scrubs (Non-Negotiable)
 
 When remediating a privacy leak on a public repo (force-push to drop PII, delete a comment that exposed a credential, rewrite a branch that leaked internal data), **every public artifact produced during the remediation must be neutral**. Do not name what leaked, do not name that a leak occurred, do not describe the scrub. Announcing the remediation on a public surface amplifies the leak (Streisand effect) — the commit subject, the PR comment, and the branch name are all crawled, cached, and indexed.
+
+## Public-Repo Commit Author Identity (Non-Negotiable)
+
+Commits pushed to a PUBLIC repo (`souliane/*`) must have an author **and** committer email that is a GitHub noreply address — `<id>+<login>@users.noreply.github.com` (e.g. `21343492+souliane@users.noreply.github.com`). A real/deliverable address (any customer/personal domain inherited from local `.git/config` or the XDG global) in public history is a permanent PII leak that GitHub's own "block pushes that expose my email" does **not** catch for third-party domains. The accepted shape is the noreply pattern itself — not one hardcoded login — so any GitHub identity passes and any real email blocks. Private overlay repos are exempt. Enforced deterministically by the pre-push gate `scripts/hooks/refuse-public-push-with-leak.sh` (#730): on a violation it blocks and prints the offending identity plus the `git filter-branch --env-filter` rewrite to the repo's GitHub noreply identity; re-push after the metadata-only rewrite.
 
 **Banned words in any public artifact produced during remediation** (commit subject/body, PR or issue description or comment, release note, changelog, public branch name):
 

--- a/tests/test_refuse_public_push_with_leak.py
+++ b/tests/test_refuse_public_push_with_leak.py
@@ -38,11 +38,19 @@ def _git(cwd: Path, *args: str) -> None:
     )
 
 
+# A GitHub-noreply identity so the shared fixtures exercise only the
+# leak-scan dimension of the gate, not the #730 author-identity guard
+# (which has its own dedicated test class). The login form keeps these
+# commits passing the noreply pattern just like a real loop commit.
+_NOREPLY_EMAIL = "21343492+souliane@users.noreply.github.com"
+_NOREPLY_NAME = "souliane"
+
+
 def _make_repo(path: Path, branch: str = "main") -> None:
     path.mkdir(parents=True)
     _git(path, "init", "-b", branch)
-    _git(path, "config", "user.email", "t@e.st")  # privacy-scan:allow test fixture
-    _git(path, "config", "user.name", "Tester")
+    _git(path, "config", "user.email", _NOREPLY_EMAIL)
+    _git(path, "config", "user.name", _NOREPLY_NAME)
     (path / "README.md").write_text("hello\n", encoding="utf-8")
     _git(path, "add", "README.md")
     _git(path, "commit", "-m", "init")
@@ -78,8 +86,8 @@ def _clone_with_remote(tmp_path: Path, gh_visibility: str) -> tuple[Path, dict[s
     _make_repo(origin)
     work = tmp_path / "work"
     _git(tmp_path, "clone", str(origin), str(work))
-    _git(work, "config", "user.email", "t@e.st")  # privacy-scan:allow test fixture
-    _git(work, "config", "user.name", "Tester")
+    _git(work, "config", "user.email", _NOREPLY_EMAIL)
+    _git(work, "config", "user.name", _NOREPLY_NAME)
     # The origin URL is a local path; rewrite it to a github.com-looking
     # URL so the gate has an owner/repo to ask gh about.
     _git(work, "remote", "set-url", "origin", "https://github.com/acme/widget.git")
@@ -123,7 +131,7 @@ class TestRefusePublicPushWithLeak:
     def test_blocks_public_push_with_planted_secret(self, tmp_path: Path) -> None:
         work, env = _clone_with_remote(tmp_path, "PUBLIC")
         (work / "leak.txt").write_text(
-            "token = glpat-XXXXXXXXXXXXXXXX\n",  # privacy-scan:allow test fixture
+            "token = glpat-XXXXXXXXXXXXXXXX\n",
             encoding="utf-8",
         )
         _git(work, "add", "leak.txt")
@@ -145,7 +153,7 @@ class TestRefusePublicPushWithLeak:
         """
         work, env = _clone_with_remote(tmp_path, "PUBLIC")
         (work / "leak.txt").write_text(
-            "token = glpat-XXXXXXXXXXXXXXXX\n",  # privacy-scan:allow test fixture
+            "token = glpat-XXXXXXXXXXXXXXXX\n",
             encoding="utf-8",
         )
         _git(work, "add", "leak.txt")
@@ -160,7 +168,7 @@ class TestRefusePublicPushWithLeak:
 
     def test_blocks_public_push_with_internal_path(self, tmp_path: Path) -> None:
         work, env = _clone_with_remote(tmp_path, "PUBLIC")
-        planted = "see /Users/someone/secret/path\n"  # privacy-scan:allow test fixture
+        planted = "see /Users/someone/secret/path\n"
         (work / "notes.txt").write_text(planted, encoding="utf-8")
         _git(work, "add", "notes.txt")
         _git(work, "commit", "-m", "add notes")
@@ -182,7 +190,7 @@ class TestRefusePublicPushWithLeak:
     def test_allows_private_repo_push_even_with_secret(self, tmp_path: Path) -> None:
         work, env = _clone_with_remote(tmp_path, "PRIVATE")
         (work / "leak.txt").write_text(
-            "token = glpat-XXXXXXXXXXXXXXXX\n",  # privacy-scan:allow test fixture
+            "token = glpat-XXXXXXXXXXXXXXXX\n",
             encoding="utf-8",
         )
         _git(work, "add", "leak.txt")
@@ -203,7 +211,7 @@ class TestRefusePublicPushWithLeak:
         # is genuinely unavailable.
         env["PATH"] = "/usr/bin:/bin"
         (work / "leak.txt").write_text(
-            "token = glpat-XXXXXXXXXXXXXXXX\n",  # privacy-scan:allow test fixture
+            "token = glpat-XXXXXXXXXXXXXXXX\n",
             encoding="utf-8",
         )
         _git(work, "add", "leak.txt")
@@ -234,7 +242,7 @@ class TestRefusePublicPushWithLeak:
         assert clean.returncode == 0, "annotated fixture must not block: " + clean.stdout + clean.stderr
 
         # Now a genuinely leaking, un-annotated file in a later commit.
-        leaking = 'API = "glpat-ZZZZZZZZZZZZZZZZ"\n'  # privacy-scan:allow test fixture
+        leaking = 'API = "glpat-ZZZZZZZZZZZZZZZZ"\n'
         (work / "config.py").write_text(leaking, encoding="utf-8")
         _git(work, "add", "config.py")
         _git(work, "commit", "-m", "add config")
@@ -280,7 +288,7 @@ class TestRefusePublicPushWithLeak:
             "-m",
             "add feature",
             "-m",
-            "token = glpat-XXXXXXXXXXXXXXXX",  # privacy-scan:allow test fixture
+            "token = glpat-XXXXXXXXXXXXXXXX",
         )
 
         result = _run_hook(work, env, _push_stdin(work))
@@ -313,6 +321,105 @@ class TestRefusePublicPushWithLeak:
 
     def test_hook_is_executable(self) -> None:
         assert os.access(HOOK, os.X_OK), f"{HOOK} must be chmod +x"
+
+
+class TestRefusePublicPushWithNonNoreplyAuthor:
+    """#730 — public history must never carry a real author/committer email.
+
+    On a PUBLIC remote every commit in the push range must have an author
+    AND committer email matching the GitHub noreply pattern; anything else
+    (e.g. a customer-domain address) blocks. Private remotes are exempt
+    (real internal emails there are fine).
+    """
+
+    def _commit_as(self, work: Path, name: str, email: str, filename: str) -> None:
+        (work / filename).write_text("clean feature line\n", encoding="utf-8")
+        _git(work, "add", filename)
+        _git(
+            work,
+            "-c",
+            f"user.name={name}",
+            "-c",
+            f"user.email={email}",
+            "commit",
+            "-m",
+            "add clean feature",
+        )
+
+    def test_blocks_public_push_with_customer_domain_author(self, tmp_path: Path) -> None:
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        self._commit_as(
+            work,
+            "Real Dev",
+            "real.dev@internal.example",
+            "feature.txt",
+        )
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode != 0, result.stdout + result.stderr
+        assert "noreply" in (result.stdout + result.stderr)
+
+    def test_blocks_public_push_when_only_committer_is_real_email(self, tmp_path: Path) -> None:
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        (work / "feature.txt").write_text("clean feature line\n", encoding="utf-8")
+        _git(work, "add", "feature.txt")
+        # Author is a valid noreply; committer is a real customer email.
+        env_commit = _hermetic_env()
+        env_commit["GIT_AUTHOR_NAME"] = "souliane"
+        env_commit["GIT_AUTHOR_EMAIL"] = "21343492+souliane@users.noreply.github.com"
+        env_commit["GIT_COMMITTER_NAME"] = "Real Dev"
+        env_commit["GIT_COMMITTER_EMAIL"] = "real.dev@internal.example"
+        subprocess.run(
+            ["git", "commit", "-m", "add clean feature"],  # noqa: S607
+            cwd=work,
+            check=True,
+            capture_output=True,
+            env=env_commit,
+        )
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode != 0, result.stdout + result.stderr
+
+    def test_allows_public_push_with_souliane_noreply_author(self, tmp_path: Path) -> None:
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        self._commit_as(
+            work,
+            "souliane",
+            "21343492+souliane@users.noreply.github.com",
+            "feature.txt",
+        )
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_allows_public_push_with_other_github_noreply_author(self, tmp_path: Path) -> None:
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        self._commit_as(
+            work,
+            "Octo Cat",
+            "987654321+octocat@users.noreply.github.com",
+            "feature.txt",
+        )
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_allows_private_repo_push_with_real_email_author(self, tmp_path: Path) -> None:
+        work, env = _clone_with_remote(tmp_path, "PRIVATE")
+        self._commit_as(
+            work,
+            "Real Dev",
+            "real.dev@internal.example",
+            "feature.txt",
+        )
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 0, result.stdout + result.stderr
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix(privacy): block non-noreply commit author on public souliane/* push (#730)

Extend the #685 pre-push privacy gate so on a PUBLIC remote every commit's author AND committer email must match the GitHub noreply pattern; a real/deliverable address inherited from local git config is blocked with a filter-branch rewrite hint. Private repos exempt. Adds a rules section + 5 integration tests.