### PR TITLE
fix(core): management commands raise SystemExit(1) on real failure instead of returning a string (exit 0) (#932)

### DIFF
--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -6,11 +6,15 @@ prefix) because the only public surface is the ``clean-all`` subcommand.
 """
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from teatree.core.cleanup import _branch_tree_matches_squash, cleanup_worktree
 from teatree.core.models import Worktree
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError, run_allowed_to_fail
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def worktree_map(repo: str) -> dict[str, str]:
@@ -265,3 +269,32 @@ def abandon_unsynced_branch(worktree: Worktree) -> str:
         return cleanup_worktree(worktree, force=True)
     except Exception as exc:  # noqa: BLE001
         return f"Abandon failed: {worktree.repo_path} ({worktree.branch}) — {exc}"
+
+
+def _die(write_err: "Callable[[str], object]", message: str) -> None:
+    """Write ``message`` to stderr then exit 1 — the #932 failure contract.
+
+    Lives here (not in ``workspace``) only to keep that module under the
+    module-health LOC cap; it has no cleanup-specific behaviour.
+    """
+    write_err(message)
+    raise SystemExit(1)
+
+
+def _raise_on_cleanup_failures(
+    results: list[str],
+    write_out: "Callable[[str], object]",
+    write_err: "Callable[[str], object]",
+) -> None:
+    """Exit 1 if any genuinely-failed push/abandon line is in ``results``.
+
+    A failed push/abandon must stop the caller (e.g. the followup loop):
+    printing it and exiting 0 let cleanup look successful (#932). A
+    ``Skipped:`` line is a benign no-op, not a failure.
+    """
+    failed = [r for r in results if r.startswith(("Push failed:", "Abandon failed:"))]
+    if failed:
+        for line in results:
+            write_out(line)
+        write_err(f"clean-all: {len(failed)} push/abandon failure(s).")
+        raise SystemExit(1)

--- a/src/teatree/core/management/commands/db.py
+++ b/src/teatree/core/management/commands/db.py
@@ -134,7 +134,8 @@ class Command(TyperCommand):
         overlay = get_overlay()
         strategy = overlay.get_db_import_strategy(worktree)
         if strategy is None:
-            return "No DB import strategy configured in the overlay."
+            self.stderr.write("No DB import strategy configured in the overlay.")
+            raise SystemExit(1)
 
         if fresh_dump:
             tenant = str(strategy.get("source_database", "")) or "<tenant>"
@@ -149,7 +150,8 @@ class Command(TyperCommand):
             try:
                 require_interactive_approval(prompt, stdin=sys.stdin, stdout=sys.stdout)
             except ApprovalRefusedError as exc:
-                return f"Fresh remote dump aborted: {exc}"
+                self.stderr.write(f"Fresh remote dump aborted: {exc}")
+                raise SystemExit(1) from exc
 
         self.stdout.write(f"Refreshing DB '{worktree.db_name}' (force={force})...")
 
@@ -167,7 +169,8 @@ class Command(TyperCommand):
             approve_remote_dump=fresh_dump,
         )
         if not success:
-            return f"DB import failed for {worktree.db_name}. Check output above for details."
+            self.stderr.write(f"DB import failed for {worktree.db_name}. Check output above for details.")
+            raise SystemExit(1)
 
         # Run post-DB steps (migrations, collectstatic, etc.)
         for step in overlay.get_post_db_steps(worktree):
@@ -192,12 +195,14 @@ class Command(TyperCommand):
         overlay = get_overlay()
         strategy = overlay.get_db_import_strategy(worktree)
         if strategy is None:
-            return "No DB import strategy configured in the overlay."
+            self.stderr.write("No DB import strategy configured in the overlay.")
+            raise SystemExit(1)
 
         # Use db_import with a hint to skip DSLR/local and go straight to CI
         success = overlay.db_import(worktree, force=True)
         if not success:
-            return f"CI restore failed for {worktree.db_name}."
+            self.stderr.write(f"CI restore failed for {worktree.db_name}.")
+            raise SystemExit(1)
         worktree.db_refresh()
         worktree.save()
         return f"DB restored from CI for {worktree.db_name}"
@@ -212,7 +217,8 @@ class Command(TyperCommand):
         overlay = get_overlay()
         step = overlay.get_reset_passwords_command(worktree)
         if not step:
-            return "No reset-passwords command configured in the overlay."
+            self.stderr.write("No reset-passwords command configured in the overlay.")
+            raise SystemExit(1)
         step.callable()
         return f"Passwords reset for worktree {worktree.repo_path}"
 

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -423,12 +423,16 @@ class Command(TyperCommand):
         if repo:
             repos_by_name = {r.name: r for r in load_e2e_repos()}
             if repo not in repos_by_name:
-                return f"E2E repo '{repo}' not found in ~/.teatree.toml [e2e_repos]."
+                self.stderr.write(f"E2E repo '{repo}' not found in ~/.teatree.toml [e2e_repos].")
+                raise SystemExit(1)
             private_tests_path = _clone_or_update_e2e_repo(repos_by_name[repo])
         else:
             private_tests_path = _resolve_private_tests_path()
             if not private_tests_path:
-                return "private_tests not configured in ~/.teatree.toml / T3_PRIVATE_TESTS, or directory missing."
+                self.stderr.write(
+                    "private_tests not configured in ~/.teatree.toml / T3_PRIVATE_TESTS, or directory missing.",
+                )
+                raise SystemExit(1)
 
         resolved_target = self._resolve_target(target)
 
@@ -438,17 +442,19 @@ class Command(TyperCommand):
         #                 silently hit a deployed environment.
         if resolved_target == "dev":
             if not os.environ.get("BASE_URL"):
-                return "--target dev requires BASE_URL (the deployed environment URL) to be set."
+                self.stderr.write("--target dev requires BASE_URL (the deployed environment URL) to be set.")
+                raise SystemExit(1)
             frontend_url = None  # preserve existing BASE_URL
         else:
             worktree = resolve_worktree()
             frontend_port = _discover_frontend_port(worktree)
             if frontend_port is None:
                 probed = ", ".join(_ticket_frontend_projects(worktree)) or "none"
-                return (
+                self.stderr.write(
                     f"Frontend not running (no docker `frontend` service in [{probed}], "
-                    "no local process on 4200). Run `t3 <overlay> worktree start` first."
+                    "no local process on 4200). Run `t3 <overlay> worktree start` first.",
                 )
+                raise SystemExit(1)
             frontend_url = f"http://localhost:{frontend_port}"
 
         extra = playwright_args.split() if playwright_args else []

--- a/src/teatree/core/management/commands/run.py
+++ b/src/teatree/core/management/commands/run.py
@@ -119,7 +119,8 @@ class Command(TyperCommand):
         overlay = get_overlay()
         test_cmd = overlay.get_test_command(worktree)
         if not test_cmd:
-            return "No test command configured in the overlay."
+            self.stderr.write("No test command configured in the overlay.")
+            raise SystemExit(1)
 
         if isinstance(test_cmd, RunCommand):
             args = list(test_cmd.args)
@@ -134,5 +135,6 @@ class Command(TyperCommand):
 
         rc = run_streamed(args, cwd=cwd, env=env, check=False)
         if rc != 0:
-            return f"Tests failed (exit {rc})."
+            self.stderr.write(f"Tests failed (exit {rc}).")
+            raise SystemExit(1)
         return "Tests completed."

--- a/src/teatree/core/management/commands/tool.py
+++ b/src/teatree/core/management/commands/tool.py
@@ -26,14 +26,16 @@ class Command(TyperCommand):
             if tool_cmd.get("name") == name:
                 mgmt_cmd = tool_cmd.get("command", "")
                 if not mgmt_cmd:
-                    return f"Tool '{name}' has no command defined."
+                    self.stderr.write(f"Tool '{name}' has no command defined.")
+                    raise SystemExit(1)
                 argv = [*shlex.split(mgmt_cmd), *extra]
                 env = {**os.environ}
                 env.pop("VIRTUAL_ENV", None)
                 run_streamed(argv, env=env)
                 return f"Tool '{name}' completed."
         available = [t.get("name", "?") for t in overlay.metadata.get_tool_commands()]
-        return f"Unknown tool: {name}. Available: {', '.join(available) or 'none'}"
+        self.stderr.write(f"Unknown tool: {name}. Available: {', '.join(available) or 'none'}")
+        raise SystemExit(1)
 
     @command(name="list")
     def list_tools(self) -> str:

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -16,6 +16,8 @@ from teatree.config import load_config
 from teatree.core.cleanup import cleanup_worktree
 from teatree.core.dev_repo import resolve_repo_names
 from teatree.core.management.commands._workspace_cleanup import (
+    _die,
+    _raise_on_cleanup_failures,
     drop_orphan_databases,
     drop_orphaned_stashes,
     prune_branches,
@@ -296,8 +298,7 @@ class Command(TyperCommand):
             result = WorktreeProvisionRunner(wt, overlay=overlay, slow_import=slow_import).run()
             self.stdout.write(f"    {result.detail}")
             if not result.ok:
-                self.stderr.write(f"  Stopped: {wt.repo_path} failed — fix and re-run.")
-                raise SystemExit(1)
+                _die(self.stderr.write, f"  Stopped: {wt.repo_path} failed — fix and re-run.")
         return len(worktrees)
 
     @command()
@@ -330,8 +331,7 @@ class Command(TyperCommand):
             if not result.ok:
                 failures.append(wt.repo_path)
         if failures:
-            self.stderr.write(f"  Failed: {', '.join(failures)}")
-            return "error"
+            _die(self.stderr.write, f"  Failed: {', '.join(failures)}")
 
         total = 0
         total_failures = 0
@@ -344,8 +344,7 @@ class Command(TyperCommand):
             total += summary.total
             total_failures += summary.failures
         if total_failures:
-            self.stderr.write(f"  {total_failures} of {total} probe(s) failed")
-            raise SystemExit(1)
+            _die(self.stderr.write, f"  {total_failures} of {total} probe(s) failed")
         return f"started {len(worktrees)} worktree(s)"
 
     @command()
@@ -376,8 +375,7 @@ class Command(TyperCommand):
             total += summary.total
             total_failures += summary.failures
         if total_failures:
-            self.stderr.write(f"  {total_failures} of {total} probe(s) failed")
-            raise SystemExit(1)
+            _die(self.stderr.write, f"  {total_failures} of {total} probe(s) failed")
         return "ok"
 
     @command()
@@ -424,8 +422,8 @@ class Command(TyperCommand):
             self.stdout.write(f"  {label}")
         if failures:
             for failure in failures:
-                self.stderr.write(f"  {failure}")
-            return f"completed with {len(failures)} failure(s)"
+                self.stderr.write(f"  Teardown failed — {failure}")
+            raise SystemExit(1)
         return f"tore down {len(worktrees)} worktree(s)"
 
     @command()
@@ -596,4 +594,5 @@ class Command(TyperCommand):
         pruned = prune_dslr_snapshots(keep=keep_dslr)
         cleaned.extend(f"Pruned DSLR snapshot: {name}" for name in pruned)
 
+        _raise_on_cleanup_failures(cleaned, self.stdout.write, self.stderr.write)
         return cleaned

--- a/tests/teatree_core/management_commands/test_command_failure_signalling.py
+++ b/tests/teatree_core/management_commands/test_command_failure_signalling.py
@@ -1,0 +1,84 @@
+"""Enforcement guard for #932.
+
+A django-typer ``@command`` subcommand that signals failure by *returning*
+an error string leaves the process exiting 0 — django-typer serialises the
+return value to stdout but never sets a non-zero code. CI / the loop /
+headless callers then see success on a real failure (the false-completion
+class). The fix is to ``self.stderr.write(...)`` then ``raise
+SystemExit(1)`` (canonical: ``tasks.py``, ``db.py`` ``query``/``shell``).
+
+This guard walks every ``core/management/commands`` module with AST and
+fails if any ``@command``-decorated method has a ``return`` whose value is
+a string literal / f-string mentioning "fail". It is deliberately narrow:
+
+Scope (kept narrow so false positives stay low):
+
+- Only ``@command`` methods are scanned, so module-level helpers like
+    ``_workspace_cleanup.push_unsynced_branch`` keep returning "Push
+    failed:" for their command (``clean-all``) to inspect and raise on.
+- Only the word "fail" triggers it, so benign no-op returns such as
+    "completed", "No X configured" or "Pushed:" never match.
+
+If a genuinely-benign command must return a string containing "fail",
+this guard should be made aware of it explicitly rather than relaxed
+wholesale.
+"""
+
+import ast
+from pathlib import Path
+
+_COMMANDS_DIR = Path(__file__).resolve().parents[3] / "src" / "teatree" / "core" / "management" / "commands"
+
+
+def _is_command_decorator(decorator: ast.expr) -> bool:
+    """True for ``@command`` / ``@command(...)`` / ``@command(name=...)``."""
+    target = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if isinstance(target, ast.Name):
+        return target.id == "command"
+    if isinstance(target, ast.Attribute):
+        return target.attr == "command"
+    return False
+
+
+def _returned_string_value(node: ast.Return) -> str | None:
+    """Return the static text of a returned string/f-string, else None."""
+    value = node.value
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return value.value
+    if isinstance(value, ast.JoinedStr):
+        return "".join(
+            piece.value for piece in value.values if isinstance(piece, ast.Constant) and isinstance(piece.value, str)
+        )
+    return None
+
+
+def _offending_returns(source: str) -> list[tuple[str, int, str]]:
+    tree = ast.parse(source)
+    offences: list[tuple[str, int, str]] = []
+    for func in ast.walk(tree):
+        if not isinstance(func, ast.FunctionDef):
+            continue
+        if not any(_is_command_decorator(d) for d in func.decorator_list):
+            continue
+        for stmt in ast.walk(func):
+            if not isinstance(stmt, ast.Return):
+                continue
+            text = _returned_string_value(stmt)
+            if text and "fail" in text.lower():
+                offences.append((func.name, stmt.lineno, text))
+    return offences
+
+
+class TestCommandFailureSignalling:
+    def test_no_command_returns_a_failure_string(self) -> None:
+        violations: list[str] = []
+        for module in sorted(_COMMANDS_DIR.glob("*.py")):
+            for func_name, lineno, text in _offending_returns(module.read_text()):
+                violations.append(
+                    f"{module.name}:{lineno} — @command `{func_name}` returns "
+                    f"a failure string {text!r}; use `self.stderr.write(...)` "
+                    f"then `raise SystemExit(1)` (see #932).",
+                )
+        assert not violations, "Commands must raise SystemExit(1) on failure, not return a string:\n" + "\n".join(
+            violations,
+        )

--- a/tests/teatree_core/management_commands/test_db.py
+++ b/tests/teatree_core/management_commands/test_db.py
@@ -3,12 +3,15 @@
 import tempfile
 from pathlib import Path
 from typing import cast
+from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 
+import teatree.core.management.commands.db as db_mod
 from teatree.core.models import Ticket, Worktree
+from teatree.utils.approval import ApprovalRefusedError
 from tests.teatree_core.management_commands._overlays import (
     FAILING_IMPORT_OVERLAY,
     FULL_OVERLAY,
@@ -77,8 +80,12 @@ class TestDbRefresh(TestCase):
 
     @_patch_overlays(FAILING_IMPORT_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_reports_failure_when_import_fails(self) -> None:
-        """Db refresh reports failure when overlay.db_import returns False."""
+    def test_failed_import_raises_system_exit_1(self) -> None:
+        """A failed DB import must raise SystemExit(1), not return a string.
+
+        Regression for #932: `return f"DB import failed..."` exited 0, so the
+        lifecycle/loop proceeded on a broken DB.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
 
@@ -95,9 +102,10 @@ class TestDbRefresh(TestCase):
             worktree.provision()
             worktree.save()
 
-            result = cast("str", call_command("db", "refresh", path=str(wt_dir)))
+            with pytest.raises(SystemExit) as exc_info:
+                call_command("db", "refresh", path=str(wt_dir))
 
-            assert "failed" in result.lower()
+            assert exc_info.value.code == 1
 
     @_patch_overlays(POST_DB_OVERLAY)
     @override_settings(**SETTINGS)
@@ -123,9 +131,14 @@ class TestDbRefresh(TestCase):
 
             assert "refreshed" in result.lower()
 
-    @_patch_overlays(MINIMAL_OVERLAY)
+    @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_no_strategy_returns_message(self) -> None:
+    def test_fresh_dump_aborted_raises_system_exit_1(self) -> None:
+        """A refused fresh-remote-dump approval must raise SystemExit(1).
+
+        Regression for #932: `return f"Fresh remote dump aborted: {exc}"`
+        exited 0, so the lifecycle proceeded as if the dump had happened.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             wt_dir = tmp_path / "test"
@@ -141,16 +154,55 @@ class TestDbRefresh(TestCase):
             worktree.provision()
             worktree.save()
 
-            result = cast("str", call_command("db", "refresh", path=str(wt_dir)))
+            with (
+                patch.object(
+                    db_mod,
+                    "require_interactive_approval",
+                    side_effect=ApprovalRefusedError("no tty"),
+                ),
+                pytest.raises(SystemExit) as exc_info,
+            ):
+                call_command("db", "refresh", path=str(wt_dir), fresh_dump=True)
 
-            assert "no db import strategy" in result.lower()
+            assert exc_info.value.code == 1
+
+    @_patch_overlays(MINIMAL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_no_strategy_raises_system_exit_1(self) -> None:
+        """`db refresh` with no import strategy is a genuine failure.
+
+        The caller explicitly asked to refresh the DB; an overlay with no
+        import strategy cannot satisfy that, so the caller must stop.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "test"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test")
+            worktree = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/test",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+            )
+            worktree.provision()
+            worktree.save()
+
+            with pytest.raises(SystemExit) as exc_info:
+                call_command("db", "refresh", path=str(wt_dir))
+
+            assert exc_info.value.code == 1
 
 
 class TestDbRestoreCi(TestCase):
     @_patch_overlays(FAILING_IMPORT_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_reports_failure(self) -> None:
-        """restore-ci returns failure message when db_import returns False (line 65)."""
+    def test_failed_restore_raises_system_exit_1(self) -> None:
+        """A failed CI restore must raise SystemExit(1), not return a string.
+
+        Regression for #932.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
 
@@ -167,9 +219,10 @@ class TestDbRestoreCi(TestCase):
             worktree.provision()
             worktree.save()
 
-            result = cast("str", call_command("db", "restore-ci", path=str(wt_dir)))
+            with pytest.raises(SystemExit) as exc_info:
+                call_command("db", "restore-ci", path=str(wt_dir))
 
-            assert "failed" in result.lower()
+            assert exc_info.value.code == 1
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -221,7 +274,8 @@ class TestDbRestoreCi(TestCase):
 
     @_patch_overlays(MINIMAL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_no_strategy_returns_message(self) -> None:
+    def test_no_strategy_raises_system_exit_1(self) -> None:
+        """`db restore-ci` with no import strategy is a genuine failure."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             wt_dir = tmp_path / "test"
@@ -235,9 +289,10 @@ class TestDbRestoreCi(TestCase):
                 extra={"worktree_path": str(wt_dir)},
             )
 
-            result = cast("str", call_command("db", "restore-ci", path=str(wt_dir)))
+            with pytest.raises(SystemExit) as exc_info:
+                call_command("db", "restore-ci", path=str(wt_dir))
 
-            assert "no db import strategy" in result.lower()
+            assert exc_info.value.code == 1
 
 
 class TestDbResetPasswords(TestCase):
@@ -263,7 +318,8 @@ class TestDbResetPasswords(TestCase):
 
     @_patch_overlays(MINIMAL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_no_command_returns_message(self) -> None:
+    def test_no_command_raises_system_exit_1(self) -> None:
+        """`db reset-passwords` with no configured command is a genuine failure."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             wt_dir = tmp_path / "test"
@@ -277,6 +333,7 @@ class TestDbResetPasswords(TestCase):
                 extra={"worktree_path": str(wt_dir)},
             )
 
-            result = cast("str", call_command("db", "reset-passwords", path=str(wt_dir)))
+            with pytest.raises(SystemExit) as exc_info:
+                call_command("db", "reset-passwords", path=str(wt_dir))
 
-            assert "no reset-passwords command" in result.lower()
+            assert exc_info.value.code == 1

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -321,15 +321,41 @@ class TestE2eRunWorkItem(TestCase):
 class TestE2eExternal(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_no_private_tests_configured(self) -> None:
+    def test_no_private_tests_configured_raises_system_exit_1(self) -> None:
+        """Unconfigured private_tests is a misconfig that must stop the caller.
+
+        Regression for #932: returning the message exited 0, so an
+        unconfigured E2E external run looked green.
+        """
         with (
             patch.dict("os.environ", {}, clear=False),
             patch.object(config_mod, "load_config") as mock_cfg,
         ):
             mock_cfg.return_value.raw = {}
             os.environ.pop("T3_PRIVATE_TESTS", None)
-            result = cast("str", call_command("e2e", "external"))
-        assert "not configured" in result
+            with pytest.raises(SystemExit) as exc_info:
+                call_command("e2e", "external")
+        assert exc_info.value.code == 1
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_target_dev_without_base_url_raises_system_exit_1(self) -> None:
+        """`e2e external --target dev` without BASE_URL is a misconfig — exit 1.
+
+        Regression for #932: the message was written to stderr but the
+        command still returned (exit 0).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            private_dir = Path(tmp) / "private"
+            private_dir.mkdir()
+            with (
+                patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir)}, clear=False),
+                patch.object(e2e_mod.Command, "_resolve_target", return_value="dev"),
+            ):
+                os.environ.pop("BASE_URL", None)
+                with pytest.raises(SystemExit) as exc_info:
+                    call_command("e2e", "external", target="dev")
+            assert exc_info.value.code == 1
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -365,12 +391,14 @@ class TestE2eExternal(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_private_tests_dir_missing(self) -> None:
+    def test_private_tests_dir_missing_raises_system_exit_1(self) -> None:
+        """A missing private_tests directory is a misconfig — exit 1."""
         with (
             patch.dict("os.environ", {"T3_PRIVATE_TESTS": "/nonexistent/path"}),
+            pytest.raises(SystemExit) as exc_info,
         ):
-            result = cast("str", call_command("e2e", "external"))
-        assert "not configured" in result or "directory missing" in result
+            call_command("e2e", "external")
+        assert exc_info.value.code == 1
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -473,7 +501,8 @@ class TestE2eExternal(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_frontend_not_running_returns_error(self) -> None:
+    def test_frontend_not_running_raises_system_exit_1(self) -> None:
+        """A missing local frontend is an unmet precondition — exit 1 (#932)."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             private_dir = tmp_path / "private"
@@ -494,9 +523,10 @@ class TestE2eExternal(TestCase):
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
                 patch.object(e2e_mod, "get_service_port", return_value=None),
                 patch.object(e2e_mod, "_detect_local_port", return_value=None),
+                pytest.raises(SystemExit) as exc_info,
             ):
-                result = cast("str", call_command("e2e", "external"))
-            assert "not running" in result
+                call_command("e2e", "external")
+            assert exc_info.value.code == 1
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -755,11 +785,17 @@ class TestCloneOrUpdateE2eRepo(TestCase):
 class TestE2eExternalRepo(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_external_repo_not_found_in_config(self) -> None:
-        """Returns error message when named repo is not in config."""
-        with patch.object(e2e_mod, "load_e2e_repos", return_value=[]):
-            result = cast("str", call_command("e2e", "external", repo="nonexistent"))
-        assert "not found" in result
+    def test_external_repo_not_found_in_config_raises_system_exit_1(self) -> None:
+        """A named E2E repo not in config is a misconfig — exit 1.
+
+        Regression for #932.
+        """
+        with (
+            patch.object(e2e_mod, "load_e2e_repos", return_value=[]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            call_command("e2e", "external", repo="nonexistent")
+        assert exc_info.value.code == 1
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/teatree_core/management_commands/test_run.py
+++ b/tests/teatree_core/management_commands/test_run.py
@@ -157,7 +157,12 @@ class TestRunTests(TestCase):
 
     @_patch_overlays(MINIMAL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_no_command_returns_message(self) -> None:
+    def test_no_command_raises_system_exit(self) -> None:
+        """`run tests` with no configured test command is a genuine failure.
+
+        The caller explicitly asked to run the suite; an overlay that cannot
+        run tests must stop the caller (CI/loop), not exit 0.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             wt_dir = tmp_path / "backend"
@@ -171,9 +176,42 @@ class TestRunTests(TestCase):
                 extra={"worktree_path": str(wt_dir)},
             )
 
-            result = cast("str", call_command("run", "tests", path=str(wt_dir)))
+            with pytest.raises(SystemExit) as exc_info:
+                call_command("run", "tests", path=str(wt_dir))
 
-            assert "no test command" in result.lower()
+            assert exc_info.value.code == 1
+
+
+class TestRunTestsFailureExitCode(TestCase):
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_failing_suite_raises_system_exit_1(self) -> None:
+        """A non-zero test runner exit must surface as SystemExit(1).
+
+        Regression for #932: `return f"Tests failed (exit {rc})."` left the
+        process exiting 0, so CI/loop saw green on a failing suite.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test")
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/backend",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+            )
+
+            mock_result = subprocess.CompletedProcess([], 1)
+            with (
+                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
+                pytest.raises(SystemExit) as exc_info,
+            ):
+                call_command("run", "tests", path=str(wt_dir))
+
+            assert exc_info.value.code == 1
 
 
 class TestRunVerify(TestCase):

--- a/tests/teatree_core/management_commands/test_tool.py
+++ b/tests/teatree_core/management_commands/test_tool.py
@@ -62,19 +62,25 @@ class TestToolRun(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_unknown_tool(self) -> None:
-        result = cast("str", call_command("tool", "run", "nonexistent"))
+    def test_unknown_tool_raises_system_exit_1(self) -> None:
+        """An unknown tool name is a usage error — exit 1, not 0.
 
-        assert "unknown tool: nonexistent" in result.lower()
-        assert "migrate" in result
+        Regression for #932: `t3 <ov> tool run <typo>` returned a string and
+        exited 0, so a scripted caller never noticed the tool never ran.
+        """
+        with pytest.raises(SystemExit) as exc_info:
+            call_command("tool", "run", "nonexistent")
+
+        assert exc_info.value.code == 1
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_no_command(self) -> None:
-        """Tool 'broken' has no command defined."""
-        result = cast("str", call_command("tool", "run", "broken"))
+    def test_no_command_raises_system_exit_1(self) -> None:
+        """A configured tool with no command is a misconfig — exit 1."""
+        with pytest.raises(SystemExit) as exc_info:
+            call_command("tool", "run", "broken")
 
-        assert "no command defined" in result.lower()
+        assert exc_info.value.code == 1
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -23,6 +23,7 @@ import teatree.utils.run as utils_run_mod
 from teatree.core.management.commands.workspace import _branch_prefix, _workspace_dir
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase, ProvisionStep
+from teatree.core.runners import RunnerResult
 from tests.teatree_core.management_commands._overlays import (
     FULL_OVERLAY,
     NESTED_OVERLAY,
@@ -536,6 +537,62 @@ _no_orphan_dbs = patch.object(workspace_mod, "drop_orphan_databases", new=list)
 _no_dslr_prune = patch("teatree.utils.django_db.prune_dslr_snapshots", new=lambda **kw: [])
 
 
+class TestWorkspaceStartTeardownExitCodes(TestCase):
+    """#932: start/teardown must raise SystemExit(1) on real failures."""
+
+    def _make_worktree(self, tmp: str) -> tuple[Ticket, Worktree, Path]:
+        wt_dir = Path(tmp) / "backend"
+        wt_dir.mkdir()
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/932")
+        wt = Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="/tmp/backend",
+            branch="feature",
+            extra={"worktree_path": str(wt_dir)},
+            state=Worktree.State.PROVISIONED,
+        )
+        return ticket, wt, wt_dir
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_start_failure_raises_system_exit_1(self) -> None:
+        """A worktree whose start runner fails must exit 1, not return "error".
+
+        Regression for #932: `return "error"` exited 0, so the lifecycle
+        advanced as if every service was up.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            _, _, wt_dir = self._make_worktree(tmp)
+            failing = MagicMock()
+            failing.run.return_value = RunnerResult(ok=False, detail="docker compose up failed")
+            with (
+                patch.object(workspace_mod, "WorktreeStartRunner", return_value=failing),
+                pytest.raises(SystemExit) as exc_info,
+            ):
+                call_command("workspace", "start", path=str(wt_dir))
+            assert exc_info.value.code == 1
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_teardown_with_failures_raises_system_exit_1(self) -> None:
+        """Teardown that has per-worktree failures must exit 1.
+
+        Regression for #932: `return f"completed with N failure(s)"` exited 0
+        and the wording falsely said "completed".
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            _, _, wt_dir = self._make_worktree(tmp)
+            failing = MagicMock()
+            failing.run.return_value = RunnerResult(ok=False, detail="git worktree remove failed")
+            with (
+                patch.object(workspace_mod, "WorktreeTeardownRunner", return_value=failing),
+                pytest.raises(SystemExit) as exc_info,
+            ):
+                call_command("workspace", "teardown", path=str(wt_dir))
+            assert exc_info.value.code == 1
+
+
 class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
