### PR TITLE
notify: convert bare MR/issue refs to Slack mrkdwn links

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -2143,6 +2143,7 @@ graph TD
     teatree.notify --> teatree.backends
     teatree.notify --> teatree.config
     teatree.notify --> teatree.core
+    teatree.notify --> teatree.slack_mrkdwn
     teatree.settings --> teatree.config
     teatree.settings --> teatree.paths
     teatree.cli_reference --> teatree.cli
@@ -2154,6 +2155,7 @@ graph TD
     teatree.claude_sessions
     teatree.overlay_init
     teatree.skill_schema
+    teatree.slack_mrkdwn
     teatree.skill_deps
     teatree.skill_map
     teatree.memory_audit

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -341,6 +341,27 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
         state = issue_data.get("state")
         return isinstance(state, str) and state in {"closed", "completed"}
 
+    def resolve_mr_token(self, iid: int) -> str | None:
+        """Return the canonical URL for ``!<iid>`` on this overlay's code host.
+
+        Overridden by overlays that own merge/pull requests across multiple
+        repositories and can resolve a bare ``!N`` to its repo's web URL.
+        The default returns ``None`` —
+        :func:`teatree.slack_mrkdwn.slack_linkify` leaves the bare token
+        unrewritten when no resolver can claim it, so the Slack reader sees
+        inert text rather than a guessed-wrong URL.
+        """
+        _ = iid
+        return None
+
+    def resolve_issue_token(self, iid: int) -> str | None:
+        """Return the canonical URL for ``#<iid>`` on this overlay's code host.
+
+        Default ``None``, for the same reason as :meth:`resolve_mr_token`.
+        """
+        _ = iid
+        return None
+
     def can_auto_merge(self, *, target_ref: str, thread_ref: str) -> MergeGuard:
         """Return a merge-guard verdict for an approved merge request.
 

--- a/src/teatree/notify.py
+++ b/src/teatree/notify.py
@@ -38,6 +38,7 @@ from teatree.backends.protocols import MessagingBackend
 from teatree.config import get_effective_settings, load_config
 from teatree.core.backend_factory import messaging_from_overlay
 from teatree.core.models import BotPing
+from teatree.slack_mrkdwn import slack_linkify
 
 logger = logging.getLogger(__name__)
 
@@ -50,13 +51,14 @@ class NotifyKind(enum.StrEnum):
     INFO = "info"
 
 
-def notify_user(
+def notify_user(  # noqa: PLR0913 — single notification egress; each kwarg is a documented opt-in / test override.
     text: str,
     *,
     kind: NotifyKind | str,
     idempotency_key: str,
     backend: MessagingBackend | None = None,
     user_id: str | None = None,
+    linkify: bool = True,
 ) -> bool:
     """Send a bot→user Slack DM and record an audit row.
 
