### PR TITLE
fix(provision): surface prek install failure so worktrees can't ship hookless (#1253)

### DIFF
--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -21,10 +21,22 @@ def _append_envrc_lines(wt_path: str, lines: list[str]) -> None:
         envrc.write_text(existing.rstrip() + "\n" + "\n".join(missing) + "\n")
 
 
-def _setup_worktree_dir(wt_path: str, worktree: Worktree, overlay: OverlayBase) -> None:
-    """Configure direnv + prek for the worktree directory."""
+def _setup_worktree_dir(wt_path: str, worktree: Worktree, overlay: OverlayBase) -> str | None:
+    """Configure direnv + prek for the worktree directory.
+
+    Returns ``None`` on success or a short failure detail when ``prek
+    install`` cannot install the hook scripts. A non-``None`` return is the
+    caller's signal to refuse to mark the worktree provisioned — without an
+    installed pre-commit hook the worktree is a silent-bypass surface for
+    every gate the project enforces at commit time (souliane/teatree#1253).
+
+    ``direnv allow`` failures are kept warning-only — direnv is a developer
+    convenience, not a correctness gate. ``prek install`` is upgraded to an
+    error because a missing pre-commit hook is a hard correctness regression
+    (migration-scoping, banned-terms, privacy guard all rely on it firing).
+    """
     if not wt_path or not Path(wt_path).is_dir():
-        return
+        return None
     core_lines = [f"dotenv {CACHE_FILENAME}"]
     _append_envrc_lines(wt_path, core_lines + overlay.get_envrc_lines(worktree))
     result = run_step("direnv-allow", ["direnv", "allow", wt_path], check=False)
@@ -33,7 +45,9 @@ def _setup_worktree_dir(wt_path: str, worktree: Worktree, overlay: OverlayBase) 
     if (Path(wt_path) / ".pre-commit-config.yaml").is_file():
         result = run_step("prek-install", ["prek", "install", "-f"], cwd=wt_path, check=False)
         if not result.success:
-            logger.warning("prek install failed: %s", result.error)
+            logger.error("prek install failed: %s", result.error)
+            return f"prek install failed: {result.error}"
+    return None
 
 
 class WorktreeProvisionRunner(RunnerBase):
@@ -67,7 +81,9 @@ class WorktreeProvisionRunner(RunnerBase):
             logger.info("Wrote env cache: %s", spec.path)
 
         wt_path = (worktree.extra or {}).get("worktree_path", "")
-        _setup_worktree_dir(wt_path, worktree, overlay)
+        setup_failure = _setup_worktree_dir(wt_path, worktree, overlay)
+        if setup_failure is not None:
+            return RunnerResult(ok=False, detail=setup_failure)
 
         if worktree.db_name and overlay.get_db_import_strategy(worktree) is not None:
             self._run_db_import()

