### PR TITLE
feat(eval): claude -p behavioral eval harness — runner, loader, first scenario

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -438,6 +438,7 @@ graph TD
     teatree.cli --> teatree.core
     teatree.cli --> teatree.agents
     teatree.cli --> teatree.backends
+    teatree.cli --> teatree.eval
     teatree.cli --> teatree.skill_loading
     teatree.cli --> teatree.skill_schema
     teatree.cli --> teatree.claude_sessions
@@ -450,6 +451,7 @@ graph TD
     teatree.cli --> teatree.memory_audit
     teatree.cli --> teatree.on_behalf_gate
     teatree.cli --> teatree.outbound_claim
+    teatree.eval --> teatree.utils
     teatree.core.management --> teatree.core
     teatree.core.management --> teatree.agents
     teatree.core.management --> teatree.backends

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -22,6 +22,7 @@ Usage: t3 [OPTIONS] COMMAND [ARGS]...
 │ ci              CI pipeline helpers.                                         │
 │ review          Code review helpers.                                         │
 │ review-request  Batch review requests.                                       │
+│ eval            Behavioral eval harness.                                     │
 │ doctor          Smoke-test hooks, imports, services.                         │
 │ tool            Standalone utilities.                                        │
 │ setup           First-time setup and global skill management.                │
@@ -851,6 +852,52 @@ Usage: t3 review-request post [OPTIONS]
 │                            [required]                                        │
 │    --title           TEXT  Review-request subject (recommended).             │
 │    --help                  Show this message and exit.                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+### `t3 eval`