@@ -80,6 +82,15 @@ def notify_user(
     stores it on the ``BotPing`` row so subsequent CLI surfaces can echo
     a clickable link back to the user (the audited DM is the canonical
     source of the answer; the CLI only points at it).
+
+    *linkify* (default ``True``) rewrites GitHub-flavored ``[label](url)``
+    and bare ``!N`` / ``#N`` tokens into Slack mrkdwn ``<url|label>`` form
+    so dashboard messages render with clickable links rather than inert
+    text. Token resolution consults the active overlay's
+    :meth:`OverlayBase.resolve_mr_token` /
+    :meth:`OverlayBase.resolve_issue_token` hooks; tokens the overlay
+    can't resolve are left bare. The transform is applied to the Slack
+    payload only — the ``BotPing.text`` audit column keeps the original.
 
     Returns ``True`` when a Slack message was published (or detected as
     an idempotent repeat); ``False`` when the helper degraded to a no-op
@@ -110,11 +121,13 @@ def notify_user(
         )
         return False
 
+    payload_text = _maybe_linkify(text) if linkify else text
+
     try:
         channel = resolved_backend.open_dm(resolved_user_id)
         response = resolved_backend.post_message(
             channel=channel,
-            text=_format(text, kind_value),
+            text=_format(payload_text, kind_value),
             thread_ts="",
         )
     except Exception as exc:  # noqa: BLE001 — notify must never bubble up
@@ -176,6 +189,28 @@ def _resolve_user_id() -> str:
             return str(user_id)
     teatree_cfg = cfg.get("teatree") or {}
     return str(teatree_cfg.get("slack_user_id", ""))
+
+
+def _maybe_linkify(text: str) -> str:
+    """Apply :func:`slack_linkify` using the active overlay's resolvers, if any.
+
+    Failure to resolve the overlay or to query a resolver is non-fatal —
+    notification routing must never crash a CLI turn. In that case the
+    text is rewritten with no resolvers, which still converts
+    ``[label](url)`` to ``<url|label>`` but leaves bare ``!N`` / ``#N``
+    tokens as-is.
+    """
+    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+
+    try:
+        overlay = get_overlay()
+    except Exception:  # noqa: BLE001 — overlay resolution is best-effort; never crash a CLI turn
+        return slack_linkify(text)
+    return slack_linkify(
+        text,
+        mr_resolver=overlay.resolve_mr_token,
+        issue_resolver=overlay.resolve_issue_token,
+    )
 
 
 def _format(text: str, kind: NotifyKind) -> str:

--- a/src/teatree/slack_mrkdwn.py
+++ b/src/teatree/slack_mrkdwn.py
@@ -1,0 +1,96 @@
+"""Rewrite GitHub-flavored markdown to Slack mrkdwn so links render.
+
+Slack's mrkdwn dialect uses ``<url|label>`` for clickable links. Two
+forms commonly leak into messages assembled from regular markdown and
+render as inert plain text in the Slack client:
+
+1.  **GitHub-flavored ``[label](url)``** — Slack ignores the brackets and
+    shows the literal characters.
+2.  **Bare references like ``!281`` or ``#1011``** — Slack has no concept
+    of cross-repo issue refs; only an explicit ``<url|!281>`` is clickable.
+
+:func:`slack_linkify` rewrites both forms in place while preserving the
+surrounding structure (table pipes, headers, newlines, fenced code).
+Token-to-URL resolution is delegated to caller-supplied lookups so the
+helper stays overlay-agnostic — ``notify_user`` wires the active
+overlay's ``resolve_mr_token`` / ``resolve_issue_token`` hooks when it
+applies the transform.
+"""
+
+import re
+from collections.abc import Callable
+
+TokenResolver = Callable[[int], str | None]
+
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+_MRKDWN_LINK_RE = re.compile(r"<https?://[^\s|>]+\|[^>]+>")
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^\s)]+)\)")
+_BARE_MR_RE = re.compile(r"(?<![A-Za-z0-9_/])!(\d+)(?![A-Za-z0-9_])")
+_BARE_ISSUE_RE = re.compile(r"(?<![A-Za-z0-9_/])#(\d+)(?![A-Za-z0-9_])")
+
+
+def slack_linkify(
+    text: str,
+    *,
+    mr_resolver: TokenResolver | None = None,
+    issue_resolver: TokenResolver | None = None,
+) -> str:
+    """Return ``text`` with GH-markdown and bare refs rewritten for Slack.
+
+    *mr_resolver* maps an integer ``N`` to the full URL of merge/pull
+    request ``!N`` (or ``None`` when the token is ambiguous across
+    repositories — in that case the bare ``!N`` is left untouched so the
+    Slack reader sees inert text rather than a wrong link).
+
+    *issue_resolver* does the same for ``#N`` issue tokens.
+
+    Content inside fenced (```` ``` ````) and inline (`` ` ``) code is
+    preserved verbatim, matching Slack's own mrkdwn rules. Existing
+    Slack mrkdwn links (``<url|label>``) are also preserved, which makes
+    the transform idempotent — applying it twice yields the same result.
+    """
+    if not text:
+        return text
+
+    protected: list[str] = []
+
+    def _stash(match: re.Match[str]) -> str:
+        protected.append(match.group(0))
+        return f"\x00{len(protected) - 1}\x00"
+
+    text = _CODE_FENCE_RE.sub(_stash, text)
+    text = _INLINE_CODE_RE.sub(_stash, text)
+    text = _MRKDWN_LINK_RE.sub(_stash, text)
+
+    text = _MD_LINK_RE.sub(_rewrite_md_link, text)
+
+    if mr_resolver is not None:
+        text = _BARE_MR_RE.sub(_make_token_rewriter("!", mr_resolver), text)
+    if issue_resolver is not None:
+        text = _BARE_ISSUE_RE.sub(_make_token_rewriter("#", issue_resolver), text)
+
+    def _restore(match: re.Match[str]) -> str:
+        return protected[int(match.group(1))]
+
+    return re.sub(r"\x00(\d+)\x00", _restore, text)
+
+
+def _rewrite_md_link(match: re.Match[str]) -> str:
+    label = match.group(1).replace("|", "❘")
+    url = match.group(2)
+    return f"<{url}|{label}>"
+
+
+def _make_token_rewriter(sigil: str, resolver: TokenResolver) -> Callable[[re.Match[str]], str]:
+    def _rewrite(match: re.Match[str]) -> str:
+        n = int(match.group(1))
+        url = resolver(n)
+        if not url:
+            return f"{sigil}{n}"
+        return f"<{url}|{sigil}{n}>"
+
+    return _rewrite
+
+
+__all__ = ["TokenResolver", "slack_linkify"]

