### PR TITLE
fix(notify): hard-fail on silent Slack non-delivery + connector preflight gate

### DIFF
--- a/src/teatree/backends/messaging_noop.py
+++ b/src/teatree/backends/messaging_noop.py
@@ -50,3 +50,7 @@ class NoopMessagingBackend:
     def resolve_user_id(handle: str) -> str:
         _ = handle
         return ""
+
+    @staticmethod
+    def auth_test() -> RawAPIDict:
+        return {}

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -168,3 +168,5 @@ class MessagingBackend(Protocol):
     def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict: ...  # pragma: no branch
 
     def resolve_user_id(self, handle: str) -> str: ...  # pragma: no branch
+
+    def auth_test(self) -> RawAPIDict: ...  # pragma: no branch

--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -227,6 +227,16 @@ class SlackBotBackend:
             self._cached_bot_id = str(data.get("user_id", "")) if data.get("ok") else ""
         return self._cached_bot_id
 
+    def auth_test(self) -> RawAPIDict:
+        """Return the raw ``auth.test`` response (``{}`` when no bot token).
+
+        A connector preflight calls this to assert the bot token is live
+        and correctly scoped before the loop proceeds — a hard-fail gate
+        rather than discovering ``missing_scope`` mid-tick via a phantom
+        ``post_message`` success.
+        """
+        return self._post("auth.test", {})
+
     def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:
         payload: SlackPayload = {"channel": channel, "text": text}
         if thread_ts:

--- a/src/teatree/core/connector_preflight.py
+++ b/src/teatree/core/connector_preflight.py
@@ -1,0 +1,57 @@
+"""Loop-start connector preflight gate.
+
+A loop tick that proceeds with a down connector (Slack ``missing_scope``,
+Notion unreachable, claude.ai connector offline) does not error — it
+silently no-ops: scanners find nothing, ``notify_user`` records a phantom
+``SENT``, the user is told nothing. The user directive is the opposite:
+*refuse to continue* when a hard-dependency connector is unreachable.
+
+This module runs every registered overlay's
+:meth:`OverlayBase.get_connector_preflight` callables before any
+connector-dependent loop work. The first ``RuntimeError`` is fatal —
+``run_connector_preflight`` ``raise SystemExit(1)`` with a message naming
+which connector is down, following teatree's management-command exit
+convention (``raise SystemExit``, never ``typer.Exit``).
+"""
+
+import logging
+
+from teatree.core.overlay_loader import get_all_overlays
+
+logger = logging.getLogger(__name__)
+
+
+def run_connector_preflight(overlay_name: str = "") -> None:
+    """Run connector probes for every registered overlay (or one named).
+
+    Each overlay contributes zero or more zero-arg callables via
+    :meth:`OverlayBase.get_connector_preflight`. A callable that raises
+    ``RuntimeError`` means a hard-dependency connector is unreachable;
+    this function then ``raise SystemExit(1)`` so the loop/lifecycle
+    entrypoint refuses to continue rather than degrade into silent
+    no-ops. A clean run returns ``None``.
+    """
+    overlays = get_all_overlays()
+    if overlay_name:
+        selected = {overlay_name: overlays[overlay_name]} if overlay_name in overlays else {}
+    else:
+        selected = overlays
+
+    for name, overlay in selected.items():
+        for check in overlay.get_connector_preflight():
+            try:
+                check()
+            except RuntimeError as exc:
+                msg = (
+                    f"Connector preflight failed for overlay {name!r}: {exc}. "
+                    "Refusing to continue — fix the connector and retry."
+                )
+                logger.exception(msg)
+                # ``SystemExit`` with a str arg: Python prints it to
+                # stderr and exits 1. ``.code`` is the message (truthy →
+                # non-zero exit). Follows teatree's mgmt-command exit
+                # convention (raise SystemExit, never typer.Exit).
+                raise SystemExit(msg) from exc
+
+
+__all__ = ["run_connector_preflight"]

