### PR TITLE
fix(core): resolve sanctioned-merge live PR head from the overlay repo, not clone origin (#931)

### DIFF
--- a/src/teatree/core/merge_execution.py
+++ b/src/teatree/core/merge_execution.py
@@ -33,6 +33,7 @@ import logging
 import shutil
 from dataclasses import dataclass
 from typing import TypedDict, cast
+from urllib.parse import urlparse
 
 from django.apps import apps
 from django.db import transaction
@@ -41,6 +42,7 @@ from django.utils import timezone
 from teatree.project import find_project_root
 from teatree.utils import git
 from teatree.utils.run import run_allowed_to_fail
+from teatree.utils.url_slug import slug_from_issue_or_pr_url
 
 logger = logging.getLogger(__name__)
 
@@ -110,29 +112,61 @@ def _project_repo_slug() -> str:
     return git.remote_slug(repo=str(root))
 
 
+def _ticket_repo_slug(clear: object) -> str:
+    """The GitHub ``owner/repo`` for *clear*'s ticket, or ``""`` (#931).
+
+    Resolved from the CLEAR's ``ticket.issue_url`` via the canonical
+    :func:`slug_from_issue_or_pr_url` parser — the repo the PR genuinely
+    belongs to, independent of which clone is running. This is the
+    authoritative source when an overlay's GitHub repo differs from the
+    editable ``t3`` clone's ``origin``: such a CLEAR must bind its
+    live-head check to the overlay repo's PR, never to a same-numbered
+    PR in the clone-origin repo (#931).
+    """
+    ticket = getattr(clear, "ticket", None)
+    if ticket is None:
+        return ""
+    issue_url = str(getattr(ticket, "issue_url", "") or "")
+    if not issue_url:
+        return ""
+    return slug_from_issue_or_pr_url(urlparse(issue_url).path)
+
+
 def resolve_pr_repo_slug(clear: object) -> str:
     """The GitHub ``owner/repo`` to target ``gh`` at for *clear*'s PR.
 
-    ``MergeClear.slug`` is a *workstream* slug, not a repo. If it already
-    looks like ``owner/repo`` it is used as-is (back-compat with rows /
-    tests that stored a repo there); otherwise the repo is resolved from
-    the running clone's git remote. Fails closed with an actionable
-    :class:`MergePreconditionError` when neither yields a repo — never the
-    opaque "could not resolve the live head" escalation that hid this gap.
+    ``MergeClear.slug`` is a *workstream* slug, not a repo. Resolution
+    order, first non-empty wins:
+
+    (1) an ``owner/repo``-shaped slug is used as-is (back-compat with
+    rows / tests that stored a repo there).
+    (2) the CLEAR's ``ticket.issue_url`` repo (#931 — authoritative: the
+    repo the PR belongs to, correct even when the overlay's repo differs
+    from the running clone's ``origin``).
+    (3) the running clone's ``origin`` git remote (the teatree-self
+    overlay, whose repo *is* the clone origin).
+
+    Fails closed with an actionable :class:`MergePreconditionError` when
+    none yields a repo — never the opaque "could not resolve the live
+    head" escalation that hid this gap.
     """
     slug = str(getattr(clear, "slug", "") or "")
     pr_id = getattr(clear, "pr_id", "?")
     if _looks_like_owner_repo(slug):
         return slug
+    from_ticket = _ticket_repo_slug(clear)
+    if from_ticket:
+        return from_ticket
     resolved = _project_repo_slug()
     if resolved:
         return resolved
     msg = (
         f"could not resolve the GitHub repo for {slug}#{pr_id}: the CLEAR slug "
-        f"{slug!r} is a workstream slug (not owner/repo) and the running teatree "
-        f"clone has no resolvable 'origin' remote. The sanctioned merge needs the "
-        f"real repo to bind the merge — re-issue the CLEAR from a checkout whose "
-        f"'origin' points at the GitHub repo, or pass an owner/repo slug."
+        f"{slug!r} is a workstream slug (not owner/repo), the CLEAR's ticket has "
+        f"no recognisable GitHub issue_url, and the running teatree clone has no "
+        f"resolvable 'origin' remote. The sanctioned merge needs the real repo to "
+        f"bind the merge — re-issue the CLEAR from a checkout whose 'origin' points "
+        f"at the GitHub repo, or pass an owner/repo slug."
     )
     raise MergePreconditionError(msg)
 

--- a/tests/teatree_core/test_merge_repo_resolution.py
+++ b/tests/teatree_core/test_merge_repo_resolution.py
@@ -131,6 +131,149 @@ class TestMergeUsesResolvedRepo(TestCase):
         assert "could not resolve the live head" not in message
 
 
+class TestOverlayRepoDiffersFromCloneOrigin(TestCase):
+    """#931 — an overlay's GitHub repo differs from the ``t3`` clone origin.
+
+    A sanctioned ``ticket merge`` for a PR in a downstream overlay repo
+    (here ``downstream-org/downstream-overlay#139``) must bind the
+    live-head check to that repo — the repo the ticket's PR belongs to —
+    NOT to ``souliane/teatree`` (the running clone's ``origin``). Before
+    #931 the live-head lookup resolved the clone-origin same-numbered PR
+    (an unrelated ``souliane/teatree#139`` whose head differs), so the
+    SHA-bind precondition saw "head moved" and every downstream-overlay
+    sanctioned merge was blocked.
+
+    The concrete repo name is not load-bearing — any ``owner/repo`` that
+    is not the clone origin reproduces the bug; a neutral placeholder is
+    used so core/tests stay overlay-agnostic (BLUEPRINT § 1).
+
+    Only the ``gh`` subprocess (the network boundary) is stubbed; the
+    repo resolution runs through real teatree code against a real
+    ``Ticket`` row.
+    """
+
+    _OVERLAY_REPO = "downstream-org/downstream-overlay"
+    _OVERLAY_SHA = "5" * 40  # overlay repo PR #139 head == reviewed SHA
+    _ORIGIN_SHA = "6" * 40  # unrelated clone-origin PR #139 head (moved-on)
+
+    def _overlay_clear(self) -> MergeClear:
+        ticket = Ticket.objects.create(
+            overlay="downstream",
+            issue_url=f"https://github.com/{self._OVERLAY_REPO}/issues/139",
+            state=Ticket.State.IN_REVIEW,
+        )
+        return MergeClear.objects.create(
+            ticket=ticket,
+            pr_id=139,
+            slug="overlay-repo-differs-from-clone-origin",
+            reviewed_sha=self._OVERLAY_SHA,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.LOGIC,
+        )
+
+    def _gh_keyed_by_repo(self, calls: list[list[str]]):
+        """A ``gh`` stub whose PR head depends on the ``--repo`` argument.
+
+        The overlay repo's PR #139 head == the reviewed SHA (mergeable);
+        the clone-origin PR #139 head is a different, unrelated SHA.
+        Which head the precondition sees is decided purely by which repo
+        the sanctioned path targets.
+        """
+
+        def _gh(argv: list[str]) -> tuple[int, str, str]:
+            calls.append(argv)
+            joined = " ".join(argv)
+            repo = argv[argv.index("--repo") + 1] if "--repo" in argv else ""
+            head = self._OVERLAY_SHA if repo == self._OVERLAY_REPO else self._ORIGIN_SHA
+            if "headRefOid" in joined:
+                return (0, head, "")
+            if "isDraft" in joined:
+                return (0, "false", "")
+            if "statusCheckRollup" in joined:
+                return (0, _GREEN, "")
+            if "pulls" in joined and "merge" in joined:
+                return (0, '{"sha": "merged0deadbeef"}', "")
+            return (0, "", "")
+
+        return _gh
+
+    def test_sha_bind_precondition_passes_against_overlay_repo(self) -> None:
+        clear = self._overlay_clear()
+        calls: list[list[str]] = []
+
+        with (
+            patch("teatree.core.merge_execution._run_gh", side_effect=self._gh_keyed_by_repo(calls)),
+            patch("teatree.core.merge_execution._project_repo_slug", return_value="souliane/teatree"),
+        ):
+            outcome = merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
+
+        assert outcome.merged_sha
+        repo_args = [argv[argv.index("--repo") + 1] for argv in calls if "--repo" in argv]
+        assert repo_args
+        assert all(r == self._OVERLAY_REPO for r in repo_args), (
+            f"sanctioned merge targeted the wrong repo: {sorted(set(repo_args))} "
+            f"(must be the ticket's overlay repo, not the clone origin)"
+        )
+
+    def test_resolve_pr_repo_slug_prefers_ticket_issue_url_over_clone_origin(self) -> None:
+        clear = self._overlay_clear()
+
+        with patch("teatree.core.merge_execution._project_repo_slug", return_value="souliane/teatree"):
+            assert resolve_pr_repo_slug(clear) == self._OVERLAY_REPO
+
+    def test_ticketless_clear_falls_through_to_clone_origin(self) -> None:
+        """A CLEAR with no ticket keeps the #872 clone-origin behaviour."""
+        clear = MergeClear.objects.create(
+            ticket=None,
+            pr_id=139,
+            slug="overlay-repo-differs-from-clone-origin",
+            reviewed_sha=self._OVERLAY_SHA,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.LOGIC,
+        )
+
+        with patch("teatree.core.merge_execution._project_repo_slug", return_value="souliane/teatree"):
+            assert resolve_pr_repo_slug(clear) == "souliane/teatree"
+
+    def test_clear_with_blank_issue_url_falls_through_to_clone_origin(self) -> None:
+        """A ticket with no issue_url keeps the #872 clone-origin behaviour."""
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = MergeClear.objects.create(
+            ticket=ticket,
+            pr_id=139,
+            slug="overlay-repo-differs-from-clone-origin",
+            reviewed_sha=self._OVERLAY_SHA,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.LOGIC,
+        )
+
+        with patch("teatree.core.merge_execution._project_repo_slug", return_value="souliane/teatree"):
+            assert resolve_pr_repo_slug(clear) == "souliane/teatree"
+
+    def test_clear_with_non_github_issue_url_falls_through_to_clone_origin(self) -> None:
+        """A ticket whose issue_url is unparsable falls back, not crash."""
+        ticket = Ticket.objects.create(
+            overlay="t3-teatree",
+            issue_url="https://example.invalid/not-an-issue",
+            state=Ticket.State.IN_REVIEW,
+        )
+        clear = MergeClear.objects.create(
+            ticket=ticket,
+            pr_id=139,
+            slug="overlay-repo-differs-from-clone-origin",
+            reviewed_sha=self._OVERLAY_SHA,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.LOGIC,
+        )
+
+        with patch("teatree.core.merge_execution._project_repo_slug", return_value="souliane/teatree"):
+            assert resolve_pr_repo_slug(clear) == "souliane/teatree"
+
+
 class TestProjectRepoSlugHelper(TestCase):
     def test_project_repo_slug_uses_project_root_git_remote(self) -> None:
         with (


### PR DESCRIPTION
## Bug

The sanctioned-merge precondition resolved the "live PR head" repo from the editable clone's `origin`, not from the repo the CLEAR's PR actually belongs to. When an overlay's GitHub repo differs from the clone origin, `resolve_pr_repo_slug` fell through to the clone-origin slug and queried a same-numbered but unrelated PR there. The SHA-bind precondition then compared the reviewed SHA against that unrelated PR's head, raised "PR head moved", and every downstream-overlay sanctioned merge was blocked with no replacement CLEAR ever self-issued.

## Fix

Extend the existing repo-resolution path (not a parallel one): before the clone-origin fallback, resolve the repo from the CLEAR's `ticket.issue_url` via the canonical `slug_from_issue_or_pr_url` parser — the authoritative source for which repo a PR belongs to, correct independent of which clone is running. Resolution order is now: owner/repo-shaped slug as-is, then `ticket.issue_url` repo, then clone origin, then fail closed. Merge semantics are untouched; only the repo the live head is queried from changed. A ticketless / blank / unparsable `issue_url` keeps the prior clone-origin behaviour for the self overlay.

## Test (anti-vacuous RED -> GREEN)

Added a regression test using a neutral placeholder repo where the ticket's issue repo differs from clone origin. RED on the unpatched resolver: it returns the clone-origin slug, the SHA-bind precondition compares against the wrong PR and blocks the merge. GREEN after the fix: the resolver returns the ticket's issue repo, the live head matches the reviewed SHA, and the precondition passes.

Closes #931 — https://github.com/souliane/teatree/issues/931