### PR TITLE
fix(loop): state-authoritative reviewing-task lifecycle (#1074, #1077)

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -434,6 +434,18 @@ t3 review unapprove <REPO> <MR_IID>    # revoke your approval
 
 **On-behalf gate.** An approval is an outward, state-changing post under your identity, so `approve`/`unapprove` also respect the `on_behalf_post_mode` pre-gate (souliane/teatree#960): under `"ask"` or `"draft_or_ask"` (the default) the command refuses unattended with an actionable message — record an `OnBehalfApproval` via `t3 review approve-on-behalf <target> approve --approver <user-id>` and re-run, or widen the mode to `"immediate"` per-overlay.
 
+### Concluding a no-postable-action external review — `mark_review_no_action` (Mandatory, #1077)
+
+When the external PR under review is one where the correct outcome is **post nothing and approve nothing** — a bot MR (Aikido / Dependabot / Renovate), an auto-generated bump there is no diff worth commenting on, an MR you are not the right reviewer for and have no finding on — the reviewing Task still has to reach a terminal state. An FSM-owned review drives `review()` by completing its reviewing task; an external review that **approves** drives `t3 review approve`. The no-action outcome has its own terminal transition — without it the reviewing Task re-dispatches every Stop-hook pump forever (the PR never gets a forge reviewer assignment, so neither the dedup nor the orphan sweep can ever fire):
+
+```bash
+t3 <overlay> ticket transition <ticket_id> mark_review_no_action
+```
+
+This records `last_review_state = reviewed_no_action` (deliberately **not** `approved`, so a later genuine review is never suppressed) at the current head SHA and consumes the PENDING reviewing task. If a new revision is pushed (head SHA moves) the recorded state is dropped and the PR is reviewed again — concluding "no action" now never costs a future obligation. Maker≠checker is preserved: the reviewer sub-agent runs its own dispatch and invokes this itself; it is not a self-approval.
+
+Use this **only** when there is genuinely nothing to post or approve. If you have a finding, post it (`t3 review post-comment` / `post-draft-note`); if the verdict is approve, use `t3 review approve`. `mark_review_no_action` is the third, distinct outcome — not a shortcut to skip a review you should have done.
+
 ## Commands
 
 | Command | When to use |

--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TypedDict, cast
 from urllib.parse import quote_plus, urlparse
 
-from teatree.backends.protocols import ApprovalState, PullRequestSpec, ReviewState
+from teatree.backends.protocols import ApprovalState, PrOpenState, PullRequestSpec, ReviewState
 from teatree.types import RawAPIDict
 from teatree.utils import git
 from teatree.utils.run import CompletedProcess, run_checked
@@ -40,6 +40,8 @@ class _GitHubPullRequestSummary(TypedDict, total=False):
     """Subset of the GitHub PR response read for the review state lookup."""
 
     requested_reviewers: list[_GitHubUser]
+    state: str
+    merged: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,6 +87,25 @@ def _latest_review_state_from_reviews(reviews: object, reviewer: str) -> ReviewS
         if mapped is not None:
             return mapped
     return None
+
+
+def _pr_open_state_from_payload(pr: object) -> PrOpenState:
+    """Map a GitHub PR payload to a :class:`PrOpenState` (#1074).
+
+    ``state=="open"`` → OPEN; ``merged is True`` → MERGED; ``state=="closed"``
+    without ``merged`` → CLOSED. Any non-dict or unrecognised shape →
+    ``UNKNOWN`` so the orphan sweep fails open.
+    """
+    if not isinstance(pr, dict):
+        return PrOpenState.UNKNOWN
+    summary = cast("_GitHubPullRequestSummary", pr)
+    if summary.get("state") == "open":
+        return PrOpenState.OPEN
+    if summary.get("merged") is True:
+        return PrOpenState.MERGED
+    if summary.get("state") == "closed":
+        return PrOpenState.CLOSED
+    return PrOpenState.UNKNOWN
 
 
 def _reviewer_is_requested(pr: object, reviewer: str) -> bool:
@@ -405,3 +426,25 @@ class GitHubCodeHost:
         if _reviewer_is_requested(pr, reviewer):
             return ReviewState.PENDING
         return ReviewState.NONE
+
+    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState:
+        """Return whether the PR at *pr_url* is genuinely open/merged/closed (#1074).
+
+        Fetches the PR's real ``state``/``merged`` fields. ``state=="open"``
+        → OPEN, ``merged is True`` → MERGED, ``state=="closed"`` without
+        ``merged`` → CLOSED. Any exception (``gh api`` failure, auth error),
+        unparsable URL, or non-dict / unrecognised payload → ``UNKNOWN`` so
+        the orphan sweep fails open (never reaps on doubt). GitLab's
+        implementation maps the same ambiguity to ``UNKNOWN`` identically.
+        """
+        match = _PR_URL_RE.match(urlparse(pr_url).path)
+        if match is None:
+            return PrOpenState.UNKNOWN
+        try:
+            pr = _gh_api_get(
+                f"repos/{match['owner']}/{match['repo']}/pulls/{match['number']}",
+                token=self._token,
+            )
+        except Exception:  # noqa: BLE001 — fail open: any failure must NOT reap a live review.
+            return PrOpenState.UNKNOWN
+        return _pr_open_state_from_payload(pr)

--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 from teatree.backends import gitlab_api as _gitlab_api
 from teatree.backends.gitlab_api import GitLabAPI, ProjectInfo
-from teatree.backends.protocols import ApprovalState, PullRequestSpec, ReviewState
+from teatree.backends.protocols import ApprovalState, PrOpenState, PullRequestSpec, ReviewState
 from teatree.types import RawAPIDict
 
 _ISSUE_URL_RE = re.compile(r"^/(?P<path>.+?)/-/issues/(?P<iid>\d+)/?$")
@@ -13,6 +13,14 @@ _MR_URL_RE = re.compile(r"^/(?P<path>.+?)/-/merge_requests/(?P<iid>\d+)/?$")
 # GitLab serves the same iid under both /-/issues/<iid> and /-/work_items/<iid>;
 # the notes API endpoint is identical for either.
 _ISSUE_OR_WORKITEM_URL_RE = re.compile(r"^/(?P<path>.+?)/-/(?:issues|work_items)/(?P<iid>\d+)/?$")
+
+
+_GITLAB_MR_STATE_MAP: dict[str, PrOpenState] = {
+    "opened": PrOpenState.OPEN,
+    "merged": PrOpenState.MERGED,
+    "closed": PrOpenState.CLOSED,
+    "locked": PrOpenState.CLOSED,
+}
 
 
 def _read_int(data: RawAPIDict, key: str) -> int:
@@ -72,9 +80,10 @@ class _GitLabUser(TypedDict, total=False):
 
 
 class _GitLabMergeRequestSummary(TypedDict, total=False):
-    """Subset of the GitLab MR response read for the review state lookup."""
+    """Subset of the GitLab MR response read for the review/open-state lookup."""
 
     reviewers: list[_GitLabUser]
+    state: str
 
 
 def get_client(*, token: str = "", base_url: str = "") -> GitLabAPI:
@@ -214,6 +223,32 @@ class GitLabCodeHost:
                     if isinstance(entry, dict) and entry.get("username") == reviewer:
                         return ReviewState.PENDING
         return ReviewState.NONE
+
+    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState:
+        """Return whether the MR at *pr_url* is genuinely open/merged/closed (#1074).
+
+        Fetches the MR's real ``state`` field. ``opened`` → OPEN, ``merged``
+        → MERGED, ``closed``/``locked`` → CLOSED. Any exception, unresolvable
+        project, unparsable URL, or non-dict / unrecognised payload →
+        ``UNKNOWN`` so the orphan sweep fails open (never reaps on doubt).
+        GitHub's implementation maps the same ambiguity to ``UNKNOWN``.
+        """
+        match = _MR_URL_RE.match(urlparse(pr_url).path)
+        if match is None:
+            return PrOpenState.UNKNOWN
+        try:
+            project = self._client.resolve_project(match["path"])
+            if project is None:
+                return PrOpenState.UNKNOWN
+            mr = self._client.get_json(f"projects/{project.project_id}/merge_requests/{match['iid']}")
+        except Exception:  # noqa: BLE001 — fail open: any failure must NOT reap a live review.
+            return PrOpenState.UNKNOWN
+        if not isinstance(mr, dict):
+            return PrOpenState.UNKNOWN
+        state = cast("_GitLabMergeRequestSummary", mr).get("state")
+        if not isinstance(state, str):
+            return PrOpenState.UNKNOWN
+        return _GITLAB_MR_STATE_MAP.get(state, PrOpenState.UNKNOWN)
 
     def get_issue(self, issue_url: str) -> RawAPIDict:
         """Fetch a GitLab issue from its full URL.

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -45,6 +45,11 @@ class ReviewState(StrEnum):
     APPROVED = "approved"
     CHANGES_REQUESTED = "changes_requested"
     DISMISSED = "dismissed"
+    # The reviewer concluded an external review with no postable/approvable
+    # action (e.g. a bot MR there is nothing to comment on or approve).
+    # Distinct from APPROVED so the dedup never hides a future genuine
+    # review, yet terminal so the reviewing task stops re-queueing (#1077).
+    REVIEWED_NO_ACTION = "reviewed_no_action"
 
 
 class PrOpenState(StrEnum):

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -47,6 +47,23 @@ class ReviewState(StrEnum):
     DISMISSED = "dismissed"
 
 
+class PrOpenState(StrEnum):
+    """Whether a pull/merge request is genuinely still open on the forge.
+
+    Used by ``CodeHostBackend.get_pr_open_state`` so the orphan-task sweep
+    (``ReviewerPrsScanner._orphaned_task_signals``) can confirm a reviewing
+    task's PR is really MERGED/CLOSED before reaping it — absence from a
+    reviewer-assignment scan is NOT proof the PR closed (#1074). ``UNKNOWN``
+    is the fail-open value: any auth error, network failure, unparsable URL,
+    or unrecognised payload maps here, and the sweep never reaps on UNKNOWN.
+    """
+
+    OPEN = "open"
+    MERGED = "merged"
+    CLOSED = "closed"
+    UNKNOWN = "unknown"
+
+
 @dataclass(frozen=True, slots=True)
 class PullRequestSpec:
     """Fields needed to open a pull/merge request on a CodeHostBackend."""
@@ -98,6 +115,8 @@ class CodeHostBackend(Protocol):
     ) -> list[RawAPIDict]: ...  # pragma: no branch
 
     def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState: ...  # pragma: no branch
+
+    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState: ...  # pragma: no branch
 
     def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict: ...  # pragma: no branch
 

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -78,6 +78,9 @@ _ALLOWED_TRANSITIONS = {
     "retrospect",
     "mark_delivered",
     "rework",
+    # #1077: reviewer concludes an external review with no postable/
+    # approvable action — terminal disposition for the reviewing task.
+    "mark_review_no_action",
 }
 
 
@@ -87,7 +90,8 @@ class Command(TyperCommand):
         """Transition a ticket to a new state.
 
         Accepts any of the allowed transition names: scope, start, code, test,
-        review, ship, request_review, mark_merged, retrospect, mark_delivered, rework.
+        review, ship, request_review, mark_merged, retrospect, mark_delivered,
+        rework, mark_review_no_action.
         """
         if transition_name not in _ALLOWED_TRANSITIONS:
             return {"error": f"Unknown transition: {transition_name}"}

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -454,6 +454,50 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
             # last_review_state.
             self.merge_extra(set_keys={"reviewed_sha": sha, "last_review_state": ReviewState.APPROVED.value})
 
+    @transition(
+        field=state,
+        source=[
+            State.NOT_STARTED,
+            State.SCOPED,
+            State.STARTED,
+            State.CODED,
+            State.TESTED,
+            State.REVIEWED,
+        ],
+        target=State.DELIVERED,
+        conditions=[lambda t: t.role == Ticket.Role.REVIEWER],
+    )
+    def mark_review_no_action(self) -> None:
+        """Reviewer-role terminal disposition for a no-postable-action review.
+
+        Sibling of :meth:`mark_reviewed_externally` for the case the
+        reviewer concludes an external review with nothing to post or
+        approve (e.g. a bot MR — Aikido/Dependabot — where there is no
+        diff worth commenting on and no approval to give). The reviewing
+        Task would otherwise never reach a terminal state — the only
+        terminal path is ``Task.complete()`` → ``mark_reviewed_externally``
+        which requires an APPROVED outcome — so ``pending-spawn``
+        re-dispatched the same task every Stop-hook pump forever (#1077).
+
+        Unlike ``mark_reviewed_externally`` (fired *from* an
+        already-COMPLETED task) this transition is driven directly via
+        ``t3 ticket transition <id> mark_review_no_action`` while the
+        reviewing task is still PENDING, so it consumes that task itself.
+        It records ``last_review_state = REVIEWED_NO_ACTION`` (NEVER
+        APPROVED): the dedup's APPROVED-only suppression therefore does not
+        hide a future *genuine* review, while ``_already_reviewed_at_head``
+        still treats a no-action observation at the current head SHA as
+        "already handled" so the task is not re-queued. A head-SHA move
+        drops ``last_review_state`` (the existing #959 reset) so a new
+        revision is still reviewed — no lost obligation.
+        """
+        from teatree.backends.protocols import ReviewState  # noqa: PLC0415
+
+        sha = str(self._extra().get("reviewed_sha", ""))
+        if self.issue_url and sha:
+            self.merge_extra(set_keys={"reviewed_sha": sha, "last_review_state": ReviewState.REVIEWED_NO_ACTION.value})
+        self._consume_pending_phase_tasks("reviewing")
+
     @transition(field=state, source=[State.REVIEWED, State.SHIPPED], target=State.SHIPPED)
     def ship(self) -> None:
         """Schedule push + PR creation.

--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -128,12 +128,14 @@ _DUAL_DISPATCH: frozenset[str] = frozenset(
 _MECHANICAL_BY_KIND: dict[str, tuple[ActionKind, str]] = {
     "ticket.completion_detected": ("mechanical", "ticket_completion"),
     "ticket.reopen_needed": ("mechanical", "ticket_reopen"),
-    # #998: a reviewer-role ticket's PENDING/CLAIMED reviewing task can be
-    # orphaned when the underlying MR is merged externally before the slot
-    # processes it — the ``state=opened`` API no longer returns the MR, so
-    # the dedup paths in persistence cannot fire and the task lingers
-    # forever. The mechanical handler completes the task so
-    # ``pending-spawn`` stops surfacing it every tick.
+    # #998/#1074: a reviewer-role ticket's PENDING/CLAIMED reviewing task
+    # can be orphaned when the underlying PR is merged/closed externally
+    # before the slot processes it. The scanner emits this signal ONLY
+    # after ``get_pr_open_state`` confirmed the PR is genuinely MERGED or
+    # CLOSED — never on mere absence from the reviewer-assignment scan
+    # (#1074: a Slack-review-request MR with no forge reviewer assignment
+    # is permanently absent yet fully OPEN). The mechanical handler then
+    # completes the task so ``pending-spawn`` stops surfacing it.
     "reviewer_pr.task_orphaned": ("mechanical", "reviewer_task_orphaned"),
     "notion.unrouted": ("webhook", "n8n"),
 }

--- a/src/teatree/loop/mechanical.py
+++ b/src/teatree/loop/mechanical.py
@@ -65,12 +65,11 @@ def reopen_ticket(payload: ActionPayload) -> None:
 def reviewer_task_orphaned(payload: ActionPayload) -> None:
     """Complete every open reviewing task on the orphaned reviewer ticket (#998).
 
-    The scanner emits this signal when a reviewer-role ticket has a
-    non-terminal reviewing task whose URL is no longer in the ``state=opened``
-    API response — the underlying MR was merged or closed externally before
-    the slot processed the task. Without this sweep the PENDING task lingers
-    forever, surfacing on every ``pending-spawn`` and dispatching a reviewer
-    sub-agent for nothing.
+    The scanner emits this signal ONLY after ``host.get_pr_open_state``
+    confirmed the PR is genuinely MERGED or CLOSED (#1074) — never on mere
+    absence from the reviewer-assignment scan. Without this sweep the
+    PENDING task for a truly-merged PR lingers forever, surfacing on every
+    ``pending-spawn`` and dispatching a reviewer sub-agent for nothing.
 
     The handler is intentionally narrow: it operates by ticket id and only
     completes tasks in ``phase=reviewing`` with non-terminal status. Other
@@ -96,7 +95,7 @@ def reviewer_task_orphaned(payload: ActionPayload) -> None:
         completed += 1
     if completed:
         logger.info(
-            "Auto-completed %d orphaned reviewing task(s) on ticket %s (MR %s no longer open)",
+            "Auto-completed %d orphaned reviewing task(s) on ticket %s (PR %s confirmed merged/closed)",
             completed,
             ticket_id,
             payload.get("url", "?"),

--- a/src/teatree/loop/persistence.py
+++ b/src/teatree/loop/persistence.py
@@ -134,14 +134,24 @@ def _handle_reviewer(action: DispatchAction) -> Task | None:
 
 
 def _already_reviewed_at_head(ticket: Ticket, head_sha: str) -> bool:
-    """Has this PR a recorded forge approval at the current head SHA?
+    """Has this PR a recorded terminal review observation at the current head?
 
     The dedup signal for an *out-of-band* review (one not driven by a
     loop reviewing Task, so there is no open/completed Task to key on) is
     the reviewer ticket's ``last_review_state``/``reviewed_sha`` pair —
-    written by ``Ticket.mark_reviewed_externally`` and the
-    ``ReviewerPrsScanner`` cache. APPROVED at the current head ⇒ the
-    review already happened; re-enqueueing would duplicate it every tick.
+    written by ``Ticket.mark_reviewed_externally`` / ``mark_review_no_action``
+    and the ``ReviewerPrsScanner`` cache. A terminal state at the current
+    head ⇒ the review already happened; re-enqueueing would duplicate it
+    every tick. Two terminal states suppress: ``APPROVED`` (a genuine
+    approving review — the existing #959 behaviour) and
+    ``REVIEWED_NO_ACTION`` (the reviewer concluded there was nothing to
+    post/approve on a bot MR — before #1077 there was no terminal state
+    for this, so the reviewing task re-dispatched every Stop-hook pump
+    forever). ``REVIEWED_NO_ACTION`` is intentionally *not* APPROVED so a
+    future genuine review is never hidden; suppression is keyed on the
+    head SHA, and a SHA move drops ``last_review_state`` (the #959 reset
+    in ``_handle_reviewer``) so a new revision is still reviewed.
+
     A blank ``head_sha`` is treated as "cannot confirm parity" so review
     is NOT suppressed (fail-open — never silently skip a real review).
     """
@@ -150,7 +160,8 @@ def _already_reviewed_at_head(ticket: Ticket, head_sha: str) -> bool:
     from teatree.backends.protocols import ReviewState  # noqa: PLC0415
 
     extra = ticket.extra or {}
-    return extra.get("last_review_state") == ReviewState.APPROVED.value and extra.get("reviewed_sha") == head_sha
+    terminal = {ReviewState.APPROVED.value, ReviewState.REVIEWED_NO_ACTION.value}
+    return extra.get("last_review_state") in terminal and extra.get("reviewed_sha") == head_sha
 
 
 def _handle_orchestrator(action: DispatchAction) -> Task | None:

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -14,7 +14,7 @@ then deleted — no migration command required.
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
-from teatree.backends.protocols import CodeHostBackend, ReviewState
+from teatree.backends.protocols import CodeHostBackend, PrOpenState, ReviewState
 from teatree.loop.scanners.base import ScanSignal
 from teatree.types import RawAPIDict
 
@@ -158,21 +158,31 @@ def _pr_url(pr: RawAPIDict) -> str:
 def _orphaned_task_signals(
     ticket_model: "TicketModel | None",
     scanned_urls: set[str],
+    host: CodeHostBackend,
     overlay: str = "",
 ) -> list[ScanSignal]:
-    """Emit ``reviewer_pr.task_orphaned`` for stuck PENDING/CLAIMED tasks (#998).
+    """Emit ``reviewer_pr.task_orphaned`` for genuinely merged/closed PRs (#1074).
 
-    Scenario the loop hit: scanner sees an open MR on tick #1 → persistence
-    creates ``Ticket(role=reviewer)`` + ``Task(phase=reviewing,
-    status=PENDING)``. The MR is merged externally before the slot processes
-    the task. On tick #2 the ``state=opened`` API no longer returns the MR,
-    so neither the dedup ``_has_open_task`` path nor the
-    ``_already_reviewed_at_head`` cache hit can ever fire — and the PENDING
-    task lingers forever, surfacing on every ``pending-spawn``. This sweep
-    closes that window: any reviewer-role ticket with a non-terminal
-    reviewing task whose URL is absent from the current scan gets a
-    ``task_orphaned`` signal so the mechanical handler can complete the
-    task and unblock the loop.
+    Scenario the sweep handles: scanner sees an open MR on tick #1 →
+    persistence creates ``Ticket(role=reviewer)`` + ``Task(phase=reviewing,
+    status=PENDING)``. The MR is merged/closed externally before the slot
+    processes the task. The PENDING task would otherwise linger forever,
+    surfacing on every ``pending-spawn`` and dispatching a reviewer
+    sub-agent for nothing (#998).
+
+    **The decision is state-authoritative, not absence-based (#1074).**
+    Absence from ``scanned_urls`` is NOT proof the PR closed:
+    ``scanned_urls`` only holds PRs returned by
+    ``list_review_requested_prs`` (a reviewer-*assignment* filter). A
+    Slack-review-request MR that never got a forge reviewer assignment is
+    permanently absent from that scan while still fully OPEN — reaping it
+    on absence alone silently drops a live review obligation. So a
+    candidate (reviewer-role ticket with a non-terminal reviewing task
+    whose URL is absent from the scan) is reaped ONLY when
+    ``host.get_pr_open_state`` confirms the PR is genuinely ``MERGED`` or
+    ``CLOSED``. ``OPEN`` and ``UNKNOWN`` (auth error, network, unparsable
+    URL, draft, anything ambiguous) both skip — fail open, never reap on
+    doubt.
 
     The scanner runs once per (overlay, code-host) pair in ``tick.py``, so
     the orphan sweep must be scoped to the scanner's own overlay — otherwise
@@ -197,14 +207,20 @@ def _orphaned_task_signals(
     if overlay:
         candidates = candidates.filter(overlay=overlay)
     candidates = candidates.exclude(issue_url="").exclude(issue_url__in=scanned_urls).distinct()
-    return [
-        ScanSignal(
-            kind="reviewer_pr.task_orphaned",
-            summary=f"Reviewing task orphaned (MR no longer open): {ticket.issue_url}",
-            payload={"url": ticket.issue_url, "ticket_id": ticket.pk},
+    signals: list[ScanSignal] = []
+    for ticket in candidates:
+        state = host.get_pr_open_state(pr_url=ticket.issue_url)
+        if state not in {PrOpenState.MERGED, PrOpenState.CLOSED}:
+            # OPEN → live review still owed; UNKNOWN → fail open. Never reap.
+            continue
+        signals.append(
+            ScanSignal(
+                kind="reviewer_pr.task_orphaned",
+                summary=f"Reviewing task orphaned (PR {state.value}): {ticket.issue_url}",
+                payload={"url": ticket.issue_url, "ticket_id": ticket.pk},
+            ),
         )
-        for ticket in candidates
-    ]
+    return signals
 
 
 def _is_dismissed_from_approved(previous: str, current: ReviewState) -> bool:
@@ -310,7 +326,7 @@ class ReviewerPrsScanner:
                 )
             if current.value != previous.state and ticket_model is not None:
                 _persist_entry(ticket_model, url, CacheEntry(sha=previous.sha, state=current.value))
-        signals.extend(_orphaned_task_signals(ticket_model, scanned_urls, self.overlay_name))
+        signals.extend(_orphaned_task_signals(ticket_model, scanned_urls, self.host, self.overlay_name))
         return signals
 
     def _resolve_identities(self) -> tuple[str, ...]:

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -435,3 +435,104 @@ def test_post_issue_comment_returns_empty_dict_when_post_returns_none() -> None:
     )
 
     assert result == {}
+
+
+def test_get_pr_open_state_maps_opened_to_open() -> None:
+    from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_json.return_value = {"state": "opened"}
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.OPEN
+    client.get_json.assert_called_once_with("projects/42/merge_requests/12")
+
+
+def test_get_pr_open_state_maps_merged_to_merged() -> None:
+    from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_json.return_value = {"state": "merged"}
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.MERGED
+
+
+def test_get_pr_open_state_maps_closed_and_locked_to_closed() -> None:
+    from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    host = GitLabCodeHost(client=client)
+
+    client.get_json.return_value = {"state": "closed"}
+    assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.CLOSED
+    client.get_json.return_value = {"state": "locked"}
+    assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.CLOSED
+
+
+def test_get_pr_open_state_unrecognised_state_is_unknown() -> None:
+    from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_json.return_value = {"state": "weird"}
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.UNKNOWN
+
+
+def test_get_pr_open_state_non_string_or_missing_state_is_unknown() -> None:
+    from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    host = GitLabCodeHost(client=client)
+
+    client.get_json.return_value = {}  # state key absent
+    assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.UNKNOWN
+    client.get_json.return_value = {"state": 42}  # non-string state
+    assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.UNKNOWN
+
+
+def test_get_pr_open_state_unparsable_url_is_unknown() -> None:
+    from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+    client = MagicMock(spec=GitLabAPI)
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_open_state(pr_url="https://github.com/o/r/pull/7") == PrOpenState.UNKNOWN
+    client.resolve_project.assert_not_called()
+
+
+def test_get_pr_open_state_unresolved_project_is_unknown() -> None:
+    from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = None
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.UNKNOWN
+
+
+def test_get_pr_open_state_non_dict_payload_is_unknown() -> None:
+    from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_json.return_value = ["not", "a", "dict"]
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.UNKNOWN
+
+
+def test_get_pr_open_state_any_exception_fails_open_to_unknown() -> None:
+    from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.side_effect = RuntimeError("network down / auth error")
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.UNKNOWN

--- a/tests/teatree_backends/test_protocols.py
+++ b/tests/teatree_backends/test_protocols.py
@@ -6,6 +6,7 @@ from teatree.backends.protocols import (
     CodeHostBackend,
     MessageSpec,
     MessagingBackend,
+    PrOpenState,
     PullRequestSpec,
     ReviewState,
 )
@@ -58,6 +59,10 @@ class _FakeCodeHost:
     def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState:
         _ = (pr_url, reviewer)
         return ReviewState.NONE
+
+    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState:
+        _ = pr_url
+        return PrOpenState.UNKNOWN
 
     def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> dict[str, object]:
         _ = (repo, pr_iid, body)

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -465,6 +465,25 @@ class TestTicketCommand(TestCase):
         )
         assert "not allowed" in str(result["error"])
 
+    def test_transition_mark_review_no_action_delivers_reviewer_ticket(self) -> None:
+        """#1077: the no-action disposition is reachable via the CLI transition."""
+        from teatree.core.models.ticket import schedule_external_review  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://gitlab/x/-/merge_requests/1077c",
+            role=Ticket.Role.REVIEWER,
+            extra={"reviewed_sha": "sha1"},
+        )
+        schedule_external_review(ticket)
+        result = cast(
+            "dict[str, object]",
+            call_command("ticket", "transition", ticket.pk, "mark_review_no_action"),
+        )
+        assert result["state"] == Ticket.State.DELIVERED
+        ticket.refresh_from_db()
+        assert ticket.extra["last_review_state"] == "reviewed_no_action"
+
     def test_list_returns_all_tickets(self) -> None:
         Ticket.objects.create(overlay="test")
         Ticket.objects.create(overlay="other")

--- a/tests/teatree_core/test_ticket_role.py
+++ b/tests/teatree_core/test_ticket_role.py
@@ -81,3 +81,66 @@ class TestMarkReviewedExternally(TestCase):
         ticket.refresh_from_db()
         # Author flow: state stays NOT_STARTED until ticket.start() is called by the orchestrator.
         assert ticket.state != Ticket.State.DELIVERED
+
+
+class TestMarkReviewNoAction(TestCase):
+    """#1077: terminal disposition for a no-postable-action external review."""
+
+    def test_consumes_pending_task_and_records_no_action_state(self) -> None:
+        """The PENDING reviewing task is terminated and the real outcome stamped.
+
+        Anti-vacuity anchor: pre-#1077 there is no ``mark_review_no_action``
+        transition, so this test cannot even resolve the attribute — RED by
+        ``AttributeError``. With the fix: ticket → DELIVERED, the reviewing
+        Task is COMPLETED (no longer PENDING — the infinite re-queue stops),
+        and ``last_review_state`` is ``reviewed_no_action`` (NEVER
+        ``approved``, so a later genuine review is not suppressed).
+        """
+        ticket = Ticket.objects.create(
+            overlay="acme",
+            issue_url="https://gitlab/x/-/merge_requests/1077",
+            role=Ticket.Role.REVIEWER,
+            extra={"reviewed_sha": "sha1"},
+        )
+        task = schedule_external_review(ticket)
+        assert task.status == Task.Status.PENDING
+
+        ticket.mark_review_no_action()
+        ticket.save()
+
+        ticket.refresh_from_db()
+        task.refresh_from_db()
+        assert ticket.state == Ticket.State.DELIVERED
+        assert task.status == Task.Status.COMPLETED
+        assert ticket.extra["last_review_state"] == "reviewed_no_action"
+        assert ticket.extra["last_review_state"] != "approved"
+        assert ticket.extra["reviewed_sha"] == "sha1"
+
+    def test_refuses_author_role_ticket(self) -> None:
+        from django_fsm import TransitionNotAllowed  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(
+            overlay="acme",
+            issue_url="https://example.com/issues/7",
+            extra={"reviewed_sha": "sha1"},
+        )
+        with pytest.raises(TransitionNotAllowed):
+            ticket.mark_review_no_action()
+
+    def test_no_extra_write_when_url_or_sha_missing(self) -> None:
+        """Body's ``if self.issue_url and sha`` guard — still terminal, no stamp."""
+        ticket = Ticket.objects.create(
+            overlay="acme",
+            issue_url="https://gitlab/x/-/merge_requests/1078",
+            role=Ticket.Role.REVIEWER,
+        )
+        task = schedule_external_review(ticket)
+
+        ticket.mark_review_no_action()
+        ticket.save()
+
+        ticket.refresh_from_db()
+        task.refresh_from_db()
+        assert ticket.state == Ticket.State.DELIVERED
+        assert task.status == Task.Status.COMPLETED
+        assert "last_review_state" not in (ticket.extra or {})

--- a/tests/teatree_loop/test_persistence.py
+++ b/tests/teatree_loop/test_persistence.py
@@ -146,6 +146,70 @@ class TestPersistReviewer(TestCase):
         assert result == []  # Existing author ticket is not converted.
         assert Ticket.objects.get(issue_url=url).role == Ticket.Role.AUTHOR
 
+    def test_no_action_disposition_stops_infinite_requeue_at_same_head(self) -> None:
+        """#1077 liveness: a concluded no-action review is not re-dispatched at head.
+
+        A colleague/bot MR (Aikido) with no postable/approvable action: the
+        reviewer concludes via ``mark_review_no_action``. The scanner keeps
+        emitting the same ``t3:reviewer`` action every tick (the MR has no
+        forge reviewer assignment so the orphan sweep can never fire). With
+        the fix, a subsequent ``_handle_reviewer`` at the SAME head SHA
+        returns None (no re-dispatch), the reviewing Task is terminal, and
+        ``last_review_state`` is the non-approved outcome.
+
+        Anti-vacuity: pre-#1077 there is no ``mark_review_no_action``
+        transition (``_handle_reviewer`` only suppresses on APPROVED), so
+        this disposition cannot be recorded and the second call re-creates
+        a reviewing Task — RED.
+        """
+        url = "https://gitlab/x/-/merge_requests/1077a"
+        first = persist_agent_actions([self._action(url=url, head_sha="sha1")])
+        assert len(first) == 1
+
+        ticket = Ticket.objects.get(issue_url=url)
+        ticket.mark_review_no_action()
+        ticket.save()
+        ticket.refresh_from_db()
+
+        assert ticket.extra["last_review_state"] == "reviewed_no_action"
+        assert ticket.extra["last_review_state"] != "approved"
+        assert not Task.objects.filter(
+            ticket=ticket,
+            phase="reviewing",
+            status__in=(Task.Status.PENDING, Task.Status.CLAIMED),
+        ).exists()
+
+        # Same url + same head SHA on the next tick → NO re-dispatch.
+        second = persist_agent_actions([self._action(url=url, head_sha="sha1")])
+        assert second == []
+        assert (
+            Task.objects.filter(
+                ticket=ticket,
+                phase="reviewing",
+                status__in=(Task.Status.PENDING, Task.Status.CLAIMED),
+            ).count()
+            == 0
+        )
+
+    def test_no_action_disposition_does_not_lose_obligation_on_new_head(self) -> None:
+        """#1077 no-lost-obligation: a head-SHA move re-schedules the review.
+
+        After a no-action disposition at SHA1, the author pushes SHA2. The
+        recorded ``reviewed_no_action`` belonged to SHA1 — the new revision
+        MUST be reviewed again (the #959 SHA-move reset drops the stale
+        state), so ``_handle_reviewer`` re-``schedule_external_review``.
+        """
+        url = "https://gitlab/x/-/merge_requests/1077b"
+        persist_agent_actions([self._action(url=url, head_sha="sha1")])
+        ticket = Ticket.objects.get(issue_url=url)
+        ticket.mark_review_no_action()
+        ticket.save()
+
+        created = persist_agent_actions([self._action(url=url, head_sha="sha2")])
+
+        assert len(created) == 1
+        assert created[0].phase == "reviewing"
+
 
 class TestPersistOrchestrator(TestCase):
     def _action(

--- a/tests/teatree_loop/test_scanners.py
+++ b/tests/teatree_loop/test_scanners.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from django.test import TestCase
 
-from teatree.backends.protocols import ReviewState
+from teatree.backends.protocols import PrOpenState, ReviewState
 from teatree.core.models import Ticket
 from teatree.loop.scanners.assigned_issues import AssignedIssuesScanner
 from teatree.loop.scanners.my_prs import MyPrsScanner
@@ -30,6 +30,9 @@ class FakeCodeHost:
     list_assigned_issues_calls: list[str] = field(default_factory=list)
     review_state_by_url: dict[str, ReviewState] = field(default_factory=dict)
     get_review_state_calls: list[tuple[str, str]] = field(default_factory=list)
+    pr_open_state_by_url: dict[str, PrOpenState] = field(default_factory=dict)
+    pr_open_state_default: PrOpenState = PrOpenState.UNKNOWN
+    get_pr_open_state_calls: list[str] = field(default_factory=list)
 
     def current_user(self) -> str:
         return self.user
@@ -49,6 +52,10 @@ class FakeCodeHost:
     def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState:
         self.get_review_state_calls.append((pr_url, reviewer))
         return self.review_state_by_url.get(pr_url, ReviewState.NONE)
+
+    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState:
+        self.get_pr_open_state_calls.append(pr_url)
+        return self.pr_open_state_by_url.get(pr_url, self.pr_open_state_default)
 
     def create_pr(self, spec: Any) -> RawAPIDict:
         _ = spec
@@ -387,10 +394,11 @@ class TestReviewerPrsScanner(TestCase):
         task lingers forever and ``pending-spawn`` keeps surfacing it,
         dispatching a reviewer sub-agent every tick for nothing.
 
-        Post-fix: the scanner emits ``reviewer_pr.task_orphaned`` for every
-        reviewer-role ticket with a non-terminal reviewing Task whose URL is
-        absent from the current open-MR scan. A mechanical handler completes
-        the task so ``pending-spawn`` stops returning it.
+        Post-fix (#1074): absence from the scan is no longer sufficient —
+        the scanner emits ``reviewer_pr.task_orphaned`` only after
+        ``get_pr_open_state`` confirms the PR is genuinely MERGED/CLOSED.
+        A mechanical handler then completes the task so ``pending-spawn``
+        stops returning it.
         """
         from teatree.core.models import Session, Task  # noqa: PLC0415
 
@@ -410,14 +418,104 @@ class TestReviewerPrsScanner(TestCase):
             execution_reason="Review needed",
         )
 
-        # API no longer returns the MR — it was merged externally.
-        host = FakeCodeHost(user="alice", review_requested_prs=[])
+        # API no longer returns the MR AND the forge confirms it merged.
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[],
+            pr_open_state_by_url={url: PrOpenState.MERGED},
+        )
         scanner = ReviewerPrsScanner(host=host)
         signals = scanner.scan()
 
         assert [s.kind for s in signals] == ["reviewer_pr.task_orphaned"]
         assert signals[0].payload["url"] == url
         assert signals[0].payload["ticket_id"] == ticket.pk
+
+    def test_open_mr_absent_from_reviewer_scan_is_never_reaped(self) -> None:
+        """#1074 regression: a live OPEN MR absent from the scan is NOT reaped.
+
+        Slack-review-request MRs (slack.review_intent → schedule_external_review)
+        never get a forge reviewer assignment, so ``list_review_requested_prs``
+        never returns them — the URL is *permanently* absent from
+        ``scanned_urls``. Pre-fix the orphan sweep reaped on absence alone:
+        it emitted ``reviewer_pr.task_orphaned`` and the mechanical handler
+        completed the reviewing Task, silently dropping a fully-OPEN review
+        obligation and logging "MR no longer open" for an open MR.
+
+        The surviving review obligation is the contract the bug violates:
+        with the fix, NO orphan signal is emitted AND the PENDING reviewing
+        Task is still PENDING (the obligation is preserved). Asserting the
+        Task is still PENDING — not merely that no signal fired — is the
+        anti-vacuity anchor: on the buggy code the signal fires, the
+        mechanical handler runs, and the Task goes COMPLETED.
+        """
+        from teatree.core.models import Session, Task  # noqa: PLC0415
+
+        url = "https://gitlab/x/-/merge_requests/1074"
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            issue_url=url,
+            overlay="acme",
+            extra={"reviewed_sha": "abc"},
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="external-review")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Review needed",
+        )
+
+        # No forge reviewer assignment (Slack-review-request MR) → absent
+        # from the scan — but the MR is genuinely OPEN.
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[],
+            pr_open_state_by_url={url: PrOpenState.OPEN},
+        )
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+
+        assert "reviewer_pr.task_orphaned" not in [s.kind for s in signals]
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+
+    def test_unknown_pr_state_fails_open_and_is_not_reaped(self) -> None:
+        """#1074: an UNKNOWN open-state (auth error, network, draft) fails open.
+
+        ``get_pr_open_state`` returns UNKNOWN on any ambiguity. The sweep
+        must NOT reap on UNKNOWN — fail open, never drop a review on doubt.
+        """
+        from teatree.core.models import Session, Task  # noqa: PLC0415
+
+        url = "https://gitlab/x/-/merge_requests/1077"
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            issue_url=url,
+            overlay="acme",
+            extra={"reviewed_sha": "abc"},
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="external-review")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Review needed",
+        )
+
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[],
+            pr_open_state_by_url={url: PrOpenState.UNKNOWN},
+        )
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+
+        assert "reviewer_pr.task_orphaned" not in [s.kind for s in signals]
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
 
     def test_orphaned_signal_not_emitted_when_mr_still_in_scan(self) -> None:
         """If the MR is still in the API response, no orphaning happens (#998)."""
@@ -543,8 +641,13 @@ class TestReviewerPrsScanner(TestCase):
                 execution_reason="Review needed",
             )
 
-        # Run the scanner scoped to github-overlay only; API returns nothing.
-        host = FakeCodeHost(user="alice", review_requested_prs=[])
+        # Run the scanner scoped to github-overlay only; API returns
+        # nothing AND both PRs are confirmed merged on the forge.
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[],
+            pr_open_state_by_url={own_url: PrOpenState.MERGED, other_url: PrOpenState.MERGED},
+        )
         scanner = ReviewerPrsScanner(host=host, overlay_name="github-overlay")
         signals = scanner.scan()
 
@@ -579,7 +682,11 @@ class TestReviewerPrsScanner(TestCase):
                 execution_reason="Review needed",
             )
 
-        host = FakeCodeHost(user="alice", review_requested_prs=[])
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[],
+            pr_open_state_by_url=dict.fromkeys(urls, PrOpenState.CLOSED),
+        )
         scanner = ReviewerPrsScanner(host=host)  # overlay_name defaults to ""
         signals = scanner.scan()
 
@@ -595,8 +702,9 @@ class TestReviewerPrsScanner(TestCase):
         """
         from teatree.loop.scanners.reviewer_prs import _orphaned_task_signals  # noqa: PLC0415
 
-        assert _orphaned_task_signals(None, set()) == []
-        assert _orphaned_task_signals(None, {"https://x"}, "any-overlay") == []
+        host = FakeCodeHost(user="alice")
+        assert _orphaned_task_signals(None, set(), host) == []
+        assert _orphaned_task_signals(None, {"https://x"}, host, "any-overlay") == []
 
     def test_legacy_json_cache_is_imported_then_deleted(self) -> None:
         """First scan migrates the legacy JSON file into reviewer tickets, then unlinks it."""

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -734,6 +734,13 @@ class TestTickReapsOrphanedReviewingTask(django.test.TransactionTestCase):
 
                 return ReviewState.NONE
 
+            def get_pr_open_state(self, *, pr_url: str):
+                # #1074: the forge confirms the MR is genuinely merged, so
+                # the orphan sweep is allowed to reap the stale task.
+                from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+                return PrOpenState.MERGED
+
         # Step 1: scanner emits the orphan signal.
         signals = ReviewerPrsScanner(host=_ReviewerHost()).scan()
         assert any(s.kind == "reviewer_pr.task_orphaned" for s in signals)

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -517,3 +517,54 @@ class TestGitHubCodeHost:
 
         host = GitHubCodeHost()
         assert host.get_review_state(pr_url="https://github.com/o/r/pull/7", reviewer="") == ReviewState.NONE
+
+    def test_get_pr_open_state_maps_open_to_open(self) -> None:
+        from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+        with patch.object(github_mod, "_gh_api_get", return_value={"state": "open"}) as mock_get:
+            host = GitHubCodeHost(token="tok")
+            assert host.get_pr_open_state(pr_url="https://github.com/o/r/pull/7") == PrOpenState.OPEN
+        mock_get.assert_called_once_with("repos/o/r/pulls/7", token="tok")
+
+    def test_get_pr_open_state_maps_merged_true_to_merged(self) -> None:
+        from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+        with patch.object(github_mod, "_gh_api_get", return_value={"state": "closed", "merged": True}):
+            host = GitHubCodeHost()
+            assert host.get_pr_open_state(pr_url="https://github.com/o/r/pull/7") == PrOpenState.MERGED
+
+    def test_get_pr_open_state_maps_closed_unmerged_to_closed(self) -> None:
+        from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+        with patch.object(github_mod, "_gh_api_get", return_value={"state": "closed", "merged": False}):
+            host = GitHubCodeHost()
+            assert host.get_pr_open_state(pr_url="https://github.com/o/r/pull/7") == PrOpenState.CLOSED
+
+    def test_get_pr_open_state_unrecognised_payload_is_unknown(self) -> None:
+        from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+        with patch.object(github_mod, "_gh_api_get", return_value={"state": "draft"}):
+            host = GitHubCodeHost()
+            assert host.get_pr_open_state(pr_url="https://github.com/o/r/pull/7") == PrOpenState.UNKNOWN
+
+    def test_get_pr_open_state_non_dict_payload_is_unknown(self) -> None:
+        from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+        with patch.object(github_mod, "_gh_api_get", return_value=["not", "a", "dict"]):
+            host = GitHubCodeHost()
+            assert host.get_pr_open_state(pr_url="https://github.com/o/r/pull/7") == PrOpenState.UNKNOWN
+
+    def test_get_pr_open_state_unparsable_url_is_unknown(self) -> None:
+        from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+        with patch.object(github_mod, "_gh_api_get") as mock_get:
+            host = GitHubCodeHost()
+            assert host.get_pr_open_state(pr_url="https://gitlab.com/o/r/-/merge_requests/7") == PrOpenState.UNKNOWN
+        mock_get.assert_not_called()
+
+    def test_get_pr_open_state_any_exception_fails_open_to_unknown(self) -> None:
+        from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+        with patch.object(github_mod, "_gh_api_get", side_effect=RuntimeError("gh api auth failure")):
+            host = GitHubCodeHost()
+            assert host.get_pr_open_state(pr_url="https://github.com/o/r/pull/7") == PrOpenState.UNKNOWN


### PR DESCRIPTION
Two fixes in the loop reviewing-task lifecycle, both rooted in the orphan-completer sweep.

## #1074 — reviewing tasks reaped on absence alone

The orphan sweep completed any reviewer-role ticket whose URL was absent from `list_review_requested_prs`. That list is a reviewer-*assignment* filter, not an open/closed probe — a Slack-review-request MR never gets a forge reviewer assignment, so it is permanently absent while still fully open. The sweep then completed the reviewing task and logged "MR no longer open" for an open MR, dropping the review obligation.

`CodeHostBackend.get_pr_open_state` (`PrOpenState` `OPEN|MERGED|CLOSED|UNKNOWN`) is added on GitLab and GitHub. The sweep now emits `task_orphaned` only when the forge confirms the PR is genuinely `MERGED` or `CLOSED`. `OPEN` and `UNKNOWN` (auth error, network, unparsable URL, draft) both fail open and never reap.

## #1077 — reviewing task re-queued forever for no-action MRs

A reviewer-role ticket for a bot MR (Aikido / Dependabot) with nothing to post or approve had no terminal path: the only way the reviewing task reached COMPLETED was `Task.complete()` → `mark_reviewed_externally`, which stamps APPROVED. The reviewer correctly posts/approves nothing, so the task stayed PENDING and `pending-spawn` re-dispatched it every Stop-hook pump.

A new `mark_review_no_action` FSM transition (sibling of `mark_reviewed_externally`) plus its CLI transition records `last_review_state=reviewed_no_action` (a new `ReviewState` value, never APPROVED) at the current head SHA and consumes the PENDING task. `_already_reviewed_at_head` treats that terminal state at the current head as already-handled so the task is not re-queued; the existing #959 SHA-move reset still drops it so a new revision is reviewed again. No DB migration — reuses the existing `extra` JSON + Task status. The review skill documents when the reviewer invokes it.

Both regression tests were checked RED on the reverted code and GREEN with the fix. Full suite green (5720 passed), coverage 94.0%.

Closes #1074
Closes #1077