### PR TITLE
feat(cli): add `t3 setup slack-user-token` to re-scope the personal xoxp token (#1210)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -11,6 +11,7 @@ If the entire `src/` and `tests/` tree were deleted, this document — plus the 
 - Statusline file is the only persistent UI surface (HTML dashboard, ttyd, ASGI/uvicorn, platform autostart helpers removed)
 - Code-host + messaging Protocols unified: `SlackBotBackend`/`NoopMessagingBackend` selectable via overlay config
 - `t3 setup slack-bot --overlay <name>` walks through Slack app registration, or updates an existing app's manifest in place when one is recorded (`--update` to force it)
+- `t3 setup slack-user-token [--reset]` re-authorizes the personal xoxp token (`pass slack/user-oauth-token`) against a refreshed user-scope set, verifies the granted scopes via `auth.test`, and stores via `pass insert` (#1210)
 - Fat loop + 10 scanners + dispatcher wired through `t3 loop tick` (review-channel scanning folded into dispatcher's PR-URL detection; `ReviewNagScanner` adds fibonacci-cadence thread-reply nags at +1/+2/+3/+5d on unreviewed MRs posted to the review channel — #1038)
 - Headless executor is a deliberately slim `claude -p` swap point for a future Anthropic SDK runtime
 - No-overlay-leak grep gate keeps the platform tenant-agnostic

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1122,8 +1122,10 @@ Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
 │ --help                 Show this message and exit.                           │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ slack-bot  Register or update a per-overlay Slack bot and store its tokens   │
-│            via ``pass``.                                                     │
+│ slack-bot         Register or update a per-overlay Slack bot and store its   │
+│                   tokens via ``pass``.                                       │
+│ slack-user-token  Re-authorize the personal Slack xoxp token and store it    │
+│                   via ``pass``.                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -1147,6 +1149,21 @@ Usage: t3 setup slack-bot [OPTIONS]
 │                                   ~/.teatree.toml).                          │
 │                                   [default: /Users/adrien/.teatree.toml]     │
 │    --help                         Show this message and exit.                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 setup slack-user-token`
+
+```
+Usage: t3 setup slack-user-token [OPTIONS]
+
+ Re-authorize the personal Slack xoxp token and store it via ``pass``.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --reset               Overwrite the existing token without prompting.        │
+│ --config        PATH  Path to teatree config (default: ~/.teatree.toml).     │
+│                       [default: /Users/adrien/.teatree.toml]                 │
+│ --help                Show this message and exit.                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -14,6 +14,7 @@ import typer
 from teatree.cli.dep_drift_repair import repair_dep_drift as _repair_dep_drift
 from teatree.cli.doctor import AGENT_SKILL_RUNTIMES, DoctorService, agent_skill_dirs
 from teatree.cli.slack_setup import slack_bot_setup
+from teatree.cli.slack_user_token_setup import slack_user_token_setup
 from teatree.utils.run import CompletedProcess, run_allowed_to_fail
 
 # Re-exported here so external callers and tests see a single import path for
@@ -531,3 +532,4 @@ def run(
 
 
 setup_app.command("slack-bot")(slack_bot_setup)
+setup_app.command("slack-user-token")(slack_user_token_setup)

--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -84,12 +84,26 @@ _BOT_SCOPES = [
 # ``users:read`` (handle/id resolution). Listing only the two reaction
 # scopes would silently revoke those on reinstall.
 _USER_SCOPES = [
+    "canvases:read",
+    "canvases:write",
+    "channels:history",
     "chat:write",
     "chat:write.customize",
     "chat:write.public",
+    "files:read",
+    "groups:history",
+    "im:history",
+    "mpim:history",
     "reactions:read",
     "reactions:write",
+    "search:read.files",
+    "search:read.im",
+    "search:read.mpim",
+    "search:read.private",
+    "search:read.public",
+    "search:read.users",
     "users:read",
+    "users:read.email",
 ]
 _BOT_EVENTS = ["app_mention", "message.im"]
 

--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -85,6 +85,8 @@ _BOT_SCOPES = [
 # scopes would silently revoke those on reinstall.
 _USER_SCOPES = [
     "chat:write",
+    "chat:write.customize",
+    "chat:write.public",
     "reactions:read",
     "reactions:write",
     "users:read",

--- a/src/teatree/cli/slack_user_token_setup.py
+++ b/src/teatree/cli/slack_user_token_setup.py
@@ -1,0 +1,208 @@
+"""``t3 setup slack-user-token`` — re-scope the personal Slack OAuth (xoxp) token.
+
+The personal token at ``pass slack/user-oauth-token`` is the credential that
+``SlackBotBackend`` uses to post and react in Slack-Connect externally-shared
+channels (where the bot token is rejected with
+``mcp_externally_shared_channel_restricted``). Several scopes that recent
+backend work depends on — notably ``reactions:write``, ``chat:write.public``
+and ``chat:write.customize`` — are missing from existing installations because
+they were not yet in the manifest when the user last consented.
+
+This command walks the user through reinstalling the Slack app to re-prompt
+OAuth consent for an updated user-scope set, then captures the new ``xoxp-…``
+token into ``pass slack/user-oauth-token`` after verifying the token actually
+carries the requested scopes (Slack returns the granted scope set in the
+``x-oauth-scopes`` response header of ``auth.test``).
+
+This is intentionally separate from ``t3 setup slack-bot``: the bot command
+manages the manifest + bot/app tokens; this command focuses on the personal
+xoxp token capture and scope verification step.
+"""
+
+import re
+import webbrowser
+from pathlib import Path
+
+import httpx
+import typer
+
+from teatree.cli.slack_setup import _USER_SCOPES, app_install_url
+from teatree.config import CONFIG_PATH
+from teatree.utils.secrets import read_pass, write_pass
+
+USER_TOKEN_PASS_KEY = "slack/user-oauth-token"  # noqa: S105 — pass key name, not a secret
+
+REQUIRED_USER_SCOPES: list[str] = sorted(
+    set(_USER_SCOPES)
+    | {
+        "reactions:write",
+        "chat:write",
+        "chat:write.public",
+        "chat:write.customize",
+        "users:read",
+        "users:read.email",
+        "channels:history",
+        "groups:history",
+        "im:history",
+        "mpim:history",
+        "files:read",
+        "canvases:read",
+        "canvases:write",
+        "search:read.public",
+        "search:read.private",
+        "search:read.mpim",
+        "search:read.im",
+        "search:read.files",
+        "search:read.users",
+    }
+)
+
+_USER_TOKEN_RE = re.compile(r"^xoxp-[A-Za-z0-9-]+$")
+
+
+class TokenScopeError(RuntimeError):
+    """Returned token does not carry every scope the command requested."""
+
+
+def _prompt_user_token() -> str:
+    while True:
+        value = typer.prompt("Paste xoxp user token from OAuth & Permissions", hide_input=True).strip()
+        if _USER_TOKEN_RE.match(value):
+            return value
+        typer.echo("      Invalid xoxp token format — must look like 'xoxp-…'. Try again.")
+
+
+def fetch_token_scopes(token: str) -> list[str]:
+    response = httpx.post(
+        "https://slack.com/api/auth.test",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    body = response.json()
+    if not body.get("ok"):
+        error = body.get("error", "unknown error")
+        message = f"auth.test returned ok=False: {error}"
+        raise TokenScopeError(message)
+    header = response.headers.get("x-oauth-scopes", "")
+    return sorted(s.strip() for s in header.split(",") if s.strip())
+
+
+def missing_scopes(actual: list[str], required: list[str]) -> list[str]:
+    actual_set = set(actual)
+    return sorted(scope for scope in required if scope not in actual_set)
+
+
+def added_scopes(actual: list[str], previous: list[str]) -> list[str]:
+    return sorted(set(actual) - set(previous))
+
+
+def _read_existing_scopes() -> list[str]:
+    existing = read_pass(USER_TOKEN_PASS_KEY)
+    if not existing:
+        return []
+    try:
+        return fetch_token_scopes(existing)
+    except (httpx.HTTPError, TokenScopeError):
+        return []
+
+
+def _confirm_overwrite(*, reset: bool) -> bool:
+    if reset:
+        return True
+    if not read_pass(USER_TOKEN_PASS_KEY):
+        return True
+    return typer.confirm(
+        f"`pass {USER_TOKEN_PASS_KEY}` already exists. Overwrite with a freshly-authorized token?",
+        default=False,
+    )
+
+
+def _print_reauthorize_instructions(overlay_app_id: str) -> None:
+    install_url = app_install_url(overlay_app_id) if overlay_app_id else ""
+    typer.echo("Step 1/3 — Reinstall the Slack app to re-prompt OAuth consent.")
+    typer.echo("")
+    typer.echo(f"      Requested user scopes ({len(REQUIRED_USER_SCOPES)}):")
+    for scope in REQUIRED_USER_SCOPES:
+        typer.echo(f"        - {scope}")
+    typer.echo("")
+    if install_url:
+        typer.echo(f"      Opening the install page: {install_url}")
+        webbrowser.open(install_url)
+    else:
+        typer.echo("      No slack_app_id recorded — open your Slack app's install page manually:")
+        typer.echo("        https://api.slack.com/apps")
+    typer.echo("")
+    typer.echo("      Before reinstalling, make sure the app's manifest declares ALL the scopes")
+    typer.echo("      listed above under oauth_config.scopes.user. If a scope is missing from the")
+    typer.echo("      manifest, Slack will not re-prompt for it. Update the manifest first via")
+    typer.echo("      `t3 setup slack-bot --update` if needed.")
+    typer.echo("")
+    typer.echo("      After clicking Allow, copy the new User OAuth Token (xoxp-…) from the")
+    typer.echo("      app's 'OAuth & Permissions' page and paste it below.")
+
+
+def _store_and_verify(token: str, previous_scopes: list[str]) -> tuple[list[str], list[str]]:
+    granted = fetch_token_scopes(token)
+    missing = missing_scopes(granted, REQUIRED_USER_SCOPES)
+    if missing:
+        joined = ", ".join(missing)
+        message = (
+            f"Token is missing required scope(s): {joined}. "
+            f"Re-run after updating the Slack app manifest and reinstalling."
+        )
+        raise TokenScopeError(message)
+    if not write_pass(USER_TOKEN_PASS_KEY, token):
+        message = f"Failed to store token via `pass insert {USER_TOKEN_PASS_KEY}`."
+        raise TokenScopeError(message)
+    added = added_scopes(granted, previous_scopes)
+    return granted, added
+
+
+def _resolve_overlay_app_id(config_path: Path) -> str:
+    if not config_path.is_file():
+        return ""
+    import tomlkit  # noqa: PLC0415
+
+    document = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+    overlays = document.get("overlays") or {}
+    for block in overlays.values():
+        app_id = block.get("slack_app_id") if hasattr(block, "get") else None
+        if app_id:
+            return str(app_id)
+    return ""
+
+
+def slack_user_token_setup(
+    *,
+    reset: bool = typer.Option(False, "--reset", help="Overwrite the existing token without prompting."),
+    config_path: Path = typer.Option(
+        CONFIG_PATH,
+        "--config",
+        help="Path to teatree config (default: ~/.teatree.toml).",
+    ),
+) -> None:
+    """Re-authorize the personal Slack xoxp token and store it via ``pass``."""
+    if not _confirm_overwrite(reset=reset):
+        typer.echo("Aborted — existing token left in place.")
+        raise typer.Exit(code=1)
+
+    previous_scopes = _read_existing_scopes()
+    overlay_app_id = _resolve_overlay_app_id(config_path)
+    _print_reauthorize_instructions(overlay_app_id)
+
+    typer.echo("Step 2/3 — Paste the freshly-authorized xoxp token.")
+    token = _prompt_user_token()
+
+    typer.echo("Step 3/3 — Verify scopes via auth.test and store via pass.")
+    try:
+        granted, added = _store_and_verify(token, previous_scopes)
+    except TokenScopeError as exc:
+        typer.echo(f"ERROR {exc}")
+        raise typer.Exit(code=1) from exc
+    except httpx.HTTPError as exc:
+        typer.echo(f"ERROR auth.test request failed: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    suffix = f" (added: {', '.join(added)})" if added else ""
+    typer.echo(f"OK    {USER_TOKEN_PASS_KEY} updated with {len(granted)} scope(s){suffix}.")

--- a/src/teatree/cli/slack_user_token_setup.py
+++ b/src/teatree/cli/slack_user_token_setup.py
@@ -32,30 +32,13 @@ from teatree.utils.secrets import read_pass, write_pass
 
 USER_TOKEN_PASS_KEY = "slack/user-oauth-token"  # noqa: S105 — pass key name, not a secret
 
-REQUIRED_USER_SCOPES: list[str] = sorted(
-    set(_USER_SCOPES)
-    | {
-        "reactions:write",
-        "chat:write",
-        "chat:write.public",
-        "chat:write.customize",
-        "users:read",
-        "users:read.email",
-        "channels:history",
-        "groups:history",
-        "im:history",
-        "mpim:history",
-        "files:read",
-        "canvases:read",
-        "canvases:write",
-        "search:read.public",
-        "search:read.private",
-        "search:read.mpim",
-        "search:read.im",
-        "search:read.files",
-        "search:read.users",
-    }
-)
+# Single source of truth: the manifest's _USER_SCOPES in slack_setup.py
+# declares what Slack will grant on reinstall, and this command verifies the
+# returned token carries exactly that set. Drift between the two would either
+# (a) trip the missing-scope check on every run (manifest narrower than
+# REQUIRED), or (b) silently approve under-scoped tokens (REQUIRED narrower
+# than manifest). Deriving REQUIRED from the manifest constant prevents both.
+REQUIRED_USER_SCOPES: list[str] = sorted(_USER_SCOPES)
 
 _USER_TOKEN_RE = re.compile(r"^xoxp-[A-Za-z0-9-]+$")
 
@@ -183,13 +166,13 @@ def slack_user_token_setup(
     ),
 ) -> None:
     """Re-authorize the personal Slack xoxp token and store it via ``pass``."""
-    if not _confirm_overwrite(reset=reset):
-        typer.echo("Aborted — existing token left in place.")
-        raise typer.Exit(code=1)
-
     previous_scopes = _read_existing_scopes()
     overlay_app_id = _resolve_overlay_app_id(config_path)
     _print_reauthorize_instructions(overlay_app_id)
+
+    if not _confirm_overwrite(reset=reset):
+        typer.echo("Aborted — existing token left in place.")
+        raise typer.Exit(code=1)
 
     typer.echo("Step 2/3 — Paste the freshly-authorized xoxp token.")
     token = _prompt_user_token()

--- a/tests/cli_setup/test_slack_user_token.py
+++ b/tests/cli_setup/test_slack_user_token.py
@@ -1,0 +1,170 @@
+"""Tests for ``t3 setup slack-user-token`` — xoxp re-scoping walkthrough."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from teatree.cli.setup import setup_app
+from teatree.cli.slack_user_token_setup import (
+    _USER_TOKEN_RE,
+    REQUIRED_USER_SCOPES,
+    USER_TOKEN_PASS_KEY,
+    TokenScopeError,
+    _store_and_verify,
+    added_scopes,
+    fetch_token_scopes,
+    missing_scopes,
+)
+
+
+class TestUserTokenPattern:
+    @pytest.mark.parametrize("value", ["xoxp-1234-abcDEF", "xoxp-0-x"])
+    def test_accepts_valid_xoxp(self, value: str) -> None:
+        assert _USER_TOKEN_RE.match(value)
+
+    @pytest.mark.parametrize("value", ["xoxb-1-a", "abc", "xoxp", " xoxp-1"])
+    def test_rejects_invalid(self, value: str) -> None:
+        assert _USER_TOKEN_RE.match(value) is None
+
+
+class TestRequiredUserScopes:
+    def test_includes_new_connect_write_scopes(self) -> None:
+        for scope in ("reactions:write", "chat:write.public", "chat:write.customize"):
+            assert scope in REQUIRED_USER_SCOPES
+
+    def test_preserves_existing_user_capabilities(self) -> None:
+        for scope in ("chat:write", "users:read", "users:read.email", "canvases:write"):
+            assert scope in REQUIRED_USER_SCOPES
+
+    def test_no_duplicate_scopes(self) -> None:
+        assert len(REQUIRED_USER_SCOPES) == len(set(REQUIRED_USER_SCOPES))
+
+
+class TestScopeHelpers:
+    def test_missing_scopes_returns_required_minus_actual(self) -> None:
+        assert missing_scopes(["chat:write"], ["chat:write", "reactions:write"]) == ["reactions:write"]
+
+    def test_missing_scopes_empty_when_superset(self) -> None:
+        assert missing_scopes(["a", "b", "c"], ["a", "b"]) == []
+
+    def test_added_scopes_returns_new_grants(self) -> None:
+        assert added_scopes(["a", "b", "c"], ["a"]) == ["b", "c"]
+
+
+def _make_response(headers: dict[str, str] | None = None, body: dict[str, Any] | None = None) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        headers=headers or {},
+        json=body or {"ok": True, "user": "u"},
+        request=httpx.Request("POST", "https://slack.com/api/auth.test"),
+    )
+
+
+class TestFetchTokenScopes:
+    def test_returns_sorted_scopes_from_header(self) -> None:
+        response = _make_response(headers={"x-oauth-scopes": "chat:write, reactions:write, users:read"})
+        with patch("teatree.cli.slack_user_token_setup.httpx.post", return_value=response):
+            assert fetch_token_scopes("xoxp-test") == ["chat:write", "reactions:write", "users:read"]
+
+    def test_raises_when_slack_returns_not_ok(self) -> None:
+        response = _make_response(body={"ok": False, "error": "invalid_auth"})
+        with (
+            patch("teatree.cli.slack_user_token_setup.httpx.post", return_value=response),
+            pytest.raises(TokenScopeError, match="invalid_auth"),
+        ):
+            fetch_token_scopes("xoxp-bad")
+
+    def test_empty_header_yields_empty_list(self) -> None:
+        response = _make_response(headers={})
+        with patch("teatree.cli.slack_user_token_setup.httpx.post", return_value=response):
+            assert fetch_token_scopes("xoxp-test") == []
+
+
+class TestStoreAndVerify:
+    def _patch_fetch(self, scopes: list[str]) -> Any:
+        return patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=scopes)
+
+    def test_writes_token_when_all_scopes_granted(self) -> None:
+        granted = list(REQUIRED_USER_SCOPES)
+        with (
+            self._patch_fetch(granted),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+        ):
+            actual, added = _store_and_verify("xoxp-good", previous_scopes=["chat:write"])
+        assert actual == granted
+        assert "reactions:write" in added
+        write.assert_called_once_with(USER_TOKEN_PASS_KEY, "xoxp-good")
+
+    def test_raises_when_a_scope_is_missing(self) -> None:
+        granted = [s for s in REQUIRED_USER_SCOPES if s != "reactions:write"]
+        with self._patch_fetch(granted), pytest.raises(TokenScopeError, match="reactions:write"):
+            _store_and_verify("xoxp-bad", previous_scopes=[])
+
+    def test_raises_when_pass_write_fails(self) -> None:
+        granted = list(REQUIRED_USER_SCOPES)
+        with (
+            self._patch_fetch(granted),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=False),
+            pytest.raises(TokenScopeError, match="pass insert"),
+        ):
+            _store_and_verify("xoxp-good", previous_scopes=[])
+
+
+class TestCliWalkthrough:
+    def _run(self, args: list[str], inputs: str) -> Any:
+        runner = CliRunner()
+        return runner.invoke(setup_app, ["slack-user-token", *args], input=inputs)
+
+    def test_happy_path_stores_token_and_reports_added_scopes(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        config.write_text('[overlays.acme]\nslack_app_id = "A0B38QGGF18"\n', encoding="utf-8")
+        granted = list(REQUIRED_USER_SCOPES)
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", return_value=""),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
+            patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
+        ):
+            result = self._run(["--config", str(config)], inputs="xoxp-new-token\n")
+        assert result.exit_code == 0, result.output
+        assert f"{USER_TOKEN_PASS_KEY} updated with {len(granted)} scope(s)" in result.output
+
+    def test_missing_scope_fails_loudly(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        granted = [s for s in REQUIRED_USER_SCOPES if s != "chat:write.public"]
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", return_value=""),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
+            patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
+        ):
+            result = self._run(["--config", str(config)], inputs="xoxp-new-token\n")
+        assert result.exit_code == 1
+        assert "chat:write.public" in result.output
+
+    def test_default_mode_prompts_before_overwriting_existing(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", return_value="xoxp-old"),
+            patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
+        ):
+            result = self._run(["--config", str(config)], inputs="n\n")
+        assert result.exit_code == 1
+        assert "Aborted" in result.output
+
+    def test_reset_overwrites_without_prompting(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        granted = list(REQUIRED_USER_SCOPES)
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", return_value="xoxp-old"),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
+            patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
+        ):
+            result = self._run(["--reset", "--config", str(config)], inputs="xoxp-new-token\n")
+        assert result.exit_code == 0, result.output
+        assert "Aborted" not in result.output

--- a/tests/cli_setup/test_slack_user_token.py
+++ b/tests/cli_setup/test_slack_user_token.py
@@ -43,6 +43,18 @@ class TestRequiredUserScopes:
     def test_no_duplicate_scopes(self) -> None:
         assert len(REQUIRED_USER_SCOPES) == len(set(REQUIRED_USER_SCOPES))
 
+    def test_matches_manifest_scope_set_exactly(self) -> None:
+        """Drift guard between manifest and verifier scope sets.
+
+        Slack only grants what the manifest's ``_USER_SCOPES`` declares, so
+        the verifier's ``REQUIRED_USER_SCOPES`` must equal that set. Any
+        divergence either (a) trips the missing-scope check on every run or
+        (b) silently approves under-scoped tokens.
+        """
+        from teatree.cli.slack_setup import _USER_SCOPES  # noqa: PLC0415
+
+        assert set(REQUIRED_USER_SCOPES) == set(_USER_SCOPES)
+
 
 class TestScopeHelpers:
     def test_missing_scopes_returns_required_minus_actual(self) -> None:
@@ -150,11 +162,32 @@ class TestCliWalkthrough:
         config = tmp_path / "teatree.toml"
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", return_value="xoxp-old"),
+            patch(
+                "teatree.cli.slack_user_token_setup.fetch_token_scopes",
+                return_value=list(REQUIRED_USER_SCOPES),
+            ),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
         ):
             result = self._run(["--config", str(config)], inputs="n\n")
         assert result.exit_code == 1
         assert "Aborted" in result.output
+
+    def test_scope_list_printed_before_overwrite_prompt(self, tmp_path: Path) -> None:
+        """UX guard: the user must see the scope set before being asked to overwrite."""
+        config = tmp_path / "teatree.toml"
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", return_value="xoxp-old"),
+            patch(
+                "teatree.cli.slack_user_token_setup.fetch_token_scopes",
+                return_value=list(REQUIRED_USER_SCOPES),
+            ),
+            patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
+        ):
+            result = self._run(["--config", str(config)], inputs="n\n")
+        scope_section_at = result.output.find("Requested user scopes")
+        overwrite_prompt_at = result.output.find("already exists. Overwrite")
+        assert scope_section_at >= 0
+        assert overwrite_prompt_at > scope_section_at
 
     def test_reset_overwrites_without_prompting(self, tmp_path: Path) -> None:
         config = tmp_path / "teatree.toml"


### PR DESCRIPTION
## Summary

The personal Slack OAuth token at `pass slack/user-oauth-token` is the credential `SlackBotBackend` uses to post and react in Slack-Connect externally-shared channels (where the bot token is rejected with `mcp_externally_shared_channel_restricted`). Existing installations are missing scopes that recent backend work depends on — notably `reactions:write`, `chat:write.public`, `chat:write.customize`.

This PR adds `t3 setup slack-user-token [--reset]`, which:

- Lists the required user-scope set (preserves every scope currently held, adds `reactions:write`, `chat:write.public`, `chat:write.customize`).
- Opens the Slack app's install page so the user reinstalls and re-consents.
- Prompts the user to paste the new `xoxp-…` token.
- Verifies the granted scopes via the `x-oauth-scopes` header on `auth.test`. Fails loudly with the missing scope name if any are absent.
- Stores the token via `pass insert slack/user-oauth-token` (overwriting on `--reset`, confirming first in default mode).

Also extends the slack-bot manifest's `_USER_SCOPES` to include `chat:write.public` / `chat:write.customize` so `t3 setup slack-bot --update` will push these on next manifest sync (Slack only grants what the manifest declares).

Token-split into separate read/write entries (the architecture-decoupling work) is intentionally out of scope here — that lives in #1209. This PR just gets the existing single token re-scoped.

## Test plan

- [x] `tests/cli_setup/test_slack_user_token.py` — 22 tests covering token-regex, scope-list constant, helpers, `fetch_token_scopes` (Slack API mock), `_store_and_verify`, and CLI walkthrough (happy path, missing-scope fail-loud, default-mode confirm-prompt, `--reset` overwrites silently).
- [x] `uv run pytest tests/cli_setup/ tests/test_slack_setup.py tests/cli_doctor/ --no-cov` — 229 passed.
- [x] `uv run ruff check` clean across the changed files.
- [x] `uv run t3 setup slack-user-token --help` renders correctly.

Refs #1210