--- a/tach.toml
+++ b/tach.toml
@@ -157,7 +157,11 @@ depends_on = ["teatree.config"]
 
 [[modules]]
 path = "teatree.notify"
-depends_on = ["teatree.backends", "teatree.config", "teatree.core"]
+depends_on = ["teatree.backends", "teatree.config", "teatree.core", "teatree.slack_mrkdwn"]
+
+[[modules]]
+path = "teatree.slack_mrkdwn"
+depends_on = []
 
 [[modules]]
 path = "teatree.settings"

--- a/tests/teatree_core/test_notify.py
+++ b/tests/teatree_core/test_notify.py
@@ -159,3 +159,98 @@ class TestNotifyUser(TestCase):
         assert sent is False
         backend.open_dm.assert_not_called()
         assert not BotPing.objects.filter(idempotency_key="disabled").exists()
+
+
+class TestNotifyUserLinkify(TestCase):
+    """Slack mrkdwn rewrite is applied to the payload, not the audit row."""
+
+    def test_dashboard_md_links_become_mrkdwn(self) -> None:
+        backend = _backend()
+        text = "see [the PR](https://example.com/pr/1) for details"
+        sent = notify_user(
+            text,
+            kind=NotifyKind.INFO,
+            idempotency_key="linkify-md",
+            backend=backend,
+            user_id="U_ME",
+        )
+
+        assert sent is True
+        sent_text = backend.post_message.call_args.kwargs["text"]
+        assert "<https://example.com/pr/1|the PR>" in sent_text
+        # The original markdown form is GONE from the payload
+        assert "[the PR](https://example.com/pr/1)" not in sent_text
+        # The audit row keeps the original
+        row = BotPing.objects.get(idempotency_key="linkify-md")
+        assert row.text == text
+
+    def test_bare_mr_token_uses_overlay_resolver(self) -> None:
+        backend = _backend()
+        fake_overlay = MagicMock()
+        fake_overlay.resolve_mr_token.side_effect = lambda n: (
+            f"https://gitlab.example.com/group/repo-a/-/merge_requests/{n}" if n == 281 else None
+        )
+        fake_overlay.resolve_issue_token.return_value = None
+
+        with patch("teatree.core.overlay_loader.get_overlay", return_value=fake_overlay):
+            notify_user(
+                "approve !281 then !999",
+                kind=NotifyKind.INFO,
+                idempotency_key="linkify-mr",
+                backend=backend,
+                user_id="U_ME",
+            )
+
+        sent_text = backend.post_message.call_args.kwargs["text"]
+        assert "<https://gitlab.example.com/group/repo-a/-/merge_requests/281|!281>" in sent_text
+        # Unresolved token stays bare — better inert than wrong
+        assert "!999" in sent_text
+        assert "<https://gitlab.example.com/group/repo-a/-/merge_requests/999" not in sent_text
+
+    def test_linkify_false_opts_out(self) -> None:
+        backend = _backend()
+        text = "raw [link](https://example.com) stays raw"
+        notify_user(
+            text,
+            kind=NotifyKind.INFO,
+            idempotency_key="linkify-off",
+            backend=backend,
+            user_id="U_ME",
+            linkify=False,
+        )
+
+        sent_text = backend.post_message.call_args.kwargs["text"]
+        assert "[link](https://example.com)" in sent_text
+        assert "<https://example.com|link>" not in sent_text
+
+    def test_overlay_resolution_failure_does_not_break_send(self) -> None:
+        backend = _backend()
+        with patch("teatree.core.overlay_loader.get_overlay", side_effect=RuntimeError("no overlay")):
+            sent = notify_user(
+                "ship [the PR](https://example.com/pr/1) and !281",
+                kind=NotifyKind.INFO,
+                idempotency_key="linkify-overlay-fail",
+                backend=backend,
+                user_id="U_ME",
+            )
+
+        assert sent is True
+        sent_text = backend.post_message.call_args.kwargs["text"]
+        # Markdown link rewrite still works (no overlay needed)
+        assert "<https://example.com/pr/1|the PR>" in sent_text
+        # Bare MR token stayed bare because no resolver
+        assert "!281" in sent_text
+
+    def test_workaround_user_id_kwarg_still_supported(self) -> None:
+        """``notify_user(user_id="U0A72P7CK0A")`` workaround must still work."""
+        backend = _backend()
+        sent = notify_user(
+            "ping",
+            kind=NotifyKind.INFO,
+            idempotency_key="user-id-workaround",
+            backend=backend,
+            user_id="U0A72P7CK0A",
+        )
+
+        assert sent is True
+        backend.open_dm.assert_called_once_with("U0A72P7CK0A")

