### PR TITLE
fix(statusline): consolidated loop summary line with time-to-next-tick

### DIFF
--- a/src/teatree/loop/rendering_zones.py
+++ b/src/teatree/loop/rendering_zones.py
@@ -35,11 +35,45 @@ _NOISE_STATES = frozenset(
 )
 _MAX_PER_STATE = 5
 
+# The ``not_started`` backlog gets a tighter cap than active-work states —
+# the user almost never needs to read past the first few items on a 40+
+# deep backlog row, and the prior 5-item dump pushed actively-shipping
+# work off-screen.
+_MAX_NOT_STARTED = 3
+
 # Tickets whose ``issue_url`` matches one of these are treated as PR-backed.
 # A PR-backed ticket that doesn't appear in the live PR set (action_needed
 # or in_flight) is considered stale — its remote MR has likely been merged
 # or closed but the local FSM never advanced.
 _PR_URL_RE = re.compile(r"/(?:merge_requests|pull|pulls)/\d+/?$")
+
+# Anchor-line state-group rendering order. Actively-shipping work comes
+# first so the operator sees their in-flight tickets before the long
+# ``not_started`` backlog. States not listed here render in their
+# original insertion order after the listed ones.
+_STATE_PRIORITY: tuple[str, ...] = (
+    "started",
+    "in_review",
+    "ready",
+    "tested",
+    "scoped",
+    "not_started",
+)
+
+
+def _state_sort_key(state: str) -> tuple[int, str]:
+    """Sort key giving listed states their explicit priority order."""
+    try:
+        return (_STATE_PRIORITY.index(state), state)
+    except ValueError:
+        return (len(_STATE_PRIORITY), state)
+
+
+def _cap_for_state(state: str) -> int:
+    """Per-state item cap. ``not_started`` is tighter than the rest."""
+    if state == "not_started":
+        return _MAX_NOT_STARTED
+    return _MAX_PER_STATE
 
 
 def _link(text: str, url: object, *, colorize: bool) -> str:
@@ -134,12 +168,18 @@ def _render_ticket_line(
     if not by_state:
         return ""
     groups: list[str] = []
-    for state, items in by_state.items():
-        shown = items[:_MAX_PER_STATE]
+    # Priority order: actively-shipping work first (``started``, ``in_review``,
+    # ``ready``) before the long backlog (``not_started``). The user's
+    # eyeballs hit the top of the line first; the backlog has been pushed
+    # the actionable bits off-screen before this reorder.
+    for state in sorted(by_state, key=_state_sort_key):
+        items = by_state[state]
+        cap = _cap_for_state(state)
+        shown = items[:cap]
         overflow = len(items) - len(shown)
         label = " ".join(shown)
         if overflow > 0:
-            label += f" (+{overflow})"
+            label += f" (+{overflow} more)"
         groups.append(f"{state}: {label}")
     return f"{prefix}{' · '.join(groups)}"
 
@@ -185,9 +225,10 @@ def _render_action_line(
 
     parts: list[str] = _disposition_parts(action_refs, colorize=colorize)
     if action_refs.ready_refs:
-        # #1324: cap the ready: row at _MAX_PER_STATE and append (+N) overflow,
-        # matching the anchor state lines. Without the cap a backlog of
-        # assigned issues spills the entire list onto a single line.
+        # Cap the ready: row at _MAX_PER_STATE and append ``(+N more)``
+        # overflow, matching the anchor state lines. Without the cap a
+        # backlog of assigned issues spills the entire list onto a single
+        # line.
         items: list[str] = []
         shown_refs = action_refs.ready_refs[:_MAX_PER_STATE]
         overflow = len(action_refs.ready_refs) - len(shown_refs)
@@ -206,7 +247,7 @@ def _render_action_line(
             consumed_pr_urls.update(p.url for p in prs)
         ready_chunk = " ".join(items)
         if overflow > 0:
-            ready_chunk += f" (+{overflow})"
+            ready_chunk += f" (+{overflow} more)"
         parts.append(f"ready: {ready_chunk}")
     if action_refs.pr_refs:
         remaining = [r for r in action_refs.pr_refs if r.url not in consumed_pr_urls]

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -2,6 +2,7 @@ import os
 import re
 import tempfile
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -207,6 +208,37 @@ def _live_loop_names() -> list[tuple[str, str]]:
     return [(row.name, row.session_id) for row in rows]
 
 
+def _loop_tick_acquired_at() -> datetime | None:
+    """Return the most recent ``acquired_at`` for the ``loop-tick`` lease.
+
+    Isolated as a thin DB-read seam (mirrors :func:`_live_loop_names`) so
+    :func:`live_loops_anchor` stays pure and tests stub this directly
+    rather than constructing LoopLease fixtures with timestamps.
+
+    Returns ``None`` when no row exists yet (no tick has ever fired) so
+    the renderer can render a ``last tick: never`` fallback instead of
+    pretending to know.
+    """
+    from django.apps import apps  # noqa: PLC0415
+
+    lease_model = apps.get_model("core", "LoopLease")
+    row = lease_model.objects.filter(name="loop-tick").values("acquired_at").first()
+    if row is None:
+        return None
+    return row.get("acquired_at")
+
+
+def _cadence_seconds() -> int:
+    """Return the resolved loop cadence in seconds.
+
+    Isolated as a seam so tests can stub it without spinning up the
+    full config layer; production reads :func:`teatree.config.cadence_seconds`.
+    """
+    from teatree.config import cadence_seconds  # noqa: PLC0415
+
+    return cadence_seconds()
+
+
 def loop_owner_anchor(status: "OwnershipStatus", this_session: str) -> tuple[str, str]:
     """Return ``(zone, line)`` for the foreign-hijack RED line (#1073, #1156).
 
@@ -233,22 +265,34 @@ def loop_owner_anchor(status: "OwnershipStatus", this_session: str) -> tuple[str
 
 
 def live_loops_anchor() -> list[str]:
-    """Return one dim anchor line per live :class:`LoopLease` row (#1163, #1156).
+    """Return one consolidated dim anchor line summarising live loops.
 
-    Five named loops run concurrently (``loop-owner``, ``loop-tick``,
-    ``loop-self-improve``, ``loop-slack-answer``, ``loop-slot``); the
-    statusline anchors zone surfaces each LIVE row as ``loop:<short>
-    [<N tasks>]`` where ``<short>`` strips the ``loop-`` prefix and
-    ``<N tasks>`` is the count of CLAIMED ``Task`` rows for loops that
-    dispatch tasks (``tick``, ``self-improve``). The task-count chunk is
-    suppressed when zero or not applicable, so a quiet loop renders as a
-    single ``loop:tick`` token.
+    Single line, prepended at the top of the statusline so the user's
+    "where is the loop right now?" question is answered with one glance:
 
-    The DB read is delegated to :func:`_live_loop_names` so tests can stub
-    a single seam instead of building LoopLease fixtures.
+        ``loop · next tick in 3m12s · 5 loops live``
 
-    Fails open: any DB / import error degrades to ``[]`` so a broken
-    LoopLease read cannot blank the statusline.
+    Components, in order:
+
+    *   ``next tick in <duration>`` when the ``loop-tick`` lease has fired
+        at least once and a cadence is configured; the next-tick instant
+        is ``acquired_at + cadence_seconds``. ``next tick due`` when the
+        deadline has already passed (the next ``t3 loop tick`` is overdue
+        but no tick has acquired the lease yet, e.g. cron paused).
+        ``last tick: never`` when no row exists yet (no tick has fired).
+    *   ``<N loops live>`` — the headline number, deduped per-loop.
+        Replaces the prior one-line-per-loop dump (``loop:tick``,
+        ``loop:owner``, …) which the user explicitly did not want at the
+        top of the statusline.
+
+    Returns ``[]`` when no loop is live — silences the line entirely on
+    a quiet machine. Fails open: any DB / import error degrades to ``[]``
+    so a broken LoopLease read cannot blank the statusline.
+
+    Backward-compat: the return signature is unchanged (``list[str]``)
+    so :func:`_populate_live_loops_anchor` keeps appending whatever lines
+    we return; today it's at most one line, tomorrow it can grow without
+    a caller-side change.
     """
     try:
         live_names = _live_loop_names()
@@ -256,47 +300,56 @@ def live_loops_anchor() -> list[str]:
         return []
     if not live_names:
         return []
-    try:
-        task_counts = _claimed_task_counts_by_session(name_session_pairs=live_names)
-    except Exception:  # noqa: BLE001
-        task_counts = {}
-    lines: list[str] = []
-    for name, session_id in live_names:
-        short = name.removeprefix("loop-")
-        line = f"loop:{short}"
-        count = task_counts.get(session_id, 0) if name in _LOOPS_WITH_TASKS else 0
-        if count:
-            line += f" [{count} tasks]"
-        lines.append(line)
-    return lines
+
+    parts: list[str] = ["loop"]
+    parts.extend(_next_tick_parts())
+    parts.append(f"{len(live_names)} loops live")
+    return [" · ".join(parts)]
 
 
-# Loops that dispatch ``Task`` rows. Only these surface a ``[N tasks]``
-# chunk on the anchor line — the others don't own a queue.
-_LOOPS_WITH_TASKS: frozenset[str] = frozenset({"loop-tick", "loop-self-improve"})
+def _next_tick_parts() -> list[str]:
+    """Return the ``next tick in <duration>`` / fallback fragments.
 
-
-def _claimed_task_counts_by_session(*, name_session_pairs: list[tuple[str, str]]) -> dict[str, int]:
-    """Return ``{session_id: claimed_task_count}`` for sessions owning a relevant loop.
-
-    The dispatching loops (``loop-tick``, ``loop-self-improve``) share a
-    global pool of CLAIMED tasks — Sessions are scoped to tickets, not to
-    the loop that dispatched them. The count surfaced on the anchor line
-    is therefore the same global CLAIMED count for every dispatching
-    loop, computed once. Fails open (``{}``) on import or DB error so a
-    broken Task read doesn't blank the anchor line.
+    Empty list when nothing useful is queryable (no cadence, no tick
+    history). Fails open on every DB / config read — the line drops the
+    fragment rather than refusing to render.
     """
-    relevant_sessions = {session_id for name, session_id in name_session_pairs if name in _LOOPS_WITH_TASKS}
-    if not relevant_sessions:
-        return {}
     try:
-        from django.apps import apps  # noqa: PLC0415
-
-        task_model = apps.get_model("core", "Task")
-        total = task_model.objects.filter(status="claimed").count()
+        acquired_at = _loop_tick_acquired_at()
     except Exception:  # noqa: BLE001
-        return {}
-    return dict.fromkeys(relevant_sessions, total)
+        return []
+    if acquired_at is None:
+        return ["last tick: never"]
+    try:
+        cadence = _cadence_seconds()
+    except Exception:  # noqa: BLE001
+        return []
+    from django.utils import timezone  # noqa: PLC0415
+
+    now = timezone.now()
+    next_tick_at = acquired_at + timedelta(seconds=cadence)
+    delta_seconds = int((next_tick_at - now).total_seconds())
+    if delta_seconds <= 0:
+        return ["next tick due"]
+    return [f"next tick in {_format_duration(delta_seconds)}"]
+
+
+_SECONDS_PER_MINUTE = 60
+_SECONDS_PER_HOUR = 3600
+
+
+def _format_duration(seconds: int) -> str:
+    """Format ``seconds`` as a compact human duration (``3m12s``, ``45s``, ``1h05m``)."""
+    if seconds < _SECONDS_PER_MINUTE:
+        return f"{seconds}s"
+    if seconds < _SECONDS_PER_HOUR:
+        minutes, remainder = divmod(seconds, _SECONDS_PER_MINUTE)
+        if remainder:
+            return f"{minutes}m{remainder:02d}s"
+        return f"{minutes}m"
+    hours, remainder = divmod(seconds, _SECONDS_PER_HOUR)
+    minutes = remainder // _SECONDS_PER_MINUTE
+    return f"{hours}h{minutes:02d}m"
 
 
 def statusline_for_slack(*, path: Path | None = None) -> str:

--- a/tests/teatree_loop/test_statusline_1324_dedup_cap_overlay.py
+++ b/tests/teatree_loop/test_statusline_1324_dedup_cap_overlay.py
@@ -90,8 +90,8 @@ class TestReadyOverflowCap:
         n = _MAX_PER_STATE + 3
         actions = [_ready(str(i), url=f"https://example.com/issues/{i}") for i in range(n)]
         blob = _blob(actions)
-        # Five rendered, three folded into (+3).
-        assert "(+3)" in blob
+        # Five rendered, three folded into (+3 more).
+        assert "(+3 more)" in blob
         assert "#0" in blob
         assert f"#{_MAX_PER_STATE - 1}" in blob
         assert f"#{_MAX_PER_STATE}" not in blob  # the first overflowed item

--- a/tests/teatree_loop/test_statusline_multiloop.py
+++ b/tests/teatree_loop/test_statusline_multiloop.py
@@ -1,11 +1,18 @@
-"""Tests for the multi-loop anchors-zone rendering (#1156).
+"""Tests for the multi-loop anchors-zone rendering.
 
-The pre-#1156 statusline rendered a verbose ``loop-owner=THIS session ✓``
-or ``loop-owner=unclaimed`` line plus the foreign-hijack RED line.
-With five named loops now in flight (loop-owner, loop-tick,
-loop-self-improve, loop-slack-answer, loop-slot) the dim doctrine
-collapses into one line per LIVE LoopLease row, and the only RED
-loop line that survives is the #1073 foreign-hijack one.
+History:
+
+*   Pre-#1156 the statusline rendered a verbose ``loop-owner=THIS session ✓``
+    or ``loop-owner=unclaimed`` line plus the foreign-hijack RED line.
+*   #1156 collapsed the dim doctrine into one line per LIVE LoopLease row
+    (``loop:tick``, ``loop:owner``, …).
+*   This refit replaces that per-loop dump with a single consolidated
+    summary line that surfaces time-to-next-tick. The user explicitly
+    asked for "time to next tick" on the first line, not a per-loop list.
+
+The #1073 foreign-hijack RED line is preserved unchanged through every
+refit — it is a different code path (``loop_owner_anchor``) and a
+different zone (``action_needed``).
 """
 
 from datetime import timedelta
@@ -29,48 +36,49 @@ def _make_lease(name: str, *, expires_in: timedelta, session_id: str = "sess-A")
 
 @pytest.mark.django_db
 class TestLiveLoopsAnchor:
-    """``live_loops_anchor()`` returns one line per live LoopLease (#1156)."""
+    """``live_loops_anchor()`` returns one consolidated summary line."""
 
-    def test_anchors_show_one_line_per_live_loop(self) -> None:
+    def test_one_consolidated_line_with_loop_count(self) -> None:
         _make_lease("loop-tick", expires_in=timedelta(minutes=30))
         _make_lease("loop-self-improve", expires_in=timedelta(minutes=30))
         _make_lease("loop-slack-answer", expires_in=timedelta(minutes=30))
 
         lines = live_loops_anchor()
 
-        assert len(lines) == 3, repr(lines)
-        # Each line should start with the short loop name (loop- prefix stripped).
-        names = sorted(line.split()[0] for line in lines)
-        assert names == ["loop:self-improve", "loop:slack-answer", "loop:tick"]
+        assert len(lines) == 1, repr(lines)
+        line = lines[0]
+        assert line.startswith("loop · "), line
+        assert "3 loops live" in line, line
 
-    def test_expired_loops_omitted(self) -> None:
+    def test_expired_loops_omitted_from_count(self) -> None:
         _make_lease("loop-tick", expires_in=timedelta(minutes=30))
         _make_lease("loop-self-improve", expires_in=timedelta(minutes=30))
-        # Expired — must be filtered out.
+        # Expired — must not be counted.
         _make_lease("loop-slack-answer", expires_in=timedelta(seconds=-5))
 
         lines = live_loops_anchor()
 
-        assert len(lines) == 2, repr(lines)
-        names = sorted(line.split()[0] for line in lines)
-        assert names == ["loop:self-improve", "loop:tick"]
+        assert len(lines) == 1, repr(lines)
+        assert "2 loops live" in lines[0], lines[0]
 
-    def test_no_owner_text_in_dim_anchors(self) -> None:
-        """The verbose ``loop-owner=THIS session ✓`` line is gone (#1156)."""
+    def test_per_loop_dump_format_gone(self) -> None:
+        """The pre-refit per-loop dump (``loop:tick`` / ``loop:owner``) is gone."""
         _make_lease("loop-owner", expires_in=timedelta(minutes=30), session_id="sess-A")
+        _make_lease("loop-tick", expires_in=timedelta(minutes=30), session_id="sess-A")
 
         lines = live_loops_anchor()
-
         joined = "\n".join(lines)
+        # The verbose pre-#1156 lines are still gone.
         assert "loop-owner=THIS session" not in joined, repr(joined)
         assert "loop-owner=unclaimed" not in joined, repr(joined)
-        # Only the loop:<short> form survives.
-        assert any(line.startswith("loop:owner") for line in lines), repr(lines)
+        # The per-loop dump (``loop:tick`` / ``loop:owner``) is gone too.
+        assert "loop:tick" not in joined, repr(joined)
+        assert "loop:owner" not in joined, repr(joined)
 
 
 @pytest.mark.django_db
 class TestForeignHijackStillRed:
-    """The #1073 foreign-hijack RED line is preserved through #1156."""
+    """The #1073 foreign-hijack RED line is preserved through every refit."""
 
     def test_foreign_owner_still_emits_red_action_needed(self) -> None:
         """A foreign session owning ``loop-owner`` still routes to action_needed."""
@@ -86,9 +94,9 @@ class TestForeignHijackStillRed:
 
 @pytest.mark.django_db
 class TestPopulateLoopsAnchorIntegration:
-    """The rendering layer emits live-loop dim lines for each LoopLease (#1163)."""
+    """The rendering layer emits the consolidated line for live LoopLease rows."""
 
-    def test_emits_dim_line_per_live_loop_and_no_owner_verbose(self) -> None:
+    def test_emits_consolidated_line_when_loops_live(self) -> None:
         from teatree.loop.rendering import _populate_live_loops_anchor  # noqa: PLC0415
 
         _make_lease("loop-tick", expires_in=timedelta(minutes=30))
@@ -98,8 +106,10 @@ class TestPopulateLoopsAnchorIntegration:
         _populate_live_loops_anchor(zones)
 
         joined = "\n".join(item if isinstance(item, str) else item.text for item in zones.anchors)
-        assert "loop:tick" in joined, repr(joined)
-        assert "loop:self-improve" in joined, repr(joined)
+        assert "loop · " in joined, repr(joined)
+        assert "2 loops live" in joined, repr(joined)
         # Verbose dim owner lines must NOT appear.
         assert "loop-owner=THIS session" not in joined, repr(joined)
         assert "loop-owner=unclaimed" not in joined, repr(joined)
+        # Per-loop dump form also gone.
+        assert "loop:tick" not in joined, repr(joined)

--- a/tests/teatree_loop/test_statusline_next_tick.py
+++ b/tests/teatree_loop/test_statusline_next_tick.py
@@ -1,0 +1,235 @@
+"""Statusline renderer refit — consolidated loop line + state-priority reorder.
+
+Three behaviours regression-locked here:
+
+*   Line 1 of the statusline is the **consolidated loop summary**, not a
+    per-loop dump (``loop:owner``, ``loop:self-improve``, ``loop:tick``).
+    The user explicitly asked for "time to next tick" on the first line.
+*   Anchor state groups render in priority order — actively-shipping work
+    first (``started``, ``in_review``, ``ready``) before the long
+    ``not_started`` backlog. A 41-deep ``not_started`` no longer pushes
+    the actionable rows off-screen.
+*   The ``not_started`` cap tightens to 3 with a clear ``(+N more)``
+    overflow marker; ``ready:`` and the rest keep the standard
+    ``_MAX_PER_STATE`` cap with the same overflow wording.
+"""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from teatree.loop.dispatch import DispatchAction
+from teatree.loop.rendering import zones_for
+from teatree.loop.statusline import _format_duration, live_loops_anchor, render
+
+
+def _active_ticket(num: str, state: str, *, url: str = "", overlay: str = "ov") -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="anchors",
+        detail=f"#{num} {state}",
+        payload={
+            "ticket_number": num,
+            "state": state,
+            "issue_url": url or f"https://example.com/issues/{num}",
+            "overlay": overlay,
+        },
+    )
+
+
+def _ready(num: str, *, overlay: str = "ov") -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="action_needed",
+        detail=f"Ready to start: #{num}",
+        payload={
+            "url": f"https://example.com/issues/{num}",
+            "ticket_number": num,
+            "overlay": overlay,
+        },
+    )
+
+
+class TestConsolidatedLoopAnchor:
+    """Line 1 = ``loop · next tick in <duration> · N loops live``."""
+
+    def test_includes_time_to_next_tick_when_acquired_at_known(self) -> None:
+        leases = [("loop-tick", "sessA"), ("loop-owner", "sessA")]
+        # Last tick fired 2 minutes ago; cadence 720s → next tick in 10m.
+        acquired_at = datetime.now(UTC) - timedelta(seconds=120)
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=acquired_at),
+            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+        ):
+            lines = live_loops_anchor()
+        assert len(lines) == 1, repr(lines)
+        line = lines[0]
+        assert line.startswith("loop · "), line
+        assert "next tick in " in line, line
+        assert "2 loops live" in line, line
+
+    def test_falls_back_to_last_tick_never_when_no_lease_history(self) -> None:
+        leases = [("loop-tick", "sessA")]
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
+            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+        ):
+            lines = live_loops_anchor()
+        assert lines == ["loop · last tick: never · 1 loops live"], repr(lines)
+
+    def test_reports_next_tick_due_when_overdue(self) -> None:
+        leases = [("loop-tick", "sessA")]
+        # Last tick was 1 hour ago; cadence 12 minutes → due now.
+        acquired_at = datetime.now(UTC) - timedelta(hours=1)
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=acquired_at),
+            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+        ):
+            lines = live_loops_anchor()
+        assert lines == ["loop · next tick due · 1 loops live"], repr(lines)
+
+    def test_no_per_loop_lines_anymore(self) -> None:
+        """The pre-refit one-line-per-loop shape is gone (user explicitly opted out)."""
+        leases = [("loop-tick", "sessA"), ("loop-owner", "sessA"), ("loop-self-improve", "sessA")]
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
+            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+        ):
+            lines = live_loops_anchor()
+        assert len(lines) == 1, repr(lines)
+        # No ``loop:owner`` / ``loop:tick`` / ``loop:self-improve`` tokens.
+        assert "loop:owner" not in lines[0], lines[0]
+        assert "loop:tick" not in lines[0], lines[0]
+        assert "loop:self-improve" not in lines[0], lines[0]
+
+    def test_empty_when_no_loops_live(self) -> None:
+        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+            assert live_loops_anchor() == []
+
+    def test_fails_open_on_db_error(self) -> None:
+        with patch("teatree.loop.statusline._live_loop_names", side_effect=RuntimeError("db down")):
+            assert live_loops_anchor() == []
+
+
+class TestFormatDuration:
+    """Pure helper — covered for completeness so the shape is locked."""
+
+    def test_seconds_only(self) -> None:
+        assert _format_duration(45) == "45s"
+
+    def test_minutes_and_seconds(self) -> None:
+        assert _format_duration(192) == "3m12s"
+
+    def test_whole_minutes(self) -> None:
+        assert _format_duration(120) == "2m"
+
+    def test_hours_and_minutes(self) -> None:
+        assert _format_duration(3900) == "1h05m"
+
+
+class TestAnchorStatePriorityOrder:
+    """Anchor state groups render in priority order, not insertion order."""
+
+    def test_in_review_renders_before_not_started(self, tmp_path: Path) -> None:
+        # Reverse-insertion order so we know the renderer is sorting, not
+        # echoing input order: not_started first in input, in_review last.
+        actions = [
+            _active_ticket("1", "not_started", overlay="ov"),
+            _active_ticket("2", "not_started", overlay="ov"),
+            _active_ticket("100", "in_review", overlay="ov"),
+        ]
+        # Suppress the loop anchor — we are only asserting overlay-row order.
+        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+            zones = zones_for(actions, colorize=False)
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=False)
+        body = target.read_text()
+        # ``in_review:`` block must appear in the line before ``not_started:``.
+        in_review_idx = body.index("in_review:")
+        not_started_idx = body.index("not_started:")
+        assert in_review_idx < not_started_idx, body
+
+    def test_started_renders_before_in_review(self, tmp_path: Path) -> None:
+        actions = [
+            _active_ticket("100", "in_review", overlay="ov"),
+            _active_ticket("200", "started", overlay="ov"),
+        ]
+        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+            zones = zones_for(actions, colorize=False)
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=False)
+        body = target.read_text()
+        started_idx = body.index("started:")
+        in_review_idx = body.index("in_review:")
+        assert started_idx < in_review_idx, body
+
+
+class TestNotStartedTightCap:
+    """``not_started`` caps at 3, with ``(+N more)`` overflow phrasing."""
+
+    def test_not_started_caps_at_three(self, tmp_path: Path) -> None:
+        actions = [_active_ticket(str(i), "not_started", overlay="ov") for i in range(1, 11)]
+        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+            zones = zones_for(actions, colorize=False)
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=False)
+        body = target.read_text()
+        # First three IDs visible, 4th IS overflowed.
+        assert "#1" in body
+        assert "#2" in body
+        assert "#3" in body
+        # Fourth not_started item is in the overflow tail, NOT inline.
+        # (#4 must NOT appear as a standalone token; the +N number does.)
+        # Overflow phrasing is the new ``(+N more)`` shape.
+        assert "(+7 more)" in body, body
+
+    def test_in_review_keeps_five_item_cap(self, tmp_path: Path) -> None:
+        actions = [_active_ticket(str(i), "in_review", overlay="ov") for i in range(1, 9)]
+        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+            zones = zones_for(actions, colorize=False)
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=False)
+        body = target.read_text()
+        # 5 items visible, 3 overflowed.
+        assert "(+3 more)" in body, body
+
+
+class TestReadyOverflowPhrasing:
+    """The action_needed ``ready:`` row uses the same ``(+N more)`` overflow shape."""
+
+    def test_ready_overflow_says_more(self, tmp_path: Path) -> None:
+        actions = [_ready(str(i), overlay="ov") for i in range(10)]
+        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+            zones = zones_for(actions, colorize=False)
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=False)
+        body = target.read_text()
+        assert "(+5 more)" in body, body
+
+
+class TestZonesForIntegration:
+    """End-to-end: ``zones_for`` + ``render`` produces the new top-line shape."""
+
+    def test_line_one_is_consolidated_loop_summary(self, tmp_path: Path) -> None:
+        leases = [("loop-tick", "sessA"), ("loop-owner", "sessA")]
+        acquired_at = datetime.now(UTC) - timedelta(seconds=60)
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=acquired_at),
+            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+        ):
+            zones = zones_for([], colorize=False)
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=False)
+        body = target.read_text()
+        first_line = body.splitlines()[0]
+        assert first_line.startswith("loop · "), repr(first_line)
+        assert "next tick in " in first_line, first_line
+        assert "2 loops live" in first_line, first_line
+        # Per-loop tokens removed at the top.
+        assert "\nloop:tick" not in body
+        assert "\nloop:owner" not in body