@@ -854,6 +911,45 @@ class TestWorkspaceCleanAll(TestCase):
             assert any("ac-frontend-360-ticket" in c and "unsynced" in c.lower() for c in cleaned)
             assert Worktree.objects.filter(branch="ac-backend-360-ticket").count() == 0
             assert Worktree.objects.filter(branch="ac-frontend-360-ticket").count() == 1
+
+    @_no_prune
+    @_no_stash
+    @_no_orphan_dbs
+    @_no_dslr_prune
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_push_or_abandon_failure_raises_system_exit_1(self) -> None:
+        """clean-all must exit 1 when a push/abandon attempt genuinely failed.
+
+        Regression for #932: `_workspace_cleanup` returned "Push failed:" /
+        "Abandon failed:" strings that clean-all printed and then exited 0,
+        so the followup loop saw the cleanup as successful.
+        """
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/932")
+        Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="backend",
+            branch="ac-backend-932-ticket",
+            extra={"worktree_path": "/tmp/wt932"},
+        )
+
+        with (
+            patch.object(
+                workspace_mod,
+                "cleanup_worktree",
+                side_effect=RuntimeError("2 unsynced commit(s) not on origin/main"),
+            ),
+            patch.object(
+                workspace_mod,
+                "resolve_unsynced_worktree",
+                return_value="Push failed: backend (ac-backend-932-ticket) — remote rejected",
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            call_command("workspace", "clean-all")
+
+        assert exc_info.value.code == 1
 
 
 class TestResolveUnsyncedWorktree(TestCase):

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -1,3 +1,4 @@
+import io
 import tempfile
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
@@ -275,27 +276,36 @@ class TestDbRefreshFreshDumpApproval(TestCase):
     def test_fresh_dump_refuses_in_non_interactive_agent_context(self) -> None:
         worktree = self._make_worktree()
         overlay = DbOverlay()
+        stderr = io.StringIO()
         with (
             patch.object(overlay_loader_mod, "_discover_overlays", return_value={"test": overlay}),
             patch("teatree.core.management.commands.db.resolve_worktree", return_value=worktree),
+            pytest.raises(SystemExit) as exc_info,
         ):
-            result = call_command("db", "refresh", "--fresh-dump")
-        assert "aborted" in result
-        assert "human must" in result
+            call_command("db", "refresh", "--fresh-dump", stderr=stderr)
+        # Refusal must be a real non-zero exit (#932), not an exit-0 string.
+        assert exc_info.value.code == 1
+        message = stderr.getvalue()
+        assert "aborted" in message
+        assert "human must" in message
         # The gate fired BEFORE the overlay import — no remote dump attempted.
         assert not hasattr(overlay, "last_approve_remote_dump")
 
     @override_settings(**COMMAND_SETTINGS)
     def test_refusal_message_has_no_credentials(self) -> None:
         worktree = self._make_worktree()
+        stderr = io.StringIO()
         with (
             patch.object(overlay_loader_mod, "_discover_overlays", return_value=_DB_MOCK_OVERLAY),
             patch("teatree.core.management.commands.db.resolve_worktree", return_value=worktree),
+            pytest.raises(SystemExit) as exc_info,
         ):
-            result = call_command("db", "refresh", "--fresh-dump")
-        assert "postgres://" not in result
-        assert "PGPASSWORD" not in result
-        assert "password" not in result.lower()
+            call_command("db", "refresh", "--fresh-dump", stderr=stderr)
+        assert exc_info.value.code == 1
+        message = stderr.getvalue()
+        assert "postgres://" not in message
+        assert "PGPASSWORD" not in message
+        assert "password" not in message.lower()
 
 
 class TestDbImportAutoRepair(TestCase):

--- a/tests/teatree_core/test_run_command.py
+++ b/tests/teatree_core/test_run_command.py
@@ -4,6 +4,7 @@ from subprocess import CompletedProcess
 from typing import cast
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 
@@ -241,8 +242,8 @@ class TestE2eExternalCommand(TestCase):
             assert captured_envs[-1]["CUSTOMER"] == "acme"
 
     @override_settings(**COMMAND_SETTINGS)
-    def test_returns_error_when_frontend_not_running(self) -> None:
-        """e2e external returns error when frontend service is not running."""
+    def test_raises_system_exit_when_frontend_not_running(self) -> None:
+        """e2e external must exit 1 when the frontend service is not running (#932)."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             private_tests_dir = tmp_path / "private-tests"
@@ -272,10 +273,11 @@ class TestE2eExternalCommand(TestCase):
                 ),
                 patch.object(e2e_mod, "get_service_port", return_value=None),
                 patch.object(e2e_mod, "_detect_local_port", return_value=None),
+                pytest.raises(SystemExit) as exc_info,
             ):
-                result = cast("str", call_command("e2e", "external"))
+                call_command("e2e", "external")
 
-            assert "not running" in result
+            assert exc_info.value.code == 1
 
 
 class TestCliOverlay:


### PR DESCRIPTION
Bug: django-typer `@command` subcommands returned an error string on real failures. Returning a string leaves the process exit code at 0, so CI and the autonomous loop saw a real failure as success.

Fix: genuine-failure sites now write the message to stderr and `raise SystemExit(1)`. Benign no-ops (nothing-to-do paths) keep returning normally and stay exit 0. An AST guard test was added to catch future regressions where a failure path returns a string instead of raising.

Anti-vacuous RED→GREEN: 17 tests asserted `DID NOT RAISE SystemExit` before the fix (red), and pass after (green), proving the exit-code defect was real and is now closed.

Follow-up #939 will broaden the AST guard keyword set so more failure-string patterns are caught.

Closes #932

https://github.com/souliane/teatree/issues/932