### PR TITLE
fix(infra): ensure_running reconciles the teatree-redis host port publish

### DIFF
--- a/src/teatree/utils/redis_container.py
+++ b/src/teatree/utils/redis_container.py
@@ -47,30 +47,71 @@ def status() -> str:
     return result.stdout.strip() or "missing"
 
 
+def _host_port_published() -> bool:
+    """True when ``teatree-redis`` publishes 6379 to the host.
+
+    A container created (by an older teatree, or any non-publishing path)
+    without ``-p 6379:6379`` answers ``docker port`` with no mapping. Such a
+    container is "running" but every worktree's web service reaches Redis via
+    ``host.docker.internal:6379`` — unpublished, that connection is refused
+    and every request that touches the cache/broker 500s (Error 111).
+    """
+    result = _docker_tolerant("port", CONTAINER_NAME, "6379")
+    if result.returncode != 0:
+        return False
+    return bool(result.stdout.strip())
+
+
+def _create(db_count: int) -> None:
+    logger.info("Creating %s container on :%d", CONTAINER_NAME, HOST_PORT)
+    _docker_checked(
+        "run",
+        "-d",
+        "--name",
+        CONTAINER_NAME,
+        "-p",
+        f"{HOST_PORT}:6379",
+        "--restart",
+        "unless-stopped",
+        IMAGE,
+        "redis-server",
+        "--databases",
+        str(db_count),
+    )
+
+
+def _recreate_with_port_publish(db_count: int) -> None:
+    logger.info(
+        "%s lacks the :%d host publish — recreating to reconcile the port mapping",
+        CONTAINER_NAME,
+        HOST_PORT,
+    )
+    _docker_tolerant("stop", CONTAINER_NAME)
+    _docker_tolerant("rm", CONTAINER_NAME)
+    _create(db_count)
+
+
 def ensure_running(db_count: int = DEFAULT_DB_COUNT) -> None:
-    """Start the shared Redis container if not already running."""
+    """Start the shared Redis container, self-healing the host port publish.
+
+    Idempotent: a *running* container that lacks the ``-p 6379:6379`` publish
+    is reconciled (recreated), not left as-is. Without this, a container
+    created by an older code path stays "running" forever while every
+    worktree's ``host.docker.internal:6379`` is unreachable and every
+    cache/broker-touching request 500s.
+    """
     current = status()
     if current == "running":
+        if not _host_port_published():
+            _recreate_with_port_publish(db_count)
         return
     if current == "missing":
-        logger.info("Creating %s container on :%d", CONTAINER_NAME, HOST_PORT)
-        _docker_checked(
-            "run",
-            "-d",
-            "--name",
-            CONTAINER_NAME,
-            "-p",
-            f"{HOST_PORT}:6379",
-            "--restart",
-            "unless-stopped",
-            IMAGE,
-            "redis-server",
-            "--databases",
-            str(db_count),
-        )
+        _create(db_count)
         return
     logger.info("Starting existing %s container (status=%s)", CONTAINER_NAME, current)
     _docker_checked("start", CONTAINER_NAME)
+    if not _host_port_published():
+        _recreate_with_port_publish(db_count)
 
 
 def stop() -> None:

--- a/tests/teatree_utils/test_redis_container.py
+++ b/tests/teatree_utils/test_redis_container.py
@@ -36,14 +36,56 @@ class TestStatus:
             assert redis_container.status() == "missing"
 
 
+class TestHostPortPublished:
+    def test_true_when_6379_mapped_to_host(self) -> None:
+        with patch.object(
+            redis_container,
+            "_docker_tolerant",
+            return_value=_completed(stdout="0.0.0.0:6379\n"),
+        ):
+            assert redis_container._host_port_published() is True
+
+    def test_false_when_no_port_mapping(self) -> None:
+        # `docker port teatree-redis 6379` prints nothing when the container
+        # was created without `-p 6379:6379` (the "Up 2 days, 6379/tcp:[]"
+        # case that silently broke every worktree's web → redis traffic).
+        with patch.object(redis_container, "_docker_tolerant", return_value=_completed(stdout="\n")):
+            assert redis_container._host_port_published() is False
+
+    def test_false_when_docker_port_fails(self) -> None:
+        with patch.object(redis_container, "_docker_tolerant", return_value=_completed(returncode=1)):
+            assert redis_container._host_port_published() is False
+
+
 class TestEnsureRunning:
