### PR TITLE
fix(core): enforce canonical-phase invariant at Session.visit_phase boundary (#782)

### DIFF
--- a/src/teatree/core/models/session.py
+++ b/src/teatree/core/models/session.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from teatree.core.managers import SessionManager
 from teatree.core.models.errors import QualityGateError
 from teatree.core.models.ticket import Ticket
+from teatree.core.phases import CANONICAL_PHASES, normalize_phase
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,19 @@ class Session(models.Model):
         "requesting_review": ["shipping"],
     }
 
+    # #782: ``_REQUIRED_PHASES`` is a second hand-maintained canonical-phase
+    # vocabulary, divorced from ``phases.py``. Validate every key and required
+    # phase against the canonical set at import so a typo or a future skill
+    # spelling that drifts from ``phases.CANONICAL_PHASES`` fails fast here
+    # instead of silently making the gate compare against a stale token.
+    _GATE_PHASES: ClassVar[frozenset[str]] = frozenset(_REQUIRED_PHASES) | {
+        phase for required in _REQUIRED_PHASES.values() for phase in required
+    }
+    if not _GATE_PHASES <= CANONICAL_PHASES:
+        _drift = ", ".join(sorted(_GATE_PHASES - CANONICAL_PHASES))
+        _msg = f"_REQUIRED_PHASES drifted from phases.CANONICAL_PHASES: {_drift}"
+        raise ImportError(_msg)
+
     def __str__(self) -> str:
         return str(self.agent_id or f"session-{self.pk}")
 
@@ -67,16 +81,30 @@ class Session(models.Model):
         writer clobbered the other's phase (the #748 / `/t3:review`
         Safety-6 unlocked read-modify-write class). The lock serialises
         the two writers so both phases survive.
