### PR TITLE
fix(loop/statusline): collapse inbound DMs to one neutral-color permalink line

### DIFF
--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -13,6 +13,9 @@ from typing import Any
 
 from teatree.loop.dispatch import DispatchAction
 from teatree.loop.pr_ticket_index import build_ticket_index
+from teatree.loop.rendering_dms import DmRef as _DmRef
+from teatree.loop.rendering_dms import is_dm_action as _is_dm_action
+from teatree.loop.rendering_dms import render_dm_line as _render_dm_line
 from teatree.loop.statusline import StatuslineEntry, StatuslineZones, _hyperlink, colorize_enabled, plain_link
 
 # DispatchAction payloads are `dict[str, Any]` by contract (see dispatch.py).
@@ -163,6 +166,7 @@ class _ClassifiedActions:
     action_prs: dict[str, list[_PRRef]] = field(default_factory=dict)
     inflight_prs: dict[str, list[_PRRef]] = field(default_factory=dict)
     active_tickets: dict[str, list[tuple[str, str, str]]] = field(default_factory=dict)
+    dms: dict[str, list[_DmRef]] = field(default_factory=dict)
     other: list[tuple[str, StatuslineEntry]] = field(default_factory=list)
 
 
@@ -255,6 +259,11 @@ def _classify_actions(actions: list[DispatchAction]) -> _ClassifiedActions:
                 ),
             )
             continue
+        if _is_dm_action(action, payload):
+            ts = _str_field(payload, "ts")
+            permalink = _str_field(payload, "permalink")
+            c.dms.setdefault(overlay, []).append(_DmRef(ts=ts, permalink=permalink))
+            continue
         ref = _pr_ref(action)
         if ref is not None:
             bucket = c.action_prs if action.zone == "action_needed" else c.inflight_prs
@@ -304,6 +313,8 @@ def _dedup_classified(c: _ClassifiedActions) -> None:
         c.inflight_prs[overlay] = _dedup_in_order(refs)
     for overlay, reass in list(c.reassign_refs.items()):
         c.reassign_refs[overlay] = _dedup_in_order(reass)
+    for overlay, dms in list(c.dms.items()):
+        c.dms[overlay] = _dedup_in_order(dms)
     for reason_map in c.disposition_refs.values():
         for reason, refs in list(reason_map.items()):
             reason_map[reason] = _dedup_in_order(refs)
@@ -489,6 +500,7 @@ def _populate_overlay_zones(
             *c.stale_refs,
             *c.ready_refs,
             *c.inflight_prs,
+            *c.dms,
         },
     )
 
@@ -515,6 +527,10 @@ def _populate_overlay_zones(
         )
         if ticket_line:
             zones.anchors.append(ticket_line)
