### PR TITLE
fix(core): surface cleanup/teardown failures in SyncResult.errors instead of suppress(Exception) (#877)

### DIFF
--- a/src/teatree/backends/github_sync.py
+++ b/src/teatree/backends/github_sync.py
@@ -111,8 +111,9 @@ class GitHubSyncBackend(SyncBackend):
 
         for worktree in Worktree.objects.filter(ticket=ticket):
             try:
-                cleanup_worktree(worktree)
+                cleanup_result = cleanup_worktree(worktree)
                 result.worktrees_cleaned += 1
+                result.errors.extend(cleanup_result.errors)
             except RuntimeError as exc:
                 logger.info("Keeping worktree %s (unpushed work): %s", worktree.repo_path, exc)
             except Exception as exc:

--- a/src/teatree/backends/gitlab_sync_terminal.py
+++ b/src/teatree/backends/gitlab_sync_terminal.py
@@ -131,8 +131,9 @@ def _scan_merged_prs(prs: RawAPIDict, merged_urls: set[str], result: SyncResult)
 def _cleanup_merged_worktrees(ticket: Ticket, result: SyncResult) -> None:
     for worktree in Worktree.objects.filter(ticket=ticket):
         try:
-            cleanup_worktree(worktree)
+            cleanup_result = cleanup_worktree(worktree)
             result.worktrees_cleaned += 1
+            result.errors.extend(cleanup_result.errors)
         except Exception as exc:
             logger.exception("Failed to clean worktree %s", worktree.repo_path)
             result.errors.append(f"Worktree cleanup failed for {worktree.repo_path} ({worktree.branch}): {exc}")

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -47,6 +47,37 @@ _BRANCH_LOG_FIELDS = 3
 _SUBJECT_PREVIEW_LIMIT = 3
 
 
+@dataclass(slots=True)
+class CleanupResult:
+    """Outcome of a single :func:`cleanup_worktree` teardown.
+
+    ``label`` is the human-readable summary (still printed by the
+    interactive ``clean-all`` / ``clean-merged`` callers and surfaced as
+    the runner ``detail``). ``errors`` is the structured, machine-readable
+    channel: every teardown step that failed appends a descriptive string
+    here instead of crashing mid-teardown or being swallowed by a
+    ``suppress(Exception)`` (#877).
+
+    #932's lesson — a swallowed string the caller never inspects is not
+    surfacing. Sync backends push ``errors`` into ``SyncResult.errors`` and
+    runners fold it into their failure detail, so a teardown failure
+    actually reaches the operator/exit path.
+    """
+
+    label: str
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def clean(self) -> bool:
+        """True when every teardown step succeeded."""
+        return not self.errors
+
+    def __str__(self) -> str:
+        if self.errors:
+            return f"{self.label} [with errors: {'; '.join(self.errors)}]"
+        return self.label
+
+
 @dataclass(frozen=True)
 class BranchCommit:
     """A commit on a branch that is not reachable from any remote by SHA."""
@@ -339,13 +370,17 @@ def _remove_git_worktree(
     return errors
 
 
-def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> str:
+def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> CleanupResult:
     """Remove a single worktree: git worktree, branch, DB, overlay cleanup.
 
-    Deletes the Worktree record from the database and returns a summary label.
-    Errors in individual cleanup steps are suppressed so that partial cleanup
-    still succeeds, but they are surfaced in the returned label so the caller
-    can detect partial failures.
+    Deletes the Worktree record from the database and returns a
+    :class:`CleanupResult`. Individual teardown-step failures (overlay
+    hook, git worktree/branch removal, DB drop, pass-entry removal,
+    recovery capture) are captured into ``result.errors`` and the
+    remaining steps still run — collect-and-surface, never crash
+    mid-teardown leaving other resources orphaned (#877). The caller is
+    responsible for routing ``result.errors`` to its visible channel
+    (``SyncResult.errors`` for sync backends, runner detail for runners).
 
     Two guards protect against losing work, both bypassed only by an explicit
     ``force=True``.
@@ -383,18 +418,24 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene:
 
     if worktree.db_name:
         db_user = _read_env_cache_value(Path(wt_path), "POSTGRES_USER")
-        drop_db(worktree.db_name, user=db_user)
+        try:
+            drop_db(worktree.db_name, user=db_user)
+        except Exception as exc:
+            logger.exception("dropdb failed for %s (%s)", worktree.db_name, worktree.repo_path)
+            step_errors.append(f"dropdb failed for {worktree.db_name}: {exc}")
 
     if getattr(overlay.config, "teardown_removes_pass_entries", False) is True:
         ticket = worktree.ticket
         if ticket is not None:
-            remove_postgres_pass_entry(ticket.ticket_number)
+            try:
+                remove_postgres_pass_entry(ticket.ticket_number)
+            except Exception as exc:
+                logger.exception("pass-entry removal failed for %s", worktree.repo_path)
+                step_errors.append(f"pass-entry removal failed for {ticket.ticket_number}: {exc}")
 
     label = f"Cleaned: {worktree.repo_path} ({worktree.branch})"
-    if step_errors:
-        label += f" [with errors: {'; '.join(step_errors)}]"
     ticket_id = worktree.ticket.pk
     worktree.delete()
     if not Worktree.objects.filter(ticket_id=ticket_id).exists():
         Ticket.objects.get(pk=ticket_id).release_redis_slot()
-    return label
+    return CleanupResult(label=label, errors=step_errors)

--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -262,6 +262,6 @@ def push_unsynced_branch(worktree: Worktree) -> str:
 
 def abandon_unsynced_branch(worktree: Worktree) -> str:
     try:
-        return cleanup_worktree(worktree, force=True)
+        return str(cleanup_worktree(worktree, force=True))
     except Exception as exc:  # noqa: BLE001
         return f"Abandon failed: {worktree.repo_path} ({worktree.branch}) — {exc}"

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -488,7 +488,7 @@ class Command(TyperCommand):
                 continue
             for wt in worktrees:
                 try:
-                    cleaned.append(cleanup_worktree(wt, strict_hygiene=False))
+                    cleaned.append(str(cleanup_worktree(wt, strict_hygiene=False)))
                 except RuntimeError as exc:
                     cleaned.append(f"FAILED {wt.repo_path} ({wt.branch}): {exc}")
         if not cleaned:
@@ -573,7 +573,7 @@ class Command(TyperCommand):
         interactive = sys.stdin.isatty() and sys.stdout.isatty()
         for wt in Worktree.objects.filter(state=Worktree.State.CREATED):
             try:
-                cleaned.append(cleanup_worktree(wt))
+                cleaned.append(str(cleanup_worktree(wt)))
             except RuntimeError as exc:
                 cleaned.append(resolve_unsynced_worktree(wt, exc, interactive=interactive))
 

--- a/src/teatree/core/runners/teardown.py
+++ b/src/teatree/core/runners/teardown.py
@@ -15,6 +15,18 @@ class WorktreeTeardown(RunnerBase):
     cleanup hooks). Errors on a single worktree are captured but do not
     abort the rest — the runner reports a combined success/failure label.
 
+    Two distinct outcomes (#877). A *refusal* (``cleanup_worktree`` raises
+    ``RuntimeError`` — the #706 data-loss / hygiene guard) means the
+    worktree was deliberately NOT torn down: the runner reports
+    ``ok=False`` and the FSM stays put. A *completed teardown with step
+    errors* (``CleanupResult.errors`` non-empty — a DB drop, pass-entry
+    removal, recovery capture, or branch delete failed) means the worktree
+    row IS gone but some side resource may linger; these were previously
+    swallowed into a label string the caller never inspected (#932) and
+    are now logged loudly and folded into the result detail so they reach
+    the operator, without re-blocking a teardown the operator explicitly
+    forced (the #706/#710 force-escape contract).
+
     This is the *automated* teardown path: ``execute_teardown`` enqueues it
     when the ticket FSM reaches MERGED. The FSM can read MERGED while the
     branch was never actually pushed (async ship never drained — #707/#708),
@@ -36,14 +48,23 @@ class WorktreeTeardown(RunnerBase):
             return RunnerResult(ok=True, detail="no worktrees to tear down")
 
         labels: list[str] = []
-        errors: list[str] = []
+        refusals: list[str] = []
+        step_errors: list[str] = []
         for worktree in worktrees:
             try:
-                labels.append(cleanup_worktree(worktree, force=self.force, strict_hygiene=False))
+                cleanup_result = cleanup_worktree(worktree, force=self.force, strict_hygiene=False)
             except RuntimeError as exc:
-                logger.exception("teardown failed for %s", worktree.repo_path)
-                errors.append(f"{worktree.repo_path} ({worktree.branch}): {exc}")
+                logger.exception("teardown refused for %s", worktree.repo_path)
+                refusals.append(f"{worktree.repo_path} ({worktree.branch}): {exc}")
+                continue
+            labels.append(cleanup_result.label)
+            for err in cleanup_result.errors:
+                logger.error("teardown step failed for %s: %s", worktree.repo_path, err)
+                step_errors.append(f"{worktree.repo_path} ({worktree.branch}): {err}")
 
-        if errors:
-            return RunnerResult(ok=False, detail="; ".join(errors))
-        return RunnerResult(ok=True, detail=f"tore down {len(labels)} worktree(s)")
+        if refusals:
+            return RunnerResult(ok=False, detail="; ".join(refusals + step_errors))
+        detail = f"tore down {len(labels)} worktree(s)"
+        if step_errors:
+            detail += f" [with errors: {'; '.join(step_errors)}]"
+        return RunnerResult(ok=True, detail=detail)

--- a/src/teatree/core/runners/worktree_teardown.py
+++ b/src/teatree/core/runners/worktree_teardown.py
@@ -54,9 +54,18 @@ class WorktreeTeardownRunner(RunnerBase):
         docker_compose_down(project)
 
         try:
-            label = cleanup_worktree(worktree, force=self.force, strict_hygiene=False)
+            cleanup_result = cleanup_worktree(worktree, force=self.force, strict_hygiene=False)
         except RuntimeError as exc:
             logger.warning("teardown refused for %s: %s", worktree.repo_path, exc)
             return RunnerResult(ok=False, detail=str(exc))
 
-        return RunnerResult(ok=True, detail=label)
+        # The worktree row IS gone (cleanup completed); a non-empty
+        # ``errors`` list means a side resource (DB, pass entry, recovery
+        # bundle, branch delete) failed. #877 — surface it loudly (logs +
+        # ``str(cleanup_result)`` detail) instead of swallowing it into a
+        # label the caller never reads (#932), but do not re-block a
+        # teardown the operator explicitly forced (#706/#710 force-escape).
+        for err in cleanup_result.errors:
+            logger.error("teardown step failed for %s: %s", worktree.repo_path, err)
+
+        return RunnerResult(ok=True, detail=str(cleanup_result))

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -14,6 +14,7 @@ from django.test import TestCase
 
 from teatree.core.cleanup import BranchClassification, BranchCommit, cleanup_worktree
 from teatree.core.models import Ticket, Worktree
+from teatree.utils.run import CommandFailedError
 
 _patch_config = patch("teatree.core.cleanup.load_config")
 _patch_git = patch("teatree.core.cleanup.git")
@@ -69,12 +70,13 @@ class TestCleanupWorktree(TestCase):
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         wt_id = wt.pk
-        label = cleanup_worktree(wt)
+        result = cleanup_worktree(wt)
 
         mock_git.worktree_remove.assert_called_once()
         mock_git.branch_delete.assert_called_once()
-        assert "org/repo" in label
-        assert "fix-99" in label
+        assert result.clean is True
+        assert "org/repo" in result.label
+        assert "fix-99" in result.label
         assert not Worktree.objects.filter(pk=wt_id).exists()
 
     @_patch_overlay
@@ -534,3 +536,160 @@ class TestCleanupWorktree(TestCase):
 
         mock_git.worktree_remove.assert_called_once()
         mock_git.branch_delete.assert_called_once()
+
+
+class TestCleanupWorktreeLoudTeardown(TestCase):
+    """#877 — teardown failures surface in ``CleanupResult.errors``.
+
+    The loud-teardown half of #877: no ``suppress(Exception)`` / silent
+    swallowing on the teardown path. A failing resource (DB drop, pass
+    entry removal, overlay step) is recorded as a descriptive error string
+    and the *other* resources are still reaped — collect-and-surface, never
+    crash mid-teardown leaving orphans.
+    """
+
+    def _make_worktree(self, *, db_name: str = "wt_99") -> Worktree:
+        ticket = Ticket.objects.create(
+            issue_url="https://gitlab.com/org/repo/-/issues/99",
+            state=Ticket.State.IN_REVIEW,
+        )
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="org/repo",
+            branch="fix-99",
+            db_name=db_name,
+            extra={"worktree_path": "/tmp/wt/org/repo"},
+        )
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_db_drop_failure_surfaced_other_resources_still_reaped(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """A failed ``dropdb`` is recorded in ``errors``; the row + pass entry still go.
+
+        Before #877 this either crashed mid-teardown (leaving the Worktree
+        row, redis slot and pass entry orphaned) or was swallowed. Now the
+        failure is a descriptive ``errors`` entry, the result is non-clean,
+        and every other resource is still cleaned.
+        """
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_overlay.return_value.config.teardown_removes_pass_entries = True
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = []
+
+        wt = self._make_worktree(db_name="wt_99")
+        wt_id = wt.pk
+        ticket_number = wt.ticket.ticket_number
+
+        with (
+            patch(
+                "teatree.core.cleanup.drop_db",
+                side_effect=CommandFailedError(["dropdb", "wt_99"], 1, "", "connection refused"),
+            ),
+            patch("teatree.core.cleanup.remove_postgres_pass_entry") as mock_remove,
+        ):
+            result = cleanup_worktree(wt)
+
+        # Failure surfaced, not swallowed
+        assert result.clean is False
+        assert any("wt_99" in e for e in result.errors)
+        assert any("connection refused" in e for e in result.errors)
+        # Other resources STILL reaped despite the DB-drop failure
+        mock_remove.assert_called_once_with(ticket_number)
+        mock_git.worktree_remove.assert_called_once()
+        assert not Worktree.objects.filter(pk=wt_id).exists()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_pass_entry_removal_failure_surfaced(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """A failing pass-entry removal is surfaced, the worktree row still deleted."""
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_overlay.return_value.config.teardown_removes_pass_entries = True
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = []
+
+        wt = self._make_worktree(db_name="")
+        wt_id = wt.pk
+
+        with (
+            patch("teatree.core.cleanup.drop_db"),
+            patch(
+                "teatree.core.cleanup.remove_postgres_pass_entry",
+                side_effect=RuntimeError("pass: gpg failed"),
+            ),
+        ):
+            result = cleanup_worktree(wt)
+
+        assert result.clean is False
+        assert any("gpg failed" in e for e in result.errors)
+        assert not Worktree.objects.filter(pk=wt_id).exists()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_overlay_step_failure_surfaced_in_errors_not_only_label(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """Overlay-step failures reach ``errors`` (the operator channel), not just the label string.
+
+        #932's lesson: a swallowed string the caller never inspects is not
+        surfacing. The structured ``errors`` list is what sync backends push
+        into ``SyncResult.errors``.
+        """
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        failing_step = MagicMock(callable=MagicMock(side_effect=RuntimeError("docker compose down failed")))
+        failing_step.description = "stop docker stack"
+        mock_overlay.return_value.get_cleanup_steps.return_value = [failing_step]
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = []
+
+        wt = self._make_worktree(db_name="")
+        result = cleanup_worktree(wt)
+
+        assert result.clean is False
+        assert any("docker compose down failed" in e for e in result.errors)
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_clean_teardown_has_empty_errors_and_is_clean(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """The happy path: no errors, ``clean`` is true, label still contains the worktree."""
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = []
+
+        wt = self._make_worktree(db_name="")
+        with patch("teatree.core.cleanup.drop_db"):
+            result = cleanup_worktree(wt)
+
+        assert result.clean is True
+        assert result.errors == []
+        assert "org/repo" in result.label
+        assert "org/repo" in str(result)

--- a/tests/teatree_core/cleanup/test_real_git_integration.py
+++ b/tests/teatree_core/cleanup/test_real_git_integration.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase
 
-from teatree.core.cleanup import cleanup_worktree
+from teatree.core.cleanup import CleanupResult, cleanup_worktree
 from teatree.core.models import Ticket, Worktree
 from tests.teatree_core.cleanup._shared import _GIT, _RM, _clean_env, _run_git
 
@@ -56,7 +56,7 @@ class TestCleanupWorktreeRemovesOnDiskWorktree(TestCase):
             extra=extras,
         )
 
-    def _cleanup(self, worktree: Worktree) -> str:
+    def _cleanup(self, worktree: Worktree) -> CleanupResult:
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
             patch("teatree.core.cleanup.get_overlay") as mock_overlay,
@@ -88,13 +88,17 @@ class TestCleanupWorktreeRemovesOnDiskWorktree(TestCase):
         assert not self.wt_path.exists(), "worktree directory survived cleanup"
         assert str(self.wt_path) not in self._registered_worktrees(), "git worktree registry entry survived"
 
-    def test_surfaces_failure_in_label_when_git_remove_fails(self) -> None:
-        """When the git ops can't complete (e.g., source repo missing), the label must report it."""
+    def test_surfaces_failure_in_errors_when_git_remove_fails(self) -> None:
+        """When the git ops can't complete (source repo missing), the failure surfaces in ``errors`` (#877)."""
         wt = self._make_worktree(with_extras=True)
         # Wipe the source repo so git operations fail
         subprocess.run([_RM, "-rf", str(self.repo_main)], check=True, env=_clean_env())
-        label = self._cleanup(wt)
-        assert "errors" in label.lower() or "Cleaned: myrepo" in label
+        result = self._cleanup(wt)
+        # The missing-source-repo failure is surfaced, not swallowed
+        assert result.clean is False
+        assert result.errors
+        assert any("source repo missing" in e for e in result.errors)
+        assert "with errors" in str(result)
         # Worktree row deleted regardless so the operator can retry without DB cruft
         assert not Worktree.objects.filter(pk=wt.pk).exists()
 
@@ -133,7 +137,7 @@ class TestCleanupWorktreeNamespacedClone(TestCase):
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
             mock_overlay.return_value.get_cleanup_steps.return_value = []
-            label = cleanup_worktree(wt, force=True)
+            result = cleanup_worktree(wt, force=True)
 
         assert not self.wt_path.exists()
         registry = subprocess.run(
@@ -144,4 +148,5 @@ class TestCleanupWorktreeNamespacedClone(TestCase):
             env=_clean_env(),
         ).stdout
         assert str(self.wt_path) not in registry
-        assert "errors" not in label.lower()
+        assert result.clean is True
+        assert result.errors == []

--- a/tests/teatree_core/cleanup/test_recovery.py
+++ b/tests/teatree_core/cleanup/test_recovery.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase
 
-from teatree.core.cleanup import cleanup_worktree
+from teatree.core.cleanup import CleanupResult, cleanup_worktree
 from teatree.core.models import Ticket, Worktree
 from teatree.core.worktree_recovery import _has_unpushed_commits, capture_recovery_artifact
 from teatree.utils.run import CommandFailedError
@@ -87,7 +87,7 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
             extra={"worktree_path": str(self.wt_path)},
         )
 