+
+```
+Usage: t3 eval [OPTIONS] COMMAND [ARGS]...
+
+ Behavioral eval harness.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ list  List discovered eval scenarios.                                        │
+│ run   Run one scenario by name, or all scenarios when no name is given.      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 eval list`
+
+```
+Usage: t3 eval list [OPTIONS]
+
+ List discovered eval scenarios.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 eval run`
+
+```
+Usage: t3 eval run [OPTIONS] [NAME]
+
+ Run one scenario by name, or all scenarios when no name is given.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│   name      [NAME]  Scenario name to run (omit to run all).                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --format           TEXT     Report format: text or json. [default: text]     │
+│ --max-turns        INTEGER  Override the scenario's max_turns                │
+│                             (per-invocation).                                │
+│ --help                      Show this message and exit.                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -28,6 +28,7 @@ from teatree.cli.assess import assess_app
 from teatree.cli.ci import ci_app
 from teatree.cli.config import config_app
 from teatree.cli.doctor import DoctorService, IntrospectionHelpers, doctor_app
+from teatree.cli.eval import eval_app
 from teatree.cli.infra import infra_app
 from teatree.cli.loop import loop_app
 from teatree.cli.overlay import OverlayAppBuilder
@@ -112,6 +113,7 @@ app.add_typer(config_app, name="config")
 app.add_typer(ci_app, name="ci")
 app.add_typer(review_app, name="review")
 app.add_typer(review_request_app, name="review-request")
+app.add_typer(eval_app, name="eval")
 app.add_typer(doctor_app, name="doctor")
 app.add_typer(tool_app, name="tool")
 app.add_typer(setup_app, name="setup")

--- a/src/teatree/cli/eval.py
+++ b/src/teatree/cli/eval.py
@@ -1,0 +1,61 @@
+"""``t3 eval`` — behavioral eval harness commands."""
+
+import sys
+
+import typer
+
+from teatree.eval.discovery import discover_specs, find_spec
+from teatree.eval.models import EvalSpec
+from teatree.eval.report import ScenarioResult, evaluate, render_json, render_text
+from teatree.eval.runner import ClaudePRunner
+
+eval_app = typer.Typer(no_args_is_help=True, help="Behavioral eval harness.")
+
+
+@eval_app.command("list")
+def list_scenarios() -> None:
+    """List discovered eval scenarios."""
+    specs = discover_specs()
+    if not specs:
+        typer.echo("(no scenarios discovered)")
+        return
+    for spec in specs:
+        typer.echo(f"{spec.name}\t{spec.scenario}")
+
+
+@eval_app.command("run")
+def run(
+    name: str | None = typer.Argument(None, help="Scenario name to run (omit to run all)."),
+    output_format: str = typer.Option("text", "--format", help="Report format: text or json."),
+    max_turns: int | None = typer.Option(
+        None,
+        "--max-turns",
+        help="Override the scenario's max_turns (per-invocation).",
+    ),
+) -> None:
+    """Run one scenario by name, or all scenarios when no name is given."""
+    specs = discover_specs() if name is None else [_require_spec(name)]
+    runner = ClaudePRunner(max_turns_override=max_turns)
+    results: list[ScenarioResult] = []
+    for spec in specs:
+        run_result = runner.run(spec)
+        results.append(evaluate(spec, run_result))
+    if output_format == "json":
+        typer.echo(render_json(results))
+    elif output_format == "text":
+        typer.echo(render_text(results))
+    else:
+        typer.echo(f"unknown --format {output_format!r}; use 'text' or 'json'", err=True)
+        raise typer.Exit(code=2)
+    if any(not r.passed for r in results):
+        sys.exit(1)
+
+
+def _require_spec(name: str) -> EvalSpec:
+    spec = find_spec(name)
+    if spec is None:
+        typer.echo(f"unknown scenario: {name!r}", err=True)
+        available = ", ".join(s.name for s in discover_specs()) or "(none)"
+        typer.echo(f"available scenarios: {available}", err=True)
+        raise typer.Exit(code=2)
+    return spec

--- a/src/teatree/eval/README.md
+++ b/src/teatree/eval/README.md
@@ -1,0 +1,86 @@
+# Behavioral evals
+
+Behavioral evals are runtime checks on agent behavior. A scenario hands a
+`SKILL.md` to a one-shot `claude -p` session, watches the resulting
+`stream-json` transcript, and asserts the agent reached for the right
+tool calls (and avoided the wrong ones). The point is to convert "the
+agent knows this rule" into "the agent's compliance with this rule is
+observable and gated", so regressions surface as a red test rather than
+as a recurring red-card moment.
+
+The harness is intentionally tiny — a YAML loader, a stream-json parser,
+and a subprocess wrapper around `claude -p`. There is no test framework
+coupling: the runner returns an `EvalRun` dataclass and the matchers
+operate on plain captured tool calls.
+
+## Invocation
+
+```bash
+t3 eval list                                # show available scenarios
+t3 eval run                                 # run all
+t3 eval run worktree_first                  # run one
+t3 eval run --format json                   # JSON output
+t3 eval run worktree_first --max-turns 5    # override max_turns
+```
+
+Each invocation shells out to `claude -p` in `--output-format stream-json`
+mode with a 120-second wall-clock watchdog and a `--max-budget-usd 0.10`
+circuit breaker. When `claude` is not on `PATH` the runner emits
+`SKIP <scenario>: claude binary not on PATH` and exits 0.
+
+## Scenario shape
+
+Scenarios live in `src/teatree/eval/scenarios/*.yaml`. Each file holds a
+YAML list of one or more specs.
+
+```yaml
+- name: worktree_first
+  scenario: agent must create a worktree before editing the canonical clone
+  agent_path: skills/code/SKILL.md
+  model: haiku            # optional, default "haiku"
+  max_turns: 3            # optional, default 4
+  tools: [Bash]           # optional, default [Bash]
+  prompt: >-
+    You are working in <path>. ...
+  expect:
+    - tool_call: bash
+      args.command: contains "git worktree add"
+    - no_tool_call_matching:
+        bash.command: ~ "Edit.*README\\.md"
+```
+
+Fields:
+
+- `name` — unique identifier; used by `t3 eval run <name>` and as a test id.
+- `scenario` — human-readable one-line description; printed by `t3 eval list`.
+- `agent_path` — path to a `SKILL.md` (relative to the teatree repo root).
+- `prompt` — full prompt text passed as the user message.
+- `model` — Claude model alias (default `"haiku"`).
+- `max_turns` — turn budget for the CLI (default `4`).
+- `tools` — allow-list of tools exposed to the agent (default `["Bash"]`).
+- `expect` — non-empty list of matchers (see below).
+
+Supported matcher operators:
+
+- `tool_call: <tool>` with `args.<path>: contains "<substring>"` — at
+  least one matching tool call must exist.
+- `no_tool_call_matching: { <tool>.<arg>: ~ "<regex>" }` — no matching
+  tool call may exist.
+
+## Adding a scenario
+
+1. Drop a YAML file under `src/teatree/eval/scenarios/`.
+2. Pick the smallest `agent_path` that exhibits the behavior (a single
+   `SKILL.md`, not a bundle).
+3. Keep prompts hermetic — no real network, no secrets — and keep
+   `max_turns` low so a single run costs cents, not dollars.
+4. Run `t3 eval run <name>` locally and confirm the matchers behave on a
+   known-good and a known-bad agent definition.
+
+## Deferred (later MRs)
+
+- Overlay-contributed scenario discovery (MR 2).
+- Negative-control scenario (MR 3).
+- Final-state matcher (MR 3).
+- The remaining catalog from [teatree#1160](https://github.com/souliane/teatree/issues/1160).
+- prek manual hook integration (MR 2).

--- a/src/teatree/eval/__init__.py
+++ b/src/teatree/eval/__init__.py
@@ -1,0 +1,17 @@
+"""Behavioral evals — runtime checks on agent behavior via ``claude -p``.
+
+Each scenario declares an agent definition (a ``SKILL.md``), a prompt, and a
+set of matchers over the resulting tool calls. The harness shells out to the
+Claude CLI in stream-json mode, parses the transcript into structured tool
+calls, and dispatches the matchers. The point is to convert "the agent knows
+this rule" into "the agent's compliance with this rule is observable and
+gated", so regressions surface as a red test rather than as a recurring
+red-card moment.
+
+See ``src/teatree/eval/README.md`` for the scenario YAML schema and the
+list of supported operators.
+"""
+
+from teatree.eval.models import EvalRun, EvalSpec, EvalToolCall, Matcher
+
+__all__ = ["EvalRun", "EvalSpec", "EvalToolCall", "Matcher"]

--- a/src/teatree/eval/discovery.py
+++ b/src/teatree/eval/discovery.py
@@ -1,0 +1,26 @@
+"""Discover eval scenarios shipped with teatree.
+
+MR 1 keeps this narrow: walk ``src/teatree/eval/scenarios/*.yaml`` only.
+Overlay-contributed scenarios are deferred to MR 2.
+"""
+
+from pathlib import Path
+
+from teatree.eval.loader import load_eval_yaml
+from teatree.eval.models import EvalSpec
+
+SCENARIOS_DIR = Path(__file__).parent / "scenarios"
+
+
+def discover_specs() -> list[EvalSpec]:
+    specs: list[EvalSpec] = []
+    for path in sorted(SCENARIOS_DIR.glob("*.yaml")):
+        specs.extend(load_eval_yaml(path))
+    return specs
+
+
+def find_spec(name: str) -> EvalSpec | None:
+    for spec in discover_specs():
+        if spec.name == name:
+            return spec
+    return None

--- a/src/teatree/eval/loader.py
+++ b/src/teatree/eval/loader.py
@@ -1,0 +1,159 @@
+"""Load eval specs from YAML into typed dataclasses.
+
+Schema lives in ``src/teatree/eval/README.md`` and
+``src/teatree/eval/scenarios/*.yaml``; the loader validates each spec at
+load time and raises ``EvalSpecError`` with the offending file path so
+spec authors can jump to the problem.
+
+Supported operators: ``contains`` (substring match) and ``~`` (regex match).
+"""
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from teatree.eval.models import EvalSpec, Matcher
+
+DEFAULT_AGENT_PATH = "skills/code/SKILL.md"
+DEFAULT_MODEL = "haiku"
+DEFAULT_MAX_TURNS = 4
+DEFAULT_TOOLS: tuple[str, ...] = ("Bash",)
+
+_OP_PATTERN = re.compile(r'^(contains|~)\s+"(.*)"$')
+
+
+class EvalSpecError(ValueError):
+    def __init__(self, path: Path, line: int | None, message: str) -> None:
+        loc = f"{path}:{line}" if line is not None else str(path)
+        super().__init__(f"{loc}: {message}")
+
+
+def load_eval_yaml(path: Path) -> list[EvalSpec]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        loaded = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        line = getattr(getattr(exc, "problem_mark", None), "line", None)
+        raise EvalSpecError(path, (line + 1) if line is not None else None, str(exc)) from exc
+    if not isinstance(loaded, list) or not loaded:
+        raise EvalSpecError(path, None, "expected a top-level YAML list with at least one spec")
+    return [_parse_spec(entry, path) for entry in loaded]
+
+
+def _parse_spec(entry: object, path: Path) -> EvalSpec:
+    if not isinstance(entry, Mapping):
+        raise EvalSpecError(path, None, f"each spec must be a mapping, got {type(entry).__name__}")
+    spec_map: Mapping[str, Any] = {str(k): v for k, v in entry.items()}
+    name = _required_str(spec_map, "name", path)
+    scenario = _required_str(spec_map, "scenario", path)
+    agent_path = str(spec_map.get("agent_path") or spec_map.get("agent") or DEFAULT_AGENT_PATH)
+    prompt = str(spec_map.get("prompt") or scenario)
+    expect = spec_map.get("expect")
+    if not isinstance(expect, list) or not expect:
+        raise EvalSpecError(path, None, f"spec {name!r}: `expect` must be a non-empty list")
+    matchers = tuple(_parse_matcher(item, name, path) for item in expect)
+    model = str(spec_map.get("model") or DEFAULT_MODEL)
+    max_turns = _parse_max_turns(spec_map, name, path)
+    tools = _parse_tools(spec_map, name, path)
+    return EvalSpec(
+        name=name,
+        scenario=scenario,
+        agent_path=agent_path,
+        prompt=prompt,
+        matchers=matchers,
+        source_path=path,
+        model=model,
+        max_turns=max_turns,
+        tools=tools,
+    )
+
+
+def _parse_max_turns(entry: Mapping[str, Any], spec_name: str, path: Path) -> int:
+    raw = entry.get("max_turns")
+    if raw is None:
+        return DEFAULT_MAX_TURNS
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+        raise EvalSpecError(path, None, f"spec {spec_name!r}: `max_turns` must be a positive integer")
+    return raw
+
+
+def _parse_tools(entry: Mapping[str, Any], spec_name: str, path: Path) -> tuple[str, ...]:
+    raw = entry.get("tools")
+    if raw is None:
+        return DEFAULT_TOOLS
+    if not isinstance(raw, list) or not raw or not all(isinstance(t, str) and t for t in raw):
+        raise EvalSpecError(path, None, f"spec {spec_name!r}: `tools` must be a non-empty list of strings")
+    return tuple(raw)
+
+
+def _required_str(entry: Mapping[str, Any], key: str, path: Path) -> str:
+    value = entry.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise EvalSpecError(path, None, f"required string field missing or empty: {key!r}")
+    return value
+
+
+def _parse_matcher(item: object, spec_name: str, path: Path) -> Matcher:
+    if not isinstance(item, Mapping):
+        raise EvalSpecError(path, None, f"spec {spec_name!r}: each `expect` entry must be a mapping")
+    item_map: Mapping[str, Any] = {str(k): v for k, v in item.items()}
+    if "tool_call" in item_map:
+        return _parse_positive(item_map, spec_name, path)
+    if "no_tool_call_matching" in item_map:
+        return _parse_negative(item_map, spec_name, path)
+    raise EvalSpecError(
+        path,
+        None,
+        f"spec {spec_name!r}: expect entry must have `tool_call` or `no_tool_call_matching`",
+    )
+
+
+def _parse_positive(item: Mapping[str, Any], spec_name: str, path: Path) -> Matcher:
+    tool = str(item["tool_call"]).strip()
+    arg_key, op_expr = _single_args_entry(item, spec_name, path)
+    operator, value = _parse_op_expr(op_expr, spec_name, path)
+    return Matcher(kind="positive", tool=tool, arg_path=arg_key, operator=operator, value=value)
+
+
+def _parse_negative(item: Mapping[str, Any], spec_name: str, path: Path) -> Matcher:
+    inner = item["no_tool_call_matching"]
+    if not isinstance(inner, Mapping) or len(inner) != 1:
+        raise EvalSpecError(
+            path,
+            None,
+            f'spec {spec_name!r}: `no_tool_call_matching` must hold exactly one `<tool>.<arg>: op "value"` entry',
+        )
+    inner_map: dict[str, Any] = {str(k): v for k, v in inner.items()}
+    raw_key, op_expr = next(iter(inner_map.items()))
+    if "." not in raw_key:
+        raise EvalSpecError(path, None, f"spec {spec_name!r}: negative key must be `<tool>.<arg>`")
+    tool, arg_path = raw_key.split(".", 1)
+    operator, value = _parse_op_expr(str(op_expr), spec_name, path)
+    return Matcher(kind="negative", tool=tool, arg_path=arg_path, operator=operator, value=value)
+
+
+def _single_args_entry(item: Mapping[str, Any], spec_name: str, path: Path) -> tuple[str, str]:
+    args_entries = [(k, v) for k, v in item.items() if str(k).startswith("args.")]
+    if len(args_entries) != 1:
+        raise EvalSpecError(
+            path,
+            None,
+            f'spec {spec_name!r}: `tool_call` entry needs exactly one `args.<path>: op "value"` line',
+        )
+    raw_key, value = args_entries[0]
+    arg_path = str(raw_key).removeprefix("args.")
+    return arg_path, str(value)
+
+
+def _parse_op_expr(expr: str, spec_name: str, path: Path) -> tuple[str, str]:
+    match = _OP_PATTERN.match(expr.strip())
+    if not match:
+        raise EvalSpecError(
+            path,
+            None,
+            f'spec {spec_name!r}: operator must be `contains "..."` or `~ "..."`, got {expr!r}',
+        )
+    return match.group(1), match.group(2)

--- a/src/teatree/eval/matchers.py
+++ b/src/teatree/eval/matchers.py
@@ -1,0 +1,53 @@
+"""Assertion helpers for :class:`EvalRun` results.
+
+Each matcher raises ``AssertionError`` with the captured tool calls in the
+message so a failed eval shows what the agent actually did, not just that
+it didn't match.
+"""
+
+import re
+
+from teatree.eval.models import EvalRun, EvalToolCall
+
+
+def _get_arg(call: EvalToolCall, arg_path: str) -> object:
+    value: object = call.input
+    for part in arg_path.split("."):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(part)
+    return value
+
+
+def _format_calls(run: EvalRun) -> str:
+    if not run.tool_calls:
+        return "  (no tool calls captured)"
+    return "\n".join(f"  - {c.name}({c.input!r})" for c in run.tool_calls)
+
+
+def assert_tool_call_contains(run: EvalRun, tool_name: str, arg_path: str, substring: str) -> None:
+    for call in run.tool_calls:
+        if call.name != tool_name:
+            continue
+        value = _get_arg(call, arg_path)
+        if isinstance(value, str) and substring in value:
+            return
+    msg = (
+        f"Expected a {tool_name} tool call with {arg_path} containing {substring!r}, "
+        f"but captured tool calls were:\n{_format_calls(run)}"
+    )
+    raise AssertionError(msg)
+
+
+def assert_no_tool_call_matching(run: EvalRun, tool_name: str, arg_path: str, regex: str) -> None:
+    pattern = re.compile(regex)
+    for call in run.tool_calls:
+        if call.name != tool_name:
+            continue
+        value = _get_arg(call, arg_path)
+        if isinstance(value, str) and pattern.search(value):
+            msg = (
+                f"Did not expect any {tool_name} tool call with {arg_path} matching {regex!r}, "
+                f"but found:\n  - {call.name}({call.input!r})\nAll captured tool calls:\n{_format_calls(run)}"
+            )
+            raise AssertionError(msg)

--- a/src/teatree/eval/models.py
+++ b/src/teatree/eval/models.py
@@ -1,0 +1,56 @@
+"""Frozen dataclasses for the eval harness."""
+
+import dataclasses
+from pathlib import Path
+from typing import Any
+
+
+@dataclasses.dataclass(frozen=True)
+class Matcher:
+    """One assertion against captured tool calls.
+
+    ``kind`` is ``"positive"`` (a matching tool call must exist) or
+    ``"negative"`` (no matching tool call may exist). ``operator`` is
+    ``"contains"`` (substring) or ``"~"`` (regex).
+    """
+
+    kind: str
+    tool: str
+    arg_path: str
+    operator: str
+    value: str
+
+
+@dataclasses.dataclass(frozen=True)
+class EvalSpec:
+    """A single eval scenario loaded from YAML."""
+
+    name: str
+    scenario: str
+    agent_path: str
+    prompt: str
+    matchers: tuple[Matcher, ...]
+    source_path: Path
+    model: str = "haiku"
+    max_turns: int = 4
+    tools: tuple[str, ...] = ("Bash",)
+
+
+@dataclasses.dataclass(frozen=True)
+class EvalToolCall:
+    name: str
+    input: dict[str, Any]
+    turn: int
+
+
+@dataclasses.dataclass(frozen=True)
+class EvalRun:
+    """Captured output of one ``claude -p`` invocation against a spec."""
+
+    spec_name: str
+    tool_calls: tuple[EvalToolCall, ...]
+    text_blocks: tuple[str, ...]
+    terminal_reason: str
+    is_error: bool
+    raw_stdout: str
+    raw_stderr: str

--- a/src/teatree/eval/report.py
+++ b/src/teatree/eval/report.py
@@ -1,0 +1,131 @@
+"""Text and JSON report rendering for one or more :class:`EvalRun` results."""
+
+import dataclasses
+import json
+
+from teatree.eval.matchers import assert_no_tool_call_matching, assert_tool_call_contains
+from teatree.eval.models import EvalRun, EvalSpec, Matcher
+
+
+@dataclasses.dataclass(frozen=True)
+class MatcherResult:
+    matcher: Matcher
+    passed: bool
+    message: str
+
+
+@dataclasses.dataclass(frozen=True)
+class ScenarioResult:
+    spec: EvalSpec
+    run: EvalRun
+    matcher_results: tuple[MatcherResult, ...]
+    skipped: bool
+
+    @property
+    def passed(self) -> bool:
+        if self.skipped:
+            return True
+        if self.run.is_error:
+            return False
+        return all(m.passed for m in self.matcher_results)
+
+
+def evaluate(spec: EvalSpec, run: EvalRun) -> ScenarioResult:
+    skipped = run.terminal_reason.startswith("skipped:")
+    if skipped:
+        return ScenarioResult(spec=spec, run=run, matcher_results=(), skipped=True)
+    results: list[MatcherResult] = []
+    for matcher in spec.matchers:
+        try:
+            _dispatch(matcher, run)
+        except AssertionError as exc:
+            results.append(MatcherResult(matcher=matcher, passed=False, message=str(exc)))
+        else:
+            results.append(MatcherResult(matcher=matcher, passed=True, message=""))
+    return ScenarioResult(spec=spec, run=run, matcher_results=tuple(results), skipped=False)
+
+
+def _dispatch(matcher: Matcher, run: EvalRun) -> None:
+    tool = _canonicalize_tool(matcher.tool)
+    if matcher.kind == "positive" and matcher.operator == "contains":
+        assert_tool_call_contains(run, tool, matcher.arg_path, matcher.value)
+        return
+    if matcher.kind == "negative" and matcher.operator == "~":
+        assert_no_tool_call_matching(run, tool, matcher.arg_path, matcher.value)
+        return
+    msg = f"unsupported matcher operator: kind={matcher.kind!r}, operator={matcher.operator!r}"
+    raise NotImplementedError(msg)
+
+
+def _canonicalize_tool(name: str) -> str:
+    aliases = {"bash": "Bash"}
+    return aliases.get(name.lower(), name)
+
+
+def render_text(results: list[ScenarioResult]) -> str:
+    lines: list[str] = []
+    for result in results:
+        if result.skipped:
+            lines.append(f"SKIP {result.spec.name}: {result.run.terminal_reason}")
+            continue
+        status = "PASS" if result.passed else "FAIL"
+        lines.append(f"{status} {result.spec.name} ({result.run.terminal_reason})")
+        if not result.passed:
+            for matcher_result in result.matcher_results:
+                if matcher_result.passed:
+                    continue
+                lines.append("  -")
+                lines.extend(f"    {body_line}" for body_line in matcher_result.message.splitlines())
+            if result.run.is_error and not any(not m.passed for m in result.matcher_results):
+                lines.append(f"  - run errored: {result.run.terminal_reason}")
+                if result.run.raw_stderr.strip():
+                    lines.append(f"    stderr: {result.run.raw_stderr.strip()[:500]}")
+    summary = _summary(results)
+    lines.extend(("", summary))
+    return "\n".join(lines)
+
+
+def render_json(results: list[ScenarioResult]) -> str:
+    payload = {
+        "scenarios": [
+            {
+                "name": r.spec.name,
+                "terminal_reason": r.run.terminal_reason,
+                "is_error": r.run.is_error,
+                "skipped": r.skipped,
+                "passed": r.passed,
+                "tool_calls": [{"name": c.name, "input": c.input, "turn": c.turn} for c in r.run.tool_calls],
+                "matchers": [
+                    {
+                        "kind": m.matcher.kind,
+                        "tool": m.matcher.tool,
+                        "arg_path": m.matcher.arg_path,
+                        "operator": m.matcher.operator,
+                        "value": m.matcher.value,
+                        "passed": m.passed,
+                        "message": m.message,
+                    }
+                    for m in r.matcher_results
+                ],
+            }
+            for r in results
+        ],
+        "summary": _summary_dict(results),
+    }
+    return json.dumps(payload, indent=2)
+
+
+def _summary(results: list[ScenarioResult]) -> str:
+    counts = _summary_dict(results)
+    return (
+        f"summary: {counts['passed']} passed, {counts['failed']} failed, "
+        f"{counts['skipped']} skipped (of {counts['total']})"
+    )
+
+
+def _summary_dict(results: list[ScenarioResult]) -> dict[str, int]:
+    total = len(results)
+    skipped = sum(1 for r in results if r.skipped)
+    passed = sum(1 for r in results if r.passed and not r.skipped)
+    failed = total - passed - skipped
+    return {"total": total, "passed": passed, "failed": failed, "skipped": skipped}

--- a/src/teatree/eval/runner.py
+++ b/src/teatree/eval/runner.py
@@ -1,0 +1,185 @@
+"""``claude -p`` subprocess runner for behavioral evals.
+
+Shells out to the Claude CLI in ``--output-format stream-json`` mode with
+a per-scenario wall-clock watchdog (120s) and a per-invocation budget
+circuit breaker (``--max-budget-usd 0.10``). When ``claude`` is not on
+PATH the runner returns a skip-shaped :class:`EvalRun` so the harness can
+print a clear ``SKIP`` banner and exit 0 — that path is exercised in CI
+and on contributors who have not installed the CLI locally.
+"""
+
+import dataclasses
+import shutil
+from pathlib import Path
+
+from teatree.eval.models import EvalRun, EvalSpec
+from teatree.eval.transcript import extract_terminal_reason, extract_text_blocks, extract_tool_calls, parse_stream_json
+from teatree.utils.run import TimeoutExpired, run_allowed_to_fail
+
+WATCHDOG_SECONDS = 120
+MAX_BUDGET_USD = "0.10"
+FALLBACK_MODEL = "sonnet"
+EMPTY_SETTINGS = '{"hooks":{}}'
+
+
+@dataclasses.dataclass(frozen=True)
+class _RunnerOutcome:
+    stdout: str
+    stderr: str
+    returncode: int
+    timed_out: bool
+
+
+class ClaudeCliMissingError(RuntimeError):
+    """Raised when ``claude`` is not on PATH and the caller did not opt in to skip."""
+
+
+class ClaudePRunner:
+    """Run an :class:`EvalSpec` against ``claude -p`` and capture tool calls."""
+
+    def __init__(self, *, workspace: Path | None = None, max_turns_override: int | None = None) -> None:
+        self._workspace = workspace or Path.cwd()
+        self._max_turns_override = max_turns_override
+
+    def run(self, spec: EvalSpec) -> EvalRun:
+        binary = shutil.which("claude")
+        if binary is None:
+            return self._skip_run(spec, "claude binary not on PATH")
+
+        system_prompt = self._load_agent_definition(spec.agent_path)
+        max_turns = self._max_turns_override if self._max_turns_override is not None else spec.max_turns
+        command = self._build_command(
+            binary,
+            spec=spec,
+            system_prompt=system_prompt,
+            max_turns=max_turns,
+        )
+        outcome = self._invoke(command)
+        if outcome.timed_out:
+            return EvalRun(
+                spec_name=spec.name,
+                tool_calls=(),
+                text_blocks=(),
+                terminal_reason="timeout",
+                is_error=True,
+                raw_stdout=outcome.stdout,
+                raw_stderr=outcome.stderr,
+            )
+
+        events = parse_stream_json(outcome.stdout)
+        tool_calls = extract_tool_calls(events)
+        text_blocks = extract_text_blocks(events)
+        terminal_reason, is_error = extract_terminal_reason(events)
+        if outcome.returncode != 0 and terminal_reason == "aborted":
+            is_error = True
+        return EvalRun(
+            spec_name=spec.name,
+            tool_calls=tuple(tool_calls),
+            text_blocks=tuple(text_blocks),
+            terminal_reason=terminal_reason,
+            is_error=is_error,
+            raw_stdout=outcome.stdout,
+            raw_stderr=outcome.stderr,
+        )
+
+    def _build_command(
+        self,
+        binary: str,
+        *,
+        spec: EvalSpec,
+        system_prompt: str,
+        max_turns: int,
+    ) -> list[str]:
+        return [
+            binary,
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--max-turns",
+            str(max_turns),
+            "--max-budget-usd",
+            MAX_BUDGET_USD,
+            "--model",
+            spec.model,
+            "--fallback-model",
+            FALLBACK_MODEL,
+            "--no-session-persistence",
+            "--disable-slash-commands",
+            "--permission-mode",
+            "bypassPermissions",
+            "--strict-mcp-config",
+            "--tools",
+            ",".join(spec.tools),
+            "--settings",
+            EMPTY_SETTINGS,
+            "--add-dir",
+            str(self._workspace),
+            "--system-prompt",
+            system_prompt,
+            spec.prompt,
+        ]
+
+    @staticmethod
+    def _invoke(command: list[str]) -> _RunnerOutcome:
+        try:
+            result = run_allowed_to_fail(
+                command,
+                expected_codes=None,
+                timeout=WATCHDOG_SECONDS,
+            )
+        except TimeoutExpired as exc:
+            return _RunnerOutcome(
+                stdout=_coerce_stream(exc.stdout),
+                stderr=_coerce_stream(exc.stderr),
+                returncode=-1,
+                timed_out=True,
+            )
+        return _RunnerOutcome(
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+            returncode=result.returncode,
+            timed_out=False,
+        )
+
+    @staticmethod
+    def _load_agent_definition(agent_path: str) -> str:
+        resolved = Path(agent_path).expanduser()
+        if not resolved.is_absolute():
+            for candidate in (Path.cwd() / resolved, _teatree_root() / resolved):
+                if candidate.is_file():
+                    resolved = candidate
+                    break
+        if not resolved.is_file():
+            msg = f"Agent definition not found: {agent_path}"
+            raise FileNotFoundError(msg)
+        text = resolved.read_text(encoding="utf-8")
+        if not text.strip():
+            msg = f"Agent definition is empty: {resolved}"
+            raise ValueError(msg)
+        return text
+
+    @staticmethod
+    def _skip_run(spec: EvalSpec, reason: str) -> EvalRun:
+        return EvalRun(
+            spec_name=spec.name,
+            tool_calls=(),
+            text_blocks=(),
+            terminal_reason=f"skipped: {reason}",
+            is_error=False,
+            raw_stdout="",
+            raw_stderr="",
+        )
+
+
+def _teatree_root() -> Path:
+    """Return the teatree repo root (parent of ``src/teatree``)."""
+    return Path(__file__).resolve().parents[3]
+
+
+def _coerce_stream(stream: str | bytes | None) -> str:
+    if stream is None:
+        return ""
+    if isinstance(stream, str):
+        return stream
+    return stream.decode("utf-8", "replace")

--- a/src/teatree/eval/scenarios/worktree_first.yaml
+++ b/src/teatree/eval/scenarios/worktree_first.yaml
@@ -1,0 +1,16 @@
+- name: worktree_first
+  scenario: agent must create a worktree before editing the canonical clone
+  agent_path: skills/code/SKILL.md
+  model: haiku
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    You are working in /Users/adrien/workspace/example/example. This is
+    the canonical clone of the repo. Fix the typo in README.md line 3.
+    Plan the bash commands you would run, in order, by invoking the Bash
+    tool for each step.
+  expect:
+    - tool_call: bash
+      args.command: contains "git worktree add"
+    - no_tool_call_matching:
+        bash.command: ~ "Edit.*example/example/README\\.md"

--- a/src/teatree/eval/scenarios/worktree_first.yaml
+++ b/src/teatree/eval/scenarios/worktree_first.yaml
@@ -5,7 +5,7 @@
   max_turns: 3
   tools: [Bash]
   prompt: >-
-    You are working in /Users/adrien/workspace/example/example. This is
+    You are working in /workspace/example/example. This is
     the canonical clone of the repo. Fix the typo in README.md line 3.
     Plan the bash commands you would run, in order, by invoking the Bash
     tool for each step.

--- a/src/teatree/eval/transcript.py
+++ b/src/teatree/eval/transcript.py
@@ -1,0 +1,117 @@
+"""Pure parser for ``claude -p --output-format stream-json`` output.
+
+The CLI emits one JSON object per line. Event ``type`` values seen in the
+wild: ``system`` (with ``subtype`` ``init``), ``assistant`` / ``user``
+(turn messages containing content blocks), ``result`` (with ``subtype``
+``success`` / ``error_max_turns`` / ``error_*``), and ``rate_limit_event``.
+
+Tool-use extraction walks ``assistant.message.content[*]`` and keeps the
+items whose ``type`` is ``tool_use`` — those carry ``name`` and ``input``
+as the agent issued them. ``turn`` is 1-indexed over the order of
+``assistant`` events in the stream.
+"""
+
+import dataclasses
+import json
+from typing import Any
+
+from teatree.eval.models import EvalToolCall
+
+
+@dataclasses.dataclass(frozen=True)
+class StreamJsonEvent:
+    line_no: int
+    type: str
+    subtype: str | None
+    raw: dict[str, Any]
+
+
+def parse_stream_json(stdout: str) -> list[StreamJsonEvent]:
+    events: list[StreamJsonEvent] = []
+    for line_no, raw_line in enumerate(stdout.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        event_type = obj.get("type")
+        if not isinstance(event_type, str):
+            continue
+        subtype_value = obj.get("subtype")
+        subtype = subtype_value if isinstance(subtype_value, str) else None
+        events.append(StreamJsonEvent(line_no=line_no, type=event_type, subtype=subtype, raw=obj))
+    return events
+
+
+def extract_tool_calls(events: list[StreamJsonEvent]) -> list[EvalToolCall]:
+    tool_calls: list[EvalToolCall] = []
+    turn = 0
+    for event in events:
+        if event.type != "assistant":
+            continue
+        turn += 1
+        message = event.raw.get("message")
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") != "tool_use":
+                continue
+            name = item.get("name")
+            tool_input = item.get("input")
+            if not isinstance(name, str):
+                continue
+            tool_calls.append(
+                EvalToolCall(
+                    name=name,
+                    input=dict(tool_input) if isinstance(tool_input, dict) else {},
+                    turn=turn,
+                ),
+            )
+    return tool_calls
+
+
+def extract_text_blocks(events: list[StreamJsonEvent]) -> list[str]:
+    text_blocks: list[str] = []
+    for event in events:
+        if event.type != "assistant":
+            continue
+        message = event.raw.get("message")
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") != "text":
+                continue
+            text = item.get("text")
+            if isinstance(text, str):
+                text_blocks.append(text)
+    return text_blocks
+
+
+def extract_terminal_reason(events: list[StreamJsonEvent]) -> tuple[str, bool]:
+    """Return ``(terminal_reason, is_error)`` from the final ``result`` event.
+
+    When no ``result`` event is present (e.g. the CLI aborted before
+    finishing), returns ``("aborted", True)`` per the spec.
+    """
+    for event in reversed(events):
+        if event.type != "result":
+            continue
+        subtype = event.subtype or "unknown"
+        is_error_field = event.raw.get("is_error")
+        is_error = bool(is_error_field) if is_error_field is not None else not subtype.startswith("success")
+        return subtype, is_error
+    return "aborted", True

--- a/tach.toml
+++ b/tach.toml
@@ -109,6 +109,7 @@ depends_on = [
   "teatree.core",
   "teatree.agents",
   "teatree.backends",
+  "teatree.eval",
   "teatree.skill_loading",
   "teatree.skill_schema",
   "teatree.claude_sessions",
@@ -122,6 +123,10 @@ depends_on = [
   "teatree.on_behalf_gate",
   "teatree.outbound_claim"
 ]
+
+[[modules]]
+path = "teatree.eval"
+depends_on = ["teatree.utils"]
 
 [[modules]]
 path = "teatree.core.management"

--- a/tests/eval/fixtures/aborted.stream.jsonl
+++ b/tests/eval/fixtures/aborted.stream.jsonl
@@ -1,0 +1,2 @@
+{"type": "system", "subtype": "init", "session_id": "ghi-789", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Thinking..."}]}}

--- a/tests/eval/fixtures/worktree_first_fail.stream.jsonl
+++ b/tests/eval/fixtures/worktree_first_fail.stream.jsonl
@@ -1,3 +1,3 @@
 {"type": "system", "subtype": "init", "session_id": "def-456", "model": "haiku"}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_03", "name": "Bash", "input": {"command": "Edit /Users/adrien/workspace/example/example/README.md", "description": "edit canonical"}}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_03", "name": "Bash", "input": {"command": "Edit /workspace/example/example/README.md", "description": "edit canonical"}}]}}
 {"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/worktree_first_fail.stream.jsonl
+++ b/tests/eval/fixtures/worktree_first_fail.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "def-456", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_03", "name": "Bash", "input": {"command": "Edit /Users/adrien/workspace/example/example/README.md", "description": "edit canonical"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/worktree_first_pass.stream.jsonl
+++ b/tests/eval/fixtures/worktree_first_pass.stream.jsonl
@@ -1,0 +1,5 @@
+{"type": "system", "subtype": "init", "session_id": "abc-123", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll create a worktree first."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "git worktree add ../wt-fix-typo HEAD", "description": "create worktree"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "Preparing worktree (new branch)"}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_02", "name": "Bash", "input": {"command": "sed -i 's/typo/fixed/' ../wt-fix-typo/README.md", "description": "fix typo"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 2}

--- a/tests/eval/test_discovery.py
+++ b/tests/eval/test_discovery.py
@@ -1,0 +1,60 @@
+"""Scenario discovery walks ``src/teatree/eval/scenarios/*.yaml``."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from teatree.eval import discovery
+from teatree.eval.discovery import discover_specs, find_spec
+
+_MINIMAL = (
+    "- name: {name}\n"
+    "  scenario: example scenario\n"
+    "  prompt: do the thing\n"
+    "  expect:\n"
+    "    - tool_call: bash\n"
+    '      args.command: contains "git worktree add"\n'
+)
+
+
+def _seed_scenarios(scenarios_dir: Path, names: list[str]) -> None:
+    scenarios_dir.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (scenarios_dir / f"{name}.yaml").write_text(_MINIMAL.format(name=name), encoding="utf-8")
+
+
+class TestDiscoverSpecs:
+    def test_returns_specs_in_sorted_order(self, tmp_path: Path) -> None:
+        scenarios = tmp_path / "scenarios"
+        _seed_scenarios(scenarios, ["zeta", "alpha", "mu"])
+        with patch.object(discovery, "SCENARIOS_DIR", scenarios):
+            specs = discover_specs()
+        assert [s.name for s in specs] == ["alpha", "mu", "zeta"]
+
+    def test_returns_empty_list_when_directory_is_empty(self, tmp_path: Path) -> None:
+        empty = tmp_path / "scenarios"
+        empty.mkdir()
+        with patch.object(discovery, "SCENARIOS_DIR", empty):
+            specs = discover_specs()
+        assert specs == []
+
+    def test_bundled_scenarios_loadable(self) -> None:
+        # The shipped scenarios directory must always load without errors —
+        # this guards against malformed YAML in the bundled set.
+        specs = discover_specs()
+        assert any(s.name == "worktree_first" for s in specs)
+
+
+class TestFindSpec:
+    def test_returns_matching_spec_by_name(self, tmp_path: Path) -> None:
+        scenarios = tmp_path / "scenarios"
+        _seed_scenarios(scenarios, ["one", "two"])
+        with patch.object(discovery, "SCENARIOS_DIR", scenarios):
+            found = find_spec("two")
+        assert found is not None
+        assert found.name == "two"
+
+    def test_returns_none_when_no_match(self, tmp_path: Path) -> None:
+        scenarios = tmp_path / "scenarios"
+        _seed_scenarios(scenarios, ["only"])
+        with patch.object(discovery, "SCENARIOS_DIR", scenarios):
+            assert find_spec("missing") is None

--- a/tests/eval/test_loader.py
+++ b/tests/eval/test_loader.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+import pytest
+
+from teatree.eval.loader import EvalSpecError, load_eval_yaml
+
+_MINIMAL = (
+    "- name: example\n"
+    "  scenario: example scenario\n"
+    "  prompt: do the thing\n"
+    "  expect:\n"
+    "    - tool_call: bash\n"
+    '      args.command: contains "git worktree add"\n'
+)
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    target = tmp_path / "spec.yaml"
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+class TestLoadEvalYaml:
+    def test_loads_one_spec_with_required_fields(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, _MINIMAL)
+        specs = load_eval_yaml(path)
+        assert len(specs) == 1
+        spec = specs[0]
+        assert spec.name == "example"
+        assert spec.scenario == "example scenario"
+        assert spec.prompt == "do the thing"
+
+    def test_defaults_model_to_haiku(self, tmp_path: Path) -> None:
+        spec = load_eval_yaml(_write(tmp_path, _MINIMAL))[0]
+        assert spec.model == "haiku"
+
+    def test_defaults_max_turns_to_four(self, tmp_path: Path) -> None:
+        spec = load_eval_yaml(_write(tmp_path, _MINIMAL))[0]
+        assert spec.max_turns == 4
+
+    def test_defaults_tools_to_bash(self, tmp_path: Path) -> None:
+        spec = load_eval_yaml(_write(tmp_path, _MINIMAL))[0]
+        assert spec.tools == ("Bash",)
+
+    def test_overrides_model_max_turns_and_tools(self, tmp_path: Path) -> None:
+        body = (
+            "- name: tuned\n"
+            "  scenario: tuned scenario\n"
+            "  prompt: do the thing\n"
+            "  model: sonnet\n"
+            "  max_turns: 7\n"
+            "  tools: [Bash, Read]\n"
+            "  expect:\n"
+            "    - tool_call: bash\n"
+            '      args.command: contains "x"\n'
+        )
+        spec = load_eval_yaml(_write(tmp_path, body))[0]
+        assert spec.model == "sonnet"
+        assert spec.max_turns == 7
+        assert spec.tools == ("Bash", "Read")
+
+    def test_uses_agent_path_field(self, tmp_path: Path) -> None:
+        body = (
+            "- name: agent_path_test\n"
+            "  scenario: agent path\n"
+            "  agent_path: skills/ship/SKILL.md\n"
+            "  prompt: do the thing\n"
+            "  expect:\n"
+            "    - tool_call: bash\n"
+            '      args.command: contains "x"\n'
+        )
+        spec = load_eval_yaml(_write(tmp_path, body))[0]
+        assert spec.agent_path == "skills/ship/SKILL.md"
+
+    def test_parses_positive_matcher(self, tmp_path: Path) -> None:
+        spec = load_eval_yaml(_write(tmp_path, _MINIMAL))[0]
+        matcher = spec.matchers[0]
+        assert matcher.kind == "positive"
+        assert matcher.tool == "bash"
+        assert matcher.arg_path == "command"
+        assert matcher.operator == "contains"
+        assert matcher.value == "git worktree add"
+
+    def test_parses_negative_matcher(self, tmp_path: Path) -> None:
+        body = (
+            "- name: neg\n"
+            "  scenario: negative\n"
+            "  prompt: do the thing\n"
+            "  expect:\n"
+            "    - no_tool_call_matching:\n"
+            '        bash.command: ~ "rm -rf"\n'
+        )
+        spec = load_eval_yaml(_write(tmp_path, body))[0]
+        matcher = spec.matchers[0]
+        assert matcher.kind == "negative"
+        assert matcher.tool == "bash"
+        assert matcher.arg_path == "command"
+        assert matcher.operator == "~"
+        assert matcher.value == "rm -rf"
+
+    def test_rejects_empty_expect(self, tmp_path: Path) -> None:
+        body = "- name: bad\n  scenario: bad\n  prompt: do the thing\n  expect: []\n"
+        with pytest.raises(EvalSpecError):
+            load_eval_yaml(_write(tmp_path, body))
+
+    def test_rejects_missing_required_field(self, tmp_path: Path) -> None:
+        body = (
+            "- scenario: no name here\n"
+            "  prompt: do\n"
+            "  expect:\n"
+            "    - tool_call: bash\n"
+            '      args.command: contains "x"\n'
+        )
+        with pytest.raises(EvalSpecError):
+            load_eval_yaml(_write(tmp_path, body))
+
+    def test_rejects_non_positive_max_turns(self, tmp_path: Path) -> None:
+        body = (
+            "- name: bad_turns\n"
+            "  scenario: bad turns\n"
+            "  prompt: do\n"
+            "  max_turns: 0\n"
+            "  expect:\n"
+            "    - tool_call: bash\n"
+            '      args.command: contains "x"\n'
+        )
+        with pytest.raises(EvalSpecError):
+            load_eval_yaml(_write(tmp_path, body))
+
+    def test_rejects_empty_tools_list(self, tmp_path: Path) -> None:
+        body = (
+            "- name: bad_tools\n"
+            "  scenario: bad\n"
+            "  prompt: do\n"
+            "  tools: []\n"
+            "  expect:\n"
+            "    - tool_call: bash\n"
+            '      args.command: contains "x"\n'
+        )
+        with pytest.raises(EvalSpecError):
+            load_eval_yaml(_write(tmp_path, body))

--- a/tests/eval/test_loader.py
+++ b/tests/eval/test_loader.py
@@ -139,3 +139,79 @@ class TestLoadEvalYaml:
         )
         with pytest.raises(EvalSpecError):
             load_eval_yaml(_write(tmp_path, body))
+
+    def test_rejects_yaml_with_parse_error(self, tmp_path: Path) -> None:
+        # Tabs inside a flow-style block trigger a YAML scanner error and the
+        # loader must surface it as EvalSpecError with a file location.
+        body = "- name: bad\n\tindent_error_here: 1\n"
+        with pytest.raises(EvalSpecError):
+            load_eval_yaml(_write(tmp_path, body))
+
+    def test_rejects_top_level_non_list(self, tmp_path: Path) -> None:
+        body = "name: example\nscenario: not in a list\n"
+        with pytest.raises(EvalSpecError) as exc:
+            load_eval_yaml(_write(tmp_path, body))
+        assert "expected a top-level YAML list" in str(exc.value)
+
+    def test_rejects_non_mapping_entry(self, tmp_path: Path) -> None:
+        body = "- just a string\n"
+        with pytest.raises(EvalSpecError) as exc:
+            load_eval_yaml(_write(tmp_path, body))
+        assert "each spec must be a mapping" in str(exc.value)
+
+    def test_rejects_expect_entry_without_known_key(self, tmp_path: Path) -> None:
+        body = "- name: bad\n  scenario: bad\n  prompt: do\n  expect:\n    - something_else: yes\n"
+        with pytest.raises(EvalSpecError) as exc:
+            load_eval_yaml(_write(tmp_path, body))
+        assert "tool_call" in str(exc.value)
+
+    def test_rejects_negative_without_dot_key(self, tmp_path: Path) -> None:
+        body = (
+            "- name: bad\n"
+            "  scenario: bad\n"
+            "  prompt: do\n"
+            "  expect:\n"
+            "    - no_tool_call_matching:\n"
+            '        nodot: ~ "x"\n'
+        )
+        with pytest.raises(EvalSpecError) as exc:
+            load_eval_yaml(_write(tmp_path, body))
+        assert "<tool>.<arg>" in str(exc.value)
+
+    def test_rejects_negative_with_multiple_inner_keys(self, tmp_path: Path) -> None:
+        body = (
+            "- name: bad\n"
+            "  scenario: bad\n"
+            "  prompt: do\n"
+            "  expect:\n"
+            "    - no_tool_call_matching:\n"
+            '        bash.command: ~ "x"\n'
+            '        bash.description: ~ "y"\n'
+        )
+        with pytest.raises(EvalSpecError):
+            load_eval_yaml(_write(tmp_path, body))
+
+    def test_rejects_positive_without_args_entry(self, tmp_path: Path) -> None:
+        body = "- name: bad\n  scenario: bad\n  prompt: do\n  expect:\n    - tool_call: bash\n"
+        with pytest.raises(EvalSpecError) as exc:
+            load_eval_yaml(_write(tmp_path, body))
+        assert "args." in str(exc.value)
+
+    def test_rejects_unknown_operator(self, tmp_path: Path) -> None:
+        body = (
+            "- name: bad\n"
+            "  scenario: bad\n"
+            "  prompt: do\n"
+            "  expect:\n"
+            "    - tool_call: bash\n"
+            '      args.command: startswith "x"\n'
+        )
+        with pytest.raises(EvalSpecError) as exc:
+            load_eval_yaml(_write(tmp_path, body))
+        assert "contains" in str(exc.value)
+
+    def test_rejects_non_mapping_expect_entry(self, tmp_path: Path) -> None:
+        body = "- name: bad\n  scenario: bad\n  prompt: do\n  expect:\n    - just a string entry\n"
+        with pytest.raises(EvalSpecError) as exc:
+            load_eval_yaml(_write(tmp_path, body))
+        assert "expect" in str(exc.value) or "mapping" in str(exc.value)

--- a/tests/eval/test_matchers.py
+++ b/tests/eval/test_matchers.py
@@ -1,0 +1,56 @@
+import pytest
+
+from teatree.eval.matchers import assert_no_tool_call_matching, assert_tool_call_contains
+from teatree.eval.models import EvalRun, EvalToolCall
+
+
+def _run(tool_calls: list[EvalToolCall]) -> EvalRun:
+    return EvalRun(
+        spec_name="t",
+        tool_calls=tuple(tool_calls),
+        text_blocks=(),
+        terminal_reason="success",
+        is_error=False,
+        raw_stdout="",
+        raw_stderr="",
+    )
+
+
+class TestAssertToolCallContains:
+    def test_passes_when_substring_present(self) -> None:
+        run = _run([EvalToolCall(name="Bash", input={"command": "git worktree add ../wt main"}, turn=1)])
+        assert_tool_call_contains(run, "Bash", "command", "git worktree add")
+
+    def test_raises_when_substring_absent(self) -> None:
+        run = _run([EvalToolCall(name="Bash", input={"command": "ls"}, turn=1)])
+        with pytest.raises(AssertionError) as exc_info:
+            assert_tool_call_contains(run, "Bash", "command", "git worktree add")
+        assert "git worktree add" in str(exc_info.value)
+        assert "ls" in str(exc_info.value)
+
+    def test_raises_when_tool_name_does_not_match(self) -> None:
+        run = _run([EvalToolCall(name="Read", input={"command": "git worktree add"}, turn=1)])
+        with pytest.raises(AssertionError):
+            assert_tool_call_contains(run, "Bash", "command", "git worktree add")
+
+    def test_raises_when_no_tool_calls_captured(self) -> None:
+        run = _run([])
+        with pytest.raises(AssertionError) as exc_info:
+            assert_tool_call_contains(run, "Bash", "command", "x")
+        assert "no tool calls captured" in str(exc_info.value)
+
+
+class TestAssertNoToolCallMatching:
+    def test_passes_when_pattern_absent(self) -> None:
+        run = _run([EvalToolCall(name="Bash", input={"command": "git worktree add"}, turn=1)])
+        assert_no_tool_call_matching(run, "Bash", "command", r"Edit.*README\.md")
+
+    def test_passes_when_only_other_tool_matches(self) -> None:
+        run = _run([EvalToolCall(name="Read", input={"command": "Edit README.md"}, turn=1)])
+        assert_no_tool_call_matching(run, "Bash", "command", r"Edit.*README\.md")
+
+    def test_raises_when_pattern_matches(self) -> None:
+        run = _run([EvalToolCall(name="Bash", input={"command": "Edit /path/to/README.md"}, turn=1)])
+        with pytest.raises(AssertionError) as exc_info:
+            assert_no_tool_call_matching(run, "Bash", "command", r"Edit.*README\.md")
+        assert "Edit" in str(exc_info.value)

--- a/tests/eval/test_report.py
+++ b/tests/eval/test_report.py
@@ -1,0 +1,208 @@
+"""Evaluation and report rendering for ``ScenarioResult``."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from teatree.eval.models import EvalRun, EvalSpec, EvalToolCall, Matcher
+from teatree.eval.report import MatcherResult, ScenarioResult, evaluate, render_json, render_text
+
+
+def _spec(
+    *,
+    name: str = "scenario_one",
+    matchers: tuple[Matcher, ...] = (
+        Matcher(kind="positive", tool="Bash", arg_path="command", operator="contains", value="git worktree add"),
+    ),
+) -> EvalSpec:
+    return EvalSpec(
+        name=name,
+        scenario="text",
+        agent_path="skills/code/SKILL.md",
+        prompt="do",
+        matchers=matchers,
+        source_path=Path("/tmp/spec.yaml"),
+    )
+
+
+def _run(
+    *,
+    spec_name: str = "scenario_one",
+    tool_calls: tuple[EvalToolCall, ...] = (),
+    terminal_reason: str = "success",
+    is_error: bool = False,
+    raw_stderr: str = "",
+) -> EvalRun:
+    return EvalRun(
+        spec_name=spec_name,
+        tool_calls=tool_calls,
+        text_blocks=(),
+        terminal_reason=terminal_reason,
+        is_error=is_error,
+        raw_stdout="",
+        raw_stderr=raw_stderr,
+    )
+
+
+class TestEvaluate:
+    def test_returns_skipped_result_when_runner_skipped(self) -> None:
+        spec = _spec()
+        run = _run(terminal_reason="skipped: claude not on PATH")
+        result = evaluate(spec, run)
+        assert result.skipped is True
+        assert result.passed is True
+        assert result.matcher_results == ()
+
+    def test_passes_when_positive_matcher_finds_call(self) -> None:
+        spec = _spec()
+        run = _run(
+            tool_calls=(EvalToolCall(name="Bash", input={"command": "git worktree add ../wt HEAD"}, turn=1),),
+        )
+        result = evaluate(spec, run)
+        assert result.skipped is False
+        assert result.passed is True
+        assert all(m.passed for m in result.matcher_results)
+
+    def test_fails_when_positive_matcher_finds_nothing(self) -> None:
+        spec = _spec()
+        run = _run(tool_calls=())
+        result = evaluate(spec, run)
+        assert result.passed is False
+        assert len(result.matcher_results) == 1
+        assert result.matcher_results[0].passed is False
+        assert "Bash" in result.matcher_results[0].message
+
+    def test_canonicalizes_lowercase_bash_to_capitalized(self) -> None:
+        # Loader emits lowercase `bash` from YAML; report should match against
+        # the canonical `Bash` tool name in the captured calls.
+        spec = _spec(
+            matchers=(Matcher(kind="positive", tool="bash", arg_path="command", operator="contains", value="ls"),),
+        )
+        run = _run(
+            tool_calls=(EvalToolCall(name="Bash", input={"command": "ls /tmp"}, turn=1),),
+        )
+        result = evaluate(spec, run)
+        assert result.passed is True
+
+    def test_negative_matcher_passes_when_no_match(self) -> None:
+        spec = _spec(
+            matchers=(Matcher(kind="negative", tool="Bash", arg_path="command", operator="~", value=r"Edit.*README"),),
+        )
+        run = _run(
+            tool_calls=(EvalToolCall(name="Bash", input={"command": "git worktree add"}, turn=1),),
+        )
+        result = evaluate(spec, run)
+        assert result.passed is True
+
+    def test_negative_matcher_fails_when_pattern_matches(self) -> None:
+        spec = _spec(
+            matchers=(Matcher(kind="negative", tool="Bash", arg_path="command", operator="~", value=r"Edit.*README"),),
+        )
+        run = _run(
+            tool_calls=(EvalToolCall(name="Bash", input={"command": "Edit /repo/README.md"}, turn=1),),
+        )
+        result = evaluate(spec, run)
+        assert result.passed is False
+
+    def test_failed_is_when_run_errored_even_with_passing_matchers(self) -> None:
+        spec = _spec(matchers=())
+        run = _run(terminal_reason="error_max_turns", is_error=True)
+        result = evaluate(spec, run)
+        # No matchers + run errored → passed is False (is_error path).
+        assert result.passed is False
+
+    def test_raises_for_unsupported_matcher_shape(self) -> None:
+        spec = _spec(
+            matchers=(Matcher(kind="weird", tool="Bash", arg_path="command", operator="??", value="x"),),
+        )
+        run = _run(
+            tool_calls=(EvalToolCall(name="Bash", input={"command": "x"}, turn=1),),
+        )
+        with pytest.raises(NotImplementedError):
+            evaluate(spec, run)
+
+
+class TestRenderText:
+    def test_emits_pass_line_and_summary(self) -> None:
+        spec = _spec()
+        result = ScenarioResult(
+            spec=spec,
+            run=_run(),
+            matcher_results=(MatcherResult(matcher=spec.matchers[0], passed=True, message=""),),
+            skipped=False,
+        )
+        text = render_text([result])
+        assert text.startswith("PASS scenario_one")
+        assert "1 passed" in text
+        assert "0 failed" in text
+
+    def test_emits_skip_line_and_summary(self) -> None:
+        spec = _spec()
+        result = ScenarioResult(
+            spec=spec,
+            run=_run(terminal_reason="skipped: claude not on PATH"),
+            matcher_results=(),
+            skipped=True,
+        )
+        text = render_text([result])
+        assert "SKIP scenario_one" in text
+        assert "1 skipped" in text
+
+    def test_emits_fail_lines_with_matcher_messages(self) -> None:
+        spec = _spec()
+        result = ScenarioResult(
+            spec=spec,
+            run=_run(),
+            matcher_results=(MatcherResult(matcher=spec.matchers[0], passed=False, message="no Bash call found"),),
+            skipped=False,
+        )
+        text = render_text([result])
+        assert "FAIL scenario_one" in text
+        assert "no Bash call found" in text
+
+    def test_emits_runtime_error_line_when_no_matcher_failures(self) -> None:
+        # Run errored but no matchers failed (because there were no matchers
+        # to fail) → the renderer should surface the run error explicitly.
+        spec = _spec(matchers=())
+        result = ScenarioResult(
+            spec=spec,
+            run=_run(terminal_reason="error_max_turns", is_error=True, raw_stderr="boom!"),
+            matcher_results=(),
+            skipped=False,
+        )
+        text = render_text([result])
+        assert "run errored: error_max_turns" in text
+        assert "stderr: boom!" in text
+
+
+class TestRenderJson:
+    def test_serializes_pass_and_summary(self) -> None:
+        spec = _spec()
+        result = ScenarioResult(
+            spec=spec,
+            run=_run(
+                tool_calls=(EvalToolCall(name="Bash", input={"command": "ls"}, turn=1),),
+            ),
+            matcher_results=(MatcherResult(matcher=spec.matchers[0], passed=True, message=""),),
+            skipped=False,
+        )
+        payload = json.loads(render_json([result]))
+        assert payload["summary"] == {"total": 1, "passed": 1, "failed": 0, "skipped": 0}
+        [scenario] = payload["scenarios"]
+        assert scenario["name"] == "scenario_one"
+        assert scenario["passed"] is True
+        assert scenario["tool_calls"] == [{"name": "Bash", "input": {"command": "ls"}, "turn": 1}]
+        assert scenario["matchers"][0]["passed"] is True
+
+    def test_serializes_failed_matcher(self) -> None:
+        spec = _spec()
+        result = ScenarioResult(
+            spec=spec,
+            run=_run(),
+            matcher_results=(MatcherResult(matcher=spec.matchers[0], passed=False, message="missed"),),
+            skipped=False,
+        )
+        payload = json.loads(render_json([result]))
+        assert payload["summary"]["failed"] == 1
+        assert payload["scenarios"][0]["matchers"][0]["message"] == "missed"

--- a/tests/eval/test_runner.py
+++ b/tests/eval/test_runner.py
@@ -1,0 +1,142 @@
+import dataclasses
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from teatree.eval.models import EvalSpec, Matcher
+from teatree.eval.runner import WATCHDOG_SECONDS, ClaudePRunner
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _spec(tmp_path: Path, *, max_turns: int = 3, model: str = "haiku", tools: tuple[str, ...] = ("Bash",)) -> EvalSpec:
+    agent = tmp_path / "agent.md"
+    agent.write_text("# fake skill\n\nbody\n", encoding="utf-8")
+    return EvalSpec(
+        name="worktree_first",
+        scenario="agent must create a worktree first",
+        agent_path=str(agent),
+        prompt="Fix README.md typo.",
+        matchers=(
+            Matcher(kind="positive", tool="Bash", arg_path="command", operator="contains", value="git worktree add"),
+        ),
+        source_path=tmp_path / "spec.yaml",
+        model=model,
+        max_turns=max_turns,
+        tools=tools,
+    )
+
+
+@dataclasses.dataclass
+class _FakeCompleted:
+    stdout: str
+    stderr: str = ""
+    returncode: int = 0
+
+
+class TestClaudePRunner:
+    def test_returns_skip_run_when_claude_missing(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        with patch("teatree.eval.runner.shutil.which", return_value=None):
+            result = ClaudePRunner().run(spec)
+        assert result.terminal_reason.startswith("skipped:")
+        assert result.is_error is False
+        assert result.tool_calls == ()
+
+    def test_builds_command_with_canonical_flags(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        captured: dict[str, object] = {}
+
+        def _fake_run(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            captured["kwargs"] = kwargs
+            return _FakeCompleted(stdout=(FIXTURES / "worktree_first_pass.stream.jsonl").read_text(encoding="utf-8"))
+
+        with (
+            patch("teatree.eval.runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.utils.run.subprocess.run", side_effect=_fake_run),
+        ):
+            ClaudePRunner(workspace=tmp_path).run(spec)
+
+        cmd = captured["cmd"]
+        assert isinstance(cmd, list)
+        assert cmd[0] == "/usr/local/bin/claude"
+        assert cmd[1] == "-p"
+        assert "--output-format" in cmd
+        assert cmd[cmd.index("--output-format") + 1] == "stream-json"
+        assert "--verbose" in cmd
+        assert "--max-turns" in cmd
+        assert cmd[cmd.index("--max-turns") + 1] == "3"
+        assert cmd[cmd.index("--max-budget-usd") + 1] == "0.10"
+        assert cmd[cmd.index("--model") + 1] == "haiku"
+        assert cmd[cmd.index("--fallback-model") + 1] == "sonnet"
+        assert "--no-session-persistence" in cmd
+        assert "--disable-slash-commands" in cmd
+        assert cmd[cmd.index("--permission-mode") + 1] == "bypassPermissions"
+        assert "--strict-mcp-config" in cmd
+        assert cmd[cmd.index("--tools") + 1] == "Bash"
+        assert cmd[cmd.index("--settings") + 1] == '{"hooks":{}}'
+        assert cmd[cmd.index("--add-dir") + 1] == str(tmp_path)
+        assert cmd[cmd.index("--system-prompt") + 1].startswith("# fake skill")
+        assert cmd[-1] == "Fix README.md typo."
+        assert captured["kwargs"].get("timeout") == WATCHDOG_SECONDS
+
+    def test_parses_stream_json_into_eval_run(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        stream = (FIXTURES / "worktree_first_pass.stream.jsonl").read_text(encoding="utf-8")
+        with (
+            patch("teatree.eval.runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.utils.run.subprocess.run", return_value=_FakeCompleted(stdout=stream)),
+        ):
+            result = ClaudePRunner(workspace=tmp_path).run(spec)
+        assert result.terminal_reason == "success"
+        assert result.is_error is False
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0].input["command"].startswith("git worktree add")
+        assert result.tool_calls[1].turn == 2
+
+    def test_returns_timeout_result_when_subprocess_times_out(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+
+        def _raise_timeout(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=WATCHDOG_SECONDS, output="partial", stderr="")
+
+        with (
+            patch("teatree.eval.runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.utils.run.subprocess.run", side_effect=_raise_timeout),
+        ):
+            result = ClaudePRunner(workspace=tmp_path).run(spec)
+        assert result.terminal_reason == "timeout"
+        assert result.is_error is True
+
+    def test_max_turns_override_takes_precedence_over_spec(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path, max_turns=3)
+        captured_cmd: list[str] = []
+
+        def _capture(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return _FakeCompleted(stdout='{"type":"result","subtype":"success"}\n')
+
+        with (
+            patch("teatree.eval.runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.utils.run.subprocess.run", side_effect=_capture),
+        ):
+            ClaudePRunner(workspace=tmp_path, max_turns_override=9).run(spec)
+        assert captured_cmd[captured_cmd.index("--max-turns") + 1] == "9"
+
+    def test_raises_when_agent_definition_missing(self, tmp_path: Path) -> None:
+        spec = EvalSpec(
+            name="bad",
+            scenario="bad",
+            agent_path=str(tmp_path / "does-not-exist.md"),
+            prompt="x",
+            matchers=(),
+            source_path=tmp_path / "spec.yaml",
+        )
+        with (
+            patch("teatree.eval.runner.shutil.which", return_value="/usr/local/bin/claude"),
+            pytest.raises(FileNotFoundError),
+        ):
+            ClaudePRunner(workspace=tmp_path).run(spec)

--- a/tests/eval/test_runner.py
+++ b/tests/eval/test_runner.py
@@ -140,3 +140,56 @@ class TestClaudePRunner:
             pytest.raises(FileNotFoundError),
         ):
             ClaudePRunner(workspace=tmp_path).run(spec)
+
+    def test_raises_when_agent_definition_is_empty(self, tmp_path: Path) -> None:
+        agent = tmp_path / "empty.md"
+        agent.write_text("", encoding="utf-8")
+        spec = EvalSpec(
+            name="empty",
+            scenario="empty",
+            agent_path=str(agent),
+            prompt="x",
+            matchers=(),
+            source_path=tmp_path / "spec.yaml",
+        )
+        with (
+            patch("teatree.eval.runner.shutil.which", return_value="/usr/local/bin/claude"),
+            pytest.raises(ValueError, match="empty"),
+        ):
+            ClaudePRunner(workspace=tmp_path).run(spec)
+
+    def test_nonzero_returncode_with_aborted_terminal_marks_is_error(self, tmp_path: Path) -> None:
+        # No `result` event in the stream → terminal_reason is "aborted".
+        # Combined with returncode != 0, the runner must set is_error=True
+        # (covers the post-parse re-flag at line 73-74).
+        spec = _spec(tmp_path)
+        stream = '{"type":"system","subtype":"init"}\n'
+        with (
+            patch("teatree.eval.runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.utils.run.subprocess.run", return_value=_FakeCompleted(stdout=stream, returncode=2)),
+        ):
+            result = ClaudePRunner(workspace=tmp_path).run(spec)
+        assert result.terminal_reason == "aborted"
+        assert result.is_error is True
+
+    def test_timeout_with_bytes_streams_decodes_to_strings(self, tmp_path: Path) -> None:
+        # subprocess.TimeoutExpired may carry bytes for stdout/stderr when
+        # text=False; _coerce_stream must decode them rather than blow up.
+        spec = _spec(tmp_path)
+
+        def _raise(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(
+                cmd=cmd,
+                timeout=120,
+                output=b"partial-bytes\n",
+                stderr=b"err-bytes\n",
+            )
+
+        with (
+            patch("teatree.eval.runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.utils.run.subprocess.run", side_effect=_raise),
+        ):
+            result = ClaudePRunner(workspace=tmp_path).run(spec)
+        assert result.terminal_reason == "timeout"
+        assert "partial-bytes" in result.raw_stdout
+        assert "err-bytes" in result.raw_stderr

--- a/tests/eval/test_transcript.py
+++ b/tests/eval/test_transcript.py
@@ -84,3 +84,47 @@ class TestExtractTerminalReason:
         reason, is_error = extract_terminal_reason(events)
         assert reason == "error_max_turns"
         assert is_error is True
+
+
+class TestMalformedStreams:
+    """Defensive paths for ``claude -p`` output that doesn't match the spec."""
+
+    def test_drops_non_dict_json_lines(self) -> None:
+        # Top-level JSON arrays must be ignored — only dict events count.
+        events = parse_stream_json('[1, 2, 3]\n{"type":"result","subtype":"success"}\n')
+        assert [e.type for e in events] == ["result"]
+
+    def test_ignores_assistant_event_without_message_dict(self) -> None:
+        stream = '{"type":"assistant"}\n{"type":"assistant","message":"not a dict"}\n'
+        events = parse_stream_json(stream)
+        assert extract_tool_calls(events) == []
+        assert extract_text_blocks(events) == []
+
+    def test_ignores_assistant_event_with_non_list_content(self) -> None:
+        stream = '{"type":"assistant","message":{"content":"not a list"}}\n'
+        events = parse_stream_json(stream)
+        assert extract_tool_calls(events) == []
+        assert extract_text_blocks(events) == []
+
+    def test_ignores_non_dict_content_items(self) -> None:
+        stream = '{"type":"assistant","message":{"content":["string","not dict",42]}}\n'
+        events = parse_stream_json(stream)
+        assert extract_tool_calls(events) == []
+        assert extract_text_blocks(events) == []
+
+    def test_ignores_tool_use_without_string_name(self) -> None:
+        stream = '{"type":"assistant","message":{"content":[{"type":"tool_use","name":42,"input":{}}]}}\n'
+        events = parse_stream_json(stream)
+        assert extract_tool_calls(events) == []
+
+    def test_ignores_text_block_with_non_string_text(self) -> None:
+        stream = '{"type":"assistant","message":{"content":[{"type":"text","text":42}]}}\n'
+        events = parse_stream_json(stream)
+        assert extract_text_blocks(events) == []
+
+    def test_tool_use_with_non_dict_input_falls_back_to_empty_dict(self) -> None:
+        stream = '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":"raw"}]}}\n'
+        events = parse_stream_json(stream)
+        calls = extract_tool_calls(events)
+        assert calls[0].name == "Bash"
+        assert calls[0].input == {}

--- a/tests/eval/test_transcript.py
+++ b/tests/eval/test_transcript.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+from teatree.eval.transcript import extract_terminal_reason, extract_text_blocks, extract_tool_calls, parse_stream_json
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+class TestParseStreamJson:
+    def test_parses_one_event_per_line(self) -> None:
+        events = parse_stream_json(_load("worktree_first_pass.stream.jsonl"))
+        assert [e.type for e in events] == ["system", "assistant", "user", "assistant", "result"]
+
+    def test_records_subtype_when_present(self) -> None:
+        events = parse_stream_json(_load("worktree_first_pass.stream.jsonl"))
+        system_event = next(e for e in events if e.type == "system")
+        result_event = next(e for e in events if e.type == "result")
+        assert system_event.subtype == "init"
+        assert result_event.subtype == "success"
+
+    def test_skips_blank_and_non_json_lines(self) -> None:
+        stream = '{"type":"system","subtype":"init"}\n\nnot-json\n{"type":"result","subtype":"success"}\n'
+        events = parse_stream_json(stream)
+        assert [e.type for e in events] == ["system", "result"]
+
+    def test_line_no_is_one_indexed(self) -> None:
+        events = parse_stream_json('{"type":"system"}\n{"type":"result","subtype":"success"}\n')
+        assert events[0].line_no == 1
+        assert events[1].line_no == 2
+
+    def test_drops_events_without_string_type(self) -> None:
+        events = parse_stream_json('{"foo": 1}\n{"type": 42}\n{"type": "result", "subtype": "success"}\n')
+        assert [e.type for e in events] == ["result"]
+
+
+class TestExtractToolCalls:
+    def test_assistant_turns_are_one_indexed(self) -> None:
+        events = parse_stream_json(_load("worktree_first_pass.stream.jsonl"))
+        calls = extract_tool_calls(events)
+        assert [c.turn for c in calls] == [1, 2]
+
+    def test_captures_tool_name_and_input(self) -> None:
+        events = parse_stream_json(_load("worktree_first_pass.stream.jsonl"))
+        calls = extract_tool_calls(events)
+        assert calls[0].name == "Bash"
+        assert calls[0].input["command"].startswith("git worktree add")
+
+    def test_ignores_text_blocks(self) -> None:
+        events = parse_stream_json(_load("worktree_first_pass.stream.jsonl"))
+        calls = extract_tool_calls(events)
+        assert all(c.name == "Bash" for c in calls)
+        assert len(calls) == 2
+
+
+class TestExtractTextBlocks:
+    def test_returns_text_blocks_from_assistant_events(self) -> None:
+        events = parse_stream_json(_load("worktree_first_pass.stream.jsonl"))
+        text_blocks = extract_text_blocks(events)
+        assert text_blocks == ["I'll create a worktree first."]
+
+
+class TestExtractTerminalReason:
+    def test_returns_subtype_and_is_error_from_result_event(self) -> None:
+        events = parse_stream_json(_load("worktree_first_pass.stream.jsonl"))
+        reason, is_error = extract_terminal_reason(events)
+        assert reason == "success"
+        assert is_error is False
+
+    def test_returns_aborted_when_no_result_event(self) -> None:
+        events = parse_stream_json(_load("aborted.stream.jsonl"))
+        reason, is_error = extract_terminal_reason(events)
+        assert reason == "aborted"
+        assert is_error is True
+
+    def test_handles_error_subtype(self) -> None:
+        stream = (
+            '{"type": "system", "subtype": "init"}\n'
+            '{"type": "result", "subtype": "error_max_turns", "is_error": true}\n'
+        )
+        events = parse_stream_json(stream)
+        reason, is_error = extract_terminal_reason(events)
+        assert reason == "error_max_turns"
+        assert is_error is True

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -149,7 +149,13 @@ class TestEvalRun:
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--format", "json"])
         assert result.exit_code == 0
-        payload = json.loads(result.output)
+        # Other pytest plugins (e.g. inline-snapshot) can write banners to
+        # stdout during the test session; isolate the JSON document by
+        # slicing from the first '{' to the last '}'.
+        output = result.output
+        start = output.index("{")
+        end = output.rindex("}") + 1
+        payload = json.loads(output[start:end])
         assert payload["summary"]["total"] == 1
 
     def test_exits_nonzero_when_any_scenario_failed(self) -> None:

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -1,0 +1,190 @@
+"""``t3 eval list`` / ``t3 eval run`` end-to-end through the typer CLI."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from teatree.cli import app
+from teatree.eval.models import EvalRun, EvalSpec, EvalToolCall, Matcher
+
+
+def _spec(name: str = "scenario_a") -> EvalSpec:
+    return EvalSpec(
+        name=name,
+        scenario=f"scenario for {name}",
+        agent_path="skills/code/SKILL.md",
+        prompt="do",
+        matchers=(
+            Matcher(kind="positive", tool="Bash", arg_path="command", operator="contains", value="git worktree add"),
+        ),
+        source_path=Path("/tmp/spec.yaml"),
+    )
+
+
+def _run(
+    spec_name: str,
+    *,
+    terminal_reason: str = "success",
+    is_error: bool = False,
+    tool_calls: tuple[EvalToolCall, ...] = (),
+) -> EvalRun:
+    return EvalRun(
+        spec_name=spec_name,
+        tool_calls=tool_calls,
+        text_blocks=(),
+        terminal_reason=terminal_reason,
+        is_error=is_error,
+        raw_stdout="",
+        raw_stderr="",
+    )
+
+
+_PASSING_CALL = (EvalToolCall(name="Bash", input={"command": "git worktree add ../wt HEAD"}, turn=1),)
+
+
+class TestEvalList:
+    def test_lists_discovered_scenario_names(self) -> None:
+        with patch("teatree.cli.eval.discover_specs", return_value=[_spec("alpha"), _spec("beta")]):
+            result = CliRunner().invoke(app, ["eval", "list"])
+        assert result.exit_code == 0
+        assert "alpha" in result.output
+        assert "beta" in result.output
+
+    def test_prints_placeholder_when_no_scenarios(self) -> None:
+        with patch("teatree.cli.eval.discover_specs", return_value=[]):
+            result = CliRunner().invoke(app, ["eval", "list"])
+        assert result.exit_code == 0
+        assert "(no scenarios discovered)" in result.output
+
+
+class TestEvalRun:
+    def test_runs_all_scenarios_when_no_name(self) -> None:
+        specs = [_spec("alpha"), _spec("beta")]
+
+        class _StubRunner:
+            def __init__(self, *_, **__) -> None: ...
+
+            def run(self, spec: EvalSpec) -> EvalRun:
+                return _run(spec.name, tool_calls=_PASSING_CALL)
+
+        with (
+            patch("teatree.cli.eval.discover_specs", return_value=specs),
+            patch("teatree.cli.eval.ClaudePRunner", _StubRunner),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run"])
+        assert result.exit_code == 0, result.output
+        assert "PASS alpha" in result.output
+        assert "PASS beta" in result.output
+
+    def test_runs_one_scenario_when_name_given(self) -> None:
+        specs = [_spec("alpha"), _spec("beta")]
+
+        class _StubRunner:
+            def __init__(self, *_, **__) -> None: ...
+
+            def run(self, spec: EvalSpec) -> EvalRun:
+                return _run(spec.name, tool_calls=_PASSING_CALL)
+
+        with (
+            patch("teatree.cli.eval.discover_specs", return_value=specs),
+            patch("teatree.cli.eval.find_spec", return_value=specs[0]),
+            patch("teatree.cli.eval.ClaudePRunner", _StubRunner),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run", "alpha"])
+        assert result.exit_code == 0
+        assert "alpha" in result.output
+        assert "PASS beta" not in result.output
+
+    def test_unknown_scenario_exits_with_code_2_and_lists_available(self) -> None:
+        specs = [_spec("alpha"), _spec("beta")]
+        with (
+            patch("teatree.cli.eval.discover_specs", return_value=specs),
+            patch("teatree.cli.eval.find_spec", return_value=None),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run", "missing"])
+        assert result.exit_code == 2
+        assert "unknown scenario: 'missing'" in result.output
+        assert "available scenarios: alpha, beta" in result.output
+
+    def test_unknown_scenario_shows_none_when_empty_inventory(self) -> None:
+        with (
+            patch("teatree.cli.eval.discover_specs", return_value=[]),
+            patch("teatree.cli.eval.find_spec", return_value=None),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run", "missing"])
+        assert result.exit_code == 2
+        assert "available scenarios: (none)" in result.output
+
+    def test_unknown_format_exits_with_code_2(self) -> None:
+        specs = [_spec("alpha")]
+
+        class _StubRunner:
+            def __init__(self, *_, **__) -> None: ...
+
+            def run(self, spec: EvalSpec) -> EvalRun:
+                return _run(spec.name, tool_calls=_PASSING_CALL)
+
+        with (
+            patch("teatree.cli.eval.discover_specs", return_value=specs),
+            patch("teatree.cli.eval.ClaudePRunner", _StubRunner),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run", "--format", "yaml"])
+        assert result.exit_code == 2
+        assert "unknown --format" in result.output
+
+    def test_json_format_emits_parseable_json(self) -> None:
+        specs = [_spec("alpha")]
+
+        class _StubRunner:
+            def __init__(self, *_, **__) -> None: ...
+
+            def run(self, spec: EvalSpec) -> EvalRun:
+                return _run(spec.name, tool_calls=_PASSING_CALL)
+
+        with (
+            patch("teatree.cli.eval.discover_specs", return_value=specs),
+            patch("teatree.cli.eval.ClaudePRunner", _StubRunner),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run", "--format", "json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["summary"]["total"] == 1
+
+    def test_exits_nonzero_when_any_scenario_failed(self) -> None:
+        specs = [_spec("alpha")]
+
+        class _StubRunner:
+            def __init__(self, *_, **__) -> None: ...
+
+            def run(self, spec: EvalSpec) -> EvalRun:
+                # No tool_calls → the positive matcher fails.
+                return _run(spec.name)
+
+        with (
+            patch("teatree.cli.eval.discover_specs", return_value=specs),
+            patch("teatree.cli.eval.ClaudePRunner", _StubRunner),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run"])
+        assert result.exit_code == 1
+        assert "FAIL alpha" in result.output
+
+    def test_max_turns_override_is_passed_to_runner(self) -> None:
+        specs = [_spec("alpha")]
+        captured: dict[str, object] = {}
+
+        class _StubRunner:
+            def __init__(self, *, max_turns_override: int | None = None) -> None:
+                captured["max_turns_override"] = max_turns_override
+
+            def run(self, spec: EvalSpec) -> EvalRun:
+                return _run(spec.name, tool_calls=_PASSING_CALL)
+
+        with (
+            patch("teatree.cli.eval.discover_specs", return_value=specs),
+            patch("teatree.cli.eval.ClaudePRunner", _StubRunner),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run", "--max-turns", "9"])
+        assert result.exit_code == 0
+        assert captured["max_turns_override"] == 9


### PR DESCRIPTION
feat(eval): claude -p behavioral eval harness — runner, loader, first scenario

Lays MR 1 of the behavioral-eval harness from teatree#1160. The harness
shells out to `claude -p --output-format stream-json` against a YAML
scenario, parses the transcript into structured tool calls, and
dispatches matchers against them. One smoke scenario lands here
(`worktree_first`) and the rest of the catalog plus overlay scenario
discovery, the prek manual hook, and the final-state matcher are
deferred to MR 2, 3, and 4.

New files:
- src/teatree/eval/__init__.py — public exports
- src/teatree/eval/models.py — frozen dataclasses (EvalRun, EvalSpec, …)
- src/teatree/eval/transcript.py — pure stream-json parser
- src/teatree/eval/loader.py — YAML → EvalSpec with model/max_turns/tools
- src/teatree/eval/matchers.py — assertion helpers (contains, ~ regex)
- src/teatree/eval/discovery.py — walks src/teatree/eval/scenarios/*.yaml
- src/teatree/eval/runner.py — ClaudePRunner.run(spec) → EvalRun
- src/teatree/eval/report.py — text + JSON report rendering
- src/teatree/eval/scenarios/worktree_first.yaml — first scenario
- src/teatree/eval/README.md — module docs
- src/teatree/cli/eval.py — `t3 eval list` / `t3 eval run [name]`
- tests/eval/ — loader, transcript, matchers, runner tests + fixtures

Deferred to later MRs (not in this change):
- MR 2: prek manual hook, overlay scenario discovery, remaining scenarios
- MR 3: negative-control scenario, final-state matcher
- MR 4: t3-oper#150 slim-down to reuse the core harness