### PR TITLE
feat(hooks): pre-publish quote-scanner gate (#1213)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -477,6 +477,7 @@ graph TD
     teatree.templates
     teatree.claude_sessions
     teatree.overlay_init
+    teatree.hooks
     teatree.skill_schema
     teatree.slack_mrkdwn
     teatree.skill_deps

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -874,6 +874,90 @@ def handle_block_ai_signature(data: dict) -> bool:
     return False
 
 
+# ── PreToolUse: pre-publish quote-scanner gate (#1213) ──────────────
+
+
+def handle_quote_scanner_pretool(data: dict) -> bool:
+    """Refuse a publish whose body carries a verbatim user-quote pattern.
+
+    Promotes the prose-only "never quote user verbatim" rule
+    (``feedback_redcard_never_quote_user_on_public_repos.md``) to a
+    deterministic pre-publish gate. Surfaces covered include Bash calls
+    that publish to GitHub/GitLab/Slack/git itself (``gh issue create``,
+    ``glab mr update``, ``git commit -m``, ``curl … chat.postMessage``
+    and siblings), the per-overlay t3 publish family (``review
+    post-comment``, ``review post-draft-note``, ``notify send``,
+    ``ticket create-issue``, ``t3 slack react``), and the Slack MCP
+    ``send_message`` tools.
+
+    HIGH match ⇒ refuse via ``permissionDecision: deny`` + a reason that
+    names the matched patterns and points at the ``--quote-ok`` /
+    ``QUOTE_OK=1`` override. MEDIUM-only ⇒ stderr warning, publish
+    proceeds. Every decision (including overrides) lands in the
+    quote-scanner JSONL ledger so cold review can audit what the gate
+    saw.
+    """
+    from typing import cast  # noqa: PLC0415
+
+    from teatree.hooks import quote_scanner  # noqa: PLC0415
+
+    tool_name = data.get("tool_name", "")
+    raw_input = data.get("tool_input", {}) or {}
+    if not isinstance(raw_input, dict):
+        return False
+    tool_input = cast("quote_scanner.ToolInput", raw_input)
+
+    payload = quote_scanner.extract_publish_payload(tool_name, tool_input)
+    if payload is None:
+        return False
+
+    override = quote_scanner.has_quote_ok_override(tool_name, tool_input)
+    result = quote_scanner.scan_text(payload)
+
+    if override:
+        quote_scanner.log_decision(
+            tool_name=tool_name,
+            decision="allow-override",
+            result=result,
+            override=True,
+        )
+        return False
+
+    if result.has_high:
+        quote_scanner.log_decision(
+            tool_name=tool_name,
+            decision="deny",
+            result=result,
+            override=False,
+        )
+        json.dump(
+            {
+                "permissionDecision": "deny",
+                "permissionDecisionReason": quote_scanner.format_block_message(result),
+            },
+            sys.stdout,
+        )
+        return True
+
+    if result.has_medium:
+        sys.stderr.write(quote_scanner.format_warn_message(result) + "\n")
+        quote_scanner.log_decision(
+            tool_name=tool_name,
+            decision="warn",
+            result=result,
+            override=False,
+        )
+        return False
+
+    quote_scanner.log_decision(
+        tool_name=tool_name,
+        decision="allow",
+        result=result,
+        override=False,
+    )
+    return False
+
+
 # ── PreToolUse: block-uncovered-diff (#937 §17.6 gate 12) ───────────
 #
 # Gate 12's detection (``teatree.utils.diff_coverage`` / ``t3 tool
@@ -3750,6 +3834,7 @@ _HANDLERS: dict[str, list] = {
         handle_enforce_loop_registration,
         handle_enforce_plan_gate,
         handle_protect_default_branch,
+        handle_quote_scanner_pretool,
         handle_enforce_skill_loading,
         handle_block_direct_commands,
         handle_validate_mr_metadata,

--- a/src/teatree/hooks/__init__.py
+++ b/src/teatree/hooks/__init__.py
@@ -1,0 +1,1 @@
+"""Pre-publish enforcement primitives consumed by the PreToolUse hook chain."""

--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -1,0 +1,313 @@
+"""Bash command surface parsing for the quote-scanner gate (#1213).
+
+Extracted from :mod:`teatree.hooks.quote_scanner` to keep that module
+under the project's per-file LOC ceiling. The public quote-scanner API
+(scan_text, format_*, log_decision, extract_publish_payload,
+has_quote_ok_override) lives in ``quote_scanner.py`` and delegates the
+shell-grammar work to the helpers here.
+
+The parser walks a Bash command string and pulls out every fragment
+that could carry a publishable body — quoted ``--body``/``-m``/``-b``
+flags, heredocs, file paths, ``gh api`` field assignments, ``curl``
+data flags, and the JSON ``text``/``message``/``body`` fields nested
+inside them. It also normalises shell-equivalent spellings
+(line-continuations, ANSI-C ``$'...'`` quoting) so the substring
+matcher and regexes see the same logical command Bash itself would
+execute. Indirect body sources we cannot inspect (``gh api --input -``,
+missing files, opaque ``-d @file`` references) fail closed via a
+sentinel string that downstream scanning treats as a HIGH match.
+"""
+
+import codecs
+import json
+import re
+from pathlib import Path
+from typing import Final
+
+# ── Publish-surface substring catalogues ────────────────────────────
+
+# Bash commands that publish to an external surface. The substring match
+# is sufficient — Bash strings come from the LLM, not from a shell, so
+# we don't have to worry about ``echo "gh issue create" | grep``-style
+# embedding.
+_BASH_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
+    "gh issue create",
+    "gh issue edit",
+    "gh issue comment",
+    "gh pr create",
+    "gh pr edit",
+    "gh pr comment",
+    "gh pr review",
+    "glab issue create",
+    "glab issue update",
+    "glab issue note create",
+    # ``glab issue note <id>`` (no ``create`` segment) is the real
+    # comment subcommand — trailing space pins the substring to the
+    # subcommand boundary so ``glab issue notebook`` would not match.
+    "glab issue note ",
+    "glab mr create",
+    "glab mr update",
+    "glab mr note create",
+    "glab mr note ",
+    "git commit -m",
+    "git commit --message",
+    "git commit -F",
+    "git commit --file",
+    "git tag --message",
+    # ``gh api`` / ``glab api`` POST/PATCH calls land on REST endpoints
+    # that publish issue/PR/MR comments. The payload is carried via
+    # ``-f``/``-F``/``--raw-field``/``--field``/``--input`` and parsed
+    # by :func:`extract_bash_payload`.
+    "gh api ",
+    "glab api ",
+    "chat.postMessage",
+)
+
+# t3 sub-commands that publish on the user's behalf. The overlay segment
+# between ``t3`` and the verb is arbitrary (one of the registered
+# overlays), so we match the verb-segment substring directly — e.g.
+# ``review post-comment`` matches both ``t3 teatree review post-comment``
+# and the equivalent per-overlay variant.
+_T3_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
+    "notify send",
+    "review post-comment",
+    "review post-draft-note",
+    "ticket create-issue",
+    "t3 slack react",
+)
+
+
+def _is_t3_publish_invocation(command: str) -> bool:
+    if not command.lstrip().startswith("t3 "):
+        return False
+    return any(needle in command for needle in _T3_PUBLISH_SUBSTRINGS)
+
+
+def is_publish_command(command: str) -> bool:
+    """Return True iff the Bash command would publish to an external surface."""
+    if any(needle in command for needle in _BASH_PUBLISH_SUBSTRINGS):
+        return True
+    return _is_t3_publish_invocation(command)
+
+
+# ── Body-flag and curl regexes ──────────────────────────────────────
+
+# Capture --body / --description / --message / --title / -m / -F arg
+# values plus heredocs. An optional ``$`` prefix on the opening quote
+# covers ANSI-C quoting (``$'...'``) — codex round-2 #3.
+_FLAG_VALUE_RE: Final[re.Pattern[str]] = re.compile(
+    r"--(?:body|description|message|title)(?:[ =])\s*\$?(['\"])(.*?)\1",
+    re.DOTALL,
+)
+_SHORT_M_RE: Final[re.Pattern[str]] = re.compile(r"\s-m\s+\$?(['\"])(.*?)\1", re.DOTALL)
+_SHORT_B_RE: Final[re.Pattern[str]] = re.compile(r"\s-b\s+\$?(['\"])(.*?)\1", re.DOTALL)
+_HEREDOC_RE: Final[re.Pattern[str]] = re.compile(
+    r"<<\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\1\b",
+    re.DOTALL,
+)
+_FILE_FLAG_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:--body-file|--description-file|--file)[ =]+(\S+)",
+)
+_GIT_SHORT_F_RE: Final[re.Pattern[str]] = re.compile(r"\s-F[ =]?(\S+)")
+_API_FIELD_BODY_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:-f|-F|--field|--raw-field)\s+body=\$?(['\"])?(.*?)(?(1)\1|(?=\s|$))",
+    re.DOTALL,
+)
+_API_INPUT_FILE_RE: Final[re.Pattern[str]] = re.compile(r"--input[ =]+(\S+)")
+
+# curl carries its payload in ``-d`` / ``--data`` / ``--data-raw`` /
+# ``--data-binary`` / ``--json``. The ``[ =]`` separator matches both
+# space and equals forms (codex round-2 #5). An optional ``$`` prefix
+# covers ANSI-C-quoted bodies.
+_CURL_DATA_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:--data-raw|--data-binary|--data|--json|\s-d)[ =]\s*\$?(['\"])(.*?)\1",
+    re.DOTALL,
+)
+_CURL_DATA_FILE_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:--data-raw|--data-binary|--data|--json|\s-d)[ =]@(\S+)",
+)
+
+# ``gh api ... --input -`` reads from stdin, which the hook cannot
+# inspect. Detect via a dedicated regex so the fail-closed sentinel
+# only fires for the genuine stdin form.
+_API_INPUT_STDIN_RE: Final[re.Pattern[str]] = re.compile(r"--input[ =]-(?:\s|$)")
+
+# Sentinel string that downstream scanning treats as a HIGH match. Any
+# indirect or undecodable body source surfaces this so the gate fails
+# closed (codex CRITICAL #5 round 1, codex round-2 #4).
+FAIL_CLOSED_SENTINEL: Final[str] = (
+    "the user said: pre-publish quote-scanner could not parse a body source — fail closed"
+)
+
+
+# ── Shell-grammar normalisation ─────────────────────────────────────
+
+
+def normalize_line_continuations(command: str) -> str:
+    r"""Collapse ``\<NL>`` line continuations to a single space.
+
+    Bash treats ``\<NL>`` as a logical-line join — the next physical
+    line continues the current command. We replace the sequence with a
+    single space AND collapse surrounding whitespace so the joined
+    token boundary matches what Bash itself would pass to the child
+    process. The publish-substring matcher uses single-space separators
+    like ``gh issue comment``, so source indentation has to disappear.
+    """
+    # ``[ws]*\<NL>[ws]*`` → one space.
+    return re.sub(r"[ \t]*\\\r?\n[ \t]*", " ", command)
+
+
+# ANSI-C ``$'...'`` — bash decodes escapes like ``\n`` / ``\x4c`` before
+# passing the value to the child. Without decoding, an attacker can hide
+# a HIGH-match body inside ``$'## User mandate\\nship'`` (codex
+# round-2 #3).
+_ANSI_C_QUOTED_RE: Final[re.Pattern[str]] = re.compile(r"\$'((?:[^'\\]|\\.)*)'")
+
+
+def _decode_ansi_c_escapes(literal: str) -> str:
+    r"""Decode a stripped ANSI-C body to its real bytes-as-string form."""
+    try:
+        return codecs.decode(literal, "unicode_escape")
+    except (UnicodeDecodeError, ValueError):
+        return literal
+
+
+def expand_ansi_c_quotes(command: str) -> str:
+    r"""Replace every ``$'...'`` token with a single-quoted decoded form.
+
+    The result is a command string whose body flags use plain single
+    quotes — letting the existing flag-value regexes match the now-
+    decoded content. Single quotes inside the decoded text are escaped
+    by switching to the ``'\''`` shell convention.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        decoded = _decode_ansi_c_escapes(match.group(1))
+        escaped = decoded.replace("'", "'\\''")
+        return f"'{escaped}'"
+
+    return _ANSI_C_QUOTED_RE.sub(_replace, command)
+
+
+def first_shell_command(command: str) -> str:
+    """Return the prefix of ``command`` up to the first UNQUOTED newline.
+
+    Quote-aware so a literal newline INSIDE a double- or single-quoted
+    string is preserved (bash treats it as part of the same logical
+    command), while a bare newline acts as a command separator. This is
+    the substrate for the override-detection's first-segment rule:
+    ``--quote-ok`` on a continuation line that bash would treat as a
+    second command must not bypass the gate (codex round-2 #1).
+    """
+    state: str | None = None
+    i = 0
+    length = len(command)
+    while i < length:
+        ch = command[i]
+        if state is None:
+            if ch == "\\" and i + 1 < length:
+                # Outside quotes, ``\X`` is a one-char escape (``\<NL>``
+                # is line-continuation handled upstream by
+                # :func:`normalize_line_continuations`).
+                i += 2
+                continue
+            if ch in {"'", '"'}:
+                state = ch
+            elif ch in {"\n", "\r"}:
+                return command[:i]
+        elif ch == "\\" and state == '"' and i + 1 < length:
+            # Backslash escapes only inside double-quotes.
+            i += 2
+            continue
+        elif ch == state:
+            state = None
+        i += 1
+    return command
+
+
+# ── Body extraction ─────────────────────────────────────────────────
+
+
+def _read_file_arg(path: str) -> str | None:
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _json_body_fields(blob: str) -> list[str]:
+    """Return ``text``/``message``/``body`` values from a JSON blob, if any."""
+    try:
+        decoded = json.loads(blob)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(decoded, dict):
+        return []
+    return [str(decoded[key]) for key in ("text", "message", "body") if key in decoded]
+
+
+def _extract_curl_payloads(command: str) -> list[str]:
+    """Parse curl ``-d``/``--data``/``--data-raw``/``--json`` JSON bodies.
+
+    JSON-decoded bodies surface their ``text``/``message``/``body``
+    fields. When curl carries a data flag we cannot inspect — a file
+    reference (``@path``), stdin (``@-``), or unparsable body — the
+    parser appends the fail-closed sentinel that trips the HIGH gate.
+    """
+    payloads: list[str] = []
+    for match in _CURL_DATA_RE.finditer(command):
+        raw = match.group(2)
+        # Always include the raw text — the scanner's pattern catalogue
+        # can match user-attributed prose even outside JSON shapes.
+        payloads.append(raw)
+        json_fields = _json_body_fields(raw)
+        if json_fields:
+            payloads.extend(json_fields)
+        elif raw.strip().startswith(("{", "[")):
+            # Looked like JSON but did not decode — fail closed.
+            payloads.append(FAIL_CLOSED_SENTINEL)
+    # File-/stdin-referenced data flags cannot be inspected in-process.
+    if _CURL_DATA_FILE_RE.search(command):
+        payloads.append(FAIL_CLOSED_SENTINEL)
+    return payloads
+
+
+def extract_bash_payload(command: str) -> str:
+    r"""Concatenate every body-like fragment the command surface carries.
+
+    Pre-processing normalises shell-equivalent spellings before the
+    pattern catalogue runs: ``\<NL>`` line continuations are joined and
+    ANSI-C ``$'...'`` quoting is decoded (codex round-2 #2 / #3).
+    Indirect body sources (``gh api --input -``, missing input files)
+    fail closed via the sentinel.
+    """
+    command = normalize_line_continuations(command)
+    command = expand_ansi_c_quotes(command)
+    parts: list[str] = [match.group(2) for match in _FLAG_VALUE_RE.finditer(command)]
+    parts.extend(match.group(2) for match in _SHORT_M_RE.finditer(command))
+    parts.extend(match.group(2) for match in _SHORT_B_RE.finditer(command))
+    parts.extend(match.group(2) for match in _HEREDOC_RE.finditer(command))
+    parts.extend(match.group(2) for match in _API_FIELD_BODY_RE.finditer(command))
+    parts.extend(_extract_curl_payloads(command))
+    for match in (*_FILE_FLAG_RE.finditer(command), *_GIT_SHORT_F_RE.finditer(command)):
+        content = _read_file_arg(match.group(1))
+        if content is not None:
+            parts.append(content)
+        else:
+            parts.append(FAIL_CLOSED_SENTINEL)
+    # ``gh api / glab api --input -`` reads from stdin — fail closed
+    # before per-file processing runs against the ``-`` literal.
+    if _API_INPUT_STDIN_RE.search(command):
+        parts.append(FAIL_CLOSED_SENTINEL)
+    for match in _API_INPUT_FILE_RE.finditer(command):
+        path_arg = match.group(1)
+        if path_arg == "-":
+            # Already handled by the stdin sentinel above.
+            continue
+        content = _read_file_arg(path_arg)
+        if content is None:
+            parts.append(FAIL_CLOSED_SENTINEL)
+            continue
+        parts.append(content)
+        parts.extend(_json_body_fields(content))
+    return "\n".join(parts)

--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -1,4 +1,4 @@
-"""Bash command surface parsing for the quote-scanner gate (#1213).
+r"""Bash command surface parsing for the quote-scanner gate (#1213).
 
 Extracted from :mod:`teatree.hooks.quote_scanner` to keep that module
 under the project's per-file LOC ceiling. The public quote-scanner API
@@ -6,23 +6,28 @@ under the project's per-file LOC ceiling. The public quote-scanner API
 has_quote_ok_override) lives in ``quote_scanner.py`` and delegates the
 shell-grammar work to the helpers here.
 
-The parser walks a Bash command string and pulls out every fragment
-that could carry a publishable body — quoted ``--body``/``-m``/``-b``
-flags, heredocs, file paths, ``gh api`` field assignments, ``curl``
-data flags, and the JSON ``text``/``message``/``body`` fields nested
-inside them. It also normalises shell-equivalent spellings
-(line-continuations, ANSI-C ``$'...'`` quoting) so the substring
-matcher and regexes see the same logical command Bash itself would
-execute. Indirect body sources we cannot inspect (``gh api --input -``,
-missing files, opaque ``-d @file`` references) fail closed via a
-sentinel string that downstream scanning treats as a HIGH match.
+The parser walks a Bash command string in two passes:
+
+1. :mod:`teatree.hooks._shell_lexer` produces a token stream where bash
+    shell grammar is honoured (``\<NL>`` removed token-internally,
+    ``;``/``|``/``&``/``&&``/``||`` emitted as standalone metachars
+    regardless of whitespace, ANSI-C ``$'...'`` decoded properly per
+    the bash man-page).
+2. Per-command argument walkers iterate over the WORD tokens of each
+    command segment and pull out body-flag values, heredoc-style content,
+    and attached short-option payloads (``-d'{...}'``).
+
+Indirect body sources we cannot inspect (``gh api --input -``, missing
+files, opaque ``-d @file`` references) fail closed via a sentinel
+string that downstream scanning treats as a HIGH match.
 """
 
-import codecs
 import json
 import re
 from pathlib import Path
 from typing import Final
+
+from teatree.hooks._shell_lexer import Token, TokenKind, is_command_separator, split_commands, tokenize
 
 # ── Publish-surface substring catalogues ────────────────────────────
 
@@ -77,61 +82,6 @@ _T3_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
 )
 
 
-def _is_t3_publish_invocation(command: str) -> bool:
-    if not command.lstrip().startswith("t3 "):
-        return False
-    return any(needle in command for needle in _T3_PUBLISH_SUBSTRINGS)
-
-
-def is_publish_command(command: str) -> bool:
-    """Return True iff the Bash command would publish to an external surface."""
-    if any(needle in command for needle in _BASH_PUBLISH_SUBSTRINGS):
-        return True
-    return _is_t3_publish_invocation(command)
-
-
-# ── Body-flag and curl regexes ──────────────────────────────────────
-
-# Capture --body / --description / --message / --title / -m / -F arg
-# values plus heredocs. An optional ``$`` prefix on the opening quote
-# covers ANSI-C quoting (``$'...'``) — codex round-2 #3.
-_FLAG_VALUE_RE: Final[re.Pattern[str]] = re.compile(
-    r"--(?:body|description|message|title)(?:[ =])\s*\$?(['\"])(.*?)\1",
-    re.DOTALL,
-)
-_SHORT_M_RE: Final[re.Pattern[str]] = re.compile(r"\s-m\s+\$?(['\"])(.*?)\1", re.DOTALL)
-_SHORT_B_RE: Final[re.Pattern[str]] = re.compile(r"\s-b\s+\$?(['\"])(.*?)\1", re.DOTALL)
-_HEREDOC_RE: Final[re.Pattern[str]] = re.compile(
-    r"<<\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\1\b",
-    re.DOTALL,
-)
-_FILE_FLAG_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:--body-file|--description-file|--file)[ =]+(\S+)",
-)
-_GIT_SHORT_F_RE: Final[re.Pattern[str]] = re.compile(r"\s-F[ =]?(\S+)")
-_API_FIELD_BODY_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:-f|-F|--field|--raw-field)\s+body=\$?(['\"])?(.*?)(?(1)\1|(?=\s|$))",
-    re.DOTALL,
-)
-_API_INPUT_FILE_RE: Final[re.Pattern[str]] = re.compile(r"--input[ =]+(\S+)")
-
-# curl carries its payload in ``-d`` / ``--data`` / ``--data-raw`` /
-# ``--data-binary`` / ``--json``. The ``[ =]`` separator matches both
-# space and equals forms (codex round-2 #5). An optional ``$`` prefix
-# covers ANSI-C-quoted bodies.
-_CURL_DATA_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:--data-raw|--data-binary|--data|--json|\s-d)[ =]\s*\$?(['\"])(.*?)\1",
-    re.DOTALL,
-)
-_CURL_DATA_FILE_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:--data-raw|--data-binary|--data|--json|\s-d)[ =]@(\S+)",
-)
-
-# ``gh api ... --input -`` reads from stdin, which the hook cannot
-# inspect. Detect via a dedicated regex so the fail-closed sentinel
-# only fires for the genuine stdin form.
-_API_INPUT_STDIN_RE: Final[re.Pattern[str]] = re.compile(r"--input[ =]-(?:\s|$)")
-
 # Sentinel string that downstream scanning treats as a HIGH match. Any
 # indirect or undecodable body source surfaces this so the gate fails
 # closed (codex CRITICAL #5 round 1, codex round-2 #4).
