### PR TITLE
fix(slack): systematic per-channel token policy for Slack-Connect posts (#1072)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1176,7 +1176,7 @@ path = "~/workspace/myproject"
 code_host = "github"                       # "github" | "gitlab"
 messaging_backend = "slack"                # "slack" | "noop" (default)
 slack_token_ref = "teatree/slack/myproject"   # `pass` entry prefix; -bot and -app suffixes resolve the two tokens
-user_token_ref = "slack/user-oauth-token"  # optional; `pass` entry holding the human's xoxp token (routes reactions on Slack-Connect channels where the bot token is rejected)
+user_token_ref = "slack/user-oauth-token"  # optional; `pass` entry holding the human's xoxp token (routes posts AND reactions on Slack-Connect channels where the bot token is rejected; internal channels/DMs stay on the bot token)
 slack_user_id = "U01ABCD1234"              # my Slack user ID (used to filter mentions/DMs)
 
 [overlays.another-project]

--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -9,14 +9,20 @@ The Phase 3 surface is intentionally minimal: enough for outbound routing
 from the loop's scanners, with the Socket Mode receiver delivering inbound
 events into the same backend through a queue managed by Phase 3.6.
 
-Slack-Connect externally-shared channels reject reactions posted with a
-bot token (``mcp_externally_shared_channel_restricted``).  When the human
-user's OAuth token (``xoxp-…``) is configured via ``user_token_ref`` in
-``~/.teatree.toml``, ``react`` and ``get_reactions`` authenticate with
-that token instead.  Everything else (DMs, ``chat.postMessage``,
-``conversations.open``, ``users.lookupByEmail``) keeps using the bot
-token because those endpoints are scoped to the bot's own IM channels
-and cache.
+Slack-Connect externally-shared channels reject the bot token with
+``mcp_externally_shared_channel_restricted`` — both for reactions and
+for ``chat.postMessage``.  When the human user's OAuth token (``xoxp-…``)
+is configured via ``user_token_ref`` in ``~/.teatree.toml``, a single
+deterministic policy (:meth:`SlackBotBackend._channel_token`) routes
+*every* outbound surface — ``post_message``, ``post_reply``, ``react``,
+``get_reactions`` — through the user token when, and only when, the
+target is an externally-shared channel.  Connect membership is resolved
+deterministically via ``conversations.info`` (``is_ext_shared`` /
+``is_shared``), cached per channel id — never a try-bot-then-fallback
+error probe.  DMs and ordinary internal channels keep the bot token
+(those are scoped to the bot's own IM channels and cache; routing them
+through ``xoxp`` would impersonate the user against their own history).
+``conversations.open`` and ``users.lookupByEmail`` are always bot-token.
 """
 
 from typing import cast
@@ -45,9 +51,10 @@ class SlackBotBackend:
     ``app_token`` (``xapp-…``) authorises Socket Mode and is consumed by the
     Phase 3.6 walkthrough — kept on the instance so the bot starter can pick
     it up without a second config read.
-    ``user_token`` (``xoxp-…``) authorises reactions in Slack-Connect
-    externally-shared channels where the bot token is rejected by the workspace
-    restriction policy.  When unset, reactions fall back to the bot token.
+    ``user_token`` (``xoxp-…``) authorises every outbound call (posts and
+    reactions) in Slack-Connect externally-shared channels where the bot
+    token is rejected by the workspace restriction policy.  When unset,
+    every call falls back to the bot token.
     ``user_id`` is the Slack user id of the human the bot speaks for; scanners
     use it to filter @mentions targeted at that user.
     """
@@ -65,6 +72,9 @@ class SlackBotBackend:
         self._user_token = user_token
         self._user_id = user_id
         self._cached_bot_id: str | None = None
+        # Per-channel Slack-Connect membership, resolved once via
+        # ``conversations.info`` then reused by the token-selection policy.
+        self._ext_shared_cache: dict[str, bool] = {}
         # Inbound queues populated by the Phase 3.6 Socket Mode receiver. Each
         # tick the loop scanner drains them via ``fetch_mentions`` /
         # ``fetch_dms`` / ``fetch_reactions``; the receiver calls
@@ -126,16 +136,59 @@ class SlackBotBackend:
         response.raise_for_status()
         return cast("RawAPIDict", response.json())
 
-    def _reaction_token(self) -> str:
-        """Token authorising ``reactions.*`` calls.
+    def _is_ext_shared(self, channel: str) -> bool:
+        """Whether *channel* is a Slack-Connect externally-shared channel.
 
-        Slack-Connect externally-shared channels block bot tokens with
-        ``mcp_externally_shared_channel_restricted``.  When the human's
-        ``xoxp`` is configured we route reactions through it so they post
-        from the user's identity; otherwise fall back to the bot token
-        for the legacy single-credential case.
+        Resolved deterministically from ``conversations.info``
+        (``is_ext_shared`` / ``is_shared``) on the bot token — the bot
+        can always *read* channel metadata even on channels it cannot
+        *post* to.  The answer is cached per channel id for the lifetime
+        of the backend so repeat posts to the same channel probe once.
+        On any lookup failure we treat the channel as internal so the
+        policy fails safe to the bot token (the legacy behaviour).
         """
-        return self._user_token or self._bot_token
+        cached = self._ext_shared_cache.get(channel)
+        if cached is not None:
+            return cached
+        data = self._get("conversations.info", {"channel": channel})
+        info = cast("RawAPIDict", data.get("channel") or {})
+        is_ext = bool(data.get("ok")) and (bool(info.get("is_ext_shared")) or bool(info.get("is_shared")))
+        self._ext_shared_cache[channel] = is_ext
+        return is_ext
+
+    def _channel_token(self, channel: str) -> str:
+        """The token authorising an outbound call to *channel*.
+
+        The single, deterministic token-selection policy consulted by
+        every outbound surface (``post_message``, ``post_reply``,
+        ``react``, ``get_reactions``).
+
+        No user (``xoxp``) token configured -> bot token (the legacy
+        single-credential case; nothing to route to).
+
+        No bot token configured -> user token. There is no second
+        credential to probe Connect membership with, and the
+        user-token-only deployment intends every call to go out under
+        the user's identity anyway.
+
+        A DM channel (id starts with ``D``) -> bot token. DMs are scoped
+        to the bot's own IM channels; routing them through the user
+        token would impersonate the user against their own DM history.
+
+        A Slack-Connect externally-shared channel -> user token. The bot
+        token is rejected there with
+        ``mcp_externally_shared_channel_restricted``; the user's
+        ``xoxp`` is a partner-channel member and can post.
+
+        Any ordinary internal channel -> bot token.
+        """
+        if not self._user_token:
+            return self._bot_token
+        if not self._bot_token:
+            return self._user_token
+        if channel.startswith("D"):
+            return self._bot_token
+        return self._user_token if self._is_ext_shared(channel) else self._bot_token
 
     def fetch_mentions(self, *, since: str = "") -> list[RawAPIDict]:
         """Drain queued Socket Mode mentions and return them in order.
@@ -281,16 +334,20 @@ class SlackBotBackend:
         payload: SlackPayload = {"channel": channel, "text": text}
         if thread_ts:
             payload["thread_ts"] = thread_ts
-        return self._post("chat.postMessage", payload)
+        return self._post("chat.postMessage", payload, token=self._channel_token(channel))
 
     def post_reply(self, *, channel: str, ts: str, text: str) -> RawAPIDict:
-        return self._post("chat.postMessage", {"channel": channel, "thread_ts": ts, "text": text})
+        return self._post(
+            "chat.postMessage",
+            {"channel": channel, "thread_ts": ts, "text": text},
+            token=self._channel_token(channel),
+        )
 
     def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
         return self._post(
             "reactions.add",
             {"channel": channel, "timestamp": ts, "name": emoji},
-            token=self._reaction_token(),
+            token=self._channel_token(channel),
         )
 
     def open_dm(self, user_id: str) -> str:
@@ -317,7 +374,7 @@ class SlackBotBackend:
         data = self._get(
             "reactions.get",
             {"channel": channel, "timestamp": ts},
-            token=self._reaction_token(),
+            token=self._channel_token(channel),
         )
         if not data.get("ok"):
             return []

--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -66,13 +66,14 @@ _BOT_SCOPES = [
     "users:read.email",
 ]
 # Scopes for the human user's OAuth token (``xoxp-…``). ``SlackBotBackend``
-# routes ``reactions.add`` / ``reactions.get`` through this token (see
-# ``SlackBotBackend._reaction_token``) because Slack-Connect externally-shared
-# channels reject the bot token with
-# ``mcp_externally_shared_channel_restricted`` — hence ``reactions:read`` /
-# ``reactions:write``. ``build_manifest`` must declare a ``user`` scopes
-# section or a reinstall never re-prompts for the reaction grants and the
-# xoxp token keeps whatever Slack defaulted (empirically: no reaction scopes).
+# routes every outbound call (``chat.postMessage``, ``reactions.add`` /
+# ``reactions.get``) through this token for Slack-Connect externally-shared
+# channels (see ``SlackBotBackend._channel_token``) because those channels
+# reject the bot token with ``mcp_externally_shared_channel_restricted`` —
+# hence ``chat:write`` (posting) plus ``reactions:read`` / ``reactions:write``.
+# ``build_manifest`` must declare a ``user`` scopes section or a reinstall
+# never re-prompts for these grants and the xoxp token keeps whatever Slack
+# defaulted (empirically: no reaction scopes).
 # A manifest reinstall re-prompts OAuth consent for *exactly* this set and
 # drops any user scope not listed, so the set must be a SUPERSET that keeps
 # the capability the xoxp token is already relied on for: ``chat:write``

--- a/tests/integration/test_slack_bridge_e2e.py
+++ b/tests/integration/test_slack_bridge_e2e.py
@@ -78,6 +78,7 @@ class FakeSlackTransport:
             },
             "reactions.add": {"ok": True},
             "reactions.get": {"ok": True, "message": {"reactions": []}},
