### PR TITLE
test(robustness): declared->produced env contract test (#876, #390 stream C)

### DIFF
--- a/src/teatree/utils/compose_contract.py
+++ b/src/teatree/utils/compose_contract.py
@@ -14,6 +14,7 @@ or ``t3 overlay contract-check``).
 """
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -81,3 +82,29 @@ def check_contract(
         for var, refs in sorted(by_var.items())
         if var not in produced and var not in allowed_set
     ]
+
+
+def unproduced_declared_keys(declared: set[str], produced_renders: Iterable[Iterable[str]]) -> set[str]:
+    """Return declared keys that no generator render actually emits.
+
+    ``check_contract`` guards the *compose → declared* direction: a compose
+    file may not reference a key nobody declared. This guards the other,
+    silent direction — the *declared → produced* one.
+
+    A key declared in ``_declared_core_keys()`` claims "core always (or
+    conditionally) emits me". If the generator stops emitting it (a deleted
+    line in ``_core_env_pairs`` / ``render_env_cache``) but the declaration
+    stays, ``check_contract`` stays green: the compose file still sees a
+    declared producer, yet the value is empty at runtime — exactly the
+    weeks-long ``rd:`` / ``POSTGRES_HOST`` drift #390 describes.
+
+    *produced_renders* is the set of key sets the generator emits across the
+    relevant conditional branches (e.g. with and without shared postgres). A
+    declared key is satisfied if *any* render emits it. Anything declared but
+    absent from every render is returned — that set must be empty, or a
+    producer was lost.
+    """
+    union: set[str] = set()
+    for render in produced_renders:
+        union |= set(render)
+    return declared - union

--- a/tests/test_env_contract.py
+++ b/tests/test_env_contract.py
@@ -9,12 +9,19 @@ Keeps silent-failure-by-missing-env out of the repo: if an author references
 ``${FOO}`` with no producer, CI turns red here.
 """
 
+import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+from django.test import TestCase
 
