### PR TITLE
fix(loop): guard _apply_phase_transition against already-delivered reviewer tickets (#1000)

### DIFF
--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -185,8 +185,29 @@ class Task(models.Model):
         from teatree.core.phases import normalize_phase  # noqa: PLC0415
 
         phase = normalize_phase(self.phase)
+        # Mirror the FSM source list of mark_reviewed_externally() — guarding
+        # only on ``role == REVIEWER`` is not enough (#1000): the #998/#999
+        # orphan sweep can complete a second reviewing task on a ticket that
+        # already advanced to DELIVERED (or any other terminal state), and an
+        # unconditional FSM call then raises TransitionNotAllowed and crashes
+        # the loop tick. Sibling branches below all guard on ``ticket.state``;
+        # this branch must too. The states enumerated here are exactly the
+        # ``source=[...]`` argument of ``mark_reviewed_externally`` — keep
+        # them in sync if that list ever changes.
+        mark_reviewed_externally_source_states = {
+            Ticket.State.NOT_STARTED,
+            Ticket.State.SCOPED,
+            Ticket.State.STARTED,
+            Ticket.State.CODED,
+            Ticket.State.TESTED,
+            Ticket.State.REVIEWED,
+        }
         with transaction.atomic():
-            if phase == "reviewing" and ticket.role == Ticket.Role.REVIEWER:
+            if (
+                phase == "reviewing"
+                and ticket.role == Ticket.Role.REVIEWER
+                and ticket.state in mark_reviewed_externally_source_states
+            ):
                 ticket.mark_reviewed_externally()
                 ticket.save()
             elif phase == "scoping" and ticket.state == Ticket.State.SCOPED:

--- a/tests/teatree_core/test_task_apply_phase_transition.py
+++ b/tests/teatree_core/test_task_apply_phase_transition.py
@@ -1,0 +1,85 @@
+"""Regression tests for ``Task._apply_phase_transition`` (#1000).
+
+The #998/#999 orphan sweep can mark a second reviewing task COMPLETED on a
+reviewer-role ticket that already advanced to DELIVERED. Without a state
+guard on the ``phase == "reviewing" and role == REVIEWER`` branch the FSM
+raises ``TransitionNotAllowed`` and the loop tick crashes.
+"""
+
+import pytest
+from django.test import TestCase
+from django_fsm import TransitionNotAllowed
+
+from teatree.core.models import Session, Task, Ticket
+
+
+class TestApplyPhaseTransitionGuardsTerminalReviewer(TestCase):
+    """#1000: reviewer-ticket already in DELIVERED must not re-fire the FSM."""
+
+    def test_completed_reviewing_task_on_delivered_ticket_no_ops(self) -> None:
+        # Reviewer-role ticket already advanced through review and is now
+        # DELIVERED (terminal). The #999 orphan sweep then completes a
+        # second reviewing task on the same ticket.
+        ticket = Ticket.objects.create(
+            overlay="test",
+            role=Ticket.Role.REVIEWER,
+            state=Ticket.State.DELIVERED,
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            status=Task.Status.COMPLETED,
+        )
+
+        # Pre-#1000 this raised TransitionNotAllowed and crashed the tick.
+        fired = task._apply_phase_transition()
+
+        ticket.refresh_from_db()
+        assert fired is False, "no transition should fire on a terminal-state reviewer ticket"
+        assert ticket.state == Ticket.State.DELIVERED, f"ticket state must remain DELIVERED, got {ticket.state}"
+
+    def test_reviewer_ticket_in_source_state_still_advances(self) -> None:
+        # Guard must not regress the happy path: a reviewer-role ticket
+        # still in a source state of mark_reviewed_externally() (here
+        # NOT_STARTED, the lowest state on the source list) must advance
+        # to DELIVERED when its reviewing task completes.
+        ticket = Ticket.objects.create(
+            overlay="test",
+            role=Ticket.Role.REVIEWER,
+            state=Ticket.State.NOT_STARTED,
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            status=Task.Status.COMPLETED,
+        )
+
+        fired = task._apply_phase_transition()
+
+        ticket.refresh_from_db()
+        assert fired is True, "reviewer ticket in a source state must advance"
+        assert ticket.state == Ticket.State.DELIVERED
+
+    def test_mark_reviewed_externally_still_raises_when_called_directly_on_delivered(self) -> None:
+        # Sanity: the guard lives in _apply_phase_transition, not in the
+        # FSM. Calling the transition directly on a DELIVERED ticket
+        # still raises — proving the guard is what protects the loop.
+        ticket = Ticket.objects.create(
+            overlay="test",
+            role=Ticket.Role.REVIEWER,
+            state=Ticket.State.DELIVERED,
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            status=Task.Status.COMPLETED,
+        )
+
+        with pytest.raises(TransitionNotAllowed):
+            ticket.mark_reviewed_externally()


### PR DESCRIPTION
## Summary

URGENT hotfix for #1000. `t3 loop tick` crashes on every tick when a reviewer-role ticket is already in a terminal state (e.g. `delivered`) and the #998/#999 orphan sweep completes a second reviewing task on it.

## Regression chain

- #998 fix shipped the orphan reaper.
- #999 introduced the case where a second `reviewing` task can be marked `completed` on a reviewer-role ticket that has already advanced to `DELIVERED`.
- `Task._apply_phase_transition` then runs its `phase == "reviewing" and ticket.role == REVIEWER` branch unconditionally and calls `ticket.mark_reviewed_externally()`.
- The FSM source for that transition is `[NOT_STARTED, SCOPED, STARTED, CODED, TESTED, REVIEWED]` — it does not include any terminal state, so the call raises `TransitionNotAllowed: Can't switch from state 'delivered' using method 'mark_reviewed_externally'` and the whole tick crashes.

## Fix

Add a state guard mirroring the FSM `source=[...]` list on `mark_reviewed_externally`. The shape now matches every sibling branch in `_apply_phase_transition` (each guards on `ticket.state`). The set is enumerated explicitly so a future change to the FSM source list shows up as a structural diff here, not as a silent re-divergence.

## Regression test

Added [`tests/teatree_core/test_task_apply_phase_transition.py`](https://github.com/souliane/teatree/blob/fix/loop-fsm-delivered-guard/tests/teatree_core/test_task_apply_phase_transition.py) with three cases:

1. **The bug** — reviewer ticket in `DELIVERED` + completed reviewing task → `_apply_phase_transition` no-ops, no exception, state stays `DELIVERED`.
2. **Happy path** — reviewer ticket in `NOT_STARTED` + completed reviewing task → still advances to `DELIVERED` (guard does not regress the normal flow).
3. **Sanity** — calling `mark_reviewed_externally()` directly on a `DELIVERED` ticket still raises (proves the guard, not an FSM relaxation, is what protects the loop).

## Mutation verification

Reverted the guard locally → test (1) FAILS with the exact production error: `TransitionNotAllowed: Can't switch from state 'delivered' using method 'mark_reviewed_externally'`. Restored → all three PASS.

## Test plan

- [x] `pytest tests/teatree_core/test_task_apply_phase_transition.py -xvs` — 3 passed
- [x] `pytest tests/teatree_core/test_tasks.py tests/teatree_loop/ tests/teatree_core/models/test_task.py -x -q` — 410 passed (#999 orphan sweep still completes the task; it just no-ops on FSM when the ticket is already terminal)
- [x] Full suite: `pytest --no-cov -x -q` — 4728 passed, 12 skipped
- [x] `ruff check` — clean
- [x] `ty check` — clean
- [x] Mutation verification — confirmed RED → GREEN

## Do not merge

Logic-class fix per blast-class rules. Awaiting CLEAR cold review before merge.