### PR TITLE
fix(core): route messaging_from_overlay to path-only TOML overlays

### DIFF
--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -5,8 +5,8 @@ This module bridges ``teatree.core`` (overlay registry) and
 need to extract tokens or branch on platform themselves.
 """
 
+import os
 from dataclasses import dataclass, field
-from functools import lru_cache
 from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
@@ -57,35 +57,84 @@ class OverlayBackends:
         return self.hosts[0] if self.hosts else None
 
 
-@lru_cache(maxsize=1)
-def code_host_from_overlay() -> CodeHostBackend | None:
+_code_host_cache: dict[str, CodeHostBackend | None] = {}
+_messaging_cache: dict[str, MessagingBackend | None] = {}
+
+
+def _active_overlay_name(overlay_name: str | None) -> str:
+    """Resolve the overlay name to use for cache and TOML lookup.
+
+    Explicit *overlay_name* wins over the ``T3_OVERLAY_NAME`` env var; an
+    empty string is the canonical "default overlay" cache key for callers
+    that rely on single-overlay environments.
+    """
+    if overlay_name:
+        return overlay_name
+    return os.environ.get("T3_OVERLAY_NAME", "") or ""
+
+
+def code_host_from_overlay(overlay_name: str | None = None) -> CodeHostBackend | None:
     """Build a code-host backend using the active overlay's credentials.
 
-    Cached for the loop tick — every scanner that needs the host shares one
-    instance per process. Tests that swap overlays must call
-    :func:`reset_backend_caches` to discard the cached client.
+    Cached per overlay name for the loop tick — every scanner that needs
+    the host shares one instance per process. Tests and wrapper scripts
+    that swap overlays must call :func:`reset_backend_caches`.
+
+    *overlay_name* lets a wrapper script select an overlay explicitly
+    without mutating ``T3_OVERLAY_NAME``. When omitted, falls back to the
+    env var (the same source ``get_overlay()`` reads). Path-only TOML
+    overlays (no ``class:`` key) are supported via a TOML fallback so a
+    bare ``django.setup()`` resolves the right credentials.
     """
+    key = _active_overlay_name(overlay_name)
+    if key in _code_host_cache:
+        return _code_host_cache[key]
+    backend = _build_code_host(key)
+    _code_host_cache[key] = backend
+    return backend
+
+
+def _build_code_host(overlay_name: str) -> CodeHostBackend | None:
     try:
-        overlay = get_overlay()
+        overlay = get_overlay(overlay_name or None)
     except ImproperlyConfigured:
-        return None
+        return _code_host_from_toml_overlay(overlay_name)
     return get_code_host(overlay)
 
 
-@lru_cache(maxsize=1)
-def messaging_from_overlay() -> MessagingBackend | None:
-    """Build a messaging backend using the active overlay's config (cached)."""
+def messaging_from_overlay(overlay_name: str | None = None) -> MessagingBackend | None:
+    """Build a messaging backend using the active overlay's config (cached).
+
+    *overlay_name* lets a wrapper script select an overlay explicitly
+    without mutating ``T3_OVERLAY_NAME``. When omitted, falls back to the
+    env var. Path-only TOML overlays (no ``class:`` key, e.g. an overlay
+    declared via ``[overlays.<name>]`` with only a ``path``) are supported
+    via a TOML fallback — the same chain ``iter_overlay_backends`` uses —
+    so wrapper scripts and bare ``django.setup()`` callers route DMs to
+    the correct overlay's Slack bot instead of silently falling back to
+    no-backend.
+    """
+    key = _active_overlay_name(overlay_name)
+    if key in _messaging_cache:
+        return _messaging_cache[key]
+    backend = _build_messaging(key)
+    _messaging_cache[key] = backend
+    return backend
+
+
+def _build_messaging(overlay_name: str) -> MessagingBackend | None:
     try:
-        overlay = get_overlay()
+        overlay = get_overlay(overlay_name or None)
     except ImproperlyConfigured:
-        return None
+        return _messaging_from_toml_overlay(overlay_name)
     return get_messaging(overlay)
 
 
