### PR TITLE
fix(deps): bump idna to >=3.15 (GHSA-65pc-fj4g-8rjx) (#1093)

### DIFF
--- a/sbom.json
+++ b/sbom.json
@@ -257,7 +257,7 @@
     },
     {
       "bom-ref": "requirements-L53",
-      "description": "requirements line 53: idna==3.14",
+      "description": "requirements line 53: idna==3.15",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -266,9 +266,9 @@
         }
       ],
       "name": "idna",
-      "purl": "pkg:pypi/idna@3.14",
+      "purl": "pkg:pypi/idna@3.15",
       "type": "library",
-      "version": "3.14"
+      "version": "3.15"
     },
     {
       "bom-ref": "requirements-L57",

--- a/uv.lock
+++ b/uv.lock
@@ -580,11 +580,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`uv audit --preview-features audit` flagged `idna 3.14` for [GHSA-65pc-fj4g-8rjx](https://github.com/kjd/idna/security/advisories/GHSA-65pc-fj4g-8rjx) — specially crafted inputs to `idna.encode()` can bypass the CVE-2024-3651 fix (fixed upstream in 3.15). `idna` is a transitive dependency via httpx/anyio/requests, so `uv-audit` was RED on every open PR and on `main`, blocking all pending keystone merges.

Refreshed `uv.lock` so `idna` resolves to 3.15. No `pyproject.toml` constraint was needed (`uv lock --upgrade-package idna` moved it cleanly) and no source changed — the diff is lockfile-only (idna version line + 2 hashes).

## Verification

**Before** (`uv audit --preview-features audit`):

```
Found 1 known vulnerability and no adverse project statuses in 125 packages
idna 3.14 has 1 known vulnerability:
- GHSA-65pc-fj4g-8rjx: ... can bypass CVE-2024-3651 fix
  Fixed in: 3.15
```

**After**:

```
Found no known vulnerabilities and no adverse project statuses in 125 packages
```

## Test plan

- [x] `uv audit --preview-features audit` → no known vulnerabilities
- [x] Full suite green: `uv run pytest -q` → 5772 passed, 12 skipped, coverage 94.08%
- [x] `uv run ruff check .` + `uv run ruff format --check .` clean
- [x] Lockfile-only change (no source, no pyproject) — no new test warranted; existing full suite is the idna-3.15 regression guard

Closes #1093