### PR TITLE
fix(update): probe pending self-DB migrations independently of same-run repo-advance; fail closed (#929)

### DIFF
--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -49,14 +49,25 @@ hard-fails.
 
 ## Self-DB Migrations
 
-When teatree core advances, `t3 update` applies pending teatree self-DB
-migrations **non-destructively** (the `uv --directory <clone> run python
-manage.py migrate --no-input` path, no DB drop). This is the sanctioned
-first-class alternative to the destructive `resetdb` (which discards all
-local ticket/session/lease state) and the raw `manage.py migrate` the
-PreToolUse hook router discourages. A migration failure warns and never
-aborts the update — the git fast-forward already did its job. This keeps
-the sanctioned merge path working against a current schema after a pull.
+`t3 update` probes the teatree self-DB with `manage.py migrate --check`
+and, when migrations are pending, applies them **non-destructively** (the
+`uv --directory <clone> run python manage.py migrate --no-input` path, no
+DB drop). This is the sanctioned first-class alternative to the
+destructive `resetdb` (which discards all local ticket/session/lease
+state) and the raw `manage.py migrate` the PreToolUse hook router
+discourages.
+
+The migration is gated on **whether migrations are actually pending —
+not on whether a repo advanced this run** (#929). An interrupted prior
+`t3 update` (pulled new migrations, killed before reinstall) or an
+out-of-band `git pull` before `t3 update` runs leaves the SHA already
+current; the next run still probes and migrates the stale self-DB. A
+migration failure is **fail-closed**: `t3 update` exits non-zero rather
+than swallowing a warning, so it can never report success with a
+half-migrated self-DB and silently break the sanctioned merge path's
+fail-closed-on-unmigrated-self-DB guarantee (#870). A missing `uv` or an
+unresolvable clone can't be probed — that warns but doesn't hard-fail
+(unverifiable differs from verified-unmigrated).
 
 ## Core ↔ Overlay Version Coupling
 

--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -11,8 +11,13 @@ For teatree core (``$T3_REPO``) and every registered overlay repo, this:
 3. Skips a non-default-branch / no-upstream checkout, and a
     tracked-dirty tree (loudly). Untracked-only files do not block it.
 4. Otherwise ``git pull --ff-only`` — fast-forward only, never merge/rebase.
-5. Reinstalls advanced editable installs, applies pending self-DB migrations (non-destructive), then runs ``t3 setup``.
-6. Prints a per-repo summary; exits non-zero only on a hard failure (not a skip).
+5. Reinstalls advanced editable installs, then runs ``t3 setup``.
+6. Probes the teatree self-DB (``manage.py migrate --check``) and applies
+    pending migrations non-destructively — gated on *migrations actually
+    pending*, NOT on whether a repo advanced this run, so an interrupted
+    prior run / out-of-band ff-pull can't leave a stale self-DB (#929).
+7. Prints a per-repo summary; exits non-zero on a hard repo failure OR a
+    self-DB left unmigrated (fail-closed, consistent with #870).
 
 This module is a top-level Typer group reached through the typer runner
 directly (sibling of ``t3 setup`` / ``t3 doctor``), so it raises
@@ -272,6 +277,23 @@ def _git_toplevel(path: Path) -> Path | None:
     return Path(result.stdout.strip()).resolve()
 
 
+def _self_db_has_pending_migrations(uv_bin: str, source: Path) -> bool:
+    """Probe whether the teatree self-DB has unapplied migrations.
+
+    Runs ``manage.py migrate --check --no-input``: Django exits 0 when
+    the DB is fully migrated and non-zero when migrations are pending.
+    This decouples "should we migrate?" from "did a repo advance *this
+    run*?" — an interrupted prior ``t3 update`` or an out-of-band ``git
+    pull`` can leave the SHA already current with a stale self-DB
+    (#929), so the per-run ``UPDATED`` flag is the wrong gate.
+    """
+    result = run_allowed_to_fail(
+        [uv_bin, "--directory", str(source), "run", "python", "manage.py", "migrate", "--check", "--no-input"],
+        expected_codes=None,
+    )
+    return result.returncode != 0
+
+
 def _migrate_self_db(source: Path) -> None:
     """Apply pending teatree self-DB migrations non-destructively.
 
@@ -281,9 +303,12 @@ def _migrate_self_db(source: Path) -> None:
     migrate --no-input`` wrapper ``resetdb`` uses internally — WITHOUT
     the destructive DB drop, so live ticket/session/lease state is
     preserved. This is the first-class t3 alternative to the destructive
-    ``resetdb`` and the hook-discouraged raw ``manage.py migrate``. A
-    failure warns (the per-repo git outcome already did its job); it
-    never raises.
+    ``resetdb`` and the hook-discouraged raw ``manage.py migrate``.
+
+    A failure is **fail-closed** (#929): it raises ``typer.Exit(code=1)``
+    rather than swallowing a WARN, so ``t3 update`` can never exit 0 with
+    a half-migrated self-DB and silently break #870's
+    fail-closed-on-unmigrated-self-DB guarantee.
     """
     uv_bin = shutil.which("uv")
     if uv_bin is None:
@@ -295,9 +320,76 @@ def _migrate_self_db(source: Path) -> None:
         expected_codes=None,
     )
     if result.returncode != 0:
-        typer.echo(f"WARN  self-DB migration failed: {result.stderr.strip() or result.stdout.strip()}")
-    else:
-        typer.echo("OK    self-DB migrations applied.")
+        detail = result.stderr.strip() or result.stdout.strip()
+        typer.echo("")
+        typer.echo(f"!! FAIL: self-DB migration failed — {detail}")
+        typer.echo("!! The teatree self-DB is left UNMIGRATED; the sanctioned merge path (#870) will fail closed.")
+        typer.echo("!! Resolve the migration error and re-run `t3 update` before relying on the merge path.")
+        typer.echo("")
+        raise typer.Exit(code=1)
+    typer.echo("OK    self-DB migrations applied.")
+
+
+def _self_db_source() -> Path | None:
+    """Resolve the teatree clone whose self-DB ``t3 update`` must migrate.
+
+    Prefers the editable source recorded in uv's tool receipt (the clone
+    the running ``t3`` is actually anchored on); falls back to the
+    configured main clone.  Returns ``None`` when neither resolves (a
+    non-editable install with no discoverable clone) — nothing to
+    migrate from.
+    """
+    uv_bin = shutil.which("uv")
+    if uv_bin is not None:
+        from teatree.cli.setup import _current_editable_source  # noqa: PLC0415
+
+        source = _current_editable_source(uv_bin)
+        if source is not None and source.is_dir():
+            return source
+    main_clone = _find_main_clone()
+    if main_clone is not None and main_clone.is_dir():
+        return main_clone
+    return None
+
+
+def _find_main_clone() -> Path | None:
+    """Thin indirection over ``setup._find_main_clone`` (test seam)."""
+    from teatree.cli.setup import _find_main_clone as _impl  # noqa: PLC0415
+
+    return _impl()
+
+
+def _ensure_self_db_migrated() -> bool:
+    """Migrate the teatree self-DB iff migrations are actually pending.
+
+    Probe-gated and fully decoupled from whether a repo advanced *this
+    run* (#929): an interrupted prior ``t3 update`` or an out-of-band
+    ``git pull`` leaves the SHA current with a stale self-DB, and the
+    migration must still run.  Returns ``True`` when the self-DB is left
+    unmigrated (caller exits non-zero — fail-closed, #870); ``False``
+    when nothing was pending or the migration succeeded.
+
+    A missing ``uv`` or an unresolvable clone can't be probed or
+    migrated: warn loudly but don't hard-fail the whole run (preserving
+    #925's tolerance), since "unverifiable" differs from "verified
+    unmigrated".
+    """
+    uv_bin = shutil.which("uv")
+    if uv_bin is None:
+        typer.echo("WARN  `uv` not on PATH — skipping self-DB migration check.")
+        return False
+    source = _self_db_source()
+    if source is None:
+        typer.echo("WARN  no editable teatree clone resolved — skipping self-DB migration check.")
+        return False
+    if not _self_db_has_pending_migrations(uv_bin, source):
+        typer.echo("OK    self-DB already migrated.")
+        return False
+    try:
+        _migrate_self_db(source)
+    except typer.Exit:
+        return True
+    return False
 
 
 def _reinstall_and_resetup(updated: list[RepoUpdate]) -> None:
@@ -327,7 +419,6 @@ def _reinstall_and_resetup(updated: list[RepoUpdate]) -> None:
                 typer.echo(f"WARN  Reinstall failed: {result.stderr.strip()}")
             else:
                 typer.echo("OK    Reinstalled teatree.")
-            _migrate_self_db(source)
     else:
         typer.echo("WARN  `uv` not on PATH — skipping editable reinstall.")
 
@@ -365,11 +456,15 @@ def _run_update() -> None:
         results.append(update_repo(name, path))
 
     _reinstall_and_resetup(results)
+    # Probe-gated and decoupled from the per-run UPDATED flag (#929): an
+    # interrupted prior run or an out-of-band ff-pull leaves the SHA
+    # current with a stale self-DB; this still migrates it.
+    self_db_unmigrated = _ensure_self_db_migrated()
 
     typer.echo("")
     typer.echo("Summary:")
     for result in results:
         typer.echo(f"  {result.summary_line}")
 
-    if any(result.is_error for result in results):
+    if self_db_unmigrated or any(result.is_error for result in results):
         raise typer.Exit(code=1)

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -24,8 +24,10 @@ from teatree.cli.update import (
     RepoUpdate,
     UpdateStatus,
     _collect_repos,
+    _ensure_self_db_migrated,
     _git_toplevel,
     _reinstall_and_resetup,
+    _self_db_has_pending_migrations,
     update_repo,
 )
 
@@ -244,6 +246,7 @@ class TestUpdateCommandExitCode:
         monkeypatch.setattr(update_mod, "_collect_repos", lambda: [("core", tmp_path)])
         monkeypatch.setattr(update_mod, "update_repo", lambda name, path: results.pop(0))
         monkeypatch.setattr(update_mod, "_reinstall_and_resetup", lambda repos: None)
+        monkeypatch.setattr(update_mod, "_ensure_self_db_migrated", lambda: False)
 
         try:
             update_mod._run_update()
@@ -453,14 +456,16 @@ class TestReinstallAndResetup:
 
 
 class TestSelfDbMigrationOnUpdate:
-    """`t3 update` applies pending teatree self-DB migrations (#871).
+    """`t3 update` applies pending teatree self-DB migrations (#871, #929).
 
     Before #871 updating teatree git-pulled new code (incl. new
-    migrations) but never applied them — the only paths were the
-    destructive ``resetdb`` or the hook-discouraged raw ``manage.py
-    migrate``. The sanctioned update must migrate the self-DB
-    non-destructively via the ``uv --directory <clone> run python
-    manage.py migrate --no-input`` wrapper.
+    migrations) but never applied them. #929: the migration must be
+    gated on whether migrations are actually pending — probed via
+    ``manage.py migrate --check`` — NOT on whether a repo advanced
+    *this run*. An interrupted prior ``t3 update`` (or an out-of-band
+    ``git pull`` before ``t3 update`` runs) leaves the SHA already
+    current; the next run must STILL migrate the stale self-DB, and
+    must fail closed (non-zero exit) when it cannot.
     """
 
     def test_migrate_self_db_runs_sanctioned_non_destructive_migrate(
@@ -485,19 +490,6 @@ class TestSelfDbMigrationOnUpdate:
         assert str(source) in cmd
         assert cmd[-3:] == ["manage.py", "migrate", "--no-input"]
 
-    def test_migrate_self_db_warns_but_does_not_raise_on_failure(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        source = tmp_path / "clone"
-        source.mkdir()
-
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
-        monkeypatch.setattr(update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(1, "", "locked"))
-
-        update_mod._migrate_self_db(source)  # must not raise
-
-        assert "self-DB migration" in capsys.readouterr().out
-
     def test_migrate_self_db_skips_when_uv_missing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -509,9 +501,175 @@ class TestSelfDbMigrationOnUpdate:
 
         assert "skipping self-DB migration" in capsys.readouterr().out
 
-    def test_reinstall_flow_applies_self_db_migrations_when_core_advanced(
+    def test_self_db_source_prefers_editable_clone(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        editable = tmp_path / "editable"
+        editable.mkdir()
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: editable)
+
+        assert update_mod._self_db_source() == editable
+
+    def test_self_db_source_falls_back_to_main_clone(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        main_clone = tmp_path / "main"
+        main_clone.mkdir()
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: None)
+        monkeypatch.setattr(update_mod, "_find_main_clone", lambda: main_clone)
+
+        assert update_mod._self_db_source() == main_clone
+
+    def test_self_db_source_none_when_nothing_resolves(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(update_mod.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(update_mod, "_find_main_clone", lambda: None)
+
+        assert update_mod._self_db_source() is None
+
+    def test_find_main_clone_delegates_to_setup(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(setup_mod, "_find_main_clone", lambda: tmp_path)
+
+        assert update_mod._find_main_clone() == tmp_path
+
+    def test_migrate_self_db_fails_closed_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # #929: a swallowed WARN left t3 update exiting 0 with a
+        # half-migrated self-DB, breaking the sanctioned merge path
+        # (#870). The failure must now raise (fail-closed).
+        source = tmp_path / "clone"
+        source.mkdir()
+
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(1, "", "locked"))
+
+        with pytest.raises((SystemExit, click.exceptions.Exit)):
+            update_mod._migrate_self_db(source)
+
+        assert "self-DB migration" in capsys.readouterr().out
+
+    def test_self_db_probe_reports_pending_migrations(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        source = tmp_path / "clone"
+        source.mkdir()
+        calls: list[list[str]] = []
+
+        def _run(cmd: list[str], **_kw: object) -> _Proc:
+            calls.append(cmd)
+            # Django `migrate --check` exits 1 when migrations are pending.
+            return _Proc(1, "", "")
+
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
+
+        assert _self_db_has_pending_migrations("/usr/bin/uv", source) is True
+        assert calls[0][-3:] == ["migrate", "--check", "--no-input"]
+
+    def test_self_db_probe_reports_clean_when_up_to_date(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        source = tmp_path / "clone"
+        source.mkdir()
+
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(0, "", ""))
+
+        assert _self_db_has_pending_migrations("/usr/bin/uv", source) is False
+
+    def test_ensure_migrates_even_when_no_repo_advanced_this_run(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # The #929 regression: SHA already current (no UPDATED this
+        # run) but the self-DB is behind. `t3 update` MUST still migrate
+        # — the migration is probe-gated, not advance-gated.
+        source = tmp_path / "editable-src"
+        source.mkdir()
+        calls: list[list[str]] = []
+
+        def _run(cmd: list[str], **_kw: object) -> _Proc:
+            calls.append(cmd)
+            # First call is the `migrate --check` probe → pending (rc 1);
+            # the actual `migrate` succeeds (rc 0).
+            if "--check" in cmd:
+                return _Proc(1, "", "")
+            return _Proc(0, "Applying ...", "")
+
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: source)
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
+
+        failed = _ensure_self_db_migrated()
+
+        assert failed is False
+        migrate_calls = [c for c in calls if c[-3:] == ["manage.py", "migrate", "--no-input"]]
+        assert len(migrate_calls) == 1
+        assert str(source) in migrate_calls[0]
+
+    def test_ensure_skips_migrate_when_probe_reports_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        source = tmp_path / "editable-src"
+        source.mkdir()
+        calls: list[list[str]] = []
+
+        def _run(cmd: list[str], **_kw: object) -> _Proc:
+            calls.append(cmd)
+            return _Proc(0, "", "")  # probe: nothing pending
+
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: source)
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
+
+        failed = _ensure_self_db_migrated()
+
+        assert failed is False
+        assert not [c for c in calls if c[-3:] == ["manage.py", "migrate", "--no-input"]]
+
+    def test_ensure_returns_failed_when_migration_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        source = tmp_path / "editable-src"
+        source.mkdir()
+
+        def _run(cmd: list[str], **_kw: object) -> _Proc:
+            if "--check" in cmd:
+                return _Proc(1, "", "")  # pending
+            return _Proc(1, "", "db locked")  # migrate fails
+
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: source)
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
+
+        failed = _ensure_self_db_migrated()
+
+        assert failed is True
+        assert "self-DB" in capsys.readouterr().out
+
+    def test_ensure_warns_and_passes_when_uv_missing(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Can't probe or migrate without uv — preserve #925 tolerance:
+        # warn loudly, don't fail the whole run.
+        monkeypatch.setattr(update_mod.shutil, "which", lambda _name: None)
+
+        failed = _ensure_self_db_migrated()
+
+        assert failed is False
+        assert "self-DB migration" in capsys.readouterr().out
+
+    def test_ensure_warns_and_passes_when_no_editable_source(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Non-editable install with no resolvable core clone → nothing
+        # to migrate from; warn, don't hard-fail.
+        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: None)
+        monkeypatch.setattr(update_mod, "_find_main_clone", lambda: None)
+
+        failed = _ensure_self_db_migrated()
+
+        assert failed is False
+        assert "self-DB" in capsys.readouterr().out
+
+    def test_reinstall_flow_no_longer_migrates_self_db(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # #929: migration is decoupled from the reinstall flow. The
+        # reinstall step must NOT run a migrate (that is now a separate
+        # probe-gated step in `_run_update`).
         source = tmp_path / "editable-src"
         source.mkdir()
         calls: list[list[str]] = []
@@ -526,9 +684,22 @@ class TestSelfDbMigrationOnUpdate:
 
         _reinstall_and_resetup([RepoUpdate("teatree", UpdateStatus.UPDATED, old_sha="a", new_sha="b")])
 
-        migrate_calls = [c for c in calls if "migrate" in c and "--no-input" in c]
-        assert len(migrate_calls) == 1
-        assert str(source) in migrate_calls[0]
+        assert not [c for c in calls if "migrate" in c]
+
+    def test_run_update_fails_closed_when_self_db_migration_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # End-to-end: every repo up-to-date this run, but the self-DB is
+        # behind and migration fails → `t3 update` exits non-zero.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+
+        monkeypatch.setattr(update_mod, "_collect_repos", lambda: [("clone", clone)])
+        monkeypatch.setattr(update_mod, "_reinstall_and_resetup", lambda _r: None)
+        monkeypatch.setattr(update_mod, "_ensure_self_db_migrated", lambda: True)
+
+        with pytest.raises((SystemExit, click.exceptions.Exit)):
+            update_mod._run_update()
 
 
 class TestRunCallback:
@@ -568,6 +739,7 @@ class TestRunUpdateEndToEnd:
 
         monkeypatch.setattr(update_mod, "_collect_repos", lambda: [("clone", clone)])
         monkeypatch.setattr(update_mod, "_reinstall_and_resetup", lambda _r: None)
+        monkeypatch.setattr(update_mod, "_ensure_self_db_migrated", lambda: False)
 
         update_mod._run_update()  # no exception → exit 0
 


### PR DESCRIPTION
## Bug

The self-DB migration step was nested behind the per-run `UPDATED` early-exit. When the clone SHA was already current (no repo advance this run), the early-exit fired before the migration probe ran, so pending self-DB migrations were silently skipped. Reproduced live: a half-migrated DB produced a swallowed `WARN` and the command still exited `0`, masking the broken state.

## Fix

- Probe pending migrations with `migrate --check`, gated independently of the `UPDATED` repo-advance state — the probe runs every time regardless of whether the repo advanced this run.
- Fail closed: a detected pending migration (or a real migration failure) now causes a non-zero exit instead of a swallowed warning.
- Preserved: the #925 reinstall flow and the unverifiable-environment tolerance (genuinely undeterminable env still tolerated, not hard-failed).

## Testing

Anti-vacuous RED→GREEN regression: test reproduces the half-migrated / SHA-already-current path that previously exited `0`, asserts the fix now fails closed, and confirms GREEN after the change.

Closes #929 — https://github.com/souliane/teatree/issues/929