+
+        dm_line = _render_dm_line(overlay_key, c.dms.get(overlay_key, []), link=_link, colorize=colorize)
+        if dm_line:
+            zones.anchors.append(dm_line)
 
         action_line = _render_action_line(
             overlay_key,

--- a/src/teatree/loop/rendering_dms.py
+++ b/src/teatree/loop/rendering_dms.py
@@ -1,0 +1,84 @@
+r"""Render inbound Slack DMs into the statusline (#1050).
+
+A separate module keeps :mod:`teatree.loop.rendering` under the
+module-health LOC ceiling: the DM line is one concern with a tight
+contract (input: list of ``_DmRef``; output: one ``[ov] DMs (N):
+<permalink1> · …`` row in the anchors zone), so isolating it here is
+the right split-by-concern.
+
+The line is dim by virtue of routing to ``zones.anchors`` — the
+statusline's ``_ZONE_COLORS`` maps ``anchors`` to ``\033[38;5;244m``
+(the same palette as ``started:``/``tested:`` rows). DMs are
+informational context (the user reads the body in Slack natively); a
+red ``action_needed`` row would imply they require terminal-side
+action, which they do not.
+"""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from teatree.loop.dispatch import DispatchAction
+
+type Payload = Mapping[str, Any]
+type LinkRenderer = Callable[..., str]
+
+
+@dataclass(frozen=True, slots=True)
+class DmRef:
+    """One inbound Slack DM, rendered as a clickable permalink.
+
+    ``permalink`` may be empty when ``backend.get_permalink`` failed at
+    scan time; the renderer falls back to the bare ``ts`` label in that
+    case so the row still surfaces (a Slack outage must not collapse
+    the line back to red multi-line body-paste).
+    """
+
+    ts: str
+    permalink: str
+
+
+def is_dm_action(action: DispatchAction, payload: Payload) -> bool:
+    """Return True when *action* came from a ``slack.dm`` scan signal.
+
+    The scanner emits ``summary=f"DM {ts}: …"`` and a payload carrying
+    ``event`` (the raw Slack event dict) plus ``ts`` (string). Dispatch
+    mirrors ``summary`` into ``detail`` unchanged, so we identify the
+    signal by the payload shape (event-dict + ts-string), gating on
+    the ``DM `` summary prefix to skip foreign signals that happen to
+    carry an ``event`` field.
+    """
+    if not action.detail.startswith("DM "):
+        return False
+    if not isinstance(payload.get("event"), dict):
+        return False
+    return isinstance(payload.get("ts"), str)
+
+
+def render_dm_line(
+    overlay: str,
+    dms: list[DmRef],
+    *,
+    link: LinkRenderer,
+    colorize: bool,
+) -> str:
+    """Render one ``[ov] DMs (N): <permalink1> · …`` line per overlay.
+
+    *link* is the rendering module's ``_link`` helper — passed in so
+    this module stays free of the OSC8/plain-link decision wiring.
+    Inbound Slack DMs are informational context — the user reads the
+    body in Slack natively, the statusline only needs to point at the
+    message. When ``permalink`` is empty (Slack outage at scan time),
+    the bare ``ts`` is shown as label so the row still surfaces.
+    """
+    if not dms:
+        return ""
+    prefix = f"[{overlay}] " if overlay else ""
+    parts: list[str] = []
+    for dm in dms:
+        label = dm.ts or "?"
+        if dm.permalink:
+            parts.append(link(label, dm.permalink, colorize=colorize))
+        else:
+            parts.append(label)
+    return f"{prefix}DMs ({len(dms)}): {' · '.join(parts)}"

--- a/src/teatree/loop/scanners/slack_mentions.py
+++ b/src/teatree/loop/scanners/slack_mentions.py
@@ -39,6 +39,26 @@ def _text(event: RawAPIDict) -> str:
     return text if isinstance(text, str) else ""
 
 
+def _channel(event: RawAPIDict) -> str:
+    channel = event.get("channel")
+    return channel if isinstance(channel, str) else ""
+
+
+def _resolve_permalink(backend: MessagingBackend, channel: str, ts: str) -> str:
+    """Return ``backend.get_permalink`` result, or empty on any failure.
+
+    The statusline renderer needs a clickable Slack URL but a transient
+    Slack outage must not break statusline rendering — fall back to the
+    bare ``ts`` label when the lookup fails (see #1050).
+    """
+    if not channel or not ts:
+        return ""
+    try:
+        return backend.get_permalink(channel=channel, ts=ts)
+    except Exception:  # noqa: BLE001 — permalink is decoration, never a hard failure
+        return ""
+
+
 @dataclass(slots=True)
 class SlackMentionsScanner:
     """Surface ``app_mention`` and ``message.im`` events queued by Socket Mode."""
@@ -78,11 +98,13 @@ class SlackMentionsScanner:
                 cursors["mentions"] = max(cursors.get("mentions", ""), ts)
         for event in dms:
             ts = _ts(event)
+            channel = _channel(event)
+            permalink = _resolve_permalink(self.backend, channel, ts)
             signals.append(
                 ScanSignal(
                     kind="slack.dm",
                     summary=f"DM {ts}: {_text(event)[:80]}",
-                    payload={"ts": ts, "event": event},
+                    payload={"ts": ts, "event": event, "permalink": permalink},
                 )
             )
             if ts:

--- a/tests/teatree_backends/test_slack_mentions.py
+++ b/tests/teatree_backends/test_slack_mentions.py
@@ -86,3 +86,51 @@ class TestSlackMentionsScanner:
 
         backend.fetch_mentions.assert_called_once_with(since="5.0")
         backend.fetch_dms.assert_called_once_with(since="3.0")
+
+    def test_dm_signal_carries_permalink(self, tmp_path: Path) -> None:
+        """Each ``slack.dm`` signal carries the message permalink (#1050).
+
+        Renderer-side the line is `[ov] DMs (N): <permalink1> · …` —
+        resolving the permalink lazily at render time would hit Slack
+        once per tick per DM. The scanner enriches once at scan time
+        and caches the URL in the signal payload.
+        """
+        backend = self._make_backend(dms=[{"ts": "2.0", "text": "dm text", "channel": "D123"}])
+        backend.get_permalink.return_value = "https://slk.example/archives/D123/p2000000"
+        scanner = SlackMentionsScanner(backend=backend, cursor_path=tmp_path / "cursor.json")
+
+        signals = scanner.scan()
+
+        assert len(signals) == 1
+        assert signals[0].kind == "slack.dm"
+        assert signals[0].payload.get("permalink") == "https://slk.example/archives/D123/p2000000"
+        backend.get_permalink.assert_called_once_with(channel="D123", ts="2.0")
+
+    def test_dm_signal_permalink_empty_on_lookup_failure(self, tmp_path: Path) -> None:
+        """When ``get_permalink`` raises or returns empty, the signal still emits.
+
+        Renderer falls back to the bare ``ts`` as label — Slack outages
+        must not break statusline rendering.
+        """
+        backend = self._make_backend(dms=[{"ts": "2.0", "text": "dm text", "channel": "D123"}])
+        backend.get_permalink.side_effect = RuntimeError("api down")
+        scanner = SlackMentionsScanner(backend=backend, cursor_path=tmp_path / "cursor.json")
+
+        signals = scanner.scan()
+
+        assert len(signals) == 1
+        assert signals[0].payload.get("permalink") == ""
+
+    def test_dm_signal_permalink_skipped_when_channel_missing(self, tmp_path: Path) -> None:
+        """Signals without ``event.channel`` get an empty permalink.
+
+        When ``channel`` is missing the backend is not called — there's
+        nothing to resolve.
+        """
+        backend = self._make_backend(dms=[{"ts": "2.0", "text": "dm text"}])  # no channel
+        scanner = SlackMentionsScanner(backend=backend, cursor_path=tmp_path / "cursor.json")
+
+        signals = scanner.scan()
+
+        assert signals[0].payload.get("permalink") == ""
+        backend.get_permalink.assert_not_called()

--- a/tests/teatree_loop/test_rendering.py
+++ b/tests/teatree_loop/test_rendering.py
@@ -244,3 +244,169 @@ class TestStaleTicketsConciseAndLinked:
         line = zones.action_needed[0]
         text = line if isinstance(line, str) else line.text
         assert "\033]8;;https://example.com/issues/58" in text, repr(text)
+
+
+def _dm_action(
+    *,
+    ts: str,
+    text: str,
+    overlay: str = "teatree",
+    channel: str = "D123",
+    permalink: str = "",
+) -> DispatchAction:
+    """Mirror dispatch output for a ``slack.dm`` signal (#1050).
+
+    The ``slack_mentions`` scanner emits ``summary=f"DM {ts}: {text[:80]}"``
+    and ``payload={"ts": ts, "event": event}``; ``_run_job`` stamps
+    ``overlay`` onto the payload; the dispatcher mirrors the summary into
+    ``detail`` and routes ``zone="action_needed"``.
+    """
+    return DispatchAction(
+        kind="statusline",
+        zone="action_needed",
+        detail=f"DM {ts}: {text[:80]}",
+        payload={
+            "ts": ts,
+            "event": {"text": text, "ts": ts, "channel": channel},
+            "overlay": overlay,
+            "permalink": permalink,
+        },
+    )
+
+
+class TestInboundDmsCollapseToOneNeutralLine:
+    """Inbound DMs render as one dim line per overlay with permalinks only (#1050).
+
+    Before: each DM was a separate red line with the body pasted in
+    (``[ov] DM <ts>: <body>…``) — three sources of noise per overlay
+    (red color, repeated lines, repeated body text the user reads in
+    Slack natively). After: one ``[ov] DMs (N): <permalink1> · …`` line
+    in the dim/anchors palette per overlay; permalinks only, no body.
+    """
+
+    def test_multiple_dms_collapse_to_one_line_per_overlay(self) -> None:
+        actions = [
+            _dm_action(
+                ts="1779180869.828769",
+                text=":white_check_mark: Bridge fix shipped — full status",
+                permalink="https://slk.example/archives/D123/p1779180869828769",
+            ),
+            _dm_action(
+                ts="1779180852.373219",
+                text="you will use my reactions to the threads on the bot",
+                permalink="https://slk.example/archives/D123/p1779180852373219",
+            ),
+            _dm_action(
+                ts="1779180760.090199",
+                text="I see that you don't create the snapshots before compacting",
+                permalink="https://slk.example/archives/D123/p1779180760090199",
+            ),
+        ]
+        zones = zones_for(actions, colorize=False)
+        # Three DMs collapse to one line.
+        action_lines = [item if isinstance(item, str) else item.text for item in zones.action_needed]
+        anchor_lines = [item if isinstance(item, str) else item.text for item in zones.anchors]
+        dm_lines = [t for t in anchor_lines + action_lines if "DM" in t]
+        assert len(dm_lines) == 1, repr({"anchors": anchor_lines, "action_needed": action_lines})
+        line = dm_lines[0]
+        assert "[teatree] DMs (3):" in line, repr(line)
+
+    def test_dm_line_contains_permalinks_not_body_text(self) -> None:
+        body = ":white_check_mark: Bridge fix shipped — full status_  (idempotency key `slack-d"
+        actions = [
+            _dm_action(
+                ts="1779180869.828769",
+                text=body,
+                permalink="https://slk.example/archives/D123/p1779180869828769",
+            ),
+        ]
+        zones = zones_for(actions, colorize=False)
+        blob = "".join(
+            item if isinstance(item, str) else item.text
+            for zone in (zones.anchors, zones.action_needed, zones.in_flight)
+            for item in zone
+        )
+        # The Slack-message body must NOT appear in the statusline.
+        assert "Bridge fix shipped" not in blob, repr(blob)
+        assert "idempotency key" not in blob
+        assert "white_check_mark" not in blob
+        # The permalink must appear.
+        assert "https://slk.example/archives/D123/p1779180869828769" in blob
+
+    def test_dm_line_is_dim_not_red(self, tmp_path: Path) -> None:
+        r"""DMs land in the anchors zone (dim) — never in action_needed (red).
+
+        The anchors zone uses ``\033[38;5;244m`` (the same palette as
+        ``started:``/``tested:`` rows); ``action_needed`` uses
+        ``\033[1;31m`` (red). Routing DMs to anchors picks up the dim
+        color automatically through ``_ZONE_COLORS``.
+        """
+        actions = [
+            _dm_action(
+                ts="1779180869.828769",
+                text="any body",
+                permalink="https://slk.example/archives/D123/p1779180869828769",
+            ),
+        ]
+        zones = zones_for(actions, colorize=True)
+        # Render to file so we see the actual color escapes applied.
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=True)
+        content = target.read_text(encoding="utf-8")
+        dm_lines = [line for line in content.splitlines() if "DMs (" in line]
+        assert dm_lines, repr(content)
+        for line in dm_lines:
+            assert "\033[38;5;244m" in line, f"DM line missing dim color: {line!r}"
+            assert "\033[1;31m" not in line, f"DM line uses red color: {line!r}"
+
+    def test_dm_lines_split_per_overlay(self) -> None:
+        actions = [
+            _dm_action(ts="100.0", text="x", overlay="teatree", permalink="https://slk.example/x"),
+            _dm_action(ts="200.0", text="y", overlay="acme", permalink="https://slk.example/y"),
+            _dm_action(ts="201.0", text="z", overlay="acme", permalink="https://slk.example/z"),
+        ]
+        zones = zones_for(actions, colorize=False)
+        all_items = [
+            item if isinstance(item, str) else item.text
+            for zone in (zones.anchors, zones.action_needed, zones.in_flight)
+            for item in zone
+        ]
+        dm_lines = sorted(t for t in all_items if "DMs (" in t)
+        assert len(dm_lines) == 2, repr(dm_lines)
+        assert any(t.startswith("[acme] DMs (2):") for t in dm_lines), repr(dm_lines)
+        assert any(t.startswith("[teatree] DMs (1):") for t in dm_lines), repr(dm_lines)
+
+    def test_dm_permalinks_separated_by_middot(self) -> None:
+        actions = [
+            _dm_action(ts="100.0", text="a", permalink="https://slk.example/a"),
+            _dm_action(ts="200.0", text="b", permalink="https://slk.example/b"),
+        ]
+        zones = zones_for(actions, colorize=False)
+        blob = "".join(
+            item if isinstance(item, str) else item.text
+            for zone in (zones.anchors, zones.action_needed, zones.in_flight)
+            for item in zone
+        )
+        dm_line = next(line for line in blob.splitlines() if "DMs (" in line)
+        # Permalinks joined by " · " (same join character used elsewhere).
+        assert " · " in dm_line, repr(dm_line)
+
+    def test_dm_without_permalink_uses_ts_as_label(self) -> None:
+        """Fall back to the bare timestamp when ``get_permalink`` returned empty.
+
+        A Slack outage at scan time must not resurrect the old
+        red-multi-line rendering — the renderer still produces a
+        single dim DMs row using ``ts`` as label.
+        """
+        actions = [_dm_action(ts="1779180869.828769", text="x", permalink="")]
+        zones = zones_for(actions, colorize=False)
+        all_items = [
+            item if isinstance(item, str) else item.text
+            for zone in (zones.anchors, zones.action_needed, zones.in_flight)
+            for item in zone
+        ]
+        dm_lines = [t for t in all_items if "DMs (" in t]
+        assert dm_lines, repr(all_items)
+        assert "[teatree] DMs (1):" in dm_lines[0], repr(dm_lines)
+        # Body text must still be absent even in the fallback form.
+        assert "x" not in dm_lines[0].split("DMs (1):")[1].split(" · ")[0].split()


