### PR TITLE
fix(views): constant-time GitLab webhook token compare (#753)

### DIFF
--- a/src/teatree/core/views/gitlab_webhook.py
+++ b/src/teatree/core/views/gitlab_webhook.py
@@ -1,4 +1,5 @@
 import hashlib
+import hmac
 import json
 import logging
 
@@ -32,7 +33,7 @@ class GitLabWebhookView(View):
             return HttpResponse(status=503)
 
         provided = request.headers.get("X-Gitlab-Token", "")
-        if not provided or provided != secret:
+        if not provided or not hmac.compare_digest(provided, secret):
             return HttpResponse(status=401)
 
         if not webhook_rate_limiter().allow(IncomingEvent.Source.GITLAB):

--- a/tests/teatree_core/test_gitlab_webhook_view.py
+++ b/tests/teatree_core/test_gitlab_webhook_view.py
@@ -1,6 +1,7 @@
 """Behaviour tests for the GitLab webhook receiver (#654 phase 6)."""
 
 import json
+from unittest.mock import patch
 
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
@@ -57,6 +58,46 @@ class TestGitLabWebhookView(TestCase):
         response = _post(self.client, body, token=None)
 
         assert response.status_code == 401
+
+    def test_token_is_compared_with_constant_time_primitive(self) -> None:
+        """The shared-secret compare must go through ``hmac.compare_digest``.
+
+        A plain ``!=`` short-circuits on the first differing byte, leaking
+        the token via response timing. The sibling GitHub/Slack views use
+        ``hmac.compare_digest``; this view must too. Asserting the primitive
+        is actually invoked (not just that a wrong token 401s — ``!=`` also
+        does that) is the anti-vacuous regression for the timing fix.
+        """
+        body = json.dumps({"object_kind": "merge_request"}).encode()
+
+        with patch(
+            "teatree.core.views.gitlab_webhook.hmac.compare_digest",
+            wraps=__import__("hmac").compare_digest,
+        ) as spy:
+            response = _post(self.client, body, token="wrong-token")
+
+        assert response.status_code == 401
+        spy.assert_called_once_with("wrong-token", SHARED_SECRET)
+
+    def test_correct_token_via_constant_time_path_is_accepted(self) -> None:
+        """The constant-time path must still accept the correct token."""
+        payload = {
+            "object_kind": "merge_request",
+            "user": {"username": "bob"},
+            "project": {"path_with_namespace": "org/repo"},
+            "object_attributes": {"iid": 7, "action": "open"},
+        }
+        body = json.dumps(payload).encode()
+
+        with patch(
+            "teatree.core.views.gitlab_webhook.hmac.compare_digest",
+            wraps=__import__("hmac").compare_digest,
+        ) as spy:
+            response = _post(self.client, body)
+
+        assert response.status_code == 200
+        spy.assert_called_once_with(SHARED_SECRET, SHARED_SECRET)
+        assert IncomingEvent.objects.count() == 1
 
     def test_replays_are_idempotent(self) -> None:
         payload = {


### PR DESCRIPTION
fix(views): constant-time GitLab webhook token compare (#753)

X-Gitlab-Token is the only authenticator for /hooks/gitlab/ (GitLab does
not HMAC-sign payloads). Comparing it with != short-circuits on the first
differing byte, exposing the shared secret via a response-timing side
channel; an attacker who recovers it can forge authenticated events that
drive autonomous agent actions. Switch to hmac.compare_digest, matching
the established pattern in the sibling github_webhook and slack_webhook
views.

Adds an anti-vacuous regression test that spies hmac.compare_digest is
invoked with the provided/expected token (a plain != also 401s a wrong
token, so the spy assertion is what guards the timing fix) plus a test
that the constant-time path still accepts the correct token.

Relates to #753