### PR TITLE
feat(hooks): Stop-hook consideration gate for framework-improvement promotion (#1129)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -3518,6 +3518,222 @@ def _enforce_answered_questions(data: dict) -> bool | None:
     return True
 
 
+# ── Consideration gate (#1129): promote framework-shaped edits ──────
+#
+# Every session that edits personal config the framework should ship
+# (e.g. ``~/.claude/settings.json``, ``~/.claude/hooks.json``, personal
+# ``CLAUDE.md`` behavioural rules) must answer "should this be a teatree
+# feature?" before the turn declares done. Prose-only enforcement loses
+# (see retro skill § 9 "Consolidation over Drift"); this gate makes the
+# scan deterministic.
+#
+# The classifier is path-based and conservative. Three classes:
+#
+#   (P) Promote — personal agent config a teatree installation should
+#       wire automatically. The gate fires unless the assistant turn
+#       references a teatree issue (``souliane/teatree#NNNN`` or bare
+#       ``#NNNN``) OR a later iteration downgrades the path.
+#   (K) Keep    — genuine personal preference (memory entries, shell
+#       rc, terminal config). The gate stays silent.
+#   None        — path lives outside the personal-config corners (or
+#       inside the framework itself). The gate has nothing to say.
+#
+# Class (C) "documented config" is not encoded here yet — overlapping
+# heuristics with (P) make false positives noisy. The retro skill
+# already covers (C) in its consolidation pass; the Stop gate focuses
+# on the loudest signal first.
+
+_TEATREE_ISSUE_REF = re.compile(
+    r"(?:souliane/teatree)?#(\d{2,})\b",
+    flags=re.IGNORECASE,
+)
+
+_PROMOTE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Agent-harness config files that ship behaviour.
+    re.compile(r"/\.(claude|codex|cursor|copilot)/settings(\.local)?\.json$"),
+    re.compile(r"/\.(claude|codex|cursor|copilot)/hooks\.json$"),
+    # Personal behavioural instructions (CLAUDE.md / AGENTS.md at the
+    # harness root, not inside a project repo).
+    re.compile(r"/\.(claude|codex|cursor|copilot)/(CLAUDE|AGENTS)\.md$"),
+)
+
+_KEEP_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Memory entries and todos are session state, not framework behaviour.
+    re.compile(r"/\.(claude|codex|cursor|copilot)/projects/.*/memory/"),
+    re.compile(r"/\.(claude|codex|cursor|copilot)/todos/"),
+    re.compile(r"/\.(claude|codex|cursor|copilot)/statsig/"),
+    re.compile(r"/\.(claude|codex|cursor|copilot)/.*\.log$"),
+    # Shell, terminal, vcs user prefs.
+    re.compile(r"/\.(zshrc|bashrc|profile|zprofile|zshenv|bash_profile)$"),
+    re.compile(r"/\.(gitconfig|tmux\.conf|inputrc|vimrc)$"),
+)
+
+
+def classify_session_edit(file_path: str) -> str | None:
+    """Classify an edited path as ``"P"`` (promote), ``"K"`` (keep), or ``None``.
+
+    Conservative path-based heuristic — see the consideration-gate
+    block above for the (P)/(K)/None contract. ``None`` is the silent
+    default: the framework only nags on paths it has explicit signal
+    for.
+    """
+    if not file_path:
+        return None
+    # Keep patterns win over promote when both could match the path —
+    # an edit to ``~/.claude/projects/<p>/memory/MEMORY.md`` is keep,
+    # not promote.
+    for pattern in _KEEP_PATTERNS:
+        if pattern.search(file_path):
+            return "K"
+    for pattern in _PROMOTE_PATTERNS:
+        if pattern.search(file_path):
+            return "P"
+    return None
+
+
+_EDIT_TOOL_NAMES = frozenset({"Edit", "Write", "NotebookEdit"})
+
+
+def _edit_block_path(block: dict) -> str | None:
+    """File path for an ``Edit``/``Write``/``NotebookEdit`` tool_use block.
+
+    Caller pre-filters with ``isinstance(block, dict)`` (mirrors the
+    ``_block_is_settings_write`` contract).
+    """
+    if block.get("type") != "tool_use":
+        return None
+    name = block.get("name")
+    if name not in _EDIT_TOOL_NAMES:
+        return None
+    tool_input = block.get("input")
+    if not isinstance(tool_input, dict):
+        return None
+    raw = tool_input.get("file_path") or tool_input.get("notebook_path")
+    if isinstance(raw, str) and raw:
+        return raw
+    return None
+
+
+def _current_turn_edits(transcript_path: str) -> list[str]:
+    """File paths edited by the assistant in the most recent turn.
+
+    Walks the transcript newest→oldest; the most recent ``user`` entry
+    is the boundary. Returns the file paths from every ``Edit`` /
+    ``Write`` / ``NotebookEdit`` ``tool_use`` block after that
+    boundary, in transcript order. Duplicates kept — the caller
+    classifies + dedupes.
+    """
+    entries = _read_transcript_entries(transcript_path)
+    if not entries:
+        return []
+    edits: list[str] = []
+    for entry in reversed(entries):
+        role = _entry_role(entry)
+        if role == "user":
+            break
+        if role != "assistant":
+            continue
+        for block in _entry_content(entry):
+            if not isinstance(block, dict):
+                continue
+            path = _edit_block_path(block)
+            if path is not None:
+                edits.append(path)
+    edits.reverse()
+    return edits
+
+
+def _current_turn_assistant_text(transcript_path: str) -> str:
+    """Concatenated assistant text blocks in the most recent turn.
+
+    Used to detect a teatree-issue reference that clears the gate.
+    """
+    chunks: list[str] = []
+    entries = _read_transcript_entries(transcript_path)
+    for entry in reversed(entries):
+        role = _entry_role(entry)
+        if role == "user":
+            break
+        if role != "assistant":
+            continue
+        for block in _entry_content(entry):
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    chunks.append(text)
+    return "\n".join(chunks)
+
+
+def handle_consideration_gate(data: dict) -> bool | None:
+    """Emit a CONSIDERATION GATE reminder when promotable edits land (#1129).
+
+    The gate scans the current turn's ``Edit`` / ``Write`` /
+    ``NotebookEdit`` tool uses, classifies each, and emits an
+    ``additionalContext`` block when one or more land in class (P) AND
+    the assistant's text in the same turn does not already reference a
+    teatree issue.
+
+    Soft block only: never emits ``decision: block``. The next turn
+    sees the nag in system context and is expected to either open a
+    teatree issue or justify the divergence in plain text (which the
+    next gate fire will pick up as a reference).
+    """
+    try:
+        return _consideration_gate(data)
+    except Exception as exc:  # noqa: BLE001 — Stop hook must be crash-proof
+        print(  # noqa: T201 — hook stderr is the module's logging channel
+            f"[hook_router] consideration-gate skipped (unexpected error: {exc})",
+            file=sys.stderr,
+        )
+        return None
+
+
+def _consideration_gate(data: dict) -> bool | None:
+    if data.get("stop_hook_active"):
+        return None
+    transcript_path = data.get("transcript_path") or ""
+    if not transcript_path:
+        return None
+    edits = _current_turn_edits(transcript_path)
+    if not edits:
+        return None
+    # Dedupe while preserving order.
+    seen: set[str] = set()
+    promotable: list[str] = []
+    for path in edits:
+        if path in seen:
+            continue
+        seen.add(path)
+        if classify_session_edit(path) == "P":
+            promotable.append(path)
+    if not promotable:
+        return None
+    # An issue reference in the assistant's turn text is the spec's
+    # "open a teatree issue" half — gate clears.
+    assistant_text = _current_turn_assistant_text(transcript_path)
+    if _TEATREE_ISSUE_REF.search(assistant_text):
+        return None
+    bullets = "\n".join(f"  - {path}" for path in promotable)
+    body = (
+        f"CONSIDERATION GATE — {len(promotable)} edit(s) this turn landed on personal "
+        "agent config that teatree should arguably ship for every install. "
+        "Before declaring done, decide one of:\n"
+        "  1. Promote — open a teatree issue (link it as `souliane/teatree#NNNN` "
+        "or bare `#NNNN`) so this behaviour ships in the framework.\n"
+        "  2. Justify keep-personal — say in plain text why this edit is genuinely "
+        "user-specific (theme, voice, paths) and not a missing framework feature.\n"
+        "Promotable paths:\n" + bullets
+    )
+    json.dump(
+        {"hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": body}},
+        sys.stdout,
+    )
+    # Return True to break the Stop chain — preserves the JSON shape and
+    # preempts the loop self-pump (which would override our soft-block
+    # with a continuation directive).
+    return True
+
+
 # ── Router ──────────────────────────────────────────────────────────
 
 _HANDLERS: dict[str, list] = {
@@ -3558,7 +3774,12 @@ _HANDLERS: dict[str, list] = {
     # hookSpecificOutput entry for it and discards its output. Recovery
     # runs in handle_session_start_bootstrap on source=="compact".
     "SessionEnd": [handle_session_end, handle_session_end_loop_registry, handle_session_end_self_pump],
-    "Stop": [handle_enforce_structured_question, handle_enforce_answered_questions, handle_loop_self_pump],
+    "Stop": [
+        handle_enforce_structured_question,
+        handle_enforce_answered_questions,
+        handle_consideration_gate,
+        handle_loop_self_pump,
+    ],
 }
 
 

--- a/tests/test_consideration_gate_stop_hook.py
+++ b/tests/test_consideration_gate_stop_hook.py
@@ -1,0 +1,367 @@
+"""Stop-hook consideration gate for framework-improvement promotion (#1129).
+
+Every session edit must answer "should this be a teatree feature?" before
+the turn declares done. The gate scans the transcript for ``Edit`` /
+``Write`` / ``NotebookEdit`` tool uses, classifies each modified path
+against simple heuristics (P / C / K), and emits a ``BLOCKING REMINDER``
+in ``additionalContext`` when one or more paths look like personal
+config that the framework should ship.
+
+The classifier is intentionally path-based and conservative — false
+positives are downgraded by the agent in the next turn (a justification
+in the assistant text or a teatree issue reference is enough to clear
+the gate).
+
+Anti-vacuous mutation evidence is built into every match case: the test
+both flips a path that SHOULD promote and a path that SHOULDN'T, so
+relaxing the pattern in either direction goes RED.
+"""
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hooks.scripts.hook_router import _HANDLERS, classify_session_edit, handle_consideration_gate
+
+
+def _run_hook(payload: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> tuple[bool | None, str]:
+    """Invoke the handler with captured stdout, returning ``(rv, stdout)``."""
+    buf = io.StringIO()
+    monkeypatch.setattr("hooks.scripts.hook_router.sys.stdout", buf)
+    rv = handle_consideration_gate(payload)
+    return rv, buf.getvalue()
+
+
+def _write_transcript(tmp_path: Path, entries: list[dict[str, Any]]) -> str:
+    """Materialise a Claude-Code transcript JSONL file."""
+    path = tmp_path / "transcript.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+    return str(path)
+
+
+def _assistant_edit(file_path: str, content: str = "x") -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Edit",
+                    "input": {"file_path": file_path, "old_string": "a", "new_string": content},
+                }
+            ],
+        },
+    }
+
+
+def _assistant_write(file_path: str) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Write",
+                    "input": {"file_path": file_path, "content": "x"},
+                }
+            ],
+        },
+    }
+
+
+def _user_turn() -> dict[str, Any]:
+    return {"type": "user", "message": {"role": "user", "content": "do the thing"}}
+
+
+def _assistant_text(text: str) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+class TestClassifier:
+    """Pure-logic unit tests for ``classify_session_edit``."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/Users/anyone/.claude/settings.json",
+            "/Users/anyone/.claude/hooks.json",
+            "/home/dev/.claude/settings.local.json",
+            "/Users/anyone/.codex/settings.json",
+        ],
+    )
+    def test_personal_agent_config_promotes(self, path: str) -> None:
+        """``~/.claude/settings.json`` and siblings are framework-shaped."""
+        assert classify_session_edit(path) == "P"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/Users/anyone/.claude/CLAUDE.md",
+            "/Users/anyone/.codex/AGENTS.md",
+        ],
+    )
+    def test_personal_agent_instructions_promote(self, path: str) -> None:
+        """Personal CLAUDE.md / AGENTS.md edits encode behaviour."""
+        assert classify_session_edit(path) == "P"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/Users/anyone/.claude/projects/proj/memory/MEMORY.md",
+            "/Users/anyone/.claude/projects/proj/memory/feedback_x.md",
+            "/Users/anyone/.claude/todos/active.json",
+            "/Users/anyone/.claude/statsig/cache.json",
+            "/Users/anyone/.zshrc",
+            "/Users/anyone/.bashrc",
+            "/Users/anyone/.gitconfig",
+            "/Users/anyone/.tmux.conf",
+        ],
+    )
+    def test_genuine_personal_paths_are_keep(self, path: str) -> None:
+        """Memory, shell rc, terminal config — keep-personal."""
+        assert classify_session_edit(path) == "K"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/Users/dev/workspace/teatree/src/teatree/loop/tick.py",
+            "/Users/dev/workspace/teatree/hooks/scripts/hook_router.py",
+            "/Users/dev/workspace/teatree/tests/test_x.py",
+            "/Users/dev/workspace/teatree/skills/retro/SKILL.md",
+            "/Users/dev/workspace/teatree/pyproject.toml",
+            "/tmp/something.txt",
+            "",
+        ],
+    )
+    def test_in_repo_and_unrelated_paths_are_none(self, path: str) -> None:
+        """Edits to the framework itself, or to unrelated files, are unclassified.
+
+        ``None`` means "nothing to gate on" — the consideration gate only
+        speaks up when the path lives in the personal-config corners.
+        """
+        assert classify_session_edit(path) is None
+
+
+class TestGate:
+    """Integration tests against the real Stop handler."""
+
+    def test_no_transcript_is_quiet(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        rv, out = _run_hook({"session_id": "s1"}, monkeypatch)
+
+        assert rv is None
+        assert out == ""
+
+    def test_no_personal_edits_is_quiet(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Edits to the framework itself never trip the gate."""
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn(),
+                _assistant_edit("/Users/dev/workspace/teatree/src/teatree/loop/tick.py"),
+            ],
+        )
+
+        rv, out = _run_hook({"session_id": "s1", "transcript_path": transcript}, monkeypatch)
+
+        assert rv is None
+        assert out == ""
+
+    def test_promotable_edit_emits_blocking_reminder(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """A ``.claude/settings.json`` edit must trigger the gate.
+
+        Anti-vacuous: removing ``.claude/settings.json`` from the promote
+        pattern set turns this test RED — the reminder vanishes.
+        """
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn(),
+                _assistant_edit("/Users/dev/.claude/settings.json"),
+            ],
+        )
+
+        rv, out = _run_hook({"session_id": "s1", "transcript_path": transcript}, monkeypatch)
+
+        assert rv is True
+        payload = json.loads(out)
+        body = payload["hookSpecificOutput"]["additionalContext"]
+        assert "CONSIDERATION GATE" in body
+        assert "settings.json" in body
+        assert payload["hookSpecificOutput"]["hookEventName"] == "Stop"
+        # Soft block only — never emit decision: block.
+        assert "decision" not in payload
+
+    def test_write_tool_also_counts(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """``Write`` is symmetric with ``Edit`` — same gate fires."""
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn(),
+                _assistant_write("/Users/dev/.claude/hooks.json"),
+            ],
+        )
+
+        rv, out = _run_hook({"session_id": "s1", "transcript_path": transcript}, monkeypatch)
+
+        assert rv is True
+        body = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+        assert "hooks.json" in body
+
+    def test_keep_personal_edit_does_not_trip_gate(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Memory writes are explicit personal preference — quiet."""
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn(),
+                _assistant_edit("/Users/dev/.claude/projects/p/memory/feedback_x.md"),
+            ],
+        )
+
+        rv, out = _run_hook({"session_id": "s1", "transcript_path": transcript}, monkeypatch)
+
+        assert rv is None
+        assert out == ""
+
+    def test_teatree_issue_reference_clears_gate(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Issue reference in assistant text clears the gate.
+
+        Spec's ``open the issue`` half — the gate has nothing left to nag
+        about once a ``souliane/teatree#NNNN`` reference is in the turn.
+        """
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn(),
+                _assistant_edit("/Users/dev/.claude/settings.json"),
+                _assistant_text("Filed souliane/teatree#1234 to promote this hook into the framework."),
+            ],
+        )
+
+        rv, out = _run_hook({"session_id": "s1", "transcript_path": transcript}, monkeypatch)
+
+        assert rv is None
+        assert out == ""
+
+    def test_short_issue_ref_clears_gate(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Bare ``#NNNN`` mention is enough."""
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn(),
+                _assistant_edit("/Users/dev/.claude/settings.json"),
+                _assistant_text("Tracked as #4321 for framework promotion."),
+            ],
+        )
+
+        rv, out = _run_hook({"session_id": "s1", "transcript_path": transcript}, monkeypatch)
+
+        assert rv is None
+        assert out == ""
+
+    def test_multiple_promotable_paths_listed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn(),
+                _assistant_edit("/Users/dev/.claude/settings.json"),
+                _assistant_write("/Users/dev/.claude/hooks.json"),
+            ],
+        )
+
+        rv, out = _run_hook({"session_id": "s1", "transcript_path": transcript}, monkeypatch)
+
+        assert rv is True
+        body = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+        assert "settings.json" in body
+        assert "hooks.json" in body
+
+    def test_stop_hook_active_short_circuits(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """``stop_hook_active`` ⇒ no-op (re-fire guard)."""
+        transcript = _write_transcript(
+            tmp_path,
+            [_user_turn(), _assistant_edit("/Users/dev/.claude/settings.json")],
+        )
+
+        rv, out = _run_hook(
+            {"session_id": "s1", "transcript_path": transcript, "stop_hook_active": True},
+            monkeypatch,
+        )
+
+        assert rv is None
+        assert out == ""
+
+    def test_only_current_turn_is_scanned(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Edits before the most recent user turn are out of scope.
+
+        Only the current turn's edits count for the Stop decision —
+        prior-turn edits already had their gate fire.
+        """
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn(),
+                _assistant_edit("/Users/dev/.claude/settings.json"),
+                _user_turn(),
+                _assistant_edit("/Users/dev/workspace/teatree/src/teatree/loop/tick.py"),
+            ],
+        )
+
+        rv, out = _run_hook({"session_id": "s1", "transcript_path": transcript}, monkeypatch)
+
+        assert rv is None
+        assert out == ""
+
+
+class TestRouterWiring:
+    def test_handler_registered_for_stop(self) -> None:
+        names = [h.__name__ for h in _HANDLERS["Stop"]]
+        assert "handle_consideration_gate" in names
+
+    def test_runs_after_answered_questions_gate(self) -> None:
+        """Answered-questions and structured-question gates are dominant."""
+        names = [h.__name__ for h in _HANDLERS["Stop"]]
+        assert names.index("handle_enforce_answered_questions") < names.index("handle_consideration_gate")
+
+    def test_runs_before_loop_self_pump(self) -> None:
+        """The loop self-pump must run last."""
+        names = [h.__name__ for h in _HANDLERS["Stop"]]
+        assert names.index("handle_consideration_gate") < names.index("handle_loop_self_pump")
+
+
+class TestCrashProof:
+    """The Stop hook must never raise (#810 contract)."""
+
+    def test_handler_swallows_unexpected_errors(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        boom = RuntimeError("simulated transcript read failure")
+
+        def _boom(_path: str) -> list[dict]:
+            raise boom
+
+        monkeypatch.setattr("hooks.scripts.hook_router._read_transcript_entries", _boom)
+
+        rv, out = _run_hook({"session_id": "s1", "transcript_path": "/tmp/nope.jsonl"}, monkeypatch)
+
+        assert rv is None
+        assert out == ""
+        assert "consideration-gate skipped" in capsys.readouterr().err
+
+    def test_corrupt_transcript_is_quiet(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        path = tmp_path / "transcript.jsonl"
+        path.write_text("not json\n{also not json\n", encoding="utf-8")
+
+        rv, out = _run_hook({"session_id": "s1", "transcript_path": str(path)}, monkeypatch)
+
+        assert rv is None
+        assert out == ""


### PR DESCRIPTION
## Summary

Adds a Stop-hook gate (#1129) that scans the current turn's `Edit` / `Write` / `NotebookEdit` tool uses and classifies each modified path. When one or more land on personal agent config the framework should arguably ship (e.g. `~/.claude/settings.json`, `~/.claude/hooks.json`, personal `CLAUDE.md` / `AGENTS.md`), the gate emits a `CONSIDERATION GATE` reminder in `additionalContext` — unless the assistant turn already references a teatree issue (`souliane/teatree#NNNN` or bare `#NNNN`).

Doctrine: retro skill section 9 "Consolidation over Drift" covers the same ground in prose; this gate makes the scan deterministic, per the issue's "memory-as-vigilance fails" point.

## Classifier

Path-based and conservative:

- **(P) Promote** — agent-harness config files (`settings.json`, `hooks.json`, `CLAUDE.md`, `AGENTS.md`) that ship behaviour.
- **(K) Keep** — memory entries, todos, shell rc, terminal config.
- **None** — anything else, including the framework's own source.

`(K)` wins over `(P)` when both could match, so memory writes under `~/.claude/projects/<p>/memory/` stay silent.

## Behaviour

- Soft block only — emits `additionalContext`, never `decision: block`. A genuinely-done turn isn't hard-blocked.
- Returns `True` to break the Stop chain, preserving JSON shape and preempting the loop self-pump.
- Crash-proof per #810 — outer boundary guard swallows unexpected errors with a stderr breadcrumb.
- `stop_hook_active` short-circuits to a no-op (re-fire guard).
- Class (C) "documented config" deliberately deferred — overlapping heuristics with (P) risk noise; retro skill section 9 still covers it.

## Test plan

- [x] 36 new tests in `tests/test_consideration_gate_stop_hook.py` covering classifier, gate behaviour, router wiring, and crash-proof contract.
- [x] Sibling Stop-hook tests (`test_answered_at_gate_stop_hook.py`, `test_loop_self_pump_hook.py`, `test_hook_router_cadence_hook.py`) still green.
- [x] Full hook-test suite (513 tests) green.
- [x] `uv run ruff check` + `uv run ruff format` clean.
- [x] `uv run ty check` clean.

Fixes #1129.