### PR TITLE
fix(setup): slack-user-token auto-detects xoxb mis-install + derives app_id (#1278)

### DIFF
--- a/src/teatree/cli/slack_user_token_setup.py
+++ b/src/teatree/cli/slack_user_token_setup.py
@@ -21,16 +21,24 @@ xoxp token capture and scope verification step.
 
 import re
 import webbrowser
+from collections.abc import Callable
 from pathlib import Path
 
 import httpx
 import typer
 
-from teatree.cli.slack_setup import _USER_SCOPES, app_install_url
+from teatree.cli.slack_setup import _USER_SCOPES
 from teatree.config import CONFIG_PATH
 from teatree.utils.secrets import read_pass, write_pass
 
 USER_TOKEN_PASS_KEY = "slack/user-oauth-token"  # noqa: S105 — pass key name, not a secret
+BOT_TOKEN_PASS_KEY = "slack/bot-token"  # noqa: S105 — pass key name, not a secret
+
+
+def app_oauth_url(app_id: str) -> str:
+    """Deep link to the app's OAuth & Permissions page — the User OAuth Token lives there."""
+    return f"https://api.slack.com/apps/{app_id}/oauth"
+
 
 # Single source of truth: the manifest's _USER_SCOPES in slack_setup.py
 # declares what Slack will grant on reinstall, and this command verifies the
@@ -102,18 +110,18 @@ def _confirm_overwrite(*, reset: bool) -> bool:
 
 
 def _print_reauthorize_instructions(overlay_app_id: str) -> None:
-    install_url = app_install_url(overlay_app_id) if overlay_app_id else ""
+    oauth_url = app_oauth_url(overlay_app_id) if overlay_app_id else ""
     typer.echo("Step 1/3 — Reinstall the Slack app to re-prompt OAuth consent.")
     typer.echo("")
     typer.echo(f"      Requested user scopes ({len(REQUIRED_USER_SCOPES)}):")
     for scope in REQUIRED_USER_SCOPES:
         typer.echo(f"        - {scope}")
     typer.echo("")
-    if install_url:
-        typer.echo(f"      Opening the install page: {install_url}")
-        webbrowser.open(install_url)
+    if oauth_url:
+        typer.echo(f"      Opening the OAuth & Permissions page: {oauth_url}")
+        webbrowser.open(oauth_url)
     else:
-        typer.echo("      No slack_app_id recorded — open your Slack app's install page manually:")
+        typer.echo("      No slack_app_id recorded or derivable — open your Slack app manually:")
         typer.echo("        https://api.slack.com/apps")
     typer.echo("")
     typer.echo("      Before reinstalling, make sure the app's manifest declares ALL the scopes")
@@ -156,6 +164,64 @@ def _resolve_overlay_app_id(config_path: Path) -> str:
     return ""
 
 
+def _detect_and_backup_xoxb_mis_install(*, echo: Callable[[str], None]) -> None:
+    """Back up a bot token mis-installed at the user-token pass key.
+
+    If the manifest was installed before user scopes were added, Slack returned
+    a bot (``xoxb-…``) token where the user (``xoxp-…``) token belongs. Preserve
+    it under ``slack/bot-token`` (for the read-only scanner) before the reinstall
+    flow overwrites the user-token slot.
+    """
+    current = read_pass(USER_TOKEN_PASS_KEY)
+    if not current.startswith("xoxb-"):
+        return
+    existing_bot = read_pass(BOT_TOKEN_PASS_KEY)
+    echo(
+        "      bot token mis-install detected at pass "
+        f"{USER_TOKEN_PASS_KEY} — backing up to {BOT_TOKEN_PASS_KEY} before reinstall."
+    )
+    if existing_bot == current:
+        return
+    write_pass(BOT_TOKEN_PASS_KEY, current)
+
+
+def _derive_app_id_from_bot(token: str) -> str:
+    """Derive the Slack app_id from any bot or user token via ``auth.test`` + ``bots.info``.
+
+    Returns the empty string when derivation fails for any reason — callers
+    fall back to the manual "open https://api.slack.com/apps" message.
+    """
+    if not token:
+        return ""
+    try:
+        auth = httpx.post(
+            "https://slack.com/api/auth.test",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30,
+        )
+        auth.raise_for_status()
+        auth_body = auth.json()
+        if not auth_body.get("ok"):
+            return ""
+        bot_id = auth_body.get("bot_id")
+        if not bot_id:
+            return ""
+        info = httpx.post(
+            "https://slack.com/api/bots.info",
+            headers={"Authorization": f"Bearer {token}"},
+            data={"bot": bot_id},
+            timeout=30,
+        )
+        info.raise_for_status()
+        info_body = info.json()
+        if not info_body.get("ok"):
+            return ""
+        app_id = (info_body.get("bot") or {}).get("app_id")
+        return str(app_id) if app_id else ""
+    except httpx.HTTPError:
+        return ""
+
+
 def slack_user_token_setup(
     *,
     reset: bool = typer.Option(False, "--reset", help="Overwrite the existing token without prompting."),
@@ -166,8 +232,11 @@ def slack_user_token_setup(
     ),
 ) -> None:
     """Re-authorize the personal Slack xoxp token and store it via ``pass``."""
+    _detect_and_backup_xoxb_mis_install(echo=typer.echo)
     previous_scopes = _read_existing_scopes()
     overlay_app_id = _resolve_overlay_app_id(config_path)
+    if not overlay_app_id:
+        overlay_app_id = _derive_app_id_from_bot(read_pass(USER_TOKEN_PASS_KEY) or read_pass(BOT_TOKEN_PASS_KEY))
     _print_reauthorize_instructions(overlay_app_id)
 
     if not _confirm_overwrite(reset=reset):

--- a/tests/cli_setup/test_slack_user_token.py
+++ b/tests/cli_setup/test_slack_user_token.py
@@ -11,9 +11,12 @@ from typer.testing import CliRunner
 from teatree.cli.setup import setup_app
 from teatree.cli.slack_user_token_setup import (
     _USER_TOKEN_RE,
+    BOT_TOKEN_PASS_KEY,
     REQUIRED_USER_SCOPES,
     USER_TOKEN_PASS_KEY,
     TokenScopeError,
+    _derive_app_id_from_bot,
+    _detect_and_backup_xoxb_mis_install,
     _store_and_verify,
     added_scopes,
     fetch_token_scopes,
@@ -166,6 +169,7 @@ class TestCliWalkthrough:
                 "teatree.cli.slack_user_token_setup.fetch_token_scopes",
                 return_value=list(REQUIRED_USER_SCOPES),
             ),
+            patch("teatree.cli.slack_user_token_setup._derive_app_id_from_bot", return_value=""),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
         ):
             result = self._run(["--config", str(config)], inputs="n\n")
