### PR TITLE
fix(db): strip caller DJANGO_SETTINGS_MODULE from reference-DB migrate (#959)

### DIFF
--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -203,7 +203,20 @@ class DjangoDbImporter:
             return _MigrateResult.ALREADY_MIGRATED
 
         ref_db_url = _local_db_url(cfg.ref_db_name)
-        run_env = {**os.environ, "DATABASE_URL": ref_db_url, "DISABLE_DATABASE_SSL": "True", **cfg.migrate_env_extra}
+        # souliane/teatree#959: strip DJANGO_SETTINGS_MODULE from the inherited
+        # environment. The reference-DB migrate runs `manage.py` from the MAIN
+        # CLONE, but `db refresh` is typically invoked from a provisioned
+        # worktree whose env-cache exports a worktree-specific settings module
+        # (e.g. `<proj>.settings_local`). That module exists only inside the
+        # worktree, so inheriting it crashes the migrate subprocess with
+        # `ModuleNotFoundError`, the restore pipeline aborts, and the ticket
+        # DB is never cloned. The main clone's `manage.py` already applies its
+        # own default settings module via `os.environ.setdefault(...)`; let it
+        # win. An overlay that genuinely needs a non-default module passes it
+        # explicitly through ``cfg.migrate_env_extra`` (merged last, so it
+        # always wins over the strip).
+        inherited_env = {k: v for k, v in os.environ.items() if k != "DJANGO_SETTINGS_MODULE"}
+        run_env = {**inherited_env, "DATABASE_URL": ref_db_url, "DISABLE_DATABASE_SSL": "True", **cfg.migrate_env_extra}
 
         self.stdout.write(f"  Migrating reference DB ({cfg.ref_db_name}) using main repo...\n")
         migrate_cmd = ["uv", "--directory", cfg.main_repo_path, "run", "python", "manage.py", "migrate", "--no-input"]
@@ -219,7 +232,15 @@ class DjangoDbImporter:
             combined = f"{result.stdout}\n{result.stderr}"
             failure_reason = self._try_fake_failing_migration(combined, result.stdout, run_env)
             if failure_reason:
+                # souliane/teatree#959: surface the real subprocess output on
+                # FAILED so the operator can see the actual error
+                # (ModuleNotFoundError, schema mismatch, etc.) — the generic
+                # one-liner alone was unactionable.
                 self.stdout.write(f"  WARNING: {failure_reason}\n")
+                if result.stdout:
+                    self.stdout.write(f"    migrate stdout:\n{result.stdout}\n")
+                if result.stderr:
+                    self.stderr.write(f"    migrate stderr:\n{result.stderr}\n")
                 return _MigrateResult.FAILED
 
         self.stdout.write("  WARNING: Reference DB migration exhausted retries, skipping.\n")

--- a/tests/django_db/_shared.py
+++ b/tests/django_db/_shared.py
@@ -13,7 +13,7 @@ from subprocess import CompletedProcess
 from teatree.utils.django_db import DjangoDbImportConfig, DjangoDbImporter
 
 
-def _make_cfg(tmp_path: Path, **overrides: str) -> DjangoDbImportConfig:
+def _make_cfg(tmp_path: Path, **overrides: object) -> DjangoDbImportConfig:
     defaults = {
         "ref_db_name": "development-acme",
         "ticket_db_name": "wt_42_acme",
@@ -26,7 +26,7 @@ def _make_cfg(tmp_path: Path, **overrides: str) -> DjangoDbImportConfig:
     return DjangoDbImportConfig(**defaults)
 
 
-def _make_importer(tmp_path: Path, *, dslr_cmd: list[str] | None = None, **cfg_overrides: str) -> DjangoDbImporter:
+def _make_importer(tmp_path: Path, *, dslr_cmd: list[str] | None = None, **cfg_overrides: object) -> DjangoDbImporter:
     """Build an importer with stubbed stdout/stderr and a controllable dslr command."""
     importer = DjangoDbImporter(_make_cfg(tmp_path, **cfg_overrides), stdout=io.StringIO(), stderr=io.StringIO())
     importer.dslr_cmd = dslr_cmd if dslr_cmd is not None else ["/usr/bin/dslr"]

--- a/tests/django_db/test_migration.py
+++ b/tests/django_db/test_migration.py
@@ -101,3 +101,89 @@ class TestMigrateReferenceDb:
 
         monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
         assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.APPLIED
+
+    def test_subprocess_env_drops_caller_django_settings_module(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reference-DB migrate must NOT inherit the caller's DJANGO_SETTINGS_MODULE.
+
+        Regression: souliane/teatree#959 — when ``db refresh`` runs from a
+        provisioned worktree, the overlay env-cache exports a worktree-specific
+        settings module that does not exist in the main clone. Inheriting it
+        crashes the migrate subprocess with ``ModuleNotFoundError``, the
+        restore pipeline aborts, and the ticket DB is never cloned.
+        """
+        (tmp_path / "manage.py").write_text("", encoding="utf-8")
+        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "worktree_only.settings_local")
+        captured_envs: list[dict[str, str]] = []
+
+        def capture_run(args, **kw):
+            captured_envs.append(dict(kw.get("env") or {}))
+            return CompletedProcess(args, 0, "", "")
+
+        monkeypatch.setattr(run_mod.subprocess, "run", capture_run)
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.APPLIED
+        assert captured_envs, "migrate subprocess was not invoked"
+        assert "DJANGO_SETTINGS_MODULE" not in captured_envs[0], (
+            f"Reference-DB migrate inherited caller's DJANGO_SETTINGS_MODULE: "
+            f"{captured_envs[0].get('DJANGO_SETTINGS_MODULE')!r}"
+        )
+
+    def test_subprocess_env_keeps_migrate_env_extra_settings_module(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An overlay-supplied ``migrate_env_extra['DJANGO_SETTINGS_MODULE']`` wins.
+
+        The strip applies only to the inherited caller env, not to an explicit
+        overlay override — that's the legitimate way to point the reference-DB
+        migrate at a non-default settings module.
+        """
+        (tmp_path / "manage.py").write_text("", encoding="utf-8")
+        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "worktree_only.settings_local")
+        captured_envs: list[dict[str, str]] = []
+
+        def capture_run(args, **kw):
+            captured_envs.append(dict(kw.get("env") or {}))
+            return CompletedProcess(args, 0, "", "")
+
+        monkeypatch.setattr(run_mod.subprocess, "run", capture_run)
+        importer = _make_importer(
+            tmp_path,
+            migrate_env_extra={"DJANGO_SETTINGS_MODULE": "myproj.settings"},
+        )
+        assert importer._migrate_reference_db() is _MigrateResult.APPLIED
+        assert captured_envs[0].get("DJANGO_SETTINGS_MODULE") == "myproj.settings"
+
+    def test_config_error_surfaces_subprocess_output(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failed reference-DB migrate must surface the captured stdout/stderr.
+
+        Regression: souliane/teatree#959 — the generic
+        ``Cannot migrate reference DB (config error), skipping.`` one-liner
+        swallowed the real ``ModuleNotFoundError``, leaving operators with no
+        diagnostic to act on. The captured subprocess output is the source of
+        truth and must reach the user.
+        """
+        import io  # noqa: PLC0415
+
+        (tmp_path / "manage.py").write_text("", encoding="utf-8")
+        monkeypatch.setattr(
+            run_mod.subprocess,
+            "run",
+            lambda *a, **kw: CompletedProcess(
+                a,
+                1,
+                "Applying initial migration...\n",
+                "ModuleNotFoundError: No module named 'worktree_only.settings_local'",
+            ),
+        )
+        importer = _make_importer(tmp_path)
+        importer.stdout = io.StringIO()
+        importer.stderr = io.StringIO()
+        assert importer._migrate_reference_db() is _MigrateResult.FAILED
+        combined_output = importer.stdout.getvalue() + importer.stderr.getvalue()
+        assert "ModuleNotFoundError" in combined_output, (
+            "Reference-DB migrate failure did not surface the real subprocess error; "
+            f"captured output was:\nSTDOUT:\n{importer.stdout.getvalue()}\n"
+            f"STDERR:\n{importer.stderr.getvalue()}"
+        )
+        assert "worktree_only.settings_local" in combined_output


### PR DESCRIPTION
fix(db): strip caller DJANGO_SETTINGS_MODULE from reference-DB migrate (#959)

The reference-DB migrate runs uv --directory <main_repo_path> run python
manage.py from the main clone, but db refresh is typically invoked from a
provisioned worktree whose env-cache exports a worktree-specific settings
module. Inheriting it crashed the migrate subprocess with
ModuleNotFoundError, the restore pipeline aborted before _copy_ref_to_ticket,
and the ticket DB was never cloned — workspace doctor reported missing-db.

Strip DJANGO_SETTINGS_MODULE from the inherited env so the main clone's
manage.py applies its own default. An overlay that genuinely needs a
non-default module passes it via cfg.migrate_env_extra (merged last, wins
over the strip).

Also surface the captured subprocess stdout/stderr when a reference-DB
migrate fails. The generic 'Cannot migrate reference DB (config error),
skipping.' one-liner swallowed the real failure, leaving operators with
nothing actionable.