### PR TITLE
fix(setup): repair dep drift in the env that actually runs t3 (#805)

### DIFF
--- a/src/teatree/cli/dep_drift_repair.py
+++ b/src/teatree/cli/dep_drift_repair.py
@@ -1,0 +1,144 @@
+"""Self-heal a teatree install whose env drifted from ``pyproject.toml``.
+
+When teatree adds a top-level dependency, an existing editable install
+hits ``ModuleNotFoundError`` until the env's deps are re-synced.  This
+module detects that drift and repairs **the environment that actually
+executes ``t3``** — never a foreign ``uv tool`` env (the #805 class of
+bug, where ``t3 setup`` printed ``OK Reinstalled`` then immediately
+WARNed the deps were still missing because the repair touched a
+different interpreter than the running one).
+
+Extracted from ``cli/setup.py`` as a distinct concern (module-health).
+"""
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+
+from teatree.utils.dep_drift import (
+    editable_source_path,
+    find_missing_dependencies,
+    running_env_is_uv_tool,
+    running_prefix,
+    running_python,
+)
+from teatree.utils.run import CompletedProcess, run_allowed_to_fail
+
+DRIFT_GUARD_ENV = "_T3_DRIFT_REPAIR_ATTEMPTED"
+
+
+def _run_captured(args: list[str], cwd: Path | None = None) -> CompletedProcess[str]:
+    """Run a subprocess, capturing output and never raising on non-zero exit."""
+    return run_allowed_to_fail(args, cwd=cwd, expected_codes=None)
+
+
+@dataclass(slots=True)
+class RepairPlan:
+    """A concrete command that repairs the *running* interpreter's env.
+
+    ``cmd`` is run as a subprocess; ``label`` is the human-readable command
+    echoed to the user (and the exact manual fallback if the subprocess
+    fails).  Both always describe the environment that actually executes
+    ``t3`` — never a foreign ``uv tool`` env.
+    """
+
+    cmd: list[str]
+    label: str
+
+
+def resolve_repair_plan(missing: list[str]) -> RepairPlan | str:
+    """Build a repair plan for the running interpreter, or a warning string.
+
+    The repair target is the environment whose ``importlib.metadata`` was
+    read to *detect* the drift (``sys.prefix`` of the running ``t3``).  When
+    that env is ``uv tool``-managed, ``uv tool install --reinstall`` is the
+    right resync.  When it is a plain editable install in a pyenv/virtualenv
+    (a *different* env than any ``uv tool`` one), repairing must install into
+    that running interpreter — ``uv tool install`` there would silently fix a
+    foreign env and leave the running ``t3`` still broken.
+    """
+    if os.environ.get(DRIFT_GUARD_ENV):
+        return (
+            f"WARN  Dep drift repair already attempted but deps still missing: "
+            f"{', '.join(missing)}\n"
+            f"      Running interpreter: {running_python()}\n"
+            f"      Manual fix: `{running_python()} -m pip install -e "
+            f"{editable_source_path() or '<teatree-source>'}`."
+        )
+    source = editable_source_path()
+    if source is None:
+        return (
+            f"WARN  Teatree is installed non-editable and is missing declared "
+            f"deps: {', '.join(missing)}\n"
+            f"      Reinstall into the running env: "
+            f"`{running_python()} -m pip install --upgrade teatree`."
+        )
+
+    if running_env_is_uv_tool():
+        uv_bin = shutil.which("uv")
+        if not uv_bin:
+            return (
+                f"WARN  Editable install missing deps ({', '.join(missing)}) but "
+                "`uv` is not on PATH — install uv and re-run `t3 setup`."
+            )
+        return RepairPlan(
+            cmd=[uv_bin, "tool", "install", "--editable", str(source), "--reinstall"],
+            label=f"uv tool install --editable {source} --reinstall",
+        )
+
+    # The running t3 is a plain editable install (pip install -e .) into a
+    # pyenv/virtualenv that uv tool does not manage.  Repair THAT env.
+    python = str(running_python())
+    return RepairPlan(
+        cmd=[python, "-m", "pip", "install", "-e", str(source)],
+        label=f"{python} -m pip install -e {source}",
+    )
+
+
+def repair_dep_drift(repo: Path) -> bool:
+    """Reinstall the running teatree if its env is missing declared deps.
+
+    Detection (:func:`find_missing_dependencies`) and repair both target the
+    environment that actually executes ``t3`` (``sys.prefix`` of the running
+    process).  Repairing a different env — e.g. ``uv tool install`` when the
+    running ``t3`` is a pyenv ``pip install -e`` — would print ``OK
+    Reinstalled`` while leaving the running interpreter still broken.
+
+    Returns ``True`` and ``execv``-replaces the process when a repair was
+    triggered (so this never actually returns ``True`` from the caller's
+    perspective).  Returns ``False`` when no drift is detected, when the
+    install is non-editable (PyPI/wheel), or when the repair tool is
+    unavailable.
+    """
+    pyproject = repo / "pyproject.toml"
+    if not pyproject.is_file():
+        return False
+    missing = find_missing_dependencies(pyproject)
+    if not missing:
+        return False
+
+    plan = resolve_repair_plan(missing)
+    if isinstance(plan, str):
+        typer.echo(plan)
+        return False
+
+    typer.echo(
+        f"NOTE  Missing deps in running env ({running_prefix()}): {', '.join(missing)}.  Re-running `{plan.label}` …",
+    )
+    result = _run_captured(plan.cmd)
+    if result.returncode != 0:
+        typer.echo(f"WARN  Reinstall failed: {result.stderr.strip()}")
+        typer.echo(f"      Manual fix: `{plan.label}`.")
+        return False
+
+    typer.echo("OK    Reinstalled — restarting `t3 setup` against the running env.")
+    os.environ[DRIFT_GUARD_ENV] = "1"
+    # Re-exec the *running* t3, not whatever `t3` happens to be first on PATH
+    # (that may be a different shim/env than the one we just repaired).
+    t3_bin = sys.argv[0] or shutil.which("t3") or "t3"
+    os.execv(t3_bin, [t3_bin, *sys.argv[1:]])  # noqa: S606
+    return True  # unreachable — execv replaces the process; here for the type-checker

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -5,16 +5,15 @@ import logging
 import os
 import re
 import shutil
-import sys
 import tomllib
 from datetime import UTC, datetime
 from pathlib import Path
 
 import typer
 
+from teatree.cli.dep_drift_repair import repair_dep_drift as _repair_dep_drift
 from teatree.cli.doctor import AGENT_SKILL_RUNTIMES, DoctorService, agent_skill_dirs
 from teatree.cli.slack_setup import slack_bot_setup
-from teatree.utils.dep_drift import editable_source_path, find_missing_dependencies
 from teatree.utils.run import CompletedProcess, run_allowed_to_fail
 
 # Re-exported here so external callers and tests see a single import path for
@@ -247,81 +246,6 @@ def _print_path_hint(bin_dir: Path | None) -> None:
     target = bin_dir or Path.home() / ".local" / "bin"
     typer.echo(f"NOTE  `{target}` is not on your PATH.")
     typer.echo(f'      Add to your shell rc (~/.zshrc or ~/.bashrc): export PATH="{target}:$PATH"')
-
-
-_DRIFT_GUARD_ENV = "_T3_DRIFT_REPAIR_ATTEMPTED"
-
-
-def _check_drift_repairable(repo: Path, missing: list[str]) -> tuple[Path, str] | str:
-    """Check if drift can be auto-repaired.
-
-    Returns ``(source, uv_bin)`` on success, or a warning string on failure.
-    """
-    if os.environ.get(_DRIFT_GUARD_ENV):
-        return (
-            f"WARN  Dep drift repair already attempted but deps still missing: "
-            f"{', '.join(missing)}\n"
-            "      The running t3 may be installed in a different tool env than\n"
-            "      the one being repaired.  Manual fix: `uv tool install --editable "
-            f"{repo} --reinstall`."
-        )
-    source = editable_source_path()
-    if source is None:
-        return (
-            f"WARN  Teatree is missing declared deps: {', '.join(missing)}\n"
-            "      Reinstall: `uv tool upgrade teatree --reinstall`."
-        )
-    uv_bin = shutil.which("uv")
-    if not uv_bin:
-        return (
-            f"WARN  Editable install missing deps ({', '.join(missing)}) but `uv` "
-            "is not on PATH — install uv and re-run `t3 setup`."
-        )
-    return source, uv_bin
-
-
-def _repair_dep_drift(repo: Path) -> bool:
-    """Reinstall the editable teatree if its venv is missing declared deps.
-
-    When teatree adds a new top-level dependency to ``pyproject.toml``, every
-    existing editable install (``uv tool install --editable .``) breaks until
-    the user re-runs the install — the venv's pinned deps don't auto-resync
-    when the source's ``pyproject.toml`` changes.  This was the catch-22 that
-    killed ``t3 setup`` when ``tomlkit`` was first added: the very command
-    that would repair the install was the one the missing dep took out.
-
-    Returns ``True`` and ``execvp``-replaces the process when a repair was
-    triggered (so this never actually returns ``True`` from the caller's
-    perspective).  Returns ``False`` when no drift is detected, when the
-    install is non-editable (PyPI/wheel), or when ``uv`` is unavailable.
-    """
-    pyproject = repo / "pyproject.toml"
-    if not pyproject.is_file():
-        return False
-    missing = find_missing_dependencies(pyproject)
-    if not missing:
-        return False
-
-    check = _check_drift_repairable(repo, missing)
-    if isinstance(check, str):
-        typer.echo(check)
-        return False
-
-    source, uv_bin = check
-    typer.echo(
-        f"NOTE  Editable install missing deps: {', '.join(missing)}.  Re-running "
-        f"`uv tool install --editable {source} --reinstall` …",
-    )
-    result = _run_captured([uv_bin, "tool", "install", "--editable", str(source), "--reinstall"])
-    if result.returncode != 0:
-        typer.echo(f"WARN  Reinstall failed: {result.stderr.strip()}")
-        return False
-
-    typer.echo("OK    Reinstalled — restarting `t3 setup` against the refreshed venv.")
-    os.environ[_DRIFT_GUARD_ENV] = "1"
-    t3_bin = shutil.which("t3") or sys.argv[0]
-    os.execv(t3_bin, [t3_bin, *sys.argv[1:]])  # noqa: S606
-    return True  # unreachable — execv replaces the process; here for the type-checker
 
 
 def _ensure_t3_installed(repo: Path) -> bool:

--- a/src/teatree/utils/dep_drift.py
+++ b/src/teatree/utils/dep_drift.py
@@ -13,6 +13,7 @@ teatree's declared deps are partially missing from the venv.
 
 import json
 import re
+import sys
 import tomllib
 from importlib.metadata import PackageNotFoundError, distribution, distributions
 from pathlib import Path
@@ -46,6 +47,53 @@ def installed_distribution_names() -> set[str]:
 def find_missing_dependencies(pyproject_path: Path) -> list[str]:
     """Return declared deps not installed in this interpreter, sorted."""
     return sorted(declared_dependency_names(pyproject_path) - installed_distribution_names())
+
+
+def running_prefix() -> Path:
+    """Return ``sys.prefix`` of the interpreter actually executing ``t3``.
+
+    The dep-drift check must detect and repair *this* environment — the one
+    whose ``importlib.metadata`` is read by :func:`find_missing_dependencies`
+    — not whatever environment ``uv tool`` happens to manage.  When the
+    running ``t3`` is a plain editable install (``pip install -e .`` into a
+    pyenv/virtualenv site-packages) it is a *different* env than the
+    ``uv tool``-managed one, so a ``uv tool install`` repair would never
+    touch the running interpreter.
+    """
+    return Path(sys.prefix)
+
+
+def running_python() -> Path:
+    """Return the interpreter executing ``t3`` (``sys.executable``)."""
+    return Path(sys.executable)
+
+
+def running_env_is_uv_tool() -> bool:
+    """``True`` iff the running interpreter lives under ``uv``'s tool dir.
+
+    A ``uv tool install``-managed teatree has its ``sys.prefix`` nested under
+    ``~/.local/share/uv/tools`` (or ``$UV_TOOL_DIR``).  Detection is purely
+    path-based so it stays usable with no non-stdlib deps even when teatree's
+    declared deps are partially missing.  When this returns ``False`` the
+    running env must be repaired in place (install into ``sys.prefix``),
+    never via ``uv tool install`` (which targets a foreign env).
+    """
+    import os  # noqa: PLC0415
+
+    prefix = running_prefix().resolve()
+    candidates: list[Path] = []
+    env_dir = os.environ.get("UV_TOOL_DIR")
+    if env_dir:
+        candidates.append(Path(env_dir).expanduser())
+    candidates.append(Path.home() / ".local" / "share" / "uv" / "tools")
+    for tool_dir in candidates:
+        try:
+            resolved = tool_dir.expanduser().resolve()
+        except OSError:
+            continue
+        if prefix == resolved or resolved in prefix.parents:
+            return True
+    return False
 
 
 def editable_source_path() -> Path | None:

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -842,12 +842,27 @@ def _write_pyproject(repo: Path, deps: list[str]) -> Path:
 
 
 class TestRepairDepDrift:
-    """``_repair_dep_drift`` — auto-reinstall when an editable venv is stale."""
+    """``_repair_dep_drift`` repairs the env that actually executes ``t3``.
+
+    The detection (:func:`find_missing_dependencies`) reads the running
+    interpreter; the regression these tests guard is the repair targeting a
+    *different* env than the one detected — printing ``OK Reinstalled`` while
+    the running ``t3`` stays broken (#805).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_drift_guard(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Clear the execv re-exec guard env between cases.
+
+        It leaks into the test process via ``os.environ`` so each case must
+        start from a clean slate (the guard test sets it back deliberately).
+        """
+        monkeypatch.delenv("_T3_DRIFT_REPAIR_ATTEMPTED", raising=False)
 
     def test_returns_false_when_no_drift(self, tmp_path: Path) -> None:
         repo = tmp_path / "repo"
         _write_pyproject(repo, ["django", "httpx"])
-        with patch("teatree.cli.setup.find_missing_dependencies", return_value=[]):
+        with patch("teatree.cli.dep_drift_repair.find_missing_dependencies", return_value=[]):
             assert _repair_dep_drift(repo) is False
 
     def test_returns_false_when_pyproject_absent(self, tmp_path: Path) -> None:
@@ -855,7 +870,7 @@ class TestRepairDepDrift:
         repo.mkdir()
         assert _repair_dep_drift(repo) is False
 
-    def test_warns_and_returns_false_on_non_editable_install(
+    def test_warns_on_non_editable_install_points_at_running_python(
         self,
         tmp_path: Path,
         capsys: "pytest.CaptureFixture[str]",
@@ -863,66 +878,108 @@ class TestRepairDepDrift:
         repo = tmp_path / "repo"
         _write_pyproject(repo, ["tomlkit"])
         with (
-            patch("teatree.cli.setup.find_missing_dependencies", return_value=["tomlkit"]),
-            patch("teatree.cli.setup.editable_source_path", return_value=None),
+            patch("teatree.cli.dep_drift_repair.find_missing_dependencies", return_value=["tomlkit"]),
+            patch("teatree.cli.dep_drift_repair.editable_source_path", return_value=None),
+            patch("teatree.cli.dep_drift_repair.running_python", return_value=Path("/envs/run/bin/python")),
         ):
             assert _repair_dep_drift(repo) is False
         out = capsys.readouterr().out
         assert "tomlkit" in out
-        assert "uv tool upgrade teatree --reinstall" in out
+        # Manual hint must name the *running* interpreter, not a uv tool env.
+        assert "/envs/run/bin/python" in out
+        assert "uv tool" not in out
 
-    def test_warns_and_returns_false_when_uv_missing(
+    def test_repairs_running_interpreter_when_not_uv_tool_managed(
         self,
         tmp_path: Path,
-        capsys: "pytest.CaptureFixture[str]",
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        repo = tmp_path / "repo"
-        _write_pyproject(repo, ["tomlkit"])
-        source = tmp_path / "main-clone"
-        with (
-            patch("teatree.cli.setup.find_missing_dependencies", return_value=["tomlkit"]),
-            patch("teatree.cli.setup.editable_source_path", return_value=source),
-            patch("teatree.cli.setup.shutil.which", return_value=None),
-        ):
-            assert _repair_dep_drift(repo) is False
-        assert "uv` is not on PATH" in capsys.readouterr().out
+        """Regression (#805): repair a non-uv-tool running env in place.
 
-    def test_reinstalls_and_re_execs_on_editable_drift(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        A pyenv/venv ``pip install -e`` t3 must be repaired against its own
+        interpreter — never via ``uv tool install`` (which targets a
+        different, foreign env and leaves the running t3 broken).
+        """
         monkeypatch.delenv("_T3_DRIFT_REPAIR_ATTEMPTED", raising=False)
         repo = tmp_path / "repo"
         _write_pyproject(repo, ["tomlkit"])
         source = tmp_path / "main-clone"
+        running_py = tmp_path / "pyenv" / "bin" / "python"
         captured: dict[str, object] = {}
 
         def fake_execv(path: str, argv: list[str]) -> None:
             captured["path"] = path
             captured["argv"] = argv
-            raise SystemExit(0)  # don't actually replace the test process
+            raise SystemExit(0)
 
         completed = SimpleNamespace(returncode=0, stdout="", stderr="")
         with (
-            patch("teatree.cli.setup.find_missing_dependencies", return_value=["tomlkit"]),
-            patch("teatree.cli.setup.editable_source_path", return_value=source),
-            patch("teatree.cli.setup.shutil.which") as mock_which,
-            patch("teatree.cli.setup._run_captured", return_value=completed) as mock_run,
-            patch("teatree.cli.setup.os.execv", side_effect=fake_execv),
-            patch("teatree.cli.setup.sys.argv", ["/usr/local/bin/t3", "setup"]),
+            patch("teatree.cli.dep_drift_repair.find_missing_dependencies", return_value=["tomlkit"]),
+            patch("teatree.cli.dep_drift_repair.editable_source_path", return_value=source),
+            patch("teatree.cli.dep_drift_repair.running_env_is_uv_tool", return_value=False),
+            patch("teatree.cli.dep_drift_repair.running_python", return_value=running_py),
+            patch("teatree.cli.dep_drift_repair.running_prefix", return_value=tmp_path / "pyenv"),
+            patch("teatree.cli.dep_drift_repair._run_captured", return_value=completed) as mock_run,
+            patch("teatree.cli.dep_drift_repair.os.execv", side_effect=fake_execv),
+            patch("teatree.cli.dep_drift_repair.sys.argv", ["/pyenv/shims/t3", "setup"]),
+            pytest.raises(SystemExit),
         ):
-            bins = {"uv": "/usr/bin/uv", "t3": "/usr/local/bin/t3"}
-            mock_which.side_effect = bins.get
-            with pytest.raises(SystemExit):
-                _repair_dep_drift(repo)
+            _repair_dep_drift(repo)
 
-        # Reinstall command must target the editable source and pass --reinstall.
+        repair_cmd = mock_run.call_args.args[0]
+        # The repair MUST target the running interpreter, NOT `uv tool`.
+        assert repair_cmd[0] == str(running_py)
+        assert repair_cmd[1:4] == ["-m", "pip", "install"]
+        assert "-e" in repair_cmd
+        assert str(source) in repair_cmd
+        assert "uv" not in repair_cmd
+        # Re-exec the *running* t3 (argv[0]), not an arbitrary PATH `t3`.
+        assert captured["argv"] == ["/pyenv/shims/t3", "setup"]
+
+    def test_uses_uv_tool_when_running_env_is_uv_tool_managed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("_T3_DRIFT_REPAIR_ATTEMPTED", raising=False)
+        repo = tmp_path / "repo"
+        _write_pyproject(repo, ["tomlkit"])
+        source = tmp_path / "main-clone"
+        completed = SimpleNamespace(returncode=0, stdout="", stderr="")
+        with (
+            patch("teatree.cli.dep_drift_repair.find_missing_dependencies", return_value=["tomlkit"]),
+            patch("teatree.cli.dep_drift_repair.editable_source_path", return_value=source),
+            patch("teatree.cli.dep_drift_repair.running_env_is_uv_tool", return_value=True),
+            patch("teatree.cli.dep_drift_repair.shutil.which", return_value="/usr/bin/uv"),
+            patch("teatree.cli.dep_drift_repair._run_captured", return_value=completed) as mock_run,
+            patch("teatree.cli.dep_drift_repair.os.execv", side_effect=SystemExit(0)),
+            patch("teatree.cli.dep_drift_repair.sys.argv", ["/uv/bin/t3", "setup"]),
+            pytest.raises(SystemExit),
+        ):
+            _repair_dep_drift(repo)
         install_cmd = mock_run.call_args.args[0]
         assert install_cmd[:3] == ["/usr/bin/uv", "tool", "install"]
-        assert "--editable" in install_cmd
-        assert str(source) in install_cmd
         assert "--reinstall" in install_cmd
-        # Re-exec preserves the original argv (so subcommands and flags survive).
-        assert captured["argv"] == ["/usr/local/bin/t3", "setup"]
+        assert str(source) in install_cmd
 
-    def test_returns_false_when_reinstall_fails(
+    def test_warns_when_uv_tool_managed_but_uv_missing(
+        self,
+        tmp_path: Path,
+        capsys: "pytest.CaptureFixture[str]",
+    ) -> None:
+        repo = tmp_path / "repo"
+        _write_pyproject(repo, ["tomlkit"])
+        source = tmp_path / "main-clone"
+        with (
+            patch("teatree.cli.dep_drift_repair.find_missing_dependencies", return_value=["tomlkit"]),
+            patch("teatree.cli.dep_drift_repair.editable_source_path", return_value=source),
+            patch("teatree.cli.dep_drift_repair.running_env_is_uv_tool", return_value=True),
+            patch("teatree.cli.dep_drift_repair.shutil.which", return_value=None),
+        ):
+            assert _repair_dep_drift(repo) is False
+        assert "uv` is not on PATH" in capsys.readouterr().out
+
+    def test_returns_false_and_prints_manual_fix_when_reinstall_fails(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -932,19 +989,26 @@ class TestRepairDepDrift:
         repo = tmp_path / "repo"
         _write_pyproject(repo, ["tomlkit"])
         source = tmp_path / "main-clone"
+        running_py = tmp_path / "pyenv" / "bin" / "python"
         completed = SimpleNamespace(returncode=1, stdout="", stderr="boom")
         with (
-            patch("teatree.cli.setup.find_missing_dependencies", return_value=["tomlkit"]),
-            patch("teatree.cli.setup.editable_source_path", return_value=source),
-            patch("teatree.cli.setup.shutil.which", return_value="/usr/bin/uv"),
-            patch("teatree.cli.setup._run_captured", return_value=completed),
-            patch("teatree.cli.setup.os.execv") as mock_execv,
+            patch("teatree.cli.dep_drift_repair.find_missing_dependencies", return_value=["tomlkit"]),
+            patch("teatree.cli.dep_drift_repair.editable_source_path", return_value=source),
+            patch("teatree.cli.dep_drift_repair.running_env_is_uv_tool", return_value=False),
+            patch("teatree.cli.dep_drift_repair.running_python", return_value=running_py),
+            patch("teatree.cli.dep_drift_repair.running_prefix", return_value=tmp_path / "pyenv"),
+            patch("teatree.cli.dep_drift_repair._run_captured", return_value=completed),
+            patch("teatree.cli.dep_drift_repair.os.execv") as mock_execv,
         ):
             assert _repair_dep_drift(repo) is False
             mock_execv.assert_not_called()
-        assert "Reinstall failed" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "Reinstall failed" in out
+        # Loud failure must carry the exact correct command for the running env.
+        assert str(running_py) in out
+        assert "pip install -e" in out
 
-    def test_guard_prevents_infinite_loop(
+    def test_guard_warns_with_running_env_not_foreign_uv_tool(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -952,9 +1016,18 @@ class TestRepairDepDrift:
     ) -> None:
         repo = tmp_path / "repo"
         _write_pyproject(repo, ["tomlkit"])
+        source = tmp_path / "main-clone"
+        running_py = tmp_path / "pyenv" / "bin" / "python"
         monkeypatch.setenv("_T3_DRIFT_REPAIR_ATTEMPTED", "1")
-        with patch("teatree.cli.setup.find_missing_dependencies", return_value=["tomlkit"]):
+        with (
+            patch("teatree.cli.dep_drift_repair.find_missing_dependencies", return_value=["tomlkit"]),
+            patch("teatree.cli.dep_drift_repair.editable_source_path", return_value=source),
+            patch("teatree.cli.dep_drift_repair.running_python", return_value=running_py),
+        ):
             assert _repair_dep_drift(repo) is False
         out = capsys.readouterr().out
         assert "already attempted" in out
         assert "tomlkit" in out
+        # The post-guard manual fix must name the running interpreter.
+        assert str(running_py) in out
+        assert "uv tool install" not in out

--- a/tests/test_dep_drift.py
+++ b/tests/test_dep_drift.py
@@ -18,6 +18,9 @@ from teatree.utils.dep_drift import (
     editable_source_path,
     find_missing_dependencies,
     normalize,
+    running_env_is_uv_tool,
+    running_prefix,
+    running_python,
 )
 
 
@@ -148,3 +151,48 @@ class _FakeDist:
 
     def read_text(self, name: str) -> str | None:
         return self._files.get(name)
+
+
+class TestRunningEnvDetection:
+    """The dep-drift repair must act on the env that executes ``t3`` (#805)."""
+
+    def test_running_prefix_is_sys_prefix(self) -> None:
+        import sys  # noqa: PLC0415
+
+        assert running_prefix() == Path(sys.prefix)
+
+    def test_running_python_is_sys_executable(self) -> None:
+        import sys  # noqa: PLC0415
+
+        assert running_python() == Path(sys.executable)
+
+    def test_uv_tool_managed_when_prefix_under_uv_tool_dir(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        tool_dir = tmp_path / "uv" / "tools"
+        prefix = tool_dir / "teatree"
+        prefix.mkdir(parents=True)
+        monkeypatch.setenv("UV_TOOL_DIR", str(tool_dir))
+        with patch("teatree.utils.dep_drift.running_prefix", return_value=prefix):
+            assert running_env_is_uv_tool() is True
+
+    def test_not_uv_tool_managed_for_pyenv_prefix(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Regression (#805): a pyenv/venv editable install is not uv-tool managed.
+
+        It must therefore not be routed through ``uv tool install`` — that
+        would repair a foreign env and leave the running ``t3`` broken.
+        """
+        tool_dir = tmp_path / "uv" / "tools"
+        tool_dir.mkdir(parents=True)
+        pyenv_prefix = tmp_path / "pyenv" / "versions" / "3.13.11"
+        pyenv_prefix.mkdir(parents=True)
+        monkeypatch.setenv("UV_TOOL_DIR", str(tool_dir))
+        monkeypatch.setattr(Path, "home", classmethod(lambda _cls: tmp_path))
+        with patch("teatree.utils.dep_drift.running_prefix", return_value=pyenv_prefix):
+            assert running_env_is_uv_tool() is False


### PR DESCRIPTION
fix(setup): repair dep drift in the env that actually runs t3 (#805)

The dep-drift self-repair detected missing declared deps against the
running interpreter (importlib.metadata) but repaired via
`uv tool install --editable . --reinstall`, which targets the
uv-tool-managed env. When the running t3 is a plain editable install
into a pyenv/virtualenv (a different env than any uv tool one), the
repair fixed a foreign env: t3 setup printed 'OK Reinstalled' then
immediately WARNed the deps were still missing, and the declared dep
(tomlkit) stayed unimportable in the running env.

Add running_prefix()/running_python()/running_env_is_uv_tool() to
dep_drift and route repair through them: when the running env is
uv-tool-managed keep the uv tool reinstall; otherwise install into the
running interpreter (<sys.executable> -m pip install -e <source>).
Re-exec the running t3 (argv[0]) rather than an arbitrary PATH t3, and
on failure print the exact correct manual command for the detected
running env instead of a misleading success.

Extract the dep-drift repair into cli/dep_drift_repair.py (single
concern; keeps setup.py under the module-health LOC cap). Regression
tests assert the repair targets the running interpreter and never uv
tool install when the running env is not uv-tool-managed.