### PR TITLE
fix(e2e): link external runner to a backend ticket via --linked-to (#1322)

### DIFF
--- a/src/teatree/core/management/commands/_e2e_discovery.py
+++ b/src/teatree/core/management/commands/_e2e_discovery.py
@@ -1,0 +1,125 @@
+"""Frontend port discovery and linked-ticket env routing for ``e2e external``.
+
+Split out of ``e2e.py`` to keep that module under the project's per-file
+LOC cap and to give the linked-ticket plumbing introduced in #1322 a clear
+home: the helpers here decide *where* the backend stack lives (which
+compose project, which env cache, which on-disk worktree path), and the
+``e2e`` command module wires them into the CLI.
+"""
+
+import socket
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.resolve import _find_env_cache, _parse_env_file
+from teatree.core.runners.worktree_start import compose_project
+from teatree.utils.ports import get_service_port
+
+
+def detect_local_port(port: int) -> int | None:
+    """Return *port* if something is listening on localhost, else None."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.3)
+        if s.connect_ex(("127.0.0.1", port)) == 0:
+            return port
+    return None
+
+
+def compose_frontend_port(project: str) -> int | None:
+    """Return the published host port for *project*'s ``frontend`` service.
+
+    The compose ``frontend`` service is nginx serving the pre-built dist on
+    container port 80; a raw dev-server setup instead listens on 4200.
+    """
+    for container_port in (80, 4200):
+        port = get_service_port(project, "frontend", container_port)
+        if port is not None:
+            return port
+    return None
+
+
+def ticket_frontend_projects(worktree: Worktree, *, linked_ticket: Ticket | None = None) -> list[str]:
+    """Compose projects that may host the frontend for this worktree's ticket.
+
+    The resolved worktree is whatever the cwd matched — for an external test
+    repo that is the *test* worktree, whose compose project has no frontend.
+    The frontend lives in a sibling repo's worktree under the same ticket, so
+    probe the resolved worktree first, then every sibling under the ticket.
+
+    ``linked_ticket`` (#1322): when the resolved worktree is an out-of-tree
+    e2e cache repo that is not DB-linked to the backend ticket (a frequent
+    shape — the user calls ``e2e external`` from the cache dir, whose
+    auto-registered worktree belongs to ``auto:<branch>`` or a different
+    ticket), the caller can name the backend ticket explicitly. Discovery
+    then routes at *that* ticket's worktrees and bypasses the resolved
+    ticket's siblings.
+    """
+    if linked_ticket is not None:
+        candidates: list[Worktree] = [worktree, *Worktree.objects.filter(ticket=linked_ticket).order_by("pk")]
+    else:
+        ticket = worktree.ticket
+        candidates = [worktree]
+        if ticket is not None:
+            candidates += [wt for wt in Worktree.objects.filter(ticket=ticket) if wt.pk != worktree.pk]
+    seen: set[str] = set()
+    projects: list[str] = []
+    for wt in candidates:
+        project = compose_project(wt)
+        if project not in seen:
+            seen.add(project)
+            projects.append(project)
+    return projects
+
+
+def discover_frontend_port(worktree: Worktree, *, linked_ticket: Ticket | None = None) -> int | None:
+    """Discover the frontend port for a worktree's stack.
+
+    ``docker compose port`` is authoritative when the stack is up; the local
+    scan is a last-ditch fallback for users who started compose outside the
+    teatree runner. The frontend may be served by a sibling repo's compose
+    project under the same ticket, so every ticket project is probed.
+
+    ``linked_ticket`` (#1322): see ``ticket_frontend_projects`` — re-routes
+    discovery at the named ticket's worktrees when the resolved worktree is
+    not DB-linked to the backend stack.
+    """
+    for project in ticket_frontend_projects(worktree, linked_ticket=linked_ticket):
+        port = compose_frontend_port(project)
+        if port is not None:
+            return port
+    # Scan the allocation range — ports start at 4200 and go up
+    for candidate in range(4200, 4211):
+        if detect_local_port(candidate) is not None:
+            return candidate
+    return None
+
+
+def resolve_linked_worktree(linked_ticket: Ticket) -> Worktree | None:
+    """Pick the worktree that owns the backend stack for ``linked_ticket``.
+
+    The env cache that feeds ``get_e2e_env_extras`` and the
+    ``COMPOSE_PROJECT_NAME`` exported for ``docker compose`` calls both live
+    on this worktree. Prefer the first stored-path worktree (deterministic
+    order by pk); fall back to any sibling so a freshly-provisioned ticket
+    with no recorded ``worktree_path`` still routes.
+    """
+    siblings = list(Worktree.objects.filter(ticket=linked_ticket).order_by("pk"))
+    for wt in siblings:
+        if (wt.extra or {}).get("worktree_path"):
+            return wt
+    return siblings[0] if siblings else None
+
+
+def linked_env_cache(linked_worktree: Worktree | None) -> dict[str, str]:
+    """Read the env cache that lives on ``linked_worktree``'s on-disk path.
+
+    Returns an empty dict when the worktree has no recorded path or the
+    cache file is absent; the caller is responsible for deciding whether
+    that is a fatal misconfig.
+    """
+    if linked_worktree is None:
+        return {}
+    wt_path = (linked_worktree.extra or {}).get("worktree_path", "")
+    if not wt_path:
+        return {}
+    envfile = _find_env_cache(str(wt_path))
+    return _parse_env_file(envfile) if envfile is not None else {}

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -1,7 +1,6 @@
 """E2E test commands: trigger CI, run from external repo, run from project."""
 
 import os
-import socket
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Annotated
@@ -10,13 +9,37 @@ import typer
 from django_typer.management import TyperCommand, command
 
 from teatree.config import E2ERepo, load_e2e_repos
-from teatree.core.models import Worktree
+from teatree.core.management.commands import _e2e_discovery as _disc
+from teatree.core.models import Ticket
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import _find_env_cache, _get_user_cwd, _parse_env_file, resolve_worktree
 from teatree.core.runners.worktree_start import compose_project
 from teatree.paths import get_data_dir
-from teatree.utils.ports import get_service_port
 from teatree.utils.run import run_checked, run_streamed
+
+# Re-exports for back-compat with tests and external callers (#1322 split).
+_ticket_frontend_projects = _disc.ticket_frontend_projects
+_discover_frontend_port = _disc.discover_frontend_port
+_resolve_linked_worktree = _disc.resolve_linked_worktree
+_linked_env_cache = _disc.linked_env_cache
+_compose_frontend_port = _disc.compose_frontend_port
+_detect_local_port = _disc.detect_local_port
+
+
+@dataclass
+class DispatchOptions:
+    """Common flags forwarded from ``e2e run`` to the resolved runner.
+
+    Bundles the runner-shared flags so internal dispatch methods stay below
+    the project's per-function argument cap without per-call ``noqa``.
+    """
+
+    test_path: str = ""
+    target: str = ""
+    headed: bool = False
+    update_snapshots: bool = False
+    docker: bool = True
+    linked_to: int = 0
 
 
 @dataclass
@@ -39,15 +62,6 @@ class PlaywrightOptions:
             args.append("--headed")
         args.extend(self.extra)
         return args
-
-
-def _detect_local_port(port: int) -> int | None:
-    """Return *port* if something is listening on localhost, else None."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.settimeout(0.3)
-        if s.connect_ex(("127.0.0.1", port)) == 0:
-            return port
-    return None
 
 
 def _clone_or_update_e2e_repo(repo: E2ERepo) -> Path:
@@ -82,63 +96,13 @@ def _resolve_private_tests_path() -> Path | None:
     return path if path.is_dir() else None
 
 
-def _compose_frontend_port(project: str) -> int | None:
-    # The compose `frontend` service is nginx serving the pre-built dist on
-    # container port 80; a raw dev-server setup instead listens on 4200.
-    for container_port in (80, 4200):
-        port = get_service_port(project, "frontend", container_port)
-        if port is not None:
-            return port
-    return None
-
-
-def _ticket_frontend_projects(worktree: Worktree) -> list[str]:
-    """Compose projects that may host the frontend for this worktree's ticket.
-
-    The resolved worktree is whatever the cwd matched — for an external test
-    repo that is the *test* worktree, whose compose project has no frontend.
-    The frontend lives in a sibling repo's worktree under the same ticket, so
-    probe the resolved worktree first, then every sibling under the ticket.
-    """
-    ticket = worktree.ticket
-    candidates = [worktree]
-    if ticket is not None:
-        candidates += [wt for wt in Worktree.objects.filter(ticket=ticket) if wt.pk != worktree.pk]
-    seen: set[str] = set()
-    projects: list[str] = []
-    for wt in candidates:
-        project = compose_project(wt)
-        if project not in seen:
-            seen.add(project)
-            projects.append(project)
-    return projects
-
-
-def _discover_frontend_port(worktree: Worktree) -> int | None:
-    """Discover the frontend port for a worktree's stack.
-
-    ``docker compose port`` is authoritative when the stack is up; the local
-    scan is a last-ditch fallback for users who started compose outside the
-    teatree runner. The frontend may be served by a sibling repo's compose
-    project under the same ticket, so every ticket project is probed.
-    """
-    for project in _ticket_frontend_projects(worktree):
-        port = _compose_frontend_port(project)
-        if port is not None:
-            return port
-    # Scan the allocation range — ports start at 4200 and go up
-    for candidate in range(4200, 4211):
-        if _detect_local_port(candidate) is not None:
-            return candidate
-    return None
-
-
 def _build_e2e_env(
     frontend_url: str | None = None,
     *,
     headed: bool,
     target: str,
     compose_project: str | None = None,
+    env_cache_override: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Build environment dict for Playwright: ``BASE_URL``, overlay extras, ``CI``.
 
@@ -171,8 +135,11 @@ def _build_e2e_env(
     if compose_project:
         env["COMPOSE_PROJECT_NAME"] = compose_project
 
-    envfile = _find_env_cache(_get_user_cwd())
-    env_cache = _parse_env_file(envfile) if envfile is not None else {}
+    if env_cache_override is not None:
+        env_cache = env_cache_override
+    else:
+        envfile = _find_env_cache(_get_user_cwd())
+        env_cache = _parse_env_file(envfile) if envfile is not None else {}
     for key, value in get_overlay().get_e2e_env_extras(env_cache).items():
         env.setdefault(key, value)
 
@@ -198,6 +165,7 @@ class Command(TyperCommand):
         headed: bool = False,
         update_snapshots: bool = False,
         docker: bool = True,
+        linked_to: int = 0,
     ) -> str:
         """Run E2E tests — the one command that works for every overlay.
 
@@ -220,37 +188,34 @@ class Command(TyperCommand):
         ``--target dev|local`` selects the dual-env target and is forwarded to
         whichever runner handles the overlay (see ``external`` for semantics).
 
+        ``--linked-to <ticket-pk>`` (#1322): when the e2e cache repo is not
+        DB-linked to the backend worktree (a frequent shape for
+        out-of-tree test repos), name the backend ticket explicitly so
+        frontend discovery, ``COMPOSE_PROJECT_NAME``, and the env cache
+        feeding ``get_e2e_env_extras`` all route at the linked stack.
+        ``0`` means "no link" (default — back-compat).
+
         Runner-specific flags (``--repo``, ``--playwright-args``) stay on the
         explicit ``external`` subcommand to keep this entry point overlay-agnostic.
         """
-        if work_item:
-            return self._run_work_item(
-                work_item,
-                test_path=test_path,
-                at=at,
-                target=target,
-                headed=headed,
-                update_snapshots=update_snapshots,
-                docker=docker,
-            )
-        return self._dispatch_runner(
+        opts = DispatchOptions(
             test_path=test_path,
             target=target,
             headed=headed,
             update_snapshots=update_snapshots,
             docker=docker,
+            linked_to=linked_to,
         )
+        if work_item:
+            return self._run_work_item(work_item, at=at, opts=opts)
+        return self._dispatch_runner(opts)
 
-    def _run_work_item(  # noqa: PLR0913
+    def _run_work_item(
         self,
         work_item: str,
         *,
-        test_path: str,
         at: str,
-        target: str,
-        headed: bool,
-        update_snapshots: bool,
-        docker: bool,
+        opts: DispatchOptions,
     ) -> str:
         """#794 keystone: resolve work item → ladder → run → record provenance.
 
@@ -294,45 +259,32 @@ class Command(TyperCommand):
         os.environ["T3_ORIG_CWD"] = primary_dir
 
         try:
-            result = self._dispatch_runner(
-                test_path=test_path,
-                target=target,
-                headed=headed,
-                update_snapshots=update_snapshots,
-                docker=docker,
-            )
+            result = self._dispatch_runner(opts)
         except SystemExit as exc:
             record_run(ticket, result="red", per_repo_shas=per_repo_shas)
             raise SystemExit(exc.code) from exc
         record_run(ticket, result="green", per_repo_shas=per_repo_shas)
         return result
 
-    def _dispatch_runner(
-        self,
-        *,
-        test_path: str,
-        target: str,
-        headed: bool,
-        update_snapshots: bool,
-        docker: bool,
-    ) -> str:
+    def _dispatch_runner(self, opts: DispatchOptions) -> str:
         overlay = get_overlay()
         e2e_config = overlay.metadata.get_e2e_config()
         runner = e2e_config.get("runner") or self._infer_runner(e2e_config)
         if runner == "project":
             return self.project(
-                test_path=test_path,
-                target=target,
-                headed=headed,
-                docker=docker,
-                update_snapshots=update_snapshots,
+                test_path=opts.test_path,
+                target=opts.target,
+                headed=opts.headed,
+                docker=opts.docker,
+                update_snapshots=opts.update_snapshots,
             )
         if runner == "external":
             return self.external(
-                test_path=test_path,
-                target=target,
-                headed=headed,
-                update_snapshots=update_snapshots,
+                test_path=opts.test_path,
+                target=opts.target,
+                headed=opts.headed,
+                update_snapshots=opts.update_snapshots,
+                linked_to=opts.linked_to,
             )
         self.stderr.write(
             f"Overlay e2e_config has no runner ({e2e_config}). "
@@ -378,6 +330,61 @@ class Command(TyperCommand):
                 self.stderr.write(f"E2E preflight failed: {exc}")
                 raise SystemExit(1) from exc
 
+    def _resolve_target_env(
+        self,
+        resolved_target: str,
+        linked_ticket: Ticket | None,
+    ) -> tuple[str | None, str | None, dict[str, str] | None]:
+        """Build the per-target trio passed to ``_build_e2e_env``.
+
+        Returns ``(frontend_url, worktree_compose_project, env_cache_override)``.
+        For ``dev`` the BASE_URL is preserved and the other two stay None.
+        For ``local`` the frontend port is discovered (routed through
+        ``linked_ticket`` when provided), the compose project comes from the
+        linked worktree (else the resolved one), and the env-cache override
+        comes from the linked worktree's on-disk path (None when no link).
+        """
+        if resolved_target == "dev":
+            if not os.environ.get("BASE_URL"):
+                self.stderr.write("--target dev requires BASE_URL (the deployed environment URL) to be set.")
+                raise SystemExit(1)
+            return None, None, None
+
+        worktree = resolve_worktree()
+        frontend_port = _discover_frontend_port(worktree, linked_ticket=linked_ticket)
+        if frontend_port is None:
+            probed = ", ".join(_ticket_frontend_projects(worktree, linked_ticket=linked_ticket)) or "none"
+            self.stderr.write(
+                f"Frontend not running (no docker `frontend` service in [{probed}], "
+                "no local process on 4200). Run `t3 <overlay> worktree start` first.",
+            )
+            raise SystemExit(1)
+
+        frontend_url = f"http://localhost:{frontend_port}"
+        if linked_ticket is not None:
+            linked_wt = _resolve_linked_worktree(linked_ticket)
+            if linked_wt is not None:
+                return frontend_url, compose_project(linked_wt), _linked_env_cache(linked_wt)
+        return frontend_url, compose_project(worktree), None
+
+    def _resolve_linked_ticket(self, linked_to: int) -> Ticket | None:
+        """Resolve ``--linked-to <pk>`` to a Ticket or exit on misconfig.
+
+        ``0`` means "no link" — return None (back-compat path). A non-zero
+        pk that misses must fail fast: silently falling through would mask
+        the user's intent to route at a specific backend stack.
+        """
+        if not linked_to:
+            return None
+        try:
+            return Ticket.objects.get(pk=linked_to)
+        except Ticket.DoesNotExist:
+            self.stderr.write(
+                f"--linked-to ticket pk={linked_to} not found. "
+                "Pass the backend ticket's pk (see `t3 <overlay> ticket list`).",
+            )
+            raise SystemExit(2) from None
+
     def _resolve_target(self, target: str) -> str:
         """Resolve the dual-env target deterministically.
 
@@ -404,6 +411,7 @@ class Command(TyperCommand):
         headed: bool = False,
         update_snapshots: bool = False,
         playwright_args: str = "",
+        linked_to: int = 0,
     ) -> str:
         """Run Playwright tests from the external test repo (T3_PRIVATE_TESTS or --repo).
 
@@ -430,6 +438,14 @@ class Command(TyperCommand):
         Discovers the frontend port from docker-compose (or local process)
         and reads the tenant variant from the env cache.
 
+        ``--linked-to <ticket-pk>`` (#1322): when the e2e cache repo's
+        auto-registered worktree is not DB-linked to the backend stack
+        (``auto:<branch>`` ticket, different ticket, or no worktree row at
+        all), name the backend ticket explicitly. Discovery,
+        ``COMPOSE_PROJECT_NAME``, and the env cache feeding
+        ``get_e2e_env_extras`` all route at the linked stack. ``0`` means
+        "no link" (default — back-compat with the resolved-worktree path).
+
         Extra Playwright flags (--config, --timeout, --grep, etc.) can be
         passed via --playwright-args: ``--playwright-args="--config x.ts --timeout 120000"``
         """
@@ -447,30 +463,12 @@ class Command(TyperCommand):
                 )
                 raise SystemExit(1)
 
+        linked_ticket = self._resolve_linked_ticket(linked_to)
         resolved_target = self._resolve_target(target)
-
-        # target=dev   → keep the pre-set BASE_URL (deployed env), no port scan.
-        # target=local → always discover the local frontend, even if a stray
-        #                 BASE_URL is exported, so `--target local` can never
-        #                 silently hit a deployed environment.
-        worktree_compose_project: str | None = None
-        if resolved_target == "dev":
-            if not os.environ.get("BASE_URL"):
-                self.stderr.write("--target dev requires BASE_URL (the deployed environment URL) to be set.")
-                raise SystemExit(1)
-            frontend_url = None  # preserve existing BASE_URL
-        else:
-            worktree = resolve_worktree()
-            frontend_port = _discover_frontend_port(worktree)
-            if frontend_port is None:
-                probed = ", ".join(_ticket_frontend_projects(worktree)) or "none"
-                self.stderr.write(
-                    f"Frontend not running (no docker `frontend` service in [{probed}], "
-                    "no local process on 4200). Run `t3 <overlay> worktree start` first.",
-                )
-                raise SystemExit(1)
-            frontend_url = f"http://localhost:{frontend_port}"
-            worktree_compose_project = compose_project(worktree)
+        frontend_url, worktree_compose_project, env_cache_override = self._resolve_target_env(
+            resolved_target,
+            linked_ticket,
+        )
 
         extra = playwright_args.split() if playwright_args else []
         opts = PlaywrightOptions(
@@ -484,6 +482,7 @@ class Command(TyperCommand):
             headed=headed,
             target=resolved_target,
             compose_project=worktree_compose_project,
+            env_cache_override=env_cache_override,
         )
 
         self.stdout.write(f"  Running from: {private_tests_path}")

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -16,6 +16,7 @@ from django.utils.module_loading import import_string
 
 import teatree.config as config_mod
 import teatree.core.backend_factory as backend_factory_mod
+import teatree.core.management.commands._e2e_discovery as e2e_disc_mod
 import teatree.core.management.commands.e2e as e2e_mod
 import teatree.utils.run as utils_run_mod
 from teatree.core.models import Ticket, Worktree
@@ -381,7 +382,7 @@ class TestE2eExternal(TestCase):
             with (
                 patch.dict("os.environ", {"T3_ORIG_CWD": str(wt_dir)}, clear=False),
                 patch.object(config_mod, "load_config") as mock_cfg,
-                patch.object(e2e_mod, "get_service_port", return_value=4200),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=4200),
                 patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
             ):
                 mock_cfg.return_value.raw = {"teatree": {"private_tests": str(private_dir)}}
@@ -427,7 +428,7 @@ class TestE2eExternal(TestCase):
             mock_result = MagicMock(returncode=0)
             with (
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
-                patch.object(e2e_mod, "get_service_port", return_value=5555),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=5555),
                 patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
             ):
                 result = cast("str", call_command("e2e", "external"))
@@ -474,13 +475,120 @@ class TestE2eExternal(TestCase):
             mock_result = MagicMock(returncode=0)
             with (
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
-                patch.object(e2e_mod, "get_service_port", return_value=5555),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=5555),
                 patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
             ):
                 result = cast("str", call_command("e2e", "external", target="local"))
             assert "passed" in result
             env = mock_run.call_args[1]["env"]
             assert env["COMPOSE_PROJECT_NAME"] == f"backend-wt{ticket.ticket_number}"
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_linked_to_routes_discovery_at_named_ticket(self) -> None:
+        """``--linked-to <ticket>`` ties the e2e cache repo's run to a backend ticket.
+
+        Defect 1 of souliane/teatree#1322: when the external e2e runner runs
+        from an external e2e cache repo whose auto-registered worktree is
+        ticketless or belongs to a different ticket than the backend stack,
+        frontend port discovery returned None and the run aborted. The
+        explicit link tells the runner which backend ticket owns the stack
+        and the COMPOSE_PROJECT_NAME / env-cache lookup also routes through
+        that ticket — so a single command boots the spec against the
+        linked backend without manual ``BASE_URL``/``COMPOSE_PROJECT_NAME``
+        overrides.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            backend_wt_dir = tmp_path / "backend-worktree"
+            backend_wt_dir.mkdir()
+            # The env cache lives on the linked backend worktree — overlay
+            # extras (CUSTOMER, app credentials) are sourced from there.
+            (backend_wt_dir / ".t3-env.cache").write_text(
+                f"WT_VARIANT=tenant-child\nTICKET_DIR={backend_wt_dir.parent}\n",
+                encoding="utf-8",
+            )
+            e2e_cache_dir = tmp_path / "e2e-cache"
+            e2e_cache_dir.mkdir()
+            private_dir = tmp_path / "private"
+            private_dir.mkdir()
+
+            # Backend ticket: the stack the user wants to test against.
+            backend_ticket = Ticket.objects.create(
+                overlay="test",
+                issue_url="https://example.com/issues/backend",
+                variant="tenant-child",
+            )
+            Worktree.objects.create(
+                overlay="test",
+                ticket=backend_ticket,
+                repo_path="backend-repo",
+                branch="backend",
+                extra={"worktree_path": str(backend_wt_dir)},
+                state=Worktree.State.SERVICES_UP,
+            )
+
+            # E2E cache "worktree": auto-registered, ticketless or different
+            # ticket. The user's CWD when calling `e2e external` is the cache.
+            e2e_ticket = Ticket.objects.create(
+                overlay="test",
+                issue_url="auto:e2e-cache",
+            )
+            Worktree.objects.create(
+                overlay="test",
+                ticket=e2e_ticket,
+                repo_path="e2e-cache-repo",
+                branch="e2e",
+                extra={"worktree_path": str(e2e_cache_dir)},
+            )
+
+            mock_result = MagicMock(returncode=0)
+            with (
+                patch.dict(
+                    "os.environ",
+                    {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(e2e_cache_dir)},
+                    clear=False,
+                ),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=62674),
+                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+            ):
+                os.environ.pop("BASE_URL", None)
+                result = cast(
+                    "str",
+                    call_command("e2e", "external", target="local", linked_to=backend_ticket.pk),
+                )
+
+            assert "passed" in result
+            env = mock_run.call_args[1]["env"]
+            # Frontend discovered via the linked backend worktree's project.
+            assert env["BASE_URL"] == "http://localhost:62674"
+            # COMPOSE_PROJECT_NAME points at the backend worktree's project,
+            # not the e2e cache worktree's.
+            assert env["COMPOSE_PROJECT_NAME"] == f"backend-repo-wt{backend_ticket.ticket_number}"
+            # Defect 2: the env-cache that feeds get_e2e_env_extras must be
+            # the linked backend worktree's, so overlay-derived extras (e.g.
+            # CUSTOMER=<variant>) reach the spec.
+            assert env["CUSTOMER"] == "tenant-child"
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_linked_to_unknown_ticket_exits_with_error(self) -> None:
+        """``--linked-to <bogus-pk>`` is a misconfig — fail fast with exit 2.
+
+        Misconfigured link IDs must not silently fall through to the
+        resolved-worktree path; that would mask the user's intent.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            private_dir = Path(tmp) / "private"
+            private_dir.mkdir()
+
+            with (
+                patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir)}, clear=False),
+                pytest.raises(SystemExit) as exc_info,
+            ):
+                call_command("e2e", "external", target="local", linked_to=9_999_999)
+
+            assert exc_info.value.code == 2
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -533,7 +641,7 @@ class TestE2eExternal(TestCase):
             mock_result = MagicMock(returncode=1)
             with (
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
-                patch.object(e2e_mod, "get_service_port", return_value=4200),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=4200),
                 patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
                 pytest.raises(SystemExit) as exc_info,
             ):
