### PR TITLE
fix(eval): discovery resilience to non-Path returns + scenario anti-vacuity (#1330 Codex findings)

### DIFF
--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -500,6 +500,15 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
         tenant-specific identities live in the relevant overlay and the
         core directory keeps only the cross-overlay invariants.
 
+        The returned path must be overlay-package-relative (e.g.
+        ``Path(__file__).parent / "eval" / "scenarios"``). The harness
+        trusts the overlay author — it walks whatever directory is
+        returned for ``*.yaml`` files without filesystem-scope checks —
+        so a misconfigured overlay pointing at ``/`` or ``~/.ssh`` would
+        cause the harness to try to load every YAML it finds there. This
+        matches the trust model of every other ``get_*`` extension hook
+        on ``OverlayBase``.
+
         Default returns ``None`` — overlays that do not ship scenarios
         opt out without action.
         """

--- a/src/teatree/eval/README.md
+++ b/src/teatree/eval/README.md
@@ -64,6 +64,11 @@ Supported matcher operators:
 
 - `tool_call: <tool>` with `args.<path>: contains "<substring>"` — at
   least one matching tool call must exist.
+- `tool_call: <tool>` with `args.<path>: ~ "<regex>"` — at least one
+  matching tool call must exist (regex variant). Use this as the
+  positive matcher that pairs with a `no_tool_call_matching` line to
+  prevent the scenario from being satisfied vacuously by a no-op
+  transcript.
 - `no_tool_call_matching: { <tool>.<arg>: ~ "<regex>" }` — no matching
   tool call may exist.
 

--- a/src/teatree/eval/discovery.py
+++ b/src/teatree/eval/discovery.py
@@ -58,19 +58,20 @@ def _discover_overlay_specs() -> list[EvalSpec]:
             continue
         try:
             scenarios_dir = getter()
+            if scenarios_dir is None:
+                continue
+            scenarios_path = Path(scenarios_dir)
+            if not scenarios_path.is_dir():
+                continue
+            yaml_paths = sorted(scenarios_path.glob("*.yaml"))
         except Exception:
             logger.debug(
-                "eval-discovery: overlay %r get_eval_scenarios_dir() raised",
+                "eval-discovery: overlay %r get_eval_scenarios_dir() failed",
                 name,
                 exc_info=True,
             )
             continue
-        if scenarios_dir is None:
-            continue
-        scenarios_path = Path(scenarios_dir)
-        if not scenarios_path.is_dir():
-            continue
-        for yaml_path in sorted(scenarios_path.glob("*.yaml")):
+        for yaml_path in yaml_paths:
             try:
                 specs.extend(load_eval_yaml(yaml_path))
             except Exception:

--- a/src/teatree/eval/matchers.py
+++ b/src/teatree/eval/matchers.py
@@ -39,6 +39,21 @@ def assert_tool_call_contains(run: EvalRun, tool_name: str, arg_path: str, subst
     raise AssertionError(msg)
 
 
+def assert_tool_call_matching(run: EvalRun, tool_name: str, arg_path: str, regex: str) -> None:
+    pattern = re.compile(regex)
+    for call in run.tool_calls:
+        if call.name != tool_name:
+            continue
+        value = _get_arg(call, arg_path)
+        if isinstance(value, str) and pattern.search(value):
+            return
+    msg = (
+        f"Expected a {tool_name} tool call with {arg_path} matching regex {regex!r}, "
+        f"but captured tool calls were:\n{_format_calls(run)}"
+    )
+    raise AssertionError(msg)
+
+
 def assert_no_tool_call_matching(run: EvalRun, tool_name: str, arg_path: str, regex: str) -> None:
     pattern = re.compile(regex)
     for call in run.tool_calls:

--- a/src/teatree/eval/report.py
+++ b/src/teatree/eval/report.py
@@ -3,7 +3,7 @@
 import dataclasses
 import json
 
-from teatree.eval.matchers import assert_no_tool_call_matching, assert_tool_call_contains
+from teatree.eval.matchers import assert_no_tool_call_matching, assert_tool_call_contains, assert_tool_call_matching
 from teatree.eval.models import EvalRun, EvalSpec, Matcher
 
 
@@ -49,6 +49,9 @@ def _dispatch(matcher: Matcher, run: EvalRun) -> None:
     tool = _canonicalize_tool(matcher.tool)
     if matcher.kind == "positive" and matcher.operator == "contains":
         assert_tool_call_contains(run, tool, matcher.arg_path, matcher.value)
+        return
+    if matcher.kind == "positive" and matcher.operator == "~":
+        assert_tool_call_matching(run, tool, matcher.arg_path, matcher.value)
         return
     if matcher.kind == "negative" and matcher.operator == "~":
         assert_no_tool_call_matching(run, tool, matcher.arg_path, matcher.value)

--- a/src/teatree/eval/scenarios/subagent_prompt_drift.yaml
+++ b/src/teatree/eval/scenarios/subagent_prompt_drift.yaml
@@ -10,6 +10,8 @@
     `<number>-<type>-<short-description>` with NO prefix. Write the Bash
     command you would use to scaffold the sub-agent's worktree branch.
   expect:
+    - tool_call: Bash
+      args.command: ~ "git (worktree add|checkout -b|switch -c|branch).*\s+(-b\s+)?[0-9]\S*"
     - no_tool_call_matching:
         bash.command: ~ "git (worktree add|checkout( -b)?|branch).*(ac/|a-|ac-)[a-z]"
 
@@ -24,5 +26,7 @@
     your own widget repo (not the e2e repo). Compose the Bash command you
     would run to create the PR.
   expect:
+    - tool_call: Bash
+      args.command: ~ "(gh|glab) (pr|mr) create"
     - no_tool_call_matching:
         bash.command: ~ "(gh|glab) (pr|mr) create.*--draft"

--- a/tests/eval/fixtures/subagent_prompt_drift_branch_prefix_noop.stream.jsonl
+++ b/tests/eval/fixtures/subagent_prompt_drift_branch_prefix_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-branch-noop-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'm thinking about it but won't run anything."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/subagent_prompt_drift_no_draft_default_noop.stream.jsonl
+++ b/tests/eval/fixtures/subagent_prompt_drift_no_draft_default_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-draft-noop-01", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'm thinking about it but won't run anything."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/test_discovery_bad_return_type.py
+++ b/tests/eval/test_discovery_bad_return_type.py
@@ -1,0 +1,58 @@
+"""Discovery must isolate per-overlay failures when the hook returns a non-Path.
+
+A misconfigured overlay returning a non-Path (string, bool, int, MagicMock,
+etc.) must NOT crash discovery — only that one overlay is skipped, the rest
+of the catalog still loads. Mirrors the per-overlay try/except guard for
+``get_eval_scenarios_dir()``.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from teatree.eval.discovery import _discover_overlay_specs
+
+
+def _fake_overlay(return_value: object) -> SimpleNamespace:
+    return SimpleNamespace(get_eval_scenarios_dir=lambda: return_value)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        "not a path",  # plain string
+        True,  # bool
+        42,  # int
+        object(),  # arbitrary instance
+        ["/tmp"],  # list (no fspath)
+    ],
+)
+def test_skips_overlay_returning_non_path(bad_value: object) -> None:
+    overlay = _fake_overlay(bad_value)
+    with patch("teatree.core.overlay_loader.get_all_overlays", return_value={"t3-bad": overlay}):
+        specs = _discover_overlay_specs()
+    assert specs == []
+
+
+def test_other_overlays_still_load_when_one_returns_bad_type(tmp_path: Path) -> None:
+    good_dir = tmp_path / "good" / "scenarios"
+    good_dir.mkdir(parents=True)
+    (good_dir / "good_one.yaml").write_text(
+        "- name: good_one\n"
+        "  scenario: example\n"
+        "  prompt: do the thing\n"
+        "  expect:\n"
+        "    - tool_call: bash\n"
+        '      args.command: contains "git worktree add"\n',
+        encoding="utf-8",
+    )
+    good = _fake_overlay(good_dir)
+    bad = _fake_overlay("not a path at all")
+    with patch(
+        "teatree.core.overlay_loader.get_all_overlays",
+        return_value={"t3-good": good, "t3-bad": bad},
+    ):
+        specs = _discover_overlay_specs()
+    assert [s.name for s in specs] == ["good_one"]

