### PR TITLE
feat(hooks): STOP-on-classifier-deny gate (#1247)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -4014,10 +4014,181 @@ def _consideration_gate(data: dict) -> bool | None:
     return True
 
 
+# ── Classifier-denial STOP gate (#1247) ─────────────────────────────
+#
+# When the auto-mode classifier denies a tool call the agent must STOP
+# and explain (action / reason / minimum-unblock) per the binding
+# "Classifier Denial Protocol" in skills/rules/SKILL.md.  Prose-only
+# enforcement has slipped repeatedly — the gate makes it deterministic:
+#
+# 1. PostToolUse scans every tool_response for the canonical denial
+#    preamble — the exact phrase the harness emits on classifier
+#    deny (see ``_CLASSIFIER_DENIAL_PREAMBLE`` below).  On a match it
+#    writes a per-session marker carrying the action fingerprint
+#    (tool name + short input excerpt).
+# 2. Stop reads the marker.  If present it emits a top-level
+#    ``systemMessage`` reminding the agent to STOP and explain.
+#    Returns True to break the Stop chain so the message survives.
+# 3. The next UserPromptSubmit clears the marker — the fresh user
+#    turn carries the explicit per-call authorisation (or a redirect),
+#    so the gate auto-disarms.
+#
+# Fail-safe-to-empty: handler returns silently on malformed input or
+# missing fields — the hook must NEVER crash the harness.
+
+_CLASSIFIER_DENIAL_PREAMBLE = "denied by the Claude Code auto mode classifier"
+_CLASSIFIER_DENY_MARKER_SUFFIX = "classifier-deny"
+_CLASSIFIER_DENY_ACTION_EXCERPT_MAX = 120
+
+
+_DENIAL_RESPONSE_STRING_KEYS = ("error", "content", "stderr", "stdout", "message", "output", "reason")
+
+
+def _tool_response_strings(tool_response: object) -> list[str]:
+    """Return every string value reachable from ``tool_response`` (shallow).
+
+    The classifier denial can land in ``error``, ``content``, ``stderr``,
+    ``message``, ``output``, or as a bare string.  We scan a fixed set of
+    likely keys rather than recursing — keeps the detector cheap and
+    predictable.  Fail-safe-to-empty on unexpected shapes.
+    """
+    from typing import cast  # noqa: PLC0415
+
+    if isinstance(tool_response, str):
+        return [tool_response]
+    if not isinstance(tool_response, dict):
+        return []
+    response = cast("dict[str, object]", tool_response)
+    out: list[str] = []
+    for key in _DENIAL_RESPONSE_STRING_KEYS:
+        value = response.get(key)
+        if isinstance(value, str):
+            out.append(value)
+    return out
+
+
+def _format_action_excerpt(tool_name: str, tool_input: object) -> str:
+    """Build a short ``<tool_name>: <input>`` excerpt naming the denied action.
+
+    Truncates to ``_CLASSIFIER_DENY_ACTION_EXCERPT_MAX`` characters so the
+    Stop gate's systemMessage stays one line.  Tries the common
+    descriptive keys (``command``, ``file_path``, ``prompt``) before
+    falling back to the repr of the full input.
+    """
+    from typing import cast  # noqa: PLC0415
+
+    name = tool_name if isinstance(tool_name, str) else "tool"
+    excerpt = name
+    if isinstance(tool_input, dict):
+        input_dict = cast("dict[str, object]", tool_input)
+        excerpt = f"{name}: {input_dict!r}"
+        for key in ("command", "file_path", "prompt", "url", "channel"):
+            value = input_dict.get(key)
+            if isinstance(value, str) and value:
+                excerpt = f"{name}: {value}"
+                break
+    if len(excerpt) > _CLASSIFIER_DENY_ACTION_EXCERPT_MAX:
+        excerpt = excerpt[: _CLASSIFIER_DENY_ACTION_EXCERPT_MAX - 1] + "…"
+    return excerpt
+
+
+def handle_track_classifier_denial(data: dict) -> None:
+    """PostToolUse: persist a marker when the classifier denies a tool call.
+
+    Scans the ``tool_response`` payload for the canonical denial preamble
+    and writes ``<session_id>.classifier-deny`` carrying enough context
+    for the Stop gate to name what was denied.  Returns silently on any
+    missing/malformed field — fail-safe-to-empty per the spec.
+    """
+    if not isinstance(data, dict):
+        return
+    session_id = data.get("session_id", "")
+    if not isinstance(session_id, str) or not session_id:
+        return
+    tool_response = data.get("tool_response")
+    if tool_response is None:
+        return
+    strings = _tool_response_strings(tool_response)
+    if not any(_CLASSIFIER_DENIAL_PREAMBLE in s for s in strings):
+        return
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input")
+    excerpt = _format_action_excerpt(tool_name, tool_input)
+    payload = {
+        "tool_name": tool_name if isinstance(tool_name, str) else "",
+        "action": excerpt,
+    }
+    try:
+        _ensure_state_dir()
+        marker = _state_file(session_id, _CLASSIFIER_DENY_MARKER_SUFFIX)
+        marker.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        # Fail-safe: a write failure must not crash the harness.
+        return
+
+
+def handle_classifier_deny_stop_gate(data: dict) -> bool | None:
+    """Stop: emit STOP-and-explain ``systemMessage`` if a denial is pending.
+
+    Returns ``True`` to break the Stop chain (mirrors the consideration
+    gate pattern) when the marker exists.  Otherwise returns ``None``
+    so the rest of the Stop chain runs unchanged.
+    """
+    if not isinstance(data, dict):
+        return None
+    session_id = data.get("session_id", "")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    marker = _state_file(session_id, _CLASSIFIER_DENY_MARKER_SUFFIX)
+    if not marker.is_file():
+        return None
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    action = payload.get("action") or payload.get("tool_name") or "the denied tool call"
+    body = (
+        f"Classifier denied {action}. STOP and explain: action / reason / "
+        'minimum-unblock — per the binding "Classifier Denial Protocol" '
+        "(skills/rules/SKILL.md). Do not retry with a different argument "
+        "shape, decompose the command, or switch tools. Ask the user via "
+        'AskUserQuestion with two options: "Allow it (relax classifier)" '
+        'or "Keep the denial (do it differently)".'
+    )
+    # Stop schema reserves ``hookSpecificOutput.additionalContext`` for
+    # other events — emit the top-level ``systemMessage`` (schema-valid;
+    # non-decision; visible to the agent) so the nag survives.
+    json.dump({"systemMessage": body}, sys.stdout)
+    return True
+
+
+def handle_clear_classifier_deny_marker(data: dict) -> None:
+    """UserPromptSubmit: clear the classifier-deny marker for this session.
+
+    The next user turn re-arms the gate — the user either grants the
+    per-call authorisation explicitly (which the agent now relays) or
+    redirects to a different approach.  Either way the previous denial
+    is no longer the active blocker.
+    """
+    if not isinstance(data, dict):
+        return
+    session_id = data.get("session_id", "")
+    if not isinstance(session_id, str) or not session_id:
+        return
+    marker = _state_file(session_id, _CLASSIFIER_DENY_MARKER_SUFFIX)
+    try:
+        marker.unlink(missing_ok=True)
+    except OSError:
+        return
+
+
 # ── Router ──────────────────────────────────────────────────────────
 
 _HANDLERS: dict[str, list] = {
     "UserPromptSubmit": [
+        handle_clear_classifier_deny_marker,
         handle_enforce_loop_on_prompt,
         handle_todo_freshness_nudge,
         handle_inject_pending_questions,
@@ -4041,6 +4212,7 @@ _HANDLERS: dict[str, list] = {
         handle_mirror_question_to_slack,
     ],
     "PostToolUse": [
+        handle_track_classifier_denial,
         handle_track_active_repo,
         handle_track_skill_usage,
         handle_track_cron_jobs,
@@ -4058,6 +4230,7 @@ _HANDLERS: dict[str, list] = {
     # runs in handle_session_start_bootstrap on source=="compact".
     "SessionEnd": [handle_session_end, handle_session_end_loop_registry, handle_session_end_self_pump],
     "Stop": [
+        handle_classifier_deny_stop_gate,
         handle_enforce_structured_question,
         handle_enforce_answered_questions,
         handle_consideration_gate,

--- a/tests/test_hook_router_classifier_deny_stop.py
+++ b/tests/test_hook_router_classifier_deny_stop.py
@@ -1,0 +1,353 @@
+"""Tests for the classifier-denial STOP gate (#1247).
+
+When the Claude Code auto-mode classifier denies a tool call, the agent must
+STOP and explain (action / reason / minimum-unblock) instead of silently
+retrying with a different argument shape, decomposing the command, or
+switching tools — per the binding "Classifier Denial Protocol".
+
+This is a two-stage hook:
+
+1. **PostToolUse** (``handle_track_classifier_denial``): scans every tool
+    result for the canonical denial string
+    (``"denied by the Claude Code auto mode classifier"``). When detected,
+    persists a per-session marker file containing the action fingerprint
+    (tool_name plus a short input excerpt) so the Stop gate can name what
+    was denied.
+2. **Stop** (``handle_classifier_deny_stop_gate``): if the session marker
+    exists, emits a top-level ``systemMessage`` instructing the agent to
+    STOP and request explicit per-call authorization. Returns ``True`` to
+    break the Stop chain (mirrors the consideration-gate pattern).
+
+Recovery: the marker is cleared by the next ``UserPromptSubmit``
+(``handle_clear_classifier_deny_marker``) — a fresh user turn re-arms the
+gate. This matches the "Recovery path: the gate auto-disarms when the next
+user message arrives" spec.
+
+Fail-safe-to-empty: the PostToolUse handler returns silently when the
+denial signal is absent or the data is malformed; the Stop gate returns
+``None`` when no marker exists. The hook NEVER crashes the harness.
+
+Integration-style: real handlers, real ``STATE_DIR`` on ``tmp_path``,
+real JSON I/O exercised through stdin/stdout.
+"""
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import (
+    handle_classifier_deny_stop_gate,
+    handle_clear_classifier_deny_marker,
+    handle_track_classifier_denial,
+)
+
+
+@pytest.fixture
+def gate_env(tmp_path: Path) -> Iterator[Path]:
+    """Pin STATE_DIR to a fresh per-test directory.
+
+    Yields the resolved STATE_DIR so tests can inspect the marker file
+    written by the PostToolUse handler.
+    """
+    original_state = router.STATE_DIR
+    router.STATE_DIR = tmp_path / "state"
+    router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        yield router.STATE_DIR
+    finally:
+        router.STATE_DIR = original_state
+
+
+# ── Sample denial payloads (from real transcript JSONL) ──────────────
+
+
+_CANONICAL_DENIAL = (
+    "Permission for this action was denied by the Claude Code auto mode "
+    "classifier. Reason: User asked an architectural question — not push "
+    'approval; user\'s standing rule requires explicit "push" before any '
+    "push.. If you have other tasks that don't depend on this action, "
+    "continue working on those."
+)
+
+
+def _denial_posttooluse(
+    *,
+    tool_name: str = "Bash",
+    tool_input: dict | None = None,
+    session_id: str = "sess-1",
+) -> dict:
+    """Build a PostToolUse data dict that carries a classifier-denial response.
+
+    The ``tool_response`` field mirrors the shape the harness emits on
+    denial — a dict with ``is_error: true`` and an ``error``/``content``
+    string containing the canonical denial preamble.
+    """
+    return {
+        "session_id": session_id,
+        "tool_name": tool_name,
+        "tool_input": tool_input or {"command": "gh pr merge 1234"},
+        "tool_response": {
+            "is_error": True,
+            "error": _CANONICAL_DENIAL,
+        },
+    }
+
+
+def _success_posttooluse(
+    *,
+    tool_name: str = "Bash",
+    tool_input: dict | None = None,
+    session_id: str = "sess-1",
+) -> dict:
+    """Build a PostToolUse data dict for a successful tool call (no denial)."""
+    return {
+        "session_id": session_id,
+        "tool_name": tool_name,
+        "tool_input": tool_input or {"command": "ls"},
+        "tool_response": {
+            "is_error": False,
+            "stdout": "file1\nfile2\n",
+            "stderr": "",
+        },
+    }
+
+
+def _stop_event(*, session_id: str = "sess-1", transcript_path: str = "") -> dict:
+    return {
+        "session_id": session_id,
+        "transcript_path": transcript_path,
+    }
+
+
+def _user_prompt(*, session_id: str = "sess-1", prompt: str = "next thing") -> dict:
+    return {
+        "session_id": session_id,
+        "prompt": prompt,
+    }
+
+
+# ── PostToolUse: detection of the denial signal ─────────────────────
+
+
+class TestClassifierDenialDetection:
+    """``handle_track_classifier_denial`` writes a marker iff the denial fires."""
+
+    def test_denial_writes_marker(self, gate_env: Path) -> None:
+        handle_track_classifier_denial(_denial_posttooluse())
+
+        marker = gate_env / "sess-1.classifier-deny"
+        assert marker.is_file(), "PostToolUse must persist a session marker on denial"
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+        # Marker must carry enough context for the Stop gate to name the action.
+        assert payload["tool_name"] == "Bash"
+        assert "gh pr merge 1234" in payload["action"]
+
+    def test_success_does_not_write_marker(self, gate_env: Path) -> None:
+        handle_track_classifier_denial(_success_posttooluse())
+
+        marker = gate_env / "sess-1.classifier-deny"
+        assert not marker.exists(), "Successful tool calls must NOT trip the gate"
+
+    def test_missing_tool_response_is_passthrough(self, gate_env: Path) -> None:
+        # Some tools (notably AskUserQuestion historically) may not emit a
+        # tool_response on every event. Fail-safe-to-empty: do nothing.
+        handle_track_classifier_denial({"session_id": "sess-1", "tool_name": "Bash", "tool_input": {"command": "ls"}})
+        assert not (gate_env / "sess-1.classifier-deny").exists()
+
+    def test_unrelated_error_does_not_trip_gate(self, gate_env: Path) -> None:
+        # An ordinary tool failure (e.g. `cat /nonexistent`) is an error but
+        # NOT a classifier denial — only the canonical preamble should match.
+        data = {
+            "session_id": "sess-1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "cat /nonexistent"},
+            "tool_response": {
+                "is_error": True,
+                "error": "cat: /nonexistent: No such file or directory",
+            },
+        }
+        handle_track_classifier_denial(data)
+        assert not (gate_env / "sess-1.classifier-deny").exists()
+
+    def test_denial_in_string_tool_response_is_detected(self, gate_env: Path) -> None:
+        # Older harness versions may pass tool_response as a bare string.
+        # The detector must still find the denial preamble.
+        data = {
+            "session_id": "sess-1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 99"},
+            "tool_response": "Error: " + _CANONICAL_DENIAL,
+        }
+        handle_track_classifier_denial(data)
+        assert (gate_env / "sess-1.classifier-deny").is_file()
+
+    def test_denial_in_content_field_is_detected(self, gate_env: Path) -> None:
+        # The transcript shows the denial inside ``tool_result.content``; the
+        # PostToolUse hook may also surface it in ``tool_response.content``.
+        data = {
+            "session_id": "sess-1",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git push origin main"},
+            "tool_response": {
+                "is_error": True,
+                "content": _CANONICAL_DENIAL,
+            },
+        }
+        handle_track_classifier_denial(data)
+        assert (gate_env / "sess-1.classifier-deny").is_file()
+
+    def test_malformed_data_does_not_crash(self, gate_env: Path) -> None:
+        # Fail-safe-to-empty: any malformed payload returns silently.
+        for bad in ({}, {"tool_response": 42}, {"session_id": ""}, {"tool_response": None}):
+            handle_track_classifier_denial(bad)
+        # No marker written for any of these.
+        assert not list(gate_env.glob("*.classifier-deny"))
+
+    def test_missing_session_id_is_passthrough(self, gate_env: Path) -> None:
+        # A denial without a session_id can't be persisted — fail-safe-to-empty.
+        data = dict(_denial_posttooluse())
+        data["session_id"] = ""
+        handle_track_classifier_denial(data)
+        assert not list(gate_env.glob("*.classifier-deny"))
+
+
+# ── Stop: gate fires when marker exists ──────────────────────────────
+
+
+class TestClassifierDenyStopGate:
+    """``handle_classifier_deny_stop_gate`` emits a systemMessage on Stop."""
+
+    def test_marker_present_emits_stop_systemmessage(self, gate_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # First the PostToolUse path records the denial.
+        handle_track_classifier_denial(_denial_posttooluse())
+
+        # Then the Stop hook fires.
+        result = handle_classifier_deny_stop_gate(_stop_event())
+
+        assert result is True, "Stop gate must return True to break the Stop chain"
+        out = json.loads(capsys.readouterr().out)
+        assert "systemMessage" in out, "Stop output must be a top-level systemMessage"
+        body = out["systemMessage"]
+        # Required wording from the spec.
+        assert "Classifier denied" in body
+        assert "STOP" in body
+        assert "action" in body.lower()
+        assert "reason" in body.lower()
+        assert "minimum-unblock" in body
+        # Must name what was denied so the agent can frame the request.
+        assert "Bash" in body or "gh pr merge" in body
+
+    def test_no_marker_is_passthrough(self, gate_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # No denial recorded => Stop gate stays silent.
+        result = handle_classifier_deny_stop_gate(_stop_event())
+
+        assert result is None, "Stop gate must return None when no denial is pending"
+        assert capsys.readouterr().out == ""
+
+    def test_missing_session_id_is_passthrough(self, gate_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # A Stop event without a session_id can't read the marker — fail-safe.
+        result = handle_classifier_deny_stop_gate({"transcript_path": ""})
+        assert result is None
+        assert capsys.readouterr().out == ""
+
+    def test_marker_for_other_session_does_not_fire(self, gate_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # Per-session isolation: a denial in session A must not gate session B.
+        handle_track_classifier_denial(_denial_posttooluse(session_id="sess-A"))
+
+        result = handle_classifier_deny_stop_gate(_stop_event(session_id="sess-B"))
+        assert result is None
+        assert capsys.readouterr().out == ""
+
+    def test_marker_for_self_session_does_fire(self, gate_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # Sanity: the same session DOES trip the gate.
+        handle_track_classifier_denial(_denial_posttooluse(session_id="sess-A"))
+
+        result = handle_classifier_deny_stop_gate(_stop_event(session_id="sess-A"))
+        assert result is True
+        capsys.readouterr()  # drain
+
+
+# ── UserPromptSubmit: recovery (auto-disarm) ─────────────────────────
+
+
+class TestClassifierDenyRecovery:
+    """A new user turn clears the marker so the gate auto-disarms."""
+
+    def test_user_prompt_clears_marker(self, gate_env: Path) -> None:
+        handle_track_classifier_denial(_denial_posttooluse())
+        marker = gate_env / "sess-1.classifier-deny"
+        assert marker.is_file()
+
+        handle_clear_classifier_deny_marker(_user_prompt())
+
+        assert not marker.exists(), "UserPromptSubmit must clear the marker"
+
+    def test_user_prompt_without_marker_is_noop(self, gate_env: Path) -> None:
+        # No marker to clear — handler must not crash.
+        handle_clear_classifier_deny_marker(_user_prompt())
+        assert not list(gate_env.glob("*.classifier-deny"))
+
+    def test_user_prompt_clears_only_own_session(self, gate_env: Path) -> None:
+        # Per-session: clearing session A leaves session B's marker intact.
+        handle_track_classifier_denial(_denial_posttooluse(session_id="sess-A"))
+        handle_track_classifier_denial(_denial_posttooluse(session_id="sess-B"))
+
+        handle_clear_classifier_deny_marker(_user_prompt(session_id="sess-A"))
+
+        assert not (gate_env / "sess-A.classifier-deny").exists()
+        assert (gate_env / "sess-B.classifier-deny").is_file()
+
+    def test_full_cycle_deny_stop_clear_stop_again(self, gate_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # End-to-end: denial → Stop fires → user prompt clears → Stop silent.
+        handle_track_classifier_denial(_denial_posttooluse())
+        assert handle_classifier_deny_stop_gate(_stop_event()) is True
+        capsys.readouterr()
+
+        handle_clear_classifier_deny_marker(_user_prompt())
+
+        assert handle_classifier_deny_stop_gate(_stop_event()) is None
+        assert capsys.readouterr().out == ""
+
+
+# ── Router wiring: hook registration in _HANDLERS and hooks.json ─────
+
+
+class TestRouterWiring:
+    """Each handler must be registered in the right phase of ``_HANDLERS``."""
+
+    def test_track_handler_registered_in_posttooluse(self) -> None:
+        assert handle_track_classifier_denial in router._HANDLERS["PostToolUse"]
+
+    def test_stop_gate_registered_in_stop(self) -> None:
+        assert handle_classifier_deny_stop_gate in router._HANDLERS["Stop"]
+
+    def test_clear_handler_registered_in_userpromptsubmit(self) -> None:
+        assert handle_clear_classifier_deny_marker in router._HANDLERS["UserPromptSubmit"]
+
+
+class TestHooksJsonRegistration:
+    """Verify ``hooks/hooks.json`` wires the events used by the gate.
+
+    ``hooks/hooks.json`` must route PostToolUse + Stop + UserPromptSubmit
+    through ``hook_router.py`` — otherwise the in-process registration
+    above is unreachable from the running harness.
+    """
+
+    def test_hooks_json_routes_required_events(self) -> None:
+        # Walk up from this test file to the repo root to find hooks.json.
+        repo_root = Path(__file__).resolve().parents[1]
+        hooks_json = repo_root / "hooks" / "hooks.json"
+        assert hooks_json.is_file(), f"hooks.json not found at {hooks_json}"
+        config = json.loads(hooks_json.read_text(encoding="utf-8"))
+        hooks = config.get("hooks", {})
+
+        for event in ("PostToolUse", "Stop", "UserPromptSubmit"):
+            assert event in hooks, f"hooks.json must register {event!r}"
+            commands = " ".join(
+                hook.get("command", "") for matcher_group in hooks[event] for hook in matcher_group.get("hooks", [])
+            )
+            assert "hook_router.py" in commands, f"{event} must route through hook_router.py for the gate to fire"
+            assert f"--event {event}" in commands, f"{event} hook command must pass --event {event}"


### PR DESCRIPTION
Closes #1247.

## Summary

When the Claude Code auto-mode classifier denies a tool call, the agent must STOP and request explicit per-call authorisation instead of silently retrying with cosmetic variation. Prose-only enforcement (`skills/rules/SKILL.md` § "Classifier Denial Protocol") has slipped repeatedly; this gate makes it deterministic.

Two-stage hook routed through the existing `hook_router.py`:

1. `handle_track_classifier_denial` (PostToolUse) — scans every `tool_response` for the canonical denial preamble (`"denied by the Claude Code auto mode classifier"`) and writes a per-session marker (`<session_id>.classifier-deny`) carrying the action fingerprint (tool name + short input excerpt).
2. `handle_classifier_deny_stop_gate` (Stop) — if the session marker exists, emits a top-level `systemMessage` reminding the agent to STOP and request explicit per-call authorisation, then returns `True` to break the Stop chain so the message survives.

Recovery: `handle_clear_classifier_deny_marker` (UserPromptSubmit) removes the marker on the next user turn — the gate auto-disarms because the user either grants the authorisation or redirects.

Fail-safe-to-empty: every handler returns silently on malformed input or missing fields — the hook never crashes the harness.

## Detection signal

The canonical denial preamble appears in the transcript `tool_result.content` when the harness denies a tool call. Real example from a recent transcript:

```
Permission for this action was denied by the Claude Code auto mode classifier.
Reason: ...
```

The detector matches the substring `"denied by the Claude Code auto mode classifier"` in any string field of `tool_response` (covers `error`, `content`, `stderr`, `stdout`, `message`, `output`, `reason`, plus bare-string responses).

## Acceptance (from the issue)

- [x] Repeat of the same denied tool call is blocked — the Stop gate fires on every turn while the marker exists, so the agent cannot silently continue.
- [x] AskUserQuestion → flag cleared, retry allowed — the next user turn (which carries the answer) clears the marker via UserPromptSubmit.
- [x] Unrelated calls not blocked — the marker is only written on the canonical denial preamble; ordinary tool failures (e.g. `cat: No such file`) do not trip the gate.
- [x] Per-session isolation — a denial in session A does not gate session B.

## Test plan

- [x] `uv run pytest tests/test_hook_router_classifier_deny_stop.py --no-cov` — 21 passed
- [x] `uv run pytest tests/test_hook_router_plan_gate.py tests/test_hook_router_agent_plan_gate.py tests/test_classifier_relax_pretooluse_hook.py tests/test_consideration_gate_stop_hook.py tests/test_structured_question_hook.py --no-cov` — 136 passed (no regression in sibling gates)
- [x] `uv run ruff check` + `uv run ruff format` + `uv run ty check hooks/scripts/hook_router.py` — all green
- [x] Router-wiring test asserts both the in-process `_HANDLERS` registration and the `hooks.json` event coverage so the gate cannot be silently disabled by an out-of-band edit.