-def ci_service_from_overlay() -> CIService | None:
+def ci_service_from_overlay(overlay_name: str | None = None) -> CIService | None:
     """Build a CI-service backend using the active overlay's credentials."""
+    key = _active_overlay_name(overlay_name)
     try:
-        overlay = get_overlay()
+        overlay = get_overlay(key or None)
     except ImproperlyConfigured:
         return None
 
@@ -93,6 +142,38 @@ def ci_service_from_overlay() -> CIService | None:
         gitlab_token=overlay.config.get_gitlab_token(),
         gitlab_url=overlay.config.gitlab_url,
     )
+
+
+def _messaging_from_toml_overlay(overlay_name: str) -> MessagingBackend | None:
+    """Build a messaging backend from a path-only TOML overlay entry.
+
+    Used by the fallback in :func:`messaging_from_overlay` so wrapper
+    scripts that opt into an overlay without a registered Python class
+    still route to its credentials. Mirrors the discovery shape of
+    ``_backends_from_toml``.
+    """
+    if not overlay_name:
+        return None
+    from teatree.config import load_config  # noqa: PLC0415
+
+    overlays = load_config().raw.get("overlays") or {}
+    cfg = overlays.get(overlay_name)
+    if not isinstance(cfg, dict):
+        return None
+    return _messaging_from_toml(cfg)
+
+
+def _code_host_from_toml_overlay(overlay_name: str) -> CodeHostBackend | None:
+    """Build a code-host backend from a path-only TOML overlay entry."""
+    if not overlay_name:
+        return None
+    from teatree.config import load_config  # noqa: PLC0415
+
+    overlays = load_config().raw.get("overlays") or {}
+    cfg = overlays.get(overlay_name)
+    if not isinstance(cfg, dict):
+        return None
+    return _host_from_toml(cfg)
 
 
 def iter_overlay_backends() -> list[OverlayBackends]:
