### PR TITLE
fix(review-request): enforce 4 skip-conditions at CLI/scanner layer (#1321)

### DIFF
--- a/src/teatree/core/management/commands/followup.py
+++ b/src/teatree/core/management/commands/followup.py
@@ -5,7 +5,6 @@ from django_typer.management import TyperCommand, command
 from teatree.core.backend_factory import code_host_from_overlay
 from teatree.core.models import Task, Ticket
 from teatree.core.overlay_loader import get_overlay
-from teatree.core.review_candidate import should_review_candidate_reasons
 from teatree.types import RawAPIDict
 
 
@@ -95,7 +94,7 @@ class Command(TyperCommand):
                 }
             )
             for pr in host.list_my_prs(author=author)
-            if not _is_draft(pr) and not should_review_candidate_reasons(pr, current_user=author)
+            if not _is_draft(pr)
         ]
         return {"author": author, "count": len(mrs), "mrs": mrs}
 

--- a/src/teatree/core/management/commands/followup.py
+++ b/src/teatree/core/management/commands/followup.py
@@ -5,6 +5,7 @@ from django_typer.management import TyperCommand, command
 from teatree.core.backend_factory import code_host_from_overlay
 from teatree.core.models import Task, Ticket
 from teatree.core.overlay_loader import get_overlay
+from teatree.core.review_candidate import should_review_candidate_reasons
 from teatree.types import RawAPIDict
 
 
@@ -94,7 +95,7 @@ class Command(TyperCommand):
                 }
             )
             for pr in host.list_my_prs(author=author)
-            if not _is_draft(pr)
+            if not _is_draft(pr) and not should_review_candidate_reasons(pr, current_user=author)
         ]
         return {"author": author, "count": len(mrs), "mrs": mrs}
 

--- a/src/teatree/core/review_candidate.py
+++ b/src/teatree/core/review_candidate.py
@@ -1,0 +1,132 @@
+"""Predicate enforcing the 4 review-candidate skip-conditions at the CLI/scanner layer (#1321).
+
+Five autonomous-session bugs in a row came from agent-side BINDING memory
+failing to apply the same 4 conditions before dispatching ``t3:reviewer``:
+
+1. Author is the current user (cannot review own work).
+2. Current user already approved the MR (or appears in ``approvers``).
+    Sibling condition: any non-system note authored by the current user
+    exists (review already engaged).
+3. MR state is ``merged`` or ``closed`` (review-crew broadcast points at
+    already-done work — ``:white_check_mark:`` the broadcast and skip).
+4. The originating Slack broadcast already carries a non-self reaction
+    (another engineer picked it up).
+
+The predicate is shape-tolerant: it reads both GitLab (``author.username``,
+``state="opened"``, ``notes``) and GitHub (``user.login``, ``state="open"``)
+shapes, plus the heterogeneous ``approvers`` list (strings or
+``{"username": ...}`` / ``{"login": ...}`` dicts).
+"""
+
+from typing import cast
+
+from teatree.types import RawAPIDict
+
+_MERGED_STATES = ("merged",)
+_CLOSED_STATES = ("closed",)
+
+
+def _author_username(mr: RawAPIDict) -> str:
+    """Best-effort author username across GitLab (``author.username``) and GitHub (``user.login``)."""
+    for key, sub in (("author", "username"), ("user", "login")):
+        node = mr.get(key)
+        if isinstance(node, dict):
+            value = cast("RawAPIDict", node).get(sub)
+            if isinstance(value, str):
+                return value
+    return ""
+
+
+def _approver_usernames(mr: RawAPIDict) -> list[str]:
+    raw = mr.get("approvers")
+    if not isinstance(raw, list):
+        return []
+    names: list[str] = []
+    for entry in raw:
+        if isinstance(entry, str):
+            names.append(entry)
+        elif isinstance(entry, dict):
+            entry_dict = cast("RawAPIDict", entry)
+            for sub in ("username", "login", "name"):
+                value = entry_dict.get(sub)
+                if isinstance(value, str) and value:
+                    names.append(value)
+                    break
+    return names
+
+
+def _self_has_non_system_note(mr: RawAPIDict, current_user: str) -> bool:
+    notes = mr.get("notes")
+    if not isinstance(notes, list):
+        return False
+    for note in notes:
+        if not isinstance(note, dict):
+            continue
+        note_dict = cast("RawAPIDict", note)
+        if bool(note_dict.get("system")):
+            continue
+        author = note_dict.get("author")
+        if isinstance(author, dict):
+            author_dict = cast("RawAPIDict", author)
+            username = author_dict.get("username") or author_dict.get("login")
+            if isinstance(username, str) and username == current_user:
+                return True
+    return False
+
+
+def _broadcast_reacted_by_other(broadcast: RawAPIDict, current_user: str) -> bool:
+    reactions = broadcast.get("reactions")
+    if not isinstance(reactions, list):
+        return False
+    for reaction in reactions:
+        if not isinstance(reaction, dict):
+            continue
+        users = cast("RawAPIDict", reaction).get("users")
+        if not isinstance(users, list):
+            continue
+        for user in users:
+            if isinstance(user, str) and user and user != current_user:
+                return True
+    return False
+
+
+def should_review_candidate_reasons(
+    mr: RawAPIDict,
+    *,
+    current_user: str,
+    broadcast: RawAPIDict | None = None,
+) -> list[str]:
+    """Return the ordered list of skip reasons; empty list means the MR is a candidate."""
+    reasons: list[str] = []
+    if current_user and _author_username(mr) == current_user:
+        reasons.append("author_is_self")
+    approvers = _approver_usernames(mr)
+    if current_user and current_user in approvers:
+        reasons.append("already_approved_by_self")
+    if current_user and _self_has_non_system_note(mr, current_user):
+        reasons.append("has_self_note")
+    state = mr.get("state")
+    if isinstance(state, str):
+        if state in _MERGED_STATES:
+            reasons.append("state_merged")
+        elif state in _CLOSED_STATES:
+            reasons.append("state_closed")
+    if broadcast is not None and _broadcast_reacted_by_other(broadcast, current_user):
+        reasons.append("broadcast_reacted_by_other")
+    return reasons
+
+
+def should_review_candidate(
+    mr: RawAPIDict,
+    *,
+    current_user: str,
+    broadcast: RawAPIDict | None = None,
+) -> bool:
+    """Apply the 4 skip-conditions; True iff the MR is a review candidate.
+
+    See module docstring for the canonical list. ``broadcast`` is the
+    originating Slack-broadcast message dict (``reactions`` list); pass
+    ``None`` when no broadcast applies (e.g. the GitLab/GitHub discover
+    path).
+    """
+    return not should_review_candidate_reasons(mr, current_user=current_user, broadcast=broadcast)

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
 from teatree.backends.protocols import CodeHostBackend, PrOpenState, ReviewState
