### PR TITLE
fix(statusline): drop stale-for-active dup, cap ready row, stamp overlay on assigned_issue.ready (#1324)

### DIFF
--- a/src/teatree/loop/rendering_classification.py
+++ b/src/teatree/loop/rendering_classification.py
@@ -290,6 +290,24 @@ def _dedup_active_tickets_across_overlays(
     return out
 
 
+def _drop_stale_already_on_active_line(
+    stale_by_overlay: dict[str, list[_IssueRef]],
+    active_by_overlay: dict[str, list[tuple[str, str, str, str]]],
+) -> dict[str, list[_IssueRef]]:
+    """Drop a stale ref when its ticket number already renders on the active line.
+
+    Every ticket in :data:`teatree.loop.scanners.stale_tickets._STALE_CANDIDATE_STATES`
+    is *also* an active ticket (#1324). Without this filter the renderer
+    shows the same ``#N`` on the dim anchor line AND on the red ``N stale:``
+    row — pure visual duplication.
+    """
+    out: dict[str, list[_IssueRef]] = {}
+    for overlay, refs in stale_by_overlay.items():
+        on_active = {num for num, _, _, _ in active_by_overlay.get(overlay, [])}
+        out[overlay] = [r for r in refs if r.label.lstrip("#") not in on_active]
+    return out
+
+
 def _dedup_classified(c: _ClassifiedActions) -> None:
     """Collapse duplicate refs in every per-overlay bucket.
 
@@ -307,6 +325,10 @@ def _dedup_classified(c: _ClassifiedActions) -> None:
     c.active_tickets = _dedup_active_tickets_across_overlays(c.active_tickets)
     for overlay, refs in list(c.stale_refs.items()):
         c.stale_refs[overlay] = _dedup_in_order(refs)
+    # #1324: drop stale refs whose ticket number already appears on the
+    # active anchor line for the same overlay. Stale is informational
+    # about an active ticket — surface it once.
+    c.stale_refs = _drop_stale_already_on_active_line(c.stale_refs, c.active_tickets)
     for overlay, refs in list(c.ready_refs.items()):
         c.ready_refs[overlay] = _dedup_in_order(refs)
     for overlay, refs in list(c.action_prs.items()):

--- a/src/teatree/loop/rendering_zones.py
+++ b/src/teatree/loop/rendering_zones.py
@@ -185,8 +185,13 @@ def _render_action_line(
 
     parts: list[str] = _disposition_parts(action_refs, colorize=colorize)
     if action_refs.ready_refs:
+        # #1324: cap the ready: row at _MAX_PER_STATE and append (+N) overflow,
+        # matching the anchor state lines. Without the cap a backlog of
+        # assigned issues spills the entire list onto a single line.
         items: list[str] = []
-        for ref in action_refs.ready_refs:
+        shown_refs = action_refs.ready_refs[:_MAX_PER_STATE]
+        overflow = len(action_refs.ready_refs) - len(shown_refs)
+        for ref in shown_refs:
             number = ref.label.lstrip("#")
             prs = prs_by_ticket.get(number, [])
             items.append(
@@ -199,7 +204,10 @@ def _render_action_line(
                 ),
             )
             consumed_pr_urls.update(p.url for p in prs)
-        parts.append(f"ready: {' '.join(items)}")
+        ready_chunk = " ".join(items)
+        if overflow > 0:
+            ready_chunk += f" (+{overflow})"
+        parts.append(f"ready: {ready_chunk}")
     if action_refs.pr_refs:
         remaining = [r for r in action_refs.pr_refs if r.url not in consumed_pr_urls]
         if remaining:

--- a/src/teatree/loop/scanners/assigned_issues.py
+++ b/src/teatree/loop/scanners/assigned_issues.py
@@ -126,6 +126,7 @@ class AssignedIssuesScanner:
                         "raw": issue,
                         "labels": labels,
                         "auto_start": self.auto_start,
+                        "overlay": self.overlay_name,
                     },
                 )
             )

--- a/tests/teatree_loop/test_statusline_1324_dedup_cap_overlay.py
+++ b/tests/teatree_loop/test_statusline_1324_dedup_cap_overlay.py
@@ -1,0 +1,128 @@
+"""Statusline renderer defects fixed in #1324.
+
+Three regressions visible on a real session statusline:
+
+* stale ticket rendered twice (anchor + action) — drop stale refs whose
+    ticket number already appears on the active line for the same overlay.
+* ``ready:`` row has no overflow cap — apply ``_MAX_PER_STATE`` + ``(+N)``.
+* ``assigned_issue.ready`` signal payload missing ``overlay`` — tracker
+    rows surfaced under the wrong overlay zone.
+"""
+
+from teatree.loop.dispatch import DispatchAction
+from teatree.loop.rendering import zones_for
+from teatree.loop.rendering_classification import _classify_actions
+from teatree.loop.rendering_zones import _MAX_PER_STATE
+from teatree.loop.scanners.assigned_issues import AssignedIssuesScanner
+
+
+def _blob(actions: list[DispatchAction]) -> str:
+    zones = zones_for(actions, colorize=False)
+    return "\n".join(
+        item if isinstance(item, str) else item.text
+        for zone in (zones.anchors, zones.action_needed, zones.in_flight)
+        for item in zone
+    )
+
+
+def _active_ticket(num: str, state: str, *, url: str = "", overlay: str = "ov") -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="anchors",
+        detail=f"#{num}",
+        payload={"ticket_number": num, "state": state, "issue_url": url, "overlay": overlay},
+    )
+
+
+def _stale(num: str, *, url: str = "", overlay: str = "ov") -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="action_needed",
+        detail=f"#{num} stale",
+        payload={
+            "stale": True,
+            "ticket_number": num,
+            "issue_url": url,
+            "overlay": overlay,
+        },
+    )
+
+
+def _ready(num: str, *, url: str, overlay: str = "ov") -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="action_needed",
+        detail=f"Ready to start: #{num}",
+        payload={"url": url, "ticket_number": num, "overlay": overlay},
+    )
+
+
+class TestStaleDropsWhenAlsoActive:
+    def test_stale_for_active_ticket_does_not_render(self) -> None:
+        url = "https://example.com/issues/42"
+        actions = [_active_ticket("42", "in_review", url=url), _stale("42", url=url)]
+        blob = _blob(actions)
+        assert "in_review:" in blob
+        assert "stale" not in blob
+
+    def test_stale_for_unrelated_ticket_still_renders(self) -> None:
+        url = "https://example.com/issues/99"
+        actions = [
+            _active_ticket("42", "in_review", url="https://example.com/issues/42"),
+            _stale("99", url=url),
+        ]
+        blob = _blob(actions)
+        assert "1 stale" in blob
+
+    def test_per_overlay_isolation_preserves_stale_in_other_overlay(self) -> None:
+        actions = [
+            _active_ticket("42", "in_review", url="https://example.com/issues/42", overlay="a"),
+            _stale("42", url="https://example.com/issues/42", overlay="b"),
+        ]
+        c = _classify_actions(actions)
+        assert c.stale_refs.get("b")
+        assert c.stale_refs["b"][0].label == "#42"
+        assert c.stale_refs.get("a") in (None, [])
+
+
+class TestReadyOverflowCap:
+    def test_ready_caps_at_max_per_state_with_overflow_marker(self) -> None:
+        n = _MAX_PER_STATE + 3
+        actions = [_ready(str(i), url=f"https://example.com/issues/{i}") for i in range(n)]
+        blob = _blob(actions)
+        # Five rendered, three folded into (+3).
+        assert "(+3)" in blob
+        assert "#0" in blob
+        assert f"#{_MAX_PER_STATE - 1}" in blob
+        assert f"#{_MAX_PER_STATE}" not in blob  # the first overflowed item
+
+    def test_ready_below_cap_renders_no_overflow_marker(self) -> None:
+        actions = [_ready(str(i), url=f"https://example.com/issues/{i}") for i in range(3)]
+        blob = _blob(actions)
+        assert "(+" not in blob
+
+
+class TestAssignedIssuesScannerStampsOverlay:
+    def test_scanner_payload_carries_overlay_name(self) -> None:
+        class _StubHost:
+            def current_user(self) -> str:
+                return "alice"
+
+            def list_assigned_issues(self, *, assignee: str) -> list[dict]:
+                _ = assignee
+                return [
+                    {
+                        "web_url": "https://example.com/issues/1",
+                        "title": "x",
+                        "labels": ["ready"],
+                    }
+                ]
+
+        scanner = AssignedIssuesScanner(
+            host=_StubHost(),
+            ready_labels=("ready",),
+            overlay_name="my-overlay",
+        )
+        signals = scanner.scan()
+        assert signals
+        assert signals[0].payload["overlay"] == "my-overlay"


### PR DESCRIPTION
fix(statusline): drop stale-for-active dup, cap ready row, stamp overlay on assigned_issue.ready (#1324)

Three renderer defects visible on a real session statusline:

1. Every ticket in `_STALE_CANDIDATE_STATES` is *also* an active ticket,
   so the same `#N` appears on the dim anchor line AND the red
   `N stale:` row. `_drop_stale_already_on_active_line` filters
   `stale_refs` by the active-line ticket numbers per overlay.

2. `_render_action_line` joined the entire `ready_refs` list with no
   cap, spilling 25 tickets onto a single row. Apply the existing
   `_MAX_PER_STATE` shape plus `(+N)` overflow used on anchor lines.

3. `AssignedIssuesScanner` did not stamp `overlay` on its payload, so
   `assigned_issue.ready` signals bucketed under the wrong overlay.