### PR TITLE
fix(tach): modules-declared guard covers single-file modules (#740)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1705,12 +1705,16 @@ graph TD
     teatree.repo_mode --> teatree.config
     teatree.skill_loading --> teatree.types
     teatree.skill_loading --> teatree.utils
+    teatree.skill_loading --> teatree.skill_deps
     teatree.core --> teatree.types
     teatree.core --> teatree.paths
     teatree.core --> teatree.config
     teatree.core --> teatree.utils
     teatree.core --> teatree.timeouts
     teatree.core --> teatree.skill_schema
+    teatree.core --> teatree.skill_deps
+    teatree.core --> teatree.skill_map
+    teatree.core --> teatree.trigger_parser
     teatree.core --> teatree.agents
     teatree.core --> teatree.backends
     teatree.agents --> teatree.types
@@ -1720,10 +1724,12 @@ graph TD
     teatree.backends --> teatree.types
     teatree.backends --> teatree.utils
     teatree.backends --> teatree.core
+    teatree.backends --> teatree.identity
     teatree.contrib --> teatree.types
     teatree.contrib --> teatree.core
     teatree.contrib --> teatree.config
     teatree.contrib --> teatree.utils
+    teatree.contrib --> teatree.visual_qa
     teatree.cli --> teatree.paths
     teatree.cli --> teatree.config
     teatree.cli --> teatree.core
@@ -1736,6 +1742,9 @@ graph TD
     teatree.cli --> teatree.loop
     teatree.cli --> teatree.utils
     teatree.cli --> teatree.repo_mode
+    teatree.cli --> teatree.triage
+    teatree.cli --> teatree.skill_deps
+    teatree.cli --> teatree.memory_audit
     teatree.core.management --> teatree.core
     teatree.core.management --> teatree.agents
     teatree.core.management --> teatree.backends
@@ -1745,6 +1754,7 @@ graph TD
     teatree.core.management --> teatree.paths
     teatree.core.management --> teatree.types
     teatree.core.management --> teatree.utils
+    teatree.core.management --> teatree.visual_qa
     teatree.loop --> teatree.types
     teatree.loop --> teatree.paths
     teatree.loop --> teatree.utils
@@ -1753,12 +1763,24 @@ graph TD
     teatree.loop --> teatree.backends
     teatree.docker --> teatree.types
     teatree.docker --> teatree.utils
+    teatree.visual_qa --> teatree.core
+    teatree.visual_qa --> teatree.utils
+    teatree.identity --> teatree.config
+    teatree.settings --> teatree.config
+    teatree.settings --> teatree.paths
+    teatree.cli_reference --> teatree.cli
+    teatree.triage --> teatree.utils
+    teatree.url_title_fetcher --> teatree.utils
     teatree.paths
     teatree.types
     teatree.templates
     teatree.claude_sessions
     teatree.overlay_init
     teatree.skill_schema
+    teatree.skill_deps
+    teatree.skill_map
+    teatree.memory_audit
+    teatree.trigger_parser
 ```
 
 <!-- tach-dependency-graph:end -->

--- a/scripts/hooks/check_tach_modules_declared.py
+++ b/scripts/hooks/check_tach_modules_declared.py
@@ -1,12 +1,21 @@
-"""Pre-commit hook: every top-level teatree package must be declared in tach.toml.
+"""Pre-commit hook: every top-level teatree module must be declared in tach.toml.
 
-tach silently ignores packages that have no ``[[modules]]`` entry — their
-cross-layer imports are unconstrained, so a whole subsystem can drift with a
-green ``tach check``. This guard fails the commit when a package under
-``src/teatree/`` has no matching ``teatree.<pkg>`` module path, so the blind
-spot that hid teatree.loop / teatree.docker cannot recur.
+tach silently ignores any top-level unit — directory **package** *or*
+single-file **module** — that has no ``[[modules]]`` entry: its cross-layer
+imports are unconstrained, so a whole subsystem can drift with a green
+``tach check``. This guard fails the commit when a top-level unit under
+``src/teatree/`` has no matching ``teatree.<name>`` module path, so the blind
+spot that hid teatree.loop / teatree.docker (packages) — and, at single-file
+granularity, teatree.visual_qa's unconstrained edge into the domain layer
+(#740) — cannot recur.
 
-Exit code 0 = every package declared, 1 = undeclared package(s).
+Genuinely isolated leaf modules (no internal imports and no internal
+importers) carry no cross-layer edge for tach to constrain; they may be
+explicitly listed in ``LEAF_MODULE_ALLOWLIST`` instead of carrying an empty
+``[[modules]]`` entry. The allowlist is deliberately small and explicit so
+adding an internal import to a leaf is a visible, reviewed change.
+
+Exit code 0 = every unit declared (or allowlisted), 1 = undeclared unit(s).
 """
 
 import sys
@@ -16,6 +25,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_ROOT = REPO_ROOT / "src" / "teatree"
 TACH_TOML = REPO_ROOT / "tach.toml"
+
+# Top-level single-file modules with zero internal teatree imports AND zero
+# internal teatree importers — no cross-layer edge exists for tach to
+# constrain, so an empty [[modules]] entry would be noise. Keep small; adding
+# an internal import to one of these must move it to a real [[modules]] entry.
+LEAF_MODULE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "teatree._overlay_api",
+        "teatree.project",
+        "teatree.urls",
+    }
+)
 
 
 def declared_module_paths() -> set[str]:
@@ -31,20 +52,34 @@ def top_level_packages() -> set[str]:
     }
 
 
-def undeclared_packages() -> list[str]:
+def top_level_modules() -> set[str]:
+    return {
+        f"teatree.{child.stem}"
+        for child in PACKAGE_ROOT.iterdir()
+        if child.is_file() and child.suffix == ".py" and not child.stem.startswith("__")
+    }
+
+
+def top_level_units() -> set[str]:
+    return top_level_packages() | top_level_modules()
+
+
+def undeclared_units() -> list[str]:
     declared = declared_module_paths()
-    return sorted(pkg for pkg in top_level_packages() if pkg not in declared)
+    return sorted(unit for unit in top_level_units() if unit not in declared and unit not in LEAF_MODULE_ALLOWLIST)
 
 
 def main() -> int:
-    missing = undeclared_packages()
+    missing = undeclared_units()
     if not missing:
         return 0
-    print("tach.toml is missing [[modules]] entries for these packages:")
-    for pkg in missing:
-        print(f"  - {pkg}")
-    print("\nUndeclared packages are unconstrained by tach. Add a [[modules]]")
-    print("entry with the correct depends_on before committing.")
+    print("tach.toml is missing [[modules]] entries for these units:")
+    for unit in missing:
+        print(f"  - {unit}")
+    print("\nUndeclared top-level packages/modules are unconstrained by tach.")
+    print("Add a [[modules]] entry with the correct depends_on (or, for a")
+    print("genuine leaf with no internal imports/importers, add it to")
+    print("LEAF_MODULE_ALLOWLIST) before committing.")
     return 1
 
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -43,6 +43,7 @@ Use `Ctrl+F`/`grep` to jump to a rule. Sections are grouped below by theme; numb
 **Communication & references**
 
 14. [Clickable References](#clickable-references)
+14a. [Lead a Completion Report With the Assigned-Work Status](#lead-a-completion-report-with-the-assigned-work-status)
 15. [No AI Signature on Posts Made on the User's Behalf](#no-ai-signature-on-posts-made-on-the-users-behalf-non-negotiable)
 16. [Never Post PR Comments from Parallel Agents](#never-post-pr-comments-from-parallel-agents-non-negotiable)
 17a. [Evidence Comes From the Deployed Environment](#evidence-comes-from-the-deployed-environment-non-negotiable)
@@ -189,6 +190,10 @@ When a bug's root cause is "our code disagrees with an external authority" — a
 ## Re-Verify Cross-Agent State Before Reporting a Dependent Request
 
 In a multi-agent / multi-loop environment, another agent may have advanced a shared artifact (a PR merged, an issue closed, a branch rebased, a baseline moved) while your task was running. Before reporting a request or recommendation whose validity depends on that artifact's state ("dispatch a reviewer for PR N", "merge X next", "rebase Y"), **re-fetch the artifact's current state in the same turn you report it**. A request built on the artifact's state at task-start is stale by the time a long task finishes; reporting it makes the agent look out of sync and wastes the coordinator's turn correcting it. The cost of one `gh pr view` / `glab mr view` before the report is trivial; the cost of a stale dependent request is a wasted round-trip.
+
+## Lead a Completion Report With the Assigned-Work Status
+
+When reporting back on assigned work, the reader's first need is an unambiguous answer to **"is the assigned work done, and where is it?"** — deliverable status, branch/PR/HEAD, gate results. Out-of-scope observations, systemic findings, or follow-up recommendations surfaced along the way must be **clearly separated and subordinate**: a labelled trailing section, never positioned so they displace, precede, or read as a substitute for the deliverable status. A correct systemic analysis that buries the "done?" answer reads as "did the analysis instead of the work" — the coordinator concludes nothing shipped and spends a round-trip re-asking for what was already finished. Separate the two concerns physically; lead with the in-scope status every time.
 
 ## Context Transparency
 
@@ -558,6 +563,8 @@ Long sessions lose context to automatic compaction. Proactively manage session l
 ## Commit Before Declaring Done (Non-Negotiable)
 
 When implementation is complete (all files written, tests pass or verified), **commit immediately** in the same response — do not wait for the user to ask. An uncommitted change is not "done"; it is in-progress work at risk of being lost to context compaction, parallel agents, or session timeout.
+
+**Commit before any long mandated pre-push step — retro especially (Non-Negotiable).** `/t3:retro` is mandated _before_ `pr create`, but `pr create` is the first step that commits. Running retro (a multi-tool, multi-minute step) with the entire change set uncommitted leaves it exposed for that whole window: a concurrent `workspace clean-all` / worktree prune that removes the worktree in that window **irrecoverably destroys uncommitted work** — no branch ref, no reflog, no remote, nothing to `git fsck`. The sequence is **implementation complete → verify → local commit → retro → privacy scan → push (`pr create`)**, not implementation → retro → commit. A local commit is cheap and reversible, and makes the work recoverable even if the worktree vanishes. Never start retro (or any other long mandated step) with the deliverable uncommitted.
 
 ## Pre-Commit Hook Failures on Unrelated Tests
 

--- a/tach.toml
+++ b/tach.toml
@@ -46,7 +46,7 @@ depends_on = ["teatree.paths", "teatree.utils", "teatree.config"]
 
 [[modules]]
 path = "teatree.skill_loading"
-depends_on = ["teatree.types", "teatree.utils"]
+depends_on = ["teatree.types", "teatree.utils", "teatree.skill_deps"]
 
 [[modules]]
 path = "teatree.skill_schema"
@@ -61,6 +61,9 @@ depends_on = [
   "teatree.utils",
   "teatree.timeouts",
   "teatree.skill_schema",
+  "teatree.skill_deps",
+  "teatree.skill_map",
+  "teatree.trigger_parser",
   "teatree.agents",
   "teatree.backends"
 ]
@@ -79,12 +82,13 @@ path = "teatree.backends"
 depends_on = [
   "teatree.types",
   "teatree.utils",
-  "teatree.core"
+  "teatree.core",
+  "teatree.identity"
 ]
 
 [[modules]]
 path = "teatree.contrib"
-depends_on = ["teatree.types", "teatree.core", "teatree.config", "teatree.utils"]
+depends_on = ["teatree.types", "teatree.core", "teatree.config", "teatree.utils", "teatree.visual_qa"]
 
 [[modules]]
 path = "teatree.cli"
@@ -100,7 +104,10 @@ depends_on = [
   "teatree.overlay_init",
   "teatree.loop",
   "teatree.utils",
-  "teatree.repo_mode"
+  "teatree.repo_mode",
+  "teatree.triage",
+  "teatree.skill_deps",
+  "teatree.memory_audit"
 ]
 
 [[modules]]
@@ -114,7 +121,8 @@ depends_on = [
   "teatree.loop",
   "teatree.paths",
   "teatree.types",
-  "teatree.utils"
+  "teatree.utils",
+  "teatree.visual_qa"
 ]
 
 [[modules]]
@@ -131,3 +139,43 @@ depends_on = [
 [[modules]]
 path = "teatree.docker"
 depends_on = ["teatree.types", "teatree.utils"]
+
+[[modules]]
+path = "teatree.visual_qa"
+depends_on = ["teatree.core", "teatree.utils"]
+
+[[modules]]
+path = "teatree.identity"
+depends_on = ["teatree.config"]
+
+[[modules]]
+path = "teatree.settings"
+depends_on = ["teatree.config", "teatree.paths"]
+
+[[modules]]
+path = "teatree.cli_reference"
+depends_on = ["teatree.cli"]
+
+[[modules]]
+path = "teatree.triage"
+depends_on = ["teatree.utils"]
+
+[[modules]]
+path = "teatree.url_title_fetcher"
+depends_on = ["teatree.utils"]
+
+[[modules]]
+path = "teatree.skill_deps"
+depends_on = []
+
+[[modules]]
+path = "teatree.skill_map"
+depends_on = []
+
+[[modules]]
+path = "teatree.memory_audit"
+depends_on = []
+
+[[modules]]
+path = "teatree.trigger_parser"
+depends_on = []

--- a/tests/test_tach_modules_declared_hook.py
+++ b/tests/test_tach_modules_declared_hook.py
@@ -20,6 +20,10 @@ def _package(repo: Path, name: str) -> None:
     (pkg / "__init__.py").touch()
 
 
+def _module(repo: Path, name: str) -> None:
+    (repo / "src" / "teatree" / f"{name}.py").write_text("x = 1\n", encoding="utf-8")
+
+
 def _tach(repo: Path, *paths: str) -> None:
     body = "\n".join(f'[[modules]]\npath = "{p}"\ndepends_on = []\n' for p in paths)
     (repo / "tach.toml").write_text(body, encoding="utf-8")
@@ -47,3 +51,35 @@ class TestTachModulesDeclaredHook:
         _package(fake_repo, "core")
         _tach(fake_repo, "teatree.core.management")
         assert guard.main() == 1
+
+    def test_flags_undeclared_single_file_module(self, fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # The #740 blind spot: a single-file module under src/teatree/ with no
+        # [[modules]] entry has unconstrained cross-layer imports while
+        # `tach check` stays green — the guard must flag it like a package.
+        _module(fake_repo, "visual_qa")
+        _tach(fake_repo, "teatree.core")
+        assert guard.main() == 1
+        assert "teatree.visual_qa" in capsys.readouterr().out
+
+    def test_passes_when_single_file_module_declared(self, fake_repo: Path) -> None:
+        _module(fake_repo, "visual_qa")
+        _tach(fake_repo, "teatree.visual_qa")
+        assert guard.main() == 0
+
+    def test_dunder_single_file_modules_are_not_required(self, fake_repo: Path) -> None:
+        # __init__.py / __main__.py are not declarable tach modules.
+        _module(fake_repo, "__init__")
+        _module(fake_repo, "__main__")
+        _tach(fake_repo, "teatree.core")
+        assert guard.main() == 0
+
+    def test_allowlisted_leaf_module_is_not_required(self, fake_repo: Path) -> None:
+        # Genuine leaf modules (no internal imports, no internal importers) may
+        # be explicitly allowlisted instead of carrying an empty [[modules]].
+        _module(fake_repo, "urls")
+        guard_allow = guard.LEAF_MODULE_ALLOWLIST | {"teatree.urls"}
+        import unittest.mock as m  # noqa: PLC0415
+
+        with m.patch.object(guard, "LEAF_MODULE_ALLOWLIST", guard_allow):
+            _tach(fake_repo, "teatree.core")
+            assert guard.main() == 0


### PR DESCRIPTION
## Summary

The #714 `check_tach_modules_declared` guard only enumerated **directory packages**, so single-file modules directly under `src/teatree/` were invisible: their cross-layer imports were unconstrained while `tach check` stayed green — the exact blind spot #714 set out to eliminate, at single-file granularity.

- **Guard extended** to also enumerate top-level `*.py` modules (excluding dunders), with a small explicit `LEAF_MODULE_ALLOWLIST` for genuine leaves (no internal imports/importers) so adding an import to a leaf becomes a visible, reviewed change.
- **10 previously-invisible single-file modules declared** in `tach.toml` with correct `depends_on`, and importer `depends_on` patched (`contrib→visual_qa`, `backends→identity`, `cli→triage/skill_deps/memory_audit`, `core→skill_deps/skill_map/trigger_parser`, `skill_loading→skill_deps`, `core.management→visual_qa`) so `tach check` stays green.
- Declaring `visual_qa` surfaced the real, previously-invisible `pr.py` (`teatree.core.management`) → `teatree.visual_qa` edge — concrete proof the blind spot was a live, not theoretical, gap.
- **Hook test** gains four cases: flags an undeclared single-file module, passes when declared, ignores dunders, honours the allowlist.
- BLUEPRINT dependency graph regenerated to reflect the now-declared modules (docs alignment).

## Verification

- `tach check`: green. Guard against the real repo: exit 0 (all units declared).
- Hook tests: 8 passed (4 new). Anti-vacuous: reverting the guard to the pre-#740 version turns `test_flags_undeclared_single_file_module` RED.
- 100% coverage of the changed guard module. Full suite: 3852 passed, 12 skipped.
- ruff / ty / prek (changed files) / privacy scan: clean.

The second commit (`docs(rules)`) carries two retro findings from the autonomous sweep session into `rules/SKILL.md` (commit-before-long-mandated-step; lead completion reports with the assigned-work status).

Closes #740