@@ -566,7 +674,7 @@ class TestE2eExternal(TestCase):
             mock_result = MagicMock(returncode=0)
             with (
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
-                patch.object(e2e_mod, "get_service_port", return_value=4200),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=4200),
                 patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
             ):
                 call_command("e2e", "external", test_path="tests/login.py")
@@ -595,7 +703,7 @@ class TestE2eExternal(TestCase):
             )
             with (
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
-                patch.object(e2e_mod, "get_service_port", return_value=None),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=None),
                 patch.object(e2e_mod, "_detect_local_port", return_value=None),
                 pytest.raises(SystemExit) as exc_info,
             ):
@@ -898,7 +1006,7 @@ class TestE2eExternalRepo(TestCase):
                 patch.dict("os.environ", {"T3_ORIG_CWD": str(wt_dir)}),
                 patch.object(e2e_mod, "load_e2e_repos", return_value=[repo]),
                 patch.object(e2e_mod, "_clone_or_update_e2e_repo", return_value=playwright_root),
-                patch.object(e2e_mod, "get_service_port", return_value=4200),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=4200),
                 patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
             ):
                 result = cast("str", call_command("e2e", "external", repo="demo-svc"))

--- a/tests/teatree_core/management_commands/test_run.py
+++ b/tests/teatree_core/management_commands/test_run.py
@@ -11,6 +11,7 @@ import pytest
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 
+import teatree.core.management.commands._e2e_discovery as e2e_disc_mod
 import teatree.core.management.commands.e2e as e2e_mod
 import teatree.core.management.commands.run as run_mod
 import teatree.utils.run as utils_run_mod
