### PR TITLE
fix(hooks): surface auto-compact kill-switch advisory on SessionStart

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -1904,6 +1904,36 @@ def _tick_owner_record(session_id: str, agent_id: str) -> dict[str, dict]:
     }
 
 
+def _autocompact_kill_switch_advisory() -> str | None:
+    """Return the #980 advisory text when the harness kill-switch trips.
+
+    The Claude Code harness silently disables auto-compaction on
+    1M-capable models (currently claude-opus-4-7) unless an
+    explicit CLAUDE_CODE_AUTO_COMPACT_WINDOW (or settings.json
+    autoCompactWindow) is set — CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+    alone is silently dropped. The advisory tells the agent the
+    matching env-var fix so it can patch ~/.claude/settings.json
+    itself (see :mod:`teatree.core.autocompact_advisory` for the full
+    decoded harness logic). Best-effort: any import / lookup failure
+    returns None so the SessionStart directive always emits.
+    """
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    added = False
+    try:
+        if str(src_dir) not in sys.path:
+            sys.path.insert(0, str(src_dir))
+            added = True
+        from teatree.core.autocompact_advisory import AutocompactConfig, advisory_text  # noqa: PLC0415
+
+        return advisory_text(AutocompactConfig.from_env())
+    except Exception:  # noqa: BLE001
+        return None
+    finally:
+        if added:
+            with contextlib.suppress(ValueError):
+                sys.path.remove(str(src_dir))
+
+
 def handle_session_start_bootstrap(data: dict) -> None:
     """Emit the tick-dispatch bootstrap directive (#786 WS3 — roster retired).
 
@@ -1966,6 +1996,13 @@ def handle_session_start_bootstrap(data: dict) -> None:
         recovered = _recover_snapshot_context(session_id)
         if recovered is not None:
             context = f"{recovered}\n\n---\n\n{context}"
+
+    # #980: surface the harness auto-compact kill-switch advisory when the
+    # env-var combo would silently disable auto-compaction on this session.
+    # Same single stdout write — see the #845 note above.
+    advisory = _autocompact_kill_switch_advisory()
+    if advisory:
+        context = f"{context}\n\n---\n\n{advisory}"
 
     json.dump({"additionalContext": context}, sys.stdout)
 

--- a/src/teatree/core/autocompact_advisory.py
+++ b/src/teatree/core/autocompact_advisory.py
@@ -1,0 +1,205 @@
+"""Advisory for a Claude Code harness silent kill-switch (issue #980).
+
+For 1M-capable models (currently ``claude-opus-4-7``) without an
+explicit auto-compact window setting, the harness in
+``@anthropic-ai/claude-code`` v2.x silently disables auto-compaction
+regardless of ``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE``.
+
+The harness logic, decoded from the bundled binary at
+``$(npm root -g)/@anthropic-ai/claude-code/bin/claude.exe``::
+
+    function zKH(H) {
+        if (!Nw_()) return false;
+        if (hP(H, fD()) !== 1e6) return false;     // model max-window is 1M
+        let _ = Z7(H);
+        if (D96(_) !== void 0) return false;        // statsig flag is set
+        return true;                                // → "kill-switch trips"
+    }
+
+    function oiH(H, _) {
+        let {source: q} = Kr(H, _);
+        return q === "env" || q === "settings";     // user explicit window
+    }
+
+    async function o13(H, _, q, K, O = 0) {
+        if (!r0()) return false;                    // autoCompactEnabled
+        if (zKH(_) && !oiH(_, q)) return false;     // ← THE BUG
+        ...
+    }
+
+The trip condition (``zKH(model) && !oiH(model, autoCompactWindow)``)
+is reached when:
+
+1. The model is 1M-capable (``claude-opus-4-7``).
+2. ``CLAUDE_CODE_AUTO_COMPACT_WINDOW`` env var is unset.
+3. The ``autoCompactWindow`` setting in ``~/.claude/settings.json`` is
+    unset.
+4. The user is not opted into the ``tengu_amber_redwood2`` statsig
+    feature flag.
+
+When those four hold, ``o13`` returns ``false`` before consulting
+``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE``: auto-compaction never fires no
+matter how full the context gets. Source spec
+``docs/claude-code-internals.md`` § 4 (Layer 2) calls the trigger
+"~90% of context window (configurable threshold)"; the configurable
+threshold is silently skipped on this path.
+
+The fix the harness wants is for the user to set
+``CLAUDE_CODE_AUTO_COMPACT_WINDOW`` to the model's max window
+(``1000000`` for ``claude-opus-4-7``). That changes
+``Kr.source`` to ``"env"``, making ``oiH`` return true and bypassing
+``zKH``'s kill-switch. The ``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`` then
+applies as a percentage of the effective window.
+
+Setting ``CLAUDE_CODE_AUTO_COMPACT_WINDOW`` to a value lower than the
+model's max window is a foot-gun (it shrinks the trigger to a fraction
+of that smaller value) — this is what motivated the advisory: the user
+hit this exact wrong-direction mistake on 2026-05-18.
+"""
+
+import os
+from dataclasses import dataclass
+
+# Models for which the harness's silent kill-switch trips when no
+# explicit window is configured. Kept narrow on purpose — the kill-
+# switch is gated on ``hP(model, betas) === 1e6`` in the harness, and
+# the only model that flips this without the ``[1m]`` beta header is
+# ``claude-opus-4-7``. The ``[1m]`` suffix is stripped by the harness's
+# ``CD`` normaliser before comparison, so both names are equivalent
+# kill-switch carriers.
+_KILL_SWITCH_MODELS: frozenset[str] = frozenset(
+    {
+        "claude-opus-4-7",
+        "claude-opus-4-7[1m]",
+    }
+)
+
+# The harness ceiling for ``claude-opus-4-7``. ``hP`` returns ``1e6``
+# unconditionally for this model name (see ``JqH(H)`` and ``nZ(H)``).
+_OPUS_4_7_MAX_WINDOW_TOKENS = 1_000_000
+
+# Upper bound the harness ``gE8`` accepts for ``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE``
+# (``parseFloat`` result in ``(0, 100]``).
+_PCT_OVERRIDE_MAX = 100
+
+
+@dataclass(frozen=True)
+class AutocompactConfig:
+    """Snapshot of the auto-compact-relevant harness env knobs.
+
+    Built deliberately from environment alone — the harness reads its
+    own settings.json itself; we only need to see the knobs the user
+    has set explicitly to decide whether the kill-switch would trip.
+    """
+
+    pct_override: str | None
+    auto_compact_window: str | None
+    disable_compact: str | None
+    disable_auto_compact: str | None
+    model: str | None
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "AutocompactConfig":
+        src = env if env is not None else os.environ
+        return cls(
+            pct_override=src.get("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"),
+            auto_compact_window=src.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW"),
+            disable_compact=src.get("DISABLE_COMPACT"),
+            disable_auto_compact=src.get("DISABLE_AUTO_COMPACT"),
+            model=src.get("CLAUDE_CODE_MODEL") or src.get("ANTHROPIC_MODEL"),
+        )
+
+
+def _is_truthy(value: str | None) -> bool:
+    """Match the harness's ``xH`` truthy-env-var helper (``"1"``/``"true"``)."""
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_kill_switch_model(model: str | None) -> bool:
+    """Return True for models whose ``hP(model, betas)`` returns 1M.
+
+    The harness's ``CD`` normaliser strips ``[1m]`` and lowercases the
+    name; mirror that here so the detection holds for any cased
+    variant the agent might be running under.
+    """
+    if not model:
+        return False
+    return model.strip().lower() in _KILL_SWITCH_MODELS
+
+
+def has_pct_override(config: AutocompactConfig) -> bool:
+    """Return True iff ``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`` is set to a usable number.
+
+    Matches the harness's ``gE8`` parsing: a numeric ``parseFloat``
+    result in ``(0, 100]`` enables the override. Empty / non-numeric /
+    out-of-range values fall back to the default and ARE NOT a
+    user-expressed preference, so we don't surface the advisory for
+    them.
+    """
+    raw = config.pct_override
+    if raw is None or not raw.strip():
+        return False
+    try:
+        value = float(raw)
+    except ValueError:
+        return False
+    return 0 < value <= _PCT_OVERRIDE_MAX
+
+
+def kill_switch_trips(config: AutocompactConfig) -> bool:
+    """Return True iff the harness will silently drop auto-compact.
+
+    Decides on the env-var combo alone. Reproduces the harness logic
+    in :mod:`teatree.core.autocompact_advisory` docstring.
+    """
+    if _is_truthy(config.disable_compact) or _is_truthy(config.disable_auto_compact):
+        # User has globally disabled compaction; not the kill-switch
+        # bug, just an explicit opt-out.
+        return False
+    if not has_pct_override(config):
+        # No user-configured threshold to silently drop.
+        return False
+    if config.auto_compact_window and config.auto_compact_window.strip():
+        # An explicit window already opts ``Kr.source`` to "env",
+        # bypassing the kill-switch.
+        return False
+    return _is_kill_switch_model(config.model)
+
+
+def recommended_env_var() -> tuple[str, str]:
+    """Return the env-var name and value that bypass the kill-switch.
+
+    Setting ``CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000`` flips
+    ``Kr.source`` to ``"env"`` so ``oiH`` returns true and the
+    ``zKH`` kill-switch is bypassed. ``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE``
+    then applies as a percentage of the effective window.
+    """
+    return "CLAUDE_CODE_AUTO_COMPACT_WINDOW", str(_OPUS_4_7_MAX_WINDOW_TOKENS)
+
+
+def advisory_text(config: AutocompactConfig) -> str | None:
+    """Return the user-facing advisory, or None when no advisory is warranted.
+
+    Designed for callers that emit ``additionalContext`` (SessionStart
+    hook) and for ``t3 doctor`` text output alike — the text is the
+    same content; the caller wraps it for its surface.
+    """
+    if not kill_switch_trips(config):
+        return None
+    var_name, var_value = recommended_env_var()
+    pct = (config.pct_override or "").strip()
+    model = (config.model or "claude-opus-4-7").strip()
+    return (
+        "AUTO-COMPACT SILENT KILL-SWITCH (souliane/teatree#980): "
+        f"`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE={pct}` is set but the Claude "
+        f"Code harness silently disables auto-compaction for `{model}` "
+        "until `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is ALSO set. "
+        f'Add `"{var_name}": "{var_value}"` to the `env` block in '
+        "`~/.claude/settings.json` to make the percentage override "
+        f"effective (auto-compact will then fire at ~{pct}% of "
+        f"{var_value} tokens). The harness function chain is "
+        "`zKH(model) && !oiH(model, autoCompactWindow) ⇒ return false` "
+        "in `o13`, before the threshold logic runs."
+    )

