### PR TITLE
fix(cli): bootstrap django before on-behalf-gate model import (#1003)

### DIFF
--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -419,6 +419,17 @@ def _refuse_if_on_behalf_gated() -> None:
 
 
 def _require_token() -> ReviewService:
+    # Bootstrap Django (idempotent) before the on-behalf pre-gate (#960)
+    # touches the ORM. CLI module stays Django-free at import time so
+    # typer can render --help / discover commands; mirrors cli/loop.py.
+    # See souliane/teatree#1003.
+    import os  # noqa: PLC0415
+
+    import django  # noqa: PLC0415
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+    django.setup()
+
     token = ReviewService.get_gitlab_token()
     if not token:
         typer.echo("No GitLab token found. Run: glab auth login")

--- a/src/teatree/cli/review_on_behalf.py
+++ b/src/teatree/cli/review_on_behalf.py
@@ -102,6 +102,13 @@ def register(review_app: typer.Typer) -> None:
         ``(target, action)`` publishes and the row is consumed; an
         audit row records who/what/when.
         """
+        import os  # noqa: PLC0415
+
+        import django  # noqa: PLC0415
+
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+        django.setup()
+
         from teatree.core.models.on_behalf_approval import OnBehalfApproval, OnBehalfApprovalError  # noqa: PLC0415
 
         try:

--- a/src/teatree/core/on_behalf_gate_recorded.py
+++ b/src/teatree/core/on_behalf_gate_recorded.py
@@ -27,9 +27,17 @@ Default ON, fail-closed: an unresolved setting defaults to ON, and ON
 with no approval blocks. The user satisfies the gate **without a TTY** via
 ``t3 review approve-on-behalf <target> <action> --approver <id>`` (the
 #777/#953 interactive-TTY-only anti-pattern is deliberately avoided).
+
+The ORM-model imports (``OnBehalfApproval`` / ``OnBehalfAudit``) live
+inside :func:`require_on_behalf_approval` rather than at module top
+because ``teatree.cli.review_on_behalf.check_on_behalf`` imports this
+module lazily so the ``teatree.cli`` package can be loaded before
+``django.setup()`` runs (typer command discovery, ``--help`` rendering,
+the privacy-scan subprocess). An eager ORM import here would defeat
+the lazy chain and crash the CLI with ``ImproperlyConfigured`` (see
+souliane/teatree#1003).
 """
 
-from teatree.core.models.on_behalf_approval import OnBehalfApproval, OnBehalfAudit
 from teatree.on_behalf_gate import ask_before_post_on_behalf_enabled
 
 
@@ -67,6 +75,8 @@ def require_on_behalf_approval(*, target: str, action: str) -> None:
     """
     if not ask_before_post_on_behalf_enabled():
         return
+    from teatree.core.models.on_behalf_approval import OnBehalfApproval, OnBehalfAudit  # noqa: PLC0415
+
     consumed = OnBehalfApproval.consume(target, action)
     if consumed is None:
         raise OnBehalfPostBlockedError(target, action)

--- a/tests/teatree_cli/test_review_django_bootstrap.py
+++ b/tests/teatree_cli/test_review_django_bootstrap.py
@@ -1,0 +1,135 @@
+"""``t3 review`` on-behalf-gated subcommands bootstrap Django before touching the ORM (#1003).
+
+Every `t3 review` subcommand that publishes under the user's identity goes through
+:func:`teatree.cli.review_on_behalf.check_on_behalf` to enforce the recorded-approval
+on-behalf pre-gate (#960). That helper imports
+:mod:`teatree.core.on_behalf_gate_recorded` lazily so the CLI package can be
+imported by typer (for help rendering, completion, or a privacy-scan subprocess)
+*before* ``django.setup()`` has run.
+
+Two invariants must hold for this to work end-to-end:
+
+* :mod:`teatree.core.on_behalf_gate_recorded` must itself be Django-free at import
+    time — it cannot eagerly import ORM models, only the pure setting resolver in
+    :mod:`teatree.on_behalf_gate`. The ORM imports go inside
+    :func:`require_on_behalf_approval` (called only after the typer command body
+    has bootstrapped Django).
+* Every gated typer command in :mod:`teatree.cli.review` must bootstrap Django
+    before invoking the gate. ``t3 review --help`` works without that bootstrap
+    because typer does not import the model layer, but the gated bodies do —
+    ``check_on_behalf`` triggers the lazy import of the gate-recorded module
+    which then accesses the ORM.
+
+Without both, ``t3 review post-draft-note`` (and every sibling gated subcommand)
+crashes with ``django.core.exceptions.ImproperlyConfigured: Requested setting
+INSTALLED_APPS, but settings are not configured``. The bug was originally
+masked by typer's rich-traceback handler exiting 0 — see souliane/teatree#932
+for the management-command equivalent.
+
+These tests pin both invariants via subprocesses (a clean child interpreter
+state) so future code additions cannot silently re-break either one.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _clean_env() -> dict[str, str]:
+    """Return an env without ``DJANGO_SETTINGS_MODULE`` — the pre-bootstrap state.
+
+    Mirrors how the user invokes ``t3 review`` from a normal shell: no Django
+    settings module is pre-exported, the CLI is responsible for setting it.
+    """
+    env = os.environ.copy()
+    env.pop("DJANGO_SETTINGS_MODULE", None)
+    return env
+
+
+class TestOnBehalfGateRecordedIsImportSafePreBootstrap:
+    """The lazy-import contract documented in ``cli/review_on_behalf.py``.
+
+    A child interpreter imports :mod:`teatree.core.on_behalf_gate_recorded`
+    with ``DJANGO_SETTINGS_MODULE`` unset and asserts the ORM modules were
+    not pulled into ``sys.modules`` as a side effect — proof the module-top
+    import chain is genuinely Django-free.
+    """
+
+    def test_module_import_does_not_eager_load_orm_models(self) -> None:
+        probe = (
+            "import sys\n"
+            "import teatree.core.on_behalf_gate_recorded  # noqa: F401\n"
+            "assert 'teatree.core.models.on_behalf_approval' not in sys.modules, (\n"
+            "    'on_behalf_gate_recorded must not eagerly import the ORM models — '\n"
+            "    'the import must be lazy inside require_on_behalf_approval so the '\n"
+            "    'CLI can be loaded before django.setup() (souliane/teatree#1003)'\n"
+            ")\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+        )
+        assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+
+
+class TestReviewPostDraftNoteBootstrapsDjango:
+    """`t3 review post-draft-note` bootstraps Django before the gate runs.
+
+    The subcommand is invoked in a child interpreter without
+    ``DJANGO_SETTINGS_MODULE`` pre-exported, the way a normal shell invocation
+    would be. It must NOT crash with ``ImproperlyConfigured`` — the typer
+    command body is responsible for calling ``django.setup()`` before the gate
+    chain executes. We patch ``ReviewService.get_gitlab_token`` to return a
+    sentinel and the underlying GitLab API call to a no-op so we never hit the
+    network; the only behaviour under test is the bootstrap path.
+    """
+
+    def test_post_draft_note_does_not_raise_improperly_configured(self, tmp_path: Path) -> None:
+        # An empty teatree.toml gate-off config so we exercise the gate
+        # chokepoint without needing a recorded approval row.
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text("[teatree]\nask_before_post_on_behalf = false\n", encoding="utf-8")
+
+        probe = (
+            "import os\n"
+            f"os.environ['HOME'] = {str(tmp_path)!r}\n"
+            "from unittest.mock import patch\n"
+            "from typer.testing import CliRunner\n"
+            "import teatree.config as cfg_mod\n"
+            f"cfg_mod.CONFIG_PATH = {str(cfg)!r}\n"
+            "from pathlib import Path as _P\n"
+            f"cfg_mod.CONFIG_PATH = _P({str(cfg)!r})\n"
+            "from teatree.cli import app\n"
+            "from teatree.cli.review import ReviewService\n"
+            "\n"
+            "runner = CliRunner()\n"
+            "with patch.object(ReviewService, 'get_gitlab_token', return_value='t'), \\\n"
+            "     patch.object(ReviewService, '_post_draft_note_impl',\n"
+            "                  return_value=('OK draft_note_id=99', 0)):\n"
+            "    result = runner.invoke(app, ['review', 'post-draft-note',\n"
+            "                                 'org/repo', '1', 'hello'])\n"
+            "if 'ImproperlyConfigured' in (result.output or '') or result.exception is not None:\n"
+            "    import traceback\n"
+            "    if result.exception:\n"
+            "        traceback.print_exception(\n"
+            "            type(result.exception), result.exception,\n"
+            "            result.exception.__traceback__,\n"
+            "        )\n"
+            "    print('OUTPUT:', result.output)\n"
+            "    raise SystemExit(2)\n"
+            "assert result.exit_code == 0, result.output\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+        )
+        assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        assert "ImproperlyConfigured" not in result.stdout
+        assert "ImproperlyConfigured" not in result.stderr


### PR DESCRIPTION
## Summary

- Fixes #1003 — `t3 review post-draft-note` (and every sibling on-behalf-gated subcommand) crashed with `django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured`. The rich traceback printed but the process exited 0 (the #932 class).
- Root cause is two-layer: `teatree.core.on_behalf_gate_recorded` eagerly imported the ORM models at module top (defeating the documented lazy-import chain `cli/review_on_behalf` sets up), AND `cli/review.py` never called `django.setup()` (unlike `cli/loop.py` and `cli/config.py`).

## Fix

- Move the ORM imports inside `require_on_behalf_approval` so `on_behalf_gate_recorded` stays Django-free at import time. Mirrors `cli/loop.py` / `cli/agent.py` lazy-import pattern.
- Bootstrap Django at the top of `_require_token` in `cli/review.py` so every gated subcommand routes through `django.setup()` before the gate fires.
- Bootstrap Django inside `approve-on-behalf` too — it is the no-TTY satisfier and bypasses `_require_token`.

## Test plan

- [x] **RED→GREEN**: new `tests/teatree_cli/test_review_django_bootstrap.py` reproduces the bug in a subprocess (so the child interpreter starts without Django configured, the way a real shell invocation does). Two invariants pinned:
  - `teatree.core.on_behalf_gate_recorded` import does not pull `teatree.core.models.on_behalf_approval` into `sys.modules` (lazy-chain holds).
  - `t3 review post-draft-note` end-to-end does not raise `ImproperlyConfigured`.
- [x] All existing `tests/teatree_cli/test_review_on_behalf_gate.py` (47 tests), `tests/test_cli_review.py` (61 tests), and `tests/teatree_core/test_on_behalf_gate_recorded.py` keep passing — 82 green in scope.
- [x] User-facing reproduction confirmed: `uv run t3 review post-draft-note org/repo 1 "test"` now emits the clean blocked-post message and exits 1 (was: traceback + exit 0).
- [x] All pre-commit and pre-push hooks pass locally (module-health, ruff, ty-check, banned-terms, BLUEPRINT, docker test matrix).