--- a/tests/test_slack_mrkdwn.py
+++ b/tests/test_slack_mrkdwn.py
@@ -1,0 +1,162 @@
+"""Tests for ``teatree.slack_mrkdwn.slack_linkify``.
+
+The dashboard markdown sent through ``notify_user`` to the user's Slack DM
+must render with clickable PR/MR/issue refs. Slack mrkdwn uses
+``<url|label>`` — GitHub-flavored ``[label](url)`` and bare ``!N`` / ``#N``
+tokens render as inert text. This module rewrites those tokens.
+"""
+
+import re
+
+from teatree.slack_mrkdwn import slack_linkify
+
+
+def _pipes_outside_mrkdwn(line: str) -> int:
+    """Count ``|`` characters that aren't the url|label separator in a <…|…> token."""
+    stripped = re.sub(r"<[^>]*>", "", line)
+    return stripped.count("|")
+
+
+def _mr(n: int) -> str | None:
+    table = {
+        281: "https://gitlab.example.com/group/repo-a/-/merge_requests/281",
+        381: "https://gitlab.example.com/group/repo-b/-/merge_requests/381",
+        7439: "https://gitlab.example.com/group/repo-c/-/merge_requests/7439",
+    }
+    return table.get(n)
+
+
+def _issue(n: int) -> str | None:
+    table = {
+        1011: "https://github.com/souliane/teatree/issues/1011",
+        1010: "https://github.com/souliane/teatree/issues/1010",
+    }
+    return table.get(n)
+
+
+class TestSlackLinkifyBareMrTokens:
+    def test_resolves_known_mr_token_to_mrkdwn_link(self) -> None:
+        out = slack_linkify("ship !281 next", mr_resolver=_mr)
+        assert out == "ship <https://gitlab.example.com/group/repo-a/-/merge_requests/281|!281> next"
+
+    def test_resolves_multiple_mr_tokens_in_one_line(self) -> None:
+        text = "| !281 | repo-a | APPROVE |\n| !381 | repo-b | APPROVE-WITH-NIT |"
+        out = slack_linkify(text, mr_resolver=_mr)
+        assert "<https://gitlab.example.com/group/repo-a/-/merge_requests/281|!281>" in out
+        assert "<https://gitlab.example.com/group/repo-b/-/merge_requests/381|!381>" in out
+        # Newlines preserved
+        assert out.count("\n") == text.count("\n")
+        # Each line keeps its table-pipe count (rewrite adds pipes only INSIDE <...>)
+        for orig_line, out_line in zip(text.splitlines(), out.splitlines(), strict=True):
+            assert _pipes_outside_mrkdwn(out_line) == orig_line.count("|")
+
+    def test_ambiguous_mr_token_left_bare(self) -> None:
+        out = slack_linkify("ship !999 next", mr_resolver=_mr)
+        assert out == "ship !999 next"
+
+    def test_no_resolver_leaves_mr_tokens_bare(self) -> None:
+        out = slack_linkify("ship !281 next")
+        assert out == "ship !281 next"
+
+
+class TestSlackLinkifyBareIssueTokens:
+    def test_resolves_known_issue_token_to_mrkdwn_link(self) -> None:
+        out = slack_linkify("fixes #1011", issue_resolver=_issue)
+        assert out == "fixes <https://github.com/souliane/teatree/issues/1011|#1011>"
+
+    def test_ambiguous_issue_token_left_bare(self) -> None:
+        out = slack_linkify("fixes #9999", issue_resolver=_issue)
+        assert out == "fixes #9999"
+
+    def test_no_resolver_leaves_issue_tokens_bare(self) -> None:
+        out = slack_linkify("fixes #1011")
+        assert out == "fixes #1011"
+
+
+class TestSlackLinkifyMarkdownLinks:
+    def test_rewrites_gh_markdown_link_to_mrkdwn(self) -> None:
+        out = slack_linkify("see [the PR](https://example.com/pr/1)")
+        assert out == "see <https://example.com/pr/1|the PR>"
+
+    def test_label_with_pipe_inside_is_escaped(self) -> None:
+        # Slack mrkdwn doesn't support pipes in labels; the helper substitutes
+        # them with a unicode bar so the label stays readable rather than the
+        # mrkdwn parser truncating the label at the first '|'.
+        out = slack_linkify("[a|b](https://example.com)")
+        # Exactly one mrkdwn token (one '<', one '>'), one url|label separator,
+        # and the literal label-pipe has been substituted out.
+        assert out.count("<") == 1
+        assert out.count(">") == 1
+        assert out.count("|") == 1
+        assert "a|b" not in out
+        assert out.endswith("b>")
+
+
+class TestSlackLinkifyCodeBlocks:
+    def test_code_block_contents_are_preserved(self) -> None:
+        text = "before\n```\n!281 should stay bare in code\n[link](http://x)\n```\nafter !281"
+        out = slack_linkify(text, mr_resolver=_mr)
+        # Inside the code block: nothing rewritten
+        assert "!281 should stay bare in code" in out
+        assert "[link](http://x)" in out
+        # Outside the code block: rewritten
+        assert "<https://gitlab.example.com/group/repo-a/-/merge_requests/281|!281>" in out
+
+    def test_inline_code_preserved(self) -> None:
+        text = "use `!281` token, ref !281"
+        out = slack_linkify(text, mr_resolver=_mr)
+        assert "`!281`" in out
+        assert "<https://gitlab.example.com/group/repo-a/-/merge_requests/281|!281>" in out
+
+
+class TestSlackLinkifyIdempotent:
+    def test_double_application_is_noop(self) -> None:
+        once = slack_linkify("see !281 and [PR](http://x)", mr_resolver=_mr)
+        twice = slack_linkify(once, mr_resolver=_mr)
+        assert once == twice
+
+    def test_already_mrkdwn_link_is_preserved(self) -> None:
+        text = "see <https://example.com/pr/1|the PR>"
+        assert slack_linkify(text) == text
+
+
+class TestSlackLinkifyEdgeCases:
+    def test_empty_string(self) -> None:
+        assert slack_linkify("") == ""
+
+    def test_token_at_end_of_line(self) -> None:
+        out = slack_linkify("approve !281\n", mr_resolver=_mr)
+        assert "<https://gitlab.example.com/group/repo-a/-/merge_requests/281|!281>" in out
+        assert out.endswith("\n")
+
+    def test_token_inside_word_not_matched(self) -> None:
+        # foo!281bar — the ! is not at a word boundary, leave alone
+        out = slack_linkify("foo!281bar", mr_resolver=_mr)
+        assert out == "foo!281bar"
+
+    def test_hash_inside_word_not_matched(self) -> None:
+        out = slack_linkify("abc#1011def", issue_resolver=_issue)
+        assert out == "abc#1011def"
+
+    def test_resolver_returning_none_leaves_token_bare(self) -> None:
+        def always_none(_n: int) -> str | None:
+            return None
+
+        out = slack_linkify("see !281", mr_resolver=always_none)
+        assert out == "see !281"
+
+    def test_markdown_link_inside_table_cell(self) -> None:
+        line = "| [PR](http://x) | done |"
+        out = slack_linkify(line)
+        assert "<http://x|PR>" in out
+        # Table structure preserved — same count of table-level pipes
+        assert _pipes_outside_mrkdwn(out) == line.count("|")
+
+    def test_preserves_headers_and_pipes(self) -> None:
+        text = "| MR | repo | verdict |\n|---|---|---|\n| !281 | repo-a | ok |"
+        out = slack_linkify(text, mr_resolver=_mr)
+        assert out.count("\n") == text.count("\n")
+        # Header row untouched
+        assert "| MR | repo | verdict |" in out
+        # Separator row untouched
+        assert "|---|---|---|" in out


