### PR TITLE
fix(slack-answer): drop 'On it' prose ack, :eyes: react is enough

### DIFF
--- a/src/teatree/loop/slack_answer/cycle.py
+++ b/src/teatree/loop/slack_answer/cycle.py
@@ -26,8 +26,10 @@ even across cycle re-runs. Then a route via the zero-token classifier:
     readback failure leaves the row loop-unreplied for retry.
 - ``NEEDS_WORK`` (or Stage B sentinel / budget-closed) → create ONE
     PENDING ``t3:answerer`` Task (the fat loop's ``claim-next`` spawns
-    the bounded sub-agent — no new spawn path), post an instant ack,
-    ``mark_loop_replied("delegated")``.
+    the bounded sub-agent — no new spawn path), ``mark_loop_replied(
+    "delegated")``. No prose ack is posted (#1155): the :eyes: receipt
+    fired earlier is the only acknowledgement; a second arrival with
+    "On it" prose is pure noise to a Slack-DM-only user.
 
 Per-unit ``try/except`` so one bad unit never blocks the rest. This is a
 management-command body — it never loads the fat skill stack.
@@ -48,7 +50,6 @@ logger = logging.getLogger(__name__)
 _BATCH = 10
 _EYES_EMOJI = "eyes"
 _ACK_EMOJI = "white_check_mark"
-_INSTANT_ACK_TEXT = "On it — investigating, I'll follow up here."
 # Consecutive messages from the same user on the same channel, with no
 # bot reply between them and received within this window, are one logical
 # turn (a message + its quick follow-up). Zero-token: pure DB/time logic.
@@ -211,7 +212,7 @@ def _handle_simple(backend: MessagingBackend, unit: _Unit) -> str:
 
 
 def _delegate_needs_work(backend: MessagingBackend, unit: _Unit) -> bool:
-    """Create ONE PENDING t3:answerer Task + instant ack for the whole unit.
+    """Create ONE PENDING t3:answerer Task for the whole unit.
 
     The lead's CAS ``mark_loop_replied("delegated")`` is the idempotency
     boundary: the Task is created only by the cycle whose CAS wins, so a
@@ -220,7 +221,14 @@ def _delegate_needs_work(backend: MessagingBackend, unit: _Unit) -> bool:
     atomic ``t3 loop claim-next`` (now routing ``(author, answering)`` →
     ``t3:answerer``) spawns the bounded sub-agent; no new spawn path. The
     sub-agent receives the FULL coalesced question, not a fragment.
+
+    No instant-ack prose is posted (#1155). The :eyes: receipt reaction
+    fired earlier in :func:`_process_unit` is the only acknowledgement —
+    the user reads Slack DMs only, so every thread reply is a phone
+    notification, and a content-free "On it" message is pure noise on
+    top of the :eyes: signal the user already received.
     """
+    _ = backend  # transport still resolved per-unit; no post side effect on delegation
     if not _mark_unit_loop_replied(unit, PendingChatInjection.AnswerKind.DELEGATED):
         return False
     ticket = Ticket.objects.create(
@@ -243,7 +251,6 @@ def _delegate_needs_work(backend: MessagingBackend, unit: _Unit) -> bool:
         execution_target=Task.ExecutionTarget.HEADLESS,
         execution_reason=(f"Answer the user's Slack message at ts={unit.slack_ts}: {unit.text}"),
     )
-    backend.post_reply(channel=unit.channel, ts=unit.slack_ts, text=_INSTANT_ACK_TEXT)
     return True
 
 

--- a/tests/teatree_loop/slack_answer/test_cycle.py
+++ b/tests/teatree_loop/slack_answer/test_cycle.py
@@ -8,7 +8,8 @@ load-bearing assertions:
 - ACK_ONLY posts a reaction, NO thread reply, stamps ``answer_kind=ack``.
 - SIMPLE Stage A posts a thread reply with no LLM and stamps ``simple``.
 - NEEDS_WORK creates **exactly one** PENDING ``t3:answerer`` Task and
-    stamps ``delegated`` + posts an instant ack.
+    stamps ``delegated``. NO thread reply (#1155): the :eyes: receipt
+    is the only acknowledgement on the delegated path.
 - A post/readback failure leaves the row unanswered (retry next cycle).
 - One bad row never blocks the others.
 """
@@ -170,9 +171,9 @@ class TestNeedsWorkDelegation:
         task = tasks.get()
         assert task.ticket.role == Ticket.Role.AUTHOR
         assert "1.0" in task.execution_reason
-        # Instant ack posted in-thread.
-        assert len(backend.replies) == 1
-        assert backend.replies[0][:2] == ("C1", "1.0")
+        # NO thread reply on the delegated path (#1155). The :eyes: react
+        # fired earlier in the cycle is the only acknowledgement.
+        assert backend.replies == []
         row.refresh_from_db()
         assert row.answer_kind == "delegated"
         assert report.delegated == 1

--- a/tests/teatree_loop/slack_answer/test_slack_answer_no_prose_ack.py
+++ b/tests/teatree_loop/slack_answer/test_slack_answer_no_prose_ack.py
@@ -1,0 +1,149 @@
+"""Regression for #1155: the delegated path posts NO prose ack.
+
+The user reads Slack DMs only and treats every thread reply as a
+notification on their phone. The :eyes: receipt reaction already signals
+"received". A second arrival that says "On it — investigating, I'll
+follow up here." is pure noise — it does not carry information the
+user does not already have from the :eyes:.
+
+This module pins two claims for the NEEDS_WORK / delegated path:
+
+- The cycle does NOT call ``post_reply`` on the delegated path
+    (no prose ack, no "On it" prose, nothing — the thread stays clean).
+- The cycle DOES react :eyes: on the same row (the existing-path
+    acknowledgement mechanism must keep firing).
+
+The fix in ``cycle.py`` deletes ``_INSTANT_ACK_TEXT`` and its
+``backend.post_reply(...)`` call site; the :eyes: react in
+``_react_eyes_once`` is untouched. Reverting the deletion makes the
+"no prose post" assertion RED — the anti-vacuousness check this
+module's bug fix relies on.
+"""
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from teatree.core.models import PendingChatInjection, Task
+from teatree.loop.slack_answer.cycle import run_slack_answer_cycle
+from teatree.types import RawAPIDict
+
+pytestmark = pytest.mark.django_db
+
+
+@dataclass
+class RecordingBackend:
+    """In-memory MessagingBackend recording react / post_reply calls."""
+
+    reactions: list[tuple[str, str, str]] = field(default_factory=list)
+    replies: list[tuple[str, str, str]] = field(default_factory=list)
+
+    def fetch_mentions(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return []
+
+    def fetch_dms(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return []
+
+    def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:
+        _ = (channel, text, thread_ts)
+        return {}
+
+    def post_reply(self, *, channel: str, ts: str, text: str) -> RawAPIDict:
+        self.replies.append((channel, ts, text))
+        return {"ok": True}
+
+    def open_dm(self, user_id: str) -> str:
+        _ = user_id
+        return "D1"
+
+    def get_permalink(self, *, channel: str, ts: str) -> str:
+        _ = (channel, ts)
+        return "https://slack/p1"
+
+    def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
+        self.reactions.append((channel, ts, emoji))
+        return {"ok": True}
+
+    def resolve_user_id(self, handle: str) -> str:
+        _ = handle
+        return ""
+
+
+def _row(text: str, ts: str = "1.0", overlay: str = "") -> PendingChatInjection:
+    row = PendingChatInjection.record(channel="C1", slack_ts=ts, text=text, overlay=overlay)
+    assert row is not None
+    return row
+
+
+def _resolver(backend: RecordingBackend):
+    return lambda _overlay: backend
+
+
+class TestDelegatedPathHasNoProseAck:
+    """The NEEDS_WORK / delegated path must post NO prose ack message."""
+
+    def test_no_post_reply_on_delegated_path(self) -> None:
+        """The cycle must not call ``post_reply`` at all on the delegated path.
+
+        The :eyes: reaction is the only acknowledgement; a thread post
+        with prose like "On it — investigating, I'll follow up here."
+        is noise the user does not want to receive.
+        """
+        _row("fix the failing pipeline")
+        backend = RecordingBackend()
+
+        report = run_slack_answer_cycle(messaging_resolver=_resolver(backend))
+
+        assert report.delegated == 1
+        # The delegated path creates the Task but posts NO thread reply.
+        assert backend.replies == [], f"Expected no thread replies on the delegated path; got: {backend.replies!r}"
+
+    def test_no_on_it_prose_in_any_reply(self) -> None:
+        """Defence-in-depth: no reply contains the 'On it' prose text.
+
+        If a future regression reintroduces an instant-ack message under
+        a different name, this guard catches the prose substring.
+        """
+        _row("investigate the flaky test")
+        backend = RecordingBackend()
+
+        run_slack_answer_cycle(messaging_resolver=_resolver(backend))
+
+        for _channel, _ts, text in backend.replies:
+            assert "On it" not in text, f"Unexpected 'On it' prose in reply: {text!r}"
+            assert "investigating" not in text.lower(), f"Unexpected 'investigating' prose in reply: {text!r}"
+
+    def test_eyes_react_still_fires_on_delegated_path(self) -> None:
+        """The acknowledgement mechanism (:eyes: react) MUST keep working.
+
+        Removing the prose post must not regress the :eyes: receipt —
+        that is the load-bearing "received" signal to the user.
+        """
+        row = _row("fix the failing pipeline")
+        backend = RecordingBackend()
+
+        run_slack_answer_cycle(messaging_resolver=_resolver(backend))
+
+        eyes = [r for r in backend.reactions if r[2] == "eyes"]
+        assert len(eyes) == 1, f"Expected exactly one :eyes: react; got: {backend.reactions!r}"
+        assert eyes[0][0] == "C1"
+        assert eyes[0][1] == "1.0"
+        row.refresh_from_db()
+        assert row.eyes_reacted_at is not None
+
+    def test_delegation_still_creates_the_answerer_task(self) -> None:
+        """Removing the prose post must not regress Task creation.
+
+        The whole point of the delegated path is to spawn the answerer
+        sub-agent via a PENDING Task — removing the prose ack must not
+        accidentally short-circuit that side effect.
+        """
+        _row("fix the failing pipeline")
+        backend = RecordingBackend()
+
+        run_slack_answer_cycle(messaging_resolver=_resolver(backend))
+
+        tasks = Task.objects.filter(phase="answering", status=Task.Status.PENDING)
+        assert tasks.count() == 1


### PR DESCRIPTION
Closes #1155

## Summary

Drops the 'On it' prose acknowledgement on the slack-answer path; the :eyes: reaction is the receipt signal.

The slack-answer cycle's `NEEDS_WORK` / delegated path posted a content-free thread reply ("On it — investigating, I'll follow up here.") right after firing the `:eyes:` receipt reaction. Since DMs are the only signal that reach the human, every thread reply is a phone notification — and the "On it" prose carries no information the `:eyes:` react didn't already convey.

The fix deletes the `_INSTANT_ACK_TEXT` constant and the `backend.post_reply(...)` call in `_delegate_needs_work`. The `:eyes:` react (fired by `_react_eyes_once` earlier in `_process_unit`) is now the only acknowledgement. Task creation, the `mark_loop_replied("delegated")` CAS, and the rest of the delegation flow are untouched.

## Control-flow audit

`_process_unit` runs `_react_eyes_once` unconditionally before any route decision, so the `:eyes:` receipt fires on every unit regardless of whether it ends up ACK / SIMPLE / NEEDS_WORK. The removed `backend.post_reply(...)` in `_delegate_needs_work` had no error-handling consumers; nothing in `claim_and_process_one_unit` / `_process_unit` keyed off the post succeeding. Verified the answerer Task is still created (TDD covers this in `test_delegation_still_creates_the_answerer_task`).

## RED → GREEN

Pre-fix, the new test fails:

```
FAILED tests/teatree_loop/slack_answer/test_slack_answer_no_prose_ack.py::TestDelegatedPathHasNoProseAck::test_no_post_reply_on_delegated_path
AssertionError: Expected no thread replies on the delegated path; got:
  [('C1', '1.0', "On it — investigating, I'll follow up here.")]
```

After fix:
- 4 new tests in `test_slack_answer_no_prose_ack.py` pass
- Full `slack_answer/` suite (109 tests) green
- Anti-vacuousness verified: re-introducing `backend.post_reply(...)` makes the assertion go RED; removing it returns it to GREEN

## Quality gates

```
uv run pytest --no-cov -q tests/teatree_loop/slack_answer/test_slack_answer_no_prose_ack.py
    4 passed

uv run pytest --no-cov -q
    6018 passed, 12 skipped, 37 subtests passed in 1:52

uv run ruff check
    All checks passed!

uv run ruff format --check
    788 files already formatted

uv run python -m tach check
    All modules validated!
```

## Test plan

- [x] New regression test in `tests/teatree_loop/slack_answer/test_slack_answer_no_prose_ack.py` covers: no `post_reply` on delegated path, no "On it" prose in any reply, `:eyes:` react still fires, answerer Task still created
- [x] Existing `test_creates_one_pending_answerer_task_and_stamps_delegated` updated to assert `backend.replies == []`
- [x] Anti-vacuousness: temporary revert confirmed RED; restore confirmed GREEN
- [x] Full test suite green
