### PR TITLE
fix(e2e): discover frontend across the ticket's sibling worktrees

### DIFF
--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from django_typer.management import TyperCommand, command
 
 from teatree.config import E2ERepo, load_e2e_repos
+from teatree.core.models import Worktree
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import _find_env_cache, _get_user_cwd, _parse_env_file, resolve_worktree
 from teatree.core.runners.worktree_start import compose_project
@@ -79,21 +80,48 @@ def _resolve_private_tests_path() -> Path | None:
     return path if path.is_dir() else None
 
 
-def _discover_frontend_port(project: str, default: int = 4200) -> int | None:
-    """Discover frontend port via docker-compose, falling back to a local scan.
-
-    The frontend is served by the compose ``frontend`` service (nginx serving
-    the pre-built dist/). ``docker compose port`` is the authoritative answer
-    when the stack is up; the local scan is a last-ditch fallback for users
-    who started compose outside the teatree runner.
-    """
+def _compose_frontend_port(project: str) -> int | None:
     # The compose `frontend` service is nginx serving the pre-built dist on
     # container port 80; a raw dev-server setup instead listens on 4200.
-    # Query both container ports — `default` is the host-scan fallback, not
-    # the container port, so it must not be passed to `docker compose port`
-    # (that always missed the nginx:80 service).
-    for container_port in (80, default):
+    for container_port in (80, 4200):
         port = get_service_port(project, "frontend", container_port)
+        if port is not None:
+            return port
+    return None
+
+
+def _ticket_frontend_projects(worktree: Worktree) -> list[str]:
+    """Compose projects that may host the frontend for this worktree's ticket.
+
+    The resolved worktree is whatever the cwd matched — for an external test
+    repo that is the *test* worktree, whose compose project has no frontend.
+    The frontend lives in a sibling repo's worktree under the same ticket, so
+    probe the resolved worktree first, then every sibling under the ticket.
+    """
+    ticket = worktree.ticket
+    candidates = [worktree]
+    if ticket is not None:
+        candidates += [wt for wt in Worktree.objects.filter(ticket=ticket) if wt.pk != worktree.pk]
+    seen: set[str] = set()
+    projects: list[str] = []
+    for wt in candidates:
+        project = compose_project(wt)
+        if project not in seen:
+            seen.add(project)
+            projects.append(project)
+    return projects
+
+
+def _discover_frontend_port(worktree: Worktree) -> int | None:
+    """Discover the frontend port for a worktree's stack.
+
+    ``docker compose port`` is authoritative when the stack is up; the local
+    scan is a last-ditch fallback for users who started compose outside the
+    teatree runner. The frontend may be served by a sibling repo's compose
+    project under the same ticket, so every ticket project is probed.
+    """
+    for project in _ticket_frontend_projects(worktree):
+        port = _compose_frontend_port(project)
         if port is not None:
             return port
     # Scan the allocation range — ports start at 4200 and go up
@@ -250,12 +278,12 @@ class Command(TyperCommand):
             frontend_url = None  # preserve existing BASE_URL
         else:
             worktree = resolve_worktree()
-            project = compose_project(worktree)
-            frontend_port = _discover_frontend_port(project)
+            frontend_port = _discover_frontend_port(worktree)
             if frontend_port is None:
+                probed = ", ".join(_ticket_frontend_projects(worktree)) or "none"
                 return (
-                    f"Frontend not running (no docker service in '{project}', no local process on 4200). "
-                    "Run `t3 <overlay> worktree start` first."
+                    f"Frontend not running (no docker `frontend` service in [{probed}], "
+                    "no local process on 4200). Run `t3 <overlay> worktree start` first."
                 )
             frontend_url = f"http://localhost:{frontend_port}"
 

