### PR TITLE
fix(cli): assorted CLI bugs surfaced by !7482 E2E run (#1306)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -45,6 +45,8 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 │                 one consolidation loop per agent identity, deduped across    │
 │                 all sessions (#786 WS4); it idles when none.                 │
 │ slack           Slack integration commands.                                  │
+│ task            Alias for `t3 <overlay> tasks <sub>` (sub-agent-friendly     │
+│                 short form, #1306).                                          │
 │ teatree         Commands for the t3-teatree overlay.                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -1973,6 +1975,47 @@ Usage: t3 slack status [OPTIONS]
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
+### `t3 task`
+
+```
+Usage: t3 task [OPTIONS] COMMAND [ARGS]...
+
+ Alias for `t3 <overlay> tasks <sub>` (sub-agent-friendly short form, #1306).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ complete  Forward `t3 task complete <id> ` to `t3 <overlay> tasks complete`. │
+│ list      Forward `t3 task list ` to `t3 <overlay> tasks list`.              │
+│ cancel    Forward `t3 task cancel <id> ` to `t3 <overlay> tasks cancel`.     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 task complete`
+
+```
+Usage: t3 task complete [OPTIONS]
+
+ Forward `t3 task complete <id> ` to `t3 <overlay> tasks complete`.
+```
+
+#### `t3 task list`
+
+```
+Usage: t3 task list [OPTIONS]
+
+ Forward `t3 task list ` to `t3 <overlay> tasks list`.
+```
+
+#### `t3 task cancel`
+
+```
+Usage: t3 task cancel [OPTIONS]
+
+ Forward `t3 task cancel <id> ` to `t3 <overlay> tasks cancel`.
+```
+
 ### `t3 teatree`
 
 ```
@@ -3542,6 +3585,11 @@ Usage: t3 teatree env overrides [OPTIONS]
 Usage: t3 teatree env check [OPTIONS]
 
  Exit non-zero if the on-disk cache diverges from the DB render.
+
+ The Python method is named ``check_drift`` (not ``check``) to avoid
+ shadowing :meth:`django.core.management.base.BaseCommand.check`,
+ which Django invokes on every command to run the system-checks
+ framework. The typer subcommand name is still ``check``.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -36,6 +36,7 @@ from teatree.cli.review import review_app
 from teatree.cli.review_request import review_request_app
 from teatree.cli.setup import setup_app
 from teatree.cli.slack_listen import slack_app
+from teatree.cli.task_alias import task_app
 from teatree.cli.tools import tool_app
 from teatree.cli.update import update_app
 
@@ -120,6 +121,7 @@ app.add_typer(overlay_dev_app, name="overlay")
 app.add_typer(infra_app, name="infra")
 app.add_typer(loop_app, name="loop")
 app.add_typer(slack_app, name="slack")
+app.add_typer(task_app, name="task")
 
 
 # ── Django-dependent overlay command groups ───────────────────────────

--- a/src/teatree/cli/task_alias.py
+++ b/src/teatree/cli/task_alias.py
@@ -1,0 +1,75 @@
+"""Top-level ``t3 task`` alias for ``t3 <overlay> tasks <sub>`` (#1306).
+
+Sub-agent prompts and skill briefs reference the short form
+``t3 task complete <id>`` for marking a task done, but the actual
+implementation lives under the overlay-scoped tasks group (e.g.
+``t3 teatree tasks complete <id>``). Without the alias the short form
+errored with ``No such command 'task'.`` and broke copy-pasted prompts.
+
+This module exposes a thin Typer group that forwards every argument to
+the active overlay's ``manage.py tasks <sub> ...`` so the existing
+implementation owns the behaviour. The active overlay is resolved the
+same way as the rest of the CLI (``discover_active_overlay``); when no
+overlay is registered the alias falls back to teatree's own management
+command via ``python -m teatree``.
+"""
+
+from pathlib import Path
+
+import typer
+
+from teatree.cli.overlay import managepy
+
+task_app = typer.Typer(
+    name="task",
+    no_args_is_help=True,
+    help="Alias for `t3 <overlay> tasks <sub>` (sub-agent-friendly short form, #1306).",
+    context_settings={
+        "allow_extra_args": True,
+        "allow_interspersed_args": False,
+        "ignore_unknown_options": True,
+    },
+)
+
+
+def _resolve_overlay() -> tuple[Path | None, str]:
+    """Return (project_path, overlay_name) for the active overlay, if any."""
+    from teatree.config import discover_active_overlay  # noqa: PLC0415
+
+    active = discover_active_overlay()
+    if active is None:
+        return None, ""
+    return active.project_path, active.name
+
+
+@task_app.command(
+    name="complete",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    add_help_option=False,
+)
+def _complete(ctx: typer.Context) -> None:
+    """Forward `t3 task complete <id> [flags]` to `t3 <overlay> tasks complete`."""
+    project_path, overlay_name = _resolve_overlay()
+    managepy(project_path, "tasks", "complete", *ctx.args, overlay_name=overlay_name)
+
+
+@task_app.command(
+    name="list",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    add_help_option=False,
+)
+def _list(ctx: typer.Context) -> None:
+    """Forward `t3 task list [flags]` to `t3 <overlay> tasks list`."""
+    project_path, overlay_name = _resolve_overlay()
+    managepy(project_path, "tasks", "list", *ctx.args, overlay_name=overlay_name)
+
+
+@task_app.command(
+    name="cancel",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    add_help_option=False,
+)
+def _cancel(ctx: typer.Context) -> None:
+    """Forward `t3 task cancel <id> [flags]` to `t3 <overlay> tasks cancel`."""
+    project_path, overlay_name = _resolve_overlay()
+    managepy(project_path, "tasks", "cancel", *ctx.args, overlay_name=overlay_name)

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -405,6 +405,15 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene:
     if Path(wt_path).is_dir() and git.status_porcelain(wt_path):
         logger.warning("%s has uncommitted changes — cleaning anyway (PR merged)", worktree.repo_path)
 
+    # Stop the docker compose project FIRST so containers don't leak when
+    # this path is reached outside the WorktreeTeardownRunner (#1306) —
+    # the auto-merged-ticket teardown, `clean-merged`, `clean-all`, and
+    # sync backends all funnel through here. Idempotent: docker compose
+    # down on a project with no containers is a no-op.
+    from teatree.core.runners.worktree_start import compose_project, docker_compose_down  # noqa: PLC0415
+
+    docker_compose_down(compose_project(worktree))
+
     step_errors: list[str] = []
     for step in overlay.get_cleanup_steps(worktree):
         try:

--- a/src/teatree/core/management/commands/_workspace_dslr.py
+++ b/src/teatree/core/management/commands/_workspace_dslr.py
@@ -1,0 +1,45 @@
+"""DSLR snapshot helpers for ``t3 workspace clean-all`` (#1306).
+
+Split from :mod:`_workspace_cleanup` so the public-functions-per-module
+cap stays clear. Functions here own the "is this tenant in use?" guard
+that prevents :func:`prune_dslr_snapshots` from destroying a snapshot
+an in-flight worktree is about to restore from.
+"""
+
+from teatree.core.models import Worktree
+from teatree.core.overlay_loader import get_overlay
+
+
+def dslr_tenants_in_use() -> set[str]:
+    """Return DSLR tenants in use by an in-flight worktree.
+
+    A worktree in CREATED state (mid-provision, DB not yet imported) is
+    about to restore from a DSLR snapshot whose tenant suffix is derived
+    from the ticket's variant. Pruning that snapshot before the worktree
+    completes provisioning leaves no recovery path. This helper returns
+    the set of tenant strings to skip in
+    :func:`prune_dslr_snapshots`.
+
+    The mapping ``variant → tenant`` is overlay-specific: an overlay may
+    prefix the variant (``client-a`` → ``development-client-a``) while
+    others return the variant verbatim. We consult
+    :meth:`OverlayBase.get_dslr_tenant_for_variant` per active variant.
+    """
+    try:
+        overlay = get_overlay()
+    except Exception:  # noqa: BLE001 — best effort; pruning continues if no overlay
+        return set()
+    variants = {
+        wt.ticket.variant or ""
+        for wt in Worktree.objects.filter(state=Worktree.State.CREATED).select_related("ticket")
+        if wt.ticket is not None
+    }
+    return {overlay.get_dslr_tenant_for_variant(v) for v in variants if v}
+
+
+def prune_dslr_snapshots_skipping(*, keep: int, in_use_tenants: set[str]) -> list[str]:
+    """Prune DSLR snapshots (skipping in-use tenants) and return cleanup labels."""
+    from teatree.utils.django_db import prune_dslr_snapshots  # noqa: PLC0415
+
+    pruned = prune_dslr_snapshots(keep=keep, in_use_tenants=in_use_tenants)
+    return [f"Pruned DSLR snapshot: {name}" for name in pruned]

--- a/src/teatree/core/management/commands/_workspace_helpers.py
+++ b/src/teatree/core/management/commands/_workspace_helpers.py
@@ -1,12 +1,14 @@
-"""DSLR snapshot helpers for ``t3 workspace clean-all`` (#1306).
+"""Helpers for ``t3 workspace`` subcommands (#1306).
 
-Split from :mod:`_workspace_cleanup` so the public-functions-per-module
-cap stays clear. Functions here own the "is this tenant in use?" guard
-that prevents :func:`prune_dslr_snapshots` from destroying a snapshot
-an in-flight worktree is about to restore from.
+Split from :mod:`workspace` to keep the command module under the per-
+module LOC cap. Covers two surfaces: the DSLR-snapshot-in-use guard
+shared by ``clean-all`` and the variant-mismatch refusal used by
+``ticket``.
 """
 
-from teatree.core.models import Worktree
+from collections.abc import Callable
+
+from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_overlay
 
 
@@ -43,3 +45,21 @@ def prune_dslr_snapshots_skipping(*, keep: int, in_use_tenants: set[str]) -> lis
 
     pruned = prune_dslr_snapshots(keep=keep, in_use_tenants=in_use_tenants)
     return [f"Pruned DSLR snapshot: {name}" for name in pruned]
+
+
+def reject_variant_mismatch(write_err: Callable[[str], None], ticket: Ticket, variant: str) -> None:
+    """Refuse to rebind an existing ticket to a different variant (#1306).
+
+    Pre-fix `workspace ticket <url> --variant <v>` silently kept the
+    existing ticket's variant and rebound to the URL's inferred branch
+    — downstream operations then targeted the wrong code. Raises
+    `SystemExit(2)` with a remediation hint when the caller supplied a
+    `--variant` that disagrees with the row's variant.
+    """
+    if variant and ticket.variant and variant != ticket.variant:
+        write_err(
+            f"  ticket #{ticket.ticket_number} already exists with variant {ticket.variant!r}; "
+            f"refusing to rebind to variant {variant!r}. "
+            f"Use `t3 <overlay> ticket switch` or create a new ticket scope."
+        )
+        raise SystemExit(2)

--- a/src/teatree/core/management/commands/env.py
+++ b/src/teatree/core/management/commands/env.py
@@ -117,12 +117,18 @@ class Command(TyperCommand):
             self.stdout.write(f"  {key}={value}")
         return 0
 
-    @command()
-    def check(
+    @command(name="check")
+    def check_drift(
         self,
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
     ) -> int:
-        """Exit non-zero if the on-disk cache diverges from the DB render."""
+        """Exit non-zero if the on-disk cache diverges from the DB render.
+
+        The Python method is named ``check_drift`` (not ``check``) to avoid
+        shadowing :meth:`django.core.management.base.BaseCommand.check`,
+        which Django invokes on every command to run the system-checks
+        framework. The typer subcommand name is still ``check``.
+        """
         worktree = resolve_worktree(path)
         drifted, cache_path = detect_drift(worktree)
         if drifted:

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -15,6 +15,7 @@ from django_typer.management import TyperCommand, command
 from teatree.config import load_config
 from teatree.core.cleanup import cleanup_worktree
 from teatree.core.dev_repo import resolve_repo_names
+from teatree.core.management.commands import _workspace_helpers as _wh
 from teatree.core.management.commands._workspace_cleanup import (
     _die,
     _raise_on_cleanup_failures,
@@ -23,7 +24,6 @@ from teatree.core.management.commands._workspace_cleanup import (
     prune_branches,
     resolve_unsynced_worktree,
 )
-from teatree.core.management.commands._workspace_dslr import dslr_tenants_in_use, prune_dslr_snapshots_skipping
 from teatree.core.models import Ticket, Worktree
 from teatree.core.models.ticket import format_intake_summary
 from teatree.core.orphan_guard import find_orphans_in_workspace
@@ -215,6 +215,9 @@ class Command(TyperCommand):
 
         with transaction.atomic():
             ticket = _locked_get_or_create_ticket(issue_url, variant, repo_names)
+
+            # Refuse a silent rebind when --variant disagrees with the existing ticket's variant (#1306).
+            _wh.reject_variant_mismatch(self.stderr.write, ticket, variant)
 
             if ticket.state == Ticket.State.NOT_STARTED:
                 ticket.scope(issue_url=issue_url, variant=variant or None, repos=repo_names)
@@ -569,7 +572,7 @@ class Command(TyperCommand):
         workspace = _workspace_dir()
         cleaned: list[str] = []
         interactive = sys.stdin.isatty() and sys.stdout.isatty()
-        in_use = dslr_tenants_in_use()  # before cleanup loop reaps CREATED worktrees (#1306)
+        in_use = _wh.dslr_tenants_in_use()  # before cleanup loop reaps CREATED worktrees (#1306)
         for wt in Worktree.objects.filter(state=Worktree.State.CREATED):
             try:
                 cleaned.append(str(cleanup_worktree(wt)))
@@ -589,7 +592,7 @@ class Command(TyperCommand):
             cleaned.extend(prune_branches(str(repo_root)))
             cleaned.extend(drop_orphaned_stashes(str(repo_root)))
 
-        cleaned.extend(prune_dslr_snapshots_skipping(keep=keep_dslr, in_use_tenants=in_use))
+        cleaned.extend(_wh.prune_dslr_snapshots_skipping(keep=keep_dslr, in_use_tenants=in_use))
 
         _raise_on_cleanup_failures(cleaned, self.stdout.write, self.stderr.write)
         return cleaned

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -23,6 +23,7 @@ from teatree.core.management.commands._workspace_cleanup import (
     prune_branches,
     resolve_unsynced_worktree,
 )
+from teatree.core.management.commands._workspace_dslr import dslr_tenants_in_use, prune_dslr_snapshots_skipping
 from teatree.core.models import Ticket, Worktree
 from teatree.core.models.ticket import format_intake_summary
 from teatree.core.orphan_guard import find_orphans_in_workspace
@@ -450,8 +451,7 @@ class Command(TyperCommand):
                     self.stdout.write(f"  {repo} commits ({count}):\n    " + "\n    ".join(log.splitlines()))
 
                 if count > 1:
-                    if not message:
-                        message = log.splitlines()[0] if log else f"Squash {count} commits"
+                    message = message or (log.splitlines()[0] if log else f"Squash {count} commits")
                     git.soft_reset(repo_dir, base)
                     git.commit(repo_dir, message)
                     results.append(f"{repo}: squashed {count} commits")
@@ -569,6 +569,7 @@ class Command(TyperCommand):
         workspace = _workspace_dir()
         cleaned: list[str] = []
         interactive = sys.stdin.isatty() and sys.stdout.isatty()
+        in_use = dslr_tenants_in_use()  # before cleanup loop reaps CREATED worktrees (#1306)
         for wt in Worktree.objects.filter(state=Worktree.State.CREATED):
             try:
                 cleaned.append(str(cleanup_worktree(wt)))
@@ -588,11 +589,7 @@ class Command(TyperCommand):
             cleaned.extend(prune_branches(str(repo_root)))
             cleaned.extend(drop_orphaned_stashes(str(repo_root)))
 
-        # Prune old DSLR snapshots
-        from teatree.utils.django_db import prune_dslr_snapshots  # noqa: PLC0415
-
-        pruned = prune_dslr_snapshots(keep=keep_dslr)
-        cleaned.extend(f"Pruned DSLR snapshot: {name}" for name in pruned)
+        cleaned.extend(prune_dslr_snapshots_skipping(keep=keep_dslr, in_use_tenants=in_use))
 
         _raise_on_cleanup_failures(cleaned, self.stdout.write, self.stderr.write)
         return cleaned

--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -79,10 +79,19 @@ def notify_user(  # noqa: PLR0913 — single notification egress; each kwarg is 
         logger.debug("notify_user disabled by settings — %s skipped", idempotency_key)
         return False
 
+    # Idempotent on SENT (the canonical "already delivered" no-op). A
+    # prior FAILED / NOOP row is a recoverable state — a sub-agent that
+    # hit a transient Slack 500 or a missing-backend window must be
+    # able to retry under the same key (#1306). We delete the recoverable
+    # row so the verify-by-re-read invariant still holds: the terminal
+    # ledger entry reflects the eventual outcome, not a transient miss.
     existing = BotPing.objects.filter(idempotency_key=idempotency_key).first()
     if existing is not None:
-        logger.debug("notify_user idempotent no-op for key=%s", idempotency_key)
-        return existing.status == BotPing.Status.SENT
+        if existing.status == BotPing.Status.SENT:
+            logger.debug("notify_user idempotent no-op for key=%s", idempotency_key)
+            return True
+        logger.info("notify_user retrying key=%s (prior status=%s)", idempotency_key, existing.status)
+        existing.delete()
 
     resolved_backend = backend if backend is not None else messaging_from_overlay()
     resolved_user_id = user_id if user_id is not None else _resolve_user_id()

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -367,6 +367,22 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
     def get_db_import_strategy(self, worktree: "Worktree") -> DbImportStrategy | None:
         return None
 
+    def get_dslr_tenant_for_variant(self, variant: str) -> str:
+        """Return the DSLR snapshot tenant name for *variant*.
+
+        Overlays whose DB-import strategy uses DSLR translate the
+        ``Ticket.variant`` string into the tenant suffix that appears in
+        DSLR snapshot names (e.g. an overlay may prefix the variant with
+        ``development-`` so the ``client-a`` variant becomes the tenant
+        ``development-client-a``). The default returns the variant
+        verbatim, which is correct for overlays that don't prefix the
+        tenant.
+
+        Used by ``workspace clean-all`` to compute the in-use tenant set
+        from active worktrees so the DSLR pruner can skip them (#1306).
+        """
+        return variant
+
     def db_import(  # noqa: PLR0913 — overlay extension-point contract; each kwarg is a documented hook input, not poor design.
         self,
         worktree: "Worktree",

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -372,14 +372,21 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
 
         Overlays whose DB-import strategy uses DSLR translate the
         ``Ticket.variant`` string into the tenant suffix that appears in
-        DSLR snapshot names (e.g. an overlay may prefix the variant with
-        ``development-`` so the ``client-a`` variant becomes the tenant
-        ``development-client-a``). The default returns the variant
-        verbatim, which is correct for overlays that don't prefix the
-        tenant.
+        DSLR snapshot names. Two transformations may stack:
 
-        Used by ``workspace clean-all`` to compute the in-use tenant set
-        from active worktrees so the DSLR pruner can skip them (#1306).
+        1.  **Prefix** — e.g. an overlay may turn ``client-a`` into the
+            tenant ``development-client-a`` so the snapshot key carries
+            the environment alongside the tenant identity.
+        2.  **Alias** — a child variant whose data is identical to its
+            parent (e.g. ``client-a-regional`` shares snapshots with
+            ``client-a``) maps to the parent's tenant so the snapshot
+            lookup actually finds the right file (#1306).
+
+        The default returns the variant verbatim, which is correct for
+        overlays that don't prefix or alias the tenant. Used by
+        ``workspace clean-all`` to compute the in-use tenant set, and by
+        overlays computing ``DjangoDbImportConfig.ref_db_name`` for the
+        DSLR snapshot lookup.
         """
         return variant
 

--- a/src/teatree/core/runners/worktree_start.py
+++ b/src/teatree/core/runners/worktree_start.py
@@ -34,7 +34,14 @@ def _compose_files(compose_file: str) -> list[str]:
 
 
 def docker_compose_down(project: str, *, timeout: int | None = 30) -> None:
-    """Stop and remove containers for the compose project."""
+    """Stop and remove containers for the compose project.
+
+    Tolerant of an unavailable docker binary (CI sandboxes, hermetic test
+    environments): a ``FileNotFoundError`` / ``PermissionError`` from
+    ``subprocess.run`` is logged and swallowed so cleanup paths that
+    funnel through here (#1306) don't break when there's no docker to
+    talk to in the first place.
+    """
     try:
         result = run_allowed_to_fail(
             ["docker", "compose", "-p", project, "down", "--remove-orphans"],
@@ -45,6 +52,8 @@ def docker_compose_down(project: str, *, timeout: int | None = 30) -> None:
             logger.warning("docker compose down: %s", result.stderr.strip()[:300])
     except TimeoutExpired:
         logger.warning("docker compose down timed out after %ss", timeout)
+    except (FileNotFoundError, PermissionError) as exc:
+        logger.debug("docker compose down skipped — docker unavailable: %s", exc)
 
 
 class WorktreeStartRunner(RunnerBase):
@@ -141,7 +150,7 @@ class WorktreeStartRunner(RunnerBase):
 
         ``up --no-build --pull=never`` fails the first time a worktree's
         compose override references a service that builds from a Dockerfile
-        (e.g. an overlay's docgen sidecar) — neither pull nor build runs, so
+        (e.g. an overlay's locally-built sidecar) — neither pull nor build runs, so
         the missing image is a hard error. Pre-flight per service, build the
         missing ones once, then let the subsequent ``up`` reuse the local
         images on every later start.

--- a/src/teatree/core/runners/worktree_teardown.py
+++ b/src/teatree/core/runners/worktree_teardown.py
@@ -4,7 +4,6 @@ from teatree.core.cleanup import cleanup_worktree
 from teatree.core.models import Worktree
 from teatree.core.models.types import WorktreeExtra
 from teatree.core.runners.base import RunnerBase, RunnerResult
-from teatree.core.runners.worktree_start import compose_project, docker_compose_down
 
 logger = logging.getLogger(__name__)
 
@@ -49,10 +48,9 @@ class WorktreeTeardownRunner(RunnerBase):
 
     def run(self) -> RunnerResult:
         worktree = self.worktree
-        project = compose_project(worktree)
-
-        docker_compose_down(project)
-
+        # `cleanup_worktree` now owns `docker compose down` so every caller
+        # (runner, sync backend, clean-all, clean-merged) tears down docker
+        # the same way (#1306).
         try:
             cleanup_result = cleanup_worktree(worktree, force=self.force, strict_hygiene=False)
         except RuntimeError as exc:

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -512,7 +512,8 @@ class DjangoDbImporter:
             self.stderr.write(
                 "\n  DSLR restore failed or unavailable. Non-DSLR fallbacks are disabled by default.\n"
                 "  Non-DSLR paths (pg_restore, remote dump) take minutes instead of seconds.\n"
-                "  To allow slow fallback paths, re-run with: --slow-import\n",
+                "  To allow slow fallback paths, re-run with: --fresh-dump --user-authorized <user-id>\n"
+                "  (the equivalent internal flag is `slow_import=True`)\n",
             )
             return False
 
@@ -536,7 +537,9 @@ class DjangoDbImporter:
         self.stdout.write(f"  - No CI dump matching {cfg.ci_dump_glob} in {cfg.main_repo_path}\n")
         self.stdout.write("\n")
         if cfg.remote_db_url:
-            self.stdout.write("  To fetch a fresh dump from the remote DB, re-run with --slow-import.\n")
+            self.stdout.write(
+                "  To fetch a fresh dump from the remote DB, re-run with `--fresh-dump --user-authorized <user-id>`.\n"
+            )
         else:
             self.stdout.write("  Configure remote_db_url in DjangoDbImportConfig to enable remote dump fetching.\n")
         return False

--- a/src/teatree/utils/django_db_dslr.py
+++ b/src/teatree/utils/django_db_dslr.py
@@ -108,10 +108,24 @@ def parse_dslr_snapshots(stdout: str) -> dict[str, list[str]]:
     return by_tenant
 
 
-def prune_dslr_snapshots(*, keep: int = 1, snapshot_tool: str = "dslr", main_repo_path: str = "") -> list[str]:
+def prune_dslr_snapshots(
+    *,
+    keep: int = 1,
+    snapshot_tool: str = "dslr",
+    main_repo_path: str = "",
+    in_use_tenants: set[str] | None = None,
+) -> list[str]:
     """Delete old DSLR snapshots, keeping the *keep* newest per tenant.
 
     Returns a list of deleted snapshot names.
+
+    *in_use_tenants* (souliane/teatree#1306): tenants whose snapshots
+    must NOT be touched because an in-flight worktree depends on them.
+    A worktree mid-provision (state CREATED, DB not yet imported) needs
+    the snapshot to remain restorable until provisioning completes;
+    pruning unconditionally and globally destroys that with no way to
+    recover short of a fresh remote dump. Pass the set of tenant strings
+    (matching the DSLR snapshot suffix after the date) to skip entirely.
     """
     dslr_cmd = find_dslr_cmd(snapshot_tool, main_repo_path)
     if not dslr_cmd:
@@ -119,9 +133,13 @@ def prune_dslr_snapshots(*, keep: int = 1, snapshot_tool: str = "dslr", main_rep
     result = run_allowed_to_fail([*dslr_cmd, "list"], expected_codes=None)
     if result.returncode != 0:
         return []
+    in_use = in_use_tenants or set()
     by_tenant = parse_dslr_snapshots(result.stdout)
     deleted: list[str] = []
     for tenant, names in by_tenant.items():
+        if tenant in in_use:
+            sys.stdout.write(f"  Skipping DSLR prune for in-use tenant: {tenant}\n")
+            continue
         for old in names[keep:]:
             sys.stdout.write(f"  Pruning DSLR snapshot: {old} (tenant={tenant})\n")
             run_allowed_to_fail([*dslr_cmd, "delete", "-y", old], expected_codes=None)

--- a/tests/django_db/test_orchestration.py
+++ b/tests/django_db/test_orchestration.py
@@ -93,7 +93,9 @@ class TestDjangoDbImport:
         monkeypatch.setattr(DjangoDbImporter, "_try_restore_from_ci_dump", lambda self: False)
         cfg = _make_cfg(tmp_path, remote_db_url="postgres://u:p@host/db")
         django_db_import(cfg, slow_import=True)
-        assert "--slow-import" in capsys.readouterr().out
+        # #1306: the hint must reference the actually-valid CLI flag (--fresh-dump),
+        # not the internal `slow_import` keyword.
+        assert "--fresh-dump" in capsys.readouterr().out
 
     def test_failure_message_without_remote_url(
         self,

--- a/tests/django_db/test_pruning.py
+++ b/tests/django_db/test_pruning.py
@@ -19,18 +19,18 @@ class TestParseDslrSnapshots:
         stdout = (
             "20260402_development-acme  125MB\n"
             "20260401_development-acme  123MB\n"
-            "20260315_development-volksbank  98MB\n"
-            "20260320_development-volksbank  100MB\n"
+            "20260315_development-tenant-b  98MB\n"
+            "20260320_development-tenant-b  100MB\n"
         )
         result = _parse_dslr_snapshots(stdout)
-        assert set(result) == {"development-acme", "development-volksbank"}
+        assert set(result) == {"development-acme", "development-tenant-b"}
         assert result["development-acme"] == [
             "20260402_development-acme",
             "20260401_development-acme",
         ]
-        assert result["development-volksbank"] == [
-            "20260320_development-volksbank",
-            "20260315_development-volksbank",
+        assert result["development-tenant-b"] == [
+            "20260320_development-tenant-b",
+            "20260315_development-tenant-b",
         ]
 
     def test_empty_output(self) -> None:
@@ -84,3 +84,52 @@ class TestPruneDslrSnapshots:
         monkeypatch.setattr(run_mod.subprocess, "run", lambda *a, **kw: CompletedProcess(a, 1, stdout="", stderr=""))
         monkeypatch.setattr(dslr_mod.shutil, "which", lambda _: "/usr/bin/uv")
         assert prune_dslr_snapshots() == []
+
+
+class TestPruneDslrSnapshotsSkipsInUseTenants:
+    """A snapshot whose tenant is referenced by an in-flight worktree must not be pruned.
+
+    Pre-fix the pruner ran unconditionally and globally: a worktree
+    midway through provision (state=CREATED, DB not yet imported) lost
+    its tenant's only snapshot, leaving no way to provision until a
+    fresh remote dump was re-fetched. The guard now skips any tenant
+    listed in *in_use_tenants*; the rest still prune normally.
+    """
+
+    def test_skips_pruning_for_in_use_tenant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dslr_output = (
+            "20260402_development-tenant-a  125MB\n"
+            "20260401_development-tenant-a  123MB\n"
+            "20260402_development-tenant-b  120MB\n"
+            "20260401_development-tenant-b  118MB\n"
+        )
+        deleted: list[str] = []
+
+        def fake_run(cmd, **kw):
+            if "delete" in cmd:
+                deleted.append(cmd[-1])
+            return CompletedProcess(cmd, 0, stdout=dslr_output, stderr="")
+
+        monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda _: "/usr/bin/uv")
+        # development-tenant-a is in use — none of its snapshots may be deleted.
+        result = prune_dslr_snapshots(keep=1, in_use_tenants={"development-tenant-a"})
+
+        assert result == ["20260401_development-tenant-b"]
+        assert deleted == ["20260401_development-tenant-b"]
+
+    def test_no_in_use_tenants_preserves_original_behavior(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dslr_output = "20260402_dev-a  10MB\n20260401_dev-a  10MB\n"
+        deleted: list[str] = []
+
+        def fake_run(cmd, **kw):
+            if "delete" in cmd:
+                deleted.append(cmd[-1])
+            return CompletedProcess(cmd, 0, stdout=dslr_output, stderr="")
+
+        monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(dslr_mod.shutil, "which", lambda _: "/usr/bin/uv")
+        # Empty in_use_tenants = same as the legacy unconditional prune.
+        result = prune_dslr_snapshots(keep=1, in_use_tenants=set())
+
+        assert result == ["20260401_dev-a"]

--- a/tests/teatree_cli/test_task_alias.py
+++ b/tests/teatree_cli/test_task_alias.py
@@ -1,0 +1,46 @@
+"""``t3 task complete <id>`` top-level alias (#1306).
+
+Skill briefs reference `t3 task complete` as the short form for marking
+a task done, but the actual command lives under the overlay's tasks
+group (e.g. `t3 teatree tasks complete <id>`). Without the alias the
+short form errored with `No such command 'task'.` and broke sub-agent
+prompts that copy-pasted the documented form.
+
+The alias forwards to `t3 <active-overlay> tasks <sub>` so the existing
+overlay-scoped implementation owns the behaviour.
+"""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from teatree.cli import app
+
+
+class TestTaskAlias:
+    def test_top_level_task_command_exists(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(app, ["task", "--help"])
+        # The group exists (exit 0 on --help) — no "No such command 'task'".
+        assert result.exit_code == 0
+        assert "No such command" not in result.output
+
+    def test_task_complete_forwards_to_overlay_tasks_complete(self) -> None:
+        runner = CliRunner()
+        captured: dict[str, object] = {}
+
+        def fake_managepy(_project_path: object, *args: str, overlay_name: str = "") -> None:
+            captured["args"] = args
+            captured["overlay_name"] = overlay_name
+
+        with patch("teatree.cli.task_alias.managepy", side_effect=fake_managepy):
+            result = runner.invoke(app, ["task", "complete", "42", "--note", "shipped via !1234"])
+
+        assert result.exit_code == 0, result.output
+        # The alias forwards the args verbatim under `tasks complete`.
+        args = captured["args"]
+        assert isinstance(args, tuple)
+        assert args[0] == "tasks"
+        assert args[1] == "complete"
+        assert "42" in args
+        assert "--note" in args

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -82,6 +82,38 @@ class TestCleanupWorktree(TestCase):
     @_patch_overlay
     @_patch_git
     @_patch_config
+    def test_stops_docker_compose_project_to_avoid_leaking_containers(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """Regression for #1306: `cleanup_worktree` must stop the docker compose project.
+
+        Pre-fix only `WorktreeTeardownRunner` called `docker_compose_down`,
+        but `cleanup_worktree` itself was also reached by the FSM-merged
+        auto-teardown path (`WorktreeTeardown`), `clean-merged`, and
+        `clean-all`. Those paths left containers running on host ports
+        5432/6379, blocking the next `worktree provision` with a port
+        conflict. Wiring docker-down into `cleanup_worktree` makes the
+        promise in the docstring ("Stop docker, drop DB, remove git
+        worktree, delete row") hold for every caller.
+        """
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        with patch("teatree.core.runners.worktree_start.docker_compose_down") as mock_down:
+            cleanup_worktree(wt)
+        # The compose project name follows `{repo_path}-wt{ticket_number}`.
+        ((project,), _kwargs) = mock_down.call_args
+        assert project.startswith("org/repo-wt")
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
     def test_drops_database_when_db_name_set(
         self,
         mock_config: MagicMock,

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -905,6 +905,51 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_passes_in_use_tenants_from_active_worktrees(self) -> None:
+        """clean-all collects DSLR tenants from CREATED worktrees and skips them (#1306).
+
+        A worktree in ``CREATED`` state is mid-provision — its DB has not
+        yet been imported and it depends on the tenant's DSLR snapshot
+        remaining intact. Pre-fix clean-all pruned unconditionally and
+        destroyed snapshots that an in-flight worktree was about to
+        restore from. The fix collects active variants from CREATED
+        worktrees and passes them to ``prune_dslr_snapshots`` via the
+        new ``in_use_tenants`` kwarg.
+        """
+        captured: dict[str, object] = {}
+
+        def fake_prune(**kw: object) -> list[str]:
+            captured.update(kw)
+            return []
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch.object(workspace_mod, "_workspace_dir", return_value=Path(tmp)),
+            patch.object(provision_mod, "_workspace_dir", return_value=Path(tmp)),
+            patch("teatree.utils.django_db.prune_dslr_snapshots", side_effect=fake_prune),
+        ):
+            ticket = Ticket.objects.create(
+                overlay="test", issue_url="https://example.com/issues/1306", variant="tenant-a"
+            )
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="ac-1306",
+                state=Worktree.State.CREATED,
+                extra={},
+            )
+            call_command("workspace", "clean-all")
+
+        # Default overlay returns the variant verbatim; the in-use tenant set
+        # carries the active variant string so the pruner skips it.
+        assert captured.get("in_use_tenants") == {"tenant-a"}
+
+    @_no_prune
+    @_no_stash
+    @_no_orphan_dbs
     @_no_dslr_prune
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -112,6 +112,28 @@ class TestWorkspaceTicket(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
+    def test_rejects_variant_mismatch_on_existing_ticket(self) -> None:
+        """Re-issuing `workspace ticket <url> --variant <v>` with a different variant must error (#1306).
+
+        Pre-fix the second invocation silently kept the existing ticket's
+        variant and rebound the call to the inferred branch from the URL
+        — downstream operations then targeted the wrong code. The fix
+        rejects the variant mismatch loudly so the operator knows they
+        need to either switch to the existing variant or pick a new
+        ticket scope.
+        """
+        from django.core.management import CommandError  # noqa: PLC0415
+
+        call_command("workspace", "ticket", "https://example.com/issues/1306", variant="client-a")
+
+        with pytest.raises((SystemExit, CommandError)) as exc_info:
+            call_command("workspace", "ticket", "https://example.com/issues/1306", variant="client-b")
+
+        if isinstance(exc_info.value, SystemExit):
+            assert exc_info.value.code != 0
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
     def test_with_custom_repos(self) -> None:
         ticket_id = cast("int", call_command("workspace", "ticket", "https://example.com/issues/92", repos="api,web"))
 
@@ -757,11 +779,10 @@ class TestWorkspaceCleanAll(TestCase):
             assert len(cleaned) == 1
             assert Worktree.objects.count() == 0
 
-            # Should have called dropdb
-            assert mock_run.call_count == 1
-            dropdb_call = mock_run.call_args_list[0]
-            assert "dropdb" in dropdb_call[0][0]
-            assert "wt_test_db" in dropdb_call[0][0]
+            # cleanup_worktree now calls docker_compose_down then dropdb (#1306).
+            calls = [c[0][0] for c in mock_run.call_args_list]
+            assert any("dropdb" in cmd and "wt_test_db" in cmd for cmd in calls)
+            assert any("docker" in cmd[0] and "compose" in cmd for cmd in calls)
 
     @_no_prune
     @_no_stash

--- a/tests/teatree_core/test_env_command.py
+++ b/tests/teatree_core/test_env_command.py
@@ -124,6 +124,37 @@ class TestEnvOverrides(TestCase):
             call_command("env", "overrides", "--path", "/tmp/wt/repo")
 
 
+class TestEnvSystemCheckCollision(TestCase):
+    """Regression: the env management command must not crash Django's system check.
+
+    Django ``BaseCommand`` calls ``self.check(**check_kwargs)`` on every
+    management command invocation to run the system checks framework. If a
+    typer ``@command`` named ``check`` shadows that method, Django ends up
+    invoking the typer wrapper with the ``typer.Option`` descriptor in
+    place of the resolved value — every other env subcommand
+    (``show`` / ``set-var`` / ``unset`` / ``overrides``) raises a
+    ``TypeError: ... not 'OptionInfo'`` before the typer dispatcher gets
+    to run. The check subcommand must be exposed under a name that does
+    not collide with Django's reserved method.
+    """
+
+    def test_django_system_check_does_not_invoke_typer_check_subcommand(self) -> None:
+        """``BaseCommand.execute`` calls ``self.check()`` with no kwargs.
+
+        Pre-fix the env command exposed a typer subcommand named ``check``
+        whose Python method shadowed Django's reserved
+        ``BaseCommand.check`` method. Calling ``cmd.check()`` (as Django
+        does on every command invocation) hit the typer wrapper with the
+        ``typer.Option`` descriptor as the ``path`` value, raising
+        ``TypeError`` from ``Path(OptionInfo(...))``.
+        """
+        from teatree.core.management.commands.env import Command  # noqa: PLC0415
+
+        # Django's system-checks framework calls this with app_configs/tags
+        # kwargs — never with our typer path/format kwargs. Must not raise.
+        Command().check()
+
+
 class TestEnvCheck(TestCase):
     def test_check_in_sync(self) -> None:
         ticket = _make_ticket()

--- a/tests/teatree_core/test_notify.py
+++ b/tests/teatree_core/test_notify.py
@@ -80,6 +80,51 @@ class TestNotifyUser(TestCase):
         assert backend.post_message.call_count == 1
         assert BotPing.objects.filter(idempotency_key="dup").count() == 1
 
+    def test_prior_failed_attempt_does_not_block_retry(self) -> None:
+        """Regression for #1306: a FAILED BotPing must not block a sub-agent retry.
+
+        Pre-fix the idempotency-key ledger was strict: ANY existing row
+        (FAILED, NOOP, SENT) made the helper return the prior outcome
+        without retrying. A sub-agent that hit a transient Slack failure
+        was permanently locked out — the only escape was a fresh key.
+
+        verify-by-re-read + idempotency means: SENT stays a no-op,
+        FAILED/NOOP are recoverable. The prior failed row is replaced
+        when delivery succeeds, so the audit trail still reflects the
+        terminal outcome.
+        """
+        # First attempt — transport raises, ledger records FAILED.
+        bad_backend = _backend()
+        bad_backend.post_message.side_effect = RuntimeError("transient slack 500")
+        assert (
+            notify_user(
+                "retry me",
+                kind=NotifyKind.INFO,
+                idempotency_key="retry-1306",
+                backend=bad_backend,
+                user_id="U_ME",
+            )
+            is False
+        )
+        assert BotPing.objects.get(idempotency_key="retry-1306").status == BotPing.Status.FAILED
+
+        # Second attempt with a working backend — must actually deliver, not no-op.
+        good_backend = _backend()
+        assert (
+            notify_user(
+                "retry me",
+                kind=NotifyKind.INFO,
+                idempotency_key="retry-1306",
+                backend=good_backend,
+                user_id="U_ME",
+            )
+            is True
+        )
+        good_backend.open_dm.assert_called_once_with("U_ME")
+        good_backend.post_message.assert_called_once()
+        # The terminal ledger row reflects the eventual success.
+        assert BotPing.objects.get(idempotency_key="retry-1306").status == BotPing.Status.SENT
+
     def test_missing_backend_records_noop_and_returns_false(self) -> None:
         with patch("teatree.core.notify.messaging_from_overlay", return_value=None):
             sent = notify_user(

--- a/tests/teatree_core/test_runner_worktree_teardown.py
+++ b/tests/teatree_core/test_runner_worktree_teardown.py
@@ -16,7 +16,7 @@ from teatree.core.cleanup import CleanupResult
 from teatree.core.models import Ticket, Worktree
 from teatree.core.runners.worktree_teardown import WorktreeTeardownRunner
 
-_PATCH_DOWN = "teatree.core.runners.worktree_teardown.docker_compose_down"
+_PATCH_DOWN = "teatree.core.runners.worktree_start.docker_compose_down"
 _PATCH_CLEANUP = "teatree.core.runners.worktree_teardown.cleanup_worktree"
 
 

--- a/tests/test_overlay_base.py
+++ b/tests/test_overlay_base.py
@@ -34,6 +34,34 @@ def test_get_env_extra_returns_empty_dict():
     assert overlay.get_env_extra(_make_worktree()) == {}
 
 
+def test_get_dslr_tenant_for_variant_default_returns_variant_verbatim():
+    """The default hook is identity (#1306) — overlays override for prefix/alias."""
+    overlay = _MinimalOverlay()
+    assert overlay.get_dslr_tenant_for_variant("client-a") == "client-a"
+    assert overlay.get_dslr_tenant_for_variant("") == ""
+
+
+def test_get_dslr_tenant_for_variant_supports_alias_mapping_in_override():
+    """An overlay can map a child variant to its parent tenant (#1306).
+
+    The motivating case: a child variant (e.g. ``client-a-regional``)
+    shares snapshots with its parent (``client-a``). Without the alias
+    hook the DSLR lookup tried ``development-client-a-regional`` and
+    found nothing; with it the overlay returns ``development-client-a``
+    and the existing parent snapshot satisfies the lookup.
+    """
+
+    class _AliasOverlay(_MinimalOverlay):
+        def get_dslr_tenant_for_variant(self, variant: str) -> str:
+            aliases = {"client-a-regional": "client-a"}
+            return f"development-{aliases.get(variant, variant)}"
+
+    overlay = _AliasOverlay()
+    assert overlay.get_dslr_tenant_for_variant("client-a") == "development-client-a"
+    assert overlay.get_dslr_tenant_for_variant("client-a-regional") == "development-client-a"
+    assert overlay.get_dslr_tenant_for_variant("client-b") == "development-client-b"
+
+
 def test_get_run_commands_returns_empty_dict():
     overlay = _MinimalOverlay()
     assert overlay.get_run_commands(_make_worktree()) == {}


### PR DESCRIPTION
## Summary

Eight CLI bugs surfaced during a local-stack E2E run that the umbrella issue [#1306](https://github.com/souliane/teatree/issues/1306) tracks. Each commit is a self-contained TDD fix (failing test → fix → green) so reviewers can step through bug-by-bug.

| # | File:line | Fix |
|---|---|---|
| 1 | \`env.py:120\` | rename \`check\` typer method to avoid shadowing Django's \`BaseCommand.check\` (TypeError on every env subcommand) |
| 2 | \`workspace.py\` | \`clean-all\` skips DSLR snapshots whose tenant is referenced by a CREATED worktree (mid-provision) |
| 3 | \`cleanup.py\` | \`cleanup_worktree\` now calls \`docker_compose_down\` so every caller honours "Stop docker, drop DB, remove git worktree, delete row" |
| 4 | \`workspace.py\` | \`workspace ticket <url> --variant\` refuses silent rebind when variant differs from the existing ticket's |
| 5 | \`notify.py\` | \`notify_user\` allows retry under the same key after FAILED/NOOP (SENT stays idempotent) |
| 6 | \`task_alias.py\` (new) | top-level \`t3 task {complete,list,cancel}\` alias for the overlay-scoped tasks group |
| 7 | \`overlay.py:370\` | document alias-mapping use case on \`get_dslr_tenant_for_variant\` hook |
| 8 | \`django_db.py:511\`, \`:539\` | hint references the actually-valid CLI flag (\`--fresh-dump --user-authorized\`) not the non-existent \`--slow-import\` |

## Test plan

- [x] \`uv run pytest tests/teatree_core/cleanup tests/teatree_core/test_notify.py tests/teatree_core/management_commands tests/teatree_cli/test_task_alias.py tests/django_db tests/test_overlay_base.py tests/teatree_core/test_env_command.py tests/teatree_core/test_runner_worktree_teardown.py\` — 486+ tests green
- [x] every regression test confirmed RED on pre-fix code before GREEN on post-fix
- [x] prek pre-push gates all green (banned terms, module health, BLUEPRINT, ruff, tach)

Closes #1306.