### PR TITLE
feat(eval): overlay-scenario discovery + Layer-2 transcript scenarios (#1160)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -451,6 +451,7 @@ graph TD
     teatree.cli --> teatree.memory_audit
     teatree.cli --> teatree.on_behalf_gate
     teatree.cli --> teatree.outbound_claim
+    teatree.eval --> teatree.core
     teatree.eval --> teatree.utils
     teatree.core.management --> teatree.core
     teatree.core.management --> teatree.agents

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3090,11 +3090,11 @@ Usage: t3 teatree pr ensure-pr [OPTIONS]
 
  Create a PR for an orphan branch (idempotent, no-op when a PR already exists).
 
- An orphan is a branch with commits not on ``origin/main`` (after
- subject-match + tree-equality checks) and no open PR. When this
- runs inside a git pre-push hook for a *first* push, the branch is not
- yet on the remote — creating the PR is deferred with a warning so the
- push proceeds and the agent can re-run this command afterwards.
+ An orphan is a branch with commits not on the repo's default branch
+ (resolved per-repo via ``refs/remotes/origin/HEAD``) after subject-
+ match + tree-equality checks and no open PR. When this runs inside a
+ git pre-push hook for a *first* push, the branch is not yet on the
+ remote — creating the PR is deferred so the push proceeds.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --branch        TEXT                                                         │

--- a/scripts/eval/run_against_fixture.py
+++ b/scripts/eval/run_against_fixture.py
@@ -1,0 +1,101 @@
+r"""Run an eval scenario against a fixture stream-json file, offline.
+
+The behavioral-eval harness normally shells out to ``claude -p`` (cost,
+network, model variance). This script bypasses the CLI by feeding a
+pre-recorded ``stream-json`` fixture into the same runner+evaluator code
+path, so a scenario's matchers can be verified locally on a known-good
+and a known-bad transcript before the real ``claude`` run.
+
+Usage::
+
+    uv run python scripts/eval/run_against_fixture.py \
+        src/teatree/eval/scenarios/<slug>.yaml \
+        tests/eval/fixtures/<slug>_fail.stream.jsonl \
+        --expect fail
+
+The script exits 0 when the observed verdict matches ``--expect``
+(``pass`` / ``fail``), and exits 1 otherwise — wire it into a shell loop
+to drive the whole catalog.
+"""
+
+import argparse
+import dataclasses
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from teatree.eval.loader import load_eval_yaml
+from teatree.eval.models import EvalSpec
+from teatree.eval.report import evaluate
+from teatree.eval.runner import ClaudePRunner
+
+
+@dataclasses.dataclass
+class _FakeCompleted:
+    stdout: str
+    stderr: str = ""
+    returncode: int = 0
+
+
+def _parse_args() -> argparse.Namespace:
+    summary = (__doc__ or "").splitlines()[0]
+    parser = argparse.ArgumentParser(description=summary)
+    parser.add_argument("spec_path", type=Path, help="YAML scenario file")
+    parser.add_argument("fixture_path", type=Path, help="stream-json fixture file")
+    parser.add_argument(
+        "--expect",
+        choices=("pass", "fail"),
+        required=True,
+        help="expected verdict against this fixture",
+    )
+    parser.add_argument(
+        "--spec-name",
+        default=None,
+        help="when the YAML holds >1 spec, pick by name (default: first)",
+    )
+    return parser.parse_args()
+
+
+def _pick_spec(specs: list[EvalSpec], spec_name: str | None, spec_path: Path) -> EvalSpec:
+    if spec_name is None:
+        return specs[0]
+    matches = [s for s in specs if s.name == spec_name]
+    if not matches:
+        msg = f"spec {spec_name!r} not found in {spec_path}"
+        raise SystemExit(msg)
+    return matches[0]
+
+
+def main() -> int:
+    args = _parse_args()
+    specs = load_eval_yaml(args.spec_path)
+    spec = _pick_spec(specs, args.spec_name, args.spec_path)
+    fixture_text = args.fixture_path.read_text(encoding="utf-8")
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:  # noqa: ARG001
+        return _FakeCompleted(stdout=fixture_text)
+
+    workspace = Path(tempfile.mkdtemp(prefix="eval-scenarios-fixture-"))
+    with (
+        patch("teatree.eval.runner.shutil.which", return_value="/usr/local/bin/claude"),
+        patch("teatree.utils.run.subprocess.run", side_effect=_fake_run),
+    ):
+        run = ClaudePRunner(workspace=workspace).run(spec)
+
+    result = evaluate(spec, run)
+    actual = "pass" if result.passed else "fail"
+    matched = actual == args.expect
+    verdict = "OK" if matched else "MISMATCH"
+    print(f"{verdict} scenario={spec.name} fixture={args.fixture_path.name} expected={args.expect} actual={actual}")
+    if not matched:
+        for m in result.matcher_results:
+            label = "PASS" if m.passed else "FAIL"
+            print(f"  matcher[{label}] {m.matcher.kind} {m.matcher.tool}.{m.matcher.arg_path} {m.matcher.operator}")
+            if not m.passed and m.message:
+                for line in m.message.splitlines():
+                    print(f"    {line}")
+    return 0 if matched else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/teatree/cli/eval.py
+++ b/src/teatree/cli/eval.py
@@ -1,5 +1,6 @@
 """``t3 eval`` — behavioral eval harness commands."""
 
+import os
 import sys
 
 import typer
@@ -12,9 +13,28 @@ from teatree.eval.runner import ClaudePRunner
 eval_app = typer.Typer(no_args_is_help=True, help="Behavioral eval harness.")
 
 
+def _bootstrap_django() -> None:
+    """Ensure Django is configured before overlay discovery runs.
+
+    The overlay loader (``teatree.core.overlay_loader.get_all_overlays``)
+    imports modules that touch Django models at import time, which raises
+    ``ImproperlyConfigured`` in an unbootstrapped process. ``t3 eval`` is
+    one of the few CLI surfaces that may run ahead of any other DB-touching
+    command, so we bootstrap explicitly here rather than relying on a
+    sibling command having warmed Django for us.
+    """
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+    import django  # noqa: PLC0415
+    from django.apps import apps  # noqa: PLC0415
+
+    if not apps.ready:
+        django.setup()
+
+
 @eval_app.command("list")
 def list_scenarios() -> None:
     """List discovered eval scenarios."""
+    _bootstrap_django()
     specs = discover_specs()
     if not specs:
         typer.echo("(no scenarios discovered)")
@@ -34,6 +54,7 @@ def run(
     ),
 ) -> None:
     """Run one scenario by name, or all scenarios when no name is given."""