--- a/tests/teatree_core/test_e2e_frontend_discovery.py
+++ b/tests/teatree_core/test_e2e_frontend_discovery.py
@@ -1,0 +1,43 @@
+from django.test import TestCase
+
+from teatree.core.management.commands.e2e import _ticket_frontend_projects
+from teatree.core.models import Ticket, Worktree
+from teatree.core.runners.worktree_start import compose_project
+
+
+class TicketFrontendProjectsTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.ticket = Ticket.objects.create(overlay="demo", issue_url="https://example.test/issues/147")
+        cls.test_repo_wt = Worktree.objects.create(ticket=cls.ticket, overlay="demo", repo_path="e2e-tests", branch="b")
+        cls.app_repo_wt = Worktree.objects.create(ticket=cls.ticket, overlay="demo", repo_path="webapp", branch="b")
+
+    def test_includes_sibling_app_project_when_resolved_to_test_repo(self) -> None:
+        # The bug: discovery only probed the resolved (test-repo) worktree's
+        # compose project, never the sibling app worktree hosting the frontend.
+        projects = _ticket_frontend_projects(self.test_repo_wt)
+
+        assert projects[0] == "e2e-tests-wt147"
+        assert "webapp-wt147" in projects
+
+    def test_resolved_worktree_is_probed_first(self) -> None:
+        projects = _ticket_frontend_projects(self.app_repo_wt)
+
+        assert projects[0] == "webapp-wt147"
+        assert "e2e-tests-wt147" in projects
+
+    def test_no_duplicate_projects(self) -> None:
+        projects = _ticket_frontend_projects(self.test_repo_wt)
+
+        assert len(projects) == len(set(projects))
+
+    def test_ticketless_worktree_yields_only_its_own_project(self) -> None:
+        orphan = Worktree.objects.create(
+            ticket=Ticket.objects.create(overlay="demo"),
+            overlay="demo",
+            repo_path="solo",
+            branch="b",
+        )
+        projects = _ticket_frontend_projects(orphan)
+
+        assert projects == [compose_project(orphan)]

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -2508,22 +2508,27 @@ class TestDetectLocalPort:
 
 class TestDiscoverFrontendPort:
     def test_returns_docker_port_when_compose_reports_it(self) -> None:
-        with patch.object(e2e_mod, "get_service_port", return_value=4201):
-            assert e2e_mod._discover_frontend_port("project") == 4201
+        with (
+            patch.object(e2e_mod, "_ticket_frontend_projects", return_value=["project"]),
+            patch.object(e2e_mod, "get_service_port", return_value=4201),
+        ):
+            assert e2e_mod._discover_frontend_port(MagicMock()) == 4201
 
     def test_scans_local_ports_as_final_fallback(self) -> None:
         with (
+            patch.object(e2e_mod, "_ticket_frontend_projects", return_value=["project"]),
             patch.object(e2e_mod, "get_service_port", return_value=None),
             patch.object(e2e_mod, "_detect_local_port", side_effect=lambda p: 4203 if p == 4203 else None),
         ):
-            assert e2e_mod._discover_frontend_port("project") == 4203
+            assert e2e_mod._discover_frontend_port(MagicMock()) == 4203
 
     def test_returns_none_when_no_port_found(self) -> None:
         with (
+            patch.object(e2e_mod, "_ticket_frontend_projects", return_value=["project"]),
             patch.object(e2e_mod, "get_service_port", return_value=None),
             patch.object(e2e_mod, "_detect_local_port", return_value=None),
         ):
-            assert e2e_mod._discover_frontend_port("project") is None
+            assert e2e_mod._discover_frontend_port(MagicMock()) is None
 
 
 class TestE2eTriggerCi(TestCase):


### PR DESCRIPTION
## Bug

`t3 <overlay> e2e external` computed the frontend compose project from `compose_project(resolve_worktree())`. In a workspace with **two repos under one ticket** (an external test repo + the app repo), the cwd-resolved worktree is the *test* repo, whose compose project has **no frontend service** — the frontend lives in the sibling app worktree's project.

Result: frontend discovery **always** failed and bailed with *"Frontend not running… Run worktree start first"* before Playwright ever ran, regardless of whether the stack was up. Runs "completed" in seconds without executing a single test.

## Fix

`_discover_frontend_port` now takes the worktree and probes the resolved worktree first, then **every sibling worktree under the same ticket** (`_ticket_frontend_projects`), before the local-port fallback. The bail message lists all probed projects.

## Test

- `tests/teatree_core/test_e2e_frontend_discovery.py` — 4 new cases: test-repo-resolved includes the sibling app project, resolved-worktree-probed-first, dedup, ticketless.
- Updated the 3 existing `TestDiscoverFrontendPort` cases for the new signature.

`ruff`/`ty` clean; full suite green (pre-push gate). Found while running a dual-env E2E locally — this was the blocker behind repeated "completed instantly" runs.