### PR TITLE
fix(contrib): resolve workspace_path from worktree.extra in t3-teatree provision (#941)

### DIFF
--- a/src/teatree/contrib/t3_teatree/overlay.py
+++ b/src/teatree/contrib/t3_teatree/overlay.py
@@ -88,7 +88,20 @@ class TeatreeOverlay(OverlayBase):
 
     @override
     def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
-        repo = Path(worktree.repo_path)
+        # ``worktree.repo_path`` is the repo identifier (e.g. ``souliane/teatree``),
+        # NOT a filesystem path — the on-disk worktree path lives in ``extra['worktree_path']``
+        # and is exposed via ``worktree.worktree_path``. Before #941 this method used
+        # ``Path(worktree.repo_path)`` directly, which produced a relative path like
+        # ``souliane/teatree`` and caused every ``workspace provision`` to fail with
+        # ``FileNotFoundError: 'souliane/teatree'`` on the ``sync-dependencies`` step.
+        on_disk = worktree.worktree_path
+        if not on_disk:
+            # Worktree row exists but has not been materialised on disk yet —
+            # ``WorktreeRowProvisionRunner`` populates ``extra['worktree_path']`` after
+            # ``git worktree add`` succeeds. Provisioning steps require a real directory,
+            # so return an empty list (no-op) rather than crash with a misleading path.
+            return []
+        repo = Path(on_disk)
 
         def sync_deps() -> None:
             run_checked(["uv", "sync"], cwd=repo)

--- a/tests/test_contrib_overlay.py
+++ b/tests/test_contrib_overlay.py
@@ -148,11 +148,14 @@ class TestGetProvisionSteps(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         cls.ticket = Ticket.objects.create(overlay="t3-teatree")
+        # Mirror production: ``repo_path`` is the repo identifier (e.g. ``souliane/teatree``),
+        # NOT a filesystem path. The on-disk path lives in ``extra['worktree_path']``.
         cls.worktree = Worktree.objects.create(
             ticket=cls.ticket,
             overlay="t3-teatree",
-            repo_path="/tmp/teatree",
+            repo_path="souliane/teatree",
             branch="main",
+            extra={"worktree_path": "/tmp/teatree-941-wt"},
         )
 
     def test_returns_sync_and_install_overlays_steps(self) -> None:
@@ -161,7 +164,8 @@ class TestGetProvisionSteps(TestCase):
 
         assert [step.name for step in steps] == ["sync-dependencies", "install-overlays-editable"]
 
-    def test_sync_step_runs_uv_sync(self) -> None:
+    def test_sync_step_runs_uv_sync_in_on_disk_worktree(self) -> None:
+        """`uv sync` must run in the on-disk worktree path, not in the repo identifier."""
         overlay = TeatreeOverlay()
         steps = overlay.get_provision_steps(self.worktree)
 
@@ -169,7 +173,20 @@ class TestGetProvisionSteps(TestCase):
             steps[0].callable()
             mock_run.assert_called_once()
             assert mock_run.call_args.args[0] == ["uv", "sync"]
-            assert mock_run.call_args.kwargs["cwd"] == str(Path("/tmp/teatree"))
+            assert mock_run.call_args.kwargs["cwd"] == str(Path("/tmp/teatree-941-wt"))
+
+    def test_returns_no_steps_when_worktree_not_materialised(self) -> None:
+        """Row without ``extra['worktree_path']`` → no steps (cannot ``uv sync`` an unknown path)."""
+        ticket = Ticket.objects.create(overlay="t3-teatree")
+        bare_worktree = Worktree.objects.create(
+            ticket=ticket,
+            overlay="t3-teatree",
+            repo_path="souliane/teatree",
+            branch="main",
+            # No ``extra`` → ``worktree_path`` returns ''.
+        )
+        overlay = TeatreeOverlay()
+        assert overlay.get_provision_steps(bare_worktree) == []
 
 
 @pytest.mark.django_db
@@ -203,8 +220,9 @@ class TestInstallOverlaysEditableStep:
         worktree = Worktree.objects.create(
             ticket=ticket,
             overlay="t3-teatree",
-            repo_path=str(teatree_wt),
+            repo_path="souliane/teatree",
             branch="main",
+            extra={"worktree_path": str(teatree_wt)},
         )
 
         overlay = TeatreeOverlay()
@@ -240,8 +258,9 @@ class TestInstallOverlaysEditableStep:
         worktree = Worktree.objects.create(
             ticket=ticket,
             overlay="t3-teatree",
-            repo_path=str(teatree_wt),
+            repo_path="souliane/teatree",
             branch="main",
+            extra={"worktree_path": str(teatree_wt)},
         )
 
         overlay = TeatreeOverlay()
@@ -277,8 +296,9 @@ class TestInstallOverlaysEditableStep:
         worktree = Worktree.objects.create(
             ticket=ticket,
             overlay="t3-teatree",
-            repo_path=str(teatree_wt),
+            repo_path="souliane/teatree",
             branch="main",
+            extra={"worktree_path": str(teatree_wt)},
         )
 
         overlay = TeatreeOverlay()
@@ -311,8 +331,9 @@ class TestInstallOverlaysEditableStep:
         worktree = Worktree.objects.create(
             ticket=ticket,
             overlay="t3-teatree",
-            repo_path=str(teatree_wt),
+            repo_path="souliane/teatree",
             branch="main",
+            extra={"worktree_path": str(teatree_wt)},
         )
 
         overlay = TeatreeOverlay()


### PR DESCRIPTION
fix(contrib): resolve workspace_path from worktree.extra in t3-teatree provision (#941)

The bundled t3-teatree overlay's get_provision_steps used
Path(worktree.repo_path) for the on-disk worktree directory, but
repo_path is a repo identifier (e.g. 'souliane/teatree'), NOT a
filesystem path — the actual path lives in extra['worktree_path']
and is exposed via worktree.worktree_path.

Every workspace provision on a code-only worktree failed rc=1 with:
  Step 'sync-dependencies' raised: [Errno 2] No such file or directory: 'souliane/teatree'

Resolution: read worktree.worktree_path; when the row exists but the
on-disk path is not populated yet (un-materialised), return [] so
provisioning is a clean no-op rather than crashing on a misleading
relative path.

Tests pre-existed but constructed unrealistic Worktree rows with
repo_path=str(/tmp/...), masking the contract drift. They now pass
realistic data (repo_path='souliane/teatree', extra={'worktree_path':
...}) and a new test asserts uv sync runs in the on-disk path.

Verified end-to-end: t3 teatree workspace provision now exits 0 on
a freshly-created code-only worktree.