### PR TITLE
fix(hooks): use systemMessage for Stop soft-block, not hookSpecificOutput

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -3642,13 +3642,20 @@ def _enforce_answered_questions(data: dict) -> bool | None:
         "or `t3 teatree pending_chat mark-answered <ts>`).\n"
         "Unanswered:\n" + "\n".join(bullets)
     )
-    json.dump({"hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": body}}, sys.stdout)
-    # Return True to break the Stop chain — we want the additionalContext
+    # Stop hooks may NOT carry ``hookSpecificOutput.additionalContext`` —
+    # the Claude Code schema reserves that field for ``UserPromptSubmit`` /
+    # ``PostToolUse`` / ``PostToolBatch``. Emitting it for ``Stop`` makes
+    # the validator reject the JSON ("Hook JSON output validation failed —
+    # (root): Invalid input") and the nag is lost. The schema-valid soft-
+    # block channel is the top-level ``systemMessage`` string, which
+    # surfaces the body to the agent without hard-blocking the turn.
+    json.dump({"systemMessage": body}, sys.stdout)
+    # Return True to break the Stop chain — we want the systemMessage
     # nag delivered intact, and we want to preempt any subsequent handler
     # (notably loop_self_pump) that would also write to stdout and either
     # corrupt the JSON or override our soft-block with a hard-block
     # continuation directive. Soft-block intent is preserved by emitting
-    # only ``additionalContext``, never ``decision: block``.
+    # only ``systemMessage``, never ``decision: block``.
     return True
 
 
@@ -3858,10 +3865,11 @@ def _consideration_gate(data: dict) -> bool | None:
         "user-specific (theme, voice, paths) and not a missing framework feature.\n"
         "Promotable paths:\n" + bullets
     )
-    json.dump(
-        {"hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": body}},
-        sys.stdout,
-    )
+    # Stop schema rejects ``hookSpecificOutput.additionalContext`` —
+    # ``additionalContext`` is reserved for ``UserPromptSubmit`` /
+    # ``PostToolUse`` / ``PostToolBatch``. Soft-block via top-level
+    # ``systemMessage`` (schema-valid; non-decision; visible to the agent).
+    json.dump({"systemMessage": body}, sys.stdout)
     # Return True to break the Stop chain — preserves the JSON shape and
     # preempts the loop self-pump (which would override our soft-block
     # with a continuation directive).

