### PR TITLE
feat(skills): pr_review_companion injection on reviewer dispatch (#1135)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -105,7 +105,7 @@ The agent layer is `teatree.agents` (headless executor + prompt + skill bundle +
 
 **Structured result schema (`agents/result_schema.py`).** Agents return JSON: `summary`, `files_modified`, `tests_run`, `tests_passed`, `tests_failed`, `decisions`, `needs_user_input`, `user_input_reason`, `next_steps`, `commands_executed`. `additionalProperties: false`. Validated without the `jsonschema` library to keep the dep tree small.
 
-**Skill bundle (`agents/skill_bundle.py`) + delegation map (`skill_map.py`).** A phase → companion-skills map (e.g. `coding → test-driven-development + verification-before-completion`), plus topo-sorted `requires:` resolution, plus per-overlay `companion_skills` (#1132).
+**Skill bundle (`agents/skill_bundle.py`) + delegation map (`skill_map.py`).** A phase → companion-skills map (e.g. `coding → test-driven-development + verification-before-completion`), plus topo-sorted `requires:` resolution, plus per-overlay `companion_skills` (#1132). Reviewer-dispatch gains a dedicated per-overlay `pr_review_companion` field (#1135, default `code-review`): when a sub-agent runs in the `reviewing` phase, the companion's SKILL.md is inlined into the dispatched prompt alongside `/t3:review` so the reviewer gets the project's review-quality bar without needing to know to load it (sub-agents do not auto-load skills).
 
 **Model tiering.** `agents/model_tiering.resolve_phase_model(phase)` downgrades mechanical phases (`reviewing`/`testing`/`shipping` → sonnet, `retrospecting` → haiku) by default; reasoning phases (`coding`, `debugging`) inherit the user's default. Per-phase overrides via `[agent] phase_models` in `~/.teatree.toml`.
 

--- a/src/teatree/agents/skill_bundle.py
+++ b/src/teatree/agents/skill_bundle.py
@@ -6,8 +6,28 @@ from teatree.types import SkillMetadata
 __all__ = [
     "DEFAULT_SKILLS_DIR",
     "active_overlay_companion_skills",
+    "active_overlay_pr_review_companion",
     "resolve_skill_bundle",
 ]
+
+
+def _active_overlay_config() -> object | None:
+    """Return the active overlay's ``config`` instance, or ``None``.
+
+    Hermetic accessor shared by the companion-skill resolvers below: the
+    overlay-loader import and ``get_overlay()`` call can each fail in
+    pre-bootstrap / test environments without a configured overlay, and the
+    caller's contract is to behave as if no overlay declared anything.
+    """
+    try:
+        from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        overlay = get_overlay()
+    except Exception:  # noqa: BLE001
+        return None
+    return getattr(overlay, "config", None)
 
 
 def active_overlay_companion_skills() -> list[str]:
@@ -19,18 +39,29 @@ def active_overlay_companion_skills() -> list[str]:
     misconfigured environment — returns ``[]`` so the caller behaves as
     if no companions were declared.
     """
-    try:
-        from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
-    except Exception:  # noqa: BLE001
+    config = _active_overlay_config()
+    if config is None:
         return []
-    try:
-        overlay = get_overlay()
-    except Exception:  # noqa: BLE001
-        return []
-    skills = getattr(overlay.config, "companion_skills", [])
+    skills = getattr(config, "companion_skills", [])
     if not isinstance(skills, list):
         return []
     return [s for s in skills if isinstance(s, str) and s]
+
+
+def active_overlay_pr_review_companion() -> str:
+    """Return the active overlay's ``pr_review_companion``, or ``""``.
+
+    The reviewer-dispatch companion (#1135). When no overlay is reachable
+    the caller behaves as if no companion was declared — the reviewer
+    sub-agent still loads ``/t3:review`` but no review-quality skill is
+    injected. The class-level default (``"code-review"``) only applies when
+    an overlay is reachable.
+    """
+    config = _active_overlay_config()
+    if config is None:
+        return ""
+    value = getattr(config, "pr_review_companion", "")
+    return value if isinstance(value, str) else ""
 
 
 def resolve_skill_bundle(
@@ -46,5 +77,6 @@ def resolve_skill_bundle(
         overlay_skill_metadata=overlay_skill_metadata,
         trigger_index=trigger_index,
         companion_skills=active_overlay_companion_skills(),
+        pr_review_companion=active_overlay_pr_review_companion(),
     )
     return result.skills

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -121,6 +121,14 @@ class OverlayConfig:
     # existing ``resolve_companions`` resolver handles the dependency chain
     # without a parallel implementation.
     companion_skills: list[str]
+    # ``pr_review_companion`` is the single skill injected alongside
+    # ``/t3:review`` whenever a reviewer sub-agent is dispatched
+    # (``phase == "reviewing"``). The global default ``"code-review"`` carries
+    # the project's review-quality bar; an overlay overrides via
+    # ``[overlays.<name>] pr_review_companion = "receiving-code-review"`` (or
+    # any other skill) in ``~/.teatree.toml``. An empty string disables
+    # injection without removing the lifecycle skill (#1135).
+    pr_review_companion: str = "code-review"
 
     def __init__(self, settings_module: str = "", overlay_name: str = "") -> None:
         # Initialize mutable defaults per-instance

--- a/src/teatree/skill_loading.py
+++ b/src/teatree/skill_loading.py
@@ -201,7 +201,7 @@ class SkillLoadingPolicy:
         suggestions = [skill for skill in resolved if skill not in loaded_skills]
         return SkillSelectionResult(skills=suggestions, lifecycle_skill=intent)
 
-    def select_for_runtime_phase(
+    def select_for_runtime_phase(  # noqa: PLR0913
         self,
         *,
         cwd: Path,
@@ -209,6 +209,7 @@ class SkillLoadingPolicy:
         overlay_skill_metadata: OverlaySkillMetadata,
         trigger_index: TriggerIndex | None = None,
         companion_skills: list[str] | None = None,
+        pr_review_companion: str = "",
     ) -> SkillSelectionResult:
         lifecycle_skill = self.lifecycle_for_phase(phase)
         ordered = self._base_detected_skills(
@@ -220,6 +221,14 @@ class SkillLoadingPolicy:
         )
         if lifecycle_skill:
             ordered.append(lifecycle_skill)
+        # #1135: a reviewer sub-agent dispatch (phase resolving to the
+        # ``review`` lifecycle skill) also loads the project's review-quality
+        # companion. Sub-agents do not auto-load skills, so the caller
+        # (``run_headless`` via ``resolve_skill_bundle``) inlines the
+        # companion's SKILL.md content into the dispatched prompt via
+        # ``_read_skill_contents_scoped``.
+        if lifecycle_skill == "review" and pr_review_companion:
+            ordered.append(pr_review_companion)
         resolved = self._resolve_with_companions(ordered, trigger_index or [])
         return SkillSelectionResult(
             skills=_dedupe(resolved),

--- a/tests/test_pr_review_companion_overlay.py
+++ b/tests/test_pr_review_companion_overlay.py
@@ -1,0 +1,194 @@
+"""Per-overlay ``pr_review_companion`` injection on reviewer dispatch (#1135).
+
+When a reviewer sub-agent is dispatched (``phase == "reviewing"``), the
+overlay's ``pr_review_companion`` skill is injected alongside ``/t3:review``.
+The global default is ``"code-review"``; the teatree overlay overrides it to
+``"receiving-code-review"`` via ``[overlays.t3-teatree] pr_review_companion = …``
+in ``~/.teatree.toml``.
+
+The injection threads through:
+
+*   ``OverlayConfig.pr_review_companion`` — the per-overlay field, default
+    ``"code-review"``.
+*   ``SkillLoadingPolicy.select_for_runtime_phase`` — accepts the value as
+    a parameter and appends it when the phase resolves to the ``review``
+    lifecycle skill. The companion goes through the standard
+    ``resolve_companions`` pipeline so its own ``requires``/``companions``
+    chain expands transitively (and a missing companion logs a warning,
+    dispatch still proceeds).
+*   ``teatree.agents.skill_bundle.resolve_skill_bundle`` — reads the active
+    overlay's ``pr_review_companion`` and passes it to the policy, keeping
+    the policy module free of a back-reference to ``teatree.core``.
+
+The companion is *injected*, never *replaces* ``/t3:review``.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from teatree.agents import skill_bundle
+from teatree.core.overlay import OverlayConfig
+from teatree.skill_loading import SkillLoadingPolicy
+
+
+def _config_with_companion(value: str | None) -> OverlayConfig:
+    """Build an ``OverlayConfig`` whose t3-teatree table sets ``pr_review_companion``.
+
+    Passing ``None`` stubs an empty toml table so the class default applies.
+    """
+    overrides: dict[str, object] = {}
+    if value is not None:
+        overrides["pr_review_companion"] = value
+    mock_config = MagicMock()
+    mock_config.raw = {"overlays": {"t3-teatree": overrides}}
+    with patch("teatree.config.load_config", return_value=mock_config):
+        return OverlayConfig(overlay_name="t3-teatree")
+
+
+class TestOverlayConfigPrReviewCompanionField:
+    """``pr_review_companion`` is a real ``OverlayConfig`` field, default ``"code-review"``."""
+
+    def test_default_is_code_review(self) -> None:
+        config = OverlayConfig()
+        assert config.pr_review_companion == "code-review"
+
+    def test_toml_override_sets_field(self) -> None:
+        config = _config_with_companion("receiving-code-review")
+        assert config.pr_review_companion == "receiving-code-review"
+
+    def test_per_instance_isolation(self) -> None:
+        first = _config_with_companion("receiving-code-review")
+        second = OverlayConfig()
+        assert first.pr_review_companion == "receiving-code-review"
+        assert second.pr_review_companion == "code-review"
+
+
+class TestSelectForRuntimePhaseInjectsPrReviewCompanion:
+    """``select_for_runtime_phase`` injects ``pr_review_companion`` on review phase."""
+
+    def test_review_phase_injects_companion(self, tmp_path: Path) -> None:
+        policy = SkillLoadingPolicy()
+        result = policy.select_for_runtime_phase(
+            cwd=tmp_path,
+            phase="reviewing",
+            overlay_skill_metadata={},
+            pr_review_companion="code-review",
+        )
+        assert "review" in result.skills
+        assert "code-review" in result.skills
+
+    def test_overlay_override_injects_receiving_code_review(self, tmp_path: Path) -> None:
+        policy = SkillLoadingPolicy()
+        result = policy.select_for_runtime_phase(
+            cwd=tmp_path,
+            phase="reviewing",
+            overlay_skill_metadata={},
+            pr_review_companion="receiving-code-review",
+        )
+        assert "review" in result.skills
+        assert "receiving-code-review" in result.skills
+
+    def test_non_review_phase_skips_companion(self, tmp_path: Path) -> None:
+        policy = SkillLoadingPolicy()
+        result = policy.select_for_runtime_phase(
+            cwd=tmp_path,
+            phase="coding",
+            overlay_skill_metadata={},
+            pr_review_companion="code-review",
+        )
+        assert "code-review" not in result.skills
+
+    def test_empty_companion_is_noop(self, tmp_path: Path) -> None:
+        policy = SkillLoadingPolicy()
+        result = policy.select_for_runtime_phase(
+            cwd=tmp_path,
+            phase="reviewing",
+            overlay_skill_metadata={},
+            pr_review_companion="",
+        )
+        assert "review" in result.skills
+        assert "code-review" not in result.skills
+
+    def test_missing_companion_in_index_dispatch_still_proceeds(self, tmp_path: Path) -> None:
+        """A companion absent from the trigger index logs a warning, doesn't fail.
+
+        ``resolve_companions`` handles unknown skills by passing them through
+        as-is when no trigger entry expands them — the policy still returns
+        ``review`` alongside the companion name, never crashes.
+        """
+        policy = SkillLoadingPolicy()
+        result = policy.select_for_runtime_phase(
+            cwd=tmp_path,
+            phase="reviewing",
+            overlay_skill_metadata={},
+            pr_review_companion="nonexistent-companion-skill",
+            trigger_index=[],
+        )
+        assert "review" in result.skills
+        assert "nonexistent-companion-skill" in result.skills
+
+    def test_companion_dedup_against_lifecycle_skill(self, tmp_path: Path) -> None:
+        """If the companion *is* the lifecycle skill, the result is deduped."""
+        policy = SkillLoadingPolicy()
+        result = policy.select_for_runtime_phase(
+            cwd=tmp_path,
+            phase="reviewing",
+            overlay_skill_metadata={},
+            pr_review_companion="review",
+        )
+        assert result.skills.count("review") == 1
+
+
+class TestResolveSkillBundleReadsOverlayPrReviewCompanion:
+    """``resolve_skill_bundle`` reads ``pr_review_companion`` from the active overlay."""
+
+    def test_resolve_skill_bundle_injects_overlay_pr_review_companion(self) -> None:
+        mock_overlay = MagicMock()
+        mock_overlay.config.companion_skills = []
+        mock_overlay.config.pr_review_companion = "receiving-code-review"
+        with (
+            patch.object(skill_bundle, "get_overlay", return_value=mock_overlay, create=True),
+            patch(
+                "teatree.core.overlay_loader.get_overlay",
+                return_value=mock_overlay,
+            ),
+        ):
+            bundle = skill_bundle.resolve_skill_bundle(
+                phase="reviewing",
+                overlay_skill_metadata={},
+            )
+        assert "review" in bundle
+        assert "receiving-code-review" in bundle
+
+    def test_resolve_skill_bundle_default_is_code_review(self) -> None:
+        mock_overlay = MagicMock()
+        mock_overlay.config.companion_skills = []
+        mock_overlay.config.pr_review_companion = "code-review"
+        with patch(
+            "teatree.core.overlay_loader.get_overlay",
+            return_value=mock_overlay,
+        ):
+            bundle = skill_bundle.resolve_skill_bundle(
+                phase="reviewing",
+                overlay_skill_metadata={},
+            )
+        assert "code-review" in bundle
+
+    def test_resolve_skill_bundle_no_overlay_no_companion(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        # No overlay reachable → companion omitted, only lifecycle skill present.
+        with patch(
+            "teatree.core.overlay_loader.get_overlay",
+            side_effect=RuntimeError("no overlay"),
+        ):
+            bundle = skill_bundle.resolve_skill_bundle(
+                phase="reviewing",
+                overlay_skill_metadata={},
+            )
+        assert "review" in bundle
+        assert "code-review" not in bundle
+        assert "receiving-code-review" not in bundle


### PR DESCRIPTION
Closes #1135. Follow-up to #1132 RED CARD.

## Summary

When a reviewer sub-agent is dispatched (`phase == "reviewing"`), the overlay's `pr_review_companion` skill is now injected alongside `/t3:review`. Sub-agents do not auto-load skills, so the existing `run_headless` path inlines the companion's SKILL.md content into the dispatched prompt via `_read_skill_contents_scoped` — the reviewer gets the project's review-quality bar without needing to know to load it.

Three reuse-existing wirings:

- **`OverlayConfig.pr_review_companion: str = "code-review"`** — a real per-overlay field with a global default, picked up by the generic `apply_toml_overrides()` setattr loop. Overrides via `[overlays.<name>] pr_review_companion = "receiving-code-review"` in `~/.teatree.toml`. Empty string disables injection without removing `/t3:review`.
- **`SkillLoadingPolicy.select_for_runtime_phase`** gains a `pr_review_companion: str = ""` parameter and appends it when the phase resolves to the `review` lifecycle skill. Companion goes through the standard `resolve_companions` pipeline so its own `requires`/`companions` chain expands transitively; missing companion in the trigger index logs a warning and dispatch still proceeds with `/t3:review` present.
- **`teatree.agents.skill_bundle.active_overlay_pr_review_companion`** reads the active overlay's config and passes the value to the policy. `resolve_skill_bundle` is the single call site — used by `run_headless`, the `tasks` management command, and the headless agent runner — so every reviewer-dispatch path picks the companion up uniformly.

Policy module stays free of a back-reference to `teatree.core` — tach module boundary intact. Companion is *injected*, never *replaces* `/t3:review`.

## Test plan

- [x] `tests/test_pr_review_companion_overlay.py` — 12 cases covering the `OverlayConfig` field default, toml override wiring, per-instance isolation, review-phase injection, non-review skip, empty-companion no-op, missing-from-index pass-through, dedup against the lifecycle skill, and `resolve_skill_bundle` overlay-config reads.
- [x] `uv run pytest tests/test_skill_loading.py tests/test_companion_skills_overlay.py tests/teatree_agents/ tests/teatree_core/test_overlay.py tests/test_pr_review_companion_overlay.py` — 312 passed, no regressions.
- [x] `uv run ruff check` / `uv run ruff format` — clean.