### PR TITLE
fix(slack): route reactions via personal user xoxp token + add `t3 slack react` CLI (#1232)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1787,6 +1787,8 @@ Usage: t3 slack [OPTIONS] COMMAND [ARGS]...
 │ listen  Run the Socket Mode receiver for all (or one) slack-enabled          │
 │         overlays.                                                            │
 │ check   Drain the event queue, ack with 👀, and print new user messages.     │
+│ react   Add *emoji* to ``(channel, ts)`` using the personal user-OAuth       │
+│         token.                                                               │
 │ status  Check if the Socket Mode listener is running.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -1821,6 +1823,35 @@ Usage: t3 slack check [OPTIONS]
  Returns exit code 0 when messages were found, 1 when the queue
  was empty. Designed to be called from a fast cron (every 30s).
 
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 slack react`
+
+```
+Usage: t3 slack react [OPTIONS] CHANNEL TS EMOJI
+
+ Add *emoji* to ``(channel, ts)`` using the personal user-OAuth token.
+
+ The personal ``xoxp-…`` token at ``pass slack/user-oauth-token``
+ (provisioned by ``t3 setup slack-user-token``) is the only credential
+ that reliably reaches user DMs and Slack-Connect externally-shared
+ channels for ``reactions.add`` (#1232). Exits 0 on success (including
+ the idempotent ``already_reacted`` case), 1 when the token is missing,
+ 2 on any other Slack-side failure.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    channel      TEXT  Slack channel id (e.g. `D…` for a DM, `C…` for a     │
+│                         channel).                                            │
+│                         [required]                                           │
+│ *    ts           TEXT  Message timestamp (e.g. `1700000000.000100`).        │
+│                         [required]                                           │
+│ *    emoji        TEXT  Emoji name without colons (e.g. `eyes`,              │
+│                         `white_check_mark`).                                 │
+│                         [required]                                           │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/src/teatree/cli/slack_listen.py
+++ b/src/teatree/cli/slack_listen.py
@@ -3,13 +3,66 @@
 import logging
 from pathlib import Path
 
+import httpx
 import typer
 
 from teatree.backends.slack_receiver import default_queue_path, run_listener
+from teatree.cli.slack_user_token_setup import USER_TOKEN_PASS_KEY
 from teatree.utils.secrets import read_pass
 from teatree.utils.singleton import AlreadyRunningError, read_pid, singleton
 
 slack_app = typer.Typer(name="slack", help="Slack integration commands.", no_args_is_help=True)
+
+
+def _resolve_reaction_token() -> str:
+    """Return the personal Slack user-OAuth token (``xoxp-…``) for reactions.
+
+    Reactions on user DMs and on Slack-Connect externally-shared channels
+    are rejected when sent with the bot token (``message_not_found`` and
+    ``mcp_externally_shared_channel_restricted`` respectively — see
+    BLUEPRINT § "Slack token routing" and ``feedback_slack_reactions_via_
+    personal_token_not_bot``). The personal ``xoxp-…`` token provisioned
+    by ``t3 setup slack-user-token`` (#1210/#1220/#1232) is the only
+    credential that reliably reaches both surfaces; this helper centralises
+    the lookup so every ad-hoc reaction call site (``t3 slack react`` and
+    the ``t3 slack check`` ack path) shares a single source of truth.
+    """
+    return read_pass(USER_TOKEN_PASS_KEY)
+
+
+def post_reaction(*, token: str, channel: str, ts: str, emoji: str) -> bool:
+    """Call Slack ``reactions.add`` with *token* and return success.
+
+    Treats ``already_reacted`` as success — the desired end state is the
+    emoji being present on the message. Network and API failures are
+    logged but never raised: a Slack outage must not break a fast loop
+    tick. Mirrors :func:`teatree.backends.slack_reactions.add_reaction`
+    but kept inline here so the CLI surface does not pull the FSM-side
+    transition-reaction module just for an HTTP POST.
+    """
+    if not (token and channel and ts and emoji):
+        return False
+    try:
+        response = httpx.post(
+            "https://slack.com/api/reactions.add",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"channel": channel, "timestamp": ts, "name": emoji},
+            timeout=10.0,
+        )
+    except httpx.HTTPError as exc:
+        logging.getLogger(__name__).warning("Slack reactions.add transport failed: %s", exc)
+        return False
+    if not response.is_success:
+        logging.getLogger(__name__).warning("Slack reactions.add HTTP %s", response.status_code)
+        return False
+    payload = response.json()
+    if payload.get("ok"):
+        return True
+    error = payload.get("error", "")
+    if error == "already_reacted":
+        return True
+    logging.getLogger(__name__).warning("Slack reactions.add error: %s", error)
+    return False
 
 
 def _resolve_overlays(restrict: str) -> list[tuple[str, str, str]]:
@@ -109,25 +162,55 @@ def check_command() -> None:
 
 
 def _ack_messages(messages: list[dict[str, str]]) -> None:
-    """React with 👀 on each message to signal the bot has read it."""
-    bot_tokens = {name: bot_token for name, bot_token, _app_token in _resolve_overlays("")}
+    """React with 👀 on each message via the personal user OAuth token.
+
+    User DMs and Slack-Connect channels reject the bot token for
+    ``reactions.add`` (``message_not_found`` / ``mcp_externally_shared_
+    channel_restricted``); routing through the personal ``xoxp-…`` token
+    at ``pass slack/user-oauth-token`` is the only path that reliably
+    succeeds on both surfaces (#1232).
+    """
+    token = _resolve_reaction_token()
+    if not token:
+        logging.getLogger(__name__).warning(
+            "Personal Slack user-OAuth token missing at `pass %s` — "
+            "run `t3 setup slack-user-token` to enable reaction acks.",
+            USER_TOKEN_PASS_KEY,
+        )
+        return
     for msg in messages:
-        token = bot_tokens.get(msg.get("overlay", ""), "")
         channel = msg.get("channel", "")
         ts = msg.get("ts", "")
-        if not token or not channel or not ts:
-            continue
-        try:
-            import httpx  # noqa: PLC0415
+        post_reaction(token=token, channel=channel, ts=ts, emoji="eyes")
 
-            httpx.post(
-                "https://slack.com/api/reactions.add",
-                headers={"Authorization": f"Bearer {token}"},
-                json={"channel": channel, "timestamp": ts, "name": "eyes"},
-                timeout=5.0,
-            )
-        except Exception:
-            logging.getLogger(__name__).debug("Failed to ack message %s", ts, exc_info=True)
+
+@slack_app.command("react")
+def react_command(
+    channel: str = typer.Argument(..., help="Slack channel id (e.g. `D…` for a DM, `C…` for a channel)."),
+    ts: str = typer.Argument(..., help="Message timestamp (e.g. `1700000000.000100`)."),
+    emoji: str = typer.Argument(..., help="Emoji name without colons (e.g. `eyes`, `white_check_mark`)."),
+) -> None:
+    """Add *emoji* to ``(channel, ts)`` using the personal user-OAuth token.
+
+    The personal ``xoxp-…`` token at ``pass slack/user-oauth-token``
+    (provisioned by ``t3 setup slack-user-token``) is the only credential
+    that reliably reaches user DMs and Slack-Connect externally-shared
+    channels for ``reactions.add`` (#1232). Exits 0 on success (including
+    the idempotent ``already_reacted`` case), 1 when the token is missing,
+    2 on any other Slack-side failure.
+    """
+    token = _resolve_reaction_token()
+    if not token:
+        typer.echo(
+            f"ERROR Personal Slack user-OAuth token missing at `pass {USER_TOKEN_PASS_KEY}`. "
+            "Run `t3 setup slack-user-token` first."
+        )
+        raise typer.Exit(code=1)
+    if post_reaction(token=token, channel=channel, ts=ts, emoji=emoji):
+        typer.echo(f"OK    Reacted :{emoji}: on {channel}/{ts}")
+        return
+    typer.echo(f"ERROR reactions.add failed for {channel}/{ts}; see logs.")
+    raise typer.Exit(code=2)
 
 
 @slack_app.command("status")

