### PR TITLE
chore(repo): ship .claudeignore for generated artifacts and large fixtures (#1027)

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,47 @@
+# Paths Claude Code's Read/Grep/Glob should skip. These are generated
+# artifacts, build output, third-party code, and large generated files that
+# add noise to searches without helping an agent understand the codebase.
+# Source, tests, skills, BLUEPRINT.md and docs prose stay readable.
+
+# Generated caches and build artifacts
+.venv/
+.ruff_cache/
+.pytest_cache/
+.mypy_cache/
+.tox/
+__pycache__/
+htmlcov/
+.coverage
+dist/
+build/
+*.egg-info/
+node_modules/
+site/
+
+# Sub-agent sidechain checkouts: Claude Code writes a full per-subagent
+# repo copy here, so every canonical file appears ~17 extra times in search.
+.claude/worktrees/
+
+# Third-party / package-manager dependency trees
+apm_modules/
+plugins/
+
+# Large generated artifacts (committed but noise for agents — the source
+# that produces them is what an agent should read instead)
+sbom.json
+uv.lock
+docs/generated/cli-reference.md
+*.min.js
+*.min.css
+*.map
+
+# Per-overlay generated E2E fixtures and run artifacts
+e2e/snapshot_tests_failures/
+e2e/.logs/
+e2e/.videos/
+
+# Per-ticket / loop runtime state regenerated from the DB, never authored
+.t3-cache/
+.t3-env.cache
+.t3.local.json
+.loop-review-state.json


### PR DESCRIPTION
Closes #1027.

Adds a `.claudeignore` at the repo root so the Read/Grep/Glob tools skip
generated artifacts, build output, sub-agent sidechain checkouts,
third-party dependency trees, and large committed-but-noisy files.

The biggest win is excluding `.claude/worktrees/`, the per-subagent
repo copies. Today a grep for any symbol in `hook_router.py` returns 18
hits — one canonical plus 17 sidechain duplicates.

`.gitignore` covers most of the runtime-generated entries already, but a
few are committed and intentionally kept in git while still being noise
for an agent: `sbom.json`, `uv.lock`, and the 262 KB generated
`docs/generated/cli-reference.md`. Those are listed explicitly here.

Source, tests, skills, `BLUEPRINT.md`, and docs prose are deliberately
not excluded — an agent needs to read them to do the work.

Pure data file; no code or tests touched. `ruff check`,
`ruff format --check`, `makemigrations --check --dry-run`, and the
pre-commit hooks are green.