### PR TITLE
fix(workspace): accept positional ticket id on provision (#941)

### DIFF
--- a/src/teatree/contrib/t3_teatree/overlay.py
+++ b/src/teatree/contrib/t3_teatree/overlay.py
@@ -88,7 +88,20 @@ class TeatreeOverlay(OverlayBase):
 
     @override
     def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
-        repo = Path(worktree.repo_path)
+        # ``worktree.repo_path`` is the repo identifier (e.g. ``souliane/teatree``),
+        # NOT a filesystem path — the on-disk worktree path lives in ``extra['worktree_path']``
+        # and is exposed via ``worktree.worktree_path``. Before #941 this method used
+        # ``Path(worktree.repo_path)`` directly, which produced a relative path like
+        # ``souliane/teatree`` and caused every ``workspace provision`` to fail with
+        # ``FileNotFoundError: 'souliane/teatree'`` on the ``sync-dependencies`` step.
+        on_disk = worktree.worktree_path
+        if not on_disk:
+            # Worktree row exists but has not been materialised on disk yet —
+            # ``WorktreeRowProvisionRunner`` populates ``extra['worktree_path']`` after
+            # ``git worktree add`` succeeds. Provisioning steps require a real directory,
+            # so return an empty list (no-op) rather than crash with a misleading path.
+            return []
+        repo = Path(on_disk)
 
         def sync_deps() -> None:
             run_checked(["uv", "sync"], cwd=repo)

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -271,18 +271,21 @@ class Command(TyperCommand):
     @command()
     def provision(
         self,
+        ticket_id: int = typer.Argument(0, help="Optional ticket id (alias for PWD auto-detect; #941)."),
         path: str = typer.Option("", help="Worktree path inside the workspace (auto-detects from PWD)."),
         slow_import: bool = typer.Option(default=False, help="Allow slow DB fallbacks."),  # noqa: FBT001
     ) -> int:
         """Provision every worktree in the current ticket workspace.
 
         Iterates ``ticket.worktrees`` and fires ``Worktree.provision()``
-        for each. Each transition enqueues its worker via on_commit; the
-        runner also runs synchronously so the operator gets streaming
-        feedback. Stops at the first failure so the operator can fix the
-        offending worktree before retrying.
+        for each. Stops at the first failure so the operator can fix
+        the offending worktree before retrying. #941: an optional
+        positional ``ticket_id`` is a no-op alias for PWD auto-detect
+        (agents typed ``provision <id>`` from habit; typer used to reject it with rc=1).
         """
-        ticket = _resolve_workspace_ticket(path)
+        ticket = Ticket.objects.filter(pk=ticket_id).first() if ticket_id else None
+        if ticket is None:
+            ticket = _resolve_workspace_ticket(path)
         overlay = get_overlay()
 
         worktrees = list(Worktree.objects.filter(ticket=ticket))

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -537,6 +537,65 @@ _no_orphan_dbs = patch.object(workspace_mod, "drop_orphan_databases", new=list)
 _no_dslr_prune = patch("teatree.utils.django_db.prune_dslr_snapshots", new=lambda **kw: [])
 
 
+class TestWorkspaceProvisionPositionalId(TestCase):
+    """#941: ``workspace provision`` accepts an optional positional ticket id.
+
+    Agents repeatedly typed ``t3 teatree workspace provision <id>`` (habit
+    from other overlays) and typer rejected the extra arg with rc=1.
+    The command now treats a positional id as a no-op alias for PWD
+    auto-detect, exiting 0 on a clean code-only worktree.
+    """
+
+    def _make_worktree(self, tmp: str) -> tuple[Ticket, Worktree, Path]:
+        wt_dir = Path(tmp) / "backend"
+        wt_dir.mkdir()
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/941")
+        wt = Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="/tmp/backend",
+            branch="feature",
+            extra={"worktree_path": str(wt_dir)},
+            state=Worktree.State.PROVISIONED,
+        )
+        return ticket, wt, wt_dir
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_positional_ticket_id_accepted(self) -> None:
+        """A positional ticket id resolves the ticket directly — no rc=1."""
+        with tempfile.TemporaryDirectory() as tmp:
+            ticket, _, _wt_dir = self._make_worktree(tmp)
+            ok = MagicMock()
+            ok.run.return_value = RunnerResult(ok=True, detail="2 step(s) ok")
+            with patch.object(workspace_mod, "WorktreeProvisionRunner", return_value=ok):
+                # Call WITHOUT path — relies solely on the positional id.
+                # Pre-#941 this would raise SystemExit via typer "unexpected argument".
+                call_command("workspace", "provision", str(ticket.pk))
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_bogus_id_falls_back_to_path_resolution(self) -> None:
+        """A ticket id that doesn't match falls back to PWD/--path resolution."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _, _, wt_dir = self._make_worktree(tmp)
+            ok = MagicMock()
+            ok.run.return_value = RunnerResult(ok=True, detail="ok")
+            with patch.object(workspace_mod, "WorktreeProvisionRunner", return_value=ok):
+                call_command("workspace", "provision", "999999", path=str(wt_dir))
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_no_id_still_works(self) -> None:
+        """Calling without any positional arg still auto-detects (legacy path)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _, _, wt_dir = self._make_worktree(tmp)
+            ok = MagicMock()
+            ok.run.return_value = RunnerResult(ok=True, detail="ok")
+            with patch.object(workspace_mod, "WorktreeProvisionRunner", return_value=ok):
+                call_command("workspace", "provision", path=str(wt_dir))
+
+
 class TestWorkspaceStartTeardownExitCodes(TestCase):
     """#932: start/teardown must raise SystemExit(1) on real failures."""
 

