### PR TITLE
fix(migrations): 0027 must merge legacy 'teatree' overlay rows that collide on unique keys

### DIFF
--- a/src/teatree/core/migrations/0027_canonicalize_teatree_overlay.py
+++ b/src/teatree/core/migrations/0027_canonicalize_teatree_overlay.py
@@ -10,6 +10,16 @@ data migration collapses every such row to the canonical ``t3-teatree``
 across all overlay-carrying models so discovery, the statusline, and the
 overlay-keyed selectors stop treating the two as distinct overlays.
 
+souliane/teatree#1154: a naive bulk ``UPDATE`` raises
+``IntegrityError`` (UNIQUE constraint failed) on any row whose
+overlay-keyed unique constraint key already has a canonical
+``t3-teatree`` twin (observed: 43 of 44 legacy rows in
+``PendingChatInjection`` on a real database). Before the update, we
+delete legacy rows whose tuple already matches a canonical row on any
+``(overlay, *others)`` unique constraint — the canonical row already
+carries the data, so the duplicate collapses into it. The non-colliding
+legacy rows are then canonicalized by the unchanged ``UPDATE``.
+
 No ``AlterField`` is emitted: the ``overlay`` field type is unchanged, so
 ``makemigrations --check`` stays "No changes".
 """
@@ -17,6 +27,7 @@ No ``AlterField`` is emitted: the ``overlay`` field type is unchanged, so
 from django.db import migrations
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
+from django.db.models import Model, Q, UniqueConstraint
 
 _OVERLAY_MODELS = (
     "Ticket",
@@ -28,9 +39,43 @@ _OVERLAY_MODELS = (
 )
 
 
+def _delete_legacy_rows_with_canonical_twin(model: type[Model]) -> None:
+    """Drop legacy ``overlay='teatree'`` rows whose other-field tuple already has a canonical twin.
+
+    Iterates over every unique constraint that names ``overlay`` plus at
+    least one other field. For each, the set of other-field tuples on
+    canonical rows is the merge key — any legacy row matching one of
+    those tuples would raise ``IntegrityError`` on the upcoming
+    ``UPDATE``, so we delete it (the canonical row survives as the
+    merged record).
+    """
+    # ``Model._meta`` is Django's documented public API for model introspection
+    # despite the leading underscore — see Django docs § "Model _meta API".
+    overlay_keyed_constraints = [
+        c
+        for c in model._meta.constraints  # noqa: SLF001
+        if isinstance(c, UniqueConstraint) and "overlay" in c.fields and len(c.fields) > 1
+    ]
+    if not overlay_keyed_constraints:
+        return
+    for constraint in overlay_keyed_constraints:
+        other_fields = [f for f in constraint.fields if f != "overlay"]
+        canonical_tuples = set(model.objects.filter(overlay="t3-teatree").values_list(*other_fields))
+        if not canonical_tuples:
+            continue
+        # Multi-column ``IN (tuple, tuple, …)`` is not portable across the
+        # backends teatree supports, so build an explicit ``OR`` chain of
+        # equality clauses — one ``Q`` per canonical tuple.
+        collision_q = Q()
+        for tup in canonical_tuples:
+            collision_q |= Q(**dict(zip(other_fields, tup, strict=True)))
+        model.objects.filter(overlay="teatree").filter(collision_q).delete()
+
+
 def _canonicalize_teatree_overlay(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
     for model_name in _OVERLAY_MODELS:
         model = apps.get_model("core", model_name)
+        _delete_legacy_rows_with_canonical_twin(model)
         model.objects.filter(overlay="teatree").update(overlay="t3-teatree")
 
 

--- a/tests/test_migration_0027_canonicalize_overlay.py
+++ b/tests/test_migration_0027_canonicalize_overlay.py
@@ -1,0 +1,156 @@
+"""Regression tests for ``core.0027_canonicalize_teatree_overlay``.
+
+souliane/teatree#1154: migration 0027 originally issued a bulk
+``filter(overlay='teatree').update(overlay='t3-teatree')``. On any model
+whose unique constraint involves ``overlay`` plus another field, a legacy
+``teatree`` row sharing the other-field values with an existing
+``t3-teatree`` row raises ``IntegrityError`` (UNIQUE constraint failed),
+which then poisons the surrounding transaction.
+
+These tests pin the merge behaviour: a legacy row that collides with a
+canonical twin is deleted; non-colliding legacy rows are still
+canonicalized; the multi-field constraint path (``ReviewAssignment``) is
+exercised so the constraint iteration is not silently single-field.
+"""
+
+import importlib
+
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+# The migration module starts with a digit so it cannot be imported via the
+# normal ``from ... import`` syntax; use ``importlib`` directly.
+_migration_module = importlib.import_module("teatree.core.migrations.0027_canonicalize_teatree_overlay")
+
+
+class CanonicalizeTeatreeOverlayCollisionMigrationTest(TransactionTestCase):
+    """0027 must merge legacy ``teatree`` rows that collide with canonical twins."""
+
+    _BEFORE = ("core", "0026_pending_chat_loop_reply_fields")
+    _AFTER = ("core", "0027_canonicalize_teatree_overlay")
+
+    def _migrate(self, target: tuple[str, str]) -> "object":
+        executor = MigrationExecutor(connection)
+        executor.migrate([target])
+        executor.loader.build_graph()
+        return executor.loader.project_state([target]).apps
+
+    def _restore_head(self) -> None:
+        """Re-apply 0027 so TransactionTestCase teardown flushes the real schema."""
+        self._migrate(self._AFTER)
+
+    def test_pending_chat_legacy_row_with_canonical_twin_is_deleted(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        pending = apps.get_model("core", "PendingChatInjection")
+        now = timezone.now()
+        canonical = pending.objects.create(
+            overlay="t3-teatree", channel="C1", slack_ts="1700000000.000100", text="canonical", received_at=now
+        )
+        legacy = pending.objects.create(
+            overlay="teatree", channel="C1", slack_ts="1700000000.000100", text="legacy", received_at=now
+        )
+
+        _migration_module._canonicalize_teatree_overlay(apps, connection.schema_editor())
+
+        survivors = list(pending.objects.filter(slack_ts="1700000000.000100"))
+        assert len(survivors) == 1, f"expected one survivor, got {[(s.pk, s.overlay, s.text) for s in survivors]}"
+        assert survivors[0].pk == canonical.pk, "canonical row must be the survivor"
+        assert survivors[0].overlay == "t3-teatree"
+        assert not pending.objects.filter(pk=legacy.pk).exists(), "legacy colliding row must be deleted"
+
+        self._restore_head()
+
+    def test_pending_chat_legacy_row_without_twin_is_canonicalized(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        pending = apps.get_model("core", "PendingChatInjection")
+        now = timezone.now()
+        legacy = pending.objects.create(
+            overlay="teatree", channel="C1", slack_ts="1700000000.000200", text="legacy-only", received_at=now
+        )
+
+        _migration_module._canonicalize_teatree_overlay(apps, connection.schema_editor())
+
+        legacy.refresh_from_db()
+        assert legacy.overlay == "t3-teatree"
+        assert pending.objects.filter(slack_ts="1700000000.000200").count() == 1
+
+        self._restore_head()
+
+    def test_review_assignment_multi_field_constraint_collision_merges(self) -> None:
+        """Exercise the multi-field (overlay, mr_url, user_id) constraint path."""
+        apps = self._migrate(self._BEFORE)
+        review = apps.get_model("core", "ReviewAssignment")
+        now = timezone.now()
+        canonical = review.objects.create(
+            overlay="t3-teatree",
+            mr_url="https://example.com/mr/9001",
+            user_id="U9001",
+            channel="C9001",
+            slack_ts="1700000000.900100",
+            observed_at=now,
+        )
+        legacy = review.objects.create(
+            overlay="teatree",
+            mr_url="https://example.com/mr/9001",
+            user_id="U9001",
+            channel="C9001",
+            slack_ts="1700000000.900101",
+            observed_at=now,
+        )
+
+        _migration_module._canonicalize_teatree_overlay(apps, connection.schema_editor())
+
+        survivors = list(review.objects.filter(mr_url="https://example.com/mr/9001", user_id="U9001"))
+        assert len(survivors) == 1
+        assert survivors[0].pk == canonical.pk
+        assert survivors[0].overlay == "t3-teatree"
+        assert not review.objects.filter(pk=legacy.pk).exists()
+
+        self._restore_head()
+
+    def test_review_assignment_non_colliding_legacy_row_is_canonicalized(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        review = apps.get_model("core", "ReviewAssignment")
+        now = timezone.now()
+        legacy = review.objects.create(
+            overlay="teatree",
+            mr_url="https://example.com/mr/9002",
+            user_id="U9002",
+            channel="C9002",
+            slack_ts="1700000000.900200",
+            observed_at=now,
+        )
+
+        _migration_module._canonicalize_teatree_overlay(apps, connection.schema_editor())
+
+        legacy.refresh_from_db()
+        assert legacy.overlay == "t3-teatree"
+
+        self._restore_head()
+
+    def test_pending_chat_many_collisions_are_all_merged(self) -> None:
+        """Mirror the real-DB shape: many legacy rows colliding on shared slack_ts."""
+        apps = self._migrate(self._BEFORE)
+        pending = apps.get_model("core", "PendingChatInjection")
+        now = timezone.now()
+        canonicals: list[object] = []
+        for i in range(5):
+            ts = f"1700000000.0003{i:02d}"
+            canonicals.append(
+                pending.objects.create(
+                    overlay="t3-teatree", channel="C1", slack_ts=ts, text=f"canonical-{i}", received_at=now
+                )
+            )
+            pending.objects.create(overlay="teatree", channel="C1", slack_ts=ts, text=f"legacy-{i}", received_at=now)
+
+        _migration_module._canonicalize_teatree_overlay(apps, connection.schema_editor())
+
+        for c in canonicals:
+            survivors = pending.objects.filter(slack_ts=c.slack_ts)
+            assert survivors.count() == 1
+            assert survivors.first().pk == c.pk
+        assert not pending.objects.filter(overlay="teatree").exists()
+
+        self._restore_head()


### PR DESCRIPTION
Closes [#1154](https://github.com/souliane/teatree/issues/1154).

## Summary

Migration `core.0027_canonicalize_teatree_overlay` raised `IntegrityError` (and cascading `TransactionManagementError`) on any model whose unique constraint involves `overlay` plus another field, when a legacy `overlay='teatree'` row shared its other-field values with an existing `overlay='t3-teatree'` row.

Observed on a real database: 44 rows in `PendingChatInjection` with `overlay='teatree'`; 43 of those shared `slack_ts` with a `t3-teatree` twin. The very first colliding `UPDATE` raised `UNIQUE constraint failed: core_pendingchatinjection.overlay, core_pendingchatinjection.slack_ts`, the transaction went into a broken state, and every subsequent `migrate` / `t3 teatree ticket clear` / `ticket merge` failed.

## Fix

For each model in `_OVERLAY_MODELS`, iterate over the unique constraints that name `overlay` plus at least one other field. For each such constraint, collect the set of other-field tuples on canonical `t3-teatree` rows, then delete the legacy `teatree` rows whose tuple matches one of those — the canonical row already carries the data, so the duplicate collapses into it. The unchanged `UPDATE` then canonicalizes the remaining (non-colliding) legacy rows.

Affected constraints on `HEAD`:

- `PendingChatInjection.uniq_pendingchat_overlay_ts` on `(overlay, slack_ts)` — observed collision shape.
- `ReviewAssignment.uniq_reviewassignment_overlay_mr_user` on `(overlay, mr_url, user_id)` — zero affected rows at coordination time; structurally identical risk.

`Ticket.unique_nonempty_issue_url` does NOT name `overlay`, so it is not handled by this loop (the iteration filter `"overlay" in c.fields` correctly skips it).

## RED -> GREEN evidence

**RED** (pre-fix code on the same test):

```
django.db.utils.IntegrityError: UNIQUE constraint failed: teatree_pending_chat_injection.overlay, teatree_pending_chat_injection.slack_ts
FAILED tests/test_migration_0027_canonicalize_overlay.py::CanonicalizeTeatreeOverlayCollisionMigrationTest::test_pending_chat_legacy_row_with_canonical_twin_is_deleted
```

**GREEN** (post-fix, all 5 tests in `tests/test_migration_0027_canonicalize_overlay.py`):

```
tests/test_migration_0027_canonicalize_overlay.py::CanonicalizeTeatreeOverlayCollisionMigrationTest::test_pending_chat_legacy_row_with_canonical_twin_is_deleted PASSED
tests/test_migration_0027_canonicalize_overlay.py::CanonicalizeTeatreeOverlayCollisionMigrationTest::test_pending_chat_legacy_row_without_twin_is_canonicalized PASSED
tests/test_migration_0027_canonicalize_overlay.py::CanonicalizeTeatreeOverlayCollisionMigrationTest::test_pending_chat_many_collisions_are_all_merged PASSED
tests/test_migration_0027_canonicalize_overlay.py::CanonicalizeTeatreeOverlayCollisionMigrationTest::test_review_assignment_multi_field_constraint_collision_merges PASSED
tests/test_migration_0027_canonicalize_overlay.py::CanonicalizeTeatreeOverlayCollisionMigrationTest::test_review_assignment_non_colliding_legacy_row_is_canonicalized PASSED

============================== 5 passed in 0.88s ===============================
```

**Anti-vacuousness verified:** commenting out the `_delete_legacy_rows_with_canonical_twin(model)` call returns the collision test to its original `IntegrityError`; restoring it returns GREEN.

## Quality gates

```
$ uv run pytest tests/test_migration_0027_canonicalize_overlay.py -x -q --no-cov
============================== 5 passed in 0.88s ===============================

$ uv run pytest --no-cov -x -q
======= 6019 passed, 12 skipped, 37 subtests passed in 105.37s (0:01:45) =======

$ uv run ruff check src/teatree/core/migrations/0027_canonicalize_teatree_overlay.py tests/test_migration_0027_canonicalize_overlay.py
All checks passed!

$ uv run ruff format --check
788 files already formatted

$ uv run python -m tach check
All modules validated!
```

`uv --directory <worktree> run python manage.py migrate --plan` reports `core.0027_canonicalize_teatree_overlay` queued as a `Raw Python operation` — the amended migration.

## Impact

Unblocks `t3 teatree ticket clear` / `ticket merge` on dev databases that accumulated legacy `overlay='teatree'` rows while the split-brain bug fixed in [#1108](https://github.com/souliane/teatree/issues/1108) was live.