### PR TITLE
fix(pr): pr create resolves branch from invoking worktree, not stale ticket.extra (#776)

### DIFF
--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -344,6 +344,18 @@ class Command(TyperCommand):
         if worktree is None:
             return WorktreeMissingError(error="ticket has no worktree")
 
+        # #776: a ticket can span multiple PRs (one branch per
+        # workstream). Record the INVOKING worktree's current git branch
+        # so ShipExecutor ships THIS branch, not the earliest (often
+        # already-merged) `worktrees.first()` row. Read from the cwd the
+        # CLI was invoked in (the worktree the user ran `pr create` from).
+        invoking_branch = git.current_branch(repo=".")
+        if invoking_branch and invoking_branch not in {"HEAD", "main", "master"}:
+            extra = cast("TicketExtra", ticket.extra or {})
+            extra["ship_invoking_branch"] = invoking_branch
+            ticket.extra = extra
+            ticket.save(update_fields=["extra"])
+
         if not skip_validation:
             gate_failure = _run_ship_gates(ticket, worktree, skip_visual_qa=skip_visual_qa)
             if gate_failure is not None:

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -29,6 +29,7 @@ from teatree.core.models.types import TicketExtra, VisualQASummary
 from teatree.core.orphan_guard import BranchStatus, classify_branch
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.public_identity import MergeResult
+from teatree.core.runners.ship import resolve_ship_worktree
 from teatree.types import RawAPIDict
 from teatree.utils import git
 
@@ -232,7 +233,14 @@ def _run_visual_qa_gate(ticket: Ticket, *, skip_reason: str = "") -> VisualQAGat
     findings are present so the caller can refuse PR creation, or
     ``None`` when the gate passes / is skipped.
     """
-    worktree = ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
+    # #776 N1: resolve the INVOKING worktree (same root cause as the
+    # ship-branch fix) — a reused multi-workstream ticket must run visual
+    # QA against the current workstream's repo, not the stale earliest
+    # `worktrees.first()` row. The `ship_invoking_branch` hint is recorded
+    # by `create()` before the gates run, so the canonical resolver has
+    # the data here too.
+    extra = cast("TicketExtra", ticket.extra or {})
+    worktree = resolve_ship_worktree(ticket, extra)
     repo_path = worktree.repo_path if worktree else "."
     base_url = _resolve_base_url(worktree)
 

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -42,6 +42,7 @@ class TicketExtra(TypedDict, total=False):
     pr_urls: list[str]
     prs: dict[str, PREntrySerialized]
     pr_title_override: str
+    ship_invoking_branch: str
     ignored_from: str
     reopened_from: str
     visual_qa: VisualQASummary

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -41,6 +41,26 @@ def overlay_pr_labels() -> list[str]:
     return [value.strip() for value in values if value.strip()]
 
 
+def resolve_ship_worktree(ticket: "Ticket", extra: "TicketExtra") -> "Worktree | None":
+    """The worktree to act on — the INVOKING branch's row, not the earliest.
+
+    #776: ``worktrees.first()`` returns the earliest (often
+    already-merged) row, so a reused ticket spanning N workstreams acted
+    on a stale branch. ``pr create`` records the invoking worktree's
+    current git branch on ``extra['ship_invoking_branch']``; prefer the
+    matching row. Fall back to ``first()`` only when no invoking branch
+    is recorded (the async-worker path that has no CLI cwd context) —
+    legacy behaviour, single-PR tickets unaffected. Public so the
+    pre-push visual-QA gate resolves the same worktree as the ship.
+    """
+    invoking = str(extra.get("ship_invoking_branch") or "")
+    if invoking:
+        matched = ticket.worktrees.filter(branch=invoking).first()  # ty: ignore[unresolved-attribute]
+        if matched is not None:
+            return matched
+    return ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
+
+
 class ShipExecutor(RunnerBase):
     """Push the worktree branch and open the pull request.
 
@@ -58,7 +78,7 @@ class ShipExecutor(RunnerBase):
         if existing_urls:
             return RunnerResult(ok=True, detail=existing_urls[-1])
 
