### PR TITLE
feat(db): sanctioned per-invocation-approved fresh remote dump path (#777)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1480,9 +1480,9 @@ django_db_import(cfg, skip_dslr=False, allow_remote_dump=False)
 ```
 
 - `skip_dslr=True` — skip DSLR snapshots (used with `--force` to get a fresh dump)
-- `allow_remote_dump=True` — enable the remote pg_dump strategy (requires explicit user approval)
+- `allow_remote_dump=True` — enable the remote pg_dump strategy. Set **only** after a successful per-invocation interactive approval (#777): `t3 <overlay> db refresh --fresh-dump` calls `teatree.utils.approval.require_interactive_approval`, which states the env + tenant + target DB and refuses unless a human confirms at a TTY. An unattended agent has no TTY and so cannot self-approve — this replaces the old blanket `T3_ALLOW_REMOTE_DUMP` env-var prohibition (a defunct, now-blocked bypass).
 
-**Overlay responsibility:** Provide the config values and decide when to set `allow_remote_dump=True` (typically gated behind `--force` or an interactive prompt).
+**Overlay responsibility:** Provide the config values and forward `approve_remote_dump` (the post-approval flag from core's `db refresh --fresh-dump` gate) into `django_db_import(..., allow_remote_dump=...)`. The overlay must not hardcode the value or invent its own gate — the single sanctioned gate is core's interactive approval.
 
 ### 14.6 DSLR Integration
 

--- a/docs/overlay-api.md
+++ b/docs/overlay-api.md
@@ -105,9 +105,11 @@ Extra environment variables to set for a worktree. Defaults to `{}`.
 
 How to import/restore a database for this worktree. Returns `None` if no DB import is needed.
 
-#### `db_import(worktree, *, force, slow_import, dslr_snapshot, dump_path) -> bool`
+#### `db_import(worktree, *, force, slow_import, dslr_snapshot, dump_path, approve_remote_dump) -> bool`
 
 Run the actual database import logic. Called by `worktree provision` and `db refresh`. Returns `True` on success. Defaults to `False` (no-op).
+
+`approve_remote_dump` is `True` only when the user explicitly approved a fresh remote DEV dump for this single invocation via the `db refresh --fresh-dump` interactive gate (`teatree.utils.approval`). It replaces the old blanket `T3_ALLOW_REMOTE_DUMP` / hardcoded-`False` prohibition: an unattended agent cannot satisfy the interactive gate, so it still cannot self-trigger a network pg_dump, but a human can sanction one per run.
 
 #### `get_post_db_steps(worktree: Worktree) -> list[ProvisionStep]`
 

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -1586,9 +1586,11 @@ def _cron_cadence_seconds(cron_expr: str) -> int | None:
 
 _REMOTE_DUMP_ENV_RE = re.compile(r"\bT3_ALLOW_REMOTE_DUMP\s*=\s*1\b")
 _REMOTE_DUMP_DENY_REASON = (
-    "BLOCKED: agents must never set `T3_ALLOW_REMOTE_DUMP=1`. "
-    "Remote pg_dump over VPN requires explicit human action in a terminal — "
-    "the agent cannot opt in. Ask the user to run the command themselves."
+    "BLOCKED: `T3_ALLOW_REMOTE_DUMP=1` is a removed, defunct bypass (#777) — "
+    "setting it does nothing and signals an attempt to circumvent the safety gate. "
+    "A fresh remote dump is available only via `t3 <overlay> db refresh --fresh-dump`, "
+    "which requires an explicit interactive per-invocation human approval the agent "
+    "cannot satisfy. Ask the user to run that command themselves."
 )
 
 

--- a/src/teatree/core/management/commands/db.py
+++ b/src/teatree/core/management/commands/db.py
@@ -1,12 +1,14 @@
 """Database operations: refresh, restore from CI, reset passwords."""
 
 import os
+import sys
 
 import typer
 from django_typer.management import TyperCommand, command
 
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import resolve_worktree
+from teatree.utils.approval import ApprovalRefusedError, require_interactive_approval
 
 
 class Command(TyperCommand):
@@ -18,6 +20,11 @@ class Command(TyperCommand):
         dump_path: str = typer.Option("", help="Path to a .pgsql dump file to restore from."),
         *,
         force: bool = False,
+        fresh_dump: bool = typer.Option(
+            default=False,
+            help="Pull a fresh dump from the remote DEV environment for this tenant. "
+            "Requires explicit interactive approval on every run.",
+        ),
     ) -> str:
         """Re-import the worktree database from DSLR snapshot or dump.
 
@@ -25,12 +32,31 @@ class Command(TyperCommand):
         With --force: drops existing DB first, then reimports from scratch.
         Use --dslr-snapshot to force a specific snapshot (skip auto-discovery).
         Use --dump-path to restore from a specific dump file.
+        Use --fresh-dump to pull a fresh dump from the remote DEV env — this
+        is the only sanctioned remote-dump path and it requires an explicit
+        per-invocation interactive approval (#777); an unattended agent
+        cannot self-approve it.
         """
         worktree = resolve_worktree(path)
         overlay = get_overlay()
         strategy = overlay.get_db_import_strategy(worktree)
         if strategy is None:
             return "No DB import strategy configured in the overlay."
+
+        if fresh_dump:
+            tenant = str(strategy.get("source_database", "")) or "<tenant>"
+            prompt = (
+                "FRESH REMOTE DUMP REQUESTED.\n"
+                f"  Source environment : DEV (remote)\n"
+                f"  Tenant / source DB : {tenant}\n"
+                f"  Target worktree DB : {worktree.db_name}\n"
+                "This pulls gigabytes over the network from the shared DEV database "
+                "and overwrites the target DB. It must be explicitly approved every run."
+            )
+            try:
+                require_interactive_approval(prompt, stdin=sys.stdin, stdout=sys.stdout)
+            except ApprovalRefusedError as exc:
+                return f"Fresh remote dump aborted: {exc}"
 
         self.stdout.write(f"Refreshing DB '{worktree.db_name}' (force={force})...")
 
@@ -40,7 +66,13 @@ class Command(TyperCommand):
         os.environ.update(overlay.get_env_extra(worktree))
 
         # Run the overlay's import logic
-        success = overlay.db_import(worktree, force=force, dslr_snapshot=dslr_snapshot, dump_path=dump_path)
+        success = overlay.db_import(
+            worktree,
+            force=force,
+            dslr_snapshot=dslr_snapshot,
+            dump_path=dump_path,
+            approve_remote_dump=fresh_dump,
+        )
         if not success:
             return f"DB import failed for {worktree.db_name}. Check output above for details."
 

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -246,7 +246,7 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
     def get_db_import_strategy(self, worktree: "Worktree") -> DbImportStrategy | None:
         return None
 
-    def db_import(
+    def db_import(  # noqa: PLR0913 — overlay extension-point contract; each kwarg is a documented hook input, not poor design.
         self,
         worktree: "Worktree",
         *,
@@ -254,6 +254,7 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
         slow_import: bool = False,
         dslr_snapshot: str = "",
         dump_path: str = "",
+        approve_remote_dump: bool = False,
     ) -> bool:
         return False
 

--- a/src/teatree/utils/approval.py
+++ b/src/teatree/utils/approval.py
@@ -1,0 +1,48 @@
+"""Per-invocation interactive approval gate (#777).
+
+The safety mechanism for privileged, expensive, or destructive
+operations that must never run unattended — e.g. pulling a fresh dump
+from a remote DEV environment. Replaces the blanket
+``T3_ALLOW_REMOTE_DUMP``/``allow_remote_dump=False`` prohibition
+anti-pattern: instead of permanently disabling the path, every
+invocation requires a fresh, explicit, human confirmation.
+
+The gate is designed so an unattended agent cannot self-approve: it
+refuses unless **both** streams are real TTYs and the human types an
+affirmative answer. An agent piping ``y`` into a non-TTY stdin is the
+exact scenario this blocks.
+"""
+
+from typing import TextIO
+
+_AFFIRMATIVE = {"y", "yes"}
+
+
+class ApprovalRefusedError(RuntimeError):
+    """Raised when a per-invocation approval gate is not satisfied."""
+
+
+def require_interactive_approval(prompt: str, *, stdin: TextIO, stdout: TextIO) -> None:
+    """Block until the human explicitly approves, else raise ``ApprovalRefusedError``.
+
+    Both *stdin* and *stdout* must be interactive TTYs — in a headless /
+    agent context one of them is not, so the gate refuses with a message
+    stating a human must run the command. A real human at a terminal must
+    type ``y``/``yes`` (anything else, including the empty default, is a
+    refusal — fail closed).
+    """
+    if not (stdin.isatty() and stdout.isatty()):
+        msg = (
+            "Approval required but no interactive terminal is attached. "
+            "This operation cannot be self-approved by an unattended agent — "
+            "a human must run this command in an interactive shell and approve it."
+        )
+        raise ApprovalRefusedError(msg)
+
+    stdout.write(f"{prompt}\n")
+    stdout.write("Type 'yes' to approve, anything else aborts: ")
+    stdout.flush()
+    answer = stdin.readline().strip().lower()
+    if answer not in _AFFIRMATIVE:
+        msg = f"Approval declined (answer: {answer!r}). Operation aborted."
+        raise ApprovalRefusedError(msg)

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -395,18 +395,14 @@ class DjangoDbImporter:
     def _try_fetch_remote_dump(self) -> bool:
         """Fetch a fresh dump from the remote DB into dump_dir.
 
-        Final safety gate: even when the caller passes ``allow_remote_dump=True``,
-        the environment variable ``T3_ALLOW_REMOTE_DUMP=1`` must also be set.
-        Prevents agent-triggered paths from auto-downloading gigabytes over VPN.
+        Reached only when the caller passed ``allow_remote_dump=True``,
+        which is set exclusively after a successful per-invocation
+        interactive approval gate (``teatree.utils.approval``, #777). That
+        gate — not a blanket env var — is the safety mechanism: an
+        unattended agent cannot self-approve, so this path cannot run
+        without a human's explicit per-run confirmation.
         """
         cfg = self.cfg
-        if os.environ.get("T3_ALLOW_REMOTE_DUMP") != "1":
-            logger.warning(
-                "Remote pg_dump blocked for %s: set T3_ALLOW_REMOTE_DUMP=1 to allow "
-                "remote dump fallback. Agents must never set this env var.",
-                cfg.ref_db_name,
-            )
-            return False
         if not cfg.remote_db_url:
             logger.info("Remote dump skipped (no remote_db_url configured)")
             return False
@@ -419,8 +415,21 @@ class DjangoDbImporter:
             dump_path = dump_dir / f"{today}_{cfg.ref_db_name}.pgsql"
             self.stdout.write(f"  Dumping from remote DB ({cfg.ref_db_name})...\n")
             dump_dir.mkdir(parents=True, exist_ok=True)
+            # --no-owner --no-privileges mirrors the user's known-good
+            # import_db_from_dev_env.sh (#777): the dump is portable across
+            # the remote→local-superuser boundary, so the local ownership-
+            # reassignment post-steps take over cleanly. -Fc keeps it the
+            # deterministic custom format db_restore auto-detects.
             result = run_allowed_to_fail(
-                ["pg_dump", "-Fc", "-f", str(dump_path), cfg.remote_db_url],
+                [
+                    "pg_dump",
+                    "-Fc",
+                    "--no-owner",
+                    "--no-privileges",
+                    "-f",
+                    str(dump_path),
+                    cfg.remote_db_url,
+                ],
                 timeout=cfg.dump_timeout,
                 expected_codes=None,
             )

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -236,9 +236,9 @@ class DbOverlay(CommandOverlay):
     """CommandOverlay with a DB import strategy that always fails."""
 
     def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy | None:
-        return DbImportStrategy(kind="dslr")
+        return DbImportStrategy(kind="dslr", source_database="development-volksbank")
 
-    def db_import(
+    def db_import(  # noqa: PLR0913 — mirrors the OverlayBase.db_import extension-point contract.
         self,
         worktree: Worktree,
         *,
@@ -246,11 +246,60 @@ class DbOverlay(CommandOverlay):
         slow_import: bool = False,
         dslr_snapshot: str = "",
         dump_path: str = "",
+        approve_remote_dump: bool = False,
     ) -> bool:
+        self.last_approve_remote_dump = approve_remote_dump
         return False
 
 
 _DB_MOCK_OVERLAY = {"test": DbOverlay()}
+
+
+class TestDbRefreshFreshDumpApproval(TestCase):
+    """`db refresh --fresh-dump` is gated by a per-invocation approval (#777).
+
+    Under `call_command` stdin/stdout are not TTYs — exactly the
+    unattended-agent context the gate must refuse. The fresh-dump path
+    therefore aborts before any overlay import runs, with no credentials
+    or connection string in the message.
+    """
+
+    def _make_worktree(self) -> Worktree:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/777")
+        return Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/backend",
+            branch="feature",
+            extra={"worktree_path": "/tmp/backend"},
+            db_name="wt_777_volksbank",
+        )
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_fresh_dump_refuses_in_non_interactive_agent_context(self) -> None:
+        worktree = self._make_worktree()
+        overlay = DbOverlay()
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={"test": overlay}),
+            patch("teatree.core.management.commands.db.resolve_worktree", return_value=worktree),
+        ):
+            result = call_command("db", "refresh", "--fresh-dump")
+        assert "aborted" in result
+        assert "human must" in result
+        # The gate fired BEFORE the overlay import — no remote dump attempted.
+        assert not hasattr(overlay, "last_approve_remote_dump")
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_refusal_message_has_no_credentials(self) -> None:
+        worktree = self._make_worktree()
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=_DB_MOCK_OVERLAY),
+            patch("teatree.core.management.commands.db.resolve_worktree", return_value=worktree),
+        ):
+            result = call_command("db", "refresh", "--fresh-dump")
+        assert "postgres://" not in result
+        assert "PGPASSWORD" not in result
+        assert "password" not in result.lower()
 
 
 class TestDbImportAutoRepair(TestCase):

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -115,7 +115,7 @@ class FullOverlay(OverlayBase):
     def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy:
         return {"kind": "test", "source_database": "test_db"}
 
-    def db_import(
+    def db_import(  # noqa: PLR0913 — mirrors the OverlayBase.db_import extension-point contract.
         self,
         worktree: Worktree,
         *,
@@ -123,6 +123,7 @@ class FullOverlay(OverlayBase):
         slow_import: bool = False,
         dslr_snapshot: str = "",
         dump_path: str = "",
+        approve_remote_dump: bool = False,
     ) -> bool:
         return True
 
@@ -207,7 +208,7 @@ class PostDbStepsOverlay(FullOverlay):
 class FailingImportOverlay(FullOverlay):
     """Overlay where db_import always fails — tests error reporting."""
 
-    def db_import(
+    def db_import(  # noqa: PLR0913 — mirrors the OverlayBase.db_import extension-point contract.
         self,
         worktree: Worktree,
         *,
@@ -215,6 +216,7 @@ class FailingImportOverlay(FullOverlay):
         slow_import: bool = False,
         dslr_snapshot: str = "",
         dump_path: str = "",
+        approve_remote_dump: bool = False,
     ) -> bool:
         return False
 

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,0 +1,73 @@
+"""Per-invocation interactive approval gate (#777).
+
+The gate is the safety mechanism for destructive/expensive privileged
+operations (fresh DEV dump fetch). It must be impossible for an
+unattended agent to self-approve: approval requires reading an
+interactive y/N confirmation from a TTY, and in a non-interactive /
+no-TTY context the gate refuses with a clear "a human must run this"
+message.
+
+Unit-level is correct here: this is pure decision logic over one
+unstoppable external (stdin/stdout TTY state), exactly the carve-out the
+Test-Writing Doctrine reserves for unit tests. The integration coverage
+(the flag actually threading through `db refresh`) lives in
+test_django_db.py / the overlay suite.
+"""
+
+import io
+
+import pytest
+
+from teatree.utils.approval import ApprovalRefusedError, require_interactive_approval
+
+
+class _FakeStream(io.StringIO):
+    def __init__(self, *, tty: bool, content: str = "") -> None:
+        super().__init__(content)
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+class TestRequireInteractiveApproval:
+    def test_refuses_when_no_tty_agent_context(self) -> None:
+        stdin = _FakeStream(tty=False, content="y\n")
+        stdout = _FakeStream(tty=False)
+        with pytest.raises(ApprovalRefusedError, match="human must"):
+            require_interactive_approval("Pull fresh DEV dump?", stdin=stdin, stdout=stdout)
+
+    def test_refuses_when_user_declines(self) -> None:
+        stdin = _FakeStream(tty=True, content="n\n")
+        stdout = _FakeStream(tty=True)
+        with pytest.raises(ApprovalRefusedError, match="declined"):
+            require_interactive_approval("Pull fresh DEV dump?", stdin=stdin, stdout=stdout)
+
+    def test_refuses_on_empty_default_no(self) -> None:
+        stdin = _FakeStream(tty=True, content="\n")
+        stdout = _FakeStream(tty=True)
+        with pytest.raises(ApprovalRefusedError):
+            require_interactive_approval("Pull fresh DEV dump?", stdin=stdin, stdout=stdout)
+
+    def test_grants_only_on_explicit_yes(self) -> None:
+        stdin = _FakeStream(tty=True, content="yes\n")
+        stdout = _FakeStream(tty=True)
+        require_interactive_approval("Pull fresh DEV dump?", stdin=stdin, stdout=stdout)
+
+    def test_prompt_is_shown_to_the_user(self) -> None:
+        stdin = _FakeStream(tty=True, content="y\n")
+        stdout = _FakeStream(tty=True)
+        require_interactive_approval(
+            "Pull fresh DEV dump for development-volksbank into ticket DB?",
+            stdin=stdin,
+            stdout=stdout,
+        )
+        assert "development-volksbank" in stdout.getvalue()
+
+    def test_agent_cannot_self_approve_even_with_yes_in_buffer(self) -> None:
+        # The decisive guard: a non-TTY stdin carrying "y" must NOT pass —
+        # an unattended agent piping "y" is exactly what this blocks.
+        stdin = _FakeStream(tty=False, content="y\ny\ny\n")
+        stdout = _FakeStream(tty=False)
+        with pytest.raises(ApprovalRefusedError, match="human must"):
+            require_interactive_approval("Pull fresh DEV dump?", stdin=stdin, stdout=stdout)

--- a/tests/test_django_db.py
+++ b/tests/test_django_db.py
@@ -608,29 +608,25 @@ class TestTryRestoreFromLocalDump:
 
 
 class TestTryFetchRemoteDump:
-    def test_blocks_when_env_gate_not_set(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Regression guard: even with remote_url configured, the env gate must block.
+    """Remote pg_dump is reached only when ``allow_remote_dump=True`` (#777).
 
-        2026-04-20 incident: agent-triggered lifecycle path auto-fetched gigabyte
-        dumps over VPN. The env gate is the final safety net.
-        """
-        monkeypatch.delenv("T3_ALLOW_REMOTE_DUMP", raising=False)
-        importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
-        assert importer._try_fetch_remote_dump() is False
+    The blanket ``T3_ALLOW_REMOTE_DUMP`` env gate is gone — the safety
+    mechanism moved to a per-invocation interactive approval gate at the
+    CLI boundary (``teatree.utils.approval``). An unattended agent cannot
+    reach this method because it cannot satisfy that gate (no TTY). These
+    tests therefore exercise the post-approval behaviour directly.
+    """
 
-    def test_skips_when_no_remote_url(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
+    def test_skips_when_no_remote_url(self, tmp_path: Path) -> None:
         importer = _make_importer(tmp_path)
         assert importer._try_fetch_remote_dump() is False
 
-    def test_skips_when_already_failed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
+    def test_skips_when_already_failed(self, tmp_path: Path) -> None:
         importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
         importer._remote_dump_failed = True
         assert importer._try_fetch_remote_dump() is False
 
     def test_handles_timeout(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
         (tmp_path / ".data").mkdir()
         importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
         monkeypatch.setattr(
@@ -641,26 +637,47 @@ class TestTryFetchRemoteDump:
         assert importer._try_fetch_remote_dump() is False
 
     def test_handles_pg_dump_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
         (tmp_path / ".data").mkdir()
         importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
         monkeypatch.setattr(run_mod.subprocess, "run", _fail_run)
         assert importer._try_fetch_remote_dump() is False
 
     def test_returns_true_after_successful_fetch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("T3_ALLOW_REMOTE_DUMP", "1")
         data_dir = tmp_path / ".data"
         data_dir.mkdir()
         importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
 
         def fake_run(args, **kw):
             if isinstance(args, list) and args[0] == "pg_dump":
-                dump_path = args[3]
+                dump_path = args[args.index("-f") + 1]
                 Path(dump_path).write_bytes(b"PGDMP")
             return _ok_run()
 
         monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
         assert importer._try_fetch_remote_dump() is True
+
+    def test_pg_dump_uses_no_owner_no_privileges(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """User script hardening: dump portable across the superuser boundary.
+
+        The user's known-good ``import_db_from_dev_env.sh`` passes
+        ``--no-owner --no-privileges`` so the local ownership-reassignment
+        post-steps can take over cleanly. Preserve that.
+        """
+        (tmp_path / ".data").mkdir()
+        importer = _make_importer(tmp_path, dslr_cmd=[], remote_db_url="postgres://u:p@host/db")
+        captured: list[list[str]] = []
+
+        def fake_run(args, **kw):
+            if isinstance(args, list) and args[0] == "pg_dump":
+                captured.append(args)
+                Path(args[args.index("-f") + 1]).write_bytes(b"PGDMP")
+            return _ok_run()
+
+        monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
+        importer._try_fetch_remote_dump()
+        assert captured, "pg_dump was not invoked"
+        assert "--no-owner" in captured[0]
+        assert "--no-privileges" in captured[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
feat(db): sanctioned per-invocation-approved fresh remote dump path (#777)

Replaces the blanket remote-dump prohibition with an explicit
per-invocation interactive approval gate. Before: the overlay
hardcoded allow_remote_dump=False and core gated the remote pg_dump
behind a T3_ALLOW_REMOTE_DUMP=1 env var with an "agents must never set
this" comment — the path was permanently dead, so the only way to pull
a fresh DEV dump was a manual pg_dump work-around.

- New teatree.utils.approval.require_interactive_approval: refuses
  unless both stdin and stdout are real TTYs and the human types yes.
  An unattended agent has no TTY, so it cannot self-approve — this is
  the safety mechanism, not a blanket ban.
- t3 <overlay> db refresh --fresh-dump: states env + tenant + target
  DB and requires that approval every run; threads approve_remote_dump
  through the OverlayBase.db_import extension-point contract into
  django_db_import.
- Removed the T3_ALLOW_REMOTE_DUMP env gate inside _try_fetch_remote_dump
  (the approval flag, set only post-approval, is now the gate). The
  command-blocker hook still rejects the defunct env var and points at
  the sanctioned --fresh-dump path.
- Integrated the dump-mechanics hardening from the user's known-good
  import_db_from_dev_env.sh: pg_dump now uses --no-owner
  --no-privileges so the dump is portable across the remote->local
  superuser boundary and the existing ownership-reassignment post-steps
  take over cleanly. Restore stays the deterministic db_restore path.
- Tenant is resolved from worktree/overlay context, never hardcoded.
- BLUEPRINT §14 + overlay-api docs updated to the new contract; no
  credentials or connection strings embedded or echoed anywhere.

TDD anti-vacuous: breaking the TTY guard flips the agent-cannot-self-
approve test red (DID NOT RAISE); reverting the pg_dump hardening flips
the no-owner test red. Full suite 3643 green, zero regression;
ruff/ty/tach clean. Cross-repo: the overlay-side wiring is a sibling MR.