### PR TITLE
fix(ship): per-branch PR URL guard — multi-workstream stale-URL short-circuit (#1263)

### DIFF
--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -40,6 +40,10 @@ class PREntrySerialized(TypedDict, total=False):
 class TicketExtra(TypedDict, total=False):
     tests_passed: bool
     pr_urls: list[str]
+    # #1263: per-branch PR URL index so a reused-ticket multi-workstream
+    # ship can tell whether the *current* invoking branch's PR exists,
+    # without short-circuiting on the truthiness of the shared ``pr_urls``.
+    pr_url_by_branch: dict[str, str]
     prs: dict[str, PREntrySerialized]
     pr_title_override: str
     ship_invoking_branch: str

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -107,9 +107,6 @@ class ShipExecutor(RunnerBase):
     def run(self) -> RunnerResult:
         ticket = self.ticket
         extra = cast("TicketExtra", ticket.extra or {})
-        existing_urls = list(extra.get("pr_urls") or [])
-        if existing_urls:
-            return RunnerResult(ok=True, detail=existing_urls[-1])
 
         worktree = resolve_ship_worktree(ticket, extra)
         if worktree is None:
@@ -121,6 +118,18 @@ class ShipExecutor(RunnerBase):
 
         repo_path = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
         branch = worktree.branch
+
+        # #1263: short-circuit only when THIS branch already has a PR.
+        # The legacy truthiness check fired on any prior ``pr_urls`` entry,
+        # so on a reused-ticket multi-workstream flow a stale URL from an
+        # earlier workstream silently advanced the FSM without pushing or
+        # opening a PR for the current branch. ``pr_url_by_branch`` is the
+        # per-branch index; fall back to ``pr_urls[-1]`` only when no
+        # ``ship_invoking_branch`` hint is recorded (single-PR async-worker
+        # path with no multi-workstream context).
+        recorded_url = self._recorded_url_for_branch(extra, branch)
+        if recorded_url:
+            return RunnerResult(ok=True, detail=recorded_url)
 
         # #776: a ticket can span multiple PRs (one branch per workstream).
         # Refuse to re-open a PR for a branch already merged into base —
@@ -168,7 +177,7 @@ class ShipExecutor(RunnerBase):
                 ok=False,
                 detail=(f"host.create_pr returned no PR url (got {url!r}; payload keys={sorted(pr.keys())!r})"),
             )
-        self._record_pr_url(ticket, extra, url)
+        self._record_pr_url(ticket, extra, url, branch)
         logger.info("Ship executor pushed %s and opened PR %s", branch, url)
         return RunnerResult(ok=True, detail=url)
 
@@ -222,6 +231,29 @@ class ShipExecutor(RunnerBase):
             ticket.merge_extra(pop_keys=["ship_invoking_branch"])
 
     @staticmethod
+    def _recorded_url_for_branch(extra: "TicketExtra", branch: str) -> str:
+        """The PR URL recorded for ``branch``, or ``""`` if none.
+
+        #1263: short-circuit only when the *current* branch already has a
+        PR. ``pr_url_by_branch`` is the per-branch index populated by
+        ``_record_pr_url`` on each successful ship; it tells us reliably
+        whether the invoking branch's PR exists. The legacy single-PR
+        fallback (``pr_urls[-1]`` when no ``ship_invoking_branch`` hint
+        is set) preserves async-worker idempotency for tickets that
+        pre-date the per-branch index.
+        """
+        by_branch = extra.get("pr_url_by_branch")
+        if isinstance(by_branch, Mapping):
+            recorded = by_branch.get(branch)
+            if isinstance(recorded, str) and recorded:
+                return recorded
+        invoking = str(extra.get("ship_invoking_branch") or "")
+        if invoking:
+            return ""
+        legacy_urls = list(extra.get("pr_urls") or [])
+        return legacy_urls[-1] if legacy_urls else ""
+
+    @staticmethod
     def _build_pr_spec(
         ticket: "Ticket",
         host: "CodeHostBackend",
@@ -249,10 +281,22 @@ class ShipExecutor(RunnerBase):
         )
 
     @staticmethod
-    def _record_pr_url(ticket: "Ticket", extra: "TicketExtra", url: str) -> None:
+    def _record_pr_url(ticket: "Ticket", extra: "TicketExtra", url: str, branch: str) -> None:
         urls = list(extra.get("pr_urls") or [])
         if url and url not in urls:
             urls.append(url)
+        # #1263: also index by branch so a later workstream on the same
+        # ticket can tell whether its own PR exists, without relying on
+        # the truthiness of the shared ``pr_urls`` list.
+        by_branch_raw = extra.get("pr_url_by_branch")
+        by_branch: dict[str, str] = (
+            {str(k): str(v) for k, v in by_branch_raw.items()} if isinstance(by_branch_raw, Mapping) else {}
+        )
+        if url and branch:
+            by_branch[branch] = url
         # #800 N3: canonical locked RMW — a concurrent visual_qa /
         # reviewed_sha writer no longer clobbers pr_urls.
-        ticket.merge_extra(set_keys={"pr_urls": urls}, pop_keys=["pr_title_override", "ship_invoking_branch"])
+        ticket.merge_extra(
+            set_keys={"pr_urls": urls, "pr_url_by_branch": by_branch},
+            pop_keys=["pr_title_override", "ship_invoking_branch"],
+        )

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -356,6 +356,126 @@ class TestShipResolvesBranchFromInvokingWorktree(TestCase):
         host.create_pr.assert_not_called()
 
 
