### PR TITLE
fix(update): ff-advance on untracked-only dirt; warn loudly on tracked-dirty (#924)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ e2e/.videos/
 # the DB; the file is regenerated on drift and must never be committed.
 .t3-env.cache
 .t3-cache/
+
+# Autonomous review-loop runtime cursor (#924): written untracked at the
+# clone root by the loop. Ignoring it keeps the clone clean so `t3 update`
+# can always ff-advance the running editable t3 (it never blocked the
+# fast-forward, but staying untracked-clean avoids any confusion).
+.loop-review-state.json

--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -8,7 +8,8 @@ For teatree core (``$T3_REPO``) and every registered overlay repo, this:
 
 1. ``git fetch`` the origin.
 2. Resolves the default branch from ``origin/HEAD``.
-3. Skips (never clobbers) a dirty, non-default-branch, or no-upstream checkout.
+3. Skips a non-default-branch / no-upstream checkout, and a
+    tracked-dirty tree (loudly). Untracked-only files do not block it.
 4. Otherwise ``git pull --ff-only`` — fast-forward only, never merge/rebase.
 5. Reinstalls advanced editable installs, applies pending self-DB migrations (non-destructive), then runs ``t3 setup``.
 6. Prints a per-repo summary; exits non-zero only on a hard failure (not a skip).
@@ -109,8 +110,17 @@ def _has_origin_remote(repo: Path) -> bool:
     return "origin" in result.stdout.split()
 
 
-def _is_dirty(repo: Path) -> bool:
-    return bool(_git(repo, "status", "--porcelain").stdout.strip())
+def _tracked_dirty_paths(repo: Path) -> list[str]:
+    """Return paths with uncommitted *tracked* changes (untracked excluded).
+
+    ``git status --porcelain`` prefixes each entry with a two-char status
+    code; an untracked path is ``"?? "``.  A fast-forward ``git pull
+    --ff-only`` and ``pip install -e`` never clobber untracked files, so
+    they must NOT block the update (#924) — only tracked modifications a
+    fast-forward could actually conflict with do.
+    """
+    lines = _git(repo, "status", "--porcelain").stdout.splitlines()
+    return [line[3:] for line in lines if line and not line.startswith("??")]
 
 
 def _has_upstream(repo: Path) -> bool:
@@ -155,15 +165,35 @@ def _check_default_branch(name: str, repo: Path) -> RepoUpdate | None:
 
 
 def _check_clean(name: str, repo: Path) -> RepoUpdate | None:
-    if not _is_dirty(repo):
+    """Refuse a ff-pull only on uncommitted *tracked* changes — loudly.
+
+    Untracked files (e.g. the loop's ``.loop-review-state.json`` runtime
+    artifact) are tolerated: a fast-forward never touches them, so the
+    update must proceed (#924).  When tracked changes do block the pull,
+    this is NOT a silent ``SKIP`` line — it emits a prominent, multi-line
+    WARNING so a stale running editable ``t3`` can never be invisible.
+    """
+    tracked = _tracked_dirty_paths(repo)
+    if not tracked:
         return None
-    return RepoUpdate(name, UpdateStatus.SKIPPED, reason="dirty working tree (uncommitted changes)")
+    listed = ", ".join(tracked)
+    typer.echo("")
+    typer.echo(f"!! WARNING: {name} has uncommitted TRACKED changes — refusing the fast-forward pull.")
+    typer.echo(f"!! Changed tracked path(s): {listed}")
+    typer.echo(f"!! The running editable t3 from {repo} will stay STALE behind origin until this is resolved.")
+    typer.echo("!! Commit, stash, or revert the tracked change, then re-run `t3 update`.")
+    typer.echo("")
+    return RepoUpdate(
+        name,
+        UpdateStatus.SKIPPED,
+        reason=f"uncommitted tracked changes ({listed}) — running t3 may be STALE; resolve and re-run `t3 update`",
+    )
 
 
 # Ordered safety gate: origin must exist before fetch, fetch before branch
-# resolution (which needs origin/HEAD), branch before the dirty check.  Each
-# guard *skips* (never clobbers) with a reason; only a failed fetch is a hard
-# failure.  The order is load-bearing — do not reorder.
+# resolution (which needs origin/HEAD), branch before the tracked-dirty
+# check.  Each guard *skips* (never clobbers) with a reason; only a failed
+# fetch is a hard failure.  The order is load-bearing — do not reorder.
 _PRECONDITIONS = (_check_origin, _check_fetch, _check_default_branch, _check_clean)
 
 
@@ -179,9 +209,11 @@ def _precondition_block(name: str, repo: Path) -> RepoUpdate | None:
 def update_repo(name: str, repo: Path) -> RepoUpdate:
     """Fetch and fast-forward *repo* to its default branch, or skip safely.
 
-    Never stashes, resets, or clobbers: a dirty tree, a non-default branch, or
-    a missing upstream each yield :class:`UpdateStatus.SKIPPED` with a reason.
-    A failed ``git fetch`` / ``git pull`` yields :class:`UpdateStatus.FAILED`.
+    Never stashes, resets, or clobbers: a tracked-dirty tree (warned
+    loudly), a non-default branch, or a missing upstream each yield
+    :class:`UpdateStatus.SKIPPED` with a reason.  An untracked-only tree
+    is NOT dirt — the ff-pull proceeds.  A failed ``git fetch`` / ``git
+    pull`` yields :class:`UpdateStatus.FAILED`.
     """
     blocked = _precondition_block(name, repo)
     if blocked is not None:

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -127,8 +127,39 @@ class TestUpdateRepoUpToDate:
         assert result.is_error is False
 
 
+class TestUpdateRepoUntrackedOnlyStillAdvances:
+    """#924: untracked files must not block the ff-pull + reinstall.
+
+    The autonomous review-loop writes an untracked runtime artifact
+    (``.loop-review-state.json``) at the clone root.  ``git pull
+    --ff-only`` and ``pip install -e`` never clobber untracked files, so
+    a tree whose only 'dirt' is untracked must still fast-forward —
+    otherwise the running editable ``t3`` silently rots behind
+    origin/main (29 PRs stale, observed).
+    """
+
+    def test_untracked_only_does_not_block_fast_forward(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        old_sha = _git(clone, "rev-parse", "--short", "HEAD")
+        new_sha = _advance_remote(tmp_path, bare)
+        # The loop's own runtime artifact: untracked, never committed.
+        (clone / ".loop-review-state.json").write_text('{"cursor": 1}\n')
+        (clone / "scratch.tmp").write_text("ad-hoc note\n")
+
+        result = update_repo("clone", clone)
+
+        assert result.status is UpdateStatus.UPDATED
+        assert result.old_sha == old_sha
+        assert result.new_sha == new_sha
+        assert _git(clone, "rev-parse", "--short", "HEAD") == new_sha
+        # Untracked files are preserved across the fast-forward.
+        assert (clone / ".loop-review-state.json").read_text() == '{"cursor": 1}\n'
+        assert (clone / "scratch.tmp").read_text() == "ad-hoc note\n"
+
+
 class TestUpdateRepoSkips:
-    def test_dirty_checkout_skips_without_clobbering(self, tmp_path: Path) -> None:
+    def test_tracked_dirty_refuses_but_warns_loudly(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         bare = _make_remote(tmp_path)
         clone = _clone(tmp_path, bare)
         _advance_remote(tmp_path, bare)
@@ -137,10 +168,16 @@ class TestUpdateRepoSkips:
         result = update_repo("clone", clone)
 
         assert result.status is UpdateStatus.SKIPPED
-        assert "dirty" in result.reason.lower()
+        assert "tracked" in result.reason.lower()
         assert result.is_error is False
         # Never clobbered — the local edit survives.
         assert (clone / "f.txt").read_text() == "local uncommitted work\n"
+        # Non-silent: a loud, prominent warning surfaces (a stale running
+        # `t3` must never be invisible — #924).
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert "stale" in out.lower()
+        assert "clone" in out
 
     def test_feature_branch_checkout_skips(self, tmp_path: Path) -> None:
         bare = _make_remote(tmp_path)


### PR DESCRIPTION
## What

`t3 update` (`src/teatree/cli/update.py`) treated **any** dirty working
tree — including a tree dirtied only by *untracked* files — as a reason
to SKIP the fast-forward pull, editable reinstall and self-DB migration.

The autonomous review-loop legitimately writes an untracked runtime
artifact (`.loop-review-state.json`) at the clone root, so the skip
fired on every `t3 update` and the running editable `t3` quietly fell
behind `origin/main` (observed: 29 PRs stale) with only a single quiet
`SKIP` line — a stale running `t3` was effectively invisible.

## Fix

- `git pull --ff-only` and `pip install -e` never clobber untracked
  files, so the precondition now inspects only *tracked* changes
  (`git status --porcelain` minus `??` entries). Untracked-only trees
  now fast-forward + reinstall + migrate as expected.
- A genuinely tracked-dirty tree still refuses the pull (never stashes
  or clobbers), but no longer via a silent `SKIP`: it emits a prominent
  multi-line `WARNING` naming the affected clone and stating the running
  `t3` will stay STALE until resolved.
- `.loop-review-state.json` is added to `.gitignore` so the loop's own
  runtime artifact is not even untracked-dirty.

## Tests

Real `git` clones under `tmp_path` (no git mocking):

- `TestUpdateRepoUntrackedOnlyStillAdvances::test_untracked_only_does_not_block_fast_forward`
  — untracked-only tree fast-forwards and the untracked files survive.
  Anti-vacuous: with `update.py` reverted to `origin/main` this fails
  `assert <UpdateStatus.SKIPPED> is <UpdateStatus.UPDATED>`.
- `TestUpdateRepoSkips::test_tracked_dirty_refuses_but_warns_loudly`
  — tracked-dirty refuses but asserts the loud WARNING surface, not a
  silent skip.

100% line + branch coverage on `src/teatree/cli/update.py`; full suite
green (4261 passed).

Scope: `src/teatree/cli/update.py`, its test, and `.gitignore` only. No
BLUEPRINT / §17 / hook_router / merge / ship changes.

Closes #924