--- a/tests/teatree_core/test_autocompact_advisory.py
+++ b/tests/teatree_core/test_autocompact_advisory.py
@@ -1,0 +1,206 @@
+"""Tests for the auto-compact kill-switch advisory (issue #980).
+
+User report (2026-05-18 PM): ``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=25``
+was set in ``~/.claude/settings.json``, the user hit 99% of the 1M
+context window without auto-compaction firing once, and a wrong-
+direction "fix" (``CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000``) shrunk
+the effective trigger to ~50k instead of restoring the intended ~250k.
+
+Root cause (decoded from
+``$(npm root -g)/@anthropic-ai/claude-code/bin/claude.exe``):
+``o13`` short-circuits on ``zKH(model) && !oiH(model,
+autoCompactWindow)``. For the 1M-capable ``claude-opus-4-7`` with no
+explicit window setting, this returns false BEFORE the pct override
+is consulted — auto-compaction is silently disabled regardless of
+``CLAUDE_AUTOCOMPACT_PCT_OVERRIDE``.
+
+The teatree-side workaround per the issue scope (no harness changes)
+is an advisory: when the kill-switch shape is detected from the
+env-var combo, surface the matching ``CLAUDE_CODE_AUTO_COMPACT_WINDOW``
+recommendation so the agent can patch ``~/.claude/settings.json``
+itself (the user is in auto mode).
+"""
+
+from teatree.core.autocompact_advisory import (
+    AutocompactConfig,
+    advisory_text,
+    has_pct_override,
+    kill_switch_trips,
+    recommended_env_var,
+)
+
+
+def _config(**overrides: str | None) -> AutocompactConfig:
+    """Build an ``AutocompactConfig`` from explicit env values.
+
+    Avoids depending on the test runner's environment, which would
+    leak whatever the developer has set in their shell into the test.
+    """
+    base = {
+        "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": None,
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW": None,
+        "DISABLE_COMPACT": None,
+        "DISABLE_AUTO_COMPACT": None,
+        "CLAUDE_CODE_MODEL": None,
+        "ANTHROPIC_MODEL": None,
+    }
+    base.update(overrides)
+    return AutocompactConfig.from_env({k: v for k, v in base.items() if v is not None})
+
+
+class TestHasPctOverride:
+    def test_unset_is_false(self) -> None:
+        assert has_pct_override(_config()) is False
+
+    def test_empty_string_is_false(self) -> None:
+        assert has_pct_override(_config(CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="")) is False
+
+    def test_non_numeric_is_false(self) -> None:
+        assert has_pct_override(_config(CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="auto")) is False
+
+    def test_zero_is_false(self) -> None:
+        # Harness ``gE8`` requires ``>0 && <=100`` — zero is treated as "default".
+        assert has_pct_override(_config(CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="0")) is False
+
+    def test_above_one_hundred_is_false(self) -> None:
+        # ``>100`` exits the override path in the harness's ``BP_``.
+        assert has_pct_override(_config(CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="150")) is False
+
+    def test_user_real_value_is_true(self) -> None:
+        # User's actual setting in 2026-05-18 incident: PCT_OVERRIDE=25.
+        assert has_pct_override(_config(CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25")) is True
+
+    def test_boundary_one_hundred_is_true(self) -> None:
+        assert has_pct_override(_config(CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="100")) is True
+
+
+class TestKillSwitchTripsExactScenario:
+    """Pin the exact 2026-05-18 user incident shape (the bug)."""
+
+    def test_user_incident_2026_05_18_trips(self) -> None:
+        # PCT_OVERRIDE=25, no AUTO_COMPACT_WINDOW, opus-4-7[1m] → bug.
+        config = _config(
+            CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25",
+            CLAUDE_CODE_MODEL="claude-opus-4-7[1m]",
+        )
+        assert kill_switch_trips(config) is True
+
+
+class TestKillSwitchTripsModelMatrix:
+    def test_kill_switch_model_normalized_name(self) -> None:
+        config = _config(
+            CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25",
+            CLAUDE_CODE_MODEL="claude-opus-4-7",
+        )
+        assert kill_switch_trips(config) is True
+
+    def test_kill_switch_model_one_megabyte_suffix(self) -> None:
+        config = _config(
+            CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25",
+            CLAUDE_CODE_MODEL="claude-opus-4-7[1m]",
+        )
+        assert kill_switch_trips(config) is True
+
+    def test_kill_switch_model_uppercase(self) -> None:
+        # Harness's ``CD`` lowercases — mirror.
+        config = _config(
+            CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25",
+            CLAUDE_CODE_MODEL="Claude-Opus-4-7",
+        )
+        assert kill_switch_trips(config) is True
+
+    def test_non_opus_47_does_not_trip(self) -> None:
+        # 200k models (opus-4-5, sonnet-4-x) hit the standard auto path
+        # — no kill-switch.
+        for model in (
+            "claude-opus-4-5",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+        ):
+            config = _config(
+                CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25",
+                CLAUDE_CODE_MODEL=model,
+            )
+            assert kill_switch_trips(config) is False, model
+
+    def test_anthropic_model_fallback_env_var(self) -> None:
+        # When the harness sets only ``ANTHROPIC_MODEL`` (older shape),
+        # detection should still fire.
+        config = _config(
+            CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25",
+            ANTHROPIC_MODEL="claude-opus-4-7",
+        )
+        assert kill_switch_trips(config) is True
+
+    def test_no_model_env_does_not_trip(self) -> None:
+        # We don't surface advisories blind; if neither env var is set
+        # we cannot know the model and stay quiet.
+        config = _config(CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25")
+        assert kill_switch_trips(config) is False
+
+
+class TestKillSwitchTripsBypassConditions:
+    def test_no_pct_override_does_not_trip(self) -> None:
+        # No user-expressed threshold → nothing to silently drop.
+        config = _config(CLAUDE_CODE_MODEL="claude-opus-4-7[1m]")
+        assert kill_switch_trips(config) is False
+
+    def test_window_already_set_does_not_trip(self) -> None:
+        # ``Kr.source`` becomes "env" → harness ``oiH`` returns true →
+        # kill-switch bypassed.
+        config = _config(
+            CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25",
+            CLAUDE_CODE_AUTO_COMPACT_WINDOW="1000000",
+            CLAUDE_CODE_MODEL="claude-opus-4-7[1m]",
+        )
+        assert kill_switch_trips(config) is False
+
+    def test_disable_compact_does_not_trip(self) -> None:
+        # User explicitly disabled compaction — not the bug, not our job.
+        config = _config(
+            CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25",
+            DISABLE_COMPACT="1",
+            CLAUDE_CODE_MODEL="claude-opus-4-7[1m]",
+        )
+        assert kill_switch_trips(config) is False
+
+    def test_disable_auto_compact_does_not_trip(self) -> None:
+        config = _config(
+            CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25",
+            DISABLE_AUTO_COMPACT="true",
+            CLAUDE_CODE_MODEL="claude-opus-4-7[1m]",
+        )
+        assert kill_switch_trips(config) is False
+
+
+class TestRecommendedEnvVar:
+    def test_recommends_one_million_for_opus_4_7(self) -> None:
+        name, value = recommended_env_var()
+        assert name == "CLAUDE_CODE_AUTO_COMPACT_WINDOW"
+        # 1,000,000 — the model's max window. Setting it lower (e.g.
+        # 200_000) shrinks the pct threshold to a fraction of that
+        # smaller value, which is the user's 2026-05-18 wrong-direction
+        # mistake. Pin the recommended value.
+        assert value == "1000000"
+
+
+class TestAdvisoryText:
+    def test_no_advisory_when_kill_switch_does_not_trip(self) -> None:
+        assert advisory_text(_config()) is None
+
+    def test_advisory_when_kill_switch_trips(self) -> None:
+        config = _config(
+            CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="25",
+            CLAUDE_CODE_MODEL="claude-opus-4-7[1m]",
+        )
+        text = advisory_text(config)
+        assert text is not None
+        # Must name the fix var so the agent can act on it.
+        assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" in text
+        assert "1000000" in text
+        # Must reference the user's actual pct so the advisory is
+        # actionable, not generic.
+        assert "25" in text
+        # Must reference the issue so the trail is followable.
+        assert "#980" in text

--- a/tests/test_session_start_bootstrap_hook.py
+++ b/tests/test_session_start_bootstrap_hook.py
@@ -351,3 +351,62 @@ class TestWs3TickDispatchContract:
     def test_no_session_id_still_silent(self, capsys: pytest.CaptureFixture[str]) -> None:
         handle_session_start_bootstrap({})
         assert capsys.readouterr().out == ""
+
+
+# ── Issue #980: auto-compact kill-switch advisory ─────────────────────
+
+
+class TestAutocompactAdvisoryIntegration:
+    """Pin that the SessionStart handler surfaces the #980 advisory.
+
+    The advisory is the teatree-side workaround for the harness's
+    silent auto-compact kill-switch on 1M-capable models (see
+    ``teatree.core.autocompact_advisory``). When the env-var combo
+    matches the trip condition, the SessionStart handler must append
+    the advisory text to ``additionalContext`` so the agent can read
+    it the moment the session starts.
+    """
+
+    def test_advisory_appended_when_kill_switch_trips(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "25")
+        monkeypatch.delenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", raising=False)
+        monkeypatch.delenv("DISABLE_COMPACT", raising=False)
+        monkeypatch.delenv("DISABLE_AUTO_COMPACT", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_MODEL", "claude-opus-4-7[1m]")
+
+        handle_session_start_bootstrap({"session_id": "s1", "agent_id": "a1"})
+
+        payload = json.loads(capsys.readouterr().out)
+        context = payload["additionalContext"]
+        assert "AUTO-COMPACT SILENT KILL-SWITCH" in context
+        assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" in context
+        assert "1000000" in context
+        assert "#980" in context
+
+    def test_no_advisory_when_window_already_set(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        # User already has the fix env var in place — must NOT nag.
+        monkeypatch.setenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "25")
+        monkeypatch.setenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "1000000")
+        monkeypatch.setenv("CLAUDE_CODE_MODEL", "claude-opus-4-7[1m]")
+
+        handle_session_start_bootstrap({"session_id": "s2", "agent_id": "a2"})
+
+        payload = json.loads(capsys.readouterr().out)
+        assert "AUTO-COMPACT SILENT KILL-SWITCH" not in payload["additionalContext"]
+
+    def test_no_advisory_when_pct_override_unset(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        # No user-expressed threshold → kill-switch doesn't matter to user.
+        monkeypatch.delenv("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_MODEL", "claude-opus-4-7[1m]")
+
+        handle_session_start_bootstrap({"session_id": "s3", "agent_id": "a3"})
+
+        payload = json.loads(capsys.readouterr().out)
+        assert "AUTO-COMPACT SILENT KILL-SWITCH" not in payload["additionalContext"]


### PR DESCRIPTION
## Summary

The Claude Code harness in `@anthropic-ai/claude-code` v2.x silently disables auto-compaction for 1M-capable models (currently `claude-opus-4-7`) when `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is set but `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is not — the percentage override never fires and the agent runs to context exhaustion.

### Root cause (decoded from the bundled binary)

`$(npm root -g)/@anthropic-ai/claude-code/bin/claude.exe`:

```js
function zKH(H) {
    if (!Nw_()) return false;
    if (hP(H, fD()) !== 1e6) return false;     // model max-window is 1M
    let _ = Z7(H);
    if (D96(_) !== void 0) return false;        // statsig flag is set
    return true;
}

function oiH(H, _) {
    let {source: q} = Kr(H, _);
    return q === "env" || q === "settings";    // user explicit window
}

async function o13(H, _, q, K, O = 0) {
    if (!r0()) return false;
    if (zKH(_) && !oiH(_, q)) return false;     // ← THE KILL-SWITCH
    let T = Wf(H, rZ(_)) - O,
        $ = zNH(T, _, q);
    ...
}
```

For Opus 4.7 with no explicit window:
- `hP("claude-opus-4-7", betas)` → `1e6` (via `JqH`/`nZ`)
- `Kr(model, undefined).source` → `"auto"`
- `D96("claude-opus-4-7")` → `undefined` (statsig flag empty for users not opted in)
- ⇒ `zKH(_) && !oiH(_, q)` → **true** → `o13` returns `false` before consulting `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`.

Setting `CLAUDE_CODE_AUTO_COMPACT_WINDOW=1000000` flips `Kr.source` to `"env"`, making `oiH` return `true`, bypassing the kill-switch. The percentage override then applies as a percentage of the effective window (`min(floor(window * pct/100), window - 13000)`).

### Fix scope

Teatree-side only, per the same scope rules as #970/#973. No harness changes.

`teatree.core.autocompact_advisory.advisory_text()` returns a directive when the env-var trip shape is detected; `handle_session_start_bootstrap` appends it to the same `additionalContext` write the tick-dispatch directive uses (#845 single-write invariant preserved). The advisory tells the agent the exact env var + value to add to `~/.claude/settings.json`.

The recommended value is `1000000` (the model's max). A smaller value (e.g. `200000`) would shrink the percentage trigger to a fraction of that smaller value — a foot-gun this PR explicitly pins against in the docstring.

### What this PR does NOT do

- It does NOT auto-patch the user's `settings.json`. The agent reads the advisory and patches it themselves under standing authorization (or asks).
- It does NOT change harness behavior — only surfaces an advisory the user can act on.
- It does NOT touch the existing `PreCompact` snapshot work from #970/#973 — that path is orthogonal (snapshot CONTENT vs. trigger FIRING).

## Test plan

- [x] Unit tests pin `kill_switch_trips()` across the model / env-var matrix (21 tests in `tests/teatree_core/test_autocompact_advisory.py`).
- [x] Integration tests pin that `handle_session_start_bootstrap` appends the advisory to `additionalContext` when the trip shape is present, and does NOT when the fix is already in place or when the pct override is unset (3 tests in `tests/test_session_start_bootstrap_hook.py::TestAutocompactAdvisoryIntegration`).
- [x] Full SessionStart / PreCompact / PostCompact hook test files still green (65 tests).
- [x] Ruff + editorconfig clean.

Closes #980. Pairs with #970 / #973 (PreCompact snapshot enrichment).