### PR TITLE
test(packaging): guard that built wheel ships t3_bootstrap (#397)

### DIFF
--- a/tests/test_t3_bootstrap.py
+++ b/tests/test_t3_bootstrap.py
@@ -1,12 +1,17 @@
 """Tests for the ``t3_bootstrap`` entry-point launcher."""
 
+import shutil
+import subprocess
 import sys
+import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 import t3_bootstrap
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _make_teatree_tree(root: Path) -> Path:
@@ -65,3 +70,44 @@ class TestMain:
             t3_bootstrap.main()
             assert sys.path == before
             mock_main.assert_called_once_with()
+
+
+class TestWheelShipsBootstrap:
+    """Regression guard for #397 / #498.
+
+    The ``t3`` console script resolves ``t3_bootstrap:main`` at runtime, so a
+    non-editable install (``uv tool install --from git+...teatree.git``) fails
+    with ``ModuleNotFoundError: No module named 't3_bootstrap'`` unless the
+    built wheel actually ships the ``t3_bootstrap`` package.  #434 declared it
+    via a hatch ``force-include`` that the project's ``uv_build`` backend
+    silently ignored, so every wheel since shipped without it and the failure
+    surfaced only at install time in CI.  Asserting the ``pyproject.toml`` key
+    alone would not catch a backend swap; only an actual build does.
+    """
+
+    @pytest.fixture(scope="class")
+    def built_wheel(self, tmp_path_factory: pytest.TempPathFactory) -> Path:
+        uv = shutil.which("uv")
+        if uv is None:
+            pytest.skip("uv not available — cannot build wheel")
+        out_dir = tmp_path_factory.mktemp("wheel")
+        subprocess.run(
+            [uv, "build", "--wheel", "-o", str(out_dir)],
+            cwd=_REPO_ROOT,
+            check=True,
+            capture_output=True,
+        )
+        wheels = list(out_dir.glob("*.whl"))
+        assert len(wheels) == 1, f"expected exactly one wheel, got {wheels}"
+        return wheels[0]
+
+    def test_wheel_contains_t3_bootstrap_package(self, built_wheel: Path) -> None:
+        with zipfile.ZipFile(built_wheel) as zf:
+            names = set(zf.namelist())
+        assert "t3_bootstrap/__init__.py" in names
+        assert "t3_bootstrap/_main.py" in names
+
+    def test_wheel_console_script_points_at_bootstrap(self, built_wheel: Path) -> None:
+        with zipfile.ZipFile(built_wheel) as zf:
+            entry_points = next(zf.read(n).decode() for n in zf.namelist() if n.endswith(".dist-info/entry_points.txt"))
+        assert "t3 = t3_bootstrap:main" in entry_points


### PR DESCRIPTION
Closes #397

## Summary

#397 bundles four e2e/docker/editable-install bugs surfaced during #393. On audit against current `main`, three are already fixed by the prior follow-up PRs (#399/#434/#498). The reopen comment's live concern — `uv_build` silently dropping `t3_bootstrap` from the wheel — is also fixed in config (#498), but was shipped with **no regression test**, which is exactly why the defect went unnoticed and the issue was reopened. This PR adds that missing guard.

## Per sub-bug

**1. `Dockerfile.e2e` build broken** — already fixed on main (#399). `dev/Dockerfile.e2e` now bases from `mcr.microsoft.com/playwright/python:v1.58.0-noble`, runs as root, no `2>/dev/null` masking, no non-root `USER`. No change needed.

**2. `--update-snapshots` Docker path broken** — already fixed on main (#399). `dev/docker-compose.yml` splits `entrypoint: ["uv","run","pytest",...]` from `command: ["e2e/"]`, so `docker compose run e2e e2e/ --update-snapshots` correctly appends args to the fixed pytest entrypoint instead of overriding it. No change needed.

**3. `_ensure_editable_if_contributing` overrides worktree editable** — already fixed on main. `src/teatree/cli/__init__.py` only re-installs teatree editable when it is *not* editable at all; a worktree editable install is left untouched. The reopen follow-up (#498: `uv_build` ignored the hatch `force-include`, dropping `t3_bootstrap` from every wheel) is fixed by `[tool.uv.build-backend] module-name = ["teatree", "t3_bootstrap"]`. This PR adds the regression test that was missing: it builds a real wheel and asserts `t3_bootstrap/__init__.py`, `t3_bootstrap/_main.py`, and the `t3 = t3_bootstrap:main` console entry point are present. Asserting the pyproject key alone would not catch a backend swap; only an actual build does.

**4. Three skipped dashboard snapshot tests** — `test_dashboard.py` does not exist in the teatree repo (0 matches); those tests live in consumer/overlay repos and are out of scope for this repo's tree. No change applicable here.

## Anti-vacuous evidence

New tests: `tests/test_t3_bootstrap.py::TestWheelShipsBootstrap::{test_wheel_contains_t3_bootstrap_package, test_wheel_console_script_points_at_bootstrap}`.

- GREEN on current `main` config (`module-name = [ "teatree", "t3_bootstrap" ]`): both pass.
- Reverted `pyproject.toml` build config to the broken #434-era state (`module-name = [ "teatree" ]`): RED with `AssertionError: assert 't3_bootstrap/__init__.py' in {...}` — reproduces the exact silent failure that caused the reopen.
- Restored config: GREEN, full `tests/test_t3_bootstrap.py` (9 tests) passes.

`uv run ruff check` + `ruff format --check` clean; `uv run ty check` passes; related suites (`test_t3_bootstrap`, `test_package_smoke`, `test_docker_build`) green. Test-only additive change (46 lines), fully exercised.