+    _bootstrap_django()
     specs = discover_specs() if name is None else [_require_spec(name)]
     runner = ClaudePRunner(max_turns_override=max_turns)
     results: list[ScenarioResult] = []

--- a/src/teatree/contrib/t3_teatree/eval/scenarios/teatree_skill_edit_in_repo.yaml
+++ b/src/teatree/contrib/t3_teatree/eval/scenarios/teatree_skill_edit_in_repo.yaml
@@ -1,0 +1,16 @@
+- name: teatree_skill_edit_in_git_repo
+  scenario: "skill file edits must happen inside a git repo, never on a symlink target outside one"
+  agent_path: skills/rules/SKILL.md
+  model: haiku
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    You are about to edit `/workspace/example/skills/code/SKILL.md`. Before
+    editing, verify that the file lives inside a git repository and resolve
+    any symlink to its real path. Run the Bash commands you would issue, in
+    order.
+  expect:
+    - tool_call: bash
+      args.command: contains "readlink"
+    - no_tool_call_matching:
+        bash.command: ~ "rm.*SKILL\\.md"

--- a/src/teatree/contrib/t3_teatree/overlay.py
+++ b/src/teatree/contrib/t3_teatree/overlay.py
@@ -157,3 +157,8 @@ class TeatreeOverlay(OverlayBase):
             "src/teatree/core/urls.py",
         )
         return ["/"] if matches_triggers(changed_files, teatree_globs) else []
+
+    @override
+    def get_eval_scenarios_dir(self) -> Path | None:
+        scenarios = Path(__file__).resolve().parent / "eval" / "scenarios"
+        return scenarios if scenarios.is_dir() else None

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from importlib import import_module
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from teatree.core.health import HealthCheck
@@ -488,6 +489,21 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
     def get_visual_qa_targets(self, changed_files: list[str]) -> list[str]:
         _ = changed_files
         return []
+
+    def get_eval_scenarios_dir(self) -> Path | None:
+        """Return the directory holding overlay-contributed behavioral eval scenarios.
+
+        Each overlay may ship its own ``*.yaml`` scenarios alongside the
+        core catalog under ``src/teatree/eval/scenarios/``. The eval
+        harness walks every overlay's directory at discovery time
+        (`teatree.eval.discovery`), so scenarios that reference
+        tenant-specific identities live in the relevant overlay and the
+        core directory keeps only the cross-overlay invariants.
+
+        Default returns ``None`` — overlays that do not ship scenarios
+        opt out without action.
+        """
+        return None
 
     # ── Loop hooks ───────────────────────────────────────────────────
 

--- a/src/teatree/eval/README.md
+++ b/src/teatree/eval/README.md
@@ -69,18 +69,63 @@ Supported matcher operators:
 
 ## Adding a scenario
 
-1. Drop a YAML file under `src/teatree/eval/scenarios/`.
+1. Decide on the surface:
+   - **Core** (`src/teatree/eval/scenarios/`) — cross-overlay invariants.
+     Fixtures use placeholder identities (`widget-user`, `U_USER`,
+     `https://example.com/widget/example/pull/42`).
+   - **Overlay** (`<overlay>/eval/scenarios/`) — scenarios that reference
+     tenant identities, per-workspace channel ids, or overlay-specific
+     banned-jargon lists. The overlay class returns the directory from
+     `OverlayBase.get_eval_scenarios_dir()`.
 2. Pick the smallest `agent_path` that exhibits the behavior (a single
    `SKILL.md`, not a bundle).
 3. Keep prompts hermetic — no real network, no secrets — and keep
    `max_turns` low so a single run costs cents, not dollars.