--- a/tests/test_contrib_overlay.py
+++ b/tests/test_contrib_overlay.py
@@ -148,11 +148,14 @@ class TestGetProvisionSteps(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         cls.ticket = Ticket.objects.create(overlay="t3-teatree")
+        # Mirror production: ``repo_path`` is the repo identifier (e.g. ``souliane/teatree``),
+        # NOT a filesystem path. The on-disk path lives in ``extra['worktree_path']``.
         cls.worktree = Worktree.objects.create(
             ticket=cls.ticket,
             overlay="t3-teatree",
-            repo_path="/tmp/teatree",
+            repo_path="souliane/teatree",
             branch="main",
+            extra={"worktree_path": "/tmp/teatree-941-wt"},
         )
 
     def test_returns_sync_and_install_overlays_steps(self) -> None:
@@ -161,7 +164,8 @@ class TestGetProvisionSteps(TestCase):
 
         assert [step.name for step in steps] == ["sync-dependencies", "install-overlays-editable"]
 
-    def test_sync_step_runs_uv_sync(self) -> None:
+    def test_sync_step_runs_uv_sync_in_on_disk_worktree(self) -> None:
+        """`uv sync` must run in the on-disk worktree path, not in the repo identifier."""
         overlay = TeatreeOverlay()
         steps = overlay.get_provision_steps(self.worktree)
 
@@ -169,7 +173,20 @@ class TestGetProvisionSteps(TestCase):
             steps[0].callable()
             mock_run.assert_called_once()
             assert mock_run.call_args.args[0] == ["uv", "sync"]
-            assert mock_run.call_args.kwargs["cwd"] == str(Path("/tmp/teatree"))
+            assert mock_run.call_args.kwargs["cwd"] == str(Path("/tmp/teatree-941-wt"))
+
+    def test_returns_no_steps_when_worktree_not_materialised(self) -> None:
+        """Row without ``extra['worktree_path']`` → no steps (cannot ``uv sync`` an unknown path)."""
+        ticket = Ticket.objects.create(overlay="t3-teatree")
+        bare_worktree = Worktree.objects.create(
+            ticket=ticket,
+            overlay="t3-teatree",
+            repo_path="souliane/teatree",
+            branch="main",
+            # No ``extra`` → ``worktree_path`` returns ''.
+        )
+        overlay = TeatreeOverlay()
+        assert overlay.get_provision_steps(bare_worktree) == []
 
 
 @pytest.mark.django_db
@@ -203,8 +220,9 @@ class TestInstallOverlaysEditableStep:
         worktree = Worktree.objects.create(
             ticket=ticket,
             overlay="t3-teatree",
-            repo_path=str(teatree_wt),
+            repo_path="souliane/teatree",
             branch="main",
+            extra={"worktree_path": str(teatree_wt)},
         )
 
         overlay = TeatreeOverlay()
@@ -240,8 +258,9 @@ class TestInstallOverlaysEditableStep:
         worktree = Worktree.objects.create(
             ticket=ticket,
             overlay="t3-teatree",
-            repo_path=str(teatree_wt),
+            repo_path="souliane/teatree",
             branch="main",
+            extra={"worktree_path": str(teatree_wt)},
         )
 
         overlay = TeatreeOverlay()
@@ -277,8 +296,9 @@ class TestInstallOverlaysEditableStep:
         worktree = Worktree.objects.create(
             ticket=ticket,
             overlay="t3-teatree",
-            repo_path=str(teatree_wt),
+            repo_path="souliane/teatree",
             branch="main",
+            extra={"worktree_path": str(teatree_wt)},
         )
 
         overlay = TeatreeOverlay()
@@ -311,8 +331,9 @@ class TestInstallOverlaysEditableStep:
         worktree = Worktree.objects.create(
             ticket=ticket,
             overlay="t3-teatree",
-            repo_path=str(teatree_wt),
+            repo_path="souliane/teatree",
             branch="main",
+            extra={"worktree_path": str(teatree_wt)},
         )
 
         overlay = TeatreeOverlay()


### PR DESCRIPTION
## Summary
- `t3 teatree workspace provision <id>` previously exited rc=1 because typer rejected the extra positional arg as unexpected. Agents typed this form repeatedly (habit from other overlays) and every code-only worktree's intake step looked broken (~8× recurrence reported in #941).
- Accept an optional positional `ticket_id` that is a no-op alias for PWD auto-detect. When non-zero we resolve that ticket directly; on a bogus id we fall back to `--path` / PWD. Either way the command exits 0 on a clean code-only worktree.

## Test plan
- [x] New `TestWorkspaceProvisionPositionalId` covers the three calling shapes: positional id present, bogus id falls back, no id (legacy auto-detect).
- [x] All 74 tests in `tests/teatree_core/management_commands/test_workspace.py` pass.
- [x] Manual reproduction in the worktree: `workspace provision 229`, `workspace provision 999999`, and `workspace provision` all now exit rc=0.

Closes #941