### PR TITLE
chore: merge origin/main into s-teatree-1065 (notify.py conflict-free, slack_bot.py from main)

### DIFF
--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -19,12 +19,13 @@ import enum
 import logging
 import re
 
-from django.db import IntegrityError, transaction
+from django.db import DatabaseError, IntegrityError, transaction
 
 from teatree.backends.protocols import MessagingBackend
 from teatree.config import get_effective_settings, load_config
 from teatree.core.backend_factory import messaging_from_overlay
 from teatree.core.models import BotPing, OutboundClaim
+from teatree.core.session_identity import current_session_id
 from teatree.slack_mrkdwn import normalize_slack_message, slack_linkify
 
 logger = logging.getLogger(__name__)
@@ -233,7 +234,14 @@ def _record_outbound_claim(
     because :mod:`teatree.outbound_claim` lives outside ``teatree.core``
     and adding ``teatree.core → teatree.outbound_claim`` would cycle
     through ``teatree.outbound_claim → teatree.core``.
+
+    Unlike the sibling :func:`teatree.outbound_claim.record_claim` (which
+    returns ``OutboundClaim | None``), this helper intentionally returns
+    ``None``: there is no consumer of the row here (the publish path
+    ignores it), so adding a return value would be dead code — a future
+    sibling-sync pass should not "fix" this asymmetry.
     """
+    session_id = current_session_id()
     try:
         with transaction.atomic():
             OutboundClaim.objects.get_or_create(
@@ -241,11 +249,14 @@ def _record_outbound_claim(
                 defaults={
                     "kind": OutboundClaim.Kind.SLACK_DM.value,
                     "target_url": target_url,
+                    "agent_session_id": session_id,
                     "extra": {"channel": channel, "ts": posted_ts},
                 },
             )
     except IntegrityError:
         logger.debug("notify_user outbound-claim race on key=%s", idempotency_key)
+    except DatabaseError as exc:
+        logger.warning("notify_user outbound-claim DB failure for key=%s: %s", idempotency_key, exc)
     except Exception as exc:  # noqa: BLE001 — claim ledger is best-effort
         logger.debug("notify_user outbound-claim record failed for key=%s: %s", idempotency_key, exc)
 

--- a/tests/teatree_core/test_notify_outbound_claim.py
+++ b/tests/teatree_core/test_notify_outbound_claim.py
@@ -66,3 +66,46 @@ class NotifyUserRecordsOutboundClaimTests(TestCase):
                 user_id="U_ME",
             )
         assert not OutboundClaim.objects.filter(idempotency_key="slack_dm:disabled-key").exists()
+
+    def test_slack_dm_claim_records_agent_session_id(self) -> None:
+        # Mirrors the GitLab/Notion path's
+        # ``test_resolves_agent_session_id_from_env`` (#1065 Nit 1): the
+        # inline Slack-DM writer must populate ``agent_session_id`` so the
+        # audit ledger's cross-reference stays symmetric with the rows
+        # ``record_claim`` writes.
+        from unittest.mock import patch  # noqa: PLC0415
+
+        with patch.dict("os.environ", {"CLAUDE_SESSION_ID": "sess-123"}, clear=False):
+            sent = notify_user(
+                "tests passing",
+                kind=NotifyKind.INFO,
+                idempotency_key="sess=z;turn=1",
+                backend=_backend(),
+                user_id="U_ME",
+            )
+        assert sent is True
+        claim = OutboundClaim.objects.get(idempotency_key="slack_dm:sess=z;turn=1")
+        assert claim.agent_session_id == "sess-123"
+
+    def test_database_error_is_swallowed_publish_path_unbroken(self) -> None:
+        # #1065 Nit 2.2: a DB outage of the audit ledger must degrade the
+        # claim record to a no-op (warning log) without turning the
+        # already-succeeded Slack post into a user-visible failure.
+        from unittest.mock import patch  # noqa: PLC0415
+
+        from django.db import DatabaseError  # noqa: PLC0415
+
+        with patch.object(
+            OutboundClaim.objects,
+            "get_or_create",
+            side_effect=DatabaseError("ledger unavailable"),
+        ):
+            sent = notify_user(
+                "tests passing",
+                kind=NotifyKind.INFO,
+                idempotency_key="db-error-key",
+                backend=_backend(),
+                user_id="U_ME",
+            )
+        assert sent is True
+        assert not OutboundClaim.objects.filter(idempotency_key="slack_dm:db-error-key").exists()


### PR DESCRIPTION
chore: merge origin/main into s-teatree-1065 (notify.py conflict-free, slack_bot.py from main)

Merge brings #1097/#1096/#1100 (slack_bot.py _is_ext_shared docstring,
token-routing test hermeticity). Disjoint file sets — no textual
conflicts. The reviewed #1065 notify.py change is byte-intact (empty
diff vs b152b2ce); slack_bot.py taken from main verbatim.