@@ -357,45 +358,45 @@ class TestPlaywrightOptions:
 
 class TestDetectLocalPort:
     def test_returns_port_when_listening(self) -> None:
-        with patch("teatree.core.management.commands.e2e.socket.socket") as mock_sock_cls:
+        with patch("teatree.core.management.commands._e2e_discovery.socket.socket") as mock_sock_cls:
             mock_sock = MagicMock()
             mock_sock_cls.return_value.__enter__ = MagicMock(return_value=mock_sock)
             mock_sock_cls.return_value.__exit__ = MagicMock(return_value=False)
             mock_sock.connect_ex.return_value = 0
-            assert e2e_mod._detect_local_port(8080) == 8080
+            assert e2e_disc_mod.detect_local_port(8080) == 8080
 
     def test_returns_none_when_not_listening(self) -> None:
-        with patch("teatree.core.management.commands.e2e.socket.socket") as mock_sock_cls:
+        with patch("teatree.core.management.commands._e2e_discovery.socket.socket") as mock_sock_cls:
             mock_sock = MagicMock()
             mock_sock_cls.return_value.__enter__ = MagicMock(return_value=mock_sock)
             mock_sock_cls.return_value.__exit__ = MagicMock(return_value=False)
             mock_sock.connect_ex.return_value = 1
