### PR TITLE
fix(ci): blueprint-invariant-numbering gates against main merge-base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,40 @@ jobs:
         env:
           SKIP: pytest,uv-audit,cyclonedx-sbom
 
+  blueprint-cross-pr:
+    # Cross-PR §17.1 invariant-numbering gate (souliane/teatree#1288).
+    # The pre-commit hook is tree-local; two concurrent PRs each adding
+    # the same §17.N pass locally and pass each PR's CI. This step reads
+    # BLUEPRINT.md at base (origin/main) and at HEAD and fails when the
+    # PR introduces a number the base also added since the merge-base.
+    # Only runs on pull_request events because push-to-main has nothing
+    # to diff against and the underlying hook covers the merge result.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # fetch-depth: 0 so `git merge-base origin/main HEAD` resolves.
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: uv sync
+      - name: Check for BLUEPRINT.md change in this PR
+        id: blueprint_diff
+        run: |
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qx 'BLUEPRINT.md'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: §17.1 invariant-numbering cross-PR check
+        if: steps.blueprint_diff.outputs.changed == 'true'
+        run: uv run python scripts/hooks/check_blueprint_invariant_numbering.py --ci --base-ref=origin/${{ github.base_ref }}
+
   docs-drift:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/hooks/check_blueprint_invariant_numbering.py
+++ b/scripts/hooks/check_blueprint_invariant_numbering.py
@@ -12,10 +12,20 @@ in ``BLUEPRINT.md`` and FAILS when the numbers are not a gapless ``1..N``
 sequence with no repeats. It runs at the same pre-commit/prek layer as
 the existing ``blueprint-sync`` / ``skill-prose-ban`` checks, so it fires
 on whatever tree is being committed — including the merge-result tree.
+
+CI mode (``--ci --base-ref <ref>``, souliane/teatree#1288): the
+pre-commit hook is tree-local — two concurrent PRs each appending the
+same next §17.N pass locally and pass each PR's CI. Only the merge
+result loses one. The CI mode reads BLUEPRINT.md at ``base-ref`` (the
+target branch tip), parses both sides' §17.1 numbers, and fails when
+the PR introduces a number that already exists on the base. Skips when
+BLUEPRINT.md is unchanged between base and HEAD to keep CI cost down.
 """
 
+import argparse
 import re
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -32,6 +42,13 @@ class NumberingResult:
     numbers: list[int]
     ok: bool
     reason: str
+
+
+@dataclass(frozen=True)
+class CrossPrResult:
+    ok: bool
+    reason: str
+    colliding: list[int]
 
 
 def _blueprint_path() -> Path:
@@ -97,6 +114,69 @@ def check_numbering(numbers: list[int]) -> NumberingResult:
     return NumberingResult(numbers=numbers, ok=True, reason="")
 
 
+def check_numbering_against_base(
+    *,
+    base: list[int],
+    pr: list[int],
+    merge_base: list[int] | None = None,
+) -> CrossPrResult:
+    """Detect cross-PR §17.1 collisions against a merge-base snapshot.
+
+    Both sides may individually be a clean ``1..N``; the collision class
+    is when the PR appends a number that the base also added since the
+    PR's branch-point (a concurrently merged PR).
+
+    Three references frame it:
+
+    - *merge_base*: the common ancestor's §17.1 sequence (where the PR
+        branched). Anything not in *merge_base* was added on one side or
+        the other.
+    - *base*: the current target branch tip's §17.1 (e.g. ``origin/main``).
+        Numbers in *base* but not in *merge_base* are "added on main"
+        since the PR diverged (typically by a concurrently merged PR).
+    - *pr*: the PR HEAD's §17.1. Numbers in *pr* but not in *merge_base*
+        are "added by this PR".
+
+    Any number added by *both* the PR and the base independently is a
+    collision: the merge result will lose one of them. When
+    *merge_base* is ``None`` (CLI invocation that did not compute it),
+    a conservative fallback uses the longest common ``1..k`` prefix as
+    a proxy.
+    """
+    if merge_base is not None:
+        mb_set = set(merge_base)
+        base_new = set(base) - mb_set
+        pr_new = set(pr) - mb_set
+    else:
+        common_prefix = 0
+        for left, right in zip(base, pr, strict=False):
+            if left == right:
+                common_prefix += 1
+            else:
+                break
+        base_new = set(base[common_prefix:])
+        pr_new = set(pr[common_prefix:])
+        if base[common_prefix:] == pr[common_prefix:]:
+            # PR didn't touch §17.1; its tail mirrors base's tail.
+            return CrossPrResult(ok=True, reason="", colliding=[])
+
+    colliding = sorted(base_new & pr_new)
+    if not colliding:
+        return CrossPrResult(ok=True, reason="", colliding=[])
+
+    return CrossPrResult(
+        ok=False,
+        reason=(
+            f"§17.1 cross-PR collision on invariant number(s) {colliding}: "
+            f"PR sequence {pr} adds {sorted(pr_new)} but base (main) "
+            f"already advertises {sorted(base_new)} from a concurrently "
+            "merged PR. Rebase on main and renumber the PR's new "
+            "invariant(s) to the next free slot."
+        ),
+        colliding=colliding,
+    )
+
+
 def _blueprint_in_commit() -> bool:
     """True when BLUEPRINT.md is part of the staged change.
 
