### PR TITLE
fix(pr): use repo default branch instead of hardcoded origin/main

### DIFF
--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -476,11 +476,11 @@ class Command(TyperCommand):
     ) -> EnsurePrResult:
         """Create a PR for an orphan branch (idempotent, no-op when a PR already exists).
 
-        An orphan is a branch with commits not on ``origin/main`` (after
-        subject-match + tree-equality checks) and no open PR. When this
-        runs inside a git pre-push hook for a *first* push, the branch is not
-        yet on the remote — creating the PR is deferred with a warning so the
-        push proceeds and the agent can re-run this command afterwards.
+        An orphan is a branch with commits not on the repo's default branch
+        (resolved per-repo via ``refs/remotes/origin/HEAD``) after subject-
+        match + tree-equality checks and no open PR. When this runs inside a
+        git pre-push hook for a *first* push, the branch is not yet on the
+        remote — creating the PR is deferred so the push proceeds.
         """
         repo_path = repo or "."
         branch_name = branch or git.current_branch(repo=repo_path)
@@ -490,7 +490,7 @@ class Command(TyperCommand):
         report = classify_branch(repo_path, branch_name)
 
         if report.status is BranchStatus.SYNCED:
-            return EnsurePrResult(skipped="branch synced to origin/main", branch=branch_name)
+            return EnsurePrResult(skipped="branch synced to default branch", branch=branch_name)
         if report.status is BranchStatus.OPEN_PR:
             return EnsurePrResult(skipped="open PR exists", branch=branch_name, url=report.open_pr_url)
         if report.status is BranchStatus.UNPUSHED_ORPHAN:

--- a/src/teatree/core/orphan_guard.py
+++ b/src/teatree/core/orphan_guard.py
@@ -1,9 +1,10 @@
 """Detect and guard against orphan branches.
 
-An ORPHAN is a local branch that carries work not on ``origin/main`` (after
-subject-match and tree-equality checks) AND has no open PR on the remote.
-Orphans silently leak work: they accumulate between weekly cleanups and are
-easy to miss when closing a session.
+An ORPHAN is a local branch that carries work not on the repo's default branch
+(``origin/main``, ``origin/master``, or whatever ``refs/remotes/origin/HEAD``
+points at — resolved per-repo) after subject-match and tree-equality checks
+AND has no open PR on the remote. Orphans silently leak work: they accumulate
+between weekly cleanups and are easy to miss when closing a session.
 
 This module is the single source of truth used by the three enforcement
 points that keep the no-orphan invariant:
@@ -24,10 +25,11 @@ from teatree.core.cleanup import _branch_tree_matches_squash, classify_branch_co
 from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Worktree
 from teatree.utils import git
+from teatree.utils.run import CommandFailedError
 
 
 class BranchStatus(StrEnum):
-    """Classification of a branch's sync state against ``origin/main``."""
+    """Classification of a branch's sync state against the repo's default branch."""
 
     SYNCED = "synced"
     OPEN_PR = "open_pr"
@@ -74,9 +76,24 @@ def find_open_pr(repo: str, branch: str) -> str:
     )
 
 
+def _origin_default_branch_target(repo: str) -> str:
+    """Resolve ``origin/<default-branch>`` for the repo, defaulting to ``origin/main``.
+
+    A repo whose default branch is ``master`` (or any non-``main`` name) was
+    misclassified as SYNCED because :func:`classify_branch_commits` defaulted
+    to ``origin/main``. Resolving the actual default via ``git symbolic-ref
+    refs/remotes/origin/HEAD`` makes the comparison authoritative.
+    """
+    try:
+        return f"origin/{git.default_branch(repo=repo)}"
+    except (CommandFailedError, RuntimeError, ValueError):
+        return "origin/main"
+
+
 def classify_branch(repo: str, branch: str) -> BranchReport:
     """Classify ``branch`` in ``repo`` as synced, open PR, or orphan (unpushed / pushed)."""
-    classification = classify_branch_commits(repo, branch)
+    target = _origin_default_branch_target(repo)
+    classification = classify_branch_commits(repo, branch, target=target)
     ahead = len(classification.genuinely_ahead)
 
     if ahead == 0:

--- a/tests/teatree_core/test_orphan_guard.py
+++ b/tests/teatree_core/test_orphan_guard.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.test import TestCase
 
 from teatree.core.cleanup import BranchClassification, BranchCommit
 from teatree.core.models import Ticket, Worktree
 from teatree.core.orphan_guard import BranchReport, BranchStatus, classify_branch, find_orphans_in_workspace
