### PR TITLE
fix(migrations): merge core leaves (0014_self_improve + 0015_on_behalf)

### DIFF
--- a/src/teatree/core/migrations/0016_merge_self_improve_and_on_behalf.py
+++ b/src/teatree/core/migrations/0016_merge_self_improve_and_on_behalf.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0014_add_self_improve_firing"),
+        ("core", "0015_onbehalfapproval_onbehalfaudit"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Problem

`src/teatree/core/migrations/` has TWO leaves on app `core`:

- `0014_add_self_improve_firing.py` (from [#986](https://github.com/souliane/teatree/pull/986) / [#979](https://github.com/souliane/teatree/pull/979)), parent `0013_ticket_context`
- `0015_onbehalfapproval_onbehalfaudit.py` (from [#968](https://github.com/souliane/teatree/pull/968) / [#960](https://github.com/souliane/teatree/pull/960)), parent `0014_dbapproval_dbaudit`

Django reports:
```
conflicts = {'core': ['0014_add_self_improve_firing', '0015_onbehalfapproval_onbehalfaudit']}
```

Pytest fails at `django_db_setup` for any test that needs the DB, so main CI is RED for every open PR.

## Fix

Pure Django merge migration `0016_merge_self_improve_and_on_behalf.py`:

- dependencies: `[("core", "0014_add_self_improve_firing"), ("core", "0015_onbehalfapproval_onbehalfaudit")]`
- operations: `[]`

No refactor of either underlying migration. Pure merge node only.

## Verification

```
$ uv run python -m django showmigrations core --settings=teatree.settings
core
 [X] 0001_initial
 ...
 [X] 0013_ticket_context
 [ ] 0014_dbapproval_dbaudit
 [ ] 0015_onbehalfapproval_onbehalfaudit
 [ ] 0014_add_self_improve_firing
 [ ] 0016_merge_self_improve_and_on_behalf
```

Single graph, no conflict. `uv run pytest tests/ --co` collects 4646 tests without migration-conflict error.

Closes [#988](https://github.com/souliane/teatree/issues/988).