### PR TITLE
test(slack): make post/reply token-routing tests hermetic; tighten _is_ext_shared docstring

### DIFF
--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -156,8 +156,13 @@ class SlackBotBackend:
         can always *read* channel metadata even on channels it cannot
         *post* to.  The answer is cached per channel id for the lifetime
         of the backend so repeat posts to the same channel probe once.
-        On any lookup failure we treat the channel as internal so the
-        policy fails safe to the bot token (the legacy behaviour).
+        On any API-level lookup failure (``ok:false`` — bad token, missing
+        scope, channel not found) we treat the channel as internal so the
+        policy fails safe to the bot token (the legacy behaviour). A
+        transport-level failure (5xx / connection error) instead propagates
+        out of ``_get``'s ``raise_for_status()`` through ``_channel_token``
+        and aborts the post — still conservative (no wrong-token send), but
+        the call does not complete.
         """
         cached = self._ext_shared_cache.get(channel)
         if cached is not None:

--- a/tests/teatree_backends/test_slack_user_token_routing.py
+++ b/tests/teatree_backends/test_slack_user_token_routing.py
@@ -51,6 +51,24 @@ def _capturing_get(captured: list[dict[str, object]]) -> object:
     return fake_get
 
 
+def _internal_channel_get(url: str, **kwargs: object) -> httpx.Response:
+    """Stub ``conversations.info`` as a non-Connect (internal) channel.
+
+    Keeps the post/reply token-routing tests hermetic: without this the
+    ``_channel_token`` → ``_is_ext_shared`` → ``_get`` path escapes to a
+    real ``slack.com`` GET. ``is_ext_shared: False`` keeps routing on the
+    bot token so the ``Bearer xoxb-bot`` assertions hold (the file's
+    ``_capturing_get`` forces ``True`` for the Connect-channel reaction
+    tests and would flip the asserted token here).
+    """
+    assert url.endswith("/conversations.info")
+    return httpx.Response(
+        200,
+        json={"ok": True, "channel": {"is_ext_shared": False}},
+        request=httpx.Request("GET", url),
+    )
+
+
 class TestReactRoutesThroughUserToken:
     """``react`` uses the user token on Slack-Connect channels (#1072)."""
 
@@ -120,6 +138,8 @@ class TestBotTokenStillAuthorisesNonReactionCalls:
         captured: list[dict[str, object]] = []
         monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
 
+        monkeypatch.setattr(slack_bot.httpx, "get", _internal_channel_get)
+
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_message(channel="C", text="hi")
 
@@ -130,6 +150,8 @@ class TestBotTokenStillAuthorisesNonReactionCalls:
     def test_post_reply_uses_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
         monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+
+        monkeypatch.setattr(slack_bot.httpx, "get", _internal_channel_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_reply(channel="C", ts="1.0", text="hi")


### PR DESCRIPTION
test(slack): make post/reply token-routing tests hermetic; tighten _is_ext_shared docstring

The two TestBotTokenStillAuthorisesNonReactionCalls cases
(test_post_message_uses_bot_token / test_post_reply_uses_bot_token)
only patched httpx.post. Post-#1072 post_message/post_reply route
through _channel_token -> _is_ext_shared -> _get("conversations.info"),
which called the unmocked httpx.get and escaped to slack.com (passing
only because Slack returned ok:false -> fail-safe to bot). Patch
httpx.get in both with an internal-channel (is_ext_shared:False) stub
so routing stays on the bot token and the Bearer xoxb-bot assertions
still hold; the stub asserts the URL ends with /conversations.info so
an unexpected GET is loud. No other test in the file is non-hermetic.

The _is_ext_shared docstring claimed any lookup failure fails safe to
the bot token. That holds only for API-level failure (ok:false). A
transport-level 5xx makes _get's raise_for_status() propagate through
_channel_token and abort the post (still conservative -- no wrong-token
send -- but the call does not complete). Docstring-only: swallowing the
5xx to post on the bot token would regress the #1084
fail-safe-toward-not-posting behaviour, so code is unchanged.

Relates to #1083