### PR TITLE
fix(worktree_env): copy env cache instead of symlinking it (#1313)

### DIFF
--- a/src/teatree/core/worktree_env.py
+++ b/src/teatree/core/worktree_env.py
@@ -12,6 +12,7 @@ truth.
 """
 
 import platform
+import shutil
 import stat
 from dataclasses import dataclass
 from pathlib import Path
@@ -144,10 +145,18 @@ def render_env_cache(worktree: Worktree) -> EnvCacheSpec | None:
 
 
 def write_env_cache(worktree: Worktree) -> EnvCacheSpec | None:
-    """Write the env cache and symlink it into the repo worktree.
+    """Write the env cache and copy it into the repo worktree.
 
     Idempotent.  Writes the file ``chmod 444``.  Callers that modify the
     DB should call this afterwards to refresh the cache.
+
+    The in-worktree copy at ``<wt_path>/.t3-env.cache`` is a real file,
+    not a symlink: when the worktree is bind-mounted into a Docker
+    container, a symlink pointing at the host-absolute cache path
+    dangles inside the container (errno 22 on stat). A real-file copy
+    survives any mount layout. Drift detection still compares the
+    canonical file under ``.t3-cache/`` against a fresh DB render, so
+    the worktree-local copy is just a consumer-facing convenience.
     """
     spec = render_env_cache(worktree)
     if spec is None:
@@ -163,10 +172,10 @@ def write_env_cache(worktree: Worktree) -> EnvCacheSpec | None:
     spec.path.write_text(spec.content, encoding="utf-8")
     spec.path.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)  # 0o444
 
-    repo_link = wt_path / CACHE_FILENAME
-    if repo_link.is_symlink() or repo_link.exists():
-        repo_link.unlink()
-    repo_link.symlink_to(spec.path)
+    repo_copy = wt_path / CACHE_FILENAME
+    if repo_copy.is_symlink() or repo_copy.exists():
+        repo_copy.unlink()
+    shutil.copy2(spec.path, repo_copy)
 
     return spec
 

--- a/tests/teatree_core/test_workflows.py
+++ b/tests/teatree_core/test_workflows.py
@@ -198,8 +198,14 @@ class TestLifecycleProvision(TestCase):
         assert "WT_VARIANT=testclient" in env_content
         assert "WT_DB_NAME=wt_42_testclient" in env_content
         assert "DJANGO_SETTINGS_MODULE=" in env_content
-        assert (ticket_dir / "backend" / ".t3-env.cache").is_symlink()
-        assert (ticket_dir / "frontend" / ".t3-env.cache").is_symlink()
+        # Per-repo copies are regular files, not symlinks (#1313) — a
+        # host-absolute symlink would dangle inside a bind-mounted container.
+        backend_copy = ticket_dir / "backend" / ".t3-env.cache"
+        frontend_copy = ticket_dir / "frontend" / ".t3-env.cache"
+        assert backend_copy.is_file()
+        assert not backend_copy.is_symlink()
+        assert frontend_copy.is_file()
+        assert not frontend_copy.is_symlink()
 
     @override_settings(**WORKFLOW_SETTINGS)
     def test_start_transitions_to_services_up(self) -> None:

--- a/tests/teatree_core/test_worktree_env.py
+++ b/tests/teatree_core/test_worktree_env.py
@@ -252,10 +252,13 @@ class TestWriteEnvCache(TestCase):
             mode = stat.S_IMODE(spec.path.stat().st_mode)
             assert mode == 0o444
 
