### PR TITLE
fix(cli/review): consume OnBehalfApproval on approve/unapprove gate

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -558,7 +558,10 @@ Usage: t3 review approve [OPTIONS] REPO MR
 
  Precondition: a review note/discussion authored by your identity must
  already exist on the MR (review before approve). Also respects the
- `ask_before_post_on_behalf` pre-gate (souliane/teatree#960).
+ `ask_before_post_on_behalf` pre-gate (souliane/teatree#960/#1013) —
+ record an approval via ``t3 review approve-on-behalf <repo>!<mr>
+ approve --approver <user-id>`` to satisfy the gate without disabling
+ it.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
@@ -578,7 +581,10 @@ Usage: t3 review unapprove [OPTIONS] REPO MR
  Revoke your approval on a GitLab MR.
 
  No review precondition (revoking is the safe direction). Respects the
- `ask_before_post_on_behalf` pre-gate (souliane/teatree#960).
+ `ask_before_post_on_behalf` pre-gate (souliane/teatree#960/#1013) —
+ record an approval via ``t3 review approve-on-behalf <repo>!<mr>
+ unapprove --approver <user-id>`` to satisfy the gate without disabling
+ it.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │

--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -1,12 +1,13 @@
 """Review CLI commands — GitLab draft note operations.
 
 Every method that publishes under the user's identity to an MR (a
-``post_*`` / ``reply_*`` / ``resolve_*`` / ``publish_*`` / ``update_*``
-call) routes through the same recorded-approval pre-gate
-(``ask_before_post_on_behalf``, #960) the reply transport uses. Read-
-only methods (``list_draft_notes``, ``delete_draft_note``) bypass the
-gate: ``list`` does not publish; deleting one's own draft *pre*-
-publication is not a colleague-facing post.
+``post_*`` / ``reply_*`` / ``resolve_*`` / ``publish_*`` / ``update_*`` /
+``approve`` / ``unapprove`` call) routes through the same recorded-
+approval pre-gate (``ask_before_post_on_behalf``, #960/#1013) the reply
+transport uses. Read-only methods (``list_draft_notes``,
+``delete_draft_note``) bypass the gate: ``list`` does not publish;
+deleting one's own draft *pre*-publication is not a colleague-facing
+post.
 
 The gate is satisfiable without a TTY — the user records an
 :class:`~teatree.core.models.on_behalf_approval.OnBehalfApproval` scoped
@@ -37,34 +38,13 @@ _TOKEN_PARTS_COUNT = 2
 _HTTP_OK_CODES = frozenset({HTTPStatus.OK, HTTPStatus.CREATED, HTTPStatus.NO_CONTENT})
 
 
-def _on_behalf_gate_active() -> bool:
-    """Whether the ask-before-post-on-behalf pre-gate forbids unattended posting.
-
-    An MR approval/unapproval is an outward, state-changing post made under
-    the user's identity, so it must respect the same
-    ``ask_before_post_on_behalf`` pre-gate the posting subcommands use
-    (souliane/teatree#960).
-
-    The gate module (``teatree.on_behalf_gate``) is the single source of
-    truth. It is wired here through a soft import so this command works
-    whether or not the gate PR has merged yet: if the module is absent the
-    gate is treated as inactive (no behaviour change until it lands); once
-    present, ``ask_before_post_on_behalf_enabled()`` decides.
-    """
-    try:
-        from teatree.on_behalf_gate import ask_before_post_on_behalf_enabled  # noqa: PLC0415
-    except ModuleNotFoundError:
-        return False
-    return ask_before_post_on_behalf_enabled()
-
-
 class ReviewService:
     """GitLab draft note operations for code review.
 
     Every method that publishes to an MR (post comment, post draft note,
-    publish drafts, reply, resolve, update note) is wrapped by the
-    recorded-approval on-behalf pre-gate. See module docstring for the
-    full contract.
+    publish drafts, reply, resolve, update note, approve, unapprove) is
+    wrapped by the recorded-approval on-behalf pre-gate. See module
+    docstring for the full contract.
     """
 
     def __init__(self, token: str) -> None:
@@ -375,7 +355,17 @@ class ReviewService:
         Returns (message, exit_code). The review-first precondition encodes
         the approve-on-review doctrine: an approval cannot be recorded
         without a prior reviewing footprint from the same identity.
+
+        Gated by ``ask_before_post_on_behalf`` (#960/#1013): an approval is
+        an outward post on the user's identity, so it routes through the
+        same recorded-approval gate every other on-behalf method uses. Gate
+        ON + no recorded :class:`OnBehalfApproval` matching
+        ``(<repo>!<mr>, "approve")`` → refuse without any GitLab side
+        effect; gate ON + recorded row → consume single-use and proceed.
         """
+        blocked = check_on_behalf(repo, mr, "approve")
+        if blocked:
+            return blocked, 1
         encoded = repo.replace("/", "%2F")
         reviewed, error = self._identity_has_reviewed(encoded, mr)
         if error:
@@ -398,24 +388,22 @@ class ReviewService:
 
         No review-first precondition — removing an approval is the safe
         direction and must always be reachable.
+
+        Gated by ``ask_before_post_on_behalf`` (#960/#1013): an unapproval
+        is still a colleague-visible post on the user's identity, so it
+        routes through the same recorded-approval gate as ``approve`` (and
+        every other on-behalf method). The recorded row scopes to
+        ``(<repo>!<mr>, "unapprove")``.
         """
+        blocked = check_on_behalf(repo, mr, "unapprove")
+        if blocked:
+            return blocked, 1
         api = self._get_api()
         encoded = repo.replace("/", "%2F")
         status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/unapprove")
         if status in _HTTP_OK_CODES:
             return f"OK unapproved !{mr}", 0
         return f"Failed: HTTP {status}", 1
-
-
-def _refuse_if_on_behalf_gated() -> None:
-    """Refuse an approval/unapproval when the on-behalf pre-gate is active."""
-    if _on_behalf_gate_active():
-        typer.echo(
-            "Refusing: `ask_before_post_on_behalf` is enabled — an MR approval is an outward "
-            "post on your behalf and must be user-approved first. Disable the gate per-overlay "
-            "in ~/.teatree.toml once you trust the workflow, or record the approval manually.",
-        )
-        raise typer.Exit(code=1)
 
 
 def _require_token() -> ReviewService:
@@ -551,9 +539,11 @@ def approve(
 
     Precondition: a review note/discussion authored by your identity must
     already exist on the MR (review before approve). Also respects the
-    `ask_before_post_on_behalf` pre-gate (souliane/teatree#960).
+    `ask_before_post_on_behalf` pre-gate (souliane/teatree#960/#1013) —
+    record an approval via ``t3 review approve-on-behalf <repo>!<mr>
+    approve --approver <user-id>`` to satisfy the gate without disabling
+    it.
     """
-    _refuse_if_on_behalf_gated()
     service = _require_token()
     msg, code = service.approve(repo, mr)
     typer.echo(msg)
@@ -569,9 +559,11 @@ def unapprove(
     """Revoke your approval on a GitLab MR.
 
     No review precondition (revoking is the safe direction). Respects the
-    `ask_before_post_on_behalf` pre-gate (souliane/teatree#960).
+    `ask_before_post_on_behalf` pre-gate (souliane/teatree#960/#1013) —
+    record an approval via ``t3 review approve-on-behalf <repo>!<mr>
+    unapprove --approver <user-id>`` to satisfy the gate without disabling
+    it.
     """
-    _refuse_if_on_behalf_gated()
     service = _require_token()
     msg, code = service.unapprove(repo, mr)
     typer.echo(msg)

--- a/tests/teatree_cli/test_review_approve_gate.py
+++ b/tests/teatree_cli/test_review_approve_gate.py
@@ -1,0 +1,149 @@
+"""The on-behalf pre-gate is enforced on ``approve`` and ``unapprove`` too (#1013).
+
+``ReviewService.approve``/``unapprove`` are outward, state-changing posts
+made under the user's identity, so they must route through the same
+satisfiable recorded-approval gate every other on-behalf publishing
+method uses (``post_comment``, ``post_draft_note``, ``publish_draft_notes``,
+``reply_to_discussion``, ``resolve_discussion``, ``update_note``).
+
+Pre-fix, the CLI consulted only the global ``ask_before_post_on_behalf``
+flag — a recorded :class:`OnBehalfApproval` row never satisfied
+``approve``/``unapprove``, so the recorded-approval channel was unusable
+for them. This module pins the corrected contract: gate ON + no approval
+→ refuse without an API call; gate ON + recorded row → publish and
+consume the row; gate OFF → publish.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from teatree.cli.review import ReviewService
+from teatree.core.models import OnBehalfApproval
+
+pytestmark = pytest.mark.django_db
+
+
+def _gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, on: bool) -> None:
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text(
+        f"[teatree]\nask_before_post_on_behalf = {'true' if on else 'false'}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+
+
+class _ApproveStubAPI:
+    """In-memory stand-in for ``GitLabAPI`` — records every network call.
+
+    Returns enough shape for ``_identity_has_reviewed`` to find a prior
+    note from ``souliane`` (so the review-before-approve precondition is
+    satisfied and the test isolates the on-behalf-gate behaviour).
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, Any]] = []
+
+    def current_username(self) -> str:
+        self.calls.append(("current_username", "", None))
+        return "souliane"
+
+    def get_json(self, endpoint: str) -> object:
+        self.calls.append(("get_json", endpoint, None))
+        return [{"notes": [{"author": {"username": "souliane"}}]}]
+
+    def post_status(self, endpoint: str) -> int:
+        self.calls.append(("post_status", endpoint, None))
+        return 200
+
+
+def _service_with_stub() -> tuple[ReviewService, _ApproveStubAPI]:
+    service = ReviewService(token="t")
+    stub = _ApproveStubAPI()
+    service._get_api = lambda: stub  # type: ignore[method-assign]
+    return service, stub
+
+
+class TestReviewServiceApproveGated:
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.tmp_path = tmp_path
+        self.monkeypatch = monkeypatch
+
+    def test_approve_blocked_when_gate_on_no_approval(self) -> None:
+        _gate(self.tmp_path, self.monkeypatch, on=True)
+        service, stub = _service_with_stub()
+
+        msg, code = service.approve("org/repo", 7)
+
+        assert code == 1
+        assert "approve-on-behalf" in msg
+        # No GitLab call may have happened — the gate short-circuits.
+        assert not any(c[0] == "post_status" for c in stub.calls)
+
+    def test_approve_proceeds_with_recorded_approval(self) -> None:
+        _gate(self.tmp_path, self.monkeypatch, on=True)
+        OnBehalfApproval.record(target="org/repo!7", action="approve", approver_id="souliane")
+        service, stub = _service_with_stub()
+
+        msg, code = service.approve("org/repo", 7)
+
+        assert code == 0, msg
+        assert "OK approved" in msg
+        assert any(c[0] == "post_status" and c[1].endswith("/approve") for c in stub.calls)
+
+    def test_approve_proceeds_when_gate_off(self) -> None:
+        _gate(self.tmp_path, self.monkeypatch, on=False)
+        service, stub = _service_with_stub()
+
+        _, code = service.approve("org/repo", 7)
+        assert code == 0
+        assert any(c[0] == "post_status" and c[1].endswith("/approve") for c in stub.calls)
+
+    def test_approve_consumes_the_recorded_approval_single_use(self) -> None:
+        """A recorded approval is single-use: the second call must refuse."""
+        _gate(self.tmp_path, self.monkeypatch, on=True)
+        OnBehalfApproval.record(target="org/repo!7", action="approve", approver_id="souliane")
+        service, _stub = _service_with_stub()
+
+        _, code1 = service.approve("org/repo", 7)
+        assert code1 == 0
+        _, code2 = service.approve("org/repo", 7)
+        assert code2 == 1
+
+
+class TestReviewServiceUnapproveGated:
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.tmp_path = tmp_path
+        self.monkeypatch = monkeypatch
+
+    def test_unapprove_blocked_when_gate_on_no_approval(self) -> None:
+        _gate(self.tmp_path, self.monkeypatch, on=True)
+        service, stub = _service_with_stub()
+
+        msg, code = service.unapprove("org/repo", 7)
+
+        assert code == 1
+        assert "approve-on-behalf" in msg
+        assert not any(c[0] == "post_status" for c in stub.calls)
+
+    def test_unapprove_proceeds_with_recorded_approval(self) -> None:
+        _gate(self.tmp_path, self.monkeypatch, on=True)
+        OnBehalfApproval.record(target="org/repo!7", action="unapprove", approver_id="souliane")
+        service, stub = _service_with_stub()
+
+        msg, code = service.unapprove("org/repo", 7)
+
+        assert code == 0, msg
+        assert "OK unapproved" in msg
+        assert any(c[0] == "post_status" and c[1].endswith("/unapprove") for c in stub.calls)
+
+    def test_unapprove_proceeds_when_gate_off(self) -> None:
+        _gate(self.tmp_path, self.monkeypatch, on=False)
+        service, stub = _service_with_stub()
+
+        _, code = service.unapprove("org/repo", 7)
+        assert code == 0
+        assert any(c[0] == "post_status" and c[1].endswith("/unapprove") for c in stub.calls)

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -1,6 +1,3 @@
-import builtins
-import sys
-import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,7 +6,6 @@ from typer.testing import CliRunner
 import teatree.backends.gitlab_api as gitlab_api_mod
 import teatree.utils.run as utils_run_mod
 from teatree.cli import app
-from teatree.cli import review as review_mod
 from teatree.cli.review import ReviewService, _find_added_line
 from tests.teatree_core._on_behalf_gate_helpers import disable_on_behalf_gate
 
@@ -581,21 +577,22 @@ class TestApprove:
             assert result.exit_code == 1
             assert "Failed: HTTP 403" in result.output
 
-    def test_approve_blocked_by_on_behalf_gate(self, monkeypatch):
-        """When the ask-before-post-on-behalf gate is active, approve refuses unattended."""
+    @pytest.mark.django_db
+    def test_approve_blocked_by_on_behalf_gate(self, tmp_path, monkeypatch):
+        """Gate ON + no recorded approval → approve refuses without an API call (#1013)."""
         monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text("[teatree]\nask_before_post_on_behalf = true\n", encoding="utf-8")
+        monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
         mock_api = MagicMock()
         mock_api.current_username.return_value = "reviewer-bot"
         mock_api.get_json.side_effect = lambda endpoint: (
             _discussions_with_author("reviewer-bot") if "/discussions" in endpoint else {"id": 1}
         )
-        with (
-            patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api),
-            patch("teatree.cli.review._on_behalf_gate_active", return_value=True),
-        ):
+        with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
             result = runner.invoke(app, ["review", "approve", "org/repo", "7"])
             assert result.exit_code == 1
-            assert "ask_before_post_on_behalf" in result.output
+            assert "approve-on-behalf" in result.output
             mock_api.post_status.assert_not_called()
 
     def test_unapprove_succeeds(self, monkeypatch):
@@ -620,44 +617,19 @@ class TestApprove:
             assert result.exit_code == 1
             assert "Failed: HTTP 404" in result.output
 
-    def test_unapprove_blocked_by_on_behalf_gate(self, monkeypatch):
+    @pytest.mark.django_db
+    def test_unapprove_blocked_by_on_behalf_gate(self, tmp_path, monkeypatch):
+        """Gate ON + no recorded approval → unapprove refuses without an API call (#1013)."""
         monkeypatch.setenv("GITLAB_TOKEN", "test-token")
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text("[teatree]\nask_before_post_on_behalf = true\n", encoding="utf-8")
+        monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
         mock_api = MagicMock()
-        with (
-            patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api),
-            patch("teatree.cli.review._on_behalf_gate_active", return_value=True),
-        ):
+        with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
             result = runner.invoke(app, ["review", "unapprove", "org/repo", "7"])
             assert result.exit_code == 1
-            assert "ask_before_post_on_behalf" in result.output
+            assert "approve-on-behalf" in result.output
             mock_api.post_status.assert_not_called()
-
-
-class TestOnBehalfGateActive:
-    def test_inactive_when_gate_module_absent(self, monkeypatch):
-        """Absent gate module (not yet merged) -> integration point reports inactive."""
-        real_import = builtins.__import__
-
-        def fake_import(name, *args, **kwargs):
-            if name == "teatree.on_behalf_gate":
-                raise ModuleNotFoundError(name)
-            return real_import(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", fake_import)
-        assert review_mod._on_behalf_gate_active() is False
-
-    def test_active_when_gate_module_present_and_enabled(self, monkeypatch):
-        """Present gate module + enabled setting -> integration point reports active."""
-        fake = types.ModuleType("teatree.on_behalf_gate")
-        fake.ask_before_post_on_behalf_enabled = lambda: True
-        monkeypatch.setitem(sys.modules, "teatree.on_behalf_gate", fake)
-        assert review_mod._on_behalf_gate_active() is True
-
-    def test_inactive_when_gate_module_present_but_disabled(self, monkeypatch):
-        fake = types.ModuleType("teatree.on_behalf_gate")
-        fake.ask_before_post_on_behalf_enabled = lambda: False
-        monkeypatch.setitem(sys.modules, "teatree.on_behalf_gate", fake)
-        assert review_mod._on_behalf_gate_active() is False
 
 
 # -- _require_token helper -----------------------------------------------------


### PR DESCRIPTION
## Summary

- `_refuse_if_on_behalf_gated()` in `src/teatree/cli/review.py` only checked the global `ask_before_post_on_behalf` flag — a recorded `OnBehalfApproval` row never satisfied `t3 review approve` / `unapprove`, so the recorded-approval channel that every other gated `ReviewService` method already used (`post_comment`, `post_draft_note`, `publish_draft_notes`, `reply_to_discussion`, `resolve_discussion`, `update_note`) was a no-op for the approve path.
- Move the gate into `ReviewService.approve` / `unapprove` via the same `check_on_behalf(repo, mr, action)` chokepoint the rest use; drop the now-dead `_refuse_if_on_behalf_gated()` / `_on_behalf_gate_active()` helpers and their typer-wrapper calls. The CLI now consumes a recorded row the way the docs already promised.

Closes #1013.

## Behaviour

| State | Before | After |
| --- | --- | --- |
| gate OFF | proceed | proceed |
| gate ON + no recorded row | refuse (generic message) | refuse (actionable `approve-on-behalf` message) |
| gate ON + recorded row | refuse (bug) | consume single-use, proceed |

## Test plan

- [x] `tests/teatree_cli/test_review_approve_gate.py` — 7 new tests pin the corrected contract on `approve` and `unapprove` (blocked-without-row, proceeds-with-row, proceeds-when-gate-off, single-use consumption).
- [x] Anti-vacuous RED captured: ran the new test file against the unfixed `src/teatree/cli/review.py`; 3 tests went red (`test_approve_blocked_when_gate_on_no_approval`, `test_approve_consumes_the_recorded_approval_single_use`, `test_unapprove_blocked_when_gate_on_no_approval`). Apply the fix → all 7 green.
- [x] Existing `tests/test_cli_review.py::TestApprove::test_*_blocked_by_on_behalf_gate` updated to drive the gate via the config file (not by patching the removed `_on_behalf_gate_active` symbol). `TestOnBehalfGateActive` deleted — it asserted on a now-removed helper; the same surface is covered by `tests/teatree_cli/test_review_on_behalf_gate.py` and the new file.
- [x] Full review suite green: `uv run pytest tests/teatree_cli/test_review_on_behalf_gate.py tests/teatree_cli/test_review_django_bootstrap.py tests/teatree_cli/test_review_approve_gate.py tests/test_cli_review.py` — 86 passed.
- [x] `ruff check` / `ruff format --check` / `ty check` clean.
- [x] Coverage on `src/teatree/cli/review.py` = 97.5% across the full review suite (threshold 93%).