### PR TITLE
fix(reactions): skip :eyes: when PR author equals loop user

### DIFF
--- a/src/teatree/backends/slack_reactions.py
+++ b/src/teatree/backends/slack_reactions.py
@@ -20,6 +20,14 @@ if TYPE_CHECKING:
 
 _APPROVAL_EMOJI = "white_check_mark"
 
+# Engagement emojis signal "someone is looking at / picking up this PR" rather
+# than "outcome reached". When the loop user is the ticket's author, posting
+# one of these on the author's own review-crew broadcast inverts the signal —
+# colleagues read "the author is reviewing his own MR". Outcome emojis
+# (``tada``, ``white_check_mark``, ``arrows_counterclockwise``) stay enabled
+# for authored tickets because they communicate state regardless of who acts.
+_ENGAGEMENT_EMOJIS: frozenset[str] = frozenset({"eyes", "hand", "raised_hand"})
+
 logger = logging.getLogger(__name__)
 
 _PERMALINK_RE = re.compile(r"/archives/(?P<channel>[^/]+)/p(?P<ts>\d+)")
@@ -100,10 +108,27 @@ def add_reactions_for_transition(ticket: "Ticket", transition_name: str) -> int:
 
     Returns the number of successful reaction posts.  Missing credentials,
     missing permalinks, and unmapped transitions are all silent no-ops.
