### PR TITLE
fix(core): SSOT — one canonical phase-visit session-selection policy (#801)

### DIFF
--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -190,6 +190,8 @@ When a test asserts something about prose (a BLUEPRINT/skill/docs invariant — 
 - **Run the language convention skill's review checklist** (if loaded) before declaring implementation complete.
 - **100% test coverage is part of the implementation (Non-Negotiable).** New code ships with tests in the same commit. Never lower coverage thresholds, add files to coverage omit lists, or exclude code from coverage measurement without **explicit user approval**. If you can't reach 100% coverage, the implementation scope is too large — break it into smaller pieces.
 
+- **Don't create an uncoverable/unreachable defensive guard — restructure so the type is precise.** A "shared core returning `T | None` + a thin wrapper that re-asserts non-`None`" shape forces an unreachable branch: the wrapper's `if x is None: raise` (or `assert x is not None`) can never execute when the core's contract guarantees non-`None` for that call, so it is both uncoverable (the 100%-new-line rule can't be met without breaking the contract) and a lint violation (`assert` is banned in `src/`; `# noqa` is not an option). The fix is at the design level, not a suppression: split into **two purpose-typed methods** — one that always produces and returns `T` (the create/attestation path), one that returns `T | None` (the read-only path) — sharing the *policy/logic*, not a `T | None` return. Each call site then gets a precisely-typed value with no narrowing, no defensive guard, no `assert`, and full coverage falls out naturally. When you find yourself adding an "unreachable / defensive, should never happen" guard purely to satisfy the type checker, that is the signal the return type is too loose — tighten it by splitting, don't guard it.
+
 ## Agent Rules
 
 ### Delegating Code to Sub-Agents

--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -9,7 +9,7 @@ from django_fsm import TransitionNotAllowed
 from django_typer.management import TyperCommand, command, initialize
 
 from teatree.core.db_anchor import assert_lifecycle_db_is_canonical
-from teatree.core.models import Session, Ticket
+from teatree.core.models import Ticket
 from teatree.core.phases import normalize_phase, phase_transition
 
 logger = logging.getLogger(__name__)
@@ -53,9 +53,11 @@ class Command(TyperCommand):
         # maker (testing/retro) and reviewer (reviewing) visits.
         assert_lifecycle_db_is_canonical(ticket)
         canonical = normalize_phase(phase)
-        session = ticket.sessions.order_by("-pk").first()
-        if session is None:
-            session = Session.objects.create(ticket=ticket)
+        # #801 SSOT: the canonical earliest+locked policy — never the
+        # old -pk-latest pick nor a raw blank-agent_id create (which
+        # failed _check_maker_checker closed). The explicit --agent-id
+        # seeds a created session's identity.
+        session = ticket.resolve_phase_session(agent_id=agent_id or "loop")
         session.visit_phase(canonical, agent_id=session.recording_identity(agent_id))
 
         transition_name = phase_transition(canonical)

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -93,7 +93,10 @@ def _check_shipping_gate(ticket: Ticket) -> ShippingGateFailure | None:
     """
     from teatree.core.models.errors import QualityGateError  # noqa: PLC0415
 
-    session = ticket.sessions.order_by("-pk").first()  # ty: ignore[unresolved-attribute]
+    # #801 SSOT: canonical earliest selection (was -pk-latest); the
+    # gate only READS — create=False so a gate check never mints a
+    # session as a side effect.
+    session = ticket.find_phase_session()
     if session is None:
         # No session => no attested work; nothing to reconcile. Returning
         # ``None`` here would let ``ticket.ship()`` raise a raw
@@ -421,7 +424,8 @@ class Command(TyperCommand):
         from teatree.core.models.errors import QualityGateError  # noqa: PLC0415
 
         ticket = Ticket.objects.get(pk=ticket_id)
-        session = ticket.sessions.order_by("-pk").first()
+        # #801 SSOT: canonical earliest selection, read-only (no create).
+        session = ticket.find_phase_session()
         if session is None:
             return {"allowed": False, "reason": "No active session", "missing": []}
         try:

--- a/src/teatree/core/management/commands/tasks.py
+++ b/src/teatree/core/management/commands/tasks.py
@@ -13,7 +13,7 @@ from rich.table import Table
 from teatree.agents.headless import UUID_RE
 from teatree.agents.prompt import build_interactive_context
 from teatree.agents.skill_bundle import resolve_skill_bundle
-from teatree.core.models import InvalidTransitionError, Session, Task, TaskAttempt, Ticket
+from teatree.core.models import InvalidTransitionError, Task, TaskAttempt, Ticket
 from teatree.core.overlay_loader import get_overlay
 
 logger = logging.getLogger(__name__)
@@ -73,10 +73,9 @@ class Command(TyperCommand):
             self.stderr.write(f"Ticket {ticket} not found.")
             raise SystemExit(1) from None
 
-        session = Session.objects.filter(ticket=ticket_obj).order_by("-pk").first() or Session.objects.create(
-            ticket=ticket_obj,
-            agent_id="phase-handoff",
-        )
+        # #801 SSOT: canonical earliest+locked policy (was -pk-latest
+        # else an unlocked raw create); non-blank agent_id on miss.
+        session = ticket_obj.resolve_phase_session(agent_id="phase-handoff")
         target = Task.ExecutionTarget.INTERACTIVE if interactive else Task.ExecutionTarget.HEADLESS
         task = Task.objects.create(
             ticket=ticket_obj,

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -264,28 +264,60 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
                     visits[phase] = record
         return visited, visits
 
-    def ensure_session(self, *, agent_id: str = "loop") -> "Session":
-        """Return a durable phase-attestation Session for this ticket (#748).
+    def resolve_phase_session(self, *, agent_id: str = "loop") -> "Session":
+        """The single canonical phase-visit session for the attestation writers (#801).
 
-        Idempotent; reuses the *earliest* existing session so maker≠checker
-        attribution and any recorded phase ledger are never split across a
-        fresh empty session. Concurrency-atomic: read+create runs in one
-        ``transaction.atomic()`` with the ticket row ``select_for_update``-
-        locked (the dispatch path calls this outside any transaction, so
-        concurrent loop ticks for the same ``issue_url`` must serialise).
-        Rationale and the gate interaction: BLUEPRINT.md §4.3.
+        Which ``Session`` a phase visit lands on was decided four
+        inconsistent ways (``ensure_session`` earliest+locked; the
+        ``lifecycle visit-phase`` CLI, the ``tasks`` phase-handoff
+        command each ``order_by("-pk")`` *latest* with an unlocked raw
+        blank-``agent_id`` create on miss; the ``pr`` gate *latest* as
+        its gate object). A CLI visit then wrote the *latest* session
+        while dispatch reused the *earliest*, and the blank-``agent_id``
+        fallback fails ``_check_maker_checker`` **closed** (#755). The
+        three attestation writers now route here; the read-only gate
+        uses :meth:`find_phase_session`.
+
+        Policy: the **earliest** session (``order_by("pk")`` — the one
+        dispatch's attestation uses, so the ledger never splits),
+        selected/created inside one ``transaction.atomic()`` with the
+        ticket row ``select_for_update``-locked (dispatch callers have
+        no surrounding transaction, so concurrent loop ticks for the
+        same ``issue_url`` must serialise). Always returns a Session —
+        on miss it creates one with a guaranteed **non-blank**
+        ``agent_id`` (never the raw blank-``agent_id`` create that made
+        ``_check_maker_checker`` unverifiable).
         """
         from teatree.core.models.session import Session  # noqa: PLC0415
         from teatree.core.models.ticket import Ticket  # noqa: PLC0415
 
         with transaction.atomic():
-            # Lock this ticket row so concurrent ensure_session callers
-            # serialise on it (the read+create critical section).
             Ticket.objects.select_for_update().filter(pk=self.pk).first()
             existing = self.sessions.order_by("pk").first()  # ty: ignore[unresolved-attribute]
             if existing is not None:
                 return existing
-            return Session.objects.create(ticket=self, agent_id=agent_id)
+            return Session.objects.create(ticket=self, agent_id=agent_id.strip() or "loop")
+
+    def find_phase_session(self) -> "Session | None":
+        """Read-only canonical phase-visit session for the gate (#801).
+
+        Same earliest + ticket-row-locked selection policy as
+        :meth:`resolve_phase_session` but **never creates** — a gate
+        check must not have the side effect of minting a session.
+        """
+        from teatree.core.models.ticket import Ticket  # noqa: PLC0415
+
+        with transaction.atomic():
+            Ticket.objects.select_for_update().filter(pk=self.pk).first()
+            return self.sessions.order_by("pk").first()  # ty: ignore[unresolved-attribute]
+
+    def ensure_session(self, *, agent_id: str = "loop") -> "Session":
+        """Durable phase-attestation Session for this ticket (#748).
+
+        Thin alias of the canonical :meth:`resolve_phase_session` (#801
+        SSOT) — kept for its existing callers / API.
+        """
+        return self.resolve_phase_session(agent_id=agent_id)
 
     def has_shippable_diff(self) -> bool:
         """Return True iff at least one worktree has commits ahead of its base branch.

--- a/tests/teatree_core/test_loop_built_ticket_session.py
+++ b/tests/teatree_core/test_loop_built_ticket_session.py
@@ -158,3 +158,105 @@ class TestLoopBuiltTicketGetsDurableSession(TestCase):
         )
         assert result.pk == rival_pk[0]
         assert ticket.ensure_session().pk == rival_pk[0]
+
+
+class TestResolvePhaseSession(TestCase):
+    """#801 — one canonical phase-visit session-selection policy.
+
+    The four phase-visit writers (``ensure_session``, ``lifecycle
+    visit-phase``, the ``tasks`` phase-handoff command, the ``pr`` gate)
+    must all select the SAME session: the *earliest* one, under the
+    ticket row lock, and never a raw blank-``agent_id`` create. This
+    pins ``Ticket.resolve_phase_session`` — the single source of truth
+    they all route through.
+    """
+
+    def test_selects_earliest_session_not_latest(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/souliane/teatree/issues/801001")
+        first = Session.objects.create(ticket=ticket, agent_id="coding")
+        Session.objects.create(ticket=ticket, agent_id="reviewer")
+
+        # The divergence #801 fixes: lifecycle/tasks/gate picked -pk
+        # (latest); the canonical policy is earliest (matches dispatch's
+        # ensure_session so attestation never splits).
+        assert ticket.resolve_phase_session().pk == first.pk
+
+    def test_creates_with_non_blank_agent_id_on_miss(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/souliane/teatree/issues/801002")
+
+        session = ticket.resolve_phase_session(agent_id="phase-handoff")
+
+        assert session is not None
+        # NEVER a raw blank-agent_id create (the lifecycle path's bug
+        # that fails _check_maker_checker closed, #755/#801).
+        assert session.agent_id == "phase-handoff"
+        assert session.agent_id.strip() != ""
+
+    def test_default_agent_id_is_non_blank(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/souliane/teatree/issues/801003")
+        session = ticket.resolve_phase_session()
+        assert session is not None
+        assert session.agent_id.strip() != ""
+
+    def test_find_phase_session_returns_none_on_miss_without_creating(self) -> None:
+        # The gate path (pr.py) only READS a session; it must not create
+        # one as a side effect of a gate check.
+        ticket = Ticket.objects.create(issue_url="https://github.com/souliane/teatree/issues/801004")
+
+        session = ticket.find_phase_session()
+
+        assert session is None
+        assert ticket.sessions.count() == 0
+
+    def test_find_phase_session_returns_earliest_existing(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/souliane/teatree/issues/801005")
+        first = Session.objects.create(ticket=ticket, agent_id="coding")
+        Session.objects.create(ticket=ticket, agent_id="reviewer")
+
+        found = ticket.find_phase_session()
+        assert found is not None
+        assert found.pk == first.pk
+
+    def test_idempotent_reuses_existing_no_ledger_split(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/souliane/teatree/issues/801006")
+        existing = Session.objects.create(ticket=ticket, agent_id="coding")
+        existing.visit_phase("testing", agent_id="coding")
+
+        returned = ticket.resolve_phase_session()
+
+        assert returned.pk == existing.pk
+        assert ticket.aggregate_phase_records()[0] == ["testing"]
+        assert ticket.sessions.count() == 1
+
+    def test_ensure_session_delegates_to_resolve_phase_session(self) -> None:
+        # ensure_session keeps its API/callers but is now the same
+        # canonical policy (delegates) — no second selection codepath.
+        ticket = Ticket.objects.create(issue_url="https://github.com/souliane/teatree/issues/801007")
+        first = Session.objects.create(ticket=ticket, agent_id="coding")
+        Session.objects.create(ticket=ticket, agent_id="b")
+        assert ticket.ensure_session().pk == first.pk == ticket.resolve_phase_session().pk
+
+    def test_reads_after_acquiring_the_row_lock(self) -> None:
+        """Concurrency: existence read happens AFTER the ticket row lock.
+
+        Same leak-free in-process interleave as the ensure_session test:
+        a rival commits its session at the ``select_for_update`` site;
+        a correctly-ordered ``resolve_phase_session`` re-reads post-lock
+        and reuses it (no duplicate empty session, no ledger split).
+        Reverting the lock/earliest policy regresses this RED.
+        """
+        ticket = Ticket.objects.create(issue_url="https://github.com/souliane/teatree/issues/801008")
+        original_qs = type(Ticket.objects).select_for_update
+        rival_pk: list[int] = []
+
+        def lock_then_rival_commits(self_mgr, *args: object, **kwargs: object):
+            if not rival_pk:
+                rival_pk.append(Session.objects.create(ticket=ticket, agent_id="rival").pk)
+            return original_qs(self_mgr, *args, **kwargs)
+
+        with patch.object(type(Ticket.objects), "select_for_update", lock_then_rival_commits):
+            result = ticket.resolve_phase_session()
+
+        assert rival_pk, "select_for_update lock site never reached — read happened before/without the row lock"
+        assert ticket.sessions.count() == 1, f"race created {ticket.sessions.count()} sessions"
+        assert result.pk == rival_pk[0]


### PR DESCRIPTION
## fix(core): SSOT — one canonical phase-visit session-selection policy

Closes #801

Relates-to #798

### Problem

Which `Session` a phase visit lands on was decided **four inconsistent ways**:

- `ensure_session()` — **earliest** (`order_by("pk")`), ticket-row-locked.
- `lifecycle visit-phase` CLI — **latest** (`order_by("-pk")`), unlocked, raw blank-`agent_id` create on miss.
- `tasks` phase-handoff command — **latest**, else raw create `agent_id="phase-handoff"`, unlocked.
- `pr` gate (`_check_shipping_gate` + `check_gates`) — **latest** as gate object.

A CLI `visit-phase` wrote the *latest* session while dispatch reused the *earliest*; the blank-`agent_id` fallback failed `_check_maker_checker` **closed** (#755).

### Fix — one canonical policy, all four writers route through it

- **`Ticket.resolve_phase_session(agent_id=…) -> Session`** — the three attestation writers (`ensure_session` is now a thin alias; `lifecycle visit-phase`; `tasks` phase-handoff). Selects the **earliest** session (`order_by("pk")` — the one dispatch's attestation uses, so the ledger never splits) inside one `transaction.atomic()` with the ticket row `select_for_update`-locked; on miss creates with a guaranteed **non-blank** `agent_id` — never the raw blank-`agent_id` create.
- **`Ticket.find_phase_session() -> Session | None`** — the read-only `pr` gate (two sites). Same earliest + row-locked selection policy but **never creates** (a gate check must not mint a session as a side effect).

Two purpose-typed methods (not one flagged method returning `Session | None`) so every call site gets a precise type with no narrowing, no unreachable defensive guard, no `assert`.

### Acceptance (issue #801)

- [x] One canonical `resolve_phase_session(ticket, …)` extracted.
- [x] All four writers route through the canonical policy (earliest, agent-aware, ticket-row-locked).
- [x] Never a raw blank-`agent_id` create.
- [x] SSOT grep proof: zero remaining divergent `sessions.order_by("-pk").first()` / raw blank-`agent_id` phase-attestation create in `src/`.

### Verification

- Anti-vacuous (B1-trap, real method): reverting `resolve_phase_session` to the pre-fix divergent policy (latest, unlocked, blank-`agent_id`) flips `TestResolvePhaseSession` RED; restored ⇒ GREEN. The concurrency test uses the accepted **leak-free in-process `select_for_update`-patch interleave** (the #800-B1 lesson — no leaky cross-thread file-SQLite).
- 100% coverage on every #801-new/changed line across all 4 touched modules, per-line self-measured (`ticket.py`, `lifecycle.py` 100%, `tasks.py`, `pr.py`).
- Composes correctly with the just-merged #800 `merge_extra`/locked-session work — no #800 regression (full suite green).
- Full project suite: **3840 passed, 12 skipped, 0 failed**. ruff + ty + format + all prek hooks clean.

Closes #801
Relates-to #798
