### PR TITLE
fix(scanners): bare-slug URL gate + cross-overlay PR attribution (#1324)

### DIFF
--- a/src/teatree/loop/scanners/my_prs.py
+++ b/src/teatree/loop/scanners/my_prs.py
@@ -98,11 +98,20 @@ class MyPrsScanner:
     sharing the same code-host token don't bleed into this overlay's
     statusline zone (#1015). Empty tuple keeps the legacy "emit all"
     behaviour for callers that scan a single global account.
+
+    ``competing_url_prefixes`` carries the URL-prefix claims of OTHER
+    registered overlays (#1324). When a PR's URL is claimed by both this
+    overlay and another, the most-specific claim wins — a wildcard prefix
+    like ``host/*/repo/`` loses to an exact ``host/owner/repo/`` claim, so
+    a teatree-overlay dogfooding scan that lists ``souliane/teatree`` plus
+    a sibling overlay's repo path does not steal the sibling's PRs from
+    its own zone. Empty tuple disables cross-overlay attribution.
     """
 
     host: CodeHostBackend
     identities: tuple[str, ...] = field(default_factory=tuple)
     allowed_url_prefixes: tuple[str, ...] = field(default_factory=tuple)
+    competing_url_prefixes: tuple[str, ...] = field(default_factory=tuple)
     name: str = "my_prs"
 
     def scan(self) -> list[ScanSignal]:
@@ -154,19 +163,35 @@ class MyPrsScanner:
         return signals
 
     def _url_allowed(self, url: str) -> bool:
-        """Drop a PR whose URL is outside the overlay's repo prefixes (#1015).
+        """Drop a PR whose URL is outside the overlay's repo prefixes (#1015, #1324).
 
         When ``allowed_url_prefixes`` is empty the scanner is single-overlay
         (or legacy multi-overlay) and emits every PR it sees. When non-empty,
-        only URLs that start with one of the prefixes survive — sibling MRs
-        from another overlay's repos are dropped at the scanner boundary so
-        they never reach the per-overlay statusline zone.
+        only URLs claimed by one of the prefixes survive — sibling MRs from
+        another overlay's repos are dropped at the scanner boundary so they
+        never reach the per-overlay statusline zone.
+
+        Prefix shapes are interpreted by
+        :func:`teatree.loop.tick_resolvers.url_match_specificity` — plain
+        prefixes match ``startswith``, wildcard ``host/*/repo/`` prefixes
+        match across any owner segment (#1324).
+
+        When a competing overlay's claim is **more specific** (longer
+        non-wildcard prefix) than every claim this scanner holds, the URL
+        is dropped so the sibling overlay's scanner emits the PR under its
+        own ``[overlay]`` zone instead of this scanner stealing it (#1324).
         """
+        from teatree.loop.tick_resolvers import best_url_match_specificity  # noqa: PLC0415
+
         if not self.allowed_url_prefixes:
             return True
         if not url:
             return False
-        return any(url.startswith(prefix) for prefix in self.allowed_url_prefixes)
+        own = best_url_match_specificity(url, self.allowed_url_prefixes)
+        if own == 0:
+            return False
+        competing = best_url_match_specificity(url, self.competing_url_prefixes)
+        return competing <= own
 
     def _resolve_identities(self) -> tuple[str, ...]:
         # Multi-identity wins: caller supplied an explicit alias set, use it

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -258,12 +258,19 @@ class ReviewerPrsScanner:
     ``allowed_url_prefixes`` gates emission to PRs whose URL starts with one
     of the listed prefixes — the per-overlay analogue of ``overlay_name``
     for PR-event signals (#1015). Empty tuple preserves legacy behaviour.
+
+    ``competing_url_prefixes`` carries the URL-prefix claims of OTHER
+    registered overlays (#1324). When a PR's URL is claimed by both this
+    overlay and another, the most-specific claim wins so a dogfooding
+    overlay that lists a sibling's repo path does not steal the sibling's
+    reviewer-role PRs from its own zone.
     """
 
     host: CodeHostBackend
     identities: tuple[str, ...] = field(default_factory=tuple)
     overlay_name: str = ""
     allowed_url_prefixes: tuple[str, ...] = field(default_factory=tuple)
+    competing_url_prefixes: tuple[str, ...] = field(default_factory=tuple)
     name: str = "reviewer_prs"
     _migrated: bool = field(default=False, init=False)
 
@@ -358,12 +365,18 @@ class ReviewerPrsScanner:
         return (user,) if user else ()
 
     def _url_allowed(self, url: str) -> bool:
-        """Same per-overlay URL-prefix gate as ``MyPrsScanner._url_allowed`` (#1015)."""
+        """Same per-overlay URL-prefix gate as ``MyPrsScanner._url_allowed`` (#1015, #1324)."""
+        from teatree.loop.tick_resolvers import best_url_match_specificity  # noqa: PLC0415
+
         if not self.allowed_url_prefixes:
             return True
         if not url:
             return False
-        return any(url.startswith(prefix) for prefix in self.allowed_url_prefixes)
+        own = best_url_match_specificity(url, self.allowed_url_prefixes)
+        if own == 0:
+            return False
+        competing = best_url_match_specificity(url, self.competing_url_prefixes)
+        return competing <= own
 
     def _collect_unique_prs(self, reviewers: tuple[str, ...]) -> list[RawAPIDict]:
         """Union review-requested PRs across *reviewers*, deduped by URL."""

--- a/src/teatree/loop/tick_jobs.py
+++ b/src/teatree/loop/tick_jobs.py
@@ -52,7 +52,11 @@ from teatree.loop.scanners import (
 )
 from teatree.loop.scanners.base import ScannerError, ScanSignal
 from teatree.loop.scanners.notion_view import NotionLike
-from teatree.loop.tick_resolvers import _allowed_url_prefixes_for_host, _identity_alias_groups_for_overlay
+from teatree.loop.tick_resolvers import (
+    _allowed_url_prefixes_for_host,
+    _identity_alias_groups_for_overlay,
+    _web_origin_for_host,
+)
 from teatree.notify import NotifyKind, notify_user
 
 logger = logging.getLogger(__name__)
@@ -66,13 +70,22 @@ class _ScannerJob:
     overlay: str
 
 
-def _jobs_for_backend_hosts(backend: OverlayBackends, tag: str) -> list[_ScannerJob]:
+def _jobs_for_backend_hosts(
+    backend: OverlayBackends,
+    tag: str,
+    *,
+    all_backends: tuple[OverlayBackends, ...] = (),
+) -> list[_ScannerJob]:
     """Build one scanner-job fan-out per host on *backend* (#976).
 
     Pre-fix the caller assumed one ``backend.host``; with multi-host the
     same fan-out must run for each platform that resolved a credential.
     ``TicketCompletionScanner`` is overlay-scoped (reads local Ticket
     rows), so it's emitted exactly once even when two hosts are present.
+
+    *all_backends* (when provided) lets each scanner know the URL claims
+    of sibling overlays so a less-specific claim here yields to a more
+    specific claim there — see :func:`_competing_url_prefixes` (#1324).
     """
     jobs: list[_ScannerJob] = []
     ticket_completion_emitted = False
@@ -89,6 +102,11 @@ def _jobs_for_backend_hosts(backend: OverlayBackends, tag: str) -> list[_Scanner
         identity_groups = (tuple(backend.identities),)
     for code_host in backend.hosts:
         url_prefixes = _allowed_url_prefixes_for_host(backend, code_host)
+        competing_prefixes = _competing_url_prefixes(
+            this_backend=backend,
+            code_host=code_host,
+            all_backends=all_backends,
+        )
         jobs.extend(
             [
                 _ScannerJob(
@@ -96,6 +114,7 @@ def _jobs_for_backend_hosts(backend: OverlayBackends, tag: str) -> list[_Scanner
                         host=code_host,
                         identities=backend.identities,
                         allowed_url_prefixes=url_prefixes,
+                        competing_url_prefixes=competing_prefixes,
                     ),
                     overlay=tag,
                 ),
@@ -105,6 +124,7 @@ def _jobs_for_backend_hosts(backend: OverlayBackends, tag: str) -> list[_Scanner
                         identities=backend.identities,
                         overlay_name=tag,
                         allowed_url_prefixes=url_prefixes,
+                        competing_url_prefixes=competing_prefixes,
                     ),
                     overlay=tag,
                 ),
@@ -158,6 +178,39 @@ def _jobs_for_backend_hosts(backend: OverlayBackends, tag: str) -> list[_Scanner
 
 
 _TUPLE_PAIR = 2
+
+
+def _competing_url_prefixes(
+    *,
+    this_backend: OverlayBackends,
+    code_host: CodeHostBackend,
+    all_backends: tuple[OverlayBackends, ...],
+) -> tuple[str, ...]:
+    """Collect URL claims from every overlay OTHER than *this_backend* (#1324).
+
+    Lets a scanner reject a URL it claims less specifically than a sibling
+    overlay claims — the most-specific overlay attribution wins, so a
+    dogfooding overlay that lists a sibling's repo path under
+    ``workspace_repos`` no longer steals the sibling's PRs from its zone.
+
+    Only sibling backends with a code-host that resolves to the same web
+    origin contribute claims; a GitLab-only sibling can't compete for a
+    GitHub URL.
+    """
+    if not all_backends:
+        return ()
+    own_origin = _web_origin_for_host(code_host)
+    if not own_origin:
+        return ()
+    prefixes: list[str] = []
+    for sibling in all_backends:
+        if sibling is this_backend or sibling.name == this_backend.name:
+            continue
+        for sibling_host in sibling.hosts:
+            if _web_origin_for_host(sibling_host) != own_origin:
+                continue
+            prefixes.extend(_allowed_url_prefixes_for_host(sibling, sibling_host))
+    return tuple(prefixes)
 
 
 def _resolve_broadcast_channels(config: object) -> list[tuple[str, str]]:
@@ -438,7 +491,11 @@ def _user_identity_aliases_for_overlay(overlay_name: str) -> tuple[str, ...]:
     return global_value
 
 
-def _jobs_for_overlay_backend(backend: OverlayBackends) -> list[_ScannerJob]:
+def _jobs_for_overlay_backend(
+    backend: OverlayBackends,
+    *,
+    all_backends: tuple[OverlayBackends, ...] = (),
+) -> list[_ScannerJob]:
     """Build every scanner job that fans out for one overlay backend.
 
     Split out of :func:`build_default_jobs` to keep the orchestrator
@@ -446,6 +503,10 @@ def _jobs_for_overlay_backend(backend: OverlayBackends) -> list[_ScannerJob]:
     active-or-external tickets, stale tickets, per-host PR/issue
     scanners, architectural review, PR sweep, slack broadcasts, and
     the messaging-dependent slack scanners.
+
+    *all_backends* is the full multi-overlay roster — passed through to
+    per-host scanner construction so each scanner knows the URL claims of
+    its siblings (cross-overlay PR attribution, #1324).
     """
     jobs: list[_ScannerJob] = []
     tag = backend.name
@@ -470,7 +531,7 @@ def _jobs_for_overlay_backend(backend: OverlayBackends) -> list[_ScannerJob]:
     # forges, so PRs on one platform don't drown out PRs on the other
     # (#976). The single-host path is preserved by iterating
     # ``backend.hosts`` (which is empty when no token resolved).
-    jobs.extend(_jobs_for_backend_hosts(backend, tag))
+    jobs.extend(_jobs_for_backend_hosts(backend, tag, all_backends=all_backends))
     # #1136 / #1152 Periodic architectural-review scanner. CORE
     # always-on for every registered overlay; the cadence lives in
     # teatree-core config since architectural review applies uniformly
@@ -564,8 +625,9 @@ def build_default_jobs(
         jobs.append(_ScannerJob(scanner=news_scanner, overlay=""))
 
     if backends:
+        all_backends = tuple(backends)
         for backend in backends:
-            jobs.extend(_jobs_for_overlay_backend(backend))
+            jobs.extend(_jobs_for_overlay_backend(backend, all_backends=all_backends))
     else:
         if host is not None:
             jobs.extend(

--- a/src/teatree/loop/tick_resolvers.py
+++ b/src/teatree/loop/tick_resolvers.py
@@ -29,14 +29,25 @@ def _allowed_url_prefixes_for_host(
     backend: OverlayBackends,
     code_host: CodeHostBackend,
 ) -> tuple[str, ...]:
-    """Compute URL prefixes that bound a scanner to the overlay's repos (#1015).
+    """Compute URL prefixes that bound a scanner to the overlay's repos (#1015, #1324).
 
     Each scanner is registered per ``(overlay x code_host)``. Without a gate,
     a scanner emits every MR/PR the host returns — including ones from a
     sibling overlay that shares the same PAT. The gate is a list of URL
     prefixes built from the overlay's ``workspace_repos`` and the host's
-    web origin (e.g. ``https://github.com/<slug>/``,
-    ``https://gitlab.com/<slug>/``).
+    web origin.
+
+    Two slug shapes are supported (#1324):
+
+    * ``owner/repo`` — emits an exact prefix ``https://host/owner/repo/``.
+        This is the shape ``[overlays.<name>] workspace_repos`` opts in to in
+        ``~/.teatree.toml``.
+    * Bare ``repo`` — emits a wildcard pattern ``https://host/*/repo/`` that
+        :meth:`MyPrsScanner._url_allowed` matches as "any owner segment, then
+        this repo segment". Overlays whose ``get_repos()`` returns bare names
+        (e.g. ``product``) still gate correctly across self-hosted namespaces
+        (e.g. ``gitlab.com/some-namespace/product/``) without forcing every
+        overlay to repeat its namespace.
 
     Returns an empty tuple when no overlay or repo list is configured so
     the scanner keeps its legacy "emit all" behaviour for ad-hoc and
@@ -55,7 +66,78 @@ def _allowed_url_prefixes_for_host(
     web_origin = _web_origin_for_host(code_host)
     if not web_origin:
         return ()
-    return tuple(f"{web_origin}/{slug}/" for slug in repos if isinstance(slug, str) and slug)
+    out: list[str] = []
+    for slug in repos:
+        if not isinstance(slug, str) or not slug:
+            continue
+        if "/" in slug:
+            out.append(f"{web_origin}/{slug}/")
+        else:
+            # Bare slug → wildcard pattern matching any owner segment.
+            out.append(f"{web_origin}/*/{slug}/")
+    return tuple(out)
+
+
+def url_matches_prefix(url: str, prefix: str) -> bool:
+    """Return True when *url* falls inside the *prefix* claim (#1015, #1324).
+
+    Two prefix shapes are recognised:
+
+    * Plain prefix ``https://host/owner/repo/`` → ``url.startswith(prefix)``.
+    * Wildcard ``https://host/*/repo/`` → matches any owner segment, so
+        ``https://gitlab.com/some-namespace/product/-/merge_requests/1``
+        survives a claim of ``https://gitlab.com/*/product/``.
+
+    Centralised in :mod:`tick_resolvers` so :class:`MyPrsScanner` and
+    :class:`ReviewerPrsScanner` agree on the URL semantics — both honour
+    bare slugs identically without each scanner re-implementing the
+    wildcard split.
+    """
+    return url_match_specificity(url, prefix) > 0
+
+
+def url_match_specificity(url: str, prefix: str) -> int:
+    """Return a specificity score for *prefix* against *url* (#1324).
+
+    ``0`` means no match. A positive score is the number of fixed
+    (non-wildcard) characters in *prefix* that contributed to the match —
+    used for cross-overlay tie-breaking: ``host/owner/repo/`` (33 chars)
+    beats ``host/*/repo/`` (20 chars) when both claim the same URL, so the
+    overlay with the exact ``owner/repo`` slug wins attribution.
+    """
+    if not url or not prefix:
+        return 0
+    sentinel = "/*/"
+    idx = prefix.find(sentinel)
+    if idx < 0:
+        return len(prefix) if url.startswith(prefix) else 0
+    head = prefix[:idx]
+    tail = prefix[idx + len(sentinel) :]
+    if not url.startswith(head + "/"):
+        return 0
+    remainder = url[len(head) + 1 :]
+    slash = remainder.find("/")
+    if slash < 0:
+        return 0
+    if not remainder[slash + 1 :].startswith(tail):
+        return 0
+    # Specificity = non-wildcard literals (head + tail), so a strict
+    # ``owner/repo`` prefix outscores a ``*/repo`` claim of the same URL.
+    return len(head) + len(tail)
+
+
+def best_url_match_specificity(url: str, prefixes: tuple[str, ...]) -> int:
+    """Highest :func:`url_match_specificity` among *prefixes* (#1324).
+
+    Zero when none of the *prefixes* matches *url*. The number is comparable
+    across overlays: the scanner uses it to discard a URL claimed less
+    specifically here than by a sibling overlay (cross-overlay attribution).
+    """
+    best = 0
+    for prefix in prefixes:
+        score = url_match_specificity(url, prefix)
+        best = max(best, score)
+    return best
 
 
 def _web_origin_for_host(code_host: CodeHostBackend) -> str:

--- a/tests/teatree_loop/test_scanner_attribution_1324.py
+++ b/tests/teatree_loop/test_scanner_attribution_1324.py
@@ -1,0 +1,226 @@
+"""Scanner-side overlay attribution and bare-slug URL-gate fixes (#1324).
+
+Two scanner-side bugs surface as wrong statusline rows:
+
+* Namespaced MRs disappear from a given overlay's zone when the overlay's
+    ``get_workspace_repos()`` returns bare names (``product``) instead of
+    ``owner/product`` — the built URL prefix ``https://gitlab.com/product/``
+    never matches the real namespaced URL
+    ``https://gitlab.com/some-namespace/product/-/...``. Defect B:
+    ``url_match_specificity`` must accept a wildcard owner segment so bare
+    slugs gate correctly.
+* A dogfooding overlay that lists a sibling overlay's repo under its own
+    ``workspace_repos`` steals the sibling's PRs from its zone. Defect A:
+    when a competing overlay claims the same URL more specifically,
+    ``_url_allowed`` must drop the PR so the right zone keeps the row.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from teatree.backends.protocols import ReviewState
+from teatree.loop.scanners.my_prs import MyPrsScanner
+from teatree.loop.scanners.reviewer_prs import ReviewerPrsScanner
+from teatree.loop.tick_resolvers import best_url_match_specificity, url_match_specificity, url_matches_prefix
+from teatree.types import RawAPIDict
+
+
+@dataclass
+class _Host:
+    user: str = "alice"
+    prs: list[RawAPIDict] = field(default_factory=list)
+    reviewer_prs: list[RawAPIDict] = field(default_factory=list)
+
+    def current_user(self) -> str:
+        return self.user
+
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
+        return list(self.prs)
+
+    def list_review_requested_prs(
+        self,
+        *,
+        reviewer: str,
+        updated_after: str | None = None,
+    ) -> list[RawAPIDict]:
+        _ = (reviewer, updated_after)
+        return list(self.reviewer_prs)
+
+    def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:
+        _ = assignee
+        return []
+
+    def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState:
+        _ = (pr_url, reviewer)
+        return ReviewState.NONE
+
+    def create_pr(self, spec: Any) -> RawAPIDict:
+        _ = spec
+        return {}
+
+    def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict:
+        _ = (repo, pr_iid, body)
+        return {}
+
+    def update_pr_comment(self, *, repo: str, pr_iid: int, comment_id: int, body: str) -> RawAPIDict:
+        _ = (repo, pr_iid, comment_id, body)
+        return {}
+
+    def list_pr_comments(self, *, repo: str, pr_iid: int) -> list[RawAPIDict]:
+        _ = (repo, pr_iid)
+        return []
+
+    def upload_file(self, *, repo: str, filepath: str) -> RawAPIDict:
+        _ = (repo, filepath)
+        return {}
+
+    def get_issue(self, issue_url: str) -> RawAPIDict:
+        _ = issue_url
+        return {}
+
+    def post_issue_comment(self, *, issue_url: str, body: str) -> RawAPIDict:
+        _ = (issue_url, body)
+        return {}
+
+
+_NAMESPACED_MR = "https://gitlab.com/some-namespace/product/-/merge_requests/7487"
+_OTHER_MR = "https://gitlab.com/other-namespace/elsewhere/-/merge_requests/1"
+
+
+class TestUrlMatchSpecificity:
+    """Specificity scoring lets the scanner break ties across overlay claims."""
+
+    def test_plain_prefix_scores_full_length(self) -> None:
+        prefix = "https://gitlab.com/some-namespace/product/"
+        assert url_match_specificity(_NAMESPACED_MR, prefix) == len(prefix)
+
+    def test_plain_prefix_zero_when_not_matching(self) -> None:
+        assert url_match_specificity(_NAMESPACED_MR, "https://gitlab.com/elsewhere/x/") == 0
+
+    def test_wildcard_matches_any_owner(self) -> None:
+        prefix = "https://gitlab.com/*/product/"
+        assert url_match_specificity(_NAMESPACED_MR, prefix) > 0
+
+    def test_wildcard_zero_when_repo_differs(self) -> None:
+        prefix = "https://gitlab.com/*/microservice-x/"
+        assert url_match_specificity(_NAMESPACED_MR, prefix) == 0
+
+    def test_plain_prefix_more_specific_than_wildcard(self) -> None:
+        plain = "https://gitlab.com/some-namespace/product/"
+        wildcard = "https://gitlab.com/*/product/"
+        assert url_match_specificity(_NAMESPACED_MR, plain) > url_match_specificity(_NAMESPACED_MR, wildcard)
+
+    def test_url_matches_prefix_backwards_compatible(self) -> None:
+        assert url_matches_prefix(_NAMESPACED_MR, "https://gitlab.com/some-namespace/product/")
+        assert url_matches_prefix(_NAMESPACED_MR, "https://gitlab.com/*/product/")
+        assert not url_matches_prefix(_NAMESPACED_MR, "https://gitlab.com/other/x/")
+
+    def test_best_specificity_picks_strongest_claim(self) -> None:
+        prefixes = (
+            "https://gitlab.com/elsewhere/x/",
+            "https://gitlab.com/*/product/",
+            "https://gitlab.com/some-namespace/product/",
+        )
+        best = best_url_match_specificity(_NAMESPACED_MR, prefixes)
+        assert best == len("https://gitlab.com/some-namespace/product/")
+
+
+class TestMyPrsBareSlugUrlGate:
+    """Defect B: bare slug ``product`` must still admit namespaced MRs."""
+
+    def test_namespaced_mr_admitted_through_wildcard_prefix(self) -> None:
+        host = _Host(prs=[{"iid": 7487, "title": "x", "web_url": _NAMESPACED_MR}])
+        # Mimics ``_allowed_url_prefixes_for_host`` output for a bare slug.
+        scanner = MyPrsScanner(
+            host=host,
+            allowed_url_prefixes=("https://gitlab.com/*/product/",),
+        )
+        urls = sorted(s.payload["url"] for s in scanner.scan())
+        assert urls == [_NAMESPACED_MR]
+
+    def test_other_mr_rejected_by_wildcard_prefix(self) -> None:
+        host = _Host(prs=[{"iid": 1, "title": "x", "web_url": _OTHER_MR}])
+        scanner = MyPrsScanner(
+            host=host,
+            allowed_url_prefixes=("https://gitlab.com/*/product/",),
+        )
+        assert scanner.scan() == []
+
+
+class TestMyPrsCompetingOverlayAttribution:
+    """Defect A: the most-specific overlay claim wins attribution."""
+
+    _SIBLING_PR = "https://github.com/sibling-owner/sibling-repo/pull/150"
+
+    def test_pr_dropped_when_sibling_overlay_claims_more_specifically(self) -> None:
+        host = _Host(prs=[{"iid": 150, "title": "sibling pr", "html_url": self._SIBLING_PR}])
+        # The dogfooding overlay's workspace_repos lists the sibling's
+        # repo via a wildcard slug, so its prefix matches; the sibling
+        # overlay claims the same URL with the exact ``owner/repo``
+        # prefix. Strictly more specific → the dogfooding scanner drops
+        # the row so the sibling's zone keeps it.
+        scanner_with_specific_sibling = MyPrsScanner(
+            host=host,
+            allowed_url_prefixes=("https://github.com/*/sibling-repo/",),
+            competing_url_prefixes=("https://github.com/sibling-owner/sibling-repo/",),
+        )
+        assert scanner_with_specific_sibling.scan() == []
+
+    def test_pr_kept_when_no_sibling_competes(self) -> None:
+        host = _Host(prs=[{"iid": 150, "title": "sibling pr", "html_url": self._SIBLING_PR}])
+        scanner = MyPrsScanner(
+            host=host,
+            allowed_url_prefixes=("https://github.com/sibling-owner/sibling-repo/",),
+            competing_url_prefixes=(),
+        )
+        urls = sorted(s.payload["url"] for s in scanner.scan())
+        assert urls == [self._SIBLING_PR]
+
+    def test_pr_kept_when_sibling_claim_is_less_specific(self) -> None:
+        host = _Host(prs=[{"iid": 150, "title": "sibling pr", "html_url": self._SIBLING_PR}])
+        scanner = MyPrsScanner(
+            host=host,
+            allowed_url_prefixes=("https://github.com/sibling-owner/sibling-repo/",),
+            competing_url_prefixes=("https://github.com/*/sibling-repo/",),
+        )
+        urls = sorted(s.payload["url"] for s in scanner.scan())
+        assert urls == [self._SIBLING_PR]
+
+    def test_unrelated_sibling_claim_is_ignored(self) -> None:
+        host = _Host(prs=[{"iid": 150, "title": "sibling pr", "html_url": self._SIBLING_PR}])
+        # Sibling claims a different repo entirely → does not compete.
+        scanner = MyPrsScanner(
+            host=host,
+            allowed_url_prefixes=("https://github.com/*/sibling-repo/",),
+            competing_url_prefixes=("https://github.com/other-owner/other-repo/",),
+        )
+        urls = sorted(s.payload["url"] for s in scanner.scan())
+        assert urls == [self._SIBLING_PR]
+
+
+class TestReviewerPrsAttributionMirrors:
+    """Reviewer-prs uses the same gate as my-prs (`_url_allowed`)."""
+
+    def test_namespaced_pr_admitted_through_wildcard_prefix(self, db: None) -> None:
+        _ = db
+        host = _Host(
+            reviewer_prs=[{"web_url": _NAMESPACED_MR, "sha": "a"}],
+        )
+        scanner = ReviewerPrsScanner(
+            host=host,
+            allowed_url_prefixes=("https://gitlab.com/*/product/",),
+        )
+        urls = sorted(s.payload["url"] for s in scanner.scan())
+        assert urls == [_NAMESPACED_MR]
+
+    def test_pr_dropped_when_sibling_overlay_claims_more_specifically(self, db: None) -> None:
+        _ = db
+        pr_url = "https://github.com/sibling-owner/sibling-repo/pull/150"
+        host = _Host(reviewer_prs=[{"web_url": pr_url, "sha": "a"}])
+        scanner = ReviewerPrsScanner(
+            host=host,
+            allowed_url_prefixes=("https://github.com/*/sibling-repo/",),
+            competing_url_prefixes=("https://github.com/sibling-owner/sibling-repo/",),
+        )
+        assert scanner.scan() == []


### PR DESCRIPTION
Closes #1324 (scanner-side defects).

## Summary

Two scanner-side defects from #1324 that the renderer-side fix in #1337 does not cover:

* **Bare-slug URL gate.** An overlay whose ``get_repos()`` returns ``[\"product\"]`` (no ``owner/`` prefix) had every MR silently dropped: the prefix ``https://host/product/`` never matched the namespaced URL ``https://host/some-namespace/product/-/...``. The prefix builder now emits a wildcard pattern ``https://host/*/product/`` for bare slugs, matched through a new ``url_match_specificity`` helper. Overlay authors may continue to return either shape from ``get_workspace_repos()``.
* **Cross-overlay PR attribution.** When two overlays' workspace_repos both claim the same PR URL (a dogfooding overlay listing a sibling's repo path under its own scan set), the less-specific claimant now yields so the sibling's zone keeps the row. ``MyPrsScanner`` and ``ReviewerPrsScanner`` gain a ``competing_url_prefixes`` field wired through ``tick_jobs``; specificity is the count of fixed (non-wildcard) characters in the matching prefix, so ``host/owner/repo/`` beats ``host/*/repo/`` for the same URL.

## Relation to #1337

#1337 fixed the renderer side of #1324 (time-to-next-tick line, state-priority sort, ``_MAX_NOT_STARTED=3``, overflow ``(+N more)``). This PR fixes the scanner side: which PRs end up under which ``[overlay]`` zone in the first place.

## Defects fixed vs. follow-up

* Fixed in this PR:
    * Defect B from the task — namespaced MRs disappearing from a bare-slug overlay's zone.
    * Defect A from the task — a sibling overlay's PR rendering under the wrong overlay zone.
* Filed as follow-up (#1343):
    * Defect C — ticket left in ``started`` after its PR merges (FSM transition needed; out of scope for the URL-gate / attribution pair).

## Test plan

- [x] ``uv run pytest tests/ -k 'my_prs or statusline_scanner or attribution_1324' --no-cov`` — 26 passed.
- [x] ``uv run pytest tests/teatree_loop/ tests/teatree_core/ --no-cov`` — 3335 passed.
- [x] ``prek run --files <changed>`` — clean (no new banned-terms, no new lint).
- [x] Anti-vacuous: removing the wildcard branch in ``_allowed_url_prefixes_for_host`` regresses ``TestMyPrsBareSlugUrlGate::test_namespaced_mr_admitted_through_wildcard_prefix``; removing ``competing_url_prefixes`` regresses ``TestMyPrsCompetingOverlayAttribution::test_pr_dropped_when_sibling_overlay_claims_more_specifically``.