### PR TITLE
fix(loop): skipped tick emits full --json contract + keeps tick-meta fresh (#744)

### DIFF
--- a/src/teatree/core/management/commands/loop_tick.py
+++ b/src/teatree/core/management/commands/loop_tick.py
@@ -5,6 +5,7 @@ actions, and renders the statusline.  Called from ``t3 loop tick`` which
 delegates here via subprocess.
 """
 
+import datetime as dt
 import json
 from dataclasses import asdict
 from pathlib import Path
@@ -26,6 +27,29 @@ def _report_to_dict(report: TickReport) -> ReportDict:
         "statusline_path": str(report.statusline_path) if report.statusline_path else "",
         "errors": report.errors,
         "actions": [asdict(action) for action in report.actions],
+        "skipped": False,
+        "skipped_reason": "",
+    }
+
+
+def _skipped_report_dict(started_at: dt.datetime, reason: str) -> ReportDict:
+    """The full report contract for a tick that skipped (sibling holds the lease).
+
+    #744 defect 1: a skipped tick must still emit every contract key
+    (zeroed) so a coordinator pumping ``t3 loop tick --json`` can
+    ``json.load(...)["signal_count"]`` / ``["errors"]`` unconditionally
+    — the bare ``{"skipped": ...}`` object ``KeyError``-ed every
+    structured consumer on each contended beat.
+    """
+    return {
+        "started_at": started_at.isoformat(),
+        "signal_count": 0,
+        "action_count": 0,
+        "statusline_path": "",
+        "errors": {},
+        "actions": [],
+        "skipped": True,
+        "skipped_reason": reason,
     }
 
 
@@ -67,10 +91,21 @@ class Command(TyperCommand):
         # ticks proceeds; the rest SKIP, same contract as the old flock.
         owner = f"pid-{os.getpid()}"
         if not LoopLease.objects.acquire("loop-tick", owner=owner):
+            from teatree.loop.tick import _write_tick_meta  # noqa: PLC0415
+
+            reason = "another tick is already running"
+            now = dt.datetime.now(tz=dt.UTC)
+            # #744 defect 2: a sibling tick holds the lease and IS
+            # keeping the loop fresh — advance tick-meta's next_epoch so
+            # sustained multi-session contention never decays into a
+            # false `tick stale` on the statusline.
+            _write_tick_meta(now, target=statusline_file)
             if json_output:
-                self.stdout.write(json.dumps({"skipped": "another tick is already running"}))
+                # #744 defect 1: full contract shape so structured
+                # consumers index unconditionally (no KeyError on skip).
+                self.stdout.write(json.dumps(_skipped_report_dict(now, reason), indent=2))
             else:
-                self.stdout.write("SKIP  another tick is already running — loop-tick lease held.")
+                self.stdout.write(f"SKIP  {reason} — loop-tick lease held.")
             return
         try:
             if overlay:

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -421,6 +421,11 @@ def _write_tick_meta(started_at: dt.datetime, *, target: Path | None = None) -> 
     from teatree.loop.statusline import default_path  # noqa: PLC0415
 
     meta_path = (target or default_path()).with_name("tick-meta.json")
+    # #744: the skip path writes tick-meta directly without the
+    # render() that side-effect-creates the dir on the normal path —
+    # ensure the parent exists so an observability write never crashes
+    # the tick (or the skipped-tick freshness touch).
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
     cadence = int(os.environ.get("T3_LOOP_CADENCE", "720") or "720")
     next_epoch = int(started_at.timestamp()) + cadence
     freshness = _collect_repo_freshness()

--- a/tests/teatree_core/test_loop_tick_command.py
+++ b/tests/teatree_core/test_loop_tick_command.py
@@ -117,12 +117,56 @@ class TestLoopTickCommand(TestCase):
         assert "SKIP" in output
         assert "another tick is already running" in output
 
-    def test_skip_emits_json_when_requested(self) -> None:
+    def test_skip_json_emits_full_contract_shape(self) -> None:
+        """#744 defect 1: a skipped tick's --json must be contract-shaped.
+
+        A coordinator that pumps ``t3 loop tick --json`` and reads
+        ``["signal_count"]`` / ``["errors"]`` must not ``KeyError`` on a
+        skipped tick (lease held by a sibling). The skip payload carries
+        the full contract keys (zeroed) plus an explicit skipped flag.
+        """
+        import tempfile  # noqa: PLC0415
+
         from teatree.core.models import LoopLease  # noqa: PLC0415
 
         assert LoopLease.objects.acquire("loop-tick", owner="rival-tick") is True
         stdout = StringIO()
-        call_command("loop_tick", "--json", stdout=stdout)
+        with tempfile.TemporaryDirectory() as d:
+            # Isolate the tick-meta freshness-touch off the real
+            # ~/.local/share path during the test.
+            call_command("loop_tick", "--json", "--statusline-file", str(Path(d) / "sl.txt"), stdout=stdout)
 
         payload = json.loads(stdout.getvalue())
-        assert payload == {"skipped": "another tick is already running"}
+        assert payload["signal_count"] == 0
+        assert payload["action_count"] == 0
+        assert payload["errors"] == {}
+        assert payload["actions"] == []
+        assert "started_at" in payload
+        assert "statusline_path" in payload
+        assert payload["skipped"] is True
+        assert "another tick is already running" in payload["skipped_reason"]
+
+    def test_skip_refreshes_tick_meta_so_no_false_stale(self) -> None:
+        """#744 defect 2: a skipped tick must keep tick-meta fresh.
+
+        The lease is held by a *sibling* tick keeping the loop alive,
+        so a skip must advance ``tick-meta.json``'s ``next_epoch`` —
+        otherwise it decays past ``now + 2*cadence`` and the statusline
+        renders a false ``tick stale`` under normal multi-session
+        contention.
+        """
+        import datetime as _dt  # noqa: PLC0415
+        import tempfile  # noqa: PLC0415
+
+        from teatree.core.models import LoopLease  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as d:
+            sl = Path(d) / "statusline.txt"
+            meta = sl.with_name("tick-meta.json")
+            assert LoopLease.objects.acquire("loop-tick", owner="rival-tick") is True
+            before = int(_dt.datetime.now(tz=_dt.UTC).timestamp())
+            call_command("loop_tick", "--statusline-file", str(sl), stdout=StringIO())
+
+            assert meta.exists(), "skipped tick did not write tick-meta.json — false 'tick stale' will follow"
+            payload = json.loads(meta.read_text(encoding="utf-8"))
+            assert payload["next_epoch"] >= before, payload


### PR DESCRIPTION
## fix(loop): skipped tick emits the full --json contract + keeps tick-meta fresh

Closes #744

When `loop_tick` hits the `loop-tick` lease (a sibling tick is running), the early-return skip path had two defects.

### Defect 1 — off-contract `--json`

It wrote `{"skipped": "another tick is already running"}` and exited 0. The documented contract is `{started_at, signal_count, action_count, statusline_path, errors, actions}`; a coordinator pumping `t3 loop tick --json` and reading `["signal_count"]`/`["errors"]` `KeyError`-ed on every skipped (contended) beat.

- New `_skipped_report_dict(started_at, reason)` emits the **full contract** (zeroed) plus explicit `skipped: true` / `skipped_reason`.
- The non-skip `_report_to_dict` gained the symmetric `skipped: false` / `skipped_reason: ""` so the JSON shape is uniform across both paths.

### Defect 2 — stale `tick-meta` ⇒ false `tick stale`

`_write_tick_meta` was only called inside `run_tick()`, so the skip path never advanced `next_epoch`. Under sustained multi-session contention (only one tick wins the lease per beat) `next_epoch` decayed past `now + 2*cadence` and `statusline.sh` rendered a red **`tick stale`** even though the loop was healthy — just contended.

- The skip path now calls `_write_tick_meta(now, target=statusline_file)` — a sibling tick **is** keeping the loop fresh, so recording that prevents the false alarm (the issue's option 1).
- **Hardening:** `_write_tick_meta` now `mkdir(parents=True, exist_ok=True)` its parent — the normal path's `render()` side-effect-created the dir before the meta write; the skip path calls it directly, so an observability write must never crash a tick (or the skipped-tick freshness touch) on a missing dir.

### Acceptance (issue #744)

- [x] On skip, `--json` emits the full contract shape with a `skipped` flag — consumers `json.load(...)["signal_count"]` unconditionally.
- [x] A skipped tick (sibling holds the lease) advances `tick-meta.json`'s `next_epoch` — no false `tick stale` under normal multi-session contention.

### Verification

- Anti-vacuous (real shipped symbol): reverting the skip path to the pre-fix off-contract `{"skipped": ...}` flips `test_skip_json_emits_full_contract_shape` RED (`KeyError: signal_count` — the exact defect); restored ⇒ GREEN.
- `loop_tick.py` 100% coverage module-wide; the one new `tick.py` line (`mkdir`) covered; remaining `tick.py` Missing is pre-existing, out of scope.
- Full project suite: **3843 passed, 12 skipped, 0 failed**. ruff + ty + format + all prek hooks clean.

Closes #744
