### PR TITLE
feat(config): t3 config show + cache-vs-intent state placement rule (#628)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1187,6 +1187,12 @@ Overlay-specific configuration lives on `overlay.config` (an `OverlayConfig` dat
 
 `~/.local/share/teatree/<namespace>/` — namespaced data directories created by `get_data_dir()`.
 
+### 10.5 State Placement Rule — Cache vs Intent (#628)
+
+**The text files are the source of truth for user *intent*; the DB caches *derived* state.** A datum may live DB-only **iff it can be deleted and deterministically rebuilt** from the text files (`~/.teatree.toml`, overlay config) plus repo state — deleting the DB must lose no user intent. If losing a datum would lose user intent, it stays text-file source-of-truth (the DB may cache a read view, never own it). The DB stays rebuildable from the text files indefinitely — no one-way migration.
+
+Consequences: bootstrap config (DB path, log level, the `mode` resolution chain) and user-authored intent (push mode, contribute, banned terms) stay in text files — they must resolve with the DB absent. Derived/observational state (cached env values, last-seen branch, lifecycle phase history) is DB-as-cache and carries a regeneration path. A DB-only user-*intent* field (e.g. #627 `Ticket.context`) is permitted **only** with a round-trip affordance so the `cat ~/.teatree.toml` affordance is not lost — `t3 config show` is that affordance: a read-only view partitioning text-file intent from DB regenerable cache, working with the DB absent.
+
 ---
 
 ## 11. Skills & Plugin Architecture

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -141,6 +141,8 @@ Usage: t3 config [OPTIONS] COMMAND [ARGS]...
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ check-update       Check if a newer version of teatree is available.         │
+│ show               Read-only view of config: text-file intent vs DB          │
+│                    regenerable cache (#628).                                 │
 │ write-skill-cache  Write overlay skill metadata + trigger index to XDG cache │
 │                    for hook consumption.                                     │
 │ autoload           List skill auto-loading rules from context-match.yml      │
@@ -159,6 +161,24 @@ Usage: t3 config check-update [OPTIONS]
  Check if a newer version of teatree is available.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 config show`
+
+```
+Usage: t3 config show [OPTIONS]
+
+ Read-only view of config: text-file intent vs DB regenerable cache (#628).
+
+ The intent section is ``~/.teatree.toml`` resolved — the user-authored
+ source of truth. The derived section is DB / data-dir state that can be
+ deleted and rebuilt from the text files; every entry is flagged
+ regenerable so the cache-vs-intent invariant is visible. Reads only.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json          Emit machine-readable JSON.                                  │
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -1950,11 +1970,15 @@ Usage: t3 teatree e2e run [OPTIONS]
  or ``"runner": "external"``; when absent, ``test_dir`` implies ``project``
  and ``project_path`` implies ``external`` for compatibility.
 
+ ``--target dev|local`` selects the dual-env target and is forwarded to
+ whichever runner handles the overlay (see ``external`` for semantics).
+
  Runner-specific flags (``--repo``, ``--playwright-args``) stay on the
  explicit ``external`` subcommand to keep this entry point overlay-agnostic.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --test-path                                    TEXT                          │
+│ --target                                       TEXT                          │
 │ --headed              --no-headed                    [default: no-headed]    │
 │ --update-snapshots    --no-update-snapshots          [default:               │
 │                                                      no-update-snapshots]    │
@@ -1991,6 +2015,19 @@ Usage: t3 teatree e2e external [OPTIONS]
  - Default: resolve from ``T3_PRIVATE_TESTS`` env var or ``.private_tests``
      config key.
 
+ ``--target dev|local`` selects the dual-env target deterministically:
+
+ - ``dev``: keep the pre-set ``BASE_URL`` (deployed env), no port scan.
+ - ``local``: always discover the local frontend, even if a stray
+     ``BASE_URL`` is exported (``--target local`` never hits a
+     deployed env silently).
+ - empty: back-compat — infer ``dev`` if ``BASE_URL`` is set,
+     else ``local``.
+
+ The resolved value is exported as ``T3_E2E_TARGET`` so a dual-mode
+ spec branches on ``process.env.T3_E2E_TARGET === 'dev'`` rather than
+ re-deriving the target from a ``BASE_URL`` host regex.
+
  Discovers the frontend port from docker-compose (or local process)
  and reads the tenant variant from the env cache.
 
@@ -2001,6 +2038,7 @@ Usage: t3 teatree e2e external [OPTIONS]
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --test-path                                    TEXT                          │
 │ --repo                                         TEXT                          │
+│ --target                                       TEXT                          │
 │ --headed              --no-headed                    [default: no-headed]    │
 │ --update-snapshots    --no-update-snapshots          [default:               │
 │                                                      no-update-snapshots]    │
@@ -2017,6 +2055,10 @@ Usage: t3 teatree e2e project [OPTIONS]
 
  Run E2E tests from the project's own test directory.
 
+ ``--target dev|local`` is exported as ``T3_E2E_TARGET`` for the in-repo
+ suite (same contract as the ``external`` runner); empty falls back to
+ ``BASE_URL``-based inference.
+
  Pass ``--update-snapshots`` to regenerate ``pytest-playwright-visual``
  baselines. Always do this inside the Docker image (the default) — the
  CI runner's Chromium renders fonts at different heights than macOS, so
@@ -2024,6 +2066,7 @@ Usage: t3 teatree e2e project [OPTIONS]
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --test-path                                    TEXT                          │
+│ --target                                       TEXT                          │
 │ --headed              --no-headed                    [default: no-headed]    │
 │ --docker              --no-docker                    [default: docker]       │
 │ --update-snapshots    --no-update-snapshots          [default:               │

--- a/src/teatree/cli/config.py
+++ b/src/teatree/cli/config.py
@@ -18,6 +18,29 @@ def check_update() -> None:
     typer.echo(message or "You are up to date.")
 
 
+@config_app.command()
+def show(
+    *,
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Read-only view of config: text-file intent vs DB regenerable cache (#628).
+
+    The intent section is ``~/.teatree.toml`` resolved — the user-authored
+    source of truth. The derived section is DB / data-dir state that can be
+    deleted and rebuilt from the text files; every entry is flagged
+    regenerable so the cache-vs-intent invariant is visible. Reads only.
+    """
+    import json as _json  # noqa: PLC0415
+
+    from teatree.cli.config_view import build_config_view, render_config_view  # noqa: PLC0415
+
+    view = build_config_view()
+    if json_output:
+        typer.echo(_json.dumps(view.to_dict()))
+        return
+    typer.echo(render_config_view(view))
+
+
 @config_app.command(name="write-skill-cache")
 def write_skill_cache() -> None:
     """Write overlay skill metadata + trigger index to XDG cache for hook consumption."""

--- a/src/teatree/cli/config_view.py
+++ b/src/teatree/cli/config_view.py
@@ -1,0 +1,126 @@
+"""Read-only ``t3 config show`` view: text-file intent vs DB-cached state.
+
+Encodes the #628 cache-vs-intent invariant in the output itself. The
+**intent** section is the resolved ``~/.teatree.toml`` — the user-authored
+source of truth; deleting it loses user intent. The **derived** section is
+DB / data-dir state that can be deleted and deterministically rebuilt from
+the text files plus repo state; every entry is flagged ``regenerable`` so
+the invariant is visible, not just documented.
+
+Building the view never imports the ORM eagerly and never writes anything
+— it must work with the DB absent (offline-readable, mirroring the
+bootstrap-config constraint #628 calls out).
+"""
+
+import dataclasses
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import teatree.config as config_mod
+from teatree.config import get_effective_settings
+from teatree.paths import CANONICAL_DB, DATA_DIR, DATA_DIR_AUTO_ISOLATED
+
+_REGENERABLE_CACHE_FILES: tuple[str, ...] = (
+    "update-check.json",
+    "skill-metadata.json",
+    "bad_artifacts.json",
+)
+
+
+@dataclass
+class ConfigView:
+    config_path: str
+    config_exists: bool
+    intent: dict[str, Any]
+    derived: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "config_path": self.config_path,
+            "config_exists": self.config_exists,
+            "intent": self.intent,
+            "derived": self.derived,
+        }
+
+
+def _intent() -> dict[str, Any]:
+    settings = get_effective_settings()
+    out: dict[str, Any] = {}
+    for f in dataclasses.fields(settings):
+        value = getattr(settings, f.name)
+        out[f.name] = str(value) if isinstance(value, Path) else value
+    out["mode"] = str(out["mode"])
+    return out
+
+
+def _ticket_session_counts() -> dict[str, int] | None:
+    try:
+        import django  # noqa: PLC0415
+
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+        django.setup()
+        from teatree.core.models.session import Session  # noqa: PLC0415
+        from teatree.core.models.ticket import Ticket  # noqa: PLC0415
+
+        return {"tickets": Ticket.objects.count(), "sessions": Session.objects.count()}
+    except Exception:  # noqa: BLE001 — DB absent/unmigrated is a valid offline state, not a crash.
+        return None
+
+
+def _derived() -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = [
+        {
+            "name": "control DB",
+            "path": str(CANONICAL_DB),
+            "exists": CANONICAL_DB.is_file(),
+            "worktree_isolated": DATA_DIR_AUTO_ISOLATED,
+            "regenerable": True,
+        }
+    ]
+    counts = _ticket_session_counts()
+    if counts is not None:
+        entries.append({"name": "DB row counts", "value": counts, "regenerable": True})
+    for filename in _REGENERABLE_CACHE_FILES:
+        cache_file = DATA_DIR / filename
+        entries.append(
+            {
+                "name": filename,
+                "path": str(cache_file),
+                "exists": cache_file.is_file(),
+                "regenerable": True,
+            }
+        )
+    return entries
+
+
+def build_config_view() -> ConfigView:
+    config_path = config_mod.CONFIG_PATH
+    return ConfigView(
+        config_path=str(config_path),
+        config_exists=config_path.is_file(),
+        intent=_intent(),
+        derived=_derived(),
+    )
+
+
+def _render_derived_entry(entry: dict[str, Any]) -> str:
+    name = entry["name"]
+    if "value" in entry:
+        return f"  {name}: {entry['value']}  [regenerable cache]"
+    extra = " (worktree-isolated)" if entry.get("worktree_isolated") else ""
+    present = "exists" if entry.get("exists") else "not yet created"
+    return f"  {name}: {entry['path']} — {present}{extra}  [regenerable cache]"
+
+
+def render_config_view(view: ConfigView) -> str:
+    status = "present" if view.config_exists else "absent (defaults shown)"
+    lines = [
+        f"Intent — text-file source of truth ({view.config_path}, {status}):",
+        *(f"  {key} = {view.intent[key]}" for key in sorted(view.intent)),
+        "",
+        "Derived — DB / data-dir regenerable cache (deletable, rebuilt from intent + repo):",
+        *(_render_derived_entry(entry) for entry in view.derived),
+    ]
+    return "\n".join(lines)

--- a/tests/test_cli_config_show.py
+++ b/tests/test_cli_config_show.py
@@ -1,0 +1,90 @@
+"""``t3 config show`` — read-only intent + DB-cache view (issue #628).
+
+Integration-first: a real ``~/.teatree.toml`` fixture under ``tmp_path``
+with ``teatree.config.CONFIG_PATH`` monkeypatched, exercised through the
+typer ``CliRunner``. The build step (``build_config_view``) is unit-tested
+for the cache-vs-intent partition because that classification is the
+load-bearing logic the #628 invariant turns on.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from teatree.cli import app
+from teatree.cli.config_view import build_config_view
+
+runner = CliRunner()
+
+
+def _write_toml(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+class TestBuildConfigView:
+    def test_intent_section_reflects_resolved_settings(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".teatree.toml"
+        _write_toml(config_path, '[teatree]\nmode = "auto"\ncontribute = true\n')
+        with patch("teatree.config.CONFIG_PATH", config_path):
+            view = build_config_view()
+        assert view.intent["mode"] == "auto"
+        assert view.intent["contribute"] is True
+        assert view.config_path == str(config_path)
+        assert view.config_exists is True
+
+    def test_missing_config_is_reported_not_crashed(self, tmp_path: Path) -> None:
+        with patch("teatree.config.CONFIG_PATH", tmp_path / "absent.toml"):
+            view = build_config_view()
+        assert view.config_exists is False
+        # Defaults still resolve so the view is never empty.
+        assert view.intent["mode"] == "interactive"
+
+    def test_derived_section_is_labelled_regenerable_cache(self, tmp_path: Path) -> None:
+        with patch("teatree.config.CONFIG_PATH", tmp_path / "absent.toml"):
+            view = build_config_view()
+        # Every derived entry must be flagged regenerable so the #628
+        # cache-vs-intent invariant is visible in the output itself.
+        assert view.derived  # non-empty
+        assert all(entry["regenerable"] is True for entry in view.derived)
+
+    def test_db_path_is_surfaced_in_derived(self, tmp_path: Path) -> None:
+        with patch("teatree.config.CONFIG_PATH", tmp_path / "absent.toml"):
+            view = build_config_view()
+        names = {entry["name"] for entry in view.derived}
+        assert "control DB" in names
+
+
+class TestConfigShowCommand:
+    def test_human_readable_output_partitions_intent_and_cache(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".teatree.toml"
+        _write_toml(config_path, '[teatree]\nmode = "auto"\n')
+        with patch("teatree.config.CONFIG_PATH", config_path):
+            result = runner.invoke(app, ["config", "show"])
+        assert result.exit_code == 0
+        assert "Intent" in result.stdout
+        assert "source of truth" in result.stdout
+        assert "regenerable cache" in result.stdout
+        assert "mode" in result.stdout
+        assert "auto" in result.stdout
+
+    def test_json_output_is_machine_readable(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".teatree.toml"
+        _write_toml(config_path, '[teatree]\nmode = "auto"\n')
+        with patch("teatree.config.CONFIG_PATH", config_path):
+            result = runner.invoke(app, ["config", "show", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["intent"]["mode"] == "auto"
+        assert payload["config_exists"] is True
+        assert isinstance(payload["derived"], list)
+
+    def test_show_is_read_only_no_config_written(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".teatree.toml"
+        _write_toml(config_path, '[teatree]\nmode = "interactive"\n')
+        before = config_path.read_text(encoding="utf-8")
+        with patch("teatree.config.CONFIG_PATH", config_path):
+            runner.invoke(app, ["config", "show"])
+        assert config_path.read_text(encoding="utf-8") == before


### PR DESCRIPTION
feat(config): t3 config show + cache-vs-intent state placement rule (#628)

Implements the pick-up-ready spec from the cross-review on #628 (items 1
and 2; items 3-4 are larger/dependent, deliberately unbundled — split
discipline).

- BLUEPRINT §10.5 "State Placement Rule": codifies the invariant the
  decision turned on — text files are the source of truth for user
  intent; the DB caches derived state. A datum may live DB-only iff it
  can be deleted and deterministically rebuilt from the text files +
  repo state; the DB stays rebuildable indefinitely (no one-way
  migration). Must exist before #627 adds the first DB-only intent
  field.
- `t3 config show [--json]`: read-only view partitioning text-file
  intent (resolved UserSettings, source of truth) from DB/data-dir
  regenerable cache (control DB path + worktree-isolated flag, row
  counts, cache files), every derived entry flagged regenerable so the
  invariant is visible in the output. Works with the DB absent
  (offline-readable, mirroring the bootstrap-config constraint).
  `build_config_view` is a pure builder; the command is thin wiring.

TDD anti-vacuous: flipping a `regenerable` flag to False makes the
invariant test go red (correct symptom), restoring makes it green. 3628
tests green, zero regression; ruff/ty/tach clean.