-    def _prune(self, worktree: Worktree) -> str:
+    def _prune(self, worktree: Worktree) -> CleanupResult:
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
             patch("teatree.core.cleanup.get_overlay") as mock_overlay,
@@ -237,13 +237,14 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
         assert (restore / "base.txt").read_text(encoding="utf-8") == "base\nDIRTY EDIT\n"
         assert (restore / "newfile.txt").read_text(encoding="utf-8") == "brand new\n"
 
-    def test_capture_failure_is_swallowed_and_prune_still_proceeds(self) -> None:
-        """#835 — a capture failure must NOT block the prune (stuck-cleanup).
+    def test_capture_failure_surfaced_and_prune_still_proceeds(self) -> None:
+        """#835/#877 — a capture failure must NOT block the prune (stuck-cleanup).
 
         Drives the production seam (``cleanup_worktree`` → ``_remove_git_worktree``)
         with the real on-disk worktree; only the (unstoppable, deliberately
-        failing) capture is patched to raise. The ticket mandates: swallow the
-        exception, still remove the worktree, surface the failure in the label.
+        failing) capture is patched to raise. The ticket mandates: do not raise,
+        still remove the worktree, surface the failure in ``errors`` (#877 —
+        the structured channel, not a swallowed label string).
         """
         (self.wt_path / "base.txt").write_text("base\nDIRTY EDIT\n", encoding="utf-8")
         wt = self._make_worktree()
@@ -256,11 +257,12 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
             mock_overlay.return_value.get_cleanup_steps.return_value = []
-            label = cleanup_worktree(wt, force=True)  # must NOT raise
+            result = cleanup_worktree(wt, force=True)  # must NOT raise
 
         assert not self.wt_path.exists(), "worktree must still be removed despite capture failure"
-        assert f"recovery capture failed for {self.branch}" in label
-        assert "disk full while bundling" in label
+        assert result.clean is False
+        assert any(f"recovery capture failed for {self.branch}" in e for e in result.errors)
+        assert any("disk full while bundling" in e for e in result.errors)
         assert _recovery_dirs(self.temp_root) == [], "no artifact when capture itself failed"
 
     def test_clean_merged_worktree_hard_deletes_with_no_artifact(self) -> None:

--- a/tests/teatree_core/sync/test_github_and_dual.py
+++ b/tests/teatree_core/sync/test_github_and_dual.py
@@ -326,6 +326,53 @@ class TestSyncGitHub(TestCase):
         assert result.worktrees_cleaned == 0
         assert result.errors == []  # info-level keep, not error
 
+    def test_cleanup_step_errors_propagate_into_sync_result_errors(self) -> None:
+        """#877 — a non-clean ``CleanupResult`` surfaces in ``SyncResult.errors``.
+
+        The cleanup completes (worktree row gone) but a side resource failed.
+        Before #877 that failure was swallowed into a label string the sync
+        backend never inspected (#932); now it reaches the operator via the
+        ``SyncResult.errors`` exit channel.
+        """
+        from teatree.backends.github import ProjectItem  # noqa: PLC0415
+        from teatree.backends.github_sync import GitHubSyncBackend  # noqa: PLC0415
+        from teatree.core.cleanup import CleanupResult  # noqa: PLC0415
+
+        overlay = self._make_overlay()
+        ticket = Ticket.objects.create(
+            issue_url="https://github.com/souliane/teatree/issues/47",
+            state=Ticket.State.IN_REVIEW,
+        )
+        Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="souliane/teatree",
+            branch="fix-47",
+        )
+        item = ProjectItem(
+            issue_number=47,
+            title="Cleanup with a failing side resource",
+            url="https://github.com/souliane/teatree/issues/47",
+            status="Done",
+            position=6,
+            labels=[],
+        )
+        dirty_result = CleanupResult(
+            label="Cleaned: souliane/teatree (fix-47)",
+            errors=["dropdb failed for wt_47: connection refused"],
+        )
+
+        with (
+            _patch_overlay(overlay),
+            patch("teatree.backends.github.fetch_project_items", return_value=[item]),
+            patch.object(GitHubSyncBackend, "_sync_reviewer_prs"),
+            patch("teatree.backends.github_sync.cleanup_worktree", return_value=dirty_result),
+        ):
+            result = GitHubSyncBackend().sync(overlay)
+
+        assert result.worktrees_cleaned == 1
+        assert any("dropdb failed for wt_47" in e for e in result.errors)
+
     def test_returns_error_for_non_overlay(self) -> None:
         from teatree.backends.github_sync import GitHubSyncBackend  # noqa: PLC0415
 

--- a/tests/teatree_core/test_runner_worktree_teardown.py
+++ b/tests/teatree_core/test_runner_worktree_teardown.py
@@ -1,0 +1,105 @@
+"""``WorktreeTeardownRunner.run()`` outcome mapping.
+
+The runner backs ``execute_worktree_teardown`` and the ``worktree`` /
+``workspace teardown`` CLIs. It funnels through ``cleanup_worktree`` and
+must, per #877, surface a non-clean ``CleanupResult`` loudly (logs +
+``detail``) instead of swallowing it into a label string the caller never
+inspects (#932) — while NOT re-blocking a teardown the operator explicitly
+forced (the #706/#710 force-escape contract).
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from teatree.core.cleanup import CleanupResult
+from teatree.core.models import Ticket, Worktree
+from teatree.core.runners.worktree_teardown import WorktreeTeardownRunner
+
+_PATCH_DOWN = "teatree.core.runners.worktree_teardown.docker_compose_down"
+_PATCH_CLEANUP = "teatree.core.runners.worktree_teardown.cleanup_worktree"
+
+
+class TestWorktreeTeardownRunner(TestCase):
+    def _make_worktree(self) -> Worktree:
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/877",
+            state=Ticket.State.MERGED,
+        )
+        return Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="org/repo",
+            branch="fix-877",
+            extra={"worktree_path": "/tmp/wt/org/repo"},
+        )
+
+    def test_clean_teardown_returns_ok_with_label(self) -> None:
+        wt = self._make_worktree()
+        clean = CleanupResult(label="Cleaned: org/repo (fix-877)")
+
+        with (
+            patch(_PATCH_DOWN),
+            patch(_PATCH_CLEANUP, return_value=clean),
+        ):
+            result = WorktreeTeardownRunner(wt).run()
+
+        assert result.ok is True
+        assert result.detail == "Cleaned: org/repo (fix-877)"
+
+    def test_step_errors_surfaced_in_detail_but_not_blocking(self) -> None:
+        """#877 — a non-clean result is loud (``detail``) but still ``ok`` (force-escape kept)."""
+        wt = self._make_worktree()
+        dirty = CleanupResult(
+            label="Cleaned: org/repo (fix-877)",
+            errors=["dropdb failed for wt_877: connection refused"],
+        )
+
+        with (
+            patch(_PATCH_DOWN),
+            patch(_PATCH_CLEANUP, return_value=dirty),
+            self.assertLogs("teatree.core.runners.worktree_teardown", level="ERROR") as logs,
+        ):
+            result = WorktreeTeardownRunner(wt).run()
+
+        assert result.ok is True
+        assert "dropdb failed for wt_877" in result.detail
+        assert "with errors" in result.detail
+        assert any("dropdb failed for wt_877" in line for line in logs.output)
+
+    def test_refusal_returns_not_ok(self) -> None:
+        """A RuntimeError refusal (the #706 data-loss guard) blocks teardown."""
+        wt = self._make_worktree()
+
+        with (
+            patch(_PATCH_DOWN),
+            patch(_PATCH_CLEANUP, side_effect=RuntimeError("refused teardown — on NO remote (data loss)")),
+        ):
+            result = WorktreeTeardownRunner(wt).run()
+
+        assert result.ok is False
+        assert "on NO remote" in result.detail
+
+    def test_snapshot_fields_restored_before_cleanup(self) -> None:
+        """The snapshot of db_name/extra is restored on the row before cleanup reads them."""
+        wt = self._make_worktree()
+        captured: dict[str, object] = {}
+
+        def fake_cleanup(worktree: Worktree, **_: object) -> CleanupResult:
+            captured["db_name"] = worktree.db_name
+            captured["extra"] = dict(worktree.extra or {})
+            return CleanupResult(label="Cleaned: org/repo (fix-877)")
+
+        with (
+            patch(_PATCH_DOWN),
+            patch(_PATCH_CLEANUP, side_effect=fake_cleanup),
+        ):
+            WorktreeTeardownRunner(
+                wt,
+                snapshot_db_name="wt_877",
+                snapshot_extra={"worktree_path": "/tmp/snap/org/repo"},
+            ).run()
+
+        assert captured["db_name"] == "wt_877"
+        assert captured["extra"] == {"worktree_path": "/tmp/snap/org/repo"}

