### PR TITLE
fix(backends/slack): stamp channel + scan threads on REST DM polls (#1043)

### DIFF
--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -19,6 +19,15 @@ from teatree.types import RawAPIDict
 type SlackPayload = dict[str, object]
 
 
+def _is_bot_authored(msg: RawAPIDict, bot_id: str) -> bool:
+    return msg.get("user") == bot_id or msg.get("bot_id") == bot_id
+
+
+def _is_thread_root(msg: RawAPIDict) -> bool:
+    thread_ts = msg.get("thread_ts")
+    return isinstance(thread_ts, str) and bool(thread_ts) and thread_ts == msg.get("ts")
+
+
 class SlackBotBackend:
     """MessagingBackend backed by a Slack bot token.
 
@@ -96,12 +105,22 @@ class SlackBotBackend:
         return events
 
     def fetch_dms(self, *, since: str = "") -> list[RawAPIDict]:
-        """Return new DMs from the user.
+        """Return new DMs from the user, including thread replies.
 
         Drains the Socket Mode queue first (populated by a running receiver).
-        When the queue is empty, falls back to polling ``conversations.history``
-        on the bot's DM channel with the configured user. Only messages FROM
-        the user are returned (bot's own messages are filtered out).
+        When the queue is empty, falls back to polling
+        ``conversations.history`` on the bot's DM channel with the
+        configured user, then for every top-level bot message also polls
+        ``conversations.replies`` so thread replies are picked up (#1044).
+
+        Slack's ``conversations.history`` and ``conversations.replies``
+        do not stamp the ``channel`` field on each message — it is the
+        request parameter, not part of the response. We stamp it here so
+        downstream consumers (``SlackDmInboundScanner`` →
+        ``PendingChatInjection.record``) have it (#1043).
+
+        Only messages FROM the user are returned (bot's own messages are
+        filtered out).
         """
         if self._dms:
             events, self._dms = self._dms, []
@@ -111,6 +130,12 @@ class SlackBotBackend:
         channel = self.open_dm(self._user_id)
         if not channel:
             return []
+        messages = self._poll_dm_history(channel=channel, since=since)
+        bot_id = self._resolve_bot_id()
+        return self._collect_user_dms(channel=channel, messages=messages, bot_id=bot_id)
+
+    def _poll_dm_history(self, *, channel: str, since: str) -> list[RawAPIDict]:
+        """Return the ``conversations.history`` messages list (or empty)."""
         params: dict[str, str | int] = {"channel": channel, "limit": 20}
         if since:
             params["oldest"] = since
@@ -118,17 +143,45 @@ class SlackBotBackend:
         if not data.get("ok"):
             return []
         messages = data.get("messages")
+        return [cast("RawAPIDict", m) for m in messages if isinstance(m, dict)] if isinstance(messages, list) else []
+
+    def _collect_user_dms(
+        self,
+        *,
+        channel: str,
+        messages: list[RawAPIDict],
+        bot_id: str,
+    ) -> list[RawAPIDict]:
+        """Filter bot-authored top-level posts; fan out to thread replies."""
+        result: list[RawAPIDict] = []
+        for msg in messages:
+            msg.setdefault("channel", channel)
+            if not _is_bot_authored(msg, bot_id):
+                result.append(msg)
+            if _is_thread_root(msg):
+                result.extend(
+                    self._fetch_thread_replies(channel=channel, thread_ts=str(msg["ts"]), bot_id=bot_id),
+                )
+        return result
+
+    def _fetch_thread_replies(self, *, channel: str, thread_ts: str, bot_id: str) -> list[RawAPIDict]:
+        """Return non-bot replies on a thread, with ``channel`` stamped."""
+        data = self._get("conversations.replies", {"channel": channel, "ts": thread_ts, "limit": 50})
+        if not data.get("ok"):
+            return []
+        messages = data.get("messages")
         if not isinstance(messages, list):
             return []
-        bot_id = self._resolve_bot_id()
-        result: list[RawAPIDict] = []
+        replies: list[RawAPIDict] = []
         for m in messages:
             if not isinstance(m, dict):
                 continue
-            msg = cast("RawAPIDict", m)
-            if msg.get("user") != bot_id and msg.get("bot_id") != bot_id:
-                result.append(msg)
-        return result
+            reply = cast("RawAPIDict", m)
+            if reply.get("ts") == thread_ts or _is_bot_authored(reply, bot_id):
+                continue
+            reply.setdefault("channel", channel)
+            replies.append(reply)
+        return replies
 
     def _resolve_bot_id(self) -> str:
         if self._cached_bot_id is None:

--- a/tests/teatree_backends/test_messaging.py
+++ b/tests/teatree_backends/test_messaging.py
@@ -468,6 +468,117 @@ def test_slack_resolve_user_id_returns_empty_when_members_not_list(monkeypatch: 
     assert backend.resolve_user_id("alice") == ""
 
 
+def test_slack_fetch_dms_stamps_channel_on_each_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stamp ``channel`` so ``PendingChatInjection.record`` accepts the row (#1043).
+
+    Without this the ``conversations.history`` payload returns each message
+    with no ``channel`` field, the record guard ``if not channel`` discards
+    every user DM, and the inbound bridge is a silent no-op.
+    """
+
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        if "conversations.open" in url:
+            return httpx.Response(200, json={"ok": True, "channel": {"id": "DXYZ"}}, request=httpx.Request("POST", url))
+        if "auth.test" in url:
+            return httpx.Response(200, json={"ok": True, "user_id": "UBOT"}, request=httpx.Request("POST", url))
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        if "conversations.history" in url:
+            return httpx.Response(
+                200,
+                json={"ok": True, "messages": [{"user": "UHUMAN", "text": "hi", "ts": "1.0"}]},
+                request=httpx.Request("GET", url),
+            )
+        return httpx.Response(200, json={"ok": True, "messages": []}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="UHUMAN")
+
+    dms = backend.fetch_dms()
+
+    assert len(dms) == 1
+    assert dms[0]["channel"] == "DXYZ"
+
+
+def test_slack_fetch_dms_preserves_existing_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Socket Mode events already carry ``channel``; stamping must not overwrite it."""
+
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        if "conversations.open" in url:
+            return httpx.Response(200, json={"ok": True, "channel": {"id": "DXYZ"}}, request=httpx.Request("POST", url))
+        if "auth.test" in url:
+            return httpx.Response(200, json={"ok": True, "user_id": "UBOT"}, request=httpx.Request("POST", url))
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "messages": [{"user": "UHUMAN", "text": "hi", "ts": "1.0", "channel": "DSOCKET"}],
+            },
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="UHUMAN")
+
+    dms = backend.fetch_dms()
+    assert dms[0]["channel"] == "DSOCKET"
+
+
+def test_slack_fetch_dms_includes_thread_replies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """For #1044: a user reply on a bot-DM thread must be returned alongside top-level DMs."""
+
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        if "conversations.open" in url:
+            return httpx.Response(200, json={"ok": True, "channel": {"id": "DXYZ"}}, request=httpx.Request("POST", url))
+        if "auth.test" in url:
+            return httpx.Response(200, json={"ok": True, "user_id": "UBOT"}, request=httpx.Request("POST", url))
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        if "conversations.history" in url:
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "messages": [
+                        # Bot-authored thread root with at least one reply (Slack returns
+                        # ``thread_ts == ts`` on the root of a thread).
+                        {"user": "UBOT", "text": "bot post", "ts": "5.0", "thread_ts": "5.0", "reply_count": 1},
+                    ],
+                },
+                request=httpx.Request("GET", url),
+            )
+        if "conversations.replies" in url:
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "messages": [
+                        {"user": "UBOT", "text": "bot post", "ts": "5.0"},
+                        {"user": "UHUMAN", "text": "thread reply", "ts": "5.1"},
+                    ],
+                },
+                request=httpx.Request("GET", url),
+            )
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    backend = SlackBotBackend(bot_token="xoxb-test", user_id="UHUMAN")
+
+    dms = backend.fetch_dms()
+
+    # Bot's top-level post is filtered out; the user's thread reply is included.
+    assert [e["ts"] for e in dms] == ["5.1"]
+    assert dms[0]["channel"] == "DXYZ"
+
+
 def test_slack_resolve_user_id_skips_non_dict_members(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url: str, **kwargs: object) -> httpx.Response:
         return httpx.Response(


### PR DESCRIPTION
## Why

After PR #1039 (`feat(loop): Slack DM inbound scanner + PendingChatInjection drain (epic #1014)`) merged this morning at `0c2b8ed7`, the inbound bridge was a silent no-op end-to-end. User DMs to both overlay bots produced zero `PendingChatInjection` rows and zero session-side injection.

Two regressions accumulated:

1. *Migration `0019_pendingchatinjection` was never applied on the live DB* — applied manually during diagnosis. Not codified here (the loop's normal setup applies migrations automatically) but worth flagging.
2. *`SlackBotBackend.fetch_dms` did not stamp `channel` on REST-polled events.* Slack's `conversations.history` returns each message *without* a `channel` field — channel is the request parameter, not the response. The scanner extracted `channel = ""` from every event; `PendingChatInjection.record` then bailed via its `if not channel` guard. No row, no signal, no inbound to the agent.
3. *Thread replies were not polled at all.* The user routinely replies in threads on bot-posted DMs; those replies landed nowhere.

This PR closes #1043 and addresses #1044.

## What

- `SlackBotBackend.fetch_dms` now stamps the resolved DM channel on each event before returning (`msg.setdefault("channel", channel)` — preserves Socket Mode payloads that already carry the field).
- The same path now also polls `conversations.replies` for every top-level bot message and surfaces non-bot replies as part of the same DM stream. Idempotency on the downstream side is unchanged: `unique(overlay, slack_ts)`.
- Refactored into `_poll_dm_history` / `_collect_user_dms` / `_fetch_thread_replies` so the public method stays under the complexity gate.
- Three regression tests:
  - `test_slack_fetch_dms_stamps_channel_on_each_event` — bare `conversations.history` payload without `channel`.
  - `test_slack_fetch_dms_preserves_existing_channel` — Socket Mode events that already have `channel` are not overwritten.
  - `test_slack_fetch_dms_includes_thread_replies` — synthetic `conversations.replies` reply lands in the DM stream.

## Verification

Local backfill against the canonical DB after applying the fix recovered all 14 unanswered messages from today (10 t3-teatree thread replies + 3 t3-company messages + 1 stale `hello`). User DM sent via the recovery channel as `slack-dm-recovery-20260519`.

`uv run pytest tests/teatree_backends/test_messaging.py --no-cov -q` — 38 passed in 0.24s

## Out of scope

- Setting up an automatic migration run on `t3 loop start` so unapplied migrations can't break a future bridge feature again — file separately if needed.
- The two-overlay duplication for the shared teatree-bot DM (one row per `(t3-teatree, ts)` *and* `(teatree, ts)`) — the drain handler dedupes by content, but the duplicate row is wasted work. Worth a follow-up.

## Test plan

- [x] `uv run pytest tests/teatree_backends/test_messaging.py` — 38 passed.
- [x] `uv run pytest tests/teatree_backends/ tests/teatree_loop/test_slack_dm_inbound.py tests/teatree_loop/test_scanners.py tests/test_pending_chat_injection_hook.py` — 315 passed.
- [x] `uv run ruff check` clean.
- [x] Live backfill against canonical DB recovered today's missing messages.