### PR TITLE
fix(slack): prefix-check tokens at backend construction (#1285)

### DIFF
--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -46,9 +46,15 @@ from typing import cast
 import httpx
 
 from teatree.backends.slack_token_policy import SlackOp, channel_token
+from teatree.backends.slack_token_validation import (
+    TokenSlotMismatchError,
+    assert_app_token,
+    assert_bot_token,
+    assert_user_token,
+)
 from teatree.types import RawAPIDict
 
-__all__ = ["SlackBotBackend", "SlackOp"]
+__all__ = ["SlackBotBackend", "SlackOp", "TokenSlotMismatchError"]
 
 type SlackPayload = dict[str, object]
 
@@ -86,6 +92,15 @@ class SlackBotBackend:
         user_token: str = "",
         user_id: str = "",
     ) -> None:
+        # Runtime token-prefix validation — codex #1282 item 5, see
+        # ``slack_token_validation``. The capture-time regex in
+        # ``slack_user_token_setup`` is not enough: a swapped token in pass
+        # reaches the slot-based policy in ``slack_token_policy`` which
+        # never inspects the prefix. Validate at the single construction
+        # chokepoint so the loop fails loud-but-early.
+        assert_bot_token(bot_token)
+        assert_user_token(user_token)
+        assert_app_token(app_token)
         self._bot_token = bot_token
         self._app_token = app_token
         self._user_token = user_token

--- a/src/teatree/backends/slack_token_validation.py
+++ b/src/teatree/backends/slack_token_validation.py
@@ -1,0 +1,91 @@
+"""Prefix-validation for Slack tokens at backend construction (#1285).
+
+Codex adversarial review #1282 item 5 surfaced this gap: PR #1279 added a
+capture-time regex in ``slack_user_token_setup._prompt_user_token``, but
+once a token sits in ``pass`` as a raw string the runtime construction
+path (``backend_factory._messaging_from_toml``,
+``backends.loader.get_messaging``) reads it back and threads it into a
+``SlackBotBackend`` slot with no prefix check. The deterministic policy
+in :mod:`teatree.backends.slack_token_policy` then routes by *slot*,
+never by prefix, so a swapped token (the field bug observed
+2026-05-20: an ``xoxb-…`` ended up at the ``xoxp-`` user slot) either
+impersonates the user or — worse — is silently dropped on a Slack-Connect
+externally-shared channel that rejects the wrong token.
+
+The gate fires inside ``SlackBotBackend.__init__`` (the single chokepoint
+every factory path hits) so the loop fails *loudly but early*: a
+``TokenSlotMismatchError`` with the offending slot named and the right
+``t3 setup …`` command pointed at, never a mid-tick crash. Empty tokens
+stay valid — they are the legitimate no-credential / bot-only /
+no-socket-mode cases the rest of the code already tolerates.
+"""
+
+import re
+
+BOT_TOKEN_RE = re.compile(r"^xoxb-[A-Za-z0-9-]+$")
+USER_TOKEN_RE = re.compile(r"^xoxp-[A-Za-z0-9-]+$")
+APP_TOKEN_RE = re.compile(r"^xapp-[A-Za-z0-9-]+$")
+
+
+class TokenSlotMismatchError(ValueError):
+    """A Slack token's prefix does not match its construction slot.
+
+    Inherits from ``ValueError`` so factory callers that already catch
+    ``ValueError`` around backend construction (see
+    ``iter_overlay_backends``) demote it to a "skipped overlay" the same
+    way they handle credential errors today — never a silent runtime
+    drop, but also never a process crash.
+    """
+
+
+def assert_bot_token(token: str) -> None:
+    """Reject ``token`` if it is non-empty and lacks the ``xoxb-`` prefix."""
+    if not token:
+        return
+    if not BOT_TOKEN_RE.match(token):
+        message = (
+            "bot_token must start with 'xoxb-' (Slack bot OAuth token). "
+            "Got a token with a different prefix in the bot slot — "
+            "this is the runtime half of codex #1282 item 5. "
+            "Re-run `t3 setup slack-bot` to capture a correctly-prefixed token."
+        )
+        raise TokenSlotMismatchError(message)
+
+
+def assert_user_token(token: str) -> None:
+    """Reject ``token`` if it is non-empty and lacks the ``xoxp-`` prefix."""
+    if not token:
+        return
+    if not USER_TOKEN_RE.match(token):
+        message = (
+            "user_token must start with 'xoxp-' (Slack user OAuth token). "
+            "Got a token with a different prefix in the user slot — "
+            "this is the exact failure mode observed on 2026-05-20 "
+            "(an xoxb- token pasted into the xoxp slot). "
+            "Re-run `t3 setup slack-user-token` to capture a correctly-prefixed token."
+        )
+        raise TokenSlotMismatchError(message)
+
+
+def assert_app_token(token: str) -> None:
+    """Reject ``token`` if it is non-empty and lacks the ``xapp-`` prefix."""
+    if not token:
+        return
+    if not APP_TOKEN_RE.match(token):
+        message = (
+            "app_token must start with 'xapp-' (Slack Socket Mode app-level token). "
+            "Got a token with a different prefix in the app slot. "
+            "Re-run `t3 setup slack-bot` to capture a correctly-prefixed app token."
+        )
+        raise TokenSlotMismatchError(message)
+
+
+__all__ = [
+    "APP_TOKEN_RE",
+    "BOT_TOKEN_RE",
+    "USER_TOKEN_RE",
+    "TokenSlotMismatchError",
+    "assert_app_token",
+    "assert_bot_token",
+    "assert_user_token",
+]

