### PR TITLE
fix(scanners): emit scanner-error signal on auth/rate-limit/missing-scope (#1287)

### DIFF
--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -52,9 +52,29 @@ from teatree.backends.slack_token_validation import (
     assert_bot_token,
     assert_user_token,
 )
-from teatree.types import RawAPIDict
+from teatree.types import RawAPIDict, ScannerError, ScannerErrorClass
 
 __all__ = ["SlackBotBackend", "SlackOp", "TokenSlotMismatchError"]
+
+
+# Slack ``ok:false`` error codes that indicate the bot/user TOKEN is
+# globally broken (auth, missing scope, rate limit, deactivated). For
+# these the scanner must raise — silent fall-through to ``[]`` masks the
+# entire workspace integration (#1287). Channel-scoped failures
+# (``channel_not_found``, ``not_in_channel``, ``is_archived``) are NOT in
+# this set: those legitimately degrade to "one channel unreachable" and
+# keep the rest of the scan running.
+_GLOBAL_TOKEN_FAILURES: dict[str, ScannerErrorClass] = {
+    "invalid_auth": ScannerErrorClass.AUTH,
+    "not_authed": ScannerErrorClass.AUTH,
+    "token_expired": ScannerErrorClass.AUTH,
+    "token_revoked": ScannerErrorClass.AUTH,
+    "account_inactive": ScannerErrorClass.AUTH,
+    "missing_scope": ScannerErrorClass.MISSING_SCOPE,
+    "no_permission": ScannerErrorClass.MISSING_SCOPE,
+    "ratelimited": ScannerErrorClass.RATE_LIMIT,
+    "rate_limited": ScannerErrorClass.RATE_LIMIT,
+}
 
 type SlackPayload = dict[str, object]
 
@@ -408,6 +428,19 @@ class SlackBotBackend:
             token=token,
         )
         if not data.get("ok"):
+            error_code = str(data.get("error", ""))
+            # Global token failures (auth / missing scope / rate limit /
+            # deactivated) suppress every Slack scan — raise so the
+            # dispatcher records the error and DMs the user (#1287).
+            # Channel-scoped failures (``channel_not_found``,
+            # ``not_in_channel``, ``is_archived``) stay quiet per the
+            # #1255 "one slow channel never breaks the scan loop" design.
+            if error_code in _GLOBAL_TOKEN_FAILURES:
+                raise ScannerError(
+                    scanner="slack_broadcasts",
+                    error_class=_GLOBAL_TOKEN_FAILURES[error_code],
+                    detail=f"conversations.history on {channel}: {error_code}",
+                )
             return []
         messages = data.get("messages")
         if not isinstance(messages, list):

--- a/src/teatree/loop/scanners/base.py
+++ b/src/teatree/loop/scanners/base.py
@@ -8,6 +8,16 @@ note, webhook trigger) or hand off to a phase agent.
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
+from teatree.types import ScannerError, ScannerErrorClass
+
+__all__ = [
+    "ScanSignal",
+    "Scanner",
+    "ScannerError",
+    "ScannerErrorClass",
+    "SignalPayload",
+]
+
 type SignalPayload = dict[str, Any]
 
 

--- a/src/teatree/loop/scanners/gitlab_approvals.py
+++ b/src/teatree/loop/scanners/gitlab_approvals.py
@@ -31,9 +31,11 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 from urllib.parse import urlparse
 
+import httpx
+
 import teatree.core.overlay_loader as _overlay_loader
 from teatree.backends.protocols import ApprovalState, CodeHostBackend
-from teatree.loop.scanners.base import ScanSignal, SignalPayload
+from teatree.loop.scanners.base import ScannerError, ScannerErrorClass, ScanSignal, SignalPayload
 from teatree.types import RawAPIDict
 
 if TYPE_CHECKING:
@@ -133,16 +135,36 @@ class GitLabApprovalsScanner:
         return signal
 
     def _fetch_approvals(self, repo_slug: str, iid: int) -> ApprovalState | None:
-        """Fetch approvals; return ``None`` on backend skip or transient error.
+        """Fetch approvals; return ``None`` on backend skip, raise on auth failure.
 
