### PR TITLE
fix(db): --fresh-dump forces slow_import so it reaches the remote dump (not stale DSLR) (#955)

### DIFF
--- a/src/teatree/core/management/commands/db.py
+++ b/src/teatree/core/management/commands/db.py
@@ -161,9 +161,15 @@ class Command(TyperCommand):
         os.environ.update(overlay.get_env_extra(worktree))
 
         # Run the overlay's import logic
+        # #955: --fresh-dump must force slow_import. The remote-dump branch
+        # in DjangoDbImporter.run() sits *after* the `if not slow_import:
+        # return False` guard (which itself follows the early DSLR return),
+        # so without this the flag silently degrades to "restore the stale
+        # local DSLR snapshot" instead of fetching a fresh remote dump.
         success = overlay.db_import(
             worktree,
             force=force,
+            slow_import=fresh_dump,
             dslr_snapshot=dslr_snapshot,
             dump_path=dump_path,
             approve_remote_dump=fresh_dump,

--- a/tests/teatree_core/management_commands/_overlays.py
+++ b/tests/teatree_core/management_commands/_overlays.py
@@ -22,6 +22,7 @@ from teatree.core.overlay import (
     ToolCommand,
     ValidationResult,
 )
+from teatree.utils.django_db import DjangoDbImportConfig, DjangoDbImporter
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore:In Typer, only the parameter 'autocompletion' is supported.*:DeprecationWarning",
@@ -201,6 +202,74 @@ class FailingImportOverlay(FullOverlay):
         return False
 
 
+class RemotePathRecordingOverlay(FullOverlay):
+    """Overlay whose ``db_import`` runs a real ``DjangoDbImporter``.
+
+    Used to prove end-to-end (issue #955) that ``db refresh --fresh-dump``
+    forwards ``slow_import=True`` so the importer's ``run()`` actually
+    reaches the ``allow_remote_dump`` remote-dump branch instead of
+    returning early on the ``not slow_import`` / DSLR guard.
+
+    Only the unstoppable subprocess boundaries are mocked: DSLR restore
+    (unavailable here so the DSLR fast path is skipped), the remote
+    ``pg_dump`` fetch, and the local-dump restore. Everything the fix
+    touches — the kwarg threading and ``run()``'s control flow — is real.
+
+    Instances expose ``calls``: ``slow_import`` is the value received by
+    ``db_import``; ``remote_branch_reached`` is True iff ``run()`` entered
+    the ``if allow_remote_dump:`` block (``_try_fetch_remote_dump`` ran).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: dict[str, object] = {}
+
+    def db_import(  # noqa: PLR0913 — mirrors the OverlayBase.db_import extension-point contract.
+        self,
+        worktree: Worktree,
+        *,
+        force: bool = False,
+        slow_import: bool = False,
+        dslr_snapshot: str = "",
+        dump_path: str = "",
+        approve_remote_dump: bool = False,
+    ) -> bool:
+        self.calls["slow_import"] = slow_import
+        self.calls["approve_remote_dump"] = approve_remote_dump
+        self.calls["remote_branch_reached"] = False
+
+        cfg = DjangoDbImportConfig(
+            ref_db_name="ref_db",
+            ticket_db_name="ticket_db",
+            main_repo_path=worktree.repo_path,
+            dump_dir="/tmp/does-not-exist",
+            dump_glob="*.pgsql",
+            ci_dump_glob="*.pgsql",
+            remote_db_url="postgres://example/remote",
+        )
+        importer = DjangoDbImporter(cfg)
+
+        def _fetch_remote() -> bool:
+            self.calls["remote_branch_reached"] = True
+            return True
+
+        # First local-dump attempt (pre-remote, run() line ~499) finds no
+        # local dump → False, so control flows into `if allow_remote_dump:`.
+        # The post-fetch restore (run() line ~504) then succeeds.
+        local_restore_results = iter([False, True])
+
+        with (
+            patch.object(importer, "_try_restore_from_dslr", return_value=False),
+            patch.object(
+                importer,
+                "_try_restore_from_local_dump",
+                side_effect=lambda: next(local_restore_results),
+            ),
+            patch.object(importer, "_try_fetch_remote_dump", side_effect=_fetch_remote),
+        ):
+            return importer.run(slow_import=slow_import, allow_remote_dump=approve_remote_dump)
+
+
 class PreRunOverlay(FullOverlay):
     """Overlay with pre-run steps — tests the pre-run loop in worktree provision."""
 
@@ -235,6 +304,9 @@ FAILING_IMPORT_OVERLAY = "tests.teatree_core.management_commands._overlays.Faili
 
 
 PRE_RUN_OVERLAY = "tests.teatree_core.management_commands._overlays.PreRunOverlay"
+
+
+REMOTE_PATH_RECORDING_OVERLAY = "tests.teatree_core.management_commands._overlays.RemotePathRecordingOverlay"
 
 
 SETTINGS: dict[str, object] = {}

--- a/tests/teatree_core/management_commands/test_db.py
+++ b/tests/teatree_core/management_commands/test_db.py
@@ -11,12 +11,14 @@ from django.test import TestCase, override_settings
 
 import teatree.core.management.commands.db as db_mod
 from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay_loader import get_overlay
 from teatree.utils.approval import ApprovalRefusedError
 from tests.teatree_core.management_commands._overlays import (
     FAILING_IMPORT_OVERLAY,
     FULL_OVERLAY,
     MINIMAL_OVERLAY,
     POST_DB_OVERLAY,
+    REMOTE_PATH_RECORDING_OVERLAY,
     SETTINGS,
     _patch_overlays,
 )
@@ -165,6 +167,81 @@ class TestDbRefresh(TestCase):
                 call_command("db", "refresh", path=str(wt_dir), fresh_dump=True)
 
             assert exc_info.value.code == 1
+
+    @_patch_overlays(REMOTE_PATH_RECORDING_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_fresh_dump_forwards_slow_import_and_reaches_remote_dump(self) -> None:
+        """`db refresh --fresh-dump` must reach the remote-dump branch.
+
+        Regression for #955. `refresh` never passed `slow_import` into
+        `overlay.db_import(...)`, so `DjangoDbImporter.run()` returned at
+        the `not slow_import` guard (after the early DSLR return) BEFORE
+        the `if allow_remote_dump:` remote `pg_dump` block. `--fresh-dump`
+        silently degraded to "restore stale local DSLR snapshot".
+
+        With the fix, `fresh_dump` forces `slow_import=True`, so `run()`
+        flows past the guard and enters the `allow_remote_dump` branch
+        (`_try_fetch_remote_dump`). DSLR is unavailable in this double, so
+        the only way the import can succeed is via the remote branch.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "test"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test")
+            worktree = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/test",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+            )
+            worktree.provision()
+            worktree.save()
+
+            with patch.object(db_mod, "require_interactive_approval", return_value=None):
+                result = cast(
+                    "str",
+                    call_command("db", "refresh", path=str(wt_dir), fresh_dump=True),
+                )
+
+            overlay = get_overlay()
+            assert overlay.calls["slow_import"] is True
+            assert overlay.calls["approve_remote_dump"] is True
+            assert overlay.calls["remote_branch_reached"] is True
+            assert "refreshed" in result.lower()
+
+    @_patch_overlays(REMOTE_PATH_RECORDING_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_non_fresh_refresh_does_not_force_slow_import(self) -> None:
+        """Regression: the non-`--fresh-dump` path is unchanged.
+
+        Without `--fresh-dump`, `db refresh` must NOT force `slow_import`
+        and must NOT reach the remote-dump branch — the DSLR-first fast
+        path stays the only sanctioned path for the default flow (#955).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "test"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test")
+            worktree = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/test",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+            )
+            worktree.provision()
+            worktree.save()
+
+            with pytest.raises(SystemExit) as exc_info:
+                call_command("db", "refresh", path=str(wt_dir))
+
+            assert exc_info.value.code == 1
+            overlay = get_overlay()
+            assert overlay.calls["slow_import"] is False
+            assert overlay.calls["remote_branch_reached"] is False
 
     @_patch_overlays(MINIMAL_OVERLAY)
     @override_settings(**SETTINGS)


### PR DESCRIPTION
`db refresh --fresh-dump` never set `slow_import`, so the remote-dump code path was unreachable: the command silently restored a stale DSLR snapshot instead of fetching the fresh remote dump.

Fix: pass `slow_import=fresh_dump` so `--fresh-dump` actually reaches the remote dump path. The #777 gate is unchanged, and the non-fresh path is unchanged. Covered by an anti-vacuous RED→GREEN regression test.

Closes #955

https://github.com/souliane/teatree/issues/955