### PR TITLE
fix(cli): normalize GitLab HTTP errors to api_unavailable in review run (#1206)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -579,6 +579,9 @@ Usage: t3 review run [OPTIONS] URL
  Exit codes:
 
  * ``0`` — audit ran, JSON printed.
+ * ``1`` — URL parsed but the GitLab API refused the audit
+     (``api_unavailable``: missing token, 401/403/404, connection
+     failure, or any other backend error).
  * ``2`` — URL refused before any API call (``unsupported_forge`` for
      GitHub PRs, ``bad_url`` for anything else).
 

--- a/src/teatree/cli/review_run.py
+++ b/src/teatree/cli/review_run.py
@@ -256,7 +256,15 @@ def _fetch_review_state(api: object, repo: str, iid: int) -> _ReviewState:
 
 
 def _audit_gitlab_mr(url: str) -> ReviewRunResult:
-    """Fetch metadata for a GitLab MR and build the audit result."""
+    """Fetch metadata for a GitLab MR and build the audit result.
+
+    Every GitLab GET is wrapped: backend exceptions (``httpx.HTTPStatusError``
+    for 401/403/404, ``httpx.RequestError`` for connection failures) are
+    normalized into :class:`_ReviewRunAPIError` so the CLI surfaces a
+    structured ``api_unavailable`` payload rather than a raw traceback.
+    """
+    import httpx  # noqa: PLC0415
+
     from teatree.backends.gitlab_api import GitLabAPI  # noqa: PLC0415
     from teatree.cli.review import ReviewService  # noqa: PLC0415
     from teatree.core.models.live_post_approval import canonical_mr_scope  # noqa: PLC0415
@@ -269,12 +277,16 @@ def _audit_gitlab_mr(url: str) -> ReviewRunResult:
     encoded = repo.replace("/", "%2F")
     api = GitLabAPI(token=ReviewService.get_gitlab_token(), base_url=ReviewService._resolve_base_url())  # noqa: SLF001
 
-    changes_payload = api.get_json(f"projects/{encoded}/merge_requests/{iid}/changes")
-    if changes_payload is None:
-        msg = f"GET /changes returned no payload for {repo}!{iid} — token missing or MR inaccessible"
-        raise _ReviewRunAPIError(msg)
-    diff = _diff_stats_from_changes(changes_payload)
-    state = _fetch_review_state(api, repo, iid)
+    try:
+        changes_payload = api.get_json(f"projects/{encoded}/merge_requests/{iid}/changes")
+        if changes_payload is None:
+            msg = f"GET /changes returned no payload for {repo}!{iid} — token missing or MR inaccessible"
+            raise _ReviewRunAPIError(msg)
+        diff = _diff_stats_from_changes(changes_payload)
+        state = _fetch_review_state(api, repo, iid)
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        msg = f"GitLab backend refused the audit for {repo}!{iid}: {exc}"
+        raise _ReviewRunAPIError(msg) from exc
     complexity = _classify_complexity(files=diff.files, additions=diff.additions, deletions=diff.deletions)
     findings = _gather_findings(complexity=complexity, files=diff.files, touched_paths=diff.touched)
     verdict = "needs_attention" if findings or state.open_discussions else "ready_to_review"
@@ -315,6 +327,9 @@ def run(
     Exit codes:
 
     * ``0`` — audit ran, JSON printed.
+    * ``1`` — URL parsed but the GitLab API refused the audit
+        (``api_unavailable``: missing token, 401/403/404, connection
+        failure, or any other backend error).
     * ``2`` — URL refused before any API call (``unsupported_forge`` for
         GitHub PRs, ``bad_url`` for anything else).
     """

--- a/tests/teatree_cli/test_review_run.py
+++ b/tests/teatree_cli/test_review_run.py
@@ -161,6 +161,50 @@ class TestReviewRunBadUrl:
         assert payload["error"] == "bad_url"
 
 
+class TestReviewRunHttpError:
+    """A backend HTTP error (401/403/404 from GitLab) maps to ``api_unavailable`` — never raw traceback.
+
+    ``GitLabHTTPClient.get_json()`` calls ``response.raise_for_status()``,
+    so a real inaccessible-repo response raises ``httpx.HTTPStatusError``.
+    The audit must normalize that into the same structured exit-1 shape
+    the null-payload branch uses, so the reviewer sub-agent has exactly
+    one error contract to handle.
+    """
+
+    def test_http_status_error_maps_to_api_unavailable(self) -> None:
+        import httpx  # noqa: PLC0415
+
+        runner = CliRunner()
+
+        class _HttpErrAPI:
+            def get_json(self, endpoint: str) -> object:
+                del endpoint
+                request = httpx.Request("GET", "https://gitlab.example/api/v4/whatever")
+                response = httpx.Response(status_code=403, request=request)
+                msg = "forbidden"
+                raise httpx.HTTPStatusError(msg, request=request, response=response)
+
+            def resolve_project(self, repo: str) -> object:
+                del repo
+                return None
+
+        url = "https://gitlab.com/org/proj/-/merge_requests/55"
+        with (
+            patch("teatree.backends.gitlab_api.GitLabAPI", return_value=_HttpErrAPI()),
+            patch(
+                "teatree.cli.review.ReviewService.get_gitlab_token",
+                return_value="t",
+            ),
+        ):
+            result = runner.invoke(review_app, ["run", url])
+
+        assert result.exit_code == 1, f"output={result.output!r} exc={result.exception!r}"
+        payload = json.loads(result.output.strip())
+        assert payload["error"] == "api_unavailable"
+        assert payload["url"] == url
+        assert "verdict" not in payload
+
+
 class TestReviewRunApiUnavailable:
     """Missing token / inaccessible repo surfaces as ``api_unavailable`` — never a fake ``ready_to_review``.
 


### PR DESCRIPTION
## Summary

Codex adversarial review of #1262 caught two follow-up issues that landed via the auto-sweep before the fixes could:

- `GET /changes` raising `httpx.HTTPStatusError` (the actual 401/403/404 inaccessible-repo path that `GitLabHTTPClient.get_json` produces via `raise_for_status()`) bypassed the `_ReviewRunAPIError` handler in `t3 review run` and surfaced as an unstructured traceback. Now wrapped: any `httpx.HTTPStatusError` or `httpx.RequestError` from the audit chain becomes the same `{"error": "api_unavailable"}` JSON + exit 1.
- The `run()` command docstring listed only exit codes `0` and `2`. Adds `1` for the `api_unavailable` branch and regenerates `docs/generated/cli-reference.md`.

Stacks on top of merged #1262.

## Test plan

- [x] `pytest tests/teatree_cli/test_review_run.py` (6 tests pass — new httpx.HTTPStatusError → api_unavailable regression)
- [x] `prek run --all-files`