-        worktree = self._resolve_target_worktree(ticket, extra)
+        worktree = resolve_ship_worktree(ticket, extra)
         if worktree is None:
             return RunnerResult(ok=False, detail="no worktree on ticket")
 
@@ -86,25 +106,6 @@ class ShipExecutor(RunnerBase):
         self._record_pr_url(ticket, extra, url)
         logger.info("Ship executor pushed %s and opened PR %s", branch, url)
         return RunnerResult(ok=True, detail=url)
-
-    @staticmethod
-    def _resolve_target_worktree(ticket: "Ticket", extra: "TicketExtra") -> "Worktree | None":
-        """The worktree to ship — the INVOKING branch's row, not the earliest.
-
-        #776: ``worktrees.first()`` returns the earliest (often
-        already-merged) row, so a reused ticket spanning N workstreams
-        shipped a stale branch. ``pr create`` records the invoking
-        worktree's current git branch on ``extra['ship_invoking_branch']``;
-        prefer the matching row. Fall back to ``first()`` only when no
-        invoking branch is recorded (the async-worker path that has no
-        CLI cwd context) — legacy behaviour, single-PR tickets unaffected.
-        """
-        invoking = str(extra.get("ship_invoking_branch") or "")
-        if invoking:
-            matched = ticket.worktrees.filter(branch=invoking).first()  # ty: ignore[unresolved-attribute]
-            if matched is not None:
-                return matched
-        return ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
 
     @staticmethod
     def _clear_invoking_branch(ticket: "Ticket", extra: "TicketExtra") -> None:

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from teatree.backends.protocols import CodeHostBackend
     from teatree.core.models.ticket import Ticket
     from teatree.core.models.types import TicketExtra
+    from teatree.core.models.worktree import Worktree
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ class ShipExecutor(RunnerBase):
         if existing_urls:
             return RunnerResult(ok=True, detail=existing_urls[-1])
 
-        worktree = ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
+        worktree = self._resolve_target_worktree(ticket, extra)
         if worktree is None:
             return RunnerResult(ok=False, detail="no worktree on ticket")
 
@@ -68,6 +69,15 @@ class ShipExecutor(RunnerBase):
         repo_path = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
         branch = worktree.branch
 
+        # #776: a ticket can span multiple PRs (one branch per workstream).
+        # Refuse to re-open a PR for a branch already merged into base —
+        # that is the stale-row symptom (a junk duplicate of merged work).
+        if git.branch_merged(repo=repo_path, branch=branch):
+            self._clear_invoking_branch(ticket, extra)
+            return RunnerResult(
+                ok=False, detail=f"branch {branch!r} is already merged into base — refusing duplicate PR"
+            )
+
         git.push(repo=repo_path, remote="origin", branch=branch)
 
         spec = self._build_pr_spec(ticket, host, repo_path, branch, extra)
@@ -76,6 +86,32 @@ class ShipExecutor(RunnerBase):
         self._record_pr_url(ticket, extra, url)
         logger.info("Ship executor pushed %s and opened PR %s", branch, url)
         return RunnerResult(ok=True, detail=url)
