### PR TITLE
fix(ship): ensure-pr defers instead of deadlocking the pre-push (#792)

### DIFF
--- a/src/teatree/core/management/commands/_ensure_pr.py
+++ b/src/teatree/core/management/commands/_ensure_pr.py
@@ -1,0 +1,92 @@
+"""Orphan-branch PR creation with the #792 pre-push-deadlock deferral.
+
+Split out of ``pr.py`` (same sibling-module pattern as ``_ship_fsm``) so
+``pr.py`` stays within the module-health LOC budget and the "create the PR
+for an orphan branch, or defer when the remote ref is not yet current"
+concern is named by its own file.
+
+#792: ``ensure-pr`` runs inside the git PRE-push hook. When the remote
+branch ref already exists at an older base (``classify_branch`` ⇒
+PUSHED_ORPHAN, not UNPUSHED_ORPHAN), ``gh pr create`` fails "No commits
+between main and <branch>" because THIS push has not updated the remote
+yet. Hard-failing there aborts the very push that would make the PR
+creatable — a permanent deadlock. That specific failure is therefore
+deferred (skip, exit 0) exactly like the documented first-push
+UNPUSHED_ORPHAN case; the post-push ``ensure-pr`` opens the PR against the
+now-current ref. Any other create failure is a real error and surfaces.
+"""
+
+import re
+from typing import TypedDict
+
+from teatree.backends.protocols import PullRequestSpec
+from teatree.core.backend_factory import code_host_from_overlay
+from teatree.core.overlay_loader import get_overlay
+from teatree.core.runners.ship import overlay_pr_labels, sanitize_close_keywords
+from teatree.utils import git
+from teatree.utils.run import CommandFailedError
+
+_REMOTE_HOST_RE = re.compile(r"^(?:git@[^:]+:|https?://[^/]+/|ssh://[^/]+/|git://[^/]+/)")
+
+
+class EnsurePrResult(TypedDict, total=False):
+    skipped: str
+    branch: str
+    url: str
+    hint: str
+    error: str
+
+
+def slug_from_remote(remote_url: str) -> str:
+    """Extract the ``org/repo`` (or ``ns/group/repo``) slug from a git remote URL."""
+    if not remote_url:
+        return ""
+    return _REMOTE_HOST_RE.sub("", remote_url.strip()).removesuffix(".git")
+
+
+def create_or_defer_pr(repo_path: str, branch_name: str) -> EnsurePrResult:
+    """Build the PR spec from the last commit and create it, or defer (#792).
+
+    The "no commits between" create failure is the pre-push stale-remote
+    race (the remote ref still lags this in-flight push); deferring it lets
+    the push proceed so the post-push ``ensure-pr`` opens the PR. Every
+    other create failure is real and re-raised.
+    """
+    host = code_host_from_overlay()
+    if host is None:
+        return EnsurePrResult(error="no code host configured")
+
+    commit_subject, commit_body = git.last_commit_message(repo=repo_path)
+    title = commit_subject or f"WIP: {branch_name}"
+    raw_description = (
+        f"{commit_subject}\n\n{commit_body}"
+        if commit_subject and commit_body
+        else (commit_subject or commit_body or f"PR auto-created to track branch `{branch_name}`.")
+    )
+    description = sanitize_close_keywords(raw_description, close_ticket=get_overlay().config.mr_close_ticket)
+
+    remote = git.remote_url(repo=repo_path)
+    repo_slug = slug_from_remote(remote)
+    assignee = host.current_user() or git.config_value(key="user.name")
+
+    try:
+        raw = host.create_pr(
+            PullRequestSpec(
+                repo=repo_slug,
+                branch=branch_name,
+                title=title,
+                description=description,
+                labels=overlay_pr_labels(),
+                assignee=assignee,
+                draft=False,
+            ),
+        )
+    except CommandFailedError as exc:
+        if "no commits between" in (exc.stderr or str(exc)).lower():
+            return EnsurePrResult(
+                skipped="remote ref not yet current (pre-push race) — re-run after push completes",
+                branch=branch_name,
+                hint=f"t3 <overlay> pr ensure-pr --branch {branch_name}",
+            )
+        raise
+    return EnsurePrResult(branch=branch_name, url=str(raw.get("url", raw.get("web_url", ""))))

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -14,8 +14,8 @@ from django_fsm import TransitionNotAllowed
 from django_typer.management import TyperCommand, command
 
 from teatree import visual_qa
-from teatree.backends.protocols import PullRequestSpec
 from teatree.core.backend_factory import code_host_from_overlay
+from teatree.core.management.commands._ensure_pr import EnsurePrResult, create_or_defer_pr
 from teatree.core.management.commands._ship_fsm import reconcile_fsm_for_ship
 from teatree.core.models import Session, Ticket, Worktree
 from teatree.core.models.types import TicketExtra, VisualQASummary
@@ -75,24 +75,12 @@ class ShippingGateFailure(TypedDict):
     hint: str
 
 
-class EnsurePrResult(TypedDict, total=False):
-    skipped: str
-    branch: str
-    url: str
-    hint: str
-    error: str
+# EnsurePrResult lives in ``_ensure_pr`` (re-exported above) so external
+# importers of ``pr.EnsurePrResult`` keep working after the ensure-pr split.
 
 
 _IMAGE_URL_RE = re.compile(r"!\[([^\]]*)\]\((/uploads/[^\)]+)\)")
 _EXTERNAL_LINK_RE = re.compile(r"https?://(?:www\.)?(?:notion\.so|linear\.app|jira\.\S+)/\S+")
-_REMOTE_HOST_RE = re.compile(r"^(?:git@[^:]+:|https?://[^/]+/|ssh://[^/]+/|git://[^/]+/)")
-
-
-def _slug_from_remote(remote_url: str) -> str:
-    """Extract the ``org/repo`` (or ``ns/group/repo``) slug from a git remote URL."""
-    if not remote_url:
-        return ""
-    return _REMOTE_HOST_RE.sub("", remote_url.strip()).removesuffix(".git")
 
 
 def _ship_preview(ticket: Ticket, worktree: Worktree) -> tuple[str, str, str]:
@@ -447,35 +435,7 @@ class Command(TyperCommand):
                 hint=f"t3 <overlay> pr ensure-pr --branch {branch_name}",
             )
 
