### PR TITLE
fix(loop): reap orphaned reviewing tasks for merged-out MRs (#998)

### DIFF
--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -115,6 +115,13 @@ _DUAL_DISPATCH: frozenset[str] = frozenset(
 _MECHANICAL_BY_KIND: dict[str, tuple[ActionKind, str]] = {
     "ticket.completion_detected": ("mechanical", "ticket_completion"),
     "ticket.reopen_needed": ("mechanical", "ticket_reopen"),
+    # #998: a reviewer-role ticket's PENDING/CLAIMED reviewing task can be
+    # orphaned when the underlying MR is merged externally before the slot
+    # processes it — the ``state=opened`` API no longer returns the MR, so
+    # the dedup paths in persistence cannot fire and the task lingers
+    # forever. The mechanical handler completes the task so
+    # ``pending-spawn`` stops surfacing it every tick.
+    "reviewer_pr.task_orphaned": ("mechanical", "reviewer_task_orphaned"),
     "notion.unrouted": ("webhook", "n8n"),
 }
 

--- a/src/teatree/loop/mechanical.py
+++ b/src/teatree/loop/mechanical.py
@@ -62,8 +62,50 @@ def reopen_ticket(payload: ActionPayload) -> None:
     logger.info("Auto-reopened ticket %s (was %s, draft MRs detected)", ticket_id, payload.get("ticket_state", "?"))
 
 
+def reviewer_task_orphaned(payload: ActionPayload) -> None:
+    """Complete every open reviewing task on the orphaned reviewer ticket (#998).
+
+    The scanner emits this signal when a reviewer-role ticket has a
+    non-terminal reviewing task whose URL is no longer in the ``state=opened``
+    API response — the underlying MR was merged or closed externally before
+    the slot processed the task. Without this sweep the PENDING task lingers
+    forever, surfacing on every ``pending-spawn`` and dispatching a reviewer
+    sub-agent for nothing.
+
+    The handler is intentionally narrow: it operates by ticket id and only
+    completes tasks in ``phase=reviewing`` with non-terminal status. Other
+    tasks on the same ticket (or other phases) are untouched. Best-effort —
+    a missing ticket or already-completed tasks no-op silently.
+    """
+    from django.apps import apps  # noqa: PLC0415
+
+    from teatree.core.models.task import Task  # noqa: PLC0415
+
+    ticket_model = apps.get_model("core", "Ticket")
+    ticket_id = payload.get("ticket_id")
+    if ticket_id is None:
+        return
+    try:
+        ticket = ticket_model.objects.get(pk=ticket_id)
+    except ticket_model.DoesNotExist:
+        return
+    open_tasks = Task.objects.pending_in_phase("reviewing").filter(ticket=ticket)
+    completed = 0
+    for task in open_tasks:
+        task.complete()
+        completed += 1
+    if completed:
+        logger.info(
+            "Auto-completed %d orphaned reviewing task(s) on ticket %s (MR %s no longer open)",
+            completed,
+            ticket_id,
+            payload.get("url", "?"),
+        )
+
+
 HANDLERS: dict[str, Callable[[ActionPayload], None]] = {
     "ticket_disposition": ignore_disposed_ticket,
     "ticket_completion": complete_ticket,
     "ticket_reopen": reopen_ticket,
+    "reviewer_task_orphaned": reviewer_task_orphaned,
 }

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -155,6 +155,50 @@ def _pr_url(pr: RawAPIDict) -> str:
     return ""
 
 
+def _orphaned_task_signals(
+    ticket_model: "TicketModel | None",
+    scanned_urls: set[str],
+) -> list[ScanSignal]:
+    """Emit ``reviewer_pr.task_orphaned`` for stuck PENDING/CLAIMED tasks (#998).
+
+    Scenario the loop hit: scanner sees an open MR on tick #1 → persistence
+    creates ``Ticket(role=reviewer)`` + ``Task(phase=reviewing,
+    status=PENDING)``. The MR is merged externally before the slot processes
+    the task. On tick #2 the ``state=opened`` API no longer returns the MR,
+    so neither the dedup ``_has_open_task`` path nor the
+    ``_already_reviewed_at_head`` cache hit can ever fire — and the PENDING
+    task lingers forever, surfacing on every ``pending-spawn``. This sweep
+    closes that window: any reviewer-role ticket with a non-terminal
+    reviewing task whose URL is absent from the current scan gets a
+    ``task_orphaned`` signal so the mechanical handler can complete the
+    task and unblock the loop.
+    """
+    if ticket_model is None:
+        return []
+    # Local import to keep the Django dependency lazy (mirrors _ticket_model).
+    from teatree.core.models.task import Task  # noqa: PLC0415
+
+    open_statuses = (Task.Status.PENDING, Task.Status.CLAIMED)
+    candidates = (
+        ticket_model.objects.filter(
+            role="reviewer",
+            tasks__phase="reviewing",
+            tasks__status__in=open_statuses,
+        )
+        .exclude(issue_url="")
+        .exclude(issue_url__in=scanned_urls)
+        .distinct()
+    )
+    return [
+        ScanSignal(
+            kind="reviewer_pr.task_orphaned",
+            summary=f"Reviewing task orphaned (MR no longer open): {ticket.issue_url}",
+            payload={"url": ticket.issue_url, "ticket_id": ticket.pk},
+        )
+        for ticket in candidates
+    ]
+
+
 def _is_dismissed_from_approved(previous: str, current: ReviewState) -> bool:
     """Did the reviewer's prior APPROVED status get invalidated?
 
@@ -199,10 +243,12 @@ class ReviewerPrsScanner:
         cache = _read_cache()
         ticket_model = _ticket_model()
         signals: list[ScanSignal] = []
+        scanned_urls: set[str] = set()
         for pr in prs:
             url = _pr_url(pr)
             if not url:
                 continue
+            scanned_urls.add(url)
             head = _head_sha(pr)
             previous = cache.get(url, CacheEntry())
             if previous.sha and previous.sha != head:
@@ -245,6 +291,7 @@ class ReviewerPrsScanner:
                 )
             if current.value != previous.state and ticket_model is not None:
                 _persist_entry(ticket_model, url, CacheEntry(sha=previous.sha, state=current.value))
+        signals.extend(_orphaned_task_signals(ticket_model, scanned_urls))
         return signals
 
     def _resolve_identities(self) -> tuple[str, ...]:

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -158,6 +158,7 @@ def _pr_url(pr: RawAPIDict) -> str:
 def _orphaned_task_signals(
     ticket_model: "TicketModel | None",
     scanned_urls: set[str],
+    overlay: str = "",
 ) -> list[ScanSignal]:
     """Emit ``reviewer_pr.task_orphaned`` for stuck PENDING/CLAIMED tasks (#998).
 
@@ -172,6 +173,15 @@ def _orphaned_task_signals(
     reviewing task whose URL is absent from the current scan gets a
     ``task_orphaned`` signal so the mechanical handler can complete the
     task and unblock the loop.
+
+    The scanner runs once per (overlay, code-host) pair in ``tick.py``, so
+    the orphan sweep must be scoped to the scanner's own overlay — otherwise
+    a GitHub scanner pass would sweep GitLab reviewer-role tickets too (and
+    vice versa), silently completing legitimate cross-host review tasks
+    because their URLs aren't in the GitHub scan's ``scanned_urls``. When
+    *overlay* is non-empty we restrict the candidate query to that overlay;
+    when empty (the fallback single-overlay path with no tag), the legacy
+    unscoped behaviour is preserved.
     """
     if ticket_model is None:
         return []
@@ -179,16 +189,14 @@ def _orphaned_task_signals(
     from teatree.core.models.task import Task  # noqa: PLC0415
 
     open_statuses = (Task.Status.PENDING, Task.Status.CLAIMED)
-    candidates = (
-        ticket_model.objects.filter(
-            role="reviewer",
-            tasks__phase="reviewing",
-            tasks__status__in=open_statuses,
-        )
-        .exclude(issue_url="")
-        .exclude(issue_url__in=scanned_urls)
-        .distinct()
+    candidates = ticket_model.objects.filter(
+        role="reviewer",
+        tasks__phase="reviewing",
+        tasks__status__in=open_statuses,
     )
+    if overlay:
+        candidates = candidates.filter(overlay=overlay)
+    candidates = candidates.exclude(issue_url="").exclude(issue_url__in=scanned_urls).distinct()
     return [
         ScanSignal(
             kind="reviewer_pr.task_orphaned",
@@ -224,10 +232,16 @@ class ReviewerPrsScanner:
     where any alias is a requested reviewer. Per-alias dedup-by-url keeps
     a PR that hits two queries from being scanned twice. Empty falls back
     to ``host.current_user()`` (#976).
+
+    ``overlay_name`` scopes the orphan-task sweep to reviewer-role tickets
+    belonging to this overlay. Required when running side-by-side scanners
+    for multiple overlays/hosts in one tick — a GitHub scanner must not
+    sweep GitLab reviewer tickets (#998).
     """
 
     host: CodeHostBackend
     identities: tuple[str, ...] = field(default_factory=tuple)
+    overlay_name: str = ""
     name: str = "reviewer_prs"
     _migrated: bool = field(default=False, init=False)
 
@@ -291,7 +305,7 @@ class ReviewerPrsScanner:
                 )
             if current.value != previous.state and ticket_model is not None:
                 _persist_entry(ticket_model, url, CacheEntry(sha=previous.sha, state=current.value))
-        signals.extend(_orphaned_task_signals(ticket_model, scanned_urls))
+        signals.extend(_orphaned_task_signals(ticket_model, scanned_urls, self.overlay_name))
         return signals
 
     def _resolve_identities(self) -> tuple[str, ...]:

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -102,7 +102,11 @@ def _jobs_for_backend_hosts(backend: OverlayBackends, tag: str) -> list[_Scanner
                     overlay=tag,
                 ),
                 _ScannerJob(
-                    scanner=ReviewerPrsScanner(host=code_host, identities=backend.identities),
+                    scanner=ReviewerPrsScanner(
+                        host=code_host,
+                        identities=backend.identities,
+                        overlay_name=tag,
+                    ),
                     overlay=tag,
                 ),
                 _ScannerJob(

--- a/tests/teatree_loop/test_dispatch.py
+++ b/tests/teatree_loop/test_dispatch.py
@@ -46,6 +46,19 @@ def test_notion_unrouted_routes_to_webhook() -> None:
     assert actions[0].zone == "n8n"
 
 
+def test_reviewer_pr_task_orphaned_routes_to_mechanical_handler() -> None:
+    """#998: scanner-emitted orphan signal dispatches to the cleanup handler."""
+    payload: dict[str, object] = {
+        "url": "https://gitlab/x/-/merge_requests/373",
+        "ticket_id": 42,
+    }
+    actions = dispatch([ScanSignal(kind="reviewer_pr.task_orphaned", summary="orphan", payload=payload)])
+    assert len(actions) == 1
+    assert actions[0].kind == "mechanical"
+    assert actions[0].zone == "reviewer_task_orphaned"
+    assert actions[0].payload == payload
+
+
 def test_unknown_kind_falls_back_to_in_flight() -> None:
     actions = dispatch([ScanSignal(kind="custom.signal", summary="Custom")])
     assert actions[0].kind == "statusline"

--- a/tests/teatree_loop/test_mechanical.py
+++ b/tests/teatree_loop/test_mechanical.py
@@ -4,9 +4,15 @@ from typing import cast
 
 from django.test import TestCase
 
-from teatree.core.models import Ticket
+from teatree.core.models import Session, Task, Ticket
 from teatree.loop.dispatch import ActionPayload
-from teatree.loop.mechanical import HANDLERS, complete_ticket, ignore_disposed_ticket, reopen_ticket
+from teatree.loop.mechanical import (
+    HANDLERS,
+    complete_ticket,
+    ignore_disposed_ticket,
+    reopen_ticket,
+    reviewer_task_orphaned,
+)
 
 
 def _payload(**kwargs: object) -> ActionPayload:
@@ -56,8 +62,55 @@ class TestReopenTicket(TestCase):
         reopen_ticket(_payload(ticket_state="?"))
 
 
+class TestReviewerTaskOrphaned(TestCase):
+    """#998: complete the orphaned reviewing task when MR is merged externally."""
+
+    def _make_reviewer_ticket_with_pending_task(self, url: str) -> tuple[Ticket, Task]:
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            issue_url=url,
+            overlay="acme",
+            extra={"reviewed_sha": "abc"},
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="external-review")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Review needed",
+        )
+        return ticket, task
+
+    def test_completes_pending_reviewing_task(self) -> None:
+        ticket, task = self._make_reviewer_ticket_with_pending_task("https://x/-/merge_requests/373")
+
+        reviewer_task_orphaned(_payload(ticket_id=ticket.pk, url=ticket.issue_url))
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+
+    def test_no_op_when_ticket_id_missing(self) -> None:
+        reviewer_task_orphaned(_payload(url="https://x/-/merge_requests/1"))  # must not raise
+
+    def test_no_op_when_ticket_does_not_exist(self) -> None:
+        reviewer_task_orphaned(_payload(ticket_id=99999, url="https://x/-/merge_requests/1"))
+
+    def test_idempotent_on_already_completed_task(self) -> None:
+        ticket, task = self._make_reviewer_ticket_with_pending_task("https://x/-/merge_requests/374")
+        task.status = Task.Status.COMPLETED
+        task.save(update_fields=["status"])
+
+        # No open task to complete — handler is a no-op.
+        reviewer_task_orphaned(_payload(ticket_id=ticket.pk, url=ticket.issue_url))
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+
+
 class TestHandlersRegistry:
     def test_registry_maps_kind_to_handler(self) -> None:
         assert HANDLERS["ticket_disposition"] is ignore_disposed_ticket
         assert HANDLERS["ticket_completion"] is complete_ticket
         assert HANDLERS["ticket_reopen"] is reopen_ticket
+        assert HANDLERS["reviewer_task_orphaned"] is reviewer_task_orphaned

--- a/tests/teatree_loop/test_scanners.py
+++ b/tests/teatree_loop/test_scanners.py
@@ -377,6 +377,138 @@ class TestReviewerPrsScanner(TestCase):
         assert ticket.extra["reviewed_sha"] == "abc"
         assert ticket.extra["last_review_state"] == ReviewState.APPROVED.value
 
+    def test_orphaned_pending_task_for_merged_mr_emits_orphaned_signal(self) -> None:
+        """A PENDING reviewing task whose MR was merged externally is reaped (#998).
+
+        Scenario: scanner sees MR X (open) on tick #1 → persistence creates
+        Ticket(role=reviewer) + Task(phase=reviewing, status=PENDING). Before
+        the slot processes the task, the MR is merged externally. On tick #2
+        the API (state=opened) no longer returns the MR. Pre-fix, the PENDING
+        task lingers forever and ``pending-spawn`` keeps surfacing it,
+        dispatching a reviewer sub-agent every tick for nothing.
+
+        Post-fix: the scanner emits ``reviewer_pr.task_orphaned`` for every
+        reviewer-role ticket with a non-terminal reviewing Task whose URL is
+        absent from the current open-MR scan. A mechanical handler completes
+        the task so ``pending-spawn`` stops returning it.
+        """
+        from teatree.core.models import Session, Task  # noqa: PLC0415
+
+        url = "https://gitlab/x/-/merge_requests/373"
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            issue_url=url,
+            overlay="acme",
+            extra={"reviewed_sha": "abc"},
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="external-review")
+        Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Review needed",
+        )
+
+        # API no longer returns the MR — it was merged externally.
+        host = FakeCodeHost(user="alice", review_requested_prs=[])
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+
+        assert [s.kind for s in signals] == ["reviewer_pr.task_orphaned"]
+        assert signals[0].payload["url"] == url
+        assert signals[0].payload["ticket_id"] == ticket.pk
+
+    def test_orphaned_signal_not_emitted_when_mr_still_in_scan(self) -> None:
+        """If the MR is still in the API response, no orphaning happens (#998)."""
+        from teatree.core.models import Session, Task  # noqa: PLC0415
+
+        url = "https://gitlab/x/-/merge_requests/374"
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            issue_url=url,
+            overlay="acme",
+            extra={"reviewed_sha": "abc"},
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="external-review")
+        Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Review needed",
+        )
+
+        # API still returns the MR with the same SHA → no orphan.
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[{"web_url": url, "sha": "abc"}],
+        )
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+
+        # No orphan signal — the task is for a still-open MR.
+        assert "reviewer_pr.task_orphaned" not in [s.kind for s in signals]
+
+    def test_orphaned_signal_not_emitted_for_completed_task(self) -> None:
+        """A COMPLETED reviewing task is not re-orphaned (#998)."""
+        from teatree.core.models import Session, Task  # noqa: PLC0415
+
+        url = "https://gitlab/x/-/merge_requests/375"
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            issue_url=url,
+            overlay="acme",
+            extra={"reviewed_sha": "abc", "last_review_state": ReviewState.APPROVED.value},
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="external-review")
+        Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Review needed",
+            status=Task.Status.COMPLETED,
+        )
+
+        host = FakeCodeHost(user="alice", review_requested_prs=[])
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+
+        # No orphan signal — the task is already terminal.
+        assert "reviewer_pr.task_orphaned" not in [s.kind for s in signals]
+
+    def test_orphaned_signal_skipped_when_no_reviewer_resolvable(self) -> None:
+        """No active reviewer identity → no scan, no orphan detection (#998).
+
+        When ``current_user()`` returns empty and no explicit identities are
+        configured, the scanner cannot tell whether the missing MR is
+        genuinely closed/merged or simply unqueryable. Fail open: don't reap.
+        """
+        from teatree.core.models import Session, Task  # noqa: PLC0415
+
+        url = "https://gitlab/x/-/merge_requests/376"
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            issue_url=url,
+            overlay="acme",
+            extra={"reviewed_sha": "abc"},
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="external-review")
+        Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Review needed",
+        )
+
+        host = FakeCodeHost(user="")  # no resolvable identity
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+
+        assert signals == []
+
     def test_legacy_json_cache_is_imported_then_deleted(self) -> None:
         """First scan migrates the legacy JSON file into reviewer tickets, then unlinks it."""
         import shutil  # noqa: PLC0415

