### PR TITLE
fix(core): apply needs_user_input suppression on the shared FSM transition path (#927)

### DIFF
--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -277,8 +277,13 @@ class TaskQuerySet(models.QuerySet):
         the required ``ticket.state``, so an already-advanced ticket
         no-ops and a ticket can never be teleported past a lifecycle gate
         it did not earn (a COMPLETED ``shipping`` task on a ``started``
-        ticket finds no matching guard). Returns the number of tickets a
-        transition actually fired for.
+        ticket finds no matching guard). The shared path also enforces
+        the needs-user-input hold (#927): a task the agent could not
+        finish (its last attempt returned ``needs_user_input``) was held
+        by ``_advance_ticket`` with an interactive followup scheduled —
+        the sweep must not force-advance it past that phase, and does not,
+        because ``_apply_phase_transition`` itself no-ops for a held task.
+        Returns the number of tickets a transition actually fired for.
         """
         from teatree.core.models.task import Task  # noqa: PLC0415
 

--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -135,6 +135,20 @@ class Task(models.Model):
         self._record_phase_visit()
         self._apply_phase_transition()
 
+    def _needs_user_input_followup_pending(self) -> bool:
+        """True iff this task was *held* for human input (#927).
+
+        The agent returned ``needs_user_input`` so ``_advance_ticket``
+        deliberately did NOT fire the FSM transition and scheduled an
+        interactive followup instead. The replay sweep
+        (``replay_orphaned_transitions``) takes this task as
+        latest-per-ticket and would otherwise force-advance the ticket
+        past a phase the agent said it could not finish, orphaning the
+        followup. The suppression therefore belongs on the *shared*
+        transition path, not only the live ``complete()`` chain.
+        """
+        return self._last_attempt_needs_user_input()
+
     def _apply_phase_transition(self) -> bool:
         """Fire the FSM transition this task's phase implies, if its guard holds.
 
@@ -151,9 +165,17 @@ class Task(models.Model):
         call (parallel child task, or a replay of an already-applied
         transition) finds the state mismatch and no-ops.
 
+        A task held for human input (#927) never fires its transition
+        here — the agent said it could not finish this phase, so neither
+        the live ``complete()`` chain nor the replay sweep may advance
+        the ticket past it. Enforced on this shared path so the gate is
+        not bypassable by any caller of ``_apply_phase_transition``.
+
         Returns ``True`` iff a transition fired (used by the replay sweep
         to count recovered tickets).
         """
+        if self._needs_user_input_followup_pending():
+            return False
         ticket = self.ticket
         ticket.refresh_from_db()
         # Normalize once, mirroring _record_phase_visit() — a task whose

--- a/tests/teatree_core/test_managers.py
+++ b/tests/teatree_core/test_managers.py
@@ -713,6 +713,64 @@ class TestReplayOrphanedTransitions(TestCase):
         assert replayed == 0
         assert ticket.state == Ticket.State.STARTED
 
+    def test_needs_user_input_held_task_is_not_force_advanced(self) -> None:
+        # #927 BLOCKER — a headless coding task that returned
+        # ``{"needs_user_input": True}`` is correctly *held* by
+        # ``_advance_ticket`` (ticket stays STARTED, an interactive
+        # followup is scheduled, the task ends COMPLETED). The replay
+        # sweep then finds that COMPLETED task as latest-per-ticket and
+        # must NOT force-advance the ticket past the phase the agent
+        # said it could not finish. The needs-user-input suppression
+        # is part of the shared transition path, not only the live
+        # ``complete()`` chain.
+        ticket = Ticket.objects.create(state=Ticket.State.STARTED)
+        session = Session.objects.create(ticket=ticket, agent_id="a")
+        task = Task.objects.create(ticket=ticket, session=session, phase="coding")
+        task.complete_with_attempt(
+            exit_code=0,
+            result={"needs_user_input": True, "user_input_reason": "blocked on a design decision"},
+        )
+        # Precondition: the live path held the ticket and scheduled the
+        # interactive followup — this is the state the sweep then sees.
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.STARTED
+        followup = Task.objects.filter(parent_task=task).first()
+        assert followup is not None
+        assert followup.execution_target == Task.ExecutionTarget.INTERACTIVE
+
+        replayed = Task.objects.replay_orphaned_transitions()
+
+        ticket.refresh_from_db()
+        assert replayed == 0
+        assert ticket.state == Ticket.State.STARTED, (
+            f"replay force-advanced a needs-user-input-held ticket to {ticket.state!r} — "
+            "the agent said it could not finish coding; the interactive followup is orphaned"
+        )
+        # The interactive followup must survive the sweep untouched.
+        followup.refresh_from_db()
+        assert followup.status == Task.Status.PENDING
+
+    def test_completed_task_without_needs_user_input_still_replays(self) -> None:
+        # #927 anti-vacuity: the fix must suppress *only* the
+        # needs-user-input case. A genuinely orphaned COMPLETED coding
+        # task (last attempt did NOT request user input) must still be
+        # replay-advanced, exactly as before — the recovery sweep is
+        # not over-blocked into uselessness.
+        ticket = Ticket.objects.create(state=Ticket.State.STARTED)
+        session = Session.objects.create(ticket=ticket, agent_id="a")
+        task = Task.objects.create(ticket=ticket, session=session, phase="coding")
+        task.complete_with_attempt(exit_code=0, result={"summary": "done"})
+        # Simulate the half-advanced orphan: complete() advanced the
+        # ticket; reset it to STARTED so the sweep has work to replay.
+        ticket.state = Ticket.State.STARTED
+        ticket.save(update_fields=["state"])
+
+        replayed = Task.objects.replay_orphaned_transitions()
+
+        ticket.refresh_from_db()
+        assert replayed == 1
+        assert ticket.state == Ticket.State.CODED
+
 
 class TestCompleteIsAtomic(TestCase):
     """#883 — ``Task.complete`` must be one transaction.


### PR DESCRIPTION
## Bug

`replay_orphaned_transitions` bypassed the `needs_user_input` guard that lived only in `_advance_ticket`. On the next loop tick, a ticket explicitly held for user input was force-advanced through its FSM transition, defeating the hold and progressing work the user had not yet approved.

## Fix

The `needs_user_input` suppression guard is hoisted out of `_advance_ticket` and into the shared `_apply_phase_transition` path, so every caller — including `replay_orphaned_transitions` — honors the hold consistently. There is now a single enforcement point for the invariant.

## Tests

- Anti-vacuous regression test: fails RED before the fix (reproduces the orphaned-transition force-advance of a held ticket; pre-fix the test body asserts the broken behaviour and fails), passes GREEN after the guard is hoisted.
- Anti-over-block test: a ticket that is *not* held still advances normally through the shared path, proving the guard does not over-suppress legitimate transitions.

Closes #927 — https://github.com/souliane/teatree/issues/927