-        host = code_host_from_overlay()
-        if host is None:
-            return EnsurePrResult(error="no code host configured")
-
-        commit_subject, commit_body = git.last_commit_message(repo=repo_path)
-        title = commit_subject or f"WIP: {branch_name}"
-        raw_description = (
-            f"{commit_subject}\n\n{commit_body}"
-            if commit_subject and commit_body
-            else (commit_subject or commit_body or f"PR auto-created to track branch `{branch_name}`.")
-        )
-        description = sanitize_close_keywords(raw_description, close_ticket=get_overlay().config.mr_close_ticket)
-
-        remote = git.remote_url(repo=repo_path)
-        repo_slug = _slug_from_remote(remote)
-        assignee = host.current_user() or git.config_value(key="user.name")
-
-        raw = host.create_pr(
-            PullRequestSpec(
-                repo=repo_slug,
-                branch=branch_name,
-                title=title,
-                description=description,
-                labels=overlay_pr_labels(),
-                assignee=assignee,
-                draft=False,
-            ),
-        )
-        return EnsurePrResult(branch=branch_name, url=str(raw.get("url", raw.get("web_url", ""))))
+        return create_or_defer_pr(repo_path, branch_name)
 
     @command(name="check-gates")
     def check_gates(self, ticket_id: int, target_phase: str = "shipping") -> dict[str, object]:

