### PR TITLE
fix(hooks): fail-safe Stop hook when interpreter lacks teatree

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -1078,8 +1078,22 @@ def _prune_dead_owner(registry: dict[str, dict]) -> dict[str, dict]:
     for preferring the existing singleton/pid mechanism. Imported lazily
     to keep this Django-free hook fast on the common path (mirrors the
     lazy ``teatree.skill_deps`` import elsewhere in this module).
+
+    Fail-safe (#810): hooks run under whatever interpreter the agent
+    harness invokes; ``teatree`` importability is NOT guaranteed there.
+    When the import fails we cannot confirm any owner pid is alive, so
+    we treat loop ownership as unknown (empty registry) and let the
+    caller skip the self-pump rather than crash the session. A ``Stop``
+    hook must be crash-proof by contract.
     """
-    from teatree.utils.singleton import pid_alive  # noqa: PLC0415
+    try:
+        from teatree.utils.singleton import pid_alive  # noqa: PLC0415
+    except ImportError as exc:
+        print(  # noqa: T201 — hook stderr is the module's logging channel
+            f"[hook_router] loop self-pump skipped: teatree unavailable ({exc})",
+            file=sys.stderr,
+        )
+        return {}
 
     return {
         name: entry
@@ -1427,7 +1441,24 @@ def handle_loop_self_pump(data: dict) -> bool | None:
     loop-owner session, with consolidated pending work, outside the
     anti-spin interval. Otherwise returns ``None`` (idle / non-owner /
     spin-guarded) so the session may end normally.
+
+    Crash-proof by contract (#810): a ``Stop`` hook must NEVER raise to
+    the session. A broad boundary guard contains any unexpected error
+    in the self-pump path (a missing/unimportable ``teatree``, registry
+    I/O, etc.) to a single stderr line and a clean ``None`` — the
+    session ends normally and the self-pump is simply skipped.
     """
+    try:
+        return _loop_self_pump(data)
+    except Exception as exc:  # noqa: BLE001 — Stop hook must be crash-proof
+        print(  # noqa: T201 — hook stderr is the module's logging channel
+            f"[hook_router] loop self-pump skipped (unexpected error: {exc})",
+            file=sys.stderr,
+        )
+        return None
+
+
+def _loop_self_pump(data: dict) -> bool | None:
     session_id = data.get("session_id", "")
     if not session_id or not _session_owns_loop(session_id):
         return None

--- a/tests/test_loop_self_pump_hook.py
+++ b/tests/test_loop_self_pump_hook.py
@@ -13,9 +13,12 @@ Integration-style: real ``hook_router`` handler, real ``STATE_DIR`` +
 ``pending-spawn`` subprocess (an external boundary) is faked.
 """
 
+import contextlib
 import json
 import os
+import sys
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -148,6 +151,97 @@ class TestSessionEndClearsPumpMarker:
 
     def test_session_end_no_session_id_is_noop(self) -> None:
         handle_session_end_self_pump({"session_id": ""})  # must not raise
+
+
+class TestStopHookFailsSafeWithoutTeatree:
+    """#810: a ``Stop`` hook must never raise to the session.
+
+    Hooks run under whatever interpreter the agent harness invokes;
+    ``teatree`` importability is NOT guaranteed there. The lazy
+    ``from teatree.utils.singleton import pid_alive`` in
+    ``_prune_dead_owner`` crashed a live session with
+    ``ModuleNotFoundError: No module named 'teatree'`` and surfaced a
+    full traceback. The Stop path must degrade gracefully (treat loop
+    ownership as unknown / skip the self-pump) on a missing or
+    unimportable ``teatree``.
+    """
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _teatree_unimportable() -> Iterator[None]:
+        """Make ``import teatree*`` raise ``ModuleNotFoundError``.
+
+        Faithfully reproduces the hook-interpreter env where ``teatree``
+        is absent from ``sys.path``: purge any cached ``teatree`` modules
+        and install a ``meta_path`` finder that refuses to resolve them.
+        """
+
+        class _BlockTeatree:
+            def find_spec(self, name: str, path: object = None, target: object = None) -> None:
+                if name == "teatree" or name.startswith("teatree."):
+                    msg = f"No module named {name!r}"
+                    raise ModuleNotFoundError(msg)
+
+        saved = {k: v for k, v in sys.modules.items() if k == "teatree" or k.startswith("teatree.")}
+        for k in saved:
+            del sys.modules[k]
+        finder = _BlockTeatree()
+        sys.meta_path.insert(0, finder)
+        try:
+            yield
+        finally:
+            with contextlib.suppress(ValueError):
+                sys.meta_path.remove(finder)
+            sys.modules.update(saved)
+
+    def test_self_pump_skips_when_teatree_unimportable(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _own_loop("owner-x")
+        _fake_pending(monkeypatch, [{"task_id": 1, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+
+        with self._teatree_unimportable():
+            # Pre-guard this raises ModuleNotFoundError straight to the
+            # caller (the Stop dispatch loop) — a session-disrupting
+            # traceback. Post-guard it must return cleanly.
+            result = handle_loop_self_pump({"session_id": "owner-x"})
+
+        assert result is None
+        # Self-pump skipped: no block decision emitted.
+        assert _decision(capsys) == {}
+
+    def test_session_owns_loop_false_when_teatree_unimportable(self) -> None:
+        _own_loop("owner-y")
+        with self._teatree_unimportable():
+            assert router._session_owns_loop("owner-y") is False
+
+    def test_prune_dead_owner_degrades_when_teatree_unimportable(self) -> None:
+        registry = {"t3-main-loop": {"session_id": "s", "pid": os.getpid()}}
+        with self._teatree_unimportable():
+            # Ownership unknown => empty registry (no entry can be
+            # confirmed live without the pid-liveness primitive).
+            assert router._prune_dead_owner(registry) == {}
+
+    def test_boundary_guard_contains_any_unexpected_stop_path_error(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Belt-and-suspenders boundary guard.
+
+        ANY unexpected error in the Stop path (not just a missing
+        ``teatree``) is contained — the broad boundary guard returns
+        ``None`` instead of raising to the session.
+        """
+
+        def _boom(_data: dict) -> bool | None:
+            msg = "unexpected Stop-path failure"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(router, "_loop_self_pump", _boom)
+
+        result = handle_loop_self_pump({"session_id": "owner-z"})
+
+        assert result is None
+        assert _decision(capsys) == {}
 
 
 class TestWiredIntoRouter:


### PR DESCRIPTION
fix(hooks): fail-safe Stop hook when interpreter lacks teatree

The loop self-pump Stop hook crashed a live session with a full
ModuleNotFoundError traceback: _prune_dead_owner does a lazy
`from teatree.utils.singleton import pid_alive`, but hooks run under
whatever interpreter the agent harness invokes and teatree
importability is not guaranteed there.

Guard the lazy import (ModuleNotFoundError is an ImportError subclass)
so a missing/unimportable teatree degrades to 'ownership unknown'
(empty registry) and the self-pump is simply skipped, with one stderr
line instead of a traceback. Add a broad boundary guard at the
handle_loop_self_pump entry so ANY unexpected Stop-path error is
contained — a Stop hook must be crash-proof by contract.

Defensive only and minimal: carries forward cleanly when #786 WS3
replaces the loop-registry code and does not reorder the Stop
handlers (#807).

Regression test simulates teatree unimportable in the hook context
(meta_path finder + sys.modules purge), asserts the Stop entry returns
cleanly with no traceback and the self-pump skipped. Anti-vacuous:
RED before the guard (the #810 ModuleNotFoundError escapes), GREEN
after.

Relates to #810
Relates-to #805 #786