### PR TITLE
feat(slack): route reactions through user-OAuth token for Slack-Connect channels

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1154,6 +1154,7 @@ path = "~/workspace/myproject"
 code_host = "github"                       # "github" | "gitlab"
 messaging_backend = "slack"                # "slack" | "noop" (default)
 slack_token_ref = "teatree/slack/myproject"   # `pass` entry prefix; -bot and -app suffixes resolve the two tokens
+user_token_ref = "slack/user-oauth-token"  # optional; `pass` entry holding the human's xoxp token (routes reactions on Slack-Connect channels where the bot token is rejected)
 slack_user_id = "U01ABCD1234"              # my Slack user ID (used to filter mentions/DMs)
 
 [overlays.another-project]

--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -110,13 +110,21 @@ def get_messaging(overlay: "OverlayBase") -> MessagingBackend:
 
     Default is :class:`NoopMessagingBackend` so callers always get a
     Protocol-conforming object — no per-call ``is None`` guards.
+
+    The optional ``user_token_ref`` field on ``OverlayConfig`` points at a
+    ``pass`` entry holding the human user's OAuth token (``xoxp-…``).  When
+    set, ``SlackBotBackend`` authenticates reactions through that token so
+    Slack-Connect externally-shared channels accept them — the bot token is
+    rejected there by the workspace restriction policy.
     """
     choice = overlay.config.messaging_backend or "noop"
     if choice == "slack":
         token_ref = overlay.config.slack_token_ref
+        user_token_ref = getattr(overlay.config, "user_token_ref", "")
         return SlackBotBackend(
             bot_token=read_pass(f"{token_ref}-bot") if token_ref else overlay.config.get_slack_token(),
             app_token=read_pass(f"{token_ref}-app") if token_ref else "",
+            user_token=read_pass(user_token_ref) if user_token_ref else "",
             user_id=overlay.config.slack_user_id,
         )
     if choice == "noop":

--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -8,6 +8,15 @@ are wired up by the ``t3 setup slack-bot`` walkthrough (see BLUEPRINT § 3.6).
 The Phase 3 surface is intentionally minimal: enough for outbound routing
 from the loop's scanners, with the Socket Mode receiver delivering inbound
 events into the same backend through a queue managed by Phase 3.6.
+
+Slack-Connect externally-shared channels reject reactions posted with a
+bot token (``mcp_externally_shared_channel_restricted``).  When the human
+user's OAuth token (``xoxp-…``) is configured via ``user_token_ref`` in
+``~/.teatree.toml``, ``react`` and ``get_reactions`` authenticate with
+that token instead.  Everything else (DMs, ``chat.postMessage``,
+``conversations.open``, ``users.lookupByEmail``) keeps using the bot
+token because those endpoints are scoped to the bot's own IM channels
+and cache.
 """
 
 from typing import cast
@@ -20,19 +29,31 @@ type SlackPayload = dict[str, object]
 
 
 class SlackBotBackend:
-    """MessagingBackend backed by a Slack bot token.
+    """MessagingBackend backed by a Slack bot token, optionally with a user token.
 
-    ``bot_token`` (``xoxb-…``) authorises Web API calls.
+    ``bot_token`` (``xoxb-…``) authorises Web API calls for DMs, posts, and
+    bot-scoped lookups.
     ``app_token`` (``xapp-…``) authorises Socket Mode and is consumed by the
     Phase 3.6 walkthrough — kept on the instance so the bot starter can pick
     it up without a second config read.
