### PR TITLE
fix(loop): make ticket disposition handlers idempotent (#1087)

### DIFF
--- a/src/teatree/loop/mechanical.py
+++ b/src/teatree/loop/mechanical.py
@@ -7,6 +7,8 @@ Called by ``tick._execute_mechanical`` after dispatch, before statusline render.
 import logging
 from collections.abc import Callable
 
+from django_fsm import can_proceed
+
 from teatree.loop.dispatch import ActionPayload
 
 logger = logging.getLogger(__name__)
@@ -20,6 +22,13 @@ def ignore_disposed_ticket(payload: ActionPayload) -> None:
     if ticket_id is None:
         return
     ticket = ticket_model.objects.get(pk=ticket_id)
+    # #1087: the disposition signal re-emits every tick while the ticket
+    # stays IGNORED (its PR keystone-merged, issue auto-closed). Driving
+    # ``ignore`` from ``ignored`` is not a valid FSM transition — guard so
+    # the already-satisfied desired state is a silent no-op, not every-tick
+    # ``TransitionNotAllowed`` noise.
+    if not can_proceed(ticket.ignore):
+        return
     ticket.ignore()
     ticket.save()
     logger.info("Auto-ignored ticket %s (reason: %s)", ticket_id, payload.get("reason", "?"))
@@ -57,6 +66,11 @@ def reopen_ticket(payload: ActionPayload) -> None:
     if ticket_id is None:
         return
     ticket = ticket_model.objects.get(pk=ticket_id)
+    # #1087: same re-emit hazard as ``ignore_disposed_ticket`` — a reopen
+    # signal that persists across ticks would drive ``reopen`` from the
+    # already-STARTED target state, raising every-tick ``TransitionNotAllowed``.
+    if not can_proceed(ticket.reopen):
+        return
     ticket.reopen()
     ticket.save()
     logger.info("Auto-reopened ticket %s (was %s, draft MRs detected)", ticket_id, payload.get("ticket_state", "?"))

--- a/tests/teatree_loop/test_mechanical.py
+++ b/tests/teatree_loop/test_mechanical.py
@@ -1,11 +1,12 @@
 """Mechanical action handlers — inline ticket transitions during a tick."""
 
+import datetime as dt
 from typing import cast
 
 from django.test import TestCase
 
 from teatree.core.models import Session, Task, Ticket
-from teatree.loop.dispatch import ActionPayload
+from teatree.loop.dispatch import ActionPayload, DispatchAction
 from teatree.loop.mechanical import (
     HANDLERS,
     complete_ticket,
@@ -13,10 +14,27 @@ from teatree.loop.mechanical import (
     reopen_ticket,
     reviewer_task_orphaned,
 )
+from teatree.loop.tick import TickReport
+from teatree.loop.tick_recovery import _execute_mechanical
 
 
 def _payload(**kwargs: object) -> ActionPayload:
     return cast("ActionPayload", kwargs)
+
+
+def _run_mechanical(zone: str, **payload: object) -> TickReport:
+    """Drive one mechanical action through ``_execute_mechanical``.
+
+    This is the exact path that turns a handler exception into the
+    every-tick WARN noise of #1087 (``report.errors`` + an ERROR log on
+    ``teatree.loop.tick_recovery``).
+    """
+    report = TickReport(started_at=dt.datetime.now(dt.UTC))
+    report.actions = [
+        DispatchAction(kind="mechanical", zone=zone, detail="x", payload=_payload(**payload)),
+    ]
+    _execute_mechanical(report)
+    return report
 
 
 class TestIgnoreDisposedTicket(TestCase):
@@ -28,6 +46,25 @@ class TestIgnoreDisposedTicket(TestCase):
 
     def test_no_op_when_ticket_id_missing(self) -> None:
         ignore_disposed_ticket(_payload(reason="duplicate"))  # should not raise
+
+    def test_idempotent_on_already_ignored_ticket(self) -> None:
+        """#1087: re-dispositioning an already-ignored ticket is a clean no-op.
+
+        Pre-fix this drove ``ticket.ignore()`` from state ``ignored`` —
+        ``ignored`` is not a source state of the ``ignore`` transition, so
+        django-fsm raised ``TransitionNotAllowed`` which ``_execute_mechanical``
+        caught, recorded in ``report.errors`` and logged on every tick. The
+        desired end state already holds, so this must be a silent no-op: no
+        exception, no recorded error, no log line.
+        """
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://x/1", state="ignored")
+
+        with self.assertNoLogs("teatree.loop.tick_recovery", level="ERROR"):
+            report = _run_mechanical("ticket_disposition", ticket_id=ticket.pk, reason="duplicate")
+
+        assert report.errors == {}
+        ticket.refresh_from_db()
+        assert ticket.state == "ignored"
 
 
 class TestCompleteTicket(TestCase):
@@ -60,6 +97,22 @@ class TestReopenTicket(TestCase):
 
     def test_no_op_when_ticket_id_missing(self) -> None:
         reopen_ticket(_payload(ticket_state="?"))
+
+    def test_idempotent_when_already_started(self) -> None:
+        """#1087: a re-emitted reopen signal on an already-STARTED ticket no-ops.
+
+        ``reopen`` targets ``started`` but ``started`` is not one of its
+        source states, so re-driving it on an already-reopened ticket raised
+        the same ``TransitionNotAllowed`` every-tick noise as the ignore path.
+        """
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://x/3", state="started")
+
+        with self.assertNoLogs("teatree.loop.tick_recovery", level="ERROR"):
+            report = _run_mechanical("ticket_reopen", ticket_id=ticket.pk, ticket_state="started")
+
+        assert report.errors == {}
+        ticket.refresh_from_db()
+        assert ticket.state == "started"
 
 
 class TestReviewerTaskOrphaned(TestCase):


### PR DESCRIPTION
## Summary

The ticket-disposition signal re-emits on every loop tick while a ticket
stays in its terminal state (typically after its PR keystone-merged and the
issue was auto-closed). `ignore_disposed_ticket` drove `ticket.ignore()`
from the already-`ignored` state, which is not a valid django-fsm
transition, so every tick logged `TransitionNotAllowed` and recorded a
scanner error. The tick still reported OK (signals == actions), so it was
non-fatal, but it was accumulating log noise that masked real disposition
warnings.

This guards `ignore_disposed_ticket` and the symmetric `reopen_ticket`
(same re-emit hazard — `reopen` targets `started` but isn't a valid
transition from `started`) with django-fsm `can_proceed`, so an
already-satisfied desired state is a silent no-op instead of an every-tick
error. `complete_ticket` and `reviewer_task_orphaned` were already
idempotent and are unchanged.

## Test plan

- [x] Regression tests drive the handlers through `_execute_mechanical`
  (the path that turns the exception into the every-tick error) on a
  ticket already in `ignored` / `started`. Confirmed RED on pre-fix code
  (reproduces `Can't switch from state 'ignored' using method 'ignore'`),
  GREEN after.
- [x] Full `tests/teatree_loop/` suite passes (709 tests).
- [x] 100% coverage on `mechanical.py` including the new guard branches.
- [x] ruff check / ruff format --check / ty check clean on touched files.
- [x] `makemigrations --check --dry-run` reports no changes.

Closes #1087