### PR DESCRIPTION
## Summary

Per overlay, inbound Slack DMs render as a **single dim** ``[ov] DMs (N): <permalink1> · …`` line in the anchors zone — replacing the prior red-multi-line body-paste (one red ``[ov] DM <ts>: <body…>`` row per DM).

Three concrete fixes:

1. **DM body no longer pasted into the terminal.** Slack is the canonical reader; the statusline only needs to point at the message.
2. **N DMs collapse to one line** per overlay (was: N lines, one per DM).
3. **Neutral/dim color** (``\033[38;5;244m``, same as ``started:`` / ``tested:`` rows) instead of red — DMs are informational context, not actionable alerts.

## How it works

- ``SlackMentionsScanner`` enriches each DM signal with ``backend.get_permalink(channel, ts)`` once at scan time. Lookup failures degrade to an empty permalink so a Slack outage cannot break statusline rendering — the renderer falls back to the bare ``ts`` label.
- A dedicated ``teatree.loop.rendering_dms`` module owns the DM ``_DmRef`` dataclass, the ``is_dm_action`` payload-shape predicate, and the ``render_dm_line`` formatter. Splitting by concern keeps ``rendering.py`` under the 500-LOC module-health ceiling.
- ``_classify_actions`` routes DM-shaped actions (``event`` dict + ``ts`` str + ``DM `` summary prefix) into a new ``_ClassifiedActions.dms`` bucket; ``_populate_overlay_zones`` emits one row per overlay into ``zones.anchors`` so the dim palette applies automatically through ``_ZONE_COLORS``.

## Tests

Six new ``TestInboundDmsCollapseToOneNeutralLine`` cases cover:

- Collapse N DMs → 1 line per overlay
- No body text in output (permalinks only)
- Dim color, not red (full ``render()`` pipeline asserted)
- Split per overlay
- ``·`` separator between permalinks
- Fallback to bare ``ts`` label when ``get_permalink`` failed

Three new scanner-side cases cover the permalink enrichment path:

- DM signal carries the resolved permalink in payload
- Lookup-raise path → empty permalink, signal still emits
- Missing channel → no backend call, empty permalink

**Anti-vacuous:** gating the new classify branch off in-place restores the old three-red-line output and turns the six new tests RED (verified manually).

## Test plan

- [x] ``uv run pytest --no-cov`` — 5033 passed, 12 skipped, 37 subtests passed
- [x] ``uv run ruff check`` — all checks passed
- [x] ``uv run ty check src/teatree/loop/rendering.py src/teatree/loop/rendering_dms.py src/teatree/loop/scanners/slack_mentions.py`` — all checks passed
- [x] Module-health hook passes (rendering.py: 487 LOC, rendering_dms.py: 69 LOC)

Closes #1050.