-        Splitting this off keeps :py:meth:`_scan_one` readable and the
-        two error paths (NotImplementedError → GitHub silent skip,
-        anything else → logged exception) explicit.
+        Three outcomes. ``NotImplementedError`` becomes ``None`` (GitHub
+        stubs ``get_mr_approvals``; the URL filter usually drops these
+        before the call, this is the belt-and-braces case). An
+        ``httpx.HTTPStatusError`` or any other ``httpx.HTTPError`` is
+        translated into ``ScannerError`` so the dispatcher records the
+        error and DMs the user (#1287) — the previous ``return None``
+        silently converted a 401 into "not approved yet". Anything else
+        is logged and returned as ``None`` so a transient defect on one
+        MR does not break the scan for the others.
         """
         try:
             return self.host.get_mr_approvals(repo=repo_slug, pr_iid=iid)
         except NotImplementedError:
             return None
+        except ScannerError:
+            raise
+        except httpx.HTTPStatusError as exc:
+            raise ScannerError(
+                scanner="gitlab_approvals",
+                error_class=_classify_http_status(exc.response.status_code),
+                detail=f"GitLab {repo_slug} !{iid}: HTTP {exc.response.status_code}",
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise ScannerError(
+                scanner="gitlab_approvals",
+                error_class=ScannerErrorClass.NETWORK,
+                detail=f"GitLab {repo_slug} !{iid}: {type(exc).__name__}",
+            ) from exc
         except Exception:
             logger.exception("GitLabApprovalsScanner: get_mr_approvals failed for %s !%d", repo_slug, iid)
             return None
@@ -199,6 +221,28 @@ def _signal_for(
         summary=f"merge blocked on {target_ref or url}: {guard.reason}",
         payload={**base_payload, "reason": guard.reason},
     )
+
+
+_HTTP_UNAUTHORIZED = 401
+_HTTP_FORBIDDEN = 403
+_HTTP_TOO_MANY_REQUESTS = 429
+
+
+def _classify_http_status(status_code: int) -> ScannerErrorClass:
+    """Classify an upstream HTTP error code into a :class:`ScannerErrorClass` (#1287).
+
+    GitLab returns 401 for missing / expired tokens, 403 for
+    insufficient scope, and 429 for rate limit. Everything else falls
+    through to :attr:`ScannerErrorClass.UNKNOWN` so the dispatcher still
+    surfaces the failure to the user.
+    """
+    if status_code == _HTTP_UNAUTHORIZED:
+        return ScannerErrorClass.AUTH
+    if status_code == _HTTP_FORBIDDEN:
+        return ScannerErrorClass.MISSING_SCOPE
+    if status_code == _HTTP_TOO_MANY_REQUESTS:
+        return ScannerErrorClass.RATE_LIMIT
+    return ScannerErrorClass.UNKNOWN
 
 
 def _str_field(data: RawAPIDict, *names: str) -> str:

--- a/src/teatree/loop/scanners/pr_sweep.py
+++ b/src/teatree/loop/scanners/pr_sweep.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass, field
 from typing import Protocol, TypedDict, cast, runtime_checkable
 
 from teatree.core.models.merge_clear import MergeClear
-from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.base import ScannerError, ScannerErrorClass, ScanSignal
 from teatree.utils.run import run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 GREEN_TERMINAL_CONCLUSIONS = frozenset({"SUCCESS", "NEUTRAL", "SKIPPED"})
 REQUIRED_CHECK_NAME = "test (3.13)"
 UV_AUDIT_CHECK_NAME = "uv-audit"
+_GH_NOT_INSTALLED_RC = 127
 
 
 class GhPrJson(TypedDict, total=False):
@@ -192,6 +193,11 @@ class PrSweepScanner:
     def _safe_list(self, slug: str) -> list[PrSummary]:
         try:
             return self.api.list_open_prs(slug=slug)
+        except ScannerError:
+            # Auth / rate-limit / missing-scope: propagate to the dispatcher
+            # so this scanner is recorded in ``report.errors`` and skipped for
+            # one tick (#1287). Silently swallowing would mask the failure.
+            raise
         except Exception:
             logger.exception("pr_sweep failed to list PRs for %s", slug)
             return []
@@ -338,6 +344,30 @@ def _as_str(value: object) -> str:
     return value if isinstance(value, str) else ""
 
 
+def _classify_gh_stderr(stderr: str) -> ScannerErrorClass:
+    """Classify a non-zero ``gh`` stderr into a :class:`ScannerErrorClass` (#1287).
+
+    The classifier reads gh's well-known error wording: auth-required
+    prompts (``gh auth login``, ``GH_TOKEN``, ``Bad credentials``, ``401``),
+    GitHub rate-limit messages (``API rate limit exceeded``, ``rate
+    limit``, ``secondary rate limit``), and network failures (``dial
+    tcp``, ``no such host``, ``Could not resolve``). Anything else falls
+    through to :attr:`ScannerErrorClass.UNKNOWN` so the dispatcher still
+    surfaces the failure rather than masking it.
+    """
+    lower = stderr.lower()
+    rate_limit_markers = ("rate limit", "rate-limit", "secondary rate")
+    auth_markers = ("gh auth login", "gh_token", "bad credentials", "401")
+    network_markers = ("no such host", "could not resolve", "dial tcp", "network is unreachable")
+    if any(marker in lower for marker in rate_limit_markers):
+        return ScannerErrorClass.RATE_LIMIT
+    if any(marker in lower for marker in auth_markers):
+        return ScannerErrorClass.AUTH
+    if any(marker in lower for marker in network_markers):
+        return ScannerErrorClass.NETWORK
+    return ScannerErrorClass.UNKNOWN
+
+
 def _signal_from_attempt(attempt: MergeAttempt, *, overlay: str) -> ScanSignal:
     return ScanSignal(
         kind="pr_sweep.merged" if attempt.merged else f"pr_sweep.{attempt.decision}",
@@ -376,8 +406,22 @@ class GhPrApiClient:
             "--json",
             "number,headRefOid,isDraft,url,title,reviews,statusCheckRollup",
         ]
-        rc, out, _ = self._run_gh(argv)
-        if rc != 0 or not out.strip():
+        rc, out, err = self._run_gh(argv)
+        if rc == _GH_NOT_INSTALLED_RC:
+            # gh-not-installed is an environmental error, not an upstream
+            # auth/rate-limit issue — preserve the pre-existing "fall back
+            # to empty" behaviour so a machine without ``gh`` does not spam
+            # ScannerError per tick.
+            return []
+        if rc != 0:
+            error_class = _classify_gh_stderr(err)
+            detail = f"gh pr list {slug!r} rc={rc}: {err.strip()[:200]}"
+            raise ScannerError(
+                scanner="pr_sweep",
+                error_class=error_class,
+                detail=detail,
+            )
+        if not out.strip():
             return []
         try:
             data = json.loads(out)

--- a/src/teatree/loop/tick_jobs.py
+++ b/src/teatree/loop/tick_jobs.py
@@ -6,6 +6,7 @@ orchestrator under the module-health LOC gate; the orchestrator
 delegates to ``build_default_jobs`` and ``build_default_scanners``.
 """
 
+import datetime as _dt
 import logging
 import os
 import tomllib
@@ -49,9 +50,10 @@ from teatree.loop.scanners import (
     TicketCompletionScanner,
     TicketDispositionScanner,
 )
-from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.base import ScannerError, ScanSignal
 from teatree.loop.scanners.notion_view import NotionLike
 from teatree.loop.tick_resolvers import _allowed_url_prefixes_for_host, _identity_alias_groups_for_overlay
+from teatree.notify import NotifyKind, notify_user
 
 logger = logging.getLogger(__name__)
 
@@ -323,10 +325,46 @@ def _run_job(job: _ScannerJob) -> tuple[str, list[ScanSignal], str]:
                 )
                 for s in signals
             ]
+    except ScannerError as exc:
+        # Auth / rate-limit / missing-scope / network: surface as a
+        # structured error and DM the user once per day per
+        # ``(scanner, error_class)`` so a sustained failure does not
+        # spam the channel (#1287). The dispatcher continues with the
+        # other scanners — only THIS scanner is skipped for one tick.
+        logger.warning("Scanner %s recoverable error: %s", label, exc)
+        _notify_scanner_error(label=label, exc=exc, overlay=job.overlay)
+        return label, [], f"ScannerError[{exc.error_class.value}]: {exc.detail or exc}"
     except Exception as exc:
         logger.exception("Scanner %s raised", label)
         return label, [], f"{type(exc).__name__}: {exc}"
     return label, signals, ""
+
+
+def _notify_scanner_error(*, label: str, exc: ScannerError, overlay: str) -> None:
+    """DM the user that a scanner is degraded — once per day per class (#1287).
+
+    Idempotency key is ``scanner_error:<scanner>:<error_class>:<utc-date>``
+    so :func:`teatree.notify.notify_user`'s ``BotPing`` ledger dedups
+    repeat ticks of the same failure inside one UTC day. The next day
+    re-notifies — if the issue is still there, the user wants the
+    reminder; if it cleared, no DM goes out.
+
+    Best-effort: any failure inside the notify path is logged and
+    swallowed so a notify failure never reverberates into the tick.
+    """
+    today = _dt.datetime.now(_dt.UTC).date().isoformat()
+    key = f"scanner_error:{exc.scanner}:{exc.error_class.value}:{today}"
+    overlay_tag = f" [overlay={overlay}]" if overlay else ""
+    text = (
+        f":warning: scanner *{exc.scanner}* hit *{exc.error_class.value}*"
+        f"{overlay_tag} — this scanner is skipped for one tick."
+    )
+    if exc.detail:
+        text = f"{text}\n_{exc.detail}_"
+    try:
+        notify_user(text, kind=NotifyKind.INFO, idempotency_key=key)
+    except Exception:
+        logger.exception("Scanner-error notify_user failed for %s", label)
 
 
 def _user_slack_id_for_overlay(overlay_name: str) -> str:

--- a/src/teatree/types.py
+++ b/src/teatree/types.py
@@ -4,12 +4,65 @@ These types have no Django dependencies and no imports from ``teatree.core``,
 so they can be used by any layer without introducing cycles.
 """
 
+import enum
 import hashlib
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TypedDict
+
+
+class ScannerErrorClass(enum.StrEnum):
+    """Classes of recoverable scanner failure surfaced to the dispatcher (#1287).
+
+    Lives in :mod:`teatree.types` (no deps) so the messaging backend
+    layer can raise it without creating a ``teatree.backends →
+    teatree.loop`` import cycle. The :mod:`teatree.loop.scanners.base`
+    module re-exports it for callers that already import from the
+    scanner-protocol module.
+    """
+
+    AUTH = "auth"
+    RATE_LIMIT = "rate_limit"
+    MISSING_SCOPE = "missing_scope"
+    NETWORK = "network"
+    UNKNOWN = "unknown"
+
+
+class ScannerError(RuntimeError):
+    """A scanner failed with a recoverable upstream error (#1287).
+
+    Raised by a scanner (or by a backend method a scanner calls) when an
+    auth / rate-limit / missing-scope / network failure prevents it from
+    returning a meaningful signal list this tick. The dispatcher
+    (:func:`teatree.loop.tick_jobs._run_job`) catches it, records the
+    error on the tick report, DMs the user once per day per
+    ``(scanner, error_class)``, and skips THAT scanner for one tick —
+    the rest of the tick continues. The next tick re-tries the failing
+    scanner cleanly.
+
+    The empty-return convention is preserved for the case it was meant
+    for: genuinely empty data (no PRs, no approvals, no broadcasts).
+    The bug this exception class fixes is the conflation of the two
+    cases — previously a scanner that hit a 401 would return ``[]`` and
+    the dispatcher would read that as "nothing to do".
+    """
+
+    def __init__(
+        self,
+        *,
+        scanner: str,
+        error_class: ScannerErrorClass,
+        detail: str = "",
+    ) -> None:
+        self.scanner = scanner
+        self.error_class = error_class
+        self.detail = detail
+        message = f"{scanner}: {error_class.value}"
+        if detail:
+            message = f"{message} ({detail})"
+        super().__init__(message)
 
 
 @dataclass(frozen=True)

--- a/tests/teatree_loop/test_scanner_error_signals.py
+++ b/tests/teatree_loop/test_scanner_error_signals.py
@@ -1,0 +1,409 @@
+"""Scanner auth/rate-limit/missing-scope failures must raise, never fail-open (#1287).
+
+Codex review of #1282 flagged that the PR-sweep, GitLab-approvals, and Slack
+``fetch_channel_history`` paths all convert upstream failures into empty
+returns. The dispatcher reads empty as "nothing to do", so a forge auth
+failure silently suppresses all signals for that scanner.
+
+The fix shape: reserve empty for genuinely empty data; raise
+``ScannerError`` on auth / rate-limit / missing-scope / network failures
+so the dispatcher's existing ``_run_job`` catcher records the error,
+notifies the user, and continues with the other scanners for the tick.
+
+These tests are the RED guard for the three scanners cited in the codex
+finding plus a dispatcher-level test that proves ``ScannerError``
+propagates cleanly into ``report.errors`` without crashing the tick.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from django.test import TestCase
+
+from teatree.backends import slack_bot
+from teatree.backends.protocols import ApprovalState, ReviewState
+from teatree.backends.slack_bot import SlackBotBackend
+from teatree.loop.scanners.base import ScannerError, ScannerErrorClass, ScanSignal
+from teatree.loop.scanners.gitlab_approvals import GitLabApprovalsScanner
+from teatree.loop.scanners.pr_sweep import GhPrApiClient, NullMergeNotifier, PrSweepScanner
+from teatree.loop.tick import TickRequest, run_tick
+from teatree.types import RawAPIDict
+
+# ---------------------------------------------------------------------------
+# PR sweep — gh auth/rate-limit failures must propagate as ScannerError.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _FakeCompleted:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+class TestPrSweepGhApiClientAuthFailure:
+    """``GhPrApiClient.list_open_prs`` must raise on auth/rate-limit failure."""
+
+    def test_gh_auth_failure_raises_scanner_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _stub_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+            _ = (cmd, kwargs)
+            return _FakeCompleted(
+                returncode=1,
+                stdout="",
+                stderr=(
+                    "gh: To get started with GitHub CLI, please run:  gh auth login\n"
+                    "Alternatively, populate the GH_TOKEN environment variable with a "
+                    "GitHub API authentication token.\n"
+                ),
+            )
+
+        monkeypatch.setattr("teatree.loop.scanners.pr_sweep.run_allowed_to_fail", _stub_run)
+        api = GhPrApiClient(token="")
+        with pytest.raises(ScannerError) as excinfo:
+            api.list_open_prs(slug="owner/repo")
+        assert excinfo.value.error_class == ScannerErrorClass.AUTH
+
+    def test_gh_rate_limit_failure_raises_scanner_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _stub_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+            _ = (cmd, kwargs)
+            return _FakeCompleted(
+                returncode=1,
+                stdout="",
+                stderr="API rate limit exceeded for user ID 12345.",
+            )
+
+        monkeypatch.setattr("teatree.loop.scanners.pr_sweep.run_allowed_to_fail", _stub_run)
+        api = GhPrApiClient(token="x")
+        with pytest.raises(ScannerError) as excinfo:
+            api.list_open_prs(slug="owner/repo")
+        assert excinfo.value.error_class == ScannerErrorClass.RATE_LIMIT
+
+    def test_gh_not_installed_still_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``FileNotFoundError`` (gh not installed) keeps the pre-existing empty fallback.
+
+        It is an environmental error, not an upstream auth/rate-limit
+        failure — the dispatcher would only get noise from a tick-per-tick
+        ScannerError, so the empty-list path stays the right call.
+        """
+
+        def _stub_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+            _ = (cmd, kwargs)
+            msg = "gh"
+            raise FileNotFoundError(msg)
+
+        monkeypatch.setattr("teatree.loop.scanners.pr_sweep.run_allowed_to_fail", _stub_run)
+        api = GhPrApiClient(token="x")
+        assert api.list_open_prs(slug="owner/repo") == []
+
+    def test_gh_returns_genuinely_empty_list_no_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returncode 0 with ``[]`` JSON output is the "no PRs" case — empty, no error.
+
+        Reserve empty for genuinely empty data; raise only on upstream
+        failure (#1287).
+        """
+
+        def _stub_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+            _ = (cmd, kwargs)
+            return _FakeCompleted(returncode=0, stdout="[]", stderr="")
+
+        monkeypatch.setattr("teatree.loop.scanners.pr_sweep.run_allowed_to_fail", _stub_run)
+        api = GhPrApiClient(token="x")
+        assert api.list_open_prs(slug="owner/repo") == []
+
+
+class TestPrSweepScannerPropagatesError:
+    """``PrSweepScanner._safe_list`` must propagate ``ScannerError`` to the dispatcher."""
+
+    def test_scanner_propagates_scanner_error_from_api(self) -> None:
+        class _AuthFailingApi:
+            def list_open_prs(self, *, slug: str) -> list[Any]:
+                _ = slug
+                raise ScannerError(
+                    scanner="pr_sweep",
+                    error_class=ScannerErrorClass.AUTH,
+                    detail="gh auth login required",
+                )
+
+            def main_check_failed(self, *, slug: str, check_name: str) -> bool:
+                _ = (slug, check_name)
+                return False
+
+            def merge_pr_squash(self, *, slug: str, pr_id: int) -> tuple[bool, str]:
+                _ = (slug, pr_id)
+                return False, ""
+
+        class _NullKeystone:
+            def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str]:
+                _ = clear_id
+                return False, "", ""
+
+        scanner = PrSweepScanner(
+            repos=("owner/repo",),
+            api=_AuthFailingApi(),
+            keystone=_NullKeystone(),
+            notifier=NullMergeNotifier(),
+            overlay="t",
+        )
+        with pytest.raises(ScannerError) as excinfo:
+            scanner.scan()
+        assert excinfo.value.error_class == ScannerErrorClass.AUTH
+
+
+# ---------------------------------------------------------------------------
+# GitLab approvals — HTTP 401 (or any non-NotImplementedError exception) must
+# propagate as ScannerError.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _AuthFailingCodeHost:
+    """In-memory ``CodeHostBackend`` whose ``get_mr_approvals`` raises an auth error."""
+
+    user: str = "alice"
+    prs: list[RawAPIDict] = field(default_factory=list)
+    approval_call_count: int = 0
+
+    def current_user(self) -> str:
+        return self.user
+
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
+        return self.prs
+
+    def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (reviewer, updated_after)
+        return []
+
+    def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:
+        _ = assignee
+        return []
+
+    def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState:
+        _ = (pr_url, reviewer)
+        return ReviewState.NONE
+
+    def create_pr(self, spec: Any) -> RawAPIDict:
+        _ = spec
+        return {}
+
+    def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict:
+        _ = (repo, pr_iid, body)
+        return {}
+
+    def update_pr_comment(self, *, repo: str, pr_iid: int, comment_id: int, body: str) -> RawAPIDict:
+        _ = (repo, pr_iid, comment_id, body)
+        return {}
+
+    def list_pr_comments(self, *, repo: str, pr_iid: int) -> list[RawAPIDict]:
+        _ = (repo, pr_iid)
+        return []
+
+    def upload_file(self, *, repo: str, filepath: str) -> RawAPIDict:
+        _ = (repo, filepath)
+        return {}
+
+    def get_issue(self, issue_url: str) -> RawAPIDict:
+        _ = issue_url
+        return {}
+
+    def post_issue_comment(self, *, issue_url: str, body: str) -> RawAPIDict:
+        _ = (issue_url, body)
+        return {}
+
+    def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState:
+        _ = (repo, pr_iid)
+        self.approval_call_count += 1
+        # Simulate a GitLab 401 surfacing as an httpx HTTPStatusError.
+        request = httpx.Request("GET", "https://gitlab.com/api/v4/projects/.../approvals")
+        response = httpx.Response(401, request=request, json={"message": "401 Unauthorized"})
+        msg = "401 Unauthorized"
+        raise httpx.HTTPStatusError(msg, request=request, response=response)
+
+
+def _gitlab_mr(*, iid: int = 42, sha: str = "deadbeef", project: str = "acme/backend") -> RawAPIDict:
+    return {
+        "iid": iid,
+        "title": "Add widget",
+        "web_url": f"https://gitlab.com/{project}/-/merge_requests/{iid}",
+        "sha": sha,
+        "target_branch": "main",
+        "state": "opened",
+    }
+
+
+class TestGitLabApprovalsScannerAuthFailure(TestCase):
+    """``GitLabApprovalsScanner`` must raise ``ScannerError`` on a GitLab 401."""
+
+    def test_gitlab_401_raises_scanner_error(self) -> None:
+        host = _AuthFailingCodeHost(prs=[_gitlab_mr(iid=42, sha="abc123")])
+        scanner = GitLabApprovalsScanner(host=host)
+
+        with pytest.raises(ScannerError) as excinfo:
+            scanner.scan()
+
+        assert excinfo.value.error_class == ScannerErrorClass.AUTH
+        # The scanner must have CALLED the backend — silent skip would also
+        # leave the call count at 0; this guards against a regression that
+        # short-circuits on the URL filter before reaching the backend.
+        assert host.approval_call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Slack ``fetch_channel_history`` — missing_scope / invalid_auth / ratelimited
+# must raise, not silently return [].
+# ---------------------------------------------------------------------------
+
+
+def _slack_response(payload: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(200, json=payload, request=httpx.Request("GET", "x"))
+
+
+class TestSlackFetchChannelHistoryAuthFailure:
+    def test_missing_scope_raises_scanner_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_get(url: str, **kwargs: object) -> httpx.Response:
+            _ = (url, kwargs)
+            return _slack_response({"ok": False, "error": "missing_scope"})
+
+        # _channel_token consults conversations.info via _post; stub it too.
+        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(
+            slack_bot.httpx,
+            "post",
+            lambda url, **kwargs: _slack_response({"ok": False, "error": "missing_scope"}),
+        )
+        backend = SlackBotBackend(bot_token="xoxb-test")
+
+        with pytest.raises(ScannerError) as excinfo:
+            backend.fetch_channel_history(channel="C42", limit=10)
+        assert excinfo.value.error_class == ScannerErrorClass.MISSING_SCOPE
+
+    def test_invalid_auth_raises_scanner_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            slack_bot.httpx,
+            "get",
+            lambda url, **kwargs: _slack_response({"ok": False, "error": "invalid_auth"}),
+        )
+        monkeypatch.setattr(
+            slack_bot.httpx,
+            "post",
+            lambda url, **kwargs: _slack_response({"ok": False, "error": "invalid_auth"}),
+        )
+        backend = SlackBotBackend(bot_token="xoxb-test")
+
+        with pytest.raises(ScannerError) as excinfo:
+            backend.fetch_channel_history(channel="C42", limit=10)
+        assert excinfo.value.error_class == ScannerErrorClass.AUTH
+
+    def test_rate_limited_raises_scanner_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            slack_bot.httpx,
+            "get",
+            lambda url, **kwargs: _slack_response({"ok": False, "error": "ratelimited"}),
+        )
+        monkeypatch.setattr(
+            slack_bot.httpx,
+            "post",
+            lambda url, **kwargs: _slack_response({"ok": False, "error": "ratelimited"}),
+        )
+        backend = SlackBotBackend(bot_token="xoxb-test")
+
+        with pytest.raises(ScannerError) as excinfo:
+            backend.fetch_channel_history(channel="C42", limit=10)
+        assert excinfo.value.error_class == ScannerErrorClass.RATE_LIMIT
+
+    def test_channel_not_found_still_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``channel_not_found`` stays empty-and-quiet — only token-global failures raise.
+
+        Preserves the explicit "one slow channel never breaks the scan
+        loop" carve-out from #1255. Only global token failures
+        (auth/scope/ratelimit) raise.
+        """
+        monkeypatch.setattr(
+            slack_bot.httpx,
+            "get",
+            lambda url, **kwargs: _slack_response({"ok": False, "error": "channel_not_found"}),
+        )
+        monkeypatch.setattr(
+            slack_bot.httpx,
+            "post",
+            lambda url, **kwargs: _slack_response({"ok": False, "error": "channel_not_found"}),
+        )
+        backend = SlackBotBackend(bot_token="xoxb-test")
+
+        assert backend.fetch_channel_history(channel="C42", limit=10) == []
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher — a raising scanner must NOT crash the tick. Other scanners still
+# run; the error appears in ``report.errors``; the user is DM'd once.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _GoodScanner:
+    name: str = "good"
+
+    def scan(self) -> list[ScanSignal]:
+        return [ScanSignal(kind="my_pr.open", summary="hi")]
+
+
+@dataclass(slots=True)
+class _AuthFailingScanner:
+    name: str = "auth_failing"
+
+    def scan(self) -> list[ScanSignal]:
+        raise ScannerError(
+            scanner=self.name,
+            error_class=ScannerErrorClass.AUTH,
+            detail="401 Unauthorized",
+        )
+
+
+class TestDispatcherHandlesScannerError:
+    def test_scanner_error_recorded_other_scanners_unaffected(self, tmp_path: Path) -> None:
+        good = _GoodScanner()
+        bad = _AuthFailingScanner()
+        statusline = tmp_path / "statusline.txt"
+
+        report = run_tick(
+            TickRequest(scanners=[good, bad]),
+            statusline_path=statusline,
+        )
+
+        # The good scanner's signal must be present.
+        assert report.signal_count == 1
+        # The bad scanner's error must be recorded — the dispatcher must NOT
+        # have crashed; the tick must complete.
+        assert any("auth_failing" in label for label in report.errors)
+        recorded = next(v for k, v in report.errors.items() if "auth_failing" in k)
+        assert "auth" in recorded.lower()
+
+    def test_scanner_error_notifies_user_once_per_class_per_day(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``_run_job`` DMs the user on a caught ``ScannerError``, idempotency-keyed.
+
+        Key shape is ``(scanner, error_class, UTC date)`` so a sustained
+        failure does not spam one DM per tick.
+        """
+        bad = _AuthFailingScanner()
+        statusline = tmp_path / "statusline.txt"
+
+        with patch("teatree.loop.tick_jobs.notify_user") as mock_notify:
+            run_tick(TickRequest(scanners=[bad]), statusline_path=statusline)
+            run_tick(TickRequest(scanners=[bad]), statusline_path=statusline)
+
+        # Both ticks called notify_user; idempotency happens INSIDE notify_user
+        # (via BotPing). The contract here is only that the dispatcher invokes
+        # the helper with a stable key per (scanner, class, day) — actual
+        # dedup is notify_user's job and already covered by its own tests.
+        assert mock_notify.call_count >= 1
+        first_call = mock_notify.call_args_list[0]
+        idempotency_key = first_call.kwargs.get("idempotency_key", "")
+        assert "auth_failing" in idempotency_key
+        assert "auth" in idempotency_key


### PR DESCRIPTION
fix(scanners): emit scanner-error signal on auth/rate-limit/missing-scope (#1287)

Codex review of #1282 surfaced that the PR-sweep, GitLab-approvals, and
Slack ``fetch_channel_history`` paths convert upstream failures into
empty returns. The dispatcher reads empty as "nothing to do", so a
forge auth failure silently suppresses all signals for that scanner
and the user has no way to know the loop is degraded.

Introduce ``ScannerError`` (in ``teatree.types`` so the messaging
backend can raise it without a teatree.backends → teatree.loop cycle),
re-exported from ``teatree.loop.scanners.base``. Reserve empty returns
for genuinely empty data; raise ``ScannerError`` on auth / rate-limit
/ missing-scope / network failures so the dispatcher's existing
``_run_job`` exception catcher records the error and continues with
the other scanners for the tick.

The dispatcher now DMs the user via the existing ``notify_user``
ledger, idempotency-keyed on ``(scanner, error_class, UTC date)`` so a
sustained failure does not spam one DM per tick. The next tick
re-tries the failing scanner cleanly.

The empty-return convention is preserved for legitimate carve-outs:
``gh not installed`` (returncode 127), genuinely-empty PR lists,
``channel_not_found`` (the #1255 "one slow channel never breaks the
scan loop" exception). The bug this fixes is the conflation of those
two cases.

Closes #1287