+            "conversations.info": {"ok": True, "channel": {"is_ext_shared": False}},
             "users.lookupByEmail": {"ok": False, "error": "users_not_found"},
             "users.list": {"ok": True, "members": []},
         }
@@ -596,16 +597,31 @@ class TestPerOverlayBotRouting:
 
 
 class TestxoxpVsxoxbRouting:
-    """Reactions route through ``xoxp-…``; DMs / posts stay on ``xoxb-…`` (#1041)."""
+    """Slack-Connect channels route through ``xoxp-…``; DMs stay on ``xoxb-…`` (#1072).
 
-    def test_reactions_route_through_xoxp_token(self, transport: FakeSlackTransport) -> None:
-        """RED if ``react()`` stops calling ``_reaction_token()``.
+    The token-selection policy (``SlackBotBackend._channel_token``)
+    resolves Connect membership deterministically via
+    ``conversations.info`` and is the single point every outbound
+    surface consults. The pre-#1072 ``_reaction_token`` routed *all*
+    reactions through ``xoxp`` whenever it was configured; the
+    systematic policy routes only externally-shared channels.
+    """
 
-        Guard: removing the ``token=self._reaction_token()`` kwarg in
-        ``SlackBotBackend.react`` makes the reaction post under the bot
-        token, which Slack-Connect rejects with
+    def test_connect_channel_reactions_route_through_xoxp_token(
+        self,
+        transport: FakeSlackTransport,
+    ) -> None:
+        """RED if ``react()`` stops consulting ``_channel_token()``.
+
+        Guard: removing the ``token=self._channel_token(channel)`` kwarg
+        in ``SlackBotBackend.react`` makes the reaction post under the
+        bot token, which Slack-Connect rejects with
         ``mcp_externally_shared_channel_restricted``.
         """
+        transport.default_responses["conversations.info"] = {
+            "ok": True,
+            "channel": {"is_ext_shared": True},
+        }
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
 
         backend.react(channel="C-CONNECT", ts="1.0", emoji="eyes")
@@ -613,14 +629,57 @@ class TestxoxpVsxoxbRouting:
         react_calls = transport.calls_to("reactions.add")
         assert len(react_calls) == 1
         assert react_calls[0].token == snapshot("xoxp-user")
+        # Connect membership was probed with the bot token.
+        info_calls = transport.calls_to("conversations.info")
+        assert len(info_calls) == 1
+        assert info_calls[0].token == snapshot("xoxb-bot")
 
-    def test_chat_post_message_stays_on_xoxb(self, transport: FakeSlackTransport) -> None:
-        """RED if ``post_message`` is rerouted through ``_reaction_token``.
+    def test_internal_channel_reactions_stay_on_xoxb(
+        self,
+        transport: FakeSlackTransport,
+    ) -> None:
+        """RED if reactions on internal channels stop using the bot token.
 
-        Guard: changing ``self._post("chat.postMessage", payload)`` to
-        ``self._post("chat.postMessage", payload, token=self._reaction_token())``
-        would impersonate the user against the bot's own DM history.
-        This test rejects that change.
+        The pre-#1072 bug: a configured ``xoxp`` hijacked *every*
+        reaction, even on internal channels where the bot token already
+        has ``reactions:write``. The default transport reports the
+        channel as not externally-shared.
+        """
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+
+        backend.react(channel="C-INTERNAL", ts="1.0", emoji="eyes")
+
+        react_calls = transport.calls_to("reactions.add")
+        assert len(react_calls) == 1
+        assert react_calls[0].token == snapshot("xoxb-bot")
+
+    def test_connect_channel_post_routes_through_xoxp_token(
+        self,
+        transport: FakeSlackTransport,
+    ) -> None:
+        """RED if ``post_message`` stops consulting ``_channel_token()``.
+
+        The capability #1072 adds: posting to a Slack-Connect channel
+        the bot cannot reach goes out under the user's ``xoxp`` identity.
+        """
+        transport.default_responses["conversations.info"] = {
+            "ok": True,
+            "channel": {"is_ext_shared": True},
+        }
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+
+        backend.post_message(channel="C-CONNECT", text="review please")
+
+        post_calls = transport.calls_to("chat.postMessage")
+        assert len(post_calls) == 1
+        assert post_calls[0].token == snapshot("xoxp-user")
+
+    def test_dm_post_stays_on_xoxb(self, transport: FakeSlackTransport) -> None:
+        """RED if a DM post is rerouted off the bot token.
+
+        Guard: routing a ``D…`` channel through ``xoxp`` would
+        impersonate the user against the bot's own DM history. DMs never
+        even trigger a Connect-membership probe.
         """
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
 