+
+    @staticmethod
+    def _resolve_target_worktree(ticket: "Ticket", extra: "TicketExtra") -> "Worktree | None":
+        """The worktree to ship — the INVOKING branch's row, not the earliest.
+
+        #776: ``worktrees.first()`` returns the earliest (often
+        already-merged) row, so a reused ticket spanning N workstreams
+        shipped a stale branch. ``pr create`` records the invoking
+        worktree's current git branch on ``extra['ship_invoking_branch']``;
+        prefer the matching row. Fall back to ``first()`` only when no
+        invoking branch is recorded (the async-worker path that has no
+        CLI cwd context) — legacy behaviour, single-PR tickets unaffected.
+        """
+        invoking = str(extra.get("ship_invoking_branch") or "")
+        if invoking:
+            matched = ticket.worktrees.filter(branch=invoking).first()  # ty: ignore[unresolved-attribute]
+            if matched is not None:
+                return matched
+        return ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
+
+    @staticmethod
+    def _clear_invoking_branch(ticket: "Ticket", extra: "TicketExtra") -> None:
+        if "ship_invoking_branch" in extra:
+            extra.pop("ship_invoking_branch", None)
+            ticket.extra = extra
+            ticket.save(update_fields=["extra"])
 
     @staticmethod
     def _build_pr_spec(
@@ -107,5 +143,6 @@ class ShipExecutor(RunnerBase):
             urls.append(url)
         extra["pr_urls"] = urls
         extra.pop("pr_title_override", None)
+        extra.pop("ship_invoking_branch", None)
         ticket.extra = extra
         ticket.save(update_fields=["extra"])

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -219,6 +219,61 @@ class TestPrCreateThinWrapper(TestCase):
         assert result["allowed"] is False
 
 
+class TestPrCreateRecordsInvokingBranch(TestCase):
+    """#776 B1: ``create()`` must PRODUCE ``extra['ship_invoking_branch']``.
+
+    The producer block (capture ``git.current_branch`` → persist the
+    hint) is the single highest-value line of #776 — ShipExecutor's
+    consumer side is meaningless without it. These tests exercise the
+    producer directly via ``call_command``, patching only ``git`` (an
+    unstoppable external). ``dry_run=True`` isolates the producer: it
+    runs before the dry-run early-return and before the gates, so no
+    ship mocking is needed.
+    """
+
+    def test_persists_invoking_branch_from_git_current_branch(self) -> None:
+        ticket = _shippable_ticket()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command.git, "current_branch", return_value="s-776-feature"),
+            patch.object(pr_command.git, "last_commit_message", return_value=("feat: x", "body")),
+        ):
+            call_command("pr", "create", str(ticket.id), dry_run=True)
+
+        ticket.refresh_from_db()
+        assert ticket.extra["ship_invoking_branch"] == "s-776-feature"
+
+    def test_guard_skips_persistence_on_non_feature_branch(self) -> None:
+        # subTest (not @parametrize): this file's classes are
+        # django.test.TestCase, which pytest does not parametrize.
+        for protected in ("HEAD", "main", "master"):
+            with self.subTest(branch=protected):
+                ticket = _shippable_ticket()
+                with (
+                    patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+                    patch.object(pr_command.git, "current_branch", return_value=protected),
+                    patch.object(pr_command.git, "last_commit_message", return_value=("feat: x", "body")),
+                ):
+                    call_command("pr", "create", str(ticket.id), dry_run=True)
+
+                ticket.refresh_from_db()
+                assert "ship_invoking_branch" not in (ticket.extra or {})
+
+    def test_guard_skips_persistence_on_empty_branch(self) -> None:
+        ticket = _shippable_ticket()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command.git, "current_branch", return_value=""),
+            patch.object(pr_command.git, "last_commit_message", return_value=("feat: x", "body")),
+        ):
+            call_command("pr", "create", str(ticket.id), dry_run=True)
+
+        ticket.refresh_from_db()
+        assert "ship_invoking_branch" not in (ticket.extra or {})
+
+
 class TestPrCreateSyncShip(TestCase):
     """`pr create --sync` runs the ship inline; async warns it is queued (#708)."""
 
@@ -805,6 +860,37 @@ class TestRunVisualQAGate(TestCase):
 
         ticket.refresh_from_db()
         assert ticket.extra["visual_qa"]["errors"] == 1
+
+    def test_resolves_invoking_worktree_not_stale_first(self) -> None:
+        """#776 N1: visual QA inspects the invoking workstream's repo.
+
+        Same ``worktrees.first()`` root cause as the ship-branch fix,
+        same path, residual on the reused-multi-workstream ticket #776
+        targets. With ``ship_invoking_branch`` recorded, the gate must
+        scan the matching worktree's repo, not the stale earliest row.
+        """
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/776")
+        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="/tmp/repo-pr-a", branch="s-776-pr-a-merged")
+        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="/tmp/repo-pr-b", branch="s-776-pr-b-current")
+        ticket.extra = {"ship_invoking_branch": "s-776-pr-b-current"}
+        ticket.save(update_fields=["extra"])
+        captured: dict[str, str] = {}
+
+        def fake_changed_files(*, repo: str) -> list[str]:
+            captured["repo"] = repo
+            return []
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(visual_qa, "changed_files", side_effect=fake_changed_files),
+            patch.object(
+                visual_qa, "evaluate", return_value=visual_qa.VisualQAReport(targets=[], skipped_reason="none")
+            ),
+        ):
+            assert _run_visual_qa_gate(ticket) is None
+
+        # The invoking PR-B repo is scanned — NOT the stale PR-A first() row.
+        assert captured["repo"] == "/tmp/repo-pr-b"
 
     def test_skip_reason_propagates(self) -> None:
         ticket = self._ticket()

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -153,6 +153,154 @@ class TestShipExecutor(TestCase):
         assert spec.assignee == "dev"
 
 