--- a/tests/teatree_loop/test_scanners.py
+++ b/tests/teatree_loop/test_scanners.py
@@ -509,6 +509,95 @@ class TestReviewerPrsScanner(TestCase):
 
         assert signals == []
 
+    def test_orphan_sweep_scoped_to_scanner_overlay(self) -> None:
+        """Orphan sweep must not cross overlay boundaries (#998 tightening).
+
+        Two reviewer-role tickets on different overlays (e.g. GitHub vs.
+        GitLab scanners) — running the scanner for one overlay must NOT
+        emit an orphan signal for the other overlay's ticket, even though
+        the other URL is absent from this scan's ``scanned_urls``.
+        """
+        from teatree.core.models import Session, Task  # noqa: PLC0415
+
+        own_url = "https://github.com/o/r/pull/501"
+        other_url = "https://gitlab/x/-/merge_requests/502"
+        own_ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            issue_url=own_url,
+            overlay="github-overlay",
+            extra={"reviewed_sha": "abc"},
+        )
+        other_ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            issue_url=other_url,
+            overlay="gitlab-overlay",
+            extra={"reviewed_sha": "def"},
+        )
+        for ticket in (own_ticket, other_ticket):
+            session = Session.objects.create(ticket=ticket, agent_id="external-review")
+            Task.objects.create(
+                ticket=ticket,
+                session=session,
+                phase="reviewing",
+                execution_target=Task.ExecutionTarget.HEADLESS,
+                execution_reason="Review needed",
+            )
+
+        # Run the scanner scoped to github-overlay only; API returns nothing.
+        host = FakeCodeHost(user="alice", review_requested_prs=[])
+        scanner = ReviewerPrsScanner(host=host, overlay_name="github-overlay")
+        signals = scanner.scan()
+
+        # Exactly one orphan signal — only the github-overlay ticket. The
+        # gitlab-overlay ticket is invisible to this scanner pass.
+        orphan_urls = [s.payload["url"] for s in signals if s.kind == "reviewer_pr.task_orphaned"]
+        assert orphan_urls == [own_url]
+
+    def test_orphan_sweep_unscoped_when_overlay_empty(self) -> None:
+        """Empty overlay_name preserves the legacy unscoped sweep (#998).
+
+        The single-overlay fallback path in tick.py builds the scanner
+        without an overlay tag — for that path the previous unscoped
+        behaviour is preserved (no overlay filter on the candidate query).
+        """
+        from teatree.core.models import Session, Task  # noqa: PLC0415
+
+        urls = ["https://gitlab/x/-/merge_requests/601", "https://github.com/o/r/pull/602"]
+        for idx, url in enumerate(urls):
+            ticket = Ticket.objects.create(
+                role=Ticket.Role.REVIEWER,
+                issue_url=url,
+                overlay=f"overlay-{idx}",
+                extra={"reviewed_sha": "abc"},
+            )
+            session = Session.objects.create(ticket=ticket, agent_id="external-review")
+            Task.objects.create(
+                ticket=ticket,
+                session=session,
+                phase="reviewing",
+                execution_target=Task.ExecutionTarget.HEADLESS,
+                execution_reason="Review needed",
+            )
+
+        host = FakeCodeHost(user="alice", review_requested_prs=[])
+        scanner = ReviewerPrsScanner(host=host)  # overlay_name defaults to ""
+        signals = scanner.scan()
+
+        orphan_urls = sorted(s.payload["url"] for s in signals if s.kind == "reviewer_pr.task_orphaned")
+        assert orphan_urls == sorted(urls)
+
+    def test_orphan_sweep_no_op_when_ticket_model_unavailable(self) -> None:
+        """``_orphaned_task_signals`` returns [] when Django isn't ready (#998 nit 2).
+
+        Guards the defensive ``ticket_model is None`` branch — when the
+        model registry can't be loaded (no Django setup, fresh subprocess),
+        the sweep must skip silently rather than blow up.
+        """
+        from teatree.loop.scanners.reviewer_prs import _orphaned_task_signals  # noqa: PLC0415
+
+        assert _orphaned_task_signals(None, set()) == []
+        assert _orphaned_task_signals(None, {"https://x"}, "any-overlay") == []
+
     def test_legacy_json_cache_is_imported_then_deleted(self) -> None:
         """First scan migrates the legacy JSON file into reviewer tickets, then unlinks it."""
         import shutil  # noqa: PLC0415

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -563,6 +563,80 @@ class TestTickReapsStaleClaims(django.test.TestCase):
         assert stale.claimed_by == ""
 
 
