### PR TITLE
fix(core): resolve real GitHub repo for ticket merge + migrate self-DB on update (#871)

### DIFF
--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -47,6 +47,17 @@ never stashed, reset, merged, or rebased away. A skip is a normal outcome,
 not a failure; the process exits non-zero only when a fetch or fast-forward
 hard-fails.
 
+## Self-DB Migrations
+
+When teatree core advances, `t3 update` applies pending teatree self-DB
+migrations **non-destructively** (the `uv --directory <clone> run python
+manage.py migrate --no-input` path, no DB drop). This is the sanctioned
+first-class alternative to the destructive `resetdb` (which discards all
+local ticket/session/lease state) and the raw `manage.py migrate` the
+PreToolUse hook router discourages. A migration failure warns and never
+aborts the update — the git fast-forward already did its job. This keeps
+the sanctioned merge path working against a current schema after a pull.
+
 ## Core ↔ Overlay Version Coupling
 
 An overlay can pin (or assume) a particular teatree core version. After core

--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -10,7 +10,7 @@ For teatree core (``$T3_REPO``) and every registered overlay repo, this:
 2. Resolves the default branch from ``origin/HEAD``.
 3. Skips (never clobbers) a dirty, non-default-branch, or no-upstream checkout.
 4. Otherwise ``git pull --ff-only`` — fast-forward only, never merge/rebase.
-5. Reinstalls advanced editable installs, then runs the idempotent ``t3 setup``.
+5. Reinstalls advanced editable installs, applies pending self-DB migrations (non-destructive), then runs ``t3 setup``.
 6. Prints a per-repo summary; exits non-zero only on a hard failure (not a skip).
 
 This module is a top-level Typer group reached through the typer runner
@@ -240,6 +240,34 @@ def _git_toplevel(path: Path) -> Path | None:
     return Path(result.stdout.strip()).resolve()
 
 
+def _migrate_self_db(source: Path) -> None:
+    """Apply pending teatree self-DB migrations non-destructively.
+
+    A teatree git-pull can land new migrations; ``t3 update`` must apply
+    them or the sanctioned merge path breaks against the now-stale
+    self-DB. Runs the same ``uv --directory <clone> run python manage.py
+    migrate --no-input`` wrapper ``resetdb`` uses internally — WITHOUT
+    the destructive DB drop, so live ticket/session/lease state is
+    preserved. This is the first-class t3 alternative to the destructive
+    ``resetdb`` and the hook-discouraged raw ``manage.py migrate``. A
+    failure warns (the per-repo git outcome already did its job); it
+    never raises.
+    """
+    uv_bin = shutil.which("uv")
+    if uv_bin is None:
+        typer.echo("WARN  `uv` not on PATH — skipping self-DB migration.")
+        return
+    typer.echo("Applying teatree self-DB migrations (non-destructive) ...")
+    result = run_allowed_to_fail(
+        [uv_bin, "--directory", str(source), "run", "python", "manage.py", "migrate", "--no-input"],
+        expected_codes=None,
+    )
+    if result.returncode != 0:
+        typer.echo(f"WARN  self-DB migration failed: {result.stderr.strip() or result.stdout.strip()}")
+    else:
+        typer.echo("OK    self-DB migrations applied.")
+
+
 def _reinstall_and_resetup(updated: list[RepoUpdate]) -> None:
     """Reinstall editable installs whose source advanced, then re-run setup.
 
@@ -267,6 +295,7 @@ def _reinstall_and_resetup(updated: list[RepoUpdate]) -> None:
                 typer.echo(f"WARN  Reinstall failed: {result.stderr.strip()}")
             else:
                 typer.echo("OK    Reinstalled teatree.")
+            _migrate_self_db(source)
     else:
         typer.echo("WARN  `uv` not on PATH — skipping editable reinstall.")
 

--- a/src/teatree/core/merge_execution.py
+++ b/src/teatree/core/merge_execution.py
@@ -38,6 +38,8 @@ from django.apps import apps
 from django.db import transaction
 from django.utils import timezone
 
+from teatree.project import find_project_root
+from teatree.utils import git
 from teatree.utils.run import run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
@@ -83,6 +85,56 @@ def _run_gh(argv: list[str]) -> tuple[int, str, str]:
     gh = shutil.which("gh") or "gh"
     result = run_allowed_to_fail([gh, *argv], expected_codes=None)
     return result.returncode, result.stdout, result.stderr
+
+
+def _looks_like_owner_repo(slug: str) -> bool:
+    """True when *slug* is already a GitHub ``owner/repo`` identifier.
+
+    A workstream slug (``statusline-stale-wakeup``) has no ``/``; a repo
+    slug (``souliane/teatree``) has exactly one path separator and is not
+    a filesystem path.
+    """
+    return "/" in slug and not slug.startswith("/") and ":" not in slug and slug.count("/") >= 1
+
+
+def _project_repo_slug() -> str:
+    """The GitHub ``owner/repo`` for the running teatree clone, or ``""``.
+
+    Resolved from the project root's ``origin`` git remote — the same
+    canonical :func:`git.remote_slug` path ``_ensure_pr.py`` /
+    ``backends.github`` use to target ``gh`` at the right repo.
+    """
+    root = find_project_root()
+    if root is None:
+        return ""
+    return git.remote_slug(repo=str(root))
+
+
+def resolve_pr_repo_slug(clear: object) -> str:
+    """The GitHub ``owner/repo`` to target ``gh`` at for *clear*'s PR.
+
+    ``MergeClear.slug`` is a *workstream* slug, not a repo. If it already
+    looks like ``owner/repo`` it is used as-is (back-compat with rows /
+    tests that stored a repo there); otherwise the repo is resolved from
+    the running clone's git remote. Fails closed with an actionable
+    :class:`MergePreconditionError` when neither yields a repo — never the
+    opaque "could not resolve the live head" escalation that hid this gap.
+    """
+    slug = str(getattr(clear, "slug", "") or "")
+    pr_id = getattr(clear, "pr_id", "?")
+    if _looks_like_owner_repo(slug):
+        return slug
+    resolved = _project_repo_slug()
+    if resolved:
+        return resolved
+    msg = (
+        f"could not resolve the GitHub repo for {slug}#{pr_id}: the CLEAR slug "
+        f"{slug!r} is a workstream slug (not owner/repo) and the running teatree "
+        f"clone has no resolvable 'origin' remote. The sanctioned merge needs the "
+        f"real repo to bind the merge — re-issue the CLEAR from a checkout whose "
+        f"'origin' points at the GitHub repo, or pass an owner/repo slug."
+    )
+    raise MergePreconditionError(msg)
 
 
 def fetch_live_head_sha(slug: str, pr_id: int) -> str:
@@ -418,7 +470,7 @@ def merge_ticket_pr(
         msg = "merge_ticket_pr requires a MergeClear instance"
         raise MergePreconditionError(msg)
 
-    slug = clear.slug
+    slug = resolve_pr_repo_slug(clear)
     pr_id = clear.pr_id
     verified_sha = assert_merge_preconditions(
         clear=clear,

--- a/tests/teatree_core/test_merge_repo_resolution.py
+++ b/tests/teatree_core/test_merge_repo_resolution.py
@@ -1,0 +1,151 @@
+"""`ticket merge` must resolve the real GitHub owner/repo (#871).
+
+`MergeClear.slug` is a *workstream* slug (e.g. ``statusline-stale-wakeup``),
+not a GitHub ``owner/repo``. Before #871 every ``gh`` call in
+``merge_execution`` passed ``clear.slug`` as ``--repo``, so a production
+CLEAR issued via ``t3 teatree ticket clear 866 statusline-stale-wakeup …``
+made ``gh pr view 866 --repo statusline-stale-wakeup`` fail, ``fetch_live_head_sha``
+return ``""``, and §17.4.3 step 2 raise the opaque "could not resolve the
+live head SHA". The sanctioned path could issue a CLEAR but never complete
+a merge.
+
+These tests pin: a workstream-slug CLEAR resolves the real repo from the
+active overlay's primary clone git remote, so ``gh`` is invoked with the
+correct ``--repo``; and an unresolvable repo fails closed with an
+actionable message, not the opaque live-head escalation.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core import merge_execution
+from teatree.core.merge_execution import MergePreconditionError, merge_ticket_pr, resolve_pr_repo_slug
+from teatree.core.models import MergeClear, Ticket
+
+pytestmark = pytest.mark.django_db
+
+_SHA = "a" * 40
+_GREEN = '[{"status": "COMPLETED", "conclusion": "SUCCESS"}]'
+
+
+def _workstream_clear(ticket: Ticket) -> MergeClear:
+    """A CLEAR exactly as `t3 teatree ticket clear` issues it in production."""
+    return MergeClear.objects.create(
+        ticket=ticket,
+        pr_id=866,
+        slug="statusline-stale-wakeup",
+        reviewed_sha=_SHA,
+        reviewer_identity="cold-reviewer",
+        gh_verify_result=MergeClear.VerifyResult.GREEN,
+        blast_class=MergeClear.BlastClass.LOGIC,
+    )
+
+
+class TestResolvePrRepoSlug(TestCase):
+    def test_owner_repo_shaped_slug_passes_through(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = MergeClear.objects.create(
+            ticket=ticket,
+            pr_id=1,
+            slug="souliane/teatree",
+            reviewed_sha=_SHA,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.DOCS,
+        )
+        assert resolve_pr_repo_slug(clear) == "souliane/teatree"
+
+    def test_workstream_slug_resolves_repo_from_clone_remote(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = _workstream_clear(ticket)
+
+        with patch(
+            "teatree.core.merge_execution._project_repo_slug",
+            return_value="souliane/teatree",
+        ):
+            assert resolve_pr_repo_slug(clear) == "souliane/teatree"
+
+    def test_unresolvable_repo_fails_closed_with_actionable_message(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = _workstream_clear(ticket)
+
+        with (
+            patch("teatree.core.merge_execution._project_repo_slug", return_value=""),
+            pytest.raises(MergePreconditionError, match="could not resolve the GitHub repo"),
+        ):
+            resolve_pr_repo_slug(clear)
+
+
+class TestMergeUsesResolvedRepo(TestCase):
+    def test_workstream_slug_merge_calls_gh_with_real_repo(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = _workstream_clear(ticket)
+        calls: list[list[str]] = []
+
+        def _gh(argv: list[str]) -> tuple[int, str, str]:
+            calls.append(argv)
+            joined = " ".join(argv)
+            if "headRefOid" in joined:
+                return (0, _SHA, "")
+            if "isDraft" in joined:
+                return (0, "false", "")
+            if "statusCheckRollup" in joined:
+                return (0, _GREEN, "")
+            if "pulls" in joined and "merge" in joined:
+                return (0, '{"sha": "merged0deadbeef"}', "")
+            return (0, "", "")
+
+        with (
+            patch("teatree.core.merge_execution._run_gh", side_effect=_gh),
+            patch(
+                "teatree.core.merge_execution._project_repo_slug",
+                return_value="souliane/teatree",
+            ),
+        ):
+            outcome = merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
+
+        assert outcome.merged_sha
+        # Every gh invocation must target the real repo, never the workstream slug.
+        for argv in calls:
+            joined = " ".join(argv)
+            assert "statusline-stale-wakeup" not in joined
+        repo_args = [argv[argv.index("--repo") + 1] for argv in calls if "--repo" in argv]
+        assert repo_args
+        assert all(r == "souliane/teatree" for r in repo_args)
+
+    def test_workstream_slug_unresolvable_repo_is_actionable_not_opaque(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = _workstream_clear(ticket)
+
+        with (
+            patch("teatree.core.merge_execution._project_repo_slug", return_value=""),
+            pytest.raises(MergePreconditionError) as exc,
+        ):
+            merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
+
+        message = str(exc.value)
+        assert "could not resolve the GitHub repo" in message
+        assert "could not resolve the live head" not in message
+
+
+class TestProjectRepoSlugHelper(TestCase):
+    def test_project_repo_slug_uses_project_root_git_remote(self) -> None:
+        with (
+            patch(
+                "teatree.core.merge_execution.find_project_root",
+                return_value=Path("/clone/teatree"),
+            ),
+            patch(
+                "teatree.core.merge_execution.git.remote_slug",
+                return_value="souliane/teatree",
+            ) as remote_slug,
+        ):
+            assert merge_execution._project_repo_slug() == "souliane/teatree"
+        remote_slug.assert_called_once_with(repo="/clone/teatree")
+
+    def test_project_repo_slug_empty_when_no_project_root(self) -> None:
+        with patch("teatree.core.merge_execution.find_project_root", return_value=None):
+            assert merge_execution._project_repo_slug() == ""

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -415,6 +415,85 @@ class TestReinstallAndResetup:
         assert "`t3 setup` reported a problem" in out
 
 
+class TestSelfDbMigrationOnUpdate:
+    """`t3 update` applies pending teatree self-DB migrations (#871).
+
+    Before #871 updating teatree git-pulled new code (incl. new
+    migrations) but never applied them — the only paths were the
+    destructive ``resetdb`` or the hook-discouraged raw ``manage.py
+    migrate``. The sanctioned update must migrate the self-DB
+    non-destructively via the ``uv --directory <clone> run python
+    manage.py migrate --no-input`` wrapper.
+    """
+
+    def test_migrate_self_db_runs_sanctioned_non_destructive_migrate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        source = tmp_path / "clone"
+        source.mkdir()
+        calls: list[list[str]] = []
+
+        def _run(cmd: list[str], **_kw: object) -> _Proc:
+            calls.append(cmd)
+            return _Proc(0, "No migrations to apply.", "")
+
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
+
+        update_mod._migrate_self_db(source)
+
+        assert len(calls) == 1
+        cmd = calls[0]
+        assert cmd[:2] == ["/usr/bin/uv", "--directory"]
+        assert str(source) in cmd
+        assert cmd[-3:] == ["manage.py", "migrate", "--no-input"]
+
+    def test_migrate_self_db_warns_but_does_not_raise_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        source = tmp_path / "clone"
+        source.mkdir()
+
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(1, "", "locked"))
+
+        update_mod._migrate_self_db(source)  # must not raise
+
+        assert "self-DB migration" in capsys.readouterr().out
+
+    def test_migrate_self_db_skips_when_uv_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        source = tmp_path / "clone"
+        source.mkdir()
+        monkeypatch.setattr(update_mod.shutil, "which", lambda _name: None)
+
+        update_mod._migrate_self_db(source)  # must not raise
+
+        assert "skipping self-DB migration" in capsys.readouterr().out
+
+    def test_reinstall_flow_applies_self_db_migrations_when_core_advanced(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        source = tmp_path / "editable-src"
+        source.mkdir()
+        calls: list[list[str]] = []
+
+        def _run(cmd: list[str], **_kw: object) -> _Proc:
+            calls.append(cmd)
+            return _Proc(0, "ok", "")
+
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: source)
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
+
+        _reinstall_and_resetup([RepoUpdate("teatree", UpdateStatus.UPDATED, old_sha="a", new_sha="b")])
+
+        migrate_calls = [c for c in calls if "migrate" in c and "--no-input" in c]
+        assert len(migrate_calls) == 1
+        assert str(source) in migrate_calls[0]
+
+
 class TestRunCallback:
     def test_callback_returns_early_for_subcommand(self) -> None:
         ctx = typer.Context(click.Command("update"))


### PR DESCRIPTION
Relates-to #871. Does not Close any umbrella.

Two root causes that prevented the sanctioned merge path (`ticket clear` → `ticket merge`) from completing a merge end-to-end, keeping the prohibited raw `gh pr merge` exception alive. #870 (cold review) is untouched — this is a separate coherent PR.

## Root cause 1 — `ticket merge` live-head-SHA resolution gap

`merge_execution.fetch_live_head_sha` / `fetch_pr_is_draft` / `fetch_required_checks_status` / `execute_bound_merge` ran `gh ... --repo <slug>` with `slug = clear.slug`. But `MergeClear.slug` is a **workstream** slug (e.g. `statusline-stale-wakeup`), not a GitHub `owner/repo`. A production CLEAR issued via `t3 teatree ticket clear 866 statusline-stale-wakeup …` therefore made `gh pr view 866 --repo statusline-stale-wakeup` fail, `fetch_live_head_sha` return `""`, and §17.4.3 step 2 raise the opaque "could not resolve the live head SHA". The path could issue a CLEAR but never *complete* a merge. (Existing tests passed only because they hardcoded a repo-shaped `slug="souliane/teatree"`.)

Fix: `resolve_pr_repo_slug(clear)` — an `owner/repo`-shaped slug is used as-is (back-compat with existing rows/tests); otherwise the repo is resolved from the running clone’s `origin` git remote via the canonical `git.remote_slug` path (same as `_ensure_pr.py` / `backends.github`). Unresolvable → fail closed with an actionable `MergePreconditionError`, never the opaque live-head escalation. `merge_ticket_pr` now binds every `gh` call to the resolved repo.

End-to-end verified: from the teatree clone, `_project_repo_slug()` resolves `souliane/teatree`, so a real workstream-slug CLEAR now drives `gh pr view <pr> --repo souliane/teatree` — the sanctioned `t3 teatree ticket merge <clear_id>` can complete a real merge (tested via stubbed `gh`, no live PR merged).

## Root cause 2 — no first-class non-destructive self-DB migrate on `t3 update`

`t3 update` git-pulled teatree (incl. new migrations) but never applied them; the only options were the destructive `resetdb` (drops all ticket/session/lease state) or raw `manage.py migrate` (PreToolUse-hook-discouraged). `_migrate_self_db` runs the non-destructive `uv --directory <clone> run python manage.py migrate --no-input` wrapper after a core reinstall — a first-class t3 path. Failure warns, never aborts the update.

## Tests (TDD, anti-vacuous, 100% new-code coverage)

- `tests/teatree_core/test_merge_repo_resolution.py` — workstream-slug CLEAR resolves the real repo; every `gh` call targets it, never the workstream slug; unresolvable → actionable not opaque. Reverting `slug = resolve_pr_repo_slug(clear)` → `clear.slug` turns it RED with `--repo statusline-stale-wakeup` (the exact production bug).
- `tests/test_cli_update.py::TestSelfDbMigrationOnUpdate` — `_migrate_self_db` runs the sanctioned non-destructive command; the reinstall flow applies it when core advanced; failure warns not raises. Removing the wiring line turns it RED.
- All 28 existing `test_merge_execution` tests still green (back-compat). ruff / ty / prek (incl. module-health, conventional-commit, BLUEPRINT, skill-prose-ban) all green. Docs aligned (`update.py` docstring, `skills/update`).

Do not merge — substrate fix for review. Together with #870 these make the sanctioned merge path the real default and retire the gh-manual exception.