### PR TITLE
fix(scanner): preserve manual all_merged flips with sticky manually_classified field (#1320)

### DIFF
--- a/src/teatree/core/migrations/0034_scannedbroadcast_sticky_manual_flag.py
+++ b/src/teatree/core/migrations/0034_scannedbroadcast_sticky_manual_flag.py
@@ -1,0 +1,27 @@
+# Generated for #1320 — sticky ``manually_classified`` flag on ScannedBroadcast.
+#
+# Operator-applied skip signals (my_notes, non-self reactions, author=me,
+# upvotes) flip a row to ``all_merged`` via ``mark_manually_classified``;
+# the flag survives subsequent rescans so ``_classify()`` does not revert
+# the verdict on the next ``t3 loop tick``.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0033_autonomous_review_crew_ledgers"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="scannedbroadcast",
+            name="manually_classified",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="scannedbroadcast",
+            name="manually_classified_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/src/teatree/core/models/scanned_broadcast.py
+++ b/src/teatree/core/models/scanned_broadcast.py
@@ -26,6 +26,17 @@ dispatches a reviewer task scoped to the open subset.
 broadcast scanner needs is "is there work left for the reviewer?" Once the
 last open MR closes, a later scan flips the row to ``all_merged`` and
 re-reacts ``:white_check_mark:``.
+
+Sticky manual flips (#1320)
+---------------------------
+
+``manually_classified`` is the operator-applied override that survives
+rescans. The auto-derived ``_classify()`` only inspects MR state + approval;
+other skip signals (my_notes on the MR, non-self ``:eyes:`` / ``:white_check_mark:``
+reactions, author=me, upvotes) are not encoded in that decision and would
+silently revert any direct ``classification='all_merged'`` write on the next
+``t3 loop tick``. :meth:`mark_manually_classified` pins the verdict and the
+flag; :meth:`record` no-ops on sticky rows so the operator's flip is durable.
 """
 
 from dataclasses import dataclass
@@ -74,6 +85,8 @@ class ScannedBroadcast(models.Model):
     reviewer_task_id = models.CharField(max_length=64, blank=True, default="")
     observed_at = models.DateTimeField(default=timezone.now)
     reclassified_at = models.DateTimeField(null=True, blank=True)
+    manually_classified = models.BooleanField(default=False)
+    manually_classified_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
         db_table = "teatree_scanned_broadcast"
@@ -111,6 +124,11 @@ class ScannedBroadcast(models.Model):
         )
         if created:
             return row
+        if row.manually_classified:
+            # #1320: an operator-applied skip-signal (my_notes, non-self reaction,
+            # author=me, upvotes) is durable. The scanner's auto-derived verdict
+            # does not override a row marked manual — only an explicit reset does.
+            return None
         if row.classification == observation.classification:
             return None
         row.classification = observation.classification
@@ -119,6 +137,33 @@ class ScannedBroadcast(models.Model):
         row.reviewer_task_id = ""
         row.save(update_fields=["classification", "mr_urls", "reclassified_at", "reviewer_task_id"])
         return row
+
+    def mark_manually_classified(self, classification: "ScannedBroadcast.Classification | str") -> bool:
+        """Pin *classification* on this row and mark it sticky against rescans (#1320).
+
+        Operators (or sub-agents) call this when a broadcast is socially
+        "done" — my_notes, non-self reactions claiming the MR, author=me,
+        upvotes — even though the auto-derived classifier would still emit
+        ``pending``. The flag survives subsequent ``record`` calls so the
+        next ``t3 loop tick`` does not revert the verdict. Idempotent:
+        re-marking with the same classification is a no-op and returns
+        ``False``.
+        """
+        value = classification.value if isinstance(classification, self.Classification) else str(classification)
+        if self.manually_classified and self.classification == value:
+            return False
+        updated = (
+            type(self)
+            .objects.filter(pk=self.pk)
+            .update(
+                classification=value,
+                manually_classified=True,
+                manually_classified_at=timezone.now(),
+            )
+        )
+        if updated:
+            self.refresh_from_db(fields=["classification", "manually_classified", "manually_classified_at"])
+        return bool(updated)
 
     def attach_reviewer_task(self, task_id: str) -> bool:
         """Persist the dispatched reviewer-task id on this broadcast row.

--- a/tests/teatree_loop/test_slack_broadcasts_classify.py
+++ b/tests/teatree_loop/test_slack_broadcasts_classify.py
@@ -1,0 +1,172 @@
+"""Manual ``all_merged`` flips survive a rescan (#1320).
+
+The bug: ``slack_broadcasts._classify()`` only emits ``ALL_MERGED`` when every
+referenced MR is both merged AND approved. Any other skip signal — my_notes,
+non-self reactions, author=me, upvotes — does NOT survive a rescan because
+``ScannedBroadcast.record`` overwrites the row's classification when it
+disagrees with the freshly-derived one. Operators (or sub-agents) that flip a
+row to ``all_merged`` because the broadcast is socially "done" see the next
+``t3 loop tick`` revert it back to ``pending``.
+
+Fix per Option A: a sticky ``manually_classified`` flag on the row. When set,
+``record`` no-ops on the row's classification and keeps the operator's verdict
+intact. The flag is set explicitly via
+:meth:`ScannedBroadcast.mark_manually_classified`; clearing requires an explicit
+reset (not modelled here — only the sticky-survives-rescan invariant).
+"""
+
+from django.test import TestCase
+
+from teatree.core.models import BroadcastObservation, ScannedBroadcast
+from teatree.loop.scanners.slack_broadcasts import MrState, SlackBroadcastsScanner
+from teatree.types import RawAPIDict
+
+CHANNEL = "C0AM3TENTLK"
+TS = "1779201478.501469"
+MR_URL = "https://gitlab.example.com/team/project/-/merge_requests/7432"
+
+
+class FakeMessaging:
+    def __init__(self) -> None:
+        self.react_calls: list[tuple[str, str, str]] = []
+
+    def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
+        self.react_calls.append((channel, ts, emoji))
+        return {"ok": True}
+
+    def fetch_mentions(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return []
+
+    def fetch_dms(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return []
+
+    def fetch_reactions(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return []
+
+    def fetch_message(self, *, channel: str, ts: str) -> RawAPIDict:
+        _ = (channel, ts)
+        return {}
+
+    def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:
+        _ = (channel, text, thread_ts)
+        return {}
+
+    def post_reply(self, *, channel: str, ts: str, text: str) -> RawAPIDict:
+        _ = (channel, ts, text)
+        return {}
+
+    def open_dm(self, user_id: str) -> str:
+        _ = user_id
+        return ""
+
+    def get_permalink(self, *, channel: str, ts: str) -> str:
+        return f"https://slack.example/{channel}/p{ts.replace('.', '')}"
+
+    def resolve_user_id(self, handle: str) -> str:
+        _ = handle
+        return ""
+
+    def auth_test(self) -> RawAPIDict:
+        return {"ok": True}
+
+
+def _fetcher(messages: list[RawAPIDict]):
+    def fetch(*, channel: str) -> list[RawAPIDict]:
+        _ = channel
+        return list(messages)
+
+    return fetch
+
+
+def _classifier(state: MrState):
+    def classify(urls):
+        return [state for _ in urls]
+
+    return classify
+
+
+def _message(text: str, ts: str) -> RawAPIDict:
+    return {"text": text, "ts": ts, "user": "USRG", "type": "message"}
+
+
+class TestManuallyClassifiedSurvivesRescan(TestCase):
+    def test_manually_classified_survives_rescan(self) -> None:
+        # Seed: a previous tick recorded the broadcast as ``pending`` (the MR was open).
+        seed = ScannedBroadcast.record(
+            BroadcastObservation(
+                channel=CHANNEL,
+                slack_ts=TS,
+                mr_urls=[MR_URL],
+                classification=ScannedBroadcast.Classification.PENDING.value,
+            ),
+        )
+        assert seed is not None
+
+        # Operator (or sub-agent) flips the row to ``all_merged`` because the
+        # broadcast is socially "done" (my_notes / reaction / author=me) even
+        # though the MR is still open. Calls the new sticky API.
+        seed.mark_manually_classified(ScannedBroadcast.Classification.ALL_MERGED)
+
+        # Re-scan: the MR is still open, so the auto-derived classification
+        # is still ``pending``. Without the sticky flag, ``record`` would
+        # overwrite the manual flip back to ``pending``.
+        backend = FakeMessaging()
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher([_message(f"please review {MR_URL}", TS)]),
+            classify_mrs=_classifier(MrState(url=MR_URL, merged=False, approved=False)),
+        )
+        scanner.scan()
+
+        row = ScannedBroadcast.objects.get(pk=seed.pk)
+        assert row.classification == ScannedBroadcast.Classification.ALL_MERGED
+        assert row.manually_classified is True
+
+    def test_mark_manually_classified_is_idempotent(self) -> None:
+        row = ScannedBroadcast.record(
+            BroadcastObservation(
+                channel=CHANNEL,
+                slack_ts=TS,
+                mr_urls=[MR_URL],
+                classification=ScannedBroadcast.Classification.PENDING.value,
+            ),
+        )
+        assert row is not None
+
+        first = row.mark_manually_classified(ScannedBroadcast.Classification.ALL_MERGED)
+        second = row.mark_manually_classified(ScannedBroadcast.Classification.ALL_MERGED)
+
+        assert first is True
+        assert second is False
+        row.refresh_from_db()
+        assert row.classification == ScannedBroadcast.Classification.ALL_MERGED
+        assert row.manually_classified is True
+
+    def test_auto_derived_classification_change_still_applies_when_not_manual(self) -> None:
+        # Pre-existing behaviour must keep working: when ``manually_classified``
+        # is False, a re-classification (pending → all_merged) still flows
+        # through.
+        ScannedBroadcast.record(
+            BroadcastObservation(
+                channel=CHANNEL,
+                slack_ts=TS,
+                mr_urls=[MR_URL],
+                classification=ScannedBroadcast.Classification.PENDING.value,
+            ),
+        )
+        backend = FakeMessaging()
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher([_message(f"please review {MR_URL}", TS)]),
+            classify_mrs=_classifier(MrState(url=MR_URL, merged=True, approved=True)),
+        )
+        scanner.scan()
+
+        row = ScannedBroadcast.objects.get(channel=CHANNEL, slack_ts=TS)
+        assert row.classification == ScannedBroadcast.Classification.ALL_MERGED
+        assert row.manually_classified is False


### PR DESCRIPTION
## Summary

`slack_broadcasts._classify()` only emits `ALL_MERGED` when every referenced MR is both merged AND approved. Operator-applied skip signals (my_notes, non-self reactions, author=me, upvotes) don't survive a rescan because `ScannedBroadcast.record` overwrites the row's classification when it disagrees with the freshly-derived one. Net effect: a row flipped to `all_merged` because the broadcast is socially "done" reverts to `pending` on the next `t3 loop tick`.

## Fix (Option A — sticky manual flag)

- New `ScannedBroadcast.manually_classified: BooleanField(default=False)` + `manually_classified_at: DateTimeField(null=True)` audit timestamp.
- New `ScannedBroadcast.mark_manually_classified(classification)` instance method — pins the verdict and the flag in one update. Idempotent.
- `ScannedBroadcast.record()` no-ops on rows where `manually_classified=True` — the scanner's auto-derived verdict does not override the operator's flip until an explicit reset.

Picked Option A over teaching `_classify()` the full signal set (Option B) for minimal blast radius and idempotency w.r.t. operator-applied skip-signals, per the ticket's recommendation.

## Tests

`tests/teatree_loop/test_slack_broadcasts_classify.py`:

- `test_manually_classified_survives_rescan` — integration test that seeds a `pending` row, calls `mark_manually_classified(ALL_MERGED)`, runs a full `SlackBroadcastsScanner.scan()` with the MR still open, and asserts the row stays `all_merged`. **Anti-vacuous verified**: reverted the early-return, confirmed RED; restored, GREEN.
- `test_mark_manually_classified_is_idempotent` — second call is a no-op.
- `test_auto_derived_classification_change_still_applies_when_not_manual` — pre-existing pending → all_merged reclassification still works when `manually_classified=False`.

## Migration

`core/0034_scannedbroadcast_sticky_manual_flag.py` — additive AddField for both new columns. No data migration.

Fixes #1320.