### PR TITLE
docs(e2e): add Angular/NgRx mocking rule for failure-path stubs

### DIFF
--- a/skills/e2e/SKILL.md
+++ b/skills/e2e/SKILL.md
@@ -68,6 +68,8 @@ The resolved value is exported as **`T3_E2E_TARGET`**. The spec branches on it �
 
 **Component placement:** Before writing E2E tests for a UI component, check the **routing module** to find which page/route renders it. Components may only appear at specific wizard steps or behind navigation — not on the page you'd naively navigate to. Grep for the component selector in templates to find its host, then check the routing module for the URL path.
 
+**Mocking — stub with the error status the failure-path expects, not `200`.** When stubbing an API call in an Angular/NgRx app to exercise the empty/failure path (e.g. a "no results" alert, a retry gate, a fall-through navigation), return the status the failure effect listens for — typically `404`, sometimes `500` — rather than `200 []`. A `200` dispatches the success Action and short-circuits the path under test (the success effect navigates away or stores the empty list as a successful result). Match the status to the effect: inspect the relevant `createEffect(...)` block, find which HTTP error the `catchError` branch maps to the failure Action, and stub that status.
+
 **`storageState` in Playwright:** `test.use({ storageState: undefined })` means "use default" (inherits global setup state). For truly unauthenticated tests, use `test.use({ storageState: { cookies: [], origins: [] } })`.
 
 **Establish baseline before attributing failures (Non-Negotiable):** When running E2E tests to validate a change, first run the same test on the **default branch** (or the unmodified code) to confirm it passes without your changes. If the test already fails on the default branch, it is a pre-existing failure — do not waste time debugging it as if your changes caused it. Report it as pre-existing and move on.


### PR DESCRIPTION
## Summary

Adds one generic Angular/NgRx mocking guidance bullet under `## Writing Tests`. When an E2E spec stubs an API call to exercise a failure path (empty-results alert, retry gate, fall-through navigation), the stub must return the status the failure effect listens for — typically `404`, sometimes `500` — rather than `200 []`. A `200` dispatches the success Action and short-circuits the path under test.

## Why this is generic, not project-specific

This is an Angular/NgRx effect interaction (`createEffect(...)` + `catchError` branch mapping to the failure Action). The rule applies to any Angular/NgRx codebase, not a particular overlay or tenant.

## Placement

Under `## Writing Tests`, immediately after the "Component placement" bullet.

## Constraints honoured

- Plain bullet, not Non-Negotiable. Net-neutral on Non-Negotiable count (7 before, 7 after). `#140` skill-prose-ban gate passes.
- One commit, one file. No scope creep.

## Test plan

- [x] `prek run --files skills/e2e/SKILL.md` — all hooks pass (markdownlint, skill-prose-ban, banned-terms, frontmatter)
- [x] `Non-Negotiable` count unchanged
- [x] No new imperative rules without companion code (#140)