### PR TITLE
feat(token): per-phase headless model tiering (#880)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -502,6 +502,15 @@ Runs `claude -p <prompt> --append-system-prompt <context> --output-format json`.
 8. Create TaskAttempt with result, exit_code, agent_session_id
 9. Call `task.complete()` which triggers automatic ticket advancement
 
+**Model tiering (#880, #562 §3):** `resolve_phase_model(phase)` (in `agents/model_tiering.py`) maps the task's phase to a Claude model tier. Mechanical phases are downgraded by default (`reviewing`/`testing`/`shipping` → `sonnet`, `retrospecting` → `haiku`); reasoning phases (`coding`, `debugging`) and unmapped phases return `None`, so no `--model` flag is added and the user's default model applies. Overridable per phase via `~/.teatree.toml`:
+
+```toml
+[agent]
+phase_models.reviewing = "opus"   # pin a phase back to the reasoning tier
+phase_models.coding = "sonnet"    # opt a reasoning phase into a cheap tier
+phase_models.testing = ""         # opt out — inherit the user's default
+```
+
 **Auth:** Uses the `claude` binary (Claude Code session auth — no API key required).
 
 ### 5.3 Prompt Building (prompt.py)
@@ -1993,6 +2002,7 @@ graph TD
     teatree.agents --> teatree.core
     teatree.agents --> teatree.skill_loading
     teatree.agents --> teatree.utils
+    teatree.agents --> teatree.config
     teatree.backends --> teatree.types
     teatree.backends --> teatree.utils
     teatree.backends --> teatree.core

--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from django.utils import timezone
 
+from teatree.agents.model_tiering import resolve_phase_model
 from teatree.agents.result_schema import RESULT_JSON_SCHEMA
 from teatree.agents.skill_bundle import resolve_skill_bundle
 from teatree.core.models import Task, TaskAttempt
@@ -72,7 +73,14 @@ def run_headless(
     lifecycle_skill = SkillLoadingPolicy.lifecycle_for_phase(phase)
     system_context = build_system_context(task, skills=skills, lifecycle_skill=lifecycle_skill)
     resume_session_id = _get_resume_session_id(task)
-    command = _build_headless_command(binary, prompt, system_context, resume_session_id=resume_session_id)
+    model = resolve_phase_model(phase)
+    command = _build_headless_command(
+        binary,
+        prompt,
+        system_context,
+        resume_session_id=resume_session_id,
+        model=model,
+    )
 
     cwd = _resolve_task_cwd(task)
     stdout, stderr, returncode = _run_with_heartbeat(task, command, cwd=cwd)
@@ -146,10 +154,19 @@ def _record_success(task: Task, envelope: dict[str, str]) -> TaskAttempt:
     return attempt
 
 
-def _build_headless_command(binary: str, prompt: str, system_context: str, *, resume_session_id: str = "") -> list[str]:
+def _build_headless_command(
+    binary: str,
+    prompt: str,
+    system_context: str,
+    *,
+    resume_session_id: str = "",
+    model: str | None = None,
+) -> list[str]:
     cmd = [binary]
     if resume_session_id:
         cmd.extend(["--resume", resume_session_id])
+    if model:
+        cmd.extend(["--model", model])
     cmd.extend(["-p", prompt, "--append-system-prompt", system_context, "--output-format", "json"])
     return cmd
 

--- a/src/teatree/agents/model_tiering.py
+++ b/src/teatree/agents/model_tiering.py
@@ -1,0 +1,80 @@
+"""Per-phase headless model tiering (#880, #562 §3).
+
+Headless tasks otherwise inherit the user's default Claude model (typically
+Opus). Per the Effective-Tokens formula in #562, Opus costs ~5x Sonnet and
+~20x Haiku per token. Mechanical phases (review, test, ship, retro) do not
+need full reasoning, so this module resolves a cheaper model tier for them
+while leaving judgment phases (coding, debugging) on the user's default.
+
+The mapping is config-driven via ``~/.teatree.toml``::
+
+    [agent]
+    phase_models.reviewing = "opus"   # pin a phase back to the reasoning tier
+    phase_models.coding = "sonnet"    # opt a reasoning phase into a cheap tier
+    phase_models.testing = ""         # opt out — inherit the user's default
+
+The shipped default (:data:`DEFAULT_PHASE_MODELS`) is conservative: it only
+downgrades phases that are mechanical by nature. Phases absent from the map
+(and reasoning phases) return ``None`` so no ``--model`` flag is added and
+the user's configured default applies unchanged.
+"""
+
+import tomllib
+from pathlib import Path
+
+from teatree.config import CONFIG_PATH
+
+# Conservative default phase -> model-tier mapping. Only phases that are
+# mechanical by nature are downgraded; coding and debugging are deliberately
+# absent so they keep the user's full-reasoning default model.
+DEFAULT_PHASE_MODELS: dict[str, str] = {
+    "reviewing": "sonnet",
+    "testing": "sonnet",
+    "shipping": "sonnet",
+    "retrospecting": "haiku",
+}
+
+# Values that explicitly opt a phase out of tiering — the resolver returns
+# ``None`` for these so the user's default model is inherited (no flag).
+_INHERIT_SENTINELS = frozenset({"", "default", "inherit"})
+
+
+def resolve_phase_model(phase: str, *, config_path: Path | None = None) -> str | None:
+    """Resolve the Claude model tier for *phase*.
+
+    Resolution order, first match wins:
+    a config override in ``[agent] phase_models.<phase>`` of
+    ``~/.teatree.toml`` (a sentinel value — empty / ``"default"`` /
+    ``"inherit"`` — disables tiering for that phase); else the
+    conservative :data:`DEFAULT_PHASE_MODELS` shipped default; else
+    ``None``, meaning the phase is unmapped (or a reasoning phase) so the
+    caller must not pass ``--model`` and the user's default model applies.
+    """
+    overrides = _load_phase_model_overrides(config_path)
+    if phase in overrides:
+        value = overrides[phase].strip()
+        if value.lower() in _INHERIT_SENTINELS:
+            return None
+        return value
+    return DEFAULT_PHASE_MODELS.get(phase)
+
+
+def _load_phase_model_overrides(config_path: Path | None) -> dict[str, str]:
+    """Read the ``[agent] phase_models`` table from the toml config.
+
+    Returns an empty mapping when the file or section is absent or malformed
+    so the shipped defaults always apply.
+    """
+    path = config_path if config_path is not None else CONFIG_PATH
+    if not path.is_file():
+        return {}
+    try:
+        with path.open("rb") as fh:
+            raw = tomllib.load(fh)
+    except (tomllib.TOMLDecodeError, OSError):
+        return {}
+    agent_section = raw.get("agent", {})
+    phase_models = agent_section.get("phase_models", {})
+    if not isinstance(phase_models, dict):
+        return {}
+    return {str(phase): str(model) for phase, model in phase_models.items()}

--- a/tach.toml
+++ b/tach.toml
@@ -74,7 +74,8 @@ depends_on = [
   "teatree.types",
   "teatree.core",
   "teatree.skill_loading",
-  "teatree.utils"
+  "teatree.utils",
+  "teatree.config"
 ]
 
 [[modules]]

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -432,3 +432,65 @@ class TestRunWithHeartbeat(TestCase):
         assert returncode == 0
         assert stdout == "ok"
         assert mock_logger.warning.call_count >= 1
+
+
+# --- _build_headless_command model tiering (#880) ---
+
+
+def test_build_command_omits_model_flag_by_default() -> None:
+    """Without a resolved model, no --model flag is appended (inherit default)."""
+    cmd = headless_mod._build_headless_command("/bin/claude", "p", "ctx")
+    assert "--model" not in cmd
+
+
+def test_build_command_appends_model_flag_when_set() -> None:
+    """A resolved model tier is passed to the Claude CLI via --model."""
+    cmd = headless_mod._build_headless_command("/bin/claude", "p", "ctx", model="sonnet")
+    assert "--model" in cmd
+    assert cmd[cmd.index("--model") + 1] == "sonnet"
+
+
+def test_build_command_empty_model_omits_flag() -> None:
+    """An empty model string means inherit the user's default — no flag."""
+    cmd = headless_mod._build_headless_command("/bin/claude", "p", "ctx", model="")
+    assert "--model" not in cmd
+
+
+class TestRunHeadlessModelTiering(TestCase):
+    """Mechanical phases invoke claude with a cheap tier; reasoning phases inherit the default."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.ticket = Ticket.objects.create()
+
+    def _run_capturing_command(self, phase: str) -> list[str]:
+        result_json = json.dumps({"summary": "Done"})
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(command: list[str], **_kwargs: object) -> CompletedProcess[str]:
+            captured["command"] = command
+            return CompletedProcess([], 0, f"{result_json}\n", "")
+
+        with (
+            patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
+            patch.object(utils_run_mod.subprocess, "run", side_effect=fake_run),
+        ):
+            session = Session.objects.create(ticket=self.ticket)
+            task = Task.objects.create(ticket=self.ticket, session=session)
+            run_headless(task, phase=phase, overlay_skill_metadata={})
+
+        return captured["command"]
+
+    def test_retrospecting_runs_on_haiku(self) -> None:
+        command = self._run_capturing_command("retrospecting")
+        assert "--model" in command
+        assert command[command.index("--model") + 1] == "haiku"
+
+    def test_reviewing_runs_on_sonnet(self) -> None:
+        command = self._run_capturing_command("reviewing")
+        assert "--model" in command
+        assert command[command.index("--model") + 1] == "sonnet"
+
+    def test_coding_inherits_user_default_model(self) -> None:
+        command = self._run_capturing_command("coding")
+        assert "--model" not in command

--- a/tests/teatree_agents/test_model_tiering.py
+++ b/tests/teatree_agents/test_model_tiering.py
@@ -1,0 +1,111 @@
+"""Tests for per-phase headless model tiering (#880, #562 §3).
+
+Mechanical phases resolve to a cheaper model tier; judgment phases keep
+the user's default model. The mapping is config-driven via
+``~/.teatree.toml [agent] phase_models.<phase>``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import teatree.agents.model_tiering as mt_mod
+from teatree.agents.model_tiering import DEFAULT_PHASE_MODELS, resolve_phase_model
+
+
+def _write_toml(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def test_default_mechanical_phase_resolves_to_cheap_tier() -> None:
+    """A mechanical phase (retrospecting) downgrades to haiku by default."""
+    assert resolve_phase_model("retrospecting", config_path=Path("/nonexistent.toml")) == "haiku"
+
+
+def test_default_review_test_ship_resolve_to_sonnet() -> None:
+    """Review/test/ship are mechanical-ish: sonnet by default."""
+    for phase in ("reviewing", "testing", "shipping"):
+        assert resolve_phase_model(phase, config_path=Path("/nonexistent.toml")) == "sonnet"
+
+
+def test_default_reasoning_phase_inherits_user_default() -> None:
+    """A judgment phase (coding) returns None so no --model flag is added."""
+    assert resolve_phase_model("coding", config_path=Path("/nonexistent.toml")) is None
+    assert resolve_phase_model("debugging", config_path=Path("/nonexistent.toml")) is None
+
+
+def test_unknown_phase_inherits_user_default() -> None:
+    """An unmapped phase is conservative: keep the user's default model."""
+    assert resolve_phase_model("scoping", config_path=Path("/nonexistent.toml")) is None
+
+
+def test_config_overrides_default_mapping(tmp_path: Path) -> None:
+    """``[agent] phase_models.reviewing = "opus"`` pins the reasoning model."""
+    cfg = tmp_path / ".teatree.toml"
+    _write_toml(cfg, '[agent]\nphase_models.reviewing = "opus"\n')
+    assert resolve_phase_model("reviewing", config_path=cfg) == "opus"
+
+
+def test_config_can_downgrade_a_reasoning_phase(tmp_path: Path) -> None:
+    """Users may opt a reasoning phase into a cheaper tier explicitly."""
+    cfg = tmp_path / ".teatree.toml"
+    _write_toml(cfg, '[agent]\nphase_models.coding = "sonnet"\n')
+    assert resolve_phase_model("coding", config_path=cfg) == "sonnet"
+
+
+def test_config_empty_string_inherits_user_default(tmp_path: Path) -> None:
+    """An explicit empty string disables tiering for that phase."""
+    cfg = tmp_path / ".teatree.toml"
+    _write_toml(cfg, '[agent]\nphase_models.reviewing = ""\n')
+    assert resolve_phase_model("reviewing", config_path=cfg) is None
+
+
+def test_default_mapping_constant_is_conservative() -> None:
+    """The shipped default only downgrades mechanical phases."""
+    assert DEFAULT_PHASE_MODELS == {
+        "reviewing": "sonnet",
+        "testing": "sonnet",
+        "shipping": "sonnet",
+        "retrospecting": "haiku",
+    }
+    for reasoning_phase in ("coding", "debugging"):
+        assert reasoning_phase not in DEFAULT_PHASE_MODELS
+
+
+def test_missing_agent_section_falls_back_to_defaults(tmp_path: Path) -> None:
+    """A config without an ``[agent]`` section uses the shipped defaults."""
+    cfg = tmp_path / ".teatree.toml"
+    _write_toml(cfg, '[teatree]\nmode = "interactive"\n')
+    assert resolve_phase_model("retrospecting", config_path=cfg) == "haiku"
+    assert resolve_phase_model("coding", config_path=cfg) is None
+
+
+@pytest.mark.parametrize("bogus", ["", "   ", "default", "inherit"])
+def test_sentinel_values_inherit_user_default(tmp_path: Path, bogus: str) -> None:
+    """Sentinel opt-out values disable the per-phase override."""
+    cfg = tmp_path / ".teatree.toml"
+    _write_toml(cfg, f'[agent]\nphase_models.testing = "{bogus}"\n')
+    assert resolve_phase_model("testing", config_path=cfg) is None
+
+
+def test_malformed_toml_falls_back_to_defaults(tmp_path: Path) -> None:
+    """A syntactically broken config never crashes resolution."""
+    cfg = tmp_path / ".teatree.toml"
+    _write_toml(cfg, "[agent\nphase_models.testing = not valid toml")
+    assert resolve_phase_model("testing", config_path=cfg) == "sonnet"
+    assert resolve_phase_model("coding", config_path=cfg) is None
+
+
+def test_non_table_phase_models_falls_back_to_defaults(tmp_path: Path) -> None:
+    """``phase_models`` declared as a scalar (not a table) is ignored."""
+    cfg = tmp_path / ".teatree.toml"
+    _write_toml(cfg, '[agent]\nphase_models = "oops"\n')
+    assert resolve_phase_model("retrospecting", config_path=cfg) == "haiku"
+
+
+def test_default_config_path_used_when_none(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When no config_path is given, the canonical CONFIG_PATH is read."""
+    cfg = tmp_path / ".teatree.toml"
+    _write_toml(cfg, '[agent]\nphase_models.shipping = "opus"\n')
+    monkeypatch.setattr(mt_mod, "CONFIG_PATH", cfg)
+    assert resolve_phase_model("shipping") == "opus"


### PR DESCRIPTION
## Summary

Headless tasks otherwise inherit the user's default Claude model (typically Opus). Mechanical phases do not need full reasoning, so this slice resolves a cheaper model tier per phase and passes it to the Claude CLI.

- New `src/teatree/agents/model_tiering.py`: `resolve_phase_model(phase)` + `DEFAULT_PHASE_MODELS`.
- `agents/headless.py`: `_build_headless_command()` gains a `model` param; `run_headless()` resolves the phase model and appends `--model <tier>` when set (omitted ⇒ user's default model applies, unchanged behaviour).
- Config surface in `~/.teatree.toml`:
  ```toml
  [agent]
  phase_models.reviewing = "opus"   # pin a phase back to the reasoning tier
  phase_models.coding = "sonnet"    # opt a reasoning phase into a cheap tier
  phase_models.testing = ""         # opt out — inherit the user's default
  ```

## Default phase → tier mapping (the "open decision" from the issue)

Per #562 §3 (the issue states this as a one-line default for the user to confirm):

| Phase | Default tier |
|---|---|
| `reviewing`, `testing`, `shipping` | `sonnet` |
| `retrospecting` | `haiku` |
| `coding`, `debugging`, any unmapped phase | inherit user default (no `--model`) |

Conservative: only phases that are mechanical by nature are downgraded; reasoning phases keep the user's full-reasoning model. Fully opt-in/overridable per phase.

## Scope guard

Stays within the headless subsystem + its config. Does not touch BLUEPRINT §17 / hook_router / merge / ship path. BLUEPRINT §5.2 updated to document the new behaviour. `tach.toml`: `teatree.agents` now declares its intentional dependency on `teatree.config` (no cycle — `teatree.config` depends only on `paths`/`utils`).

## Testing

- TDD: failing test written first (`ModuleNotFoundError` / missing `--model`), then implemented to green.
- Anti-vacuous: reverted prod code via `git checkout origin/main -- headless.py` + removed the new module → confirmed RED (`assert '--model' in [...]` failed for `test_retrospecting_runs_on_haiku`), then restored → GREEN.
- 100% coverage on `model_tiering.py` (new code). `headless.py` change fully covered (the 2 uncovered lines are pre-existing heartbeat-thread lines, unrelated).
- Full suite: 4145 passed, 12 skipped, 0 failures. ruff + ruff format + ty + tach all clean.

Closes #880
Relates-to #562