@@ -258,8 +339,8 @@ def reset_backend_caches() -> None:
     Call when the active overlay changes (overlay reload, multi-overlay
     test fixtures) so the next factory call rebuilds with fresh credentials.
     """
-    code_host_from_overlay.cache_clear()
-    messaging_from_overlay.cache_clear()
+    _code_host_cache.clear()
+    _messaging_cache.clear()
     _reset_loader_caches()
 
 

--- a/src/teatree/notify.py
+++ b/src/teatree/notify.py
@@ -76,6 +76,29 @@ def notify_user(
     the active ``[overlays.<name>]`` table (falling back to the global
     ``[teatree] slack_user_id``).
 
+    Wrapper scripts that need to route a DM to a specific overlay's bot
+    (e.g. a post-session helper that wants overlay X's bot rather than
+    the one inferred from the current ``T3_OVERLAY_NAME``) should pass
+    *backend* explicitly using :func:`messaging_from_overlay(overlay_name=...)`:
+
+    .. code-block:: python
+
+        from teatree.core.backend_factory import messaging_from_overlay
+        from teatree.notify import notify_user, NotifyKind
+
+        backend = messaging_from_overlay(overlay_name="my-overlay")
+        notify_user(
+            "ready for review",
+            kind=NotifyKind.INFO,
+            idempotency_key="session=...;turn=...",
+            backend=backend,
+            user_id="UXXXX",
+        )
+
+    The factory falls back to ``[overlays.<name>]`` in ``~/.teatree.toml``
+    when an overlay has no registered Python class, so path-only overlays
+    route to their own bot instead of silently returning ``None``.
+
     On success, fetches the message permalink via ``get_permalink`` and
     stores it on the ``BotPing`` row so subsequent CLI surfaces can echo
     a clickable link back to the user (the audited DM is the canonical

--- a/tests/teatree_core/test_backend_factory.py
+++ b/tests/teatree_core/test_backend_factory.py
@@ -1,10 +1,17 @@
 """Tests for the overlay-aware backend factory bridge."""
 
+import os
+from collections.abc import Iterator
 from unittest.mock import patch
 
+import pytest
+
 import teatree.core.overlay_loader as overlay_loader_mod
+from teatree.backends.github import GitHubCodeHost
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab_ci import GitLabCIService
+from teatree.backends.slack_bot import SlackBotBackend
+from teatree.core import backend_factory
 from teatree.core.backend_factory import (
     ci_service_from_overlay,
     code_host_from_overlay,
@@ -12,6 +19,13 @@ from teatree.core.backend_factory import (
     reset_backend_caches,
 )
 from teatree.core.overlay import OverlayBase, OverlayConfig
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Iterator[None]:
+    reset_backend_caches()
+    yield
+    reset_backend_caches()
 
 
 class _TokenConfig(OverlayConfig):
@@ -35,14 +49,6 @@ class _NoTokenOverlay(OverlayBase):
 
     def get_provision_steps(self, worktree):
         return []
-
-
-def setup_function() -> None:
-    reset_backend_caches()
-
-
-def teardown_function() -> None:
-    reset_backend_caches()
 
 
 def _patch_overlay(overlay_cls):
@@ -120,3 +126,191 @@ def test_reset_backend_caches_clears_all_caches() -> None:
     with _patch_overlay(_NoTokenOverlay):
         second = code_host_from_overlay()
     assert first is not second
+
+
+def _toml_only_config(overlays: dict) -> object:
+    return type("Cfg", (), {"raw": {"overlays": overlays}})()
+
+
+class TestMessagingFromOverlayTomlFallback:
+    """A path-only TOML overlay (no ``class:`` key) still resolves a backend.
+
+    Regression: a wrapper script that sets ``T3_OVERLAY_NAME`` and calls
+    ``django.setup()`` would get ``None`` because ``_discover_overlays``
+    skips path-only TOML entries — the messaging factory then never
+    consulted the TOML fallback that ``iter_overlay_backends`` uses,
+    silently routing DMs to the wrong overlay's bot.
+    """
+
+    def test_falls_back_to_toml_when_overlay_class_missing(self) -> None:
+        cfg = _toml_only_config(
+            {
+                "private-x": {
+                    "path": "~/workspace/private-x",
+                    "messaging_backend": "slack",
+                    "slack_token_ref": "teatree/private-x/slack",
+                    "slack_user_id": "U1",
+                },
+            },
+        )
+        seen: list[str] = []
+
+        def fake_read(key: str) -> str:
+            seen.append(key)
+            return {
+                "teatree/private-x/slack-bot": "x-bot-tok",
+                "teatree/private-x/slack-app": "x-app-tok",
+            }.get(key, "")
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=fake_read),
+        ):
+            backend = messaging_from_overlay(overlay_name="private-x")
+
+        assert isinstance(backend, SlackBotBackend)
+        assert "teatree/private-x/slack-bot" in seen
+        assert "teatree/private-x/slack-app" in seen
+
+    def test_explicit_overlay_name_wins_over_env_var(self) -> None:
+        cfg = _toml_only_config(
+            {
+                "private-x": {
+                    "path": "~/workspace/private-x",
+                    "messaging_backend": "slack",
+                    "slack_token_ref": "teatree/private-x/slack",
+                },
+                "teatree": {
+                    "messaging_backend": "slack",
+                    "slack_token_ref": "teatree/teatree/slack",
+                },
+            },
+        )
+        seen: list[str] = []
+
+        def fake_read(key: str) -> str:
+            seen.append(key)
+            return {
+                "teatree/private-x/slack-bot": "x-bot",
+                "teatree/private-x/slack-app": "x-app",
+                "teatree/teatree/slack-bot": "teatree-bot",
+                "teatree/teatree/slack-app": "teatree-app",
+            }.get(key, "")
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=fake_read),
+            patch.dict(os.environ, {"T3_OVERLAY_NAME": "teatree"}, clear=False),
+        ):
+            backend = messaging_from_overlay(overlay_name="private-x")
+
+        assert isinstance(backend, SlackBotBackend)
+        # Read keys must come from private-x, not teatree.
+        assert any(k.startswith("teatree/private-x/") for k in seen)
+        assert not any(k.startswith("teatree/teatree/") for k in seen)
+
+    def test_reads_env_var_when_overlay_name_not_passed(self) -> None:
+        cfg = _toml_only_config(
+            {
+                "private-x": {
+                    "messaging_backend": "slack",
+                    "slack_token_ref": "teatree/private-x/slack",
+                },
+            },
+        )
+
+        def fake_read(key: str) -> str:
+            return "x-bot" if key == "teatree/private-x/slack-bot" else ""
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=fake_read),
+            patch.dict(os.environ, {"T3_OVERLAY_NAME": "private-x"}, clear=False),
+        ):
+            backend = messaging_from_overlay()
+
+        assert isinstance(backend, SlackBotBackend)
+
+    def test_returns_none_when_named_overlay_absent_from_toml(self) -> None:
+        cfg = _toml_only_config({})
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+        ):
+            assert messaging_from_overlay(overlay_name="ghost") is None
+
+    def test_caches_separately_per_overlay_name(self) -> None:
+        cfg = _toml_only_config(
+            {
+                "private-x": {"messaging_backend": "slack", "slack_token_ref": "ref-x"},
+                "teatree": {"messaging_backend": "slack", "slack_token_ref": "ref-tt"},
+            },
+        )
+
+        def fake_read(key: str) -> str:
+            return {
+                "ref-x-bot": "x-bot",
+                "ref-tt-bot": "tt-bot",
+            }.get(key, "")
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=fake_read),
+        ):
+            x = messaging_from_overlay(overlay_name="private-x")
+            tt = messaging_from_overlay(overlay_name="teatree")
+
+        assert isinstance(x, SlackBotBackend)
+        assert isinstance(tt, SlackBotBackend)
+        assert x is not tt
+
+
+class TestCodeHostFromOverlayTomlFallback:
+    def test_falls_back_to_toml_host_when_overlay_class_missing(self) -> None:
+        cfg = _toml_only_config(
+            {
+                "private-x": {
+                    "path": "~/workspace/private-x",
+                    "github_token_ref": "github/private-x/pat",
+                },
+            },
+        )
+
+        def fake_read(key: str) -> str:
+            return "ghp-test" if key == "github/private-x/pat" else ""
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=fake_read),
+        ):
+            host = code_host_from_overlay(overlay_name="private-x")
+
+        assert isinstance(host, GitHubCodeHost)
+
+    def test_returns_none_when_named_overlay_absent_from_toml(self) -> None:
+        cfg = _toml_only_config({})
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+        ):
+            assert code_host_from_overlay(overlay_name="ghost") is None
+
+
+class TestActiveOverlayName:
+    def test_explicit_name_overrides_env(self) -> None:
+        with patch.dict(os.environ, {"T3_OVERLAY_NAME": "env-name"}, clear=False):
+            assert backend_factory._active_overlay_name("explicit") == "explicit"
+
+    def test_falls_back_to_env_when_not_provided(self) -> None:
+        with patch.dict(os.environ, {"T3_OVERLAY_NAME": "env-name"}, clear=False):
+            assert backend_factory._active_overlay_name(None) == "env-name"
+
+    def test_empty_string_when_neither_set(self) -> None:
+        env = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+        with patch.dict(os.environ, env, clear=True):
+            assert backend_factory._active_overlay_name(None) == ""


### PR DESCRIPTION
fix(core): route messaging_from_overlay to path-only TOML overlays

A path-only ``[overlays.<name>]`` entry in ~/.teatree.toml (one with only
``path = "..."`` and credential keys, no ``class:`` import path) is skipped
by ``_discover_overlays`` because there's no Python overlay class to
instantiate. ``messaging_from_overlay()`` and ``code_host_from_overlay()``
relied on ``get_overlay()`` and so returned ``None`` for those overlays —
even though the iter_overlay_backends path already has a sibling TOML
resolver for exactly this shape. A wrapper script setting
``T3_OVERLAY_NAME`` to one of these overlays and calling
``django.setup()`` got ``None`` and silently fell back to no-backend,
mis-routing DMs to the wrong messaging bot.

Add a TOML fallback to both factory entry points: when class-based
discovery fails for a named overlay, build the backend from the
``[overlays.<name>]`` TOML table directly using the same chain
``_backends_from_toml`` uses. Also add an explicit ``overlay_name`` kwarg
so wrapper scripts can select an overlay without mutating
``T3_OVERLAY_NAME`` (cache keys on overlay name so concurrent
multi-overlay callers don't clobber each other).