### PR TITLE
test(workspace): make #910 squash-merge data-loss guard order-independent (#915)

### DIFF
--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1556,7 +1556,24 @@ class TestPruneSquashMergedDataLossGuard(TestCase):
             )
 
     def test_genuinely_squash_merged_branch_is_still_pruned(self) -> None:
-        """No regression: a branch whose work IS on origin/main is still cleaned."""
+        """No regression: a branch whose work IS on origin/main is still cleaned.
+
+        A real merged PR leaves two facts true: the source branch was pushed
+        to its own remote ref (the PR existed), and the squash commit on
+        ``main`` has a SHA distinct from the source-branch commit (different
+        parent/message/timestamp). The original test only passed when both
+        commits happened to land in the same wall-clock second and so collided
+        on a single SHA — under a slow full-directory run they straddled a
+        second boundary, the SHAs diverged, and the genuinely-squash-merged
+        branch was wrongly classified ``unsynced`` (the #915 order-dependence).
+
+        This models the realistic case deterministically: ``feature`` is pushed
+        to ``origin`` so the #706 data-loss guard correctly sees the work IS on
+        a remote, and the PR-merge-SHA probe returns the actual squash commit
+        (whose tree equals the feature tip), so ``_branch_tree_matches_squash``
+        classifies the distinct-SHA branch as squash-merged — independent of
+        commit timestamps.
+        """
         with tempfile.TemporaryDirectory() as tmp_s:
             tmp = Path(tmp_s)
             _remote, work = _init_repo_with_remote(tmp)
@@ -1565,11 +1582,14 @@ class TestPruneSquashMergedDataLossGuard(TestCase):
             (work / "f.py").write_text("work\n", encoding="utf-8")
             _git(work, "add", "f.py")
             _git(work, "commit", "-q", "-m", "feat: real work (#99)")
+            # The PR existed: its source branch was pushed to a remote.
+            _git(work, "push", "-q", "origin", "feature")
 
             # Squash-merge into main and push: the content is now on a remote.
             _git(work, "checkout", "-q", "main")
             _git(work, "merge", "-q", "--squash", "feature")
             _git(work, "commit", "-q", "-m", "feat: real work (#99)")
+            squash_sha = _git(work, "rev-parse", "main")
             _git(work, "push", "-q", "origin", "main")
             _git(work, "fetch", "-q", "origin")
 
@@ -1578,7 +1598,10 @@ class TestPruneSquashMergedDataLossGuard(TestCase):
             repo = str(work)
             wt_map = {"feature": str(wt_path)}
 
-            with patch.object(cleanup_mod, "_pr_merge_commit_sha", return_value=""):
+            # The PR's squash commit tree equals the feature tip tree by
+            # construction, so `_branch_tree_matches_squash` is True and the
+            # branch is correctly classified squash-merged regardless of SHA.
+            with patch.object(cleanup_mod, "_pr_merge_commit_sha", return_value=squash_sha):
                 result = ws_cleanup_mod.prune_squash_merged(repo, "feature", wt_map)
 
             branches = _git(work, "branch", "--format=%(refname:short)").split()
@@ -1595,13 +1618,18 @@ class TestPruneSquashMergedDataLossGuard(TestCase):
             (work / "f.py").write_text("work\n", encoding="utf-8")
             _git(work, "add", "f.py")
             _git(work, "commit", "-q", "-m", "feat: real work (#99)")
+            _git(work, "push", "-q", "origin", "feature")
             _git(work, "checkout", "-q", "main")
             _git(work, "merge", "-q", "--squash", "feature")
             _git(work, "commit", "-q", "-m", "feat: real work (#99)")
+            squash_sha = _git(work, "rev-parse", "main")
             _git(work, "push", "-q", "origin", "main")
             _git(work, "fetch", "-q", "origin")
 