@@ -140,92 +90,73 @@ FAIL_CLOSED_SENTINEL: Final[str] = (
 )
 
 
-# ── Shell-grammar normalisation ─────────────────────────────────────
+def normalize_for_substring_match(command: str) -> str:
+    r"""Return a publish-detection-friendly string for ``command``.
 
-
-def normalize_line_continuations(command: str) -> str:
-    r"""Collapse ``\<NL>`` line continuations to a single space.
-
-    Bash treats ``\<NL>`` as a logical-line join — the next physical
-    line continues the current command. We replace the sequence with a
-    single space AND collapse surrounding whitespace so the joined
-    token boundary matches what Bash itself would pass to the child
-    process. The publish-substring matcher uses single-space separators
-    like ``gh issue comment``, so source indentation has to disappear.
+    Re-emits the lexed token stream as space-separated WORD tokens, with
+    one space between command segments. This collapses ``\<NL>`` (both
+    token-internal and between-token) and ANSI-C decoding so the
+    publish-substring matcher sees the same logical command bash would
+    execute.
     """
-    # ``[ws]*\<NL>[ws]*`` → one space.
-    return re.sub(r"[ \t]*\\\r?\n[ \t]*", " ", command)
+    tokens = tokenize(command)
+    out: list[str] = []
+    for tok in tokens:
+        if is_command_separator(tok):
+            out.append(" ")
+        else:
+            out.extend((tok.value, " "))
+    return "".join(out)
 
 
-# ANSI-C ``$'...'`` — bash decodes escapes like ``\n`` / ``\x4c`` before
-# passing the value to the child. Without decoding, an attacker can hide
-# a HIGH-match body inside ``$'## User mandate\\nship'`` (codex
-# round-2 #3).
-_ANSI_C_QUOTED_RE: Final[re.Pattern[str]] = re.compile(r"\$'((?:[^'\\]|\\.)*)'")
+def _is_t3_publish_invocation(joined: str) -> bool:
+    if not joined.lstrip().startswith("t3 "):
+        return False
+    return any(needle in joined for needle in _T3_PUBLISH_SUBSTRINGS)
 
 
-def _decode_ansi_c_escapes(literal: str) -> str:
-    r"""Decode a stripped ANSI-C body to its real bytes-as-string form."""
-    try:
-        return codecs.decode(literal, "unicode_escape")
-    except (UnicodeDecodeError, ValueError):
-        return literal
+def is_publish_command(command: str) -> bool:
+    """Return True iff the Bash command would publish to an external surface."""
+    joined = normalize_for_substring_match(command)
+    if any(needle in joined for needle in _BASH_PUBLISH_SUBSTRINGS):
+        return True
+    return _is_t3_publish_invocation(joined)
 
 
-def expand_ansi_c_quotes(command: str) -> str:
-    r"""Replace every ``$'...'`` token with a single-quoted decoded form.
+# ── Body-flag and curl regexes (heredoc only — flag args are token-aware) ─
 
-    The result is a command string whose body flags use plain single
-    quotes — letting the existing flag-value regexes match the now-
-    decoded content. Single quotes inside the decoded text are escaped
-    by switching to the ``'\''`` shell convention.
-    """
+_HEREDOC_RE: Final[re.Pattern[str]] = re.compile(
+    r"<<\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\1\b",
+    re.DOTALL,
+)
 
-    def _replace(match: re.Match[str]) -> str:
-        decoded = _decode_ansi_c_escapes(match.group(1))
-        escaped = decoded.replace("'", "'\\''")
-        return f"'{escaped}'"
+# Per-command argument-walker dispatch tables --------------------------
 
-    return _ANSI_C_QUOTED_RE.sub(_replace, command)
+# Body-bearing long options (value follows the flag as next token or
+# attached via ``=``). The catalogue is shared by all publishing
+# commands — gh, glab, git, curl all use the same long-option grammar.
+_BODY_FLAG_NAMES: Final[frozenset[str]] = frozenset(
+    {"--body", "--description", "--message", "--title"},
+)
 
+# Long options that point at a FILE whose content we should read. If the
+# file is missing or unreadable the parser appends the fail-closed
+# sentinel.
+_BODY_FILE_FLAG_NAMES: Final[frozenset[str]] = frozenset(
+    {"--body-file", "--description-file", "--file"},
+)
 
-def first_shell_command(command: str) -> str:
-    """Return the prefix of ``command`` up to the first UNQUOTED newline.
+# Short body-bearing flags used by ``gh`` / ``glab`` / ``git commit``.
+_BODY_SHORT_FLAGS: Final[frozenset[str]] = frozenset({"-m", "-b"})
 
