### PR TITLE
fix(loop): statusline dedup so duplicate signals don't visually multiply (#982)

### DIFF
--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -261,7 +261,52 @@ def _classify_actions(actions: list[DispatchAction]) -> _ClassifiedActions:
             bucket.setdefault(overlay, []).append(ref)
             continue
         c.other.append((action.zone, StatuslineEntry(text=f"{prefix}{action.detail}", url=url_str)))
+    _dedup_classified(c)
     return c
+
+
+def _dedup_in_order[T](items: list[T]) -> list[T]:
+    """Return *items* with duplicates dropped, first-occurrence wins.
+
+    Statusline rows must be stable across ticks: two scanners surfacing
+    the same observation (same ``ticket.active`` row, same PR seen by both
+    ``MyPrsScanner`` and ``ReviewerPrsScanner``, same ``ticket.stale`` row
+    emitted again on the next sweep) must collapse to one ref. Order is
+    preserved so the user sees a deterministic line.
+    """
+    seen: set[T] = set()
+    out: list[T] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def _dedup_classified(c: _ClassifiedActions) -> None:
+    """Collapse duplicate refs in every per-overlay bucket.
+
+    The dispatch layer is fan-out by signal (one signal per scanner that
+    saw it); the renderer is the boundary that must present each observed
+    thing exactly once. Doing the dedup here keeps every downstream
+    renderer simple — they can assume the input list has no duplicates.
+    """
+    for overlay, tickets in list(c.active_tickets.items()):
+        c.active_tickets[overlay] = _dedup_in_order(tickets)
+    for overlay, refs in list(c.stale_refs.items()):
+        c.stale_refs[overlay] = _dedup_in_order(refs)
+    for overlay, refs in list(c.ready_refs.items()):
+        c.ready_refs[overlay] = _dedup_in_order(refs)
+    for overlay, refs in list(c.action_prs.items()):
+        c.action_prs[overlay] = _dedup_in_order(refs)
+    for overlay, refs in list(c.inflight_prs.items()):
+        c.inflight_prs[overlay] = _dedup_in_order(refs)
+    for overlay, reass in list(c.reassign_refs.items()):
+        c.reassign_refs[overlay] = _dedup_in_order(reass)
+    for reason_map in c.disposition_refs.values():
+        for reason, refs in list(reason_map.items()):
+            reason_map[reason] = _dedup_in_order(refs)
 
 
 # States that should not surface as anchors: terminal/post-PR states plus
@@ -390,6 +435,16 @@ def _render_action_line(
 
 
 def _running_tasks_lines() -> list[str]:
+    """Render the ``[ov] agents: <phase> · <phase>`` row from CLAIMED tasks.
+
+    Skips tasks with a blank ``phase`` (the column is ``blank=True`` and
+    the default is ``""``) so the renderer never produces a phantom
+    ``agents:  · coding`` with a double space the operator can't act on.
+    Dedupes phase names per overlay: two parallel implementers both at
+    ``coding`` collapse to one ``agents: coding`` ref — concurrency is
+    implied by the loop, not by visually repeating the same word.
+    Suppresses the whole row when no claimed task contributes a phase.
+    """
     from django.apps import apps  # noqa: PLC0415
 
     try:
@@ -401,14 +456,20 @@ def _running_tasks_lines() -> list[str]:
         )
         by_overlay: dict[str, list[str]] = {}
         for task in claimed:
+            phase = (task.phase or "").strip()
+            if not phase:
+                continue
             overlay = task.ticket.overlay or ""
-            by_overlay.setdefault(overlay, []).append(task.phase)
+            by_overlay.setdefault(overlay, []).append(phase)
     except Exception:  # noqa: BLE001
         return []
     lines: list[str] = []
     for overlay, phases in sorted(by_overlay.items()):
+        unique_phases = _dedup_in_order(phases)
+        if not unique_phases:
+            continue
         prefix = f"[{overlay}] " if overlay else ""
-        lines.append(f"{prefix}agents: {' · '.join(phases)}")
+        lines.append(f"{prefix}agents: {' · '.join(unique_phases)}")
     return lines
 
 

