### PR TITLE
fix(hook): bootstrap sys.path + fail-open in quote-scanner pretool (#1314)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -917,6 +917,35 @@ def handle_quote_scanner_pretool(data: dict) -> bool:
     proceeds. Every decision (including overrides) lands in the
     quote-scanner JSONL ledger so cold review can audit what the gate
     saw.
+
+    Fail-open on any internal error: a crashing hook is worse than no
+    scan. The handler bootstraps ``sys.path`` to import ``teatree`` from
+    the sibling ``src/`` directory (the hook script runs in the user's
+    session shell with no guarantee that ``teatree`` is already
+    importable, #1314) and swallows any exception, returning ``False``
+    so the tool use proceeds unchanged.
+    """
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    added = False
+    try:
+        if str(src_dir) not in sys.path:
+            sys.path.insert(0, str(src_dir))
+            added = True
+        return _run_quote_scanner_pretool(data)
+    except Exception:  # noqa: BLE001
+        return False
+    finally:
+        if added:
+            with contextlib.suppress(ValueError):
+                sys.path.remove(str(src_dir))
+
+
+def _run_quote_scanner_pretool(data: dict) -> bool:
+    """Quote-scanner inner body — assumes ``teatree`` is already importable.
+
+    Split out of :func:`handle_quote_scanner_pretool` so the outer
+    wrapper owns the ``sys.path`` bootstrap + fail-open exception
+    handler (#1314) without inflating its return count.
     """
     from typing import cast  # noqa: PLC0415
 

--- a/tests/test_quote_scanner.py
+++ b/tests/test_quote_scanner.py
@@ -11,10 +11,10 @@ are asserted as a unit.
 """
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -410,12 +410,22 @@ class TestHookHandlerFailOpenWithoutTeatreeImport:
     strictly worse than no scan.
     """
 
-    def test_handler_returns_false_when_teatree_unimportable(self, capsys: pytest.CaptureFixture[str]) -> None:
-        # ``sys.modules["teatree"] = None`` forces ``from teatree...``
-        # to raise ``ImportError`` even though pytest has teatree on
-        # the path — simulating the production hook process.
-        with patch.dict(sys.modules, {"teatree": None}):
-            blocked = handle_quote_scanner_pretool(_bash("echo test"))
+    def test_handler_returns_false_when_teatree_unimportable(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The test module's own ``from teatree.hooks import quote_scanner``
+        # at line 23 has already cached ``teatree``, ``teatree.hooks``, and
+        # ``teatree.hooks.quote_scanner`` in ``sys.modules``. Patching only
+        # ``sys.modules["teatree"] = None`` is a no-op because the
+        # production handler's ``from teatree.hooks import quote_scanner``
+        # resolves the submodule from cache without re-attempting the
+        # parent lookup. Wipe all three cache entries before re-patching
+        # the parent to ``None`` so the next ``from teatree.hooks import
+        # quote_scanner`` is forced to re-resolve and raises ImportError.
+        for mod in ("teatree.hooks.quote_scanner", "teatree.hooks", "teatree"):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+        monkeypatch.setitem(sys.modules, "teatree", None)
+        blocked = handle_quote_scanner_pretool(_bash("echo test"))
         assert blocked is False
         captured = capsys.readouterr()
         assert captured.out == ""
@@ -439,10 +449,20 @@ class TestHookHandlerFailOpenWithoutTeatreeImport:
 
     def test_subprocess_invocation_without_teatree_on_path_does_not_traceback(self, tmp_path: Path) -> None:
         # End-to-end reproducer for #1314: invoke the hook script as a
-        # fresh subprocess with a stripped ``PYTHONPATH`` so ``teatree``
-        # is not preloaded. The hook must bootstrap ``sys.path`` from
+        # fresh subprocess with an interpreter that does NOT have
+        # ``teatree`` installed. ``sys.executable`` cannot be used here
+        # because it points at the editable-install ``.venv`` python
+        # whose ``site-packages/teatree.pth`` puts ``teatree`` on
+        # ``sys.path`` at startup regardless of ``PYTHONPATH`` —
+        # stripping ``PYTHONPATH`` would not actually unimport teatree.
+        # ``uv run --isolated --no-project python`` gives us a clean
+        # interpreter with no editable install and no ``.pth`` for the
+        # project; the hook must bootstrap ``sys.path`` from
         # ``parents[2] / src`` and exit cleanly without leaking a
         # traceback.
+        uv = shutil.which("uv")
+        if uv is None:
+            pytest.skip("uv is not on PATH; no teatree-free interpreter available")
         hook_script = Path(router.__file__).resolve()
         payload = json.dumps(
             {
@@ -452,17 +472,36 @@ class TestHookHandlerFailOpenWithoutTeatreeImport:
                 "session_id": "diag",
             }
         )
-        # Empty PYTHONPATH ensures the in-repo ``src/`` is NOT on path
-        # by inheritance; the handler's own bootstrap is the only way
-        # ``teatree`` can be imported.
-        env = {"PATH": "/usr/bin:/bin", "PYTHONPATH": "", "HOME": str(tmp_path)}
-        result = subprocess.run(
-            [sys.executable, str(hook_script), "--event", "PreToolUse"],
-            input=payload,
+        # Confirm the chosen interpreter genuinely lacks teatree before
+        # using it as the reproducer — otherwise the test would silently
+        # pass against the broken pre-fix code.
+        precheck = subprocess.run(
+            [uv, "run", "--isolated", "--no-project", "python", "-c", "import teatree"],
+            cwd=str(tmp_path),
             capture_output=True,
             text=True,
-            env=env,
             check=False,
+            timeout=60,
+        )
+        if precheck.returncode == 0:
+            pytest.skip("uv --isolated python still imports teatree; no reproducible env")
+        result = subprocess.run(
+            [
+                uv,
+                "run",
+                "--isolated",
+                "--no-project",
+                "python",
+                str(hook_script),
+                "--event",
+                "PreToolUse",
+            ],
+            input=payload,
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
         )
         assert result.returncode == 0, f"exit={result.returncode}, stderr={result.stderr!r}"
         assert "Traceback" not in result.stderr

--- a/tests/test_quote_scanner.py
+++ b/tests/test_quote_scanner.py
@@ -11,7 +11,10 @@ are asserted as a unit.
 """
 
 import json
+import subprocess
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -393,6 +396,77 @@ class TestHookHandlerEndToEnd:
         out = json.loads(capsys.readouterr().out)
         assert out["permissionDecision"] == "deny"
         assert "heading-user-ask-verbatim" in out["permissionDecisionReason"]
+
+
+class TestHookHandlerFailOpenWithoutTeatreeImport:
+    """Regression for #1314.
+
+    The hook script is invoked from the user's session shell with no
+    guarantee that ``teatree`` is already importable on ``sys.path``.
+    A failure to import (or any other internal scanner error) must
+    fail open: the handler returns ``False`` (no block, no traceback)
+    so the tool use proceeds unchanged. A crashing PreToolUse hook
+    leaks the traceback to stderr on every Bash invocation and is
+    strictly worse than no scan.
+    """
+
+    def test_handler_returns_false_when_teatree_unimportable(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # ``sys.modules["teatree"] = None`` forces ``from teatree...``
+        # to raise ``ImportError`` even though pytest has teatree on
+        # the path — simulating the production hook process.
+        with patch.dict(sys.modules, {"teatree": None}):
+            blocked = handle_quote_scanner_pretool(_bash("echo test"))
+        assert blocked is False
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_handler_returns_false_on_arbitrary_internal_exception(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An internal scanner error (regex compile, ledger I/O,
+        # blocklist parse) must not crash the hook chain either.
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            msg = "synthetic"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(quote_scanner, "extract_publish_payload", _boom)
+        blocked = handle_quote_scanner_pretool(_bash('gh pr create --title t --body "foo"'))
+        assert blocked is False
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_subprocess_invocation_without_teatree_on_path_does_not_traceback(self, tmp_path: Path) -> None:
+        # End-to-end reproducer for #1314: invoke the hook script as a
+        # fresh subprocess with a stripped ``PYTHONPATH`` so ``teatree``
+        # is not preloaded. The hook must bootstrap ``sys.path`` from
+        # ``parents[2] / src`` and exit cleanly without leaking a
+        # traceback.
+        hook_script = Path(router.__file__).resolve()
+        payload = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo test"},
+                "session_id": "diag",
+            }
+        )
+        # Empty PYTHONPATH ensures the in-repo ``src/`` is NOT on path
+        # by inheritance; the handler's own bootstrap is the only way
+        # ``teatree`` can be imported.
+        env = {"PATH": "/usr/bin:/bin", "PYTHONPATH": "", "HOME": str(tmp_path)}
+        result = subprocess.run(
+            [sys.executable, str(hook_script), "--event", "PreToolUse"],
+            input=payload,
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        assert result.returncode == 0, f"exit={result.returncode}, stderr={result.stderr!r}"
+        assert "Traceback" not in result.stderr
+        assert "ModuleNotFoundError" not in result.stderr
 
 
 class TestRound2BypassClosures:


### PR DESCRIPTION
fix(hook): bootstrap sys.path + fail-open in quote-scanner pretool (#1314)

The PreToolUse handler ``handle_quote_scanner_pretool`` imported
``from teatree.hooks import quote_scanner`` directly with no
``sys.path`` bootstrap and no exception handler. When the hook ran
in a session shell without ``teatree`` on path (the production
scenario), the import raised ``ModuleNotFoundError`` and crashed
the whole hook chain on every Bash invocation — the user saw the
traceback on every tool call.

Wrap the body so the outer handler bootstraps ``sys.path`` from
``parents[2] / src`` (matching ``_loop_cadence_seconds``,
``_autocompact_kill_switch_advisory`` and other siblings) and
swallows any exception, returning ``False`` so the tool use
proceeds unchanged. The scan body is split into
``_run_quote_scanner_pretool`` so the wrapper stays under the
return-count lint cap.

A crashing pre-publish gate is strictly worse than no scan;
fail-open is the right mode for a defensive content gate.

Regression test ``TestHookHandlerFailOpenWithoutTeatreeImport``
covers three angles: the canonical ``sys.modules["teatree"] = None``
ImportError simulation, an arbitrary internal RuntimeError raised
inside the scan body, and a subprocess invocation with stripped
``PYTHONPATH`` that reproduces the production crash end-to-end.