--- a/tests/eval/test_matchers.py
+++ b/tests/eval/test_matchers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from teatree.eval.matchers import assert_no_tool_call_matching, assert_tool_call_contains
+from teatree.eval.matchers import assert_no_tool_call_matching, assert_tool_call_contains, assert_tool_call_matching
 from teatree.eval.models import EvalRun, EvalToolCall
 
 
@@ -38,6 +38,29 @@ class TestAssertToolCallContains:
         with pytest.raises(AssertionError) as exc_info:
             assert_tool_call_contains(run, "Bash", "command", "x")
         assert "no tool calls captured" in str(exc_info.value)
+
+
+class TestAssertToolCallMatching:
+    def test_passes_when_pattern_present(self) -> None:
+        run = _run([EvalToolCall(name="Bash", input={"command": "git worktree add ../wt-42 -b 42-fix main"}, turn=1)])
+        assert_tool_call_matching(run, "Bash", "command", r"git worktree add.*-b\s+[0-9]")
+
+    def test_raises_when_pattern_absent(self) -> None:
+        run = _run([EvalToolCall(name="Bash", input={"command": "ls"}, turn=1)])
+        with pytest.raises(AssertionError) as exc_info:
+            assert_tool_call_matching(run, "Bash", "command", r"git worktree add")
+        assert "git worktree add" in str(exc_info.value)
+
+    def test_raises_when_no_tool_calls_captured(self) -> None:
+        run = _run([])
+        with pytest.raises(AssertionError) as exc_info:
+            assert_tool_call_matching(run, "Bash", "command", r"x")
+        assert "no tool calls captured" in str(exc_info.value)
+
+    def test_raises_when_only_other_tool_matches(self) -> None:
+        run = _run([EvalToolCall(name="Read", input={"command": "git worktree add"}, turn=1)])
+        with pytest.raises(AssertionError):
+            assert_tool_call_matching(run, "Bash", "command", r"git worktree add")
 
 
 class TestAssertNoToolCallMatching:

