### PR TITLE
chore(scanners): de-hardcode SCANNING_NEWS_OVERLAY (#1267)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -579,6 +579,9 @@ Usage: t3 review run [OPTIONS] URL
  Exit codes:
 
  * ``0`` — audit ran, JSON printed.
+ * ``1`` — URL parsed but the GitLab API refused the audit
+     (``api_unavailable``: missing token, 401/403/404, connection
+     failure, or any other backend error).
  * ``2`` — URL refused before any API call (``unsupported_forge`` for
      GitHub PRs, ``bad_url`` for anything else).
 

--- a/src/teatree/cli/review_run.py
+++ b/src/teatree/cli/review_run.py
@@ -256,7 +256,15 @@ def _fetch_review_state(api: object, repo: str, iid: int) -> _ReviewState:
 
 
 def _audit_gitlab_mr(url: str) -> ReviewRunResult:
-    """Fetch metadata for a GitLab MR and build the audit result."""
+    """Fetch metadata for a GitLab MR and build the audit result.
+
+    Every GitLab GET is wrapped: backend exceptions (``httpx.HTTPStatusError``
+    for 401/403/404, ``httpx.RequestError`` for connection failures) are
+    normalized into :class:`_ReviewRunAPIError` so the CLI surfaces a
+    structured ``api_unavailable`` payload rather than a raw traceback.
+    """
+    import httpx  # noqa: PLC0415
+
     from teatree.backends.gitlab_api import GitLabAPI  # noqa: PLC0415
     from teatree.cli.review import ReviewService  # noqa: PLC0415
     from teatree.core.models.live_post_approval import canonical_mr_scope  # noqa: PLC0415
@@ -269,12 +277,16 @@ def _audit_gitlab_mr(url: str) -> ReviewRunResult:
     encoded = repo.replace("/", "%2F")
     api = GitLabAPI(token=ReviewService.get_gitlab_token(), base_url=ReviewService._resolve_base_url())  # noqa: SLF001
 
-    changes_payload = api.get_json(f"projects/{encoded}/merge_requests/{iid}/changes")
-    if changes_payload is None:
-        msg = f"GET /changes returned no payload for {repo}!{iid} — token missing or MR inaccessible"
-        raise _ReviewRunAPIError(msg)
-    diff = _diff_stats_from_changes(changes_payload)
-    state = _fetch_review_state(api, repo, iid)
+    try:
+        changes_payload = api.get_json(f"projects/{encoded}/merge_requests/{iid}/changes")
+        if changes_payload is None:
+            msg = f"GET /changes returned no payload for {repo}!{iid} — token missing or MR inaccessible"
+            raise _ReviewRunAPIError(msg)
+        diff = _diff_stats_from_changes(changes_payload)
+        state = _fetch_review_state(api, repo, iid)
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        msg = f"GitLab backend refused the audit for {repo}!{iid}: {exc}"
+        raise _ReviewRunAPIError(msg) from exc
     complexity = _classify_complexity(files=diff.files, additions=diff.additions, deletions=diff.deletions)
     findings = _gather_findings(complexity=complexity, files=diff.files, touched_paths=diff.touched)
     verdict = "needs_attention" if findings or state.open_discussions else "ready_to_review"
@@ -315,6 +327,9 @@ def run(
     Exit codes:
 
     * ``0`` — audit ran, JSON printed.
+    * ``1`` — URL parsed but the GitLab API refused the audit
+        (``api_unavailable``: missing token, 401/403/404, connection
+        failure, or any other backend error).
     * ``2`` — URL refused before any API call (``unsupported_forge`` for
         GitHub PRs, ``bad_url`` for anything else).
     """

--- a/src/teatree/loop/scanners/scanning_news.py
+++ b/src/teatree/loop/scanners/scanning_news.py
@@ -1,4 +1,4 @@
-"""Periodic scanning-news scanner — #1191.
+"""Periodic scanning-news scanner — #1191, #1267.
 
 Companion to the ``scanning-news`` skill (#1190): the loop should fire a
 daily ``scanning_news`` task that runs the news-scan / improvement-ideas
@@ -9,9 +9,15 @@ deliberately simpler:
 * **Single trigger.** Only a cadence (``scanning_news_cadence_hours``,
     default 24h). There is no after-merge backstop — news scanning is a
     fixed-rate platform behaviour, not coupled to delivery velocity.
-* **Single overlay anchor.** The task is always anchored to the
-    ``teatree`` overlay (the skill belongs to teatree-core); the wiring
-    layer attaches the scanner globally, not per-overlay.
+* **Overlay anchor is injected, not baked.** This is a core scanner —
+    it does not know any overlay's name. The wiring layer
+    (``teatree.loop.tick_jobs._scanning_news_scanner``) resolves the
+    active core overlay via :func:`teatree.config.discover_active_overlay`
+    and passes the result as the ``overlay_name`` constructor kwarg.
+    Tasks queued by the scanner are anchored at a placeholder Ticket
+    keyed off that resolved name (#1267 — pre-fix this module hardcoded
+    the legacy ``"teatree"`` value, which migration 0027 had already
+    canonicalized to ``"t3-teatree"``).
 * **Same dedup contract.** A pending or claimed ``scanning_news`` task
     acts as the lock — completion (or failure) unlocks the next cadence
     window. No new model fields; the ``Session.started_at`` of the most
@@ -40,26 +46,30 @@ logger = logging.getLogger(__name__)
 #: Canonical phase token written to ``Task.phase`` for scanning-news tasks.
 SCANNING_NEWS_PHASE = "scanning_news"
 
-#: The scanning-news skill is teatree-core; tasks are always anchored on
-#: the ``teatree`` overlay placeholder ticket.
-SCANNING_NEWS_OVERLAY = "teatree"
-
 #: States that mean a news task is still in-flight (cannot queue a dupe).
 _IN_FLIGHT_TASK_STATES: frozenset[str] = frozenset({"pending", "claimed"})
 
 
 @dataclass(slots=True)
 class ScanningNewsScanner:
-    """Queue a periodic ``scanning_news`` task for the teatree overlay.
+    """Queue a periodic ``scanning_news`` task for the active core overlay.
 
     Configuration fields are passed explicitly (rather than read from a
     global at scan time) so test setup is deterministic and the wiring
     layer is the single place that resolves
-    :class:`teatree.config.UserSettings` to scanner kwargs. The on/off
-    decision lives at the wiring layer (``scanning_news_disabled`` in
-    core config); the scanner itself always scans when invoked.
+    :class:`teatree.config.UserSettings` and
+    :func:`teatree.config.discover_active_overlay` to scanner kwargs. The
+    on/off decision lives at the wiring layer
+    (``scanning_news_disabled`` in core config); the scanner itself
+    always scans when invoked.
+
+    ``overlay_name`` is the resolved overlay-anchor identity for the
+    placeholder ticket (#1267). The scanner never reads or assumes the
+    name — it stamps whatever value the wiring layer hands it. The
+    canonical post-0027 default in production is ``"t3-teatree"``.
     """
 
+    overlay_name: str
     skill: str = "scanning-news"
     cadence_hours: int = 24
     name: str = "scanning_news"
@@ -80,9 +90,9 @@ class ScanningNewsScanner:
         return [
             ScanSignal(
                 kind="scanning_news.queued",
-                summary=f"scanning-news queued for {SCANNING_NEWS_OVERLAY} (trigger: {trigger})",
+                summary=f"scanning-news queued for {self.overlay_name} (trigger: {trigger})",
                 payload={
-                    "overlay": SCANNING_NEWS_OVERLAY,
+                    "overlay": self.overlay_name,
                     "skill": self.skill,
                     "phase": SCANNING_NEWS_PHASE,
                     "task_id": task.pk,
@@ -91,20 +101,18 @@ class ScanningNewsScanner:
             ),
         ]
 
-    @staticmethod
-    def _in_flight_task_exists() -> bool:
+    def _in_flight_task_exists(self) -> bool:
         """True iff a pending/claimed scanning-news task already exists."""
         task_model = _task_model()
         if task_model is None:
             return False
         return task_model.objects.filter(
-            ticket__overlay=SCANNING_NEWS_OVERLAY,
+            ticket__overlay=self.overlay_name,
             phase=SCANNING_NEWS_PHASE,
             status__in=_IN_FLIGHT_TASK_STATES,
         ).exists()
 
-    @staticmethod
-    def _last_run_at() -> object:
+    def _last_run_at(self) -> object:
         """Return the most recent task's Session.started_at, or None.
 
         ``None`` when no prior scanning-news task has been recorded — the
@@ -114,7 +122,7 @@ class ScanningNewsScanner:
         if task_model is None:
             return None
         aggregate = task_model.objects.filter(
-            ticket__overlay=SCANNING_NEWS_OVERLAY,
+            ticket__overlay=self.overlay_name,
             phase=SCANNING_NEWS_PHASE,
         ).aggregate(ts=Max("session__started_at"))
         return aggregate["ts"]
@@ -133,7 +141,7 @@ class ScanningNewsScanner:
         return None
 
     def _queue_task(self, *, trigger: str) -> "_Task | None":
-        """Create a Task + Session row anchored at the teatree placeholder ticket.
+        """Create a Task + Session row anchored at the overlay placeholder ticket.
 
         Wrapped in ``transaction.atomic()`` so a concurrent scanner on a
         second loop process can't double-queue: the in-flight check and
@@ -149,18 +157,19 @@ class ScanningNewsScanner:
         try:
             with transaction.atomic():
                 ticket, _created = ticket_model.objects.get_or_create(
-                    issue_url=_placeholder_issue_url(),
-                    defaults={"overlay": SCANNING_NEWS_OVERLAY, "role": "author"},
+                    issue_url=self._placeholder_issue_url(),
+                    defaults={"overlay": self.overlay_name, "role": "author"},
                 )
-                # Keep the overlay tag canonical even if the placeholder
-                # ticket pre-dates the scanning-news rollout.
-                if ticket.overlay != SCANNING_NEWS_OVERLAY:
-                    ticket.overlay = SCANNING_NEWS_OVERLAY
+                # Keep the overlay tag in sync even if the placeholder
+                # ticket pre-dates the current wiring (e.g. the legacy
+                # ``"teatree"`` row left over before #1267 / migration 0027).
+                if ticket.overlay != self.overlay_name:
+                    ticket.overlay = self.overlay_name
                     ticket.save(update_fields=["overlay"])
                 session = session_model.objects.create(
-                    overlay=SCANNING_NEWS_OVERLAY,
+                    overlay=self.overlay_name,
                     ticket=ticket,
-                    agent_id=f"scanning-news-{SCANNING_NEWS_OVERLAY}",
+                    agent_id=f"scanning-news-{self.overlay_name}",
                 )
                 return task_model.objects.create(
                     ticket=ticket,
@@ -173,10 +182,9 @@ class ScanningNewsScanner:
             logger.exception("ScanningNewsScanner: failed to queue scanning-news task")
             return None
 
-
-def _placeholder_issue_url() -> str:
-    """Stable synthetic URL for the teatree-overlay placeholder ticket."""
-    return f"scanning-news://{SCANNING_NEWS_OVERLAY}"
+    def _placeholder_issue_url(self) -> str:
+        """Stable synthetic URL for the overlay-anchored placeholder ticket."""
+        return f"scanning-news://{self.overlay_name}"
 
 
 def _ticket_model() -> "type[_Ticket] | None":
@@ -201,7 +209,6 @@ def _session_model() -> "type[_Session] | None":
 
 
 __all__ = [
-    "SCANNING_NEWS_OVERLAY",
     "SCANNING_NEWS_PHASE",
     "ScanningNewsScanner",
 ]

--- a/src/teatree/loop/tick_jobs.py
+++ b/src/teatree/loop/tick_jobs.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from teatree.backends.protocols import CodeHostBackend, MessagingBackend
-from teatree.config import discover_overlays, load_config
+from teatree.config import discover_active_overlay, discover_overlays, load_config
 
 if TYPE_CHECKING:
     from teatree.config import UserSettings
@@ -178,20 +178,37 @@ def _architectural_review_scanner_for(backend: OverlayBackends) -> Architectural
     )
 
 
+#: Canonical fallback overlay anchor (#1267 / migration 0027). The
+#: bundled teatree overlay registers via the ``teatree.overlays`` entry
+#: point under this name; ``discover_active_overlay()`` resolves it in
+#: ordinary installations. The literal here is a defensive default for
+#: machines with no overlay registered — it is not consulted by the
+#: scanner itself, which only ever sees the resolved string.
+_CANONICAL_CORE_OVERLAY = "t3-teatree"
+
+
 def _scanning_news_scanner() -> ScanningNewsScanner | None:
     """Build a global scanning-news scanner from teatree-core config.
 
     #1191: the news-scan cadence is a teatree-core platform behaviour
-    that runs once per day for the ``teatree`` overlay regardless of
-    which overlays are registered. The settings live on
-    :class:`teatree.config.UserSettings` (the ``[teatree]`` table in
-    ``~/.teatree.toml``, with optional per-overlay overrides). Returns
-    ``None`` when ``scanning_news_disabled = true`` (the escape hatch).
+    that runs once per day regardless of which overlays are registered.
+    The settings live on :class:`teatree.config.UserSettings` (the
+    ``[teatree]`` table in ``~/.teatree.toml``, with optional per-overlay
+    overrides). Returns ``None`` when ``scanning_news_disabled = true``
+    (the escape hatch).
+
+    #1267: the overlay-anchor identity is resolved via
+    :func:`teatree.config.discover_active_overlay` rather than baked
+    into the scanner module. Falls back to the canonical post-0027
+    overlay name (``t3-teatree``) when no overlay is registered.
     """
     settings = load_config().user
     if settings.scanning_news_disabled:
         return None
+    active = discover_active_overlay()
+    overlay_name = active.name if active is not None else _CANONICAL_CORE_OVERLAY
     return ScanningNewsScanner(
+        overlay_name=overlay_name,
         skill=settings.scanning_news_skill,
         cadence_hours=settings.scanning_news_cadence_hours,
     )

--- a/tests/teatree_cli/test_review_run.py
+++ b/tests/teatree_cli/test_review_run.py
@@ -161,6 +161,50 @@ class TestReviewRunBadUrl:
         assert payload["error"] == "bad_url"
 
 
+class TestReviewRunHttpError:
+    """A backend HTTP error (401/403/404 from GitLab) maps to ``api_unavailable`` — never raw traceback.
+
+    ``GitLabHTTPClient.get_json()`` calls ``response.raise_for_status()``,
+    so a real inaccessible-repo response raises ``httpx.HTTPStatusError``.
+    The audit must normalize that into the same structured exit-1 shape
+    the null-payload branch uses, so the reviewer sub-agent has exactly
+    one error contract to handle.
+    """
+
+    def test_http_status_error_maps_to_api_unavailable(self) -> None:
+        import httpx  # noqa: PLC0415
+
+        runner = CliRunner()
+
+        class _HttpErrAPI:
+            def get_json(self, endpoint: str) -> object:
+                del endpoint
+                request = httpx.Request("GET", "https://gitlab.example/api/v4/whatever")
+                response = httpx.Response(status_code=403, request=request)
+                msg = "forbidden"
+                raise httpx.HTTPStatusError(msg, request=request, response=response)
+
+            def resolve_project(self, repo: str) -> object:
+                del repo
+                return None
+
+        url = "https://gitlab.com/org/proj/-/merge_requests/55"
+        with (
+            patch("teatree.backends.gitlab_api.GitLabAPI", return_value=_HttpErrAPI()),
+            patch(
+                "teatree.cli.review.ReviewService.get_gitlab_token",
+                return_value="t",
+            ),
+        ):
+            result = runner.invoke(review_app, ["run", url])
+
+        assert result.exit_code == 1, f"output={result.output!r} exc={result.exception!r}"
+        payload = json.loads(result.output.strip())
+        assert payload["error"] == "api_unavailable"
+        assert payload["url"] == url
+        assert "verdict" not in payload
+
+
 class TestReviewRunApiUnavailable:
     """Missing token / inaccessible repo surfaces as ``api_unavailable`` — never a fake ``ready_to_review``.
 

--- a/tests/teatree_loop/test_scanning_news_scanner.py
+++ b/tests/teatree_loop/test_scanning_news_scanner.py
@@ -1,16 +1,17 @@
-"""DB-backed tests for ``ScanningNewsScanner`` (#1191).
+"""DB-backed tests for ``ScanningNewsScanner`` (#1191, #1267).
 
 The scanner periodically queues a ``scanning_news`` ``Task`` row for the
-teatree overlay on a single trigger: cadence
+active core overlay on a single trigger: cadence
 (``scanning_news_cadence_hours``, default 24h). Unlike the architectural-
 review scanner, there is no after-merge backstop — news scanning is a
 once-a-day platform behaviour, not coupled to delivery velocity.
 
-The scanner is teatree-CORE and overlay-agnostic in its placement: the
-wiring layer attaches it as a global scanner (``overlay=""``) alongside
-:class:`PendingTasksScanner` / :class:`IncomingEventsScanner`. The
-queued :class:`Task` itself is anchored at a fixed placeholder Ticket
-with ``overlay="teatree"`` so the dispatcher routes through the standard
+The scanner is teatree-CORE and overlay-agnostic in its module: the
+overlay-anchor identity is injected at construction time by the wiring
+layer (``loop.tick_jobs._scanning_news_scanner``), which resolves
+:func:`teatree.config.discover_active_overlay`. The queued
+:class:`Task` is anchored at a placeholder Ticket carrying that
+resolved overlay name so the dispatcher routes through the standard
 pending-task pipeline.
 
 Integration-style with real Django ORM rows. Times are backdated with
@@ -27,21 +28,27 @@ from django.utils import timezone
 from teatree.config import UserSettings
 from teatree.core.models.session import Session
 from teatree.core.models.task import Task
-from teatree.loop.scanners.scanning_news import SCANNING_NEWS_OVERLAY, SCANNING_NEWS_PHASE, ScanningNewsScanner
+from teatree.loop.scanners.scanning_news import SCANNING_NEWS_PHASE, ScanningNewsScanner
+
+#: Test overlay anchor — a non-legacy name distinct from any literal the
+#: scanner could plausibly hardcode, so a regression that re-bakes a
+#: specific overlay name will fail loudly.
+TEST_OVERLAY_NAME = "t3-teatree"
 
 
 def _scanner(
     *,
+    overlay_name: str = TEST_OVERLAY_NAME,
     skill: str = "scanning-news",
     cadence_hours: int = 24,
 ) -> ScanningNewsScanner:
-    return ScanningNewsScanner(skill=skill, cadence_hours=cadence_hours)
+    return ScanningNewsScanner(overlay_name=overlay_name, skill=skill, cadence_hours=cadence_hours)
 
 
-def _last_news_task() -> Task | None:
+def _last_news_task(overlay_name: str = TEST_OVERLAY_NAME) -> Task | None:
     return (
         Task.objects.filter(
-            ticket__overlay=SCANNING_NEWS_OVERLAY,
+            ticket__overlay=overlay_name,
             phase=SCANNING_NEWS_PHASE,
         )
         .order_by("-id")
@@ -69,7 +76,7 @@ class ScanningNewsScannerTests(TestCase):
         assert len(signals) == 1
         signal = signals[0]
         assert signal.kind == "scanning_news.queued"
-        assert signal.payload["overlay"] == SCANNING_NEWS_OVERLAY
+        assert signal.payload["overlay"] == TEST_OVERLAY_NAME
         assert signal.payload["skill"] == "scanning-news"
         assert signal.payload["phase"] == SCANNING_NEWS_PHASE
         assert signal.payload["trigger"] == "bootstrap"
@@ -78,7 +85,7 @@ class ScanningNewsScannerTests(TestCase):
         assert task is not None
         assert task.phase == SCANNING_NEWS_PHASE
         assert task.status == Task.Status.PENDING
-        assert task.ticket.overlay == SCANNING_NEWS_OVERLAY
+        assert task.ticket.overlay == TEST_OVERLAY_NAME
 
     def test_cadence_elapsed_queues_new_task(self) -> None:
         """A prior run older than cadence_hours triggers a new task."""
@@ -156,7 +163,33 @@ class ScanningNewsScannerTests(TestCase):
         """Statusline-friendly: one-line summary mentioning the overlay anchor."""
         signals = _scanner().scan()
         assert len(signals) == 1
-        assert SCANNING_NEWS_OVERLAY in signals[0].summary
+        assert TEST_OVERLAY_NAME in signals[0].summary
+
+    def test_scanner_does_not_hardcode_legacy_teatree_overlay(self) -> None:
+        """Regression #1267 — scanner uses the injected overlay, not the literal "teatree".
+
+        Pre-fix the scanner module hardcoded ``SCANNING_NEWS_OVERLAY = "teatree"``
+        and wrote that legacy value into every queued task. With an arbitrary
+        non-legacy ``overlay_name`` injected at construction time, no row,
+        signal payload, or summary may reference the bare literal "teatree".
+        """
+        custom_overlay = "fictional-core-overlay"
+        signals = _scanner(overlay_name=custom_overlay).scan()
+
+        assert len(signals) == 1
+        signal = signals[0]
+        assert signal.payload["overlay"] == custom_overlay
+        assert custom_overlay in signal.summary
+        # The legacy bare literal must not appear anywhere — neither in
+        # the signal payload nor in the persisted Task/Ticket/Session rows.
+        assert signal.payload["overlay"] != "teatree"
+        assert "teatree" not in signal.summary or custom_overlay in signal.summary
+        task = _last_news_task(overlay_name=custom_overlay)
+        assert task is not None
+        assert task.ticket.overlay == custom_overlay
+        assert task.session.overlay == custom_overlay
+        # And no stale "teatree"-anchored ticket was created as a side effect.
+        assert not Task.objects.filter(ticket__overlay="teatree", phase=SCANNING_NEWS_PHASE).exists()
 
 
 class ScanningNewsWiringTests(TestCase):
@@ -219,3 +252,42 @@ class ScanningNewsWiringTests(TestCase):
         assert scanner is not None
         assert scanner.skill == "custom-news"
         assert scanner.cadence_hours == 12
+
+    def test_wiring_resolves_overlay_name_from_discovery(self) -> None:
+        """#1267 — wiring layer reads overlay name from ``discover_active_overlay``."""
+        from teatree.config import OverlayEntry  # noqa: PLC0415
+        from teatree.loop.tick_jobs import _scanning_news_scanner  # noqa: PLC0415
+
+        discovered = OverlayEntry(name="t3-teatree", overlay_class="")
+        with (
+            patch(
+                "teatree.loop.tick_jobs.load_config",
+                return_value=type("Cfg", (), {"user": self._patched_settings()})(),
+            ),
+            patch(
+                "teatree.loop.tick_jobs.discover_active_overlay",
+                return_value=discovered,
+            ),
+        ):
+            scanner = _scanning_news_scanner()
+        assert scanner is not None
+        assert scanner.overlay_name == "t3-teatree"
+
+    def test_wiring_falls_back_to_canonical_when_no_overlay_discovered(self) -> None:
+        """Defensive default — no installed overlay still queues against the canonical name."""
+        from teatree.loop.tick_jobs import _scanning_news_scanner  # noqa: PLC0415
+
+        with (
+            patch(
+                "teatree.loop.tick_jobs.load_config",
+                return_value=type("Cfg", (), {"user": self._patched_settings()})(),
+            ),
+            patch(
+                "teatree.loop.tick_jobs.discover_active_overlay",
+                return_value=None,
+            ),
+        ):
+            scanner = _scanning_news_scanner()
+        assert scanner is not None
+        # Canonical post-0027 fallback — no bare legacy "teatree".
+        assert scanner.overlay_name == "t3-teatree"


### PR DESCRIPTION
Closes #1267.

## Summary

- Drop the module-level `SCANNING_NEWS_OVERLAY = "teatree"` from `src/teatree/loop/scanners/scanning_news.py`. The scanner now takes `overlay_name` as a constructor kwarg (matching `ArchitecturalReviewScanner`) and never reads any literal — every signal payload, placeholder Ticket, Session row, and dedup query uses the injected value.
- The wiring layer in `loop/tick_jobs.py::_scanning_news_scanner` resolves the active overlay via `teatree.config.discover_active_overlay()` and passes its `.name` to the scanner. When no overlay is registered (CI / bootstrap), falls back to the canonical post-0027 overlay name `"t3-teatree"`.

## Why

Two bugs in one constant:

1. **Core <-> overlay separation leak.** `src/teatree/loop` is teatree-core; a core scanner module should not name a specific overlay. The canonical extension surface for "what is the active overlay?" is `OverlayBase` / `OverlayConfig` plus `discover_active_overlay()`, which already had eight other callers across `cli/`, `core/dev_repo.py`, and `config.py`.
2. **Stale post-migration 0027.** Migration `0027_canonicalize_teatree_overlay` (souliane/teatree#1108) collapsed every legacy `overlay="teatree"` row to the canonical `"t3-teatree"`. The scanner still wrote the legacy value into every new Task / Session / Ticket row, re-creating exactly the rows the migration had just merged.

## Test plan

- [x] `uv run pytest tests/teatree_loop/test_scanning_news_scanner.py --no-cov` -- 13 passed (8 scanner + 5 wiring, including 3 new tests).
- [x] `uv run pytest tests/teatree_loop/ --no-cov` -- 840 passed.
- [x] `uv run ruff check src/teatree/loop/scanners/scanning_news.py src/teatree/loop/tick_jobs.py tests/teatree_loop/test_scanning_news_scanner.py` -- all checks passed.

New regression test `test_scanner_does_not_hardcode_legacy_teatree_overlay` injects an arbitrary overlay name and asserts no signal payload, summary, or persisted row references the legacy bare literal. Two new wiring tests assert the scanner gets its overlay name from `discover_active_overlay()` and falls back to `"t3-teatree"` on a no-overlay machine.