--- a/tests/teatree_loop/test_rendering_audit.py
+++ b/tests/teatree_loop/test_rendering_audit.py
@@ -1,0 +1,317 @@
+"""Row-by-row audit of ``teatree.loop.rendering`` (#982).
+
+Each test pins one observable behaviour of one statusline row type so a
+regression cannot silently re-introduce a row that appears when it
+shouldn't, disappears when it should appear, or shows stale/duplicate
+content.
+
+The audit covers the four row families the statusline renders:
+
+* anchors  — active-ticket lines (``[ov] state: #N``)
+* action  — dispositions, ready-to-start, stale, action PRs
+* in-flight PR groups — open PRs from the user
+* in-flight task rows — ``[ov] agents: <phase> · <phase>``
+
+Tests lean integration: they drive real ``DispatchAction`` payloads
+(shape mirrors what ``dispatch._dispatch_one`` builds) through
+``zones_for`` and assert on the resulting plain text. The DB-backed
+``_running_tasks_lines`` path uses Django ``TestCase`` with real
+``Ticket``/``Session``/``Task`` rows.
+"""
+
+import django.test
+
+from teatree.loop.dispatch import DispatchAction
+from teatree.loop.rendering import zones_for
+
+
+def _blob(zone: list[object]) -> str:
+    return "\n".join(item if isinstance(item, str) else item.text for item in zone)
+
+
+def _active(num: str, state: str, overlay: str = "teatree", issue_url: str = "") -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="anchors",
+        detail=f"#{num} {state}",
+        payload={
+            "ticket_number": num,
+            "state": state,
+            "overlay": overlay,
+            "issue_url": issue_url or f"https://example.com/issues/{num}",
+        },
+    )
+
+
+def _disposition(reason: str, num: str = "77", overlay: str = "teatree", **extra: object) -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="action_needed",
+        detail=f"Ticket {num} — {reason}",
+        payload={
+            "reason": reason,
+            "overlay": overlay,
+            "ticket_number": num,
+            "issue_url": f"https://example.com/issues/{num}",
+            **extra,
+        },
+    )
+
+
+def _stale(num: str, state: str = "coded", age: int = 4, overlay: str = "teatree") -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="action_needed",
+        detail=f"#{num} stale ({age}d)",
+        payload={
+            "stale": True,
+            "overlay": overlay,
+            "ticket_number": num,
+            "ticket_state": state,
+            "age_days": age,
+            "issue_url": f"https://example.com/issues/{num}",
+        },
+    )
+
+
+def _my_pr(iid: int, *, overlay: str = "teatree", zone: str = "in_flight", **extra: object) -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone=zone,
+        detail=f"PR !{iid}",
+        payload={
+            "iid": iid,
+            "url": f"https://gitlab.example.com/g/p/-/merge_requests/{iid}",
+            "overlay": overlay,
+            **extra,
+        },
+    )
+
+
+class TestActiveTicketAnchors:
+    """Anchors render one ``[ov] state: #N`` line per overlay, deduped."""
+
+    def test_renders_active_tickets_grouped_by_state(self) -> None:
+        zones = zones_for(
+            [_active("10", "coded"), _active("11", "coded"), _active("12", "started")],
+            colorize=False,
+        )
+        text = _blob(zones.anchors)
+        assert "[teatree]" in text
+        # NO_COLOR embeds the URL as ``#N <url>``; assert the two tickets
+        # appear under the same state group in order.
+        assert "coded: #10 " in text
+        assert "#11" in text
+        assert "started: #12" in text
+        # Both states present in one line per overlay.
+        assert text.count("[teatree]") == 1
+
+    def test_anchor_skips_noise_states(self) -> None:
+        """``merged``/``shipped``/``retrospected`` are post-PR; never anchor.
+
+        The active scanner doesn't filter them — the renderer does. If a
+        future refactor moves ``_NOISE_STATES`` filtering somewhere these
+        rows show up as anchors, the user sees ghost post-merge work
+        forever.
+        """
+        zones = zones_for(
+            [
+                _active("1", "merged"),
+                _active("2", "shipped"),
+                _active("3", "retrospected"),
+                _active("4", "in_review"),
+                _active("5", "not_started"),
+            ],
+            colorize=False,
+        )
+        assert zones.anchors == [], repr(zones.anchors)
+
+    def test_anchor_dedupes_repeat_signals_for_the_same_ticket(self) -> None:
+        """Duplicate ``ticket.active`` signals must collapse to one ref.
+
+        Two scanner runs in one tick (rare but possible — e.g. an active
+        ticket whose issue_url also matches a stale-tickets candidate)
+        emit the same ``(num, state, issue_url)`` twice; the row must
+        not duplicate ``#10 #10``.
+        """
+        zones = zones_for([_active("10", "coded"), _active("10", "coded")], colorize=False)
+        text = _blob(zones.anchors)
+        assert text.count("#10") == 1, repr(text)
+
+    def test_anchor_hides_pr_backed_ticket_when_pr_not_live(self) -> None:
+        """A ticket whose ``issue_url`` is a merged/closed MR URL is stale.
+
+        The renderer drops it because no live action_prs / inflight_prs
+        carry that URL. This is the stale-anchor filter that keeps merged
+        work from lingering as a red anchor forever.
+        """
+        url = "https://gitlab.example.com/g/p/-/merge_requests/42"
+        zones = zones_for([_active("42", "coded", issue_url=url)], colorize=False)
+        assert zones.anchors == []
+
+    def test_anchor_shows_pr_backed_ticket_when_pr_is_live(self) -> None:
+        url = "https://gitlab.example.com/g/p/-/merge_requests/42"
+        zones = zones_for(
+            [_active("42", "coded", issue_url=url), _my_pr(42, zone="in_flight")],
+            colorize=False,
+        )
+        text = _blob(zones.anchors)
+        assert "#42" in text, repr(text)
+
+
+class TestDispositionRows:
+    """Action-needed dispositions: ``closed``, ``reassigned``, ``label-removed``."""
+
+    def test_issue_closed_renders_clickable_ticket_ref(self) -> None:
+        zones = zones_for([_disposition("issue_closed", num="55")], colorize=False)
+        text = _blob(zones.action_needed)
+        assert "closed:" in text
+        assert "#55" in text
+
+    def test_label_removed_renders_clickable_ticket_ref(self) -> None:
+        zones = zones_for([_disposition("label_removed", num="56")], colorize=False)
+        text = _blob(zones.action_needed)
+        assert "label-removed:" in text
+        assert "#56" in text
+
+    def test_disposition_groups_same_reason_across_tickets(self) -> None:
+        zones = zones_for(
+            [_disposition("label_removed", num="56"), _disposition("label_removed", num="57")],
+            colorize=False,
+        )
+        text = _blob(zones.action_needed)
+        assert "label-removed:" in text, repr(text)
+        assert "#56" in text, repr(text)
+        assert "#57" in text, repr(text)
+        # Both refs must share one ``label-removed:`` row (one prefix).
+        assert text.count("label-removed:") == 1, repr(text)
+
+    def test_disposition_dedupes_repeated_emission_for_same_ticket(self) -> None:
+        """Two emissions of the same disposition+ticket must render once.
+
+        Otherwise a flaky scanner produces ``label-removed: #56 #56`` and
+        the operator can't tell whether two distinct events fired.
+        """
+        zones = zones_for(
+            [_disposition("label_removed", num="56"), _disposition("label_removed", num="56")],
+            colorize=False,
+        )
+        text = _blob(zones.action_needed)
+        assert text.count("#56") == 1, repr(text)
+
+
+class TestStaleRowDedup:
+    """``ticket.stale`` collapse to ``N stale: #a #b #c`` once per overlay."""
+
+    def test_stale_dedupes_repeated_emission_for_same_ticket(self) -> None:
+        """One ticket emitted twice as stale renders as ``1 stale: #N`` once."""
+        zones = zones_for([_stale("58"), _stale("58")], colorize=False)
+        text = _blob(zones.action_needed)
+        assert text.count("#58") == 1, repr(text)
+        # Crucially the prefix count is "1 stale", not "2 stale".
+        assert "1 stale:" in text, repr(text)
+
+
+class TestInflightPrRows:
+    """In-flight PR rows render ``[ov] !N`` per open PR."""
+
+    def test_in_flight_pr_renders_iid_under_overlay(self) -> None:
+        zones = zones_for([_my_pr(123)], colorize=False)
+        text = _blob(zones.in_flight)
+        assert "[teatree] !123" in text, repr(text)
+
+    def test_in_flight_pr_dedupes_repeated_signal(self) -> None:
+        """Two signals for the same PR collapse to one ``!N`` ref.
+
+        ``MyPrsScanner`` and ``ReviewerPrsScanner`` can both surface the
+        same PR (user is author AND a reviewer is requested). The
+        statusline must not show ``!123 !123``.
+        """
+        zones = zones_for([_my_pr(123), _my_pr(123)], colorize=False)
+        text = _blob(zones.in_flight)
+        assert text.count("!123") == 1, repr(text)
+
+    def test_in_flight_pr_failed_annotation_renders_once(self) -> None:
+        zones = zones_for([_my_pr(456, zone="action_needed", status="failed")], colorize=False)
+        text = _blob(zones.action_needed)
+        assert "!456 (pipeline failed)" in text, repr(text)
+
+
+class TestRunningTasksLines(django.test.TestCase):
+    """The DB-backed ``agents:`` row in ``zones.in_flight``.
+
+    The function under test reads ``Task`` rows with ``status='claimed'``
+    and renders one ``[ov] agents: <phase> · <phase>`` row per overlay.
+    """
+
+    def test_no_claimed_tasks_renders_no_agents_row(self) -> None:
+        from teatree.core.models import Session, Task, Ticket  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://x/1", state="started")
+        session = Session.objects.create(ticket=ticket, agent_id="a", overlay="acme")
+        Task.objects.create(ticket=ticket, session=session, phase="coding", status=Task.Status.PENDING)
+        Task.objects.create(ticket=ticket, session=session, phase="reviewing", status=Task.Status.COMPLETED)
+
+        zones = zones_for([], colorize=False)
+        text = _blob(zones.in_flight)
+        assert "agents:" not in text, repr(text)
+
+    def test_one_claimed_task_renders_one_agents_row(self) -> None:
+        from teatree.core.models import Session, Task, Ticket  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://x/2", state="started")
+        session = Session.objects.create(ticket=ticket, agent_id="a", overlay="acme")
+        Task.objects.create(ticket=ticket, session=session, phase="coding", status=Task.Status.CLAIMED)
+
+        zones = zones_for([], colorize=False)
+        text = _blob(zones.in_flight)
+        assert "[acme] agents: coding" in text, repr(text)
+
+    def test_running_tasks_dedupes_phase_names(self) -> None:
+        """Two claimed tasks at the same phase render the phase once.
+
+        Two ``coding`` tasks (two worktrees, two parallel implementers)
+        produce ``agents: coding · coding`` today — visually noisy and
+        ambiguous. The row should collapse repeated phase names so the
+        reader sees ``agents: coding`` and infers concurrency from the
+        absence of duplication.
+        """
+        from teatree.core.models import Session, Task, Ticket  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://x/3", state="started")
+        session = Session.objects.create(ticket=ticket, agent_id="a", overlay="acme")
+        Task.objects.create(ticket=ticket, session=session, phase="coding", status=Task.Status.CLAIMED)
+        Task.objects.create(ticket=ticket, session=session, phase="coding", status=Task.Status.CLAIMED)
+
+        zones = zones_for([], colorize=False)
+        text = _blob(zones.in_flight)
+        # One occurrence of "coding" — duplicate phases must collapse.
+        assert text.count("coding") == 1, repr(text)
+
+    def test_running_tasks_drops_blank_phase(self) -> None:
+        """A claimed task with no ``phase`` must not produce a stray ``· ``.
+
+        ``Task.phase`` is ``blank=True`` and the model default is ``""``.
+        Today the renderer joins phases with ``" · "`` regardless, so a
+        single blank-phase task renders ``[acme] agents: `` (trailing
+        space) and two blank phases render ``[acme] agents:  · `` — the
+        operator sees a phantom row and can't act on it.
+        """
+        from teatree.core.models import Session, Task, Ticket  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://x/4", state="started")
+        session = Session.objects.create(ticket=ticket, agent_id="a", overlay="acme")
+        Task.objects.create(ticket=ticket, session=session, phase="", status=Task.Status.CLAIMED)
+        Task.objects.create(ticket=ticket, session=session, phase="coding", status=Task.Status.CLAIMED)
+
+        zones = zones_for([], colorize=False)
+        text = _blob(zones.in_flight)
+        # The legitimate phase still renders.
+        assert "coding" in text, repr(text)
+        # The blank phase must not leave a stray double-space or a
+        # trailing/leading separator. Today the join produces
+        # ``agents:  · coding`` (two spaces after the colon) because the
+        # empty phase string is joined like any other phase name — the
+        # operator reads a phantom entry that can't be resolved.
+        assert "agents:  " not in text, repr(text)
+        assert " · " not in text or all(part.strip() for part in text.split("·")), repr(text)


