### PR TITLE
chore(privacy): scrub verbatim user-attributed strings from worktree files

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -338,7 +338,7 @@ A `// TODO`, `# TODO`, `/* TODO */`, `// FIXME`, `# FIXME`, `// XXX`, `# XXX`, `
 
 `t3 review post-comment` and `post-draft-note` enforce this deterministically via `src/teatree/cli/review_todo_gate.py` (souliane/teatree#1186): a blocker-shaped body anchored on a TODO-adjacent line is REFUSED with a clear error before any GitLab API call. If you genuinely believe the TODO must be addressed in THIS MR (rare — the author knows their scope), STOP and surface to the user — never post on their identity.
 
-Failure mode this prevents: re-asking a colleague to do work they have explicitly deferred makes the reviewer (and the user, whose identity posts on-behalf) look unable to read code. RED CARD !6192 (2026-05-20).
+Failure mode this prevents: re-asking a colleague to do work they have explicitly deferred makes the reviewer (and the user, whose identity posts on-behalf) look unable to read code.
 
 **Step 3 — Post Draft Review Comments:**
 

--- a/src/teatree/cli/review_todo_gate.py
+++ b/src/teatree/cli/review_todo_gate.py
@@ -5,7 +5,7 @@ on :class:`teatree.cli.review.ReviewService` anchored to (or within ±3
 lines of) an author-marked TODO/FIXME/XXX/HACK marker on an added line,
 the gate refuses the post. The author has explicitly documented the work
 is deferred via the marker; re-asking them to implement it makes the
-reviewer look unable to read code (RED CARD !6192, 2026-05-20).
+reviewer look unable to read code (see #1186).
 
 Sibling gates on the same publishing flow:
 
@@ -27,14 +27,14 @@ Design choices:
     ``has to``, ``needs to``, ``required``, ``cannot merge``, etc.). The
     list intentionally errs on the side of refusing — a false-positive
     on a borderline body is a harmless downgrade to "rephrase the
-    comment"; a false-negative is the !6192 failure mode recurring.
+    comment"; a false-negative is the #1186 failure mode recurring.
 * **Fail-open.** Any failure to fetch the diff (network, missing token,
     test stub without the relevant endpoints) returns ``""`` — the gate
     is an additional safety net, never a hard block on the existing
     happy path.
 * **Window size ±3.** The marker can sit slightly above or below the
     diff line the reviewer chose to anchor on. A 7-line window
-    (anchor + 3 above + 3 below) covers the !6192 shape (anchor on the
+    (anchor + 3 above + 3 below) covers the #1186 shape (anchor on the
     TODO itself) and the common "anchor on the function body, TODO on
     the same line or the function header" variant.
 """
@@ -61,7 +61,7 @@ _TODO_MARKER_RE = re.compile(
 )
 
 # Blocker-shaped language in the COMMENT BODY (not in the code). Matches
-# the !6192 shape — "must be done", "this is blocking", "has to be
+# the #1186 shape — "must be done", "this is blocking", "has to be
 # implemented", "required before merge", etc. Anchored on word
 # boundaries so an incidental "blockchain" or "mustard" does not trip.
 _BLOCKER_BODY_RE = re.compile(
@@ -90,7 +90,7 @@ def looks_like_blocker(body: str) -> bool:
     True when the body contains any of the canonical blocker phrases
     (``must``, ``blocking``, ``cannot merge``, ``required before merge``,
     etc.). The list is biased to refuse — a false-positive on a borderline
-    body costs one rephrase; a false-negative recurs !6192.
+    body costs one rephrase; a false-negative recurs #1186.
     """
     if not body:
         return False
@@ -212,7 +212,7 @@ def _refusal(file: str, anchor_line: int, marker_line: int, marker_text: str) ->
         f"Refusing TODO-anchored blocker post: {file}:{anchor_line} — the diff line "
         f"{at_anchor} reads {truncated!r}, which is the AUTHOR explicitly documenting "
         "this work is deferred (not in this MR). Re-asking them to implement it makes "
-        "the reviewer look unable to read code (RED CARD !6192).\n"
+        "the reviewer look unable to read code (see #1186).\n"
         "Remediation: downgrade to a non-blocker comment (e.g. `Nit: tracked at #NNN`), "
         "or skip the comment entirely. If you genuinely believe the TODO must be "
         "addressed in THIS MR, STOP and surface to the user — do NOT post on their "