-            assert e2e_mod._detect_local_port(8080) is None
+            assert e2e_disc_mod.detect_local_port(8080) is None
 
 
 class TestDiscoverFrontendPort:
     def test_returns_docker_port_when_compose_reports_it(self) -> None:
         with (
-            patch.object(e2e_mod, "_ticket_frontend_projects", return_value=["project"]),
-            patch.object(e2e_mod, "get_service_port", return_value=4201),
+            patch.object(e2e_disc_mod, "ticket_frontend_projects", return_value=["project"]),
+            patch.object(e2e_disc_mod, "get_service_port", return_value=4201),
         ):
-            assert e2e_mod._discover_frontend_port(MagicMock()) == 4201
+            assert e2e_disc_mod.discover_frontend_port(MagicMock()) == 4201
 
     def test_scans_local_ports_as_final_fallback(self) -> None:
         with (
-            patch.object(e2e_mod, "_ticket_frontend_projects", return_value=["project"]),
-            patch.object(e2e_mod, "get_service_port", return_value=None),
-            patch.object(e2e_mod, "_detect_local_port", side_effect=lambda p: 4203 if p == 4203 else None),
+            patch.object(e2e_disc_mod, "ticket_frontend_projects", return_value=["project"]),
+            patch.object(e2e_disc_mod, "get_service_port", return_value=None),
+            patch.object(e2e_disc_mod, "detect_local_port", side_effect=lambda p: 4203 if p == 4203 else None),
         ):
