### PR TITLE
fix(ship): pr create refuses hollow shipped with 0 commits ahead of base (#788)

### DIFF
--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -32,6 +32,7 @@ from teatree.core.public_identity import MergeResult
 from teatree.core.runners.ship import resolve_ship_worktree
 from teatree.types import RawAPIDict
 from teatree.utils import git
+from teatree.utils.run import CommandFailedError
 
 
 class VisualQAGateFailure(TypedDict):
@@ -49,6 +50,12 @@ class VisualQAGateFailure(TypedDict):
 
 class WorktreeMissingError(TypedDict):
     error: str
+
+
+class NoCommitsAheadError(TypedDict):
+    error: str
+    branch: str
+    base: str
 
 
 class ShipEnqueued(TypedDict):
@@ -79,6 +86,46 @@ class ShippingGateFailure(TypedDict):
 
 _IMAGE_URL_RE = re.compile(r"!\[([^\]]*)\]\((/uploads/[^\)]+)\)")
 _EXTERNAL_LINK_RE = re.compile(r"https?://(?:www\.)?(?:notion\.so|linear\.app|jira\.\S+)/\S+")
+
+
+def _assert_commits_ahead_of_base(worktree: Worktree) -> NoCommitsAheadError | None:
+    """Block a hollow ship: the branch must have ≥1 commit ahead of base (#788).
+
+    The phase gate answers "is the work attested?"; this answers "is
+    there actually anything to ship?". Without it, a
+    reviewer-approved-but-uncommitted (or committed-elsewhere) branch
+    produced a hollow ``state: shipped`` — the CLI reported success, the
+    FSM advanced, then ``execute_ship`` later failed with "No commits
+    between main and branch", deferring the real failure into the async
+    worker where it is easy to miss.
+
+    Blocks **only on a confirmed zero** (``rev_count(base..branch) ==
+    0``), naming the branch and the base it was compared against. If git
+    introspection cannot be performed (no real repo, base undetectable,
+    git error) the state is *unverifiable* — distinct from the
+    confirmed-zero bug — so the prior behaviour (proceed) is preserved
+    rather than blocking on an unknown.
+    """
+    repo = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
+    branch = worktree.branch
+    if not repo or not branch:
+        return None
+    try:
+        base = f"origin/{git.default_branch(repo=repo)}"
+        ahead = git.rev_count(repo=repo, range_spec=f"{base}..{branch}")
+    except (CommandFailedError, RuntimeError, ValueError):
+        return None  # unverifiable ≠ the confirmed-zero bug — do not block
+    if ahead > 0:
+        return None
+    return NoCommitsAheadError(
+        error=(
+            f"Refusing to ship: branch {branch!r} has 0 commits ahead of {base} — "
+            f"nothing to push (work uncommitted or committed elsewhere). "
+            f"Commit the work on {branch!r}, then retry `pr create`."
+        ),
+        branch=branch,
+        base=base,
+    )
 
 
 def _check_shipping_gate(ticket: Ticket) -> ShippingGateFailure | None:
@@ -324,6 +371,7 @@ class Command(TyperCommand):
         | VisualQAGateFailure
         | ShippingGateFailure
         | WorktreeMissingError
+        | NoCommitsAheadError
     ):
         """Validate ship gates and trigger the ship transition.
 
@@ -366,6 +414,20 @@ class Command(TyperCommand):
             # overwrite from a stale read — clobbered the ship worker's
             # pr_urls / visual_qa).
             ticket.merge_extra(set_keys={"ship_invoking_branch": invoking_branch})
+
+        # #788: refuse a hollow ship — the branch ShipExecutor will
+        # actually push (the #776/#800 canonical resolver, so the check
+        # matches what is shipped) must have ≥1 commit ahead of base.
+        # Placed before BOTH the gate and the --skip-validation
+        # reconcile so no path can advance the FSM to a hollow SHIPPED.
+        # `resolve_ship_worktree` cannot be None here — the
+        # WorktreeMissingError check above guarantees a worktree (it
+        # falls back to that same `worktrees.first()`).
+        no_commits = _assert_commits_ahead_of_base(
+            resolve_ship_worktree(ticket, cast("TicketExtra", ticket.extra or {})) or worktree
+        )
+        if no_commits is not None:
+            return no_commits
 
         if not skip_validation:
             gate_failure = _run_ship_gates(ticket, worktree, skip_visual_qa=skip_visual_qa)

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -1035,3 +1035,72 @@ class TestAssertCommitsAheadOfBase(TestCase):
     def test_missing_repo_or_branch_returns_none(self) -> None:
         assert _assert_commits_ahead_of_base(self._wt("", "feat")) is None
         assert _assert_commits_ahead_of_base(self._wt("/tmp/x", "")) is None
+
+    def test_confirmed_zero_returns_structured_error(self) -> None:
+        """Branch at exact parity with base (0 commits ahead) → block contract.
+
+        Neutering the confirmed-zero arm (e.g. ``ahead > 0`` flipped, or
+        the ``return NoCommitsAheadError`` removed) makes this RED — the
+        guard's whole reason to exist (#788).
+        """
+        import tempfile  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as root:
+            self._git(root, "init", "-q", "-b", "main")
+            self._git(root, "config", "user.email", "t@example.com")
+            self._git(root, "config", "user.name", "t")
+            (Path(root) / "a").write_text("1", encoding="utf-8")
+            self._git(root, "add", "-A")
+            self._git(root, "commit", "-q", "-m", "base")
+            self._git(root, "update-ref", "refs/remotes/origin/main", "HEAD")
+            # Branch points at the SAME commit as origin/main → 0 ahead.
+            self._git(root, "checkout", "-q", "-b", "feat-parity")
+
+            result = _assert_commits_ahead_of_base(self._wt(root, "feat-parity"))
+
+        assert result is not None, "confirmed-zero MUST block (returns NoCommitsAheadError)"
+        assert result["branch"] == "feat-parity"
+        assert result["base"] == "origin/main"
+        assert "0 commits ahead" in result["error"]
+
+    def test_unverifiable_git_error_returns_none_proceeds(self) -> None:
+        """No-block-on-unknown safety contract (#788's make-or-break fail-direction).
+
+        When git introspection cannot be performed — ``default_branch``
+        raising :class:`CommandFailedError`, ``rev_count`` raising, or an
+        ``int()`` ``ValueError`` — the state is *unverifiable*, distinct
+        from the confirmed-zero bug, so the guard MUST return ``None``
+        (ship proceeds, prior behaviour preserved). Neutering this arm
+        (e.g. ``except`` block returning the error, or removed) makes
+        this RED. Real on-disk repo so only the failing primitive is
+        mocked.
+        """
+        import tempfile  # noqa: PLC0415
+
+        from teatree.utils import git as git_mod  # noqa: PLC0415
+        from teatree.utils.run import CommandFailedError  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as root:
+            self._git(root, "init", "-q", "-b", "main")
+            self._git(root, "config", "user.email", "t@example.com")
+            self._git(root, "config", "user.name", "t")
+            (Path(root) / "a").write_text("1", encoding="utf-8")
+            self._git(root, "add", "-A")
+            self._git(root, "commit", "-q", "-m", "base")
+            self._git(root, "update-ref", "refs/remotes/origin/main", "HEAD")
+            wt = self._wt(root, "main")
+
+            with patch.object(git_mod, "default_branch", side_effect=CommandFailedError(["git"], 1, "", "boom")):
+                assert _assert_commits_ahead_of_base(wt) is None, (
+                    "default_branch failure is unverifiable → MUST proceed (None)"
+                )
+
+            with patch.object(git_mod, "rev_count", side_effect=RuntimeError("git exploded")):
+                assert _assert_commits_ahead_of_base(wt) is None, (
+                    "rev_count failure is unverifiable → MUST proceed (None)"
+                )
+
+            with patch.object(git_mod, "rev_count", side_effect=ValueError("not an int")):
+                assert _assert_commits_ahead_of_base(wt) is None, (
+                    "rev_count ValueError is unverifiable → MUST proceed (None)"
+                )

--- a/tests/teatree_core/test_pr_command.py
+++ b/tests/teatree_core/test_pr_command.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock, patch
 
@@ -9,7 +10,12 @@ from django.test import TestCase
 from teatree import visual_qa
 from teatree.core.management.commands import _ensure_pr as ensure_pr_mod
 from teatree.core.management.commands import pr as pr_command
-from teatree.core.management.commands.pr import _check_shipping_gate, _resolve_base_url, _run_visual_qa_gate
+from teatree.core.management.commands.pr import (
+    _assert_commits_ahead_of_base,
+    _check_shipping_gate,
+    _resolve_base_url,
+    _run_visual_qa_gate,
+)
 from teatree.core.models import Session, Ticket, Worktree
 from teatree.core.orphan_guard import BranchReport, BranchStatus
 from teatree.core.overlay_loader import reset_overlay_cache
@@ -928,3 +934,104 @@ class TestRunVisualQAGate(TestCase):
             assert _run_visual_qa_gate(ticket, skip_reason="my reason") is None
 
         assert captured["skip_reason"] == "my reason"
+
+
+class TestPrCreateNoCommitsAheadGuard(TestCase):
+    """#788: pr create must fail loudly on a 0-commits-ahead branch.
+
+    No hollow ``shipped`` — instead of advancing the FSM and deferring
+    an empty-diff failure into the async ship worker, the branch must
+    have ≥1 commit ahead of its base.
+    """
+
+    @staticmethod
+    def _git(repo: str, *args: str) -> None:
+        from teatree.utils import run as run_mod  # noqa: PLC0415
+
+        run_mod.run_checked(["git", "-C", repo, *args])
+
+    def _repo_at_parity_with_base(self, root: str) -> str:
+        # A real git repo where the feature branch has NO commits ahead
+        # of the base it would be compared against.
+        self._git(root, "init", "-q", "-b", "main")
+        self._git(root, "config", "user.email", "t@example.com")
+        self._git(root, "config", "user.name", "t")
+        (Path(root) / "f.txt").write_text("x", encoding="utf-8")
+        self._git(root, "add", "-A")
+        self._git(root, "commit", "-q", "-m", "base")
+        self._git(root, "update-ref", "refs/remotes/origin/main", "HEAD")
+        self._git(root, "checkout", "-q", "-b", "feature-parity")
+        return "feature-parity"
+
+    def test_branch_at_parity_with_base_does_not_reach_shipped(self) -> None:
+        import tempfile  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as root:
+            branch = self._repo_at_parity_with_base(root)
+            ticket = Ticket.objects.create(overlay="test", state=Ticket.State.REVIEWED)
+            session = Session.objects.create(ticket=ticket, overlay="test")
+            session.visit_phase("testing")
+            session.visit_phase("reviewing")
+            session.visit_phase("retro")
+            Worktree.objects.create(
+                ticket=ticket,
+                overlay="test",
+                repo_path=root,
+                branch=branch,
+                extra={"worktree_path": root},
+            )
+
+            with (
+                patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+                patch.object(pr_command, "_run_visual_qa_gate", return_value=None),
+                patch.object(pr_command, "validate_pr_metadata", return_value=None),
+                patch.object(pr_command.git, "current_branch", return_value=branch),
+            ):
+                result = cast("dict[str, object]", call_command("pr", "create", str(ticket.id)))
+
+            ticket.refresh_from_db()
+            # No hollow success, no FSM transition.
+            assert ticket.state == Ticket.State.REVIEWED, f"hollow shipped: state={ticket.state}"
+            assert result.get("state") != Ticket.State.SHIPPED
+            # Structured no-commits error naming branch + base.
+            assert "error" in result
+            assert branch in str(result.get("error", "")) or branch in str(result.get("branch", ""))
+            assert "base" in result or "ahead" in str(result.get("error", "")).lower()
+
+
+class TestAssertCommitsAheadOfBase(TestCase):
+    """#788 helper unit branches (real tmp git repo per the doctrine)."""
+
+    @staticmethod
+    def _git(repo: str, *args: str) -> None:
+        from teatree.utils import run as run_mod  # noqa: PLC0415
+
+        run_mod.run_checked(["git", "-C", repo, *args])
+
+    def _wt(self, repo_path: str, branch: str) -> Worktree:
+        t = Ticket.objects.create(overlay="test")
+        return Worktree.objects.create(
+            ticket=t, overlay="test", repo_path=repo_path, branch=branch, extra={"worktree_path": repo_path}
+        )
+
+    def test_branch_with_a_commit_ahead_returns_none(self) -> None:
+        import tempfile  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as root:
+            self._git(root, "init", "-q", "-b", "main")
+            self._git(root, "config", "user.email", "t@example.com")
+            self._git(root, "config", "user.name", "t")
+            (Path(root) / "a").write_text("1", encoding="utf-8")
+            self._git(root, "add", "-A")
+            self._git(root, "commit", "-q", "-m", "base")
+            self._git(root, "update-ref", "refs/remotes/origin/main", "HEAD")
+            self._git(root, "checkout", "-q", "-b", "feat-ahead")
+            (Path(root) / "b").write_text("2", encoding="utf-8")
+            self._git(root, "add", "-A")
+            self._git(root, "commit", "-q", "-m", "ahead")  # 1 commit ahead of base
+
+            assert _assert_commits_ahead_of_base(self._wt(root, "feat-ahead")) is None
+
+    def test_missing_repo_or_branch_returns_none(self) -> None:
+        assert _assert_commits_ahead_of_base(self._wt("", "feat")) is None
+        assert _assert_commits_ahead_of_base(self._wt("/tmp/x", "")) is None


### PR DESCRIPTION
## Summary

`pr create` reported a hollow `state: shipped` and advanced the FSM when the branch had **0 commits ahead of base** (work uncommitted, or committed on a different branch). `execute_ship` then failed later inside the async worker ("No commits between main and branch"), where the failure is easy to miss.

This adds `_assert_commits_ahead_of_base`, which:

- resolves the **same** branch `ShipExecutor` will actually push (the #776/#800 canonical `resolve_ship_worktree`), so the precheck matches what is shipped;
- blocks **only on a confirmed zero** (`rev_count(origin/<base>..branch) == 0`), returning a structured `NoCommitsAheadError` naming the branch and base;
- treats an *unverifiable* state (no real repo / base undetectable / git error) as distinct from the confirmed-zero bug and **preserves the prior proceed behaviour** rather than blocking on an unknown;
- runs **before both** the phase gate and the `--skip-validation` reconcile, so no path can advance the FSM to a hollow `SHIPPED`.

## Tests

- Integration test with a **real tmp git repo**: a branch at parity with `origin/main` returns the structured error and never reaches `SHIPPED`. Anti-vacuous: reverting the guard turns it RED (`hollow shipped: state=shipped`).
- Focused helper-level unit tests for `_assert_commits_ahead_of_base`: confirmed-zero → structured error; unverifiable/git-error → proceed (None); legitimate commits-ahead → proceed (None).
- Full suite green; ruff / ty / prek clean; 100% of new lines covered.

Closes #788

---

**Review protocol:** opened for independent cold review. Please do not merge until an independent reviewer has verified the diff and the coordinator issues an explicit CLEAR. The author is HOLDING.
