### PR TITLE
fix(merge): require full 40-char SHA in MergeClear, improve diagnostic (#1162)

### DIFF
--- a/src/teatree/core/merge_execution.py
+++ b/src/teatree/core/merge_execution.py
@@ -609,10 +609,13 @@ def execute_bound_merge(*, slug: str, pr_id: int, expected_head_oid: str) -> str
     if rc != 0:
         combined = f"{out}\n{err}".lower()
         if "head" in combined and ("modif" in combined or "changed" in combined or "409" in combined):
+            # Print the full ``expected_head_oid`` so a length mismatch can never
+            # masquerade as a value mismatch (#1162).
             msg = (
                 f"GitHub refused the merge of {slug}#{pr_id}: head moved off "
-                f"{expected_head_oid[:8]} (expected_head_oid mismatch). Treated as a "
-                f"failed check — NOT retried with a new head (§17.4.3)"
+                f"{expected_head_oid} (length={len(expected_head_oid)}, "
+                f"expected_head_oid mismatch). Treated as a failed check — "
+                f"NOT retried with a new head (§17.4.3)"
             )
             raise MergeHeadMovedError(msg)
         msg = f"merge of {slug}#{pr_id} failed: {err.strip() or out.strip() or 'gh api non-zero'}"

--- a/src/teatree/core/merge_execution.py
+++ b/src/teatree/core/merge_execution.py
@@ -550,10 +550,15 @@ def assert_merge_preconditions(
         msg = f"could not resolve the live head SHA for {slug}#{pr_id} (§17.4.3 step 2)"
         raise MergePreconditionError(msg)
     if live_sha != authorized_clear.reviewed_sha:
+        # Show full SHAs (not [:8] prefixes) so a length-mismatch or any other
+        # silent difference is obvious in the diagnostic (#1162).
+        reviewed_sha = authorized_clear.reviewed_sha
         msg = (
-            f"PR head moved: live={live_sha[:8]} != reviewed={authorized_clear.reviewed_sha[:8]} — "
-            f"the CLEAR is stale (force-push / new commits). Re-escalate; the loop never "
-            f"self-issues a replacement (§17.4.3 step 2)"
+            f"PR head moved: live={live_sha} (length={len(live_sha)}) != "
+            f"reviewed={reviewed_sha} (length={len(reviewed_sha)}) — "
+            f"the CLEAR is stale (force-push / new commits) or was issued with a "
+            f"truncated SHA. Re-escalate; the loop never self-issues a replacement "
+            f"(§17.4.3 step 2)"
         )
         raise MergePreconditionError(msg)
 

--- a/src/teatree/core/models/merge_clear.py
+++ b/src/teatree/core/models/merge_clear.py
@@ -200,12 +200,17 @@ class MergeClear(models.Model):
             )
             raise ClearIssuanceError(msg)
 
+        # Store the canonical lowercase hex form so the merge-time
+        # equality gate against GitHub's lowercase ``headRefOid`` cannot
+        # silently fail on a mixed-case input (#1162). ``is_commit_sha``
+        # already lowercases for validation; persist the same form.
+        normalized_sha = request.reviewed_sha.strip().lower()
         with transaction.atomic():
             return cls.objects.create(
                 ticket=request.ticket,
                 pr_id=request.pr_id,
                 slug=request.slug.strip(),
-                reviewed_sha=request.reviewed_sha.strip(),
+                reviewed_sha=normalized_sha,
                 reviewer_identity=reviewer,
                 gh_verify_result=normalized_verify,
                 blast_class=normalized_blast,

--- a/src/teatree/core/models/merge_clear.py
+++ b/src/teatree/core/models/merge_clear.py
@@ -33,7 +33,12 @@ from teatree.core.models.ticket import Ticket
 NON_REVIEWER_AGENT_PREFIXES = ("maker:", "maker-", "coding-agent", "coding", "loop")
 
 _SHA_ALPHABET = frozenset("0123456789abcdef")
-_MIN_SHA_LEN = 7
+# A CLEAR binds to the exact reviewed tree (§17.4.2). An abbreviated SHA is
+# ambiguous AND cannot satisfy the merge-time equality gate, which compares the
+# stored ``reviewed_sha`` against the full 40-char ``headRefOid`` returned by
+# ``gh pr view`` (#1162). A truncated SHA therefore produces an unmergeable
+# CLEAR — refuse it at issuance.
+SHA_FULL_LEN = 40
 
 
 def is_non_reviewer_role(identity: str) -> bool:
@@ -43,9 +48,16 @@ def is_non_reviewer_role(identity: str) -> bool:
 
 
 def is_commit_sha(value: str) -> bool:
-    """True iff ``value`` looks like a hex commit id, not a branch ref (§17.4.2)."""
+    """True iff ``value`` is a full 40-char hex commit SHA (§17.4.2, #1162).
+
+    A CLEAR must bind to the exact reviewed tree, and the merge-time gate
+    compares ``reviewed_sha`` against the full 40-char ``headRefOid`` from
+    ``gh pr view``. Accepting an abbreviated SHA produces a CLEAR that can
+    never satisfy the equality gate — the row is unmergeable from birth.
+    Only the full 40-char SHA-1 is accepted (git's current default).
+    """
     candidate = value.strip().lower()
-    return len(candidate) >= _MIN_SHA_LEN and all(char in _SHA_ALPHABET for char in candidate)
+    return len(candidate) == SHA_FULL_LEN and all(char in _SHA_ALPHABET for char in candidate)
 
 
 class ClearIssuanceError(ValueError):
@@ -169,9 +181,14 @@ class MergeClear(models.Model):
             raise ClearIssuanceError(msg)
 
         if not is_commit_sha(request.reviewed_sha):
+            candidate = request.reviewed_sha.strip()
             msg = (
-                f"reviewed_sha {request.reviewed_sha!r} is not a hex commit SHA — a CLEAR binds to "
-                f"the exact reviewed tree, never a branch ref (§17.4.2)"
+                f"reviewed_sha {request.reviewed_sha!r} (length={len(candidate)}) is not a full "
+                f"{SHA_FULL_LEN}-char hex commit SHA — a CLEAR binds to the exact reviewed tree, "
+                f"never a branch ref or abbreviated SHA (§17.4.2, #1162). The merge-time gate "
+                f"compares against GitHub's full ``headRefOid`` returned by ``gh pr view``; a "
+                f"truncated SHA can never match. Pass the full 40-char SHA — e.g. the output "
+                f"of ``git rev-parse HEAD`` or ``gh pr view <id> --json headRefOid``"
             )
             raise ClearIssuanceError(msg)
 

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -237,6 +237,37 @@ class TestClearIssuanceSeam(TestCase):
         assert "sha" in result["error"].lower()
         assert MergeClear.objects.count() == 0
 
+    def test_clear_rejects_truncated_sha_with_actionable_diagnostic(self) -> None:
+        """A short hex SHA (#1162) is unmergeable from birth — refuse at issuance.
+
+        The merge-time gate compares ``reviewed_sha`` against the full 40-char
+        ``headRefOid`` from ``gh pr view``. A truncated SHA can never satisfy
+        that equality — the CLEAR would be unusable on day one. The diagnostic
+        must tell the operator what was passed (truncated form + length), what
+        is required (full 40-char SHA), and where to find it.
+        """
+        truncated = "abc1234"
+        result = cast(
+            "dict[str, object]",
+            call_command(
+                "ticket",
+                "clear",
+                "1162",
+                "souliane/teatree",
+                truncated,
+                reviewer_identity="cold-reviewer",
+                gh_verify_result="green",
+                blast_class="docs",
+            ),
+        )
+        assert not result["issued"]
+        error = cast("str", result["error"])
+        assert truncated in error
+        assert f"length={len(truncated)}" in error
+        assert "40" in error
+        assert "git rev-parse HEAD" in error or "headRefOid" in error
+        assert MergeClear.objects.count() == 0
+
 
 class TestSubstrateStaysHumanMergeOnly(TestCase):
     """The loop never auto-merges substrate; an un-authorised substrate CLEAR holds."""

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -237,6 +237,33 @@ class TestClearIssuanceSeam(TestCase):
         assert "sha" in result["error"].lower()
         assert MergeClear.objects.count() == 0
 
+    def test_clear_normalizes_mixed_case_sha_to_lowercase(self) -> None:
+        """Mixed-case 40-char SHAs are accepted but stored in canonical lowercase (#1162).
+
+        The merge-time gate compares against GitHub's lowercase ``headRefOid``
+        — persisting the mixed-case input verbatim would produce the same
+        silent-failure mode this issue closes for truncated SHAs.
+        """
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        mixed_case = "ABCDEF1234567890abcdef1234567890ABCDEF12"
+        result = cast(
+            "dict[str, object]",
+            call_command(
+                "ticket",
+                "clear",
+                "1163",
+                "souliane/teatree",
+                mixed_case,
+                reviewer_identity="cold-reviewer",
+                gh_verify_result="green",
+                blast_class="docs",
+                ticket_id=int(ticket.pk),
+            ),
+        )
+        assert result["issued"]
+        clear = MergeClear.objects.get(pk=result["clear_id"])
+        assert clear.reviewed_sha == mixed_case.lower()
+
     def test_clear_rejects_truncated_sha_with_actionable_diagnostic(self) -> None:
         """A short hex SHA (#1162) is unmergeable from birth — refuse at issuance.
 

--- a/tests/teatree_loop/self_improve/test_forgotten_merge.py
+++ b/tests/teatree_loop/self_improve/test_forgotten_merge.py
@@ -15,7 +15,7 @@ def _issue_clear(
     *,
     pr_id: int = 100,
     slug: str = "souliane/teatree",
-    reviewed_sha: str = "deadbeef0123456789",
+    reviewed_sha: str = "deadbeef0123456789abcdef0123456789abcdef",
     reviewer_identity: str = "reviewer@example.com",
     blast_class: str = "logic",
 ) -> MergeClear:
@@ -89,4 +89,4 @@ class ForgottenMergeDetectorTests(TestCase):
         report = ForgottenMergeDetector().detect()[0]
         assert report.payload["pr_id"] == 205
         assert report.payload["slug"] == "souliane/teatree"
-        assert report.payload["reviewed_sha"] == "deadbeef0123456789"
+        assert report.payload["reviewed_sha"] == "deadbeef0123456789abcdef0123456789abcdef"

--- a/tests/teatree_loop/self_improve/test_loop_self_improve_command.py
+++ b/tests/teatree_loop/self_improve/test_loop_self_improve_command.py
@@ -40,7 +40,7 @@ class LoopSelfImproveCommandTests(TestCase):
             ClearRequest(
                 pr_id=999,
                 slug="souliane/teatree",
-                reviewed_sha="deadbeefcafe1234",
+                reviewed_sha="deadbeefcafe1234" + "0" * 24,
                 reviewer_identity="reviewer@example.com",
                 gh_verify_result="green",
                 blast_class="logic",
@@ -62,7 +62,7 @@ class LoopSelfImproveCommandTests(TestCase):
             ClearRequest(
                 pr_id=1000,
                 slug="souliane/teatree",
-                reviewed_sha="deadbeefcafe5678",
+                reviewed_sha="deadbeefcafe5678" + "0" * 24,
                 reviewer_identity="reviewer@example.com",
                 gh_verify_result="green",
                 blast_class="logic",


### PR DESCRIPTION
## Summary

Closes #1162.

A `MergeClear` row issued with an abbreviated `reviewed_sha` is unmergeable from birth: the merge-time gate compares the stored value against GitHub's full 40-char `headRefOid` returned by `gh pr view`, so the string-equality check can never hold. The previous `is_commit_sha` accepted any hex string of length >= 7, letting truncated SHAs silently slip through — and the head-moved diagnostic truncated *both* sides with `[:8]`, masking the real difference (the original report on PR #1149 / CLEAR 140).

Changes:

- **Tighten `is_commit_sha`** to require exactly 40 hex chars (git's current SHA-1 default). Rejected at `MergeClear.issue` time.
- **Issuance diagnostic** now names what was passed (value + length), what is required (full 40-char SHA), and where to find it (`git rev-parse HEAD`, `gh pr view --json headRefOid`).
- **Merge-execution head-moved error** now prints the full SHAs and their lengths so a length-mismatch can never masquerade as a value-mismatch.
- **Regression test** (`test_clear_rejects_truncated_sha_with_actionable_diagnostic`): an 8-char hex SHA raises with the new diagnostic and writes no row.
- **Test caller cleanup**: two existing self-improve tests that issued CLEARs with truncated hex literals now pass the full 40-char form — they previously relied on the loose check.

## Test plan

- [x] `uv run pytest --no-cov -x -q tests/teatree_core/test_clear_issuance_and_human_substrate.py` — 20 passed (incl. new regression test)
- [x] Full `uv run pytest --no-cov -q` — 6315 passed, 1 pre-existing failure on `tests/test_contrib_overlay.py::TestMaxConcurrentAutoStarts::test_in_repo_overlay_resolves_to_three` (unrelated; same failure on main)
- [x] `uv run prek run --all-files` — all hooks pass