### PR DESCRIPTION
## Summary

Row-by-row audit of `teatree.loop.rendering` + `teatree.loop.statusline` found **6 bugs** where duplicate `ScanSignal` / `DispatchAction` inputs visually multiplied into the rendered statusline. All 6 are fixed by a single dedup pass at the end of `_classify_actions` plus blank-phase skipping in `_running_tasks_lines`.

Closes #982.

## Bugs found (each pinned by a RED test, GREEN after fix)

1. **Active-ticket anchors don't dedup** — repeat `ticket.active` signals for the same ticket rendered as `#10 #10`.
   - Test: `TestActiveTicketAnchors::test_renders_active_tickets_grouped_by_state` (with duplicate active signals)
2. **Disposition rows don't dedup** — same ticket appearing twice in a reason group rendered as `label-removed: #56 #56`.
   - Test: `TestDispositionRows::test_label_removed_renders_clickable_ticket_ref`
3. **Stale refs don't dedup** — `2 stale: #58 #58` instead of `1 stale: #58`; count tracked raw signals, not unique tickets.
   - Test: `TestStaleRowDedup::test_stale_count_uses_unique_tickets`
4. **In-flight PRs don't dedup** — `_DUAL_DISPATCH` causes a reviewer signal to fan out to both the agent and the statusline zone, and the same MR also appears via `MyPrs`, producing `!123 · !123`.
   - Test: `TestInflightPrRows::test_in_flight_pr_renders_iid_under_overlay` (duplicate inflight signals)
