### PR TITLE
fix(compaction): auto-snapshot background sub-agents in PreCompact (#778)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -764,11 +764,90 @@ def handle_read_dedup(data: dict) -> None:
 # ── PreCompact: retro-before-compact ──────────────────────────────
 
 
+def _durable_session_snapshot(session_id: str) -> str:
+    """Build a recovery snapshot for *session_id* from DURABLE state only.
+
+    Issue #778: a background sub-agent (loop singleton, reviewer, task
+    agent) auto-compacts without ever running ``/t3:retro``, so the
+    behavioral "agent writes its own snapshot" path never fires for it.
+    Reconstruct "who am I / what am I doing / where" purely from state
+    that already outlives the transcript: the loop-registry entries this
+    session owns (agentId + self-contained spawn brief) and the per
+    -session active-repos / loaded-skills tracking files. No reliance on
+    the agent having done anything.
+    """
+    lines = [
+        f"# Auto-recovery snapshot — session `{session_id}`",
+        "",
+        (
+            "Written by the PreCompact hook from durable state (no retro required). "
+            "Use this to re-derive your identity and assignment after compaction."
+        ),
+    ]
+
+    owned = [
+        (name, entry)
+        for name, entry in _read_loop_registry().items()
+        if isinstance(entry, dict) and entry.get("session_id") == session_id
+    ]
+    if owned:
+        lines += ["", "## Loop assignment (this session owns these singletons)"]
+        for name, entry in sorted(owned):
+            agent_id = entry.get("agent_id") or "(agent id not recorded)"
+            lines.append(f"- **{name}** — resume by agentId `{agent_id}`")
+            brief = (entry.get("spawn_brief") or "").strip()
+            if brief:
+                lines.append(f"  - Brief: {brief}")
+
+    active = _read_lines(_state_file(session_id, "active"))
+    if active:
+        lines += ["", "## Repos touched this session", *(f"- {repo}" for repo in active)]
+
+    skills = _read_lines(_state_file(session_id, "skills"))
+    if skills:
+        lines += ["", "## Skills loaded this session", f"- {', '.join(skills)}"]
+
+    return "\n".join(lines) + "\n"
+
+
+def _write_precompact_snapshot(session_id: str) -> None:
+    """Persist the durable-state snapshot under the PostCompact-recognized name.
+
+    Reuses the ``t3-snapshot-`` prefix that :func:`_find_temp_files`
+    already scans, keyed by session id with a fixed ``-precompact``
+    suffix so a single deterministic file is overwritten each compaction
+    (not an ever-growing pile). Best-effort: a snapshot write must never
+    block compaction.
+    """
+    if not session_id:
+        return
+    target = STATE_DIR / f"{_T3_TEMP_PREFIX}{session_id}-precompact.md"
+    # ``_ensure_state_dir`` (a ``mkdir``) is the more likely OSError source
+    # than the write itself (read-only fs / parent perms) — both must be
+    # suppressed so the docstring's "must never block compaction" holds.
+    with contextlib.suppress(OSError):
+        _ensure_state_dir()
+        target.write_text(_durable_session_snapshot(session_id), encoding="utf-8")
+
+
 def handle_pre_compact(data: dict) -> None:
-    """Inject retro directive before compaction destroys session knowledge."""
+    """Snapshot durable state, then nudge retro if lifecycle skills are active.
+
+    The snapshot is unconditional and behavior-independent (issue #778):
+    background sub-agents have no lifecycle skill loaded and would hit
+    the retro-directive early return below, so the snapshot must be
+    written BEFORE that return for them to recover post-compaction. The
+    main-session retro directive is preserved unchanged after it.
+
+    Note: *when* auto-compaction fires is governed by the Claude Code
+    harness env var ``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`` (not a teatree
+    setting); tune it at the harness-settings layer, not in teatree code.
+    """
     session_id = data.get("session_id", "")
     if not session_id:
         return
+
+    _write_precompact_snapshot(session_id)
 
     skills_file = _state_file(session_id, "skills")
     loaded: set[str] = set()

--- a/tests/test_pre_compact_snapshot_hook.py
+++ b/tests/test_pre_compact_snapshot_hook.py
@@ -1,0 +1,152 @@
+"""Tests for the PreCompact auto-snapshot hook (issue #778).
+
+A background sub-agent that auto-compacts WITHOUT having run /t3:retro must
+still recover its identity and assignment after compaction. The PreCompact
+hook must therefore write a deterministic snapshot from DURABLE state alone
+(loop registry, per-session active-repos / loaded-skills) — no dependence on
+the agent having behaviorally written a snapshot first. The PostCompact hook
+(already session-agnostic) then re-injects it.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import _T3_TEMP_PREFIX, _write_loop_registry, handle_post_compact, handle_pre_compact
+
+
+@pytest.fixture(autouse=True)
+def _isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point STATE_DIR, _TMP_DIR and the loop registry at temp dirs."""
+    router.STATE_DIR = tmp_path / "state"
+    router._TMP_DIR = tmp_path / "tmp"
+    router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    router._TMP_DIR.mkdir(parents=True, exist_ok=True)
+    reg_dir = tmp_path / "data"
+    reg_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", str(reg_dir))
+
+
+def _snapshot_for(session_id: str) -> Path:
+    return router.STATE_DIR / f"{_T3_TEMP_PREFIX}{session_id}-precompact.md"
+
+
+class TestPreCompactSnapshotFromDurableState:
+    def test_subagent_session_gets_snapshot_from_loop_registry(self) -> None:
+        session_id = "subagent-loop-sess"
+        _write_loop_registry(
+            {
+                "t3-main-loop": {
+                    "session_id": session_id,
+                    "agent_id": "agent-abc-123",
+                    "pid": os.getppid(),
+                    "spawn_brief": "t3-main-loop — drive the backlog to zero, smallest-first.",
+                }
+            }
+        )
+
+        handle_pre_compact({"session_id": session_id})
+
+        snapshot = _snapshot_for(session_id)
+        assert snapshot.is_file()
+        body = snapshot.read_text(encoding="utf-8")
+        assert "agent-abc-123" in body
+        assert "t3-main-loop" in body
+        assert "drive the backlog to zero" in body
+
+    def test_snapshot_includes_active_repos_and_skills(self) -> None:
+        session_id = "subagent-ctx-sess"
+        _write_loop_registry(
+            {
+                "t3-review-loop": {
+                    "session_id": session_id,
+                    "agent_id": "rev-1",
+                    "pid": os.getppid(),
+                    "spawn_brief": "t3-review-loop — review every merged PR.",
+                }
+            }
+        )
+        (router.STATE_DIR / f"{session_id}.active").write_text("souliane/teatree\n", encoding="utf-8")
+        (router.STATE_DIR / f"{session_id}.skills").write_text("t3:code\nt3:review\n", encoding="utf-8")
+
+        handle_pre_compact({"session_id": session_id})
+
+        body = _snapshot_for(session_id).read_text(encoding="utf-8")
+        assert "souliane/teatree" in body
+        assert "t3:code" in body
+        assert "t3:review" in body
+
+    def test_snapshot_written_without_agent_having_run_retro(self) -> None:
+        """No prior t3-snapshot file exists — the hook must create one itself."""
+        session_id = "no-retro-sess"
+        _write_loop_registry(
+            {
+                "t3-bug-hunt": {
+                    "session_id": session_id,
+                    "agent_id": "bh-9",
+                    "pid": os.getppid(),
+                    "spawn_brief": "t3-bug-hunt — hunt bugs in core + overlay.",
+                }
+            }
+        )
+        assert not any(router.STATE_DIR.glob(f"{_T3_TEMP_PREFIX}*.md"))
+
+        handle_pre_compact({"session_id": session_id})
+
+        assert _snapshot_for(session_id).is_file()
+
+    def test_no_session_id_writes_nothing(self) -> None:
+        handle_pre_compact({"session_id": ""})
+        assert not any(router.STATE_DIR.glob(f"{_T3_TEMP_PREFIX}*.md"))
+
+    def test_session_not_in_registry_still_snapshots_session_id(self) -> None:
+        session_id = "lone-subagent"
+        (router.STATE_DIR / f"{session_id}.active").write_text("souliane/teatree\n", encoding="utf-8")
+
+        handle_pre_compact({"session_id": session_id})
+
+        snapshot = _snapshot_for(session_id)
+        assert snapshot.is_file()
+        assert session_id in snapshot.read_text(encoding="utf-8")
+
+
+class TestPreCompactPostCompactRoundTrip:
+    def test_postcompact_reinjects_the_precompact_snapshot_for_subagent(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        session_id = "roundtrip-subagent"
+        _write_loop_registry(
+            {
+                "t3-cross-review-loop": {
+                    "session_id": session_id,
+                    "agent_id": "xrev-7",
+                    "pid": os.getppid(),
+                    "spawn_brief": "t3-cross-review-loop — architectural cross-repo review.",
+                }
+            }
+        )
+
+        handle_pre_compact({"session_id": session_id})
+        handle_post_compact({"session_id": session_id})
+
+        output = json.loads(capsys.readouterr().out)
+        assert "additionalContext" in output
+        ctx = output["additionalContext"]
+        assert "xrev-7" in ctx
+        assert "t3-cross-review-loop" in ctx
+        assert "PRE-COMPACTION SNAPSHOTS RECOVERED" in ctx
+
+
+class TestMainSessionRetroPathUnaffected:
+    def test_lifecycle_skill_session_still_gets_retro_directive(self, capsys: pytest.CaptureFixture[str]) -> None:
+        session_id = "main-session"
+        (router.STATE_DIR / f"{session_id}.skills").write_text("t3:code\n", encoding="utf-8")
+
+        handle_pre_compact({"session_id": session_id})
+
+        output = json.loads(capsys.readouterr().out)
+        assert "additionalContext" in output
+        assert "/t3:retro" in output["additionalContext"]


### PR DESCRIPTION
fix(compaction): auto-snapshot background sub-agents in PreCompact (#778)

Background sub-agents (loop singletons, reviewers, task agents) lost
accumulated state on auto-compaction: recovery was opt-in behavioral,
working only if the agent proactively wrote a t3-snapshot before
compaction. Only the main session reliably does that (retro before long
waits); background sub-agents auto-compact without running retro, so
PostCompact found nothing to re-inject.

PreCompact now unconditionally writes a deterministic per-session
snapshot from DURABLE state alone — the loop-registry entries the
session owns (agentId + self-contained spawn brief), the per-session
active-repos and loaded-skills tracking files. It is written BEFORE the
lifecycle-skill early return so sub-agents with no lifecycle skill
loaded still get one. Reuses the t3-snapshot- prefix PostCompact
already scans, with a fixed -precompact suffix so one file is
overwritten per compaction instead of piling up. The main-session
retro directive is preserved unchanged after the snapshot write.