### PR TITLE
fix(review): treat GitLab already-approved 401 as idempotent success

### DIFF
--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -26,7 +26,7 @@ from http import HTTPStatus
 
 import typer
 
-from teatree.cli.review_approval import identity_has_reviewed
+from teatree.cli.review_approval import identity_has_reviewed, identity_in_approved_by
 from teatree.cli.review_audit import record_note_claim
 from teatree.cli.review_diff import find_added_line, resolve_inline_position
 from teatree.cli.review_drafts import register as _register_drafts
@@ -411,6 +411,11 @@ class ReviewService:
         if status in _HTTP_OK_CODES:
             record_note_claim(self._resolve_base_url, repo, mr, "approve", kind="gitlab_approve", endpoint="approve")
             return f"OK approved !{mr}", 0
+        # GitLab returns 401 for the idempotent already-approved case as
+        # well as a genuine auth failure (#1029). Probe /approvals to
+        # distinguish: identity already in approved_by → no-op success.
+        if identity_in_approved_by(api, encoded, mr):
+            return f"Already approved by {api.current_username()} (!{mr})", 0
         return f"Failed: HTTP {status}", 1
 
     def unapprove(self, repo: str, mr: int) -> tuple[str, int]:

--- a/src/teatree/cli/review_approval.py
+++ b/src/teatree/cli/review_approval.py
@@ -45,4 +45,33 @@ def identity_has_reviewed(api: "GitLabAPI", encoded_repo: str, mr: int) -> tuple
     return False, ""
 
 
-__all__ = ["identity_has_reviewed"]
+def identity_in_approved_by(api: "GitLabAPI", encoded_repo: str, mr: int) -> bool:
+    """Whether the approving identity is already in the MR's ``approved_by``.
+
+    GitLab's ``POST /merge_requests/:iid/approve`` returns ``401
+    Unauthorized`` for *both* a genuine auth failure and the idempotent
+    case where this identity has already approved (#1029). The two are
+    distinguished only by probing ``GET /merge_requests/:iid/approvals``:
+    a username match in ``approved_by[*].user.username`` means the
+    approve is a no-op success; no match (or an unresolvable identity)
+    means the failure is real and must surface.
+    """
+    username = api.current_username()
+    if not username:
+        return False
+    approvals = api.get_json(f"projects/{encoded_repo}/merge_requests/{mr}/approvals")
+    if not isinstance(approvals, dict):
+        return False
+    approved_by = approvals.get("approved_by")
+    if not isinstance(approved_by, list):
+        return False
+    for entry in approved_by:
+        if not isinstance(entry, dict):
+            continue
+        user = cast("RawAPIDict", entry).get("user")
+        if isinstance(user, dict) and cast("RawAPIDict", user).get("username") == username:
+            return True
+    return False
+
+
+__all__ = ["identity_has_reviewed", "identity_in_approved_by"]