-from teatree.core.worktree_env import _declared_core_keys
-from teatree.utils.compose_contract import ComposeVarRef, check_contract, extract_refs
+import teatree.core.overlay_loader as overlay_loader_mod
+from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay import OverlayBase, ProvisionStep
+from teatree.core.worktree_env import _declared_core_keys, render_env_cache
+from teatree.types import DbImportStrategy
+from teatree.utils.compose_contract import ComposeVarRef, check_contract, extract_refs, unproduced_declared_keys
 
 REPO_ROOT = Path(__file__).parent.parent
 COMPOSE_FILES = [
@@ -109,3 +116,90 @@ class TestCoreComposeFiles:
         if violations:
             formatted = "\n  ".join(v.format() for v in violations)
             pytest.fail(f"Compose contract violations:\n  {formatted}")
+
+
+class TestUnproducedDeclaredKeys:
+    """Unit-level guard for the declared → produced direction."""
+
+    def test_returns_empty_when_every_declared_key_is_produced(self) -> None:
+        assert unproduced_declared_keys({"A", "B"}, [{"A", "B"}]) == set()
+
+    def test_satisfied_when_any_render_produces_the_key(self) -> None:
+        # B only appears in the second render (e.g. the shared-postgres branch).
+        assert unproduced_declared_keys({"A", "B"}, [{"A"}, {"A", "B"}]) == set()
+
+    def test_reports_declared_key_no_render_produces(self) -> None:
+        assert unproduced_declared_keys({"A", "B", "C"}, [{"A"}, {"A", "B"}]) == {"C"}
+
+    def test_empty_renders_means_everything_unproduced(self) -> None:
+        assert unproduced_declared_keys({"A"}, []) == {"A"}
+
+
+class _ProducerOverlay(OverlayBase):
+    """Minimal overlay: no extra env keys, dedicated postgres."""
+
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        return []
+
+
+class _SharedPostgresProducerOverlay(_ProducerOverlay):
+    """Same, but requests the shared-postgres branch (produces POSTGRES_HOST)."""
+
+    def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy:
+        return DbImportStrategy(shared_postgres=True)
+
+
+_DEDICATED_PG = {"test": _ProducerOverlay()}
+_SHARED_PG = {"test": _SharedPostgresProducerOverlay()}
+
+
+class TestProducerContract(TestCase):
+    """Every key core *declares* must actually be *produced* by the generator.
+
+    ``check_contract`` only guards compose → declared. This guards declared →
+    produced: if a producer line is deleted from ``_core_env_pairs`` /
+    ``render_env_cache`` while the declaration stays, this turns red instead
+    of the failure going silent (the #390 ``POSTGRES_HOST`` / ``rd:`` class).
+    """
+
+    def _render_keys(self, overlays: dict[str, OverlayBase], *, slug: str, redis_db_index: int) -> set[str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            ticket_dir = Path(tmp) / "ticket"
+            ticket_dir.mkdir()
+            wt_path = ticket_dir / "backend"
+            wt_path.mkdir()
+            ticket = Ticket.objects.create(
+                overlay="test",
+                issue_url=f"https://example.com/issues/{slug}",
+                redis_db_index=redis_db_index,
+            )
+            wt = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature",
+                db_name="wt_1",
+                extra={"worktree_path": str(wt_path)},
+            )
+            with patch.object(overlay_loader_mod, "_discover_overlays", return_value=overlays):
+                spec = render_env_cache(wt)
+            assert spec is not None
+            return set(spec.keys)
+
+    def test_every_declared_core_key_is_produced_by_the_generator(self) -> None:
+        # POSTGRES_HOST is only emitted on the shared-postgres branch; the
+        # union across both branches must still cover every declared key.
+        renders = [
+            self._render_keys(_DEDICATED_PG, slug="dedicated", redis_db_index=3),
+            self._render_keys(_SHARED_PG, slug="shared", redis_db_index=4),
+        ]
+        missing = unproduced_declared_keys(_declared_core_keys(), renders)
+        if missing:
+            pytest.fail(
+                "Declared core keys with no generator producer "
+                f"(declared in _declared_core_keys but never emitted by "
+                f"render_env_cache): {sorted(missing)}"
+            )


### PR DESCRIPTION
## Summary

Stream C of #390 shipped the compose<->declared contract (#401): a compose file may not reference an undeclared `${VAR}`. That guards only one direction.

This adds the missing inverse guard. A key declared in `_declared_core_keys()` claims the generator emits it. If a producer line is later deleted from `_core_env_pairs` / `render_env_cache` while the declaration stays, the compose->declared test stays green, but the value is empty at runtime - the exact weeks-long `rd:` / `POSTGRES_HOST` drift #390 describes.

## Changes

- `compose_contract.unproduced_declared_keys(declared, produced_renders)` - returns declared keys no generator render emits (union across conditional branches; a key is satisfied if any render emits it).
- `TestProducerContract` - renders the real `render_env_cache` across the dedicated- and shared-postgres branches and fails if any declared core key is never produced.
- Unit coverage for the helper.

## Anti-vacuous evidence

Temporarily deleting the `WT_DB_NAME` producer line from `_core_env_pairs` (declaration left intact) turned the new test red:

```
Failed: Declared core keys with no generator producer (declared in
_declared_core_keys but never emitted by render_env_cache): ['WT_DB_NAME']
```

The pre-existing compose->declared test stayed green for the same edit - confirming this closes a real gap. Reverted before commit.

## Verification

- 100% coverage on `compose_contract.py` (32 stmts, 6 branches).
- `uv run ruff check` + `format`: clean. `uv run ty check`: passed.
- Full suite: 4128 passed, 12 skipped.

Scope is compose generation + test only; no BLUEPRINT / hook_router / merge / ship changes.

Closes #876
Relates-to #390