### PR TITLE
fix(merge-clear): _assert_clear_authorized enforces is_non_reviewer_role (#1283)

### DIFF
--- a/src/teatree/core/merge_execution.py
+++ b/src/teatree/core/merge_execution.py
@@ -407,6 +407,7 @@ def _assert_clear_authorized(
     returns the narrowed :class:`MergeClear` on success.
     """
     from teatree.core.models import MergeClear  # noqa: PLC0415
+    from teatree.core.models.merge_clear import is_non_reviewer_role  # noqa: PLC0415
 
     if not isinstance(clear, MergeClear):
         msg = f"no MergeClear row for {slug}#{pr_id} — refusing to merge (§17.4.3 step 1)"
@@ -428,6 +429,23 @@ def _assert_clear_authorized(
             f"MergeClear reviewer_identity ({clear.reviewer_identity!r}) equals the "
             f"executing loop identity — a CLEAR must be issued by an independent "
             f"cold reviewer, not self-issued (§17.8 clause 3)"
+        )
+        raise MergePreconditionError(msg)
+
+    # The factory ``MergeClear.issue()`` rejects a maker/coding-agent/loop
+    # reviewer_identity at issue time (§17.8 clause 3 — the same shared
+    # ``is_non_reviewer_role`` helper), but a row written directly via
+    # ``.objects.create()`` (fixture, migration, or any non-factory ORM
+    # path — e.g. ``ticket.py`` loads the row by pk without re-validation)
+    # would otherwise smuggle a self-attesting maker through the equality
+    # check above. Re-check the same role classification here so the
+    # issue-time and merge-time gates cannot drift apart (codex #1282
+    # finding 1 / #1283).
+    if is_non_reviewer_role(clear.reviewer_identity):
+        msg = (
+            f"MergeClear reviewer_identity ({clear.reviewer_identity!r}) is a "
+            f"maker/coding-agent/loop non-reviewer role — a CLEAR must be issued "
+            f"by an independent cold reviewer, not self-attested (§17.8 clause 3)"
         )
         raise MergePreconditionError(msg)
 

--- a/tests/teatree_core/test_merge_execution.py
+++ b/tests/teatree_core/test_merge_execution.py
@@ -120,6 +120,44 @@ class TestMergeKeystonePreconditions(TestCase):
         with pytest.raises(MergePreconditionError, match="independent"):
             _run(clear, _GhStub(), identity="merge-loop")
 
+    def test_non_reviewer_role_clear_is_refused_at_merge_time(self) -> None:
+        # codex #1282 finding 1 / #1283: ``MergeClear.issue()`` rejects a
+        # maker/coding-agent/loop reviewer_identity at issue time, but a row
+        # written directly via ``.objects.create()`` (fixture, migration,
+        # ORM bypass) skips that guard. ``_assert_clear_authorized`` must
+        # therefore re-check the same role classification at merge time —
+        # an equality check against the executing loop alone is not enough.
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = _clear(ticket, reviewer_identity="coding-agent")
+        with pytest.raises(MergePreconditionError, match=r"non-reviewer role|independent cold reviewer"):
+            _run(clear, _GhStub(), identity="merge-loop")
+        ticket.refresh_from_db()
+        clear.refresh_from_db()
+        assert ticket.state == Ticket.State.IN_REVIEW
+        assert clear.consumed_at is None
+
+    def test_every_non_reviewer_role_prefix_is_refused_at_merge_time(self) -> None:
+        # Every prefix in ``NON_REVIEWER_AGENT_PREFIXES`` (the shared role
+        # list at ``merge_clear.py``) must be rejected. The merge-time
+        # guard reads the same helper as the issue-time guard so the two
+        # gates cannot drift apart (§17.8 clause 3).
+        non_reviewer_identities = [
+            "maker:agent-7",
+            "maker-bot-3",
+            "coding-agent",
+            "coding-agent-9",
+            "coding",
+            "loop",
+            "loop-merge",
+        ]
+        for identity in non_reviewer_identities:
+            ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+            clear = _clear(ticket, reviewer_identity=identity)
+            with pytest.raises(MergePreconditionError, match=r"non-reviewer role|independent cold reviewer"):
+                _run(clear, _GhStub(), identity="merge-loop")
+            clear.refresh_from_db()
+            assert clear.consumed_at is None, f"non-reviewer {identity!r} must not consume the CLEAR"
+
     def test_human_authorized_on_non_substrate_clear_is_refused(self) -> None:
         # The recorded-human-approval path is substrate-only — presenting
         # --human-authorized against a logic/docs CLEAR is refused so it


### PR DESCRIPTION
fix(merge-clear): _assert_clear_authorized enforces is_non_reviewer_role (#1283)

The merge keystone's runtime guard only checked equality against
``--loop-identity``. A ``MergeClear`` row written directly via the ORM
(fixture, migration, or any non-factory path — ``ticket.py`` loads the
row by pk without re-validation) could carry
``reviewer_identity="coding-agent"`` and pass the equality check,
bypassing §17.8 clause 3's "independent cold reviewer" guarantee.

``MergeClear.issue()`` already rejects maker/coding-agent/loop roles at
issue time via the shared ``is_non_reviewer_role`` helper. The merge-time
guard now re-applies the same helper so the two gates cannot drift apart.

Anti-vacuous: with the new guard reverted the two new tests go RED
(`DID NOT RAISE` — the merge actually proceeds with a maker reviewer);
restoring the guard turns them GREEN. The other 41 tests in
``test_merge_execution.py`` (plus the broader 97-test merge-related
suite) stay green.

Reference: codex review on #1282, finding 1.