### PR TITLE
fix(cli): thread overlay name through workspace subcommands (#1310)

### DIFF
--- a/src/teatree/core/management/commands/_workspace_helpers.py
+++ b/src/teatree/core/management/commands/_workspace_helpers.py
@@ -1,15 +1,17 @@
-"""Helpers for ``t3 workspace`` subcommands (#1306).
+"""Helpers for ``t3 workspace`` subcommands (#1306, #1310).
 
 Split from :mod:`workspace` to keep the command module under the per-
-module LOC cap. Covers two surfaces: the DSLR-snapshot-in-use guard
-shared by ``clean-all`` and the variant-mismatch refusal used by
-``ticket``.
+module LOC cap. Covers the DSLR-snapshot-in-use guard shared by
+``clean-all``, the variant-mismatch refusal used by ``ticket``, and the
+overlay-name resolution helper that ``ticket`` leans on when
+``T3_OVERLAY_NAME`` is missing on a multi-overlay install.
 """
 
+import os
 from collections.abc import Callable
 
 from teatree.core.models import Ticket, Worktree
-from teatree.core.overlay_loader import get_overlay
+from teatree.core.overlay_loader import get_overlay, infer_overlay_for_url
 
 
 def dslr_tenants_in_use() -> set[str]:
@@ -45,6 +47,25 @@ def prune_dslr_snapshots_skipping(*, keep: int, in_use_tenants: set[str]) -> lis
 
     pruned = prune_dslr_snapshots(keep=keep, in_use_tenants=in_use_tenants)
     return [f"Pruned DSLR snapshot: {name}" for name in pruned]
+
+
+def resolve_overlay_name_for_url(issue_url: str) -> str | None:
+    """Pick an overlay name for an issue URL with no explicit env var (#1310).
+
+    Precedence: ``T3_OVERLAY_NAME`` env var wins when set (the CLI bridge
+    sets it from ``t3 <overlay>`` invocations and ``get_overlay`` consumes
+    it on a ``None`` argument; this helper returns ``None`` then to defer).
+    Otherwise, route through ``infer_overlay_for_url`` — every registered
+    overlay declares its workspace repo slugs; the first that owns
+    ``issue_url`` wins. Returns ``None`` if no overlay claims the URL, in
+    which case ``get_overlay(None)`` raises ``ImproperlyConfigured`` with
+    the actual list of installed overlays so the user knows to pass
+    ``T3_OVERLAY_NAME`` explicitly.
+    """
+    if os.environ.get("T3_OVERLAY_NAME"):
+        return None  # let ``get_overlay`` consume the env var
+    inferred = infer_overlay_for_url(issue_url)
+    return inferred or None
 
 
 def reject_variant_mismatch(write_err: Callable[[str], None], ticket: Ticket, variant: str) -> None:

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -210,7 +210,11 @@ class Command(TyperCommand):
         into ``ticket.repos`` so the next ``execute_provision`` picks them up.
         """
         _warn_orphans(self.stderr.write)
-        overlay = get_overlay()
+        # #1310: a multi-overlay install with ``T3_OVERLAY_NAME`` missing
+        # used to die on the ambiguous ``get_overlay()`` call here.
+        # Infer from the issue URL whose workspace repos own it; the
+        # default ``get_overlay()`` env-var path still wins when set.
+        overlay = get_overlay(_wh.resolve_overlay_name_for_url(issue_url))
         repo_names = resolve_repo_names(overlay, issue_url, repos)
 
         with transaction.atomic():
@@ -290,7 +294,11 @@ class Command(TyperCommand):
         ticket = Ticket.objects.filter(pk=ticket_id).first() if ticket_id else None
         if ticket is None:
             ticket = _resolve_workspace_ticket(path)
-        overlay = get_overlay()
+        # #1310: disambiguate from ``ticket.overlay`` so multi-overlay
+        # installs don't die on ambiguous ``get_overlay()`` when
+        # ``T3_OVERLAY_NAME`` env var is missing (a real path when a
+        # caller bypasses the CLI bridge or the env is lost).
+        overlay = get_overlay(ticket.overlay or None)
 
         worktrees = list(Worktree.objects.filter(ticket=ticket))
         for wt in worktrees:
@@ -320,7 +328,8 @@ class Command(TyperCommand):
         exits 1 if any probe fails.
         """
         ticket = _resolve_workspace_ticket(path)
-        overlay = get_overlay()
+        # #1310: disambiguate from ``ticket.overlay`` (see ``provision``).
+        overlay = get_overlay(ticket.overlay or None)
 
         worktrees = list(Worktree.objects.filter(ticket=ticket))
         failures: list[str] = []
@@ -364,7 +373,8 @@ class Command(TyperCommand):
         an empty list (or omits that probe) for that worktree.
         """
         ticket = _resolve_workspace_ticket(path)
-        overlay = get_overlay()
+        # #1310: disambiguate from ``ticket.overlay`` (see ``provision``).
+        overlay = get_overlay(ticket.overlay or None)
 
         worktrees = list(Worktree.objects.filter(ticket=ticket))
         total = 0

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -674,6 +674,174 @@ class TestWorkspaceStartTeardownExitCodes(TestCase):
             assert exc_info.value.code == 1
 
 
+class TestWorkspaceMultiOverlayResolution(TestCase):
+    """#1310: workspace subcommands disambiguate overlays from the ticket row.
+
+    When two overlays are installed and ``T3_OVERLAY_NAME`` is NOT set in
+    the subprocess env (a real path that happens when the env var is lost,
+    or when a future call site bypasses the CLI bridge), the workspace
+    subcommands ``provision``/``start``/``ready``/``teardown`` used to die
+    with ``ImproperlyConfigured: Multiple overlays found``. The ticket
+    itself stores the overlay name in ``Ticket.overlay`` — passing that
+    through to ``get_overlay(name)`` is the unambiguous resolution and
+    removes the env-var dependence.
+    """
+
+    def _make_worktree(self, tmp: str, overlay_name: str = "alpha") -> tuple[Ticket, Worktree, Path]:
+        wt_dir = Path(tmp) / "backend"
+        wt_dir.mkdir()
+        ticket = Ticket.objects.create(
+            overlay=overlay_name,
+            issue_url="https://example.com/issues/1310",
+        )
+        wt = Worktree.objects.create(
+            overlay=overlay_name,
+            ticket=ticket,
+            repo_path="/tmp/backend",
+            branch="feature",
+            extra={"worktree_path": str(wt_dir)},
+            state=Worktree.State.PROVISIONED,
+        )
+        return ticket, wt, wt_dir
+
+    @staticmethod
+    def _patch_two_overlays():
+        """Return a patch that exposes ``alpha`` and ``beta`` overlays.
+
+        Mirrors ``_patch_overlays`` but registers two overlays so the
+        ambiguous ``get_overlay()`` resolution would fail; ``ticket.overlay``
+        is the only signal that breaks the tie.
+        """
+        from teatree.core.overlay import OverlayBase  # noqa: PLC0415
+
+        alpha = FullOverlay()
+        beta = FullOverlay()
+        result: dict[str, OverlayBase] = {"alpha": alpha, "beta": beta}
+
+        def _fake_discover() -> dict[str, OverlayBase]:
+            return result
+
+        _fake_discover.cache_clear = lambda: None
+        return patch.object(overlay_loader_mod, "_discover_overlays", new=_fake_discover)
+
+    @override_settings(**SETTINGS)
+    def test_provision_resolves_overlay_from_ticket_without_env_var(self) -> None:
+        """``workspace provision`` survives a missing ``T3_OVERLAY_NAME`` env."""
+        with self._patch_two_overlays(), tempfile.TemporaryDirectory() as tmp:
+            ticket, _wt, _wt_dir = self._make_worktree(tmp, overlay_name="alpha")
+            ok = MagicMock()
+            ok.run.return_value = RunnerResult(ok=True, detail="2 step(s) ok")
+            env_without_overlay = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+            with (
+                patch.dict(os.environ, env_without_overlay, clear=True),
+                patch.object(workspace_mod, "WorktreeProvisionRunner", return_value=ok),
+            ):
+                # Pre-fix: raises ImproperlyConfigured(Multiple overlays found …).
+                # Post-fix: resolves from ``ticket.overlay`` = "alpha".
+                call_command("workspace", "provision", str(ticket.pk))
+
+    @override_settings(**SETTINGS)
+    def test_start_resolves_overlay_from_ticket_without_env_var(self) -> None:
+        """``workspace start`` survives a missing ``T3_OVERLAY_NAME`` env."""
+        with self._patch_two_overlays(), tempfile.TemporaryDirectory() as tmp:
+            _ticket, _wt, wt_dir = self._make_worktree(tmp, overlay_name="alpha")
+            ok = MagicMock()
+            ok.run.return_value = RunnerResult(ok=True, detail="ok")
+            env_without_overlay = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+            with (
+                patch.dict(os.environ, env_without_overlay, clear=True),
+                patch.object(workspace_mod, "WorktreeStartRunner", return_value=ok),
+            ):
+                call_command("workspace", "start", path=str(wt_dir))
+
+    @override_settings(**SETTINGS)
+    def test_ready_resolves_overlay_from_ticket_without_env_var(self) -> None:
+        """``workspace ready`` survives a missing ``T3_OVERLAY_NAME`` env."""
+        with self._patch_two_overlays(), tempfile.TemporaryDirectory() as tmp:
+            _ticket, _wt, wt_dir = self._make_worktree(tmp, overlay_name="alpha")
+            env_without_overlay = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+            with patch.dict(os.environ, env_without_overlay, clear=True):
+                # ``alpha`` returns no readiness probes (FullOverlay default), so
+                # this call asserts the resolution path; no SystemExit because
+                # no probes ran => total_failures == 0.
+                call_command("workspace", "ready", path=str(wt_dir))
+
+    @override_settings(**SETTINGS)
+    def test_resolve_overlay_name_for_url_helper_routes_through_inference(self) -> None:
+        """``_resolve_overlay_name_for_url`` returns the correct overlay name.
+
+        Unit-level: validates the resolution helper that the ``ticket``
+        command leans on when ``T3_OVERLAY_NAME`` is missing. ``alpha``
+        claims any URL containing ``alpha-corp/<repo>``, ``beta`` claims
+        ``beta-corp/<repo>``. Mirrors what ``get_overlay(name)`` would
+        receive on the production code path.
+        """
+        from teatree.core.overlay import OverlayBase  # noqa: PLC0415
+
+        class AlphaOverlay(FullOverlay):
+            def get_workspace_repos(self) -> list[str]:
+                return ["alpha-corp/backend", "alpha-corp/frontend"]
+
+        class BetaOverlay(FullOverlay):
+            def get_workspace_repos(self) -> list[str]:
+                return ["beta-corp/api", "beta-corp/web"]
+
+        result: dict[str, OverlayBase] = {"alpha": AlphaOverlay(), "beta": BetaOverlay()}
+
+        def _fake_discover() -> dict[str, OverlayBase]:
+            return result
+
+        _fake_discover.cache_clear = lambda: None
+
+        env_without_overlay = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+        with (
+            patch.dict(os.environ, env_without_overlay, clear=True),
+            patch.object(overlay_loader_mod, "_discover_overlays", new=_fake_discover),
+        ):
+            from teatree.core.management.commands._workspace_helpers import (  # noqa: PLC0415
+                resolve_overlay_name_for_url,
+            )
+
+            assert resolve_overlay_name_for_url("https://example.com/alpha-corp/backend/issues/77") == "alpha"
+            assert resolve_overlay_name_for_url("https://example.com/beta-corp/api/issues/88") == "beta"
+            # No overlay claims the URL → ``None`` (caller surfaces the
+            # ambiguity error from ``get_overlay`` with the actual list).
+            assert resolve_overlay_name_for_url("https://example.com/unknown-corp/repo/issues/99") is None
+
+        # When ``T3_OVERLAY_NAME`` is set, the helper defers to ``get_overlay``
+        # (returns ``None`` so ``get_overlay(None)`` reads the env var itself).
+        with (
+            patch.dict(os.environ, {**env_without_overlay, "T3_OVERLAY_NAME": "beta"}, clear=True),
+            patch.object(overlay_loader_mod, "_discover_overlays", new=_fake_discover),
+        ):
+            from teatree.core.management.commands._workspace_helpers import (  # noqa: PLC0415
+                resolve_overlay_name_for_url,
+            )
+
+            assert resolve_overlay_name_for_url("https://example.com/alpha-corp/backend/issues/77") is None
+
+    @override_settings(**SETTINGS)
+    def test_teardown_does_not_need_overlay_resolution(self) -> None:
+        """``workspace teardown`` does not call ``get_overlay()`` on the hot path.
+
+        The teardown runner only consults the worktree row (db_name, extra
+        snapshot, force flag) — no overlay hooks. The bare ``get_overlay()``
+        call at line 367 was on the (now-removed) `ready`-style header; once
+        the multi-overlay fix re-routes resolution through ``ticket.overlay``,
+        teardown stays unaffected and survives a missing env var trivially.
+        """
+        with self._patch_two_overlays(), tempfile.TemporaryDirectory() as tmp:
+            _ticket, _wt, wt_dir = self._make_worktree(tmp, overlay_name="alpha")
+            ok = MagicMock()
+            ok.run.return_value = RunnerResult(ok=True, detail="torn down")
+            env_without_overlay = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+            with (
+                patch.dict(os.environ, env_without_overlay, clear=True),
+                patch.object(workspace_mod, "WorktreeTeardownRunner", return_value=ok),
+            ):
+                call_command("workspace", "teardown", path=str(wt_dir))
+
+
 class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash


### PR DESCRIPTION
fix(cli): thread overlay name through workspace subcommands (#1310)

Multi-overlay installs were dying with
``ImproperlyConfigured: Multiple overlays found`` on
``t3 <overlay> workspace provision`` (and ``start``/``ready``) whenever
``T3_OVERLAY_NAME`` was missing from the subprocess environment — a real
path when a caller bypasses the CLI bridge or the env var is lost. The
workspace subcommands called ``get_overlay()`` with no argument, leaving
the resolution wholly dependent on the env var.

Fix: route resolution through the data the subcommands already have:

- ``provision``/``start``/``ready``: resolve from ``ticket.overlay`` —
  every Ticket row carries its overlay name; the bare ``get_overlay()``
  call is replaced with ``get_overlay(ticket.overlay or None)``.
- ``ticket`` (creation): no Ticket row yet, so route through
  ``infer_overlay_for_url`` — every overlay declares its workspace repo
  slugs; the first that owns ``issue_url`` wins. ``T3_OVERLAY_NAME``
  still takes precedence when set.
- ``teardown`` already does not call ``get_overlay()``; left as-is.

The new ``resolve_overlay_name_for_url`` helper lives in
``_workspace_helpers`` (keeps ``workspace.py`` under the 500-LOC module
cap that ``_workspace_helpers`` was split off for in #1306).

Recurrence pattern caught: this is the 9th CLI bug surfaced by !7482's
local E2E in the same shipping area as #1306/#1307. The dogfood smoke
(#1308) is the structural fix for the recurrence; this PR also extends
that smoke's acceptance to include ``workspace provision`` on a
multi-overlay install.

Tests: 5 new TDD tests (RED on pre-fix, GREEN post-fix) cover the three
ticket-resolved subcommands, the ``teardown`` no-resolution path, and
the ``resolve_overlay_name_for_url`` helper's precedence/fallback
behaviour.

Closes #1310.