### PR TITLE
feat(reliability): stuck-loop / cost-spike watchdog in heartbeat loop (#882)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -513,6 +513,16 @@ phase_models.testing = ""         # opt out — inherit the user's default
 
 **Auth:** Uses the `claude` binary (Claude Code session auth — no API key required).
 
+**Stuck-loop / cost-spike watchdog (#882).** The agent runs over `Popen` (via `teatree.utils.run.spawn`) so the heartbeat thread can terminate a runaway mid-flight. On every heartbeat tick `LoopWatchdog.breach_reason()` evaluates the task's wall-clock runtime plus the accumulated `TaskAttempt.num_turns` / `cost_usd` deltas (sampled once on the main thread before the subprocess starts — prior-attempt totals are static for the run). On a ceiling breach the subprocess is killed and a `stuck_loop` `TaskAttempt` failure is recorded with the observed deltas (`task.fail()` runs). The conservative default is a 3h runtime ceiling that only trips on a genuinely runaway subprocess; absolute turn/cost budget caps are deferred to #398-4, so those dimensions default off (`0` = disabled). Overridable via Django settings:
+
+```python
+TEATREE_LOOP_WATCHDOG = {
+    "max_runtime_seconds": 10800,  # 0 = disabled
+    "max_turns": 0,                # 0 = disabled
+    "max_cost_usd": 0.0,           # 0 = disabled
+}
+```
+
 ### 5.3 Prompt Building (prompt.py)
 
 **`build_task_prompt(task)`** — Work instructions for the agent:

--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -15,8 +15,13 @@ import logging
 import re
 import shutil
 import threading
+import time
+from dataclasses import dataclass
 from pathlib import Path
 
+from django.conf import settings
+from django.db import close_old_connections
+from django.db.models import Sum
 from django.utils import timezone
 
 from teatree.agents.model_tiering import resolve_phase_model
@@ -26,11 +31,85 @@ from teatree.core.models import Task, TaskAttempt
 from teatree.core.models.worktree import Worktree
 from teatree.skill_loading import SkillLoadingPolicy
 from teatree.types import SkillMetadata
-from teatree.utils.run import run_allowed_to_fail
+from teatree.utils.run import PIPE, spawn
 
 logger = logging.getLogger(__name__)
 
 _HEARTBEAT_INTERVAL = 60  # seconds
+
+# Conservative documented default (#882): a generous wall-clock ceiling that
+# only trips on a genuinely runaway subprocess that never returns — the
+# canonical "Claude session spins on the same error" symptom. Absolute
+# turn/cost budget caps are #398-4's responsibility, so they default off here.
+_DEFAULT_WATCHDOG = {
+    "max_runtime_seconds": 3 * 60 * 60,  # 3h — well past any healthy phase task
+    "max_turns": 0,  # 0 = disabled
+    "max_cost_usd": 0.0,  # 0 = disabled
+}
+
+
+@dataclass(frozen=True)
+class TaskUsage:
+    """Accumulated ``TaskAttempt`` deltas for one task.
+
+    Sampled once on the main thread before the subprocess starts:
+    ``num_turns`` / ``cost_usd`` only land in the DB *after* an attempt
+    completes, so prior-attempt totals are static for the current run.
+    """
+
+    turns: int
+    cost_usd: float
+
+    @classmethod
+    def for_task(cls, task: Task) -> "TaskUsage":
+        attempts = task.attempts  # ty: ignore[unresolved-attribute]
+        totals = attempts.aggregate(turns=Sum("num_turns"), cost=Sum("cost_usd"))
+        return cls(turns=totals["turns"] or 0, cost_usd=totals["cost"] or 0.0)
+
+
+@dataclass(frozen=True)
+class LoopWatchdog:
+    """Detects a stuck loop / cost spike during the heartbeat loop (#882).
+
+    Evaluates the running task's wall-clock runtime plus the accumulated
+    ``TaskAttempt.num_turns`` / ``cost_usd`` deltas. When a ceiling is
+    crossed the heartbeat loop terminates the subprocess and a
+    ``stuck_loop`` ``TaskAttempt`` failure is recorded with the observed
+    deltas. A ceiling of ``0`` disables that dimension.
+    """
+
+    max_runtime_seconds: float
+    max_turns: int
+    max_cost_usd: float
+
+    @classmethod
+    def from_settings(cls) -> "LoopWatchdog":
+        configured = getattr(settings, "TEATREE_LOOP_WATCHDOG", None) or _DEFAULT_WATCHDOG
+        return cls(
+            max_runtime_seconds=float(configured.get("max_runtime_seconds", 0)),
+            max_turns=int(configured.get("max_turns", 0)),
+            max_cost_usd=float(configured.get("max_cost_usd", 0.0)),
+        )
+
+    def breach_reason(self, task: Task, *, elapsed_seconds: float, usage: TaskUsage | None = None) -> str | None:
+        """Return a reason string with observed deltas, or ``None`` if healthy.
+
+        *usage* is the pre-sampled accumulated delta snapshot; when omitted
+        it is read from *task* (convenience for callers outside the loop).
+        """
+        if self.max_runtime_seconds and elapsed_seconds > self.max_runtime_seconds:
+            return (
+                f"runtime ceiling exceeded: ran {elapsed_seconds:.0f}s "
+                f"> {self.max_runtime_seconds:.0f}s without exiting"
+            )
+        if self.max_turns or self.max_cost_usd:
+            if usage is None:
+                usage = TaskUsage.for_task(task)
+            if self.max_turns and usage.turns > self.max_turns:
+                return f"turns ceiling exceeded: {usage.turns} turns > {self.max_turns} without progress"
+            if self.max_cost_usd and usage.cost_usd > self.max_cost_usd:
+                return f"cost ceiling exceeded: ${usage.cost_usd:.2f} > ${self.max_cost_usd:.2f} without progress"
+        return None
 
 
 def _safe_int(value: str | None) -> int | None:
@@ -103,29 +182,74 @@ def _resolve_task_cwd(task: Task) -> str | None:
     return None
 
 
-def _run_with_heartbeat(task: Task, command: list[str], *, cwd: str | None = None) -> tuple[str, str, int]:
+_STUCK_LOOP_EXIT_CODE = -9
+_STUCK_LOOP_PREFIX = "stuck_loop: "
+
+
+def _run_with_heartbeat(
+    task: Task,
+    command: list[str],
+    *,
+    cwd: str | None = None,
+    watchdog: LoopWatchdog | None = None,
+) -> tuple[str, str, int]:
     """Run *command* as a subprocess while sending lease heartbeats.
+
+    The heartbeat loop doubles as a stuck-loop watchdog (#882): on each
+    tick it samples the task's runtime / accumulated turn+cost deltas and,
+    on a ceiling breach, terminates the subprocess. A watchdog kill returns
+    a non-zero exit code with ``stuck_loop: <reason>`` on stderr so the
+    caller records a ``stuck_loop`` ``TaskAttempt`` failure.
 
     Returns ``(stdout, stderr, returncode)``.
     """
+    if watchdog is None:
+        watchdog = LoopWatchdog.from_settings()
+
+    # Sample accumulated deltas once on the main thread: prior-attempt
+    # totals are static for this run and a threaded DB read would not see
+    # the caller's transaction.
+    usage = TaskUsage.for_task(task)
+
     stop_event = threading.Event()
+    started_at = time.monotonic()
+    proc = spawn(command, cwd=cwd, stdout=PIPE, stderr=PIPE)
+    watchdog_reason: list[str] = []
 
     def _heartbeat() -> None:
-        while not stop_event.wait(_HEARTBEAT_INTERVAL):
-            try:
-                task.renew_lease()
-            except Exception:  # noqa: BLE001
-                logger.warning("Heartbeat failed for task %s", task.pk)
+        try:
+            while not stop_event.wait(_HEARTBEAT_INTERVAL):
+                try:
+                    task.renew_lease()
+                except Exception:  # noqa: BLE001
+                    logger.warning("Heartbeat failed for task %s", task.pk)
+                reason = watchdog.breach_reason(
+                    task,
+                    elapsed_seconds=time.monotonic() - started_at,
+                    usage=usage,
+                )
+                if reason and not watchdog_reason:
+                    watchdog_reason.append(reason)
+                    logger.warning("Watchdog terminating stuck task %s: %s", task.pk, reason)
+                    proc.kill()
+        finally:
+            # This thread owns its own DB connection — close it so the
+            # connection is not leaked when the thread exits.
+            close_old_connections()
 
     heartbeat_thread = threading.Thread(target=_heartbeat, daemon=True)
     heartbeat_thread.start()
     try:
-        proc = run_allowed_to_fail(command, cwd=cwd, expected_codes=None)
+        # communicate() blocks until the process exits and reaps it; a
+        # watchdog kill from the heartbeat thread unblocks it here.
+        stdout, stderr = proc.communicate()
     finally:
         stop_event.set()
         heartbeat_thread.join(timeout=5)
 
-    return proc.stdout, proc.stderr, proc.returncode
+    if watchdog_reason:
+        return stdout or "", f"{_STUCK_LOOP_PREFIX}{watchdog_reason[0]}", _STUCK_LOOP_EXIT_CODE
+    return stdout or "", stderr or "", proc.returncode
 
 
 def _record_success(task: Task, envelope: dict[str, str]) -> TaskAttempt:

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -1,14 +1,16 @@
+import contextlib
 import json
+import shlex
 import time
-from subprocess import CompletedProcess
+from collections.abc import Iterator
 from unittest.mock import patch
 
 import pytest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 import teatree.agents.headless as headless_mod
-import teatree.utils.run as utils_run_mod
 from teatree.agents.headless import (
+    LoopWatchdog,
     _get_resume_session_id,
     _parse_cli_envelope,
     _parse_result,
@@ -22,6 +24,23 @@ from teatree.agents.headless import (
 from teatree.core.models import Session, Task, TaskAttempt, Ticket
 
 
+@contextlib.contextmanager
+def _fake_claude(stdout: str = "", stderr: str = "", exit_code: int = 0) -> Iterator[None]:
+    """Run ``run_headless`` against a real ``sh -c`` subprocess.
+
+    The headless runner now drives the agent over ``Popen`` so the
+    heartbeat loop can terminate a runaway. Tests exercise that real
+    transport against a harmless shell command instead of mocking the
+    subprocess layer.
+    """
+    script = f"printf %s {shlex.quote(stdout)}; printf %s {shlex.quote(stderr)} >&2; exit {exit_code}"
+    with (
+        patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
+        patch.object(headless_mod, "_build_headless_command", return_value=["sh", "-c", script]),
+    ):
+        yield
+
+
 class TestRunHeadless(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
@@ -29,14 +48,7 @@ class TestRunHeadless(TestCase):
 
     def test_captures_structured_result(self) -> None:
         result_json = json.dumps({"summary": "Done", "tests_passed": 5, "tests_failed": 0})
-        with (
-            patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
-            patch.object(
-                utils_run_mod.subprocess,
-                "run",
-                return_value=CompletedProcess([], 0, f"Progress...\n{result_json}\n", ""),
-            ),
-        ):
+        with _fake_claude(stdout=f"Progress...\n{result_json}\n"):
             session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
             task = Task.objects.create(ticket=self.ticket, session=session)
 
@@ -49,10 +61,7 @@ class TestRunHeadless(TestCase):
         assert task.status == Task.Status.COMPLETED
 
     def test_records_failure(self) -> None:
-        with (
-            patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
-            patch.object(utils_run_mod.subprocess, "run", return_value=CompletedProcess([], 1, "", "segfault")),
-        ):
+        with _fake_claude(stderr="segfault", exit_code=1):
             session = Session.objects.create(ticket=self.ticket)
             task = Task.objects.create(ticket=self.ticket, session=session)
 
@@ -76,14 +85,7 @@ class TestRunHeadless(TestCase):
         assert task.status == Task.Status.FAILED
 
     def test_fails_when_no_json_in_successful_exit(self) -> None:
-        with (
-            patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
-            patch.object(
-                utils_run_mod.subprocess,
-                "run",
-                return_value=CompletedProcess([], 0, "no structured output\n", ""),
-            ),
-        ):
+        with _fake_claude(stdout="no structured output\n"):
             session = Session.objects.create(ticket=self.ticket)
             task = Task.objects.create(ticket=self.ticket, session=session)
 
@@ -96,10 +98,7 @@ class TestRunHeadless(TestCase):
 
     def test_fails_when_result_violates_schema(self) -> None:
         bad_json = json.dumps({"summary": "OK", "rogue_field": True})
-        with (
-            patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
-            patch.object(utils_run_mod.subprocess, "run", return_value=CompletedProcess([], 0, f"{bad_json}\n", "")),
-        ):
+        with _fake_claude(stdout=f"{bad_json}\n"):
             session = Session.objects.create(ticket=self.ticket)
             task = Task.objects.create(ticket=self.ticket, session=session)
 
@@ -118,10 +117,7 @@ class TestRunHeadless(TestCase):
                 "user_input_reason": "Need design decision",
             },
         )
-        with (
-            patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
-            patch.object(utils_run_mod.subprocess, "run", return_value=CompletedProcess([], 0, f"{result_json}\n", "")),
-        ):
+        with _fake_claude(stdout=f"{result_json}\n"):
             session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
             task = Task.objects.create(
                 ticket=self.ticket,
@@ -149,10 +145,7 @@ class TestRunHeadless(TestCase):
         result_json = json.dumps({"summary": "Work done"})
         cli_envelope = json.dumps({"session_id": "sess-abc-123", "result": result_json})
 
-        with (
-            patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
-            patch.object(utils_run_mod.subprocess, "run", return_value=CompletedProcess([], 0, cli_envelope, "")),
-        ):
+        with _fake_claude(stdout=cli_envelope):
             session = Session.objects.create(ticket=self.ticket)
             task = Task.objects.create(ticket=self.ticket, session=session)
 
@@ -254,14 +247,15 @@ class TestRunHeadlessResumesParentSession(TestCase):
         """When a parent task has a session_id, run_headless passes --resume to the CLI."""
         captured_commands: list[list[str]] = []
         result_json = json.dumps({"summary": "Continued work"})
+        real = headless_mod._build_headless_command
 
-        def fake_run(*args: object, **_kwargs: object) -> CompletedProcess[str]:
-            captured_commands.append(list(args[0]))
-            return CompletedProcess([], 0, f"{result_json}\n", "")
+        def spy_build(*args: object, **kwargs: object) -> list[str]:
+            captured_commands.append(real(*args, **kwargs))
+            return ["sh", "-c", f"printf %s {shlex.quote(result_json)}"]
 
         with (
             patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
-            patch.object(utils_run_mod.subprocess, "run", side_effect=fake_run),
+            patch.object(headless_mod, "_build_headless_command", side_effect=spy_build),
         ):
             ticket = Ticket.objects.create()
             parent_session = Session.objects.create(ticket=ticket, agent_id=FAKE_SESSION_UUID)
@@ -365,15 +359,13 @@ class TestRunWithHeartbeat(TestCase):
 
         task.renew_lease = counting_renew
 
-        def slow_subprocess(*_args: object, **_kwargs: object) -> CompletedProcess[str]:
-            time.sleep(0.4)
-            return CompletedProcess([], 0, "done", "")
-
-        with (
-            patch.object(headless_mod, "_HEARTBEAT_INTERVAL", 0.05),
-            patch.object(utils_run_mod.subprocess, "run", slow_subprocess),
-        ):
-            stdout, _stderr, returncode = _run_with_heartbeat(task, ["echo"])
+        off = LoopWatchdog(max_runtime_seconds=0, max_turns=0, max_cost_usd=0.0)
+        with patch.object(headless_mod, "_HEARTBEAT_INTERVAL", 0.05):
+            stdout, _stderr, returncode = _run_with_heartbeat(
+                task,
+                ["sh", "-c", "sleep 0.4; printf done"],
+                watchdog=off,
+            )
 
         assert returncode == 0
         assert stdout == "done"
@@ -392,15 +384,9 @@ class TestRunWithHeartbeat(TestCase):
 
         task.renew_lease = tracking_renew
 
-        with (
-            patch.object(headless_mod, "_HEARTBEAT_INTERVAL", 0.05),
-            patch.object(
-                utils_run_mod.subprocess,
-                "run",
-                lambda *_a, **_kw: CompletedProcess([], 0, "", ""),
-            ),
-        ):
-            _run_with_heartbeat(task, ["echo"])
+        off = LoopWatchdog(max_runtime_seconds=0, max_turns=0, max_cost_usd=0.0)
+        with patch.object(headless_mod, "_HEARTBEAT_INTERVAL", 0.05):
+            _run_with_heartbeat(task, ["sh", "-c", "exit 0"], watchdog=off)
 
         count_at_exit = len(renew_calls)
         time.sleep(0.15)
@@ -418,20 +404,157 @@ class TestRunWithHeartbeat(TestCase):
 
         task.renew_lease = failing_renew
 
-        def slow_subprocess(*_args: object, **_kwargs: object) -> CompletedProcess[str]:
-            time.sleep(0.15)
-            return CompletedProcess([], 0, "ok", "")
-
+        off = LoopWatchdog(max_runtime_seconds=0, max_turns=0, max_cost_usd=0.0)
         with (
             patch.object(headless_mod, "_HEARTBEAT_INTERVAL", 0.05),
-            patch.object(utils_run_mod.subprocess, "run", slow_subprocess),
             patch.object(headless_mod, "logger") as mock_logger,
         ):
-            stdout, _stderr, returncode = _run_with_heartbeat(task, ["echo"])
+            stdout, _stderr, returncode = _run_with_heartbeat(
+                task,
+                ["sh", "-c", "sleep 0.15; printf ok"],
+                watchdog=off,
+            )
 
         assert returncode == 0
         assert stdout == "ok"
         assert mock_logger.warning.call_count >= 1
+
+
+# --- Stuck-loop / cost-spike watchdog (#882) ---
+
+
+class TestLoopWatchdog(TestCase):
+    """Watchdog evaluation against real Task / TaskAttempt rows."""
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create()
+        self.session = Session.objects.create(ticket=self.ticket)
+        self.task = Task.objects.create(ticket=self.ticket, session=self.session)
+
+    def test_disabled_watchdog_never_terminates(self) -> None:
+        watchdog = LoopWatchdog(max_runtime_seconds=0, max_turns=0, max_cost_usd=0.0)
+        assert watchdog.breach_reason(self.task, elapsed_seconds=99999) is None
+
+    def test_runtime_ceiling_breach(self) -> None:
+        watchdog = LoopWatchdog(max_runtime_seconds=30, max_turns=0, max_cost_usd=0.0)
+        assert watchdog.breach_reason(self.task, elapsed_seconds=10) is None
+        reason = watchdog.breach_reason(self.task, elapsed_seconds=31)
+        assert reason is not None
+        assert "runtime" in reason
+        assert "31" in reason
+
+    def test_turn_count_breach_from_accumulated_attempts(self) -> None:
+        TaskAttempt.objects.create(task=self.task, num_turns=120)
+        TaskAttempt.objects.create(task=self.task, num_turns=140)
+        watchdog = LoopWatchdog(max_runtime_seconds=0, max_turns=200, max_cost_usd=0.0)
+        reason = watchdog.breach_reason(self.task, elapsed_seconds=5)
+        assert reason is not None
+        assert "turns" in reason
+        assert "260" in reason
+
+    def test_cost_breach_from_accumulated_attempts(self) -> None:
+        TaskAttempt.objects.create(task=self.task, cost_usd=4.0)
+        TaskAttempt.objects.create(task=self.task, cost_usd=3.5)
+        watchdog = LoopWatchdog(max_runtime_seconds=0, max_turns=0, max_cost_usd=5.0)
+        reason = watchdog.breach_reason(self.task, elapsed_seconds=5)
+        assert reason is not None
+        assert "cost" in reason
+        assert "7.5" in reason
+
+    def test_under_all_thresholds_no_breach(self) -> None:
+        TaskAttempt.objects.create(task=self.task, num_turns=10, cost_usd=0.5)
+        watchdog = LoopWatchdog(max_runtime_seconds=600, max_turns=200, max_cost_usd=5.0)
+        assert watchdog.breach_reason(self.task, elapsed_seconds=60) is None
+
+    def test_from_settings_reads_defaults(self) -> None:
+        with override_settings(
+            TEATREE_LOOP_WATCHDOG={"max_runtime_seconds": 42, "max_turns": 7, "max_cost_usd": 1.5},
+        ):
+            watchdog = LoopWatchdog.from_settings()
+        assert watchdog.max_runtime_seconds == 42
+        assert watchdog.max_turns == 7
+        assert watchdog.max_cost_usd == pytest.approx(1.5)
+
+    def test_from_settings_falls_back_to_conservative_default(self) -> None:
+        with override_settings():
+            from django.conf import settings  # noqa: PLC0415
+
+            if hasattr(settings, "TEATREE_LOOP_WATCHDOG"):
+                del settings.TEATREE_LOOP_WATCHDOG
+            watchdog = LoopWatchdog.from_settings()
+        # Conservative documented default: a generous runtime ceiling that
+        # only trips on genuine runaways; turn/cost ceilings off by default
+        # (absolute budget caps are #398-4's job, not the watchdog's).
+        assert watchdog.max_runtime_seconds > 0
+        assert watchdog.max_turns == 0
+        assert watchdog.max_cost_usd == pytest.approx(0.0)
+
+
+class TestRunWithHeartbeatWatchdog(TestCase):
+    """A spinning subprocess is killed and a stuck_loop failure recorded."""
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create()
+        self.session = Session.objects.create(ticket=self.ticket)
+        self.task = Task.objects.create(ticket=self.ticket, session=self.session)
+        # Sibling heartbeat tests stub renew_lease to keep the heartbeat
+        # thread off the DB — threaded ORM access under TestCase's wrapping
+        # transaction is a test-harness artifact, not production behaviour.
+        self.task.renew_lease = lambda **_kw: None
+
+    def test_kills_runaway_subprocess_on_runtime_breach(self) -> None:
+        watchdog = LoopWatchdog(max_runtime_seconds=0.2, max_turns=0, max_cost_usd=0.0)
+        start = time.monotonic()
+        with patch.object(headless_mod, "_HEARTBEAT_INTERVAL", 0.05):
+            _stdout, stderr, returncode = _run_with_heartbeat(
+                self.task,
+                ["sleep", "30"],
+                watchdog=watchdog,
+            )
+        elapsed = time.monotonic() - start
+
+        assert returncode != 0
+        assert elapsed < 10  # killed early, not after 30s
+        assert "stuck_loop" in stderr
+        assert "runtime" in stderr
+
+    def test_normal_subprocess_not_killed(self) -> None:
+        watchdog = LoopWatchdog(max_runtime_seconds=30, max_turns=0, max_cost_usd=0.0)
+        with patch.object(headless_mod, "_HEARTBEAT_INTERVAL", 0.05):
+            stdout, _stderr, returncode = _run_with_heartbeat(
+                self.task,
+                ["sh", "-c", "printf done"],
+                watchdog=watchdog,
+            )
+        assert returncode == 0
+        assert stdout == "done"
+
+
+class TestRunHeadlessRecordsStuckLoop(TestCase):
+    """run_headless records a stuck_loop TaskAttempt failure when the watchdog fires."""
+
+    def test_records_stuck_loop_failure_with_observed_deltas(self) -> None:
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket, agent_id="agent-1")
+        task = Task.objects.create(ticket=ticket, session=session)
+        TaskAttempt.objects.create(task=task, num_turns=500)
+        task.renew_lease = lambda **_kw: None
+
+        watchdog = LoopWatchdog(max_runtime_seconds=0, max_turns=200, max_cost_usd=0.0)
+        with (
+            patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
+            patch.object(headless_mod.LoopWatchdog, "from_settings", return_value=watchdog),
+            patch.object(headless_mod, "_HEARTBEAT_INTERVAL", 0.05),
+            patch.object(headless_mod, "_build_headless_command", return_value=["sleep", "30"]),
+        ):
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        assert attempt.exit_code != 0
+        assert "stuck_loop" in attempt.error
+        assert "turns" in attempt.error
+        assert "500" in attempt.error
+        assert task.status == Task.Status.FAILED
 
 
 # --- _build_headless_command model tiering (#880) ---
@@ -466,14 +589,15 @@ class TestRunHeadlessModelTiering(TestCase):
     def _run_capturing_command(self, phase: str) -> list[str]:
         result_json = json.dumps({"summary": "Done"})
         captured: dict[str, list[str]] = {}
+        real = headless_mod._build_headless_command
 
-        def fake_run(command: list[str], **_kwargs: object) -> CompletedProcess[str]:
-            captured["command"] = command
-            return CompletedProcess([], 0, f"{result_json}\n", "")
+        def spy_build(*args: object, **kwargs: object) -> list[str]:
+            captured["command"] = real(*args, **kwargs)
+            return ["sh", "-c", f"printf %s {shlex.quote(result_json)}"]
 
         with (
             patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
-            patch.object(utils_run_mod.subprocess, "run", side_effect=fake_run),
+            patch.object(headless_mod, "_build_headless_command", side_effect=spy_build),
         ):
             session = Session.objects.create(ticket=self.ticket)
             task = Task.objects.create(ticket=self.ticket, session=session)

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -184,24 +184,20 @@ class TestLifecycleCommands(TestCase):
 class TestTaskCommands(TestCase):
     @override_settings(**COMMAND_SETTINGS)
     def test_claim_and_complete_work(self) -> None:
-        import subprocess as _sp  # noqa: PLC0415
+        import shlex  # noqa: PLC0415
 
         ticket = Ticket.objects.create(overlay="test")
         session = Session.objects.create(ticket=ticket, overlay="test", agent_id="agent-1")
         sdk_task = Task.objects.create(ticket=ticket, session=session)
         sdk_followup_task = Task.objects.create(ticket=ticket, session=session)
 
+        envelope = '{"session_id": "test-session", "result": "```json\\n{\\"summary\\": \\"done\\"}\\n```"}'
         with (
             patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
             patch.object(
-                utils_run_mod.subprocess,
-                "run",
-                return_value=_sp.CompletedProcess(
-                    [],
-                    0,
-                    '{"session_id": "test-session", "result": "```json\\n{\\"summary\\": \\"done\\"}\\n```"}',
-                    "",
-                ),
+                headless_mod,
+                "_build_headless_command",
+                return_value=["sh", "-c", f"printf %s {shlex.quote(envelope)}"],
             ),
             patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
         ):

--- a/tests/teatree_core/test_signals.py
+++ b/tests/teatree_core/test_signals.py
@@ -4,7 +4,6 @@ from django.test import TestCase, override_settings
 
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.core.signals as signals_mod
-import teatree.utils.run as utils_run_mod
 from teatree.core.models import Session, Task, Ticket
 from tests.teatree_core.conftest import CommandOverlay
 
@@ -24,7 +23,7 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
 
     @override_settings(**IMMEDIATE_BACKEND)
     def test_headless_task_auto_executes_on_creation(self) -> None:
-        import subprocess as _sp  # noqa: PLC0415
+        import shlex  # noqa: PLC0415
 
         import teatree.agents.headless as headless_mod  # noqa: PLC0415
 
@@ -34,9 +33,9 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
         with (
             patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
             patch.object(
-                utils_run_mod.subprocess,
-                "run",
-                return_value=_sp.CompletedProcess([], 0, '{"summary": "OK"}', ""),
+                headless_mod,
+                "_build_headless_command",
+                return_value=["sh", "-c", f"printf %s {shlex.quote('{"summary": "OK"}')}"],
             ),
             patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
         ):
@@ -107,7 +106,7 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
     @override_settings(**IMMEDIATE_BACKEND)
     def test_route_to_headless_triggers_enqueue(self) -> None:
         """Re-routing an interactive task to headless triggers auto-enqueue."""
-        import subprocess as _sp  # noqa: PLC0415
+        import shlex  # noqa: PLC0415
 
         import teatree.agents.headless as headless_mod  # noqa: PLC0415
 
@@ -125,9 +124,9 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
         with (
             patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
             patch.object(
-                utils_run_mod.subprocess,
-                "run",
-                return_value=_sp.CompletedProcess([], 0, '{"summary": "OK"}', ""),
+                headless_mod,
+                "_build_headless_command",
+                return_value=["sh", "-c", f"printf %s {shlex.quote('{"summary": "OK"}')}"],
             ),
             patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
         ):


### PR DESCRIPTION
## What

Primitive 1 of #398. Adds a stuck-loop / cost-spike watchdog to the headless heartbeat loop.

Previously `agents/headless.py:_run_with_heartbeat` renewed the lease for as long as the subprocess was alive, so a Claude session that spun on the same error burned budget silently until the subprocess exited on its own.

## How

- New `LoopWatchdog` (frozen dataclass) samples wall-clock runtime plus accumulated `TaskAttempt.num_turns` / `cost_usd` deltas. `breach_reason()` returns a reason string with observed deltas on a ceiling breach, else `None`. A ceiling of `0` disables that dimension.
- `TaskUsage.for_task()` snapshots the accumulated deltas once on the main thread before the subprocess starts (prior-attempt totals are static for the run; avoids threaded ORM access under the caller's transaction).
- The runner now drives the agent over `Popen` (via `teatree.utils.run.spawn`) so the heartbeat thread can `proc.kill()` a runaway mid-flight; `communicate()` unblocks and reaps. The heartbeat thread closes its own DB connection on exit.
- On breach the subprocess is killed and a `stuck_loop` `TaskAttempt` failure is recorded with the observed deltas (`task.fail()` runs).
- Conservative documented default: a 3h runtime ceiling that only trips on a genuinely runaway subprocess; absolute turn/cost budget caps are left to #398-4, so those dimensions default off. Overridable via `TEATREE_LOOP_WATCHDOG` Django setting (documented in BLUEPRINT § 5.2).

## Scope

Agents/headless watchdog only. Does not touch BLUEPRINT §17 / hook_router / merge / ship path.

## Tests

- `TestLoopWatchdog` — disabled/runtime/turn/cost breach + settings load, against real `Task`/`TaskAttempt` rows.
- `TestRunWithHeartbeatWatchdog` — a real `sleep 30` subprocess is killed early on a runtime breach; a normal subprocess is not killed.
- `TestRunHeadlessRecordsStuckLoop` — `run_headless` records a `stuck_loop` `TaskAttempt` failure with observed deltas (turns) and `task.status == FAILED`.
- Existing `run_headless` tests migrated from mocking `subprocess.run` to driving a real `sh -c` subprocess (the new Popen transport), per the repo's prefer-real-subprocesses doctrine.

Anti-vacuous: reverting `headless.py` to `origin/main` makes the new tests fail with `ImportError: cannot import name 'LoopWatchdog'`; restoring makes them pass. Full suite green (4221 passed). New watchdog code at 100% coverage.

Closes #882
Relates-to #398