+class TestTickReapsOrphanedReviewingTask(django.test.TransactionTestCase):
+    """#998: a tick reaps a PENDING reviewing task when its MR was merged externally.
+
+    End-to-end coverage of the scanner → dispatch → mechanical pipeline:
+    a reviewer-role ticket with a PENDING reviewing task whose URL is not
+    in the current open-MR scan must have its task completed in the SAME
+    tick so ``pending-spawn`` stops re-emitting it.
+
+    Runs the scanner inline (no ``run_tick`` thread pool) so the SQLite
+    test backend doesn't deadlock — ``TestCase``'s outer transaction
+    locks the table the worker thread tries to read, and the unraisable
+    cleanup warning makes the test flaky. The pipeline this validates is
+    a flat handler chain: scanner emits → dispatch routes → mechanical
+    runs; the unit-level tests for each stage are already in
+    ``test_scanners.py`` and ``test_mechanical.py``. This integration
+    test wires them together.
+    """
+
+    def test_pipeline_completes_pending_reviewing_task_for_missing_mr(self) -> None:
+        from teatree.core.models import Session, Task, Ticket  # noqa: PLC0415
+        from teatree.loop.dispatch import dispatch  # noqa: PLC0415
+        from teatree.loop.mechanical import HANDLERS  # noqa: PLC0415
+        from teatree.loop.scanners.reviewer_prs import ReviewerPrsScanner  # noqa: PLC0415
+
+        # The bug scenario: PENDING task survived the MR's external merge.
+        url = "https://gitlab.example.com/x/-/merge_requests/373"
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            issue_url=url,
+            overlay="acme",
+            extra={"reviewed_sha": "abc"},
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="external-review")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Review needed",
+        )
+
+        @dataclass(slots=True)
+        class _ReviewerHost:
+            user_name: str = "alice"
+
+            def current_user(self) -> str:
+                return self.user_name
+
+            def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None):
+                # API no longer returns the merged MR.
+                return []
+
+            def get_review_state(self, *, pr_url: str, reviewer: str):
+                from teatree.backends.protocols import ReviewState  # noqa: PLC0415
+
+                return ReviewState.NONE
+
+        # Step 1: scanner emits the orphan signal.
+        signals = ReviewerPrsScanner(host=_ReviewerHost()).scan()
+        assert any(s.kind == "reviewer_pr.task_orphaned" for s in signals)
+
+        # Step 2: dispatch routes to the mechanical handler.
+        actions = dispatch(signals)
+        orphan_actions = [a for a in actions if a.zone == "reviewer_task_orphaned"]
+        assert len(orphan_actions) == 1
+        assert orphan_actions[0].kind == "mechanical"
+
+        # Step 3: mechanical handler completes the orphaned task.
+        HANDLERS[orphan_actions[0].zone](orphan_actions[0].payload)
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+
+
 class TestTickReplaysOrphanedTransitions(django.test.TestCase):
     def test_run_tick_replays_a_half_advanced_ticket(self) -> None:
         """#883: a tick recovers a ticket left half-advanced by a crash.


### PR DESCRIPTION
fix(loop): reap orphaned reviewing tasks for merged-out MRs (#998)

A reviewer-role ticket whose PENDING/CLAIMED reviewing task survived the
MR's external merge would linger forever: GitLab's state=opened filter
correctly stops returning the MR, so neither _has_open_task nor
_already_reviewed_at_head ever fires, and pending-spawn re-emits the
same task every tick. The scanner now compares the open-MR scan
against reviewer-role tickets with non-terminal reviewing tasks; any
ticket whose URL is absent from the scan emits reviewer_pr.task_orphaned
and a mechanical handler completes the task.

Coverage: scanner emit, mechanical handler completion, dispatch routing,
and the full scanner→dispatch→mechanical pipeline. The single-call sweep
is conservative — fails open when no reviewer identity is resolvable so a
network/auth blip never silently completes real work.