### PR TITLE
fix(merge_execution): probe candidate overlay repos when clone-origin SHA does not match (#1335)

### DIFF
--- a/src/teatree/core/merge_execution.py
+++ b/src/teatree/core/merge_execution.py
@@ -66,6 +66,7 @@ from django.apps import apps
 from django.db import transaction
 from django.utils import timezone
 
+from teatree.config import discover_overlays
 from teatree.project import find_project_root
 from teatree.utils import git
 from teatree.utils.run import run_allowed_to_fail
@@ -322,6 +323,148 @@ def resolve_pr_repo_slug(clear: object) -> str:
         f"at the GitHub repo, or pass an owner/repo slug."
     )
     raise MergePreconditionError(msg)
+
+
+def _iter_candidate_repo_slugs() -> list[str]:
+    """Every ``owner/repo`` reachable from this machine's overlay registry (#1335).
+
+    Source set, de-duplicated preserving insertion order:
+
+    (1) the running clone's ``origin`` (the same value
+        :func:`_project_repo_slug` returns).
+    (2) the ``origin`` slug of every registered overlay's ``project_path``
+        (entry-point + TOML overlays via :func:`discover_overlays`).
+
+    Used by :func:`_probe_candidate_repos` to recover from the #1335
+    cross-repo confusion: a CLEAR issued from the teatree clone for a PR
+    in a downstream overlay's repo (e.g. ``downstream-org/downstream-overlay#159``)
+    used to resolve to ``souliane/teatree``'s same-numbered (unrelated)
+    PR. With this enumeration the probe can verify each candidate and
+    pick the one whose ``pulls/<N>`` head matches the reviewed SHA.
+
+    Probe-side failures (``discover_overlays`` raises, a project path
+    has no ``origin`` remote) are swallowed: the candidate set is best-
+    effort, never load-bearing for the happy path.
+    """
+    seen: set[str] = set()
+    candidates: list[str] = []
+
+    def _add(slug: str) -> None:
+        if slug and slug not in seen:
+            seen.add(slug)
+            candidates.append(slug)
+
+    _add(_project_repo_slug())
+
+    try:
+        entries = discover_overlays()
+    except Exception:  # noqa: BLE001 — overlay discovery is best-effort here
+        entries = []
+    for entry in entries:
+        path = getattr(entry, "project_path", None)
+        if path is None:
+            continue
+        try:
+            slug = git.remote_slug(repo=str(path))
+        except Exception:  # noqa: BLE001 — a missing remote must not block the probe
+            slug = ""
+        _add(slug)
+
+    return candidates
+
+
+def _reconcile_slug_against_reviewed_sha(
+    *,
+    initial_slug: str,
+    pr_id: int,
+    reviewed_sha: str,
+    host_kind: str,
+) -> str:
+    """Pick the right repo when *initial_slug*'s PR doesn't carry *reviewed_sha* (#1335).
+
+    The initial slug is what :func:`resolve_pr_repo_slug` returned: an
+    explicit ``owner/repo`` from the CLEAR, the ticket's ``issue_url``
+    repo, or — the #1335 trap — the running clone's ``origin`` for a
+    CLEAR with no ticket and a non-``owner/repo`` slug. When that initial
+    slug's PR head SHA matches *reviewed_sha* the merge proceeds against
+    it unchanged (the common path). When the SHAs disagree, the same
+    PR number may live in a downstream overlay's repo at the right SHA;
+    the probe enumerates :func:`_iter_candidate_repo_slugs` and returns
+    the first candidate whose ``pulls/<N>`` head matches.
+
+    No reviewed SHA, no probe (back-compat with legacy callers that did
+    not carry the SHA). No candidate match raises a
+    :class:`MergePreconditionError` whose message names every candidate
+    considered so the diagnosis is unambiguous — never the opaque "head
+    moved" escalation that hid the #1335 bug.
+    """
+    if not reviewed_sha:
+        return initial_slug
+    initial_live = fetch_live_head_sha(initial_slug, pr_id, host_kind=host_kind)
+    if initial_live == reviewed_sha:
+        return initial_slug
+    if not initial_live:
+        # The forge call failed (missing credentials, network) or returned an
+        # empty payload — that's a transient/auth condition, not a cross-repo
+        # confusion. Defer to ``assert_merge_preconditions``, which raises the
+        # established "could not resolve the live head" error against the
+        # initial slug.
+        return initial_slug
+    candidates = _iter_candidate_repo_slugs()
+    # The initial slug was already probed above — exclude it from the secondary
+    # set so the candidates list in the error message reflects what was probed.
+    other_candidates = [c for c in candidates if c != initial_slug]
+    match = _probe_candidate_repos(
+        pr_id=pr_id,
+        reviewed_sha=reviewed_sha,
+        candidates=other_candidates,
+        host_kind=host_kind,
+    )
+    if match:
+        logger.info(
+            "merge_execution: cross-repo recovery for #%s — initial slug %r "
+            "live=%s != reviewed=%s; probed %s, matched %r",
+            pr_id,
+            initial_slug,
+            initial_live or "(unresolved)",
+            reviewed_sha,
+            other_candidates,
+            match,
+        )
+        return match
+    considered = [initial_slug, *other_candidates]
+    msg = (
+        f"PR head moved: live={initial_live or '(unresolved)'} != "
+        f"reviewed={reviewed_sha} on the initial repo ({initial_slug!r}), and "
+        f"no other candidate repo's PR #{pr_id} carries that SHA either. "
+        f"Candidates considered: {considered}. This is either a genuine "
+        f"force-push / new commits on the PR, or the CLEAR was issued from a "
+        f"clone whose overlay registry doesn't include the target repo. "
+        f"Re-escalate; the loop never self-issues a replacement "
+        f"(§17.4.3 step 2 / #1335)."
+    )
+    raise MergePreconditionError(msg)
+
+
+def _probe_candidate_repos(
+    *,
+    pr_id: int,
+    reviewed_sha: str,
+    candidates: list[str],
+    host_kind: str,
+) -> str:
+    """Return the candidate ``owner/repo`` whose PR <pr_id> head == *reviewed_sha*.
+
+    Iterates candidates in order and returns the first whose live head
+    SHA matches *reviewed_sha* — the #1335 recovery path: when the
+    initially-resolved repo's PR is an unrelated same-numbered PR, this
+    finds the repo that actually owns the reviewed work. Returns ``""``
+    when no candidate matches (a real force-push or a truly stale CLEAR).
+    """
+    for slug in candidates:
+        if fetch_live_head_sha(slug, pr_id, host_kind=host_kind) == reviewed_sha:
+            return slug
+    return ""
 
 
 def fetch_live_head_sha(slug: str, pr_id: int, *, host_kind: str = "github") -> str:
@@ -992,6 +1135,12 @@ def merge_ticket_pr(
     slug = resolve_pr_repo_slug(clear)
     pr_id = clear.pr_id
     host_kind = _resolve_host_kind(clear)
+    slug = _reconcile_slug_against_reviewed_sha(
+        initial_slug=slug,
+        pr_id=pr_id,
+        reviewed_sha=str(getattr(clear, "reviewed_sha", "") or ""),
+        host_kind=host_kind,
+    )
     precheck = assert_merge_preconditions(
         clear=clear,
         executing_loop_identity=executing_loop_identity,

--- a/tests/teatree_core/test_merge_execution_cross_repo.py
+++ b/tests/teatree_core/test_merge_execution_cross_repo.py
@@ -1,0 +1,245 @@
+"""Cross-repo PR resolution — probe candidate repos on SHA mismatch (#1335).
+
+A CLEAR issued from the teatree clone for a PR in a DIFFERENT GitHub repo
+(a downstream overlay's repo, e.g. ``downstream-org/downstream-overlay#159``)
+used to resolve to the running clone's ``origin`` (``souliane/teatree``)
+whenever the CLEAR carried no ticket and its slug wasn't ``owner/repo``-
+shaped. The engine then fetched the head SHA of an unrelated PR with the
+same number in ``souliane/teatree``, and the §17.4.3 SHA-bind step raised
+"PR head moved" — the CLEAR went stale on a SHA mismatch, even though a
+different registered overlay's repo did own the right PR at the reviewed
+SHA. The concrete downstream repo name is not load-bearing (BLUEPRINT § 1).
+
+These tests pin Path 1 from #1335: when the resolved repo's PR #N head SHA
+does NOT match ``reviewed_sha``, the engine probes other candidate repos
+(every registered overlay's ``project_path`` ``origin`` plus the running
+clone's ``origin``) and picks the one whose ``pulls/<N>`` head SHA matches.
+If no candidate matches, the engine raises a clear error naming every
+candidate it considered.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.config import OverlayEntry
+from teatree.core.merge_execution import MergePreconditionError, merge_ticket_pr
+from teatree.core.models import MergeClear
+
+pytestmark = pytest.mark.django_db
+
+_RIGHT_SHA = "a" * 40  # the reviewed SHA on the cross-repo PR
+_WRONG_SHA = "b" * 40  # the unrelated same-numbered PR on the clone origin
+_GREEN = '[{"status": "COMPLETED", "conclusion": "SUCCESS"}]'
+
+_CLONE_ORIGIN = "souliane/teatree"
+_OVERLAY_REPO = "downstream-org/downstream-overlay"
+
+
+def _cross_repo_clear() -> MergeClear:
+    """A CLEAR shaped like CLEAR 22 from the #1335 incident.
+
+    No ``ticket`` (reusing the §872 ``ticketless_clear_falls_through`` path
+    in :func:`resolve_pr_repo_slug`), a workstream-shaped slug, and a
+    ``pr_id`` whose number happens to exist as an unrelated PR in the
+    running clone's ``origin``.
+    """
+    return MergeClear.objects.create(
+        ticket=None,
+        pr_id=159,
+        slug="fix-ensure-pr-default-branch-153",
+        reviewed_sha=_RIGHT_SHA,
+        reviewer_identity="cold-reviewer",
+        gh_verify_result=MergeClear.VerifyResult.GREEN,
+        blast_class=MergeClear.BlastClass.LOGIC,
+    )
+
+
+def _gh_keyed_by_repo(calls: list[list[str]], right_repo: str = _OVERLAY_REPO):
+    """``gh`` stub keyed by ``--repo`` argument.
+
+    The right repo's PR head == ``_RIGHT_SHA``; every other repo's PR head
+    is ``_WRONG_SHA``. Which head the precondition sees is decided purely
+    by which repo the sanctioned path targets.
+    """
+
+    def _gh(argv: list[str]) -> tuple[int, str, str]:
+        calls.append(argv)
+        joined = " ".join(argv)
+        repo = argv[argv.index("--repo") + 1] if "--repo" in argv else ""
+        head = _RIGHT_SHA if repo == right_repo else _WRONG_SHA
+        if "headRefOid" in joined:
+            return (0, head, "")
+        if "isDraft" in joined:
+            return (0, "false", "")
+        if "statusCheckRollup" in joined:
+            return (0, _GREEN, "")
+        if "state,mergeCommit" in joined:
+            return (0, '{"state": "OPEN", "mergeCommit": null}', "")
+        if "pulls" in joined and "merge" in joined:
+            return (0, '{"sha": "merged0deadbeef"}', "")
+        return (0, "", "")
+
+    return _gh
+
+
+class TestCrossRepoCandidateProbe(TestCase):
+    """#1335: probe candidate overlay repos when the clone-origin SHA doesn't match.
+
+    The fix path Path 1 from the issue: detect mismatch on the resolved
+    repo (``_project_repo_slug()``), then probe every candidate
+    ``owner/repo`` derivable from the registered overlay project paths,
+    and pick the one whose PR head SHA matches ``reviewed_sha``.
+    """
+
+    def test_probe_finds_overlay_repo_when_clone_origin_pr_is_unrelated(self) -> None:
+        clear = _cross_repo_clear()
+        calls: list[list[str]] = []
+        candidate_entries = [
+            OverlayEntry(name="downstream", overlay_class="", project_path=Path("/clones/downstream-overlay")),
+        ]
+
+        def _remote_slug_for_path(repo: str = ".", remote: str = "origin") -> str:
+            del remote
+            if repo == "/clones/downstream-overlay":
+                return _OVERLAY_REPO
+            return ""
+
+        with (
+            patch(
+                "teatree.core.merge_execution._run_gh",
+                side_effect=_gh_keyed_by_repo(calls),
+            ),
+            patch(
+                "teatree.core.merge_execution._project_repo_slug",
+                return_value=_CLONE_ORIGIN,
+            ),
+            patch(
+                "teatree.core.merge_execution.discover_overlays",
+                return_value=candidate_entries,
+            ),
+            patch(
+                "teatree.core.merge_execution.git.remote_slug",
+                side_effect=_remote_slug_for_path,
+            ),
+        ):
+            outcome = merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
+
+        assert outcome.merged_sha
+        assert outcome.slug == _OVERLAY_REPO, (
+            f"engine must pick the candidate repo whose PR head matches reviewed_sha; got slug={outcome.slug!r}"
+        )
+        # The merge call (`gh api ... pulls/159/merge`) MUST target the overlay repo,
+        # never the clone origin.
+        merge_endpoints = [
+            arg
+            for argv in calls
+            if "merge" in " ".join(argv) and "pulls" in " ".join(argv)
+            for arg in argv
+            if "pulls/" in arg
+        ]
+        assert merge_endpoints
+        assert all(_OVERLAY_REPO in endpoint for endpoint in merge_endpoints), (
+            f"merge endpoint targeted the wrong repo: {merge_endpoints}"
+        )
+
+    def test_no_candidate_match_raises_with_candidates_named(self) -> None:
+        """When every candidate's PR head SHA misses, the error names them.
+
+        The opaque "PR head moved" message was the original #1335 symptom:
+        the agent had no way to tell whether the SHA mismatch was a real
+        force-push or the clone-origin same-numbered confusion. The new
+        error must list every candidate repo considered so the diagnosis
+        is unambiguous.
+        """
+        clear = _cross_repo_clear()
+        candidate_entries = [
+            OverlayEntry(name="downstream", overlay_class="", project_path=Path("/clones/downstream-overlay")),
+        ]
+
+        # No repo returns _RIGHT_SHA — both clone-origin and overlay return _WRONG_SHA.
+        def _gh_all_wrong(argv: list[str]) -> tuple[int, str, str]:
+            joined = " ".join(argv)
+            if "headRefOid" in joined:
+                return (0, _WRONG_SHA, "")
+            if "isDraft" in joined:
+                return (0, "false", "")
+            if "statusCheckRollup" in joined:
+                return (0, _GREEN, "")
+            return (0, "", "")
+
+        def _remote_slug_for_path(repo: str = ".", remote: str = "origin") -> str:
+            del remote
+            if repo == "/clones/downstream-overlay":
+                return _OVERLAY_REPO
+            return ""
+
+        with (
+            patch("teatree.core.merge_execution._run_gh", side_effect=_gh_all_wrong),
+            patch(
+                "teatree.core.merge_execution._project_repo_slug",
+                return_value=_CLONE_ORIGIN,
+            ),
+            patch(
+                "teatree.core.merge_execution.discover_overlays",
+                return_value=candidate_entries,
+            ),
+            patch(
+                "teatree.core.merge_execution.git.remote_slug",
+                side_effect=_remote_slug_for_path,
+            ),
+            pytest.raises(MergePreconditionError) as exc,
+        ):
+            merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
+
+        message = str(exc.value)
+        assert _CLONE_ORIGIN in message
+        assert _OVERLAY_REPO in message
+        assert "candidate" in message.lower()
+
+    def test_resolved_repo_matches_skip_probe(self) -> None:
+        """Happy path: when the resolved repo's PR matches, no probe runs.
+
+        The probe is the recovery path for the cross-repo mismatch; in the
+        common case the resolved repo IS the right repo and the merge
+        proceeds with no extra ``gh`` calls.
+        """
+        clear = _cross_repo_clear()
+        calls: list[list[str]] = []
+        # The clone origin owns the matching SHA — no need to probe overlays.
+        candidate_entries = [
+            OverlayEntry(name="downstream", overlay_class="", project_path=Path("/clones/downstream-overlay")),
+        ]
+
+        def _remote_slug_for_path(repo: str = ".", remote: str = "origin") -> str:
+            del remote
+            if repo == "/clones/downstream-overlay":
+                return _OVERLAY_REPO
+            return ""
+
+        with (
+            patch(
+                "teatree.core.merge_execution._run_gh",
+                side_effect=_gh_keyed_by_repo(calls, right_repo=_CLONE_ORIGIN),
+            ),
+            patch(
+                "teatree.core.merge_execution._project_repo_slug",
+                return_value=_CLONE_ORIGIN,
+            ),
+            patch(
+                "teatree.core.merge_execution.discover_overlays",
+                return_value=candidate_entries,
+            ),
+            patch(
+                "teatree.core.merge_execution.git.remote_slug",
+                side_effect=_remote_slug_for_path,
+            ),
+        ):
+            outcome = merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
+
+        assert outcome.slug == _CLONE_ORIGIN
+        # No overlay-repo probe call was made.
+        overlay_calls = [argv for argv in calls if _OVERLAY_REPO in " ".join(argv)]
+        assert not overlay_calls, f"probe must not run when resolved repo's PR head matches: {overlay_calls}"


### PR DESCRIPTION
## Summary

Resolves #1335. Today's CLEAR 22 for a cross-repo PR (a downstream overlay's
GitHub repo, different from the running teatree clone's `origin`) failed
because `merge_execution.resolve_pr_repo_slug` fell through to the running
clone's `origin` (`souliane/teatree`), then `fetch_live_head_sha` returned
the head SHA of an unrelated PR with the same number in `souliane/teatree`.
The §17.4.3 SHA-bind step raised "PR head moved", and the merge went stale
on a SHA mismatch — even though a registered overlay's repo did own the
right PR at the reviewed SHA.

This implements Path 1 from the issue body (probe candidate repos) — the
non-breaking option. Paths 2 (require \`--repo\` on \`ticket clear\`) and 3
(persist \`target_repo\` on the CLEAR row) were both more invasive without
solving the back-compat case where the resolution falls through silently.

## What changes

\`merge_ticket_pr\` now interposes \`_reconcile_slug_against_reviewed_sha\`
between \`resolve_pr_repo_slug\` and \`assert_merge_preconditions\`:

1. Fetch the live head SHA against the resolved slug (the existing path).
2. If it matches \`reviewed_sha\`, proceed unchanged — no extra \`gh\` calls
   in the common case.
3. If it does not match and the SHA was non-empty, enumerate every
   registered overlay's \`project_path\` \`origin\` slug via
   \`discover_overlays()\` + \`git.remote_slug()\` (the same helper
   \`_project_repo_slug\` and \`dev_repo.resolve_dev_repo\` already use).
4. Probe each candidate's \`pulls/<N>\` head SHA; pick the first whose SHA
   matches \`reviewed_sha\` and rebind the merge to that slug.
5. If no candidate matches, raise \`MergePreconditionError\` naming every
   candidate considered — never the opaque "head moved" message that hid
   the original incident.

If the initial probe returned an empty live SHA (\`gh\` failed / auth /
network), defer to \`assert_merge_preconditions\` so the established
"could not resolve the live head" error still fires unchanged.

## Candidate-repo resolver

The enumeration uses \`teatree.config.discover_overlays()\` — the same
entry-point + TOML overlay registry that \`dev_repo.resolve_dev_repo\`
already consults — and reads each entry's \`project_path\` \`origin\`
remote via \`git.remote_slug\`. This matches the existing pattern; no
new helper introduced beyond the local \`_iter_candidate_repo_slugs\`
and \`_probe_candidate_repos\` functions in \`merge_execution.py\`.
(\`backend_factory.code_host_from_overlay\` was considered but only
returns a backend object, not a repo slug — the existing pattern via
overlay project paths is the smallest-surface fit.)

## Test plan

- [x] TDD red/green/anti-vacuous: new \`test_merge_execution_cross_repo.py\`
  with the CLEAR 22 shape (no ticket, workstream-shaped slug, PR #N
  whose number happens to exist in the clone origin). With the fix
  reverted, the test fails exactly with the incident error: \`PR head
  moved: live=bbb… != reviewed=aaa…\`. With the fix, the engine probes
  the candidate overlay repo and merges against it.
- [x] Adversarial: \`test_no_candidate_match_raises_with_candidates_named\`
  pins the new error message naming every candidate considered.
- [x] Happy-path regression: \`test_resolved_repo_matches_skip_probe\`
  pins that no extra probe runs when the resolved slug's SHA matches.
- [x] Full \`tests/teatree_core/\` suite (2378 passed, 12 skipped, 37
  subtests) — no regressions.
- [x] \`prek run\` on the changed files green (ruff, ty-check, banned-
  terms, tach, all hooks).