+class TestShipMultiWorkstreamStaleUrlGuard(TestCase):
+    """#1263: ``ShipExecutor.run`` must not short-circuit on a stale prior URL.
+
+    Reused-ticket / multi-workstream flow: one ticket spans several PRs,
+    each on its own branch. The first workstream records its URL on
+    ``extra['pr_urls']``; a second workstream then invokes ship on a
+    different branch. The legacy short-circuit returned the first
+    workstream's URL on truthiness alone — the new branch was never
+    pushed and no PR was opened, yet ``pr create --sync`` reported
+    success and the FSM advanced to ``IN_REVIEW``.
+
+    The guard: when ``ship_invoking_branch`` names a branch whose URL is
+    not the one recorded for that branch, the runner must proceed to
+    push and open a new PR for the invoking branch.
+    """
+
+    def _multi_worktree_ticket(self) -> Ticket:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/1263")
+        # Workstream A (already shipped; URL on the ticket).
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/repo-1263-a",
+            branch="s-1263-pr-a-shipped",
+            extra={"worktree_path": "/tmp/repo-1263-a"},
+        )
+        # Workstream B (current; needs its own PR).
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/repo-1263-b",
+            branch="s-1263-pr-b-current",
+            extra={"worktree_path": "/tmp/repo-1263-b"},
+        )
+        return ticket
+
+    def test_does_not_short_circuit_when_prior_url_is_for_a_different_branch(self) -> None:
+        """Stale ``pr_urls`` from workstream A must not skip workstream B."""
+        ticket = self._multi_worktree_ticket()
+        ticket.extra = {
+            "pr_urls": ["https://example.com/pr/a-shipped"],
+            "ship_invoking_branch": "s-1263-pr-b-current",
+        }
+        ticket.save(update_fields=["extra"])
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://example.com/pr/b-new"}
+        host.current_user.return_value = "souliane"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat: b", "body")),
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        # The runner must push the current invoking branch and open a new PR —
+        # NOT silently return the stale workstream-A URL.
+        assert result.ok is True
+        assert result.detail == "https://example.com/pr/b-new"
+        push.assert_called_once_with(repo="/tmp/repo-1263-b", remote="origin", branch="s-1263-pr-b-current")
+        host.create_pr.assert_called_once()
+        (spec,) = host.create_pr.call_args.args
+        assert spec.branch == "s-1263-pr-b-current"
+        ticket.refresh_from_db()
+        # Both URLs are recorded; the new one is appended (not replacing the prior).
+        assert "https://example.com/pr/a-shipped" in ticket.extra["pr_urls"]
+        assert "https://example.com/pr/b-new" in ticket.extra["pr_urls"]
+
+    def test_short_circuits_when_current_branch_already_has_pr_recorded(self) -> None:
+        """Idempotent retry: same branch + URL already mapped ⇒ short-circuit.
+
+        The guard rail must NOT regress the original idempotency: a retry
+        of ship on the SAME workstream (the recorded URL is for this
+        branch) must still short-circuit and return the recorded URL.
+        """
+        ticket = self._multi_worktree_ticket()
+        ticket.extra = {
+            "pr_urls": ["https://example.com/pr/b-already"],
+            "pr_url_by_branch": {"s-1263-pr-b-current": "https://example.com/pr/b-already"},
+            "ship_invoking_branch": "s-1263-pr-b-current",
+        }
+        ticket.save(update_fields=["extra"])
+        host = MagicMock()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is True
+        assert result.detail == "https://example.com/pr/b-already"
+        push.assert_not_called()
+        host.create_pr.assert_not_called()
+
+    def test_records_pr_url_by_branch_for_each_workstream(self) -> None:
+        """After a successful ship, the URL is recorded against its branch."""
+        ticket = self._multi_worktree_ticket()
+        ticket.extra = {"ship_invoking_branch": "s-1263-pr-b-current"}
+        ticket.save(update_fields=["extra"])
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://example.com/pr/b-new"}
+        host.current_user.return_value = "souliane"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push"),
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat: b", "body")),
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+        ):
+            ShipExecutor(ticket).run()
+
+        ticket.refresh_from_db()
+        assert ticket.extra["pr_url_by_branch"]["s-1263-pr-b-current"] == "https://example.com/pr/b-new"
+
+
 class TestSanitizeCloseKeywords:
     @pytest.mark.parametrize(
         ("description", "expected"),


### PR DESCRIPTION
## Summary

- `ShipExecutor.run` short-circuited on truthiness of `extra['pr_urls']`, returning the most recent URL without resolving the invoking worktree.
- On reused-ticket multi-workstream flows (one ticket spanning N PRs), the second workstream silently advanced the FSM with the first workstream's stale URL — `pr create --sync` reported success but no PR was opened for the new branch.
- Move the short-circuit AFTER worktree resolution and gate it on a per-branch index (`pr_url_by_branch`) populated by `_record_pr_url`. The legacy `pr_urls[-1]` fallback only applies when no `ship_invoking_branch` hint is recorded (single-PR async-worker path that pre-dates the per-branch index).

Closes #1263.

## Test plan

- [x] RED test reproducing multi-workstream stale-URL advancement (`TestShipMultiWorkstreamStaleUrlGuard::test_does_not_short_circuit_when_prior_url_is_for_a_different_branch`) — pre-fix it asserted `result.detail == 'https://example.com/pr/b-new'` and got `'https://example.com/pr/a-shipped'`.
- [x] Idempotency preserved on same-branch retry (`test_short_circuits_when_current_branch_already_has_pr_recorded`).
- [x] Per-branch index recorded after each successful ship (`test_records_pr_url_by_branch_for_each_workstream`).
- [x] Full suite GREEN: 6944 passed, 13 skipped, 1 pre-existing unrelated failure (`tests/test_contrib_overlay.py::TestMaxConcurrentAutoStarts::test_in_repo_overlay_resolves_to_three`) deselected.
- [x] prek on changed files: all hooks green.