--- a/src/teatree/core/management/commands/loop_tick.py
+++ b/src/teatree/core/management/commands/loop_tick.py
@@ -79,8 +79,15 @@ class Command(TyperCommand):
             iter_overlay_backends,
             messaging_from_overlay,
         )
+        from teatree.core.connector_preflight import run_connector_preflight  # noqa: PLC0415
         from teatree.core.models import LoopLease  # noqa: PLC0415
         from teatree.loop.tick import TickRequest, run_tick  # noqa: PLC0415
+
+        # Refuse to tick into silent no-ops when a hard-dependency
+        # connector is unreachable. Raises SystemExit naming the down
+        # connector, before the lease is taken, so the loop fails fast
+        # instead of degrading.
+        run_connector_preflight(overlay)
 
         # #786 WS2: DB lease/heartbeat replaces the flock/pidfile singleton.
         # The lease row is queryable and reapable by expiry, so loop

--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -76,31 +76,28 @@ def notify_user(  # noqa: PLR0913 — single notification egress; each kwarg is 
 
     payload_text = _maybe_linkify(text) if linkify else text
 
-    try:
-        channel = resolved_backend.open_dm(resolved_user_id)
-        response = resolved_backend.post_message(
-            channel=channel,
-            text=_format(payload_text, kind_value),
-            thread_ts="",
-        )
-    except Exception as exc:  # noqa: BLE001 — notify must never bubble up
-        logger.warning("notify_user transport failed for key=%s: %s", idempotency_key, exc)
-        _record_failed(
-            idempotency_key=idempotency_key,
-            kind=kind_value,
-            text=text,
-            error=str(exc),
-        )
+    channel, posted_ts, failure = _deliver_dm(
+        resolved_backend,
+        user_id=resolved_user_id,
+        text=_format(payload_text, kind_value),
+    )
+    if failure:
+        # Any non-delivery — empty channel from ``open_dm`` (Slack
+        # ``conversations.open ok:false``), a transport exception, a
+        # ``post_message`` ``ok:false``, or an ``ok:true`` with no
+        # ``ts`` — is a HARD FAILURE. The pre-fix code keyed solely off
+        # ``ts`` and recorded SENT + returned ``True`` for every one of
+        # these, the exact phantom-success this guards against.
+        logger.warning("notify_user delivery failed for key=%s: %s", idempotency_key, failure)
+        _record_failed(idempotency_key=idempotency_key, kind=kind_value, text=text, error=failure)
         return False
-
-    posted_ts = str(response.get("ts", "")) if isinstance(response, dict) else ""
-    permalink = ""
-    if channel and posted_ts:
-        try:
-            permalink = resolved_backend.get_permalink(channel=channel, ts=posted_ts)
-        except Exception as exc:  # noqa: BLE001 — permalink lookup is best-effort
-            logger.debug("notify_user permalink lookup failed for key=%s: %s", idempotency_key, exc)
-            permalink = ""
+    # ``channel`` and ``posted_ts`` are both non-empty here — ``_deliver_dm``
+    # only returns no failure when both are set, so no defensive re-check.
+    try:
+        permalink = resolved_backend.get_permalink(channel=channel, ts=posted_ts)
+    except Exception as exc:  # noqa: BLE001 — permalink lookup is best-effort
+        logger.debug("notify_user permalink lookup failed for key=%s: %s", idempotency_key, exc)
+        permalink = ""
     try:
         with transaction.atomic():
             BotPing.objects.create(
@@ -121,6 +118,44 @@ def notify_user(  # noqa: PLR0913 — single notification egress; each kwarg is 
         posted_ts=posted_ts,
     )
     return True
+
+
+def _deliver_dm(
+    backend: MessagingBackend,
+    *,
+    user_id: str,
+    text: str,
+) -> tuple[str, str, str]:
+    """Open a DM and post ``text``, returning ``(channel, ts, failure)``.
+
+    ``failure`` is ``""`` on a confirmed delivery (non-empty channel,
+    ``ok:true`` response with a non-empty ``ts``). Otherwise it holds a
+    human-readable reason and ``(channel, ts)`` must NOT be trusted —
+    every non-empty ``failure`` is a HARD FAILURE for the caller.
+
+    The three non-delivery shapes Slack produces, all previously treated
+    as benign successes, are:
+    (a) ``open_dm`` returns ``""`` — ``conversations.open ok:false``
+    (missing scope, user not found); posting to ``""`` silently no-ops.
+    (b) ``post_message`` raises — transport/network error.
+    (c) ``post_message`` returns ``ok:false`` (missing_scope,
+    channel_not_found) or ``ok:true`` with no ``ts`` — nothing landed.
+    """
+    try:
+        channel = backend.open_dm(user_id)
+        if not channel:
+            return "", "", "open_dm returned an empty channel (Slack conversations.open ok:false)"
+        response = backend.post_message(channel=channel, text=text, thread_ts="")
+    except Exception as exc:  # noqa: BLE001 — notify must never bubble up
+        return "", "", str(exc)
+
+    posted_ts = str(response.get("ts", "")) if isinstance(response, dict) else ""
+    response_ok = bool(response.get("ok")) if isinstance(response, dict) else False
+    if not response_ok or not posted_ts:
+        slack_error = str(response.get("error", "")) if isinstance(response, dict) else ""
+        detail = f"Slack post failed: {slack_error}" if slack_error else "Slack post returned no message ts"
+        return channel, posted_ts, detail
+    return channel, posted_ts, ""
 
 
 def _record_outbound_claim(

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -315,6 +315,20 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
         _ = customer, base_url
         return []
 
+    def get_connector_preflight(self) -> list[Callable[[], None]]:
+        """Return zero-arg probes run before any connector-dependent loop work.
+
+        Each callable raises ``RuntimeError`` (caught by the loop
+        entrypoint, which then ``raise SystemExit``) when a connector the
+        overlay hard-depends on (Slack, Notion, claude.ai) is unreachable.
+        The default is empty — an overlay opts in only when it cannot
+        function correctly with a degraded connector (silent no-ops are
+        worse than refusing to start). Analogous to
+        :meth:`get_e2e_preflight` but fired at loop/lifecycle start
+        rather than before an E2E run.
+        """
+        return []
+
     def get_verify_endpoints(self, worktree: "Worktree") -> dict[str, str]:
         return {}
 

--- a/tests/teatree_backends/test_messaging.py
+++ b/tests/teatree_backends/test_messaging.py
@@ -85,6 +85,44 @@ def test_slack_react_calls_reactions_add(monkeypatch: pytest.MonkeyPatch) -> Non
     assert captured["json"] == {"channel": "C", "timestamp": "1.2", "name": "white_check_mark"}
 
 
+def test_slack_auth_test_returns_raw_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        captured["url"] = url
+        return httpx.Response(
+            200,
+            json={"ok": True, "user_id": "UBOT", "team": "T1"},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    backend = SlackBotBackend(bot_token="xoxb-test")
+
+    result = backend.auth_test()
+
+    assert result == {"ok": True, "user_id": "UBOT", "team": "T1"}
+    assert captured["url"] == "https://slack.com/api/auth.test"
+
+
+def test_slack_auth_test_surfaces_ok_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"ok": False, "error": "missing_scope"},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    backend = SlackBotBackend(bot_token="xoxb-test")
+
+    assert backend.auth_test() == {"ok": False, "error": "missing_scope"}
+
+
+def test_slack_auth_test_returns_empty_when_no_token() -> None:
+    assert SlackBotBackend(bot_token="").auth_test() == {}
+
+
 def test_slack_post_returns_empty_when_no_token() -> None:
     backend = SlackBotBackend(bot_token="")
     assert backend.post_message(channel="C", text="hi") == {}

--- a/tests/teatree_backends/test_protocols.py
+++ b/tests/teatree_backends/test_protocols.py
@@ -125,6 +125,9 @@ class _FakeMessaging:
         _ = handle
         return ""
 
+    def auth_test(self) -> dict[str, object]:
+        return {}
+
 
 def test_ci_service_protocol_is_structural() -> None:
     assert isinstance(_FakeCIService(), CIService)

--- a/tests/teatree_core/test_connector_preflight.py
+++ b/tests/teatree_core/test_connector_preflight.py
@@ -1,0 +1,98 @@
+"""Loop-start connector preflight gate (refuse-to-continue on down connector).
+
+An overlay that hard-depends on external connectors must HARD-FAIL
+(refuse to continue) when one is unreachable, rather than degrade into
+silent no-ops. The gate ``raise SystemExit`` with a message naming
+WHICH connector is down.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.connector_preflight import run_connector_preflight
+from teatree.core.models import Worktree
+from teatree.core.overlay import OverlayBase, ProvisionStep
+
+
+class _NoOpOverlay(OverlayBase):
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        _ = worktree
+        return []
+
+
+class _SlackDownOverlay(OverlayBase):
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        _ = worktree
+        return []
+
+    def get_connector_preflight(self) -> list:
+        def _probe() -> None:
+            msg = "Slack auth.test failed: missing_scope"
+            raise RuntimeError(msg)
+
+        return [_probe]
+
+
+class TestOverlayBaseConnectorPreflightDefault(TestCase):
+    def test_default_is_empty(self) -> None:
+        assert _NoOpOverlay().get_connector_preflight() == []
+
+
+class TestRunConnectorPreflight(TestCase):
+    def test_clean_overlays_return_none(self) -> None:
+        with patch(
+            "teatree.core.connector_preflight.get_all_overlays",
+            return_value={"clean": _NoOpOverlay()},
+        ):
+            assert run_connector_preflight() is None
+
+    def test_down_connector_raises_systemexit_naming_the_connector(self) -> None:
+        with (
+            patch(
+                "teatree.core.connector_preflight.get_all_overlays",
+                return_value={"acme": _SlackDownOverlay()},
+            ),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            run_connector_preflight()
+
+        assert excinfo.value.code != 0
+        message = str(excinfo.value)
+        assert "acme" in message
+        assert "Slack" in message
+        assert "missing_scope" in message
+
+    def test_named_overlay_filter_skips_other_overlays(self) -> None:
+        with patch(
+            "teatree.core.connector_preflight.get_all_overlays",
+            return_value={"clean": _NoOpOverlay(), "acme": _SlackDownOverlay()},
+        ):
+            # Restricting to the clean overlay must not trip the down one.
+            assert run_connector_preflight("clean") is None
+
+    def test_named_overlay_filter_still_gates_the_selected_overlay(self) -> None:
+        with (
+            patch(
+                "teatree.core.connector_preflight.get_all_overlays",
+                return_value={"clean": _NoOpOverlay(), "acme": _SlackDownOverlay()},
+            ),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            run_connector_preflight("acme")
+
+        assert excinfo.value.code != 0
+
+    def test_unknown_named_overlay_is_a_clean_noop(self) -> None:
+        with patch(
+            "teatree.core.connector_preflight.get_all_overlays",
+            return_value={"acme": _SlackDownOverlay()},
+        ):
+            assert run_connector_preflight("does-not-exist") is None

--- a/tests/teatree_core/test_loop_tick_command.py
+++ b/tests/teatree_core/test_loop_tick_command.py
@@ -6,6 +6,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -96,6 +97,27 @@ class TestLoopTickCommand(TestCase):
             call_command("loop_tick", "--overlay", "myoverlay", stdout=stdout)
 
         host_mock.assert_called_once()
+
+    def test_connector_preflight_aborts_tick_before_running(self) -> None:
+        """A down connector ``raise SystemExit`` before any tick work.
+
+        Guards the user directive: the loop must refuse to continue when
+        a hard-dependency connector is unreachable, not degrade into a
+        silent no-op tick.
+        """
+        report = _build_report()
+        with (
+            patch(
+                "teatree.core.connector_preflight.run_connector_preflight",
+                side_effect=SystemExit("Connector preflight failed for overlay 'acme': Slack down"),
+            ),
+            patch("teatree.loop.tick.run_tick", return_value=report) as run_tick_mock,
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            call_command("loop_tick", stdout=StringIO())
+
+        assert excinfo.value.code != 0
+        run_tick_mock.assert_not_called()
 
     def test_skips_tick_when_lease_held_by_another_owner(self) -> None:
         """A live DB lease held by another owner makes the command skip (#786 WS2).

--- a/tests/teatree_core/test_notify.py
+++ b/tests/teatree_core/test_notify.py
@@ -126,6 +126,80 @@ class TestNotifyUser(TestCase):
         assert row.status == BotPing.Status.FAILED
         assert "slack timeout" in row.error_message
 
+    def test_empty_channel_from_open_dm_is_hard_failure(self) -> None:
+        """``open_dm`` returns ``""`` on Slack ``ok:false`` (e.g. missing_scope).
+
+        The bug this guards: the empty channel was treated as benign, the
+        DM never landed, yet ``BotPing`` was marked ``SENT`` and the
+        function returned ``True`` — a silent success. The contract is a
+        HARD FAILURE: ``FAILED`` row, ``False`` return, no claim recorded.
+        """
+        backend = _backend()
+        backend.open_dm.return_value = ""
+
+        sent = notify_user(
+            "this never lands",
+            kind=NotifyKind.INFO,
+            idempotency_key="empty-channel",
+            backend=backend,
+            user_id="U_ME",
+        )
+
+        assert sent is False
+        backend.post_message.assert_not_called()
+        row = BotPing.objects.get(idempotency_key="empty-channel")
+        assert row.status == BotPing.Status.FAILED
+        assert "open_dm" in row.error_message or "channel" in row.error_message
+        from teatree.core.models import OutboundClaim  # noqa: PLC0415
+
+        assert not OutboundClaim.objects.filter(idempotency_key="slack_dm:empty-channel").exists()
+
+    def test_post_message_ok_false_is_hard_failure(self) -> None:
+        """``post_message`` returning ``{"ok": false}`` must be a HARD FAILURE.
+
+        Slack returns ``ok:false`` (missing_scope, channel_not_found, …)
+        with no ``ts``. The pre-fix code recorded ``SENT`` + returned
+        ``True`` because it only looked at ``response.get("ts")``.
+        """
+        backend = _backend()
+        backend.post_message.return_value = {"ok": False, "error": "missing_scope"}
+
+        sent = notify_user(
+            "not actually posted",
+            kind=NotifyKind.INFO,
+            idempotency_key="ok-false",
+            backend=backend,
+            user_id="U_ME",
+        )
+
+        assert sent is False
+        row = BotPing.objects.get(idempotency_key="ok-false")
+        assert row.status == BotPing.Status.FAILED
+        assert "missing_scope" in row.error_message
+        from teatree.core.models import OutboundClaim  # noqa: PLC0415
+
+        assert not OutboundClaim.objects.filter(idempotency_key="slack_dm:ok-false").exists()
+
+    def test_post_message_empty_ts_is_hard_failure(self) -> None:
+        """An ``ok:true`` response with no ``ts`` still means nothing landed."""
+        backend = _backend()
+        backend.post_message.return_value = {"ok": True}
+
+        sent = notify_user(
+            "phantom success",
+            kind=NotifyKind.INFO,
+            idempotency_key="empty-ts",
+            backend=backend,
+            user_id="U_ME",
+        )
+
+        assert sent is False
+        row = BotPing.objects.get(idempotency_key="empty-ts")
+        assert row.status == BotPing.Status.FAILED
+        from teatree.core.models import OutboundClaim  # noqa: PLC0415
+
+        assert not OutboundClaim.objects.filter(idempotency_key="slack_dm:empty-ts").exists()
+
     def test_permalink_lookup_failure_does_not_break_send(self) -> None:
         backend = _backend()
         backend.get_permalink.side_effect = RuntimeError("permalink api down")

--- a/tests/teatree_core/test_on_behalf_autodraft_dm.py
+++ b/tests/teatree_core/test_on_behalf_autodraft_dm.py
@@ -44,7 +44,10 @@ def _stub_backend() -> MagicMock:
     """A ``MessagingBackend``-shaped MagicMock that records ``post_message`` calls."""
     backend = MagicMock()
     backend.open_dm.return_value = "D-OPERATOR"
-    backend.post_message.return_value = {"ts": "1700000000.0001"}
+    # Real Slack ``chat.postMessage`` success carries ``ok:true`` AND a
+    # ``ts``. ``notify_user`` hard-fails on a missing ``ok`` (#1048-class
+    # phantom success), so the stub must mirror the real contract.
+    backend.post_message.return_value = {"ok": True, "ts": "1700000000.0001"}
     backend.get_permalink.return_value = "https://slack.example/archives/D-OPERATOR/p1"
     return backend
 


### PR DESCRIPTION
## Summary

`notify_user` treated a non-delivered Slack DM as a success: `open_dm`
returning `""` (Slack `conversations.open ok:false`, e.g. `missing_scope`)
and `post_message` returning `ok:false` / no `ts` were both swallowed —
the `BotPing` row was marked `SENT` and the function returned `True` for
a DM that never landed. This is the [#1048](https://github.com/souliane/teatree/pull/1048)-class
phantom-success (transport "succeeded", audit said sent, nothing delivered).

- Delivery is now validated centrally in `_deliver_dm`. Any non-delivery
  (empty channel, transport exception, `ok:false`, or `ok:true` with no
  `ts`) records `BotPing` `FAILED`, returns `False`, and records **no**
  `OutboundClaim` — consistent with the outbound-audit ledger contract.
- New extension point `OverlayBase.get_connector_preflight()` (default
  empty) + `core.connector_preflight.run_connector_preflight`, wired into
  the `loop_tick` entrypoint **before** the lease is taken. An overlay
  that hard-depends on an external connector can now make the loop
  `raise SystemExit` (mgmt-command exit convention) — naming the down
  connector — instead of ticking into silent no-ops.
- `SlackBotBackend.auth_test()` exposes `auth.test` for connector probes
  (added to the `MessagingBackend` protocol + noop backend).

A test stub in `test_on_behalf_autodraft_dm` returned `post_message`
without `ok:true` (it relied on the buggy `ts`-only check); corrected to
mirror the real Slack success contract.

The companion overlay-side change (a registered overlay implementing
`get_connector_preflight` to probe Slack/Notion/claude.ai) ships
separately in the private overlay repo and depends on this PR's
extension point landing first.

## RED→GREEN evidence

- `notify_user` hard-fail: with the pre-fix delivery logic restored,
  `test_empty_channel_from_open_dm_is_hard_failure` fails
  `assert True is False`; with the fix it passes. Same for the
  `ok:false` / empty-`ts` variants.
- connector preflight: with the `raise SystemExit` replaced by a
  silent `continue` (pre-fix degrade), the gate test fails
  `DID NOT RAISE <class 'SystemExit'>`; restored → green.

## Test plan

- [x] `uv run pytest --no-cov` full suite: 5252 passed, 12 skipped
- [x] `uv run ruff check && uv run ruff format` clean
- [x] New code (`_deliver_dm`, `connector_preflight`) at 100% line+branch coverage
- [ ] CI green