### PR TITLE
fix(loop): attribute persisted tickets to the URL owner, not scan tag (#806)

### DIFF
--- a/src/teatree/loop/persistence.py
+++ b/src/teatree/loop/persistence.py
@@ -44,6 +44,41 @@ def persist_agent_actions(actions: list[DispatchAction]) -> list[Task]:
     return created
 
 
+def _owning_overlay(url: str, scan_tag: str) -> str:
+    """Resolve the overlay that *owns* ``url``, preferring URL inference.
+
+    The dispatch payload carries ``overlay`` = the *scanning* overlay's tag
+    (``loop/tick.py`` injects ``job.overlay``), not necessarily the overlay
+    whose workspace repos own the URL.  When a multi-overlay tick's
+    reviewer/orchestrator scanner surfaces an issue/PR owned by a *different*
+    overlay, persisting the scan tag leaks the ticket into the scanning
+    overlay's statusline zone — and because ``overlay`` is then non-empty,
+    ``Ticket.save()`` never runs ``_infer_overlay()`` to correct it (#806,
+    incomplete #743).
+
+    Inference (``infer_overlay_for_url``) is the single source of truth; the
+    scan tag is only a fallback for the inconclusive case (URL owned by no
+    registered overlay, e.g. a host neither overlay declares).
+    """
+    from teatree.core.overlay_loader import infer_overlay_for_url  # noqa: PLC0415
+
+    return infer_overlay_for_url(url) or scan_tag
+
+
+def _reconcile_existing_overlay(ticket: Ticket, *, created: bool) -> None:
+    """Correct an already-persisted ticket whose overlay no longer matches.
+
+    ``get_or_create`` may resolve a pre-existing row whose ``overlay`` was
+    written from a stale/wrong scan tag.  Re-infer from ``issue_url`` and
+    persist the correction.  ``apply_inferred_overlay`` keeps the #743
+    invariant: an inconclusive (empty) inference never blanks a value that
+    is already set, so a host no overlay declares is left as-is.
+    """
+    if created:
+        return
+    ticket.reconcile_overlay()
+
+
 def _handle_reviewer(action: DispatchAction) -> Task | None:
     """Reviewer-requested PR → Ticket(role=reviewer) + Task(phase=reviewing)."""
     payload = action.payload
@@ -52,15 +87,16 @@ def _handle_reviewer(action: DispatchAction) -> Task | None:
         logger.debug("Skipping t3:reviewer action with no url: %r", action.detail)
         return None
     head_sha = str(payload.get("head_sha") or "")
-    overlay = str(payload.get("overlay") or "")
-    ticket, _ = Ticket.objects.get_or_create(
+    scan_tag = str(payload.get("overlay") or "")
+    ticket, created = Ticket.objects.get_or_create(
         issue_url=pr_url,
         defaults={
-            "overlay": overlay,
+            "overlay": _owning_overlay(pr_url, scan_tag),
             "role": Ticket.Role.REVIEWER,
             "extra": {"reviewed_sha": head_sha} if head_sha else {},
         },
     )
+    _reconcile_existing_overlay(ticket, created=created)
     if ticket.role != Ticket.Role.REVIEWER:
         logger.debug(
             "Ticket %s exists with role=%s, not promoting to reviewer for PR %s",
@@ -97,11 +133,12 @@ def _handle_orchestrator(action: DispatchAction) -> Task | None:
     if not issue_url:
         logger.debug("Skipping t3:orchestrator action with no issue_url: %r", action.detail)
         return None
-    overlay = str(payload.get("overlay") or "")
-    ticket, _ = Ticket.objects.get_or_create(
+    scan_tag = str(payload.get("overlay") or "")
+    ticket, created = Ticket.objects.get_or_create(
         issue_url=issue_url,
-        defaults={"overlay": overlay, "role": Ticket.Role.AUTHOR},
+        defaults={"overlay": _owning_overlay(issue_url, scan_tag), "role": Ticket.Role.AUTHOR},
     )
+    _reconcile_existing_overlay(ticket, created=created)
     # #748: a loop/coordinator-built ticket must have a durable phase-
     # attestation session even when scheduling below is skipped (role
     # mismatch / not NOT_STARTED / open task), so the shipping gate can

--- a/tests/teatree_loop/test_persistence.py
+++ b/tests/teatree_loop/test_persistence.py
@@ -1,5 +1,7 @@
 """Tick → DB persistence: kind=agent actions become Ticket + Task rows."""
 
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from teatree.core.models import Task, Ticket
@@ -186,3 +188,97 @@ class TestReviewerCacheUpdate(TestCase):
         ticket = Ticket.objects.get(role=Ticket.Role.REVIEWER, issue_url="https://example.com/pr/7")
         assert ticket.extra["reviewed_sha"] == "zzz"
         assert ticket.extra["last_review_state"] == "approved"
+
+
+class TestCrossOverlayLeak(TestCase):
+    """Loop persistence attributes a ticket to its URL owner (#806, #743).
+
+    The loop persistence path must attribute a ticket to the overlay that
+    *owns* its URL, not the scanning overlay's tag — otherwise the ticket
+    leaks into the wrong overlay's statusline zone and ``Ticket.save()``
+    never corrects it (the explicit non-empty overlay disables
+    ``_infer_overlay``). Incomplete-fix follow-up to #743.
+    """
+
+    _URL = "https://gitlab.example.com/team/widgets/-/merge_requests/7"
+
+    def _reviewer_action(self, scan_tag: str) -> DispatchAction:
+        return DispatchAction(
+            kind="agent",
+            zone="t3:reviewer",
+            detail=f"Review needed: {self._URL}",
+            payload={"url": self._URL, "head_sha": "deadbee", "previous_sha": "", "overlay": scan_tag},
+        )
+
+    def _orchestrator_action(self, scan_tag: str) -> DispatchAction:
+        return DispatchAction(
+            kind="agent",
+            zone="t3:orchestrator",
+            detail="Auto-start assigned issue",
+            payload={"issue_url": self._URL, "auto_start": True, "overlay": scan_tag},
+        )
+
+    def test_reviewer_ticket_attributed_to_url_owner_not_scan_tag(self) -> None:
+        # The scanning overlay is "gh"; the URL is owned by "gl".
+        with patch(
+            "teatree.core.overlay_loader.infer_overlay_for_url",
+            return_value="gl",
+        ):
+            persist_agent_actions([self._reviewer_action(scan_tag="gh")])
+        ticket = Ticket.objects.get(issue_url=self._URL)
+        assert ticket.overlay == "gl", (
+            f"reviewer ticket leaked into the scanning overlay's zone: "
+            f"overlay={ticket.overlay!r}, expected 'gl' (the URL owner)"
+        )
+
+    def test_orchestrator_ticket_attributed_to_url_owner_not_scan_tag(self) -> None:
+        with patch(
+            "teatree.core.overlay_loader.infer_overlay_for_url",
+            return_value="gl",
+        ):
+            persist_agent_actions([self._orchestrator_action(scan_tag="gh")])
+        ticket = Ticket.objects.get(issue_url=self._URL)
+        assert ticket.overlay == "gl"
+
+    def test_falls_back_to_scan_tag_when_inference_inconclusive(self) -> None:
+        # No registered overlay owns the URL → inference returns "" →
+        # the scan tag is the only signal we have; keep it.
+        with patch(
+            "teatree.core.overlay_loader.infer_overlay_for_url",
+            return_value="",
+        ):
+            persist_agent_actions([self._reviewer_action(scan_tag="gh")])
+        ticket = Ticket.objects.get(issue_url=self._URL)
+        assert ticket.overlay == "gh"
+
+    def test_existing_misattributed_row_is_reconciled(self) -> None:
+        # A pre-existing row persisted with the wrong (scanning) overlay.
+        Ticket.objects.create(
+            issue_url=self._URL,
+            overlay="gh",
+            role=Ticket.Role.REVIEWER,
+        )
+        with patch(
+            "teatree.core.overlay_loader.infer_overlay_for_url",
+            return_value="gl",
+        ):
+            persist_agent_actions([self._reviewer_action(scan_tag="gh")])
+        ticket = Ticket.objects.get(issue_url=self._URL)
+        assert ticket.overlay == "gl", (
+            "an already-persisted cross-overlay-leaked row was not reconciled to its URL owner"
+        )
+
+    def test_inconclusive_inference_never_blanks_existing_attribution(self) -> None:
+        # #743 invariant: an empty inference must not wipe a set overlay.
+        Ticket.objects.create(
+            issue_url=self._URL,
+            overlay="gl",
+            role=Ticket.Role.REVIEWER,
+        )
+        with patch(
+            "teatree.core.overlay_loader.infer_overlay_for_url",
+            return_value="",
+        ):
+            persist_agent_actions([self._reviewer_action(scan_tag="gh")])
+        ticket = Ticket.objects.get(issue_url=self._URL)
+        assert ticket.overlay == "gl"


### PR DESCRIPTION
fix(loop): attribute persisted tickets to the URL owner, not scan tag (#806)

Relates-to #743.

_handle_reviewer/_handle_orchestrator created the ticket with
defaults={'overlay': payload['overlay']}, where payload['overlay'] is
the *scanning* overlay's tag (loop/tick.py injects job.overlay), not
the overlay whose workspace repos own the issue/PR URL. When a
multi-overlay tick's reviewer/orchestrator scanner surfaced an issue
owned by a different overlay, the ticket was persisted with the
scanning overlay's name and leaked into that overlay's statusline zone.
Because overlay was then non-empty, Ticket.save()'s 'if not
self.overlay' guard skipped _infer_overlay(), so the #743 inference fix
never ran for these rows and reconcile_overlay() (manual command only)
never auto-corrected them.

Add _owning_overlay(url, scan_tag) — infer_overlay_for_url() is the
single source of truth, scan tag only a fallback for the inconclusive
case — and _reconcile_existing_overlay() to correct already-persisted
mis-attributed rows via the existing apply_inferred_overlay (preserving
the #743 invariant that an inconclusive inference never blanks a set
attribution). Regression suite reproduces the leak RED->GREEN for both
the reviewer and orchestrator paths plus the existing-row reconcile.