--- a/src/teatree/cli/slack_user_token_setup.py
+++ b/src/teatree/cli/slack_user_token_setup.py
@@ -19,7 +19,6 @@ manages the manifest + bot/app tokens; this command focuses on the personal
 xoxp token capture and scope verification step.
 """
 
-import re
 import webbrowser
 from collections.abc import Callable
 from pathlib import Path
@@ -27,6 +26,13 @@ from pathlib import Path
 import httpx
 import typer
 
+# Re-export under the local underscored name for backward-compat with prior
+# imports inside this module. Source of truth lives in
+# ``teatree.backends.slack_token_validation`` so the runtime gate at
+# backend construction (#1285) and the capture-time gate here agree on
+# the exact regex — drift between the two would let a token shape pass
+# capture but fail at construction, or vice versa.
+from teatree.backends.slack_token_validation import USER_TOKEN_RE as _USER_TOKEN_RE
 from teatree.cli.slack_setup import _USER_SCOPES
 from teatree.config import CONFIG_PATH
 from teatree.utils.secrets import read_pass, write_pass
@@ -47,8 +53,6 @@ def app_oauth_url(app_id: str) -> str:
 # REQUIRED), or (b) silently approve under-scoped tokens (REQUIRED narrower
 # than manifest). Deriving REQUIRED from the manifest constant prevents both.
 REQUIRED_USER_SCOPES: list[str] = sorted(_USER_SCOPES)
-
-_USER_TOKEN_RE = re.compile(r"^xoxp-[A-Za-z0-9-]+$")
 
 
 class TokenScopeError(RuntimeError):

--- a/tests/teatree_backends/test_loader.py
+++ b/tests/teatree_backends/test_loader.py
@@ -172,7 +172,12 @@ def test_get_messaging_resolves_user_token_ref(monkeypatch: pytest.MonkeyPatch) 
 
 def test_get_messaging_user_token_absent_when_ref_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     """Without ``user_token_ref`` the backend keeps an empty user token."""
-    monkeypatch.setattr("teatree.backends.loader.read_pass", lambda _: "xoxb-resolved")
+
+    # Per-slot prefixes — #1285 validates them at construction.
+    def fake_read_pass(key: str) -> str:
+        return {"ref/bot-bot": "xoxb-resolved", "ref/bot-app": "xapp-resolved"}.get(key, "")
+
+    monkeypatch.setattr("teatree.backends.loader.read_pass", fake_read_pass)
 
     overlay = _build_overlay(messaging_backend="slack", slack_token_ref="ref/bot")
     backend = get_messaging(overlay)

--- a/tests/teatree_backends/test_messaging.py
+++ b/tests/teatree_backends/test_messaging.py
@@ -30,7 +30,7 @@ def test_noop_returns_empty_dict_for_outbound() -> None:
 
 
 def test_slack_satisfies_messaging_protocol() -> None:
-    assert isinstance(SlackBotBackend(bot_token="x"), MessagingBackend)
+    assert isinstance(SlackBotBackend(bot_token="xoxb-x"), MessagingBackend)
 
 
 def test_slack_post_message_omits_thread_ts_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -212,8 +212,8 @@ def test_slack_fetch_dms_drains_enqueued_events() -> None:
 
 
 def test_slack_exposes_app_token_and_user_id() -> None:
-    backend = SlackBotBackend(bot_token="xoxb", app_token="xapp", user_id="U123")
-    assert backend.app_token == "xapp"
+    backend = SlackBotBackend(bot_token="xoxb-test", app_token="xapp-test", user_id="U123")
+    assert backend.app_token == "xapp-test"
     assert backend.user_id == "U123"
 
 

--- a/tests/teatree_backends/test_slack_token_prefix_validation.py
+++ b/tests/teatree_backends/test_slack_token_prefix_validation.py
@@ -1,0 +1,123 @@
+"""Token-prefix validation at backend construction (#1285, codex #1282 item 5).
+
+``SlackBotBackend.__init__`` must reject a token whose prefix does not
+match its slot:
+
+- ``bot_token`` must start with ``xoxb-``
+- ``user_token`` must start with ``xoxp-`` (only when non-empty)
+- ``app_token`` must start with ``xapp-`` (only when non-empty)
+
+The capture-time check in ``slack_user_token_setup._prompt_user_token`` is
+not sufficient — the token sits in pass as a raw string and the runtime
+construction path (``backend_factory._messaging_from_toml``,
+``backends.loader.get_messaging``) never re-validates. A swapped or
+pasted-wrong token reaches the deterministic policy in
+``slack_token_policy.channel_token()`` which routes by *slot*, never by
+prefix; the post then either impersonates the user or is silently dropped
+on a Slack-Connect channel.
+
+The runtime gate fires at backend construction (``__init__``) so the
+loop fails *loudly but early* — a clear ``TokenSlotMismatchError`` with
+the offending slot named and the right ``t3 setup …`` command pointed
+at, never a mid-tick crash. Empty tokens stay valid (the legacy
+single-credential / no-credential cases).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from teatree.backends.slack_bot import SlackBotBackend
+from teatree.backends.slack_token_validation import TokenSlotMismatchError
+from teatree.core import backend_factory
+
+
+class TestSlackBotBackendConstructionRejectsSwappedTokens:
+    """``SlackBotBackend(...)`` is the single chokepoint every factory path hits."""
+
+    def test_bot_slot_rejects_xoxp_user_token(self) -> None:
+        with pytest.raises(TokenSlotMismatchError) as excinfo:
+            SlackBotBackend(bot_token="xoxp-pasted-into-bot-slot")
+        message = str(excinfo.value)
+        assert "bot_token" in message
+        assert "xoxb-" in message
+        assert "t3 setup slack-bot" in message
+
+    def test_user_slot_rejects_xoxb_bot_token(self) -> None:
+        """The exact failure mode observed in the field on 2026-05-20."""
+        with pytest.raises(TokenSlotMismatchError) as excinfo:
+            SlackBotBackend(bot_token="xoxb-real-bot", user_token="xoxb-pasted-into-user-slot")
+        message = str(excinfo.value)
+        assert "user_token" in message
+        assert "xoxp-" in message
+        assert "t3 setup slack-user-token" in message
+
+    def test_app_slot_rejects_xoxb_in_app_token(self) -> None:
+        with pytest.raises(TokenSlotMismatchError) as excinfo:
+            SlackBotBackend(bot_token="xoxb-real-bot", app_token="xoxb-not-an-app-token")
+        message = str(excinfo.value)
+        assert "app_token" in message
+        assert "xapp-" in message
+        assert "t3 setup slack-bot" in message
+
+    def test_bot_slot_rejects_unrecognised_prefix(self) -> None:
+        """A typo'd token (no recognised Slack prefix) fails just as loud."""
+        with pytest.raises(TokenSlotMismatchError):
+            SlackBotBackend(bot_token="not-a-slack-token")
+
+    def test_well_formed_tokens_all_three_slots_accepted(self) -> None:
+        """Happy path — every slot carries the right prefix, construction succeeds."""
+        backend = SlackBotBackend(
+            bot_token="xoxb-real-bot-token",
+            app_token="xapp-real-app-token",
+            user_token="xoxp-real-user-token",
+            user_id="U123",
+        )
+        assert backend.user_token == "xoxp-real-user-token"
+        assert backend.app_token == "xapp-real-app-token"
+
+    def test_empty_bot_token_still_allowed(self) -> None:
+        """Empty bot_token is the no-credential case — must stay accepted."""
+        SlackBotBackend(bot_token="")
+
+    def test_empty_user_token_still_allowed(self) -> None:
+        """Empty user_token is the bot-only deployment — must stay accepted."""
+        SlackBotBackend(bot_token="xoxb-real-bot")
+
+    def test_empty_app_token_still_allowed(self) -> None:
+        """Empty app_token is the no-socket-mode case — must stay accepted."""
+        SlackBotBackend(bot_token="xoxb-real-bot", app_token="")
+
+
+class TestFactoryConstructionFailsLoudOnPassSwap:
+    """The runtime path the codex finding flagged: a swapped token in ``pass``."""
+
+    def test_messaging_from_toml_swapped_user_slot_raises(self) -> None:
+        """``pass slack/user-oauth-token`` holds an ``xoxb-…`` token (the field bug)."""
+        cfg = {
+            "messaging_backend": "slack",
+            "slack_token_ref": "ref",
+            "user_token_ref": "slack/user-oauth",
+            "slack_user_id": "U1",
+        }
+        # The exact field failure mode: an xoxb-… ended up at the xoxp slot.
+        pass_lookups = {
+            "ref-bot": "xoxb-real-bot",
+            "ref-app": "xapp-real-app",
+            "slack/user-oauth": "xoxb-mistakenly-pasted-here",
+        }
+        with (
+            patch("teatree.utils.secrets.read_pass", side_effect=lambda k: pass_lookups.get(k, "")),
+            pytest.raises(TokenSlotMismatchError),
+        ):
+            backend_factory._messaging_from_toml(cfg)
+
+    def test_messaging_from_toml_swapped_bot_slot_raises(self) -> None:
+        """The mirror case: ``pass slack/ref-bot`` holds an ``xoxp-…`` token."""
+        cfg = {"messaging_backend": "slack", "slack_token_ref": "ref"}
+        pass_lookups = {"ref-bot": "xoxp-pasted-into-bot-slot", "ref-app": "xapp-real-app"}
+        with (
+            patch("teatree.utils.secrets.read_pass", side_effect=lambda k: pass_lookups.get(k, "")),
+            pytest.raises(TokenSlotMismatchError),
+        ):
+            backend_factory._messaging_from_toml(cfg)

--- a/tests/teatree_core/test_backend_factory.py
+++ b/tests/teatree_core/test_backend_factory.py
@@ -158,8 +158,8 @@ class TestMessagingFromOverlayTomlFallback:
         def fake_read(key: str) -> str:
             seen.append(key)
             return {
-                "teatree/private-x/slack-bot": "x-bot-tok",
-                "teatree/private-x/slack-app": "x-app-tok",
+                "teatree/private-x/slack-bot": "xoxb-bot-tok",
+                "teatree/private-x/slack-app": "xapp-app-tok",
             }.get(key, "")
 
         with (
@@ -192,10 +192,10 @@ class TestMessagingFromOverlayTomlFallback:
         def fake_read(key: str) -> str:
             seen.append(key)
             return {
-                "teatree/private-x/slack-bot": "x-bot",
-                "teatree/private-x/slack-app": "x-app",
-                "teatree/teatree/slack-bot": "teatree-bot",
-                "teatree/teatree/slack-app": "teatree-app",
+                "teatree/private-x/slack-bot": "xoxb-x-bot",
+                "teatree/private-x/slack-app": "xapp-x-app",
+                "teatree/teatree/slack-bot": "xoxb-teatree-bot",
+                "teatree/teatree/slack-app": "xapp-teatree-app",
             }.get(key, "")
 
         with (
@@ -222,7 +222,7 @@ class TestMessagingFromOverlayTomlFallback:
         )
 
         def fake_read(key: str) -> str:
-            return "x-bot" if key == "teatree/private-x/slack-bot" else ""
+            return "xoxb-x-bot" if key == "teatree/private-x/slack-bot" else ""
 
         with (
             patch.object(overlay_loader_mod, "_discover_overlays", return_value={}),
@@ -252,8 +252,8 @@ class TestMessagingFromOverlayTomlFallback:
 
         def fake_read(key: str) -> str:
             return {
-                "ref-x-bot": "x-bot",
-                "ref-tt-bot": "tt-bot",
+                "ref-x-bot": "xoxb-x-bot",
+                "ref-tt-bot": "xoxb-tt-bot",
             }.get(key, "")
 
         with (

--- a/tests/teatree_core/test_backend_factory_toml.py
+++ b/tests/teatree_core/test_backend_factory_toml.py
@@ -167,7 +167,7 @@ class TestMessagingFromToml:
         cfg = {"messaging_backend": "slack", "slack_token_ref": "ref", "slack_user_id": "U1"}
 
         def fake_read(key: str) -> str:
-            return {"ref-bot": "bot-tok", "ref-app": "app-tok"}.get(key, "")
+            return {"ref-bot": "xoxb-bot-tok", "ref-app": "xapp-app-tok"}.get(key, "")
 
         with patch("teatree.utils.secrets.read_pass", side_effect=fake_read):
             backend = backend_factory._messaging_from_toml(cfg)
@@ -187,7 +187,7 @@ class TestMessagingFromToml:
             "user_token_ref": "slack/user-oauth",
             "slack_user_id": "U1",
         }
-        pass_lookups = {"ref-bot": "bot-tok", "ref-app": "app-tok", "slack/user-oauth": "xoxp-tok"}
+        pass_lookups = {"ref-bot": "xoxb-bot-tok", "ref-app": "xapp-app-tok", "slack/user-oauth": "xoxp-tok"}
         with patch("teatree.utils.secrets.read_pass", side_effect=lambda k: pass_lookups.get(k, "")):
             backend = backend_factory._messaging_from_toml(cfg)
         assert isinstance(backend, SlackBotBackend)
@@ -197,7 +197,7 @@ class TestMessagingFromToml:
         cfg = {"messaging_backend": "slack", "slack_token_ref": "ref"}
 
         def fake_read(key: str) -> str:
-            return {"ref-bot": "bot-tok", "ref-app": "app-tok"}.get(key, "")
+            return {"ref-bot": "xoxb-bot-tok", "ref-app": "xapp-app-tok"}.get(key, "")
 
         with patch("teatree.utils.secrets.read_pass", side_effect=fake_read):
             backend = backend_factory._messaging_from_toml(cfg)


### PR DESCRIPTION
Closes #1285. Runtime half of codex #1282 item 5.

## Why

PR #1279 closed the **capture-time** half (the `xoxp-` regex in `slack_user_token_setup._prompt_user_token`, plus the xoxb-at-user-slot auto-detect / back-up). Runtime construction was still trustful: `_messaging_from_toml` read pass contents and threaded raw strings into `SlackBotBackend` slots, and the deterministic policy in `slack_token_policy.channel_token` picked the *slot*, never the prefix.

The field bug from 2026-05-20 (an `xoxb-…` token at the `xoxp-` user slot) is exactly this failure mode — the swapped token either impersonates the user (writes go out as user when they should be bot) or, worse, is silently dropped on a Slack-Connect channel that rejects the wrong identity.

## What

- New module `teatree.backends.slack_token_validation` with `TokenSlotMismatchError` (inherits `ValueError`) and per-slot `assert_bot_token` / `assert_user_token` / `assert_app_token` helpers, each pointing the user at the right `t3 setup …` recovery command. Empty tokens stay valid — they are the legitimate no-credential / bot-only / no-socket-mode cases.
- `SlackBotBackend.__init__` is the single construction chokepoint every factory path hits (loader, `_messaging_from_toml`, the `iter_overlay_backends` TOML fallback, CLI setup, tests). Validation lives here so the loop fails loud-but-early at backend construction — never a mid-tick crash, never a silent slot-swap.
- `slack_user_token_setup` now imports the shared `USER_TOKEN_RE` (re-exported as `_USER_TOKEN_RE` to keep prior in-module imports stable). Single source of truth — capture-time and runtime gates can't drift.
- 10 new tests in `tests/teatree_backends/test_slack_token_prefix_validation.py` covering each slot/prefix combination, the swap cases through `_messaging_from_toml`, and the happy path with all three correctly-prefixed tokens.

## Mock-test fallout

8 existing tests across `test_loader`, `test_messaging`, `test_backend_factory`, and `test_backend_factory_toml` used short non-realistic mock pass returns (`"x"`, `"bot-tok"`, `"x-bot"`, `"x-app"`, `"teatree-bot"`, etc.) that the new runtime gate correctly rejects. Updated each to a correctly-prefixed token (`xoxb-x-bot`, `xapp-x-app`, …); the tests still cover their original behaviour, just with realistic input.

## Anti-vacuous evidence

Reverted the `SlackBotBackend.__init__` validation lines, ran the new test file: 10/10 RED with `DID NOT RAISE TokenSlotMismatchError`. Restored, re-ran: 10/10 GREEN.

## Gates

- `uv run pytest --no-cov -q` — 6528 passed, 13 skipped, 1 deselected (one pre-existing flaky test on `TestMaxConcurrentAutoStarts::test_in_repo_overlay_resolves_to_three` that fails on `origin/main` and is unrelated to this change).
- `uv run ruff check` / `uv run ruff format` — clean.
- `uv run ty check` on the changed modules — clean.

## Out of scope

Items 1, 2, 3, 4, 6, 7 from codex #1282 — separate tickets.