### PR TITLE
refactor(cli): split review.py under the 500-LOC module-health gate (#1056)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -98,7 +98,11 @@ src/teatree/
     loop.py             # `t3 loop start|stop|status|tick` (tick delegates to loop_tick mgmt cmd)
     overlay.py          # OverlayAppBuilder — builds the per-overlay subapp
     overlay_dev.py      # `t3 overlay install|uninstall|status` (dev loop)
-    review.py           # `t3 review ...`
+    review.py           # `t3 review ...` (typer entrypoint + ReviewService)
+    review_approvals.py # `t3 review approve|unapprove` + review-before-approve precondition (#1056)
+    review_diff.py      # MR-diff helpers shared by `review` (find_added_line, resolve_inline_position)
+    review_drafts.py    # `t3 review delete-draft-note|delete-discussion|...` (draft-note cluster)
+    review_on_behalf.py # `t3 review approve-on-behalf` + on-behalf-gate chokepoint (#960)
     review_request.py   # `t3 review-request ...`
     sessions.py         # `t3 sessions`
     setup.py            # `t3 setup ...`

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -401,8 +401,6 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 │ post-comment         Post an immediate (non-draft) comment on a GitLab MR.   │
 │ reply-to-discussion  Reply to a GitLab MR discussion thread (immediate, not  │
 │                      draft).                                                 │
-│ approve              Approve a GitLab MR — only after you have reviewed it.  │
-│ unapprove            Revoke your approval on a GitLab MR.                    │
 │ approve-on-behalf    Record an :class:`OnBehalfApproval` that satisfies the  │
 │                      on-behalf gate.                                         │
 │ delete-draft-note    Delete a draft note from a GitLab MR.                   │
@@ -414,6 +412,8 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 │                      published.                                              │
 │ resolve-discussion   Mark a GitLab MR discussion thread resolved or          │
 │                      unresolved.                                             │
+│ approve              Approve a GitLab MR — only after you have reviewed it.  │
+│ unapprove            Revoke your approval on a GitLab MR.                    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -493,55 +493,6 @@ Usage: t3 review reply-to-discussion [OPTIONS] REPO MR DISCUSSION_ID BODY
 │ *    mr                 INTEGER  Merge request IID [required]                │
 │ *    discussion_id      TEXT     Discussion (thread) ID [required]           │
 │ *    body               TEXT     Reply body (markdown) [required]            │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                  │
-╰──────────────────────────────────────────────────────────────────────────────╯
-```
-
-#### `t3 review approve`
-
-```
-Usage: t3 review approve [OPTIONS] REPO MR
-
- Approve a GitLab MR — only after you have reviewed it.
-
- Precondition: a review note/discussion authored by your identity must
- already exist on the MR (review before approve). Gated by
- `on_behalf_post_mode` (BLOCK under `ask` / `draft_or_ask`,
- souliane/teatree#960/#1013) — record an approval via
- ``t3 review approve-on-behalf <repo>!<mr> approve --approver
- <user-id>`` to satisfy the gate without switching mode to
- `immediate`.
-
-╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-│ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
-│                         [required]                                           │
-│ *    mr        INTEGER  Merge request IID [required]                         │
-╰──────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                  │
-╰──────────────────────────────────────────────────────────────────────────────╯
-```
-
-#### `t3 review unapprove`
-
-```
-Usage: t3 review unapprove [OPTIONS] REPO MR
-
- Revoke your approval on a GitLab MR.
-
- No review precondition (revoking is the safe direction). Gated by
- `on_behalf_post_mode` (BLOCK under `ask` / `draft_or_ask`,
- souliane/teatree#960/#1013) — record an approval via
- ``t3 review approve-on-behalf <repo>!<mr> unapprove --approver
- <user-id>`` to satisfy the gate without switching mode to
- `immediate`.
-
-╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-│ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
-│                         [required]                                           │
-│ *    mr        INTEGER  Merge request IID [required]                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
@@ -697,6 +648,55 @@ Usage: t3 review resolve-discussion [OPTIONS] REPO MR DISCUSSION_ID
 │ --resolved    --no-resolved      Mark resolved (default) or re-open.         │
 │                                  [default: resolved]                         │
 │ --help                           Show this message and exit.                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 review approve`
+
+```
+Usage: t3 review approve [OPTIONS] REPO MR
+
+ Approve a GitLab MR — only after you have reviewed it.
+
+ Precondition: a review note/discussion authored by your identity must
+ already exist on the MR (review before approve). Gated by
+ `on_behalf_post_mode` (BLOCK under `ask` / `draft_or_ask`,
+ souliane/teatree#960/#1013) — record an approval via
+ ``t3 review approve-on-behalf <repo>!<mr> approve --approver
+ <user-id>`` to satisfy the gate without switching mode to
+ `immediate`.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
+│                         [required]                                           │
+│ *    mr        INTEGER  Merge request IID [required]                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 review unapprove`
+
+```
+Usage: t3 review unapprove [OPTIONS] REPO MR
+
+ Revoke your approval on a GitLab MR.
+
+ No review precondition (revoking is the safe direction). Gated by
+ `on_behalf_post_mode` (BLOCK under `ask` / `draft_or_ask`,
+ souliane/teatree#960/#1013) — record an approval via
+ ``t3 review approve-on-behalf <repo>!<mr> unapprove --approver
+ <user-id>`` to satisfy the gate without switching mode to
+ `immediate`.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
+│                         [required]                                           │
+│ *    mr        INTEGER  Merge request IID [required]                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -26,6 +26,8 @@ from http import HTTPStatus
 
 import typer
 
+from teatree.cli import review_approvals
+from teatree.cli.review_approvals import register as _register_approvals
 from teatree.cli.review_diff import find_added_line, resolve_inline_position
 from teatree.cli.review_drafts import register as _register_drafts
 from teatree.cli.review_on_behalf import check_on_behalf, on_behalf_gate_active
@@ -40,7 +42,6 @@ _on_behalf_gate_active = on_behalf_gate_active
 
 review_app = typer.Typer(no_args_is_help=True, help="Code review helpers.")
 _TOKEN_PARTS_COUNT = 2
-_HTTP_OK_CODES = frozenset({HTTPStatus.OK, HTTPStatus.CREATED, HTTPStatus.NO_CONTENT})
 
 
 class ReviewService:
@@ -354,91 +355,22 @@ class ReviewService:
             lines.append(f"  {nid}  {fp}:{ln}  {body}...")
         return "\n".join(lines), 0
 
-    def _identity_has_reviewed(self, encoded_repo: str, mr: int) -> tuple[bool, str]:
-        """Whether the approving identity already authored a note on this MR.
-
-        Encodes the review-before-approve doctrine: an approval may only be
-        recorded once the same identity has left a reviewing footprint
-        (any note in any discussion thread). Returns ``(reviewed, error)``;
-        ``error`` is non-empty only when the identity itself cannot be
-        resolved (a hard precondition failure, not "no review yet").
-        """
-        api = self._get_api()
-        username = api.current_username()
-        if not username:
-            return False, "Could not resolve the approving GitLab identity (check token / `glab auth status`)."
-        discussions = api.get_json(f"projects/{encoded_repo}/merge_requests/{mr}/discussions?per_page=100")
-        if not isinstance(discussions, list):
-            return False, ""
-        for discussion in discussions:
-            if not isinstance(discussion, dict):
-                continue
-            notes = discussion.get("notes")
-            if not isinstance(notes, list):
-                continue
-            for note in notes:
-                if not isinstance(note, dict):
-                    continue
-                author = note.get("author")
-                if isinstance(author, dict) and author.get("username") == username:
-                    return True, ""
-        return False, ""
-
     def approve(self, repo: str, mr: int) -> tuple[str, int]:
         """Approve an MR — refuses unless the identity has already reviewed it.
 
-        Returns (message, exit_code). The review-first precondition encodes
-        the approve-on-review doctrine: an approval cannot be recorded
-        without a prior reviewing footprint from the same identity.
-
-        Gated by ``ask_before_post_on_behalf`` (#960/#1013): an approval is
-        an outward post on the user's identity, so it routes through the
-        same recorded-approval gate every other on-behalf method uses. Gate
-        ON + no recorded :class:`OnBehalfApproval` matching
-        ``(<repo>!<mr>, "approve")`` → refuse without any GitLab side
-        effect; gate ON + recorded row → consume single-use and proceed.
+        Delegates to :func:`teatree.cli.review_approvals.approve` for the
+        implementation body; see that module for the full review-first
+        precondition and on-behalf-gate contract.
         """
-        blocked = check_on_behalf(repo, mr, "approve")
-        if blocked:
-            return blocked, 1
-        encoded = repo.replace("/", "%2F")
-        reviewed, error = self._identity_has_reviewed(encoded, mr)
-        if error:
-            return error, 1
-        if not reviewed:
-            msg = (
-                f"Refusing to approve !{mr}: review before approve — no review note authored by your "
-                "identity exists on this MR yet. Post a review (`t3 review post-comment` / "
-                "`post-draft-note`) first, then approve."
-            )
-            return msg, 1
-        api = self._get_api()
-        status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/approve")
-        if status in _HTTP_OK_CODES:
-            return f"OK approved !{mr}", 0
-        return f"Failed: HTTP {status}", 1
+        return review_approvals.approve(self, repo, mr)
 
     def unapprove(self, repo: str, mr: int) -> tuple[str, int]:
         """Revoke this identity's approval on an MR. Returns (message, exit_code).
 
-        No review-first precondition — removing an approval is the safe
-        direction and must always be reachable.
-
-        Gated by ``ask_before_post_on_behalf`` (#960/#1013): an unapproval
-        is still a colleague-visible post on the user's identity, so it
-        routes through the same recorded-approval gate as ``approve`` (and
-        every other on-behalf method). The recorded row scopes to
-        ``(<repo>!<mr>, "unapprove")``.
+        Delegates to :func:`teatree.cli.review_approvals.unapprove`; see
+        that module for the on-behalf-gate contract.
         """
-        blocked = check_on_behalf(repo, mr, "unapprove")
-        if blocked:
-            return blocked, 1
-        api = self._get_api()
-        encoded = repo.replace("/", "%2F")
-        status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/unapprove")
-        if status in _HTTP_OK_CODES:
-            return f"OK unapproved !{mr}", 0
-        return f"Failed: HTTP {status}", 1
+        return review_approvals.unapprove(self, repo, mr)
 
 
 def _require_token() -> ReviewService:
@@ -543,52 +475,10 @@ def reply_to_discussion(
         raise typer.Exit(code=code)
 
 
-@review_app.command(name="approve")
-def approve(
-    repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
-    mr: int = typer.Argument(help="Merge request IID"),
-) -> None:
-    """Approve a GitLab MR — only after you have reviewed it.
-
-    Precondition: a review note/discussion authored by your identity must
-    already exist on the MR (review before approve). Gated by
-    `on_behalf_post_mode` (BLOCK under `ask` / `draft_or_ask`,
-    souliane/teatree#960/#1013) — record an approval via
-    ``t3 review approve-on-behalf <repo>!<mr> approve --approver
-    <user-id>`` to satisfy the gate without switching mode to
-    `immediate`.
-    """
-    service = _require_token()
-    msg, code = service.approve(repo, mr)
-    typer.echo(msg)
-    if code:
-        raise typer.Exit(code=code)
-
-
-@review_app.command(name="unapprove")
-def unapprove(
-    repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
-    mr: int = typer.Argument(help="Merge request IID"),
-) -> None:
-    """Revoke your approval on a GitLab MR.
-
-    No review precondition (revoking is the safe direction). Gated by
-    `on_behalf_post_mode` (BLOCK under `ask` / `draft_or_ask`,
-    souliane/teatree#960/#1013) — record an approval via
-    ``t3 review approve-on-behalf <repo>!<mr> unapprove --approver
-    <user-id>`` to satisfy the gate without switching mode to
-    `immediate`.
-    """
-    service = _require_token()
-    msg, code = service.unapprove(repo, mr)
-    typer.echo(msg)
-    if code:
-        raise typer.Exit(code=code)
-
-
 # Register sibling-module typer commands. Kept out of this file so the
 # OOP/LOC ceiling (`scripts/hooks/check_module_health.py`) stays
-# satisfied — see `teatree.cli.review_on_behalf` and
-# `teatree.cli.review_drafts`.
+# satisfied — see `teatree.cli.review_on_behalf`,
+# `teatree.cli.review_drafts`, and `teatree.cli.review_approvals`.
 _register_on_behalf(review_app)
 _register_drafts(review_app)
+_register_approvals(review_app)

--- a/src/teatree/cli/review_approvals.py
+++ b/src/teatree/cli/review_approvals.py
@@ -1,0 +1,191 @@
+"""Approval CLI commands and review-before-approve precondition (#1056).
+
+Kept separate from :mod:`teatree.cli.review` so the GitLab-MR review
+mechanics module stays under the OOP/LOC ceiling
+(``scripts/hooks/check_module_health.py``). Three concerns live here:
+
+* :func:`identity_has_reviewed` — encodes the review-before-approve
+    doctrine: an approval may only be recorded once the same identity
+    has left a reviewing footprint (any note in any discussion thread)
+    on the MR. Returns ``(reviewed, error)``; ``error`` is non-empty
+    only when the approving identity itself cannot be resolved
+    (a hard precondition failure, not "no review yet").
+* :func:`approve` / :func:`unapprove` — free-function bodies the
+    matching :class:`~teatree.cli.review.ReviewService` methods
+    delegate to. Both route through the recorded-approval
+    ``on_behalf_post_mode`` pre-gate (#960/#1013) before any GitLab
+    API call.
+* :func:`register` — wires the ``approve`` and ``unapprove`` typer
+    commands onto the ``review`` typer app, mirroring the
+    :mod:`teatree.cli.review_drafts` /
+    :mod:`teatree.cli.review_on_behalf` registration pattern.
+
+The helpers import their service-layer dependencies lazily inside
+each command body so this module can be imported (by typer for
+command discovery) before ``django.setup()`` has run, matching the
+sibling :mod:`teatree.cli.review_on_behalf` pattern.
+"""
+
+from collections.abc import Callable
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any
+
+import typer
+
+from teatree.cli.review_on_behalf import check_on_behalf
+
+if TYPE_CHECKING:
+    from teatree.cli.review import ReviewService
+
+_HTTP_OK_CODES = frozenset({HTTPStatus.OK, HTTPStatus.CREATED, HTTPStatus.NO_CONTENT})
+
+
+def identity_has_reviewed(service: "ReviewService", encoded_repo: str, mr: int) -> tuple[bool, str]:
+    """Whether the approving identity already authored a note on this MR.
+
+    Encodes the review-before-approve doctrine: an approval may only be
+    recorded once the same identity has left a reviewing footprint
+    (any note in any discussion thread). Returns ``(reviewed, error)``;
+    ``error`` is non-empty only when the identity itself cannot be
+    resolved (a hard precondition failure, not "no review yet").
+    """
+    api = service._get_api()  # noqa: SLF001
+    username = api.current_username()
+    if not username:
+        return False, "Could not resolve the approving GitLab identity (check token / `glab auth status`)."
+    discussions = api.get_json(f"projects/{encoded_repo}/merge_requests/{mr}/discussions?per_page=100")
+    if not isinstance(discussions, list):
+        return False, ""
+    for discussion in discussions:
+        if not isinstance(discussion, dict):
+            continue
+        notes = discussion.get("notes")
+        if not isinstance(notes, list):
+            continue
+        for note in notes:
+            if not isinstance(note, dict):
+                continue
+            author = note.get("author")
+            if isinstance(author, dict) and author.get("username") == username:
+                return True, ""
+    return False, ""
+
+
+def approve(service: "ReviewService", repo: str, mr: int) -> tuple[str, int]:
+    """Approve an MR — refuses unless the identity has already reviewed it.
+
+    Returns (message, exit_code). The review-first precondition encodes
+    the approve-on-review doctrine: an approval cannot be recorded
+    without a prior reviewing footprint from the same identity.
+
+    Gated by ``ask_before_post_on_behalf`` (#960/#1013): an approval is
+    an outward post on the user's identity, so it routes through the
+    same recorded-approval gate every other on-behalf method uses. Gate
+    ON + no recorded :class:`OnBehalfApproval` matching
+    ``(<repo>!<mr>, "approve")`` → refuse without any GitLab side
+    effect; gate ON + recorded row → consume single-use and proceed.
+    """
+    blocked = check_on_behalf(repo, mr, "approve")
+    if blocked:
+        return blocked, 1
+    encoded = repo.replace("/", "%2F")
+    reviewed, error = identity_has_reviewed(service, encoded, mr)
+    if error:
+        return error, 1
+    if not reviewed:
+        msg = (
+            f"Refusing to approve !{mr}: review before approve — no review note authored by your "
+            "identity exists on this MR yet. Post a review (`t3 review post-comment` / "
+            "`post-draft-note`) first, then approve."
+        )
+        return msg, 1
+    api = service._get_api()  # noqa: SLF001
+    status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/approve")
+    if status in _HTTP_OK_CODES:
+        return f"OK approved !{mr}", 0
+    return f"Failed: HTTP {status}", 1
+
+
+def unapprove(service: "ReviewService", repo: str, mr: int) -> tuple[str, int]:
+    """Revoke this identity's approval on an MR. Returns (message, exit_code).
+
+    No review-first precondition — removing an approval is the safe
+    direction and must always be reachable.
+
+    Gated by ``ask_before_post_on_behalf`` (#960/#1013): an unapproval
+    is still a colleague-visible post on the user's identity, so it
+    routes through the same recorded-approval gate as ``approve`` (and
+    every other on-behalf method). The recorded row scopes to
+    ``(<repo>!<mr>, "unapprove")``.
+    """
+    blocked = check_on_behalf(repo, mr, "unapprove")
+    if blocked:
+        return blocked, 1
+    api = service._get_api()  # noqa: SLF001
+    encoded = repo.replace("/", "%2F")
+    status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/unapprove")
+    if status in _HTTP_OK_CODES:
+        return f"OK unapproved !{mr}", 0
+    return f"Failed: HTTP {status}", 1
+
+
+def _approve_command(
+    repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
+    mr: int = typer.Argument(help="Merge request IID"),
+) -> None:
+    """Approve a GitLab MR — only after you have reviewed it.
+
+    Precondition: a review note/discussion authored by your identity must
+    already exist on the MR (review before approve). Gated by
+    `on_behalf_post_mode` (BLOCK under `ask` / `draft_or_ask`,
+    souliane/teatree#960/#1013) — record an approval via
+    ``t3 review approve-on-behalf <repo>!<mr> approve --approver
+    <user-id>`` to satisfy the gate without switching mode to
+    `immediate`.
+    """
+    from teatree.cli.review import _require_token  # noqa: PLC0415
+
+    service = _require_token()
+    msg, code = service.approve(repo, mr)
+    typer.echo(msg)
+    if code:
+        raise typer.Exit(code=code)
+
+
+def _unapprove_command(
+    repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
+    mr: int = typer.Argument(help="Merge request IID"),
+) -> None:
+    """Revoke your approval on a GitLab MR.
+
+    No review precondition (revoking is the safe direction). Gated by
+    `on_behalf_post_mode` (BLOCK under `ask` / `draft_or_ask`,
+    souliane/teatree#960/#1013) — record an approval via
+    ``t3 review approve-on-behalf <repo>!<mr> unapprove --approver
+    <user-id>`` to satisfy the gate without switching mode to
+    `immediate`.
+    """
+    from teatree.cli.review import _require_token  # noqa: PLC0415
+
+    service = _require_token()
+    msg, code = service.unapprove(repo, mr)
+    typer.echo(msg)
+    if code:
+        raise typer.Exit(code=code)
+
+
+_COMMANDS: tuple[tuple[str, Callable[..., Any]], ...] = (
+    ("approve", _approve_command),
+    ("unapprove", _unapprove_command),
+)
+
+
+def register(review_app: typer.Typer) -> None:
+    """Register the approve/unapprove typer commands on the review app.
+
+    Wired by :mod:`teatree.cli.review` at import-time so every command
+    is part of ``t3 review`` exactly like the rest, while the OOP/LOC
+    ceiling stays satisfied.
+    """
+    for name, fn in _COMMANDS:
+        review_app.command(name=name)(fn)

--- a/tests/teatree_cli/test_review_approvals_module.py
+++ b/tests/teatree_cli/test_review_approvals_module.py
@@ -1,0 +1,52 @@
+"""Locks the approval helpers into :mod:`teatree.cli.review_approvals`.
+
+Created alongside the #1056 split of ``review.py`` (502 LOC, at the
+``scripts/hooks/check_module_health.py`` 500-LOC ceiling). The approve
+/ unapprove / review-precondition cluster was moved into its own
+sibling module so the parent module-health gate stays satisfied as the
+review surface grows.
+
+This test pins the **module location** so a future "tidy-up" can't
+quietly move the helpers back to ``review.py`` and re-violate the LOC
+budget. The behavioural contract continues to live in
+``test_review_approve_gate.py`` /
+``test_review_on_behalf_gate.py`` / ``test_cli_review.py``; those
+files still import ``ReviewService`` from ``teatree.cli.review`` and
+prove every method (approve, unapprove) behaves identically after the
+move — so this file deliberately stays narrow.
+"""
+
+import importlib
+
+
+class TestReviewApprovalsModule:
+    """The approval cluster has its own importable module."""
+
+    def test_module_imports(self) -> None:
+        """``teatree.cli.review_approvals`` is importable."""
+        importlib.import_module("teatree.cli.review_approvals")
+
+    def test_module_exposes_register(self) -> None:
+        """The module exposes a ``register(review_app)`` wiring entrypoint.
+
+        Mirrors :mod:`teatree.cli.review_drafts` /
+        :mod:`teatree.cli.review_on_behalf`: each split-out module
+        registers its own typer commands on the shared ``review_app``,
+        invoked from :mod:`teatree.cli.review` at import time.
+        """
+        module = importlib.import_module("teatree.cli.review_approvals")
+        assert callable(module.register)
+
+    def test_approve_and_unapprove_callables_exist(self) -> None:
+        """Free-function entry points for the approval helpers exist.
+
+        The ``ReviewService.approve`` / ``unapprove`` methods on
+        :class:`teatree.cli.review.ReviewService` still exist (the
+        public service surface is unchanged), but the implementation
+        body lives here as a free function the service method
+        delegates to. Pins the delegation target so it stays in this
+        module.
+        """
+        module = importlib.import_module("teatree.cli.review_approvals")
+        assert callable(module.approve)
+        assert callable(module.unapprove)


### PR DESCRIPTION
Closes [#1056](https://github.com/souliane/teatree/issues/1056).

## Why

`src/teatree/cli/review.py` sat at exactly **502 non-comment LOC on `main`** — the `scripts/hooks/check_module_health.py` ceiling is **500**, and the gate has **no relax escape** per `t3:rules § "No commit-type bypass for the quality gates"`. The file was a systemic blocker: any feature branch that touched the review surface and added a single non-comment line tripped the module-health hook and could not merge. This change clears that blocker.

## Move map (behaviour-preserving)

| From `review.py` (502 LOC) | To `review_approvals.py` (new, 159 LOC) |
|---|---|
| `ReviewService._identity_has_reviewed` | `identity_has_reviewed(service, ...)` (free function) |
| `ReviewService.approve` body | `approve(service, repo, mr)` |
| `ReviewService.unapprove` body | `unapprove(service, repo, mr)` |
| `t3 review approve` typer command | `_approve_command` (registered via `register(review_app)`) |
| `t3 review unapprove` typer command | `_unapprove_command` (registered via `register(review_app)`) |

`ReviewService.approve` / `unapprove` stay on the class as **thin delegators** so every test that calls `service.approve(repo, mr)` keeps working without modification. The composition pattern matches the existing sibling modules (`review_drafts.register`, `review_on_behalf.register`).

Every publishing method still routes through `check_on_behalf` exactly as before — the on-behalf gate's chokepoint shape (PR [#1009](https://github.com/souliane/teatree/pull/1009)) is unchanged.

## Post-split LOC

| File | Non-comment LOC | Status |
|---|---|---|
| `src/teatree/cli/review.py` | **402** (was 502) | under the 500 budget |
| `src/teatree/cli/review_approvals.py` | 159 (new) | well under |

## Verification

- `uv run pytest --no-cov -q tests/` → **5111 passed, 12 skipped, 37 subtests passed** (was 5108 pre-refactor; +3 for the new `test_review_approvals_module` pin test).
- `uv run pytest --cov=teatree.cli.review_approvals` → **100% coverage** on the new module.
- `uv run ruff check src/ tests/` → clean.
- `uv run ruff format --check src/ tests/` → clean.
- `python scripts/hooks/check_module_health.py` → green on the staged diff.
- `uv run ty check src/teatree/cli/review_approvals.py` → clean.

## Test attestation

The new `tests/teatree_cli/test_review_approvals_module.py` is deliberately narrow — it pins the module location so a future tidy-up cannot quietly move the helpers back to `review.py` and re-violate the LOC budget. The behavioural contract continues to live in:

- `tests/teatree_cli/test_review_approve_gate.py` — gate behaviour on `service.approve` / `unapprove`.
- `tests/teatree_cli/test_review_on_behalf_gate.py` — on-behalf chokepoint across every publishing method.
- `tests/test_cli_review.py` — `ReviewService.approve` review-before-approve precondition + happy path.

All three import `ReviewService` from `teatree.cli.review` and prove every method behaves identically after the move — the public surface is preserved.

## Out of scope

- No logic changes. No behaviour changes. No public-API renames. No new commands.
- `BLUEPRINT.md` is updated to enumerate the existing sibling modules (`review_diff.py`, `review_drafts.py`, `review_on_behalf.py`) alongside the new `review_approvals.py`, since BLUEPRINT only listed `review.py` before this change.