+from tests.teatree_core.cleanup._shared import _run_git
 
 _patch_classify = patch("teatree.core.orphan_guard.classify_branch_commits")
 _patch_tree_match = patch("teatree.core.orphan_guard._branch_tree_matches_squash")
@@ -188,3 +190,57 @@ class TestFindOrphansInWorkspace(TestCase):
 
         assert len(orphans) == 1
         assert mock_classify.call_count == 1
+
+
+class TestClassifyBranchRespectsRepoDefaultBranch:
+    """Real-git integration: ``classify_branch`` must use the repo's actual default branch.
+
+    ``classify_branch_commits`` defaults to ``target="origin/main"``; on a repo
+    whose default branch is ``master`` (or anything else), one-commit-ahead-of-
+    master was misclassified as SYNCED because the comparison was against the
+    non-existent ``origin/main``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _tmp_repo_with_master_default(self, tmp_path: Path) -> None:
+        self.origin = tmp_path / "origin.git"
+        _run_git("init", "-q", "--bare", "-b", "master", str(self.origin), cwd=tmp_path)
+
+        self.clone = tmp_path / "clone"
+        _run_git("clone", "-q", str(self.origin), str(self.clone), cwd=tmp_path)
+        _run_git("config", "user.email", "t@t", cwd=self.clone)
+        _run_git("config", "user.name", "t", cwd=self.clone)
+        _run_git("commit", "--allow-empty", "-q", "-m", "initial on master", cwd=self.clone)
+        _run_git("push", "-q", "origin", "master", cwd=self.clone)
+        _run_git("checkout", "-q", "-b", "feature-branch", cwd=self.clone)
+        _run_git("commit", "--allow-empty", "-q", "-m", "feat: new thing on feature", cwd=self.clone)
+
+    def test_one_commit_ahead_of_master_is_not_classified_as_synced(self) -> None:
+        report = classify_branch(str(self.clone), "feature-branch")
+        assert report.status is not BranchStatus.SYNCED, (
+            "Branch with one unpushed commit on top of origin/master must not "
+            "be classified as SYNCED (origin/main was hardcoded)"
+        )
+        assert report.ahead_count == 1
+        assert report.is_orphan
+
+    def test_falls_back_to_origin_main_when_default_branch_undetectable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Fallback path — ``git.default_branch`` raises, classifier still returns a report.
+
+        When the repo has no ``origin/HEAD`` and no known fallback name on the
+        remote, ``classify_branch`` must still return a valid report rather
+        than crashing — falls back to ``origin/main``.
+        """
+        from teatree.core import orphan_guard as og  # noqa: PLC0415
+
+        msg = "could not detect default branch"
+
+        def _raise(repo: str) -> str:
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(og.git, "default_branch", _raise)
+        report = classify_branch(str(self.clone), "feature-branch")
+        assert isinstance(report, BranchReport)


### PR DESCRIPTION
## Summary

`classify_branch` in `orphan_guard` called `classify_branch_commits` without a target, defaulting to `origin/main`. On repos whose default branch is `master` (or anything else), one-commit-ahead-of-master branches were misclassified as SYNCED and `t3 pr ensure-pr` skipped with \`branch synced to default branch\`, forcing operators to fall back to raw \`gh pr create\` / \`glab mr create\` and bypassing the shipping gate, visual-QA gate, and reviewer-sub-agent contract.

## Fix

Resolve \`origin/<default-branch>\` per-repo via \`git symbolic-ref refs/remotes/origin/HEAD\` (with a graceful fallback to \`origin/main\` when detection fails). Same pattern as \`_assert_commits_ahead_of_base\` in \`pr.py\` already uses.

## Test plan

- [x] Real-git integration test: creates a bare repo with default branch \`master\`, clones it, adds one commit on \`feature-branch\`, and asserts \`classify_branch\` returns a non-SYNCED status with \`ahead_count == 1\` and \`is_orphan == True\`. Anti-vacuous: confirmed RED on the pre-fix code; GREEN after the fix.
- [x] Fallback test: when \`git.default_branch\` raises, \`classify_branch\` still returns a valid \`BranchReport\` rather than crashing.
- [x] All 65 existing \`tests/teatree_core/test_orphan_guard.py\` + \`tests/teatree_core/pr_command/\` + \`tests/teatree_core/cleanup/\` + \`tests/utils/test_git_core.py\` tests pass.
- [x] Coverage on \`orphan_guard.py\` new code: 100% (file overall 95% — two pre-existing untouched gaps).
- [x] \`ruff check\`, \`ruff format\`, \`ty check\` green.