--- a/tests/teatree_core/test_prek_install_during_provision.py
+++ b/tests/teatree_core/test_prek_install_during_provision.py
@@ -1,0 +1,207 @@
+"""Regression tests for the prek-install step during worktree provisioning.
+
+souliane/teatree#1253 — sub-agent commits bypassed the migration-scoping
+pre-commit hook because ``prek install`` failed silently during worktree
+provisioning. The runner only logged a warning and returned ok; the worktree
+then served as a coding environment with no pre-commit gate at all, so the
+next ``git commit`` shipped unchecked.
+
+Two failure paths covered here:
+
+1. **Real subprocess path**: when ``.pre-commit-config.yaml`` is present in a
+    freshly created worktree and ``prek`` is on PATH, ``_setup_worktree_dir``
+    must produce an executable hook script at the resolved hooks directory
+    (``git rev-parse --git-path hooks``). A worktree without that hook script
+    is a silent bypass surface.
+
+2. **Failure surfacing**: when ``prek install`` fails (binary missing, exit
+    non-zero, the worktree's ``.pre-commit-config.yaml`` rejected), the
+    provisioning runner MUST surface the failure (``RunnerResult.ok == False``)
+    instead of swallowing it as a warning. Returning ok-with-a-warning is the
+    bypass class the issue reports.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.runners.worktree_provision import WorktreeProvisionRunner, _setup_worktree_dir
+from teatree.core.step_runner import StepResult
+
+# Minimal valid prek/pre-commit config. The hook body itself never runs in
+# these tests (we either drive ``_setup_worktree_dir`` directly with a real
+# prek binary, or stub ``run_step`` entirely); the file only needs to exist
+# so the ``.pre-commit-config.yaml`` gate in ``_setup_worktree_dir`` opens.
+# Indentation inside the literal is 4-space-multiple to keep editorconfig
+# happy on the *.py side while still being valid YAML on disk.
+_HOOK_YAML = (
+    "default_install_hook_types: [pre-commit, commit-msg]\n"
+    "default_stages: [pre-commit, manual]\n"
+    "fail_fast: false\n"
+    "repos:\n"
+    "    - repo: local\n"
+    "      hooks:\n"
+    "          - id: noop\n"
+    "            name: noop\n"
+    "            language: system\n"
+    "            entry: 'true'\n"
+    "            pass_filenames: false\n"
+    "            always_run: true\n"
+)
+
+_GIT_BIN = shutil.which("git") or "/usr/bin/git"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        [_GIT_BIN, "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.fixture
+def real_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Initialise a main git clone and add a worktree off it.
+
+    Returns ``(main_clone, worktree_path)``. The worktree carries a real
+    ``.pre-commit-config.yaml`` so the hook-install path is exercised end to
+    end.
+    """
+    main = tmp_path / "main"
+    main.mkdir()
+    _git(main, "init", "--initial-branch=main", "-q")
+    _git(main, "config", "user.email", "test@example.com")
+    _git(main, "config", "user.name", "test")
+    _git(main, "commit", "--allow-empty", "-m", "root")
+    wt = tmp_path / "wt"
+    _git(main, "worktree", "add", "-q", str(wt), "-b", "feature/1253")
+    (wt / ".pre-commit-config.yaml").write_text(_HOOK_YAML)
+    return main, wt
+
+
+@pytest.mark.skipif(shutil.which("prek") is None, reason="prek not on PATH")
+class TestPrekInstallProducesHookFile:
+    """The real provisioning path must install a usable pre-commit hook script.
+
+    This is the structural invariant the #1253 bypass violated: every
+    provisioned worktree's resolved hooks directory must contain an executable
+    ``pre-commit`` script that dispatches to ``prek hook-impl``. Without it,
+    nothing intercepts ``git commit`` and the next sub-agent commit slips
+    through unchecked.
+    """
+
+    def test_setup_writes_executable_pre_commit_hook(self, real_worktree: tuple[Path, Path]) -> None:
+        _main, wt = real_worktree
+        worktree = MagicMock()
+        overlay = MagicMock()
+        overlay.get_envrc_lines.return_value = []
+
+        _setup_worktree_dir(str(wt), worktree, overlay)
+
+        # ``git rev-parse --git-path hooks`` resolves to the SHARED hooks dir
+        # for worktrees (main clone's ``.git/hooks``), which is where prek
+        # writes the dispatch scripts. The worktree-first invariant only
+        # holds if THAT file is present and executable.
+        proc = subprocess.run(
+            [_GIT_BIN, "-C", str(wt), "rev-parse", "--git-path", "hooks"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        hooks_dir = (wt / proc.stdout.strip()).resolve()
+        pre_commit = hooks_dir / "pre-commit"
+        assert pre_commit.is_file(), f"expected pre-commit hook at {pre_commit}"
+        # Executable bit — git refuses to run a non-executable hook script.
+        mode = pre_commit.stat().st_mode
+        assert mode & 0o100, f"pre-commit hook at {pre_commit} is not executable (mode={mode:o})"
+        # The dispatch script must reference prek's hook-impl entry point;
+        # a stub that ``exit 0``s would also satisfy the executable bit but
+        # is the very bypass class we're guarding against.
+        body = pre_commit.read_text()
+        assert "prek" in body.lower(), f"pre-commit hook at {pre_commit} does not dispatch to prek:\n{body}"
+
+
+class TestPrekInstallFailureSurfaces(TestCase):
+    """When ``prek install`` exits non-zero, the runner must surface the failure.
+
+    Today's behaviour: log a warning and return ``RunnerResult(ok=True)`` —
+    the worktree is reported "provisioned" with no pre-commit gate at all,
+    which is the structural bypass surface from souliane/teatree#1253.
+
+    Expected behaviour (this regression test enforces): the runner returns
+    ``RunnerResult(ok=False)`` so the worktree FSM does NOT flip to
+    PROVISIONED, the CLI prints a diagnosable error, and the operator fixes
+    the prek install problem before any commit happens.
+    """
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/1253",
+        )
+
+    def _worktree(self, tmp_path: Path) -> Worktree:
+        wt_dir = tmp_path / "backend"
+        wt_dir.mkdir(parents=True, exist_ok=True)
+        (wt_dir / ".pre-commit-config.yaml").write_text(_HOOK_YAML)
+        return Worktree.objects.create(
+            ticket=self.ticket,
+            repo_path="backend",
+            branch="b",
+            db_name="",
+            extra={"worktree_path": str(wt_dir)},
+        )
+
+    def test_failed_prek_install_makes_provision_runner_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            worktree = self._worktree(Path(tmp))
+
+            overlay = MagicMock()
+            overlay.get_envrc_lines.return_value = []
+            overlay.get_db_import_strategy.return_value = None
+            overlay.get_provision_steps.return_value = []
+            overlay.get_post_db_steps.return_value = []
+            overlay.get_pre_run_steps.return_value = []
+            overlay.get_run_commands.return_value = {}
+            overlay.get_reset_passwords_command.return_value = ""
+            overlay.get_env_extra.return_value = {}
+            overlay.get_health_checks.return_value = []
+            overlay.metadata.get_skill_metadata.return_value = {}
+
+            # Stub ``run_step`` so direnv passes and prek install fails — the
+            # real binary may or may not be on PATH on a contributor's
+            # machine, so we model the failure directly rather than depend
+            # on its absence.
+            def fake_run_step(name: str, *_args: object, **_kwargs: object) -> StepResult:
+                if name == "prek-install":
+                    return StepResult(
+                        name=name,
+                        success=False,
+                        error="prek: command not found",
+                    )
+                return StepResult(name=name, success=True)
+
+            with (
+                patch(
+                    "teatree.core.runners.worktree_provision.run_step",
+                    side_effect=fake_run_step,
+                ),
+                patch("teatree.core.runners.worktree_provision.write_env_cache", return_value=None),
+            ):
+                result = WorktreeProvisionRunner(worktree, overlay=overlay).run()
+
+            assert not result.ok, (
+                "prek install failed but the provision runner returned ok=True — "
+                "this is the silent-bypass class from souliane/teatree#1253. "
+                f"detail={result.detail!r}"
+            )
+            assert "prek" in result.detail.lower(), (
+                f"failure detail must name prek so the operator can fix it: {result.detail!r}"
+            )

--- a/tests/teatree_core/test_runner_db_import.py
+++ b/tests/teatree_core/test_runner_db_import.py
@@ -79,7 +79,10 @@ class TestRunnerSkipsDbImportWhenNoDbName(TestCase):
         worktree = self._make_worktree(db_name="")
         overlay = _RecordingOverlay()
 
-        with patch("teatree.core.runners.worktree_provision._setup_worktree_dir"):
+        with patch(
+            "teatree.core.runners.worktree_provision._setup_worktree_dir",
+            return_value=None,
+        ):
             WorktreeProvisionRunner(worktree, overlay=overlay).run()
 
         assert overlay.db_import_calls == 0
@@ -90,7 +93,10 @@ class TestRunnerSkipsDbImportWhenNoDbName(TestCase):
         overlay = _RecordingOverlay()
 
         with (
-            patch("teatree.core.runners.worktree_provision._setup_worktree_dir"),
+            patch(
+                "teatree.core.runners.worktree_provision._setup_worktree_dir",
+                return_value=None,
+            ),
             patch("teatree.utils.db.db_exists", return_value=False),
         ):
             WorktreeProvisionRunner(worktree, overlay=overlay).run()


### PR DESCRIPTION
Fixes souliane/teatree#1253.

## Root cause

`WorktreeProvisionRunner` runs `prek install -f` against the freshly added worktree as part of provisioning (`src/teatree/core/runners/worktree_provision.py`). Before this change, when that install failed (binary not on PATH, exit non-zero, config rejected) the runner only logged a warning and returned `RunnerResult(ok=True)`. The worktree FSM flipped to `PROVISIONED`, the operator (or sub-agent) saw a "ready" worktree, and every subsequent `git commit` in that worktree bypassed every configured pre-commit hook — migration-scoping, banned-terms, privacy guard, and so on — because `.git/hooks/pre-commit` was never written.

This is the structural bypass class the issue describes: not "hook ran and shouldn't have passed", but "hook never installed in the first place, so git's pre-commit phase is a no-op".

## Fix

`_setup_worktree_dir` now returns a failure detail when prek install exits non-zero, and the runner converts that into `RunnerResult(ok=False)` so the FSM does not advance. The operator gets a diagnosable error and fixes the prek install problem before any commit happens.

`direnv allow` failures stay warning-only — direnv is a developer convenience, not a correctness gate.

## Where it sits

Provisioning-side, not hook-side. The migration-scoping hook itself is correct in the consumer repo — the bypass came from teatree's own provisioning silently tolerating a hookless worktree.

## RED → GREEN

- **RED reproduction (pre-fix code).** Stub `run_step` so the `prek-install` step returns `success=False`; call `WorktreeProvisionRunner(...).run()`. Pre-fix: `RunnerResult(ok=True, detail='0 step(s) ok')` despite the warning. The worktree is marked provisioned.
- **GREEN proof (post-fix).** Same scenario: `RunnerResult(ok=False, detail='prek install failed: prek: command not found')`. FSM stays in `CREATED`, operator sees the failure.

Anti-vacuity verified by `git stash`-ing the fix and re-running the regression test — RED with the exact assertion message; restore, GREEN.

## Tests

- `tests/teatree_core/test_prek_install_during_provision.py::TestPrekInstallProducesHookFile::test_setup_writes_executable_pre_commit_hook` — real `git init` + `git worktree add` under `tmp_path`, runs `_setup_worktree_dir` for real, asserts the resolved hooks directory contains an executable `pre-commit` script that dispatches to prek. Skipped if prek isn't on PATH.
- `tests/teatree_core/test_prek_install_during_provision.py::TestPrekInstallFailureSurfaces::test_failed_prek_install_makes_provision_runner_fail` — stubs `run_step` so prek install fails; asserts `RunnerResult.ok is False` and the detail names prek.

## Test plan

- [x] `uv run pytest tests/teatree_core/test_prek_install_during_provision.py` — 2 passed
- [x] `uv run pytest tests/teatree_core/` — 2383 passed, 12 skipped
- [x] Full suite (minus one pre-existing unrelated env-config test) — 6943 passed
- [x] `uv run ruff check` + `uv run ty check` clean on changed files
- [x] Pre-commit hooks all pass locally (the same chain that runs in CI)