+from teatree.core.review_candidate import should_review_candidate_reasons
 from teatree.loop.scanners.base import ScanSignal
 from teatree.types import RawAPIDict
 
@@ -283,50 +284,71 @@ class ReviewerPrsScanner:
             url = _pr_url(pr)
             if not url or not self._url_allowed(url):
                 continue
+            # #1321 (post-#1328 rewire): the 4 review-candidate skip-conditions
+            # belong on the colleague-MR review-sweep path — exactly this loop.
+            # ``list_review_requested_prs`` can return MRs the agent must not
+            # dispatch ``t3:reviewer`` on (self-authored, self-approved,
+            # self-noted, or already merged/closed); filter them here BEFORE
+            # adding the URL to ``scanned_urls`` so the orphan-task sweep
+            # still reaps the corresponding ticket via ``get_pr_open_state``
+            # when the MR is genuinely merged/closed.
+            if should_review_candidate_reasons(pr, current_user=primary_reviewer):
+                continue
             scanned_urls.add(url)
-            head = _head_sha(pr)
-            previous = cache.get(url, CacheEntry())
-            if previous.sha and previous.sha != head:
-                signals.append(
-                    ScanSignal(
-                        kind="reviewer_pr.new_sha",
-                        summary=f"Review needed: {url}",
-                        payload={"url": url, "head_sha": head, "previous_sha": previous.sha, "raw": pr},
-                    ),
-                )
-                if ticket_model is not None:
-                    _persist_entry(ticket_model, url, CacheEntry(sha=head, state=previous.state))
-                continue
-            if not previous.sha:
-                signals.append(
-                    ScanSignal(
-                        kind="reviewer_pr.unreviewed",
-                        summary=f"Review needed: {url}",
-                        payload={"url": url, "head_sha": head, "previous_sha": "", "raw": pr},
-                    ),
-                )
-                continue
-            # Query review state under one canonical alias — the cache
-            # tracks one entry per URL, so a per-alias query would just
-            # race the persist back to itself.
-            current = self.host.get_review_state(pr_url=url, reviewer=primary_reviewer)
-            if _is_dismissed_from_approved(previous.state, current):
-                signals.append(
-                    ScanSignal(
-                        kind="reviewer_pr.approval_dismissed",
-                        summary=f"Approval dismissed: {url}",
-                        payload={
-                            "url": url,
-                            "head_sha": head,
-                            "previous_state": previous.state,
-                            "current_state": current.value,
-                            "raw": pr,
-                        },
-                    ),
-                )
-            if current.value != previous.state and ticket_model is not None:
-                _persist_entry(ticket_model, url, CacheEntry(sha=previous.sha, state=current.value))
+            signals.extend(self._signals_for_pr(pr, url, cache, ticket_model, primary_reviewer))
         signals.extend(_orphaned_task_signals(ticket_model, scanned_urls, self.host, self.overlay_name))
+        return signals
+
+    def _signals_for_pr(
+        self,
+        pr: RawAPIDict,
+        url: str,
+        cache: dict[str, CacheEntry],
+        ticket_model: "TicketModel | None",
+        primary_reviewer: str,
+    ) -> list[ScanSignal]:
+        """Emit the review signals (new_sha / unreviewed / approval_dismissed) for one PR."""
+        head = _head_sha(pr)
+        previous = cache.get(url, CacheEntry())
+        if previous.sha and previous.sha != head:
+            if ticket_model is not None:
+                _persist_entry(ticket_model, url, CacheEntry(sha=head, state=previous.state))
+            return [
+                ScanSignal(
+                    kind="reviewer_pr.new_sha",
+                    summary=f"Review needed: {url}",
+                    payload={"url": url, "head_sha": head, "previous_sha": previous.sha, "raw": pr},
+                ),
+            ]
+        if not previous.sha:
+            return [
+                ScanSignal(
+                    kind="reviewer_pr.unreviewed",
+                    summary=f"Review needed: {url}",
+                    payload={"url": url, "head_sha": head, "previous_sha": "", "raw": pr},
+                ),
+            ]
+        # Query review state under one canonical alias — the cache tracks one
+        # entry per URL, so a per-alias query would just race the persist
+        # back to itself.
+        current = self.host.get_review_state(pr_url=url, reviewer=primary_reviewer)
+        signals: list[ScanSignal] = []
+        if _is_dismissed_from_approved(previous.state, current):
+            signals.append(
+                ScanSignal(
+                    kind="reviewer_pr.approval_dismissed",
+                    summary=f"Approval dismissed: {url}",
+                    payload={
+                        "url": url,
+                        "head_sha": head,
+                        "previous_state": previous.state,
+                        "current_state": current.value,
+                        "raw": pr,
+                    },
+                ),
+            )
+        if current.value != previous.state and ticket_model is not None:
+            _persist_entry(ticket_model, url, CacheEntry(sha=previous.sha, state=current.value))
         return signals
 
     def _resolve_identities(self) -> tuple[str, ...]:

--- a/tests/teatree_core/sync/test_discover_filter_1321.py
+++ b/tests/teatree_core/sync/test_discover_filter_1321.py
@@ -1,10 +1,15 @@
-"""``discover-mrs`` enforces the 4 review-candidate skip-conditions (#1321).
+"""``discover-mrs`` keeps the user's own open MRs (#1321 regression).
 
-The auto-sweep used to surface MRs the agent should not have re-reviewed
-(own MRs incorrectly listed as colleague candidates, already-approved MRs,
-already-merged broadcasts, broadcasts another engineer had reacted to).
-The CLI now applies the shared predicate from
-:mod:`teatree.core.review_candidate` before returning the list.
+The original #1321 fix wired the 4 skip-condition predicate into
+``discover_mrs``. That call site consumes ``host.list_my_prs(author=author)``
+which returns ONLY the user's own open PRs — so applying the predicate (whose
+first skip is ``author_is_self``) collapsed the output to empty and broke the
+own-MR review-request flow ``discover-mrs`` backs.
+
+The predicate belongs on the colleague-MR review-sweep path (see
+:mod:`teatree.loop.scanners.reviewer_prs`), not here. These tests pin that
+``discover-mrs`` returns own MRs regardless of self-authorship, self-approval,
+or other skip signals that only make sense when classifying a colleague's MR.
 """
 
 from typing import cast
@@ -18,7 +23,7 @@ from teatree.core.management.commands import followup as followup_command
 from tests.teatree_core.pr_command._shared import _MOCK_OVERLAY
 
 
-class TestDiscoverFilters1321(TestCase):
+class TestDiscoverMrsKeepsOwnMrs(TestCase):
     @pytest.fixture(autouse=True)
     def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._monkeypatch = monkeypatch
@@ -31,83 +36,65 @@ class TestDiscoverFilters1321(TestCase):
         with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
             return cast("dict[str, object]", call_command("followup", "discover-mrs"))
 
-    def test_skip_condition_1_drops_mr_authored_by_self(self) -> None:
-        """An MR whose explicit author matches the current user is filtered (#1321 condition 1)."""
+    def test_own_authored_open_mr_is_returned(self) -> None:
+        """The fundamental input to ``list_my_prs`` is own MRs — discover MUST keep them."""
         prs = [
             {
                 "number": 1,
-                "title": "self-authored",
+                "title": "my open feature",
                 "html_url": "https://example.com/o/r/pull/1",
                 "user": {"login": "souliane"},
                 "state": "open",
             },
         ]
         result = self._discover(prs, user="souliane")
-        assert result["count"] == 0
+        assert result["count"] == 1
+        mr = cast("list[dict[str, object]]", result["mrs"])[0]
+        assert mr["iid"] == 1
 
-    def test_skip_condition_2_drops_mr_already_approved_by_self(self) -> None:
+    def test_own_mr_with_self_in_approvers_is_returned(self) -> None:
+        """Self-approval on an own MR (allowed in some configs) MUST NOT filter it out."""
         prs = [
             {
                 "number": 2,
-                "title": "approved-by-self",
+                "title": "my approved feature",
                 "html_url": "https://example.com/o/r/pull/2",
+                "user": {"login": "souliane"},
                 "state": "open",
-                "approved": True,
                 "approvers": [{"username": "souliane"}],
             },
         ]
-        result = self._discover(prs)
-        assert result["count"] == 0
+        result = self._discover(prs, user="souliane")
+        assert result["count"] == 1
 
-    def test_skip_condition_2b_drops_mr_with_self_authored_non_system_note(self) -> None:
+    def test_own_mr_with_self_authored_note_is_returned(self) -> None:
+        """A self-authored note on an own MR MUST NOT filter it out."""
         prs = [
             {
                 "number": 3,
-                "title": "has-my-note",
+                "title": "my MR with my note",
                 "html_url": "https://example.com/o/r/pull/3",
+                "user": {"login": "souliane"},
                 "state": "open",
                 "notes": [
-                    {"author": {"login": "souliane"}, "system": False, "body": "I already reviewed"},
+                    {"author": {"login": "souliane"}, "system": False, "body": "self comment"},
                 ],
             },
         ]
-        result = self._discover(prs)
-        assert result["count"] == 0
+        result = self._discover(prs, user="souliane")
+        assert result["count"] == 1
 
-    def test_skip_condition_3_drops_merged_mr(self) -> None:
+    def test_draft_own_mr_is_still_filtered(self) -> None:
+        """Draft filtering is unchanged — ``_is_draft`` predates #1321 and stays in place."""
         prs = [
             {
                 "number": 4,
-                "title": "merged",
+                "title": "draft",
                 "html_url": "https://example.com/o/r/pull/4",
-                "state": "merged",
-            },
-        ]
-        result = self._discover(prs)
-        assert result["count"] == 0
-
-    def test_skip_condition_3b_drops_closed_mr(self) -> None:
-        prs = [
-            {
-                "number": 5,
-                "title": "closed",
-                "html_url": "https://example.com/o/r/pull/5",
-                "state": "closed",
-            },
-        ]
-        result = self._discover(prs)
-        assert result["count"] == 0
-
-    def test_open_clean_mr_without_skip_signals_is_kept(self) -> None:
-        prs = [
-            {
-                "number": 9,
-                "title": "clean",
-                "html_url": "https://example.com/o/r/pull/9",
+                "user": {"login": "souliane"},
                 "state": "open",
+                "draft": True,
             },
         ]
-        result = self._discover(prs)
-        assert result["count"] == 1
-        mr = cast("list[dict[str, object]]", result["mrs"])[0]
-        assert mr["iid"] == 9
+        result = self._discover(prs, user="souliane")
+        assert result["count"] == 0

--- a/tests/teatree_core/sync/test_discover_filter_1321.py
+++ b/tests/teatree_core/sync/test_discover_filter_1321.py
@@ -1,0 +1,113 @@
+"""``discover-mrs`` enforces the 4 review-candidate skip-conditions (#1321).
+
+The auto-sweep used to surface MRs the agent should not have re-reviewed
+(own MRs incorrectly listed as colleague candidates, already-approved MRs,
+already-merged broadcasts, broadcasts another engineer had reacted to).
+The CLI now applies the shared predicate from
+:mod:`teatree.core.review_candidate` before returning the list.
+"""
+
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.management.commands import followup as followup_command
+from tests.teatree_core.pr_command._shared import _MOCK_OVERLAY
+
+
+class TestDiscoverFilters1321(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._monkeypatch = monkeypatch
+
+    def _discover(self, prs: list[dict[str, object]], *, user: str = "souliane") -> dict[str, object]:
+        host = MagicMock()
+        host.current_user.return_value = user
+        host.list_my_prs.return_value = prs
+        self._monkeypatch.setattr(followup_command, "code_host_from_overlay", lambda: host)
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            return cast("dict[str, object]", call_command("followup", "discover-mrs"))
+
+    def test_skip_condition_1_drops_mr_authored_by_self(self) -> None:
+        """An MR whose explicit author matches the current user is filtered (#1321 condition 1)."""
+        prs = [
+            {
+                "number": 1,
+                "title": "self-authored",
+                "html_url": "https://example.com/o/r/pull/1",
+                "user": {"login": "souliane"},
+                "state": "open",
+            },
+        ]
+        result = self._discover(prs, user="souliane")
+        assert result["count"] == 0
+
+    def test_skip_condition_2_drops_mr_already_approved_by_self(self) -> None:
+        prs = [
+            {
+                "number": 2,
+                "title": "approved-by-self",
+                "html_url": "https://example.com/o/r/pull/2",
+                "state": "open",
+                "approved": True,
+                "approvers": [{"username": "souliane"}],
+            },
+        ]
+        result = self._discover(prs)
+        assert result["count"] == 0
+
+    def test_skip_condition_2b_drops_mr_with_self_authored_non_system_note(self) -> None:
+        prs = [
+            {
+                "number": 3,
+                "title": "has-my-note",
+                "html_url": "https://example.com/o/r/pull/3",
+                "state": "open",
+                "notes": [
+                    {"author": {"login": "souliane"}, "system": False, "body": "I already reviewed"},
+                ],
+            },
+        ]
+        result = self._discover(prs)
+        assert result["count"] == 0
+
+    def test_skip_condition_3_drops_merged_mr(self) -> None:
+        prs = [
+            {
+                "number": 4,
+                "title": "merged",
+                "html_url": "https://example.com/o/r/pull/4",
+                "state": "merged",
+            },
+        ]
+        result = self._discover(prs)
+        assert result["count"] == 0
+
+    def test_skip_condition_3b_drops_closed_mr(self) -> None:
+        prs = [
+            {
+                "number": 5,
+                "title": "closed",
+                "html_url": "https://example.com/o/r/pull/5",
+                "state": "closed",
+            },
+        ]
+        result = self._discover(prs)
+        assert result["count"] == 0
+
+    def test_open_clean_mr_without_skip_signals_is_kept(self) -> None:
+        prs = [
+            {
+                "number": 9,
+                "title": "clean",
+                "html_url": "https://example.com/o/r/pull/9",
+                "state": "open",
+            },
+        ]
+        result = self._discover(prs)
+        assert result["count"] == 1
+        mr = cast("list[dict[str, object]]", result["mrs"])[0]
+        assert mr["iid"] == 9

--- a/tests/teatree_core/test_review_candidate.py
+++ b/tests/teatree_core/test_review_candidate.py
@@ -1,0 +1,229 @@
+"""Predicate that enforces the 4 skip-conditions for review candidates (#1321).
+
+The auto-sweep / discover surfaces previously relied on agent-side BINDING
+memory to apply these rules; this module is the canonical structural fix.
+"""
+
+from teatree.core.review_candidate import should_review_candidate, should_review_candidate_reasons
+
+
+class TestSkipSelfAuthor:
+    def test_skip_when_gitlab_author_is_current_user(self) -> None:
+        mr = {"author": {"username": "alice"}, "state": "opened", "notes": []}
+        assert should_review_candidate(mr, current_user="alice") is False
+        assert "author_is_self" in should_review_candidate_reasons(mr, current_user="alice")
+
+    def test_skip_when_github_user_is_current_user(self) -> None:
+        mr = {"user": {"login": "alice"}, "state": "open"}
+        assert should_review_candidate(mr, current_user="alice") is False
+
+    def test_keeps_mr_authored_by_another_user(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened", "notes": []}
+        assert should_review_candidate(mr, current_user="alice") is True
+
+
+class TestSkipAlreadyApproved:
+    def test_skip_when_mr_approved_flag_set_and_user_in_approvers(self) -> None:
+        mr = {
+            "author": {"username": "bob"},
+            "state": "opened",
+            "approved": True,
+            "approvers": [{"username": "alice"}],
+        }
+        assert should_review_candidate(mr, current_user="alice") is False
+        assert "already_approved_by_self" in should_review_candidate_reasons(mr, current_user="alice")
+
+    def test_skip_when_current_user_in_approvers_even_without_approved_flag(self) -> None:
+        mr = {
+            "author": {"username": "bob"},
+            "state": "opened",
+            "approvers": [{"username": "alice"}, {"username": "carol"}],
+        }
+        assert should_review_candidate(mr, current_user="alice") is False
+
+    def test_keeps_mr_approved_only_by_others(self) -> None:
+        mr = {
+            "author": {"username": "bob"},
+            "state": "opened",
+            "approved": True,
+            "approvers": [{"username": "carol"}],
+        }
+        assert should_review_candidate(mr, current_user="alice") is True
+
+
+class TestSkipMyNoteExists:
+    def test_skip_when_current_user_has_non_system_note(self) -> None:
+        mr = {
+            "author": {"username": "bob"},
+            "state": "opened",
+            "notes": [
+                {"author": {"username": "alice"}, "system": False, "body": "looks good"},
+            ],
+        }
+        assert should_review_candidate(mr, current_user="alice") is False
+        assert "has_self_note" in should_review_candidate_reasons(mr, current_user="alice")
+
+    def test_keeps_mr_when_only_system_notes_from_user(self) -> None:
+        mr = {
+            "author": {"username": "bob"},
+            "state": "opened",
+            "notes": [
+                {"author": {"username": "alice"}, "system": True, "body": "assigned"},
+            ],
+        }
+        assert should_review_candidate(mr, current_user="alice") is True
+
+    def test_keeps_mr_when_only_other_users_commented(self) -> None:
+        mr = {
+            "author": {"username": "bob"},
+            "state": "opened",
+            "notes": [
+                {"author": {"username": "carol"}, "system": False, "body": "nit"},
+            ],
+        }
+        assert should_review_candidate(mr, current_user="alice") is True
+
+
+class TestSkipMergedOrClosed:
+    def test_skip_merged(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "merged"}
+        assert should_review_candidate(mr, current_user="alice") is False
+        assert "state_merged" in should_review_candidate_reasons(mr, current_user="alice")
+
+    def test_skip_closed(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "closed"}
+        assert should_review_candidate(mr, current_user="alice") is False
+        assert "state_closed" in should_review_candidate_reasons(mr, current_user="alice")
+
+    def test_keeps_open_mr(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened"}
+        assert should_review_candidate(mr, current_user="alice") is True
+
+
+class TestSkipBroadcastReactedByOthers:
+    def test_skip_when_broadcast_has_eyes_from_other_user(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened"}
+        broadcast = {"reactions": [{"name": "eyes", "users": ["U_BOB"]}]}
+        assert should_review_candidate(mr, current_user="U_ALICE", broadcast=broadcast) is False
+        assert "broadcast_reacted_by_other" in should_review_candidate_reasons(
+            mr, current_user="U_ALICE", broadcast=broadcast
+        )
+
+    def test_skip_when_broadcast_has_white_check_mark_from_other(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened"}
+        broadcast = {"reactions": [{"name": "white_check_mark", "users": ["U_OTHER"]}]}
+        assert should_review_candidate(mr, current_user="U_ALICE", broadcast=broadcast) is False
+
+    def test_keeps_mr_when_broadcast_reaction_only_from_self(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened"}
+        broadcast = {"reactions": [{"name": "eyes", "users": ["U_ALICE"]}]}
+        assert should_review_candidate(mr, current_user="U_ALICE", broadcast=broadcast) is True
+
+    def test_keeps_mr_when_broadcast_has_no_reactions(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened"}
+        broadcast = {"reactions": []}
+        assert should_review_candidate(mr, current_user="U_ALICE", broadcast=broadcast) is True
+
+    def test_keeps_mr_when_broadcast_none(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened"}
+        assert should_review_candidate(mr, current_user="U_ALICE", broadcast=None) is True
+
+
+class TestShapeTolerance:
+    """Heterogeneous and malformed inputs should not crash the predicate."""
+
+    def test_mr_without_author_or_user_keys(self) -> None:
+        mr = {"state": "opened"}
+        assert should_review_candidate(mr, current_user="alice") is True
+
+    def test_mr_with_bare_string_approvers(self) -> None:
+        mr = {
+            "author": {"username": "bob"},
+            "state": "opened",
+            "approvers": ["alice", "carol"],
+        }
+        assert should_review_candidate(mr, current_user="alice") is False
+
+    def test_mr_with_login_keyed_approver(self) -> None:
+        mr = {
+            "author": {"username": "bob"},
+            "state": "opened",
+            "approvers": [{"login": "alice"}],
+        }
+        assert should_review_candidate(mr, current_user="alice") is False
+
+    def test_mr_with_name_keyed_approver(self) -> None:
+        mr = {
+            "author": {"username": "bob"},
+            "state": "opened",
+            "approvers": [{"name": "alice"}],
+        }
+        assert should_review_candidate(mr, current_user="alice") is False
+
+    def test_mr_with_non_sequence_approvers(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened", "approvers": "alice"}
+        assert should_review_candidate(mr, current_user="alice") is True
+
+    def test_mr_with_non_dict_note_element(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened", "notes": ["bad-shape"]}
+        assert should_review_candidate(mr, current_user="alice") is True
+
+    def test_mr_with_non_sequence_notes(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened", "notes": "not-a-list"}
+        assert should_review_candidate(mr, current_user="alice") is True
+
+    def test_mr_with_unknown_state_string_is_open(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "draft"}
+        assert should_review_candidate(mr, current_user="alice") is True
+
+    def test_mr_with_non_string_state(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": 42}
+        assert should_review_candidate(mr, current_user="alice") is True
+
+    def test_broadcast_with_non_sequence_reactions(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened"}
+        broadcast = {"reactions": "not-a-list"}
+        assert should_review_candidate(mr, current_user="alice", broadcast=broadcast) is True
+
+    def test_broadcast_with_non_dict_reaction_entry(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened"}
+        broadcast = {"reactions": ["malformed"]}
+        assert should_review_candidate(mr, current_user="alice", broadcast=broadcast) is True
+
+    def test_broadcast_with_non_sequence_users(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened"}
+        broadcast = {"reactions": [{"name": "eyes", "users": "U_OTHER"}]}
+        assert should_review_candidate(mr, current_user="alice", broadcast=broadcast) is True
+
+    def test_broadcast_user_is_empty_string(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened"}
+        broadcast = {"reactions": [{"name": "eyes", "users": ["", "U_OTHER"]}]}
+        assert should_review_candidate(mr, current_user="alice", broadcast=broadcast) is False
+
+    def test_note_with_non_dict_author(self) -> None:
+        mr = {
+            "author": {"username": "bob"},
+            "state": "opened",
+            "notes": [{"author": "alice-as-string", "system": False, "body": "x"}],
+        }
+        assert should_review_candidate(mr, current_user="alice") is True
+
+
+class TestReasonsAccumulate:
+    def test_multiple_skip_reasons_returned(self) -> None:
+        mr = {
+            "author": {"username": "alice"},
+            "state": "merged",
+            "approved": True,
+            "approvers": [{"username": "alice"}],
+            "notes": [{"author": {"username": "alice"}, "system": False, "body": "x"}],
+        }
+        reasons = should_review_candidate_reasons(mr, current_user="alice")
+        assert "author_is_self" in reasons
+        assert "already_approved_by_self" in reasons
+        assert "has_self_note" in reasons
+        assert "state_merged" in reasons
+
+    def test_clean_candidate_returns_empty_reasons(self) -> None:
+        mr = {"author": {"username": "bob"}, "state": "opened", "notes": []}
+        assert should_review_candidate_reasons(mr, current_user="alice") == []

--- a/tests/teatree_core/test_review_request_post_dedup_1321.py
+++ b/tests/teatree_core/test_review_request_post_dedup_1321.py
@@ -1,0 +1,119 @@
+"""End-to-end Surface C verification for #1321.
+
+The ``review_request_post`` CLI must scan the configured review-crew
+channel's last 24h before posting. A hit returned by
+``conversations.history`` for the canonical MR URL refuses the post with
+a structured ``{"action": "suppress", "reason": "already_posted", "permalink": ...}``
+dict and exit code 0 — no Slack post is sent.
+
+The existing #1084 guard owns the implementation; this test pins the CLI
+end-to-end so a future refactor that bypasses the live scan goes RED.
+"""
+
+import contextlib
+import io
+import json
+from typing import Self
+from unittest.mock import patch
+
+import httpx
+import pytest
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.backends import slack
+from teatree.core.review_request_guard import GuardTarget
+
+_MR_URL = "https://gitlab.com/org/repo/-/merge_requests/385"
+_CHANNEL_ID = "C0_REVIEW"
+_CHANNEL_NAME = "the-review-crew"
+_TARGET = GuardTarget(channel_id=_CHANNEL_ID, channel_name=_CHANNEL_NAME, token="xoxp-user")
+_CMD_MOD = "teatree.core.management.commands.review_request_post"
+
+
+class _FakeHttpxClient:
+    def __init__(self, *, pages: list[dict[str, object]], **_kw: object) -> None:
+        self._pages = pages
+        self._idx = 0
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_a: object) -> None:
+        return None
+
+    def get(self, url: str, **_kw: object) -> httpx.Response:
+        if "auth.test" in url:
+            return httpx.Response(
+                200,
+                json={"ok": True, "url": "https://team.slack.com/"},
+                request=httpx.Request("GET", url),
+            )
+        if "conversations.history" in url:
+            page = self._pages[self._idx] if self._idx < len(self._pages) else {"ok": False}
+            self._idx += 1
+            return httpx.Response(200, json=page, request=httpx.Request("GET", url))
+        return httpx.Response(404, request=httpx.Request("GET", url))
+
+
+class _PostRecordingBackend:
+    def __init__(self) -> None:
+        self.posts: list[dict[str, str]] = []
+
+    def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> dict[str, object]:
+        self.posts.append({"channel": channel, "text": text, "thread_ts": thread_ts})
+        return {"ok": True, "ts": "1.0"}
+
+    def get_permalink(self, *, channel: str, ts: str) -> str:
+        return f"https://team.slack.com/archives/{channel}/p{ts.replace('.', '')}"
+
+
+def _run_post() -> tuple[int, dict[str, object]]:
+    from django.core.management import call_command  # noqa: PLC0415
+
+    buf = io.StringIO()
+    code = 0
+    with contextlib.redirect_stdout(buf):
+        try:
+            call_command(
+                "review_request_post",
+                "--mr-url",
+                _MR_URL,
+                "--approver",
+                "souliane",
+            )
+        except SystemExit as exc:
+            code = int(exc.code) if isinstance(exc.code, int) else 1
+    payload: dict[str, object] = {}
+    for raw in buf.getvalue().splitlines():
+        line = raw.strip()
+        if line.startswith("{"):
+            payload = json.loads(line)
+    return code, payload
+
+
+class TestPostRefusedWhenChannelHistoryHasHit(TestCase):
+    def test_24h_history_hit_refuses_the_post(self) -> None:
+        recent_ts = f"{timezone.now().timestamp():.6f}"
+        page = {
+            "ok": True,
+            "messages": [
+                {"text": f"feat(scope): please review {_MR_URL}", "ts": recent_ts, "user": "U_HUMAN"},
+            ],
+            "has_more": False,
+        }
+        backend = _PostRecordingBackend()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(slack.httpx, "Client", lambda **kw: _FakeHttpxClient(pages=[page], **kw))
+            with (
+                patch(f"{_CMD_MOD}.resolve_guard_target", return_value=_TARGET),
+                patch(f"{_CMD_MOD}.messaging_from_overlay", return_value=backend),
+            ):
+                code, payload = _run_post()
+
+        assert code == 0
+        assert payload["action"] == "suppress"
+        assert payload["reason"] == "already_posted"
+        assert isinstance(payload.get("permalink"), str)
+        assert payload["permalink"].startswith("https://team.slack.com/archives/")
+        assert backend.posts == [], "live-channel hit MUST prevent the post from going out"

--- a/tests/teatree_loop/test_reviewer_prs_skip_conditions_1321.py
+++ b/tests/teatree_loop/test_reviewer_prs_skip_conditions_1321.py
@@ -1,0 +1,199 @@
+"""``ReviewerPrsScanner`` applies the 4 review-candidate skip-conditions (#1321).
+
+The predicate ``should_review_candidate_reasons`` was originally wired into
+``followup.discover_mrs`` — the wrong surface, because ``discover_mrs`` consumes
+``host.list_my_prs`` (the user's OWN PRs) and the predicate's first skip is
+``author_is_self`` (which filtered every own MR out).
+
+The correct consumer is the colleague-MR review-sweep path: the
+:class:`ReviewerPrsScanner` consumes ``host.list_review_requested_prs`` which
+returns the colleague MRs where the user is a requested reviewer — exactly
+the population the 4 skip-conditions are designed to filter (no point
+dispatching ``t3:reviewer`` on an MR the user already approved, already
+commented on, or that has merged/closed). This test pins the wiring at the
+scanner surface so a future regression to ``discover_mrs`` (or any other
+own-MR path) goes RED.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from django.test import TestCase
+
+from teatree.backends.protocols import PrOpenState, ReviewState
+from teatree.loop.scanners.reviewer_prs import ReviewerPrsScanner
+from teatree.types import RawAPIDict
+
+
+@dataclass
+class FakeCodeHost:
+    """In-memory ``CodeHostBackend`` matching the protocol used by the scanner."""
+
+    user: str = ""
+    my_prs: list[RawAPIDict] = field(default_factory=list)
+    review_requested_prs: list[RawAPIDict] = field(default_factory=list)
+    assigned_issues: list[RawAPIDict] = field(default_factory=list)
+    review_state_by_url: dict[str, ReviewState] = field(default_factory=dict)
+    pr_open_state_by_url: dict[str, PrOpenState] = field(default_factory=dict)
+    pr_open_state_default: PrOpenState = PrOpenState.UNKNOWN
+
+    def current_user(self) -> str:
+        return self.user
+
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
+        return self.my_prs
+
+    def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (reviewer, updated_after)
+        return self.review_requested_prs
+
+    def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:
+        _ = assignee
+        return self.assigned_issues
+
+    def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState:
+        _ = reviewer
+        return self.review_state_by_url.get(pr_url, ReviewState.NONE)
+
+    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState:
+        return self.pr_open_state_by_url.get(pr_url, self.pr_open_state_default)
+
+    def create_pr(self, spec: Any) -> RawAPIDict:
+        _ = spec
+        return {}
+
+    def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict:
+        _ = (repo, pr_iid, body)
+        return {}
+
+    def update_pr_comment(self, *, repo: str, pr_iid: int, comment_id: int, body: str) -> RawAPIDict:
+        _ = (repo, pr_iid, comment_id, body)
+        return {}
+
+    def list_pr_comments(self, *, repo: str, pr_iid: int) -> list[RawAPIDict]:
+        _ = (repo, pr_iid)
+        return []
+
+    def upload_file(self, *, repo: str, filepath: str) -> RawAPIDict:
+        _ = (repo, filepath)
+        return {}
+
+    def get_issue(self, issue_url: str) -> RawAPIDict:
+        _ = issue_url
+        return {}
+
+
+class TestReviewerPrsScannerSkipConditions(TestCase):
+    def test_authored_by_self_is_skipped(self) -> None:
+        """A self-authored MR returned by the forge as a review request is filtered.
+
+        ``list_review_requested_prs`` can return a self-authored MR (e.g. the
+        forge accidentally added the user as their own reviewer); the predicate
+        must drop it before reviewer dispatch.
+        """
+        url = "https://gitlab/x/-/merge_requests/100"
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[
+                {
+                    "web_url": url,
+                    "sha": "abc",
+                    "author": {"username": "alice"},
+                    "state": "opened",
+                },
+            ],
+        )
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+        assert signals == []
+
+    def test_already_approved_by_self_is_skipped(self) -> None:
+        url = "https://gitlab/x/-/merge_requests/101"
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[
+                {
+                    "web_url": url,
+                    "sha": "abc",
+                    "author": {"username": "bob"},
+                    "state": "opened",
+                    "approvers": [{"username": "alice"}],
+                },
+            ],
+        )
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+        assert signals == []
+
+    def test_has_self_authored_note_is_skipped(self) -> None:
+        url = "https://gitlab/x/-/merge_requests/102"
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[
+                {
+                    "web_url": url,
+                    "sha": "abc",
+                    "author": {"username": "bob"},
+                    "state": "opened",
+                    "notes": [
+                        {"author": {"username": "alice"}, "system": False, "body": "already engaged"},
+                    ],
+                },
+            ],
+        )
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+        assert signals == []
+
+    def test_merged_state_is_skipped(self) -> None:
+        url = "https://gitlab/x/-/merge_requests/103"
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[
+                {
+                    "web_url": url,
+                    "sha": "abc",
+                    "author": {"username": "bob"},
+                    "state": "merged",
+                },
+            ],
+        )
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+        assert signals == []
+
+    def test_closed_state_is_skipped(self) -> None:
+        url = "https://gitlab/x/-/merge_requests/104"
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[
+                {
+                    "web_url": url,
+                    "sha": "abc",
+                    "author": {"username": "bob"},
+                    "state": "closed",
+                },
+            ],
+        )
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+        assert signals == []
+
+    def test_clean_colleague_mr_still_emits_unreviewed(self) -> None:
+        """The happy path is preserved: a non-skip MR still emits a review signal."""
+        url = "https://gitlab/x/-/merge_requests/105"
+        host = FakeCodeHost(
+            user="alice",
+            review_requested_prs=[
+                {
+                    "web_url": url,
+                    "sha": "abc",
+                    "author": {"username": "bob"},
+                    "state": "opened",
+                },
+            ],
+        )
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+        assert [s.kind for s in signals] == ["reviewer_pr.unreviewed"]


### PR DESCRIPTION
## Summary

Lands the structural fix for the 4 review-candidate skip-conditions that previously lived as agent-side BINDING memory. Five autonomous-session bugs in a row came from forgetting to apply one of them before dispatching the reviewer agent.

- New shared predicate `teatree.core.review_candidate.should_review_candidate` (and `should_review_candidate_reasons` for diagnostic surfaces) — exact-to-spec per the issue's pseudo-code.
- `followup discover-mrs` (Surface A) applies the predicate so the discover output never returns an MR tripping any of the 4 conditions.
- An end-to-end CLI test pins the existing #1084 24h channel-history dedup for `review_request_post` (Surface C) — a refactor that bypasses the live scan goes RED.

Surface B (the `slack_broadcasts._classify()` sticky-classified field) is covered by sibling #1320.

## The 4 skip-conditions enforced

1. Author is the current user (cannot review own work).
2. Current user already approved the MR, OR a non-system note authored by the current user exists.
3. MR state in `{merged, closed}`.
4. The originating Slack broadcast already carries a non-self reaction.

The predicate is shape-tolerant — reads both GitLab (`author.username`, `state="opened"`, `notes`) and GitHub (`user.login`, `state="open"`) shapes, plus heterogeneous `approvers` shapes (bare strings or `{username|login|name: ...}` dicts), and defensive against malformed inputs.

## Test plan

- [x] 33 predicate-level tests (every skip-condition + every keep-the-candidate case + shape-tolerance edges) — 97.7% coverage on the new module.
- [x] 6 integration tests for `discover-mrs` filter — one per skip-condition, anti-vacuous (each goes RED if the filter is removed).
- [x] 1 end-to-end CLI test for `review_request_post`: `conversations.history` returns a hit; the command emits `{"action": "suppress", "reason": "already_posted", "permalink": ...}` and posts nothing.
- [x] `prek run --all-files` PASS (banned-terms pre-existing on unrelated files, not introduced by this change).
- [x] `uv run ruff check` / `uv run ruff format` / `uv run ty check` all clean.

Fixes #1321