### PR TITLE
fix(resolve): route step-1 env-cache resolution through the main-clone guard

### DIFF
--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -197,6 +197,25 @@ def _is_main_clone(path: str) -> bool:
     return git_marker.is_dir()
 
 
+def _reject_main_clone(worktree: Worktree) -> None:
+    """Raise ``WorktreeNotFoundError`` if *worktree* points at a main clone.
+
+    Single source of truth for the main-clone refusal. Every
+    ``resolve_worktree()`` return path that hands back a DB-matched
+    ``Worktree`` must pass through this — a stale or mis-recorded env
+    cache / row whose ``worktree_path`` is a main clone would otherwise
+    route destructive consumers (db reset, teardown, cleanup) at the
+    main clone instead of an isolated worktree (#752).
+    """
+    wt_path = (worktree.extra or {}).get("worktree_path", "")
+    if wt_path and _is_main_clone(wt_path):
+        msg = (
+            f"Refusing to operate on main clone at {wt_path}.\n"
+            "Create a worktree first: t3 <overlay> workspace ticket <issue_url>"
+        )
+        raise WorktreeNotFoundError(msg)
+
+
 def _warn_cwd_mismatch(worktree: Worktree, cwd: str) -> None:
     """Log a warning when the resolved worktree path and user's CWD are unrelated.
 
@@ -237,19 +256,14 @@ def resolve_worktree(path: str = "") -> Worktree:
         if ticket_dir:
             wt = _match_worktree_by_path(ticket_dir)
             if wt is not None:  # pragma: no branch
+                _reject_main_clone(wt)
                 _warn_cwd_mismatch(wt, cwd)
                 return wt
 
     # 2. Match CWD directly against stored worktree paths
     wt = _match_worktree_by_path(cwd)
     if wt is not None:
-        wt_path = (wt.extra or {}).get("worktree_path", "")
-        if wt_path and _is_main_clone(wt_path):
-            msg = (
-                f"Refusing to operate on main clone at {wt_path}.\n"
-                "Create a worktree first: t3 <overlay> workspace ticket <issue_url>"
-            )
-            raise WorktreeNotFoundError(msg)
+        _reject_main_clone(wt)
         _warn_cwd_mismatch(wt, cwd)
         return wt
 

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -239,6 +239,70 @@ class TestResolveWorktree(TestCase):
             resolve_worktree()
 
 
+class TestResolveWorktreeRejectsMainClone(TestCase):
+    """The main-clone refusal must apply to every return path (#752).
+
+    A stale or mis-recorded env cache whose ``TICKET_DIR`` resolves to a
+    ``Worktree`` row pointing at a *main clone* must be rejected by the
+    same guard step 2 uses — not handed back as a usable worktree, which
+    would route destructive consumers (db reset, teardown, cleanup) at
+    the main clone.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        self._monkeypatch = monkeypatch
+        self._tmp_path = tmp_path
+
+    def _make_main_clone(self, name: str) -> Path:
+        """A main clone has ``.git`` as a directory (not a file)."""
+        clone = self._tmp_path / name
+        clone.mkdir()
+        (clone / ".git").mkdir()
+        return clone
+
+    def test_step1_env_cache_pointing_at_main_clone_is_rejected(self) -> None:
+        """Step 1 (env-cache TICKET_DIR) must hit the main-clone guard.
+
+        RED before #752: step 1 returns the main-clone Worktree with no
+        ``WorktreeNotFoundError`` (the guard only ran on step 2).
+        """
+        main_clone = self._make_main_clone("teatree")
+        ticket = Ticket.objects.create()
+        Worktree.objects.create(
+            ticket=ticket,
+            repo_path="teatree",
+            branch="main",
+            extra={"worktree_path": str(main_clone)},
+        )
+
+        # CWD is elsewhere; an env cache there points TICKET_DIR at the
+        # main clone (the stale/mis-recorded condition the guard catches).
+        cwd = self._tmp_path / "elsewhere"
+        cwd.mkdir()
+        envfile = cwd / ".t3-env.cache"
+        envfile.write_text(f"TICKET_DIR={main_clone}\n", encoding="utf-8")
+        self._monkeypatch.setenv("T3_ORIG_CWD", str(cwd))
+
+        with pytest.raises(WorktreeNotFoundError, match="Refusing to operate on main clone"):
+            resolve_worktree()
+
+    def test_step2_main_clone_guard_still_fires(self) -> None:
+        """Step 2 keeps refusing a main clone after the guard is shared."""
+        main_clone = self._make_main_clone("teatree")
+        ticket = Ticket.objects.create()
+        Worktree.objects.create(
+            ticket=ticket,
+            repo_path="teatree",
+            branch="main",
+            extra={"worktree_path": str(main_clone)},
+        )
+        self._monkeypatch.setenv("T3_ORIG_CWD", str(main_clone))
+
+        with pytest.raises(WorktreeNotFoundError, match="Refusing to operate on main clone"):
+            resolve_worktree()
+
+
 class TestWarnCwdMismatch(TestCase):
     @pytest.fixture(autouse=True)
     def _inject_fixtures(self, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
fix(resolve): route step-1 env-cache resolution through the main-clone guard

resolve_worktree() applied the main-clone refusal only on step 2
(direct CWD match). Step 1 (env-cache TICKET_DIR) returned a matched
Worktree with no guard, so a stale or mis-recorded env cache pointing
at a main clone could route destructive consumers (db reset, teardown,
cleanup) at the main clone — exactly what the step-2 guard prevents.

Factor the refusal into a single _reject_main_clone() helper and call
it before every DB-matched return path (step 1 and step 2). The
env-cache fast path is preserved; only the missing correctness check
is added.

Relates to #752