--- a/tests/teatree_core/test_stop_hook_output_schema.py
+++ b/tests/teatree_core/test_stop_hook_output_schema.py
@@ -1,0 +1,145 @@
+"""Stop-hook output schema conformance (#1335).
+
+The Claude Code hook JSON schema rejects ``hookSpecificOutput.additionalContext``
+for ``Stop`` events — ``additionalContext`` is reserved for ``UserPromptSubmit``,
+``PostToolUse`` and ``PostToolBatch``. A Stop handler that emits the
+``hookSpecificOutput`` envelope with ``additionalContext`` triggers
+"Hook JSON output validation failed — (root): Invalid input" and the nag
+text is lost — the validator drops the whole turn-end payload.
+
+The schema-valid soft-block channel for ``Stop`` is the top-level
+``systemMessage`` string. It surfaces the body to the agent without
+hard-blocking via ``decision: block`` (the soft-block intent both Stop
+gates document in their comments).
+
+This module asserts the POSITIVE shape — top-level ``systemMessage``
+that contains the BLOCKING REMINDER / CONSIDERATION GATE body — and is
+designed to flip RED if either Stop handler ever regresses back to the
+``hookSpecificOutput.additionalContext`` envelope.
+"""
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hooks.scripts.hook_router import handle_consideration_gate, handle_enforce_answered_questions
+from teatree.core.models import PendingChatInjection
+
+pytestmark = pytest.mark.django_db
+
+
+def _run_handler(handler: Any, payload: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> str:
+    """Invoke ``handler(payload)`` with captured stdout; return the raw stdout string."""
+    buf = io.StringIO()
+    monkeypatch.setattr("hooks.scripts.hook_router.sys.stdout", buf)
+    handler(payload)
+    return buf.getvalue()
+
+
+def _write_transcript(tmp_path: Path, entries: list[dict[str, Any]]) -> str:
+    path = tmp_path / "transcript.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+    return str(path)
+
+
+def _user_turn() -> dict[str, Any]:
+    return {"type": "user", "message": {"role": "user", "content": "do the thing"}}
+
+
+def _assistant_edit(file_path: str) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Edit",
+                    "input": {"file_path": file_path, "old_string": "a", "new_string": "b"},
+                }
+            ],
+        },
+    }
+
+
+class TestAnsweredQuestionsGateUsesSystemMessage:
+    """``handle_enforce_answered_questions`` must emit top-level ``systemMessage``."""
+
+    def test_payload_has_top_level_system_message_with_blocking_reminder(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The positive-shape assertion: schema-valid Stop output.
+
+        Anti-vacuous: revert the fix (emit ``hookSpecificOutput.additionalContext``
+        for Stop) and this turns RED on three independent assertions —
+        ``systemMessage`` is missing, ``hookSpecificOutput`` is present, and
+        the body text moves into the wrong field.
+        """
+        PendingChatInjection.record(
+            channel="D",
+            slack_ts="1700000000.0001",
+            text="why are some tests skipped?",
+        )
+
+        out = _run_handler(handle_enforce_answered_questions, {"session_id": "s1"}, monkeypatch)
+
+        payload = json.loads(out)
+        # POSITIVE: schema-valid top-level systemMessage carrying the nag.
+        assert "systemMessage" in payload, (
+            "Stop handler must emit top-level `systemMessage` — "
+            "`hookSpecificOutput.additionalContext` is rejected by the Claude Code schema."
+        )
+        system_message = payload["systemMessage"]
+        assert isinstance(system_message, str)
+        assert system_message, "systemMessage must be non-empty"
+        assert "BLOCKING REMINDER" in system_message
+        assert "why are some tests skipped?" in system_message
+        # NEGATIVE: must NOT carry the rejected envelope.
+        assert "hookSpecificOutput" not in payload, (
+            "Stop schema rejects `hookSpecificOutput.additionalContext`; the body belongs in top-level `systemMessage`."
+        )
+        # Soft-block intent: never hard-block via `decision: block`.
+        assert "decision" not in payload
+
+
+class TestConsiderationGateUsesSystemMessage:
+    """``handle_consideration_gate`` must emit top-level ``systemMessage``."""
+
+    def test_payload_has_top_level_system_message_with_consideration_gate_body(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Sibling Stop handler — same schema rule applies.
+
+        Anti-vacuous: revert the fix and ``systemMessage`` disappears
+        from the parsed JSON, ``hookSpecificOutput`` reappears, and the
+        body migrates into the schema-rejected location.
+        """
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn(),
+                _assistant_edit("/Users/dev/.claude/settings.json"),
+            ],
+        )
+
+        out = _run_handler(
+            handle_consideration_gate,
+            {"session_id": "s1", "transcript_path": transcript},
+            monkeypatch,
+        )
+
+        payload = json.loads(out)
+        assert "systemMessage" in payload, (
+            "Stop handler must emit top-level `systemMessage` — "
+            "`hookSpecificOutput.additionalContext` is rejected by the Claude Code schema."
+        )
+        system_message = payload["systemMessage"]
+        assert isinstance(system_message, str)
+        assert system_message, "systemMessage must be non-empty"
+        assert "CONSIDERATION GATE" in system_message
+        assert "settings.json" in system_message
+        assert "hookSpecificOutput" not in payload
+        assert "decision" not in payload

--- a/tests/test_answered_at_gate_stop_hook.py
+++ b/tests/test_answered_at_gate_stop_hook.py
@@ -57,7 +57,9 @@ class TestUnansweredQuestionEmitsBlockingReminder:
 
         assert rv is True
         payload = json.loads(out)