@@ -106,6 +186,44 @@ def _blueprint_in_commit() -> bool:
     """
     result = subprocess.run(
         ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return "BLUEPRINT.md" in result.stdout.splitlines()
+
+
+def _git_show(repo: Path, ref: str, path: str) -> str | None:
+    """Return ``git show <ref>:<path>`` content, or ``None`` if absent."""
+    result = subprocess.run(
+        ["git", "-C", str(repo), "show", f"{ref}:{path}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _merge_base(repo: Path, base_ref: str) -> str | None:
+    """Return the merge-base SHA between *base_ref* and HEAD, or None."""
+    result = subprocess.run(
+        ["git", "-C", str(repo), "merge-base", base_ref, "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def _blueprint_in_pr(repo: Path, base_ref: str) -> bool:
+    """True when BLUEPRINT.md differs between *base_ref* and HEAD."""
+    result = subprocess.run(
+        ["git", "-C", str(repo), "diff", "--name-only", f"{base_ref}...HEAD"],
         capture_output=True,
         text=True,
         check=False,
@@ -125,10 +243,13 @@ def main() -> int:
         # fail open rather than block on a broken tree.
         return 0
 
-    result = check_numbering(extract_invariant_numbers(text))
+    return _report_tree_local(text)
+
+
+def _report_tree_local(blueprint_text: str) -> int:
+    result = check_numbering(extract_invariant_numbers(blueprint_text))
     if result.ok:
         return 0
-
     print()
     print("  BLUEPRINT.md §17.1 invariant-numbering integrity FAILED:")
     print()
@@ -141,5 +262,101 @@ def main() -> int:
     return 1
 
 
+def ci_main(*, repo: Path, base_ref: str) -> int:
+    """Cross-PR invariant-numbering check, evaluated against *base_ref*.
+
+    Reads ``BLUEPRINT.md`` at HEAD (the PR tip) and at *base_ref* (the
+    target branch tip — typically ``origin/main``). If BLUEPRINT.md is
+    unchanged between the two, no-op (keep CI cost down per the
+    BLUEPRINT-touching diff scope). Otherwise:
+
+    1. Apply the existing ``check_numbering`` to the HEAD tree — a
+        PR-side gap or duplicate is still a fail.
+    2. Apply ``check_numbering_against_base`` — a §17.N introduced on
+        both sides independently is the cross-PR collision.
+
+    Returns ``0`` on pass, ``1`` on fail. Prints actionable diagnostics
+    to stdout for the CI log.
+    """
+    if not _blueprint_in_pr(repo, base_ref):
+        return 0
+
+    head_path = repo / "BLUEPRINT.md"
+    try:
+        head_text = head_path.read_text(encoding="utf-8")
+    except OSError:
+        # PR deleted BLUEPRINT.md — out of scope for this gate.
+        return 0
+
+    base_text = _git_show(repo, base_ref, "BLUEPRINT.md")
+    if base_text is None:
+        # Base ref doesn't have BLUEPRINT.md yet (first introduction);
+        # nothing to compare against. Defer to the tree-local check.
+        return _report_tree_local(head_text)
+
+    head_numbers = extract_invariant_numbers(head_text)
+    base_numbers = extract_invariant_numbers(base_text)
+
+    merge_base_sha = _merge_base(repo, base_ref)
+    merge_base_numbers: list[int] | None = None
+    if merge_base_sha is not None:
+        mb_text = _git_show(repo, merge_base_sha, "BLUEPRINT.md")
+        if mb_text is not None:
+            merge_base_numbers = extract_invariant_numbers(mb_text)
+
+    tree_local = check_numbering(head_numbers)
+    if not tree_local.ok:
+        print()
+        print("  BLUEPRINT.md §17.1 invariant-numbering integrity FAILED (PR tree):")
+        print()
+        print(f"    {tree_local.reason}")
+        print()
+        return 1
+
+    cross_pr = check_numbering_against_base(
+        base=base_numbers,
+        pr=head_numbers,
+        merge_base=merge_base_numbers,
+    )
+    if not cross_pr.ok:
+        print()
+        print("  BLUEPRINT.md §17.1 cross-PR invariant-numbering integrity FAILED:")
+        print()
+        print(f"    {cross_pr.reason}")
+        print()
+        print("    Recurring collision class (#836 §17.6 gate 1 / #1288): the")
+        print("    pre-commit hook is tree-local and cannot see concurrently")
+        print("    merged PRs. Rebase the branch on the base ref and renumber")
+        print("    the PR's new invariant(s).")
+        print()
+        return 1
+
+    return 0
+
+
+def _cli_entry(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="Run the cross-PR (merge-base) check, not the staged-tree check.",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Base ref to diff against in --ci mode (default: origin/main).",
+    )
+    parser.add_argument(
+        "--repo",
+        default=".",
+        help="Repository root (default: cwd).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.ci:
+        return ci_main(repo=Path(args.repo).resolve(), base_ref=args.base_ref)
+    return main()
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(_cli_entry(sys.argv[1:]))

--- a/tests/test_check_blueprint_invariant_numbering.py
+++ b/tests/test_check_blueprint_invariant_numbering.py
@@ -6,11 +6,28 @@ duplicated or dropped one (occurred 3x in one session: #856/#859,
 #859/#863). This gate parses §17.1's numbered list and fails when the
 numbers are not a gapless 1..N with no repeats, evaluated on whatever
 tree (incl. merge result) is being committed.
+
+`TestCiCrossPrDetection` covers the cross-PR mode (codex #1282 item 7,
+souliane/teatree#1288): the pre-commit gate is tree-local and cannot
+catch two concurrent PRs each adding the same §17.N against a stale
+base. The CI mode reads the base ref's BLUEPRINT.md and fails when the
+PR introduces invariant numbers that already exist on the base.
 """
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
 
 import pytest
 
