### PR TITLE
fix(ship): align GitHub backend url field with ship runner — close silent pr create failure (#1226 #1222)

### DIFF
--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -10,7 +10,7 @@ from urllib.parse import quote_plus, urlparse
 from teatree.backends.protocols import ApprovalState, PrOpenState, PullRequestSpec, ReviewState
 from teatree.types import RawAPIDict
 from teatree.utils import git
-from teatree.utils.run import CompletedProcess, run_checked
+from teatree.utils.run import CommandFailedError, CompletedProcess, run_checked
 
 _ISSUE_URL_RE = re.compile(r"^/(?P<owner>[^/]+)/(?P<repo>[^/]+)/issues/(?P<number>\d+)/?$")
 _PR_URL_RE = re.compile(r"^/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pulls?/(?P<number>\d+)/?$")
@@ -278,7 +278,21 @@ class GitHubCodeHost:
             cmd.append("--draft")
 
         result = _run_gh(*cmd, token=self._token)
-        return {"url": result.stdout.strip()}
+        # #1222 / #1226: align with the cross-host canonical key (``web_url``)
+        # that ``ShipExecutor`` reads — returning ``url`` silently produced
+        # empty PR rows because the consumer never looked at that field. The
+        # producer also enforces the verify-by-re-read invariant: an empty /
+        # non-URL stdout (e.g. the ``no commits between`` pre-push race that
+        # exits 0) is rejected so ``ok=True`` never escapes with no PR.
+        url = result.stdout.strip()
+        if not url.startswith(("http://", "https://")):
+            raise CommandFailedError(
+                cmd,
+                result.returncode,
+                result.stdout,
+                f"gh pr create produced no PR URL (stdout={url!r})",
+            )
+        return {"web_url": url}
 
     def current_user(self) -> str:
         """Return the authenticated GitHub login (e.g. ``souliane``)."""

--- a/src/teatree/core/management/commands/_ensure_pr.py
+++ b/src/teatree/core/management/commands/_ensure_pr.py
@@ -112,4 +112,7 @@ def create_or_defer_pr(repo_path: str, branch_name: str) -> EnsurePrResult:
                 hint=f"t3 <overlay> pr ensure-pr --branch {branch_name}",
             )
         raise
-    return EnsurePrResult(branch=branch_name, url=str(raw.get("url", raw.get("web_url", ""))))
+    # #1222 / #1226: ``web_url`` is the cross-host canonical key (GitLab
+    # API native; GitHub backend was aligned to it). ``html_url`` is kept
+    # for raw GitHub API payloads piped through other producers.
+    return EnsurePrResult(branch=branch_name, url=str(raw.get("web_url") or raw.get("html_url") or ""))

--- a/src/teatree/core/management/commands/_ensure_pr.py
+++ b/src/teatree/core/management/commands/_ensure_pr.py
@@ -114,5 +114,14 @@ def create_or_defer_pr(repo_path: str, branch_name: str) -> EnsurePrResult:
         raise
     # #1222 / #1226: ``web_url`` is the cross-host canonical key (GitLab
     # API native; GitHub backend was aligned to it). ``html_url`` is kept