+    ``user_token`` (``xoxp-…``) authorises reactions in Slack-Connect
+    externally-shared channels where the bot token is rejected by the workspace
+    restriction policy.  When unset, reactions fall back to the bot token.
     ``user_id`` is the Slack user id of the human the bot speaks for; scanners
     use it to filter @mentions targeted at that user.
     """
 
-    def __init__(self, *, bot_token: str = "", app_token: str = "", user_id: str = "") -> None:
+    def __init__(
+        self,
+        *,
+        bot_token: str = "",
+        app_token: str = "",
+        user_token: str = "",
+        user_id: str = "",
+    ) -> None:
         self._bot_token = bot_token
         self._app_token = app_token
+        self._user_token = user_token
         self._user_id = user_id
         self._cached_bot_id: str | None = None
         # Inbound queues populated by the Phase 3.6 Socket Mode receiver. Each
@@ -49,6 +70,10 @@ class SlackBotBackend:
     def user_id(self) -> str:
         return self._user_id
 
+    @property
+    def user_token(self) -> str:
+        return self._user_token
+
     def enqueue_mention(self, event: RawAPIDict) -> None:
         """Push a Socket Mode ``app_mention`` event into the inbound queue."""
         self._mentions.append(event)
@@ -57,13 +82,14 @@ class SlackBotBackend:
         """Push a Socket Mode ``message.im`` event into the inbound queue."""
         self._dms.append(event)
 
-    def _post(self, method: str, payload: SlackPayload) -> RawAPIDict:
-        if not self._bot_token:
+    def _post(self, method: str, payload: SlackPayload, *, token: str = "") -> RawAPIDict:
+        auth = token or self._bot_token
+        if not auth:
             return {}
         response = httpx.post(
             f"https://slack.com/api/{method}",
             headers={
-                "Authorization": f"Bearer {self._bot_token}",
+                "Authorization": f"Bearer {auth}",
                 "Content-Type": "application/json; charset=utf-8",
             },
             json=payload,
@@ -72,17 +98,29 @@ class SlackBotBackend:
         response.raise_for_status()
         return cast("RawAPIDict", response.json())
 
-    def _get(self, method: str, params: dict[str, str | int]) -> RawAPIDict:
-        if not self._bot_token:
+    def _get(self, method: str, params: dict[str, str | int], *, token: str = "") -> RawAPIDict:
+        auth = token or self._bot_token
+        if not auth:
             return {}
         response = httpx.get(
             f"https://slack.com/api/{method}",
-            headers={"Authorization": f"Bearer {self._bot_token}"},
+            headers={"Authorization": f"Bearer {auth}"},
             params=params,
             timeout=10.0,
         )
         response.raise_for_status()
         return cast("RawAPIDict", response.json())
+
+    def _reaction_token(self) -> str:
+        """Token authorising ``reactions.*`` calls.
+
+        Slack-Connect externally-shared channels block bot tokens with
+        ``mcp_externally_shared_channel_restricted``.  When the human's
+        ``xoxp`` is configured we route reactions through it so they post
+        from the user's identity; otherwise fall back to the bot token
+        for the legacy single-credential case.
+        """
+        return self._user_token or self._bot_token
 
     def fetch_mentions(self, *, since: str = "") -> list[RawAPIDict]:
         """Drain queued Socket Mode mentions and return them in order.
@@ -146,7 +184,11 @@ class SlackBotBackend:
         return self._post("chat.postMessage", {"channel": channel, "thread_ts": ts, "text": text})
 
     def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
-        return self._post("reactions.add", {"channel": channel, "timestamp": ts, "name": emoji})
+        return self._post(
+            "reactions.add",
+            {"channel": channel, "timestamp": ts, "name": emoji},
+            token=self._reaction_token(),
+        )
 
     def open_dm(self, user_id: str) -> str:
         """Open a direct-message channel with *user_id* and return its channel id."""
@@ -169,7 +211,11 @@ class SlackBotBackend:
 
     def get_reactions(self, *, channel: str, ts: str) -> list[str]:
         """Return the emoji names currently set on a message."""
-        data = self._get("reactions.get", {"channel": channel, "timestamp": ts})
+        data = self._get(
+            "reactions.get",
+            {"channel": channel, "timestamp": ts},
+            token=self._reaction_token(),
+        )
         if not data.get("ok"):
             return []
         message = cast("RawAPIDict", data.get("message") or {})

--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -327,9 +327,16 @@ def _messaging_from_toml(cfg: dict) -> MessagingBackend | None:
         return None
     bot_token = read_pass(f"{token_ref}-bot")
     app_token = read_pass(f"{token_ref}-app")
+    user_token_ref = cfg.get("user_token_ref", "")
+    user_token = read_pass(user_token_ref) if user_token_ref else ""
     user_id = cfg.get("slack_user_id", "")
     if bot_token:
-        return SlackBotBackend(bot_token=bot_token, app_token=app_token or "", user_id=user_id)
+        return SlackBotBackend(
+            bot_token=bot_token,
+            app_token=app_token or "",
+            user_token=user_token,
+            user_id=user_id,
+        )
     return None
 
 

--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -5,8 +5,8 @@ This module bridges ``teatree.core`` (overlay registry) and
 need to extract tokens or branch on platform themselves.
 """
 
+import os
 from dataclasses import dataclass, field
-from functools import lru_cache
 from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
@@ -57,35 +57,84 @@ class OverlayBackends:
         return self.hosts[0] if self.hosts else None
 
 
-@lru_cache(maxsize=1)
-def code_host_from_overlay() -> CodeHostBackend | None:
+_code_host_cache: dict[str, CodeHostBackend | None] = {}
+_messaging_cache: dict[str, MessagingBackend | None] = {}
+
+
+def _active_overlay_name(overlay_name: str | None) -> str:
+    """Resolve the overlay name to use for cache and TOML lookup.
+
+    Explicit *overlay_name* wins over the ``T3_OVERLAY_NAME`` env var; an
+    empty string is the canonical "default overlay" cache key for callers
+    that rely on single-overlay environments.
+    """
+    if overlay_name:
+        return overlay_name
+    return os.environ.get("T3_OVERLAY_NAME", "") or ""
+
+
+def code_host_from_overlay(overlay_name: str | None = None) -> CodeHostBackend | None:
     """Build a code-host backend using the active overlay's credentials.
 