--- a/tests/test_slack_listen.py
+++ b/tests/test_slack_listen.py
@@ -2,11 +2,13 @@
 
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import httpx
+import pytest
 from typer.testing import CliRunner
 
-from teatree.cli.slack_listen import _resolve_overlays, slack_app
+from teatree.cli.slack_listen import _resolve_overlays, post_reaction, slack_app
 
 runner = CliRunner()
 
@@ -115,7 +117,11 @@ class TestCheckCommand:
             {"overlay": "ov1", "event": {"type": "message", "user": "U1", "text": "hello", "ts": "1.0"}},
             {"overlay": "ov1", "event": {"type": "app_mention", "user": "U2", "text": "hey @bot", "ts": "2.0"}},
         ]
-        with patch("teatree.backends.slack_receiver.drain_event_queue", return_value=events):
+        with (
+            patch("teatree.backends.slack_receiver.drain_event_queue", return_value=events),
+            patch("teatree.cli.slack_listen._resolve_reaction_token", return_value="xoxp-test"),
+            patch("teatree.cli.slack_listen.post_reaction", return_value=True),
+        ):
             result = runner.invoke(slack_app, ["check"])
 
         assert result.exit_code == 0
@@ -128,13 +134,56 @@ class TestCheckCommand:
             {"overlay": "ov", "event": {"type": "message", "subtype": "bot_message", "text": "sub"}},
             {"overlay": "ov", "event": {"type": "message", "user": "U1", "text": "human"}},
         ]
-        with patch("teatree.backends.slack_receiver.drain_event_queue", return_value=events):
+        with (
+            patch("teatree.backends.slack_receiver.drain_event_queue", return_value=events),
+            patch("teatree.cli.slack_listen._resolve_reaction_token", return_value="xoxp-test"),
+            patch("teatree.cli.slack_listen.post_reaction", return_value=True),
+        ):
             result = runner.invoke(slack_app, ["check"])
 
         assert result.exit_code == 0
         lines = result.stdout.strip().splitlines()
         assert len(lines) == 1
         assert "human" in lines[0]
+
+    def test_ack_uses_personal_user_token_not_bot(self) -> None:
+        """``_ack_messages`` reads ``pass slack/user-oauth-token`` (#1232).
+
+        The bot token cannot ``reactions.add`` on user DMs
+        (``message_not_found``) or Slack-Connect channels
+        (``mcp_externally_shared_channel_restricted``); the personal
+        ``xoxp-…`` token is the only credential that reliably reaches both.
+        """
+        events = [{"overlay": "ov", "event": {"type": "message", "user": "U1", "text": "hi", "ts": "1.0"}}]
+        captured: dict[str, str] = {}
+
+        def _spy(*, token: str, channel: str, ts: str, emoji: str) -> bool:
+            captured.update(token=token, channel=channel, ts=ts, emoji=emoji)
+            return True
+
+        with (
+            patch("teatree.backends.slack_receiver.drain_event_queue", return_value=events),
+            patch("teatree.cli.slack_listen._resolve_reaction_token", return_value="xoxp-personal-abc"),
+            patch("teatree.cli.slack_listen.post_reaction", side_effect=_spy),
+        ):
+            result = runner.invoke(slack_app, ["check"])
+
+        assert result.exit_code == 0
+        assert captured["token"] == "xoxp-personal-abc"
+        assert captured["emoji"] == "eyes"
+
+    def test_ack_warns_and_skips_when_user_token_missing(self) -> None:
+        """No personal token → warn and skip the reaction (do not crash)."""
+        events = [{"overlay": "ov", "event": {"type": "message", "user": "U1", "text": "hi", "ts": "1.0"}}]
+        with (
+            patch("teatree.backends.slack_receiver.drain_event_queue", return_value=events),
+            patch("teatree.cli.slack_listen._resolve_reaction_token", return_value=""),
+            patch("teatree.cli.slack_listen.post_reaction") as posted,
+        ):
+            result = runner.invoke(slack_app, ["check"])
+
+        assert result.exit_code == 0
+        posted.assert_not_called()
 
 
 class TestListenCommand:
@@ -209,3 +258,104 @@ class TestListenCommand:
         pid_file = tmp_path / "slack-listener.pid"
         with singleton("slack-listener", pid_path=pid_file) as held:
             assert held == pid_file
+
+
+class TestPostReaction:
+    """Direct tests of the ``post_reaction`` helper used by ``react`` / ``check`` (#1232)."""
+
+    def _response(self, *, status: int = 200, payload: dict[str, object] | None = None) -> MagicMock:
+        response = MagicMock(spec=httpx.Response)
+        response.is_success = status < 400
+        response.status_code = status
+        response.json.return_value = payload or {"ok": True}
+        return response
+
+    def test_empty_arg_returns_false(self) -> None:
+        assert post_reaction(token="", channel="C1", ts="1.0", emoji="eyes") is False
+        assert post_reaction(token="xoxp-x", channel="", ts="1.0", emoji="eyes") is False
+        assert post_reaction(token="xoxp-x", channel="C1", ts="", emoji="eyes") is False
+        assert post_reaction(token="xoxp-x", channel="C1", ts="1.0", emoji="") is False
+
+    def test_ok_response_is_success(self) -> None:
+        with patch("teatree.cli.slack_listen.httpx.post", return_value=self._response()) as post:
+            assert post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes") is True
+        post.assert_called_once()
+        kwargs = post.call_args.kwargs
+        assert kwargs["headers"]["Authorization"] == "Bearer xoxp-1"
+        assert kwargs["json"] == {"channel": "D1", "timestamp": "1.0", "name": "eyes"}
+
+    def test_already_reacted_is_success(self) -> None:
+        payload = {"ok": False, "error": "already_reacted"}
+        with patch("teatree.cli.slack_listen.httpx.post", return_value=self._response(payload=payload)):
+            assert post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes") is True
+
+    def test_missing_scope_is_failure(self) -> None:
+        payload = {"ok": False, "error": "missing_scope"}
+        with patch("teatree.cli.slack_listen.httpx.post", return_value=self._response(payload=payload)):
+            assert post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes") is False
+
+    def test_transport_error_is_failure(self) -> None:
+        with patch("teatree.cli.slack_listen.httpx.post", side_effect=httpx.ConnectError("nope")):
+            assert post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes") is False
+
+    def test_non_2xx_is_failure(self) -> None:
+        with patch("teatree.cli.slack_listen.httpx.post", return_value=self._response(status=500)):
+            assert post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes") is False
+
+
+class TestReactCommand:
+    """``t3 slack react`` CLI surface (#1232)."""
+
+    def test_missing_user_token_exits_1(self) -> None:
+        with patch("teatree.cli.slack_listen._resolve_reaction_token", return_value=""):
+            result = runner.invoke(slack_app, ["react", "D1", "1.0", "eyes"])
+
+        assert result.exit_code == 1
+        assert "Run `t3 setup slack-user-token`" in result.stdout
+
+    def test_success_exits_0(self) -> None:
+        with (
+            patch("teatree.cli.slack_listen._resolve_reaction_token", return_value="xoxp-abc"),
+            patch("teatree.cli.slack_listen.post_reaction", return_value=True) as post,
+        ):
+            result = runner.invoke(slack_app, ["react", "D1", "1.0", "eyes"])
+
+        assert result.exit_code == 0
+        assert "Reacted :eyes:" in result.stdout
+        post.assert_called_once_with(token="xoxp-abc", channel="D1", ts="1.0", emoji="eyes")
+
+    def test_api_failure_exits_2(self) -> None:
+        with (
+            patch("teatree.cli.slack_listen._resolve_reaction_token", return_value="xoxp-abc"),
+            patch("teatree.cli.slack_listen.post_reaction", return_value=False),
+        ):
+            result = runner.invoke(slack_app, ["react", "D1", "1.0", "eyes"])
+
+        assert result.exit_code == 2
+        assert "reactions.add failed" in result.stdout
+
+
+class TestPostReactionLive:
+    """Integration test that fires a real ``reactions.add`` if creds + target are configured.
+
+    Skipped by default so CI stays hermetic. Set ``T3_SLACK_REACT_TEST_CHANNEL``
+    and ``T3_SLACK_REACT_TEST_TS`` to a channel+ts the personal token at
+    ``pass slack/user-oauth-token`` can write to (typically a self-DM scratch
+    message), then ``uv run pytest tests/test_slack_listen.py::TestPostReactionLive``.
+    The test passes when ``post_reaction`` returns True (idempotent ``already_reacted``
+    is treated as success), proving the ``reactions:write`` scope is actually granted.
+    """
+
+    @pytest.mark.skipif(
+        not (os.environ.get("T3_SLACK_REACT_TEST_CHANNEL") and os.environ.get("T3_SLACK_REACT_TEST_TS")),
+        reason="Set T3_SLACK_REACT_TEST_CHANNEL and T3_SLACK_REACT_TEST_TS to exercise the live path.",
+    )
+    def test_reacts_with_personal_token(self) -> None:
+        from teatree.cli.slack_listen import _resolve_reaction_token  # noqa: PLC0415
+
+        token = _resolve_reaction_token()
+        if not token:
+            pytest.skip("No personal user-OAuth token in pass — run `t3 setup slack-user-token` first.")
+        channel = os.environ["T3_SLACK_REACT_TEST_CHANNEL"]
+        ts = os.environ["T3_SLACK_REACT_TEST_TS"]
+        assert post_reaction(token=token, channel=channel, ts=ts, emoji="white_check_mark") is True


