### PR TITLE
test(commands): broaden failure-signalling AST guard keyword set (#939)

### DIFF
--- a/src/teatree/core/management/commands/overlay.py
+++ b/src/teatree/core/management/commands/overlay.py
@@ -25,7 +25,8 @@ class Command(TyperCommand):
 
         if key:
             if key not in fields:
-                return f"Unknown config key: {key}. Available: {', '.join(fields)}"
+                self.stderr.write(f"Unknown config key: {key}. Available: {', '.join(fields)}")
+                raise SystemExit(1)
             return str(getattr(cfg, key))
 
         return "\n".join(f"{field}: {getattr(cfg, field)}" for field in fields)

--- a/src/teatree/core/management/commands/worktree.py
+++ b/src/teatree/core/management/commands/worktree.py
@@ -403,7 +403,8 @@ class Command(TyperCommand):
         if model == "task":
             return _task_diagram()
         if model not in model_map:
-            return f"Unknown model: {model}. Choose from: worktree, ticket, task"
+            self.stderr.write(f"Unknown model: {model}. Choose from: worktree, ticket, task")
+            raise SystemExit(1)
         return _fsm_diagram(model_map[model])
 
 

--- a/tests/teatree_core/management_commands/test_command_failure_signalling.py
+++ b/tests/teatree_core/management_commands/test_command_failure_signalling.py
@@ -1,4 +1,4 @@
-"""Enforcement guard for #932.
+"""Enforcement guard for #932 (keyword set broadened in #939).
 
 A django-typer ``@command`` subcommand that signals failure by *returning*
 an error string leaves the process exiting 0 — django-typer serialises the
@@ -9,25 +9,56 @@ SystemExit(1)`` (canonical: ``tasks.py``, ``db.py`` ``query``/``shell``).
 
 This guard walks every ``core/management/commands`` module with AST and
 fails if any ``@command``-decorated method has a ``return`` whose value is
-a string literal / f-string mentioning "fail". It is deliberately narrow:
+a string literal / f-string matching any failure keyword in
+``_FAILURE_KEYWORDS``.
 
 Scope (kept narrow so false positives stay low):
 
 - Only ``@command`` methods are scanned, so module-level helpers like
     ``_workspace_cleanup.push_unsynced_branch`` keep returning "Push
     failed:" for their command (``clean-all``) to inspect and raise on.
-- Only the word "fail" triggers it, so benign no-op returns such as
-    "completed", "No X configured" or "Pushed:" never match.
+- Only string / f-string returns are inspected; dynamic returns are out
+    of AST reach and out of scope here.
 
-If a genuinely-benign command must return a string containing "fail",
-this guard should be made aware of it explicitly rather than relaxed
-wholesale.
+The #939 broadening covers the sites the original "fail"-only set missed
+(messages worded "aborted", "error", "not found", "not configured", "not
+running", "unknown", "requires …"). The guard therefore catches the
+high-blast subset of the anti-pattern that is statically detectable on
+the current command tree — it is not a proof that the anti-pattern can
+never regress (a return whose error wording avoids every keyword, or a
+dynamically-built message, is still out of AST reach). It is a strong,
+low-false-positive backstop, not an absolute one.
+
+If a genuinely-benign command must return a string containing one of
+these keywords, this guard should be made aware of it explicitly rather
+than relaxed wholesale.
 """
 
 import ast
+import textwrap
 from pathlib import Path
 
+import pytest
+
 _COMMANDS_DIR = Path(__file__).resolve().parents[3] / "src" / "teatree" / "core" / "management" / "commands"
+
+# Case-insensitive substrings that mark a returned string as failure
+# signalling. Kept low-false-positive: only words/phrases that, in a
+# command's *return value*, denote an error condition the process should
+# exit non-zero on. Verified against the full command tree (see
+# ``test_broadened_set_flags_only_the_known_sites``).
+_FAILURE_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "fail",
+        "error",
+        "abort",
+        "unknown",
+        "not configured",
+        "not found",
+        "not running",
+        "requires ",
+    },
+)
 
 
 def _is_command_decorator(decorator: ast.expr) -> bool:
@@ -52,6 +83,15 @@ def _returned_string_value(node: ast.Return) -> str | None:
     return None
 
 
+def _matched_keyword(text: str) -> str | None:
+    """First failure keyword found in ``text`` (case-insensitive), else None."""
+    lowered = text.lower()
+    for keyword in _FAILURE_KEYWORDS:
+        if keyword in lowered:
+            return keyword
+    return None
+
+
 def _offending_returns(source: str) -> list[tuple[str, int, str]]:
     tree = ast.parse(source)
     offences: list[tuple[str, int, str]] = []
@@ -64,7 +104,7 @@ def _offending_returns(source: str) -> list[tuple[str, int, str]]:
             if not isinstance(stmt, ast.Return):
                 continue
             text = _returned_string_value(stmt)
-            if text and "fail" in text.lower():
+            if text and _matched_keyword(text) is not None:
                 offences.append((func.name, stmt.lineno, text))
     return offences
 
@@ -77,8 +117,86 @@ class TestCommandFailureSignalling:
                 violations.append(
                     f"{module.name}:{lineno} — @command `{func_name}` returns "
                     f"a failure string {text!r}; use `self.stderr.write(...)` "
-                    f"then `raise SystemExit(1)` (see #932).",
+                    f"then `raise SystemExit(1)` (see #932/#939).",
                 )
         assert not violations, "Commands must raise SystemExit(1) on failure, not return a string:\n" + "\n".join(
             violations,
+        )
+
+
+def _command_source(return_value: str) -> str:
+    """Minimal @command-decorated method whose return is ``return_value``."""
+    return textwrap.dedent(
+        f"""
+        class Command:
+            @command()
+            def sub(self):
+                return {return_value}
+        """,
+    )
+
+
+class TestBroadenedKeywordSet:
+    """#939: every newly-covered keyword trips the guard; benign returns don't."""
+
+    @pytest.mark.parametrize(
+        ("keyword", "message"),
+        [
+            ("fail", '"DB import failed for db."'),
+            ("error", '"error: could not connect"'),
+            ("abort", '"Fresh remote dump aborted"'),
+            ("unknown", '"Unknown config key: x"'),
+            ("not configured", '"reset-passwords not configured"'),
+            ("not found", '"Worktree not found for path"'),
+            ("not running", '"Backend not running on port"'),
+            ("requires ", '"This command requires BASE_URL"'),
+        ],
+    )
+    def test_each_failure_keyword_is_flagged(self, keyword: str, message: str) -> None:
+        assert keyword in _FAILURE_KEYWORDS
+        offences = _offending_returns(_command_source(message))
+        assert offences, f"keyword {keyword!r} in {message} should be flagged"
+        assert offences[0][0] == "sub"
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            '"completed"',
+            '"Pushed: 3 commits"',
+            '"No DB import strategy"',
+            '"refreshed"',
+            '"\\n".join(parts)',  # dynamic, non-string-constant return — out of scope
+        ],
+    )
+    def test_benign_returns_do_not_trip(self, message: str) -> None:
+        assert _offending_returns(_command_source(message)) == []
+
+    def test_match_is_case_insensitive(self) -> None:
+        assert _offending_returns(_command_source('"FATAL ERROR"'))
+        assert _offending_returns(_command_source('"Aborted."'))
+
+    def test_module_level_helper_is_not_scanned(self) -> None:
+        source = textwrap.dedent(
+            """
+            def push_unsynced_branch():
+                return "Push failed: remote rejected"
+            """,
+        )
+        assert _offending_returns(source) == []
+
+    def test_broadened_set_flags_only_the_known_sites(self) -> None:
+        """Full command tree: no command returns a failure string.
+
+        Pins the low-false-positive claim. If a NEW command legitimately
+        returns a keyword string, fix it to raise SystemExit(1) — do not
+        relax the keyword set.
+        """
+        flagged: set[tuple[str, str]] = {
+            (module.name, func_name)
+            for module in sorted(_COMMANDS_DIR.glob("*.py"))
+            for func_name, _lineno, _text in _offending_returns(module.read_text())
+        }
+        assert flagged == set(), (
+            "Unexpected command(s) returning a failure string — fix them to "
+            f"raise SystemExit(1), do not relax the guard: {sorted(flagged)}"
         )