-            assert e2e_mod._discover_frontend_port(MagicMock()) == 4203
+            assert e2e_disc_mod.discover_frontend_port(MagicMock()) == 4203
 
     def test_returns_none_when_no_port_found(self) -> None:
         with (
-            patch.object(e2e_mod, "_ticket_frontend_projects", return_value=["project"]),
-            patch.object(e2e_mod, "get_service_port", return_value=None),
-            patch.object(e2e_mod, "_detect_local_port", return_value=None),
+            patch.object(e2e_disc_mod, "ticket_frontend_projects", return_value=["project"]),
+            patch.object(e2e_disc_mod, "get_service_port", return_value=None),
+            patch.object(e2e_disc_mod, "detect_local_port", return_value=None),
         ):
-            assert e2e_mod._discover_frontend_port(MagicMock()) is None
+            assert e2e_disc_mod.discover_frontend_port(MagicMock()) is None
 
 
 class TestRunHealthChecks(TestCase):

--- a/tests/teatree_core/test_e2e_frontend_discovery.py
+++ b/tests/teatree_core/test_e2e_frontend_discovery.py
@@ -41,3 +41,25 @@ class TicketFrontendProjectsTests(TestCase):
         projects = _ticket_frontend_projects(orphan)
 
         assert projects == [compose_project(orphan)]
