### PR TITLE
feat(hooks): enrich PreCompact snapshot with cwd, git state, open PRs, and TODOs (#970)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -50,7 +50,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|Write|Edit|Read|Grep|Glob",
+        "matcher": "Bash|Write|Edit|Read|Grep|Glob|TodoWrite",
         "hooks": [
           {
             "type": "command",

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -1170,10 +1170,169 @@ def handle_read_dedup(data: dict) -> None:
     )
 
 
+# ── PostToolUse: capture TodoWrite into durable per-session state ──
+#
+# Issue #970: the recovery snapshot was missing the active TODO list.
+# When ``TodoWrite`` fires, persist the latest todos to
+# ``<session>.todos`` so the PreCompact snapshot can quote them back.
+# Anthropic's newer ``TaskCreate``/``TaskUpdate`` tools currently bypass
+# PostToolUse (documented regression in ``docs/claude-code-internals.md``);
+# whenever they start firing hooks again, register them here too.
+
+
+def handle_track_todos(data: dict) -> None:
+    """Persist the current ``TodoWrite`` todo list to ``<session>.todos``.
+
+    Stores one ``- [status] content`` line per todo so the snapshot
+    renderer can include it verbatim. Overwrites on each TodoWrite so
+    completed/removed items don't linger — TodoWrite is the source of
+    truth for the active list. No-op for any other tool name.
+    """
+    if data.get("tool_name") != "TodoWrite":
+        return
+    session_id = data.get("session_id", "")
+    if not session_id:
+        return
+    todos = data.get("tool_input", {}).get("todos", [])
+    if not isinstance(todos, list):
+        return
+
+    _ensure_state_dir()
+    todos_file = _state_file(session_id, "todos")
+    lines: list[str] = []
+    for todo in todos:
+        if not isinstance(todo, dict):
+            continue
+        content = str(todo.get("content", "")).strip()
+        if not content:
+            continue
+        status = str(todo.get("status", "pending")).strip() or "pending"
+        lines.append(f"- [{status}] {content}")
+    todos_file.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
 # ── PreCompact: retro-before-compact ──────────────────────────────
 
 
-def _durable_session_snapshot(session_id: str) -> str:
+def _git_state_for_repo(repo_path: Path) -> dict[str, str] | None:
+    """Best-effort current branch / HEAD / dirty / unpushed for *repo_path*.
+
+    Returns ``None`` if *repo_path* is not a git working tree. All subprocess
+    calls are short-timeout and exceptions are swallowed — the snapshot must
+    never block compaction (#970 / #845 invariant).
+    """
+    if not (repo_path / ".git").exists():
+        return None
+
+    def _git(*args: str) -> str:
+        try:
+            return subprocess.check_output(  # noqa: S603
+                ["git", "-C", str(repo_path), "--no-optional-locks", *args],  # noqa: S607
+                text=True,
+                timeout=3,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            return ""
+
+    branch = _git("rev-parse", "--abbrev-ref", "HEAD")
+    head = _git("rev-parse", "--short", "HEAD")
+    porcelain = _git("status", "--porcelain")
+    # ``@{u}`` resolves to the configured upstream; absent ⇒ empty output ⇒ 0.
+    unpushed_log = _git("log", "@{u}..HEAD", "--oneline")
+
+    uncommitted_count = len([line for line in porcelain.splitlines() if line.strip()])
+    unpushed_count = len([line for line in unpushed_log.splitlines() if line.strip()])
+    return {
+        "branch": branch or "(detached)",
+        "head": head or "(unknown)",
+        "uncommitted": str(uncommitted_count),
+        "unpushed": str(unpushed_count),
+    }
+
+
+def _open_prs_for_repo(repo_path: Path) -> list[dict]:
+    """Return open PRs authored by the current user for *repo_path*.
+
+    Best-effort: a missing ``gh``, no auth, no network, or a non-GitHub
+    remote returns ``[]``. Never raises. Tests monkeypatch this symbol
+    directly to avoid hitting the network — see
+    ``tests/test_pre_compact_snapshot_enriched.py``.
+    """
+    if not (repo_path / ".git").exists():
+        return []
+    try:
+        out = subprocess.check_output(
+            [  # noqa: S607
+                "gh",
+                "pr",
+                "list",
+                "--author",
+                "@me",
+                "--state",
+                "open",
+                "--limit",
+                "20",
+                "--json",
+                "number,title,headRefName,isDraft",
+            ],
+            cwd=str(repo_path),
+            text=True,
+            timeout=3,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _resolve_cwd_repo(data: dict) -> Path | None:
+    """Resolve the harness-provided ``cwd`` to a directory, if any."""
+    cwd = data.get("cwd", "")
+    if not cwd:
+        return None
+    path = Path(cwd)
+    return path if path.is_dir() else None
+
+
+def _render_git_state_section(repo: Path) -> list[str]:
+    state = _git_state_for_repo(repo)
+    if state is None:
+        return []
+    return [
+        "",
+        "## Current git state",
+        f"- worktree: `{repo}`",
+        f"- branch: `{state['branch']}`",
+        f"- HEAD: `{state['head']}`",
+        f"- {state['uncommitted']} uncommitted file(s)",
+        f"- {state['unpushed']} unpushed commit(s)",
+    ]
+
+
+def _render_open_prs_section(repo: Path) -> list[str]:
+    try:
+        prs = _open_prs_for_repo(repo)
+    except Exception:  # noqa: BLE001 — never block compaction on a lookup
+        return []
+    if not prs:
+        return []
+    lines = ["", "## Open PRs (this repo, @me, open)"]
+    for pr in prs:
+        number = pr.get("number", "?")
+        title = pr.get("title", "(no title)")
+        head = pr.get("headRefName", "")
+        draft = " [draft]" if pr.get("isDraft") else ""
+        suffix = f" — `{head}`" if head else ""
+        lines.append(f"- #{number}{draft}: {title}{suffix}")
+    return lines
+
+
+def _durable_session_snapshot(session_id: str, data: dict | None = None) -> str:
     """Build a recovery snapshot for *session_id* from DURABLE state only.
 
     Issue #778: a background sub-agent (a per-unit loop sub-agent,
@@ -1185,7 +1344,17 @@ def _durable_session_snapshot(session_id: str) -> str:
     ``_OWNER_LOOP`` record; there is no roster of singletons and no spawn
     brief) and the per-session active-repos / loaded-skills tracking
     files. No reliance on the agent having done anything.
+
+    Issue #970: the original capture was too thin to actually resume —
+    just the ever-touched ``.active`` ledger and the loaded skills. This
+    additionally pins, when ``data`` carries the harness ``cwd``: the
+    current worktree, branch, HEAD short SHA, uncommitted/unpushed
+    counts, and the live open PRs for that repo (best-effort, never
+    blocking). Captured TODOs (via :func:`handle_track_todos`) round out
+    "what was I about to do next" from the durable side, since the Tasks
+    API doesn't fire ``PostToolUse``.
     """
+    data = data or {}
     lines = [
         f"# Auto-recovery snapshot — session `{session_id}`",
         "",
@@ -1194,6 +1363,12 @@ def _durable_session_snapshot(session_id: str) -> str:
             "Use this to re-derive your identity and assignment after compaction."
         ),
     ]
+
+    cwd_repo = _resolve_cwd_repo(data)
+    if cwd_repo is not None:
+        lines += ["", "## Current working directory", f"- `{cwd_repo}`"]
+        lines += _render_git_state_section(cwd_repo)
+        lines += _render_open_prs_section(cwd_repo)
 
     owned = [
         (name, entry)
@@ -1216,6 +1391,10 @@ def _durable_session_snapshot(session_id: str) -> str:
             agent_id = entry.get("agent_id") or "(agent id not recorded)"
             lines.append(f"- tick-owner agentId `{agent_id}` (pid {entry.get('pid', '?')})")
 
+    todos = _read_lines(_state_file(session_id, "todos"))
+    if todos:
+        lines += ["", "## Pending TODOs", *todos]
+
     active = _read_lines(_state_file(session_id, "active"))
     if active:
         lines += ["", "## Repos touched this session", *(f"- {repo}" for repo in active)]
@@ -1227,7 +1406,7 @@ def _durable_session_snapshot(session_id: str) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _write_precompact_snapshot(session_id: str) -> None:
+def _write_precompact_snapshot(session_id: str, data: dict | None = None) -> None:
     """Persist the durable-state snapshot under the recovery-recognized name.
 
     Reuses the ``t3-snapshot-`` prefix that :func:`_find_temp_files`
@@ -1245,7 +1424,7 @@ def _write_precompact_snapshot(session_id: str) -> None:
     # suppressed so the docstring's "must never block compaction" holds.
     with contextlib.suppress(OSError):
         _ensure_state_dir()
-        target.write_text(_durable_session_snapshot(session_id), encoding="utf-8")
+        target.write_text(_durable_session_snapshot(session_id, data), encoding="utf-8")
 
 
 def handle_pre_compact(data: dict) -> None:
@@ -1265,7 +1444,7 @@ def handle_pre_compact(data: dict) -> None:
     if not session_id:
         return
 
-    _write_precompact_snapshot(session_id)
+    _write_precompact_snapshot(session_id, data)
 
     skills_file = _state_file(session_id, "skills")
     loaded: set[str] = set()
@@ -2880,6 +3059,7 @@ _HANDLERS: dict[str, list] = {
         handle_track_skill_usage,
         handle_track_cron_jobs,
         handle_read_dedup,
+        handle_track_todos,
     ],
     "InstructionsLoaded": [handle_track_skill_usage],
     "SessionStart": [handle_session_start_bootstrap],

--- a/tests/test_pre_compact_snapshot_enriched.py
+++ b/tests/test_pre_compact_snapshot_enriched.py
@@ -1,0 +1,285 @@
+"""Tests for the enriched PreCompact snapshot content (issue #970).
+
+The existing #778 snapshot only captures (a) loop assignment, (b) the
+ever-touched ``.active`` ledger and (c) the loaded skills. The user
+report on #970 is that this is too thin to actually resume work: it
+misses the *current* worktree (cwd), branch, HEAD, working-tree dirty
+state, unpushed commits, the live in-flight PRs and the current TODO
+list — the things the agent and the user both need to rebuild "what
+was I doing" after compaction. These tests pin the enriched capture so
+the snapshot reliably contains that recovery-relevant state.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import _T3_TEMP_PREFIX, handle_pre_compact, handle_track_todos
+
+
+@pytest.fixture(autouse=True)
+def _isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate STATE_DIR, _TMP_DIR, loop registry and disable network shell-outs.
+
+    The snapshot enrichments shell out to ``gh`` for live PR state; the test
+    suite must never hit the network, so the helper is monkeypatched to a
+    deterministic stub. Real ``git`` under ``tmp_path`` is the project's
+    standard pattern (see ``test_claude_statusline.py``) and is used as-is
+    for the per-repo branch / dirty / unpushed checks.
+    """
+    router.STATE_DIR = tmp_path / "state"
+    router._TMP_DIR = tmp_path / "tmp"
+    router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    router._TMP_DIR.mkdir(parents=True, exist_ok=True)
+    reg_dir = tmp_path / "data"
+    reg_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", str(reg_dir))
+    monkeypatch.setattr(router, "_TTY_PATH", str(tmp_path / "fake-tty"))
+    # Default: PRs lookup returns empty (no network). Individual tests
+    # override this to assert PR rendering.
+    monkeypatch.setattr(router, "_open_prs_for_repo", lambda _path: [])
+
+
+def _snapshot_for(session_id: str) -> Path:
+    return router.STATE_DIR / f"{_T3_TEMP_PREFIX}{session_id}-precompact.md"
+
+
+def _git_init_repo(path: Path) -> None:
+    """Create a real git repo with one initial commit on ``main``."""
+    path.mkdir(parents=True, exist_ok=True)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True, env=env)  # noqa: S607
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "t@t"], check=True)  # noqa: S607
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "t"], check=True)  # noqa: S607
+    (path / "README.md").write_text("init\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(path), "add", "."], check=True, env=env)  # noqa: S607
+    subprocess.run(["git", "-C", str(path), "commit", "-q", "-m", "init"], check=True, env=env)  # noqa: S607
+
+
+class TestSnapshotIncludesCurrentWorktreeCwd:
+    """The cwd the harness passes is the single most useful "where am I" anchor."""
+
+    def test_cwd_when_inside_workspace_appears_in_snapshot(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session_id = "sess-cwd"
+        workspace = tmp_path / "workspace"
+        repo = workspace / "myticket" / "myrepo"
+        _git_init_repo(repo)
+        monkeypatch.setenv("T3_WORKSPACE_DIR", str(workspace))
+
+        handle_pre_compact({"session_id": session_id, "cwd": str(repo)})
+
+        body = _snapshot_for(session_id).read_text(encoding="utf-8")
+        assert "Current working directory" in body
+        assert str(repo) in body
+
+    def test_missing_cwd_does_not_crash_hook(self) -> None:
+        # Older harness payloads may omit cwd — the hook must not raise.
+        handle_pre_compact({"session_id": "sess-nocwd"})
+        assert _snapshot_for("sess-nocwd").is_file()
+
+
+class TestSnapshotIncludesCurrentGitState:
+    """Branch, HEAD, dirty, unpushed — the post-compaction "don't lose work" set."""
+
+    def test_branch_and_head_sha_for_cwd_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_id = "sess-git"
+        workspace = tmp_path / "workspace"
+        repo = workspace / "tk" / "repo"
+        _git_init_repo(repo)
+        subprocess.run(
+            ["git", "-C", str(repo), "checkout", "-q", "-b", "ac/feature-x"],  # noqa: S607
+            check=True,
+        )
+        monkeypatch.setenv("T3_WORKSPACE_DIR", str(workspace))
+
+        handle_pre_compact({"session_id": session_id, "cwd": str(repo)})
+
+        body = _snapshot_for(session_id).read_text(encoding="utf-8")
+        assert "ac/feature-x" in body
+        # Short HEAD SHA appears (first 7 chars of the rev-parse output).
+        head = subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", "--short", "HEAD"],  # noqa: S607
+            text=True,
+        ).strip()
+        assert head in body
+
+    def test_uncommitted_changes_flagged_in_snapshot(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_id = "sess-dirty"
+        workspace = tmp_path / "workspace"
+        repo = workspace / "tk" / "repo"
+        _git_init_repo(repo)
+        (repo / "uncommitted.txt").write_text("WIP\n", encoding="utf-8")
+        monkeypatch.setenv("T3_WORKSPACE_DIR", str(workspace))
+
+        handle_pre_compact({"session_id": session_id, "cwd": str(repo)})
+
+        body = _snapshot_for(session_id).read_text(encoding="utf-8")
+        # The exact phrasing is not the contract; the contract is that
+        # "there is uncommitted work" is visible to a fresh session.
+        assert "uncommitted" in body.lower()
+
+    def test_clean_repo_does_not_falsely_claim_dirty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_id = "sess-clean"
+        workspace = tmp_path / "workspace"
+        repo = workspace / "tk" / "repo"
+        _git_init_repo(repo)
+        monkeypatch.setenv("T3_WORKSPACE_DIR", str(workspace))
+
+        handle_pre_compact({"session_id": session_id, "cwd": str(repo)})
+
+        body = _snapshot_for(session_id).read_text(encoding="utf-8")
+        assert "uncommitted" not in body.lower() or "0 uncommitted" in body.lower()
+
+
+class TestSnapshotIncludesOpenPRs:
+    """In-flight PRs — recovery-relevant per #970 'in-flight PRs'."""
+
+    def test_open_prs_for_cwd_repo_rendered(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_id = "sess-pr"
+        workspace = tmp_path / "workspace"
+        repo = workspace / "tk" / "repo"
+        _git_init_repo(repo)
+        monkeypatch.setenv("T3_WORKSPACE_DIR", str(workspace))
+        monkeypatch.setattr(
+            router,
+            "_open_prs_for_repo",
+            lambda _p: [
+                {
+                    "number": 970,
+                    "title": "feat(hooks): enrich PreCompact snapshot",
+                    "headRefName": "s-teatree-970-fix",
+                    "isDraft": False,
+                },
+                {
+                    "number": 845,
+                    "title": "fix(hooks): SessionStart compact recovery",
+                    "headRefName": "ac/recover",
+                    "isDraft": True,
+                },
+            ],
+        )
+
+        handle_pre_compact({"session_id": session_id, "cwd": str(repo)})
+
+        body = _snapshot_for(session_id).read_text(encoding="utf-8")
+        assert "Open PRs" in body
+        assert "#970" in body
+        assert "enrich PreCompact snapshot" in body
+        assert "#845" in body
+        # Draft state is visible so the agent knows the PR is not ready.
+        assert "draft" in body.lower()
+
+    def test_no_open_prs_does_not_print_header(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_id = "sess-nopr"
+        workspace = tmp_path / "workspace"
+        repo = workspace / "tk" / "repo"
+        _git_init_repo(repo)
+        monkeypatch.setenv("T3_WORKSPACE_DIR", str(workspace))
+        # Default stub already returns [] — no PRs.
+
+        handle_pre_compact({"session_id": session_id, "cwd": str(repo)})
+
+        body = _snapshot_for(session_id).read_text(encoding="utf-8")
+        assert "Open PRs" not in body
+
+
+class TestTodoCaptureAndSnapshot:
+    """The TODO list is durable-state we have to populate ourselves.
+
+    Anthropic's current Tasks API doesn't fire PostToolUse, but the legacy
+    ``TodoWrite`` tool does (and any tool the agent uses to maintain a
+    visible task list can plug in here). The hook captures the latest
+    snapshot of the todos to ``<session>.todos`` so PreCompact can quote
+    them back into the snapshot.
+    """
+
+    def test_todowrite_is_captured_to_session_todos_file(self) -> None:
+        session_id = "sess-todo-capture"
+        handle_track_todos(
+            {
+                "session_id": session_id,
+                "tool_name": "TodoWrite",
+                "tool_input": {
+                    "todos": [
+                        {"content": "fix snapshot", "status": "in_progress"},
+                        {"content": "push and open PR", "status": "pending"},
+                    ]
+                },
+            }
+        )
+        todos_file = router.STATE_DIR / f"{session_id}.todos"
+        assert todos_file.is_file()
+        text = todos_file.read_text(encoding="utf-8")
+        assert "fix snapshot" in text
+        assert "push and open PR" in text
+
+    def test_non_todowrite_tool_does_not_clobber_todos(self) -> None:
+        session_id = "sess-todo-noclobber"
+        todos_file = router.STATE_DIR / f"{session_id}.todos"
+        router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        todos_file.write_text("- existing\n", encoding="utf-8")
+        handle_track_todos({"session_id": session_id, "tool_name": "Read", "tool_input": {"file_path": "x"}})
+        assert todos_file.read_text(encoding="utf-8") == "- existing\n"
+
+    def test_snapshot_renders_captured_todos(self) -> None:
+        session_id = "sess-todo-render"
+        router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (router.STATE_DIR / f"{session_id}.todos").write_text(
+            "- [in_progress] fix snapshot\n- [pending] push PR\n", encoding="utf-8"
+        )
+
+        handle_pre_compact({"session_id": session_id})
+
+        body = _snapshot_for(session_id).read_text(encoding="utf-8")
+        assert "Pending TODOs" in body
+        assert "fix snapshot" in body
+        assert "push PR" in body
+
+
+class TestSnapshotResilience:
+    """The snapshot must never fail compaction — the worst case is empty sections."""
+
+    def test_cwd_not_a_git_repo_renders_no_git_section_no_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session_id = "sess-nogit"
+        workspace = tmp_path / "workspace"
+        not_a_repo = workspace / "loose"
+        not_a_repo.mkdir(parents=True)
+        monkeypatch.setenv("T3_WORKSPACE_DIR", str(workspace))
+
+        handle_pre_compact({"session_id": session_id, "cwd": str(not_a_repo)})
+
+        body = _snapshot_for(session_id).read_text(encoding="utf-8")
+        # No crash, file exists, no fake git data injected.
+        assert _snapshot_for(session_id).is_file()
+        assert "rev-parse" not in body  # no error tracebacks leaked
+
+    def test_gh_failure_in_pr_lookup_is_swallowed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_id = "sess-gh-fail"
+        workspace = tmp_path / "workspace"
+        repo = workspace / "tk" / "repo"
+        _git_init_repo(repo)
+        monkeypatch.setenv("T3_WORKSPACE_DIR", str(workspace))
+
+        boom_msg = "gh: auth failed"
+
+        def _boom(_p: Path) -> list[dict]:
+            raise RuntimeError(boom_msg)
+
+        monkeypatch.setattr(router, "_open_prs_for_repo", _boom)
+
+        # The hook must still produce a snapshot — never block on a PR lookup.
+        handle_pre_compact({"session_id": session_id, "cwd": str(repo)})
+        assert _snapshot_for(session_id).is_file()


### PR DESCRIPTION
Closes #970.

## What

Enriches the auto-written PreCompact snapshot so a fresh post-compaction session has enough state to resume meaningfully. Previously the snapshot was effectively a header + the ever-touched `.active` ledger + the loaded skills, which is the "in the clouds" thinness reported in the issue.

The hook now adds, when the harness passes `cwd`:

* `## Current working directory` — anchor for "where am I working now".
* `## Current git state` — branch, short HEAD SHA, count of uncommitted files, count of unpushed commits.
* `## Open PRs (this repo, @me, open)` — best-effort `gh` call; missing tool / no auth / no network all silently return `[]`.

And, independent of `cwd`:

* `## Pending TODOs` — a new PostToolUse handler on `TodoWrite` writes the live todo list to `<session>.todos`; the renderer quotes it back.

## Resilience

Every new section is best-effort: a non-git `cwd`, a `gh` failure, or a missing `TodoWrite` history all just omit their section. The hook still never blocks compaction (the #778 / #845 invariant).

The router stays Django-free. No changes to the #778 sub-agent recovery path or the #845 SessionStart-compact recovery hop.

## Tests

`tests/test_pre_compact_snapshot_enriched.py` — 12 tests against real `git init` repos under `tmp_path` and a monkeypatched `_open_prs_for_repo` stub (no network):

* cwd present / missing
* branch + short HEAD render
* dirty vs clean repo
* open PRs rendered with draft flag
* no PRs → no header
* TodoWrite captured to `.todos` and rendered in snapshot
* non-TodoWrite tool does not clobber existing todos
* cwd not a git repo → no git section, no crash
* `_open_prs_for_repo` raising → snapshot still written

Existing `tests/test_pre_compact_snapshot_hook.py` (#778) and `tests/test_post_compact_hook.py` (#845) still green.

## Substrate / not auto-merging

This is hook substrate. Independent review + recorded human approver required before the §17.4 keystone merge. Do not merge from this PR.