-            # Symlink in repo
-            repo_link = wt_path / CACHE_FILENAME
-            assert repo_link.is_symlink()
-            assert repo_link.resolve() == spec.path.resolve()
+            # Real file in repo — not a symlink (#1313). A symlink would dangle
+            # inside a bind-mounted container because the target is a host-only
+            # absolute path.
+            repo_copy = wt_path / CACHE_FILENAME
+            assert not repo_copy.is_symlink()
+            assert repo_copy.is_file()
+            assert repo_copy.read_text(encoding="utf-8") == spec.path.read_text(encoding="utf-8")
 
     def test_shared_postgres_adds_host(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -322,6 +325,50 @@ class TestWriteEnvCache(TestCase):
                 spec = write_env_cache(wt)
             assert spec is not None
             assert "MYAPP_BASE_IMAGE=myapp-local:deps-" in spec.content
+
+
+class TestRepoCopyNotSymlink(TestCase):
+    """Regression for #1313 — the in-worktree copy must be a real file.
+
+    A symlink at ``<wt_path>/.t3-env.cache`` pointing at the host-absolute
+    cache path dangles inside a bind-mounted container, breaking any
+    in-container reader of the env file (pipenv, dotenv, plain ``stat``)
+    with errno 22.
+    """
+
+    def test_repo_copy_is_regular_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt, wt_path = _make_worktree(tmp, ticket_name="t-r1", ticket_url="https://ex.com/r1", db_name="wt_r1")
+            with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_COMMAND):
+                spec = write_env_cache(wt)
+            assert spec is not None
+            repo_copy = wt_path / CACHE_FILENAME
+            assert not repo_copy.is_symlink()
+            assert repo_copy.is_file()
+
+    def test_repo_copy_content_equals_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt, wt_path = _make_worktree(tmp, ticket_name="t-r2", ticket_url="https://ex.com/r2", db_name="wt_r2")
+            with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_COMMAND):
+                spec = write_env_cache(wt)
+            assert spec is not None
+            repo_copy = wt_path / CACHE_FILENAME
+            assert repo_copy.read_text(encoding="utf-8") == spec.path.read_text(encoding="utf-8")
+
+    def test_repo_copy_survives_source_deletion(self) -> None:
+        """A real file is independent of the source — symlinks would dangle."""
+        with tempfile.TemporaryDirectory() as tmp:
+            wt, wt_path = _make_worktree(tmp, ticket_name="t-r3", ticket_url="https://ex.com/r3", db_name="wt_r3")
+            with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_COMMAND):
+                spec = write_env_cache(wt)
+            assert spec is not None
+            repo_copy = wt_path / CACHE_FILENAME
+            expected = spec.path.read_text(encoding="utf-8")
+            spec.path.chmod(stat.S_IWUSR | stat.S_IRUSR)
+            spec.path.unlink()
+            assert repo_copy.is_file()
+            assert not repo_copy.is_symlink()
+            assert repo_copy.read_text(encoding="utf-8") == expected
 
 
 class TestDetectDrift(TestCase):


### PR DESCRIPTION
## Summary

`teatree/src/teatree/core/worktree_env.py:169` wrote the in-worktree `.t3-env.cache` as a symlink pointing at the host-absolute cache path under `<ticket_dir>/.t3-cache/`. When the worktree directory is bind-mounted into a Docker container (overlay-common pattern), the symlink lives inside the container at e.g. `/app/.t3-env.cache` but its target is host-only — `stat` fails with `OSError: [Errno 22] Invalid argument` for any in-container reader (pipenv's `load_dot_env`, dotenv, plain `Path.is_file()`).

Cascade in the wild: `install-custom-requirements` fails, the worktree DB is never created, `web` crashes with `database "<wt_db>" does not exist`, and the FSM stalls at `services_up`.

Picked **the `shutil.copy2` shape** from the issue: replace `repo_link.symlink_to(spec.path)` with `shutil.copy2(spec.path, repo_link)`. The canonical file under `.t3-cache/` is still the source for drift detection — the worktree-local copy is just a consumer-facing convenience and is regenerated on every `worktree start` / `env set`. No extension-point obligation on overlay authors (which the relative-symlink shape would impose by requiring each overlay's compose generator to bind-mount `.t3-cache/` as a sibling).

Closes [#1313](https://github.com/souliane/teatree/issues/1313).

## Changes

- `src/teatree/core/worktree_env.py`: `shutil.copy2` instead of `symlink_to` in `write_env_cache`, docstring updated to explain the bind-mount rationale, idempotent unlink of any pre-existing symlink or file.
- `tests/teatree_core/test_worktree_env.py`: new `TestRepoCopyNotSymlink` regression class — asserts the in-worktree copy is a regular file, content equals the source, and the copy survives source deletion. Existing `test_writes_cache_in_hidden_dir` updated to match.
- `tests/teatree_core/test_workflows.py`: `TestLifecycleProvision.test_setup_provisions_worktrees_and_generates_env` updated to assert `is_file() and not is_symlink()`.

## Test plan

- [x] `uv run pytest tests/teatree_core/test_worktree_env.py -q --no-cov` — 22 passed (including 3 new regression tests).
- [x] `uv run pytest tests/teatree_core/test_workflows.py -q --no-cov` — 15 passed.
- [x] Pre-fix RED proof: reverted `shutil.copy2` to `symlink_to`, ran `TestRepoCopyNotSymlink` — `test_repo_copy_is_regular_file` failed with `AssertionError: assert not True is_symlink()`. Post-fix GREEN restored.
- [x] `prek` on changed files — all hooks pass (banned-terms `--all-files` failures are pre-existing, untouched by this PR).