-from scripts.hooks.check_blueprint_invariant_numbering import check_numbering, extract_invariant_numbers, main
+from scripts.hooks.check_blueprint_invariant_numbering import (
+    check_numbering,
+    check_numbering_against_base,
+    ci_main,
+    extract_invariant_numbers,
+    main,
+)
 
 _CLEAN = """\
 ## 17. Factory
@@ -147,3 +164,261 @@ class TestMain:
         monkeypatch.setattr(mod, "_blueprint_in_commit", lambda: True)
         monkeypatch.setattr(mod, "_blueprint_path", lambda: bp)
         assert main() == 0
+
+
+_BASE_THREE = """\
+### 17.1 Invariants
+
+1. **One.** a
+
+2. **Two.** b
+
+3. **Three.** c
+
+### 17.2 Next
+"""
+
+# Two concurrent PRs: base has 1..3; PR A merges first, adding §17.4
+# "Alpha". PR B branched from the same base, also adds §17.4 "Beta".
+# Tree-local check passes for both PRs (each ships a clean 1..N
+# sequence). Only a base-aware check catches the collision.
+_BASE_AFTER_PR_A_MERGED = """\
+### 17.1 Invariants
+
+1. **One.** a
+
+2. **Two.** b
+
+3. **Three.** c
+
+4. **Alpha.** added by PR A, now on main
+
+### 17.2 Next
+"""
+
+_PR_B_AGAINST_STALE_BASE = """\
+### 17.1 Invariants
+
+1. **One.** a
+
+2. **Two.** b
+
+3. **Three.** c
+
+4. **Beta.** PR B, branched from BASE_THREE (stale)
+
+### 17.2 Next
+"""
+
+_PR_C_NEW_NUMBER = """\
+### 17.1 Invariants
+
+1. **One.** a
+
+2. **Two.** b
+
+3. **Three.** c
+
+4. **Alpha.** already on main (PR A)
+
+5. **Gamma.** PR C, rebased on top of PR A — no collision
+
+### 17.2 Next
+"""
+
+
+_GIT_BIN = shutil.which("git") or "/usr/bin/git"
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    """Run ``git`` inside *repo* with a sanitized env.
+
+    The pre-commit pytest hook exports ``GIT_*`` vars from the outer
+    ``git commit``; inheriting them would let the inner ``git`` calls
+    hijack the real repo. See AGENTS.md § Test-Writing Doctrine.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env.setdefault("GIT_AUTHOR_NAME", "test")
+    env.setdefault("GIT_AUTHOR_EMAIL", "test@example.com")
+    env.setdefault("GIT_COMMITTER_NAME", "test")
+    env.setdefault("GIT_COMMITTER_EMAIL", "test@example.com")
+    result = subprocess.run(
+        [_GIT_BIN, *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+class TestCheckNumberingAgainstBase:
+    """Pure logic: given base + pr invariants, detect collisions."""
+
+    def test_disjoint_additions_ok(self) -> None:
+        # merge-base 1..3; base unchanged 1..3; pr adds 4 — no collision.
+        result = check_numbering_against_base(base=[1, 2, 3], pr=[1, 2, 3, 4], merge_base=[1, 2, 3])
+        assert result.ok is True
+
+    def test_same_number_added_by_pr_and_base_fails(self) -> None:
+        # merge-base 1..3; base advanced to 1..4 (PR A merged) while
+        # this PR was in flight; PR also adds 4 from the stale base.
+        result = check_numbering_against_base(base=[1, 2, 3, 4], pr=[1, 2, 3, 4], merge_base=[1, 2, 3])
+        # Each side has a clean 1..N, but PR's 4 collides with base's 4.
+        assert result.ok is False
+        assert "4" in result.reason
+        assert "base" in result.reason.lower() or "main" in result.reason.lower()
+
+    def test_pr_post_rebase_no_collision(self) -> None:
+        # Post-rebase the merge-base advances to wherever main was;
+        # PR's 4 is now identical to main's 4 and PR adds 5 cleanly.
+        result = check_numbering_against_base(base=[1, 2, 3, 4], pr=[1, 2, 3, 4, 5], merge_base=[1, 2, 3, 4])
+        assert result.ok is True
+
+    def test_pr_subset_no_added_numbers_ok(self) -> None:
+        # PR doesn't touch §17.1 at all (same numbers as merge-base/base).
+        result = check_numbering_against_base(base=[1, 2, 3], pr=[1, 2, 3], merge_base=[1, 2, 3])
+        assert result.ok is True
+
+    def test_pr_removes_a_number_ok(self) -> None:
+        # PR retires an invariant (renumbering); not a collision.
+        result = check_numbering_against_base(base=[1, 2, 3], pr=[1, 2], merge_base=[1, 2, 3])
+        assert result.ok is True
+
+    def test_fallback_no_merge_base_uses_common_prefix(self) -> None:
+        # CLI / programmatic callers may not have a merge-base handy.
+        # The fallback compares everything past the longest common
+        # 1..k prefix — the conservative proxy.
+        result = check_numbering_against_base(base=[1, 2, 3], pr=[1, 2, 3, 4])
+        assert result.ok is True
+        result = check_numbering_against_base(base=[1, 2, 3, 4], pr=[1, 2, 3])
+        assert result.ok is True
+
+
+class TestCiCrossPrDetection:
+    """End-to-end with real git: simulate the cross-PR collision class.
+
+    Builds a tmp repo with the merge-base BLUEPRINT.md, branches the
+    PR off it, then advances ``base-ref`` (the "main" pointer) past
+    the branch-point to simulate a concurrently-merged PR. ``ci_main``
+    must:
+
+    1. RED — fail when the PR's BLUEPRINT adds a §17.N that the
+        advanced base also added (the cross-PR collision).
+    2. GREEN — pass when the PR rebases and adds a strictly newer
+        number.
+    3. SKIP — no-op when BLUEPRINT.md isn't in the PR diff.
+    """
+
+    def _make_repo_with_branch_point(
+        self,
+        tmp_path: Path,
+        *,
+        ancestor: str,
+        base_after_concurrent_merge: str | None = None,
+    ) -> Path:
+        """Build a repo. Branch off ``ancestor``, optionally advance base.
+
+        - Commit 1: ``ancestor`` (BLUEPRINT.md). Tag as ``base-ref``.
+        - Create branch ``pr-branch`` HERE (so the merge-base is this commit).
+        - If ``base_after_concurrent_merge`` is set: switch to ``main``,
+            commit it (simulating PR A merging into main), and update
+            ``base-ref`` to point at that new tip. ``pr-branch`` still
+            points at the ancestor — that's its stale base.
+        - Switch back to ``pr-branch`` for the test to add the PR's
+            commits on top.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _run_git(repo, "init", "-q", "-b", "main")
+        bp = repo / "BLUEPRINT.md"
+        bp.write_text(ancestor, encoding="utf-8")
+        _run_git(repo, "add", "BLUEPRINT.md")
+        _run_git(repo, "commit", "-q", "-m", "ancestor")
+        # Snapshot the branch-point now.
+        _run_git(repo, "branch", "pr-branch")
+        # The base-ref starts pointing at the ancestor too.
+        _run_git(repo, "branch", "-f", "base-ref", "main")
+
+        if base_after_concurrent_merge is not None:
+            # Advance main with the "PR A merged" content.
+            bp.write_text(base_after_concurrent_merge, encoding="utf-8")
+            _run_git(repo, "add", "BLUEPRINT.md")
+            _run_git(repo, "commit", "-q", "-m", "concurrently-merged-pr-a")
+            _run_git(repo, "branch", "-f", "base-ref", "main")
+
+        _run_git(repo, "checkout", "-q", "pr-branch")
+        return repo
+
+    def test_red_collision_with_concurrently_merged_pr(self, tmp_path: Path) -> None:
+        # Ancestor (merge-base) has 1..3. While PR was in flight, main
+        # advanced to 1..4 ("Alpha"). PR also picked 4 ("Beta") against
+        # the stale base — that's the collision the gate must catch.
+        repo = self._make_repo_with_branch_point(
+            tmp_path,
+            ancestor=_BASE_THREE,
+            base_after_concurrent_merge=_BASE_AFTER_PR_A_MERGED,
+        )
+        bp = repo / "BLUEPRINT.md"
+        bp.write_text(_PR_B_AGAINST_STALE_BASE, encoding="utf-8")
+        _run_git(repo, "add", "BLUEPRINT.md")
+        _run_git(repo, "commit", "-q", "-m", "pr-b")
+
+        exit_code = ci_main(repo=repo, base_ref="base-ref")
+        assert exit_code == 1
+
+    def test_green_when_pr_picks_a_strictly_new_number(self, tmp_path: Path) -> None:
+        # Post-rebase scenario: PR branched from main AFTER PR A
+        # merged, so the merge-base IS _BASE_AFTER_PR_A_MERGED (1..4)
+        # and the PR cleanly adds 5.
+        repo = self._make_repo_with_branch_point(
+            tmp_path,
+            ancestor=_BASE_AFTER_PR_A_MERGED,
+        )
+        bp = repo / "BLUEPRINT.md"
+        bp.write_text(_PR_C_NEW_NUMBER, encoding="utf-8")
+        _run_git(repo, "add", "BLUEPRINT.md")
+        _run_git(repo, "commit", "-q", "-m", "pr-c")
+
+        exit_code = ci_main(repo=repo, base_ref="base-ref")
+        assert exit_code == 0
+
+    def test_skip_when_blueprint_unchanged_in_pr(self, tmp_path: Path) -> None:
+        repo = self._make_repo_with_branch_point(tmp_path, ancestor=_BASE_THREE)
+        # PR touches a different file — BLUEPRINT.md unchanged from base.
+        (repo / "OTHER.md").write_text("hello", encoding="utf-8")
+        _run_git(repo, "add", "OTHER.md")
+        _run_git(repo, "commit", "-q", "-m", "pr-other")
+
+        exit_code = ci_main(repo=repo, base_ref="base-ref")
+        assert exit_code == 0
+
+    def test_green_on_clean_addition_against_unchanged_base(self, tmp_path: Path) -> None:
+        # Base has 1..3, PR adds 4 — the common case (no concurrent merge).
+        repo = self._make_repo_with_branch_point(tmp_path, ancestor=_BASE_THREE)
+        bp = repo / "BLUEPRINT.md"
+        bp.write_text(
+            _BASE_THREE.replace("### 17.2 Next", "4. **Four.** new\n\n### 17.2 Next"),
+            encoding="utf-8",
+        )
+        _run_git(repo, "add", "BLUEPRINT.md")
+        _run_git(repo, "commit", "-q", "-m", "pr-add-four")
+
+        exit_code = ci_main(repo=repo, base_ref="base-ref")
+        assert exit_code == 0
+
+    def test_red_when_pr_introduces_local_gap(self, tmp_path: Path) -> None:
+        # Even without a base collision, a 1..N gap on the PR side is
+        # still wrong — ci_main must defer to the tree-local check too.
+        repo = self._make_repo_with_branch_point(tmp_path, ancestor=_BASE_THREE)
+        bp = repo / "BLUEPRINT.md"
+        bp.write_text(
+            _BASE_THREE.replace("### 17.2 Next", "5. **Five.** gap!\n\n### 17.2 Next"),
+            encoding="utf-8",
+        )
+        _run_git(repo, "add", "BLUEPRINT.md")
+        _run_git(repo, "commit", "-q", "-m", "pr-gap")
+
+        exit_code = ci_main(repo=repo, base_ref="base-ref")
+        assert exit_code == 1


### PR DESCRIPTION
## Summary

Adds a CI-mode (`--ci --base-ref`) to `scripts/hooks/check_blueprint_invariant_numbering.py` that catches the cross-PR collision class the pre-commit hook cannot: two concurrent PRs each appending the same §17.N against a stale base. The pre-commit gate is tree-local; both PRs pass locally and pass each PR's CI; only the merge result loses one invariant. Adds a `blueprint-cross-pr` job in `.github/workflows/ci.yml` that runs on `pull_request` events when BLUEPRINT.md is in the PR diff, fetches full history, and invokes the new mode against `origin/${{ github.base_ref }}`.

The collision class recurred in [#856](https://github.com/souliane/teatree/issues/856) / [#859](https://github.com/souliane/teatree/issues/859) / [#863](https://github.com/souliane/teatree/issues/863). The pre-commit hook (added in #836's §17.6 enforcement-gate bundle) closes the merge-tree case; this PR closes the per-PR-side case codex flagged in [#1282](https://github.com/souliane/teatree/issues/1282) item 7.

## What changed

- `check_numbering_against_base()` walks the merge-base when supplied, comparing the PR's §17.1 added numbers (`set(pr) - set(merge_base)`) against the base's added numbers (`set(base) - set(merge_base)`); overlap = collision. Fallback to longest common 1..k prefix when no merge-base is available (CLI callers without git context).
- `ci_main(repo, base_ref)` reads BLUEPRINT.md at HEAD and at base, computes merge-base via `git merge-base`, then applies tree-local + cross-PR checks in sequence. No-ops when BLUEPRINT.md is unchanged between base and HEAD (keeps CI cost down).
- New `blueprint-cross-pr` job in `.github/workflows/ci.yml` gated on `github.event_name == 'pull_request'`, with `fetch-depth: 0` so merge-base resolves, and a `git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qx BLUEPRINT.md` gate so the step only runs when relevant.
- Tests use real `git init` under `tmp_path` per `AGENTS.md` § Test-Writing Doctrine: a controlled merge-base / advanced-base / PR-tip topology, no mocking of `subprocess` or `Path`.

## Anti-vacuous verification

Stubbed `check_numbering_against_base` to always return `ok=True`:

- `TestCheckNumberingAgainstBase::test_same_number_added_by_pr_and_base_fails` → RED (assert ok is False fails because stub returns ok=True)
- `TestCiCrossPrDetection::test_red_collision_with_concurrently_merged_pr` → RED (assert exit_code == 1 fails because the stub lets ci_main return 0)

Restored the real implementation → all 25 tests in the file pass GREEN.

## Test plan

- [x] `uv run pytest tests/test_check_blueprint_invariant_numbering.py --no-cov` — 25 passed
- [x] `uv run ruff check` + `ruff format` — clean
- [x] `uv run ty check scripts/hooks/check_blueprint_invariant_numbering.py` — clean
- [x] CLI smoke: `uv run python scripts/hooks/check_blueprint_invariant_numbering.py --ci --base-ref=origin/main --repo=.` returns 0 on a no-BLUEPRINT-change branch
- [ ] CI: the new `blueprint-cross-pr` job runs on this PR (no BLUEPRINT.md change → step is skipped via the `if: steps.blueprint_diff.outputs.changed == 'true'` guard; job itself is green)

Fixes #1288
Relates-to #1282