-    # for raw GitHub API payloads piped through other producers.
-    return EnsurePrResult(branch=branch_name, url=str(raw.get("web_url") or raw.get("html_url") or ""))
+    # for raw GitHub API payloads piped through other producers. An empty
+    # / non-URL payload surfaces as ``error`` so the orphan-branch path
+    # never silently advances with no PR — same invariant the ship runner
+    # enforces.
+    url = str(raw.get("web_url") or raw.get("html_url") or "")
+    if not url.startswith(("http://", "https://")):
+        return EnsurePrResult(
+            branch=branch_name,
+            error=f"host.create_pr returned no PR url (got {url!r}; payload keys={sorted(raw.keys())!r})",
+        )
+    return EnsurePrResult(branch=branch_name, url=url)

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -163,10 +163,10 @@ class ShipExecutor(RunnerBase):
         """
         pr = host.create_pr(spec)
         url = str(pr.get("web_url") or pr.get("html_url") or "")
-        if not url:
+        if not url.startswith(("http://", "https://")):
             return RunnerResult(
                 ok=False,
-                detail=f"host.create_pr returned no PR url (payload keys={sorted(pr.keys())!r})",
+                detail=(f"host.create_pr returned no PR url (got {url!r}; payload keys={sorted(pr.keys())!r})"),
             )
         self._record_pr_url(ticket, extra, url)
         logger.info("Ship executor pushed %s and opened PR %s", branch, url)

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -141,10 +141,33 @@ class ShipExecutor(RunnerBase):
             return RunnerResult(ok=False, detail=currency_error)
 
         git.push(repo=repo_path, remote="origin", branch=branch)
-
         spec = self._build_pr_spec(ticket, host, repo_path, branch, extra)
+        return self._open_pr_and_record(ticket, extra, host, spec, branch)
+
+    def _open_pr_and_record(
+        self,
+        ticket: "Ticket",
+        extra: "TicketExtra",
+        host: "CodeHostBackend",
+        spec: PullRequestSpec,
+        branch: str,
+    ) -> RunnerResult:
+        """Open the PR, verify the URL is present, and record it on the ticket.
+
+        #1222 / #1226 verify-by-re-read: a backend that returns a payload
+        without a URL (or with the wrong field name) MUST surface as
+        ``ok=False`` — otherwise the FSM advances to SHIPPED with an empty
+        ``pr_urls`` entry and downstream gates think no PR exists.
+        ``web_url`` is the cross-host canonical key; ``html_url`` is kept
+        for raw GitHub API payloads piped through other producers.
+        """
         pr = host.create_pr(spec)
         url = str(pr.get("web_url") or pr.get("html_url") or "")
+        if not url:
+            return RunnerResult(
+                ok=False,
+                detail=f"host.create_pr returned no PR url (payload keys={sorted(pr.keys())!r})",
+            )
         self._record_pr_url(ticket, extra, url)
         logger.info("Ship executor pushed %s and opened PR %s", branch, url)
         return RunnerResult(ok=True, detail=url)

--- a/tests/teatree_core/pr_command/test_ensure_pr.py
+++ b/tests/teatree_core/pr_command/test_ensure_pr.py
@@ -91,7 +91,9 @@ class TestEnsurePr(TestCase):
 
     def test_creates_pr_when_pushed_orphan(self) -> None:
         host = MagicMock()
-        host.create_pr.return_value = {"url": "https://github.com/souliane/teatree/pull/999"}
+        # #1222 / #1226: ``web_url`` is the canonical cross-host key
+        # (GitHub backend was aligned to it; GitLab API native).
+        host.create_pr.return_value = {"web_url": "https://github.com/souliane/teatree/pull/999"}
         host.current_user.return_value = "souliane"
         self._monkeypatch.setattr(ensure_pr_mod, "code_host_from_overlay", lambda: host)
 

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -175,7 +175,7 @@ class TestShipExecutor(TestCase):
     def test_description_is_just_subject_when_body_empty(self) -> None:
         ticket = self._ticket_with_worktree()
         host = MagicMock()
-        host.create_pr.return_value = {"web_url": "u"}
+        host.create_pr.return_value = {"web_url": "https://example.com/mr/u"}
         host.current_user.return_value = "dev"
 
         with (
@@ -192,7 +192,7 @@ class TestShipExecutor(TestCase):
     def test_assignee_falls_back_to_git_user_name_when_host_returns_empty(self) -> None:
         ticket = self._ticket_with_worktree()
         host = MagicMock()
-        host.create_pr.return_value = {"web_url": "u"}
+        host.create_pr.return_value = {"web_url": "https://example.com/mr/u"}
         host.current_user.return_value = ""
 
         with (

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -87,6 +87,61 @@ class TestShipExecutor(TestCase):
         assert result.ok is False
         assert "worktree" in result.detail.lower()
 
+    def test_returns_failure_when_backend_returns_empty_url(self) -> None:
+        """#1226 / #1222: empty backend URL must surface as ``ok=False``.
+
+        The producer (``host.create_pr``) is expected to refuse empty URLs
+        (covered in the GitHub backend tests). This consumer-side guard is
+        belt-and-braces: even if a backend mis-returns ``{}`` or a dict with
+        only ``url=""`` / ``web_url=""``, the ship runner must NOT advance
+        the FSM to ``SHIPPED`` with an empty ``pr_urls`` entry.
+        """
+        ticket = self._ticket_with_worktree()
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": ""}
+        host.current_user.return_value = "souliane"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push"),
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat: x", "body")),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is False
+        assert "url" in result.detail.lower()
+        ticket.refresh_from_db()
+        assert "pr_urls" not in (ticket.extra or {})
+
+    def test_accepts_html_url_for_github_native_payloads(self) -> None:
+        """The consumer reads ``html_url`` too — GitHub's native API key.
+
+        The canonical cross-host key is ``web_url`` (GitLab) and the GitHub
+        backend produces it. But raw GitHub API payloads piped through other
+        producers (e.g. webhooks, lists) carry ``html_url`` natively. The
+        consumer's fallback chain must keep accepting it so future code that
+        forwards raw payloads doesn't hit the same field-name silent-failure
+        trap as #1222.
+        """
+        ticket = self._ticket_with_worktree()
+        host = MagicMock()
+        host.create_pr.return_value = {"html_url": "https://github.com/org/repo/pull/9"}
+        host.current_user.return_value = "souliane"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push"),
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat: x", "body")),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is True
+        assert result.detail == "https://github.com/org/repo/pull/9"
+        ticket.refresh_from_db()
+        assert ticket.extra["pr_urls"] == ["https://github.com/org/repo/pull/9"]
+
     def test_description_starts_with_commit_subject(self) -> None:
         """Default MR description prepends the commit subject.
 

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -213,6 +213,13 @@ class TestFetchProjectItems:
 
 class TestGitHubCodeHost:
     def test_create_pr(self) -> None:
+        """#1222: GitHub backend returns the canonical ``web_url`` field.
+
+        Cross-host code paths (notably ``ShipExecutor``) read ``web_url`` —
+        GitLab's API native key. Returning ``url`` here silently produced
+        empty PR rows on the ticket and tricked downstream gates into
+        thinking the PR was missing.
+        """
         with patch.object(github_mod, "_run_gh") as mock_run:
             mock_run.return_value = MagicMock(stdout="https://github.com/org/repo/pull/1\n")
             host = GitHubCodeHost(token="tok")
@@ -224,7 +231,33 @@ class TestGitHubCodeHost:
                     description="Description",
                 ),
             )
-        assert result == {"url": "https://github.com/org/repo/pull/1"}
+        assert result == {"web_url": "https://github.com/org/repo/pull/1"}
+
+    def test_create_pr_raises_when_gh_returns_no_url(self) -> None:
+        """#1226: an empty/non-URL ``gh pr create`` stdout must surface as a failure.
+
+        ``gh pr create`` can exit 0 while printing a non-URL line (e.g. the
+        "no commits between" pre-push race). The backend MUST refuse to claim
+        success with an empty URL; the ship runner relies on this invariant
+        to flip ``ok=False`` instead of advancing the FSM with an empty
+        ``pr_urls`` entry.
+        """
+        import pytest  # noqa: PLC0415
+
+        from teatree.utils.run import CommandFailedError  # noqa: PLC0415
+
+        with patch.object(github_mod, "_run_gh") as mock_run:
+            mock_run.return_value = MagicMock(stdout="\n")
+            host = GitHubCodeHost(token="tok")
+            with pytest.raises(CommandFailedError):
+                host.create_pr(
+                    PullRequestSpec(
+                        repo="org/repo",
+                        branch="feature",
+                        title="Add feature",
+                        description="Description",
+                    ),
+                )
 
     def test_create_pr_resolves_local_path_to_owner_repo_slug(self, tmp_path: object) -> None:
         """``gh pr create --repo`` requires ``owner/repo`` — local paths must be resolved first."""


### PR DESCRIPTION
## Summary

Close two related bugs around `t3 teatree pr create` silently succeeding on the GitHub backend:

- **#1222** — GitHub backend returned `{"url": <url>}` from `create_pr`, but `ShipExecutor` and `_ensure_pr` consumers read `web_url` / `html_url` (the cross-host canonical keys GitLab's API uses natively). The field-name mismatch made every GitHub PR creation "successful" with an empty URL.
- **#1226** — Symptom: `Ship executor pushed … and opened PR` log fires, result is `{'ok': True, 'detail': ''}`, but `pr_urls` is empty so downstream gates think no PR exists.

## Fix

- GitHub backend (`src/teatree/backends/github.py`) returns the canonical `web_url` key.
- Backend enforces the verify-by-re-read invariant: an empty / non-URL `gh pr create` stdout (e.g. the "no commits between" pre-push race that exits 0) is rejected as `CommandFailedError`, so `ok=True` never escapes with no PR.
- Ship runner (`src/teatree/core/runners/ship.py`) gains a belt-and-braces guard: a backend that returns an empty / wrong-keyed payload surfaces as `ok=False` instead of advancing the FSM to SHIPPED with no `pr_urls` entry. Logic extracted into `_open_pr_and_record` to keep `run()` within complexity limits.
- `_ensure_pr` consumer (`src/teatree/core/management/commands/_ensure_pr.py`) prefers `web_url` over the legacy `url` key.

## Tests

- `tests/test_github_backend.py::test_create_pr` — backend now returns `web_url`.
- `tests/test_github_backend.py::test_create_pr_raises_when_gh_returns_no_url` — empty/non-URL `gh pr create` stdout raises.
- `tests/teatree_core/test_runners_ship.py::test_returns_failure_when_backend_returns_empty_url` — empty backend URL surfaces as `ok=False`.
- `tests/teatree_core/test_runners_ship.py::test_accepts_html_url_for_github_native_payloads` — confirms `html_url` fallback is kept for raw GitHub payloads.

Full suite: 6317 passed, 13 skipped (1 deselected unrelated pre-existing config-value test).

## Self-validation

This PR was opened via `t3 teatree pr create` itself — the operation that was silently failing — to validate the fix end-to-end. (Note: the local editable install pointed at the main clone, not this worktree, so this PR was opened against the un-patched code; once merged and the editable install is refreshed, future runs will exercise the patched path.)

Closes #1226
Closes #1222