### PR TITLE
feat(prek): hard-fail BLUEPRINT.md > 100KB without override (#1180)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -243,6 +243,12 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [commit-msg]
+      - id: check-blueprint-size
+        name: BLUEPRINT.md size cap (100KB)
+        language: system
+        entry: uv run python scripts/hooks/check_blueprint_size.py
+        files: ^BLUEPRINT\.md$
+        pass_filenames: false
 
   # Phase 7c - Version sync
   - repo: local

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -381,6 +381,12 @@ Implementation details that previously lived in nine prose-of-code appendices (`
 
 ---
 
+## Maintenance
+
+A pre-commit gate (`scripts/hooks/check_blueprint_size.py`, [#1180](https://github.com/souliane/teatree/issues/1180)) hard-fails any commit when this file exceeds 100 KB. The cap forces a per-commit acknowledgement that further growth is architectural, not implementation prose. To raise the cap for a planned, reviewed bump in the same commit, set `T3_BLUEPRINT_SIZE_OVERRIDE=1` in the environment.
+
+---
+
 ## Module Dependency Graph
 
 <!-- tach-dependency-graph:start -->

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -383,7 +383,7 @@ Implementation details that previously lived in nine prose-of-code appendices (`
 
 ## Maintenance
 
-A pre-commit gate (`scripts/hooks/check_blueprint_size.py`, [#1180](https://github.com/souliane/teatree/issues/1180)) hard-fails any commit when this file exceeds 100 KB. The cap forces a per-commit acknowledgement that further growth is architectural, not implementation prose. To raise the cap for a planned, reviewed bump in the same commit, set `T3_BLUEPRINT_SIZE_OVERRIDE=1` in the environment.
+A pre-commit gate (`scripts/hooks/check_blueprint_size.py`, [#1180](https://github.com/souliane/teatree/issues/1180)) hard-fails any commit that touches this file when it exceeds 100 KB. The cap forces a per-commit acknowledgement that further growth is architectural, not implementation prose. To raise the cap for a planned, reviewed bump in the same commit, set `T3_BLUEPRINT_SIZE_OVERRIDE=1` in the environment.
 
 ---
 

--- a/scripts/hooks/check_blueprint_size.py
+++ b/scripts/hooks/check_blueprint_size.py
@@ -6,10 +6,14 @@ fire when BLUEPRINT.md (or an appendix) is touched in the same commit;
 this #1180 gate is the deterministic hard cap that fires whenever the
 file changes and exceeds 100 KB.
 
-Threshold: 100 KB (100 * 1024 bytes). Escape hatch:
-``T3_BLUEPRINT_SIZE_OVERRIDE=1`` skips the check — use only when a
-planned, reviewed addition deliberately grows the file and the cap
-itself is being raised in the same commit.
+Threshold: 100 KB (100 * 1024 bytes). The hook is scoped to commits
+that touch ``BLUEPRINT.md`` (via ``files:`` in
+``.pre-commit-config.yaml``), so it gates every growth event without
+re-running on unrelated commits. Escape hatch:
+``T3_BLUEPRINT_SIZE_OVERRIDE=1`` (strict ``"1"`` — empty, ``0``,
+``false`` are not accepted) skips the check; use only when a planned,
+reviewed addition deliberately grows the file and the cap itself is
+being raised in the same commit.
 """
 
 import os
@@ -26,7 +30,7 @@ def _repo_root() -> pathlib.Path:
 
 
 def main() -> int:
-    if os.environ.get(_OVERRIDE_ENV_VAR):
+    if os.environ.get(_OVERRIDE_ENV_VAR) == "1":
         return 0
 
     blueprint = _repo_root() / _BLUEPRINT_FILE

--- a/scripts/hooks/check_blueprint_size.py
+++ b/scripts/hooks/check_blueprint_size.py
@@ -1,0 +1,60 @@
+"""Pre-commit hook: hard cap on ``BLUEPRINT.md`` size (#1180).
+
+The BLUEPRINT is architectural, not a prose mirror of the code. The
+companion #1128 corpus-budget gate sets per-file soft budgets that only
+fire when BLUEPRINT.md (or an appendix) is touched in the same commit;
+this #1180 gate is the deterministic hard cap that fires whenever the
+file changes and exceeds 100 KB.
+
+Threshold: 100 KB (100 * 1024 bytes). Escape hatch:
+``T3_BLUEPRINT_SIZE_OVERRIDE=1`` skips the check — use only when a
+planned, reviewed addition deliberately grows the file and the cap
+itself is being raised in the same commit.
+"""
+
+import os
+import pathlib
+import sys
+
+_BLUEPRINT_FILE = "BLUEPRINT.md"
+_THRESHOLD_BYTES = 100 * 1024
+_OVERRIDE_ENV_VAR = "T3_BLUEPRINT_SIZE_OVERRIDE"
+
+
+def _repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    if os.environ.get(_OVERRIDE_ENV_VAR):
+        return 0
+
+    blueprint = _repo_root() / _BLUEPRINT_FILE
+    if not blueprint.is_file():
+        return 0
+
+    size = blueprint.stat().st_size
+    if size <= _THRESHOLD_BYTES:
+        return 0
+
+    print(file=sys.stderr)
+    print("  BLUEPRINT.md size cap FAILED (#1180):", file=sys.stderr)
+    print(
+        f"    current size: {size:,} B > threshold {_THRESHOLD_BYTES:,} B",
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)
+    print(
+        "  The BLUEPRINT is architectural, not a prose mirror of the code.",
+        file=sys.stderr,
+    )
+    print(
+        f"  To bypass for a reviewed, intentional bump: {_OVERRIDE_ENV_VAR}=1 git commit ...",
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_blueprint_size.py
+++ b/tests/test_check_blueprint_size.py
@@ -47,9 +47,17 @@ class TestOverride:
         monkeypatch.setenv(gate._OVERRIDE_ENV_VAR, "1")
         assert gate.main() == 0
 
-    def test_empty_env_value_does_not_override(self, fake_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "true"])
+    def test_non_one_env_value_does_not_override(
+        self,
+        fake_repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        value: str,
+    ) -> None:
+        # Strict "1" is the only override token — mirrors the sibling
+        # #1128 gate so neither hook silently accepts "0"/"false".
         (fake_repo / "BLUEPRINT.md").write_text("x" * (gate._THRESHOLD_BYTES + 1), encoding="utf-8")
-        monkeypatch.setenv(gate._OVERRIDE_ENV_VAR, "")
+        monkeypatch.setenv(gate._OVERRIDE_ENV_VAR, value)
         assert gate.main() == 1
 
 

--- a/tests/test_check_blueprint_size.py
+++ b/tests/test_check_blueprint_size.py
@@ -1,0 +1,58 @@
+"""Tests for the BLUEPRINT.md hard size cap (#1180).
+
+The gate hard-fails when ``BLUEPRINT.md`` exceeds 100 KB. The
+documented escape hatch is ``T3_BLUEPRINT_SIZE_OVERRIDE=1`` for
+intentional, reviewed growth.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.hooks import check_blueprint_size as gate
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Throwaway repo root with the gate pointed at it."""
+    monkeypatch.setattr(gate, "_repo_root", lambda: tmp_path)
+    monkeypatch.delenv(gate._OVERRIDE_ENV_VAR, raising=False)
+    return tmp_path
+
+
+class TestSizeCap:
+    def test_small_file_passes(self, fake_repo: Path) -> None:
+        (fake_repo / "BLUEPRINT.md").write_text("x" * 1000, encoding="utf-8")
+        assert gate.main() == 0
+
+    def test_at_threshold_passes(self, fake_repo: Path) -> None:
+        (fake_repo / "BLUEPRINT.md").write_text("x" * gate._THRESHOLD_BYTES, encoding="utf-8")
+        assert gate.main() == 0
+
+    def test_over_threshold_fails(self, fake_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        (fake_repo / "BLUEPRINT.md").write_text("x" * (gate._THRESHOLD_BYTES + 1), encoding="utf-8")
+        assert gate.main() == 1
+        captured = capsys.readouterr()
+        assert "BLUEPRINT.md" in captured.err
+        assert "threshold" in captured.err
+        assert gate._OVERRIDE_ENV_VAR in captured.err
+
+    def test_missing_file_passes(self, fake_repo: Path) -> None:
+        assert gate.main() == 0
+
+
+class TestOverride:
+    def test_env_override_skips_check(self, fake_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (fake_repo / "BLUEPRINT.md").write_text("x" * (gate._THRESHOLD_BYTES * 5), encoding="utf-8")
+        monkeypatch.setenv(gate._OVERRIDE_ENV_VAR, "1")
+        assert gate.main() == 0
+
+    def test_empty_env_value_does_not_override(self, fake_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (fake_repo / "BLUEPRINT.md").write_text("x" * (gate._THRESHOLD_BYTES + 1), encoding="utf-8")
+        monkeypatch.setenv(gate._OVERRIDE_ENV_VAR, "")
+        assert gate.main() == 1
+
+
+class TestRepoRoot:
+    def test_resolves_to_actual_repo_root(self) -> None:
+        assert (gate._repo_root() / "BLUEPRINT.md").exists()


### PR DESCRIPTION
## Summary

- Adds `scripts/hooks/check_blueprint_size.py` — stdlib-only gate that hard-fails any commit when `BLUEPRINT.md` exceeds 100 KB (100 * 1024 bytes).
- Registers it as a local prek hook (`check-blueprint-size`) scoped to `^BLUEPRINT\.md$` so it fires only when the file is touched.
- Documents the cap and the `T3_BLUEPRINT_SIZE_OVERRIDE` escape hatch in a new "Maintenance" section of BLUEPRINT.md.
- Unit tests cover pass / fail / override paths via `tmp_path`.

Mirrors the #140 skill-prose-ban shape and complements the soft #1128 corpus-budget gate.

Closes #1180.

## Test plan

- [x] `uv run pytest tests/test_check_blueprint_size.py --no-cov -x` — 7 passed
- [x] `prek run --all-files` — green, including the new `BLUEPRINT.md size cap (100KB)` hook
- [x] Current `wc -c BLUEPRINT.md` ≈ 49 KB — well under the cap; the gate does not fire on this PR