--- a/src/teatree/loop/scanners/slack_broadcasts.py
+++ b/src/teatree/loop/scanners/slack_broadcasts.py
@@ -16,9 +16,9 @@ via the injected :class:`MrStateClassifier`, persists a
 ``(channel, slack_ts)``), and reacts on the Slack message:
 
 * **All merged + approved** → react ``:white_check_mark:`` and skip
-    reviewer dispatch. Matches the user mandate in #1131 comment 2: the
-    reaction is sufficient acknowledgement, the agent does not re-review
-    already-done work.
+    reviewer dispatch. Matches the rule from #1131: the reaction is
+    sufficient acknowledgement, the agent does not re-review already-done
+    work.
 * **At least one open MR** → react ``:eyes:`` and emit one
     ``slack.review_intent`` signal per open MR. The existing dispatcher
     routes each signal to the ``t3:reviewer`` agent — no separate

--- a/tests/teatree_cli/test_review_default_to_draft.py
+++ b/tests/teatree_cli/test_review_default_to_draft.py
@@ -1,8 +1,8 @@
 """``t3 review post-comment`` defaults to DRAFT — ``--live`` needs a Slack-recorded token (#1207).
 
 The historical ``post-comment`` published live to GitLab on every
-invocation. Per the user mandate captured on #1207 the default flips to
-a DRAFT (safe-by-default); the live, colleague-visible path is gated on
+invocation. Per #1207 the default flips to a DRAFT (safe-by-default);
+the live, colleague-visible path is gated on
 a single-use, MR-URL-scoped
 :class:`~teatree.core.models.live_post_approval.LivePostApproval`
 minted by ``t3 review approve-live-post`` after the helper verifies a

--- a/tests/teatree_cli/test_review_shape_gate.py
+++ b/tests/teatree_cli/test_review_shape_gate.py
@@ -142,8 +142,7 @@ class TestColleagueMRShapeGate:
     def test_legitimate_three_sentence_finding_passes(self) -> None:
         """Issue #1159: a legitimate 3-sentence MR-level finding must pass.
 
