### PR TITLE
fix(loop): take over orphaned in-flight tasks instead of failing them (#652)

### DIFF
--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -216,6 +216,44 @@ class TaskQuerySet(models.QuerySet):
                 return None
         return self.get(pk=oldest_pk)
 
+    def reclaim_orphaned_claims(self) -> int:
+        """Return expired-lease CLAIMED tasks to PENDING. Returns the count (#652).
+
+        When the Claude session driving the loop exits mid-task — terminal
+        closed, ``/exit``, crash — its CLAIMED ``Task`` stops heartbeating
+        and the lease expires. ``reap_stale_claims`` would transition that
+        row CLAIMED→FAILED, which needs a manual ``reopen()`` before any
+        other open session can resume it, so the loop silently stalls
+        until the user notices. This instead returns the orphan to PENDING
+        so the next ``PendingTasksScanner`` tick — in *any* still-open
+        session — re-surfaces it and the loop continues on its own ("the
+        fastest open session takes over").
+
+        Same backend-agnostic compare-and-swap as ``claim_next_pending`` /
+        ``reap_stale_claims``: a single conditional ``UPDATE ... WHERE
+        status=CLAIMED AND lease_expires_at < now`` where the expiry
+        predicate is the CAS token, re-evaluated atomically at write time.
+        A lease renewed by a still-live owner between any read and the
+        write moves ``lease_expires_at`` past ``now``, the ``WHERE`` no
+        longer matches, and the healthy claim is left with its owner —
+        never yanked away. Correct on the production SQLite backend (where
+        ``select_for_update(skip_locked=True)`` is a silent no-op — the
+        #786 B1 lesson): exactly one of N concurrent ticks updates the row
+        and the losers update 0 rows. Runs *before* ``reap_stale_claims``
+        in the tick so a recoverable orphan is taken over, not failed.
+        """
+        from teatree.core.models.task import Task  # noqa: PLC0415
+
+        now = timezone.now()
+        with transaction.atomic():
+            return self.filter(status=Task.Status.CLAIMED, lease_expires_at__lt=now).update(
+                status=Task.Status.PENDING,
+                claimed_at=None,
+                claimed_by="",
+                lease_expires_at=None,
+                heartbeat_at=None,
+            )
+
     def reap_stale_claims(self) -> int:
         """Fail CLAIMED tasks whose lease is *still* expired. Returns the count.
 

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -278,16 +278,27 @@ def run_tick(
 
 
 def _reap_stale_task_claims() -> None:
-    """Sweep CLAIMED tasks whose lease has expired so the statusline reflects fresh state.
+    """Take over orphaned claims, then fail any still-stale ones (#652).
 
-    Best-effort: if the test harness blocks DB access (pytest-django without
-    a ``db`` marker), the loop tick should still render scanners and signals.
+    A CLAIMED task whose lease expired because its owning Claude session
+    exited mid-task is *recoverable*: ``reclaim_orphaned_claims`` returns
+    it to PENDING first so this tick — running in another still-open
+    session — re-surfaces and continues it ("fastest open session takes
+    over"), instead of ``reap_stale_claims`` failing it (which would need
+    a manual ``reopen()`` and stall the loop). Reclaim runs *before* the
+    reap so a recoverable orphan is taken over, never failed; the reap
+    still catches any residual stale CLAIMED rows.
+
+    Best-effort: if the test harness blocks DB access (pytest-django
+    without a ``db`` marker), the loop tick should still render scanners
+    and signals.
     """
     import contextlib  # noqa: PLC0415
 
     from teatree.core.models import Task  # noqa: PLC0415
 
     with contextlib.suppress(RuntimeError):
+        Task.objects.reclaim_orphaned_claims()
         Task.objects.reap_stale_claims()
 
 

--- a/tests/teatree_core/test_managers.py
+++ b/tests/teatree_core/test_managers.py
@@ -142,6 +142,155 @@ class TestTaskQuerySet(TestCase):
         assert got.pk == fresh.pk  # skipped the already-claimed one
 
 
+class TestReclaimOrphanedClaims(TestCase):
+    """#652 — an orphaned in-flight task must be *taken over*, not failed.
+
+    When the Claude session driving the loop exits mid-task, its CLAIMED
+    Task stops heartbeating and the lease expires. The pre-#652 behaviour
+    (``reap_stale_claims``) transitions that row CLAIMED→FAILED, which
+    needs a manual ``reopen()`` before any other open session can resume
+    it — so the loop silently stalls. ``reclaim_orphaned_claims`` instead
+    returns the expired-lease CLAIMED row to PENDING so the next tick's
+    ``PendingTasksScanner`` (in any still-open session) re-surfaces it and
+    the loop continues. Same backend-agnostic conditional-UPDATE CAS as
+    ``claim_next_pending`` — fastest tick wins, losers update 0 rows.
+    """
+
+    def test_backend_is_sqlite(self) -> None:
+        from django.db import connection  # noqa: PLC0415
+
+        assert connection.vendor == "sqlite"
+
+    def test_expired_claimed_task_is_returned_to_pending_not_failed(self) -> None:
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket, agent_id="a")
+        expired = timezone.now() - timedelta(seconds=30)
+        orphan = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            status=Task.Status.CLAIMED,
+            claimed_by="pid-99999",
+            claimed_at=expired,
+            lease_expires_at=expired,
+            heartbeat_at=expired,
+        )
+
+        reclaimed = Task.objects.reclaim_orphaned_claims()
+
+        orphan.refresh_from_db()
+        assert reclaimed == 1
+        # Takeover, NOT fail: the row is claimable again so another open
+        # session's loop tick resumes it (issue #652 "fastest wins").
+        assert orphan.status == Task.Status.PENDING, (
+            f"orphaned task was not taken over (got {orphan.status!r}) — the loop stalls until a manual reopen()"
+        )
+        assert orphan.claimed_by == ""
+        assert orphan.claimed_at is None
+        assert orphan.lease_expires_at is None
+        assert orphan.heartbeat_at is None
+
+    def test_a_live_claim_is_left_untouched(self) -> None:
+        # Anti-vacuity: a healthy in-flight task (lease in the future)
+        # must NOT be yanked away from its live owner.
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket, agent_id="a")
+        future = timezone.now() + timedelta(seconds=300)
+        live = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            status=Task.Status.CLAIMED,
+            claimed_by="pid-1",
+            claimed_at=timezone.now(),
+            lease_expires_at=future,
+            heartbeat_at=timezone.now(),
+        )
+
+        reclaimed = Task.objects.reclaim_orphaned_claims()
+
+        live.refresh_from_db()
+        assert reclaimed == 0
+        assert live.status == Task.Status.CLAIMED
+        assert live.claimed_by == "pid-1"
+
+    def test_terminal_tasks_are_not_resurrected(self) -> None:
+        # A COMPLETED/FAILED task must never be dragged back to PENDING by
+        # the orphan sweep even if its (stale) lease columns are in the past.
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket, agent_id="a")
+        expired = timezone.now() - timedelta(seconds=30)
+        done = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            status=Task.Status.COMPLETED,
+            lease_expires_at=expired,
+        )
+        failed = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            status=Task.Status.FAILED,
+            lease_expires_at=expired,
+        )
+
+        reclaimed = Task.objects.reclaim_orphaned_claims()
+
+        done.refresh_from_db()
+        failed.refresh_from_db()
+        assert reclaimed == 0
+        assert done.status == Task.Status.COMPLETED
+        assert failed.status == Task.Status.FAILED
+
+    def test_concurrent_ticks_reclaim_one_orphan_exactly_once(self) -> None:
+        """#652 fastest-wins on the PRODUCTION SQLite backend.
+
+        Two ticks both observe the orphan; the conditional-UPDATE CAS
+        (``WHERE status=CLAIMED AND lease_expires_at < now``) lets exactly
+        one tick's UPDATE match — the other updates 0 rows. Same in-process
+        interleave technique as ``TestClaimNextPendingConcurrencyOnSqlite``
+        so it runs under the real SQLite test DB where
+        ``select_for_update(skip_locked=True)`` is a silent no-op.
+        """
+        from unittest.mock import patch  # noqa: PLC0415
+
+        from django.db.models import QuerySet  # noqa: PLC0415
+
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket, agent_id="a")
+        expired = timezone.now() - timedelta(seconds=30)
+        Task.objects.create(
+            ticket=ticket,
+            session=session,
+            status=Task.Status.CLAIMED,
+            claimed_by="pid-dead",
+            claimed_at=expired,
+            lease_expires_at=expired,
+            heartbeat_at=expired,
+        )
+
+        fired: list[str] = []
+        rival_result: list[int] = [-1]
+        real_update = QuerySet.update
+
+        def _fire_rival_once() -> None:
+            if fired:
+                return
+            fired.append("x")
+            rival_result[0] = Task.objects.reclaim_orphaned_claims()
+
+        def update_with_rival(self: object, *args: object, **kwargs: object) -> object:
+            _fire_rival_once()
+            return real_update(self, *args, **kwargs)
+
+        with patch.object(QuerySet, "update", update_with_rival):
+            caller1 = Task.objects.reclaim_orphaned_claims()
+
+        rival = rival_result[0]
+        # Exactly one tick reclaimed the single orphan (count 1); the other
+        # raced inside the first's write boundary and updated 0 rows.
+        assert sorted([caller1, rival]) == [0, 1], (
+            f"orphan reclaimed by both ticks (not fastest-wins): {caller1=} {rival=}"
+        )
+
+
 class TestReapStaleClaimsCasOnSqlite(TestCase):
     """#800 N5 — the reap must not spurious-fail a just-renewed lease.
 

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -404,7 +404,17 @@ class TestDispositionMechanical(django.test.TestCase):
 
 
 class TestTickReapsStaleClaims(django.test.TestCase):
-    def test_run_tick_reaps_claims_with_expired_lease(self) -> None:
+    def test_run_tick_takes_over_an_orphaned_claim(self) -> None:
+        """#652: a tick returns an orphaned in-flight claim to PENDING.
+
+        The session that claimed the Task exited and its lease expired.
+        A fresh tick (this one, in another open session) must take the
+        orphan over — return it to PENDING so the loop continues — rather
+        than FAIL it (which, pre-#652, stalled the loop until a manual
+        ``reopen()``). ``reclaim_orphaned_claims`` runs before
+        ``reap_stale_claims`` in the tick, so the recoverable orphan is
+        reclaimed, not reaped.
+        """
         import tempfile  # noqa: PLC0415
         from datetime import timedelta  # noqa: PLC0415
 
@@ -427,7 +437,8 @@ class TestTickReapsStaleClaims(django.test.TestCase):
             run_tick(TickRequest(scanners=[]), statusline_path=Path(tmp) / "statusline.txt")
 
         stale.refresh_from_db()
-        assert stale.status == Task.Status.FAILED
+        assert stale.status == Task.Status.PENDING
+        assert stale.claimed_by == ""
 
 
 def test_tick_captures_mechanical_handler_exception(


### PR DESCRIPTION
## Problem

When the Claude session driving a teatree loop exits mid-task (terminal closed, `/exit`, crash), its `CLAIMED` `Task` stops heartbeating and the lease expires. The existing reap path transitioned that row `CLAIMED`->`FAILED`, which needs a manual `reopen()` before any other open session can resume it — so the loop silently stalled until the user noticed and re-ran something.

## Change

Adds `TaskQuerySet.reclaim_orphaned_claims()`: a backend-agnostic conditional-UPDATE compare-and-swap (the same shape as `claim_next_pending` / `reap_stale_claims`, correct on the production SQLite backend where `select_for_update(skip_locked=True)` is a silent no-op) that returns expired-lease `CLAIMED` tasks to `PENDING`.

The loop tick runs `reclaim_orphaned_claims()` **before** `reap_stale_claims()`, so the next `PendingTasksScanner` tick — in *any* still-open session — re-surfaces the orphan and the fastest tick takes it over (no leader election; row-level CAS picks a single winner). A still-live owner that renewed its lease is left untouched (the `WHERE` predicate re-evaluates at write time); terminal (`COMPLETED`/`FAILED`) tasks are never resurrected.

No change to BLUEPRINT §17 / hook_router / merge / ship paths — loop-coordination Task-lease scope only, matching the existing lease conventions.

## Tests (TDD, anti-vacuous verified)

New, RED before the fix on `git checkout origin/main`:

- `TestReclaimOrphanedClaims` (manager): expired CLAIMED -> PENDING (not FAILED); live claim untouched; terminal tasks not resurrected; concurrent fastest-wins CAS on real SQLite — RED: `AttributeError: 'ManagerFromTaskQuerySet' object has no attribute 'reclaim_orphaned_claims'`.
- `TestTickReapsStaleClaims::test_run_tick_takes_over_an_orphaned_claim` (real `run_tick` path) — RED: `AssertionError: assert 'failed' == Task.Status.PENDING`.

100% coverage of the new code (managers.py 219-256, tick.py 280-302: zero missing lines). Full suite: 4216 passed, 12 skipped.

Closes #652