--- a/tests/teatree_cli/test_review_approval.py
+++ b/tests/teatree_cli/test_review_approval.py
@@ -1,16 +1,16 @@
-"""Unit tests for ``teatree.cli.review_approval.identity_has_reviewed`` (#1019).
+"""Unit tests for ``teatree.cli.review_approval`` helpers (#1019, #1029).
 
-The function is exercised end-to-end in ``test_review_approve_gate.py``,
-but the branches around malformed payloads and the username-resolution
-failure mode are easier to pin directly. Pure stub against the
-``GitLabAPI.current_username`` / ``get_json`` shape — no Django, no
-network, no migrations.
+The functions are exercised end-to-end in ``test_review_approve_gate.py``
+and ``test_review_approve_already_approved.py``, but the branches around
+malformed payloads and the username-resolution failure mode are easier
+to pin directly. Pure stub against the ``GitLabAPI.current_username`` /
+``get_json`` shape — no Django, no network, no migrations.
 """
 
 from typing import Any
 from unittest.mock import MagicMock
 
-from teatree.cli.review_approval import identity_has_reviewed
+from teatree.cli.review_approval import identity_has_reviewed, identity_in_approved_by
 
 
 def _api(*, username: str = "souliane", discussions: Any = None) -> MagicMock:
@@ -116,3 +116,50 @@ class TestIdentityHasReviewed:
         reviewed, error = identity_has_reviewed(api, "org%2Frepo", 1)
         assert reviewed is False
         assert error == ""
+
+
+class TestIdentityInApprovedBy:
+    """Distinguish GitLab's idempotent already-approved 401 from a real one (#1029)."""
+
+    def test_true_when_identity_in_approved_by(self) -> None:
+        api = _api(
+            username="souliane",
+            discussions={"approved_by": [{"user": {"username": "souliane"}}]},
+        )
+        assert identity_in_approved_by(api, "org%2Frepo", 7) is True
+
+    def test_false_when_identity_not_in_approved_by(self) -> None:
+        api = _api(
+            username="souliane",
+            discussions={"approved_by": [{"user": {"username": "someone-else"}}]},
+        )
+        assert identity_in_approved_by(api, "org%2Frepo", 7) is False
+
+    def test_false_when_username_unresolved(self) -> None:
+        # An unresolvable identity can't be matched — fail closed so a
+        # genuine auth failure still surfaces.
+        api = _api(username="")
+        assert identity_in_approved_by(api, "org%2Frepo", 7) is False
+        api.get_json.assert_not_called()
+
+    def test_false_when_approvals_payload_not_a_dict(self) -> None:
+        api = _api(username="souliane", discussions=["garbage"])
+        assert identity_in_approved_by(api, "org%2Frepo", 7) is False
+
+    def test_false_when_approved_by_not_a_list(self) -> None:
+        api = _api(username="souliane", discussions={"approved_by": "nope"})
+        assert identity_in_approved_by(api, "org%2Frepo", 7) is False
+
+    def test_skips_non_dict_and_non_dict_user_entries(self) -> None:
+        api = _api(
+            username="souliane",
+            discussions={
+                "approved_by": [
+                    None,
+                    "garbage",
+                    {"user": "not-a-dict"},
+                    {"user": {"username": "souliane"}},
+                ],
+            },
+        )
+        assert identity_in_approved_by(api, "org%2Frepo", 7) is True

--- a/tests/teatree_cli/test_review_approve_already_approved.py
+++ b/tests/teatree_cli/test_review_approve_already_approved.py
@@ -1,0 +1,104 @@
+"""``approve`` treats GitLab's idempotent already-approved 401 as success (#1029).
+
+GitLab's ``POST /merge_requests/:iid/approve`` returns ``401 Unauthorized``
+with body ``{"message":"401 Unauthorized"}`` for *both* a genuine
+auth failure (expired/revoked PAT) **and** the idempotent case where the
+current identity is already in the MR's ``approved_by`` list. Pre-fix,
+``ReviewService.approve`` treated every non-2xx as a hard failure, so a
+no-op re-approve printed ``Failed: HTTP 401`` — indistinguishable from a
+real token problem and noisy on loop review sweeps.
+
+This module pins the corrected contract: on a non-2xx approve response,
+probe ``GET /merge_requests/:iid/approvals``; if the current username is
+in ``approved_by[*].user.username`` the approve is idempotently
+successful (exit 0, ``Already approved by <username>``). A genuine 401
+(identity NOT in ``approved_by``) must still fail.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from teatree.cli.review import ReviewService
+
+pytestmark = pytest.mark.django_db
+
+
+def _gate_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text("[teatree]\nask_before_post_on_behalf = false\n", encoding="utf-8")
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+
+
+class _AlreadyApprovedAPI:
+    """GitLab stub: ``approve`` 401s, but the current user IS in ``approved_by``."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def current_username(self) -> str:
+        return "souliane"
+
+    def get_json(self, endpoint: str) -> object:
+        self.calls.append(("get_json", endpoint))
+        if endpoint.endswith("/approvals"):
+            return {"approved_by": [{"user": {"username": "souliane"}}]}
+        # discussions probe for the review-before-approve precondition
+        return [{"notes": [{"author": {"username": "souliane"}}]}]
+
+    def post_status(self, endpoint: str) -> int:
+        self.calls.append(("post_status", endpoint))
+        return 401
+
+
+class _GenuineAuthFailureAPI:
+    """GitLab stub: ``approve`` 401s and the current user is NOT in ``approved_by``."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def current_username(self) -> str:
+        return "souliane"
+
+    def get_json(self, endpoint: str) -> object:
+        self.calls.append(("get_json", endpoint))
+        if endpoint.endswith("/approvals"):
+            return {"approved_by": [{"user": {"username": "someone-else"}}]}
+        return [{"notes": [{"author": {"username": "souliane"}}]}]
+
+    def post_status(self, endpoint: str) -> int:
+        self.calls.append(("post_status", endpoint))
+        return 401
+
+
+def _service_with(stub: Any) -> ReviewService:
+    service = ReviewService(token="t")
+    service._get_api = lambda: stub  # type: ignore[method-assign]
+    return service
+
+
+class TestApproveAlreadyApprovedIsIdempotent:
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _gate_off(tmp_path, monkeypatch)
+
+    def test_already_approved_401_reports_success(self) -> None:
+        stub = _AlreadyApprovedAPI()
+        service = _service_with(stub)
+
+        msg, code = service.approve("org/repo", 7)
+
+        assert code == 0, msg
+        assert "Already approved by souliane" in msg
+        assert any(c[0] == "get_json" and c[1].endswith("/approvals") for c in stub.calls)
+
+    def test_genuine_401_still_fails(self) -> None:
+        stub = _GenuineAuthFailureAPI()
+        service = _service_with(stub)
+
+        msg, code = service.approve("org/repo", 7)
+
+        assert code == 1
+        assert "Failed" in msg
+        assert "401" in msg


### PR DESCRIPTION
Closes #1029

## Problem

`t3 review approve <mr-url>` printed `Failed: HTTP 401` when the configured reviewer was already in the MR's `approved_by` list. GitLab's `/approve` endpoint returns `401 Unauthorized` for the idempotent already-approved case as well as for a genuine auth failure, and the CLI treated every non-2xx as a hard failure. On loop review sweeps this painted re-runs red and looked like an expired PAT.

## Fix

On a non-2xx approve response, probe `GET /merge_requests/:iid/approvals` and check whether the current username is in `approved_by[*].user.username`:

- match → idempotent no-op success, exit 0, `Already approved by <username> (!<mr>)`
- no match (or an unresolvable identity) → fall through to the existing `Failed: HTTP <status>` so a real auth failure still surfaces

The probe is added as `identity_in_approved_by` in `review_approval.py`, alongside the existing `identity_has_reviewed` helper.

## Tests

- New `tests/teatree_cli/test_review_approve_already_approved.py`: drives `approve()` against a faked GitLab returning 401, asserting idempotent success when the identity is in `approved_by`, and a still-failing genuine 401 when it is not. The first test was confirmed RED on pre-fix code (`Failed: HTTP 401`).
- `tests/teatree_cli/test_review_approval.py`: added `TestIdentityInApprovedBy` covering the helper's branches (100% line coverage on the new code).
- `tests/teatree_cli/` suite green (75 passed); ruff check + format clean.