### PR TITLE
feat(reliability): per-ticket cost-cap consumer for TaskAttempt metrics (#885)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -523,6 +523,14 @@ TEATREE_LOOP_WATCHDOG = {
 }
 ```
 
+**Per-ticket cost cap (#885 / #398-4).** Where the watchdog above bounds a single in-flight subprocess (it kills a runaway mid-run), `TicketBudget` bounds the *whole ticket's lifetime spend* at dispatch time. Before a task's subprocess is launched, `run_headless` sums `TaskAttempt.cost_usd` across every task under the task's ticket; once the cumulative spend crosses the configured ceiling the subprocess is not launched and a `budget_exceeded` `TaskAttempt` failure is recorded (`task.fail()` runs), surfacing the breach on the failure record so a pathological ticket stops draining budget in unattended batch runs. The conservative default mirrors #882's precedent — the cap is opt-in (`0.0` = disabled), so the consumer changes no behaviour until a ceiling is configured. Overridable via Django settings:
+
+```python
+TEATREE_TICKET_BUDGET = {
+    "max_cost_usd": 0.0,  # 0 = disabled
+}
+```
+
 ### 5.3 Prompt Building (prompt.py)
 
 **`build_task_prompt(task)`** — Work instructions for the agent:

--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -27,7 +27,7 @@ from django.utils import timezone
 from teatree.agents.model_tiering import resolve_phase_model
 from teatree.agents.result_schema import RESULT_JSON_SCHEMA
 from teatree.agents.skill_bundle import resolve_skill_bundle
-from teatree.core.models import Task, TaskAttempt
+from teatree.core.models import Task, TaskAttempt, Ticket
 from teatree.core.models.worktree import Worktree
 from teatree.skill_loading import SkillLoadingPolicy
 from teatree.types import SkillMetadata
@@ -44,6 +44,15 @@ _HEARTBEAT_INTERVAL = 60  # seconds
 _DEFAULT_WATCHDOG = {
     "max_runtime_seconds": 3 * 60 * 60,  # 3h — well past any healthy phase task
     "max_turns": 0,  # 0 = disabled
+    "max_cost_usd": 0.0,  # 0 = disabled
+}
+
+# Conservative documented default (#885 / #398-4): the per-ticket cumulative
+# cost cap is opt-in. ``0.0`` = disabled, so installing this consumer changes
+# no behaviour until the user configures a ceiling — the same precedent #882
+# set for the watchdog's absolute cost dimension. The user picks a ceiling
+# that matches their budget appetite once they want batch runs bounded.
+_DEFAULT_TICKET_BUDGET = {
     "max_cost_usd": 0.0,  # 0 = disabled
 }
 
@@ -112,6 +121,39 @@ class LoopWatchdog:
         return None
 
 
+@dataclass(frozen=True)
+class TicketBudget:
+    """Per-ticket cumulative cost cap consumer (#885 / #398-4).
+
+    Where ``LoopWatchdog`` bounds a *single in-flight subprocess* (it kills
+    a runaway mid-run from the heartbeat thread), this consumer bounds the
+    *whole ticket's lifetime spend* at dispatch time. Before a task's
+    subprocess is launched it sums ``TaskAttempt.cost_usd`` across every
+    task under the ticket; once the cumulative spend crosses the configured
+    ceiling no further attempt is dispatched and a ``budget_exceeded``
+    ``TaskAttempt`` failure is recorded (``task.fail()`` runs), surfacing
+    the breach on the failure record. A ceiling of ``0.0`` disables the cap.
+    """
+
+    max_cost_usd: float
+
+    @classmethod
+    def from_settings(cls) -> "TicketBudget":
+        configured = getattr(settings, "TEATREE_TICKET_BUDGET", None) or _DEFAULT_TICKET_BUDGET
+        return cls(max_cost_usd=float(configured.get("max_cost_usd", 0.0)))
+
+    def breach_reason(self, ticket: Ticket) -> str | None:
+        """Return a reason string with the observed total, or ``None`` if healthy."""
+        if not self.max_cost_usd:
+            return None
+        total = TaskAttempt.objects.filter(task__ticket=ticket).aggregate(cost=Sum("cost_usd"))["cost"] or 0.0
+        if total > self.max_cost_usd:
+            return (
+                f"budget_exceeded: ticket spent ${total:.2f} > cap ${self.max_cost_usd:.2f} — refusing further dispatch"
+            )
+        return None
+
+
 def _safe_int(value: str | None) -> int | None:
     if value is None:
         return None
@@ -147,6 +189,11 @@ def run_headless(
     binary = shutil.which("claude")
     if binary is None:
         return _record_failure(task, error="claude is not installed")
+
+    budget_breach = TicketBudget.from_settings().breach_reason(task.ticket)
+    if budget_breach is not None:
+        logger.warning("Refusing dispatch for task %s: %s", task.pk, budget_breach)
+        return _record_failure(task, error=budget_breach)
 
     prompt = build_task_prompt(task)
     lifecycle_skill = SkillLoadingPolicy.lifecycle_for_phase(phase)

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -11,6 +11,7 @@ from django.test import TestCase, override_settings
 import teatree.agents.headless as headless_mod
 from teatree.agents.headless import (
     LoopWatchdog,
+    TicketBudget,
     _get_resume_session_id,
     _parse_cli_envelope,
     _parse_result,
@@ -555,6 +556,120 @@ class TestRunHeadlessRecordsStuckLoop(TestCase):
         assert "turns" in attempt.error
         assert "500" in attempt.error
         assert task.status == Task.Status.FAILED
+
+
+class TestTicketBudget(TestCase):
+    """Per-ticket cumulative cost-cap consumer (#885 / #398-4).
+
+    Sums ``TaskAttempt.cost_usd`` across *every* task under the ticket
+    (not just the task being dispatched, unlike the per-task
+    ``LoopWatchdog``) and refuses further dispatch once the configured
+    per-ticket ceiling is crossed.
+    """
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create()
+        self.session = Session.objects.create(ticket=self.ticket)
+        self.task = Task.objects.create(ticket=self.ticket, session=self.session)
+
+    def test_disabled_budget_never_refuses(self) -> None:
+        TaskAttempt.objects.create(task=self.task, cost_usd=9999.0)
+        budget = TicketBudget(max_cost_usd=0.0)
+        assert budget.breach_reason(self.ticket) is None
+
+    def test_under_cap_does_not_refuse(self) -> None:
+        TaskAttempt.objects.create(task=self.task, cost_usd=2.0)
+        budget = TicketBudget(max_cost_usd=5.0)
+        assert budget.breach_reason(self.ticket) is None
+
+    def test_over_cap_refuses_with_observed_total(self) -> None:
+        TaskAttempt.objects.create(task=self.task, cost_usd=4.0)
+        TaskAttempt.objects.create(task=self.task, cost_usd=3.5)
+        budget = TicketBudget(max_cost_usd=5.0)
+        reason = budget.breach_reason(self.ticket)
+        assert reason is not None
+        assert "budget" in reason
+        assert "7.50" in reason
+        assert "5.00" in reason
+
+    def test_sums_across_all_tasks_of_the_ticket(self) -> None:
+        other_session = Session.objects.create(ticket=self.ticket)
+        other_task = Task.objects.create(ticket=self.ticket, session=other_session)
+        TaskAttempt.objects.create(task=self.task, cost_usd=3.0)
+        TaskAttempt.objects.create(task=other_task, cost_usd=3.0)
+        budget = TicketBudget(max_cost_usd=5.0)
+        reason = budget.breach_reason(self.ticket)
+        assert reason is not None
+        assert "6.00" in reason
+
+    def test_ignores_other_tickets(self) -> None:
+        other_ticket = Ticket.objects.create()
+        other_session = Session.objects.create(ticket=other_ticket)
+        other_task = Task.objects.create(ticket=other_ticket, session=other_session)
+        TaskAttempt.objects.create(task=other_task, cost_usd=99.0)
+        TaskAttempt.objects.create(task=self.task, cost_usd=1.0)
+        budget = TicketBudget(max_cost_usd=5.0)
+        assert budget.breach_reason(self.ticket) is None
+
+    def test_from_settings_reads_configured_cap(self) -> None:
+        with override_settings(TEATREE_TICKET_BUDGET={"max_cost_usd": 12.5}):
+            budget = TicketBudget.from_settings()
+        assert budget.max_cost_usd == pytest.approx(12.5)
+
+    def test_from_settings_defaults_to_disabled(self) -> None:
+        with override_settings():
+            from django.conf import settings  # noqa: PLC0415
+
+            if hasattr(settings, "TEATREE_TICKET_BUDGET"):
+                del settings.TEATREE_TICKET_BUDGET
+            budget = TicketBudget.from_settings()
+        # Conservative documented default mirrors #882's precedent: the
+        # cap is opt-in (0.0 = disabled) so no behaviour change until the
+        # user configures a ceiling.
+        assert budget.max_cost_usd == pytest.approx(0.0)
+
+
+class TestRunHeadlessRefusesOverBudgetTicket(TestCase):
+    """run_headless refuses dispatch and records a budget_exceeded failure."""
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create()
+        self.session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
+
+    def test_over_budget_ticket_is_not_dispatched(self) -> None:
+        spent = Task.objects.create(ticket=self.ticket, session=self.session)
+        TaskAttempt.objects.create(task=spent, cost_usd=8.0)
+        task = Task.objects.create(ticket=self.ticket, session=self.session)
+
+        with (
+            override_settings(TEATREE_TICKET_BUDGET={"max_cost_usd": 5.0}),
+            patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
+            patch.object(
+                headless_mod,
+                "_build_headless_command",
+                side_effect=AssertionError("subprocess must not be launched over budget"),
+            ),
+        ):
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        assert attempt.exit_code != 0
+        assert "budget_exceeded" in attempt.error
+        assert "8.00" in attempt.error
+        assert task.status == Task.Status.FAILED
+
+    def test_under_budget_ticket_proceeds(self) -> None:
+        spent = Task.objects.create(ticket=self.ticket, session=self.session)
+        TaskAttempt.objects.create(task=spent, cost_usd=1.0)
+        task = Task.objects.create(ticket=self.ticket, session=self.session)
+        result_json = json.dumps({"summary": "Done"})
+
+        with override_settings(TEATREE_TICKET_BUDGET={"max_cost_usd": 5.0}), _fake_claude(stdout=f"{result_json}\n"):
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        assert attempt.exit_code == 0
+        assert task.status == Task.Status.COMPLETED
 
 
 # --- _build_headless_command model tiering (#880) ---


### PR DESCRIPTION
## What

Primitive 4 of #398. Adds a consumer for the cost metrics #882 started recording on `TaskAttempt`.

Where the #882 `LoopWatchdog` bounds a *single in-flight subprocess* (it kills a runaway mid-run from the heartbeat thread), `TicketBudget` bounds the *whole ticket's lifetime spend* at dispatch time. Before a task's subprocess is launched, `run_headless` sums `TaskAttempt.cost_usd` across every task under the task's ticket; once the cumulative spend crosses the configured ceiling the subprocess is not launched and a `budget_exceeded` `TaskAttempt` failure is recorded (`task.fail()` runs), surfacing the breach on the failure record so a pathological ticket stops draining budget in unattended batch runs.

## How

- New `TicketBudget` frozen dataclass mirrors `LoopWatchdog`'s shape exactly: a `from_settings()` classmethod reading the `TEATREE_TICKET_BUDGET` Django setting, and `breach_reason(ticket)` returning a reason string or `None`.
- The cumulative aggregation reuses the same `Sum("cost_usd")` ORM pattern as `TaskUsage.for_task`, scoped to the whole ticket (`TaskAttempt.objects.filter(task__ticket=ticket)`) rather than a single task.
- The gate runs in `run_headless` right after the binary check and before any prompt/command building — refuse before doing work, mirroring the existing early-return `_record_failure` pattern.
- Conservative documented default mirrors #882's precedent for the watchdog's absolute cost dimension: the cap is opt-in (`0.0` = disabled), so the consumer changes no behaviour until a ceiling is configured. BLUEPRINT § 5.2 documents the setting next to `TEATREE_LOOP_WATCHDOG`.

## Reconciliation with the merged #905 watchdog

`TicketBudget` and `LoopWatchdog` are complementary, not overlapping:

| | `LoopWatchdog` (#882/#905) | `TicketBudget` (#885) |
|---|---|---|
| Scope | one in-flight subprocess | whole ticket lifetime |
| When | every heartbeat tick | once, at dispatch (pre-launch) |
| Aggregation | `Sum` over one task's attempts | `Sum` over all the ticket's attempts |
| Action | `proc.kill()` mid-run → `stuck_loop` | refuse dispatch → `budget_exceeded` |

Both are frozen dataclasses with the same `from_settings`/`breach_reason` shape and reuse the same `Sum("cost_usd")` ORM idiom; no watchdog code was modified.

## Scope

Dispatch-side cap check + config only. Does not touch BLUEPRINT § 17 / `hook_router` / merge / ship path.

## Tests

- `TestTicketBudget` — disabled / under-cap / over-cap / sums across all tasks of the ticket / ignores other tickets / settings load / default disabled, against real `Task`/`TaskAttempt`/`Ticket` rows.
- `TestRunHeadlessRefusesOverBudgetTicket` — an over-budget ticket is not dispatched (the subprocess builder raises if called), a `budget_exceeded` `TaskAttempt` failure is recorded and `task.status == FAILED`; an under-budget ticket proceeds to `COMPLETED`.

Anti-vacuous: reverting `headless.py` to `origin/main` makes the new tests fail with `ImportError: cannot import name 'TicketBudget'`; restoring makes them pass. Full suite green (4235 passed). New consumer code at 100% coverage; repo coverage 93.9%.

Closes #885
Relates-to #398