### PR TITLE
fix(core): Task._advance_ticket normalizes phase before the FSM compare (#750)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -406,7 +406,7 @@ Represents a unit of work for an agent (headless or interactive).
 
 **Claiming:** `claim(claimed_by, lease_seconds=300)` uses `select_for_update()` for atomic distributed locking. Raises `InvalidTransitionError` if already claimed with a valid lease.
 
-**Completion flow:** `complete()` → clears claim → calls `_advance_ticket()`:
+**Completion flow:** `complete()` → clears claim → calls `_advance_ticket()`. `_advance_ticket()` **normalizes `self.phase` via `normalize_phase()` once** before the FSM dispatch (#750), mirroring `_record_phase_visit()` — a task whose phase is a short verb (`review`/`code`/…, the vocabulary skills emit and `tasks create` stores verbatim) advances the FSM, not just records the session visit; raw comparison previously left `ticket.state` silently desynced from `visited_phases` (one root cause `reconcile_reviewed()` papered over). The phase-keyed branches below match on the **normalized** token:
 
 - If last attempt has `needs_user_input: true`: creates interactive followup task (same phase, parent_task linked, session carries the `agent_session_id` for resume)
 - If phase is "scoping" and ticket is SCOPED: calls `ticket.start()` (→ schedules coding)

--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -121,23 +121,30 @@ class Task(models.Model):
         self._record_phase_visit()
         ticket = self.ticket
         ticket.refresh_from_db()
+        # Normalize once, mirroring _record_phase_visit() — a task whose
+        # phase is a short verb ("review"/"code"/...) must advance the
+        # FSM too, not just record the session visit (#750). Raw
+        # comparison silently desynced ticket.state from visited_phases.
+        from teatree.core.phases import normalize_phase  # noqa: PLC0415
+
+        phase = normalize_phase(self.phase)
         with transaction.atomic():
-            if self.phase == "reviewing" and ticket.role == Ticket.Role.REVIEWER:
+            if phase == "reviewing" and ticket.role == Ticket.Role.REVIEWER:
                 ticket.mark_reviewed_externally()
                 ticket.save()
-            elif self.phase == "scoping" and ticket.state == Ticket.State.SCOPED:
+            elif phase == "scoping" and ticket.state == Ticket.State.SCOPED:
                 ticket.start()
                 ticket.save()
-            elif self.phase == "coding" and ticket.state == Ticket.State.STARTED:
+            elif phase == "coding" and ticket.state == Ticket.State.STARTED:
                 ticket.code()
                 ticket.save()
-            elif self.phase == "testing" and ticket.state == Ticket.State.CODED:
+            elif phase == "testing" and ticket.state == Ticket.State.CODED:
                 ticket.test(passed=True)
                 ticket.save()
-            elif self.phase == "reviewing" and ticket.state == Ticket.State.TESTED:
+            elif phase == "reviewing" and ticket.state == Ticket.State.TESTED:
                 ticket.review()
                 ticket.save()
-            elif self.phase == "shipping" and ticket.state == Ticket.State.REVIEWED:
+            elif phase == "shipping" and ticket.state == Ticket.State.REVIEWED:
                 ticket.ship()
                 ticket.save()
 

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -337,3 +337,66 @@ class TestExecuteHeadlessTask(TestCase):
         assert attempt is not None
         assert attempt.exit_code == 1
         assert "headless runtime crashed" in attempt.error
+
+
+class TestAdvanceTicketNormalizesPhase(TestCase):
+    """``Task._advance_ticket`` normalizes phase before the FSM compare (#750).
+
+    Mirrors ``_record_phase_visit``. A task whose phase is a short verb
+    (``review``/``code``/``test``/...)
+    — the vocabulary skills emit and ``tasks create`` stores verbatim —
+    records the phase visit on the session but, pre-fix, never advances
+    the ticket FSM (``"review" == "reviewing"`` is False). Silent
+    persistence/FSM desync.
+    """
+
+    def _ticket_with_session(self, state: Ticket.State) -> tuple[Ticket, Session]:
+        ticket = Ticket.objects.create(overlay="test", state=state)
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        return ticket, session
+
+    def test_short_verb_review_advances_tested_to_reviewed(self) -> None:
+        ticket, session = self._ticket_with_session(Ticket.State.TESTED)
+        # review()'s FSM condition requires a completed reviewing task to
+        # exist (#694) — the real loop always has one. That condition's
+        # own raw phase= filter (canonical-only) is a *separate* adjacent
+        # bug filed as a follow-up; this test isolates the #750 scope
+        # (_advance_ticket normalization) by satisfying the precondition
+        # canonically, exactly as the loop's schedule_* chain does.
+        Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            status=Task.Status.COMPLETED,
+        )
+        task = Task.objects.create(ticket=ticket, session=session, phase="review")
+
+        task._advance_ticket()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED, (
+            f"short-verb 'review' task did not advance FSM (state={ticket.state}); "
+            "_advance_ticket compared raw self.phase instead of normalize_phase()"
+        )
+        # The session record agrees (already normalized by _record_phase_visit).
+        assert "reviewing" in (session.visited_phases or [])
+
+    def test_short_verb_code_advances_started_to_coded(self) -> None:
+        ticket, session = self._ticket_with_session(Ticket.State.STARTED)
+        task = Task.objects.create(ticket=ticket, session=session, phase="code")
+
+        task._advance_ticket()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.CODED
+
+    def test_canonical_gerund_still_advances(self) -> None:
+        # Regression guard: normalization must not break the already-correct
+        # canonical-token path (the loop's auto-scheduled chain).
+        ticket, session = self._ticket_with_session(Ticket.State.CODED)
+        task = Task.objects.create(ticket=ticket, session=session, phase="testing")
+
+        task._advance_ticket()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.TESTED


### PR DESCRIPTION
fix(core): Task._advance_ticket normalizes phase before the FSM compare (#750)

_advance_ticket compared raw self.phase against canonical gerunds while the sibling _record_phase_visit normalizes — a short-verb task (review/code/test/..., the vocabulary skills emit and tasks create stores verbatim) recorded the session phase visit but never advanced the ticket FSM (silent persistence/FSM desync, one root cause reconcile_reviewed papers over). Normalize self.phase once via normalize_phase() at the top of the dispatch, mirroring _record_phase_visit. TDD: short-verb code/review tests RED-verified on the pre-fix raw compare (state stayed 'started'/'tested'), GREEN on the fix; canonical-gerund regression guard included. Scope kept surgical per the issue directive — the sibling review() FSM-condition raw phase= filter (same root-cause class, distinct concern) is filed as follow-up #757. 79 tests green across task/worktree-task/fsm/dispatch suites, zero regression. BLUEPRINT completion-flow updated.