### PR DESCRIPTION
## Summary
- New `teatree.slack_mrkdwn` module: idempotent linkifier converting GH markdown `[label](url)` -> Slack mrkdwn `<url|label>` and resolving bare `!N` / `#N` tokens via two new optional hooks on `OverlayBase` ([resolve_mr_token](https://github.com/souliane/teatree/issues/1017), [resolve_issue_token](https://github.com/souliane/teatree/issues/1017), both default `None`).
- `notify.py` wired with `linkify=True` kwarg (default on) — applies transform when backend is Slack.
- 20 unit tests + 5 integration tests; 100% line+branch coverage on the new module.
- Non-breaking: overlays that don't implement the two new hooks see no change in behavior.

## Why
Dashboard / CI / notification messages emitted by `notify.notify_user` use GH-flavored markdown. Slack renders that literally — bare `!N` / `#N` references and `[label](url)` links show as inert text, not clickable. The fix converts to Slack mrkdwn at the boundary, and gives overlays an extension point to map bare tokens to URLs.

## Test plan
- [x] `uv run pytest tests/test_slack_mrkdwn.py tests/teatree_core/test_notify.py --no-cov -q` -> 33 pass
- [x] Broader sweep `tests/teatree_core/ tests/test_slack_mrkdwn.py` -> 1814 pass, 12 skipped
- [x] Idempotency: `linkify(linkify(text)) == linkify(text)`
- [ ] Manual: send a dashboard DM via `notify_user` and confirm `!N` tokens render as clickable links in Slack (requires an overlay that implements the two new hooks)

## Follow-up
Overlay-side: overlays that want bare `!N` / `#N` linkified must implement `resolve_mr_token(n)` and `resolve_issue_token(n)` with their own repo-IID range table. Filed separately on the overlay side.

Closes [#1017](https://github.com/souliane/teatree/issues/1017)