--- a/tests/teatree_core/test_ensure_pr.py
+++ b/tests/teatree_core/test_ensure_pr.py
@@ -1,0 +1,29 @@
+"""Tests for the ensure-pr helpers (mirrors ``_ensure_pr``).
+
+Split out of ``test_pr_command`` alongside the ``_ensure_pr`` module
+extraction: test files mirror the production module path. The behavioural
+``ensure-pr`` command tests (PUSHED_ORPHAN / pre-push-deadlock deferral)
+stay in ``test_pr_command`` because they drive ``call_command("pr",
+"ensure-pr")`` end to end.
+"""
+
+from django.test import TestCase
+
+from teatree.core.management.commands._ensure_pr import slug_from_remote
+
+
+class TestSlugFromRemote(TestCase):
+    def test_github_ssh(self) -> None:
+        assert slug_from_remote("git@github.com:souliane/teatree.git") == "souliane/teatree"
+
+    def test_github_https(self) -> None:
+        assert slug_from_remote("https://github.com/souliane/teatree.git") == "souliane/teatree"
+
+    def test_gitlab_nested_namespace(self) -> None:
+        assert slug_from_remote("git@gitlab.com:acme/team/backend.git") == "acme/team/backend"
+
+    def test_no_dot_git_suffix(self) -> None:
+        assert slug_from_remote("https://github.com/souliane/teatree") == "souliane/teatree"
+
+    def test_empty_returns_empty(self) -> None:
+        assert slug_from_remote("") == ""

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -7,13 +7,13 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from teatree import visual_qa
+from teatree.core.management.commands import _ensure_pr as ensure_pr_mod
 from teatree.core.management.commands import pr as pr_command
 from teatree.core.management.commands.pr import (
     _check_shipping_gate,
     _resolve_base_url,
     _run_visual_qa_gate,
     _ship_preview,
-    _slug_from_remote,
 )
 from teatree.core.models import Session, Ticket, Worktree
 from teatree.core.orphan_guard import BranchReport, BranchStatus
@@ -389,23 +389,6 @@ class TestShipPreviewTitleDescriptionInvariant(TestCase):
         assert self._first_line(description) == title
 
 
-class TestSlugFromRemote(TestCase):
-    def test_github_ssh(self) -> None:
-        assert _slug_from_remote("git@github.com:souliane/teatree.git") == "souliane/teatree"
-
-    def test_github_https(self) -> None:
-        assert _slug_from_remote("https://github.com/souliane/teatree.git") == "souliane/teatree"
-
-    def test_gitlab_nested_namespace(self) -> None:
-        assert _slug_from_remote("git@gitlab.com:acme/team/backend.git") == "acme/team/backend"
-
-    def test_no_dot_git_suffix(self) -> None:
-        assert _slug_from_remote("https://github.com/souliane/teatree") == "souliane/teatree"
-
-    def test_empty_returns_empty(self) -> None:
-        assert _slug_from_remote("") == ""
-
-
 class TestEnsurePr(TestCase):
     @pytest.fixture(autouse=True)
     def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -487,13 +470,13 @@ class TestEnsurePr(TestCase):
         host = MagicMock()
         host.create_pr.return_value = {"url": "https://github.com/souliane/teatree/pull/999"}
         host.current_user.return_value = "souliane"