--- a/tests/teatree_core/management_commands/test_lifecycle.py
+++ b/tests/teatree_core/management_commands/test_lifecycle.py
@@ -1081,10 +1081,19 @@ class TestLifecycleDiagram(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_unknown_model(self) -> None:
-        result = cast("str", call_command("worktree", "diagram", model="unknown"))
+    def test_unknown_model_raises_system_exit_1(self) -> None:
+        """#939: an unknown model is a real error — exit 1, message on stderr.
 
-        assert "Unknown model: unknown" in result
+        Regression: `return f"Unknown model..."` exited 0, so a typo in
+        `worktree diagram --model` looked like success to headless callers.
+        """
+        stderr = StringIO()
+
+        with pytest.raises(SystemExit) as exc_info:
+            call_command("worktree", "diagram", model="unknown", stderr=stderr)
+
+        assert exc_info.value.code == 1
+        assert "Unknown model: unknown" in stderr.getvalue()
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/teatree_core/test_overlay_command.py
+++ b/tests/teatree_core/test_overlay_command.py
@@ -34,11 +34,20 @@ class TestOverlayConfig:
 
         assert result == "False"
 
-    def test_returns_error_for_unknown_key(self) -> None:
-        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
-            result = call_command("overlay", "config", "--key", "nonexistent")
+    def test_unknown_key_raises_system_exit_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """#939: an unknown config key is a real error — exit 1, stderr.
 
-        assert "Unknown config key" in result
+        Regression: `return f"Unknown config key..."` exited 0, so a typo
+        in `overlay config --key` looked like success to headless callers.
+        """
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            call_command("overlay", "config", "--key", "nonexistent")
+
+        assert exc_info.value.code == 1
+        assert "Unknown config key" in capsys.readouterr().err
 
 
 class TestOverlayInfo:


### PR DESCRIPTION
test(commands): broaden failure-signalling AST guard keyword set (#939)

The #932 guard only flagged returned strings mentioning "fail". That
covered the highest-blast regressions ("Tests failed", "DB import
failed", "CI restore failed", teardown "...failure(s)") but missed
sites the same anti-pattern was already living at with different
wording: db.py "aborted", workspace start "error", e2e.py/tool.py
"not found"/"not configured"/"requires BASE_URL"/"not running", and
overlay/worktree "Unknown ...".

Broaden the keyword set to {fail, error, abort, unknown, not configured,
not found, not running, requires } (case-insensitive). Keep the
scoping narrow (only @command-decorated methods, only string /
f-string returns) so the false-positive rate stays low.

Add:
- One parametrized test per newly-covered keyword (RED→GREEN).
- Benign-return parametrized cases (no false-positive on "completed",
  "Pushed: ...", "No DB import strategy", dynamic returns).
- Case-insensitivity check.
- Module-level-helper exemption check (_workspace_cleanup helpers
  still return failure strings for their command to inspect).
- Full-command-tree pin: no command currently returns a failure
  string. If a new one does, fix it to raise SystemExit(1) — do not
  relax the keyword set.

The #932 commit-message claim "the anti-pattern cannot silently
regress" is softened in the module docstring: the guard catches the
statically-detectable subset, not every conceivable regression
(a return whose wording avoids every keyword, or a dynamically-built
message, is still out of AST reach). Strong low-false-positive
backstop, not an absolute proof.