+
+    Engagement emojis (``eyes``, ``hand``, ``raised_hand``) are gated when
+    ``ticket.role == "author"``: the loop user is the PR's author, so an
+    "I'm engaging" reaction on the author's own review-crew broadcast
+    misrepresents the author as reviewing their own MR. Outcome emojis
+    (``tada``, ``white_check_mark``, ``arrows_counterclockwise``) post
+    regardless because they communicate state rather than engagement.
     """
     overlay = get_overlay(name=ticket.overlay or None)
     emoji = overlay.config.get_transition_emojis().get(transition_name)
     if not emoji:
+        return 0
+
+    if emoji in _ENGAGEMENT_EMOJIS and _ticket_role(ticket) == "author":
+        logger.info(
+            "Skipping %s reaction on authored ticket %s (transition=%s) — "
+            "author cannot signal engagement on their own PR broadcast.",
+            emoji,
+            getattr(ticket, "pk", "?"),
+            transition_name,
+        )
         return 0
 
     token = overlay.config.get_slack_token()
@@ -119,6 +144,16 @@ def add_reactions_for_transition(ticket: "Ticket", transition_name: str) -> int:
         if add_reaction(token, channel_id, timestamp, emoji):
             posted += 1
     return posted
+
+
+def _ticket_role(ticket: "Ticket") -> str:
+    """Return ``ticket.role`` as a plain string, defaulting to ``"author"``.
+
+    ``Ticket.role`` is a CharField backed by :class:`Ticket.Role` text choices;
+    callers in tests may pass a ``SimpleNamespace`` without the attribute, so
+    fall back to the model default (``author``) the same way Django does.
+    """
+    return str(getattr(ticket, "role", "author") or "author")
 
 
 def add_approval_reaction(pull_request: "PullRequest") -> int:

--- a/tests/teatree_backends/test_slack_reactions.py
+++ b/tests/teatree_backends/test_slack_reactions.py
@@ -140,10 +140,16 @@ class _StubOverlay:
 
 
 class TestAddReactionsForTransition:
-    def _ticket(self, permalinks: list[str], overlay: str = "") -> SimpleNamespace:
+    def _ticket(
+        self,
+        permalinks: list[str],
+        overlay: str = "",
+        role: str = "author",
+    ) -> SimpleNamespace:
         return SimpleNamespace(
             extra={"prs": {f"pr-{i}": {"review_permalink": p} for i, p in enumerate(permalinks)}},
             overlay=overlay,
+            role=role,
         )
 
     def test_posts_one_reaction_per_permalink(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -214,6 +220,72 @@ class TestAddReactionsForTransition:
             ],
         )
         assert add_reactions_for_transition(ticket, "mark_merged") == 2
+
+    def test_skips_eyes_on_authored_ticket(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Author's own request_review must NOT put :eyes: on the author's PR broadcast.
+
+        The transition ``request_review`` maps to ``eyes`` in the default emoji map,
+        signalling "someone is engaging with this PR". When the loop user — the
+        ticket's author — transitions their OWN ticket into the reviewing phase,
+        posting :eyes: on the author's review-crew broadcast looks like the author
+        is reviewing their own MR, which inverts the intended signal. Skip these
+        reactions when ``ticket.role == "author"`` and the transition emoji is
+        :eyes:.
+        """
+        overlay = _StubOverlay(_StubConfig(token="xoxb"))
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda name=None: overlay)
+        calls: list[tuple[str, str, str, str]] = []
+        monkeypatch.setattr(
+            slack_reactions,
+            "add_reaction",
+            lambda token, ch, ts, emoji: calls.append((token, ch, ts, emoji)) or True,
+        )
+
+        ticket = self._ticket(
+            [
+                "https://team.slack.com/archives/C111/p1700000001000100",
+                "https://team.slack.com/archives/C222/p1700000002000200",
+            ],
+            role="author",
+        )
+        assert add_reactions_for_transition(ticket, "request_review") == 0
+        assert calls == []
+
+    def test_posts_eyes_on_reviewer_ticket(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Reviewer role still triggers :eyes: — the author skip does not affect reviewer flows."""
+        overlay = _StubOverlay(_StubConfig(token="xoxb"))
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda name=None: overlay)
+        calls: list[tuple[str, str, str, str]] = []
+        monkeypatch.setattr(
+            slack_reactions,
+            "add_reaction",
+            lambda token, ch, ts, emoji: calls.append((token, ch, ts, emoji)) or True,
+        )
+
+        ticket = self._ticket(
+            ["https://team.slack.com/archives/C111/p1700000001000100"],
+            role="reviewer",
+        )
+        assert add_reactions_for_transition(ticket, "request_review") == 1
+        assert calls == [("xoxb", "C111", "1700000001.000100", "eyes")]
+
+    def test_posts_outcome_emoji_on_authored_ticket(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Outcome emojis (tada, white_check_mark) still post on authored tickets — only :eyes: is gated."""
+        overlay = _StubOverlay(_StubConfig(token="xoxb"))
+        monkeypatch.setattr("teatree.backends.slack_reactions.get_overlay", lambda name=None: overlay)
+        calls: list[tuple[str, str, str, str]] = []
+        monkeypatch.setattr(
+            slack_reactions,
+            "add_reaction",
+            lambda token, ch, ts, emoji: calls.append((token, ch, ts, emoji)) or True,
+        )
+
+        ticket = self._ticket(
+            ["https://team.slack.com/archives/C111/p1700000001000100"],
+            role="author",
+        )
+        assert add_reactions_for_transition(ticket, "mark_merged") == 1
+        assert calls == [("xoxb", "C111", "1700000001.000100", "tada")]
 
     def test_overlay_override_takes_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
         overlay = _StubOverlay(_StubConfig(token="xoxb", emojis={"mark_merged": "rocket"}))


### PR DESCRIPTION
## Summary

The default transition emoji map sends `:eyes:` onto every PR's review-crew Slack broadcast when a ticket transitions into a reviewing phase (`request_review → eyes`). On the loop user's **own** tickets (role=author), this puts `:eyes:` on the user's own MR broadcasts — colleagues read it as "the author is reviewing his own MR", which inverts the intended signal and disrupts the team review flow.

Gate engagement emojis (`eyes`, `hand`, `raised_hand`) on `ticket.role == "author"`: skip without posting. Outcome emojis (`tada`, `white_check_mark`, `arrows_counterclockwise`) still fire on authored tickets because they communicate state regardless of who acts.

## Why

The fix relies on the existing `Ticket.role` field (`Ticket.Role.AUTHOR` vs `Ticket.Role.REVIEWER`) that already discriminates author tickets from reviewer assignments. No schema migration, no host-side PR re-fetch — the existing typed field is sufficient because PRs in `ticket.extra["prs"]` for an author ticket are by definition authored by the loop user (they were synced from `list_my_prs(author=<loop_user>)`).

This closes the gap captured in `feedback_no_eyes_react_on_own_mr_broadcasts` (no `:eyes:` reactions on the user's own MR broadcasts).

## Changes

- `src/teatree/backends/slack_reactions.py` — add `_ENGAGEMENT_EMOJIS` frozenset and an early-return in `add_reactions_for_transition` when emoji is engagement-class and `ticket.role == "author"`. New `_ticket_role` helper defaults to `"author"` (Django default) for SimpleNamespace test tickets that lack the attribute.
- `tests/teatree_backends/test_slack_reactions.py` — three new tests:
  - `test_skips_eyes_on_authored_ticket` — RED-proven: 2 bogus reactions without fix, 0 with.
  - `test_posts_eyes_on_reviewer_ticket` — preserves the legitimate signal on reviewer-role tickets.
  - `test_posts_outcome_emoji_on_authored_ticket` — outcome emojis (tada, etc.) still post on authored tickets.

## Test plan

- [x] `uv run pytest tests/teatree_backends/test_slack_reactions.py --no-cov` → 29 passed (3 new)
- [x] `uv run pytest tests/teatree_backends/ tests/teatree_core/test_signals.py --no-cov` → 336 passed (no regression)
- [x] Anti-vacuous proof: temporarily reverted the gate, RED reproduced (`assert 2 == 0`), restored, GREEN.
- [x] `prek run --files src/teatree/backends/slack_reactions.py tests/teatree_backends/test_slack_reactions.py` → all passed.

Closes #1321.