-        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+        self._monkeypatch.setattr(ensure_pr_mod, "code_host_from_overlay", lambda: host)
 
         with (
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
             patch.object(pr_command.git, "current_branch", return_value="feat-q"),
-            patch.object(pr_command.git, "remote_url", return_value="git@github.com:souliane/teatree.git"),
-            patch.object(pr_command.git, "last_commit_message", return_value=("feat: cool thing", "body")),
+            patch.object(ensure_pr_mod.git, "remote_url", return_value="git@github.com:souliane/teatree.git"),
+            patch.object(ensure_pr_mod.git, "last_commit_message", return_value=("feat: cool thing", "body")),
             patch.object(
                 pr_command,
                 "classify_branch",
@@ -514,6 +497,85 @@ class TestEnsurePr(TestCase):
         assert spec.branch == "feat-q"
         assert spec.repo == "souliane/teatree"
         assert spec.title == "feat: cool thing"
+
+    def test_defers_when_remote_ref_stale_in_pre_push_race(self) -> None:
+        """#792: ensure-pr must defer (not raise) on the pre-push stale-remote race.
+
+        ensure-pr runs in the PRE-push hook. The remote branch ref exists at
+        an older base (classify_branch => PUSHED_ORPHAN), but THIS push has
+        not landed yet, so the forge rejects PR creation with "No commits
+        between main and <branch>". Hard-failing aborts the very push that
+        would make the PR creatable — a permanent deadlock. ensure-pr must
+        DEFER (skip + exit 0) so the push proceeds and the post-push
+        ensure-pr opens the PR.
+        """
+        from teatree.utils.run import CommandFailedError  # noqa: PLC0415
+
+        host = MagicMock()
+        host.current_user.return_value = "souliane"
+        host.create_pr.side_effect = CommandFailedError(
+            cmd=["gh", "pr", "create"],
+            returncode=1,
+            stdout="",
+            stderr="pull request create failed: GraphQL: No commits between main and feat-q (createPullRequest)",
+        )
+        self._monkeypatch.setattr(ensure_pr_mod, "code_host_from_overlay", lambda: host)
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command.git, "current_branch", return_value="feat-q"),
+            patch.object(ensure_pr_mod.git, "remote_url", return_value="git@github.com:souliane/teatree.git"),
+            patch.object(ensure_pr_mod.git, "last_commit_message", return_value=("feat: cool thing", "body")),
+            patch.object(
+                pr_command,
+                "classify_branch",
+                return_value=BranchReport(
+                    repo=".",
+                    branch="feat-q",
+                    status=BranchStatus.PUSHED_ORPHAN,
+                    ahead_count=3,
+                ),
+            ),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "ensure-pr"))
+
+        # Deferred, not raised: the push must be allowed to proceed.
+        assert "pre-push race" in str(result["skipped"])
+        assert "feat-q" in str(result["hint"])
+        host.create_pr.assert_called_once()
+
+    def test_other_create_pr_failure_still_raises(self) -> None:
+        """A non-race create_pr failure must still surface (no silent swallow)."""
+        from teatree.utils.run import CommandFailedError  # noqa: PLC0415
+
+        host = MagicMock()
+        host.current_user.return_value = "souliane"
+        host.create_pr.side_effect = CommandFailedError(
+            cmd=["gh", "pr", "create"],
+            returncode=1,
+            stdout="",
+            stderr="pull request create failed: GraphQL: API rate limit exceeded",
+        )
+        self._monkeypatch.setattr(ensure_pr_mod, "code_host_from_overlay", lambda: host)
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command.git, "current_branch", return_value="feat-q"),
+            patch.object(ensure_pr_mod.git, "remote_url", return_value="git@github.com:souliane/teatree.git"),
+            patch.object(ensure_pr_mod.git, "last_commit_message", return_value=("feat: x", "body")),
+            patch.object(
+                pr_command,
+                "classify_branch",
+                return_value=BranchReport(
+                    repo=".",
+                    branch="feat-q",
+                    status=BranchStatus.PUSHED_ORPHAN,
+                    ahead_count=3,
+                ),
+            ),
+            pytest.raises(CommandFailedError, match="rate limit"),
+        ):
+            call_command("pr", "ensure-pr")
 
 
 class TestPostEvidence(TestCase):


### PR DESCRIPTION
## Summary

`ensure-pr` runs inside the git PRE-push hook. When the remote branch ref already exists at an older base (`classify_branch` ⇒ PUSHED_ORPHAN, not UNPUSHED_ORPHAN), `gh pr create` fails "No commits between main and <branch>" because THIS push has not updated the remote yet. Hard-failing there aborts the very push that would make the PR creatable — a permanent deadlock (a pre-push hook depending on post-push remote state; same lifecycle-ordering family as #779/#788).

- The "no commits between" create failure is caught and deferred (skip, exit 0) exactly like the documented first-push UNPUSHED_ORPHAN case, so the push proceeds and the post-push `ensure-pr` opens the PR.
- Any other create failure still surfaces (narrowly scoped to "no commits between").
- The create-or-defer concern (+ `slug_from_remote`, `EnsurePrResult`) is extracted into a sibling `_ensure_pr` module (mirrors `_ship_fsm`) so `pr.py` stays within the module-health LOC budget; tests follow the split.

This PR's own push is the proof: the pre-push `ensure-pr` deferred gracefully instead of deadlocking, so the branch pushed successfully — which the bug previously made impossible.

## Test plan

- [x] Anti-vacuous regression tests: a PUSHED_ORPHAN branch whose `create_pr` raises the "no commits between" race must DEFER (RED-before: it raised and aborted the push); a non-race failure must still raise.
- [x] Full pre-push Docker matrix: 3673 passed, 12 skipped, 4 subtests passed.
- [x] Module-health gate passes (pr.py back under the LOC budget via the `_ensure_pr` split).