-        Per user feedback "it's ok if nits are longer than 2 sentences...
-        you must just not abuse. the 2 sentences hard check is too much".
+        Per #1159 the cap is paragraph-and-word, not sentence-count.
         A short, single-paragraph 3-sentence finding with a file:line cite
         is the canonical case the old 2-sentence cap false-rejected.
         """

--- a/tests/teatree_cli/test_review_todo_gate.py
+++ b/tests/teatree_cli/test_review_todo_gate.py
@@ -7,10 +7,9 @@ author has already documented the work is deferred ("not in this MR" /
 "follow-up" / "deferred" / "implement later" / "out of scope"); re-asking
 them to implement it makes the reviewer look unable to read code.
 
-This is the structural fix for the !6192 RED CARD (2026-05-20): two
-blocker comments were posted anchored to `// TODO: Navigate to the
-results page` and `// TODO: Load user data from CRM`. The user deleted
-the comments and approved the MR.
+This is the structural fix for #1186: blocker comments were posted
+anchored to author-marked `// TODO:` lines documenting deferred work.
+The fix gates publishing so the same shape cannot recur.
 
 The gate is independent of the colleague-MR shape gate and the on-behalf
 gate; all three run on every publishing method.

--- a/tests/teatree_loop/slack_answer/test_coalescing.py
+++ b/tests/teatree_loop/slack_answer/test_coalescing.py
@@ -1,10 +1,9 @@
 """Message coalescing — consecutive follow-ups are one logical turn (#1014).
 
-Real example the user flagged: two Slack messages 3s apart ("will you
-bump my review requests..." then "I have a lot") are one logical request,
-not two. The loop must concatenate consecutive same-user/channel rows
-with no bot reply between them and within the window into ONE unit:
-classify once, thread on the FIRST ts, :eyes: + answer ALL rows together.
+Real example: two Slack messages 3s apart - same logical request coalesced.
+The loop must concatenate consecutive same-user/channel rows with no bot
+reply between them and within the window into ONE unit: classify once,
+thread on the FIRST ts, :eyes: + answer ALL rows together.
 Zero-token — pure DB/time logic.
 """
 
@@ -70,14 +69,14 @@ def _seed(ts: str, text: str, *, user: str, channel: str, secs_after_base: float
 
 class TestCoalesceGrouping:
     def test_two_messages_3s_apart_no_bot_between_is_one_unit(self) -> None:
-        _seed("1.0", "will you bump my review requests", user="U1", channel="C1", secs_after_base=0)
-        _seed("2.0", "I have a lot", user="U1", channel="C1", secs_after_base=3)
+        _seed("1.0", "please bump my review requests", user="U1", channel="C1", secs_after_base=0)
+        _seed("2.0", "there are several", user="U1", channel="C1", secs_after_base=3)
 
         units = _coalesce(list(PendingChatInjection.loop_unreplied()))
 
         assert len(units) == 1
         assert units[0].slack_ts == "1.0"  # threads on the FIRST message
-        assert units[0].text == "will you bump my review requests\nI have a lot"
+        assert units[0].text == "please bump my review requests\nthere are several"
         assert len(units[0].rows) == 2
 
     def test_gap_greater_than_window_is_two_units(self) -> None:

--- a/tests/teatree_loop/slack_answer/test_simple_answer.py
+++ b/tests/teatree_loop/slack_answer/test_simple_answer.py
@@ -146,12 +146,12 @@ class TestStageAReturnsStatuslineNotDashboard:
     def test_stage_a_does_not_return_dashboard_table_for_dashboard_keyword(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Exact regression: user typed "wtf is this loop dashboard?" — Stage
-        # A matched on the "dashboard" token in _DASHBOARD_TOKENS and replied
-        # with the dashboard table. The fix must return statusline content
-        # instead, regardless of which dashboard keyword matched.
+        # Regression: a message containing the "dashboard" token from
+        # _DASHBOARD_TOKENS used to make Stage A reply with the dashboard
+        # table. The fix must return statusline content instead, regardless
+        # of which dashboard keyword matched.
         self._write_statusline(tmp_path, monkeypatch, "overlay=teatree\nticket=#1121\n")
-        row = _row("wtf is this loop dashboard?")
+        row = _row("hey what is this loop dashboard")
         with patch("teatree.loop.slack_answer.simple_answer._run_haiku") as haiku:
             answer = build_simple_answer(row)
 

--- a/tests/teatree_loop/test_slack_broadcasts_scanner.py
+++ b/tests/teatree_loop/test_slack_broadcasts_scanner.py
@@ -4,7 +4,7 @@ The scanner polls one or more configured Slack channels, extracts MR URLs
 from each message, classifies the set via an injected classifier, and:
 
 * reacts ``:white_check_mark:`` and skips dispatch when every MR is merged +
-    approved (the user mandate from #1131 comment 2);
+    approved;
 * reacts ``:eyes:`` and emits one ``slack.review_intent`` signal per open
     MR in the open subset for mixed and all-pending broadcasts;
 * persists one :class:`ScannedBroadcast` row per ``(channel, slack_ts)``


### PR DESCRIPTION
## Summary

Closes #1213.

Local-only scrub of verbatim user-quoted text and dated RED-CARD / user-mandate tags across 9 files. All substitutions preserve test logic (matcher tokens and assertion shapes still hit).

### Files

HIGH (verbatim quotes paraphrased):
- tests/teatree_loop/slack_answer/test_simple_answer.py — dashboard-matcher regression input + comment paraphrased.
- tests/teatree_loop/slack_answer/test_coalescing.py — docstring + coalesce fixtures paraphrased.
- tests/teatree_cli/test_review_shape_gate.py — docstring rephrased to cite #1159 instead of quoting feedback.

MEDIUM (framing tags dropped/neutralised):
- src/teatree/loop/scanners/slack_broadcasts.py — "user mandate in #1131 comment 2" -> "the rule from #1131".
- tests/teatree_loop/test_slack_broadcasts_scanner.py — drops the "user mandate from #1131 comment 2" parenthetical.
- tests/teatree_cli/test_review_default_to_draft.py — "user mandate captured on #1207" -> "Per #1207".
- src/teatree/cli/review_todo_gate.py + tests/teatree_cli/test_review_todo_gate.py — dated RED-CARD-!6192 tags replaced with #1186 references.
- skills/review/SKILL.md — dated RED-CARD tag removed; failure-mode prose stands.

### Verification

- uv run pytest --no-cov -x -q on the changed test modules: 87 passed.
- uv run ruff check: All checks passed.
- pre-push privacy-leak gate (#685): Passed.