### PR TITLE
feat(ship): reject auto-close trailers in pre-push gate for opted-in overlays (#1012)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -801,6 +801,8 @@ Defined in `teatree.core.overlay`. All methods receive the `worktree` instance f
 | `get_e2e_env_extras(env_cache)` | `→ dict[str, str]` | `{}` | Overlay-specific env vars merged into the Playwright environment (e.g. `WT_VARIANT`→`CUSTOMER`) |
 | `get_e2e_preflight(customer, base_url)` | `→ list[Callable[[], None]]` | `[]` | Pre-Playwright gates; each callable raises `RuntimeError` on failure |
 
+**Auto-close trailer rejection (`OverlayConfig.forbid_close_keywords`, default `False`, [#1012](https://github.com/souliane/teatree/issues/1012)).** An overlay that manages issue closure through the forge's linked-items API — not `Closes/Fixes/Resolves #N` auto-close trailers — sets `config.forbid_close_keywords = True`. The `_run_ship_gates` sequence then runs `_close_keyword_gate.run_close_keyword_gate` after the shipping gate and before visual QA: it scans the **raw** MR-description source (the branch's last commit message, pre-`sanitize_close_keywords` — that rewrite would otherwise mask the trailer) and every branch commit body for the full GitHub/GitLab auto-close keyword set (`close/closes/closed`, `fix/fixes/fixed`, `resolve/resolves/resolved`; `#N`, `<project>#N`, full-URL forms; case-insensitive) and `raise SystemExit` with the offending line + a suggested `Relates to` rewrite. A merged trailer would otherwise auto-close the referenced issue and break the lifecycle FSM. teatree's own overlay leaves the flag at its `False` default, so teatree PRs that legitimately use `Closes #N` are unaffected — the gate is a no-op unless an overlay opts in.
+
 ### 6.2 Supporting TypedDicts
 
 ```python

--- a/src/teatree/core/management/commands/_close_keyword_gate.py
+++ b/src/teatree/core/management/commands/_close_keyword_gate.py
@@ -1,0 +1,99 @@
+"""Pre-push gate: reject auto-close keywords for overlays that forbid them.
+
+Some overlays manage issue closure through the forge's linked-items API,
+not through ``Closes #N`` / ``Fixes #N`` / ``Resolves #N`` auto-close
+trailers (#1012). A trailer that slips into an MR description or a commit
+body auto-closes the referenced issue the instant the MR merges, which then
+fires the "ticket closed" cleanup in followup and breaks the lifecycle FSM.
+
+This gate is overlay-scoped: it only enforces when the active overlay sets
+``config.forbid_close_keywords``. teatree's own overlay leaves it at the
+``False`` default, so teatree PRs that legitimately use ``Closes #N`` are
+unaffected. It scans both the proposed MR description and every commit body
+on the branch, and raises ``SystemExit`` with the offending line + suggested
+rewrite when an auto-close keyword is found.
+"""
+
+import re
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay_loader import get_overlay
+from teatree.utils import git
+from teatree.utils.run import CommandFailedError
+
+# GitHub/GitLab recognise the full close/fix/resolve verb set including the
+# past-tense ``-ed`` forms. ``#N``, ``<project>#N``, ``<group/project>#N``
+# and the full ``https://…/issues/N`` URL form all trigger auto-close.
+_FORBIDDEN_CLOSE_RE = re.compile(
+    r"\b(?P<kw>close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+"
+    r"(?P<ref>(?:[\w./-]+)?#\d+|https?://\S+/issues/\d+)",
+    re.IGNORECASE,
+)
+
+
+def _offending_lines(text: str) -> list[str]:
+    """Return each line of *text* that carries a forbidden auto-close keyword."""
+    return [line.strip() for line in text.splitlines() if _FORBIDDEN_CLOSE_RE.search(line)]
+
+
+def _suggest_rewrite(line: str) -> str:
+    """Rewrite the keyword to the allowlisted ``Relates to`` form."""
+    return _FORBIDDEN_CLOSE_RE.sub(lambda m: f"Relates to {m.group('ref')}", line)
+
+
+def _scan_sources(worktree: Worktree) -> list[str]:
+    """Raw author-intent text to scan: the MR description + every commit body.
+
+    The MR description is *derived from* the branch's last commit message
+    (see ``ship_preview``), so the raw last-commit message is the proposed
+    description's source. It is scanned RAW — before ``sanitize_close_keywords``
+    rewrites it — because that rewrite would otherwise mask the very trailer
+    this gate must reject. A git failure (no real repo, base undetectable,
+    detached HEAD) is *unverifiable*: skip that source rather than block on
+    an unknown.
+    """
+    repo = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
+    branch = worktree.branch
+    if not repo or not branch:
+        return []
+    sources: list[str] = []
+    try:
+        subject, body = git.last_commit_message(repo=repo)
+        sources.append(f"{subject}\n\n{body}" if body else subject)
+        base = f"origin/{git.default_branch(repo=repo)}"
+        sources.extend(git.commit_messages(repo=repo, range_spec=f"{base}..{branch}"))
+    except (CommandFailedError, RuntimeError, ValueError):
+        return sources
+    return sources
+
+
+def run_close_keyword_gate(ticket: Ticket, worktree: Worktree) -> None:
+    """Reject forbidden auto-close keywords for overlays that opt in.
+
+    No-op when the active overlay does not set
+    ``config.forbid_close_keywords``. Raises ``SystemExit(1)`` (the CLI
+    gate convention) with the offending line(s) + suggested rewrite when
+    a keyword is found in the MR description or any branch commit body.
+    """
+    _ = ticket  # signature parity with the other ``_run_ship_gates`` steps
+    if not get_overlay().config.forbid_close_keywords:
+        return
+
+    sources = _scan_sources(worktree)
+
+    offenders: list[str] = []
+    for source in sources:
+        offenders.extend(_offending_lines(source))
+    if not offenders:
+        return
+
+    bullets = "\n".join(f"  - {line}\n    → suggest: {_suggest_rewrite(line)}" for line in offenders)
+    msg = (
+        "Refusing to ship: this overlay manages issue closure via forge "
+        "linked-items, not auto-close trailers. The MR description or a "
+        "commit body contains a forbidden auto-close keyword:\n"
+        f"{bullets}\n"
+        "Rewrite the trailer to `Relates to` (or `Refs`/`See`) and retry "
+        "`pr create`."
+    )
+    raise SystemExit(msg)

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -15,6 +15,7 @@ from teatree import visual_qa
 from teatree.core.backend_factory import code_host_from_overlay
 from teatree.core.branch_currency import require_current_branch
 from teatree.core.db_anchor import assert_lifecycle_db_is_canonical
+from teatree.core.management.commands._close_keyword_gate import run_close_keyword_gate
 from teatree.core.management.commands._ensure_pr import EnsurePrResult, create_or_defer_pr
 from teatree.core.management.commands._pr_preview import (
     PrValidationError,
@@ -318,6 +319,9 @@ def _run_ship_gates(
     gate_error = _check_shipping_gate(ticket)
     if gate_error is not None:
         return gate_error
+    # Overlay-scoped (#1012): no-op unless the overlay forbids auto-close
+    # trailers; raises SystemExit with the offending line otherwise.
+    run_close_keyword_gate(ticket, worktree)
     visual_qa_error = _run_visual_qa_gate(ticket, skip_reason=skip_visual_qa)
     if visual_qa_error is not None:
         return visual_qa_error

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -83,6 +83,13 @@ class OverlayConfig:
     stale_threshold_days: int = 3
     notion_database_id: str = ""
     mr_close_ticket: bool = False
+    # When True the pre-push ship gate REJECTS any auto-close keyword
+    # (Closes/Fixes/Resolves #N, full-URL forms) in the MR description or
+    # any commit body on the branch, instead of silently rewriting it.
+    # An overlay sets this when issue closure is managed via the forge's
+    # linked-items API rather than auto-close trailers (#1012); teatree's
+    # own overlay leaves it False (teatree PRs legitimately use ``Closes #N``).
+    forbid_close_keywords: bool = False
     teardown_removes_pass_entries: bool = False
     known_variants: list[str]
     pr_auto_labels: list[str]

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -255,6 +255,21 @@ def last_commit_message(repo: str = ".") -> tuple[str, str]:
     return subject, body
 
 
+def commit_messages(repo: str = ".", range_spec: str = "") -> list[str]:
+    """Return the full message (subject + body) of each commit in *range_spec*.
+
+    Commits are separated by an ASCII record separator so a body that
+    itself contains blank lines never splits one commit into two. An
+    empty/missing range yields ``[]`` (nothing to scan, not an error) —
+    a close-keyword gate over zero commits must pass, not blow up.
+    """
+    if not range_spec:
+        return []
+    sep = "\x1e"
+    output = run(repo=repo, args=["log", range_spec, f"--format=%B{sep}"])
+    return [chunk.strip() for chunk in output.split(sep) if chunk.strip()]
+
+
 def worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = True) -> bool:
     args = ["worktree", "add"]
     if create_branch:
@@ -347,6 +362,9 @@ class GitRepo:
 
     def last_commit_message(self) -> tuple[str, str]:
         return last_commit_message(self.path)
+
+    def commit_messages(self, range_spec: str = "") -> list[str]:
+        return commit_messages(self.path, range_spec)
 
     def worktree_add(self, path: str, branch: str, *, create_branch: bool = True) -> bool:
         return worktree_add(self.path, path, branch, create_branch=create_branch)

--- a/tests/teatree_core/management_commands/_overlays.py
+++ b/tests/teatree_core/management_commands/_overlays.py
@@ -129,6 +129,21 @@ class ServicesOverlay(FullOverlay):
         }
 
 
+class ForbidCloseKeywordsOverlay(FullOverlay):
+    """Overlay that manages issue closure via forge linked-items, not trailers.
+
+    Sets ``config.forbid_close_keywords`` so the pre-push close-keyword
+    gate (#1012) enforces. ``FullOverlay`` (teatree-style) leaves it at
+    the ``False`` default, so a teatree push with ``Closes #N`` is allowed.
+    """
+
+    config = OverlayConfig()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.config.forbid_close_keywords = True
+
+
 class _MinimalMetadata(OverlayMetadata):
     def get_tool_commands(self) -> list[ToolCommand]:
         return []
@@ -286,6 +301,9 @@ class PreRunOverlay(FullOverlay):
 
 
 FULL_OVERLAY = "tests.teatree_core.management_commands._overlays.FullOverlay"
+
+
+FORBID_CLOSE_KEYWORDS_OVERLAY = "tests.teatree_core.management_commands._overlays.ForbidCloseKeywordsOverlay"
 
 
 NESTED_OVERLAY = "tests.teatree_core.management_commands._overlays.NestedRepoOverlay"

--- a/tests/teatree_core/management_commands/test_close_keyword_gate.py
+++ b/tests/teatree_core/management_commands/test_close_keyword_gate.py
@@ -1,0 +1,213 @@
+"""Pre-push close-keyword gate (#1012).
+
+The gate is overlay-scoped: it rejects ``Closes/Fixes/Resolves #N`` (and the
+full GitHub/GitLab auto-close keyword set, case-insensitive, ``#N`` and
+full-URL forms) in the MR description or any branch commit body — but ONLY
+for overlays that set ``config.forbid_close_keywords``; teatree's own
+overlay does not. Driven through the real ``pr create`` entrypoint;
+only the unstoppable git subprocess + visual-QA boundary are patched.
+"""
+
+import contextlib
+from collections.abc import Iterator
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+import teatree.core.management.commands._close_keyword_gate as gate_mod
+import teatree.core.management.commands.pr as pr_mod
+from teatree.core.management.commands._close_keyword_gate import _scan_sources
+from teatree.core.models import Session, Ticket, Worktree
+from teatree.utils import git as git_mod
+from tests.teatree_core.management_commands._overlays import (
+    FORBID_CLOSE_KEYWORDS_OVERLAY,
+    FULL_OVERLAY,
+    SETTINGS,
+    _patch_overlays,
+)
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:In Typer, only the parameter 'autocompletion' is supported.*:DeprecationWarning",
+)
+
+
+def _shippable_ticket(*, repo: str = "/tmp/wt", branch: str = "feature-x") -> Ticket:
+    ticket = Ticket.objects.create(
+        overlay="test",
+        state=Ticket.State.REVIEWED,
+        issue_url="https://example.com/issues/70",
+    )
+    session = Session.objects.create(overlay="test", ticket=ticket)
+    for phase in ("testing", "reviewing", "retro"):
+        session.visit_phase(phase)
+    Worktree.objects.create(
+        overlay="test",
+        ticket=ticket,
+        repo_path=repo,
+        branch=branch,
+        extra={"worktree_path": repo},
+    )
+    return ticket
+
+
+@contextlib.contextmanager
+def _git_boundary(
+    *,
+    subject: str = "feat: x",
+    body: str = "",
+    commit_bodies: list[str] | None = None,
+) -> Iterator[None]:
+    """Patch the git boundary the gate + ``ship_preview`` reach.
+
+    ``last_commit_message`` is the raw MR-description source the gate scans
+    (and also what ``ship_preview`` derives the post-sanitize description
+    from); ``commit_messages`` feeds the branch-commit scan; ``default_branch``
+    lets the ``origin/main..branch`` range be built. Visual QA is the other
+    unstoppable boundary (browser).
+    """
+    with (
+        patch.object(pr_mod, "_run_visual_qa_gate", return_value=None),
+        patch(
+            "teatree.core.management.commands._close_keyword_gate.git.last_commit_message",
+            return_value=(subject, body),
+        ),
+        patch(
+            "teatree.core.management.commands._pr_preview.git.last_commit_message",
+            return_value=(subject, body),
+        ),
+        patch(
+            "teatree.core.management.commands._close_keyword_gate.git.default_branch",
+            return_value="main",
+        ),
+        patch(
+            "teatree.core.management.commands._close_keyword_gate.git.commit_messages",
+            return_value=list(commit_bodies or []),
+        ),
+    ):
+        yield
+
+
+class TestCloseKeywordGateForbiddenOverlay(TestCase):
+    """Overlay with ``forbid_close_keywords=True``: the gate rejects."""
+
+    @_patch_overlays(FORBID_CLOSE_KEYWORDS_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_rejects_closes_in_mr_description(self) -> None:
+        ticket = _shippable_ticket()
+        with pytest.raises(SystemExit) as ctx, _git_boundary(subject="Closes downstream-product#1632."):
+            call_command("pr", "create", str(ticket.pk))
+        assert ctx.value.code != 0
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED
+
+    @_patch_overlays(FORBID_CLOSE_KEYWORDS_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_rejects_fixes_in_commit_body(self) -> None:
+        ticket = _shippable_ticket()
+        with (
+            pytest.raises(SystemExit) as ctx,
+            _git_boundary(
+                subject="feat: clean subject",
+                commit_bodies=["feat: clean subject\n\nFixes #1632"],
+            ),
+        ):
+            call_command("pr", "create", str(ticket.pk))
+        assert ctx.value.code != 0
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED
+
+    @_patch_overlays(FORBID_CLOSE_KEYWORDS_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_error_message_names_offender_and_suggests_rewrite(self) -> None:
+        ticket = _shippable_ticket()
+        url = "https://gitlab.com/eng-group/downstream-product/-/issues/9"
+        with (
+            pytest.raises(SystemExit) as ctx,
+            _git_boundary(subject=f"Resolves {url}"),
+        ):
+            call_command("pr", "create", str(ticket.pk))
+        message = str(ctx.value)
+        assert f"Resolves {url}" in message
+        assert f"Relates to {url}" in message
+
+    @_patch_overlays(FORBID_CLOSE_KEYWORDS_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_relates_to_and_see_pass(self) -> None:
+        ticket = _shippable_ticket()
+        with _git_boundary(
+            subject="Relates to downstream-product#1632.",
+            commit_bodies=["Relates to downstream-product#1632.\n\nSee downstream-product#99"],
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert "error" not in result
+
+    @_patch_overlays(FORBID_CLOSE_KEYWORDS_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_all_keyword_variants_rejected(self) -> None:
+        for keyword in ("Close", "Closes", "Closed", "fix", "Fixes", "fixed", "resolve", "Resolves", "RESOLVED"):
+            ticket = _shippable_ticket()
+            with (
+                pytest.raises(SystemExit),
+                _git_boundary(subject="feat: x", body=f"{keyword} #42"),
+            ):
+                call_command("pr", "create", str(ticket.pk))
+            ticket.delete()
+
+
+class TestCloseKeywordGateNonForbiddenOverlay(TestCase):
+    """teatree-style overlay (default ``forbid_close_keywords=False``): allowed."""
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_closes_allowed_for_teatree_overlay(self) -> None:
+        ticket = _shippable_ticket()
+        with _git_boundary(
+            subject="Closes #1012",
+            commit_bodies=["Closes #1012\n\nFixes #999"],
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert "error" not in result
+
+
+class TestScanSourcesUnverifiable(TestCase):
+    """``_scan_sources`` skips sources it cannot read rather than blocking."""
+
+    def test_no_repo_or_branch_returns_empty(self) -> None:
+        worktree = Worktree(overlay="test", repo_path="", branch="")
+        assert _scan_sources(worktree) == []
+
+    def test_git_failure_returns_partial_sources(self) -> None:
+        worktree = Worktree(overlay="test", repo_path="/tmp/wt", branch="feat")
+        with (
+            patch.object(gate_mod.git, "last_commit_message", return_value=("feat: x", "")),
+            patch.object(
+                gate_mod.git,
+                "default_branch",
+                side_effect=gate_mod.CommandFailedError(["git", "branch"], 128, "", "boom"),
+            ),
+        ):
+            # The last-commit source was collected before the failure; the
+            # branch-range scan is skipped (unverifiable, not a block).
+            assert _scan_sources(worktree) == ["feat: x"]
+
+
+class TestCommitMessagesHelper(TestCase):
+    """``git.commit_messages`` — pure parsing over the ``git log`` boundary."""
+
+    def test_empty_range_returns_empty(self) -> None:
+        assert git_mod.commit_messages(repo="/tmp/wt", range_spec="") == []
+
+    def test_splits_on_record_separator_keeping_multiline_bodies(self) -> None:
+        raw = "feat: a\n\nbody line 1\n\nbody line 2\x1e\nfix: b\n\nFixes #1\x1e\n"
+        with patch.object(git_mod, "run", return_value=raw):
+            assert git_mod.commit_messages(repo="/tmp/wt", range_spec="origin/main..feat") == [
+                "feat: a\n\nbody line 1\n\nbody line 2",
+                "fix: b\n\nFixes #1",
+            ]

--- a/tests/test_git_repo_wrapper.py
+++ b/tests/test_git_repo_wrapper.py
@@ -37,6 +37,7 @@ class TestGitRepoDelegation:
             ("remote_slug", "remote_slug", (), ("/some/repo", "origin")),
             ("config_value", "config_value", ("user.name",), ("/some/repo", "user.name")),
             ("last_commit_message", "last_commit_message", (), ("/some/repo",)),
+            ("commit_messages", "commit_messages", ("a..b",), ("/some/repo", "a..b")),
         ],
     )
     def test_simple_methods_pass_repo_path(


### PR DESCRIPTION
Closes #1012

## Problem

Some overlays manage issue closure through the forge's linked-items API rather than `Closes`/`Fixes`/`Resolves` auto-close trailers. When such a trailer reaches a merged MR description or commit body, the platform auto-closes the referenced issue the instant the MR lands, which then fires the "ticket closed" cleanup in followup and breaks the lifecycle FSM. Today nothing stops the trailer before the push.

## Change

- New `OverlayConfig.forbid_close_keywords` flag (default `False`, same pattern as the existing `mr_close_ticket`). An overlay opts in; teatree's own overlay leaves it `False`.
- New `_close_keyword_gate.run_close_keyword_gate`, wired into the existing `_run_ship_gates` sequence after the shipping gate and before visual QA. When the active overlay opts in, it scans the **raw** MR-description source (the branch's last commit message, before `sanitize_close_keywords` rewrites it — that rewrite would otherwise mask the trailer) and every branch commit body for the full GitHub/GitLab auto-close keyword set (`close/closes/closed`, `fix/fixes/fixed`, `resolve/resolves/resolved`; `#N`, `<project>#N`, full-URL forms; case-insensitive), and `raise SystemExit` with the offending line plus a suggested `Relates to` rewrite.
- New `git.commit_messages` helper (record-separator framed so multi-line bodies stay intact) + `GitRepo` wrapper.
- Documented in BLUEPRINT.md §6.1.

The gate is a no-op unless an overlay opts in, so teatree's own PRs that legitimately use `Closes #N` (like this one) are unaffected.

## Tests

`tests/teatree_core/management_commands/test_close_keyword_gate.py`, driven through the real `pr create` entrypoint (only the git subprocess + visual-QA boundary patched):

- opted-in overlay + `Closes` in the MR description → rejected, FSM stays at `reviewed`
- opted-in overlay + `Fixes #N` in a commit body → rejected
- full keyword variant set rejected; error names the offender + suggests the rewrite
- opted-in overlay + only `Relates to`/`See` → ships
- non-opted-in (teatree-style) overlay + `Closes #N` → ships
- unverifiable-git and empty-range branches covered

Anti-vacuity confirmed: with the gate call removed the opted-in tests fail (push proceeds, no `SystemExit`); restored, they pass.

Full suite green (5738 passed, total coverage 94.05%); the new gate module is at 100% line/branch coverage.