-    def test_no_op_when_already_running(self) -> None:
+    def test_no_op_when_already_running_and_port_published(self) -> None:
         with (
             patch.object(redis_container, "status", return_value="running"),
+            patch.object(redis_container, "_host_port_published", return_value=True),
             patch.object(redis_container, "_docker_checked") as mock,
         ):
             redis_container.ensure_running()
         mock.assert_not_called()
+
+    def test_recreates_running_container_when_port_not_published(self) -> None:
+        # Regression: a running teatree-redis created without the host port
+        # publish must be reconciled (recreated), not left as-is — otherwise
+        # the web container's host.docker.internal:6379 is unreachable and
+        # every /api/jwt/ returns HTTP 500 (Error 111). The old code
+        # early-returned on status=="running" and never noticed.
+        calls: list[tuple[str, ...]] = []
+        with (
+            patch.object(redis_container, "status", return_value="running"),
+            patch.object(redis_container, "_host_port_published", return_value=False),
+            patch.object(redis_container, "_docker_tolerant", side_effect=lambda *a: calls.append(a) or _completed()),
+            patch.object(redis_container, "_docker_checked", side_effect=lambda *a: calls.append(a) or _completed()),
+        ):
+            redis_container.ensure_running(db_count=16)
+        assert ("stop", "teatree-redis") in calls
+        assert ("rm", "teatree-redis") in calls
+        run_call = next(c for c in calls if c and c[0] == "run")
+        assert "-p" in run_call
+        assert "6379:6379" in run_call
 
     def test_creates_container_when_missing(self) -> None:
         with (
@@ -60,10 +102,28 @@ class TestEnsureRunning:
     def test_starts_existing_stopped_container(self) -> None:
         with (
             patch.object(redis_container, "status", return_value="exited"),
+            patch.object(redis_container, "_host_port_published", return_value=True),
             patch.object(redis_container, "_docker_checked") as mock,
         ):
             redis_container.ensure_running()
         mock.assert_called_once_with("start", "teatree-redis")
+
+    def test_recreates_after_start_when_port_not_published(self) -> None:
+        # A previously-`docker stop`ped container that was originally created
+        # without the publish: `docker start` brings it back still
+        # unpublished, so it must also be reconciled.
+        calls: list[tuple[str, ...]] = []
+        with (
+            patch.object(redis_container, "status", return_value="exited"),
+            patch.object(redis_container, "_host_port_published", return_value=False),
+            patch.object(redis_container, "_docker_tolerant", side_effect=lambda *a: calls.append(a) or _completed()),
+            patch.object(redis_container, "_docker_checked", side_effect=lambda *a: calls.append(a) or _completed()),
+        ):
+            redis_container.ensure_running(db_count=16)
+        assert ("start", "teatree-redis") in calls
+        assert ("rm", "teatree-redis") in calls
+        run_call = next(c for c in calls if c and c[0] == "run")
+        assert "6379:6379" in run_call
 
 
 class TestStop:


### PR DESCRIPTION
## Problem

A `teatree-redis` container created without `-p 6379:6379` (an older code path, or any non-publishing start) stays `status==running` indefinitely. `ensure_running()` early-returned on `running`, so the missing host publish was never reconciled. Every worktree's web container reaches Redis via `host.docker.internal:6379`; unpublished, that connection is refused and **every cache/broker-touching request 500s** (`Error 111 connecting to host.docker.internal:6379`). Hit live this session: a "Up 2 days" teatree-redis with `docker inspect` showing `6379/tcp:[]` made every `/api/jwt/` on a freshly-started COMPANY worktree return HTTP 500, blocking an E2E run end-to-end.

## Fix

`ensure_running()` now probes `docker port teatree-redis 6379` and, when the container is running-but-unpublished (or becomes so after a `docker start` of a previously-stopped unpublished container), recreates it with the publish. Idempotent and self-healing — re-running converges on the documented `localhost:6379` state.

## Tests

TDD: RED first (`_host_port_published` absent), then GREEN. `tests/teatree_utils/test_redis_container.py` — 19 passed; `tests/teatree_utils/` + `test_redis_slots.py` — 59 passed. prek/lint/format clean.

## Scope

One of several t3 infra root-causes found while validating a release-blocker E2E. The companion DATABASE_URL-to-compose-`.env` and single-command-replay items are tracked separately.