+
+    def test_linked_ticket_override_uses_named_tickets_worktrees(self) -> None:
+        """``linked_ticket`` reroutes discovery at the named ticket's worktrees.
+
+        Defect 1 of souliane/teatree#1322: when the e2e cache repo's
+        auto-registered worktree belongs to a different ticket than the
+        backend, the explicit override bypasses the resolved ticket's
+        siblings and probes the linked ticket's projects.
+        """
+        other_ticket = Ticket.objects.create(overlay="demo", issue_url="https://example.test/issues/1322")
+        backend_wt = Worktree.objects.create(
+            ticket=other_ticket,
+            overlay="demo",
+            repo_path="backend-repo",
+            branch="other",
+        )
+
+        projects = _ticket_frontend_projects(self.test_repo_wt, linked_ticket=other_ticket)
+
+        assert compose_project(backend_wt) in projects
+        # The resolved-worktree ticket's siblings are bypassed when a link is given.
+        assert "webapp-wt147" not in projects

--- a/tests/teatree_core/test_run_command.py
+++ b/tests/teatree_core/test_run_command.py
@@ -8,7 +8,7 @@ import pytest
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 
-import teatree.core.management.commands.e2e as e2e_mod
+import teatree.core.management.commands._e2e_discovery as e2e_disc_mod
 import teatree.core.management.commands.run as run_mod
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.utils.run as utils_run_mod
@@ -231,7 +231,7 @@ class TestE2eExternalCommand(TestCase):
                     },
                 ),
                 patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
