### PR TITLE
chore(lint): justify bare # noqa suppressions across src/teatree/ (#1271)

### DIFF
--- a/src/teatree/agents/handover.py
+++ b/src/teatree/agents/handover.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from django.conf import settings
 
-_DEFAULT_STATUSLINE_STATE_DIR = Path("/tmp/claude-statusline")  # noqa: S108
+_DEFAULT_STATUSLINE_STATE_DIR = Path("/tmp/claude-statusline")  # noqa: S108 — fixed agent-controlled path, not user input
 _DEFAULT_AGENT_HANDOVER = [
     {
         "runtime": "claude-code",

--- a/src/teatree/cli/agent.py
+++ b/src/teatree/cli/agent.py
@@ -91,7 +91,7 @@ def _launch_claude(
         cmd.extend(["-p", task])
 
     typer.echo(f"Launching Claude Code in {project_root}...")
-    os.execvp(claude_bin, cmd)  # noqa: S606
+    os.execvp(claude_bin, cmd)  # noqa: S606 — argv list, no shell
 
 
 def agent(

--- a/src/teatree/cli/dep_drift_repair.py
+++ b/src/teatree/cli/dep_drift_repair.py
@@ -140,5 +140,5 @@ def repair_dep_drift(repo: Path) -> bool:
     # Re-exec the *running* t3, not whatever `t3` happens to be first on PATH
     # (that may be a different shim/env than the one we just repaired).
     t3_bin = sys.argv[0] or shutil.which("t3") or "t3"
-    os.execv(t3_bin, [t3_bin, *sys.argv[1:]])  # noqa: S606
+    os.execv(t3_bin, [t3_bin, *sys.argv[1:]])  # noqa: S606 — argv from sys.argv, no shell
     return True  # unreachable — execv replaces the process; here for the type-checker

--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -567,7 +567,7 @@ class ReviewService:
 # `teatree.cli.review_commands`.
 from teatree.cli import review_commands as _review_commands  # noqa: E402 — registration side-effect
 from teatree.cli.review_commands import _require_token  # noqa: E402, F401 — re-exported for monkeypatch targets
-from teatree.cli.review_live_approval import register as _register_live_approval  # noqa: E402
+from teatree.cli.review_live_approval import register as _register_live_approval  # noqa: E402 — late, after typer app
 
 _register_on_behalf(review_app)
 _register_drafts(review_app)

--- a/src/teatree/core/management/commands/run.py
+++ b/src/teatree/core/management/commands/run.py
@@ -49,7 +49,7 @@ class Command(TyperCommand):
         all_ok = True
         for name, url in endpoints.items():
             try:
-                with urllib.request.urlopen(url, timeout=5) as resp:  # noqa: S310
+                with urllib.request.urlopen(url, timeout=5) as resp:  # noqa: S310 — fixed http://localhost URL built from local ports
                     results[name] = {"url": url, "status": resp.status, "ok": True}
                     self.stdout.write(f"  {name}: {url} → {resp.status}")
             except Exception as exc:  # noqa: BLE001

--- a/src/teatree/core/step_runner.py
+++ b/src/teatree/core/step_runner.py
@@ -5,7 +5,7 @@ pattern with explicit success/failure tracking per step.
 """
 
 import logging
-import subprocess  # noqa: S404
+import subprocess  # noqa: S404 — only TimeoutExpired/CompletedProcess accessed, no shelling
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field

--- a/src/teatree/loop/scanners/external_tickets.py
+++ b/src/teatree/loop/scanners/external_tickets.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 _TERMINAL_STATES = ("delivered", "ignored")
 _PLACEHOLDERS = ", ".join("?" for _ in _TERMINAL_STATES)
-_QUERY = f"SELECT id, state, issue_url, overlay FROM teatree_ticket WHERE state NOT IN ({_PLACEHOLDERS}) ORDER BY id"  # noqa: S608
+_QUERY = f"SELECT id, state, issue_url, overlay FROM teatree_ticket WHERE state NOT IN ({_PLACEHOLDERS}) ORDER BY id"  # noqa: S608 — literal placeholder count, no user input
 
 
 @dataclass(slots=True)

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -28,7 +28,7 @@ from pathlib import Path
 # module has its own binding patched by the test setup that exercises
 # the moved functions).
 from teatree.backends.protocols import CodeHostBackend, MessagingBackend
-from teatree.config import discover_overlays, load_config  # noqa: F401
+from teatree.config import discover_overlays, load_config  # noqa: F401 — re-export kept live for test monkeypatch
 from teatree.core.backend_factory import OverlayBackends
 from teatree.loop.dispatch import DispatchAction, dispatch
 from teatree.loop.rendering import zones_for

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -37,7 +37,7 @@ def _discover_overlay_apps() -> list[str]:
     return apps
 
 
-SECRET_KEY = "teatree-dev-insecure"  # noqa: S105
+SECRET_KEY = "teatree-dev-insecure"  # noqa: S105 — local-dev CLI, never deployed
 DEBUG = True
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "[::1]"]
 INTERNAL_IPS = ["127.0.0.1"]
@@ -147,7 +147,7 @@ TEATREE_TIMEOUTS = {
     "provision_step": 120,
     "pre_run_step": 60,
 }
-TEATREE_CLAUDE_STATUSLINE_STATE_DIR = "/tmp/claude-statusline"  # noqa: S108
+TEATREE_CLAUDE_STATUSLINE_STATE_DIR = "/tmp/claude-statusline"  # noqa: S108 — fixed agent-controlled path, not user input
 
 TASKS = {
     "default": {


### PR DESCRIPTION
## Summary

Audit finding B2: add inline justification to the 10 bare `# noqa: <RULE>` suppressions in `src/teatree/`, per CLAUDE.md § "Code Quality Standard". Each suppression now carries a short reason specific to the actual code on that line, so the next reader can decide whether the suppression still applies without re-deriving the context.

Closes #1271.

## Changes

| File | Rule | Justification |
|------|------|---------------|
| `src/teatree/settings.py:40` | `S105` | local-dev CLI, never deployed |
| `src/teatree/settings.py:150` | `S108` | fixed agent-controlled path, not user input |
| `src/teatree/core/step_runner.py:8` | `S404` | only TimeoutExpired/CompletedProcess accessed, no shelling |
| `src/teatree/core/management/commands/run.py:52` | `S310` | fixed http://localhost URL built from local ports |
| `src/teatree/agents/handover.py:7` | `S108` | fixed agent-controlled path, not user input |
| `src/teatree/cli/dep_drift_repair.py:143` | `S606` | argv from sys.argv, no shell |
| `src/teatree/cli/agent.py:94` | `S606` | argv list, no shell |
| `src/teatree/cli/review.py:570` | `E402` | late, after typer app |
| `src/teatree/loop/tick.py:31` | `F401` | re-export kept live for test monkeypatch |
| `src/teatree/loop/scanners/external_tickets.py:19` | `S608` | literal placeholder count, no user input |

## Test plan

- [x] `grep -rEn "# noqa: [A-Z][0-9]+(, ?[A-Z][0-9]+)*\s*$" src/teatree/` returns zero hits (verification gate).
- [x] `uv run ruff check src/` — all checks pass.
- [x] `uv run ruff format src/` — no changes (already conformant).
- [x] `uv run pytest --no-cov -q` — 6324 passed, 13 skipped. The single pre-existing failure (`test_in_repo_overlay_resolves_to_three`) reproduces on `origin/main` without this branch and is unrelated to noqa suppressions.

Comment-only change. Zero behaviour difference.