+class TestShipResolvesBranchFromInvokingWorktree(TestCase):
+    """#776: ship the invoking worktree's branch, not stale first().
+
+    A ticket spanning multiple PRs must ship the invoking worktree's
+    branch, never the stale earliest ``worktrees.first()`` row.
+    Reused-ticket workflows (one ticket, sequential workstreams each on
+    its own branch) created a Worktree row per workstream. ``ShipExecutor``
+    resolved the branch via ``ticket.worktrees.first()`` — the EARLIEST
+    (already-merged) row — so ``pr create --sync`` pushed a stale merged
+    branch and opened a junk duplicate PR while the intended branch was
+    never pushed and ``extra['pr_urls']`` stayed empty.
+    """
+
+    def _multi_worktree_ticket(self) -> Ticket:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/776")
+        # PR-A: created first → the stale row worktrees.first() returns.
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/repo-pr-a",
+            branch="s-776-pr-a-merged",
+            extra={"worktree_path": "/tmp/repo-pr-a"},
+        )
+        # PR-B: the current/invoking workstream.
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/repo-pr-b",
+            branch="s-776-pr-b-current",
+            extra={"worktree_path": "/tmp/repo-pr-b"},
+        )
+        return ticket
+
+    def test_ships_invoking_branch_not_stale_first_worktree(self) -> None:
+        ticket = self._multi_worktree_ticket()
+        ticket.extra = {"ship_invoking_branch": "s-776-pr-b-current"}
+        ticket.save(update_fields=["extra"])
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://example.com/mr/b"}
+        host.current_user.return_value = "souliane"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat: b", "body")),
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is True
+        # The intended PR-B branch is pushed — NOT the stale PR-A row.
+        push.assert_called_once_with(repo="/tmp/repo-pr-b", remote="origin", branch="s-776-pr-b-current")
+        (spec,) = host.create_pr.call_args.args
+        assert spec.branch == "s-776-pr-b-current"
+        assert spec.repo == "/tmp/repo-pr-b"
+        ticket.refresh_from_db()
+        assert ticket.extra["pr_urls"] == ["https://example.com/mr/b"]
+        # The transient resolution hint is cleared after use.
+        assert "ship_invoking_branch" not in ticket.extra
+
+    def test_refuses_when_resolved_branch_already_merged(self) -> None:
+        ticket = self._multi_worktree_ticket()
+        ticket.extra = {"ship_invoking_branch": "s-776-pr-a-merged"}
+        ticket.save(update_fields=["extra"])
+        host = MagicMock()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=True),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is False
+        assert "merged" in result.detail.lower()
+        push.assert_not_called()
+        host.create_pr.assert_not_called()
+
+    def test_falls_back_to_first_when_no_invoking_branch(self) -> None:
+        """Async-worker path (no CLI cwd context): legacy behaviour kept."""
+        ticket = self._multi_worktree_ticket()
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://example.com/mr/legacy"}
+        host.current_user.return_value = "souliane"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat", "b")),
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is True
+        push.assert_called_once_with(repo="/tmp/repo-pr-a", remote="origin", branch="s-776-pr-a-merged")
+
+    def test_invoking_branch_set_but_no_matching_row_falls_back_to_first(self) -> None:
+        """Recorded invoking branch has no Worktree row → legacy fallback.
+
+        Covers the resolution arc where ``ship_invoking_branch`` is set
+        but no row matches (e.g. the row was pruned); ``first()`` is used.
+        """
+        ticket = self._multi_worktree_ticket()
+        ticket.extra = {"ship_invoking_branch": "s-776-branch-with-no-row"}
+        ticket.save(update_fields=["extra"])
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://example.com/mr/fb"}
+        host.current_user.return_value = "souliane"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat", "b")),
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is True
+        push.assert_called_once_with(repo="/tmp/repo-pr-a", remote="origin", branch="s-776-pr-a-merged")
+
+    def test_refuses_merged_branch_when_no_invoking_hint_recorded(self) -> None:
+        """Merged-branch refusal with no ``ship_invoking_branch`` key set.
+
+        Covers ``_clear_invoking_branch`` early-exit (key absent) on the
+        async-worker / single-PR path where the resolved first() branch
+        is already merged.
+        """
+        ticket = self._multi_worktree_ticket()  # no ship_invoking_branch in extra
+        host = MagicMock()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=True),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is False
+        assert "merged" in result.detail.lower()
+        push.assert_not_called()
+        host.create_pr.assert_not_called()
+
+
 class TestSanitizeCloseKeywords:
     @pytest.mark.parametrize(
         ("description", "expected"),


### PR DESCRIPTION
## fix(pr): ship the invoking worktree's branch, not the stale `first()` row

Relates-to #776

### Defect

`ShipExecutor` resolved the ship branch via `ticket.worktrees.first()` — the **earliest** Worktree row. A ticket spanning multiple PRs (one branch per workstream — e.g. a reused umbrella ticket across sequential workstreams) shipped a stale, already-merged branch and opened a junk duplicate PR, while the intended branch was never pushed and `ticket.extra['pr_urls']` stayed empty (forcing the canonical PR onto the empty-body `ensure-pr` fallback). This is the recurring stale-branch junk-dup class observed throughout the #786 epic.

### Fix

- `ShipExecutor._resolve_target_worktree` prefers the Worktree row matching `ticket.extra['ship_invoking_branch']` over `.first()`; falls back to `.first()` only when no invoking branch is recorded (the async-worker path with no CLI cwd context — single-PR tickets and legacy behaviour unaffected).
- `pr create` captures the invoking worktree's current git branch (`git.current_branch(repo='.')`, skipping `HEAD`/`main`/`master`) and persists it to `extra['ship_invoking_branch']` before the ship transition — mirrors the existing `pr_title_override` threading; no new mechanism. The hint is cleared after ship (success or merged-refusal), like `pr_title_override`.
- Refuse to open a PR whose resolved branch is already merged into base (`git.branch_merged`) — the duplicate-of-merged-work symptom.
- `ship_invoking_branch` added to the `TicketExtra` TypedDict so it survives `validated_ticket_extra`'s strict key filter.

`pr_urls` reconciliation and the empty-body canonical PR are resolved transitively: with correct branch resolution the push targets the intended branch, `_record_pr_url` records under the right ticket, and `_build_pr_spec` generates the body from the correct branch's last commit.

### Acceptance (issue #776)

- [x] `pr create` from a worktree opens a PR for THAT worktree's branch, never a stale `ticket.extra`/`first()` branch.
- [x] A ticket spanning multiple PRs (PR-A merged, PR-B in progress) does not produce a duplicate PR of merged work.
- [x] Refuses to open a PR whose branch is already merged into base.
- [x] Regression test for the multi-PR-per-ticket scenario.

### Verification (real counts)

- Not DB-concurrency (query-resolution fix, no `select_for_update` CAS) — the SQLite-prod B1-trap rule is N/A.
- Anti-vacuous: reverting `_resolve_target_worktree` to the buggy `.first()` turns the regression tests RED (ship pushes the stale `s-776-pr-a-merged` branch); restored ⇒ GREEN. New `TestShipResolvesBranchFromInvokingWorktree` (5 tests).
- 100% coverage on all new lines (the two pre-existing uncovered spots in `ship.py` — the `pr_urls` early-return and a `_record_pr_url` arc — predate this change and are out of scope).
- Full project suite: 3814 passed, 12 skipped, 0 failed. ruff + ty clean. All prek hooks pass.

Relates-to #776