-                patch.object(e2e_mod, "get_service_port", return_value=4299),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=4299),
                 patch.object(utils_run_mod.subprocess, "run", side_effect=fake_run),
             ):
                 result = cast("str", call_command("e2e", "external"))
@@ -271,8 +271,8 @@ class TestE2eExternalCommand(TestCase):
                         "T3_ORIG_CWD": str(worktree_dir),
                     },
                 ),
-                patch.object(e2e_mod, "get_service_port", return_value=None),
-                patch.object(e2e_mod, "_detect_local_port", return_value=None),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=None),
+                patch.object(e2e_disc_mod, "detect_local_port", return_value=None),
                 pytest.raises(SystemExit) as exc_info,
             ):
                 call_command("e2e", "external")


### PR DESCRIPTION
Closes #1322.

## What

Adds `--linked-to <ticket-pk>` to `t3 <overlay> e2e external` (forwarded by `e2e run`) so the external e2e cache repo can target a specific backend worktree when the cache repo is not DB-linked to it. When given:

- Frontend discovery routes at the linked ticket's worktrees instead of the resolved (cache-repo) worktree's siblings — fixes the reported `_discover_frontend_port` returning None for an out-of-tree cache repo.
- `COMPOSE_PROJECT_NAME` exports the linked backend worktree's project so spec-side bare `docker compose port web 8000` / `docker compose exec -T web` calls hit the right stack.
- The env cache feeding `get_e2e_env_extras` reads from the linked backend worktree's on-disk path. Overlay-derived extras (`CUSTOMER`, per-app credentials including the brokerage user the overlay binds on a tenant-scoped restored dump) reach the spec instead of falling through the empty cwd env cache and triggering the superuser login fallback that 401s on a tenant-scoped local dump.