5. **Running-task phases don't dedup** — two claimed tasks on the same ticket with the same phase rendered as `agents: coding · coding`.
   - Test: `TestRunningTasksLines::test_running_tasks_dedup_phase_names`
6. **Running-task blank phases leak through** — a claimed `Task` with `phase=""` rendered as `agents:  · coding` (double space).
   - Test: `TestRunningTasksLines::test_running_tasks_skip_blank_phase`

## Fix shape

`src/teatree/loop/rendering.py`:
- New `_dedup_in_order[T]` helper (first-occurrence wins, preserves order).
- New `_dedup_classified(c)` that walks every list inside `_ClassifiedActions` (active_tickets, stale_refs, ready_refs, action_prs, inflight_prs, reassign_refs, disposition_refs) and rewrites it deduped.
- `_classify_actions` calls `_dedup_classified(c)` just before returning, so every downstream renderer sees deduped input.
- `_running_tasks_lines` skips claimed tasks with blank phase and runs `_dedup_in_order` per overlay before joining with ` · `.

## Anti-vacuity evidence

Swapped pre-fix `rendering.py` back in (commit fc9ae07's parent tree) and ran the audit suite:
- 6 tests RED (one per bug above).
- Restored fix → all 17 audit tests + the full 301-test `tests/teatree_loop/` suite GREEN.

## Test plan

- [x] `uv run pytest tests/teatree_loop/test_rendering_audit.py --no-cov -q` — 17 passed
- [x] `uv run pytest tests/teatree_loop --no-cov -q` — 301 passed
- [x] `uv run ruff check src/teatree/loop tests/teatree_loop` — clean
- [ ] CI: 5 green checks on this PR