@@ -629,6 +688,7 @@ class TestxoxpVsxoxbRouting:
         post_calls = transport.calls_to("chat.postMessage")
         assert len(post_calls) == 1
         assert post_calls[0].token == snapshot("xoxb-bot")
+        assert transport.calls_to("conversations.info") == []
 
     def test_missing_xoxp_scope_surfaces_clearly(self, transport: FakeSlackTransport) -> None:
         """RED if ``react`` swallows the Slack error body.

--- a/tests/teatree_backends/test_slack_connect_channel_routing.py
+++ b/tests/teatree_backends/test_slack_connect_channel_routing.py
@@ -1,0 +1,287 @@
+"""Tests for the systematic Slack-Connect token-selection policy.
+
+Slack-Connect externally-shared channels (``#the-review-crew``,
+``#ext_project_mbh_api``) reject the bot token with
+``mcp_externally_shared_channel_restricted``. The user's personal
+``xoxp-…`` token *is* a member of those partner channels and can post
+there. The deterministic policy: ``chat.postMessage`` (and reactions) to
+an externally-shared / Slack-Connect channel routes through the user
+token; ordinary internal channels and DMs keep the bot token.
+
+Connect membership is detected deterministically via
+``conversations.info`` (``is_ext_shared`` / ``is_shared``), cached per
+channel id — not by a try-bot-then-fallback error probe. The selection
+is concentrated in one function, :meth:`SlackBotBackend._channel_token`,
+which every outbound surface consults.
+"""
+
+from typing import cast
+
+import httpx
+import pytest
+
+from teatree.backends import slack_bot
+from teatree.backends.slack_bot import SlackBotBackend
+
+_EXT_SHARED = "C0AM3TENTLK"  # #the-review-crew (Slack-Connect)
+_INTERNAL = "C09INTERNAL0"  # an ordinary workspace channel
+_DM = "D0000000001"
+
+
+def _conversations_info_response(*, is_ext_shared: bool) -> dict[str, object]:
+    return {
+        "ok": True,
+        "channel": {
+            "id": _EXT_SHARED if is_ext_shared else _INTERNAL,
+            "is_ext_shared": is_ext_shared,
+            "is_shared": is_ext_shared,
+        },
+    }
+
+
+def _router(
+    captured: list[dict[str, object]],
+    *,
+    ext_shared_channels: set[str],
+) -> tuple[object, object]:
+    """Return ``(fake_post, fake_get)`` that record every call.
+
+    ``conversations.info`` answers ``is_ext_shared`` based on the
+    requested channel so the policy can resolve membership
+    deterministically; all other calls return a bland ``{"ok": True}``.
+    """
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        captured.append({"method": "GET", "url": url, **kwargs})
+        if url.endswith("/conversations.info"):
+            params = cast("dict[str, object]", kwargs.get("params") or {})
+            channel = str(params.get("channel", ""))
+            return httpx.Response(
+                200,
+                json=_conversations_info_response(is_ext_shared=channel in ext_shared_channels),
+                request=httpx.Request("GET", url),
+            )
+        return httpx.Response(
+            200,
+            json={"ok": True, "message": {"reactions": [{"name": "eyes"}]}},
+            request=httpx.Request("GET", url),
+        )
+
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        captured.append({"method": "POST", "url": url, **kwargs})
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    return fake_post, fake_get
+
+
+def _auth_header_for(captured: list[dict[str, object]], *, url_suffix: str) -> str:
+    for call in captured:
+        if str(call["url"]).endswith(url_suffix):
+            headers = cast("dict[str, str]", call["headers"])
+            return headers["Authorization"]
+    message = f"no call to {url_suffix} in {[c['url'] for c in captured]}"
+    raise AssertionError(message)
+
+
+class TestPostMessageRoutesConnectChannelsThroughUserToken:
+    """``chat.postMessage`` to an ext-shared channel uses the xoxp token."""
+
+    def test_post_message_to_ext_shared_channel_uses_user_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+        fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        result = backend.post_message(channel=_EXT_SHARED, text="review please")
+
+        assert result == {"ok": True}
+        # conversations.info is the bot's own scoped call — bot token.
+        assert _auth_header_for(captured, url_suffix="/conversations.info") == "Bearer xoxb-bot"
+        # the actual post must go out under the user's identity.
+        assert _auth_header_for(captured, url_suffix="/chat.postMessage") == "Bearer xoxp-user"
+
+    def test_post_reply_to_ext_shared_channel_uses_user_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+        fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.post_reply(channel=_EXT_SHARED, ts="1.0", text="ping")
+
+        assert _auth_header_for(captured, url_suffix="/chat.postMessage") == "Bearer xoxp-user"
+
+
+class TestPostMessageKeepsInternalChannelsOnBotToken:
+    """Ordinary internal channels and DMs keep the bot token."""
+
+    def test_post_message_to_internal_channel_uses_bot_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+        fake_post, fake_get = _router(captured, ext_shared_channels=set())
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.post_message(channel=_INTERNAL, text="status")
+
+        assert _auth_header_for(captured, url_suffix="/chat.postMessage") == "Bearer xoxb-bot"
+
+    def test_post_message_to_dm_skips_lookup_and_uses_bot_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+        fake_post, fake_get = _router(captured, ext_shared_channels=set())
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.post_message(channel=_DM, text="dm")
+
+        assert _auth_header_for(captured, url_suffix="/chat.postMessage") == "Bearer xoxb-bot"
+        # DM channels never trigger a Connect-membership probe.
+        assert not any(str(c["url"]).endswith("/conversations.info") for c in captured)
+
+    def test_no_user_token_keeps_everything_on_bot_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+        fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot")
+        backend.post_message(channel=_EXT_SHARED, text="hi")
+
+        assert _auth_header_for(captured, url_suffix="/chat.postMessage") == "Bearer xoxb-bot"
+        # With no user token there is nothing to route to — skip the probe.
+        assert not any(str(c["url"]).endswith("/conversations.info") for c in captured)
+
+
+class TestConnectMembershipIsCachedPerChannel:
+    """``conversations.info`` is called once per channel id, then cached."""
+
+    def test_repeat_posts_to_same_channel_probe_once(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+        fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.post_message(channel=_EXT_SHARED, text="one")
+        backend.post_message(channel=_EXT_SHARED, text="two")
+
+        info_calls = [c for c in captured if str(c["url"]).endswith("/conversations.info")]
+        assert len(info_calls) == 1
+        post_calls = [c for c in captured if str(c["url"]).endswith("/chat.postMessage")]
+        assert len(post_calls) == 2
+        for call in post_calls:
+            headers = cast("dict[str, str]", call["headers"])
+            assert headers["Authorization"] == "Bearer xoxp-user"
+
+
+class TestReactionsRoutedByTheSamePolicy:
+    """Reactions consult the same per-channel policy (fixes #1072).
+
+    The pre-#1072 ``_reaction_token`` routed *every* reaction through
+    xoxp whenever it was configured, even on internal/DM channels where
+    the bot token already has ``reactions:write``. The systematic policy
+    routes only ext-shared channels through xoxp.
+    """
+
+    def test_react_on_internal_channel_uses_bot_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+        fake_post, fake_get = _router(captured, ext_shared_channels=set())
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.react(channel=_INTERNAL, ts="1.0", emoji="eyes")
+
+        assert _auth_header_for(captured, url_suffix="/reactions.add") == "Bearer xoxb-bot"
+
+    def test_react_on_ext_shared_channel_uses_user_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+        fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.react(channel=_EXT_SHARED, ts="1.0", emoji="eyes")
+
+        assert _auth_header_for(captured, url_suffix="/reactions.add") == "Bearer xoxp-user"
+
+    def test_get_reactions_on_ext_shared_channel_uses_user_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+        fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        backend.get_reactions(channel=_EXT_SHARED, ts="1.0")
+
+        assert _auth_header_for(captured, url_suffix="/reactions.get") == "Bearer xoxp-user"
+
+
+class TestChannelTokenIsTheSingleSelectionPoint:
+    """The selection is one well-tested function, not scattered conditionals."""
+
+    def test_channel_token_returns_user_token_for_ext_shared(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+        fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        assert backend._channel_token(_EXT_SHARED) == "xoxp-user"
+        assert backend._channel_token(_INTERNAL) == "xoxb-bot"
+        assert backend._channel_token(_DM) == "xoxb-bot"
+
+    def test_channel_token_fails_safe_to_bot_on_info_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: list[dict[str, object]] = []
+
+        def fake_get(url: str, **kwargs: object) -> httpx.Response:
+            captured.append({"url": url, **kwargs})
+            return httpx.Response(
+                200,
+                json={"ok": False, "error": "channel_not_found"},
+                request=httpx.Request("GET", url),
+            )
+
+        def fake_post(url: str, **kwargs: object) -> httpx.Response:
+            return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+
+        backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
+        assert backend._channel_token(_EXT_SHARED) == "xoxb-bot"

--- a/tests/teatree_backends/test_slack_user_token_routing.py
+++ b/tests/teatree_backends/test_slack_user_token_routing.py
@@ -34,6 +34,14 @@ def _capturing_post(captured: list[dict[str, object]]) -> object:
 def _capturing_get(captured: list[dict[str, object]]) -> object:
     def fake_get(url: str, **kwargs: object) -> httpx.Response:
         captured.append({"url": url, **kwargs})
+        if url.endswith("/conversations.info"):
+            # The token-selection policy probes Connect membership here;
+            # C0AM3TENTLK is the real Slack-Connect #the-review-crew.
+            return httpx.Response(
+                200,
+                json={"ok": True, "channel": {"is_ext_shared": True}},
+                request=httpx.Request("GET", url),
+            )
         return httpx.Response(
             200,
             json={"ok": True, "message": {"reactions": [{"name": "eyes"}]}},
@@ -44,19 +52,19 @@ def _capturing_get(captured: list[dict[str, object]]) -> object:
 
 
 class TestReactRoutesThroughUserToken:
-    """``react`` uses the user token whenever one is configured."""
+    """``react`` uses the user token on Slack-Connect channels (#1072)."""
 
     def test_react_uses_user_token_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
         monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+        monkeypatch.setattr(slack_bot.httpx, "get", _capturing_get(captured))
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.react(channel="C0AM3TENTLK", ts="1779168774.186559", emoji="eyes")
 
-        assert len(captured) == 1
-        headers = cast("dict[str, str]", captured[0]["headers"])
+        react_call = next(c for c in captured if c["url"] == "https://slack.com/api/reactions.add")
+        headers = cast("dict[str, str]", react_call["headers"])
         assert headers["Authorization"] == "Bearer xoxp-user"
-        assert captured[0]["url"] == "https://slack.com/api/reactions.add"
 
     def test_react_falls_back_to_bot_token_when_user_token_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
@@ -74,7 +82,7 @@ class TestReactRoutesThroughUserToken:
 
 
 class TestGetReactionsRoutesThroughUserToken:
-    """``get_reactions`` uses the user token whenever one is configured."""
+    """``get_reactions`` uses the user token on Slack-Connect channels (#1072)."""
 
     def test_get_reactions_uses_user_token_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
@@ -83,10 +91,9 @@ class TestGetReactionsRoutesThroughUserToken:
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.get_reactions(channel="C0AM3TENTLK", ts="1779168774.186559")
 
-        assert len(captured) == 1
-        headers = cast("dict[str, str]", captured[0]["headers"])
+        get_call = next(c for c in captured if c["url"] == "https://slack.com/api/reactions.get")
+        headers = cast("dict[str, str]", get_call["headers"])
         assert headers["Authorization"] == "Bearer xoxp-user"
-        assert captured[0]["url"] == "https://slack.com/api/reactions.get"
 
     def test_get_reactions_falls_back_to_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
@@ -184,7 +191,23 @@ class TestUserTokenOnly:
         headers = cast("dict[str, str]", captured[0]["headers"])
         assert headers["Authorization"] == "Bearer xoxp-user"
 
-    def test_post_message_returns_empty_when_only_user_token(self) -> None:
-        """post_message has no fallback — bot token is mandatory for DMs/chat."""
+    def test_post_message_uses_user_token_when_only_user_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A user-token-only deployment posts under the user's identity.
+
+        With no bot token there is no second credential to probe Connect
+        membership with, and the deployment intends every outbound call
+        to go out as the user — the systematic policy routes
+        ``chat.postMessage`` through ``xoxp`` (#1072).
+        """
+        captured: list[dict[str, object]] = []
+        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+
         backend = SlackBotBackend(user_token="xoxp-user")
-        assert backend.post_message(channel="C", text="hi") == {}
+        result = backend.post_message(channel="C", text="hi")
+
+        assert result == {"ok": True}
+        headers = cast("dict[str, str]", captured[0]["headers"])
+        assert headers["Authorization"] == "Bearer xoxp-user"


### PR DESCRIPTION
fix(slack): systematic per-channel token policy for Slack-Connect posts (#1072)

Slack-Connect externally-shared channels reject the bot token with
`mcp_externally_shared_channel_restricted` — for `chat.postMessage` as
well as reactions. Before this change `post_message`/`post_reply` always
used the bot token, so posting to partner channels was impossible and
the pre-#1072 `_reaction_token` unconditionally routed every reaction
through the scope-poor user token even on internal channels.

Replace both with one deterministic policy, `_channel_token(channel)`,
that every outbound surface (`post_message`, `post_reply`, `react`,
`get_reactions`) consults:

- no user token   -> bot token (legacy single-credential)
- no bot token    -> user token (user-token-only deployment)
- DM channel      -> bot token (never impersonate the user vs their DMs)
- Connect channel -> user token (the only token that can post there)
- internal channel-> bot token

Connect membership is resolved deterministically via
`conversations.info` (`is_ext_shared`/`is_shared`) on the bot token,
cached per channel id — never a try-bot-then-fallback error probe. Any
lookup failure fails safe to the bot token.

The xoxp token is never logged or persisted; it stays in `pass` and
only reaches the `Authorization` header on the outbound request.

Closes #1072
