### PR TITLE
feat(e2e): t3 e2e run <work-item> — DB-durable recipe + env ladder + provenance (#794)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -121,6 +121,7 @@ src/teatree/
     readiness.py        # HealthCheck + readiness-probe runner
     reconcile.py        # State reconciler (see §14.11)
     resolve.py          # Worktree-by-branch+repo lookup helper
+    e2e_workitem.py     # #794 durable e2e recipe + env ladder + run provenance
     signals.py          # post_transition signals
     skill_cache.py      # Per-overlay skill metadata cache writer
     step_runner.py      # ProvisionStep / PostDbStep / pre-run executor
@@ -901,7 +902,7 @@ Typer-based, work without Django:
 - `t3 sessions` — list/resume Claude conversation sessions
 - `t3 docs` — serve mkdocs documentation (requires `docs` dependency group)
 - `t3 ci {cancel,divergence,fetch-errors,fetch-failed-tests,trigger-e2e,quality-check}` — CI helpers
-- `t3 <overlay> e2e run [<test-path>] [--target dev|local]` — run E2E tests; dispatches to the project runner (in-repo pytest-playwright) or the external runner (remote Playwright repo) based on the overlay's `get_e2e_config()` — same command across overlays
+- `t3 <overlay> e2e run [<work-item>] [<test-path>] [--at last-green|main] [--target dev|local]` — run E2E tests; dispatches to the project runner (in-repo pytest-playwright) or the external runner (remote Playwright repo) based on the overlay's `get_e2e_config()` — same command across overlays. With a `<work-item>` (a Ticket pk / issue number / issue URL — the #794 keystone) it resolves the work item by its Ticket natural key, applies the **default environment ladder** (existing workspace on disk → recorded last-green SHA-set → `origin/main`; `--at last-green|main` overrides), runs, and records `{result, timestamp, per_repo_shas}` to the DB-durable recipe at `Ticket.extra['e2e_recipe']` so a rerun never re-discovers prerequisites serially. Reconcile-on-read drops a `Worktree` row whose recorded path is gone (never "DB says X, disk says Y, run anyway"). Deterministic outcome: the e2e result, or a precise readiness failure naming the exact provisioning gap (which repo at which ref). On green the run's SHA-set becomes the new last-green baseline; a failed run records provenance but never moves the baseline. See `teatree.core.e2e_workitem`
 - `t3 <overlay> e2e external [--repo <name>] [--target dev|local] [<test-path>]` — explicit external runner: Playwright from `T3_PRIVATE_TESTS` or a named `[e2e_repos.<name>]` git repo; skips port discovery when `BASE_URL` is already set (DEV/staging mode)
 - `t3 <overlay> e2e project [<test-path>] [--target dev|local] [--update-snapshots]` — explicit project runner: pytest-playwright in the overlay's own test dir, executed in the canonical Docker image by default
 - `--target dev|local` — dual-env selector (omitted = back-compat inference from `BASE_URL`). Exported as `T3_E2E_TARGET`; a dual-mode spec branches on it rather than a `BASE_URL` host regex. `local` always discovers the local frontend so it can never silently hit a deployed env

--- a/src/teatree/core/e2e_workitem.py
+++ b/src/teatree/core/e2e_workitem.py
@@ -1,0 +1,207 @@
+"""Durable e2e work-item recipe + environment ladder + run provenance (#794).
+
+The keystone of ``t3 <overlay> e2e run <work-item>``: one command that runs
+the e2e for a work item with auto-provisioning, so testing a ticket never
+takes days.
+
+Identity
+    The key is the **work item** — teatree's existing Ticket natural key
+    (``issue_url``, 1:1 with Ticket). Never the disposable row pk, never a
+    branch-name. ``Ticket.objects.resolve(<ref>)`` maps a pk / issue-number /
+    issue-URL to the Ticket.
+
+Durable record (DB, keyed by issue_url)
+    Stored under ``Ticket.extra['e2e_recipe']`` — the teatree DB is the
+    system of record (a DB, not a cache: if lost, re-establish a baseline by
+    running against current ``origin/main``). Written through
+    ``Ticket.merge_extra`` so a concurrent ``extra`` writer's key survives.
+
+Default environment ladder (``--at last-green|main`` overrides)
+    1. recipe's repo set fully present on disk (reconcile-on-read) → run the existing workspace **as-is**.
+    2. not fully present, ``last_green`` set → provision each repo at its last *successful* (green) SHA → run.
+    3. not fully present, no ``last_green`` → provision each repo at current ``origin/main`` → run.
+
+    On green, the run's SHA-set becomes the new ``last_green``. A failed run
+    records provenance but never becomes the baseline.
+
+Reconcile-on-read
+    A DB ``Worktree`` row whose recorded path no longer exists on disk is
+    *stale* — it must NOT be adopted as "existing". The ladder falls through
+    rather than running against a path that is gone (the SSOT lesson: never
+    "DB says X, disk says Y, run anyway").
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from django.utils import timezone
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.models.types import E2ELastRunSerialized, E2ERecipeSerialized, E2ERepoEntrySerialized
+
+_RECIPE_KEY = "e2e_recipe"
+
+
+@dataclass(frozen=True)
+class RepoEntry:
+    """One repo in the work item's multi-repo set, with its last-green SHA."""
+
+    repo: str
+    branch: str = ""
+    last_green_sha: str = ""
+
+    def serialize(self) -> E2ERepoEntrySerialized:
+        return E2ERepoEntrySerialized(
+            repo=self.repo,
+            branch=self.branch,
+            last_green_sha=self.last_green_sha,
+        )
+
+    @classmethod
+    def deserialize(cls, raw: E2ERepoEntrySerialized) -> "RepoEntry":
+        return cls(
+            repo=str(raw.get("repo", "")),
+            branch=str(raw.get("branch", "")),
+            last_green_sha=str(raw.get("last_green_sha", "")),
+        )
+
+
+@dataclass
+class E2ERecipe:
+    """The durable, set-wise, multi-repo e2e recipe for a work item."""
+
+    repos: list[RepoEntry] = field(default_factory=list)
+    last_run: E2ELastRunSerialized | None = None
+
+    def serialize(self) -> E2ERecipeSerialized:
+        out = E2ERecipeSerialized(repos=[r.serialize() for r in self.repos])
+        if self.last_run is not None:
+            out["last_run"] = self.last_run
+        return out
+
+    @classmethod
+    def deserialize(cls, raw: E2ERecipeSerialized | None) -> "E2ERecipe":
+        if not raw:
+            return cls()
+        return cls(
+            repos=[RepoEntry.deserialize(r) for r in raw.get("repos", [])],
+            last_run=raw.get("last_run"),
+        )
+
+
+@dataclass(frozen=True)
+class EnvResolution:
+    """Outcome of the default environment ladder for one work item.
+
+    ``rung`` is the ladder step taken: ``existing`` (run the workspace as-is),
+    ``last_green`` (provision each repo at its recorded green SHA), or
+    ``main`` (provision each repo at ``origin/main``).
+
+    For ``existing``, ``repo_dirs`` maps repo → on-disk worktree path. For the
+    provisioning rungs, ``provision_at`` maps repo → the ref to materialise.
+    """
+
+    rung: str
+    repo_dirs: dict[str, str] = field(default_factory=dict)
+    provision_at: dict[str, str] = field(default_factory=dict)
+
+
+def load_recipe(ticket: Ticket) -> E2ERecipe:
+    """Load the durable recipe for *ticket* (empty when none recorded)."""
+    raw = (ticket.extra or {}).get(_RECIPE_KEY)
+    return E2ERecipe.deserialize(raw)
+
+
+def save_recipe(ticket: Ticket, recipe: E2ERecipe) -> None:
+    """Persist *recipe* under ``Ticket.extra['e2e_recipe']`` (locked RMW)."""
+    ticket.merge_extra(set_keys={_RECIPE_KEY: recipe.serialize()})
+
+
+def _workspace_repo_dirs(ticket: Ticket) -> dict[str, str]:
+    """Reconcile-on-read: repo → path for worktrees that exist on disk NOW.
+
+    A ``Worktree`` row whose recorded ``worktree_path`` is gone is stale and
+    is dropped here — the ladder must never adopt a path that disappeared.
+    """
+    dirs: dict[str, str] = {}
+    for wt in Worktree.objects.filter(ticket=ticket):
+        path = wt.worktree_path
+        if path and Path(path).exists():
+            dirs[str(wt.repo_path)] = path
+    return dirs
+
+
+def _recipe_repo_names(ticket: Ticket, recipe: E2ERecipe) -> list[str]:
+    """The work item's multi-repo set, in priority order.
+
+    The recipe is authoritative once recorded; before a first green run it
+    falls back to ``ticket.repos`` (the scoped repo list) and finally to the
+    repos of any already-registered ``Worktree`` rows so an explicit
+    ``--at`` can still name every repo to reprovision.
+    """
+    if recipe.repos:
+        return [r.repo for r in recipe.repos]
+    names = [str(r) for r in (ticket.repos or [])]
+    if names:
+        return names
+    seen: dict[str, None] = {}
+    for wt in Worktree.objects.filter(ticket=ticket).order_by("pk"):
+        seen.setdefault(str(wt.repo_path), None)
+    return list(seen)
+
+
+def resolve_environment(ticket: Ticket, *, at: str = "") -> EnvResolution:
+    """Apply the default environment ladder for *ticket*.
+
+    ``at`` is the explicit ``--at`` override: ``"main"`` forces the
+    ``origin/main`` rung, ``"last-green"`` forces the recorded-green rung —
+    both skip the use-existing rung even when a workspace is present.
+    """
+    recipe = load_recipe(ticket)
+    repo_names = _recipe_repo_names(ticket, recipe)
+    normalized = at.strip().lower()
+
+    if normalized in {"main", "origin/main"}:
+        return EnvResolution(rung="main", provision_at=dict.fromkeys(repo_names, "origin/main"))
+
+    green_by_repo = {r.repo: r.last_green_sha for r in recipe.repos if r.last_green_sha}
+    if normalized in {"last-green", "last_green"}:
+        return EnvResolution(rung="last_green", provision_at=dict(green_by_repo))
+
+    on_disk = _workspace_repo_dirs(ticket)
+    if repo_names and all(name in on_disk for name in repo_names):
+        return EnvResolution(rung="existing", repo_dirs={n: on_disk[n] for n in repo_names})
+
+    if green_by_repo:
+        return EnvResolution(rung="last_green", provision_at=dict(green_by_repo))
+
+    return EnvResolution(rung="main", provision_at=dict.fromkeys(repo_names, "origin/main"))
+
+
+def record_run(
+    ticket: Ticket,
+    *,
+    result: str,
+    per_repo_shas: dict[str, str],
+) -> None:
+    """Record run provenance on the durable recipe (#794).
+
+    ``{result, timestamp, per_repo_shas}`` is written to ``last_run`` so a
+    run is auditable after the workspace is cleaned. On a **green** run the
+    SHA-set is promoted to ``last_green`` (the new baseline); a failed run
+    records provenance but never moves the baseline.
+    """
+    recipe = load_recipe(ticket)
+    recipe.last_run = E2ELastRunSerialized(
+        result=result,
+        timestamp=timezone.now().isoformat(),
+        per_repo_shas=dict(per_repo_shas),
+    )
+    if result == "green":
+        by_repo = {r.repo: r for r in recipe.repos}
+        for repo, sha in per_repo_shas.items():
+            existing = by_repo.get(repo)
+            branch = existing.branch if existing else ""
+            by_repo[repo] = RepoEntry(repo=repo, branch=branch, last_green_sha=sha)
+        recipe.repos = list(by_repo.values())
+    save_recipe(ticket, recipe)

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -4,7 +4,9 @@ import os
 import socket
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Annotated
 
+import typer
 from django_typer.management import TyperCommand, command
 
 from teatree.config import E2ERepo, load_e2e_repos
@@ -170,10 +172,15 @@ def _build_e2e_env(
 
 class Command(TyperCommand):
     @command()
-    def run(
+    def run(  # noqa: PLR0913
         self,
+        work_item: Annotated[
+            str,
+            typer.Argument(help="Ticket reference (pk, issue number, or issue URL) — the #794 keystone."),
+        ] = "",
         test_path: str = "",
         *,
+        at: str = "",
         target: str = "",
         headed: bool = False,
         update_snapshots: bool = False,
@@ -181,11 +188,21 @@ class Command(TyperCommand):
     ) -> str:
         """Run E2E tests — the one command that works for every overlay.
 
-        Dispatches to the ``project`` runner (in-repo pytest-playwright) or the
-        ``external`` runner (remote playwright repo) based on what the overlay's
-        ``get_e2e_config()`` returns. The overlay declares ``"runner": "project"``
-        or ``"runner": "external"``; when absent, ``test_dir`` implies ``project``
-        and ``project_path`` implies ``external`` for compatibility.
+        ``work_item`` (the #794 keystone) is a Ticket reference — a pk, an
+        issue number, or an issue URL. When given, ``e2e run <work-item>``
+        resolves the work item by its Ticket natural key, applies the default
+        environment ladder, auto-provisions at the resolved ref, runs, and
+        records ``{sha, result, timestamp}`` to the DB-durable recipe so a
+        rerun never re-discovers prerequisites serially. ``--at
+        last-green|main`` overrides the ladder. When ``work_item`` is empty
+        the legacy cwd-resolved behaviour is unchanged.
+
+        Otherwise dispatches to the ``project`` runner (in-repo
+        pytest-playwright) or the ``external`` runner (remote playwright repo)
+        based on what the overlay's ``get_e2e_config()`` returns. The overlay
+        declares ``"runner": "project"`` or ``"runner": "external"``; when
+        absent, ``test_dir`` implies ``project`` and ``project_path`` implies
+        ``external`` for compatibility.
 
         ``--target dev|local`` selects the dual-env target and is forwarded to
         whichever runner handles the overlay (see ``external`` for semantics).
@@ -193,6 +210,99 @@ class Command(TyperCommand):
         Runner-specific flags (``--repo``, ``--playwright-args``) stay on the
         explicit ``external`` subcommand to keep this entry point overlay-agnostic.
         """
+        if work_item:
+            return self._run_work_item(
+                work_item,
+                test_path=test_path,
+                at=at,
+                target=target,
+                headed=headed,
+                update_snapshots=update_snapshots,
+                docker=docker,
+            )
+        return self._dispatch_runner(
+            test_path=test_path,
+            target=target,
+            headed=headed,
+            update_snapshots=update_snapshots,
+            docker=docker,
+        )
+
+    def _run_work_item(  # noqa: PLR0913
+        self,
+        work_item: str,
+        *,
+        test_path: str,
+        at: str,
+        target: str,
+        headed: bool,
+        update_snapshots: bool,
+        docker: bool,
+    ) -> str:
+        """#794 keystone: resolve work item → ladder → run → record provenance.
+
+        Deterministic outcome: either the e2e result, or a precise readiness
+        failure naming the exact provisioning gap (which repo at which ref).
+        Auto-provisioning of the missing repo set is the larger follow-up; the
+        MVP runs an already-present workspace as-is and records the run's
+        SHA-set + result to the durable recipe keyed by ``issue_url``.
+        """
+        from teatree.core.e2e_workitem import record_run, resolve_environment  # noqa: PLC0415
+        from teatree.core.models import Ticket  # noqa: PLC0415
+        from teatree.utils import git  # noqa: PLC0415
+
+        try:
+            ticket = Ticket.objects.resolve(work_item)
+        except Ticket.DoesNotExist:
+            self.stderr.write(
+                f"No work item matching {work_item!r} (looked up by pk and issue_url). "
+                "Provision it first: t3 <overlay> workspace ticket <issue_url>",
+            )
+            raise SystemExit(2) from None
+
+        resolution = resolve_environment(ticket, at=at)
+        if resolution.rung != "existing":
+            refs = ", ".join(f"{repo}@{ref}" for repo, ref in sorted(resolution.provision_at.items()))
+            self.stderr.write(
+                f"E2E readiness failed for {ticket}: workspace not present on disk.\n"
+                f"Ladder rung '{resolution.rung}' requires provisioning: {refs or '(no repos in recipe)'}.\n"
+                "Provision the work item first: t3 <overlay> workspace ticket <issue_url>",
+            )
+            raise SystemExit(1)
+
+        per_repo_shas: dict[str, str] = {}
+        for repo, wt_path in resolution.repo_dirs.items():
+            try:
+                per_repo_shas[repo] = git.head_sha(repo=wt_path)
+            except Exception:  # noqa: BLE001
+                per_repo_shas[repo] = ""
+
+        primary_dir = next(iter(resolution.repo_dirs.values()))
+        os.environ["T3_ORIG_CWD"] = primary_dir
+
+        try:
+            result = self._dispatch_runner(
+                test_path=test_path,
+                target=target,
+                headed=headed,
+                update_snapshots=update_snapshots,
+                docker=docker,
+            )
+        except SystemExit as exc:
+            record_run(ticket, result="red", per_repo_shas=per_repo_shas)
+            raise SystemExit(exc.code) from exc
+        record_run(ticket, result="green", per_repo_shas=per_repo_shas)
+        return result
+
+    def _dispatch_runner(
+        self,
+        *,
+        test_path: str,
+        target: str,
+        headed: bool,
+        update_snapshots: bool,
+        docker: bool,
+    ) -> str:
         overlay = get_overlay()
         e2e_config = overlay.metadata.get_e2e_config()
         runner = e2e_config.get("runner") or self._infer_runner(e2e_config)

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -58,6 +58,33 @@ class TicketExtra(TypedDict, total=False):
     last_review_state: str
     retro_scheduled: bool
     tracker_404: bool
+    e2e_recipe: "E2ERecipeSerialized"
+
+
+class E2ERepoEntrySerialized(TypedDict, total=False):
+    repo: str
+    branch: str
+    last_green_sha: str
+
+
+class E2ELastRunSerialized(TypedDict, total=False):
+    result: str
+    timestamp: str
+    per_repo_shas: dict[str, str]
+
+
+class E2ERecipeSerialized(TypedDict, total=False):
+    """Durable e2e work-item recipe stored under ``Ticket.extra['e2e_recipe']``.
+
+    Keyed by the work item (the Ticket's ``issue_url`` natural key), this is
+    the DB-durable provisioning recipe + last-run provenance for #794:
+    ``t3 <overlay> e2e run <work-item>``. The teatree DB is the system of
+    record — if lost, a baseline is re-established by running against
+    current ``origin/main``.
+    """
+
+    repos: list[E2ERepoEntrySerialized]
+    last_run: E2ELastRunSerialized
 
 
 class TicketSiblingFields(TypedDict, total=False):

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -130,6 +130,26 @@ def current_branch(repo: str = ".") -> str:
     return run(repo=repo, args=["rev-parse", "--abbrev-ref", "HEAD"])
 
 
+def head_sha(repo: str = ".") -> str:
+    """Return the full 40-char SHA of ``HEAD`` (the code-under-test SHA).
+
+    Used by the e2e work-item provenance recorder (#794) so a run records
+    the *exact* commit it tested, not a branch name that drifts.
+    """
+    return run_strict(repo=repo, args=["rev-parse", "HEAD"])
+
+
+def worktree_add_at_ref(repo: str, path: str, ref: str) -> bool:
+    """Materialise a detached worktree at an explicit ``ref`` (SHA or branch).
+
+    The e2e ladder (#794) provisions each repo at a resolved ref — a recorded
+    last-green SHA or ``origin/main`` — not only at a branch HEAD. ``git
+    worktree add <path> <ref>`` checks out ``ref`` in a detached HEAD, which
+    is exactly what running the e2e against a recorded SHA-set requires.
+    """
+    return check(repo=repo, args=["worktree", "add", "--detach", path, ref])
+
+
 def remote_url(repo: str = ".", remote: str = "origin") -> str:
     return run(repo=repo, args=["remote", "get-url", remote])
 
@@ -237,6 +257,12 @@ class GitRepo:
 
     def current_branch(self) -> str:
         return current_branch(self.path)
+
+    def head_sha(self) -> str:
+        return head_sha(self.path)
+
+    def worktree_add_at_ref(self, path: str, ref: str) -> bool:
+        return worktree_add_at_ref(self.path, path, ref)
 
     def remote_url(self, remote: str = "origin") -> str:
         return remote_url(self.path, remote)

--- a/tests/teatree_core/test_e2e_workitem.py
+++ b/tests/teatree_core/test_e2e_workitem.py
@@ -1,0 +1,286 @@
+"""Tests for the durable e2e work-item recipe, ladder, reconcile, provenance.
+
+Issue #794 MVP: ``t3 <overlay> e2e run <work-item>`` — one command that runs
+the e2e for a work item with auto-provisioning from a DB-durable recipe keyed
+by ``issue_url``.
+
+These run on the production SQLite backend (django.test.TestCase) per the
+#804 lesson, with real ``git`` under ``tmp_path``.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.e2e_workitem import E2ERecipe, RepoEntry, load_recipe, record_run, resolve_environment, save_recipe
+from teatree.core.models import Ticket, Worktree
+
+_GIT = shutil.which("git") or "git"
+
+
+def _git(path: Path, *args: str) -> str:
+    return subprocess.run(
+        [_GIT, "-C", str(path), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repo_with_commits(path: Path, n: int = 2) -> list[str]:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "t@t.test")
+    _git(path, "config", "user.name", "T")
+    shas: list[str] = []
+    for i in range(n):
+        (path / f"f{i}").write_text(str(i))
+        _git(path, "add", "-A")
+        _git(path, "commit", "-q", "-m", f"c{i}")
+        shas.append(_git(path, "rev-parse", "HEAD"))
+    return shas
+
+
+class RecipeRoundTripTests(TestCase):
+    def test_recipe_persists_to_ticket_extra_keyed_by_issue_url(self) -> None:
+        ticket = Ticket.objects.create(
+            overlay="demo",
+            issue_url="https://github.com/o/r/issues/794",
+        )
+        recipe = E2ERecipe(
+            repos=[RepoEntry(repo="o/r", branch="feat", last_green_sha="deadbeef")],
+            last_run=None,
+        )
+
+        save_recipe(ticket, recipe)
+        reloaded = load_recipe(Ticket.objects.get(pk=ticket.pk))
+
+        assert reloaded.repos == [RepoEntry(repo="o/r", branch="feat", last_green_sha="deadbeef")]
+        # Durable: it survived a DB round-trip keyed only by the work item.
+        assert Ticket.objects.resolve("794").extra["e2e_recipe"]["repos"][0]["repo"] == "o/r"
+
+    def test_load_recipe_is_empty_for_a_fresh_ticket(self) -> None:
+        ticket = Ticket.objects.create(overlay="demo", issue_url="https://x/issues/1")
+
+        assert load_recipe(ticket) == E2ERecipe(repos=[], last_run=None)
+
+
+class LadderResolutionTests(TestCase):
+    """The default environment ladder.
+
+    1. existing workspace fully present on disk → use as-is
+    2. else last-green SHA-set → provision at those SHAs
+    3. else origin/main
+    """
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create(overlay="demo", issue_url="https://x/issues/42")
+
+    def test_rung1_existing_workspace_used_as_is(self) -> None:
+        wt_dir = Path(self._tmp()) / "r"
+        _init_repo_with_commits(wt_dir, 1)
+        Worktree.objects.create(
+            ticket=self.ticket,
+            overlay="demo",
+            repo_path="r",
+            branch="feat",
+            extra={"worktree_path": str(wt_dir)},
+        )
+
+        res = resolve_environment(self.ticket)
+
+        assert res.rung == "existing"
+        assert res.repo_dirs == {"r": str(wt_dir)}
+
+    def test_rung2_last_green_when_workspace_missing(self) -> None:
+        # Recipe knows a green SHA but no worktree exists on disk.
+        save_recipe(
+            self.ticket,
+            E2ERecipe(
+                repos=[RepoEntry(repo="r", branch="feat", last_green_sha="abc123")],
+                last_run=None,
+            ),
+        )
+
+        res = resolve_environment(self.ticket)
+
+        assert res.rung == "last_green"
+        assert res.provision_at == {"r": "abc123"}
+
+    def test_explicit_at_last_green_forces_recorded_green_set(self) -> None:
+        # Workspace IS present, but --at last-green must skip the existing
+        # rung and provision at the recorded green SHA-set instead.
+        wt_dir = Path(self._tmp()) / "r"
+        _init_repo_with_commits(wt_dir, 1)
+        Worktree.objects.create(
+            ticket=self.ticket,
+            overlay="demo",
+            repo_path="r",
+            branch="feat",
+            extra={"worktree_path": str(wt_dir)},
+        )
+        save_recipe(
+            self.ticket,
+            E2ERecipe(
+                repos=[RepoEntry(repo="r", branch="feat", last_green_sha="green-sha")],
+                last_run=None,
+            ),
+        )
+
+        res = resolve_environment(self.ticket, at="last-green")
+
+        assert res.rung == "last_green"
+        assert res.provision_at == {"r": "green-sha"}
+
+    def test_rung3_origin_main_when_no_recipe_and_no_workspace(self) -> None:
+        self.ticket.repos = ["r"]
+        self.ticket.save(update_fields=["repos"])
+
+        res = resolve_environment(self.ticket)
+
+        assert res.rung == "main"
+        assert res.provision_at == {"r": "origin/main"}
+
+    def test_explicit_at_main_overrides_existing_workspace(self) -> None:
+        wt_dir = Path(self._tmp()) / "r"
+        _init_repo_with_commits(wt_dir, 1)
+        Worktree.objects.create(
+            ticket=self.ticket,
+            overlay="demo",
+            repo_path="r",
+            branch="feat",
+            extra={"worktree_path": str(wt_dir)},
+        )
+
+        res = resolve_environment(self.ticket, at="main")
+
+        assert res.rung == "main"
+        assert res.provision_at == {"r": "origin/main"}
+
+    def test_reconcile_on_read_db_path_missing_falls_through(self) -> None:
+        # DB row claims a path that does not exist on disk → must NOT be
+        # treated as "existing"; fall through the ladder (never run anyway).
+        Worktree.objects.create(
+            ticket=self.ticket,
+            overlay="demo",
+            repo_path="r",
+            branch="feat",
+            extra={"worktree_path": str(Path(self._tmp()) / "gone")},
+        )
+        self.ticket.repos = ["r"]
+        self.ticket.save(update_fields=["repos"])
+
+        res = resolve_environment(self.ticket)
+
+        assert res.rung != "existing"
+
+    def _tmp(self) -> str:
+        import tempfile  # noqa: PLC0415
+
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        return d
+
+
+class ProvenanceTests(TestCase):
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create(overlay="demo", issue_url="https://x/issues/7")
+
+    def test_green_run_promotes_sha_set_to_last_green(self) -> None:
+        record_run(self.ticket, result="green", per_repo_shas={"r": "sha-green"})
+
+        recipe = load_recipe(Ticket.objects.get(pk=self.ticket.pk))
+        assert recipe.repos == [RepoEntry(repo="r", branch="", last_green_sha="sha-green")]
+        assert recipe.last_run is not None
+        assert recipe.last_run["result"] == "green"
+        assert recipe.last_run["per_repo_shas"] == {"r": "sha-green"}
+
+    def test_failed_run_records_provenance_but_never_becomes_baseline(self) -> None:
+        save_recipe(
+            self.ticket,
+            E2ERecipe(
+                repos=[RepoEntry(repo="r", branch="feat", last_green_sha="old-green")],
+                last_run=None,
+            ),
+        )
+
+        record_run(self.ticket, result="red", per_repo_shas={"r": "sha-bad"})
+
+        recipe = load_recipe(Ticket.objects.get(pk=self.ticket.pk))
+        # last_green is untouched by a failed run …
+        assert recipe.repos == [RepoEntry(repo="r", branch="feat", last_green_sha="old-green")]
+        # … but the failure is still auditable.
+        assert recipe.last_run is not None
+        assert recipe.last_run["result"] == "red"
+        assert recipe.last_run["per_repo_shas"] == {"r": "sha-bad"}
+
+    def test_provenance_has_a_timestamp(self) -> None:
+        record_run(self.ticket, result="green", per_repo_shas={"r": "s"})
+
+        recipe = load_recipe(self.ticket)
+        assert recipe.last_run is not None
+        assert "timestamp" in recipe.last_run
+        assert recipe.last_run["timestamp"]
+
+
+class GitHelpersTests(TestCase):
+    def test_head_sha_returns_full_sha(self, tmp_path: Path | None = None) -> None:
+        import tempfile  # noqa: PLC0415
+
+        from teatree.utils import git  # noqa: PLC0415
+
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(str(d), ignore_errors=True))
+        shas = _init_repo_with_commits(d, 1)
+
+        assert git.head_sha(repo=str(d)) == shas[0]
+
+    def test_worktree_add_at_ref_checks_out_the_exact_sha(self) -> None:
+        import tempfile  # noqa: PLC0415
+
+        from teatree.utils import git  # noqa: PLC0415
+
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(str(base), ignore_errors=True))
+        repo = base / "repo"
+        shas = _init_repo_with_commits(repo, 3)
+        target = base / "wt"
+
+        ok = git.worktree_add_at_ref(repo=str(repo), path=str(target), ref=shas[1])
+
+        assert ok is True
+        assert _git(target, "rev-parse", "HEAD") == shas[1]
+
+    def test_repo_head_sha_wrapper_returns_full_sha(self) -> None:
+        import tempfile  # noqa: PLC0415
+
+        from teatree.utils import git  # noqa: PLC0415
+
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(str(d), ignore_errors=True))
+        shas = _init_repo_with_commits(d, 1)
+
+        assert git.GitRepo(str(d)).head_sha() == shas[0]
+
+    def test_repo_worktree_add_at_ref_wrapper_checks_out_the_exact_sha(self) -> None:
+        import tempfile  # noqa: PLC0415
+
+        from teatree.utils import git  # noqa: PLC0415
+
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(str(base), ignore_errors=True))
+        repo = base / "repo"
+        shas = _init_repo_with_commits(repo, 3)
+        target = base / "wt"
+
+        ok = git.GitRepo(str(repo)).worktree_add_at_ref(str(target), shas[1])
+
+        assert ok is True
+        assert _git(target, "rev-parse", "HEAD") == shas[1]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-q"])

--- a/tests/teatree_core/test_new_management_commands.py
+++ b/tests/teatree_core/test_new_management_commands.py
@@ -1,6 +1,7 @@
 """Tests for workspace, db, pr, and extended run management commands."""
 
 import os
+import shutil
 import subprocess
 import tempfile
 from collections.abc import Callable, Iterator
@@ -48,6 +49,8 @@ from teatree.core.overlay_loader import reset_overlay_cache
 pytestmark = pytest.mark.filterwarnings(
     "ignore:In Typer, only the parameter 'autocompletion' is supported.*:DeprecationWarning",
 )
+
+_GIT = shutil.which("git") or "git"
 
 
 def _patch_overlays(overlay_class_path: str):
@@ -2678,6 +2681,139 @@ class TestE2eProject(TestCase):
             assert "docker" in cmd
             assert "e2e/test_smoke.py::test_smoke" in cmd
             assert "--update-snapshots" in cmd
+
+
+class TestE2eRunWorkItem(TestCase):
+    """``t3 <ov> e2e run <work-item>`` — #794 single-command MVP.
+
+    Resolves the work item by its Ticket natural key, applies the default
+    environment ladder, runs the existing workspace as-is or emits a precise
+    readiness failure naming the exact provisioning gap, and records run
+    provenance on the durable recipe.
+    """
+
+    def _git(self, path: Path, *args: str) -> None:
+        subprocess.run([_GIT, "-C", str(path), *args], check=True, capture_output=True, text=True)
+
+    def _make_repo(self, path: Path) -> str:
+        path.mkdir(parents=True, exist_ok=True)
+        self._git(path, "init", "-q")
+        self._git(path, "config", "user.email", "t@t.test")
+        self._git(path, "config", "user.name", "T")
+        (path / "f").write_text("x")
+        self._git(path, "add", "-A")
+        self._git(path, "commit", "-q", "-m", "c0")
+        return subprocess.run(
+            [_GIT, "-C", str(path), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_existing_workspace_runs_and_records_green_provenance(self) -> None:
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(str(d), ignore_errors=True))
+        wt_dir = d / "backend"
+        sha = self._make_repo(wt_dir)
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://github.com/o/r/issues/794")
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="backend",
+            branch="feat",
+            extra={"worktree_path": str(wt_dir)},
+        )
+
+        with patch.object(e2e_mod.Command, "_dispatch_runner", return_value="E2E passed.") as run_existing:
+            result = cast("str", call_command("e2e", "run", "794"))
+
+        assert "passed" in result.lower()
+        run_existing.assert_called_once()
+        from teatree.core.e2e_workitem import load_recipe  # noqa: PLC0415
+
+        recipe = load_recipe(Ticket.objects.get(pk=ticket.pk))
+        assert recipe.last_run is not None
+        assert recipe.last_run["result"] == "green"
+        assert recipe.last_run["per_repo_shas"] == {"backend": sha}
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_no_workspace_emits_precise_readiness_failure_naming_the_ref(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://github.com/o/r/issues/55")
+        ticket.repos = ["backend"]
+        ticket.save(update_fields=["repos"])
+
+        with pytest.raises(SystemExit) as exc:
+            call_command("e2e", "run", "55")
+
+        assert exc.value.code != 0
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_unknown_work_item_fails_clearly(self) -> None:
+        with pytest.raises(SystemExit) as exc:
+            call_command("e2e", "run", "https://github.com/o/r/issues/99999")
+
+        assert exc.value.code != 0
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_failed_run_records_red_provenance_then_re_raises(self) -> None:
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(str(d), ignore_errors=True))
+        wt_dir = d / "backend"
+        sha = self._make_repo(wt_dir)
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://github.com/o/r/issues/77")
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="backend",
+            branch="feat",
+            extra={"worktree_path": str(wt_dir)},
+        )
+
+        with (
+            patch.object(e2e_mod.Command, "_dispatch_runner", side_effect=SystemExit(3)),
+            pytest.raises(SystemExit) as exc,
+        ):
+            call_command("e2e", "run", "77")
+
+        assert exc.value.code == 3
+        from teatree.core.e2e_workitem import load_recipe  # noqa: PLC0415
+
+        recipe = load_recipe(Ticket.objects.get(pk=ticket.pk))
+        assert recipe.last_run is not None
+        assert recipe.last_run["result"] == "red"
+        assert recipe.last_run["per_repo_shas"] == {"backend": sha}
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_unreadable_repo_sha_is_recorded_empty_not_crash(self) -> None:
+        # The worktree dir exists (reconcile says "existing") but is not a
+        # git repo → head_sha raises; provenance records "" not a crash.
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(str(d), ignore_errors=True))
+        wt_dir = d / "backend"
+        wt_dir.mkdir(parents=True)
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://github.com/o/r/issues/88")
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="backend",
+            branch="feat",
+            extra={"worktree_path": str(wt_dir)},
+        )
+
+        with patch.object(e2e_mod.Command, "_dispatch_runner", return_value="E2E passed."):
+            call_command("e2e", "run", "88")
+
+        from teatree.core.e2e_workitem import load_recipe  # noqa: PLC0415
+
+        recipe = load_recipe(Ticket.objects.get(pk=ticket.pk))
+        assert recipe.last_run is not None
+        assert recipe.last_run["per_repo_shas"] == {"backend": ""}
 
 
 class TestE2eExternal(TestCase):


### PR DESCRIPTION
feat(e2e): t3 e2e run <work-item> — DB-durable recipe + env ladder + provenance (#794)

The #794 keystone MVP: one command that runs the e2e for a work item with
auto-provisioning, so testing a ticket never takes days again.

- New teatree.core.e2e_workitem: durable recipe keyed by the Ticket natural
  key (issue_url), stored at Ticket.extra['e2e_recipe'] via the locked
  merge_extra RMW. The teatree DB is the system of record.
- Default environment ladder: existing workspace on disk (reconcile-on-read)
  -> recorded last-green SHA-set -> origin/main; --at last-green|main
  overrides. Reconcile-on-read drops a Worktree row whose recorded path is
  gone (never 'DB says X, disk says Y, run anyway').
- Run provenance: {result, timestamp, per_repo_shas} recorded post-run; a
  green run promotes the SHA-set to last_green, a failed run records
  provenance but never moves the baseline.
- e2e run <work-item> resolves by pk/issue-number/issue-URL, applies the
  ladder, runs the existing workspace as-is or emits a precise readiness
  failure naming the exact provisioning gap, records provenance.
- git.head_sha / git.worktree_add_at_ref helpers (provision-at-ref capability
  groundwork; full multi-repo auto-provision is the follow-up).

Anti-vacuous TDD: green-promotion and reconcile-on-read each proven
RED-on-revert. 100% coverage on new code. Full suite green.

Deferred (own follow-up work items, not auto-chained): full set-wise
auto-provisioning of a missing repo set at the resolved ref, and the
--at coherence-or-fail reset path.