### PR TITLE
fix(hooks): treat overdue ScheduleWakeup beyond grace as stale (#865)

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -155,16 +155,27 @@ if [ -n "$session_id" ] && [ -r "$_crons_file" ] && command -v jq >/dev/null 2>&
     if [ -n "$_wakeup_epoch" ] && [ "$_wakeup_epoch" != "null" ]; then
         _wname=$(jq -r '.wakeup.name // "loop"' "$_crons_file" 2>/dev/null)
         _wdiff=$(( _wakeup_epoch - _now ))
+        # The wakeup epoch is written only by ScheduleWakeup and has no clear
+        # path: a long-finished wakeup would otherwise keep rendering as a
+        # live "→now" forever. Treat anything more than the grace window
+        # overdue as stale and omit it. A wakeup within the grace window
+        # (0 to GRACE seconds overdue) still shows "now" — a real imminent
+        # fire, not a stale leftover.
+        _wakeup_stale_grace=120
         if (( _wdiff > 60 )); then
             _wtiming="$(( _wdiff / 60 ))m"
         elif (( _wdiff > 0 )); then
             _wtiming="${_wdiff}s"
-        else
+        elif (( _wdiff >= -_wakeup_stale_grace )); then
             _wtiming="now"
+        else
+            _wtiming=""
         fi
-        _wlabel="${_CYN}${_wname}${_RST}${_LBL}→${_wtiming}${_RST}"
-        [ -n "$_loop_parts" ] && _loop_parts="${_loop_parts}${isep}"
-        _loop_parts="${_loop_parts}${_wlabel}"
+        if [ -n "$_wtiming" ]; then
+            _wlabel="${_CYN}${_wname}${_RST}${_LBL}→${_wtiming}${_RST}"
+            [ -n "$_loop_parts" ] && _loop_parts="${_loop_parts}${isep}"
+            _loop_parts="${_loop_parts}${_wlabel}"
+        fi
     fi
     [ -n "$_loop_parts" ] && _loops_segment="${_LBL}loops:${_RST} ${_loop_parts}"
 fi

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -182,6 +182,71 @@ class TestStatuslineHook:
         assert "loops:" in plain
         assert "checking build" in plain
 
+    def test_future_wakeup_renders_normally(self, tmp_path: Path) -> None:
+        """A wakeup whose epoch is in the future renders with its countdown."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        crons = {
+            "jobs": {},
+            "wakeup": {"name": "future build", "next_epoch": int(time.time()) + 600},
+        }
+        (state_dir / "s-future.crons").write_text(json.dumps(crons), encoding="utf-8")
+
+        result = _run(
+            {"session_id": "s-future", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "loops:" in plain
+        assert "future build" in plain
+
+    def test_expired_wakeup_beyond_grace_not_rendered_as_live(self, tmp_path: Path) -> None:
+        """A wakeup overdue beyond the grace window is stale — not a live '→now'.
+
+        Anti-vacuous: reverting the staleness guard makes this assertion fail
+        because the unguarded `else` branch would print "stale build→now".
+        """
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        crons = {
+            "jobs": {},
+            # ~4h overdue — a long-finished wakeup that never got cleared.
+            "wakeup": {"name": "stale build", "next_epoch": int(time.time()) - 14400},
+        }
+        (state_dir / "s-stale.crons").write_text(json.dumps(crons), encoding="utf-8")
+
+        result = _run(
+            {"session_id": "s-stale", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "stale build" not in plain
+        assert "stale build→now" not in plain
+
+    def test_recently_overdue_wakeup_within_grace_still_shows_now(self, tmp_path: Path) -> None:
+        """A wakeup ~30s overdue is a real imminent fire — still shows 'now'."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        crons = {
+            "jobs": {},
+            "wakeup": {"name": "imminent build", "next_epoch": int(time.time()) - 30},
+        }
+        (state_dir / "s-imminent.crons").write_text(json.dumps(crons), encoding="utf-8")
+
+        result = _run(
+            {"session_id": "s-imminent", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "loops:" in plain
+        assert "imminent build→now" in plain
+
     def test_omits_loops_when_no_crons_file(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"
         state_dir.mkdir()


### PR DESCRIPTION
## Problem

`hooks/scripts/statusline.sh` renders the loop `wakeup` from the `<session>.crons` cache. The `wakeup` field is written only by `ScheduleWakeup` and has no expiry/clear path. When `wakeup.next_epoch` is in the past, the render block fell into the `else` branch and printed `<name>→now` indefinitely.

In an interactively-driven session (no fresh `ScheduleWakeup` ever issued), a long-finished wakeup kept rendering as a misleading live `→now`. Reproduced: a wakeup whose epoch expired ~4h ago still showed as `<name>→now`.

## Fix

Add a 120s grace window in the wakeup render block:
- `>60s` future → `Nm`
- `>0s` future → `Ns`
- `0` to `120s` overdue → `now` (a real imminent fire)
- more than `120s` overdue → stale, omitted entirely

Recurring `jobs` cron rendering is untouched.

### Exact guard added

```sh
_wakeup_stale_grace=120
if (( _wdiff > 60 )); then
    _wtiming="$(( _wdiff / 60 ))m"
elif (( _wdiff > 0 )); then
    _wtiming="${_wdiff}s"
elif (( _wdiff >= -_wakeup_stale_grace )); then
    _wtiming="now"
else
    _wtiming=""
fi
# _wlabel only appended when _wtiming is non-empty
```

## Tests

Extended `tests/test_claude_statusline.py` (the existing subprocess-driven shell test suite):
- `test_future_wakeup_renders_normally` — future wakeup (+600s) renders normally
- `test_expired_wakeup_beyond_grace_not_rendered_as_live` — wakeup ~4h overdue is NOT rendered (no `stale build→now`)
- `test_recently_overdue_wakeup_within_grace_still_shows_now` — wakeup ~30s overdue still shows `imminent build→now`

Anti-vacuous: reverting the guard makes `test_expired_wakeup_beyond_grace_not_rendered_as_live` go RED (unguarded `else` prints `stale build→now`). Full statusline suite: 16 passed. `prek` green on changed files.

Relates-to #865