### PR DESCRIPTION
## Summary

Closes #1232.

The `:eyes:` / `:white_check_mark:` reaction-on-read pattern (per `feedback_no_on_it_text_eyes_react_only`) needs a working `reactions.add` call site. The bot token fails on the two surfaces the agent actually has to react on:

- **User DMs** — Slack returns `message_not_found` because the bot's IM channel id is not the same surface as the user's view of the same DM.
- **Slack Connect externally-shared channels** — Slack returns `mcp_externally_shared_channel_restricted`.

The personal `xoxp-…` token at `pass slack/user-oauth-token` (provisioned by `t3 setup slack-user-token`, PRs #1210/#1220) is the only credential that reliably reaches both. Per `feedback_slack_reactions_via_personal_token_not_bot`, reactions on those surfaces must go through that token.

## What changed

- `_ack_messages` in `slack_listen.py` no longer uses per-overlay bot tokens; it loads the personal user xoxp once and reacts with it.
- New `t3 slack react <channel> <ts> <emoji>` CLI lets the agent (or a human) react ad-hoc through the same path.
- Shared `post_reaction()` helper: treats `already_reacted` as success, swallows transport / non-2xx / `error:*` failures so a Slack outage never breaks a fast loop tick.
- The manifest's `_USER_SCOPES` and `REQUIRED_USER_SCOPES` already contain `reactions:read` / `reactions:write` from PRs #1067, #1112, #1220 — no manifest change required.

## Prerequisite (manual / out-of-band step)

Existing installs must mint a new xoxp token that carries the reaction scopes:

```
t3 setup slack-user-token --reset
```

That walks the Slack app reinstall + re-OAuth flow at `https://api.slack.com/apps/<app_id>/oauth`, prompting consent for the full `_USER_SCOPES` set including `reactions:write` and `reactions:read`. The scope verifier (`auth.test`'s `x-oauth-scopes` header) blocks storage of an under-scoped token, so a misconfigured manifest is caught at setup time.

## Test plan

- [x] `uv run pytest tests/test_slack_listen.py --no-cov -q` → 28 passed, 1 skipped (the live integration test, by design — see below).
- [x] `uv run pytest --no-cov -q` → 6221 passed, 13 skipped (no regressions).
- [x] `uv run ruff check src/ tests/` → clean.
- [x] `uv run ruff format --check` → clean.
- [ ] After `t3 setup slack-user-token --reset` on a dev workspace, run `T3_SLACK_REACT_TEST_CHANNEL=<self-dm-channel> T3_SLACK_REACT_TEST_TS=<msg-ts> uv run pytest tests/test_slack_listen.py::TestPostReactionLive` — exercises the real `reactions.add` end-to-end and proves the granted scope set actually includes `reactions:write`.