--- a/tests/teatree_loop/test_statusline_refinements_1163.py
+++ b/tests/teatree_loop/test_statusline_refinements_1163.py
@@ -117,7 +117,7 @@ class TestItemFormatDescriptionAlwaysShown:
                 "ticket_number": "500",
                 "state": "started",
                 "issue_url": "https://example.com/tracker/500",
-                "title": "add new docgen guard",
+                "title": "add new scanner guard",
             },
         )
         zones = zones_for([action], colorize=False)
@@ -125,7 +125,7 @@ class TestItemFormatDescriptionAlwaysShown:
         render(zones, target=target, colorize=False)
         body = target.read_text()
         assert "#500" in body
-        assert "(add new docgen guard)" in body
+        assert "(add new scanner guard)" in body
 
 
 class TestNo404Links:
@@ -205,20 +205,28 @@ class TestDedupAcrossOverlays:
 
 
 class TestLiveLoopsAnchor:
-    """Refinement 5: one anchor line per live loop."""
+    """Refinement 5 (revised): one consolidated summary line for live loops.
 
-    def test_one_anchor_line_per_live_lease(self) -> None:
+    The original refinement returned one line per live loop. The user
+    asked instead for a single first-line summary with time-to-next-tick;
+    this rewrites the tests to lock the consolidated shape.
+    """
+
+    def test_returns_one_consolidated_summary_line(self) -> None:
         leases = [
             ("loop-tick", "sessA"),
             ("loop-slack-answer", "sessB"),
             ("loop-owner", "sessA"),
         ]