@@ -181,6 +185,7 @@ class TestCliWalkthrough:
                 "teatree.cli.slack_user_token_setup.fetch_token_scopes",
                 return_value=list(REQUIRED_USER_SCOPES),
             ),
+            patch("teatree.cli.slack_user_token_setup._derive_app_id_from_bot", return_value=""),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
         ):
             result = self._run(["--config", str(config)], inputs="n\n")
@@ -196,8 +201,186 @@ class TestCliWalkthrough:
             patch("teatree.cli.slack_user_token_setup.read_pass", return_value="xoxp-old"),
             patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
             patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
+            patch("teatree.cli.slack_user_token_setup._derive_app_id_from_bot", return_value=""),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
         ):
             result = self._run(["--reset", "--config", str(config)], inputs="xoxp-new-token\n")
         assert result.exit_code == 0, result.output
         assert "Aborted" not in result.output
+
+
+class TestDetectAndBackupXoxbMisInstall:
+    def test_xoxb_at_user_token_path_backed_up_when_bot_slot_empty(self) -> None:
+        def fake_read(key: str) -> str:
+            return {USER_TOKEN_PASS_KEY: "xoxb-1-abc", BOT_TOKEN_PASS_KEY: ""}.get(key, "")
+
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+        ):
+            messages: list[str] = []
+            _detect_and_backup_xoxb_mis_install(echo=messages.append)
+        write.assert_called_once_with(BOT_TOKEN_PASS_KEY, "xoxb-1-abc")
+        assert any("bot token mis-install detected" in m for m in messages)
+
+    def test_xoxb_skips_backup_when_bot_slot_already_matches(self) -> None:
+        def fake_read(key: str) -> str:
+            return {USER_TOKEN_PASS_KEY: "xoxb-1-abc", BOT_TOKEN_PASS_KEY: "xoxb-1-abc"}.get(key, "")
+
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+        ):
+            _detect_and_backup_xoxb_mis_install(echo=lambda _msg: None)
+        write.assert_not_called()
+
+    def test_xoxp_at_user_token_path_does_nothing(self) -> None:
+        def fake_read(key: str) -> str:
+            return {USER_TOKEN_PASS_KEY: "xoxp-1-good", BOT_TOKEN_PASS_KEY: ""}.get(key, "")
+
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+        ):
+            _detect_and_backup_xoxb_mis_install(echo=lambda _msg: None)
+        write.assert_not_called()
+
+    def test_xoxb_backup_overwrites_when_bot_slot_holds_different_value(self) -> None:
+        def fake_read(key: str) -> str:
+            return {USER_TOKEN_PASS_KEY: "xoxb-1-new", BOT_TOKEN_PASS_KEY: "xoxb-1-stale"}.get(key, "")
+
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+        ):
+            messages: list[str] = []
+            _detect_and_backup_xoxb_mis_install(echo=messages.append)
+        write.assert_called_once_with(BOT_TOKEN_PASS_KEY, "xoxb-1-new")
+        assert any("bot token mis-install detected" in m for m in messages)
+
+
+def _slack_response(body: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        json=body,
+        request=httpx.Request("POST", "https://slack.com/api/auth.test"),
+    )
+
+
+class TestDeriveAppIdFromBot:
+    def test_returns_app_id_when_auth_test_and_bots_info_succeed(self) -> None:
+        responses = [
+            _slack_response({"ok": True, "bot_id": "B12345"}),
+            _slack_response({"ok": True, "bot": {"app_id": "A99999"}}),
+        ]
+        with patch("teatree.cli.slack_user_token_setup.httpx.post", side_effect=responses):
+            assert _derive_app_id_from_bot("xoxb-anything") == "A99999"
+
+    def test_returns_empty_when_auth_test_fails(self) -> None:
+        response = _slack_response({"ok": False, "error": "invalid_auth"})
+        with patch("teatree.cli.slack_user_token_setup.httpx.post", return_value=response):
+            assert _derive_app_id_from_bot("xoxb-bad") == ""
+
+    def test_returns_empty_when_bots_info_fails(self) -> None:
+        responses = [
+            _slack_response({"ok": True, "bot_id": "B12345"}),
+            _slack_response({"ok": False, "error": "bot_not_found"}),
+        ]
+        with patch("teatree.cli.slack_user_token_setup.httpx.post", side_effect=responses):
+            assert _derive_app_id_from_bot("xoxb-anything") == ""
+
+    def test_returns_empty_when_no_bot_id_in_auth_test(self) -> None:
+        response = _slack_response({"ok": True})
+        with patch("teatree.cli.slack_user_token_setup.httpx.post", return_value=response):
+            assert _derive_app_id_from_bot("xoxb-anything") == ""
+
+    def test_returns_empty_when_no_app_id_in_bots_info(self) -> None:
+        responses = [
+            _slack_response({"ok": True, "bot_id": "B12345"}),
+            _slack_response({"ok": True, "bot": {}}),
+        ]
+        with patch("teatree.cli.slack_user_token_setup.httpx.post", side_effect=responses):
+            assert _derive_app_id_from_bot("xoxb-anything") == ""
+
+    def test_returns_empty_on_http_error(self) -> None:
+        with patch(
+            "teatree.cli.slack_user_token_setup.httpx.post",
+            side_effect=httpx.ConnectError("boom"),
+        ):
+            assert _derive_app_id_from_bot("xoxb-anything") == ""
+
+    def test_returns_empty_when_token_is_blank(self) -> None:
+        assert _derive_app_id_from_bot("") == ""
+
+
+class TestNewIntegrationsInWalkthrough:
+    """Wires the new helpers into the CLI walkthrough."""
+
+    def _run(self, args: list[str], inputs: str) -> Any:
+        runner = CliRunner()
+        return runner.invoke(setup_app, ["slack-user-token", *args], input=inputs)
+
+    def test_xoxb_in_user_token_slot_triggers_backup_before_reinstall(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        config.write_text('[overlays.acme]\nslack_app_id = "A0B38QGGF18"\n', encoding="utf-8")
+        granted = list(REQUIRED_USER_SCOPES)
+
+        def fake_read(key: str) -> str:
+            return {USER_TOKEN_PASS_KEY: "xoxb-1-abc", BOT_TOKEN_PASS_KEY: ""}.get(key, "")
+
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+            patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
+            patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
+        ):
+            result = self._run(["--reset", "--config", str(config)], inputs="xoxp-new-token\n")
+        assert result.exit_code == 0, result.output
+        assert "bot token mis-install detected" in result.output
+        write.assert_any_call(BOT_TOKEN_PASS_KEY, "xoxb-1-abc")
+
+    def test_app_id_derived_when_config_empty_and_token_present(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        granted = list(REQUIRED_USER_SCOPES)
+        opens: list[str] = []
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", return_value="xoxp-existing"),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
+            patch("teatree.cli.slack_user_token_setup._derive_app_id_from_bot", return_value="AABCDEF"),
+            patch("teatree.cli.slack_user_token_setup.webbrowser.open", side_effect=opens.append),
+        ):
+            result = self._run(["--reset", "--config", str(config)], inputs="xoxp-new-token\n")
+        assert result.exit_code == 0, result.output
+        assert opens == ["https://api.slack.com/apps/AABCDEF/oauth"]
+
+    def test_app_id_derivation_failure_prints_fallback(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        granted = list(REQUIRED_USER_SCOPES)
+        opens: list[str] = []
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", return_value="xoxp-existing"),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
+            patch("teatree.cli.slack_user_token_setup._derive_app_id_from_bot", return_value=""),
+            patch("teatree.cli.slack_user_token_setup.webbrowser.open", side_effect=opens.append),
+        ):
+            result = self._run(["--reset", "--config", str(config)], inputs="xoxp-new-token\n")
+        assert result.exit_code == 0, result.output
+        assert "https://api.slack.com/apps" in result.output
+        assert opens == []
+
+    def test_install_url_targets_oauth_section_when_app_id_known(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        config.write_text('[overlays.acme]\nslack_app_id = "A0B38QGGF18"\n', encoding="utf-8")
+        granted = list(REQUIRED_USER_SCOPES)
+        opens: list[str] = []
+        with (
+            patch("teatree.cli.slack_user_token_setup.read_pass", return_value=""),
+            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
+            patch("teatree.cli.slack_user_token_setup.webbrowser.open", side_effect=opens.append),
+        ):
+            result = self._run(["--config", str(config)], inputs="xoxp-new-token\n")
+        assert result.exit_code == 0, result.output
+        assert opens == ["https://api.slack.com/apps/A0B38QGGF18/oauth"]


### PR DESCRIPTION
fix(setup): slack-user-token auto-detects xoxb mis-install + derives app_id (#1278)

Closes the three manual steps observed during the 2026-05-20 personal-token
rotation: detect a bot token mis-installed at the user-token pass key and back
it up to slack/bot-token, derive the app_id via auth.test + bots.info when the
config lacks slack_app_id, and open the OAuth & Permissions page directly via
a new app_oauth_url helper local to slack_user_token_setup (kept the existing
app_install_url and its slack-bot consumer unchanged).