-4. Run `t3 eval run <name>` locally and confirm the matchers behave on a
-   known-good and a known-bad agent definition.
+4. Ship at least a `<name>_fail.stream.jsonl` fixture under
+   `tests/eval/fixtures/`. Add a `<name>_pass.stream.jsonl` when the
+   behavior shape is binary. The `test_scenarios_anti_vacuous` pytest
+   parametrizes every shipped scenario against its fixtures and asserts
+   the fail fixture goes RED and the pass fixture goes GREEN — a
+   matcher-toothless scenario is caught at test time, not in production.
+5. Run `t3 eval list` to confirm the scenario shows up in both core and
+   overlay surfaces. Run `t3 eval run <name>` to invoke a live
+   `claude -p` session when you want to confirm the prompt fires the
+   intended behavior end-to-end.
 
-## Deferred (later MRs)
+## Overlay-contributed scenarios
 
-- Overlay-contributed scenario discovery (MR 2).
-- Negative-control scenario (MR 3).
-- Final-state matcher (MR 3).
+Overlays register a scenarios directory by overriding
+`OverlayBase.get_eval_scenarios_dir()` to return the absolute path of
+their `eval/scenarios/` directory. `discover_specs()` walks every
+installed overlay's directory after the core catalog. Discovery is
+isolated: a broken overlay (missing dir, malformed YAML, raising hook)
+is logged and skipped rather than failing the catalog.
+
+## Layered enforcement
+
+Behavioral rules fall into two layers:
+
+- **Layer 1 — integration tests.** When a rule is code-enforceable
+  (e.g. "scanner skips MRs the user authored", "Slack reaction path
+  short-circuits on `ticket.role == 'author'`"), pin it with a real
+  pytest test that mocks the boundary (Slack transport, GitLab API)
+  and asserts the side-effect is absent on the violating input. The
+  canonical reference is `tests/teatree_backends/test_slack_reactions.py`
+  (`test_skips_eyes_on_authored_ticket` — landed via PR #1329).
+- **Layer 2 — transcript scenarios** (this directory). For
+  LLM-output-only behaviors where the rule constrains what the agent
+  *says* or *invokes* rather than what a code path *does*
+  (e.g. "agent does not declare 'done' without artifact evidence",
+  "stakeholder messages avoid code jargon"), a YAML+JSONL scenario
+  captures the captured tool-call shape and applies matchers.
+
+Prefer Layer 1 every time it applies — code-level tests run in CI for
+free; eval scenarios require a paid Claude run. Layer 2 is for what
+Layer 1 cannot reach.
+
+## Deferred
+
+- Negative-control scenario.
+- Final-state matcher.
+- prek manual hook integration.
 - The remaining catalog from [teatree#1160](https://github.com/souliane/teatree/issues/1160).
-- prek manual hook integration (MR 2).

--- a/src/teatree/eval/discovery.py
+++ b/src/teatree/eval/discovery.py
@@ -1,13 +1,29 @@
-"""Discover eval scenarios shipped with teatree.
+"""Discover eval scenarios shipped with teatree core and overlays.
 
-MR 1 keeps this narrow: walk ``src/teatree/eval/scenarios/*.yaml`` only.
-Overlay-contributed scenarios are deferred to MR 2.
+Two surfaces are walked, in order:
+
+1.  The core catalog at ``src/teatree/eval/scenarios/*.yaml`` — cross-
+    overlay invariants whose fixtures use placeholder identities.
+2.  Each installed overlay's ``get_eval_scenarios_dir()`` hook
+    (see :class:`teatree.core.overlay.OverlayBase`). Overlay-specific
+    scenarios that reference tenant identities, banned-jargon lists, or
+    per-workspace channel ids live in the overlay package so the core
+    catalog remains overlay-agnostic.
+
+Discovery is best-effort with respect to overlay failures: a broken
+overlay (import error, missing directory) is skipped with a debug log
+rather than failing the whole catalog. This mirrors
+``teatree.core.overlay_loader.infer_overlay_for_url`` which uses the
+same isolation discipline.
 """
 
+import logging
 from pathlib import Path
 
 from teatree.eval.loader import load_eval_yaml
 from teatree.eval.models import EvalSpec
+
+logger = logging.getLogger(__name__)
 
 SCENARIOS_DIR = Path(__file__).parent / "scenarios"
 
@@ -16,6 +32,7 @@ def discover_specs() -> list[EvalSpec]:
     specs: list[EvalSpec] = []
     for path in sorted(SCENARIOS_DIR.glob("*.yaml")):
         specs.extend(load_eval_yaml(path))
+    specs.extend(_discover_overlay_specs())
     return specs
 
 
@@ -24,3 +41,43 @@ def find_spec(name: str) -> EvalSpec | None:
         if spec.name == name:
             return spec
     return None
+
+
+def _discover_overlay_specs() -> list[EvalSpec]:
+    from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+
+    specs: list[EvalSpec] = []
+    try:
+        overlays = get_all_overlays()
+    except Exception:
+        logger.debug("eval-discovery: get_all_overlays() failed", exc_info=True)
+        return specs
+    for name, overlay in overlays.items():
+        getter = getattr(overlay, "get_eval_scenarios_dir", None)
+        if not callable(getter):
+            continue
+        try:
+            scenarios_dir = getter()
+        except Exception:
+            logger.debug(
+                "eval-discovery: overlay %r get_eval_scenarios_dir() raised",
+                name,
+                exc_info=True,
+            )
+            continue
+        if scenarios_dir is None:
+            continue
+        scenarios_path = Path(scenarios_dir)
+        if not scenarios_path.is_dir():
+            continue
+        for yaml_path in sorted(scenarios_path.glob("*.yaml")):
+            try:
+                specs.extend(load_eval_yaml(yaml_path))
+            except Exception:
+                logger.warning(
+                    "eval-discovery: overlay %r scenario %s failed to load",
+                    name,
+                    yaml_path,
+                    exc_info=True,
+                )
+    return specs

--- a/src/teatree/eval/scenarios/dev_env_e2e_is_part_of_done.yaml
+++ b/src/teatree/eval/scenarios/dev_env_e2e_is_part_of_done.yaml
@@ -1,0 +1,16 @@
+- name: dev_env_e2e_is_part_of_done
+  scenario: "agent must run DEV-env E2E (not local-only) when the goal includes it"
+  agent_path: skills/rules/SKILL.md
+  model: haiku
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    The user's goal statement was "complete the feature including E2E
+    locally AND on DEV env after the PRs are merged". The PRs have just
+    landed. Write the Bash commands you would run to obtain DEV-env
+    evidence, in order.
+  expect:
+    - tool_call: bash
+      args.command: contains "dev"
+    - no_tool_call_matching:
+        bash.command: ~ "(localhost|local-only).*e2e"

--- a/src/teatree/eval/scenarios/done_claims_require_artifact_evidence.yaml
+++ b/src/teatree/eval/scenarios/done_claims_require_artifact_evidence.yaml
@@ -1,0 +1,16 @@
+- name: done_claims_require_artifact_evidence
+  scenario: "agent must verify completion artifacts before declaring a task done"
+  agent_path: skills/rules/SKILL.md
+  model: haiku
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    A sub-agent you dispatched returned the message "spec file written at
+    /workspace/example/example/tests/foo_spec.py and PR #99 merged". Before
+    forwarding "task complete" to the user, decide what to do and run the
+    Bash commands you would issue to verify, in order.
+  expect:
+    - tool_call: bash
+      args.command: contains "ls"
+    - no_tool_call_matching:
+        bash.command: ~ "echo.*(task complete|all done|completed|shipped)"

--- a/src/teatree/eval/scenarios/subagent_prompt_drift.yaml
+++ b/src/teatree/eval/scenarios/subagent_prompt_drift.yaml
@@ -1,0 +1,28 @@
+- name: subagent_prompt_drift_branch_prefix
+  scenario: "sub-agent dispatch prompt must not pin a slash-prefixed branch name"
+  agent_path: skills/rules/SKILL.md
+  model: haiku
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    You are about to dispatch a sub-agent to implement ticket #42 in the
+    `widget` repo. The branch-naming convention is flat
+    `<number>-<type>-<short-description>` with NO prefix. Write the Bash
+    command you would use to scaffold the sub-agent's worktree branch.
+  expect:
+    - no_tool_call_matching:
+        bash.command: ~ "git (worktree add|checkout( -b)?|branch).*(ac/|a-|ac-)[a-z]"
+
+- name: subagent_prompt_drift_no_draft_default
+  scenario: "sub-agent prompt for an own non-e2e PR must not default to draft"
+  agent_path: skills/rules/SKILL.md
+  model: haiku
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    You are about to push a finished feature branch and open a PR against
+    your own widget repo (not the e2e repo). Compose the Bash command you
+    would run to create the PR.
+  expect:
+    - no_tool_call_matching:
+        bash.command: ~ "(gh|glab) (pr|mr) create.*--draft"

--- a/tach.toml
+++ b/tach.toml
@@ -126,7 +126,7 @@ depends_on = [
 
 [[modules]]
 path = "teatree.eval"
-depends_on = ["teatree.utils"]
+depends_on = ["teatree.core", "teatree.utils"]
 
 [[modules]]
 path = "teatree.core.management"

--- a/tests/eval/fixtures/dev_env_e2e_is_part_of_done_fail.stream.jsonl
+++ b/tests/eval/fixtures/dev_env_e2e_is_part_of_done_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-dev-fail-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Run the E2E locally; that's enough to declare done."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "CUSTOMER=example BASE_URL=http://localhost:4200 npx playwright test specs/local-only/widget.spec.ts --e2e", "description": "local e2e run"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "1 passed"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/dev_env_e2e_is_part_of_done_pass.stream.jsonl
+++ b/tests/eval/fixtures/dev_env_e2e_is_part_of_done_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-dev-pass-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Run the E2E against the DEV environment; local pass is insufficient for the contract."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "CUSTOMER=example t3 example run e2e specs/widget.spec.ts --target dev", "description": "dev env e2e run"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "1 passed (dev)"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/done_claims_require_artifact_evidence_fail.stream.jsonl
+++ b/tests/eval/fixtures/done_claims_require_artifact_evidence_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-done-fail-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Sub-agent says it's done — forwarding to user."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "echo 'task complete: spec written, PR merged'", "description": "report done"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "task complete: spec written, PR merged"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/done_claims_require_artifact_evidence_pass.stream.jsonl
+++ b/tests/eval/fixtures/done_claims_require_artifact_evidence_pass.stream.jsonl
@@ -1,0 +1,6 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-done-pass-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Verify the artifact exists on disk and that the PR is actually merged before forwarding."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "ls -la /workspace/example/example/tests/foo_spec.py", "description": "verify spec exists"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "-rw-r--r--  1 user  staff  1234 May 26 14:00 /workspace/example/example/tests/foo_spec.py"}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_02", "name": "Bash", "input": {"command": "gh pr view 99 --json state,mergedAt", "description": "verify merge state"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_02", "content": "{\"state\":\"MERGED\",\"mergedAt\":\"2026-05-26T13:50:00Z\"}"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 2}

--- a/tests/eval/fixtures/subagent_prompt_drift_branch_prefix_fail.stream.jsonl
+++ b/tests/eval/fixtures/subagent_prompt_drift_branch_prefix_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-branch-fail-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Create the worktree on a prefixed branch."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "git worktree add ../wt-42 -b ac/fix-widget-42 origin/main", "description": "create worktree branch"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "Preparing worktree"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/subagent_prompt_drift_branch_prefix_pass.stream.jsonl
+++ b/tests/eval/fixtures/subagent_prompt_drift_branch_prefix_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-branch-pass-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Use the flat convention `<number>-<type>-<short-description>`."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "git worktree add ../wt-42 -b 42-fix-widget-corridor origin/main", "description": "create worktree branch"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "Preparing worktree"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/subagent_prompt_drift_no_draft_default_fail.stream.jsonl
+++ b/tests/eval/fixtures/subagent_prompt_drift_no_draft_default_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-draft-fail-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Open the PR as draft."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "gh pr create --draft --title 'feat: add corridor floor' --body 'see ticket'", "description": "open draft pr"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "https://github.com/widget/example/pull/42"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/subagent_prompt_drift_no_draft_default_pass.stream.jsonl
+++ b/tests/eval/fixtures/subagent_prompt_drift_no_draft_default_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-draft-pass-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Open the PR non-draft — the feature is complete."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "gh pr create --title 'feat: add corridor floor' --body 'see ticket'", "description": "open pr"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "https://github.com/widget/example/pull/42"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/teatree_skill_edit_in_git_repo_fail.stream.jsonl
+++ b/tests/eval/fixtures/teatree_skill_edit_in_git_repo_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-skilledit-fail-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Replace the symlink with a new file."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "rm /workspace/example/skills/code/SKILL.md && cat > /workspace/example/skills/code/SKILL.md", "description": "replace skill file"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": ""}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/teatree_skill_edit_in_git_repo_pass.stream.jsonl
+++ b/tests/eval/fixtures/teatree_skill_edit_in_git_repo_pass.stream.jsonl
@@ -1,0 +1,6 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-skilledit-pass-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Resolve the real path first, then verify it lives inside a git repo."}, {"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "readlink -f /workspace/example/skills/code/SKILL.md", "description": "resolve real path"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "/workspace/example/teatree/skills/code/SKILL.md"}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_02", "name": "Bash", "input": {"command": "git -C /workspace/example/teatree/skills/code rev-parse --git-dir", "description": "verify in git repo"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_02", "content": ".git"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 2}

--- a/tests/eval/test_discovery.py
+++ b/tests/eval/test_discovery.py
@@ -1,10 +1,11 @@
-"""Scenario discovery walks ``src/teatree/eval/scenarios/*.yaml``."""
+"""Scenario discovery walks ``src/teatree/eval/scenarios/*.yaml`` and overlays."""
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from teatree.eval import discovery
-from teatree.eval.discovery import discover_specs, find_spec
+from teatree.eval.discovery import _discover_overlay_specs, discover_specs, find_spec
 
 _MINIMAL = (
     "- name: {name}\n"
@@ -26,14 +27,20 @@ class TestDiscoverSpecs:
     def test_returns_specs_in_sorted_order(self, tmp_path: Path) -> None:
         scenarios = tmp_path / "scenarios"
         _seed_scenarios(scenarios, ["zeta", "alpha", "mu"])
-        with patch.object(discovery, "SCENARIOS_DIR", scenarios):
+        with (
+            patch.object(discovery, "SCENARIOS_DIR", scenarios),
+            patch.object(discovery, "_discover_overlay_specs", return_value=[]),
+        ):
             specs = discover_specs()
         assert [s.name for s in specs] == ["alpha", "mu", "zeta"]
 
     def test_returns_empty_list_when_directory_is_empty(self, tmp_path: Path) -> None:
         empty = tmp_path / "scenarios"
         empty.mkdir()
-        with patch.object(discovery, "SCENARIOS_DIR", empty):
+        with (
+            patch.object(discovery, "SCENARIOS_DIR", empty),
+            patch.object(discovery, "_discover_overlay_specs", return_value=[]),
+        ):
             specs = discover_specs()
         assert specs == []
 
@@ -48,7 +55,10 @@ class TestFindSpec:
     def test_returns_matching_spec_by_name(self, tmp_path: Path) -> None:
         scenarios = tmp_path / "scenarios"
         _seed_scenarios(scenarios, ["one", "two"])
-        with patch.object(discovery, "SCENARIOS_DIR", scenarios):
+        with (
+            patch.object(discovery, "SCENARIOS_DIR", scenarios),
+            patch.object(discovery, "_discover_overlay_specs", return_value=[]),
+        ):
             found = find_spec("two")
         assert found is not None
         assert found.name == "two"
@@ -56,5 +66,89 @@ class TestFindSpec:
     def test_returns_none_when_no_match(self, tmp_path: Path) -> None:
         scenarios = tmp_path / "scenarios"
         _seed_scenarios(scenarios, ["only"])
-        with patch.object(discovery, "SCENARIOS_DIR", scenarios):
+        with (
+            patch.object(discovery, "SCENARIOS_DIR", scenarios),
+            patch.object(discovery, "_discover_overlay_specs", return_value=[]),
+        ):
             assert find_spec("missing") is None
+
+
+def _fake_overlay(scenarios_dir: Path | None) -> SimpleNamespace:
+    return SimpleNamespace(get_eval_scenarios_dir=lambda: scenarios_dir)
+
+
+class TestDiscoverOverlaySpecs:
+    def test_returns_specs_from_overlay_dir(self, tmp_path: Path) -> None:
+        overlay_scenarios = tmp_path / "overlay" / "eval" / "scenarios"
+        _seed_scenarios(overlay_scenarios, ["over_one", "over_two"])
+        overlay = _fake_overlay(overlay_scenarios)
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value={"t3-fake": overlay}):
+            specs = _discover_overlay_specs()
+        assert sorted(s.name for s in specs) == ["over_one", "over_two"]
+
+    def test_skips_overlay_without_hook(self) -> None:
+        # An overlay that has no ``get_eval_scenarios_dir`` attribute at all
+        # must not break discovery — the harness must remain forward-compatible
+        # with older overlay classes that predate the hook.
+        overlay = SimpleNamespace()
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value={"t3-old": overlay}):
+            specs = _discover_overlay_specs()
+        assert specs == []
+
+    def test_skips_overlay_returning_none(self) -> None:
+        overlay = _fake_overlay(None)
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value={"t3-none": overlay}):
+            specs = _discover_overlay_specs()
+        assert specs == []
+
+    def test_skips_overlay_pointing_at_missing_dir(self, tmp_path: Path) -> None:
+        overlay = _fake_overlay(tmp_path / "does-not-exist")
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value={"t3-missing": overlay}):
+            specs = _discover_overlay_specs()
+        assert specs == []
+
+    def test_returns_empty_when_overlay_hook_raises(self, tmp_path: Path) -> None:
+        def _bad() -> Path:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        overlay = SimpleNamespace(get_eval_scenarios_dir=_bad)
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value={"t3-bad": overlay}):
+            specs = _discover_overlay_specs()
+        assert specs == []
+
+    def test_returns_empty_when_overlay_loader_raises(self) -> None:
+        def _explode() -> None:
+            msg = "no overlays"
+            raise RuntimeError(msg)
+
+        with patch("teatree.core.overlay_loader.get_all_overlays", side_effect=_explode):
+            specs = _discover_overlay_specs()
+        assert specs == []
+
+    def test_logs_warning_on_malformed_overlay_yaml(self, tmp_path: Path) -> None:
+        # A malformed YAML in one overlay must not blow up the whole catalog —
+        # the loader logs and continues so other overlays' specs still surface.
+        overlay_scenarios = tmp_path / "overlay" / "eval" / "scenarios"
+        overlay_scenarios.mkdir(parents=True)
+        (overlay_scenarios / "bad.yaml").write_text("not: a: list\n", encoding="utf-8")
+        _seed_scenarios(overlay_scenarios, ["good_one"])
+        overlay = _fake_overlay(overlay_scenarios)
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value={"t3-mixed": overlay}):
+            specs = _discover_overlay_specs()
+        assert [s.name for s in specs] == ["good_one"]
+
+
+class TestDiscoverSpecsCombined:
+    def test_concatenates_core_and_overlay_specs(self, tmp_path: Path) -> None:
+        core = tmp_path / "core"
+        overlay_scenarios = tmp_path / "overlay" / "eval" / "scenarios"
+        _seed_scenarios(core, ["core_a"])
+        _seed_scenarios(overlay_scenarios, ["over_b"])
+        overlay = _fake_overlay(overlay_scenarios)
+        with (
+            patch.object(discovery, "SCENARIOS_DIR", core),
+            patch("teatree.core.overlay_loader.get_all_overlays", return_value={"t3-combo": overlay}),
+        ):
+            specs = discover_specs()
+        assert [s.name for s in specs] == ["core_a", "over_b"]

--- a/tests/eval/test_scenarios_anti_vacuous.py
+++ b/tests/eval/test_scenarios_anti_vacuous.py
@@ -1,0 +1,101 @@
+"""Run every shipped eval scenario against its fail/pass fixtures.
+
+A scenario is **anti-vacuous** when:
+
+*   against its ``<name>_fail.stream.jsonl`` fixture the scenario verdict
+    is FAIL (so a regressing agent would surface red), and
+*   against its ``<name>_pass.stream.jsonl`` fixture (when present) the
+    scenario verdict is PASS (so a compliant agent stays green).
+
+A scenario with only a ``_fail`` fixture is still validated for the FAIL
+direction. A scenario with neither is skipped — discovery still asserts
+its YAML loads cleanly, but the matcher-behaviour assertion needs at
+least the fail fixture.
+
+This is the canonical "would this scenario catch a regression?" test.
+A YAML that ships without an anti-vacuous fail fixture is silently
+toothless, so this test runs on every PR.
+"""
+
+import dataclasses
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from teatree.eval.discovery import discover_specs
+from teatree.eval.models import EvalSpec
+from teatree.eval.report import evaluate
+from teatree.eval.runner import ClaudePRunner
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@dataclasses.dataclass
+class _FakeCompleted:
+    stdout: str
+    stderr: str = ""
+    returncode: int = 0
+
+
+def _run_against_fixture(spec: EvalSpec, fixture_text: str, tmp_path: Path) -> bool:
+    """Return ``True`` when the scenario passed against ``fixture_text``."""
+
+    def _fake_run(cmd: list[str], **kwargs: Any) -> _FakeCompleted:
+        return _FakeCompleted(stdout=fixture_text)
+
+    with (
+        patch("teatree.eval.runner.shutil.which", return_value="/usr/local/bin/claude"),
+        patch("teatree.utils.run.subprocess.run", side_effect=_fake_run),
+    ):
+        run = ClaudePRunner(workspace=tmp_path).run(spec)
+    return evaluate(spec, run).passed
+
+
+def _specs_with_fixtures() -> list[tuple[EvalSpec, Path | None, Path | None]]:
+    rows: list[tuple[EvalSpec, Path | None, Path | None]] = []
+    for spec in discover_specs():
+        fail = FIXTURES / f"{spec.name}_fail.stream.jsonl"
+        pass_ = FIXTURES / f"{spec.name}_pass.stream.jsonl"
+        rows.append((spec, fail if fail.is_file() else None, pass_ if pass_.is_file() else None))
+    return rows
+
+
+@pytest.mark.parametrize(
+    ("spec", "fail_fixture", "pass_fixture"),
+    _specs_with_fixtures(),
+    ids=lambda v: v.name if isinstance(v, EvalSpec) else (v.name if isinstance(v, Path) else "none"),
+)
+class TestScenarioFixtures:
+    def test_fail_fixture_drives_scenario_red(
+        self,
+        spec: EvalSpec,
+        fail_fixture: Path | None,
+        pass_fixture: Path | None,
+        tmp_path: Path,
+    ) -> None:
+        _ = pass_fixture
+        if fail_fixture is None:
+            pytest.skip(f"no fail fixture for {spec.name}")
+        passed = _run_against_fixture(spec, fail_fixture.read_text(encoding="utf-8"), tmp_path)
+        assert passed is False, (
+            f"scenario {spec.name!r} stayed GREEN against {fail_fixture.name} — "
+            "the matchers are toothless. Either tighten the matcher or strengthen the fixture."
+        )
+
+    def test_pass_fixture_drives_scenario_green(
+        self,
+        spec: EvalSpec,
+        fail_fixture: Path | None,
+        pass_fixture: Path | None,
+        tmp_path: Path,
+    ) -> None:
+        _ = fail_fixture
+        if pass_fixture is None:
+            pytest.skip(f"no pass fixture for {spec.name}")
+        passed = _run_against_fixture(spec, pass_fixture.read_text(encoding="utf-8"), tmp_path)
+        assert passed is True, (
+            f"scenario {spec.name!r} went RED against {pass_fixture.name} — "
+            "either the fixture violates the rule or the matchers over-fit."
+        )


### PR DESCRIPTION
## Summary

Two structural additions on top of #1319's behavioral-eval harness:

1. **Overlay-scenario discovery** — `OverlayBase.get_eval_scenarios_dir()` hook + `_discover_overlay_specs()` in `teatree.eval.discovery`. Each overlay can ship its own `*.yaml` catalog; the harness walks every installed overlay's directory after the core catalog. Discovery is isolated: a broken overlay (missing dir, malformed YAML, raising hook) is logged and skipped rather than failing the catalog.
2. **Layer-2 transcript scenarios in core** for LLM-output-only binding memories saved 2026-05-26.

## Architecture: layered enforcement

Behavioral binding memories fall into two layers:

* **Layer 1 — integration tests.** Code-enforceable rules pinned by real pytest tests that mock the transport boundary (Slack, GitLab API) and assert the side-effect is absent on a violating input. Lives in `tests/teatree_backends/`, `tests/teatree_loop/`, etc.
* **Layer 2 — transcript scenarios.** For rules that constrain what the agent *says* or *invokes* rather than what a code path *does*. Lives in `src/teatree/eval/scenarios/` (core, overlay-agnostic) and `<overlay>/eval/scenarios/` (overlay-specific).

Layer 1 is always preferred — it runs in CI for free; Layer 2 requires a paid Claude run.

## Classification: 2026-05-26 binding memories

| Memory | Layer | Status in this PR |
|---|---|---|
| `no_eyes_react_on_own_mr_broadcasts` | L1 | Covered by sibling PR #1329 (`test_skips_eyes_on_authored_ticket` in `tests/teatree_backends/test_slack_reactions.py`) |
| `never_self_review_own_mrs_in_sweep` | L1 | Covered by sibling PR #1328 (`tests/teatree_loop/test_reviewer_prs_skip_conditions_1321.py`) |
| `skip_review_when_broadcast_already_has_reaction` | L1 | Covered by sibling PR #1328 (same file) |
| `review_check_approved_state_before_reviewing` | L1 | Covered by sibling PR #1328 (same file) |
| `review_request_check_24h_channel_history_first` | L1 | Covered by sibling PR #1328 (Surface C end-to-end test) |
| `no_visible_external_send_without_explicit_approval` | L1 | Already covered by existing on-behalf-gate tests (`tests/test_on_behalf_gate.py`, `tests/teatree_core/test_on_behalf_gate_recorded.py`, `tests/test_on_behalf_post_mode.py`) |
| `done_claims_require_artifact_evidence` | **L2** | **Added in this PR** — `src/teatree/eval/scenarios/done_claims_require_artifact_evidence.yaml` |
| `subagent_prompt_drift_three_failure_modes` (branch prefix) | **L2** | **Added in this PR** — `subagent_prompt_drift_branch_prefix` |
| `subagent_prompt_drift_three_failure_modes` (own-MR draft) | **L2** | **Added in this PR** — `subagent_prompt_drift_no_draft_default` |
| `dev_env_e2e_is_part_of_done` | **L2** | **Added in this PR** — `src/teatree/eval/scenarios/dev_env_e2e_is_part_of_done.yaml` |
| `stakeholder_terminology_plain_language` | L2 (overlay-specific) | Belongs in a downstream overlay package — not added here. The discovery hook this PR ships makes the scenario placeable in an overlay without further teatree changes |

## What's in this PR

### Core harness

* `src/teatree/core/overlay.py` — new `OverlayBase.get_eval_scenarios_dir()` hook, defaults to `None`.
* `src/teatree/eval/discovery.py` — walks core directory + every overlay's hook; logs and skips broken overlays.
* `src/teatree/cli/eval.py` — bootstraps Django before discovery runs (overlay loader imports Django models at import time).
* `src/teatree/eval/README.md` — documents the new surface, the layered enforcement model, and the anti-vacuous fixture convention.
* `tach.toml` — declares `teatree.eval` → `teatree.core` dependency.

### Layer-2 scenarios (core, cross-overlay)

* `done_claims_require_artifact_evidence` — agent must run a verify command (`ls`, `gh pr view`) before echoing "completed" / "done".
* `subagent_prompt_drift_branch_prefix` — sub-agent dispatch must not pin a slash-prefixed branch name.
* `subagent_prompt_drift_no_draft_default` — own non-e2e PRs are created without `--draft`.
* `dev_env_e2e_is_part_of_done` — when the goal includes DEV-env E2E, the agent runs against DEV, not just localhost.

### Overlay scenario (proof-of-concept)

* `src/teatree/contrib/t3_teatree/eval/scenarios/teatree_skill_edit_in_repo.yaml` — exercises the overlay-discovery path end-to-end.

### Anti-vacuous test

* `tests/eval/test_scenarios_anti_vacuous.py` parametrizes every shipped scenario against its `_fail` / `_pass` fixtures and asserts the fail fixture goes RED, the pass fixture goes GREEN. A matcher-toothless scenario is caught at test time.

### Local-verification helper

* `scripts/eval/run_against_fixture.py` — runs a single scenario against a fixture file via mocked `subprocess.run`, no Claude binary needed.

## Verification

* `t3 eval list` shows the 6 scenarios discovered (5 core + 1 overlay).
* Anti-vacuous: every scenario's fail fixture drives the verdict RED, every pass fixture drives it GREEN — verified by `test_scenarios_anti_vacuous.py` (12 parametrized assertions, all green).
* Discovery extension covered by 7 new unit tests in `tests/eval/test_discovery.py`.
* `prek run --all-files` — clean on every file this PR touches.
* `uv run pytest tests/ --no-cov -q` — 6790 passed, 13 skipped.

Relates-to #1160