+
+        ``phase`` is normalized to its canonical token **here, at the
+        write boundary** (#782). The canonical-phase invariant
+        ("``visited_phases`` holds canonical tokens, the spelling
+        ``_REQUIRED_PHASES`` is keyed by") is owned by this method, not
+        by caller convention. Before #782 it held only because
+        ``lifecycle.py``/``task.py`` happened to ``normalize_phase``
+        before calling; any other caller passing a raw ``review``
+        silently corrupted the gate (``_check_phases`` then sees
+        ``"reviewing" not in ["review"]`` and falsely blocks shipping —
+        the #779 symptom, the structural root of the #759/#767/#770
+        whack-a-mole). Enforcing it once at the boundary makes the
+        invariant structural; callers no longer need to remember.
         """
+        canonical = normalize_phase(phase)
         with transaction.atomic():
             locked = type(self).objects.select_for_update().get(pk=self.pk)
             visited = list(locked.visited_phases or [])
             visits = dict(locked.phase_visits or {})
 
-            if phase not in visited:
-                visited.append(phase)
-            if agent_id and phase not in visits:
-                visits[phase] = {
+            if canonical not in visited:
+                visited.append(canonical)
+            if agent_id and canonical not in visits:
+                visits[canonical] = {
                     "agent_id": agent_id,
                     "timestamp": timezone.now().isoformat(),
                 }
@@ -114,7 +142,19 @@ class Session(models.Model):
         self._check_phases(target_phase, visited)
 
     def _check_phases(self, target_phase: str, visited: list[str]) -> None:
-        missing = [phase for phase in self._REQUIRED_PHASES.get(target_phase, []) if phase not in visited]
+        """Gate ``target_phase`` against the required canonical phases.
+
+        Both sides are normalized at this read boundary (#782):
+        ``visited`` may carry legacy raw spellings (rows written before
+        #782, or by a path that bypassed :meth:`visit_phase` such as
+        ``merge_execution``); ``_REQUIRED_PHASES`` is keyed canonically.
+        Normalizing membership here means a legacy ``review`` row still
+        satisfies the canonical ``reviewing`` requirement instead of the
+        gate falsely blocking shipping forever.
+        """
+        canonical_visited = {normalize_phase(phase) for phase in visited}
+        canonical_target = normalize_phase(target_phase)
+        missing = [phase for phase in self._REQUIRED_PHASES.get(canonical_target, []) if phase not in canonical_visited]
         if missing:
             joined = ", ".join(missing)
             msg = f"{target_phase} requires: {joined}"

--- a/src/teatree/core/phases.py
+++ b/src/teatree/core/phases.py
@@ -27,6 +27,11 @@ _ALIAS_TO_CANONICAL: dict[str, str] = {
     alias: canonical for canonical, aliases in _PHASE_ALIASES.items() for alias in aliases
 }
 
+#: The canonical phase vocabulary — the single source of truth a second
+#: hand-maintained set (``Session._REQUIRED_PHASES``) must be validated
+#: against so the two cannot drift silently (#782).
+CANONICAL_PHASES: frozenset[str] = frozenset(_PHASE_ALIASES)
+
 # Canonical phase -> the ``Ticket`` FSM transition method that records it.
 _CANONICAL_TO_TRANSITION: dict[str, str] = {
     "scoping": "scope",

--- a/tests/teatree_core/test_models.py
+++ b/tests/teatree_core/test_models.py
@@ -973,6 +973,62 @@ class TestSession(TestCase):
 
         session.check_gate("shipping", force=True)  # force bypasses all checks
 
+    def test_visit_phase_normalizes_raw_spelling_at_write_boundary(self) -> None:
+        """#782: ``visit_phase`` owns the canonical-phase invariant.
+
+        A caller that passes a raw short spelling (``review``/``test`` —
+        the verbs skills emit) instead of the canonical gerund must not
+        corrupt the gate. Before #782 the invariant was upheld only by
+        ``lifecycle.py``/``task.py`` normalizing *before* calling; any
+        other caller (a new loop path, an overlay, a fixture) passing a
+        raw ``review`` stored ``"review"`` verbatim, and
+        ``_check_phases`` — keyed by the canonical ``reviewing`` in
+        ``_REQUIRED_PHASES`` — then falsely blocked shipping with a
+        stale ``requires:`` set (the #779 symptom). Enforcing
+        normalization at the write boundary makes the invariant
+        structural, not a caller convention.
+        """
+        session = Session.objects.create(ticket=Ticket.objects.create())
+
+        # Raw short spellings, exactly as a non-normalizing caller would.
+        session.visit_phase("test", agent_id="agent-1")
+        session.visit_phase("review", agent_id="agent-2")
+        session.refresh_from_db()
+
+        # Stored canonical, regardless of the spelling the caller used.
+        assert session.visited_phases == ["testing", "reviewing"]
+        # The shipping gate must pass — not falsely block on a stale set.
+        session.check_gate("shipping")
+
+    def test_check_phases_normalizes_legacy_raw_rows_at_read_boundary(self) -> None:
+        """#782: the read boundary tolerates pre-existing raw-spelling rows.
+
+        Rows written before #782 (or by ``merge_execution`` / any path
+        that bypassed ``visit_phase``) may already hold a raw ``review``.
+        ``_check_phases`` must normalize membership so a legacy row still
+        satisfies the canonical ``reviewing`` requirement instead of
+        falsely blocking shipping forever.
+        """
+        session = Session.objects.create(ticket=Ticket.objects.create())
+
+        # Simulate a legacy row written verbatim, bypassing visit_phase.
+        Session.objects.filter(pk=session.pk).update(visited_phases=["test", "review"])
+        session.refresh_from_db()
+
+        session.check_gate("shipping")  # must not raise on legacy spellings
+
+    def test_required_phases_vocabulary_cannot_drift_from_canonical(self) -> None:
+        """#782: the second hand-maintained phase set stays in lockstep.
+
+        ``Session._REQUIRED_PHASES`` is a vocabulary divorced from
+        ``phases.py``. Every gate key and required phase must be a
+        canonical token; the import-time guard rejects any drift so a
+        typo cannot silently make the gate compare against a stale set.
+        """
+        from teatree.core.phases import CANONICAL_PHASES  # noqa: PLC0415
+
+        assert Session._GATE_PHASES <= CANONICAL_PHASES
+
     def test_repo_tracking(self) -> None:
         session = Session.objects.create(ticket=Ticket.objects.create())
 


### PR DESCRIPTION
## Problem

The canonical-phase invariant — *"`Session.visited_phases` holds canonical tokens, the spelling `_REQUIRED_PHASES` is keyed by"* — was upheld only by **caller discipline**, not at the boundary that owns it.

`lifecycle.py` and `task.py` call `normalize_phase` *before* `Session.visit_phase`, but `visit_phase` itself stored the phase verbatim. Any other caller (a new loop path, an overlay, a fixture) passing a raw short spelling such as `review`/`test` — the verbs skills emit — silently corrupted the gate: `_check_phases` then evaluates `"reviewing" not in ["review"]` and **falsely blocks shipping** with a stale `requires:` set (the #779 symptom).

This is the structural root of the #759/#767/#770/#779 cluster — three consecutive fixes each patched a *different call site*, classic whack-a-mole.

## Fix — move enforcement to the boundary

1. **Write boundary**: `visit_phase` runs `normalize_phase(phase)` before appending to `visited_phases` and keying `phase_visits`. Callers no longer need to remember.
2. **Read boundary**: `_check_phases` normalizes both the visited set and the target, so legacy rows stored with any spelling (or written by a path that bypassed `visit_phase`, e.g. `merge_execution`) still match.
3. **Anti-drift**: expose `phases.CANONICAL_PHASES` and validate `Session._REQUIRED_PHASES` against it at import time, so the second hand-maintained phase vocabulary cannot silently diverge from `phases.py`.

## Tests (per the every-fix-ships-a-regression-test mandate)

Three boundary regression tests in `TestSession`:

- `test_visit_phase_normalizes_raw_spelling_at_write_boundary` — `visit_phase("test"/"review")` stores canonical tokens and the shipping gate passes.
- `test_check_phases_normalizes_legacy_raw_rows_at_read_boundary` — a pre-existing raw-spelling row still satisfies the gate.
- `test_required_phases_vocabulary_cannot_drift_from_canonical` — the two vocabularies stay in lockstep.

Anti-vacuous verified: reverting the production change to `origin/main` turns `test_visit_phase_normalizes_raw_spelling_at_write_boundary` RED with `AssertionError: assert ['test', 'review'] == ['testing', 'reviewing']`; restoring turns it GREEN.

Scope is confined to `session.py`, `phases.py`, and the test file — no change to the BLUEPRINT, hook router, merge path, or ship path.

Closes #782