-        with patch("teatree.loop.statusline._live_loop_names", return_value=leases):
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
+            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+        ):
             lines = live_loops_anchor()
-        assert len(lines) == 3
-        assert any("loop:tick" in line for line in lines)
-        assert any("loop:slack-answer" in line for line in lines)
-        assert any("loop:owner" in line for line in lines)
+        assert len(lines) == 1
+        assert lines[0].startswith("loop · ")
+        assert "3 loops live" in lines[0]
 
     def test_no_live_leases_returns_empty(self) -> None:
         # Empty list → no lines (no statusline noise when no loop is live).
@@ -233,16 +241,23 @@ class TestLiveLoopsAnchor:
 
 
 class TestZonesForIntegratesLoopsAnchor:
-    """``zones_for`` surfaces live loops in the anchors zone."""
+    """``zones_for`` surfaces the consolidated loop summary in the anchors zone."""
 
-    def test_zones_for_appends_live_loops(self, tmp_path: Path) -> None:
-        with patch(
-            "teatree.loop.statusline._live_loop_names",
-            return_value=[("loop-tick", "sessA"), ("loop-owner", "sessA")],
+    def test_zones_for_appends_consolidated_loop_line(self, tmp_path: Path) -> None:
+        with (
+            patch(
+                "teatree.loop.statusline._live_loop_names",
+                return_value=[("loop-tick", "sessA"), ("loop-owner", "sessA")],
+            ),
+            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
+            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
         ):
             zones: StatuslineZones = zones_for([], colorize=False)
         target = tmp_path / "statusline.txt"
         render(zones, target=target, colorize=False)
         body = target.read_text()
-        assert "loop:tick" in body
-        assert "loop:owner" in body
+        assert "loop · " in body
+        assert "2 loops live" in body
+        # Per-loop dump tokens absent.
+        assert "loop:tick" not in body
+        assert "loop:owner" not in body

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -1083,9 +1083,15 @@ class TestLoopOwnerAnchorWiring(django.test.TestCase):
             sl = Path(d) / "sl.txt"
             with patch.dict("os.environ", {"CLAUDE_SESSION_ID": "owner-sess"}):
                 run_tick(TickRequest(scanners=[]), statusline_path=sl)
-            # #1156: a live LoopLease row is rendered as ``loop:owner``
-            # (the ``loop-`` prefix is stripped).
-            assert "loop:owner" in sl.read_text(encoding="utf-8")
+            # A live LoopLease row surfaces in the consolidated summary
+            # line — ``loop · … · N loops live`` — at the top of the
+            # statusline. The pre-refit one-line-per-loop dump
+            # (``loop:owner``, ``loop:tick``, …) was removed at the user's
+            # explicit request; the count carries the same signal in less
+            # vertical space.
+            body = sl.read_text(encoding="utf-8")
+            assert "loop · " in body, body
+            assert "1 loops live" in body, body
 
     def test_normal_path_flags_foreign_owner_in_red_zone(self) -> None:
         import tempfile  # noqa: PLC0415


### PR DESCRIPTION
## Why

Two user complaints about the statusline (BEFORE):

1. *"I never asked for this in statusline: ``loop:owner / loop:self-improve / loop:tick``. I asked for this info on the first line with time to next tick, basically."*
2. *"bug hunt statusline, it still doesn't show appropriate tickets / MRs / PRs."*

The first surfaces a missing UX: the user wants one consolidated loop-status line with time-to-next-tick, not a verbose per-loop dump that takes 3 lines and tells them nothing about cadence. The second is a backlog-row complaint — a 41-deep ``not_started`` row was pushing actively-shipping tickets off-screen.

## What changed

### Line 1 — consolidated loop summary

Reading ``LoopLease.acquired_at(name='loop-tick')`` + ``cadence_seconds()`` from config, the renderer now writes:

```
loop · next tick in 11m56s · 4 loops live
```

The next-tick instant is ``acquired_at + cadence_seconds``. Fallbacks (every branch covered by a test):

- No tick has fired yet → ``loop · last tick: never · N loops live``
- Deadline passed (cron paused) → ``loop · next tick due · N loops live``
- No live loop at all → empty (no statusline noise)
- DB / config error → empty (fail-open)

The two DB / config reads are isolated as seams (``_loop_tick_acquired_at`` and ``_cadence_seconds``) so tests stub timestamps directly instead of constructing LoopLease fixtures.

### Anchor-row state-group ordering

State groups now sort by priority — actively-shipping work first — instead of insertion order:

```
started → in_review → ready → tested → scoped → not_started → (rest)
```

### Tightened ``not_started`` cap + ``(+N more)`` overflow

``not_started`` drops from a 5-item cap to **3**. Overflow phrasing switches from ``(+N)`` to ``(+N more)`` everywhere (anchor rows AND the action-needed ``ready:`` row) so the truncation is unambiguous. Other states (``started``, ``in_review``, ``ready``, …) keep the standard 5-item cap.

## BEFORE / AFTER

### BEFORE (from `/Users/adrien/.local/share/teatree/statusline.txt`, NO_COLOR stripped)

```
loop:owner
loop:tick

[private overlay] not_started: #1 #5 #6 #1634 #8454 (+41) · in_review: #855 #59 #61 #69 · started: #330 #2241 #80
[private overlay] ready: #2259

[t3-teatree] in_review: #1255 #1206 #1278 #1283 #1284 (+1) · started: #1282 #1296 #1317 #1330-fix · not_started: #55 #56 #58 #62 #65 (+1)
[t3-teatree] ready: #2259 #2242 #2241 #8521 #1634 (+21)
[t3-teatree] !150 (feat(evals): first behavioral eval …)
```

### AFTER (regenerated locally via `t3 loop tick` against this branch)

```
loop · next tick in 11m56s · 4 loops live

[private overlay] DMs (4): 1779807366.516079 · 1779806524.638009 · …
[private overlay] 2 stale: #59 #61

[t3-teatree] started: #1282 #1296 #123 · in_review: #1255 #1206 #1278 #1283 #1284 (+1 more) · not_started: #55 #56 #58 (+3 more)
[t3-teatree] no_clear_for_head: ? · ready: #2259 #2242 #2241 #8521 #1634 (+21 more)
[t3-teatree] !1336 (fix(merge_execution): add GitLab transp…) !150 (feat(evals): first behavioral eval …)
```

Differences:

- Line 1 is now the consolidated summary; the three pre-fix `loop:owner` / `loop:tick` lines are gone.
- ``[t3-teatree]`` anchor row now leads with ``started:`` and ``in_review:`` — actively-shipping work first. ``not_started:`` moved to the tail and capped at 3 with ``(+3 more)``.
- ``ready: (+21 more)`` replaces ``(+21)`` for consistency.

## Out of scope

The user noted other things in the bug report that are not renderer-side and stay for a separate ticket:

- **MR #150 is merged but still appears.** This is a scanner-attribution bug — the GitHub PR is in ``private downstream overlay`` but surfaces under ``[t3-teatree]``. Likely a missing ``allowed_url_prefixes`` config on the t3-teatree MyPrsScanner registration, or a scanner not filtering merged state. Renderer can't see ``state="merged"`` on the PR payload today; fixing that needs scanner-side work.
- **GitLab MRs (!7487, !7490, !6264, !368, !2694) not surfacing.** Same scanner-side issue — host attribution / pagination / dedup at the scanner boundary, not at the renderer.
- **Stale ``started:`` items where the corresponding PR has merged** (e.g. #1317 whose PR #1315 merged). Requires the FSM transition to advance after merge; the renderer correctly reflects the FSM state it was given.

I've left these to be picked up as separate tickets so this PR stays focused on the three things actually in renderer scope.

## Tests

`tests/teatree_loop/test_statusline_next_tick.py` — 16 new tests covering:

- The 3 line-1 branches (duration / never / due) and the 2 degenerate cases (no loops / DB error).
- ``_format_duration`` shape (4 size buckets).
- Anchor state ordering (``in_review`` before ``not_started``; ``started`` before ``in_review``).
- ``not_started`` cap at 3 / ``in_review`` cap at 5.
- ``ready:`` overflow phrase.
- End-to-end ``zones_for`` integration.

Existing per-loop tests in `test_statusline_multiloop.py`, `test_statusline_refinements_1163.py`, `test_tick.py`, and the `(+N)` regex in `test_statusline_1324_dedup_cap_overlay.py` are rewritten to assert the new contract.

### Anti-vacuous revert evidence

Each fix verified by reverting it and confirming the corresponding test goes RED before restoring:

| Revert | Test that goes RED |
|---|---|
| (a) Line-1 fix → restore per-loop dump | `test_includes_time_to_next_tick_when_acquired_at_known` (`AssertionError: 2 == 1`) |
| (b) State-priority sort → insertion order | `test_in_review_renders_before_not_started` (`AssertionError: 88 < 5`) |
| (c) Tighten not_started cap → flat 5-cap | `test_not_started_caps_at_three` (`AssertionError: '(+7 more)' in '(+5 more)'`) |

## Verification

- `prek run --all-files` — green on touched files (pre-existing banned-term hit fixed in passing).
- `uv run pytest tests/ -k statusline --no-cov` — **136 passed**.
- `uv run pytest tests/teatree_loop/ --no-cov` — **938 passed**.
- `uv run pytest tests/ --no-cov` minus one pre-existing failure (`test_in_repo_overlay_resolves_to_three`, unrelated, on origin/main too) — **6829 passed**.
- Local statusline regenerated via `t3 loop tick` against this branch — output matches AFTER above.
