### PR TITLE
fix(loop): route hook_router cadence reads + README through shared resolver (#1036)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ t3 loop tick
 t3 loop status
 ```
 
-The cadence is configurable via `T3_LOOP_CADENCE` (seconds, default `720`). To stop the loop, run `/loop unregister t3-loop` in the Claude Code session.
+The cadence is configurable via `T3_LOOP_CADENCE` (seconds), or by setting `loop_cadence_seconds` in `~/.teatree.toml` (env wins; default `720`). To stop the loop, run `/loop unregister t3-loop` in the Claude Code session.
 
 **Wire up the Claude Code statusline hook** so the rendered file actually shows in the bottom bar. Either enable the `t3` plugin (the plugin's `settings.json` registers the hook automatically), or add it to `~/.claude/settings.json`:
 

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -270,12 +270,39 @@ _LOOP_CADENCE_DEFAULT = 720
 _LOOP_PROMPT = "Run `t3 loop tick` in Bash, then briefly report the tick summary."
 
 
+def _loop_cadence_seconds() -> int:
+    """Resolve the loop cadence the same way ``t3 loop`` does (#1036).
+
+    Routes through the shared ``teatree.config.cadence_seconds()`` resolver
+    (``T3_LOOP_CADENCE`` env first, then ``~/.teatree.toml``
+    ``loop_cadence_seconds``) so the hook's tick-staleness window and the
+    loop-registration cron minutes can never diverge from the real slot
+    cadence. Best-effort: if ``teatree`` is not importable in this hook
+    process, fall back to the env-only read.
+    """
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    added = False
+    try:
+        if str(src_dir) not in sys.path:
+            sys.path.insert(0, str(src_dir))
+            added = True
+        from teatree.config import cadence_seconds  # noqa: PLC0415
+
+        return cadence_seconds()
+    except Exception:  # noqa: BLE001
+        return int(os.environ.get("T3_LOOP_CADENCE", _LOOP_CADENCE_DEFAULT) or _LOOP_CADENCE_DEFAULT)
+    finally:
+        if added:
+            with contextlib.suppress(ValueError):
+                sys.path.remove(str(src_dir))
+
+
 def _tick_meta_stale() -> bool:
     xdg = os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share"))
     meta = Path(xdg) / "teatree" / "tick-meta.json"
     if not meta.is_file():
         return True
-    cadence = int(os.environ.get("T3_LOOP_CADENCE", _LOOP_CADENCE_DEFAULT) or _LOOP_CADENCE_DEFAULT)
+    cadence = _loop_cadence_seconds()
     import time  # noqa: PLC0415
 
     age = int(time.time()) - int(meta.stat().st_mtime)
@@ -320,7 +347,7 @@ def handle_enforce_loop_on_prompt(data: dict) -> None:
         return
     if not _tick_meta_stale():
         return
-    cadence = int(os.environ.get("T3_LOOP_CADENCE", _LOOP_CADENCE_DEFAULT) or _LOOP_CADENCE_DEFAULT)
+    cadence = _loop_cadence_seconds()
     minutes = max(1, cadence // 60)
     pending.write_text("1", encoding="utf-8")
     print(  # noqa: T201
@@ -344,7 +371,7 @@ def handle_enforce_loop_registration(data: dict) -> bool:
     if _session_has_loop(session_id):
         pending.unlink(missing_ok=True)
         return False
-    cadence = int(os.environ.get("T3_LOOP_CADENCE", _LOOP_CADENCE_DEFAULT) or _LOOP_CADENCE_DEFAULT)
+    cadence = _loop_cadence_seconds()
     minutes = max(1, cadence // 60)
     reason = (
         f"The teatree background loop is not registered yet. "

--- a/src/teatree/cli/loop.py
+++ b/src/teatree/cli/loop.py
@@ -38,6 +38,7 @@ import typer
 
 from teatree.cli.loop_owner import register as register_loop_owner
 from teatree.cli.loop_slack_answer import slack_answer_app
+from teatree.config import cadence_seconds
 from teatree.loop.statusline import default_path
 
 loop_app = typer.Typer(
@@ -225,12 +226,13 @@ def spawn_claim_command(
 
 
 def _cadence_for_loop_slot() -> str:
-    """Return the ``/loop <duration>`` argument from ``T3_LOOP_CADENCE`` (seconds, default 720)."""
-    raw = os.environ.get("T3_LOOP_CADENCE", "720").strip() or "720"
-    try:
-        seconds = max(60, int(raw))
-    except ValueError:
-        seconds = 720
+    """Return the ``/loop <duration>`` argument.
+
+    The cadence is resolved by :func:`cadence_seconds` — ``T3_LOOP_CADENCE``
+    env first, then ``~/.teatree.toml`` ``loop_cadence_seconds`` (per-overlay
+    override, then global ``[teatree]``), then the 720 default.
+    """
+    seconds = cadence_seconds()
     if seconds % 60 == 0:
         return f"{seconds // 60}m"
     return f"{seconds}s"
@@ -283,7 +285,10 @@ def start_command(
         typer.echo("Run this in your interactive Claude Code session to register the loop:")
         typer.echo(f"    {register_command}")
         typer.echo("")
-        typer.echo("Override the cadence with `T3_LOOP_CADENCE=<seconds> t3 loop start` (default 720).")
+        typer.echo(
+            "Override the cadence with `T3_LOOP_CADENCE=<seconds> t3 loop start`, or set"
+            " `loop_cadence_seconds` in `~/.teatree.toml` (env wins; default 720)."
+        )
         typer.echo("")
         typer.echo(
             "The tick scans, dispatches, persists agent dispatches as Ticket+Task DB"

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -463,6 +463,31 @@ def get_effective_settings() -> UserSettings:
     return replace(base, **overrides)
 
 
+def cadence_seconds() -> int:
+    """Resolve the loop slot cadence in seconds (minimum 60s).
+
+    This setting is not registered in ``ENV_SETTING_OVERRIDES`` — its env
+    layer is a bespoke direct read, so its resolution does NOT go through
+    the generic effective-settings env layer. Layers, first match wins:
+    first the ``T3_LOOP_CADENCE`` env var (the bespoke direct read), then
+    ``get_effective_settings().loop_cadence_seconds`` which covers the
+    per-overlay ``[overlays.<name>]`` override, then the global
+    ``[teatree]`` value in ``~/.teatree.toml``, then the ``UserSettings``
+    default of 720.
+
+    Any ``T3_LOOP_CADENCE`` parse failure falls back to 720. The result is
+    clamped to a 60s minimum so a misconfigured tiny value cannot busy-loop
+    the tick.
+    """
+    raw = os.environ.get("T3_LOOP_CADENCE")
+    if raw is not None and raw.strip():
+        try:
+            return max(60, int(raw.strip()))
+        except ValueError:
+            return 720
+    return max(60, get_effective_settings().loop_cadence_seconds)
+
+
 def _active_overlay_entry() -> OverlayEntry | None:
     """Find the active overlay's toml entry (carrying any overrides).
 

--- a/src/teatree/loop/tick_freshness.py
+++ b/src/teatree/loop/tick_freshness.py
@@ -110,6 +110,7 @@ def _collect_repo_freshness() -> dict[str, dict[str, int | str]]:
 
 
 def _write_tick_meta(started_at: dt.datetime, *, target: Path | None = None) -> None:
+    from teatree.config import cadence_seconds  # noqa: PLC0415
     from teatree.loop.statusline import default_path  # noqa: PLC0415
 
     meta_path = (target or default_path()).with_name("tick-meta.json")
@@ -118,7 +119,9 @@ def _write_tick_meta(started_at: dt.datetime, *, target: Path | None = None) -> 
     # ensure the parent exists so an observability write never crashes
     # the tick (or the skipped-tick freshness touch).
     meta_path.parent.mkdir(parents=True, exist_ok=True)
-    cadence = int(os.environ.get("T3_LOOP_CADENCE", "720") or "720")
+    # #1036: share the slot's cadence resolver so the displayed next-tick
+    # countdown can never diverge from the real loop cadence.
+    cadence = cadence_seconds()
     next_epoch = int(started_at.timestamp()) + cadence
     freshness = _collect_repo_freshness()
     meta_path.write_text(

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -80,6 +80,23 @@ def test_tick_with_no_scanners_writes_tick_meta(tmp_path: Path) -> None:
     assert data["cadence"] == 720
 
 
+def test_tick_meta_cadence_falls_back_to_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # #1036: tick-meta.json `cadence` (drives the statusline next-tick
+    # countdown) must honor ~/.teatree.toml loop_cadence_seconds when
+    # T3_LOOP_CADENCE is unset, never diverging from the slot cadence.
+    monkeypatch.delenv("T3_LOOP_CADENCE", raising=False)
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text("[teatree]\nloop_cadence_seconds = 300\n", encoding="utf-8")
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+    statusline = tmp_path / "statusline.txt"
+    started = dt.datetime(2026, 5, 6, tzinfo=dt.UTC)
+    run_tick(TickRequest(scanners=[]), statusline_path=statusline, now=started)
+    meta = tmp_path / "tick-meta.json"
+    data = json.loads(meta.read_text(encoding="utf-8"))
+    assert data["cadence"] == 300
+    assert data["next_epoch"] == int(started.timestamp()) + 300
+
+
 def test_repo_freshness_on_real_git_repo(tmp_path: Path) -> None:
     from teatree.utils.run import run_allowed_to_fail  # noqa: PLC0415
 

--- a/tests/test_cli_loop.py
+++ b/tests/test_cli_loop.py
@@ -87,6 +87,24 @@ class TestCadenceParser:
         monkeypatch.delenv("T3_LOOP_CADENCE", raising=False)
         assert _cadence_for_loop_slot() == "12m"
 
+    def test_uses_toml_cadence_when_env_unset(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # #1036: with no T3_LOOP_CADENCE env, the slot cadence must fall
+        # back to ~/.teatree.toml [teatree] loop_cadence_seconds, not the
+        # hardcoded 720 default.
+        monkeypatch.delenv("T3_LOOP_CADENCE", raising=False)
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text("[teatree]\nloop_cadence_seconds = 60\n", encoding="utf-8")
+        monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+        assert _cadence_for_loop_slot() == "1m"
+
+    def test_env_overrides_toml_cadence(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # #1036: env wins over toml (established sibling precedence).
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text("[teatree]\nloop_cadence_seconds = 60\n", encoding="utf-8")
+        monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+        monkeypatch.setenv("T3_LOOP_CADENCE", "600")
+        assert _cadence_for_loop_slot() == "10m"
+
 
 class TestStartCommand:
     def test_print_only_emits_slash_command(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_hook_router_cadence_hook.py
+++ b/tests/test_hook_router_cadence_hook.py
@@ -1,0 +1,132 @@
+"""Tests for hook_router loop-cadence consistency (#1036).
+
+``_tick_meta_stale`` (staleness window = cadence*2) and the
+loop-registration cron-minutes computation must resolve the loop cadence
+through the shared ``teatree.config.cadence_seconds`` resolver, so they
+honor ``~/.teatree.toml`` ``loop_cadence_seconds`` and never diverge from
+the real slot cadence registered by ``t3 loop``.
+
+Integration-style: real ``hook_router`` helper, real ``teatree.config``
+loader pointed at a tmp ``.teatree.toml``; only the clock-dependent
+tick-meta mtime is staged on disk.
+"""
+
+import time
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import _tick_meta_stale, handle_enforce_loop_on_prompt, handle_enforce_loop_registration
+
+
+def test_loop_cadence_seconds_honors_toml_when_env_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # #1036: with no T3_LOOP_CADENCE env, the hook cadence must fall back
+    # to ~/.teatree.toml loop_cadence_seconds, not the hardcoded 720.
+    monkeypatch.delenv("T3_LOOP_CADENCE", raising=False)
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text("[teatree]\nloop_cadence_seconds = 60\n", encoding="utf-8")
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+    from hooks.scripts.hook_router import _loop_cadence_seconds  # noqa: PLC0415
+
+    assert _loop_cadence_seconds() == 60
+
+
+def test_tick_meta_stale_uses_toml_cadence_window(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # #1036: staleness window is cadence*2. With toml cadence 60s (env
+    # unset), a 200s-old tick-meta is stale (200 > 120). Pre-fix this read
+    # env-only -> default 720 -> window 1440s -> 200 < 1440 -> NOT stale,
+    # so this asserts the toml-aware behavior (RED pre-fix, GREEN after).
+    monkeypatch.delenv("T3_LOOP_CADENCE", raising=False)
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text("[teatree]\nloop_cadence_seconds = 60\n", encoding="utf-8")
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+
+    data_home = tmp_path / "xdg"
+    meta_dir = data_home / "teatree"
+    meta_dir.mkdir(parents=True)
+    meta = meta_dir / "tick-meta.json"
+    meta.write_text('{"next_epoch": 0, "cadence": 60}\n', encoding="utf-8")
+    old = time.time() - 200
+    import os  # noqa: PLC0415
+
+    os.utime(meta, (old, old))
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+
+    assert _tick_meta_stale() is True
+
+
+def test_enforce_loop_on_prompt_emits_toml_cron_minutes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # #1036: the loop-registration cron minutes must match the toml
+    # cadence (1800s -> */30). Pre-fix env-only -> 720 -> */12.
+    monkeypatch.delenv("T3_LOOP_CADENCE", raising=False)
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text("[teatree]\nloop_cadence_seconds = 1800\n", encoding="utf-8")
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+
+    data_home = tmp_path / "xdg"
+    (data_home / "teatree").mkdir(parents=True)
+    monkeypatch.setenv("XDG_DATA_HOME", str(data_home))
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setattr(router, "STATE_DIR", state)
+
+    handle_enforce_loop_on_prompt({"session_id": "s-1036"})
+    out = capsys.readouterr().out
+    assert "*/30 * * * *" in out
+
+
+def test_enforce_loop_registration_uses_toml_cron_minutes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # #1036: the PreToolUse deny reason's cron minutes must also match the
+    # toml cadence (1800s -> */30). Covers the third hook_router reader.
+    monkeypatch.delenv("T3_LOOP_CADENCE", raising=False)
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text("[teatree]\nloop_cadence_seconds = 1800\n", encoding="utf-8")
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setattr(router, "STATE_DIR", state)
+    (state / "s-1036.loop-pending").write_text("1", encoding="utf-8")
+
+    blocked = handle_enforce_loop_registration({"session_id": "s-1036", "tool_name": "Bash"})
+    assert blocked is True
+    assert "*/30 * * * *" in capsys.readouterr().out
+
+
+def test_loop_cadence_seconds_falls_back_to_env_when_teatree_unimportable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #1036: best-effort — if teatree.config cannot resolve, the helper
+    # falls back to the env-only read (covers the except branch).
+    monkeypatch.setenv("T3_LOOP_CADENCE", "240")
+
+    def _boom() -> int:
+        msg = "teatree unavailable in this hook process"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("teatree.config.cadence_seconds", _boom)
+    from hooks.scripts.hook_router import _loop_cadence_seconds  # noqa: PLC0415
+
+    assert _loop_cadence_seconds() == 240
+
+
+def test_loop_cadence_seconds_inserts_src_on_path_when_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # #1036: covers the sys.path-insert + finally-cleanup branch taken
+    # when the hook process does not already have teatree's src on path.
+    import sys  # noqa: PLC0415
+
+    src_dir = str(Path(router.__file__).resolve().parents[2] / "src")
+    monkeypatch.setattr(sys, "path", [p for p in sys.path if p != src_dir])
+    monkeypatch.delenv("T3_LOOP_CADENCE", raising=False)
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text("[teatree]\nloop_cadence_seconds = 120\n", encoding="utf-8")
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+    from hooks.scripts.hook_router import _loop_cadence_seconds  # noqa: PLC0415
+
+    assert _loop_cadence_seconds() == 120
+    assert src_dir not in sys.path


### PR DESCRIPTION
fix(loop): route hook_router cadence reads + README through shared resolver (#1036)

Review delta for #1036. README.md still documented the loop cadence as
T3_LOOP_CADENCE-only — align it with the start_command help (env wins;
loop_cadence_seconds in ~/.teatree.toml; default 720). hook_router's
_tick_meta_stale staleness window and the loop-registration cron-minutes
(three env-only readers) bypassed the shared resolver, so a toml-only
loop_cadence_seconds left the hook emitting the wrong cron and a wrong
staleness window. Add _loop_cadence_seconds() routing through
teatree.config.cadence_seconds() via the established best-effort
sys.path bootstrap (falls back to env-only if teatree is unimportable in
the hook process) and route all three reads through it. New RED-first
hook_router cadence-consistency tests cover all branches.