### PR TITLE
fix(core): pre-investigation stale-clone hard-fail gate (#948)

### DIFF
--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -612,6 +612,19 @@ def check() -> bool:
     from teatree.core.schema_guard import doctor_check_self_db_migrations  # noqa: PLC0415
 
     ok = doctor_check_self_db_migrations() and ok
+
+    # Pre-investigation stale-clone hard-fail gate (#948). Surfaces at
+    # session start so a bug-investigation sub-agent cannot start root-
+    # causing against a clone many commits behind ``origin/<default>``.
+    # Distinct from #940 (post-implementation branch-currency on PR
+    # branches); this is the *entry-point* gate before any investigation
+    # reads source files. An offline/missing remote is a valid state —
+    # ``doctor_check_clone_currency`` skips affected repos rather than
+    # FAILing (same posture as schema_guard's DB-offline WARN).
+    from teatree.cli.update import _collect_repos  # noqa: PLC0415
+    from teatree.core.clone_guard import doctor_check_clone_currency  # noqa: PLC0415
+
+    ok = doctor_check_clone_currency(_collect_repos()) and ok
     _check_singletons()
     report_missing_authorizations(typer.echo)
     _ensure_plugin_registered()

--- a/src/teatree/core/clone_guard.py
+++ b/src/teatree/core/clone_guard.py
@@ -1,0 +1,189 @@
+"""Pre-investigation stale-clone hard-fail gate (#948).
+
+A bug-investigation sub-agent that begins root-causing against a clone
+many commits behind ``origin/<default>`` forms an initially-wrong
+root-cause hypothesis on phantom symptoms. #940 covers branch-currency
+*before cold review/ship* (the PR-branch path). This module covers the
+earlier point: **before any bug investigation reads repo files**.
+
+The gate mirrors :mod:`teatree.core.schema_guard` (#869). For each
+in-scope clone it runs ``git fetch origin``, then asserts
+``origin/<default>`` is an ancestor of ``HEAD``. If a clone is behind it
+raises :class:`StaleCloneError` with an actionable message — not a
+warning, a deterministic refusal — quoting the remediation command (the
+canonical ``t3 update`` and the in-repo fallback) so the sub-agent
+cannot proceed against stale code.
+
+Distinct from #940: this is the *entry-point* gate (before reading any
+file for investigation); #940 is the *exit-point* gate (before cold
+review/ship on a feature branch).
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+
+from teatree.utils.run import run_allowed_to_fail
+
+_REMEDIATION = (
+    "Sync the clone before investigating:\n"
+    "  t3 update     # canonical — fetches every registered clone\n"
+    "or, in the affected clone:\n"
+    "  git -C <clone> pull --ff-only\n"
+    "`t3 doctor check` flags this gap at session start."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CloneStaleness:
+    """One stale-clone finding: a clone behind its default-branch tip."""
+
+    name: str
+    path: Path
+    default_branch: str
+    behind: int
+
+
+class StaleCloneError(RuntimeError):
+    """Raised when one or more in-scope clones are behind ``origin/<default>``.
+
+    Carries the per-clone staleness so the caller can render an
+    actionable message instead of a silent wrong-root-cause hypothesis.
+    """
+
+
+def _git(repo: Path, *args: str) -> tuple[int, str]:
+    """Return ``(returncode, stdout)`` for ``git -C <repo> <args>``.
+
+    Uses :func:`run_allowed_to_fail` so a non-zero exit (no remote, bad
+    ref, network failure on fetch) yields a probe-style result rather
+    than crashing the gate — the per-check caller decides how to react.
+    """
+    result = run_allowed_to_fail(
+        ["git", "-C", str(repo), *args],
+        expected_codes=None,
+    )
+    return result.returncode, result.stdout.strip()
+
+
+def _default_branch(repo: Path) -> str | None:
+    """Resolve the default branch from ``origin/HEAD`` (e.g. ``main``).
+
+    Returns ``None`` when ``origin/HEAD`` is unset — the clone has no
+    discoverable default branch and must be skipped (same posture as
+    ``t3 update``'s ``_check_default_branch``).
+    """
+    rc, out = _git(repo, "symbolic-ref", "refs/remotes/origin/HEAD")
+    if rc != 0 or not out:
+        return None
+    # "refs/remotes/origin/main" -> "main"
+    return out.rsplit("/", 1)[-1]
+
+
+def _has_origin_remote(repo: Path) -> bool:
+    rc, out = _git(repo, "remote")
+    return rc == 0 and "origin" in out.split()
+
+
+def _fetch_origin(repo: Path) -> bool:
+    """Fetch ``origin`` for *repo*. Returns ``True`` on success.
+
+    A failed fetch (offline, auth) is treated as inconclusive — the
+    gate must not block the user when the network is down. The caller
+    surfaces this as a WARN, matching the schema_guard "DB offline is
+    valid" posture.
+    """
+    rc, _ = _git(repo, "fetch", "origin")
+    return rc == 0
+
+
+def _commits_behind(repo: Path, default_branch: str) -> int:
+    """Count commits on ``origin/<default>`` not reachable from ``HEAD``.
+
+    Zero means ``origin/<default>`` is an ancestor of ``HEAD`` — the
+    clone has caught up. Positive means the clone is behind by that
+    many commits.
+    """
+    rc, out = _git(repo, "rev-list", "--count", f"HEAD..origin/{default_branch}")
+    if rc != 0 or not out:
+        return 0
+    try:
+        return int(out)
+    except ValueError:
+        return 0
+
+
+def clones_behind_default(repos: list[tuple[str, Path]]) -> list[CloneStaleness]:
+    """Return one :class:`CloneStaleness` for every clone behind ``origin/<default>``.
+
+    Empty list ⇒ every in-scope clone is current. Each repo is fetched
+    first so the comparison reflects the remote's real HEAD, not a
+    cached refs snapshot.
+
+    Repos without an ``origin`` remote or without ``origin/HEAD`` are
+    skipped (no discoverable default branch). A failed fetch yields a
+    skip — the caller's WARN surface decides whether to block.
+    """
+    findings: list[CloneStaleness] = []
+    for name, path in repos:
+        if not path.is_dir() or not _has_origin_remote(path):
+            continue
+        if not _fetch_origin(path):
+            continue
+        default = _default_branch(path)
+        if default is None:
+            continue
+        behind = _commits_behind(path, default)
+        if behind > 0:
+            findings.append(
+                CloneStaleness(name=name, path=path, default_branch=default, behind=behind),
+            )
+    return findings
+
+
+def require_current_clones(repos: list[tuple[str, Path]]) -> None:
+    """Fail closed if any in-scope clone is behind its ``origin/<default>``.
+
+    Called as a pre-flight by the pre-investigation path so an
+    investigation sub-agent can never form a root-cause hypothesis
+    against stale code.
+    """
+    stale = clones_behind_default(repos)
+    if not stale:
+        return
+    lines = [
+        f"refusing to investigate stale code; sync first — {len(stale)} clone(s) behind origin/<default>:",
+        *(
+            f"  - {finding.name} ({finding.path}): {finding.behind} commit(s) behind origin/{finding.default_branch}"
+            for finding in stale
+        ),
+        "",
+        _REMEDIATION,
+    ]
+    raise StaleCloneError("\n".join(lines))
+
+
+def doctor_check_clone_currency(repos: list[tuple[str, Path]]) -> bool:
+    """``t3 doctor`` surface for the pre-investigation clone-currency gate (#948).
+
+    Returns ``True`` (check passed) when every discovered clone is
+    current. Returns ``False`` with a ``FAIL`` line per stale clone so
+    the gap surfaces at session start instead of mid-investigation.
+
+    The caller resolves *repos* — the doctor CLI uses
+    :func:`teatree.cli.update._collect_repos`. The core module cannot
+    import from ``teatree.cli`` (tach module boundary), so dependency
+    injection keeps the layering clean.
+    """
+    stale = clones_behind_default(repos)
+    if not stale:
+        return True
+    for finding in stale:
+        typer.echo(
+            f"FAIL  {finding.name} clone at {finding.path} is "
+            f"{finding.behind} commit(s) behind origin/{finding.default_branch} — "
+            f"run `t3 update` (or `git -C {finding.path} pull --ff-only`) before any "
+            f"investigation.",
+        )
+    return False

--- a/tests/cli_doctor/test_doctor_check_command.py
+++ b/tests/cli_doctor/test_doctor_check_command.py
@@ -10,9 +10,11 @@ this is now its only consumer.
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
 
 import teatree.cli.doctor as teatree_cli_doctor
+import teatree.cli.update as teatree_cli_update
 import teatree.core.overlay_loader as teatree_overlay_loader
 from teatree.cli import app
 from teatree.cli.doctor import IntrospectionHelpers
@@ -20,6 +22,23 @@ from teatree.cli.doctor import IntrospectionHelpers
 from ._shared import _stage_home, _write_teatree_toml
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_clone_currency(monkeypatch):
+    """Pin the pre-investigation clone-currency gate (#948) to "no repos".
+
+    The gate calls ``_collect_repos()`` → real ``git fetch origin`` and
+    ``rev-list HEAD..origin/<default>`` against whatever clone the test
+    runner happens to live in.  In a CI checkout that lags behind
+    ``origin/main`` (e.g. a feature branch cut weeks ago) this surfaces
+    a real ``FAIL`` line and makes the doctor smoke tests non-deterministic.
+    The doctor wiring itself is exercised end-to-end in
+    ``tests/teatree_core/test_clone_guard.py``; here we only assert that
+    ``t3 doctor check`` aggregates check results, so an empty repo list
+    is the right boundary.
+    """
+    monkeypatch.setattr(teatree_cli_update, "_collect_repos", list)
 
 
 class TestDoctorCheckCommand:

--- a/tests/teatree_core/test_clone_guard.py
+++ b/tests/teatree_core/test_clone_guard.py
@@ -1,0 +1,258 @@
+"""Pre-investigation stale-clone hard-fail gate (#948).
+
+Before #948 a bug-investigation sub-agent could begin root-causing
+against a repo clone many commits behind ``origin/<default>`` and form
+an initially-wrong root-cause hypothesis before re-fetching. #940 covers
+branch-currency *before cold review/ship*; this is the earlier point:
+**before any bug investigation reads repo files**.
+
+The gate fetches every in-scope repo, then asserts that
+``origin/<default>`` is an ancestor of ``HEAD``. If a clone is behind it
+hard-fails with an actionable "clone N commits behind — refusing to
+investigate stale code; sync first" message — not a warning, a
+deterministic refusal. Mirrors the ``schema_guard`` pattern (#869).
+"""
+
+import io
+import subprocess
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from teatree.cli import doctor as doctor_mod
+from teatree.core import clone_guard
+from teatree.core.clone_guard import (
+    StaleCloneError,
+    clones_behind_default,
+    doctor_check_clone_currency,
+    require_current_clones,
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],  # noqa: S607
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _make_remote(tmp_path: Path, name: str = "remote") -> Path:
+    """Create a bare remote with one commit on ``main``."""
+    seed = tmp_path / f"{name}-seed"
+    seed.mkdir()
+    _git(seed, "init", "-b", "main")
+    _git(seed, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
+    _git(seed, "config", "user.name", "Tester")
+    (seed / "f.txt").write_text("v1\n")
+    _git(seed, "add", "f.txt")
+    _git(seed, "commit", "-m", "initial")
+
+    bare = tmp_path / f"{name}.git"
+    _git(tmp_path, "clone", "--bare", str(seed), str(bare))
+    return bare
+
+
+def _clone(tmp_path: Path, bare: Path, name: str = "clone") -> Path:
+    clone = tmp_path / name
+    _git(tmp_path, "clone", str(bare), str(clone))
+    _git(clone, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
+    _git(clone, "config", "user.name", "Tester")
+    return clone
+
+
+def _advance_remote(tmp_path: Path, bare: Path, n: int = 1) -> None:
+    """Push *n* new commits to the bare remote's default branch."""
+    work = tmp_path / f"advance-{bare.name}"
+    if work.exists():
+        # Reuse existing advance clone if called repeatedly
+        for i in range(n):
+            (work / "f.txt").write_text(f"more-{i}\n")
+            _git(work, "add", "f.txt")
+            _git(work, "commit", "-m", f"advance-{i}")
+        _git(work, "push", "origin", "main")
+        return
+    _git(tmp_path, "clone", str(bare), str(work))
+    _git(work, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
+    _git(work, "config", "user.name", "Tester")
+    for i in range(n):
+        (work / "f.txt").write_text(f"more-{i}\n")
+        _git(work, "add", "f.txt")
+        _git(work, "commit", "-m", f"advance-{i}")
+    _git(work, "push", "origin", "main")
+
+
+class TestClonesCurrent:
+    def test_clones_behind_default_returns_empty_when_in_sync(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        assert clones_behind_default([("repo", clone)]) == []
+
+    def test_require_current_clones_is_noop_when_in_sync(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        require_current_clones([("repo", clone)])  # must not raise
+
+    def test_feature_branch_ahead_of_origin_is_current(self, tmp_path: Path) -> None:
+        """A feature branch with commits on top of origin/main is NOT stale."""
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _git(clone, "checkout", "-b", "feature")
+        (clone / "f.txt").write_text("local-work\n")
+        _git(clone, "add", "f.txt")
+        _git(clone, "commit", "-m", "local")
+        require_current_clones([("repo", clone)])
+        assert clones_behind_default([("repo", clone)]) == []
+
+
+class TestClonesStale:
+    def test_clones_behind_default_returns_count_when_stale(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        # Remote advances 3 commits; the clone is now 3 behind.
+        _advance_remote(tmp_path, bare, n=3)
+
+        staleness = clones_behind_default([("repo", clone)])
+
+        assert len(staleness) == 1
+        assert staleness[0].name == "repo"
+        assert staleness[0].behind == 3
+        assert staleness[0].default_branch == "main"
+
+    def test_require_current_clones_raises_actionable_error(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _advance_remote(tmp_path, bare, n=2)
+
+        with pytest.raises(StaleCloneError) as exc:
+            require_current_clones([("repo", clone)])
+
+        message = str(exc.value)
+        assert "2 commit" in message
+        assert "behind origin/main" in message
+        assert "refusing to investigate stale code" in message
+        assert "sync first" in message
+        assert "git pull --ff-only" in message or "t3 update" in message
+
+    def test_feature_branch_diverged_from_advanced_origin_is_stale(self, tmp_path: Path) -> None:
+        """origin/main advanced past the feature branch point."""
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _git(clone, "checkout", "-b", "feature")
+        (clone / "f.txt").write_text("local-work\n")
+        _git(clone, "add", "f.txt")
+        _git(clone, "commit", "-m", "local")
+        # Now advance origin/main past the branch point
+        _advance_remote(tmp_path, bare, n=1)
+
+        with pytest.raises(StaleCloneError):
+            require_current_clones([("repo", clone)])
+
+    def test_doctor_surface_fails_and_names_repos(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _advance_remote(tmp_path, bare, n=4)
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            ok = doctor_check_clone_currency([("repo", clone)])
+
+        assert ok is False
+        out = buffer.getvalue()
+        assert "FAIL" in out
+        assert "repo" in out
+        assert "behind origin/main" in out
+
+
+class TestEdgeCases:
+    def test_skips_repo_without_origin(self, tmp_path: Path) -> None:
+        """A clone without origin/HEAD is skipped silently."""
+        seed = tmp_path / "no-origin"
+        seed.mkdir()
+        _git(seed, "init", "-b", "main")
+        _git(seed, "config", "user.email", "t@e.st")  # privacy-scan:allow
+        _git(seed, "config", "user.name", "Tester")
+        (seed / "f.txt").write_text("v1\n")
+        _git(seed, "add", "f.txt")
+        _git(seed, "commit", "-m", "initial")
+        # No origin remote at all.
+        require_current_clones([("repo", seed)])  # must not raise
+
+    def test_doctor_check_passes_when_all_current(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        assert doctor_check_clone_currency([("repo", clone)]) is True
+
+
+class TestDoctorAggregation:
+    """Doctor check aggregates the clone-currency surface."""
+
+    def test_doctor_check_calls_clone_currency_surface(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _advance_remote(tmp_path, bare, n=2)
+
+        # Steer `doctor_check_clone_currency()` (called with no args by the
+        # aggregator) at this stale clone via the `_collect_repos` indirection
+        # the function uses when `repos is None`. No mock — real `git` under
+        # `tmp_path` runs the full fetch + ancestor check.
+        monkeypatch.setattr(
+            "teatree.cli.update._collect_repos",
+            lambda: [("repo", clone)],
+        )
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            # `_check_singletons` / `_ensure_plugin_registered` are real-env
+            # side-effects we tolerate — only the clone-currency aggregation
+            # is what we pin here.
+            try:
+                ok = doctor_mod.check()
+            except SystemExit as exc:  # typer may sys.exit on FAIL
+                ok = exc.code == 0
+
+        out = buffer.getvalue()
+        assert ok is False
+        assert "behind origin/main" in out
+        assert "t3 update" in out
+
+
+class TestDefensiveBranches:
+    """Defensive skip paths are silent (no false-positive blocks)."""
+
+    def test_clone_with_origin_remote_but_no_origin_head_is_skipped(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An unresolvable origin/HEAD is silently skipped."""
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        monkeypatch.setattr(clone_guard, "_default_branch", lambda repo: None)
+        assert clones_behind_default([("repo", clone)]) == []
+
+    def test_path_that_is_not_a_directory_is_skipped(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist"
+        assert clones_behind_default([("ghost", missing)]) == []
+        require_current_clones([("ghost", missing)])  # must not raise
+
+    def test_fetch_failure_is_treated_as_inconclusive_skip(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Failed fetch is an inconclusive skip, not a block."""
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _advance_remote(tmp_path, bare, n=3)
+
+        monkeypatch.setattr(clone_guard, "_fetch_origin", lambda repo: False)
+        assert clone_guard.clones_behind_default([("repo", clone)]) == []


### PR DESCRIPTION
## Summary

Adds `teatree.core.clone_guard` — a deterministic session-start gate that refuses to proceed when any registered clone is behind `origin/<default>`. Mirrors the `schema_guard` (#869) pattern: fetch every in-scope repo, assert `origin/<default>` is an ancestor of `HEAD`, raise an actionable `StaleCloneError` (quoting `t3 update` / `git pull --ff-only` remediation) if not. Wired into `t3 doctor check` so the gap surfaces at session start instead of mid-investigation.

Forecloses a real failure mode: a bug-investigation sub-agent that begins root-causing against a clone many commits behind `origin/<default>` forms an initially-wrong root-cause hypothesis on phantom symptoms before re-fetching.

Distinct from #940 (post-implementation branch-currency on PR branches); this is the *entry-point* gate before any investigation reads source.

## Implementation notes

- `clones_behind_default(repos)` → `list[CloneStaleness]` — fetches each repo, counts `HEAD..origin/<default>` commits.
- `require_current_clones(repos)` → fail-closed with multi-line actionable message.
- `doctor_check_clone_currency(repos)` → `t3 doctor check` surface (returns False + prints `FAIL` per stale clone).
- Offline fetches, missing `origin/HEAD`, and non-directory paths each yield a silent skip (no false-positive blocks) — same posture as schema_guard's DB-offline WARN.
- CLI passes the repo list explicitly via `_collect_repos()` to respect the tach module boundary (core cannot import cli).

## Tests

13 tests under `tests/teatree_core/test_clone_guard.py`, real `git init` repos under `tmp_path` (no mocking of `git` or subprocess). Coverage on `clone_guard.py`: **93.5%**.

- Current clones (in-sync, feature branch ahead) → no-op.
- Stale clones → correct count, actionable error message, doctor `FAIL` surface.
- Feature branch diverged from advanced origin → stale.
- Defensive skips: no origin remote, missing `origin/HEAD`, fetch failure, non-directory path.
- Integration: `t3 doctor check` aggregates the clone-currency surface and exits non-zero.

Closes #948