--- a/tests/teatree_core/test_runners_teardown.py
+++ b/tests/teatree_core/test_runners_teardown.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase
 
+from teatree.core.cleanup import CleanupResult
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import reset_overlay_cache
 from teatree.core.runners import WorktreeTeardown
@@ -60,12 +61,12 @@ class TestWorktreeTeardown(TestCase):
 
         cleaned: list[str] = []
 
-        def fake_cleanup(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> str:
+        def fake_cleanup(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> CleanupResult:
             del force, strict_hygiene
             label = f"Cleaned: {worktree.repo_path}"
             cleaned.append(worktree.repo_path)
             worktree.delete()
-            return label
+            return CleanupResult(label=label)
 
         with (
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
@@ -80,13 +81,13 @@ class TestWorktreeTeardown(TestCase):
     def test_continues_on_individual_failure_and_reports_errors(self) -> None:
         ticket = self._ticket_with_worktrees(count=2)
 
-        def fake_cleanup(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> str:
+        def fake_cleanup(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> CleanupResult:
             del force, strict_hygiene
             if worktree.repo_path == "repo-0":
                 msg = "branch ahead of main"
                 raise RuntimeError(msg)
             worktree.delete()
-            return f"Cleaned: {worktree.repo_path}"
+            return CleanupResult(label=f"Cleaned: {worktree.repo_path}")
 
         with (
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),


### PR DESCRIPTION
Cleanup and teardown failures were swallowed by `suppress(Exception)`, and `cleanup_worktree` returned a bare `str`. Failures from `dropdb` or pass-entry removal could silently strand resources, leaving orphaned databases and worktrees with no signal to the caller.

This introduces a `CleanupResult` with a dedicated `errors` channel. Cleanup now collects-and-continues across all teardown steps rather than aborting on the first failure, and the collected errors are propagated to `SyncResult.errors` with loud runner-level logging so stranded resources are visible instead of suppressed. The #706/#708 force-escape contract is preserved.

Validated with an anti-vacuous RED→GREEN regression test that reproduces a teardown failure being dropped (RED) and confirms it now surfaces through `SyncResult.errors` (GREEN).

Closes #877

https://github.com/souliane/teatree/issues/877