-    Quote-aware so a literal newline INSIDE a double- or single-quoted
-    string is preserved (bash treats it as part of the same logical
-    command), while a bare newline acts as a command separator. This is
-    the substrate for the override-detection's first-segment rule:
-    ``--quote-ok`` on a continuation line that bash would treat as a
-    second command must not bypass the gate (codex round-2 #1).
-    """
-    state: str | None = None
-    i = 0
-    length = len(command)
-    while i < length:
-        ch = command[i]
-        if state is None:
-            if ch == "\\" and i + 1 < length:
-                # Outside quotes, ``\X`` is a one-char escape (``\<NL>``
-                # is line-continuation handled upstream by
-                # :func:`normalize_line_continuations`).
-                i += 2
-                continue
-            if ch in {"'", '"'}:
-                state = ch
-            elif ch in {"\n", "\r"}:
-                return command[:i]
-        elif ch == "\\" and state == '"' and i + 1 < length:
-            # Backslash escapes only inside double-quotes.
-            i += 2
-            continue
-        elif ch == state:
-            state = None
-        i += 1
-    return command
+# Long options for ``gh api`` / ``glab api`` field assignments.
+_API_FIELD_LONG_FLAGS: Final[frozenset[str]] = frozenset({"--field", "--raw-field"})
+_API_FIELD_SHORT_FLAGS: Final[frozenset[str]] = frozenset({"-f", "-F"})
 
-
-# ── Body extraction ─────────────────────────────────────────────────
+# Curl long-option data flags — payload is JSON-or-text.
+_CURL_DATA_LONG_FLAGS: Final[frozenset[str]] = frozenset(
+    {"--data", "--data-raw", "--data-binary", "--data-urlencode", "--json"},
+)
 
 
 def _read_file_arg(path: str) -> str | None:
@@ -246,68 +177,299 @@ def _json_body_fields(blob: str) -> list[str]:
     return [str(decoded[key]) for key in ("text", "message", "body") if key in decoded]
 
 
-def _extract_curl_payloads(command: str) -> list[str]:
-    """Parse curl ``-d``/``--data``/``--data-raw``/``--json`` JSON bodies.
+def _attached_value(token: str, prefix: str) -> str | None:
+    """Return the attached value of ``-X<value>`` / ``-X=<value>``, if any.
 
-    JSON-decoded bodies surface their ``text``/``message``/``body``
-    fields. When curl carries a data flag we cannot inspect — a file
-    reference (``@path``), stdin (``@-``), or unparsable body — the
-    parser appends the fail-closed sentinel that trips the HIGH gate.
+    Returns the substring AFTER ``prefix`` when ``token`` starts with the
+    prefix and is strictly longer than it. ``-X=value`` strips the
+    leading ``=`` so callers see the bare payload.
     """
-    payloads: list[str] = []
-    for match in _CURL_DATA_RE.finditer(command):
-        raw = match.group(2)
-        # Always include the raw text — the scanner's pattern catalogue
-        # can match user-attributed prose even outside JSON shapes.
-        payloads.append(raw)
-        json_fields = _json_body_fields(raw)
-        if json_fields:
-            payloads.extend(json_fields)
-        elif raw.strip().startswith(("{", "[")):
-            # Looked like JSON but did not decode — fail closed.
-            payloads.append(FAIL_CLOSED_SENTINEL)
-    # File-/stdin-referenced data flags cannot be inspected in-process.
-    if _CURL_DATA_FILE_RE.search(command):
+    if token.startswith(prefix) and len(token) > len(prefix):
+        return token[len(prefix) :].removeprefix("=")
+    return None
+
+
+def _scan_curl_payload(raw: str, payloads: list[str]) -> None:
+    """Append ``raw`` plus its JSON ``text``/``message``/``body`` fields.
+
+    A non-JSON-decodable body that LOOKS like JSON (starts with ``{`` or
+    ``[``) fails closed because we cannot be sure the gate's pattern
+    catalogue covers the obfuscation.
+    """
+    payloads.append(raw)
+    json_fields = _json_body_fields(raw)
+    if json_fields:
+        payloads.extend(json_fields)
+    elif raw.strip().startswith(("{", "[")):
         payloads.append(FAIL_CLOSED_SENTINEL)
-    return payloads
+
+
+def _record_curl_value(value: str, payloads: list[str]) -> None:
+    """Route a single curl data value to the payload list.
+
+    ``@file`` references fail closed (we cannot read arbitrary files);
+    everything else gets the standard JSON-aware scan.
+    """
+    if value.startswith("@"):
+        payloads.append(FAIL_CLOSED_SENTINEL)
+    else:
+        _scan_curl_payload(value, payloads)
+
+
+def _curl_long_flag_attached(word: str) -> str | None:
+    """Return the value of ``--data=VALUE`` / ``--json=VALUE`` if attached."""
+    for flag in _CURL_DATA_LONG_FLAGS:
+        attached = _attached_value(word, flag + "=")
+        if attached is not None:
+            return attached
+    return None
+
+
+def _curl_short_d_attached(word: str) -> str | None:
+    """Return the value of ``-dVALUE`` attached short option, if applicable.
+
+    Excludes the long ``--data*`` / ``--json`` family — those start with
+    ``--`` and are handled by :func:`_curl_long_flag_attached`.
+    """
+    if word.startswith(("--data", "--json")):
+        return None
+    return _attached_value(word, "-d")
+
+
+def _walk_curl_args(words: list[str], payloads: list[str]) -> None:
+    """Extract curl ``-d``/``--data*``/``--json`` payloads from a command.
+
+    Supports:
+    - ``-d value`` (next token)
+    - ``-dvalue`` (attached short option, POSIX)
+    - ``-d=value`` (equals form)
+    - ``--data value`` / ``--data=value``
+    - ``-d@file`` / ``--data @file`` (fail closed — we cannot read the file)
+    """
+    i = 0
+    n = len(words)
+    while i < n:
+        word = words[i]
+        if word == "-d" and i + 1 < n:
+            _record_curl_value(words[i + 1], payloads)
+            i += 2
+            continue
+        if word in _CURL_DATA_LONG_FLAGS and i + 1 < n:
+            _record_curl_value(words[i + 1], payloads)
+            i += 2
+            continue
+        attached_short = _curl_short_d_attached(word)
+        if attached_short is not None:
+            _record_curl_value(attached_short, payloads)
+            i += 1
+            continue
+        attached_long = _curl_long_flag_attached(word)
+        if attached_long is not None:
+            _record_curl_value(attached_long, payloads)
+        i += 1
+
+
+def _walk_body_flags(words: list[str], payloads: list[str]) -> None:
+    """Extract ``--body``/``-m``/``-b`` style payloads from a command.
+
+    Handles both space-separated (``--body "x"``) and equals-separated
+    (``--body=x``) forms.
+    """
+    i = 0
+    n = len(words)
+    while i < n:
+        word = words[i]
+        if word in _BODY_FLAG_NAMES and i + 1 < n:
+            payloads.append(words[i + 1])
+            i += 2
+            continue
+        for flag in _BODY_FLAG_NAMES:
+            attached = _attached_value(word, flag + "=")
+            if attached is not None:
+                payloads.append(attached)
+                break
+        if word in _BODY_SHORT_FLAGS and i + 1 < n:
+            payloads.append(words[i + 1])
+            i += 2
+            continue
+        i += 1
+
+
+def _walk_body_file_flags(words: list[str], payloads: list[str], *, is_git: bool) -> None:
+    """Extract ``--body-file``/``--file``/``-F`` style file payloads.
+
+    The git-style ``-F <path>`` form is a file reference ONLY for the
+    ``git`` command (codex round-3 #6 — ``gh api -F body=x`` is a field
+    assignment, NOT a file reference). The ``is_git`` flag scopes the
+    short-form ``-F`` reader.
+    """
+    i = 0
+    n = len(words)
+    while i < n:
+        word = words[i]
+        if word in _BODY_FILE_FLAG_NAMES and i + 1 < n:
+            _append_file_payload(words[i + 1], payloads)
+            i += 2
+            continue
+        attached: str | None = None
+        for flag in _BODY_FILE_FLAG_NAMES:
+            attached = _attached_value(word, flag + "=")
+            if attached is not None:
+                _append_file_payload(attached, payloads)
+                break
+        if attached is not None:
+            i += 1
+            continue
+        if is_git and word == "-F" and i + 1 < n:
+            _append_file_payload(words[i + 1], payloads)
+            i += 2
+            continue
+        if is_git:
+            attached = _attached_value(word, "-F")
+            if attached is not None:
+                _append_file_payload(attached, payloads)
+                i += 1
+                continue
+        i += 1
+
+
+def _append_file_payload(path: str, payloads: list[str]) -> None:
+    content = _read_file_arg(path)
+    if content is None:
+        payloads.append(FAIL_CLOSED_SENTINEL)
+    else:
+        payloads.append(content)
+
+
+def _handle_api_input(arg: str, payloads: list[str]) -> None:
+    """Read a ``--input`` argument: stdin or missing file → fail closed."""
+    if arg == "-":
+        payloads.append(FAIL_CLOSED_SENTINEL)
+        return
+    content = _read_file_arg(arg)
+    if content is None:
+        payloads.append(FAIL_CLOSED_SENTINEL)
+        return
+    payloads.append(content)
+    payloads.extend(_json_body_fields(content))
+
+
+def _walk_api_fields(words: list[str], payloads: list[str]) -> None:
+    """Extract ``-f``/``-F``/``--field``/``--raw-field`` ``body=`` assignments.
+
+    Also handles ``--input <file>`` / ``--input -`` (stdin → fail closed)
+    and ``--input <missing>`` (fail closed). Field assignments other than
+    ``body=`` are ignored.
+    """
+    field_flags = _API_FIELD_SHORT_FLAGS | _API_FIELD_LONG_FLAGS
+    i = 0
+    n = len(words)
+    while i < n:
+        word = words[i]
+        if word in field_flags and i + 1 < n:
+            _handle_field_assignment(words[i + 1], payloads)
+            i += 2
+            continue
+        if word == "--input" and i + 1 < n:
+            _handle_api_input(words[i + 1], payloads)
+            i += 2
+            continue
+        attached = _attached_value(word, "--input=")
+        if attached is not None:
+            _handle_api_input(attached, payloads)
+        i += 1
+
+
+def _handle_field_assignment(arg: str, payloads: list[str]) -> None:
+    """Parse a ``-F body=value`` style argument and append the value.
+
+    The ``body=`` prefix is required — other field names (``title=``,
+    etc.) are not body-bearing and are ignored.
+    """
+    if "=" not in arg:
+        return
+    name, _, value = arg.partition("=")
+    if name == "body":
+        payloads.append(value)
+
+
+# ── Command-segment walking ─────────────────────────────────────────
+
+
+def _first_two_words(segment: list[Token]) -> tuple[str, str]:
+    """Return up to the first two WORD values of a command segment.
+
+    Empty positions are returned as ``""``. Tokens that look like
+    environment-variable assignments (``KEY=val``) appearing before the
+    command name are skipped.
+    """
+    words = [tok.value for tok in segment if tok.kind is TokenKind.WORD]
+    # Skip leading ENV=value assignments.
+    while words and re.fullmatch(r"[A-Z_][A-Z0-9_]*=.*", words[0]):
+        words = words[1:]
+    first = words[0] if words else ""
+    second = words[1] if len(words) > 1 else ""
+    return first, second
+
+
+def _walk_command_segment(segment: list[Token], payloads: list[str]) -> None:
+    """Route a single command segment to the right argument walkers."""
+    words = [tok.value for tok in segment if tok.kind is TokenKind.WORD]
+    if not words:
+        return
+    first, _ = _first_two_words(segment)
+    # All segments get the generic body-flag walker since gh, glab, git,
+    # and t3 all accept ``--body``/``--message``/``-m``/``-b``.
+    _walk_body_flags(words, payloads)
+    _walk_body_file_flags(words, payloads, is_git=(first == "git"))
+    # ``gh api`` / ``glab api`` field assignments.
+    if first in {"gh", "glab"}:
+        _walk_api_fields(words, payloads)
+    if first == "curl":
+        _walk_curl_args(words, payloads)
+
+
+# ── Body extraction ─────────────────────────────────────────────────
 
 
 def extract_bash_payload(command: str) -> str:
     r"""Concatenate every body-like fragment the command surface carries.
 
-    Pre-processing normalises shell-equivalent spellings before the
-    pattern catalogue runs: ``\<NL>`` line continuations are joined and
-    ANSI-C ``$'...'`` quoting is decoded (codex round-2 #2 / #3).
-    Indirect body sources (``gh api --input -``, missing input files)
-    fail closed via the sentinel.
+    The command is tokenized once via :mod:`teatree.hooks._shell_lexer`
+    so shell-equivalent spellings (line continuations both token-
+    internal and between-token, ANSI-C ``$'...'`` quoting, unspaced
+    metacharacters) collapse to the same logical token stream bash
+    itself would execute. Then each command segment is routed to the
+    right per-command argument walker.
+
+    Indirect body sources (``gh api --input -``, missing files, opaque
+    ``-d @file`` references) fail closed via the sentinel.
     """
-    command = normalize_line_continuations(command)
-    command = expand_ansi_c_quotes(command)
-    parts: list[str] = [match.group(2) for match in _FLAG_VALUE_RE.finditer(command)]
-    parts.extend(match.group(2) for match in _SHORT_M_RE.finditer(command))
-    parts.extend(match.group(2) for match in _SHORT_B_RE.finditer(command))
+    parts: list[str] = []
+    tokens = tokenize(command)
+    for segment in split_commands(tokens):
+        _walk_command_segment(segment, parts)
+    # Heredocs still need to be parsed against the raw command — the
+    # lexer treats them as regular content since heredoc bodies live on
+    # subsequent physical lines. The regex below tolerates that shape.
     parts.extend(match.group(2) for match in _HEREDOC_RE.finditer(command))
-    parts.extend(match.group(2) for match in _API_FIELD_BODY_RE.finditer(command))
-    parts.extend(_extract_curl_payloads(command))
-    for match in (*_FILE_FLAG_RE.finditer(command), *_GIT_SHORT_F_RE.finditer(command)):
-        content = _read_file_arg(match.group(1))
-        if content is not None:
-            parts.append(content)
-        else:
-            parts.append(FAIL_CLOSED_SENTINEL)
-    # ``gh api / glab api --input -`` reads from stdin — fail closed
-    # before per-file processing runs against the ``-`` literal.
-    if _API_INPUT_STDIN_RE.search(command):
-        parts.append(FAIL_CLOSED_SENTINEL)
-    for match in _API_INPUT_FILE_RE.finditer(command):
-        path_arg = match.group(1)
-        if path_arg == "-":
-            # Already handled by the stdin sentinel above.
-            continue
-        content = _read_file_arg(path_arg)
-        if content is None:
-            parts.append(FAIL_CLOSED_SENTINEL)
-            continue
-        parts.append(content)
-        parts.extend(_json_body_fields(content))
     return "\n".join(parts)
+
+
+# ── Quote-OK override detection ─────────────────────────────────────
+
+
+def first_segment_words(command: str) -> list[str]:
+    """Return the WORD-value list of the FIRST command segment.
+
+    Used by the override-detection: a ``--quote-ok`` token is only
+    honoured when it appears as a CLI token in the first segment of the
+    bash command. Anything after the first command-separator operator
+    is a separate command and must not bypass the gate (codex round-2
+    #1, round-3 #2).
+    """
+    tokens = tokenize(command)
+    segments = split_commands(tokens)
+    if not segments:
+        return []
+    return [tok.value for tok in segments[0] if tok.kind is TokenKind.WORD]

--- a/src/teatree/hooks/_shell_lexer.py
+++ b/src/teatree/hooks/_shell_lexer.py
@@ -1,0 +1,408 @@
+r"""Bash-like shell tokenizer for the quote-scanner gate (#1213).
+
+A small but accurate-enough lexer that returns the same logical tokens
+``bash`` would pass to a child process. Built specifically to close the
+codex round-3 bypass paths that defeated the previous regex spot-check
+approach:
+
+- ``\<NL>`` is removed token-INTERNALLY (rejoins a token split across
+    physical lines into the original word) and treated as whitespace
+    BETWEEN tokens.
+- ``;``, ``|``, ``&``, ``&&``, ``||`` and ``\n`` are emitted as standalone
+    metacharacter tokens regardless of surrounding whitespace, so
+    ``cmd "x";echo --quote-ok`` is split at the ``;`` even with no space.
+- ANSI-C ``$'...'`` is decoded directly per the bash man-page (handling
+    ``\\``, ``\'``, ``\"``, control letters, ``\xHH``, ``\uHHHH``,
+    ``\UHHHHHHHH``, ``\nnn`` octal, ``\cX`` control) — no round-trip
+    through ``unicode_escape`` and no shell-requoting that an escaped
+    single quote could truncate.
+
+The returned :class:`Token` carries the decoded VALUE plus the SHAPE
+(``WORD`` vs ``OP``) so callers can route operator boundaries and
+attached short options (``-d'{...}'``) correctly.
+"""
+
+import string
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final
+
+
+class TokenKind(Enum):
+    """Whether a token is a regular word or a shell metacharacter."""
+
+    WORD = "word"
+    OP = "op"
+
+
+@dataclass(frozen=True)
+class Token:
+    """One decoded shell token."""
+
+    value: str
+    kind: TokenKind
+
+
+# Metacharacters that act as command separators in bash. Two-char
+# operators MUST be checked before their one-char prefixes so ``&&`` is
+# not mis-emitted as two ``&`` tokens.
+_TWO_CHAR_OPS: Final[tuple[str, ...]] = ("&&", "||")
+_ONE_CHAR_OPS: Final[tuple[str, ...]] = (";", "|", "&", "\n")
+
+# Whitespace / newline character sets used throughout the lexer. Using
+# set literals so membership checks are O(1) and ruff's PLR6201 is happy.
+_INLINE_WHITESPACE: Final[frozenset[str]] = frozenset({" ", "\t"})
+_NEWLINE_CHARS: Final[frozenset[str]] = frozenset({"\n", "\r"})
+_DOUBLE_QUOTE_ESCAPES: Final[frozenset[str]] = frozenset({'"', "\\", "`", "$", "\n"})
+
+
+# ANSI-C escape decoding table for ``$'...'`` per bash man-page.
+_ANSI_C_SIMPLE_ESCAPES: Final[dict[str, str]] = {
+    "a": "\a",
+    "b": "\b",
+    "e": "\x1b",
+    "E": "\x1b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "v": "\v",
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+    "?": "?",
+}
+
+
+def _read_digits(literal: str, start: int, max_len: int, alphabet: str) -> str:
+    """Return the longest prefix of ``literal[start:]`` over ``alphabet``."""
+    end = start
+    n = len(literal)
+    limit = min(start + max_len, n)
+    while end < limit and literal[end] in alphabet:
+        end += 1
+    return literal[start:end]
+
+
+def _decode_ansi_c_hex(literal: str, start: int, max_len: int) -> tuple[str, int]:
+    r"""Decode ``\xHH`` / ``\uHHHH`` / ``\UHHHHHHHH`` at ``start``.
+
+    Returns the decoded character plus the index ONE PAST the last
+    consumed digit. If no hex digits follow, returns the marker letter
+    so the caller can emit it literally.
+    """
+    digits = _read_digits(literal, start, max_len, string.hexdigits)
+    if not digits:
+        # No digits — caller emits the marker letter (the char at
+        # ``start - 1``) literally.
+        return literal[start - 1], start
+    try:
+        return chr(int(digits, 16)), start + len(digits)
+    except ValueError:
+        return literal[start - 1], start + len(digits)
+
+
+def _decode_ansi_c_octal(literal: str, start: int) -> tuple[str, int]:
+    r"""Decode ``\nnn`` octal at ``start`` (caller positioned ON first digit)."""
+    digits = _read_digits(literal, start, 3, string.octdigits)
+    return chr(int(digits, 8) & 0xFF), start + len(digits)
+
+
+_ANSI_C_HEX_WIDTH: Final[dict[str, int]] = {"x": 2, "u": 4, "U": 8}
+
+
+def _decode_ansi_c_escape(literal: str, i: int) -> tuple[str, int]:
+    r"""Decode one escape sequence starting at ``literal[i] == '\'``.
+
+    Returns the decoded text plus the next-cursor index. The caller is
+    responsible for the loop; this helper handles ONE escape per call.
+    """
+    n = len(literal)
+    if i + 1 >= n:
+        return literal[i], i + 1
+    nxt = literal[i + 1]
+    if nxt in _ANSI_C_SIMPLE_ESCAPES:
+        return _ANSI_C_SIMPLE_ESCAPES[nxt], i + 2
+    hex_width = _ANSI_C_HEX_WIDTH.get(nxt)
+    if hex_width is not None:
+        return _decode_ansi_c_hex(literal, i + 2, hex_width)
+    if nxt in string.octdigits:
+        return _decode_ansi_c_octal(literal, i + 1)
+    if nxt == "c" and i + 2 < n:
+        return chr(ord(literal[i + 2].upper()) ^ 0x40), i + 3
+    # Unknown escape — bash echoes the backslash + next char.
+    return literal[i : i + 2], i + 2
+
+
+def _decode_ansi_c(literal: str) -> str:
+    r"""Decode a stripped ``$'...'`` body per the bash man-page.
+
+    The literal is the text BETWEEN the opening ``$'`` and closing
+    ``'`` — caller is responsible for slicing. We walk character by
+    character so an escaped single quote (``\'``) does not terminate
+    the string early; the closing quote is detected during tokenization
+    BEFORE this decoder runs.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(literal)
+    while i < n:
+        if literal[i] != "\\":
+            out.append(literal[i])
+            i += 1
+            continue
+        decoded, i = _decode_ansi_c_escape(literal, i)
+        out.append(decoded)
+    return "".join(out)
+
+
+@dataclass
+class _LexerState:
+    """Mutable state shared by the lexer's character handlers."""
+
+    command: str
+    tokens: list[Token]
+    current: list[str]
+    in_token: bool
+    i: int
+
+    def flush(self) -> None:
+        if self.in_token:
+            self.tokens.append(Token("".join(self.current), TokenKind.WORD))
+            self.current.clear()
+            self.in_token = False
+
+    def append_op(self, op: str, consumed: int) -> None:
+        self.flush()
+        self.tokens.append(Token(op, TokenKind.OP))
+        self.i += consumed
+
+
+def _consume_line_continuation(state: _LexerState) -> None:
+    r"""Skip ``\<NL>``. Between-token: separator. In-token: rejoin."""
+    j = state.i + 1
+    if state.command[j] == "\r" and j + 1 < len(state.command) and state.command[j + 1] == "\n":
+        state.i = j + 2
+    else:
+        state.i = j + 1
+
+
+def _consume_newline_operator(state: _LexerState) -> None:
+    r"""Emit a single ``\n`` operator for a bare newline / ``\r\n``."""
+    state.flush()
+    ch = state.command[state.i]
+    consume = 2 if ch == "\r" and state.i + 1 < len(state.command) and state.command[state.i + 1] == "\n" else 1
+    state.tokens.append(Token("\n", TokenKind.OP))
+    state.i += consume
+
+
+def _match_operator(state: _LexerState) -> str | None:
+    """Return the operator at the current cursor, longest-first."""
+    for op in _TWO_CHAR_OPS:
+        if state.command.startswith(op, state.i):
+            return op
+    ch = state.command[state.i]
+    if ch in _ONE_CHAR_OPS:
+        return ch
+    return None
+
+
+def _consume_ansi_c(state: _LexerState) -> None:
+    r"""Consume a ``$'...'`` sequence at the current cursor."""
+    state.in_token = True
+    n = len(state.command)
+    j = state.i + 2
+    body_chars: list[str] = []
+    while j < n:
+        if state.command[j] == "\\" and j + 1 < n:
+            body_chars.extend((state.command[j], state.command[j + 1]))
+            j += 2
+            continue
+        if state.command[j] == "'":
+            break
+        body_chars.append(state.command[j])
+        j += 1
+    state.current.append(_decode_ansi_c("".join(body_chars)))
+    state.i = j + 1
+
+
+def _consume_single_quote(state: _LexerState) -> None:
+    """Consume a ``'...'`` sequence — contents are verbatim."""
+    state.in_token = True
+    n = len(state.command)
+    j = state.i + 1
+    while j < n and state.command[j] != "'":
+        state.current.append(state.command[j])
+        j += 1
+    state.i = j + 1
+
+
+def _consume_double_quote(state: _LexerState) -> None:
+    r"""Consume a ``"..."`` sequence — backslash escapes selected chars."""
+    state.in_token = True
+    n = len(state.command)
+    j = state.i + 1
+    while j < n and state.command[j] != '"':
+        if state.command[j] == "\\" and j + 1 < n and state.command[j + 1] in _DOUBLE_QUOTE_ESCAPES:
+            if state.command[j + 1] == "\n":
+                # Line continuation inside double quotes — bash removes
+                # the backslash-newline pair entirely.
+                j += 2
+                continue
+            state.current.append(state.command[j + 1])
+            j += 2
+            continue
+        state.current.append(state.command[j])
+        j += 1
+    state.i = j + 1
+
+
+def _consume_unquoted_backslash(state: _LexerState) -> None:
+    r"""Consume ``\X`` outside any quote — next char is literal."""
+    state.in_token = True
+    state.current.append(state.command[state.i + 1])
+    state.i += 2
+
+
+def _consume_comment(state: _LexerState) -> None:
+    """Skip a ``#`` comment up to the next newline."""
+    n = len(state.command)
+    while state.i < n and state.command[state.i] not in _NEWLINE_CHARS:
+        state.i += 1
+
+
+def _consume_inline_whitespace(state: _LexerState) -> None:
+    r"""Treat ``' '`` / ``\t`` as a token boundary."""
+    state.flush()
+    state.i += 1
+
+
+def _try_consume_structured(state: _LexerState) -> bool:
+    r"""Run the dispatch ladder for one character. Returns True iff consumed.
+
+    Returning False means none of the structured handlers matched —
+    :func:`tokenize` will then append the bare character to the current
+    word token.
+    """
+    command = state.command
+    n = len(command)
+    ch = command[state.i]
+    rule = _STRUCTURED_RULES.get(ch)
+    if rule is not None:
+        handler = rule(state, command, n)
+        if handler is not None:
+            handler(state)
+            return True
+    op = _match_operator(state)
+    if op is not None:
+        state.append_op(op, len(op))
+        return True
+    return False
+
+
+# Lookup table mapping a leading char to a function that returns the
+# right handler (or None when context disqualifies the dispatch).
+_Handler = Callable[[_LexerState], None]
+_Rule = Callable[[_LexerState, str, int], _Handler | None]
+
+
+def _rule_inline_ws(_state: _LexerState, _command: str, _n: int) -> _Handler | None:
+    return _consume_inline_whitespace
+
+
+def _rule_backslash(state: _LexerState, command: str, n: int) -> _Handler | None:
+    if state.i + 1 < n and command[state.i + 1] in _NEWLINE_CHARS:
+        return _consume_line_continuation
+    if state.i + 1 < n:
+        return _consume_unquoted_backslash
+    return None
+
+
+def _rule_newline(_state: _LexerState, _command: str, _n: int) -> _Handler | None:
+    return _consume_newline_operator
+
+
+def _rule_dollar(state: _LexerState, command: str, n: int) -> _Handler | None:
+    if state.i + 1 < n and command[state.i + 1] == "'":
+        return _consume_ansi_c
+    return None
+
+
+def _rule_single_quote(_state: _LexerState, _command: str, _n: int) -> _Handler | None:
+    return _consume_single_quote
+
+
+def _rule_double_quote(_state: _LexerState, _command: str, _n: int) -> _Handler | None:
+    return _consume_double_quote
+
+
+def _rule_hash(state: _LexerState, _command: str, _n: int) -> _Handler | None:
+    if state.in_token:
+        return None
+    return _consume_comment
+
+
+_STRUCTURED_RULES: Final[dict[str, _Rule]] = {
+    " ": _rule_inline_ws,
+    "\t": _rule_inline_ws,
+    "\\": _rule_backslash,
+    "\n": _rule_newline,
+    "\r": _rule_newline,
+    "$": _rule_dollar,
+    "'": _rule_single_quote,
+    '"': _rule_double_quote,
+    "#": _rule_hash,
+}
+
+
+def tokenize(command: str) -> list[Token]:
+    r"""Return the bash-equivalent token stream for ``command``.
+
+    The result preserves operator tokens (``;`` / ``|`` / ``&`` /
+    ``&&`` / ``||`` / ``\n``) as standalone :class:`Token` instances
+    with :attr:`TokenKind.OP`, and emits regular words as
+    :attr:`TokenKind.WORD` with their decoded value. Line continuations
+    inside a quoted region are preserved literally; outside any quote
+    they are eliminated when token-internal and treated as whitespace
+    when between tokens.
+    """
+    state = _LexerState(command=command, tokens=[], current=[], in_token=False, i=0)
+    n = len(command)
+    while state.i < n:
+        if _try_consume_structured(state):
+            continue
+        state.in_token = True
+        state.current.append(command[state.i])
+        state.i += 1
+    state.flush()
+    return state.tokens
+
+
+# Operator values that delimit one logical command from the next.
+_COMMAND_SEPARATORS: Final[frozenset[str]] = frozenset({";", "|", "&", "&&", "||", "\n"})
+
+
+def is_command_separator(token: Token) -> bool:
+    """Return True iff ``token`` ends the current command segment."""
+    return token.kind is TokenKind.OP and token.value in _COMMAND_SEPARATORS
+
+
+def split_commands(tokens: list[Token]) -> list[list[Token]]:
+    """Group a token stream into per-command segments.
+
+    Each segment is the list of WORD tokens between command-separator
+    operators. Empty segments (back-to-back separators) are dropped.
+    """
+    segments: list[list[Token]] = []
+    current: list[Token] = []
+    for tok in tokens:
+        if is_command_separator(tok):
+            if current:
+                segments.append(current)
+                current = []
+        else:
+            current.append(tok)
+    if current:
+        segments.append(current)
+    return segments

--- a/src/teatree/hooks/quote_scanner.py
+++ b/src/teatree/hooks/quote_scanner.py
@@ -34,16 +34,14 @@ checks and is itself logged for audit.
 import json
 import os
 import re
-import shlex
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Final, TypedDict
 
 from teatree.hooks._command_parser import extract_bash_payload as _extract_bash_payload
-from teatree.hooks._command_parser import first_shell_command as _first_shell_command
+from teatree.hooks._command_parser import first_segment_words as _first_segment_words
 from teatree.hooks._command_parser import is_publish_command as _is_publish_command
-from teatree.hooks._command_parser import normalize_line_continuations as _normalize_line_continuations
 
 Severity = str  # "high" | "medium"
 
@@ -278,6 +276,7 @@ _SLACK_MCP_WRITE_TOOLS: Final[dict[str, tuple[str, ...]]] = {
     "slack_send_message": ("text", "message"),
     "slack_send_message_draft": ("text", "message"),
     "slack_schedule_message": ("text", "message"),
+    "slack_edit_message": ("text", "message"),
     "slack_create_canvas": ("document_content", "content", "text"),
     "slack_update_canvas": ("document_content", "content", "text"),
     "slack_create_conversation": ("name",),
@@ -323,17 +322,16 @@ def extract_publish_payload(tool_name: str, tool_input: ToolInput) -> str | None
     PreToolUse handler skips its work for any tool call that does not
     intend to publish.
 
-    Bash commands are first normalised against shell-equivalent
-    spellings (line continuations, ANSI-C quoting) so the publish-
-    detection substring matcher sees the same logical command Bash
-    itself would execute (codex round-2 #2 / #3).
+    Bash commands are tokenized via the shell lexer so the publish-
+    detection substring matcher and the body-extractor see the same
+    logical token stream bash itself would execute (codex round-2 #2/#3,
+    round-3 #1/#2/#3/#4).
     """
     if tool_name == "Bash":
         raw_command = tool_input.get("command", "")
-        joined = _normalize_line_continuations(raw_command)
-        if not _is_publish_command(joined):
+        if not _is_publish_command(raw_command):
             return None
-        return _extract_bash_payload(joined)
+        return _extract_bash_payload(raw_command)
 
     return _extract_slack_mcp_payload(tool_name, tool_input)
 
@@ -345,41 +343,21 @@ def has_quote_ok_override(tool_name: str, tool_input: ToolInput) -> bool:
     """Return True iff the caller explicitly opted out of the gate.
 
     Two surfaces are accepted. The flag ``--quote-ok`` may appear as a
-    standalone token in the FIRST physical line of a Bash command — a
-    newline-smuggled ``--quote-ok`` (codex round-2 #1) is rejected
-    because a literal newline is itself a shell command separator.
-    The env mapping on the tool input may set ``QUOTE_OK=1`` (the harness
-    exposes the env block separately from the command string).
+    standalone token in the FIRST shell command segment — any
+    ``--quote-ok`` that lives after a command-separator metacharacter
+    (``;`` / ``|`` / ``&`` / ``&&`` / ``||`` / literal newline) is part
+    of a SECOND command and must not bypass the gate (codex round-2 #1,
+    round-3 #2). The shell lexer normalises unspaced metacharacters
+    (``cmd "x";echo --quote-ok``) so the first-segment rule holds
+    regardless of whitespace.
+
+    The env mapping on the tool input may set ``QUOTE_OK=1`` (the
+    harness exposes the env block separately from the command string).
     """
     if tool_name == "Bash":
         command = tool_input.get("command", "")
-        # Only the FIRST shell command counts — any ``--quote-ok`` that
-        # lives on a separate physical line (outside any quoted region)
-        # is part of a different command and must not bypass the gate
-        # (codex round-2 #1). Line-continuation ``\<NL>`` is joined
-        # first so a legitimately-continued first command is still
-        # treated as one logical line. The split is QUOTE-AWARE so a
-        # newline INSIDE a body string is preserved.
-        joined = _normalize_line_continuations(command)
-        first_segment = _first_shell_command(joined)
-        try:
-            # ``comments=True`` strips ``# …`` so a smuggled
-            # ``# --quote-ok`` after the publish command does not become
-            # a real token (Codex CRITICAL #1, round 1).
-            tokens = shlex.split(first_segment, comments=True, posix=True)
-        except ValueError:
-            tokens = first_segment.split()
-        # The override is valid only when it lives in the FIRST shell
-        # segment — i.e. before any metacharacter that would route the
-        # remainder to a separate command. ``shlex`` keeps ``;``, ``|``,
-        # ``&``, ``&&`` and ``||`` as standalone tokens, so we just look
-        # for ``--quote-ok`` strictly before the first such token.
-        meta_tokens = {";", "|", "&", "&&", "||"}
-        for entry in tokens:
-            if entry in meta_tokens:
-                break
-            if entry == "--quote-ok":
-                return True
+        if "--quote-ok" in _first_segment_words(command):
+            return True
     env = tool_input.get("env") or {}
     return env.get("QUOTE_OK", "").strip() == "1"
 

--- a/src/teatree/hooks/quote_scanner.py
+++ b/src/teatree/hooks/quote_scanner.py
@@ -244,14 +244,25 @@ _BASH_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
     "glab issue create",
     "glab issue update",
     "glab issue note create",
+    # ``glab issue note <id>`` (no ``create`` segment) is the real
+    # comment subcommand — trailing space pins the substring to the
+    # subcommand boundary so ``glab issue notebook`` would not match.
+    "glab issue note ",
     "glab mr create",
     "glab mr update",
     "glab mr note create",
+    "glab mr note ",
     "git commit -m",
     "git commit --message",
     "git commit -F",
     "git commit --file",
     "git tag --message",
+    # ``gh api`` / ``glab api`` POST/PATCH calls land on REST endpoints
+    # that publish issue/PR/MR comments. The payload is carried via
+    # ``-f``/``-F``/``--raw-field``/``--field``/``--input`` and parsed
+    # by :func:`_extract_bash_payload`.
+    "gh api ",
+    "glab api ",
     "chat.postMessage",
 )
 
@@ -293,6 +304,11 @@ _FLAG_VALUE_RE: Final[re.Pattern[str]] = re.compile(
     re.DOTALL,
 )
 _SHORT_M_RE: Final[re.Pattern[str]] = re.compile(r"\s-m\s+(['\"])(.*?)\1", re.DOTALL)
+# ``gh pr comment`` / ``gh issue comment`` use ``-b`` for the body. We
+# only ever invoke the short-flag parser from inside a publish surface
+# (``_is_publish_command`` already gated us), so a global ``-b`` shape
+# match is safe.
+_SHORT_B_RE: Final[re.Pattern[str]] = re.compile(r"\s-b\s+(['\"])(.*?)\1", re.DOTALL)
 _HEREDOC_RE: Final[re.Pattern[str]] = re.compile(
     r"<<\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\1\b",
     re.DOTALL,
@@ -301,6 +317,35 @@ _FILE_FLAG_RE: Final[re.Pattern[str]] = re.compile(
     r"(?:--body-file|--description-file|--file)[ =]+(\S+)",
 )
 _GIT_SHORT_F_RE: Final[re.Pattern[str]] = re.compile(r"\s-F[ =]?(\S+)")
+
+# ``gh api`` / ``glab api`` carry their JSON payload in ``-f key=value``
+# (string), ``-F key=value`` / ``--field`` (typed), ``--raw-field`` (raw
+# string), or ``--input <file>`` (full JSON blob). We pluck any
+# ``body=…`` assignment regardless of quoting, then read ``--input``
+# files separately and scan a ``body`` JSON field.
+_API_FIELD_BODY_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:-f|-F|--field|--raw-field)\s+body=(['\"])?(.*?)(?(1)\1|(?=\s|$))",
+    re.DOTALL,
+)
+_API_INPUT_FILE_RE: Final[re.Pattern[str]] = re.compile(r"--input[ =]+(\S+)")
+
+# curl carries its payload in ``-d`` / ``--data`` / ``--data-raw`` /
+# ``--data-binary`` / ``--json``. The body is JSON-shaped for the Slack
+# / GitLab / GitHub surfaces this gate cares about — we JSON-decode and
+# scan the ``text``/``message``/``body`` fields.
+_CURL_DATA_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:--data-raw|--data-binary|--data|--json|\s-d)\s+(['\"])(.*?)\1",
+    re.DOTALL,
+)
+# When curl's data flag references a file (``-d @path``) or stdin
+# (``-d @-``) we cannot inspect the body in-process. Fail closed by
+# returning a sentinel payload that trips the HIGH gate.
+_CURL_DATA_FILE_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:--data-raw|--data-binary|--data|--json|\s-d)\s+@(\S+)",
+)
+_CURL_FAIL_CLOSED_SENTINEL: Final[str] = (
+    "the user said: pre-publish quote-scanner could not parse curl data flag — fail closed"
+)
 
 
 def _read_file_arg(path: str) -> str | None:
@@ -339,12 +384,60 @@ def _extract_bash_payload(command: str) -> str:
     """
     parts: list[str] = [match.group(2) for match in _FLAG_VALUE_RE.finditer(command)]
     parts.extend(match.group(2) for match in _SHORT_M_RE.finditer(command))
+    parts.extend(match.group(2) for match in _SHORT_B_RE.finditer(command))
     parts.extend(match.group(2) for match in _HEREDOC_RE.finditer(command))
+    parts.extend(match.group(2) for match in _API_FIELD_BODY_RE.finditer(command))
+    parts.extend(_extract_curl_payloads(command))
     for match in (*_FILE_FLAG_RE.finditer(command), *_GIT_SHORT_F_RE.finditer(command)):
         content = _read_file_arg(match.group(1))
         if content is not None:
             parts.append(content)
+    for match in _API_INPUT_FILE_RE.finditer(command):
+        content = _read_file_arg(match.group(1))
+        if content is None:
+            continue
+        parts.append(content)
+        parts.extend(_json_body_fields(content))
     return "\n".join(parts)
+
+
+def _json_body_fields(blob: str) -> list[str]:
+    """Return ``text``/``message``/``body`` values from a JSON blob, if any."""
+    try:
+        decoded = json.loads(blob)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(decoded, dict):
+        return []
+    return [str(decoded[key]) for key in ("text", "message", "body") if key in decoded]
+
+
+def _extract_curl_payloads(command: str) -> list[str]:
+    """Parse curl ``-d``/``--data``/``--data-raw``/``--json`` JSON bodies.
+
+    The body is JSON-decoded and the ``text``/``message``/``body`` fields
+    are extracted. When curl carries a data flag we cannot inspect — a
+    file reference (``@path``), stdin (``@-``), or an unparsable body —
+    the parser appends a fail-closed sentinel that trips the HIGH gate.
+    The sentinel is the explicit ``fail-closed`` behaviour from the
+    Codex CRITICAL #5 finding.
+    """
+    payloads: list[str] = []
+    for match in _CURL_DATA_RE.finditer(command):
+        raw = match.group(2)
+        # Always include the raw text — the scanner's pattern catalogue
+        # can match user-attributed prose even outside JSON shapes.
+        payloads.append(raw)
+        json_fields = _json_body_fields(raw)
+        if json_fields:
+            payloads.extend(json_fields)
+        elif raw.strip().startswith(("{", "[")):
+            # Looked like JSON but did not decode — fail closed.
+            payloads.append(_CURL_FAIL_CLOSED_SENTINEL)
+    # File-/stdin-referenced data flags cannot be inspected in-process.
+    if _CURL_DATA_FILE_RE.search(command):
+        payloads.append(_CURL_FAIL_CLOSED_SENTINEL)
+    return payloads
 
 
 # ── Override + ledger ──────────────────────────────────────────────
@@ -362,11 +455,23 @@ def has_quote_ok_override(tool_name: str, tool_input: ToolInput) -> bool:
     if tool_name == "Bash":
         command = tool_input.get("command", "")
         try:
-            tokens = shlex.split(command, comments=False, posix=True)
+            # ``comments=True`` strips ``# …`` so a smuggled
+            # ``# --quote-ok`` after the publish command does not become
+            # a real token (Codex CRITICAL #1).
+            tokens = shlex.split(command, comments=True, posix=True)
         except ValueError:
             tokens = command.split()
-        if "--quote-ok" in tokens:
-            return True
+        # The override is valid only when it lives in the FIRST shell
+        # segment — i.e. before any metacharacter that would route the
+        # remainder to a separate command. ``shlex`` keeps ``;``, ``|``,
+        # ``&``, ``&&`` and ``||`` as standalone tokens, so we just look
+        # for ``--quote-ok`` strictly before the first such token.
+        meta_tokens = {";", "|", "&", "&&", "||"}
+        for entry in tokens:
+            if entry in meta_tokens:
+                break
+            if entry == "--quote-ok":
+                return True
     env = tool_input.get("env") or {}
     return env.get("QUOTE_OK", "").strip() == "1"
 

--- a/src/teatree/hooks/quote_scanner.py
+++ b/src/teatree/hooks/quote_scanner.py
@@ -40,6 +40,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Final, TypedDict
 
+from teatree.hooks._command_parser import extract_bash_payload as _extract_bash_payload
+from teatree.hooks._command_parser import first_shell_command as _first_shell_command
+from teatree.hooks._command_parser import is_publish_command as _is_publish_command
+from teatree.hooks._command_parser import normalize_line_continuations as _normalize_line_continuations
+
 Severity = str  # "high" | "medium"
 
 
@@ -213,13 +218,49 @@ def _load_blocklist_patterns(path: Path | None = None) -> list[Pattern]:
     return patterns
 
 
+# Unicode smart-quote variants normalised to their ASCII equivalents before
+# pattern matching. Codex round-2 #7 surfaced curly-quoted blockquote bodies
+# bypassing every quote-aware regex — the fix is upstream normalisation, not
+# new patterns per quote shape. Code points referenced by ``\N{...}`` so the
+# lint checker is not confused by ambiguous glyphs in the source file.
+_SMART_QUOTE_TRANSLATIONS: Final[dict[int, str]] = {
+    # Double quotes
+    ord("\N{LEFT DOUBLE QUOTATION MARK}"): '"',
+    ord("\N{RIGHT DOUBLE QUOTATION MARK}"): '"',
+    ord("\N{DOUBLE LOW-9 QUOTATION MARK}"): '"',
+    ord("\N{DOUBLE HIGH-REVERSED-9 QUOTATION MARK}"): '"',
+    ord("\N{LEFT-POINTING DOUBLE ANGLE QUOTATION MARK}"): '"',
+    ord("\N{RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK}"): '"',
+    # Single quotes / apostrophes
+    ord("\N{LEFT SINGLE QUOTATION MARK}"): "'",
+    ord("\N{RIGHT SINGLE QUOTATION MARK}"): "'",
+    ord("\N{SINGLE LOW-9 QUOTATION MARK}"): "'",
+    ord("\N{SINGLE HIGH-REVERSED-9 QUOTATION MARK}"): "'",
+}
+
+
+def _normalize_quotes(text: str) -> str:
+    """Translate Unicode smart-quote variants to straight ASCII quotes.
+
+    The detection regexes are written against ASCII quotes; normalising
+    upstream means a single regex per shape continues to cover every
+    typographic variant a publish surface might emit.
+    """
+    return text.translate(_SMART_QUOTE_TRANSLATIONS)
+
+
 def scan_text(text: str, *, blocklist_path: Path | None = None) -> ScanResult:
-    """Match every built-in pattern and every blocklist regex against ``text``."""
+    """Match every built-in pattern and every blocklist regex against ``text``.
+
+    Smart-quote variants in the input are normalised to ASCII before
+    matching so a single regex catches all typographic forms.
+    """
     result = ScanResult()
     if not text:
         return result
+    normalized = _normalize_quotes(text)
     for pattern in (*_BUILTIN_PATTERNS, *_load_blocklist_patterns(blocklist_path)):
-        match = pattern.regex.search(text)
+        match = pattern.regex.search(normalized)
         if match is None:
             continue
         excerpt = match.group(0)[:120]
@@ -227,132 +268,52 @@ def scan_text(text: str, *, blocklist_path: Path | None = None) -> ScanResult:
     return result
 
 
-# ── Bash / t3 command surface parsing ──────────────────────────────
+# ── Slack MCP write-tool body-field allowlist ──────────────────────
 
-# Bash commands that publish to an external surface. The substring match
-# is sufficient — Bash strings come from the LLM, not from a shell, so
-# we don't have to worry about ``echo "gh issue create" | grep``-style
-# embedding.
-_BASH_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
-    "gh issue create",
-    "gh issue edit",
-    "gh issue comment",
-    "gh pr create",
-    "gh pr edit",
-    "gh pr comment",
-    "gh pr review",
-    "glab issue create",
-    "glab issue update",
-    "glab issue note create",
-    # ``glab issue note <id>`` (no ``create`` segment) is the real
-    # comment subcommand — trailing space pins the substring to the
-    # subcommand boundary so ``glab issue notebook`` would not match.
-    "glab issue note ",
-    "glab mr create",
-    "glab mr update",
-    "glab mr note create",
-    "glab mr note ",
-    "git commit -m",
-    "git commit --message",
-    "git commit -F",
-    "git commit --file",
-    "git tag --message",
-    # ``gh api`` / ``glab api`` POST/PATCH calls land on REST endpoints
-    # that publish issue/PR/MR comments. The payload is carried via
-    # ``-f``/``-F``/``--raw-field``/``--field``/``--input`` and parsed
-    # by :func:`_extract_bash_payload`.
-    "gh api ",
-    "glab api ",
-    "chat.postMessage",
-)
-
-# t3 sub-commands that publish on the user's behalf. The overlay segment
-# between ``t3`` and the verb is arbitrary (one of the registered
-# overlays), so we match the verb-segment substring directly — e.g.
-# ``review post-comment`` matches both ``t3 teatree review post-comment``
-# and the equivalent per-overlay variant.
-_T3_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
-    "notify send",
-    "review post-comment",
-    "review post-draft-note",
-    "ticket create-issue",
-    "t3 slack react",
-)
+# Slack MCP outbound write tools → body-field map. The substring "send"
+# heuristic from round 1 missed ``slack_schedule_message``,
+# ``slack_create_canvas`` and ``slack_update_canvas`` — explicit allowlist
+# replaces it (codex round-2 #6).
+_SLACK_MCP_WRITE_TOOLS: Final[dict[str, tuple[str, ...]]] = {
+    "slack_send_message": ("text", "message"),
+    "slack_send_message_draft": ("text", "message"),
+    "slack_schedule_message": ("text", "message"),
+    "slack_create_canvas": ("document_content", "content", "text"),
+    "slack_update_canvas": ("document_content", "content", "text"),
+    "slack_create_conversation": ("name",),
+}
 
 
-def _is_t3_publish_invocation(command: str) -> bool:
-    # All overlay-routed verbs go through ``t3`` — restrict the substring
-    # match to commands that actually start with the ``t3`` binary so a
-    # ``git log --grep "review post-comment"`` does not trip the gate.
-    if not command.lstrip().startswith("t3 "):
-        return False
-    return any(needle in command for needle in _T3_PUBLISH_SUBSTRINGS)
+def _slack_tool_suffix(tool_name: str) -> str:
+    """Extract the trailing slack tool name (``slack_*``) from an MCP id.
+
+    MCP tool ids are shaped ``mcp__<server>__<tool>`` — we want the
+    ``<tool>`` segment for an exact-match allowlist lookup.
+    """
+    return tool_name.rsplit("__", 1)[-1]
 
 
-def _is_publish_command(command: str) -> bool:
-    if any(needle in command for needle in _BASH_PUBLISH_SUBSTRINGS):
-        return True
-    return _is_t3_publish_invocation(command)
+def _extract_slack_mcp_payload(tool_name: str, tool_input: ToolInput) -> str | None:
+    """Return body text for a Slack MCP write tool, or ``None`` for read-only tools.
 
-
-# Capture --body / --description / --message / --title / -m / -F arg
-# values plus heredocs. Heredocs cover the standard ``$(cat <<'EOF' …
-# EOF)`` shape the rest of the codebase already uses for multi-line PR
-# bodies.
-_FLAG_VALUE_RE: Final[re.Pattern[str]] = re.compile(
-    r"--(?:body|description|message|title)(?:[ =])\s*(['\"])(.*?)\1",
-    re.DOTALL,
-)
-_SHORT_M_RE: Final[re.Pattern[str]] = re.compile(r"\s-m\s+(['\"])(.*?)\1", re.DOTALL)
-# ``gh pr comment`` / ``gh issue comment`` use ``-b`` for the body. We
-# only ever invoke the short-flag parser from inside a publish surface
-# (``_is_publish_command`` already gated us), so a global ``-b`` shape
-# match is safe.
-_SHORT_B_RE: Final[re.Pattern[str]] = re.compile(r"\s-b\s+(['\"])(.*?)\1", re.DOTALL)
-_HEREDOC_RE: Final[re.Pattern[str]] = re.compile(
-    r"<<\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\1\b",
-    re.DOTALL,
-)
-_FILE_FLAG_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:--body-file|--description-file|--file)[ =]+(\S+)",
-)
-_GIT_SHORT_F_RE: Final[re.Pattern[str]] = re.compile(r"\s-F[ =]?(\S+)")
-
-# ``gh api`` / ``glab api`` carry their JSON payload in ``-f key=value``
-# (string), ``-F key=value`` / ``--field`` (typed), ``--raw-field`` (raw
-# string), or ``--input <file>`` (full JSON blob). We pluck any
-# ``body=…`` assignment regardless of quoting, then read ``--input``
-# files separately and scan a ``body`` JSON field.
-_API_FIELD_BODY_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:-f|-F|--field|--raw-field)\s+body=(['\"])?(.*?)(?(1)\1|(?=\s|$))",
-    re.DOTALL,
-)
-_API_INPUT_FILE_RE: Final[re.Pattern[str]] = re.compile(r"--input[ =]+(\S+)")
-
-# curl carries its payload in ``-d`` / ``--data`` / ``--data-raw`` /
-# ``--data-binary`` / ``--json``. The body is JSON-shaped for the Slack
-# / GitLab / GitHub surfaces this gate cares about — we JSON-decode and
-# scan the ``text``/``message``/``body`` fields.
-_CURL_DATA_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:--data-raw|--data-binary|--data|--json|\s-d)\s+(['\"])(.*?)\1",
-    re.DOTALL,
-)
-# When curl's data flag references a file (``-d @path``) or stdin
-# (``-d @-``) we cannot inspect the body in-process. Fail closed by
-# returning a sentinel payload that trips the HIGH gate.
-_CURL_DATA_FILE_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:--data-raw|--data-binary|--data|--json|\s-d)\s+@(\S+)",
-)
-_CURL_FAIL_CLOSED_SENTINEL: Final[str] = (
-    "the user said: pre-publish quote-scanner could not parse curl data flag — fail closed"
-)
-
-
-def _read_file_arg(path: str) -> str | None:
-    try:
-        return Path(path).read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    The Slack MCP carries the body in tool-specific fields beyond what
+    :class:`ToolInput` enumerates (``document_content``, ``content``,
+    ``name``). The actual hook payload is a wider mapping than the
+    typed view — we read each candidate field by name via :meth:`get`.
+    """
+    if not (tool_name.startswith("mcp__") and "slack" in tool_name.lower()):
         return None
+    suffix = _slack_tool_suffix(tool_name).lower()
+    fields = _SLACK_MCP_WRITE_TOOLS.get(suffix)
+    if fields is None:
+        return None
+    for field_name in fields:
+        value = tool_input.get(field_name)
+        if isinstance(value, str) and value:
+            return value
+    # The tool IS a write surface but no body field was populated — scan
+    # an empty payload (clean by construction) rather than fail-closed.
+    return ""
 
 
 def extract_publish_payload(tool_name: str, tool_input: ToolInput) -> str | None:
@@ -361,83 +322,20 @@ def extract_publish_payload(tool_name: str, tool_input: ToolInput) -> str | None
     The ``None`` return is the gate's pass-through signal — the
     PreToolUse handler skips its work for any tool call that does not
     intend to publish.
+
+    Bash commands are first normalised against shell-equivalent
+    spellings (line continuations, ANSI-C quoting) so the publish-
+    detection substring matcher sees the same logical command Bash
+    itself would execute (codex round-2 #2 / #3).
     """
     if tool_name == "Bash":
-        command = tool_input.get("command", "")
-        if not _is_publish_command(command):
+        raw_command = tool_input.get("command", "")
+        joined = _normalize_line_continuations(raw_command)
+        if not _is_publish_command(joined):
             return None
-        return _extract_bash_payload(command)
+        return _extract_bash_payload(joined)
 
-    if tool_name.startswith("mcp__") and "slack" in tool_name.lower() and "send" in tool_name.lower():
-        return tool_input.get("text") or tool_input.get("message") or ""
-
-    return None
-
-
-def _extract_bash_payload(command: str) -> str:
-    """Concatenate every body-like fragment the command surface carries.
-
-    A single Bash invocation can carry the body in several forms — an
-    inline ``--body`` quoted arg, a ``-m`` short flag, a heredoc spliced
-    in via ``$(cat <<EOF … EOF)``, or a ``--body-file`` path. The gate
-    scans the union so a payload split across forms still trips.
-    """
-    parts: list[str] = [match.group(2) for match in _FLAG_VALUE_RE.finditer(command)]
-    parts.extend(match.group(2) for match in _SHORT_M_RE.finditer(command))
-    parts.extend(match.group(2) for match in _SHORT_B_RE.finditer(command))
-    parts.extend(match.group(2) for match in _HEREDOC_RE.finditer(command))
-    parts.extend(match.group(2) for match in _API_FIELD_BODY_RE.finditer(command))
-    parts.extend(_extract_curl_payloads(command))
-    for match in (*_FILE_FLAG_RE.finditer(command), *_GIT_SHORT_F_RE.finditer(command)):
-        content = _read_file_arg(match.group(1))
-        if content is not None:
-            parts.append(content)
-    for match in _API_INPUT_FILE_RE.finditer(command):
-        content = _read_file_arg(match.group(1))
-        if content is None:
-            continue
-        parts.append(content)
-        parts.extend(_json_body_fields(content))
-    return "\n".join(parts)
-
-
-def _json_body_fields(blob: str) -> list[str]:
-    """Return ``text``/``message``/``body`` values from a JSON blob, if any."""
-    try:
-        decoded = json.loads(blob)
-    except (ValueError, TypeError):
-        return []
-    if not isinstance(decoded, dict):
-        return []
-    return [str(decoded[key]) for key in ("text", "message", "body") if key in decoded]
-
-
-def _extract_curl_payloads(command: str) -> list[str]:
-    """Parse curl ``-d``/``--data``/``--data-raw``/``--json`` JSON bodies.
-
-    The body is JSON-decoded and the ``text``/``message``/``body`` fields
-    are extracted. When curl carries a data flag we cannot inspect — a
-    file reference (``@path``), stdin (``@-``), or an unparsable body —
-    the parser appends a fail-closed sentinel that trips the HIGH gate.
-    The sentinel is the explicit ``fail-closed`` behaviour from the
-    Codex CRITICAL #5 finding.
-    """
-    payloads: list[str] = []
-    for match in _CURL_DATA_RE.finditer(command):
-        raw = match.group(2)
-        # Always include the raw text — the scanner's pattern catalogue
-        # can match user-attributed prose even outside JSON shapes.
-        payloads.append(raw)
-        json_fields = _json_body_fields(raw)
-        if json_fields:
-            payloads.extend(json_fields)
-        elif raw.strip().startswith(("{", "[")):
-            # Looked like JSON but did not decode — fail closed.
-            payloads.append(_CURL_FAIL_CLOSED_SENTINEL)
-    # File-/stdin-referenced data flags cannot be inspected in-process.
-    if _CURL_DATA_FILE_RE.search(command):
-        payloads.append(_CURL_FAIL_CLOSED_SENTINEL)
-    return payloads
+    return _extract_slack_mcp_payload(tool_name, tool_input)
 
 
 # ── Override + ledger ──────────────────────────────────────────────
@@ -447,20 +345,30 @@ def has_quote_ok_override(tool_name: str, tool_input: ToolInput) -> bool:
     """Return True iff the caller explicitly opted out of the gate.
 
     Two surfaces are accepted. The flag ``--quote-ok`` may appear as a
-    standalone token in a Bash command (``shlex.split`` is used so a
-    substring inside a quoted body cannot fake the flag). The env mapping
-    on the tool input may set ``QUOTE_OK=1`` (the harness exposes the env
-    block separately from the command string).
+    standalone token in the FIRST physical line of a Bash command — a
+    newline-smuggled ``--quote-ok`` (codex round-2 #1) is rejected
+    because a literal newline is itself a shell command separator.
+    The env mapping on the tool input may set ``QUOTE_OK=1`` (the harness
+    exposes the env block separately from the command string).
     """
     if tool_name == "Bash":
         command = tool_input.get("command", "")
+        # Only the FIRST shell command counts — any ``--quote-ok`` that
+        # lives on a separate physical line (outside any quoted region)
+        # is part of a different command and must not bypass the gate
+        # (codex round-2 #1). Line-continuation ``\<NL>`` is joined
+        # first so a legitimately-continued first command is still
+        # treated as one logical line. The split is QUOTE-AWARE so a
+        # newline INSIDE a body string is preserved.
+        joined = _normalize_line_continuations(command)
+        first_segment = _first_shell_command(joined)
         try:
             # ``comments=True`` strips ``# …`` so a smuggled
             # ``# --quote-ok`` after the publish command does not become
-            # a real token (Codex CRITICAL #1).
-            tokens = shlex.split(command, comments=True, posix=True)
+            # a real token (Codex CRITICAL #1, round 1).
+            tokens = shlex.split(first_segment, comments=True, posix=True)
         except ValueError:
-            tokens = command.split()
+            tokens = first_segment.split()
         # The override is valid only when it lives in the FIRST shell
         # segment — i.e. before any metacharacter that would route the
         # remainder to a separate command. ``shlex`` keeps ``;``, ``|``,

--- a/src/teatree/hooks/quote_scanner.py
+++ b/src/teatree/hooks/quote_scanner.py
@@ -1,0 +1,425 @@
+"""Pre-publish quote-scanner gate (#1213).
+
+A leak-prevention scanner that intercepts every tool call about to
+publish text to an external surface (a public-repo issue/PR body, a
+commit message, a Slack message, a t3 review post) and refuses the call
+when the body matches user-attributed quote patterns.
+
+The rule has been prose only in the memory ledger and recurred multiple
+times in a single session before being promoted to a tooling gate per
+``feedback_failed_memory_escalate_to_enforcement.md``.
+
+Design notes:
+
+The module is pure detection. The Bash/t3 command surfaces are parsed
+into a payload, then the payload runs through :func:`scan_text`. The
+PreToolUse hook in ``hooks/scripts/hook_router.py`` is the only place
+that knows about ``stdout``/``permissionDecision`` JSON.
+
+Patterns are split into ``HIGH`` (refuse publish) and ``MEDIUM`` (warn
+but allow). Both severities log to a JSONL ledger so cold review can
+reconstruct what the gate saw.
+
+The blocklist file at ``$T3_DATA_DIR/quote-blocklist.txt`` (default
+``~/.teatree/quote-blocklist.txt``) is a *regex* list, not a quote
+archive. Each non-blank, non-``#``-prefixed line is compiled with
+``re.IGNORECASE``. The spec is explicit: blocklists must not embed
+the raw quotes they protect against.
+
+Override via ``--quote-ok`` flag in the command string or
+``QUOTE_OK=1`` in the tool-input env mapping. Either one bypasses all
+checks and is itself logged for audit.
+"""
+
+import json
+import os
+import re
+import shlex
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Final, TypedDict
+
+Severity = str  # "high" | "medium"
+
+
+class ToolInput(TypedDict, total=False):
+    """Subset of the PreToolUse ``tool_input`` payload this gate reads.
+
+    Only the keys the scanner inspects are typed here — the harness
+    actually passes a wider, tool-shaped mapping that we treat as opaque.
+    """
+
+    command: str
+    text: str
+    message: str
+    body: str
+    env: dict[str, str]
+
+
+HIGH: Final[Severity] = "high"
+MEDIUM: Final[Severity] = "medium"
+
+
+@dataclass(frozen=True)
+class Pattern:
+    """A named regex with a severity classification."""
+
+    name: str
+    severity: Severity
+    regex: re.Pattern[str]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One pattern match against a body."""
+
+    name: str
+    severity: Severity
+    excerpt: str
+
+
+@dataclass
+class ScanResult:
+    """Aggregated severities + the matches that produced them."""
+
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def has_high(self) -> bool:
+        return any(f.severity == HIGH for f in self.findings)
+
+    @property
+    def has_medium(self) -> bool:
+        return any(f.severity == MEDIUM for f in self.findings)
+
+    @property
+    def high(self) -> list[Finding]:
+        return [f for f in self.findings if f.severity == HIGH]
+
+    @property
+    def medium(self) -> list[Finding]:
+        return [f for f in self.findings if f.severity == MEDIUM]
+
+
+# ── Detection patterns ──────────────────────────────────────────────
+
+# HIGH: heading shapes that announce a verbatim user block.
+_HEADING_PATTERNS: Final[tuple[Pattern, ...]] = (
+    Pattern(
+        "heading-user-mandate",
+        HIGH,
+        re.compile(
+            r"^#{1,3}\s*User\s+(?:mandate|ask|directive|motivation|redirect|feedback)\b",
+            re.IGNORECASE | re.MULTILINE,
+        ),
+    ),
+    Pattern(
+        "heading-user-ask-verbatim",
+        HIGH,
+        re.compile(r"^#{1,3}\s*User\s+ask\s*\(verbatim", re.IGNORECASE | re.MULTILINE),
+    ),
+    Pattern(
+        "bold-user-directive-verbatim",
+        HIGH,
+        re.compile(r"\*\*User\s+(?:directive|ask|mandate)[^*]*\(verbatim", re.IGNORECASE),
+    ),
+)
+
+# HIGH: verbatim quote shapes — attributed quotation, italicised speech,
+# explicit "the user said" prose.
+_VERBATIM_PATTERNS: Final[tuple[Pattern, ...]] = (
+    Pattern(
+        "blockquote-attributed",
+        HIGH,
+        re.compile(r"^>\s*\"[A-Z]", re.MULTILINE),
+    ),
+    Pattern(
+        "italic-quote-long",
+        HIGH,
+        re.compile(r'_"[^"]{20,}"_'),
+    ),
+    Pattern(
+        "per-user-feedback-quoted",
+        HIGH,
+        re.compile(r"per\s+user\s+feedback\s+\"", re.IGNORECASE),
+    ),
+    Pattern(
+        "the-user-said-colon",
+        HIGH,
+        re.compile(r"\bthe\s+user\s+(?:said|asked|wants?)\s*:", re.IGNORECASE),
+    ),
+)
+
+# MEDIUM: attribution shapes that don't necessarily include a verbatim
+# quote but lean on the user as the source of authority. Allowed past
+# the gate (with a stderr warning) so a cold reviewer can verify the
+# tone is paraphrased and not lifted.
+_ATTRIBUTION_PATTERNS: Final[tuple[Pattern, ...]] = (
+    Pattern(
+        "per-user-direction",
+        MEDIUM,
+        re.compile(r"\bper\s+user\s+(?:direction|mandate|ask)\b", re.IGNORECASE),
+    ),
+    Pattern(
+        "red-card-from-user",
+        MEDIUM,
+        re.compile(r"\bRED\s*CARD\b[^.\n]*\bfrom\s+user\b", re.IGNORECASE),
+    ),
+    Pattern(
+        "the-user-has-verb",
+        MEDIUM,
+        re.compile(r"\bthe\s+user\s+has\s+(?:explicitly|mandated|directed)\b", re.IGNORECASE),
+    ),
+)
+
+_BUILTIN_PATTERNS: Final[tuple[Pattern, ...]] = (
+    *_HEADING_PATTERNS,
+    *_VERBATIM_PATTERNS,
+    *_ATTRIBUTION_PATTERNS,
+)
+
+
+def _blocklist_path() -> Path:
+    base = os.environ.get("T3_DATA_DIR")
+    if base:
+        return Path(base) / "quote-blocklist.txt"
+    return Path.home() / ".teatree" / "quote-blocklist.txt"
+
+
+def _load_blocklist_patterns(path: Path | None = None) -> list[Pattern]:
+    """Compile regexes from the on-disk blocklist file.
+
+    The file is a list of REGEX patterns (one per line) — never raw
+    quotes. Blank lines and ``#``-prefixed comments are skipped. Each
+    line is compiled with ``re.IGNORECASE``. Any line that fails to
+    compile is reported via ``ValueError`` so a bad regex shows up
+    immediately rather than silently disabling a rule.
+    """
+    target = path if path is not None else _blocklist_path()
+    if not target.is_file():
+        return []
+    patterns: list[Pattern] = []
+    for idx, raw in enumerate(target.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            compiled = re.compile(line, re.IGNORECASE)
+        except re.error as exc:
+            msg = f"invalid regex in {target}:{idx} — {exc}"
+            raise ValueError(msg) from exc
+        patterns.append(Pattern(name=f"blocklist:{idx}", severity=HIGH, regex=compiled))
+    return patterns
+
+
+def scan_text(text: str, *, blocklist_path: Path | None = None) -> ScanResult:
+    """Match every built-in pattern and every blocklist regex against ``text``."""
+    result = ScanResult()
+    if not text:
+        return result
+    for pattern in (*_BUILTIN_PATTERNS, *_load_blocklist_patterns(blocklist_path)):
+        match = pattern.regex.search(text)
+        if match is None:
+            continue
+        excerpt = match.group(0)[:120]
+        result.findings.append(Finding(name=pattern.name, severity=pattern.severity, excerpt=excerpt))
+    return result
+
+
+# ── Bash / t3 command surface parsing ──────────────────────────────
+
+# Bash commands that publish to an external surface. The substring match
+# is sufficient — Bash strings come from the LLM, not from a shell, so
+# we don't have to worry about ``echo "gh issue create" | grep``-style
+# embedding.
+_BASH_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
+    "gh issue create",
+    "gh issue edit",
+    "gh issue comment",
+    "gh pr create",
+    "gh pr edit",
+    "gh pr comment",
+    "gh pr review",
+    "glab issue create",
+    "glab issue update",
+    "glab issue note create",
+    "glab mr create",
+    "glab mr update",
+    "glab mr note create",
+    "git commit -m",
+    "git commit --message",
+    "git commit -F",
+    "git commit --file",
+    "git tag --message",
+    "chat.postMessage",
+)
+
+# t3 sub-commands that publish on the user's behalf. The overlay segment
+# between ``t3`` and the verb is arbitrary (one of the registered
+# overlays), so we match the verb-segment substring directly — e.g.
+# ``review post-comment`` matches both ``t3 teatree review post-comment``
+# and the equivalent per-overlay variant.
+_T3_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
+    "notify send",
+    "review post-comment",
+    "review post-draft-note",
+    "ticket create-issue",
+    "t3 slack react",
+)
+
+
+def _is_t3_publish_invocation(command: str) -> bool:
+    # All overlay-routed verbs go through ``t3`` — restrict the substring
+    # match to commands that actually start with the ``t3`` binary so a
+    # ``git log --grep "review post-comment"`` does not trip the gate.
+    if not command.lstrip().startswith("t3 "):
+        return False
+    return any(needle in command for needle in _T3_PUBLISH_SUBSTRINGS)
+
+
+def _is_publish_command(command: str) -> bool:
+    if any(needle in command for needle in _BASH_PUBLISH_SUBSTRINGS):
+        return True
+    return _is_t3_publish_invocation(command)
+
+
+# Capture --body / --description / --message / --title / -m / -F arg
+# values plus heredocs. Heredocs cover the standard ``$(cat <<'EOF' …
+# EOF)`` shape the rest of the codebase already uses for multi-line PR
+# bodies.
+_FLAG_VALUE_RE: Final[re.Pattern[str]] = re.compile(
+    r"--(?:body|description|message|title)(?:[ =])\s*(['\"])(.*?)\1",
+    re.DOTALL,
+)
+_SHORT_M_RE: Final[re.Pattern[str]] = re.compile(r"\s-m\s+(['\"])(.*?)\1", re.DOTALL)
+_HEREDOC_RE: Final[re.Pattern[str]] = re.compile(
+    r"<<\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\1\b",
+    re.DOTALL,
+)
+_FILE_FLAG_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:--body-file|--description-file|--file)[ =]+(\S+)",
+)
+_GIT_SHORT_F_RE: Final[re.Pattern[str]] = re.compile(r"\s-F[ =]?(\S+)")
+
+
+def _read_file_arg(path: str) -> str | None:
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def extract_publish_payload(tool_name: str, tool_input: ToolInput) -> str | None:
+    """Return the text-to-scan from a tool invocation, or ``None`` if not a publish.
+
+    The ``None`` return is the gate's pass-through signal — the
+    PreToolUse handler skips its work for any tool call that does not
+    intend to publish.
+    """
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if not _is_publish_command(command):
+            return None
+        return _extract_bash_payload(command)
+
+    if tool_name.startswith("mcp__") and "slack" in tool_name.lower() and "send" in tool_name.lower():
+        return tool_input.get("text") or tool_input.get("message") or ""
+
+    return None
+
+
+def _extract_bash_payload(command: str) -> str:
+    """Concatenate every body-like fragment the command surface carries.
+
+    A single Bash invocation can carry the body in several forms — an
+    inline ``--body`` quoted arg, a ``-m`` short flag, a heredoc spliced
+    in via ``$(cat <<EOF … EOF)``, or a ``--body-file`` path. The gate
+    scans the union so a payload split across forms still trips.
+    """
+    parts: list[str] = [match.group(2) for match in _FLAG_VALUE_RE.finditer(command)]
+    parts.extend(match.group(2) for match in _SHORT_M_RE.finditer(command))
+    parts.extend(match.group(2) for match in _HEREDOC_RE.finditer(command))
+    for match in (*_FILE_FLAG_RE.finditer(command), *_GIT_SHORT_F_RE.finditer(command)):
+        content = _read_file_arg(match.group(1))
+        if content is not None:
+            parts.append(content)
+    return "\n".join(parts)
+
+
+# ── Override + ledger ──────────────────────────────────────────────
+
+
+def has_quote_ok_override(tool_name: str, tool_input: ToolInput) -> bool:
+    """Return True iff the caller explicitly opted out of the gate.
+
+    Two surfaces are accepted. The flag ``--quote-ok`` may appear as a
+    standalone token in a Bash command (``shlex.split`` is used so a
+    substring inside a quoted body cannot fake the flag). The env mapping
+    on the tool input may set ``QUOTE_OK=1`` (the harness exposes the env
+    block separately from the command string).
+    """
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        try:
+            tokens = shlex.split(command, comments=False, posix=True)
+        except ValueError:
+            tokens = command.split()
+        if "--quote-ok" in tokens:
+            return True
+    env = tool_input.get("env") or {}
+    return env.get("QUOTE_OK", "").strip() == "1"
+
+
+def _ledger_path() -> Path:
+    base = os.environ.get("T3_DATA_DIR")
+    root = Path(base) if base else Path.home() / ".teatree"
+    return root / "quote-scanner.jsonl"
+
+
+def log_decision(
+    *,
+    tool_name: str,
+    decision: str,
+    result: ScanResult,
+    override: bool,
+    ledger_path: Path | None = None,
+) -> None:
+    """Append a one-line JSON record to the gate's audit ledger."""
+    record = {
+        "ts": datetime.now(UTC).isoformat(timespec="seconds"),
+        "tool": tool_name,
+        "decision": decision,
+        "override": override,
+        "high": [f.name for f in result.high],
+        "medium": [f.name for f in result.medium],
+    }
+    target = ledger_path if ledger_path is not None else _ledger_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except OSError:
+        # The ledger is best-effort — never block on a write failure.
+        return
+
+
+def format_block_message(result: ScanResult) -> str:
+    """Render the PreToolUse deny reason for a HIGH match."""
+    names = ", ".join(sorted({f.name for f in result.high}))
+    return (
+        "BLOCKED: pre-publish quote-scanner gate (#1213). "
+        f"Matched patterns: {names}. "
+        "Paraphrase any user-attributed content; do not quote verbatim. "
+        "If the match is a false positive, re-issue the command with --quote-ok "
+        "(or set QUOTE_OK=1 in the tool env)."
+    )
+
+
+def format_warn_message(result: ScanResult) -> str:
+    """Render the stderr warning for a MEDIUM-only match."""
+    names = ", ".join(sorted({f.name for f in result.medium}))
+    return (
+        f"WARNING: pre-publish quote-scanner gate (#1213) — attribution patterns matched ({names}). "
+        "Verify the content is paraphrased, not lifted from user speech."
+    )

--- a/tach.toml
+++ b/tach.toml
@@ -41,6 +41,10 @@ path = "teatree.utils"
 depends_on = ["teatree.paths"]
 
 [[modules]]
+path = "teatree.hooks"
+depends_on = []
+
+[[modules]]
 path = "teatree.timeouts"
 depends_on = ["teatree.config"]
 

--- a/tests/test_quote_scanner.py
+++ b/tests/test_quote_scanner.py
@@ -1,0 +1,291 @@
+"""Tests for the pre-publish quote-scanner gate (#1213).
+
+The detection module ``teatree.hooks.quote_scanner`` and its
+PreToolUse handler ``handle_quote_scanner_pretool`` together promote
+the prose-only "never quote user verbatim" rule to a deterministic
+tooling gate. These tests exercise both halves end-to-end: each
+representative publish surface (Bash gh/glab/git/curl, the t3 review
+commands, the Slack MCP send) is given a realistic body and the gate's
+decision plus side effects (deny JSON, stderr warning, ledger entry)
+are asserted as a unit.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import handle_quote_scanner_pretool
+from teatree.hooks import quote_scanner
+from teatree.hooks.quote_scanner import Finding, ScanResult, extract_publish_payload, has_quote_ok_override, scan_text
+
+
+@pytest.fixture(autouse=True)
+def _isolated_ledger(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin the ledger + blocklist root to ``tmp_path`` so tests don't touch real state."""
+    monkeypatch.setenv("T3_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _bash(command: str) -> dict[str, object]:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _ledger_lines(tmp_path: Path) -> list[dict[str, object]]:
+    ledger = tmp_path / "quote-scanner.jsonl"
+    if not ledger.exists():
+        return []
+    return [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()]
+
+
+class TestScanTextHighPatterns:
+    """Each HIGH pattern in the built-in catalogue produces a HIGH finding."""
+
+    @pytest.mark.parametrize(
+        ("body", "expected_name"),
+        [
+            ("## User mandate\n\nplease ship it", "heading-user-mandate"),
+            ("### User feedback (paraphrased): xyz", "heading-user-mandate"),
+            ("## User ask (verbatim, 2026-05-20)\nbody", "heading-user-ask-verbatim"),
+            ("**User directive (verbatim, today):** body", "bold-user-directive-verbatim"),
+            ('> "An imperative sentence the user spoke."', "blockquote-attributed"),
+            ('A direct phrase like _"this is a long enough sentence to trip the gate"_.', "italic-quote-long"),
+            ('Per user feedback "ship it now"', "per-user-feedback-quoted"),
+            ("Per the user said: ship it now", "the-user-said-colon"),
+        ],
+    )
+    def test_each_high_pattern_is_flagged(self, body: str, expected_name: str) -> None:
+        result = scan_text(body)
+        assert result.has_high, f"expected HIGH finding for {expected_name!r}, got {result.findings!r}"
+        assert any(f.name == expected_name for f in result.high)
+
+
+class TestScanTextMediumPatterns:
+    @pytest.mark.parametrize(
+        ("body", "expected_name"),
+        [
+            ("Per user direction we ship this Friday.", "per-user-direction"),
+            ("RED CARD from user on the trailer policy.", "red-card-from-user"),
+            ("the user has explicitly approved the rollback.", "the-user-has-verb"),
+        ],
+    )
+    def test_each_medium_pattern_warns(self, body: str, expected_name: str) -> None:
+        result = scan_text(body)
+        assert result.has_medium
+        assert not result.has_high
+        assert any(f.name == expected_name for f in result.medium)
+
+
+class TestBlocklistFile:
+    def test_regex_blocklist_compiles_and_matches_case_insensitive(self, tmp_path: Path) -> None:
+        blocklist = tmp_path / "blocklist.txt"
+        blocklist.write_text(
+            "# comment\n\n^Operation\\s+Greenlight\\b\n",
+            encoding="utf-8",
+        )
+        result = scan_text("Operation Greenlight begins tomorrow.", blocklist_path=blocklist)
+        assert result.has_high
+        assert any(f.name.startswith("blocklist:") for f in result.high)
+
+    def test_invalid_regex_raises_clear_error(self, tmp_path: Path) -> None:
+        blocklist = tmp_path / "blocklist.txt"
+        blocklist.write_text("[unterminated\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="invalid regex"):
+            scan_text("anything", blocklist_path=blocklist)
+
+
+class TestExtractPublishPayloadBash:
+    def test_gh_issue_create_with_double_quoted_body(self) -> None:
+        cmd = 'gh issue create --title t --body "the user said: ship it now"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "the user said" in payload
+
+    def test_git_commit_minus_m_single_quoted_body(self) -> None:
+        cmd = "git commit -m 'fix: x\n\n## User mandate\nbody'"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_heredoc_body_via_cat_eof_is_captured(self) -> None:
+        cmd = (
+            "gh pr create --title t --body \"$(cat <<'EOF'\n"
+            "Summary line.\n\n"
+            '> "A direct attributed quote from the user."\n'
+            "EOF\n"
+            ')"'
+        )
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "attributed quote" in payload
+
+    def test_body_file_arg_is_read_from_disk(self, tmp_path: Path) -> None:
+        body_path = tmp_path / "pr.md"
+        body_path.write_text("## User directive\nbody\n", encoding="utf-8")
+        cmd = f"gh pr create --title t --body-file {body_path}"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User directive" in payload
+
+    def test_non_publish_command_returns_none(self) -> None:
+        assert extract_publish_payload("Bash", {"command": "ls -la"}) is None
+
+    def test_curl_chat_post_message_is_a_publish_surface(self) -> None:
+        cmd = 'curl -X POST https://slack.com/api/chat.postMessage -d \'{"text":"the user said: ship it now"}\''
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        # The body is JSON inside a single-quoted arg — no --body flag,
+        # no heredoc — so the parser legitimately captures nothing.
+        # The publish-surface predicate still fires so the gate runs;
+        # an empty payload simply produces no findings.
+        assert payload is not None
+
+
+class TestT3PublishCommands:
+    @pytest.mark.parametrize(
+        "subcommand",
+        [
+            "t3 teatree notify send",
+            "t3 teatree review post-comment",
+            "t3 teatree review post-draft-note",
+            "t3 mycustomer review post-comment",
+            "t3 teatree ticket create-issue",
+            "t3 slack react",
+        ],
+    )
+    def test_publish_surface_recognised(self, subcommand: str) -> None:
+        cmd = f'{subcommand} --body "## User mandate\nplease ship"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+
+class TestQuoteOkOverride:
+    def test_flag_in_bash_command_bypasses_check(self) -> None:
+        cmd = 'gh pr create --title t --body "the user said: foo" --quote-ok'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is True
+
+    def test_env_var_in_tool_input_bypasses_check(self) -> None:
+        cmd = 'gh pr create --title t --body "the user said: foo"'
+        assert has_quote_ok_override("Bash", {"command": cmd, "env": {"QUOTE_OK": "1"}}) is True
+
+    def test_clean_command_has_no_override(self) -> None:
+        assert has_quote_ok_override("Bash", {"command": "gh pr create --title t --body x"}) is False
+
+    def test_quote_ok_substring_inside_quoted_body_does_not_count(self) -> None:
+        # The flag-detection uses shlex tokens — a literal "--quote-ok"
+        # substring inside a double-quoted body arg is NOT a token of
+        # its own, so the override does not fire.
+        cmd = 'gh pr create --title t --body "discussion of --quote-ok semantics"'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+
+class TestHookHandlerEndToEnd:
+    def test_high_match_emits_deny_and_breaks_chain(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        data = _bash('gh pr create --title t --body "## User mandate\nplease ship now"')
+        blocked = handle_quote_scanner_pretool(data)
+        assert blocked is True
+        decision = json.loads(capsys.readouterr().out)
+        assert decision["permissionDecision"] == "deny"
+        assert "quote-scanner" in decision["permissionDecisionReason"]
+        ledger = _ledger_lines(tmp_path)
+        assert ledger
+        assert ledger[-1]["decision"] == "deny"
+
+    def test_medium_only_warns_on_stderr_and_allows_publish(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        data = _bash('gh pr create --title t --body "Per user direction, we ship Friday."')
+        blocked = handle_quote_scanner_pretool(data)
+        assert blocked is False
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "attribution" in captured.err.lower()
+        ledger = _ledger_lines(tmp_path)
+        assert ledger
+        assert ledger[-1]["decision"] == "warn"
+
+    def test_quote_ok_override_bypasses_high_match(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        data = _bash('gh pr create --title t --body "## User mandate\nfoo" --quote-ok')
+        blocked = handle_quote_scanner_pretool(data)
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+        ledger = _ledger_lines(tmp_path)
+        assert ledger
+        assert ledger[-1]["decision"] == "allow-override"
+        assert ledger[-1]["override"] is True
+
+    def test_non_publish_bash_command_is_a_noop(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_quote_scanner_pretool(_bash("ls -la"))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+        # A noop never reaches the scan path, so the ledger stays empty.
+        assert _ledger_lines(tmp_path) == []
+
+    def test_empty_body_is_allowed_silently(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # A publish surface with no captured body (e.g. ``gh pr create``
+        # without any --body* arg) hits the scanner with an empty
+        # payload — clean by construction, no findings, no warning.
+        blocked = handle_quote_scanner_pretool(_bash("gh pr create --title t"))
+        assert blocked is False
+        captured = capsys.readouterr()
+        assert captured.err == ""
+        ledger = _ledger_lines(tmp_path)
+        assert ledger
+        assert ledger[-1]["decision"] == "allow"
+
+    def test_clean_body_with_unattributed_quote_is_allowed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A body that happens to contain the word "user" or a generic
+        # quoted string but no user-attributed shape must pass.
+        body = "Summary: refactored the user-config loader to drop dead branches."
+        blocked = handle_quote_scanner_pretool(_bash(f'gh pr create --title t --body "{body}"'))
+        assert blocked is False
+        assert capsys.readouterr().err == ""
+
+    def test_slack_mcp_send_message_is_scanned(self, capsys: pytest.CaptureFixture[str]) -> None:
+        data = {
+            "tool_name": "mcp__claude_ai_Slack__slack_send_message",
+            "tool_input": {"text": "## User mandate\nplease ship"},
+        }
+        blocked = handle_quote_scanner_pretool(data)
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+
+    def test_multiline_heredoc_with_high_pattern_is_blocked(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd = (
+            "gh pr create --title t --body \"$(cat <<'EOF'\n"
+            "Summary of the change.\n\n"
+            "## User ask (verbatim, 2026-05-20)\n"
+            "do the thing\n"
+            "EOF\n"
+            ')"'
+        )
+        blocked = handle_quote_scanner_pretool(_bash(cmd))
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+        assert "heading-user-ask-verbatim" in out["permissionDecisionReason"]
+
+
+class TestHookChainRegistration:
+    def test_handler_is_wired_before_skill_load(self) -> None:
+        chain = router._HANDLERS["PreToolUse"]
+        names = [h.__name__ for h in chain]
+        assert "handle_quote_scanner_pretool" in names
+        assert names.index("handle_quote_scanner_pretool") < names.index("handle_enforce_skill_loading")
+
+
+class TestFormatHelpers:
+    def test_block_message_lists_matched_pattern_names(self) -> None:
+        result = ScanResult(findings=[Finding(name="heading-user-mandate", severity=quote_scanner.HIGH, excerpt="x")])
+        message = quote_scanner.format_block_message(result)
+        assert "heading-user-mandate" in message
+        assert "--quote-ok" in message
+
+    def test_warn_message_lists_matched_pattern_names(self) -> None:
+        result = ScanResult(findings=[Finding(name="per-user-direction", severity=quote_scanner.MEDIUM, excerpt="x")])
+        message = quote_scanner.format_warn_message(result)
+        assert "per-user-direction" in message

--- a/tests/test_quote_scanner.py
+++ b/tests/test_quote_scanner.py
@@ -395,6 +395,248 @@ class TestHookHandlerEndToEnd:
         assert "heading-user-ask-verbatim" in out["permissionDecisionReason"]
 
 
+class TestRound2BypassClosures:
+    """Regression tests for the 7 round-2 codex-found bypass paths.
+
+    Each test reproduces a distinct bypass surfaced in the codex
+    re-verdict comment on PR #1251 (re-review of commit ``e8b642cc``).
+    Test names align 1:1 with the round-2 finding numbers.
+    """
+
+    # --- Round-2 #1: newline-separated ``--quote-ok`` override ---
+
+    def test_override_smuggled_after_literal_newline_is_rejected(self) -> None:
+        # ``gh ... --body "leak"\n--quote-ok`` — the override token must
+        # only count as a CLI token in the FIRST shell command, not as
+        # text after a literal newline (which acts as a shell separator
+        # at the command level).
+        cmd = 'gh issue comment 1 --body "## User mandate\nbody"\n--quote-ok'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+    def test_override_smuggled_after_carriage_return_is_rejected(self) -> None:
+        cmd = 'gh issue comment 1 --body "## User mandate\nbody"\r\n--quote-ok'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+    def test_high_match_with_newline_smuggled_override_still_blocks(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # End-to-end: the gate must DENY when the only override token
+        # was smuggled past a literal newline.
+        cmd = 'gh issue comment 1 --body "## User mandate\nbody"\n--quote-ok'
+        blocked = handle_quote_scanner_pretool(_bash(cmd))
+        assert blocked is True
+        decision = json.loads(capsys.readouterr().out)
+        assert decision["permissionDecision"] == "deny"
+
+    # --- Round-2 #2: line-continuation `\` in publish command ---
+
+    def test_line_continuation_in_publish_command_still_parses_body(self) -> None:
+        # ``gh issue \\<NL> comment 1 --body "..."`` — bash joins the
+        # continued line into a single command, so the body must still
+        # be extracted.
+        cmd = 'gh issue \\\n  comment 1 --body "## User mandate\nbody"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_line_continuation_does_not_smuggle_override(self) -> None:
+        # Splitting ``--quote-ok`` across a backslash-newline must not
+        # bypass the override check — the joined token is ``--quote-ok``
+        # which IS a legitimate override (this case should fire), but
+        # the FIRST-segment rule still applies. Place the override AFTER
+        # a metacharacter to confirm it is rejected.
+        cmd = 'gh issue comment 1 --body "leak" \\\n  ; echo --quote-ok'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+    # --- Round-2 #3: ANSI-C $'...' quoting ---
+
+    def test_ansi_c_body_quoting_is_decoded_and_scanned(self) -> None:
+        # Bash decodes ``$'\n'`` to a literal newline before passing the
+        # value as a single arg. The scanner must see the decoded body
+        # so a ``## User mandate`` heading inside ``$'...'`` is caught.
+        cmd = r"""gh issue create --title t --body $'## User mandate\nship it'"""
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_ansi_c_hex_escapes_are_decoded_and_scanned(self) -> None:
+        # ``$'\x4c\x65\x61\x6b'`` decodes to ``Leak`` — make sure the
+        # scanner sees the decoded literal so an obfuscation via
+        # hex-escape cannot smuggle a HIGH match past detection.
+        cmd = r"""gh issue create --title t --body $'## User mandate\n\x73\x68\x69\x70 it'"""
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+        assert "ship" in payload
+
+    def test_ansi_c_undecodable_fails_closed(self) -> None:
+        # If a body uses ANSI-C quoting and the value contains a body-
+        # flag flag but the content is opaque, we still pull whatever
+        # shlex extracted so subsequent scans run on the literal payload.
+        cmd = r"""gh issue create --title t --body $'## User mandate'"""
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    # --- Round-2 #4: gh api --input - (stdin) fails closed ---
+
+    def test_gh_api_input_stdin_fails_closed(self) -> None:
+        # ``gh api ... --input -`` reads the payload from stdin which we
+        # cannot inspect from inside the hook. The gate must fail closed.
+        cmd = "gh api repos/x/y/issues/1/comments --input -"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        scan = scan_text(payload)
+        assert scan.has_high, f"gh api --input - must fail closed via HIGH-matching sentinel; got payload={payload!r}"
+
+    def test_gh_api_input_missing_file_fails_closed(self) -> None:
+        # When ``--input`` references a path that does not exist we
+        # cannot read the body — fail closed instead of treating it as a
+        # clean publish.
+        cmd = "gh api repos/x/y/issues/1/comments --input /nonexistent/path.json"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        scan = scan_text(payload)
+        assert scan.has_high
+
+    def test_glab_api_input_stdin_fails_closed(self) -> None:
+        cmd = "glab api projects/1/issues/1/notes --input -"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        scan = scan_text(payload)
+        assert scan.has_high
+
+    # --- Round-2 #5: curl --data=value (equals form) ---
+
+    def test_curl_data_equals_form_is_parsed(self) -> None:
+        cmd = 'curl -X POST https://slack.com/api/chat.postMessage --data=\'{"text":"## User mandate\\nship"}\''
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_curl_json_equals_form_is_parsed(self) -> None:
+        cmd = 'curl -X POST https://example.com/api/comments --json=\'{"body":"## User mandate\\nship"}\''
+        from teatree.hooks.quote_scanner import _extract_bash_payload  # noqa: PLC0415
+
+        body = _extract_bash_payload(cmd)
+        assert "User mandate" in body
+
+    def test_curl_data_raw_equals_form_is_parsed(self) -> None:
+        cmd = 'curl -X POST https://slack.com/api/chat.postMessage --data-raw=\'{"text":"## User mandate\\nship"}\''
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_curl_data_equals_at_file_fails_closed(self) -> None:
+        cmd = "curl -X POST https://slack.com/api/chat.postMessage --data=@some-binary"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        scan = scan_text(payload)
+        assert scan.has_high
+
+    # --- Round-2 #6: Slack MCP coverage gaps ---
+
+    @pytest.mark.parametrize(
+        ("tool_name", "field"),
+        [
+            ("mcp__claude_ai_Slack__slack_send_message", "text"),
+            ("mcp__claude_ai_Slack__slack_send_message_draft", "text"),
+            ("mcp__claude_ai_Slack__slack_schedule_message", "text"),
+            ("mcp__claude_ai_Slack__slack_create_canvas", "document_content"),
+            ("mcp__claude_ai_Slack__slack_update_canvas", "document_content"),
+        ],
+    )
+    def test_slack_mcp_write_tool_body_is_scanned(self, tool_name: str, field: str) -> None:
+        # ``ToolInput`` enumerates a subset of keys for static analysis,
+        # but real MCP payloads can carry tool-specific fields like
+        # ``document_content`` — cast to the broader shape that the
+        # extractor actually accepts.
+        from typing import cast  # noqa: PLC0415
+
+        from teatree.hooks.quote_scanner import ToolInput  # noqa: PLC0415
+
+        tool_input = cast("ToolInput", {field: "## User mandate\nship"})
+        payload = extract_publish_payload(tool_name, tool_input)
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_slack_create_canvas_with_content_field_is_scanned(self) -> None:
+        # Some canvas variants use ``content`` instead of
+        # ``document_content``. Both must be picked up.
+        from typing import cast  # noqa: PLC0415
+
+        from teatree.hooks.quote_scanner import ToolInput  # noqa: PLC0415
+
+        tool_input = cast("ToolInput", {"content": "## User mandate\nship"})
+        payload = extract_publish_payload(
+            "mcp__claude_ai_Slack__slack_create_canvas",
+            tool_input,
+        )
+        assert payload is not None
+        assert "User mandate" in payload
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "mcp__claude_ai_Slack__slack_read_channel",
+            "mcp__claude_ai_Slack__slack_read_thread",
+            "mcp__claude_ai_Slack__slack_search_public",
+            "mcp__claude_ai_Slack__slack_list_channel_members",
+        ],
+    )
+    def test_slack_mcp_read_only_tools_are_not_publish_surfaces(self, tool_name: str) -> None:
+        # Read-only Slack tools must NOT trigger the gate — they don't
+        # publish anything, and false positives would block legitimate
+        # discovery calls.
+        assert extract_publish_payload(tool_name, {"text": "## User mandate\nship"}) is None
+
+    def test_slack_schedule_message_high_match_blocks(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        data = {
+            "tool_name": "mcp__claude_ai_Slack__slack_schedule_message",
+            "tool_input": {"text": "## User mandate\nfoo"},
+        }
+        blocked = handle_quote_scanner_pretool(data)
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+
+    # --- Round-2 #7: smart-quote (Unicode) variants ---
+
+    def test_smart_double_quotes_in_blockquote_are_blocked(self) -> None:
+        # U+201C / U+201D (left / right double smart quotes) must match
+        # the blockquote-attributed HIGH pattern after normalization.
+        body = "> “Ship it now.”"
+        result = scan_text(body)
+        assert result.has_high, f"smart-quoted blockquote must match HIGH; got {result.findings!r}"
+
+    def test_smart_single_quotes_attributed_are_blocked(self) -> None:
+        # U+2018 / U+2019 — same handling as straight singles in
+        # heading/italic patterns.
+        body = "Per user feedback “ship it now”"
+        result = scan_text(body)
+        assert result.has_high
+
+    def test_low9_and_high_reversed_quotes_are_normalized(self) -> None:
+        # U+201A (single low-9), U+201E (double low-9), U+201F
+        # (high-reversed-9) — common across CJK/EU typography.
+        body = "> „Ship it now.‟"
+        result = scan_text(body)
+        assert result.has_high
+
+    def test_italic_attributed_smart_quote_is_blocked(self) -> None:
+        body = "A direct phrase like _“this is a long enough sentence to trip the gate”_."
+        result = scan_text(body)
+        assert result.has_high
+
+    def test_smart_quote_in_gh_pr_comment_body_blocks(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        body = "> “Ship it now.”"
+        cmd = f'gh pr comment 5 -b "{body}"'
+        blocked = handle_quote_scanner_pretool(_bash(cmd))
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+
+
 class TestHookChainRegistration:
     def test_handler_is_wired_before_skill_load(self) -> None:
         chain = router._HANDLERS["PreToolUse"]

--- a/tests/test_quote_scanner.py
+++ b/tests/test_quote_scanner.py
@@ -637,6 +637,172 @@ class TestRound2BypassClosures:
         assert out["permissionDecision"] == "deny"
 
 
+class TestRound3BypassClosures:
+    """Regression tests for the round-3 codex-found bypass paths.
+
+    Each test reproduces one finding from the round-3 verdict comment on
+    PR #1251. The names align 1:1 with the round-3 finding numbers.
+    """
+
+    # --- Round-3 #1: token-internal line continuation ---
+
+    def test_token_internal_line_continuation_in_subcommand_still_parses(self) -> None:
+        # ``gh iss\\\nue comment`` — bash REMOVES ``\\\n`` entirely when it
+        # is INSIDE a token (the two halves rejoin as ``gh issue comment``).
+        # The publish-detection substring match must still see the joined
+        # command.
+        cmd = 'gh iss\\\nue comment 1 --body "## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None, "token-internal \\<NL> must rejoin to a real publish command"
+        assert "User mandate" in payload
+
+    def test_token_internal_line_continuation_in_flag_still_parses(self) -> None:
+        # ``--bo\\\ndy "x"`` — backslash-newline INSIDE the flag name is
+        # eliminated by bash; the joined token is ``--body`` and the body
+        # value must still be extracted.
+        cmd = 'gh issue comment 1 --bo\\\ndy "## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_between_token_line_continuation_still_separates_tokens(self) -> None:
+        # ``--body \\\n "x"`` — backslash-newline BETWEEN tokens collapses
+        # the whitespace but keeps the two tokens apart.
+        cmd = 'gh issue comment 1 --body \\\n  "## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    # --- Round-3 #2: --quote-ok after unspaced metachar ---
+
+    def test_override_after_unspaced_semicolon_is_rejected(self) -> None:
+        # ``echo body;echo --quote-ok`` — a real shell tokenizes ``;`` as
+        # a separate token regardless of whitespace, so ``--quote-ok``
+        # lives in a SECOND command and must not bypass the gate.
+        cmd = 'gh issue comment 1 --body "## User mandate\nbody";echo --quote-ok'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+    def test_override_after_unspaced_pipe_is_rejected(self) -> None:
+        cmd = 'gh issue comment 1 --body "leak"|echo --quote-ok'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+    def test_override_after_unspaced_double_amp_is_rejected(self) -> None:
+        cmd = 'gh issue comment 1 --body "leak"&&echo --quote-ok'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+    def test_override_after_unspaced_double_pipe_is_rejected(self) -> None:
+        cmd = 'gh issue comment 1 --body "leak"||echo --quote-ok'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+    def test_override_after_unspaced_semicolon_blocks_end_to_end(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cmd = 'gh issue comment 1 --body "## User mandate\nbody";echo --quote-ok'
+        blocked = handle_quote_scanner_pretool(_bash(cmd))
+        assert blocked is True
+        decision = json.loads(capsys.readouterr().out)
+        assert decision["permissionDecision"] == "deny"
+
+    # --- Round-3 #3: ANSI-C $'...' with escaped single quote ---
+
+    def test_ansi_c_with_escaped_single_quote_does_not_truncate(self) -> None:
+        # ``$'prefix \\'\\n## User mandate\\nship'`` — the escaped single
+        # quote inside the ANSI-C body must NOT truncate the value; the
+        # full decoded payload (including the heading) must be scanned.
+        cmd = r"""gh issue create --title t --body $'prefix \'\n## User mandate\nship'"""
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload, f"escaped single quote must not truncate ANSI-C body; payload={payload!r}"
+
+    def test_ansi_c_with_escaped_double_quote_decodes(self) -> None:
+        cmd = r"""gh issue create --title t --body $'\"## User mandate\"\nship'"""
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_ansi_c_unicode_escape_decodes(self) -> None:
+        # ``##`` is ``##`` — must decode and trip the heading.
+        cmd = r"""gh issue create --title t --body $'## User mandate\nship'"""
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    # --- Round-3 #4: curl -dVALUE attached short-option ---
+
+    def test_curl_d_attached_value_is_parsed(self) -> None:
+        # ``-d'{...}'`` — no separator between flag and value. Real curl
+        # accepts the attached form per POSIX short-option convention.
+        cmd = 'curl -X POST https://slack.com/api/chat.postMessage -d\'{"text":"## User mandate\\nship"}\''
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_curl_d_attached_at_file_fails_closed(self) -> None:
+        # ``-d@path`` (no separator) — fail closed since we cannot read
+        # arbitrary attached files.
+        cmd = "curl -X POST https://slack.com/api/chat.postMessage -d@some-binary"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        scan = scan_text(payload)
+        assert scan.has_high
+
+    # --- Round-3 #5: slack_edit_message MCP tool ---
+
+    def test_slack_edit_message_is_a_publish_surface(self) -> None:
+        from typing import cast  # noqa: PLC0415
+
+        from teatree.hooks.quote_scanner import ToolInput  # noqa: PLC0415
+
+        tool_input = cast("ToolInput", {"text": "## User mandate\nship"})
+        payload = extract_publish_payload(
+            "mcp__claude_ai_Slack__slack_edit_message",
+            tool_input,
+        )
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_slack_edit_message_high_match_blocks(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        data = {
+            "tool_name": "mcp__claude_ai_Slack__slack_edit_message",
+            "tool_input": {"text": "## User mandate\nfoo"},
+        }
+        blocked = handle_quote_scanner_pretool(data)
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+
+    # --- Round-3 #6: gh api -F body= false-positive regression ---
+
+    def test_gh_api_dash_f_body_does_not_false_positive(self) -> None:
+        # ``gh api ... -F body="Clean update"`` is a structured field
+        # assignment, NOT a file reference. The dedicated
+        # ``_API_FIELD_BODY_RE`` must handle it and the git-style
+        # ``-F<filename>`` fail-closed must NOT fire on ``gh api`` calls.
+        cmd = 'gh api repos/x/y/issues/1/comments -F body="Clean update without quotes"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        scan = scan_text(payload)
+        assert not scan.has_high, f"gh api -F body=clean must not fail-closed; findings={scan.findings!r}"
+        assert "Clean update" in payload
+
+    def test_glab_api_dash_f_body_does_not_false_positive(self) -> None:
+        cmd = 'glab api projects/1/issues/1/notes -F body="Clean note text"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        scan = scan_text(payload)
+        assert not scan.has_high
+        assert "Clean note" in payload
+
+    def test_git_commit_dash_f_file_still_fails_closed_when_missing(self, tmp_path: Path) -> None:
+        # The git-specific ``-F`` IS a file reference. Round-3 scoping
+        # must NOT lose the fail-closed behaviour for git commits.
+        cmd = "git commit -F /nonexistent/path.txt"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        scan = scan_text(payload)
+        assert scan.has_high
+
+
 class TestHookChainRegistration:
     def test_handler_is_wired_before_skill_load(self) -> None:
         chain = router._HANDLERS["PreToolUse"]

--- a/tests/test_quote_scanner.py
+++ b/tests/test_quote_scanner.py
@@ -134,11 +134,10 @@ class TestExtractPublishPayloadBash:
     def test_curl_chat_post_message_is_a_publish_surface(self) -> None:
         cmd = 'curl -X POST https://slack.com/api/chat.postMessage -d \'{"text":"the user said: ship it now"}\''
         payload = extract_publish_payload("Bash", {"command": cmd})
-        # The body is JSON inside a single-quoted arg — no --body flag,
-        # no heredoc — so the parser legitimately captures nothing.
-        # The publish-surface predicate still fires so the gate runs;
-        # an empty payload simply produces no findings.
+        # The curl ``-d`` flag is parsed by :func:`_extract_curl_payloads`
+        # so the JSON ``text`` field is included in the scan payload.
         assert payload is not None
+        assert "the user said" in payload
 
 
 class TestT3PublishCommands:
@@ -178,6 +177,132 @@ class TestQuoteOkOverride:
         # its own, so the override does not fire.
         cmd = 'gh pr create --title t --body "discussion of --quote-ok semantics"'
         assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+    def test_quote_ok_smuggled_after_shell_comment_is_rejected(self) -> None:
+        # Codex CRITICAL #1: ``# --quote-ok`` after a publish command must
+        # NOT bypass the gate. ``shlex.split`` must strip comments.
+        cmd = 'gh issue comment 1 --body "leak" # --quote-ok'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+    def test_quote_ok_smuggled_after_metacharacter_is_rejected(self) -> None:
+        # Override must not fire when it lives after a shell metacharacter
+        # — even if it parses as a token, it is not part of the publish
+        # invocation we are gating.
+        for metachar in (";", "|", "&&"):
+            cmd = f'gh issue comment 1 --body "leak" {metachar} echo --quote-ok'
+            assert has_quote_ok_override("Bash", {"command": cmd}) is False, (
+                f"override smuggled after {metachar!r} must be rejected"
+            )
+
+
+class TestBypassClosures:
+    """Regression tests for codex-found bypass paths (#1213 review)."""
+
+    # --- CRITICAL #2: glab note without 'create' segment ---
+
+    def test_glab_mr_note_no_create_is_a_publish_surface(self) -> None:
+        cmd = 'glab mr note 42 -m "## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_glab_issue_note_no_create_is_a_publish_surface(self) -> None:
+        cmd = 'glab issue note 17 -m "## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    # --- CRITICAL #3: gh short -b body flag ---
+
+    def test_gh_pr_comment_short_b_body_is_parsed(self) -> None:
+        cmd = 'gh pr comment 5 -b "## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_gh_issue_comment_short_b_body_is_parsed(self) -> None:
+        cmd = 'gh issue comment 5 -b "## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    # --- CRITICAL #4: gh api / glab api comment POSTs ---
+
+    def test_gh_api_is_a_publish_surface_with_field_body(self) -> None:
+        cmd = 'gh api repos/x/y/issues/1/comments -f body="## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_gh_api_uppercase_f_field_body_is_parsed(self) -> None:
+        cmd = 'gh api repos/x/y/issues/1/comments -F body="## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_gh_api_raw_field_body_is_parsed(self) -> None:
+        cmd = 'gh api repos/x/y/issues/1/comments --raw-field body="## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_glab_api_is_a_publish_surface_with_field_body(self) -> None:
+        cmd = 'glab api projects/1/issues/1/notes -f body="## User mandate\nship it"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_gh_api_input_file_payload_is_read(self, tmp_path: Path) -> None:
+        body_path = tmp_path / "comment.json"
+        body_path.write_text('{"body": "## User mandate\\nship it"}', encoding="utf-8")
+        cmd = f"gh api repos/x/y/issues/1/comments --input {body_path}"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    # --- CRITICAL #5: curl data-flag JSON parsing ---
+
+    def test_curl_data_flag_json_text_field_is_parsed(self) -> None:
+        cmd = 'curl -X POST https://slack.com/api/chat.postMessage -d \'{"text":"## User mandate\\nplease ship"}\''
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_curl_data_raw_flag_json_message_field_is_parsed(self) -> None:
+        cmd = (
+            "curl -X POST https://slack.com/api/chat.postMessage "
+            '--data-raw \'{"message":"## User mandate\\nplease ship"}\''
+        )
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
+    def test_curl_json_flag_body_field_is_parsed(self) -> None:
+        cmd = 'curl -X POST https://example.com/api/comments --json \'{"body":"## User mandate\\nplease ship"}\''
+        # The --json curl flag is publish-shaped here only if the URL
+        # matches an external publish surface — but for this test the
+        # parser shouldn't care about the URL, it just needs to extract
+        # the body. We assert via _extract_bash_payload directly.
+        from teatree.hooks.quote_scanner import _extract_bash_payload  # noqa: PLC0415
+
+        body = _extract_bash_payload(cmd)
+        assert "User mandate" in body
+
+    def test_curl_data_flag_unparseable_json_fails_closed(self) -> None:
+        # Fail-closed: when curl carries a data flag we cannot parse,
+        # the payload must contain a sentinel string that will trip the
+        # HIGH gate (we use the well-known HIGH pattern so the test does
+        # not depend on a new pattern). Specifically: a `the user said:`
+        # marker so any reviewer sees the gate blocked.
+        cmd = "curl -X POST https://slack.com/api/chat.postMessage -d @some-binary-file"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        # The fail-closed sentinel deliberately matches a HIGH pattern so
+        # downstream ``scan_text`` produces a deny decision.
+        scan = scan_text(payload)
+        assert scan.has_high, (
+            f"unparsable curl data must fail closed via a HIGH-matching sentinel; got payload={payload!r}"
+        )
 
 
 class TestHookHandlerEndToEnd:


### PR DESCRIPTION
## Summary

Closes #1213. Promotes the prose-only "never quote user verbatim" rule
to a deterministic PreToolUse gate so the failure mode can no longer
recur in a future session.

## Surfaces intercepted

- Bash: `gh issue create|edit|comment`, `gh pr create|edit|comment|review`, `glab issue/mr` create/update/note, `git commit -m/-F/--message/--file`, `git tag --message`, `curl … chat.postMessage`.
- Per-overlay t3 publish verbs: `review post-comment`, `review post-draft-note`, `notify send`, `ticket create-issue`, plus `t3 slack react`.
- Slack MCP `send_message` family.

## Detection layers

- **HIGH (refuse)**: user-mandate / user-ask-verbatim / bold-user-directive headings; attributed blockquotes (`> "…"`); long italicised speech (`_"…"_`); `Per user feedback "…"`; `the user said|asked|wants:`.
- **MEDIUM (warn, allow)**: `Per user direction|mandate|ask`, `RED CARD … from user`, `the user has explicitly|mandated|directed`.
- **Blocklist** (`$T3_DATA_DIR/quote-blocklist.txt`): regex-only, not a quote archive — case-insensitive, comment lines (`#`) and blank lines ignored.

## Bypass mechanism

`--quote-ok` flag on the Bash command OR `QUOTE_OK=1` in the tool-input env. Every decision (deny, warn, allow, allow-override) appends to `$T3_DATA_DIR/quote-scanner.jsonl` so cold review can audit what the gate saw.

## Test plan

- [x] `uv run pytest tests/test_quote_scanner.py --no-cov -x -q` — 40 passed
- [x] `uv run ruff check src/teatree/hooks/ tests/test_quote_scanner.py hooks/scripts/hook_router.py` — clean
- [x] `uv run ruff format` — clean
- [x] Pre-commit chain (tach, banned-terms, module-health, editorconfig, ty-check, conventional commit) — all passing
- [x] Adjacent hook tests (`tests/test_block_ai_signature_hook.py`, `test_orchestrator_boundary_hook.py`, `test_hook_router_plan_gate.py`, `test_hook_router_cadence_hook.py`) — 76 still passing