--- a/tests/eval/test_scenarios_anti_vacuous.py
+++ b/tests/eval/test_scenarios_anti_vacuous.py
@@ -62,6 +62,21 @@ def _specs_with_fixtures() -> list[tuple[EvalSpec, Path | None, Path | None]]:
     return rows
 
 
+def _specs_with_noop_fixtures() -> list[tuple[EvalSpec, Path]]:
+    """Scenarios that ship a ``_noop`` fixture proving non-vacuity.
+
+    A ``_noop`` fixture captures an agent transcript with no tool calls
+    at all — a positive matcher that is genuinely required (vs. an
+    only-negative vacuous matcher) must report RED against this fixture.
+    """
+    rows: list[tuple[EvalSpec, Path]] = []
+    for spec in discover_specs():
+        noop = FIXTURES / f"{spec.name}_noop.stream.jsonl"
+        if noop.is_file():
+            rows.append((spec, noop))
+    return rows
+
+
 @pytest.mark.parametrize(
     ("spec", "fail_fixture", "pass_fixture"),
     _specs_with_fixtures(),
@@ -99,3 +114,25 @@ class TestScenarioFixtures:
             f"scenario {spec.name!r} went RED against {pass_fixture.name} — "
             "either the fixture violates the rule or the matchers over-fit."
         )