A bogus pk fails fast (exit 2) instead of silently routing at the resolved worktree.

## Two defects, one fix

Both defects named in #1322 are coupled by the same root cause — the external e2e command resolved env from the cwd (the cache repo), not from the linked backend worktree. The same `--linked-to` plumbing unblocks both: defect 1 (frontend discovery) by routing the project list, defect 2 (overlay env extras like the brokerage user binding) by sourcing the env cache from the linked worktree.

## Real-world hit

The screenshot-evidence sub-agent on `!7482` (id `a7b4868493746194a`) reported this exact symptom: `_discover_frontend_port` failed against the backend worktree's compose project from the e2e cache, and the superuser login fallback triggered when overriding `BASE_URL` manually. This PR unblocks that path and the in-flight local E2E sub-agent `a7b4868493746194a` can use `--linked-to <backend-ticket-pk>` instead of manual `BASE_URL` / `COMPOSE_PROJECT_NAME` overrides.

## Tests (RED → GREEN)

Defect 1 — `tests/teatree_core/test_e2e_frontend_discovery.py::TicketFrontendProjectsTests::test_linked_ticket_override_uses_named_tickets_worktrees`
- Before: `_ticket_frontend_projects` did not accept a `linked_ticket` kwarg → `TypeError`.
- After: explicit override routes at the named ticket's siblings.

Defect 1 + 2 (integration) — `tests/teatree_core/management_commands/test_e2e.py::TestE2eExternal::test_linked_to_routes_discovery_at_named_ticket`
- Before: discovery routed at the e2e cache repo's ticket, missing the backend stack; env cache lookup from cwd was empty so `CUSTOMER` / overlay extras were absent.
- After: `BASE_URL`, `COMPOSE_PROJECT_NAME`, and overlay extras all source from the linked backend worktree.

Bogus pk validation — `tests/teatree_core/management_commands/test_e2e.py::TestE2eExternal::test_linked_to_unknown_ticket_exits_with_error`
- Asserts `--linked-to 9_999_999` exits 2 instead of silently falling through.

## Architecture

Splits the frontend-discovery / linked-ticket helpers out of `e2e.py` into `src/teatree/core/management/commands/_e2e_discovery.py` to keep `e2e.py` under the per-file LOC cap, and refactors `_dispatch_runner` / `_run_work_item` to take a `DispatchOptions` dataclass so the added flag does not push the internal dispatch over the per-function argument cap. No lint suppressions added.

## Verification

- `uv run pytest tests/ -k 'e2e or creds' --no-cov` → 165 passed
- `uv run pytest tests/teatree_core/ --no-cov` → 2360 passed, 12 skipped
- `prek run --files <changed-files>` → all checks pass

## Notes

- Companion change for `helpers/login.ts` CREDS map (the private overlay-e2e-side fallback for callers that don't pass `--linked-to`) is a follow-up in the `private overlay-e2e` repo and outside this PR's scope; the overlay-set `E2E_BROKERAGE_USER` env var already takes priority over the CREDS map fallback in `helpers/login.ts`.
