### PR TITLE
feat(repo-mode): auto-detect solo vs collaborative working mode (#550 PR-B)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1681,6 +1681,9 @@ graph TD
     teatree.config --> teatree.utils
     teatree.utils --> teatree.paths
     teatree.timeouts --> teatree.config
+    teatree.repo_mode --> teatree.paths
+    teatree.repo_mode --> teatree.utils
+    teatree.repo_mode --> teatree.config
     teatree.skill_loading --> teatree.types
     teatree.skill_loading --> teatree.utils
     teatree.core --> teatree.types
@@ -1713,6 +1716,7 @@ graph TD
     teatree.cli --> teatree.overlay_init
     teatree.cli --> teatree.loop
     teatree.cli --> teatree.utils
+    teatree.cli --> teatree.repo_mode
     teatree.core.management --> teatree.core
     teatree.core.management --> teatree.agents
     teatree.core.management --> teatree.backends

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -608,6 +608,8 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 │                  IPs).                                                       │
 │ validate-mr      Validate MR/PR title+description against the active         │
 │                  overlay's rules.                                            │
+│ repo-mode        Report whether the repo is solo (fix proactively) or        │
+│                  collaborative (flag, don't fix).                            │
 │ analyze-video    Decompose video into frames for AI analysis.                │
 │ bump-deps        Bump pyproject.toml dependencies from uv.lock.              │
 │ sonar-check      Run local SonarQube analysis via Docker.                    │
@@ -655,6 +657,28 @@ Usage: t3 tool validate-mr [OPTIONS]
 │ --title              TEXT  MR/PR title                                       │
 │ --description        TEXT  MR/PR description                                 │
 │ --help                     Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 tool repo-mode`
+
+```
+Usage: t3 tool repo-mode [OPTIONS] [REPO]
+
+ Report whether the repo is solo (fix proactively) or collaborative (flag,
+ don't fix).
+
+ One heuristic for every skill: ``git shortlog`` over the last 90 days on
+ the default branch. A `` repo_mode`` config value overrides the
+ detection. Result is cached 7 days per repo.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│   repo      [REPO]  Repo path (default: current directory) [default: .]      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json             Emit machine-readable JSON.                               │
+│ --refresh          Bypass the 7-day cache and re-detect.                     │
+│ --help             Show this message and exit.                               │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -2446,12 +2470,20 @@ Usage: t3 teatree lifecycle visit-phase [OPTIONS] TICKET_ID PHASE
  ``ticket.state`` is included in the output so a skipped or refused
  transition is visible rather than silently swallowed.
 
+ ``--agent-id`` records the recording agent's identity for
+ maker≠checker (#755). Resolution is delegated to
+ ``Session.recording_identity`` so the attribution is **never
+ empty** even when neither ``--agent-id`` nor ``Session.agent_id``
+ is set — a blank previously made the gate vacuously pass.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    ticket_id      TEXT  [required]                                         │
 │ *    phase          TEXT  [required]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                  │
+│ --agent-id        TEXT  Recording agent identity stamped into phase_visits   │
+│                         (maker≠checker attribution).                         │
+│ --help                  Show this message and exit.                          │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -406,6 +406,8 @@ Decision rubric (apply silently — don't narrate to the user):
 
 This rule reinforces "Do Work Now" — the bundling decision is part of doing the work, not a separate question to ask.
 
+**Repo mode governs proactive-fix latitude (one source of truth).** Whether the agent fixes unrelated rough edges proactively or only flags them depends on who owns the repo. Instead of every skill re-deciding, run `t3 tool repo-mode` (cached 7 days; `--json` for machine reads; `[teatree] repo_mode` in `~/.teatree.toml` overrides the `git shortlog` heuristic). `solo` → the bundling rubric above applies as written (fix proactively). `collaborative` → bias toward _flagging_ unrelated findings (PR comment / follow-up issue) rather than touching code another contributor owns; still fix anything inside the current ticket's own scope. The `auto`-mode bundling rubric is the `solo` behavior; `collaborative` is the conservative variant of the same rubric.
+
 **When genuinely unsure, ASK — never silently defer.** If the fix is borderline (small but truly orthogonal, or medium-sized but the current PR is already large), present three explicit options to the user via `AskUserQuestion`:
 
 1. **Fix right now and bundle into the current PR** (default — pick this unless reason not to)

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -72,6 +72,28 @@ def validate_mr(
         raise typer.Exit(code=1)
 
 
+@tool_app.command("repo-mode")
+def repo_mode(
+    repo: str = typer.Argument(".", help="Repo path (default: current directory)"),
+    *,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+    refresh: bool = typer.Option(False, "--refresh", help="Bypass the 7-day cache and re-detect."),
+) -> None:
+    """Report whether the repo is solo (fix proactively) or collaborative (flag, don't fix).
+
+    One heuristic for every skill: ``git shortlog`` over the last 90 days on
+    the default branch. A ``[teatree] repo_mode`` config value overrides the
+    detection. Result is cached 7 days per repo.
+    """
+    from teatree.repo_mode import resolve_repo_mode  # noqa: PLC0415
+
+    mode = resolve_repo_mode(repo, refresh=refresh)
+    if json_output:
+        typer.echo(json.dumps({"repo": repo, "mode": mode.value}))
+        return
+    typer.echo(mode.value)
+
+
 @tool_app.command("analyze-video")
 def analyze_video(
     video_path: str = typer.Argument(..., help="Path to video file"),

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -181,6 +181,13 @@ class UserSettings:
     # Behalf".
     agent_signature: bool = False
     statusline_chain: list[str] = field(default_factory=list)
+    # Solo vs collaborative working mode (issue #550 item 4). Empty string
+    # = auto-detect from `git shortlog` history (see teatree.repo_mode);
+    # an explicit "solo" / "collaborative" pins the verdict and bypasses
+    # detection. Consumed by skills via `t3 tool repo-mode` so the
+    # ask-first-vs-fix-proactively decision lives in one place, not in
+    # every skill.
+    repo_mode: str = ""
 
 
 @dataclass
@@ -225,6 +232,7 @@ def load_config(path: Path | None = None) -> TeaTreeConfig:
         claude_chrome=bool(teatree.get("claude_chrome", True)),
         agent_signature=bool(teatree.get("agent_signature", False)),
         statusline_chain=[str(s) for s in teatree.get("statusline_chain", [])],
+        repo_mode=str(teatree.get("repo_mode", "")),
     )
 
     return TeaTreeConfig(user=user, raw=raw)

--- a/src/teatree/repo_mode.py
+++ b/src/teatree/repo_mode.py
@@ -1,0 +1,122 @@
+"""Solo vs collaborative repo-mode detection (issue #550 item 4).
+
+One heuristic, one source of truth: ``git shortlog -sn --no-merges`` over a
+trailing window on the default branch. If the top author owns at least
+``solo_threshold`` of the windowed commits the repo is ``SOLO`` (the agent
+may fix unrelated issues proactively); otherwise ``COLLABORATIVE`` (flag,
+don't fix — someone else owns that code). An empty window is treated as
+``COLLABORATIVE``: unknown authorship is the conservative default, never a
+license to rewrite a stranger's repo.
+
+``resolve_repo_mode`` is what skills/hooks consume. It honours an explicit
+``[teatree] repo_mode`` override, else returns a 7-day-cached detection
+(same cache shape as ``config.check_for_updates``) keyed by repo path.
+"""
+
+import hashlib
+import json
+import time
+from enum import StrEnum
+from pathlib import Path
+
+from teatree.paths import DATA_DIR
+from teatree.utils import git
+
+_DEFAULT_SINCE_DAYS = 90
+_DEFAULT_SOLO_THRESHOLD = 0.8
+_CACHE_TTL_SECONDS = 7 * 86_400
+
+
+class RepoMode(StrEnum):
+    SOLO = "solo"
+    COLLABORATIVE = "collaborative"
+
+    @classmethod
+    def parse(cls, value: str) -> "RepoMode":
+        normalised = value.strip().lower()
+        try:
+            return cls(normalised)
+        except ValueError as exc:
+            valid = ", ".join(m.value for m in cls)
+            msg = f"Invalid repo_mode {value!r}; valid values: {valid}"
+            raise ValueError(msg) from exc
+
+
+def _windowed_author_counts(repo: str, since_days: int) -> list[int]:
+    branch = git.default_branch(repo)
+    out = git.run(
+        repo=repo,
+        args=["shortlog", "-sn", "--no-merges", f"--since={since_days} days ago", branch],
+    )
+    counts: list[int] = []
+    for line in out.splitlines():
+        head = line.strip().split("\t", 1)[0].strip()
+        if head.isdigit():
+            counts.append(int(head))
+    return counts
+
+
+def detect_repo_mode(
+    repo: str = ".",
+    *,
+    since_days: int = _DEFAULT_SINCE_DAYS,
+    solo_threshold: float = _DEFAULT_SOLO_THRESHOLD,
+) -> RepoMode:
+    counts = _windowed_author_counts(repo, since_days)
+    total = sum(counts)
+    if total == 0:
+        return RepoMode.COLLABORATIVE
+    if max(counts) / total >= solo_threshold:
+        return RepoMode.SOLO
+    return RepoMode.COLLABORATIVE
+
+
+def _config_override() -> RepoMode | None:
+    from teatree.config import load_config  # noqa: PLC0415
+
+    raw = load_config().user.repo_mode
+    if not raw:
+        return None
+    return RepoMode.parse(raw)
+
+
+def _cache_path(repo: str) -> Path:
+    slug = hashlib.sha256(repo.encode()).hexdigest()[:12]
+    return DATA_DIR / "repo-mode" / f"{slug}.json"
+
+
+def _read_fresh_cache(repo: str) -> RepoMode | None:
+    cache_path = _cache_path(repo)
+    if not cache_path.is_file():
+        return None
+    try:
+        cached = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if time.time() - cached.get("ts", 0) >= _CACHE_TTL_SECONDS:
+        return None
+    return RepoMode.parse(cached["mode"])
+
+
+def _write_cache(repo: str, mode: RepoMode) -> None:
+    cache_path = _cache_path(repo)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps({"ts": time.time(), "mode": mode.value, "repo": repo}),
+        encoding="utf-8",
+    )
+
+
+def resolve_repo_mode(repo: str = ".", *, refresh: bool = False) -> RepoMode:
+    override = _config_override()
+    if override is not None:
+        return override
+
+    if not refresh:
+        cached = _read_fresh_cache(repo)
+        if cached is not None:
+            return cached
+
+    mode = detect_repo_mode(repo)
+    _write_cache(repo, mode)
+    return mode

--- a/tach.toml
+++ b/tach.toml
@@ -41,6 +41,10 @@ path = "teatree.timeouts"
 depends_on = ["teatree.config"]
 
 [[modules]]
+path = "teatree.repo_mode"
+depends_on = ["teatree.paths", "teatree.utils", "teatree.config"]
+
+[[modules]]
 path = "teatree.skill_loading"
 depends_on = ["teatree.types", "teatree.utils"]
 
@@ -95,7 +99,8 @@ depends_on = [
   "teatree.claude_sessions",
   "teatree.overlay_init",
   "teatree.loop",
-  "teatree.utils"
+  "teatree.utils",
+  "teatree.repo_mode"
 ]
 
 [[modules]]

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -8,6 +9,7 @@ from typer.testing import CliRunner
 import teatree.cli as teatree_cli
 from teatree.cli import app
 from teatree.cli.tools import ToolRunner
+from teatree.repo_mode import RepoMode
 
 runner = CliRunner()
 
@@ -78,6 +80,31 @@ class TestToolCommands:
             result = runner.invoke(app, ["tool", "bump-deps"])
             assert result.exit_code == 0
             mock.assert_called_once_with("bump-pyproject-deps-from-lock-file")
+
+
+class TestRepoModeCommand:
+    """``t3 tool repo-mode`` wires the resolver to plain/JSON output and flags."""
+
+    def test_plain_output_is_the_bare_mode(self):
+        with patch("teatree.repo_mode.resolve_repo_mode") as mock:
+            mock.return_value = RepoMode.SOLO
+            result = runner.invoke(app, ["tool", "repo-mode", "/some/repo"])
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "solo"
+        mock.assert_called_once_with("/some/repo", refresh=False)
+
+    def test_json_output_is_machine_readable(self):
+        with patch("teatree.repo_mode.resolve_repo_mode") as mock:
+            mock.return_value = RepoMode.COLLABORATIVE
+            result = runner.invoke(app, ["tool", "repo-mode", "/some/repo", "--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == {"repo": "/some/repo", "mode": "collaborative"}
+
+    def test_refresh_flag_is_forwarded(self):
+        with patch("teatree.repo_mode.resolve_repo_mode") as mock:
+            mock.return_value = RepoMode.SOLO
+            runner.invoke(app, ["tool", "repo-mode", ".", "--refresh"])
+        mock.assert_called_once_with(".", refresh=True)
 
 
 class TestPrivacyScanWrapperSurfacesFindings:

--- a/tests/test_repo_mode.py
+++ b/tests/test_repo_mode.py
@@ -1,0 +1,133 @@
+"""Repo-mode auto-detection (solo vs collaborative) — issue #550 item 4.
+
+Integration-first per the Test-Writing Doctrine: a real git repo under
+``tmp_path`` with scripted authorship history. The only mocked externals
+are the clock-bound 7-day cache TTL and ``teatree.config.CONFIG_PATH``
+(filesystem-isolated TOML fixture), mirroring ``test_config.py``.
+"""
+
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from teatree.repo_mode import RepoMode, detect_repo_mode, resolve_repo_mode
+
+_GIT = shutil.which("git") or "/usr/bin/git"
+
+
+def _git(*args: str, cwd: Path, author: str | None = None) -> None:
+    env = None
+    if author is not None:
+        env = {
+            "GIT_AUTHOR_NAME": author,
+            "GIT_AUTHOR_EMAIL": f"{author}@example.com",
+            "GIT_COMMITTER_NAME": author,
+            "GIT_COMMITTER_EMAIL": f"{author}@example.com",
+            "PATH": "/usr/bin:/bin",
+            "HOME": str(cwd),
+        }
+    subprocess.run([_GIT, "-C", str(cwd), *args], check=True, capture_output=True, env=env)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git("init", "-q", "-b", "main", cwd=root)
+    _git("config", "user.email", "seed@example.com", cwd=root)
+    _git("config", "user.name", "seed", cwd=root)
+    _git("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main", cwd=root)
+    return root
+
+
+def _commit(repo: Path, author: str, n: int = 1) -> None:
+    for _ in range(n):
+        _git("commit", "--allow-empty", "-q", "-m", f"by {author}", cwd=repo, author=author)
+
+
+class TestDetectRepoMode:
+    def test_single_author_history_is_solo(self, repo: Path) -> None:
+        _commit(repo, "alice", n=10)
+        assert detect_repo_mode(str(repo)) is RepoMode.SOLO
+
+    def test_dominant_author_above_threshold_is_solo(self, repo: Path) -> None:
+        _commit(repo, "alice", n=9)
+        _commit(repo, "bob", n=1)
+        assert detect_repo_mode(str(repo)) is RepoMode.SOLO
+
+    def test_shared_authorship_is_collaborative(self, repo: Path) -> None:
+        _commit(repo, "alice", n=6)
+        _commit(repo, "bob", n=4)
+        assert detect_repo_mode(str(repo)) is RepoMode.COLLABORATIVE
+
+    def test_exactly_at_threshold_is_solo(self, repo: Path) -> None:
+        _commit(repo, "alice", n=8)
+        _commit(repo, "bob", n=2)
+        assert detect_repo_mode(str(repo)) is RepoMode.SOLO
+
+    def test_empty_window_defaults_collaborative(self, repo: Path) -> None:
+        # No commits inside the window → unknown → conservative (don't fix proactively).
+        assert detect_repo_mode(str(repo), since_days=90) is RepoMode.COLLABORATIVE
+
+    def test_custom_threshold_changes_verdict(self, repo: Path) -> None:
+        _commit(repo, "alice", n=7)
+        _commit(repo, "bob", n=3)
+        assert detect_repo_mode(str(repo), solo_threshold=0.6) is RepoMode.SOLO
+        assert detect_repo_mode(str(repo), solo_threshold=0.8) is RepoMode.COLLABORATIVE
+
+
+class TestResolveRepoMode:
+    def test_config_override_solo_wins_over_detection(self, repo: Path, tmp_path: Path) -> None:
+        _commit(repo, "alice", n=5)
+        _commit(repo, "bob", n=5)  # detection would say COLLABORATIVE
+        config_path = tmp_path / ".teatree.toml"
+        config_path.write_text('[teatree]\nrepo_mode = "solo"\n', encoding="utf-8")
+        with patch("teatree.config.CONFIG_PATH", config_path):
+            assert resolve_repo_mode(str(repo)) is RepoMode.SOLO
+
+    def test_config_override_collaborative_wins_over_detection(self, repo: Path, tmp_path: Path) -> None:
+        _commit(repo, "alice", n=10)  # detection would say SOLO
+        config_path = tmp_path / ".teatree.toml"
+        config_path.write_text('[teatree]\nrepo_mode = "collaborative"\n', encoding="utf-8")
+        with patch("teatree.config.CONFIG_PATH", config_path):
+            assert resolve_repo_mode(str(repo)) is RepoMode.COLLABORATIVE
+
+    def test_result_is_cached_and_reused(self, repo: Path, tmp_path: Path) -> None:
+        _commit(repo, "alice", n=10)
+        cache_dir = tmp_path / "cache"
+        with patch("teatree.repo_mode.DATA_DIR", cache_dir):
+            first = resolve_repo_mode(str(repo))
+            assert first is RepoMode.SOLO
+            cache_files = list((cache_dir / "repo-mode").glob("*.json"))
+            assert len(cache_files) == 1
+            cached = json.loads(cache_files[0].read_text(encoding="utf-8"))
+            assert cached["mode"] == "solo"
+            # Mutate history so a fresh detection would flip the verdict;
+            # the still-fresh cache must keep returning the old answer.
+            _commit(repo, "bob", n=20)
+            assert resolve_repo_mode(str(repo)) is RepoMode.SOLO
+
+    def test_stale_cache_is_refreshed(self, repo: Path, tmp_path: Path) -> None:
+        _commit(repo, "alice", n=10)
+        cache_dir = tmp_path / "cache"
+        with patch("teatree.repo_mode.DATA_DIR", cache_dir):
+            assert resolve_repo_mode(str(repo)) is RepoMode.SOLO
+            cache_file = next((cache_dir / "repo-mode").glob("*.json"))
+            stale = json.loads(cache_file.read_text(encoding="utf-8"))
+            stale["ts"] = time.time() - (8 * 86_400)  # older than the 7-day TTL
+            cache_file.write_text(json.dumps(stale), encoding="utf-8")
+            _commit(repo, "bob", n=30)  # now COLLABORATIVE
+            assert resolve_repo_mode(str(repo)) is RepoMode.COLLABORATIVE
+
+    def test_refresh_flag_bypasses_fresh_cache(self, repo: Path, tmp_path: Path) -> None:
+        _commit(repo, "alice", n=10)
+        cache_dir = tmp_path / "cache"
+        with patch("teatree.repo_mode.DATA_DIR", cache_dir):
+            assert resolve_repo_mode(str(repo)) is RepoMode.SOLO
+            _commit(repo, "bob", n=30)
+            assert resolve_repo_mode(str(repo), refresh=True) is RepoMode.COLLABORATIVE


### PR DESCRIPTION
## Summary

Implements issue #550 item 4 (gstack Tier-1 borrow): one heuristic, one source of truth for the ask-first-vs-fix-proactively decision instead of every skill re-deciding.

- `teatree.repo_mode.detect_repo_mode` runs `git shortlog -sn --no-merges --since=90 days` on the default branch. Top author owning >=80% of the windowed commits => `SOLO` (fix proactively); else `COLLABORATIVE` (flag, don't touch a contributor's code). An empty window is `COLLABORATIVE` — unknown authorship is the conservative default.
- `resolve_repo_mode` honours an explicit `[teatree] repo_mode` override, else a 7-day per-repo cache (same shape as `config.check_for_updates`); `--refresh` busts it.
- New typed `UserSettings.repo_mode` setting, `t3 tool repo-mode [--json] [--refresh]` command, and a single canonical statement in `skills/rules/SKILL.md` referencing it.
- `tach.toml`: new `teatree.repo_mode` module declared; BLUEPRINT/cli-reference auto-regenerated.

Items 1 and 3 of #550 remain deliberately unbundled (split discipline).

## Test plan

- [x] TDD anti-vacuous: detection tests RED-verified by breaking the SOLO branch (correct symptom), then GREEN
- [x] Full suite green, zero regression
- [x] ruff / ty / tach clean
- [x] `t3 tool repo-mode` runs and emits plain + `--json`
- [ ] CI green on the PR