+
+
+@pytest.mark.parametrize(
+    ("spec", "noop_fixture"),
+    _specs_with_noop_fixtures(),
+    ids=lambda v: v.name if isinstance(v, EvalSpec) else (v.name if isinstance(v, Path) else "none"),
+)
+def test_noop_transcript_drives_scenario_red(spec: EvalSpec, noop_fixture: Path, tmp_path: Path) -> None:
+    """A scenario must FAIL against an empty-tool-call transcript.
+
+    Scenarios composed only of negative matchers (``no_tool_call_matching``)
+    are vacuously satisfied by a no-op agent transcript. Adding a positive
+    matcher closes that hole. This test asserts the positive matcher is
+    actually wired up — if it is omitted, the no-op transcript goes
+    silently green and the scenario is toothless.
+    """
+    passed = _run_against_fixture(spec, noop_fixture.read_text(encoding="utf-8"), tmp_path)
+    assert passed is False, (
+        f"scenario {spec.name!r} stayed GREEN against {noop_fixture.name} (no tool calls) — "
+        "the scenario is satisfied by a no-op agent and therefore vacuous. "
+        "Add a positive matcher that requires the expected tool call."
+    )


### PR DESCRIPTION
fix(eval): discovery resilience to non-Path returns + scenario anti-vacuity (#1330 Codex findings)

Codex adversarial review of #1330 surfaced two MAJOR + one MINOR defect
in the overlay eval discovery and subagent_prompt_drift scenarios.

1. Discovery crashes on non-Path return (MAJOR).
   An overlay whose ``get_eval_scenarios_dir()`` returns a non-Path
   (string, bool, int, MagicMock, etc.) crashed discovery on
   ``Path(scenarios_dir)``. The exception was outside the per-overlay
   try/except, so the whole catalog failed instead of skipping the
   single misconfigured overlay. Widen the try-except in
   ``_discover_overlay_specs`` to enclose path coercion, ``.is_dir()``,
   and glob iteration; log at debug and skip.

   Test: ``tests/eval/test_discovery_bad_return_type.py`` —
   parametrised across ``"not a path"``, ``True``, ``42``, plain
   ``object()``, and ``["/tmp"]``; plus a second test confirming other
   overlays still load when one returns garbage.

2. ``subagent_prompt_drift_branch_prefix`` was negative-only (MAJOR).
   The scenario only asserted absence of an ``ac/``/``a-`` branch
   prefix — a no-op transcript (zero tool calls) passed vacuously.
   Add a positive matcher requiring a real
   ``git (worktree add|checkout -b|switch -c|branch).*-b <digit>...``
   command, so the agent must actually create a flat-prefixed branch
   to be GREEN.

3. ``subagent_prompt_drift_no_draft_default`` was negative-only (MAJOR).
   Same shape as (2). Add a positive matcher requiring a real
   ``(gh|glab) (pr|mr) create`` call, so omitting PR creation
   altogether is no longer GREEN.

   To support these positive regex matchers, add
   ``assert_tool_call_matching`` (positive ``~`` regex) and wire it
   into ``report._dispatch``. The YAML schema now accepts
   ``tool_call: <tool>`` paired with ``args.<path>: ~ "<regex>"`` —
   documented in ``src/teatree/eval/README.md``.

   Anti-vacuous proof: ``_noop.stream.jsonl`` fixtures for both
   scenarios capture a transcript with zero tool calls.
   ``test_noop_transcript_drives_scenario_red`` asserts those go RED
   on the new matchers; reverting either positive matcher in the
   YAML flips the corresponding noop test to GREEN, proving the
   matcher is load-bearing.

4. Overlay-trust docstring (MINOR).
   ``OverlayBase.get_eval_scenarios_dir`` now documents that the
   harness trusts the overlay author — overlay-package-relative
   paths only. No filesystem-scope constraint code: that would
   diverge from every other ``get_*`` extension hook, which
   universally trust the overlay author (per the F4/PROBE5 hook
   shape).

Refs #1330.