### PR TITLE
fix(core): review() FSM conditions normalize phase via completed_in_phase (#757)

### DIFF
--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -122,6 +122,20 @@ class ReplyDispatchQuerySet(models.QuerySet):
 
 
 class TaskQuerySet(models.QuerySet):
+    def completed_in_phase(self, phase: str) -> models.QuerySet:
+        """Completed tasks whose phase normalizes to ``phase`` (#757).
+
+        Matches any accepted spelling (short verb or gerund) — the FSM
+        ``review()`` / ``mark_reviewed_externally()`` conditions must see
+        a short-verb ``review`` task the same as a canonical
+        ``reviewing`` one, mirroring the ``normalize_phase`` contract the
+        rest of the system honours.
+        """
+        from teatree.core.models.task import Task  # noqa: PLC0415
+        from teatree.core.phases import phase_spellings  # noqa: PLC0415
+
+        return self.filter(phase__in=phase_spellings(phase), status=Task.Status.COMPLETED)
+
     def claimable_for_headless(self, overlay: str | None = None) -> models.QuerySet:
         from teatree.core.models.task import Task  # noqa: PLC0415
 

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -162,7 +162,7 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         field=state,
         source=State.TESTED,
         target=State.REVIEWED,
-        conditions=[lambda t: t.tasks.filter(phase="reviewing", status="completed").exists()],
+        conditions=[lambda t: t.tasks.completed_in_phase("reviewing").exists()],
     )
     def review(self) -> None:
         self._consume_pending_phase_tasks("reviewing")
@@ -356,7 +356,7 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         ],
         target=State.DELIVERED,
         conditions=[
-            lambda t: t.role == Ticket.Role.REVIEWER and t.tasks.filter(phase="reviewing", status="completed").exists(),
+            lambda t: t.role == Ticket.Role.REVIEWER and t.tasks.completed_in_phase("reviewing").exists(),
         ],
     )
     def mark_reviewed_externally(self) -> None:

--- a/src/teatree/core/phases.py
+++ b/src/teatree/core/phases.py
@@ -51,6 +51,18 @@ def normalize_phase(phase: str) -> str:
     return _ALIAS_TO_CANONICAL.get(cleaned, cleaned)
 
 
+def phase_spellings(phase: str) -> tuple[str, ...]:
+    """Every stored spelling that normalizes to ``phase``'s canonical form.
+
+    Lets a DB query match a phase regardless of which accepted spelling a
+    row was stored with (``phase__in=phase_spellings(...)``) without a
+    per-row ``normalize_phase`` call. For an unknown phase, returns just
+    its own normalized form so callers still get an exact match.
+    """
+    canonical = normalize_phase(phase)
+    return _PHASE_ALIASES.get(canonical, (canonical,))
+
+
 def phase_transition(phase: str) -> str | None:
     """Return the FSM transition method name for ``phase``, or ``None``.
 

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -400,3 +400,75 @@ class TestAdvanceTicketNormalizesPhase(TestCase):
 
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.TESTED
+
+
+class TestReviewConditionNormalizesPhase(TestCase):
+    """#757: the review FSM conditions match the canonical phase contract.
+
+    review()/mark_reviewed_externally() must not use raw
+    ``phase="reviewing"``. Distinct from #750's tests (which satisfy the precondition
+    canonically to isolate _advance_ticket): here the ONLY completed
+    reviewing task is the short-verb ``review`` one, so the condition
+    itself must normalize or the transition is refused end-to-end.
+    """
+
+    def test_short_verb_review_task_alone_advances_tested_to_reviewed(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.TESTED)
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        # The sole reviewing task uses the short verb (unnormalized, as
+        # `tasks create <id> review` stores it). Pre-fix, review()'s
+        # condition `tasks.filter(phase="reviewing")` misses it.
+        task = Task.objects.create(ticket=ticket, session=session, phase="review", status=Task.Status.COMPLETED)
+
+        task._advance_ticket()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED, (
+            f"short-verb 'review' task did not satisfy review()'s condition "
+            f"(state={ticket.state}); the FSM condition compared raw phase"
+        )
+
+    def test_reviewer_role_short_verb_review_advances(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.TESTED, role=Ticket.Role.REVIEWER)
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        task = Task.objects.create(ticket=ticket, session=session, phase="review", status=Task.Status.COMPLETED)
+
+        task._advance_ticket()
+
+        ticket.refresh_from_db()
+        # mark_reviewed_externally()'s condition must also normalize.
+        assert ticket.state != Ticket.State.TESTED, (
+            f"reviewer-role short-verb 'review' did not advance (state={ticket.state})"
+        )
+
+    def test_canonical_reviewing_task_still_satisfies_condition(self) -> None:
+        # Regression guard: the canonical spelling must keep working.
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.TESTED)
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        task = Task.objects.create(ticket=ticket, session=session, phase="reviewing", status=Task.Status.COMPLETED)
+
+        task._advance_ticket()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED
+
+
+class TestTaskCompletedInPhase(TestCase):
+    """The shared queryset method both FSM conditions use (#757)."""
+
+    def test_matches_both_short_verb_and_canonical(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.TESTED)
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        Task.objects.create(ticket=ticket, session=session, phase="review", status=Task.Status.COMPLETED)
+
+        assert Task.objects.completed_in_phase("reviewing").filter(ticket=ticket).exists()
+        # Symmetric: querying by the short verb also resolves.
+        assert Task.objects.completed_in_phase("review").filter(ticket=ticket).exists()
+
+    def test_excludes_non_completed_and_other_phases(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.TESTED)
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        Task.objects.create(ticket=ticket, session=session, phase="review", status=Task.Status.PENDING)
+        Task.objects.create(ticket=ticket, session=session, phase="coding", status=Task.Status.COMPLETED)
+
+        assert not Task.objects.completed_in_phase("reviewing").filter(ticket=ticket).exists()


### PR DESCRIPTION
fix(core): review() FSM conditions normalize phase via completed_in_phase (#757)

Sibling of #750 (same root-cause class, distinct concern). review() and mark_reviewed_externally() gated on raw t.tasks.filter(phase='reviewing', status='completed'), missing short-verb 'review' tasks (tasks create <id> review stores it unnormalized) — so even after #750's _advance_ticket normalization routed to review(), the FSM condition refused the transition end-to-end. Add phase_spellings() to phases.py (SSOT — all stored spellings normalizing to a canonical token) + TaskQuerySet.completed_in_phase() (Django manager convention, normalized phase__in match); both conditions use it. Read-side filters only; schedule_* writes are canonical-by-construction and untouched. TDD anti-vacuous: short-verb-review-alone advances tested->reviewed RED-verified by reverting to the raw filter. 163 tests green across the FSM-condition blast radius, zero regression.