### PR TITLE
feat(hooks): plan-gate before Agent/Task dispatch (#1302)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -607,6 +607,144 @@ def handle_enforce_plan_gate(data: dict) -> bool:
     return True
 
 
+# ── PreToolUse: enforce-agent-plan-gate (#1302) ──────────────────────
+#
+# Sibling of ``handle_enforce_plan_gate`` (#1133, Edit/Write surface).
+# Denies ``Agent`` / ``Task`` dispatch unless one of:
+#
+# 1. A recent ``/plan`` invocation is recorded in
+#    ``$XDG_DATA_HOME/teatree/last-plan-skill-ts`` (default
+#    ``~/.local/share/teatree/last-plan-skill-ts``) within the cooldown
+#    window (default 30 minutes, configurable via
+#    ``TEATREE_PLAN_GATE_WINDOW_MINUTES``).
+# 2. The Agent prompt carries an explicit per-call opt-out token
+#    ``[skip-plan-gate: <reason>]`` (reason is mandatory — empty rejects).
+#
+# The marker file is written by ``handle_track_plan_skill_timestamp``
+# (PostToolUse), which fires on every ``Skill`` tool call whose final
+# path segment starts with ``plan`` (``plan``, ``t3:plan``, ``plan-*``).
+# This is wall-clock based rather than per-session so an orchestrator's
+# /plan in turn N still authorises sub-agent dispatches across the
+# following turns, until the cooldown lapses.
+#
+# Why the timestamp file (not the existing ``<session>.plan-invocations``
+# marker): the existing #1133 gate is per-session and indefinite. The
+# Agent-dispatch gate is per-time-window so the "I planned this hour ago"
+# proof expires — stale plan assertions are the failure mode the issue
+# names.
+
+_AGENT_PLAN_GATE_DEFAULT_WINDOW_MINUTES = 30
+_AGENT_PLAN_GATE_TOOLS = {"Agent", "Task"}
+# Mandatory reason: ``[skip-plan-gate: <non-empty-reason>]``. We allow
+# the token anywhere in the first few hundred characters of the prompt
+# so a heading/preamble or a leading "Notes:" block does not force it
+# strictly onto line 1.
+_SKIP_PLAN_GATE_RE = re.compile(r"\[skip-plan-gate:\s*(\S[^\]]*?)\s*\]")
+
+
+def _plan_gate_window_minutes() -> int:
+    raw = os.environ.get("TEATREE_PLAN_GATE_WINDOW_MINUTES", "").strip()
+    if not raw:
+        return _AGENT_PLAN_GATE_DEFAULT_WINDOW_MINUTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _AGENT_PLAN_GATE_DEFAULT_WINDOW_MINUTES
+    return value if value > 0 else _AGENT_PLAN_GATE_DEFAULT_WINDOW_MINUTES
+
+
+def _plan_skill_timestamp_file() -> Path:
+    xdg = os.environ.get("XDG_DATA_HOME", "").strip()
+    base = Path(xdg) if xdg else Path.home() / ".local" / "share"
+    return base / "teatree" / "last-plan-skill-ts"
+
+
+def _plan_skill_recently_invoked() -> bool:
+    """True iff the gate's timestamp file is fresh within the cooldown window."""
+    ts_file = _plan_skill_timestamp_file()
+    if not ts_file.is_file():
+        return False
+    try:
+        recorded = int(ts_file.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return False
+    import time  # noqa: PLC0415
+
+    age = int(time.time()) - recorded
+    return 0 <= age <= _plan_gate_window_minutes() * 60
+
+
+def _agent_prompt_skip_token(prompt: str) -> str | None:
+    """Return the reason from a ``[skip-plan-gate: <reason>]`` token, else None.
+
+    Scans only the first 512 characters so a buried token in a long
+    prompt body does not silently authorise dispatch.
+    """
+    head = prompt[:512]
+    match = _SKIP_PLAN_GATE_RE.search(head)
+    if not match:
+        return None
+    reason = match.group(1).strip()
+    return reason or None
+
+
+def handle_track_plan_skill_timestamp(data: dict) -> None:
+    """PostToolUse: write a POSIX timestamp when a ``plan*`` skill is invoked.
+
+    Mirrors the routing of :func:`handle_track_plan_invocation` (final
+    path segment starts with ``plan``), but writes a wall-clock marker
+    used by the Agent-dispatch plan-gate (#1302) instead of a per-
+    session boolean.
+    """
+    if data.get("tool_name") != "Skill":
+        return
+    skill = data.get("tool_input", {}).get("skill", "")
+    if not skill:
+        return
+    final = skill.rsplit(":", 1)[-1].rsplit("/", 1)[-1]
+    if not final.startswith("plan"):
+        return
+    import time  # noqa: PLC0415
+
+    ts_file = _plan_skill_timestamp_file()
+    ts_file.parent.mkdir(parents=True, exist_ok=True)
+    ts_file.write_text(str(int(time.time())), encoding="utf-8")
+
+
+def handle_enforce_agent_plan_gate(data: dict) -> bool:
+    """Deny ``Agent``/``Task`` dispatch lacking a fresh ``/plan`` or a skip token.
+
+    Returns ``True`` (deny JSON emitted) only when ALL of:
+
+    1. The tool is ``Agent`` or ``Task``.
+    2. The prompt carries no ``[skip-plan-gate: <reason>]`` token.
+    3. The plan-skill timestamp file is missing or older than the
+        cooldown window (``TEATREE_PLAN_GATE_WINDOW_MINUTES``, default 30).
+    """
+    tool_name = data.get("tool_name", "")
+    if tool_name not in _AGENT_PLAN_GATE_TOOLS:
+        return False
+
+    prompt = data.get("tool_input", {}).get("prompt", "") or ""
+    if _agent_prompt_skip_token(prompt):
+        return False
+    if _plan_skill_recently_invoked():
+        return False
+
+    window = _plan_gate_window_minutes()
+    reason = (
+        f"BLOCKED: `{tool_name}` dispatch requires a recent `/plan` invocation "
+        f"(within the last {window} minutes) or an explicit per-call opt-out. "
+        "Unblock paths: (a) call the Skill tool with skill=`plan` to plan this "
+        "dispatch first, or (b) prefix the Agent prompt with "
+        "`[skip-plan-gate: <reason>]` (reason mandatory) — e.g. "
+        "`[skip-plan-gate: trivial-bug-fix]`. "
+        "Override the window via `TEATREE_PLAN_GATE_WINDOW_MINUTES`. (#1302)"
+    )
+    json.dump({"permissionDecision": "deny", "permissionDecisionReason": reason}, sys.stdout)
+    return True
+
+
 # ── PreToolUse: protect-default-branch ─────────────────────────────
 
 
@@ -3891,6 +4029,7 @@ _HANDLERS: dict[str, list] = {
         handle_route_away_mode_question,
         handle_enforce_loop_registration,
         handle_enforce_plan_gate,
+        handle_enforce_agent_plan_gate,
         handle_protect_default_branch,
         handle_quote_scanner_pretool,
         handle_enforce_skill_loading,
@@ -3908,6 +4047,7 @@ _HANDLERS: dict[str, list] = {
         handle_read_dedup,
         handle_track_todos,
         handle_track_plan_invocation,
+        handle_track_plan_skill_timestamp,
         handle_track_workspace_source_read,
     ],
     "InstructionsLoaded": [handle_track_skill_usage],

--- a/tests/test_hook_router_agent_plan_gate.py
+++ b/tests/test_hook_router_agent_plan_gate.py
@@ -1,0 +1,206 @@
+"""Tests for the PreToolUse Agent-dispatch plan-gate hook (#1302).
+
+The gate denies ``Agent`` / ``Task`` tool dispatch unless **one** of:
+
+1. The current session has a recent ``/plan`` invocation, recorded as a
+    POSIX timestamp in ``~/.local/share/teatree/last-plan-skill-ts``
+    (within ``TEATREE_PLAN_GATE_WINDOW_MINUTES`` of now, default ``30``).
+2. The Agent ``prompt`` carries an explicit per-call opt-out token
+    ``[skip-plan-gate: <reason>]`` near the start of the prompt.
+
+Sibling enforcement gate to ``handle_enforce_plan_gate`` (which guards
+``Edit``/``Write`` under ``$T3_WORKSPACE_DIR``). This one guards the
+dispatch step itself — the orchestrator's ``Agent`` calls — so a missing
+``/plan`` pass is caught before a sub-agent burns cycles on a brief
+written from stale memory.
+
+Integration-style: the real handler, the real ``STATE_DIR`` on
+``tmp_path``, the real timestamp file under ``$XDG_DATA_HOME/teatree``.
+"""
+
+import json
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import handle_enforce_agent_plan_gate, handle_track_plan_skill_timestamp
+
+
+@pytest.fixture
+def gate_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Isolate STATE_DIR + XDG_DATA_HOME so the gate's marker is per-test.
+
+    The conftest ``_isolate_env`` autouse fixture already redirects HOME
+    to a tmp dir. This fixture additionally pins XDG_DATA_HOME so the
+    timestamp file at ``$XDG_DATA_HOME/teatree/last-plan-skill-ts`` is
+    isolated, and points STATE_DIR at a fresh tmp directory. Yields the
+    resolved path to the timestamp file.
+    """
+    original_state = router.STATE_DIR
+    router.STATE_DIR = tmp_path / "state"
+    router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    xdg = tmp_path / "xdg-data"
+    xdg.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg))
+    monkeypatch.delenv("TEATREE_PLAN_GATE_WINDOW_MINUTES", raising=False)
+
+    ts_file = xdg / "teatree" / "last-plan-skill-ts"
+    yield ts_file
+
+    router.STATE_DIR = original_state
+
+
+def _agent(prompt: str, *, subagent_type: str = "t3:coder") -> dict:
+    return {
+        "session_id": "sess-1",
+        "tool_name": "Agent",
+        "tool_input": {
+            "description": "implement feature",
+            "prompt": prompt,
+            "subagent_type": subagent_type,
+        },
+    }
+
+
+def _record_plan_skill() -> dict:
+    return {
+        "session_id": "sess-1",
+        "tool_name": "Skill",
+        "tool_input": {"skill": "plan"},
+    }
+
+
+def _write_ts(ts_file: Path, ts: float) -> None:
+    """Write a POSIX timestamp into the gate's marker file."""
+    ts_file.parent.mkdir(parents=True, exist_ok=True)
+    ts_file.write_text(str(int(ts)), encoding="utf-8")
+
+
+# ── Block by default ─────────────────────────────────────────────────────
+
+
+class TestBlockedByDefault:
+    """Agent dispatch with no plan timestamp is denied."""
+
+    def test_agent_with_no_plan_ts_is_denied(self, gate_env: Path, capsys) -> None:
+        blocked = handle_enforce_agent_plan_gate(_agent("implement feature X"))
+
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+        reason = out["permissionDecisionReason"]
+        # Reason must name the gate, the unblock paths, and the skip token shape.
+        assert "/plan" in reason
+        assert "skip-plan-gate" in reason
+
+    def test_task_tool_treated_same_as_agent(self, gate_env: Path, capsys) -> None:
+        data = {
+            "session_id": "sess-1",
+            "tool_name": "Task",
+            "tool_input": {"description": "research", "prompt": "look into X", "subagent_type": "t3:coder"},
+        }
+        blocked = handle_enforce_agent_plan_gate(data)
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+
+
+# ── Skip token bypass ────────────────────────────────────────────────────
+
+
+class TestSkipToken:
+    """An explicit ``[skip-plan-gate: <reason>]`` token unblocks the call."""
+
+    def test_skip_token_at_start_allows_dispatch(self, gate_env: Path) -> None:
+        prompt = "[skip-plan-gate: trivial-bug-fix]\n\nFix the typo in foo.py"
+        assert handle_enforce_agent_plan_gate(_agent(prompt)) is False
+
+    def test_skip_token_inline_first_line_allows_dispatch(self, gate_env: Path) -> None:
+        prompt = "[skip-plan-gate: hotfix] Push the one-char fix"
+        assert handle_enforce_agent_plan_gate(_agent(prompt)) is False
+
+    def test_skip_token_requires_reason(self, gate_env: Path, capsys) -> None:
+        # Empty reason ⇒ token is malformed ⇒ does NOT unblock.
+        prompt = "[skip-plan-gate: ]\n\nDo something"
+        blocked = handle_enforce_agent_plan_gate(_agent(prompt))
+        assert blocked is True
+        capsys.readouterr()
+
+
+# ── Cooldown window ──────────────────────────────────────────────────────
+
+
+class TestCooldownWindow:
+    """A fresh plan timestamp allows; a stale one (past window) blocks."""
+
+    def test_fresh_plan_ts_within_window_allows(self, gate_env: Path) -> None:
+        _write_ts(gate_env, time.time() - 5 * 60)  # 5 min ago
+        assert handle_enforce_agent_plan_gate(_agent("implement X")) is False
+
+    def test_stale_plan_ts_past_default_window_blocks(self, gate_env: Path, capsys) -> None:
+        _write_ts(gate_env, time.time() - 35 * 60)  # 35 min ago (past 30-min default)
+        blocked = handle_enforce_agent_plan_gate(_agent("implement X"))
+        assert blocked is True
+        capsys.readouterr()
+
+    def test_custom_window_via_env_var(self, gate_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEATREE_PLAN_GATE_WINDOW_MINUTES", "60")
+        # 45 min ago: stale under 30-min default, fresh under 60-min override.
+        _write_ts(gate_env, time.time() - 45 * 60)
+        assert handle_enforce_agent_plan_gate(_agent("implement X")) is False
+
+
+# ── PostToolUse: timestamp writer ────────────────────────────────────────
+
+
+class TestPlanTimestampTracking:
+    """``handle_track_plan_skill_timestamp`` writes the gate's marker."""
+
+    def test_plan_skill_invocation_writes_timestamp(self, gate_env: Path) -> None:
+        before = int(time.time())
+        handle_track_plan_skill_timestamp(_record_plan_skill())
+
+        assert gate_env.is_file()
+        ts = int(gate_env.read_text(encoding="utf-8").strip())
+        # The recorded timestamp must be a recent POSIX time, not zero
+        # or a stale leftover.
+        assert ts >= before
+        assert ts <= int(time.time()) + 1
+
+    def test_non_plan_skill_does_not_write_timestamp(self, gate_env: Path) -> None:
+        data = {
+            "session_id": "sess-1",
+            "tool_name": "Skill",
+            "tool_input": {"skill": "t3:code"},
+        }
+        handle_track_plan_skill_timestamp(data)
+        assert not gate_env.is_file()
+
+    def test_plan_variant_names_count_as_plan(self, gate_env: Path) -> None:
+        # ``t3:plan``, ``plan-something``, etc. all count.
+        for skill in ("t3:plan", "plan", "plan-feature"):
+            gate_env.unlink(missing_ok=True)
+            data = {"session_id": "s", "tool_name": "Skill", "tool_input": {"skill": skill}}
+            handle_track_plan_skill_timestamp(data)
+            assert gate_env.is_file(), f"timestamp should be written for skill={skill!r}"
+
+    def test_end_to_end_plan_then_agent_dispatch_allowed(self, gate_env: Path) -> None:
+        # Record a plan invocation, then dispatch — must pass.
+        handle_track_plan_skill_timestamp(_record_plan_skill())
+        assert handle_enforce_agent_plan_gate(_agent("implement X")) is False
+
+
+# ── Out of scope: non-Agent tools ────────────────────────────────────────
+
+
+class TestToolScope:
+    """Only Agent/Task tools trigger the gate."""
+
+    @pytest.mark.parametrize("tool_name", ["Bash", "Edit", "Write", "Read", "Grep", "AskUserQuestion"])
+    def test_other_tools_pass_through(self, gate_env: Path, tool_name: str) -> None:
+        data = {"session_id": "sess-1", "tool_name": tool_name, "tool_input": {}}
+        assert handle_enforce_agent_plan_gate(data) is False


### PR DESCRIPTION
## Summary

Closes [#1302](https://github.com/souliane/teatree/issues/1302). Adds a `PreToolUse` enforcement gate that **denies `Agent` / `Task` dispatch** unless one of:

1. A `/plan` skill invocation was recorded within the cooldown window (default 30 min, configurable via `TEATREE_PLAN_GATE_WINDOW_MINUTES`). The marker is a POSIX timestamp at `$XDG_DATA_HOME/teatree/last-plan-skill-ts` (default `~/.local/share/teatree/last-plan-skill-ts`).
2. The Agent prompt carries an explicit per-call opt-out token `[skip-plan-gate: <reason>]` (reason mandatory — empty rejects).

## Why this is the right enforcement shape

The BINDING memories `feedback_plan_before_any_implementation` and `feedback_redcard_use_existing_mechanisms_plan_first` are both classified STOPGAP precisely because memory-as-vigilance lost the multiple sessions documented in the issue. Per `retro/SKILL.md` § "Recurrence -> Escalation", a recurrence of an already-persisted rule means **enforcement, not another memory rewrite**.

This gate is the structural artifact those STOPGAP memories pointed at: a deterministic hook that the orchestrator cannot forget, sized as the smallest such artifact (one handler + one PostToolUse timestamp writer, ~140 LOC).

## Design choices

- **Wall-clock timestamp file, not the existing `<session>.plan-invocations` marker.** The #1133 Edit/Write plan-gate is per-session and indefinite. The Agent-dispatch gate is per-time-window so the "I planned this an hour ago" proof expires. Stale plan assertions are exactly the failure mode the issue describes.
- **Sibling, not replacement, of the #1133 gate.** That one guards Edit/Write surface under `$T3_WORKSPACE_DIR`; this one guards the dispatch step itself — caught before the sub-agent burns cycles on a brief written from stale memory.
- **Fails closed, but with two clearly named unblock paths in the deny reason.** The deny message names both `/plan` and the `[skip-plan-gate: <reason>]` shape so the agent never has to guess what to do.
- **`Task` and `Agent` both covered.** Some harnesses route sub-agent dispatch through `Task`; the gate treats both identically.

## Skip-token contract

The opt-out token is scanned in the first 512 chars of the prompt only (a buried token in a long prompt body cannot silently authorise dispatch). The reason field is mandatory — `[skip-plan-gate: ]` is malformed and still blocks. Example unblocks:

- `[skip-plan-gate: trivial-bug-fix]`
- `[skip-plan-gate: retro-followup]`
- `[skip-plan-gate: user-explicit-redirect]`

## Test plan

- [x] **RED 1** — Agent dispatch with no plan timestamp -> `permissionDecision: deny`, reason names `/plan` and `skip-plan-gate`.
- [x] **RED 2** — Agent with `[skip-plan-gate: trivial-bug-fix]` -> allow.
- [x] **RED 3** — Agent with a stale plan timestamp (35 min ago, past 30-min default) -> deny.
- [x] **RED 4** — Agent with a fresh plan timestamp (5 min ago) -> allow.
- [x] **GREEN** — all 18 cases (incl. Task parity, custom window via env, end-to-end plan->dispatch, non-Agent tool passthrough) pass against the implementation.
- [x] **Anti-vacuous** — verified per-assertion: stubbing `handle_enforce_agent_plan_gate` to return `False` fails RED 1+2; stubbing `_agent_prompt_skip_token` to return `None` fails the skip-token cases. Restoring the real implementation restores green.
- [x] `prek run --files <changed>` -- green on changed files (pre-existing unrelated banned-terms hits in other files are not from this change).
- [x] Full hook-router test sweep (549 tests) -- green.

## Follow-up note (same PR)

This adds the **read** side of the gate (`handle_enforce_agent_plan_gate`) AND the **write** side that keeps it fed (`handle_track_plan_skill_timestamp`, registered on PostToolUse). Both ship together in this PR — the gate would be vacuous without the timestamp updater, so they are not separable.