-        body = payload["hookSpecificOutput"]["additionalContext"]
+        # #1335: Stop schema rejects ``hookSpecificOutput.additionalContext``;
+        # nag rides in top-level ``systemMessage``.
+        body = payload["systemMessage"]
         assert "BLOCKING REMINDER" in body
         assert "why are some tests skipped?" in body
         assert "1700000000.0001" in body
@@ -88,7 +90,7 @@ class TestUnansweredQuestionEmitsBlockingReminder:
         _, out = _run_hook({"session_id": "s1"}, monkeypatch)
 
         payload = json.loads(out)
-        body = payload["hookSpecificOutput"]["additionalContext"]
+        body = payload["systemMessage"]
         assert "why is this red?" in body
         assert "what about merging?" in body
         # The list should claim 2 questions.
@@ -144,8 +146,13 @@ class TestUnansweredQuestionEmitsBlockingReminder:
         _, out = _run_hook({"session_id": "s1"}, monkeypatch)
 
         payload = json.loads(out)
+        # Soft-block: top-level ``systemMessage`` (schema-valid), never
+        # ``decision: block`` (hard-block). Stop schema also rejects
+        # ``hookSpecificOutput.additionalContext`` (#1335).
         assert "decision" not in payload
-        assert payload["hookSpecificOutput"]["hookEventName"] == "Stop"
+        assert "hookSpecificOutput" not in payload
+        assert isinstance(payload["systemMessage"], str)
+        assert payload["systemMessage"]
 
 
 class TestRouterWiring:

--- a/tests/test_consideration_gate_stop_hook.py
+++ b/tests/test_consideration_gate_stop_hook.py
@@ -194,10 +194,12 @@ class TestGate:
 
         assert rv is True
         payload = json.loads(out)
-        body = payload["hookSpecificOutput"]["additionalContext"]
+        # #1335: Stop schema rejects ``hookSpecificOutput.additionalContext``;
+        # soft-block body rides in top-level ``systemMessage``.
+        body = payload["systemMessage"]
         assert "CONSIDERATION GATE" in body
         assert "settings.json" in body
-        assert payload["hookSpecificOutput"]["hookEventName"] == "Stop"
+        assert "hookSpecificOutput" not in payload
         # Soft block only — never emit decision: block.
         assert "decision" not in payload
 
@@ -214,7 +216,7 @@ class TestGate:
         rv, out = _run_hook({"session_id": "s1", "transcript_path": transcript}, monkeypatch)
 
         assert rv is True
-        body = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+        body = json.loads(out)["systemMessage"]
         assert "hooks.json" in body
 
     def test_keep_personal_edit_does_not_trip_gate(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -281,7 +283,7 @@ class TestGate:
         rv, out = _run_hook({"session_id": "s1", "transcript_path": transcript}, monkeypatch)
 
         assert rv is True
-        body = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+        body = json.loads(out)["systemMessage"]
         assert "settings.json" in body
         assert "hooks.json" in body
 


### PR DESCRIPTION
## Bug

Stop handlers in ``hooks/scripts/hook_router.py`` emit ``{"hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": ...}}``. The Claude Code hook schema reserves ``additionalContext`` for ``UserPromptSubmit`` / ``PostToolUse`` / ``PostToolBatch`` only, so every Stop turn that triggers the answered-questions gate or consideration gate fails validation with ``Hook JSON output validation failed — (root): Invalid input`` and the nag text is dropped.

## Fix

Both Stop handlers now emit a top-level ``systemMessage`` — the schema-valid channel that surfaces the body to the agent without hard-blocking via ``decision: block``. Soft-block intent the surrounding comments document is preserved.

## Regression test (anti-vacuous)

New ``tests/teatree_core/test_stop_hook_output_schema.py`` asserts the positive shape (top-level ``systemMessage`` carrying "BLOCKING REMINDER" / "CONSIDERATION GATE", ``hookSpecificOutput`` absent, ``decision`` absent). RED → GREEN confirmed by reverting the fix in the worktree and re-running the test — both cases failed on the ``"systemMessage" in payload`` assertion before the fix was restored.