### PR TITLE
fix(core): fail closed on unmigrated self-DB in sanctioned merge path (#869)

### DIFF
--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -606,6 +606,10 @@ def check() -> bool:
     ok = _check_editable_sanity() and ok
     ok = _check_skills() and ok
     ok = _check_single_db() and ok
+
+    from teatree.core.schema_guard import doctor_check_self_db_migrations  # noqa: PLC0415
+
+    ok = doctor_check_self_db_migrations() and ok
     _check_singletons()
     _ensure_plugin_registered()
 

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -10,6 +10,7 @@ from django_typer.management import TyperCommand, command
 
 from teatree.core.merge_execution import MergePreconditionError, merge_ticket_pr
 from teatree.core.models import ClearIssuanceError, ClearRequest, MergeClear, Ticket
+from teatree.core.schema_guard import SelfDbMigrationError, require_current_schema
 
 
 class CompletionResult(TypedDict, total=False):
@@ -164,6 +165,12 @@ class Command(TyperCommand):
         through the SAME sanctioned ``ticket merge`` transition (invariant 8 —
         never raw ``gh``), with the human decision durably on the CLEAR.
         """
+        try:
+            require_current_schema()
+        except SelfDbMigrationError as exc:
+            self.stdout.write(f"  CLEAR refused: {exc}")
+            return {"issued": False, "error": str(exc)}
+
         resolved_ticket = None
         if ticket_id:
             try:
@@ -245,6 +252,12 @@ class Command(TyperCommand):
         result is flagged ``escalated`` so the durable backlog re-escalation
         is visible (the loop never self-issues a replacement CLEAR).
         """
+        try:
+            require_current_schema()
+        except SelfDbMigrationError as exc:
+            self.stdout.write(f"  merge refused: {exc}")
+            return {"error": str(exc), "merged": False}
+
         try:
             clear = MergeClear.objects.get(pk=clear_id)
         except MergeClear.DoesNotExist:

--- a/src/teatree/core/schema_guard.py
+++ b/src/teatree/core/schema_guard.py
@@ -1,0 +1,90 @@
+"""Self-DB schema pre-flight for the sanctioned merge path (#869).
+
+The sanctioned merge commands ``t3 teatree ticket clear`` and
+``t3 teatree ticket merge`` write/read ``MergeClear``/``MergeAudit`` rows.
+When the teatree self-DB (the dogfood control DB) has unapplied migrations
+those tables do not exist, and the ORM call surfaces a raw
+``django.db.utils.OperationalError: no such table: teatree_merge_clear``
+traceback.
+
+Since #863 mechanically prohibits raw ``gh pr merge`` on teatree-managed
+tickets, that opaque failure blocks the *entire* merge pipeline with no
+actionable signal. This module provides a cheap pre-flight that converts
+the silent traceback into a clear, sanctioned-remediation error and a
+``t3 doctor`` check that surfaces the gap proactively at session start.
+"""
+
+import typer
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.executor import MigrationExecutor
+
+_REMEDIATION = (
+    "Run the sanctioned non-destructive migrate:\n"
+    "  uv --directory <teatree-clone> run python manage.py migrate --no-input\n"
+    "(or `t3 <overlay> resetdb` only if losing all local ticket/session state "
+    "is acceptable). `t3 doctor check` flags this gap at session start."
+)
+
+
+class SelfDbMigrationError(RuntimeError):
+    """Raised when the teatree self-DB has unapplied migrations.
+
+    Carries the unapplied migration labels so the caller can render an
+    actionable message instead of a raw ``OperationalError`` traceback.
+    """
+
+
+def pending_migrations(alias: str = DEFAULT_DB_ALIAS) -> list[str]:
+    """Return ``"<app>.<name>"`` for every unapplied migration on *alias*.
+
+    Empty list ⇒ the schema is current. Uses Django's own
+    :class:`MigrationExecutor` so the result matches ``showmigrations``.
+    """
+    connection = connections[alias]
+    executor = MigrationExecutor(connection)
+    targets = executor.loader.graph.leaf_nodes()
+    plan = executor.migration_plan(targets)
+    return [f"{migration.app_label}.{migration.name}" for migration, _backwards in plan]
+
+
+def require_current_schema(alias: str = DEFAULT_DB_ALIAS) -> None:
+    """Fail closed with an actionable message if the self-DB is unmigrated.
+
+    Called as a pre-flight by the sanctioned merge commands so an
+    unmigrated self-DB can never produce a raw ``no such table`` traceback
+    on the critical merge path.
+    """
+    pending = pending_migrations(alias)
+    if not pending:
+        return
+    listed = ", ".join(pending)
+    msg = (
+        f"teatree self-DB has {len(pending)} unapplied migration(s): {listed}. "
+        f"The sanctioned merge path (ticket clear/merge) needs a current schema "
+        f"(e.g. the MergeClear/MergeAudit tables) and refuses to run against a "
+        f"stale DB rather than fail with an opaque traceback.\n{_REMEDIATION}"
+    )
+    raise SelfDbMigrationError(msg)
+
+
+def doctor_check_self_db_migrations(alias: str = DEFAULT_DB_ALIAS) -> bool:
+    """``t3 doctor`` surface for the self-DB schema pre-flight (#869).
+
+    Returns ``True`` (check passed) when the schema is current. Returns
+    ``False`` with a ``FAIL`` line naming the pending migrations so the
+    gap is caught at session start instead of mid-merge. A DB that is
+    absent/offline is a valid state — it ``WARN``s and does not fail.
+    """
+    try:
+        pending = pending_migrations(alias)
+    except Exception as exc:  # noqa: BLE001 — DB absent/offline is a valid state, not a doctor crash.
+        typer.echo(f"WARN  Could not inspect self-DB migrations: {exc.__class__.__name__}: {exc}")
+        return True
+    if not pending:
+        return True
+    typer.echo(
+        f"FAIL  teatree self-DB has {len(pending)} unapplied migration(s): {', '.join(pending)}. "
+        f"The sanctioned merge path needs a current schema — run "
+        f"`uv --directory <teatree-clone> run python manage.py migrate --no-input`."
+    )
+    return False

--- a/tests/teatree_core/test_schema_guard.py
+++ b/tests/teatree_core/test_schema_guard.py
@@ -1,0 +1,151 @@
+"""Self-DB schema pre-flight on the sanctioned merge path (#869).
+
+Before #869 `t3 teatree ticket clear`/`merge` called the ORM with no
+schema check, so an unmigrated self-DB (missing `teatree_merge_clear`)
+surfaced a raw `django.db.utils.OperationalError: no such table`
+traceback. Since #863 prohibits raw `gh pr merge`, that opaque failure
+blocked the entire merge pipeline. These tests pin the actionable
+behaviour and the doctor surfacing.
+"""
+
+import io
+from contextlib import redirect_stdout
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.db import OperationalError, connection
+from django.test import TransactionTestCase
+
+from teatree.cli.doctor import check as doctor_check
+from teatree.core.models import MergeClear
+from teatree.core.schema_guard import (
+    SelfDbMigrationError,
+    doctor_check_self_db_migrations,
+    pending_migrations,
+    require_current_schema,
+)
+
+_MERGE_MIGRATIONS = ("0011_mergeclear_mergeaudit", "0012_mergeclear_human_authorizer")
+
+
+def _unapply_merge_migrations() -> None:
+    """Reproduce the real #869 self-DB state exactly.
+
+    The dogfood DB ran #863/#864's code but never applied migrations
+    0011/0012, so the ``teatree_merge_clear`` table is absent *and* the
+    ``django_migrations`` ledger has no record of them — precisely what
+    ``MigrationExecutor`` inspects.
+    """
+    with connection.schema_editor() as editor:
+        editor.delete_model(MergeClear)
+    with connection.cursor() as cursor:
+        cursor.executemany(
+            "DELETE FROM django_migrations WHERE app = 'core' AND name = %s",
+            [(name,) for name in _MERGE_MIGRATIONS],
+        )
+
+
+def _reapply_merge_migrations() -> None:
+    """Restore the table + ledger so ``TransactionTestCase`` teardown flushes."""
+    with connection.schema_editor() as editor:
+        editor.create_model(MergeClear)
+    with connection.cursor() as cursor:
+        cursor.executemany(
+            "INSERT INTO django_migrations (app, name, applied) VALUES ('core', %s, CURRENT_TIMESTAMP)",
+            [(name,) for name in _MERGE_MIGRATIONS],
+        )
+
+
+class PendingMigrationsTest(TransactionTestCase):
+    def test_returns_empty_when_schema_current(self) -> None:
+        assert pending_migrations() == []
+
+    def test_require_current_schema_is_noop_when_current(self) -> None:
+        require_current_schema()  # must not raise
+
+
+class UnmigratedSelfDbTest(TransactionTestCase):
+    """The exact #869 reproduction: the MergeClear table is absent."""
+
+    def setUp(self) -> None:
+        _unapply_merge_migrations()
+        self.addCleanup(_reapply_merge_migrations)
+
+    def test_raw_orm_call_would_fail_with_operationalerror(self) -> None:
+        # Anti-vacuous anchor: without the guard the ORM raises the raw,
+        # opaque error this fix exists to replace.
+        with pytest.raises(OperationalError, match="no such table"):
+            MergeClear.objects.count()
+
+    def test_require_current_schema_raises_actionable_error(self) -> None:
+        with pytest.raises(SelfDbMigrationError) as exc:
+            require_current_schema()
+        message = str(exc.value)
+        assert "unapplied migration" in message
+        assert "ticket clear/merge" in message
+        assert "manage.py migrate" in message
+
+    def test_ticket_clear_command_fails_closed_with_remediation(self) -> None:
+        result = cast(
+            "dict[str, object]",
+            call_command(
+                "ticket",
+                "clear",
+                866,
+                "statusline-stale-wakeup",
+                "29f0a77a4fd03bd281b23e53cfc47ea9a928620b",
+                reviewer_identity="coldrev-866",
+                blast_class="logic",
+            ),
+        )
+        assert result["issued"] is False
+        assert "unapplied migration" in str(result["error"])
+        assert "manage.py migrate" in str(result["error"])
+
+    def test_ticket_merge_command_fails_closed_with_remediation(self) -> None:
+        result = cast(
+            "dict[str, object]",
+            call_command("ticket", "merge", 1),
+        )
+        assert result["merged"] is False
+        assert "unapplied migration" in str(result["error"])
+
+    def test_doctor_surface_fails_and_names_pending_migrations(self) -> None:
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            result = doctor_check_self_db_migrations()
+        assert result is False
+        out = buffer.getvalue()
+        assert "unapplied migration" in out
+        assert "0011_mergeclear_mergeaudit" in out
+
+    def test_doctor_check_command_aggregates_pending_migrations(self) -> None:
+        # The `t3 doctor check` aggregation wires the schema-guard surface
+        # into its pass/fail result, so the gap shows at session start.
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            ok = doctor_check()
+        assert ok is False
+        assert "unapplied migration" in buffer.getvalue()
+
+
+class DoctorCheckCurrentSchemaTest(TransactionTestCase):
+    def test_doctor_check_passes_when_schema_current(self) -> None:
+        assert doctor_check_self_db_migrations() is True
+
+    def test_doctor_check_warns_but_does_not_fail_when_db_unreachable(self) -> None:
+        # DB absent/offline at session start is a valid state — the doctor
+        # check must WARN, not crash or block the session with a FAIL.
+        buffer = io.StringIO()
+        with (
+            patch(
+                "teatree.core.schema_guard.pending_migrations",
+                side_effect=OperationalError("unable to open database file"),
+            ),
+            redirect_stdout(buffer),
+        ):
+            result = doctor_check_self_db_migrations()
+        assert result is True
+        assert "Could not inspect self-DB migrations" in buffer.getvalue()


### PR DESCRIPTION
Closes nothing — scoped bug fix. Relates-to #869.

## Problem

The sanctioned merge commands `t3 teatree ticket clear` / `t3 teatree ticket merge` call the ORM directly. When the teatree self-DB has unapplied migrations the `MergeClear`/`MergeAudit` tables do not exist, so the call surfaced a raw `django.db.utils.OperationalError: no such table: teatree_merge_clear` traceback.

Since #863 mechanically prohibits raw `gh pr merge` on teatree-managed tickets, that opaque failure blocked the **entire merge pipeline** with no actionable signal. This actually happened: #863 added migration 0011 and #864 added migration 0012, both merged to `main`, but the running dogfood self-DB was never migrated.

## Root cause

`Command.clear` / `Command.merge` had no schema pre-flight, and there was no non-destructive `migrate` surfaced on the t3 CLI (only the destructive `resetdb`, which drops all live ticket/session/lease state) nor a `t3 doctor` check for pending self-DB migrations — so the gap was invisible until it blocked a merge with a raw traceback.

## Fix

- **`teatree.core.schema_guard`** — a cheap `MigrationExecutor`-based pre-flight (`require_current_schema`) that `clear`/`merge` run before any ORM write, failing closed with a clear remediation message instead of a traceback.
- **`doctor_check_self_db_migrations`** — wired into `t3 doctor check` so the gap is caught proactively at session start. An absent/offline DB warns (does not crash or block the session).

## Tests (TDD, anti-vacuous, 100% new-code coverage)

`tests/teatree_core/test_schema_guard.py` reproduces the exact self-DB state (the `teatree_merge_clear` table dropped *and* its `django_migrations` ledger rows removed — precisely what `MigrationExecutor` inspects):

- Anchor test asserts the raw `OperationalError` is what the bare ORM raises (the failure this fix replaces).
- `ticket clear` / `ticket merge` now return `issued=False` / `merged=False` with the actionable remediation instead of a traceback.
- Reverting the guard (restoring `ticket.py` from `main`) turns the command tests RED with the exact production error — proving the tests are not vacuous.
- `schema_guard.py` 100% line+branch coverage; all touched lines in `doctor.py` / `ticket.py` covered.

ruff / ty / prek (incl. module-health, conventional-commit, BLUEPRINT) all green.

Do not merge — this is the durable substrate fix for review.