### PR TITLE
docs(blueprint): close 4 drift issues — Ticket states, [teatree] toml, entry-point shim, Stop-gate chain (#1141 #1147 #1150 #1151)

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -19,6 +19,7 @@ on_behalf_post_mode = "draft_or_ask"       # tri-state pre-gate (#960): draft_or
 notify_on_post_on_behalf = true            # DM the user after every on-behalf post (#949)
 user_identity_aliases = []                 # cross-platform handles for the same human (#975/#976); consumed by TicketDispositionScanner + multi-identity scanning
 statusline_chain = []                      # extra statusline scripts (glob patterns) chained after the loop's zones
+repo_mode = ""                             # solo/collaborative working mode (#550 item 4); "" = auto-detect from git shortlog history
 claude_chrome = true                       # spawn `claude` with --chrome so sessions can drive the browser
 agent_signature = false                    # never append agent identity (Co-Authored-By, "Sent using …") to user-on-behalf posts
 
@@ -77,7 +78,7 @@ The env var `T3_MODE` overrides the toml setting. Unknown values raise
 A subset of `[teatree]` keys can be overridden per-overlay in
 `[overlays.<name>]`. The resolution chain (first match wins):
 
-1. `T3_*` env var (currently only `T3_MODE` is wired as a one-off).
+1. `T3_*` env var (wired one-offs declared in `ENV_SETTING_OVERRIDES`; currently `T3_MODE` and `T3_ON_BEHALF_POST_MODE`).
 2. Active overlay's override from `[overlays.<name>]`.
 3. Global `[teatree]` value.
 4. `UserSettings` dataclass default.
@@ -102,16 +103,16 @@ below mirrors it; consult the dataclass for type signatures and defaults.
 | `require_human_approval_to_answer` | Training-wheel for `t3:answerer`: drafts + DMs, posts only on confirm |
 | `ask_before_post_on_behalf` | Legacy boolean pre-gate over on-behalf posts (kept for back-compat — prefer `on_behalf_post_mode`) |
 | `on_behalf_post_mode` | Tri-state pre-gate (#960): `draft_or_ask` / `ask` / `immediate`, scoped per overlay so a client overlay can stay `ask` while a personal one runs `immediate` |
-| `notify_user_via_bot` | Whether agent-on-behalf notifications use the overlay's Slack bot vs the user's xoxp token |
+| `notify_user_via_bot` | Whether the bot→operator `notify_user(...)` channel (#963) DMs the user via the overlay's Slack bot (out of scope for the on-behalf gates — see config.py for the boundary) |
 | `notify_on_post_on_behalf` | DM the user after every on-behalf post (#949) — per-overlay because noise tolerance differs |
 | `user_identity_aliases` | Per-overlay handles (e.g. different GitHub login on a client overlay), consumed by §5.6 scanners (#975/#976) |
 | `architectural_review_disabled` | Escape hatch for the periodic architectural-review scanner on a given overlay |
 | `architectural_review_skill` | Override which skill the scanner dispatches (default `/ac-reviewing-codebase`) |
 | `architectural_review_cadence_hours` | Per-overlay cadence floor for the architectural-review scanner |
 | `architectural_review_after_merge_count` | Per-overlay merge-count trigger for the architectural-review scanner |
-| `scanning_news_disabled` | Escape hatch for the daily `t3:scanning-news` scanner (#1191) on a given overlay |
-| `scanning_news_skill` | Override which skill the scanner dispatches (default `/t3:scanning-news`) |
-| `scanning_news_cadence_hours` | Per-overlay cadence floor for the news-scanning scanner |
+| `scanning_news_disabled` | Escape hatch for the daily `t3:scanning-news` scanner (#1191) — registered as overridable, but the live scanner reads the global `[teatree]` value (the news-scan is anchored on the `teatree` overlay placeholder ticket; per-overlay overrides are accepted in the registry but not yet consumed by `_scanning_news_scanner` in `loop/tick_jobs.py`) |
+| `scanning_news_skill` | Override which skill the scanner dispatches (default `/t3:scanning-news`) — same registry/consumer gap as `scanning_news_disabled` above |
+| `scanning_news_cadence_hours` | Cadence floor for the news-scanning scanner — same registry/consumer gap as `scanning_news_disabled` above |
 
 Callers use `get_effective_settings()` (returns a `UserSettings` with the
 active overlay's overrides applied) instead of reaching into

--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -87,7 +87,8 @@ The active overlay is resolved via (in order): `T3_OVERLAY_NAME` env var
 single installed overlay.
 
 Overridable keys live in `OVERLAY_OVERRIDABLE_SETTINGS` in
-`src/teatree/config.py`:
+`src/teatree/config.py`. The registry is the single source of truth — the table
+below mirrors it; consult the dataclass for type signatures and defaults.
 
 | Key | Why overridable |
 |-----|------------------|
@@ -96,6 +97,21 @@ Overridable keys live in `OVERLAY_OVERRIDABLE_SETTINGS` in
 | `privacy` | Stricter for client code, looser for personal |
 | `contribute` | Contribute to one overlay's skills but not another |
 | `excluded_skills` | Project-specific skill exclusions |
+| `loop_cadence_seconds` | Per-overlay tick cadence (e.g. tighter on a hot overlay, looser on a maintenance one) |
+| `require_human_approval_to_merge` | Training-wheel: auto-mode overlay can publish autonomously, merge stays gated |
+| `require_human_approval_to_answer` | Training-wheel for `t3:answerer`: drafts + DMs, posts only on confirm |
+| `ask_before_post_on_behalf` | Legacy boolean pre-gate over on-behalf posts (kept for back-compat — prefer `on_behalf_post_mode`) |
+| `on_behalf_post_mode` | Tri-state pre-gate (#960): `draft_or_ask` / `ask` / `immediate`, scoped per overlay so a client overlay can stay `ask` while a personal one runs `immediate` |
+| `notify_user_via_bot` | Whether agent-on-behalf notifications use the overlay's Slack bot vs the user's xoxp token |
+| `notify_on_post_on_behalf` | DM the user after every on-behalf post (#949) — per-overlay because noise tolerance differs |
+| `user_identity_aliases` | Per-overlay handles (e.g. different GitHub login on a client overlay), consumed by §5.6 scanners (#975/#976) |
+| `architectural_review_disabled` | Escape hatch for the periodic architectural-review scanner on a given overlay |
+| `architectural_review_skill` | Override which skill the scanner dispatches (default `/ac-reviewing-codebase`) |
+| `architectural_review_cadence_hours` | Per-overlay cadence floor for the architectural-review scanner |
+| `architectural_review_after_merge_count` | Per-overlay merge-count trigger for the architectural-review scanner |
+| `scanning_news_disabled` | Escape hatch for the daily `t3:scanning-news` scanner (#1191) on a given overlay |
+| `scanning_news_skill` | Override which skill the scanner dispatches (default `/t3:scanning-news`) |
+| `scanning_news_cadence_hours` | Per-overlay cadence floor for the news-scanning scanner |
 
 Callers use `get_effective_settings()` (returns a `UserSettings` with the
 active overlay's overrides applied) instead of reaching into

--- a/docs/blueprint/factory-architecture.md
+++ b/docs/blueprint/factory-architecture.md
@@ -134,6 +134,8 @@ This is spec-only — §17.6.1 (anti-relaxation checks) and §17.6.2 (sound tach
 
 #### 17.6.1 Anti-relaxation checks
 
+**SPEC ONLY — not yet implemented.** The seven checks below describe a gate-shape tracked under the issues referenced at the end of §17.6; none are wired into `hook_router.py` today. The shipped enforcement gates from this family are enumerated in §17.6.4.
+
 The gate runs on every PR diff and blocks merge if any of the following are present **beyond the established boilerplate baseline**:
 
 | Check | Trigger |


### PR DESCRIPTION
## Summary

Closes the live-doc drift cited in #1141, #1147, #1150, #1151 against `BLUEPRINT.md` and `docs/blueprint/`. Pure additive corrections — no architectural restructuring.

## What this PR actually changes (real drift still present on `main`)

Two of the four issues still pointed at live drift; this PR fixes both:

- **#1147 F2 — `OVERLAY_OVERRIDABLE_SETTINGS` table in `docs/blueprint/configuration.md` §10.1.1.** The table listed 5 keys; the registry in `src/teatree/config.py:177` declares 20. Extended the table to mirror the registry (`loop_cadence_seconds`, `require_human_approval_to_merge`, `require_human_approval_to_answer`, `ask_before_post_on_behalf`, `on_behalf_post_mode`, `notify_user_via_bot`, `notify_on_post_on_behalf`, `user_identity_aliases`, and the six `architectural_review_*` / `scanning_news_*` keys) and added a one-line "registry is the source of truth" pointer.
- **#1151 F2 — spec/shipped boundary in `docs/blueprint/factory-architecture.md` §17.6.1.** Added an explicit "**SPEC ONLY — not yet implemented**" banner at the top of §17.6.1, with a pointer to §17.6.4 for the shipped gates.

## Follow-up commit (addresses codex adversarial review)

A second commit (`87ac450a`) addresses four findings from a codex read of the first commit:

1. §10.1.1 resolution chain prose listed only `T3_MODE` as a wired env override, but `ENV_SETTING_OVERRIDES` also wires `T3_ON_BEHALF_POST_MODE` — corrected and pointed at the registry.
2. `notify_user_via_bot` description rewritten to match `config.py` (bot→operator `notify_user(...)` channel #963, out of scope for on-behalf gates) — the previous "bot vs xoxp routing" framing was wrong.
3. `scanning_news_*` description softened — the keys are registered as overridable but `_scanning_news_scanner` in `loop/tick_jobs.py:181` still reads `load_config().user` directly, so the override is not yet consumed at the live scanner path.
4. `repo_mode` (#550 item 4) added to the §10.1 example — the last `UserSettings` field cited in #1147 F3 that was still missing from the example.

## Issues whose cited drift is already corrected on `main` (closed as no-op)

Verified by reading the live sections — these were closed separately:

- **#1141** — §4.1 Ticket state list. `BLUEPRINT.md` line 83 already shows `(plus terminal ignored)`, and line 77 already introduces the `Role` enum (`AUTHOR` / `REVIEWER`). [Closed.]
- **#1147 F1** — `[user]` toml table is already `[teatree]` on `main`.
- **#1147 F3** — three of the four cited missing fields (`notify_on_post_on_behalf`, `user_identity_aliases`, `statusline_chain`) were already in the example on `main`. The fourth (`repo_mode`) is now added in `87ac450a`.
- **#1150** — `BLUEPRINT.md` §3 line 53 already says `t3 = t3_bootstrap:main`; §15 lines 292/300 already list `croniter>=6.2.2` and `tomlkit>=0.13`; §15 lines 305–310 already carry the `optional-dependencies` block. [Closed.]
- **#1151 F1** — §17.6.4 lines 197–198 already enumerate `handle_enforce_answered_questions` (#1063) and `handle_loop_self_pump`.

## Test plan

- [x] `prek run --files docs/blueprint/configuration.md docs/blueprint/factory-architecture.md` passes on each commit
- [x] §10.1.1 table mirrors `OVERLAY_OVERRIDABLE_SETTINGS` 1:1; each row description verified against the dataclass field doc
- [x] §17.6.1 banner is unambiguous; surrounding §17.6 preamble already names §17.6.4 as the shipped-gate enumeration
- [x] Codex adversarial review pass — 4 findings addressed in the follow-up commit

Relates-to #1147 #1151