### PR TITLE
fix(cli): add followup discover-mrs subcommand for review-request discover

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3012,9 +3012,11 @@ Usage: t3 teatree followup [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ refresh  Return counts of tickets and tasks.                                 │
-│ sync     Synchronize followup data from MRs.                                 │
-│ remind   Return list of pending user input tasks.                            │
+│ refresh       Return counts of tickets and tasks.                            │
+│ sync          Synchronize followup data from MRs.                            │
+│ discover-mrs  List the user's open non-draft PRs/MRs awaiting a review       │
+│               request.                                                       │
+│ remind        Return list of pending user input tasks.                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -3032,6 +3034,24 @@ Usage: t3 teatree followup refresh [OPTIONS]
 
 ```
 Usage: t3 teatree followup sync [OPTIONS]
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree followup discover-mrs`
+
+```
+Usage: t3 teatree followup discover-mrs [OPTIONS]
+
+ List the user's open, non-draft PRs/MRs awaiting a review request.
+
+ Backs ``t3 review-request discover`` (BLUEPRINT.md §10.1). Mirrors
+ ``glab api /merge_requests?scope=created_by_me&state=opened``
+ filtered to non-draft MRs; each entry carries ``repo``, ``iid``,
+ ``title`` and ``url`` so the result is suitable for the
+ review-request batch ping or a human paste into Slack.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │

--- a/docs/management-commands.md
+++ b/docs/management-commands.md
@@ -84,6 +84,7 @@ Monitoring and reminders.
 |------------|-----------|---------|-------------|
 | `refresh` | -- | dict | Returns counts of tickets, tasks, and open tasks |
 | `sync` | -- | dict | Syncs follow-up data: discovered MRs, created/updated tickets, errors |
+| `discover-mrs` | -- | dict | Lists the user's open, non-draft PRs/MRs (`repo`, `iid`, `title`, `url`) awaiting a review request |
 | `remind` | -- | list of IDs | Returns IDs of pending interactive tasks |
 
 ## `standup`

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -114,6 +114,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
         [
             ("refresh", "Return counts of tickets and tasks."),
             ("sync", "Synchronize followup data from MRs."),
+            ("discover-mrs", "List the user's open non-draft PRs/MRs awaiting a review request."),
             ("remind", "Return list of pending user input tasks."),
         ],
     ),

--- a/src/teatree/core/management/commands/followup.py
+++ b/src/teatree/core/management/commands/followup.py
@@ -1,6 +1,47 @@
+from typing import cast
+
 from django_typer.management import TyperCommand, command
 
+from teatree.core.backend_factory import code_host_from_overlay
 from teatree.core.models import Task, Ticket
+from teatree.core.overlay_loader import get_overlay
+from teatree.types import RawAPIDict
+
+
+def _str_field(data: RawAPIDict, *names: str) -> str:
+    for name in names:
+        value = data.get(name)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _int_field(data: RawAPIDict, *names: str) -> int:
+    for name in names:
+        value = data.get(name)
+        if isinstance(value, int):
+            return value
+    return 0
+
+
+def _is_draft(pr: RawAPIDict) -> bool:
+    return bool(pr.get("draft") or pr.get("work_in_progress"))
+
+
+def _repo_slug(pr: RawAPIDict) -> str:
+    """Best-effort ``owner/name`` for a PR/MR across GitLab and GitHub shapes."""
+    references = pr.get("references")
+    if isinstance(references, dict):
+        full = cast("RawAPIDict", references).get("full")
+        if isinstance(full, str) and full:
+            return full.split("!", 1)[0].split("#", 1)[0]
+    repository_url = _str_field(pr, "repository_url")
+    if "/repos/" in repository_url:
+        return repository_url.split("/repos/", 1)[-1]
+    url = _str_field(pr, "web_url", "html_url")
+    if "/-/merge_requests/" in url:
+        return url.split("://", 1)[-1].split("/", 1)[-1].split("/-/merge_requests/", 1)[0]
+    return ""
 
 
 class Command(TyperCommand):
@@ -24,6 +65,36 @@ class Command(TyperCommand):
             "worktrees_cleaned": result.worktrees_cleaned,
             "errors": result.errors,
         }
+
+    @command(name="discover-mrs")
+    def discover_mrs(self) -> RawAPIDict:
+        """List the user's open, non-draft PRs/MRs awaiting a review request.
+
+        Backs ``t3 review-request discover`` (BLUEPRINT.md §10.1). Mirrors
+        ``glab api /merge_requests?scope=created_by_me&state=opened``
+        filtered to non-draft MRs; each entry carries ``repo``, ``iid``,
+        ``title`` and ``url`` so the result is suitable for the
+        review-request batch ping or a human paste into Slack.
+        """
+        host = code_host_from_overlay()
+        if host is None:
+            return {"error": "No code host configured (check overlay tokens)"}
+
+        author = get_overlay().config.get_gitlab_username() or host.current_user()
+        if not author:
+            return {"error": "Could not resolve author username — set <host>_username in ~/.teatree.toml"}
+
+        mrs = [
+            {
+                "repo": _repo_slug(pr),
+                "iid": _int_field(pr, "iid", "number"),
+                "title": _str_field(pr, "title"),
+                "url": _str_field(pr, "web_url", "html_url"),
+            }
+            for pr in host.list_my_prs(author=author)
+            if not _is_draft(pr)
+        ]
+        return {"author": author, "count": len(mrs), "mrs": mrs}
 
     @command()
     def remind(self) -> list[int]:

--- a/tests/teatree_core/sync/test_followup_discover_mrs.py
+++ b/tests/teatree_core/sync/test_followup_discover_mrs.py
@@ -1,0 +1,144 @@
+"""``followup discover-mrs`` — enumerate the user's open non-draft PRs/MRs.
+
+Regression for souliane/teatree#1008: ``t3 review-request discover``
+delegated to ``manage.py followup discover-mrs``, a subcommand that did
+not exist, so the documented review-request discovery flow was dead.
+"""
+
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.management.commands import followup as followup_command
+from tests.teatree_core.conftest import CommandOverlay
+from tests.teatree_core.pr_command._shared import _MOCK_OVERLAY
+
+
+class TestDiscoverMrs(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._monkeypatch = monkeypatch
+
+    def test_returns_open_non_draft_prs_for_authenticated_user(self) -> None:
+        from teatree.core.overlay import OverlayConfig  # noqa: PLC0415
+
+        host = MagicMock()
+        host.list_my_prs.return_value = [
+            {
+                "iid": 1,
+                "title": "feat: x",
+                "web_url": "https://gitlab.com/org/repo/-/merge_requests/1",
+                "references": {"full": "org/repo!1"},
+            },
+            {
+                "iid": 2,
+                "title": "fix: y (draft)",
+                "web_url": "https://gitlab.com/org/other/-/merge_requests/2",
+                "references": {"full": "org/other!2"},
+                "draft": True,
+            },
+        ]
+        self._monkeypatch.setattr(followup_command, "code_host_from_overlay", lambda: host)
+        overlay = CommandOverlay()
+        # Per-instance config so we don't mutate the class-level default shared by other tests.
+        overlay.config = OverlayConfig()
+        overlay.config.get_gitlab_username = lambda: "adrien"  # type: ignore[method-assign]
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value={"test": overlay}):
+            result = cast("dict[str, object]", call_command("followup", "discover-mrs"))
+
+        assert result["author"] == "adrien"
+        assert result["count"] == 1
+        mrs = cast("list[dict[str, object]]", result["mrs"])
+        assert len(mrs) == 1
+        assert mrs[0]["iid"] == 1
+        assert mrs[0]["repo"] == "org/repo"
+        assert mrs[0]["title"] == "feat: x"
+        assert mrs[0]["url"] == "https://gitlab.com/org/repo/-/merge_requests/1"
+        host.list_my_prs.assert_called_once_with(author="adrien")
+
+    def test_resolves_github_repo_slug_from_repository_url(self) -> None:
+        host = MagicMock()
+        host.current_user.return_value = "souliane"
+        host.list_my_prs.return_value = [
+            {
+                "number": 7,
+                "title": "chore: z",
+                "html_url": "https://github.com/souliane/teatree/pull/7",
+                "repository_url": "https://api.github.com/repos/souliane/teatree",
+            },
+        ]
+        self._monkeypatch.setattr(followup_command, "code_host_from_overlay", lambda: host)
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast("dict[str, object]", call_command("followup", "discover-mrs"))
+
+        mrs = cast("list[dict[str, object]]", result["mrs"])
+        assert mrs[0]["repo"] == "souliane/teatree"
+        assert mrs[0]["iid"] == 7
+        assert mrs[0]["url"] == "https://github.com/souliane/teatree/pull/7"
+
+    def test_falls_back_to_current_user_when_no_username_configured(self) -> None:
+        host = MagicMock()
+        host.current_user.return_value = "souliane"
+        host.list_my_prs.return_value = []
+        self._monkeypatch.setattr(followup_command, "code_host_from_overlay", lambda: host)
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast("dict[str, object]", call_command("followup", "discover-mrs"))
+
+        assert result["author"] == "souliane"
+        assert result["count"] == 0
+        assert result["mrs"] == []
+        host.list_my_prs.assert_called_once_with(author="souliane")
+
+    def test_returns_error_when_no_code_host_configured(self) -> None:
+        self._monkeypatch.setattr(followup_command, "code_host_from_overlay", lambda: None)
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast("dict[str, object]", call_command("followup", "discover-mrs"))
+
+        assert "error" in result
+
+    def test_returns_error_when_username_unresolved(self) -> None:
+        host = MagicMock()
+        host.current_user.return_value = ""
+        self._monkeypatch.setattr(followup_command, "code_host_from_overlay", lambda: host)
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast("dict[str, object]", call_command("followup", "discover-mrs"))
+
+        assert "error" in result
+        host.list_my_prs.assert_not_called()
+
+
+class TestRepoSlug:
+    """Pure parsing of ``owner/name`` from heterogeneous PR/MR shapes."""
+
+    def test_gitlab_url_fallback_when_no_references(self) -> None:
+        slug = followup_command._repo_slug(
+            {"web_url": "https://gitlab.com/org/sub/repo/-/merge_requests/9"},
+        )
+        assert slug == "org/sub/repo"
+
+    def test_empty_when_no_recognisable_fields(self) -> None:
+        assert followup_command._repo_slug({"title": "no urls here"}) == ""
+
+    def test_references_dict_without_full_falls_through(self) -> None:
+        slug = followup_command._repo_slug(
+            {"references": {}, "web_url": "https://gitlab.com/org/repo/-/merge_requests/3"},
+        )
+        assert slug == "org/repo"
+
+
+class TestFieldExtractors:
+    """``_str_field`` / ``_int_field`` no-match fallbacks."""
+
+    def test_str_field_returns_empty_when_absent(self) -> None:
+        assert followup_command._str_field({"a": "x"}, "b", "c") == ""
+
+    def test_int_field_returns_zero_when_absent(self) -> None:
+        assert followup_command._int_field({"a": 1}, "b", "c") == 0


### PR DESCRIPTION
## Summary

`t3 review-request discover` delegated to `manage.py followup discover-mrs`, but that subcommand never existed — the `followup` group only had `refresh`, `sync`, and `remind`. So the documented review-request discovery flow (BLUEPRINT.md §10.1) failed at runtime and the discovery had to be done by hand with raw `glab api`.

This adds the missing `discover-mrs` subcommand. It enumerates the user's open, non-draft PRs/MRs via the code-host backend (the canonical equivalent of `glab api /merge_requests?scope=created_by_me&state=opened` filtered to non-draft MRs), returning `repo`, `iid`, `title`, and `url` per entry so the result can feed the review-request batch ping or a human paste. It mirrors the existing `pr sweep` resolution (username from overlay config, falling back to `current_user()`) and is bridged through the overlay CLI like the other `followup` subcommands.

Closes #1008

## Test plan

- [x] `uv run ruff check .` — passed
- [x] `uv run ruff format --check .` — passed
- [x] `uv run pytest -q` — 5706 passed, 12 skipped, coverage 94.03%
- [x] New `tests/teatree_core/sync/test_followup_discover_mrs.py` covers: happy path (non-draft filtering, repo/iid/title/url shape), GitHub `repository_url` slug, username fallback, no-code-host error, unresolved-username error, plus the pure repo-slug / field-extractor branches
- [x] Verified RED before the fix (subcommand absent), GREEN after