-    Cached for the loop tick — every scanner that needs the host shares one
-    instance per process. Tests that swap overlays must call
-    :func:`reset_backend_caches` to discard the cached client.
+    Cached per overlay name for the loop tick — every scanner that needs
+    the host shares one instance per process. Tests and wrapper scripts
+    that swap overlays must call :func:`reset_backend_caches`.
+
+    *overlay_name* lets a wrapper script select an overlay explicitly
+    without mutating ``T3_OVERLAY_NAME``. When omitted, falls back to the
+    env var (the same source ``get_overlay()`` reads). Path-only TOML
+    overlays (no ``class:`` key) are supported via a TOML fallback so a
+    bare ``django.setup()`` resolves the right credentials.
     """
+    key = _active_overlay_name(overlay_name)
+    if key in _code_host_cache:
+        return _code_host_cache[key]
+    backend = _build_code_host(key)
+    _code_host_cache[key] = backend
+    return backend
+
+
+def _build_code_host(overlay_name: str) -> CodeHostBackend | None:
     try:
-        overlay = get_overlay()
+        overlay = get_overlay(overlay_name or None)
     except ImproperlyConfigured:
-        return None
+        return _code_host_from_toml_overlay(overlay_name)
     return get_code_host(overlay)
 
 
-@lru_cache(maxsize=1)
-def messaging_from_overlay() -> MessagingBackend | None:
-    """Build a messaging backend using the active overlay's config (cached)."""
+def messaging_from_overlay(overlay_name: str | None = None) -> MessagingBackend | None:
+    """Build a messaging backend using the active overlay's config (cached).
+
+    *overlay_name* lets a wrapper script select an overlay explicitly
+    without mutating ``T3_OVERLAY_NAME``. When omitted, falls back to the
+    env var. Path-only TOML overlays (no ``class:`` key, e.g. an overlay
+    declared via ``[overlays.<name>]`` with only a ``path``) are supported
+    via a TOML fallback — the same chain ``iter_overlay_backends`` uses —
+    so wrapper scripts and bare ``django.setup()`` callers route DMs to
+    the correct overlay's Slack bot instead of silently falling back to
+    no-backend.
+    """
+    key = _active_overlay_name(overlay_name)
+    if key in _messaging_cache:
+        return _messaging_cache[key]
+    backend = _build_messaging(key)
+    _messaging_cache[key] = backend
+    return backend
+
+
+def _build_messaging(overlay_name: str) -> MessagingBackend | None:
     try:
-        overlay = get_overlay()
+        overlay = get_overlay(overlay_name or None)
     except ImproperlyConfigured:
-        return None
+        return _messaging_from_toml_overlay(overlay_name)
     return get_messaging(overlay)
 
 
-def ci_service_from_overlay() -> CIService | None:
+def ci_service_from_overlay(overlay_name: str | None = None) -> CIService | None:
     """Build a CI-service backend using the active overlay's credentials."""
+    key = _active_overlay_name(overlay_name)
     try:
-        overlay = get_overlay()
+        overlay = get_overlay(key or None)
     except ImproperlyConfigured:
         return None
 
@@ -93,6 +142,38 @@ def ci_service_from_overlay() -> CIService | None:
         gitlab_token=overlay.config.get_gitlab_token(),
         gitlab_url=overlay.config.gitlab_url,
     )
+
+
+def _messaging_from_toml_overlay(overlay_name: str) -> MessagingBackend | None:
+    """Build a messaging backend from a path-only TOML overlay entry.
+
+    Used by the fallback in :func:`messaging_from_overlay` so wrapper
+    scripts that opt into an overlay without a registered Python class
+    still route to its credentials. Mirrors the discovery shape of
+    ``_backends_from_toml``.
+    """
+    if not overlay_name:
+        return None
+    from teatree.config import load_config  # noqa: PLC0415
+
+    overlays = load_config().raw.get("overlays") or {}
+    cfg = overlays.get(overlay_name)
+    if not isinstance(cfg, dict):
+        return None
+    return _messaging_from_toml(cfg)
+
+
+def _code_host_from_toml_overlay(overlay_name: str) -> CodeHostBackend | None:
+    """Build a code-host backend from a path-only TOML overlay entry."""
+    if not overlay_name:
+        return None
+    from teatree.config import load_config  # noqa: PLC0415
+
+    overlays = load_config().raw.get("overlays") or {}
+    cfg = overlays.get(overlay_name)
+    if not isinstance(cfg, dict):
+        return None
+    return _host_from_toml(cfg)
 
 
 def iter_overlay_backends() -> list[OverlayBackends]:
@@ -258,8 +339,8 @@ def reset_backend_caches() -> None:
     Call when the active overlay changes (overlay reload, multi-overlay
     test fixtures) so the next factory call rebuilds with fresh credentials.
     """
-    code_host_from_overlay.cache_clear()
-    messaging_from_overlay.cache_clear()
+    _code_host_cache.clear()
+    _messaging_cache.clear()
     _reset_loader_caches()
 
 

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -69,6 +69,11 @@ class OverlayConfig:
     code_host: str = ""
     messaging_backend: str = "noop"
     slack_token_ref: str = ""
+    # ``user_token_ref`` points at a ``pass`` entry holding the human user's
+    # Slack OAuth token (``xoxp-…``).  Routed by ``SlackBotBackend`` for
+    # reactions on Slack-Connect externally-shared channels where the bot
+    # token is rejected by the workspace restriction policy.
+    user_token_ref: str = ""
     slack_user_id: str = ""
     require_ticket: bool = False
     ready_labels: list[str]

--- a/src/teatree/notify.py
+++ b/src/teatree/notify.py
@@ -76,6 +76,29 @@ def notify_user(
     the active ``[overlays.<name>]`` table (falling back to the global
     ``[teatree] slack_user_id``).
 
+    Wrapper scripts that need to route a DM to a specific overlay's bot
+    (e.g. a post-session helper that wants overlay X's bot rather than
+    the one inferred from the current ``T3_OVERLAY_NAME``) should pass
+    *backend* explicitly using :func:`messaging_from_overlay(overlay_name=...)`:
+
+    .. code-block:: python
+
+        from teatree.core.backend_factory import messaging_from_overlay
+        from teatree.notify import notify_user, NotifyKind
+
+        backend = messaging_from_overlay(overlay_name="my-overlay")
+        notify_user(
+            "ready for review",
+            kind=NotifyKind.INFO,
+            idempotency_key="session=...;turn=...",
+            backend=backend,
+            user_id="UXXXX",
+        )
+
+    The factory falls back to ``[overlays.<name>]`` in ``~/.teatree.toml``
+    when an overlay has no registered Python class, so path-only overlays
+    route to their own bot instead of silently returning ``None``.
+
     On success, fetches the message permalink via ``get_permalink`` and
     stores it on the ``BotPing`` row so subsequent CLI surfaces can echo
     a clickable link back to the user (the audited DM is the canonical

--- a/tests/teatree_backends/test_loader.py
+++ b/tests/teatree_backends/test_loader.py
@@ -141,6 +141,46 @@ def test_get_messaging_raises_on_unknown_choice() -> None:
         get_messaging(overlay)
 
 
+def test_get_messaging_resolves_user_token_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``user_token_ref`` is resolved via ``pass`` and threaded into ``SlackBotBackend``.
+
+    Slack-Connect channels reject ``xoxb`` reactions; routing them through
+    the human's ``xoxp`` token is the workaround.  The loader must read the
+    ref from ``pass`` and hand the resolved secret to the backend.
+    """
+    pass_lookups: dict[str, str] = {
+        "ref/bot-bot": "xoxb-resolved",
+        "ref/bot-app": "xapp-resolved",
+        "slack/user-oauth": "xoxp-resolved",
+    }
+
+    def fake_read_pass(key: str) -> str:
+        return pass_lookups.get(key, "")
+
+    monkeypatch.setattr("teatree.backends.loader.read_pass", fake_read_pass)
+
+    overlay = _build_overlay(
+        messaging_backend="slack",
+        slack_token_ref="ref/bot",
+        user_token_ref="slack/user-oauth",
+    )
+    backend = get_messaging(overlay)
+
+    assert isinstance(backend, SlackBotBackend)
+    assert backend.user_token == "xoxp-resolved"
+
+
+def test_get_messaging_user_token_absent_when_ref_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without ``user_token_ref`` the backend keeps an empty user token."""
+    monkeypatch.setattr("teatree.backends.loader.read_pass", lambda _: "xoxb-resolved")
+
+    overlay = _build_overlay(messaging_backend="slack", slack_token_ref="ref/bot")
+    backend = get_messaging(overlay)
+
+    assert isinstance(backend, SlackBotBackend)
+    assert backend.user_token == ""
+
+
 def test_get_ci_service_returns_none_when_no_token() -> None:
     assert get_ci_service() is None
 

--- a/tests/teatree_backends/test_slack_user_token_routing.py
+++ b/tests/teatree_backends/test_slack_user_token_routing.py
@@ -1,0 +1,190 @@
+"""Tests for SlackBotBackend's user-token reaction routing.
+
+Slack-Connect externally-shared channels block bot tokens (``xoxb-…``) from
+posting reactions with ``mcp_externally_shared_channel_restricted`` /
+``not_in_channel``. The fix is to route reactions through the human's
+user-OAuth token (``xoxp-…``) when one is configured, while keeping the
+bot token as the authoriser for DMs, mentions, and outgoing messages —
+DMs are scoped to the bot's IM channels and have to stay on the bot
+token.
+
+These tests assert the routing split: ``react`` and ``get_reactions``
+authenticate with the user token when present; ``post_message``,
+``post_reply``, ``open_dm``, ``fetch_dms``, and ``resolve_user_id`` keep
+using the bot token.
+"""
+
+from typing import cast
+
+import httpx
+import pytest
+
+from teatree.backends import slack_bot
+from teatree.backends.slack_bot import SlackBotBackend
+
+
+def _capturing_post(captured: list[dict[str, object]]) -> object:
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        captured.append({"url": url, **kwargs})
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    return fake_post
+
+
+def _capturing_get(captured: list[dict[str, object]]) -> object:
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        captured.append({"url": url, **kwargs})
+        return httpx.Response(
+            200,
+            json={"ok": True, "message": {"reactions": [{"name": "eyes"}]}},
+            request=httpx.Request("GET", url),
+        )
+
+    return fake_get
+
+
+class TestReactRoutesThroughUserToken:
+    """``react`` uses the user token whenever one is configured."""
+
+    def test_react_uses_user_token_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[dict[str, object]] = []
+        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.react(channel="C0AM3TENTLK", ts="1779168774.186559", emoji="eyes")
+
+        assert len(captured) == 1
+        headers = cast("dict[str, str]", captured[0]["headers"])
+        assert headers["Authorization"] == "Bearer xoxp-user"
+        assert captured[0]["url"] == "https://slack.com/api/reactions.add"
+
+    def test_react_falls_back_to_bot_token_when_user_token_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[dict[str, object]] = []
+        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+
+        backend = SlackBotBackend(bot_token="xoxb-bot")
+        backend.react(channel="C1", ts="1.0", emoji="eyes")
+
+        headers = cast("dict[str, str]", captured[0]["headers"])
+        assert headers["Authorization"] == "Bearer xoxb-bot"
+
+    def test_react_returns_empty_when_neither_token_set(self) -> None:
+        backend = SlackBotBackend()
+        assert backend.react(channel="C", ts="1.0", emoji="eyes") == {}
+
+
+class TestGetReactionsRoutesThroughUserToken:
+    """``get_reactions`` uses the user token whenever one is configured."""
+
+    def test_get_reactions_uses_user_token_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[dict[str, object]] = []
+        monkeypatch.setattr(slack_bot.httpx, "get", _capturing_get(captured))
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.get_reactions(channel="C0AM3TENTLK", ts="1779168774.186559")
+
+        assert len(captured) == 1
+        headers = cast("dict[str, str]", captured[0]["headers"])
+        assert headers["Authorization"] == "Bearer xoxp-user"
+        assert captured[0]["url"] == "https://slack.com/api/reactions.get"
+
+    def test_get_reactions_falls_back_to_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[dict[str, object]] = []
+        monkeypatch.setattr(slack_bot.httpx, "get", _capturing_get(captured))
+
+        backend = SlackBotBackend(bot_token="xoxb-bot")
+        backend.get_reactions(channel="C1", ts="1.0")
+
+        headers = cast("dict[str, str]", captured[0]["headers"])
+        assert headers["Authorization"] == "Bearer xoxb-bot"
+
+
+class TestBotTokenStillAuthorisesNonReactionCalls:
+    """DMs, mentions, post_message, open_dm, resolve_user_id keep using bot token.
+
+    The bot token is the only credential authorised for the bot's own DM
+    channels, ``conversations.open`` against the bot's IM, and the bot's
+    ``users.lookupByEmail`` cache.  Routing those through ``xoxp`` would
+    impersonate the user against their own DM history, which the user
+    explicitly opted out of by configuring the bot in the first place.
+    """
+
+    def test_post_message_uses_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[dict[str, object]] = []
+        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.post_message(channel="C", text="hi")
+
+        headers = cast("dict[str, str]", captured[0]["headers"])
+        assert headers["Authorization"] == "Bearer xoxb-bot"
+        assert captured[0]["url"] == "https://slack.com/api/chat.postMessage"
+
+    def test_post_reply_uses_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[dict[str, object]] = []
+        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.post_reply(channel="C", ts="1.0", text="hi")
+
+        headers = cast("dict[str, str]", captured[0]["headers"])
+        assert headers["Authorization"] == "Bearer xoxb-bot"
+
+    def test_open_dm_uses_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[dict[str, object]] = []
+
+        def fake_post(url: str, **kwargs: object) -> httpx.Response:
+            captured.append({"url": url, **kwargs})
+            return httpx.Response(
+                200,
+                json={"ok": True, "channel": {"id": "D1"}},
+                request=httpx.Request("POST", url),
+            )
+
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.open_dm("U123")
+
+        headers = cast("dict[str, str]", captured[0]["headers"])
+        assert headers["Authorization"] == "Bearer xoxb-bot"
+        assert captured[0]["url"] == "https://slack.com/api/conversations.open"
+
+    def test_resolve_user_id_uses_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[dict[str, object]] = []
+
+        def fake_get(url: str, **kwargs: object) -> httpx.Response:
+            captured.append({"url": url, **kwargs})
+            return httpx.Response(
+                200,
+                json={"ok": True, "members": [{"id": "U1", "name": "alice"}]},
+                request=httpx.Request("GET", url),
+            )
+
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.resolve_user_id("alice")
+
+        headers = cast("dict[str, str]", captured[0]["headers"])
+        assert headers["Authorization"] == "Bearer xoxb-bot"
+
+
+class TestUserTokenOnly:
+    """A backend configured with only a user token (no bot) still posts reactions."""
+
+    def test_react_works_with_only_user_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: list[dict[str, object]] = []
+        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+
+        backend = SlackBotBackend(user_token="xoxp-user")
+        result = backend.react(channel="C", ts="1.0", emoji="eyes")
+
+        assert result == {"ok": True}
+        headers = cast("dict[str, str]", captured[0]["headers"])
+        assert headers["Authorization"] == "Bearer xoxp-user"
+
+    def test_post_message_returns_empty_when_only_user_token(self) -> None:
+        """post_message has no fallback — bot token is mandatory for DMs/chat."""
+        backend = SlackBotBackend(user_token="xoxp-user")
+        assert backend.post_message(channel="C", text="hi") == {}

--- a/tests/teatree_core/test_backend_factory.py
+++ b/tests/teatree_core/test_backend_factory.py
@@ -1,10 +1,17 @@
 """Tests for the overlay-aware backend factory bridge."""
 
+import os
+from collections.abc import Iterator
 from unittest.mock import patch
 
+import pytest
+
 import teatree.core.overlay_loader as overlay_loader_mod
+from teatree.backends.github import GitHubCodeHost
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab_ci import GitLabCIService
+from teatree.backends.slack_bot import SlackBotBackend
+from teatree.core import backend_factory
 from teatree.core.backend_factory import (
     ci_service_from_overlay,
     code_host_from_overlay,
@@ -12,6 +19,13 @@ from teatree.core.backend_factory import (
     reset_backend_caches,
 )
 from teatree.core.overlay import OverlayBase, OverlayConfig
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Iterator[None]:
+    reset_backend_caches()
+    yield
+    reset_backend_caches()
 
 
 class _TokenConfig(OverlayConfig):
@@ -35,14 +49,6 @@ class _NoTokenOverlay(OverlayBase):
 
     def get_provision_steps(self, worktree):
         return []
-
-
-def setup_function() -> None:
-    reset_backend_caches()
-
-
-def teardown_function() -> None:
-    reset_backend_caches()
 
 
 def _patch_overlay(overlay_cls):
@@ -120,3 +126,191 @@ def test_reset_backend_caches_clears_all_caches() -> None:
     with _patch_overlay(_NoTokenOverlay):
         second = code_host_from_overlay()
     assert first is not second
+
+
+def _toml_only_config(overlays: dict) -> object:
+    return type("Cfg", (), {"raw": {"overlays": overlays}})()
+
+
+class TestMessagingFromOverlayTomlFallback:
+    """A path-only TOML overlay (no ``class:`` key) still resolves a backend.
+
+    Regression: a wrapper script that sets ``T3_OVERLAY_NAME`` and calls
+    ``django.setup()`` would get ``None`` because ``_discover_overlays``
+    skips path-only TOML entries — the messaging factory then never
+    consulted the TOML fallback that ``iter_overlay_backends`` uses,
+    silently routing DMs to the wrong overlay's bot.
+    """
+
+    def test_falls_back_to_toml_when_overlay_class_missing(self) -> None:
+        cfg = _toml_only_config(
+            {
+                "private-x": {
+                    "path": "~/workspace/private-x",
+                    "messaging_backend": "slack",
+                    "slack_token_ref": "teatree/private-x/slack",
+                    "slack_user_id": "U1",
+                },
+            },
+        )
+        seen: list[str] = []
+
+        def fake_read(key: str) -> str:
+            seen.append(key)
+            return {
+                "teatree/private-x/slack-bot": "x-bot-tok",
+                "teatree/private-x/slack-app": "x-app-tok",
+            }.get(key, "")
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=fake_read),
+        ):
+            backend = messaging_from_overlay(overlay_name="private-x")
+
+        assert isinstance(backend, SlackBotBackend)
+        assert "teatree/private-x/slack-bot" in seen
+        assert "teatree/private-x/slack-app" in seen
+
+    def test_explicit_overlay_name_wins_over_env_var(self) -> None:
+        cfg = _toml_only_config(
+            {
+                "private-x": {
+                    "path": "~/workspace/private-x",
+                    "messaging_backend": "slack",
+                    "slack_token_ref": "teatree/private-x/slack",
+                },
+                "teatree": {
+                    "messaging_backend": "slack",
+                    "slack_token_ref": "teatree/teatree/slack",
+                },
+            },
+        )
+        seen: list[str] = []
+
+        def fake_read(key: str) -> str:
+            seen.append(key)
+            return {
+                "teatree/private-x/slack-bot": "x-bot",
+                "teatree/private-x/slack-app": "x-app",
+                "teatree/teatree/slack-bot": "teatree-bot",
+                "teatree/teatree/slack-app": "teatree-app",
+            }.get(key, "")
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=fake_read),
+            patch.dict(os.environ, {"T3_OVERLAY_NAME": "teatree"}, clear=False),
+        ):
+            backend = messaging_from_overlay(overlay_name="private-x")
+
+        assert isinstance(backend, SlackBotBackend)
+        # Read keys must come from private-x, not teatree.
+        assert any(k.startswith("teatree/private-x/") for k in seen)
+        assert not any(k.startswith("teatree/teatree/") for k in seen)
+
+    def test_reads_env_var_when_overlay_name_not_passed(self) -> None:
+        cfg = _toml_only_config(
+            {
+                "private-x": {
+                    "messaging_backend": "slack",
+                    "slack_token_ref": "teatree/private-x/slack",
+                },
+            },
+        )
+
+        def fake_read(key: str) -> str:
+            return "x-bot" if key == "teatree/private-x/slack-bot" else ""
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=fake_read),
+            patch.dict(os.environ, {"T3_OVERLAY_NAME": "private-x"}, clear=False),
+        ):
+            backend = messaging_from_overlay()
+
+        assert isinstance(backend, SlackBotBackend)
+
+    def test_returns_none_when_named_overlay_absent_from_toml(self) -> None:
+        cfg = _toml_only_config({})
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+        ):
+            assert messaging_from_overlay(overlay_name="ghost") is None
+
+    def test_caches_separately_per_overlay_name(self) -> None:
+        cfg = _toml_only_config(
+            {
+                "private-x": {"messaging_backend": "slack", "slack_token_ref": "ref-x"},
+                "teatree": {"messaging_backend": "slack", "slack_token_ref": "ref-tt"},
+            },
+        )
+
+        def fake_read(key: str) -> str:
+            return {
+                "ref-x-bot": "x-bot",
+                "ref-tt-bot": "tt-bot",
+            }.get(key, "")
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=fake_read),
+        ):
+            x = messaging_from_overlay(overlay_name="private-x")
+            tt = messaging_from_overlay(overlay_name="teatree")
+
+        assert isinstance(x, SlackBotBackend)
+        assert isinstance(tt, SlackBotBackend)
+        assert x is not tt
+
+
+class TestCodeHostFromOverlayTomlFallback:
+    def test_falls_back_to_toml_host_when_overlay_class_missing(self) -> None:
+        cfg = _toml_only_config(
+            {
+                "private-x": {
+                    "path": "~/workspace/private-x",
+                    "github_token_ref": "github/private-x/pat",
+                },
+            },
+        )
+
+        def fake_read(key: str) -> str:
+            return "ghp-test" if key == "github/private-x/pat" else ""
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=fake_read),
+        ):
+            host = code_host_from_overlay(overlay_name="private-x")
+
+        assert isinstance(host, GitHubCodeHost)
+
+    def test_returns_none_when_named_overlay_absent_from_toml(self) -> None:
+        cfg = _toml_only_config({})
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
+            patch("teatree.config.load_config", return_value=cfg),
+        ):
+            assert code_host_from_overlay(overlay_name="ghost") is None
+
+
+class TestActiveOverlayName:
+    def test_explicit_name_overrides_env(self) -> None:
+        with patch.dict(os.environ, {"T3_OVERLAY_NAME": "env-name"}, clear=False):
+            assert backend_factory._active_overlay_name("explicit") == "explicit"
+
+    def test_falls_back_to_env_when_not_provided(self) -> None:
+        with patch.dict(os.environ, {"T3_OVERLAY_NAME": "env-name"}, clear=False):
+            assert backend_factory._active_overlay_name(None) == "env-name"
+
+    def test_empty_string_when_neither_set(self) -> None:
+        env = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+        with patch.dict(os.environ, env, clear=True):
+            assert backend_factory._active_overlay_name(None) == ""

--- a/tests/teatree_core/test_backend_factory_toml.py
+++ b/tests/teatree_core/test_backend_factory_toml.py
@@ -173,6 +173,37 @@ class TestMessagingFromToml:
             backend = backend_factory._messaging_from_toml(cfg)
         assert isinstance(backend, SlackBotBackend)
 
+    def test_resolves_user_token_ref_from_pass(self) -> None:
+        """``user_token_ref`` is honoured by the TOML path-only resolver.
+
+        A wrapper script driving an overlay through the TOML fallback
+        (no registered ``teatree.overlays`` entry point) still needs
+        reactions to route through the xoxp token, so the TOML resolver
+        must read ``user_token_ref`` and thread it into ``SlackBotBackend``.
+        """
+        cfg = {
+            "messaging_backend": "slack",
+            "slack_token_ref": "ref",
+            "user_token_ref": "slack/user-oauth",
+            "slack_user_id": "U1",
+        }
+        pass_lookups = {"ref-bot": "bot-tok", "ref-app": "app-tok", "slack/user-oauth": "xoxp-tok"}
+        with patch("teatree.utils.secrets.read_pass", side_effect=lambda k: pass_lookups.get(k, "")):
+            backend = backend_factory._messaging_from_toml(cfg)
+        assert isinstance(backend, SlackBotBackend)
+        assert backend.user_token == "xoxp-tok"
+
+    def test_user_token_empty_when_ref_absent(self) -> None:
+        cfg = {"messaging_backend": "slack", "slack_token_ref": "ref"}
+
+        def fake_read(key: str) -> str:
+            return {"ref-bot": "bot-tok", "ref-app": "app-tok"}.get(key, "")
+
+        with patch("teatree.utils.secrets.read_pass", side_effect=fake_read):
+            backend = backend_factory._messaging_from_toml(cfg)
+        assert isinstance(backend, SlackBotBackend)
+        assert backend.user_token == ""
+
 
 class TestFindExternalDb:
     def test_returns_none_when_path_missing(self) -> None:


### PR DESCRIPTION
## Summary

Slack-Connect externally-shared channels reject reactions posted with the bot token — the workspace restriction policy returns `mcp_externally_shared_channel_restricted` / `not_in_channel`. The fix is to authenticate `reactions.add` / `reactions.get` with the human user's OAuth token (`xoxp-…`) when configured, while leaving DMs, `chat.postMessage`, `conversations.open`, and `users.lookupByEmail` on the bot token (those endpoints are scoped to the bot's own IM channels and cache).

- New optional `user_token_ref` field on `OverlayConfig` (also honoured by the path-only TOML overlay resolver in `backend_factory`) points at a `pass` entry holding the user's xoxp.
- `SlackBotBackend` gains a `user_token` kwarg; `_reaction_token()` picks it when present and falls back to the bot token for the legacy single-credential case.
- BLUEPRINT § overlay TOML example documents the new field.

## Validation

Wrapper script `/tmp/slack_react_test.py` calls \`messaging_from_overlay(overlay_name=\"t3-company\").react(channel=\"C0AM3TENTLK\", ts=\"1779168774.186559\", emoji=\"eyes\")\` against the pending review pickup message.

- **Routing confirmed:** the call authenticates as the user (\`auth.test\` returns \`user_id: U0A72P7CK0A\`, \`user: adrien.cossa\`), not the bot. The previous \`mcp_externally_shared_channel_restricted\` failure no longer occurs.
- **Token scope blocker:** the xoxp token at \`pass:slack/user-oauth-token\` lacks \`reactions:write\` — Slack returns \`{ok: False, error: 'missing_scope', needed: 'reactions:write'}\`. Re-granting the OAuth scopes unblocks the reaction itself; this PR's routing fix is independently complete.

## Tests

- \`tests/teatree_backends/test_slack_user_token_routing.py\` (new) — 11 tests asserting \`react\` / \`get_reactions\` route through xoxp when configured, \`post_message\` / \`post_reply\` / \`open_dm\` / \`resolve_user_id\` keep using xoxb, fallback behaviour when one or the other is absent.
- \`tests/teatree_backends/test_loader.py\` — 2 new tests for \`user_token_ref\` resolution via \`pass\` in the standard loader path.
- \`tests/teatree_core/test_backend_factory_toml.py\` — 2 new tests for \`user_token_ref\` resolution in the path-only TOML overlay resolver.

Full suite: **4815 passed, 12 skipped, 29 subtests passed**. Ruff lint + format: green. \`ty check\`: green.

## Security

The xoxp token is treated as a password: never logged, never echoed to stderr, never included in commit messages or PR body. It lives in memory only between the \`pass show\` call and the \`Authorization: Bearer\` header on the outbound httpx request.

## Test plan

- [x] Unit tests for \`SlackBotBackend\` reaction-routing split
- [x] Loader test for \`user_token_ref\` resolution from \`pass\`
- [x] TOML factory test for the path-only overlay shape
- [x] Live validation confirms routing through user identity (Slack-side scope grant pending)
- [x] Full test suite + ruff + ty green