-            with patch.object(cleanup_mod, "_pr_merge_commit_sha", return_value=""):
+            # Mock the PR squash commit (tree == feature tip) so the branch is
+            # classified squash-merged via the tree match, not via an accidental
+            # SHA collision — hermetic regardless of commit timestamps (#915).
+            with patch.object(cleanup_mod, "_pr_merge_commit_sha", return_value=squash_sha):
                 result = ws_cleanup_mod.prune_squash_merged(str(work), "feature", {})
 
             assert "feature" not in _git(work, "branch", "--format=%(refname:short)").split()


### PR DESCRIPTION
## Summary

`tests/teatree_core/management_commands/test_workspace.py::TestPruneSquashMergedDataLossGuard::test_genuinely_squash_merged_branch_is_still_pruned`
— the no-regression guard for the #710/#706 `prune_squash_merged`
data-loss fix (added by #910) — was intermittently order-dependent. It
passed in isolation and in CI but `ws-443d`'s full-directory run (PR #914)
observed it FAIL. This is purely test-isolation; the #910 production fix
is sound and untouched. `Closes #915`, `Relates-to #710`.

## Reproduced RED

Running the whole `tests/teatree_core/management_commands/` package in
file order (`uv run pytest tests/teatree_core/management_commands/ -p no:randomly`)
intermittently failed (observed roughly 1 run in 6–13, and immediately
under `-x`):

```
AssertionError: squash-merged branch should be pruned, got:
  "SKIPPED 'feature': 1 unsynced commit(s) — push to a new branch:
```

## Root cause

The test built the feature commit, then `git merge --squash feature`
and a second `git commit` on `main` with the **same message**. Git's
author/committer dates default to wall-clock "now". When both commits
land in the same second they hash to the **same SHA**, so the feature
commit is reachable from `origin/main`, `git log feature --not origin/main`
is empty, and `prune_squash_merged` prunes. Under a slow full-directory
run the two commits straddle a one-second boundary, their SHAs diverge
(what a *real* squash-merge always produces), the feature commit is no
longer an ancestor of `origin/main`, `unsynced_commits` returns 1, and
— with `_pr_merge_commit_sha` mocked to `""` so `_branch_tree_matches_squash`
is False — the branch is wrongly classified `unsynced` and not pruned.
The test only ever "passed" by an accidental SHA collision, not by
exercising a genuine squash-merge. The sibling
`test_unsynced_squash_merged_branch_without_linked_worktree_is_pruned`
had the identical latent flaw.

## Hermetic fix (test-only — zero `src/` change)

Model a real merged PR deterministically instead of relying on a SHA
collision:

- Push the feature branch to its remote (`git push origin feature`).
  A merged PR's source branch was pushed, so the #706 data-loss guard
  (`git log feature --not --remotes`) correctly sees the work IS on a
  remote and does not refuse — independent of the commit SHA.
- Return the actual squash commit SHA from the mocked `_pr_merge_commit_sha`
  probe so `_branch_tree_matches_squash` (tree of squash == tree of
  feature tip, by construction) classifies the distinct-SHA branch as
  squash-merged — the realistic detection path, independent of timestamps.

The data-loss assertions are unchanged: a genuinely squash-merged branch
IS still pruned (`result == "Pruned squash-merged branch: feature"`), and
the companion guard `test_branch_with_unique_unpushed_work_is_not_force_deleted`
(a unique-unpushed branch is NOT deleted) still holds.

## Verification

- Adverse harness forcing a >1s gap between the two commits (the exact
  flake trigger): old model FAILs, fixed model PASSes for both the
  same-second and distinct-second cases.
- `TestPruneSquashMergedDataLossGuard` (all 4) green in isolation.
- `tests/teatree_core/management_commands/` file order: 12/12 clean runs
  (previously flaked within 6–13); `-x` mode 6/6; `-n 4` xdist parallel
  (timing-adverse) 4/4.
- `tests/teatree_core/` full: 3/3 clean (1550 passed each).
- Full `tests/` suite: 4260 passed, coverage 93.97% ≥ 93% gate.
- ruff check + format, ty, module-health, conventional-commit, prek
  (changed files only) all green.

## Scope

Test-isolation only. No `src/` change. BLUEPRINT §17, hook router,
merge, and ship paths untouched.
