### PR TITLE
fix(review-request): route discover/check/post to teatree-core dispatch (#1312)

### DIFF
--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shutil
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import typer
@@ -25,8 +26,25 @@ across Typer's ``get_command`` conversion.
 """
 
 
-DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
-    "worktree": (
+@dataclass(frozen=True)
+class DjangoGroup:
+    """One overlay sub-app group description.
+
+    ``core_dispatch`` flags groups whose subcommands live in
+    ``teatree.core.management.commands`` (not in any overlay-owned
+    ``manage.py``). When ``True``, :meth:`OverlayAppBuilder._bridge_subcommand`
+    dispatches via :func:`managepy_core` (``python -m teatree``) so the call
+    never reaches an overlay's ``manage.py`` whose settings module may not
+    register the command (#1318 follow-up to #1312).
+    """
+
+    help_text: str
+    subcommands: list[tuple[str, str]]
+    core_dispatch: bool = False
+
+
+DJANGO_GROUPS: dict[str, DjangoGroup] = {
+    "worktree": DjangoGroup(
         "Per-worktree FSM operations.",
         [
             ("provision", "Run DB import + env cache + direnv + prek + overlay setup steps for one worktree."),
@@ -40,7 +58,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("diagram", "Print a state diagram as Mermaid. Models: worktree, ticket, task."),
         ],
     ),
-    "workspace": (
+    "workspace": DjangoGroup(
         "Ticket-level workspace operations (every worktree in the ticket).",
         [
             ("ticket", "Create or update a ticket and trigger worktree provisioning."),
@@ -55,7 +73,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("list-orphans", "List orphan branches (commits not on main, no open PR)."),
         ],
     ),
-    "run": (
+    "run": DjangoGroup(
         "Run services.",
         [
             ("verify", "Verify worktree state and return URLs."),
@@ -66,7 +84,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("tests", "Run the project test suite."),
         ],
     ),
-    "e2e": (
+    "e2e": DjangoGroup(
         "E2E test commands.",
         [
             ("run", "Run E2E tests — dispatches to project or external runner based on overlay config."),
@@ -75,7 +93,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("project", "Run E2E tests from the project's own test directory."),
         ],
     ),
-    "db": (
+    "db": DjangoGroup(
         "Database operations.",
         [
             ("refresh", "Re-import the worktree database from dump/DSLR."),
@@ -85,7 +103,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("shell", "Drop into a Django shell against the resolved (gate) control DB."),
         ],
     ),
-    "pr": (
+    "pr": DjangoGroup(
         "Pull request helpers.",
         [
             ("create", "Create a pull request for the ticket's branch."),
@@ -97,7 +115,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("sweep", "List your open PRs across the forge for the /t3:sweeping-prs skill."),
         ],
     ),
-    "tasks": (
+    "tasks": DjangoGroup(
         "Async task queue.",
         [
             ("cancel", "Cancel a task by ID."),
@@ -110,7 +128,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("work-next-user-input", "Claim and execute a user input task."),
         ],
     ),
-    "followup": (
+    "followup": DjangoGroup(
         "Follow-up snapshots.",
         [
             ("refresh", "Return counts of tickets and tasks."),
@@ -118,22 +136,23 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("discover-mrs", "List the user's open non-draft PRs/MRs awaiting a review request."),
             ("remind", "Return list of pending user input tasks."),
         ],
+        core_dispatch=True,
     ),
-    "standup": (
+    "standup": DjangoGroup(
         "Auto-generated daily update (read-only).",
         [
             ("generate", "Generate a standup from transition + attempt data (read-only)."),
             ("stale", "List tickets with no activity past the staleness threshold (read-only)."),
         ],
     ),
-    "lifecycle": (
+    "lifecycle": DjangoGroup(
         "Session lifecycle and phase tracking.",
         [
             ("visit-phase", "Mark a phase as visited on the ticket's latest session."),
             ("clear-ledger", "Clear a reused ticket's stale phase ledger (sanctioned session-retire)."),
         ],
     ),
-    "env": (
+    "env": DjangoGroup(
         "Inspect and mutate the worktree env cache.",
         [
             ("show", "Print the env cache as the DB would render it."),
@@ -144,7 +163,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("migrate-secrets", "Move POSTGRES_PASSWORD literals out of .t3-env.cache into pass."),
         ],
     ),
-    "ticket": (
+    "ticket": DjangoGroup(
         "Ticket state management.",
         [
             ("transition", "Transition a ticket to a new state."),
@@ -156,7 +175,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("context", "Durable per-ticket knowledge store: show / add / edit (#627)."),
         ],
     ),
-    "availability": (
+    "availability": DjangoGroup(
         "24/7 dual question-mode (#58, BLUEPRINT §17.1 invariant 9).",
         [
             ("away", "Set manual away-mode override (questions queue as DeferredQuestion rows)."),
@@ -165,7 +184,7 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("show", "Print the currently resolved mode and source (override/schedule/default)."),
         ],
     ),
-    "questions": (
+    "questions": DjangoGroup(
         "Manage the away-mode deferred-question backlog (#58).",
         [
             ("record", "Record a deferred question (used by the PreToolUse away-mode hook)."),
@@ -174,14 +193,14 @@ DJANGO_GROUPS: dict[str, tuple[str, list[tuple[str, str]]]] = {
             ("dismiss", "Dismiss a pending question without answering it."),
         ],
     ),
-    "pending_chat": (
+    "pending_chat": DjangoGroup(
         "Manage the inbound Slack-DM queue (#1063).",
         [
             ("list", "List inbound rows from the last hour (or --all)."),
             ("mark-answered", "Stamp ``answered_at`` on rows matching a Slack ts."),
         ],
     ),
-    "notify": (
+    "notify": DjangoGroup(
         "Bot→user Slack DM from the shell (#1030).",
         [
             ("send", "DM the user; exit 0 on delivery, 1 otherwise (sub-agent direct notify)."),
@@ -305,10 +324,10 @@ class OverlayAppBuilder:
         self._register_shortcut_commands()
         self._register_config_commands()
 
-        for group_name, (help_text, subcommands) in DJANGO_GROUPS.items():
-            group = typer.Typer(no_args_is_help=True, help=help_text)
-            for sub_name, sub_help in subcommands:
-                self._bridge_subcommand(group, group_name, sub_name, sub_help)
+        for group_name, dj_group in DJANGO_GROUPS.items():
+            group = typer.Typer(no_args_is_help=True, help=dj_group.help_text)
+            for sub_name, sub_help in dj_group.subcommands:
+                self._bridge_subcommand(group, group_name, sub_name, sub_help, core_dispatch=dj_group.core_dispatch)
             self.overlay_app.add_typer(group, name=group_name)
 
         self._register_overlay_tools()
@@ -367,7 +386,11 @@ class OverlayAppBuilder:
         @overlay_app.command(name="full-status")
         def full_status() -> None:
             """Show ticket, worktree, and session state summary."""
-            managepy(project_path, "followup", "refresh", overlay_name=overlay_name)
+            # ``followup`` is a teatree-CORE management command — dispatch via
+            # ``python -m teatree`` so an overlay clone with its own
+            # ``manage.py`` (different settings module) does not crash with
+            # ``Unknown command: 'followup'`` (#1318).
+            managepy_core("followup", "refresh", overlay_name=overlay_name)
 
         @overlay_app.command(name="ship")
         def ship(
@@ -383,7 +406,8 @@ class OverlayAppBuilder:
         @overlay_app.command(name="daily")
         def daily() -> None:
             """Daily followup — sync MRs, check gates, remind reviewers."""
-            managepy(project_path, "followup", "sync", overlay_name=overlay_name)
+            # Same as ``full-status``: ``followup`` is core-only (#1318).
+            managepy_core("followup", "sync", overlay_name=overlay_name)
 
         self._register_agent_command()
 
@@ -443,12 +467,20 @@ class OverlayAppBuilder:
         group_name: str,
         sub_name: str,
         sub_help: str,
+        *,
+        core_dispatch: bool = False,
     ) -> None:
         """Register a single subcommand that forwards to ``manage.py <group> <sub>``.
 
         Uses ``invoke_without_command=True`` and disables the default typer help
         so that ``--help`` is forwarded to the Django management command, which
         shows the real options (``--path``, ``--variant``, etc.).
+
+        When ``core_dispatch`` is ``True`` the command is dispatched via
+        :func:`managepy_core` (teatree-native ``python -m teatree``) instead
+        of :func:`managepy` — required for groups whose commands live in
+        teatree core only and would crash if routed through an overlay's
+        own ``manage.py`` (#1312, #1318).
         """
         project_path = self.project_path
         overlay_name = self.overlay_name
@@ -464,7 +496,10 @@ class OverlayAppBuilder:
             add_help_option=False,
         )
         def _run(ctx: typer.Context) -> None:
-            managepy(project_path, group_name, sub_name, *ctx.args, overlay_name=overlay_name)
+            if core_dispatch:
+                managepy_core(group_name, sub_name, *ctx.args, overlay_name=overlay_name)
+            else:
+                managepy(project_path, group_name, sub_name, *ctx.args, overlay_name=overlay_name)
 
         _run.__name__ = f"_run_{group_name}_{sub_name.replace('-', '_')}"
         OVERLAY_PROXY_COMMANDS[_run.__name__] = (group_name, sub_name)

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -260,6 +260,28 @@ def managepy(project_path: Path | None, *args: str, overlay_name: str = "") -> N
         run_streamed([sys.executable, "-m", "teatree", *args], env=env)
 
 
+def managepy_core(*args: str, overlay_name: str = "") -> None:
+    """Run a teatree-CORE management command via ``python -m teatree``.
+
+    Use this for commands that live in ``teatree.core.management.commands`` —
+    ``followup``, ``review_request_check``, ``review_request_post``, etc.
+    These exist on teatree core, not on overlay-owned ``manage.py`` projects
+    (an overlay clone may run against its own settings module that has no
+    such commands). Routing them through :func:`managepy` would crash when
+    invoked from such a clone, because :func:`managepy` prefers the overlay's
+    ``manage.py`` whenever the resolved project path has one (#1312).
+
+    When *overlay_name* is provided, ``T3_OVERLAY_NAME`` is set in the subprocess
+    environment so that ``get_overlay()`` can resolve the correct overlay even
+    when multiple overlays are installed.
+    """
+    env = _base_env()
+    if overlay_name:
+        env["T3_OVERLAY_NAME"] = overlay_name
+    env.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+    run_streamed([sys.executable, "-m", "teatree", *args], env=env)
+
+
 class OverlayAppBuilder:
     """Build a Typer sub-app for a single installed overlay."""
 

--- a/src/teatree/cli/review_request.py
+++ b/src/teatree/cli/review_request.py
@@ -4,13 +4,13 @@ from pathlib import Path
 
 import typer
 
-from teatree.cli.overlay import managepy
+from teatree.cli.overlay import managepy_core
 
 review_request_app = typer.Typer(no_args_is_help=True, help="Batch review requests.")
 
 
 def _active_project() -> tuple[Path, str]:
-    """Resolve the (project_path, overlay_name) the managepy delegate runs as.
+    """Resolve the (project_path, overlay_name) for review-request dispatch.
 
     Routes through :func:`config._active_overlay_entry` so the precedence
     matches ``get_overlay()``: ``T3_OVERLAY_NAME`` env first, then the
@@ -21,6 +21,11 @@ def _active_project() -> tuple[Path, str]:
     configured overlay could not resolve that overlay's Connect
     channel/token (#1103). The cwd-``manage.py`` discovery is preserved as
     the final fallback (dev-mode unbroken).
+
+    The returned ``project_path`` is no longer used to pick the dispatch
+    target (commands here are teatree-CORE — see :func:`managepy_core` and
+    #1312); it is kept on the tuple only to preserve the existing return
+    shape for callers and tests.
     """
     from teatree.cli import _find_project_root  # noqa: PLC0415
     from teatree.config import _active_overlay_entry  # noqa: PLC0415
@@ -33,8 +38,8 @@ def _active_project() -> tuple[Path, str]:
 @review_request_app.command()
 def discover() -> None:
     """Discover open merge requests awaiting review."""
-    project, overlay_name = _active_project()
-    managepy(project, "followup", "discover-mrs", overlay_name=overlay_name)
+    _, overlay_name = _active_project()
+    managepy_core("followup", "discover-mrs", overlay_name=overlay_name)
 
 
 @review_request_app.command()
@@ -48,8 +53,8 @@ def check(mr_url: str = typer.Option(..., "--mr-url", help="Canonical MR/PR URL 
     ``ReviewRequestPost`` claim (``peek_should_post_review_request``), so
     it can never leave an orphan that wedges a later real post (#1103).
     """
-    project, overlay_name = _active_project()
-    managepy(project, "review_request_check", "--mr-url", mr_url, overlay_name=overlay_name)
+    _, overlay_name = _active_project()
+    managepy_core("review_request_check", "--mr-url", mr_url, overlay_name=overlay_name)
 
 
 @review_request_app.command()
@@ -65,10 +70,9 @@ def post(
     the only way to satisfy it), then the post. Refuses with the exact
     ``approve-on-behalf`` remediation when no recorded approval matches.
     """
-    project, overlay_name = _active_project()
+    _, overlay_name = _active_project()
     extra = ("--title", title) if title else ()
-    managepy(
-        project,
+    managepy_core(
         "review_request_post",
         "--mr-url",
         mr_url,

--- a/tests/teatree_core/test_overlay_core_dispatch.py
+++ b/tests/teatree_core/test_overlay_core_dispatch.py
@@ -1,0 +1,133 @@
+"""Followup / full-status / daily must dispatch via teatree-core (#1318 follow-up).
+
+#1312's first fix routed ``review-request discover/check/post`` through
+:func:`managepy_core`, but ``full-status``, ``daily``, and every
+``followup`` subcommand still went through :func:`managepy` — which prefers
+the overlay's own ``manage.py`` whenever one exists. From an overlay clone
+whose ``manage.py`` runs against its own settings module (no ``followup``
+management command), every one of these commands crashed exactly the same
+way ``review-request`` did before #1312.
+
+These tests pin the contract: each of the four entry points emits a
+``python -m teatree`` invocation (the teatree-core dispatch path),
+regardless of any resolved project path — including the overlay-clone
+case where the project path DOES contain a ``manage.py``, which is the
+exact shape that crashed the bug.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from teatree.cli.overlay import DJANGO_GROUPS, OverlayAppBuilder
+
+
+@pytest.fixture
+def overlay_clone_path(tmp_path: Path) -> Path:
+    """An overlay clone with its own ``manage.py`` — the bug's reproduction shape.
+
+    :func:`managepy` prefers ``uv --directory <path> run python manage.py``
+    whenever the resolved path contains a ``manage.py``. Before #1318's
+    follow-up fix, the followup group + ``full-status``/``daily``
+    shortcuts went through that branch and crashed because the overlay's
+    ``manage.py`` ran against settings that don't register the
+    ``followup`` management command.
+    """
+    (tmp_path / "manage.py").write_text("# stub overlay manage.py\n", encoding="utf-8")
+    return tmp_path
+
+
+def _build_overlay_app(project_path: Path) -> typer.Typer:
+    """Build a fully-configured overlay Typer app for the test runner."""
+    return OverlayAppBuilder(overlay_name="acme", project_path=project_path).build()
+
+
+class TestFollowupGroupCoreDispatch:
+    """``followup refresh/sync/discover-mrs/remind`` route through ``python -m teatree``."""
+
+    def test_followup_group_is_marked_core_dispatch(self) -> None:
+        """``DJANGO_GROUPS['followup']`` carries the ``core_dispatch`` marker."""
+        entry = DJANGO_GROUPS["followup"]
+        assert getattr(entry, "core_dispatch", False) is True, (
+            f"followup group must opt into core dispatch (#1318), got {entry!r}"
+        )
+
+    def test_followup_refresh_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["followup", "refresh"])
+        assert result.exit_code == 0, result.output
+        assert run_streamed.called
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"followup refresh must dispatch via python -m teatree, got {cmd!r}"
+        assert "teatree" in cmd, f"followup refresh must dispatch via python -m teatree, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd), f"followup refresh must NOT route through manage.py, got {cmd!r}"
+
+    def test_followup_sync_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["followup", "sync"])
+        assert result.exit_code == 0, result.output
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"followup sync must use core dispatch, got {cmd!r}"
+        assert "teatree" in cmd, f"followup sync must use core dispatch, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd)
+
+    def test_followup_discover_mrs_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["followup", "discover-mrs"])
+        assert result.exit_code == 0, result.output
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"followup discover-mrs must use core dispatch, got {cmd!r}"
+        assert "teatree" in cmd, f"followup discover-mrs must use core dispatch, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd)
+
+    def test_followup_remind_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["followup", "remind"])
+        assert result.exit_code == 0, result.output
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"followup remind must use core dispatch, got {cmd!r}"
+        assert "teatree" in cmd, f"followup remind must use core dispatch, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd)
+
+
+class TestShortcutCoreDispatch:
+    """``full-status`` and ``daily`` shortcut to followup commands — same dispatch rule."""
+
+    def test_full_status_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        """``t3 <overlay> full-status`` must reach ``python -m teatree followup refresh``."""
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["full-status"])
+        assert result.exit_code == 0, result.output
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"full-status must use core dispatch, got {cmd!r}"
+        assert "teatree" in cmd, f"full-status must use core dispatch, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd)
+        assert "followup" in cmd
+        assert "refresh" in cmd
+
+    def test_daily_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        """``t3 <overlay> daily`` must reach ``python -m teatree followup sync``."""
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["daily"])
+        assert result.exit_code == 0, result.output
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"daily must use core dispatch, got {cmd!r}"
+        assert "teatree" in cmd, f"daily must use core dispatch, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd)
+        assert "followup" in cmd
+        assert "sync" in cmd

--- a/tests/teatree_core/test_review_request_cli.py
+++ b/tests/teatree_core/test_review_request_cli.py
@@ -1,6 +1,6 @@
-"""``t3 review-request`` overlay routing — ``_active_project`` (#1103).
+"""``t3 review-request`` overlay routing — ``_active_project`` (#1103, #1312).
 
-Bug B: the typer ``post``/``check`` delegates resolved the managepy
+Bug B (#1103): the typer ``post``/``check`` delegates resolved the managepy
 target via ``discover_active_overlay()``, which the cwd-``manage.py``
 discovery resolves to the clone the agent runs from (→ the teatree
 project when run from the teatree repo) — so a review-request post for a
@@ -8,14 +8,25 @@ project when run from the teatree repo) — so a review-request post for a
 channel/token. The fix routes through ``config._active_overlay_entry``
 so ``T3_OVERLAY_NAME`` wins first (matching ``get_overlay()``), with the
 cwd-``manage.py`` developer fallback preserved.
+
+Bug (#1312): the same delegates then handed the resolved overlay
+``project_path`` to :func:`managepy`, which prefers the overlay's own
+``manage.py`` when one exists. ``followup`` / ``review_request_check`` /
+``review_request_post`` are teatree-CORE management commands and an
+overlay's ``manage.py`` (running against its own settings module) has
+no such commands, so both crashed with ``Unknown command: 'followup'``.
+The fix routes them via :func:`managepy_core` so dispatch is always
+``python -m teatree`` regardless of overlay project path.
 """
 
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import typer
+from typer.testing import CliRunner
 
-from teatree.cli.review_request import _active_project
+from teatree.cli.review_request import _active_project, review_request_app
 from teatree.config import OverlayEntry
 
 _TEATREE_PATH = Path("/workspace/teatree")
@@ -39,14 +50,70 @@ class TestActiveProjectOverlayRouting:
         assert (project, name) == (_OTHER_PATH, _OTHER_NAME)
 
     def test_post_delegate_threads_resolved_overlay_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """``t3 review-request post`` runs managepy with the resolved overlay."""
+        """``t3 review-request post`` runs the core dispatch with the resolved overlay."""
         monkeypatch.setenv("T3_OVERLAY_NAME", _OTHER_NAME)
         with (
             patch("teatree.config.discover_overlays", return_value=_two_overlays()),
-            patch("teatree.cli.review_request.managepy") as managepy,
+            patch("teatree.cli.review_request.managepy_core") as managepy_core,
         ):
             from teatree.cli.review_request import post  # noqa: PLC0415
 
             post(mr_url="https://gitlab.com/org/repo/-/merge_requests/385", approver="souliane", title="")
-        assert managepy.call_args.kwargs["overlay_name"] == _OTHER_NAME
-        assert managepy.call_args.args[0] == _OTHER_PATH
+        assert managepy_core.call_args.kwargs["overlay_name"] == _OTHER_NAME
+
+
+class TestCoreDispatch:
+    """Both ``discover`` and ``post`` use teatree-core dispatch (#1312).
+
+    The bug: running ``t3 review-request {discover,post}`` from an overlay
+    clone whose ``manage.py`` runs against its own settings module crashed
+    with ``CommandFailedError`` because the call was routed through the
+    overlay's ``manage.py``, which has no ``followup`` /
+    ``review_request_post`` commands. Both commands MUST use
+    ``python -m teatree`` dispatch regardless of resolved project path.
+    """
+
+    def test_discover_uses_managepy_core(self) -> None:
+        with patch("teatree.cli.review_request.managepy_core") as managepy_core:
+            from teatree.cli.review_request import discover  # noqa: PLC0415
+
+            discover()
+        assert managepy_core.call_args.args == ("followup", "discover-mrs")
+
+    def test_check_uses_managepy_core(self) -> None:
+        with patch("teatree.cli.review_request.managepy_core") as managepy_core:
+            from teatree.cli.review_request import check  # noqa: PLC0415
+
+            check(mr_url="https://gitlab.com/org/repo/-/merge_requests/385")
+        assert managepy_core.call_args.args[0] == "review_request_check"
+
+    def test_post_uses_managepy_core(self) -> None:
+        with patch("teatree.cli.review_request.managepy_core") as managepy_core:
+            from teatree.cli.review_request import post  # noqa: PLC0415
+
+            post(mr_url="https://gitlab.com/org/repo/-/merge_requests/385", approver="souliane", title="")
+        assert managepy_core.call_args.args[0] == "review_request_post"
+
+    def test_discover_via_cli_runner_uses_core_dispatch(self) -> None:
+        """End-to-end via CliRunner: discover routes through teatree-core dispatch (#1312).
+
+        Regression test: before the fix, this invocation crashed with
+        ``CommandFailedError`` from the overlay's ``manage.py``. Now it
+        completes by calling :func:`managepy_core` (teatree-native
+        dispatch), independent of any project path. The patch target is
+        ``teatree.cli.overlay.run_streamed`` to catch BOTH dispatch paths
+        — :func:`managepy_core` (teatree-native) and the would-be-buggy
+        :func:`managepy` (overlay ``manage.py``) — at the same chokepoint
+        so the test fails either way the bug regresses.
+        """
+        runner = CliRunner()
+        app = typer.Typer()
+        app.add_typer(review_request_app, name="review-request")
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["review-request", "discover"])
+        assert result.exit_code == 0, result.output
+        assert run_streamed.called
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"discover must use python -m teatree dispatch, got {cmd!r}"
+        assert "teatree" in cmd, f"discover must use python -m teatree dispatch, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd), f"discover must NOT route through overlay manage.py, got {cmd!r}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -510,11 +510,11 @@ class TestReviewRequestDiscover:
         active = OverlayEntry(name="t3-test", overlay_class="test.Overlay", project_path=tmp_path)
         with (
             patch.object(config_mod, "_active_overlay_entry", return_value=active),
-            patch.object(cli_review_request_mod, "managepy") as mock_manage,
+            patch.object(cli_review_request_mod, "managepy_core") as mock_manage,
         ):
             result = runner.invoke(app, ["review-request", "discover"])
             assert result.exit_code == 0
-            mock_manage.assert_called_once_with(tmp_path, "followup", "discover-mrs", overlay_name="t3-test")
+            mock_manage.assert_called_once_with("followup", "discover-mrs", overlay_name="t3-test")
 
     def test_review_request_check(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -526,12 +526,11 @@ class TestReviewRequestDiscover:
         mr = "https://gitlab.com/org/repo/-/merge_requests/385"
         with (
             patch.object(config_mod, "_active_overlay_entry", return_value=active),
-            patch.object(cli_review_request_mod, "managepy") as mock_manage,
+            patch.object(cli_review_request_mod, "managepy_core") as mock_manage,
         ):
             result = runner.invoke(app, ["review-request", "check", "--mr-url", mr])
             assert result.exit_code == 0
             mock_manage.assert_called_once_with(
-                tmp_path,
                 "review_request_check",
                 "--mr-url",
                 mr,

--- a/tests/test_cli_overlay_groups.py
+++ b/tests/test_cli_overlay_groups.py
@@ -10,8 +10,7 @@ from teatree.cli.overlay import DJANGO_GROUPS
 
 
 def _ticket_subcommands() -> set[str]:
-    _help, subcommands = DJANGO_GROUPS["ticket"]
-    return {name for name, _desc in subcommands}
+    return {name for name, _desc in DJANGO_GROUPS["ticket"].subcommands}
 
 
 def test_ticket_group_exposes_comment() -> None:


### PR DESCRIPTION
## Summary

- `t3 review-request {discover,post,check}` crashed with `CommandFailedError` when run from an overlay clone whose `manage.py` runs against its own settings module — `managepy()` prefers the overlay's `manage.py` when present, but `followup`, `review_request_check`, and `review_request_post` are teatree-CORE commands the overlay's manage.py has no idea about.
- Add `managepy_core(...)` in `src/teatree/cli/overlay.py` that always dispatches via `python -m teatree`, and route the three review-request CLI commands through it.
- The `post` gate now reaches its structured `approve-on-behalf` error (correct CLI behavior) instead of failing earlier at command lookup.

Closes [#1312](https://github.com/souliane/teatree/issues/1312).

## Test plan

- [x] `uv run pytest tests/teatree_core/test_review_request_cli.py tests/test_cli.py::TestReviewRequestDiscover` — 8 tests pass, including a new CliRunner end-to-end regression that patches `run_streamed` (the chokepoint for BOTH dispatch paths) and asserts the invoked command is `python -m teatree …` with no `manage.py` substring.
- [x] Manual reproduction from `oper-product` worktree: `t3 review-request discover` returns JSON, `t3 review-request post --mr-url … --approver souliane` returns `{"action": "suppress", "reason": "no_review_channel_or_token", …}` — the structured suppress message proves dispatch reached `review_request_post.py`, not a missing-command crash.