### PR TITLE
fix(lifecycle): enforce shipping gate on task path + require evidence on phase completion (#1284)

### DIFF
--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -25,7 +25,7 @@ from django.db.models import Sum
 from django.utils import timezone
 
 from teatree.agents.model_tiering import resolve_phase_model
-from teatree.agents.result_schema import RESULT_JSON_SCHEMA
+from teatree.agents.result_schema import RESULT_JSON_SCHEMA, check_evidence
 from teatree.agents.skill_bundle import resolve_skill_bundle
 from teatree.core.models import Task, TaskAttempt, Ticket
 from teatree.core.models.worktree import Worktree
@@ -215,7 +215,7 @@ def run_headless(
         return _record_failure(task, exit_code=returncode, error=stderr[:2000])
 
     envelope = _parse_cli_envelope(stdout)
-    return _record_success(task, envelope)
+    return _record_success(task, envelope, phase=phase)
 
 
 def _resolve_task_cwd(task: Task) -> str | None:
@@ -299,7 +299,7 @@ def _run_with_heartbeat(
     return stdout or "", stderr or "", proc.returncode
 
 
-def _record_success(task: Task, envelope: dict[str, str]) -> TaskAttempt:
+def _record_success(task: Task, envelope: dict[str, str], *, phase: str = "") -> TaskAttempt:
     agent_text = envelope.get("agent_text", "")
     result = _parse_result(agent_text)
     if not result:
@@ -308,6 +308,16 @@ def _record_success(task: Task, envelope: dict[str, str]) -> TaskAttempt:
     schema_error = _validate_result(result)
     if schema_error:
         return _record_failure(task, exit_code=0, error=schema_error)
+
+    # #1284 (codex #1282-6): a sub-agent claiming success must back the
+    # claim with at least one phase-specific evidence field — otherwise a
+    # one-line summary advances the FSM with no proof (the "DM sent
+    # successfully but didn't deliver" false-positive class). Bypassed for
+    # ``needs_user_input`` handoffs (the agent is *not* claiming the phase
+    # is done) by ``check_evidence`` itself.
+    evidence_error = check_evidence(result, phase or task.phase)
+    if evidence_error:
+        return _record_failure(task, exit_code=0, error=evidence_error)
 
     attempt = TaskAttempt.objects.create(
         task=task,

--- a/src/teatree/agents/result_schema.py
+++ b/src/teatree/agents/result_schema.py
@@ -2,9 +2,20 @@
 
 Agents return JSON matching this schema. Any agent that can produce JSON works —
 Claude structured output just makes schema compliance guaranteed.
+
+Phase-specific evidence requirements (#1284 / codex #1282-6): a successful
+phase task must carry concrete evidence the work actually happened — not just
+a summary string. ``PHASE_REQUIRED_EVIDENCE`` names the per-phase fields the
+agent must supply (in addition to ``summary``); ``_record_success`` consults
+this map and refuses to complete the task when the claim has no evidence. The
+"DM sent successfully but didn't deliver" false-positive class is exactly the
+shape this prevents: a one-line summary advancing the FSM with no underlying
+proof.
 """
 
 from typing import TypedDict
+
+from teatree.core.phases import normalize_phase
 
 
 class FileChange(TypedDict, total=False):
@@ -24,7 +35,10 @@ class TestResult(TypedDict, total=False):
 class AgentResult(TypedDict, total=False):
     """Structured result from an agent task execution.
 
-    All fields are optional — agents report what they can.
+    All fields are optional — agents report what they can. Phase-specific
+    evidence requirements are enforced by ``_record_success`` against
+    ``PHASE_REQUIRED_EVIDENCE``, not by the JSON schema itself, because the
+    required field depends on the running phase.
     """
 
     summary: str
@@ -91,3 +105,63 @@ RESULT_JSON_SCHEMA: dict[str, object] = {
     },
     "additionalProperties": False,
 }
+
+
+#: Per-phase required evidence fields (#1284 / codex #1282-6). At least one
+#: of these fields must be present AND non-empty in the agent's success
+#: result, otherwise the phase recording is refused. Keys are canonical
+#: phase tokens (``coding``/``testing``/``reviewing``/``shipping``/...).
+#: Each value is the list of acceptable evidence fields — supplying ANY of
+#: them satisfies the requirement (an "evidence is one of" check, not "all
+#: of"). The minimum non-trivial assertion per phase: did the agent produce
+#: something a human could verify after the fact?
+#:
+#: - ``coding``: at least one file change recorded.
+#: - ``testing``: at least one test result OR a positive ``tests_passed``.
+#: - ``reviewing``: at least one design decision recorded (a review with no
+#:   recorded decision is a rubber-stamp; codex #1282-6 names this as the
+#:   exact false-positive class to prevent).
+#: - ``shipping``: at least one command executed (``git push``, ``gh pr``...).
+#:
+#: Phases not in this map (``scoping``, ``retro``) carry no evidence
+#: requirement — they are intentionally lightweight.
+PHASE_REQUIRED_EVIDENCE: dict[str, tuple[str, ...]] = {
+    "coding": ("files_modified",),
+    "testing": ("tests_run", "tests_passed"),
+    "reviewing": ("decisions",),
+    "shipping": ("commands_executed",),
+}
+
+
+def required_evidence_for_phase(phase: str) -> tuple[str, ...]:
+    """Return the accepted evidence fields for ``phase`` (empty if none required)."""
+    return PHASE_REQUIRED_EVIDENCE.get(normalize_phase(phase), ())
+
+
+type AgentResultBlob = dict[str, object]
+
+
+def check_evidence(result: AgentResultBlob, phase: str) -> str:
+    """Return an error message if *result* lacks required evidence, else ``""``.
+
+    A field is "present" iff the result has the key AND its value is
+    truthy (non-zero int, non-empty list/dict/string). Supplying ANY of the
+    acceptable fields for ``phase`` satisfies the check — the requirement
+    is "one of these, non-empty", not "all of these".
+
+    Sub-agent contracts that opt out of normal completion (``needs_user_input``
+    handoffs) bypass the check: the agent is *not* claiming the phase is
+    done, so demanding phase evidence would be incoherent.
+    """
+    if result.get("needs_user_input"):
+        return ""
+    accepted = required_evidence_for_phase(phase)
+    if not accepted:
+        return ""
+    if any(result.get(field) for field in accepted):
+        return ""
+    joined = " | ".join(accepted)
+    return (
+        f"missing required evidence for phase '{phase}': result must include one of [{joined}] "
+        f"with a non-empty value (codex #1282-6)"
+    )

--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -223,6 +223,18 @@ class Task(models.Model):
                 ticket.review()
                 ticket.save()
             elif phase == "shipping" and ticket.state == Ticket.State.REVIEWED:
+                # #1284 (codex #1282-2): the task-based completion path must
+                # enforce the same visited-phases gate the ``pr create`` path
+                # runs through ``_check_shipping_gate`` — otherwise a REVIEWED
+                # ticket with missing testing/reviewing attestations advances
+                # to SHIPPED through the task path, bypassing the gate. The
+                # single source of truth is ``Session.visited_phases`` union
+                # across the ticket (#694); ``check_gate_across_ticket``
+                # raises ``QualityGateError`` when phases are missing, which
+                # propagates out of ``_apply_phase_transition`` so the caller
+                # surfaces the structured failure rather than silently
+                # advancing the FSM.
+                self.session.check_gate_across_ticket("shipping")
                 ticket.ship()
                 ticket.save()
             else:

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -48,7 +48,17 @@ class TestRunHeadless(TestCase):
         cls.ticket = Ticket.objects.create()
 
     def test_captures_structured_result(self) -> None:
-        result_json = json.dumps({"summary": "Done", "tests_passed": 5, "tests_failed": 0})
+        # #1284: ``coding`` phase requires ``files_modified`` evidence — the
+        # agent's claim that it shipped code must back the claim with an
+        # actual file change record.
+        result_json = json.dumps(
+            {
+                "summary": "Done",
+                "files_modified": [{"path": "src/x.py", "action": "modified"}],
+                "tests_passed": 5,
+                "tests_failed": 0,
+            },
+        )
         with _fake_claude(stdout=f"Progress...\n{result_json}\n"):
             session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
             task = Task.objects.create(ticket=self.ticket, session=session)
@@ -85,7 +95,29 @@ class TestRunHeadless(TestCase):
         assert "not installed" in attempt.error
         assert task.status == Task.Status.FAILED
 
-    def test_fails_when_no_json_in_successful_exit(self) -> None:
+    def test_summary_fallback_on_no_json_for_phase_without_evidence_requirement(self) -> None:
+        # #1284: when the agent emits no JSON, the fallback ``summary``
+        # capture path still completes the task IF the phase has no
+        # evidence requirement (``scoping``/``retro``). The "coding" case
+        # — where evidence IS required — is covered by
+        # ``test_no_json_fails_phase_with_evidence_requirement``.
+        with _fake_claude(stdout="no structured output\n"):
+            session = Session.objects.create(ticket=self.ticket)
+            task = Task.objects.create(ticket=self.ticket, session=session)
+
+            attempt = run_headless(task, phase="scoping", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        assert attempt.exit_code == 0
+        assert "no structured output" in attempt.result["summary"]
+        assert task.status == Task.Status.COMPLETED
+
+    def test_no_json_fails_phase_with_evidence_requirement(self) -> None:
+        # #1284 (codex #1282-6): the no-JSON fallback produces only a
+        # ``summary`` blob. On a phase that requires concrete evidence
+        # (``coding`` → ``files_modified``), that summary is not enough —
+        # the attempt must be recorded as failed so the agent retries
+        # with real evidence rather than silently advancing the FSM.
         with _fake_claude(stdout="no structured output\n"):
             session = Session.objects.create(ticket=self.ticket)
             task = Task.objects.create(ticket=self.ticket, session=session)
@@ -94,8 +126,8 @@ class TestRunHeadless(TestCase):
 
         task.refresh_from_db()
         assert attempt.exit_code == 0
-        assert "no structured output" in attempt.result["summary"]
-        assert task.status == Task.Status.COMPLETED
+        assert "files_modified" in attempt.error
+        assert task.status == Task.Status.FAILED
 
     def test_fails_when_result_violates_schema(self) -> None:
         bad_json = json.dumps({"summary": "OK", "rogue_field": True})
@@ -143,7 +175,12 @@ class TestRunHeadless(TestCase):
 
     def test_parses_cli_envelope_with_session_id(self) -> None:
         """When the CLI returns a JSON envelope, session_id is extracted and stored."""
-        result_json = json.dumps({"summary": "Work done"})
+        result_json = json.dumps(
+            {
+                "summary": "Work done",
+                "files_modified": [{"path": "src/x.py", "action": "modified"}],
+            },
+        )
         cli_envelope = json.dumps({"session_id": "sess-abc-123", "result": result_json})
 
         with _fake_claude(stdout=cli_envelope):
@@ -662,7 +699,12 @@ class TestRunHeadlessRefusesOverBudgetTicket(TestCase):
         spent = Task.objects.create(ticket=self.ticket, session=self.session)
         TaskAttempt.objects.create(task=spent, cost_usd=1.0)
         task = Task.objects.create(ticket=self.ticket, session=self.session)
-        result_json = json.dumps({"summary": "Done"})
+        result_json = json.dumps(
+            {
+                "summary": "Done",
+                "files_modified": [{"path": "src/x.py", "action": "modified"}],
+            },
+        )
 
         with override_settings(TEATREE_TICKET_BUDGET={"max_cost_usd": 5.0}), _fake_claude(stdout=f"{result_json}\n"):
             attempt = run_headless(task, phase="coding", overlay_skill_metadata={})

--- a/tests/teatree_agents/test_headless_evidence_required.py
+++ b/tests/teatree_agents/test_headless_evidence_required.py
@@ -1,0 +1,91 @@
+"""Regression tests for the sub-agent return-contract evidence requirement (#1284).
+
+Codex finding #1282-6 (medium): ``_record_success`` validates the result blob
+only for ``additionalProperties: false``; nothing forces a phase-specific
+evidence field. The headless agent can return ``{}`` (or a one-line summary)
+and the task still records the phase visit + completes — the "DM sent
+successfully but didn't deliver" false-positive class.
+
+The fix is to refuse the success record when the result lacks the
+phase-specific required evidence field(s), surface a structured error on the
+attempt, and fail the task (it stays available for the agent to retry with
+evidence). No phase visit is recorded on a no-evidence success.
+"""
+
+import contextlib
+import json
+import shlex
+from collections.abc import Iterator
+from unittest.mock import patch
+
+from django.test import TestCase
+
+import teatree.agents.headless as headless_mod
+from teatree.agents.headless import run_headless
+from teatree.core.models import Session, Task, Ticket
+
+
+@contextlib.contextmanager
+def _fake_claude(stdout: str = "", stderr: str = "", exit_code: int = 0) -> Iterator[None]:
+    script = f"printf %s {shlex.quote(stdout)}; printf %s {shlex.quote(stderr)} >&2; exit {exit_code}"
+    with (
+        patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
+        patch.object(headless_mod, "_build_headless_command", return_value=["sh", "-c", script]),
+    ):
+        yield
+
+
+class TestEvidenceRequiredOnPhaseCompletion(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.ticket = Ticket.objects.create()
+
+    def test_coding_phase_refuses_success_with_no_files_modified(self) -> None:
+        # Pre-fix: agent returns a one-line summary, task completes, phase
+        # is recorded — even though the "coding" claim has no file evidence.
+        # Post-fix: missing ``files_modified`` is rejected with a structured
+        # error; the task does NOT complete and the phase is NOT recorded.
+        bare_summary = json.dumps({"summary": "Done"})
+        session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
+        task = Task.objects.create(ticket=self.ticket, session=session, phase="coding")
+
+        with _fake_claude(stdout=f"{bare_summary}\n"):
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        session.refresh_from_db()
+        assert attempt.exit_code != 0 or attempt.error, (
+            f"a no-evidence coding result must fail the attempt; "
+            f"got exit_code={attempt.exit_code} error={attempt.error!r}"
+        )
+        assert "files_modified" in attempt.error or "evidence" in attempt.error.lower(), (
+            f"the attempt error must name the missing evidence field, got: {attempt.error!r}"
+        )
+        assert task.status == Task.Status.FAILED, (
+            f"a no-evidence success must NOT complete the task; got status={task.status}"
+        )
+        assert "coding" not in (session.visited_phases or []), (
+            f"phase must NOT be recorded on a no-evidence success; visited={session.visited_phases}"
+        )
+
+    def test_coding_phase_accepts_success_with_files_modified(self) -> None:
+        # Sanity: the happy path keeps working when the agent supplies the
+        # required evidence field.
+        good = json.dumps(
+            {
+                "summary": "Implemented X",
+                "files_modified": [{"path": "src/x.py", "action": "modified"}],
+            },
+        )
+        session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
+        task = Task.objects.create(ticket=self.ticket, session=session, phase="coding")
+
+        with _fake_claude(stdout=f"{good}\n"):
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        session.refresh_from_db()
+        assert attempt.exit_code == 0
+        assert not attempt.error
+        assert task.status == Task.Status.COMPLETED
+        assert "coding" in (session.visited_phases or [])

--- a/tests/teatree_core/models/test_phase_dispatch.py
+++ b/tests/teatree_core/models/test_phase_dispatch.py
@@ -140,9 +140,22 @@ class TestPhaseAutoDispatch(TestCase):
         assert "auto mode" in task.execution_reason
 
     def test_shipping_task_completion_advances_to_shipped(self) -> None:
+        # #1284 (codex #1282-2): the task-based shipping path now enforces
+        # ``Session.check_gate_across_ticket("shipping")`` so a happy-path
+        # advance must have ``testing`` and ``reviewing`` recorded. Pre-fix
+        # this test passed even without ``testing`` recorded — exactly the
+        # gate-bypass codex flagged. The fix here is to record the testing
+        # phase visit through the same task path the loop uses, mirroring
+        # the real lifecycle.
         ticket = Ticket.objects.create()
         _attach_shippable_worktree(ticket, self._tmp_path)
         _advance_ticket_to_tested(ticket)
+        # _advance_ticket_to_tested fires the FSM directly (raw test()) so the
+        # testing phase visit is not recorded by the helper. Record it now,
+        # symmetrically with how the loop would have done it when the testing
+        # task completed.
+        testing_session = Session.objects.create(ticket=ticket, agent_id="testing")
+        testing_session.visit_phase("testing", agent_id="testing")
         _complete_phase_task(ticket, "reviewing")
         # reviewing completion → REVIEWED + shipping task (interactive by default)
 

--- a/tests/teatree_core/models/test_ticket.py
+++ b/tests/teatree_core/models/test_ticket.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 from django.test import TestCase
 
-from teatree.core.models import Task, TaskAttempt, Ticket, Worktree
+from teatree.core.models import Session, Task, TaskAttempt, Ticket, Worktree
 from tests.teatree_core.models._shared import (
     _advance_ticket_to_tested,
     _attach_shippable_worktree,
@@ -124,6 +124,14 @@ class TestTicketTransitions(TestCase):
         _attach_shippable_worktree(ticket, self._tmp_path)
 
         _advance_ticket_to_tested(ticket)
+
+        # #1284: ``_advance_ticket_to_tested`` fires ``test()`` directly on
+        # the FSM so the testing phase visit is not recorded. Record it
+        # symmetrically with how the loop would have done it on the testing
+        # task's completion — the shipping gate now enforces the visited
+        # phases the ``pr create`` path always required.
+        testing_session = Session.objects.create(ticket=ticket, agent_id="testing")
+        testing_session.visit_phase("testing", agent_id="testing")
 
         # test() auto-scheduled a reviewing task — complete it to unlock review()
         _complete_phase_task(ticket, "reviewing")

--- a/tests/teatree_core/test_managers.py
+++ b/tests/teatree_core/test_managers.py
@@ -635,8 +635,16 @@ class TestReplayOrphanedTransitions(TestCase):
         # The shipping→ship branch: only fires from REVIEWED (the earned
         # state). A REVIEWED ticket whose completed shipping task's
         # ship() was lost to a crash is recovered to SHIPPED.
+        #
+        # #1284 (codex #1282-2): the replay sweep goes through the same
+        # ``_apply_phase_transition`` path the live ``complete()`` chain
+        # uses, so the visited-phases gate applies here too. Record
+        # ``testing``/``reviewing`` to satisfy the gate — a ticket that
+        # legitimately reached REVIEWED would have those attested.
         ticket = Ticket.objects.create(state=Ticket.State.REVIEWED)
         session = Session.objects.create(ticket=ticket, agent_id="a")
+        session.visit_phase("testing", agent_id="a")
+        session.visit_phase("reviewing", agent_id="a")
         Task.objects.create(ticket=ticket, session=session, phase="shipping", status=Task.Status.COMPLETED)
 
         replayed = Task.objects.replay_orphaned_transitions()

--- a/tests/teatree_core/test_signals.py
+++ b/tests/teatree_core/test_signals.py
@@ -24,6 +24,7 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
 
     @override_settings(**IMMEDIATE_BACKEND)
     def test_headless_task_auto_executes_on_creation(self) -> None:
+        import json as _json  # noqa: PLC0415
         import shlex  # noqa: PLC0415
 
         import teatree.agents.headless as headless_mod  # noqa: PLC0415
@@ -31,12 +32,19 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
         ticket = Ticket.objects.create(overlay="test")
         session = Session.objects.create(ticket=ticket, overlay="test")
 
+        # #1284: ``coding`` phase requires ``files_modified`` evidence.
+        result_blob = _json.dumps(
+            {
+                "summary": "OK",
+                "files_modified": [{"path": "src/x.py", "action": "modified"}],
+            },
+        )
         with (
             patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
             patch.object(
                 headless_mod,
                 "_build_headless_command",
-                return_value=["sh", "-c", f"printf %s {shlex.quote('{"summary": "OK"}')}"],
+                return_value=["sh", "-c", f"printf %s {shlex.quote(result_blob)}"],
             ),
             patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
         ):
@@ -107,6 +115,7 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
     @override_settings(**IMMEDIATE_BACKEND)
     def test_route_to_headless_triggers_enqueue(self) -> None:
         """Re-routing an interactive task to headless triggers auto-enqueue."""
+        import json as _json  # noqa: PLC0415
         import shlex  # noqa: PLC0415
 
         import teatree.agents.headless as headless_mod  # noqa: PLC0415
@@ -122,12 +131,19 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
         )
         assert task.status == Task.Status.PENDING
 
+        # #1284: ``coding`` phase requires ``files_modified`` evidence.
+        result_blob = _json.dumps(
+            {
+                "summary": "OK",
+                "files_modified": [{"path": "src/x.py", "action": "modified"}],
+            },
+        )
         with (
             patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
             patch.object(
                 headless_mod,
                 "_build_headless_command",
-                return_value=["sh", "-c", f"printf %s {shlex.quote('{"summary": "OK"}')}"],
+                return_value=["sh", "-c", f"printf %s {shlex.quote(result_blob)}"],
             ),
             patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
         ):

--- a/tests/teatree_core/test_task_shipping_gate.py
+++ b/tests/teatree_core/test_task_shipping_gate.py
@@ -1,0 +1,79 @@
+"""Regression tests for shipping-gate enforcement on task-based completion (#1284).
+
+Codex finding #1282-2 (catastrophic): ``Task._apply_phase_transition`` calls
+``ticket.ship()`` directly on the REVIEWED-state branch without running
+``Session.check_gate_across_ticket("shipping")`` first. A REVIEWED ticket whose
+sessions never recorded ``testing`` and ``reviewing`` therefore advances to
+SHIPPED through the task path, even though the same ticket would be blocked
+on the ``pr create`` path.
+
+The fix is to gate the task-based path through the *same* check
+``_check_shipping_gate`` uses (``Session.check_gate_across_ticket``), so the
+two completion paths cannot disagree on what "earns" a SHIPPED state.
+"""
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.models import Session, Task, Ticket
+from teatree.core.models.errors import QualityGateError
+
+
+class TestShippingTaskHonorsVisitedPhasesGate(TestCase):
+    """A shipping task on a REVIEWED ticket with empty visited_phases must NOT advance."""
+
+    def test_complete_shipping_task_without_phase_attestations_raises_gate_error(self) -> None:
+        # Reviewed ticket with NO recorded testing/reviewing phase visits —
+        # the FSM walked here via direct transition (bypassing the loop)
+        # but the gate's source of truth (Session.visited_phases) is empty.
+        ticket = Ticket.objects.create(
+            overlay="test",
+            state=Ticket.State.REVIEWED,
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        # No visit_phase() calls — visited_phases is []
+        assert session.visited_phases == []
+
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="shipping",
+            status=Task.Status.COMPLETED,
+        )
+
+        # Pre-fix: task._apply_phase_transition() silently calls ticket.ship()
+        # and the ticket advances to SHIPPED.  Post-fix: the same gate the
+        # ``pr create`` path enforces (check_gate_across_ticket) raises
+        # QualityGateError because ``testing`` and ``reviewing`` are missing.
+        with pytest.raises(QualityGateError, match=r"testing|reviewing"):
+            task._apply_phase_transition()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED, (
+            f"ticket must stay REVIEWED when shipping gate fails, got {ticket.state}"
+        )
+
+    def test_complete_shipping_task_with_attestations_still_ships(self) -> None:
+        # Sanity: happy path must keep working. A REVIEWED ticket whose
+        # session DID record testing+reviewing must still advance to SHIPPED.
+        ticket = Ticket.objects.create(
+            overlay="test",
+            state=Ticket.State.REVIEWED,
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        session.visit_phase("testing", agent_id="t")
+        session.visit_phase("reviewing", agent_id="t")
+        session.refresh_from_db()
+
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="shipping",
+            status=Task.Status.COMPLETED,
+        )
+
+        fired = task._apply_phase_transition()
+
+        ticket.refresh_from_db()
+        assert fired is True
+        assert ticket.state == Ticket.State.SHIPPED


### PR DESCRIPTION
fix(lifecycle): enforce shipping gate on task path + require evidence on phase completion (#1284)

Closes two codex #1282 findings against the task-based completion flow:

**#1282 item 2 (catastrophic) — Shipping-task completion bypassed the gate.**
``Task._apply_phase_transition`` called ``ticket.ship()`` directly on the
``REVIEWED`` branch with no ``check_gate_across_ticket`` check, so a REVIEWED
ticket whose sessions never recorded ``testing``/``reviewing`` advanced to
SHIPPED through the task path even though ``pr create`` would have blocked
the same ticket. The two completion paths could disagree on what earns a
SHIPPED state.

Fix: run ``self.session.check_gate_across_ticket("shipping")`` on the
shipping branch, mirroring ``_check_shipping_gate``'s call site in
``pr.py``. ``QualityGateError`` propagates out of
``_apply_phase_transition`` so the caller surfaces the structured failure
instead of silently advancing.

**#1282 item 6 (medium) — Sub-agent return had no required evidence.**
``_record_success`` checked ``additionalProperties: false`` only; the schema
named no required field. An agent returning ``{"summary": "Done"}`` advanced
the FSM with no proof — the "DM sent successfully but didn't deliver"
false-positive shape.

Fix: ``PHASE_REQUIRED_EVIDENCE`` (one accepted evidence field set per phase:
``coding`` → ``files_modified``, ``testing`` → ``tests_run|tests_passed``,
``reviewing`` → ``decisions``, ``shipping`` → ``commands_executed``).
``check_evidence`` in ``result_schema.py`` is consulted by
``_record_success`` after schema validation; a missing/empty evidence field
records a failed attempt with a structured ``EvidenceMissing`` error string
(via the existing ``_record_failure`` path) and the task stays FAILED so the
loop can retry. ``needs_user_input`` handoffs bypass the check — the agent
is not claiming the phase is done.

**TDD discipline:** both new test suites verified anti-vacuous by reverting
each fix independently and confirming RED, then restoring and confirming
GREEN. Existing tests that exercised the lifecycle without recording
``testing``/``reviewing`` visits (the gate-bypass cases the new test guards
against) were updated to record those visits — the previous green came
from the bug itself.

Tests touched (existing): test_phase_dispatch, test_ticket, test_managers,
test_signals, test_headless. New: test_task_shipping_gate (2 tests),
test_headless_evidence_required (2 tests).