### PR TITLE
fix(scanners): drop bot's own outbound DMs from inbound bridge (#1346)

### DIFF
--- a/src/teatree/loop/scanners/slack_dm_inbound.py
+++ b/src/teatree/loop/scanners/slack_dm_inbound.py
@@ -9,12 +9,21 @@ the agent's next ``additionalContext`` block — so a Slack DM reaches the
 agent as if the user had typed it in Claude Code chat (BLUEPRINT §17.1
 invariant 2 / §5.6).
 
-The Slack backend's ``fetch_dms`` already filters out bot-authored
-messages (`SlackBotBackend.fetch_dms` matches ``user`` and ``bot_id``
-against the resolved bot id); the scanner trusts that contract and adds
-only idempotent persistence. Duplicate ``ts`` values across polls are
-swallowed by ``PendingChatInjection.record``'s ``unique(overlay, ts)``
-constraint, so over-polling is safe.
+The scanner applies the bot's own self-filter at the write side via
+:func:`teatree.loop.scanners.slack_self_filter.filter_self_messages` so
+rows that came from the bot's own outbound DMs never reach the DB. Both
+downstream consumers — the reactive Slack-answer cycle and the
+``UserPromptSubmit`` injection handler — read from
+:class:`PendingChatInjection`, so filtering at the scanner is the lowest
+common helper: a bot-authored message is dropped exactly once, before
+persistence, and both consumers inherit the filter for free (#1346).
+
+Fail-closed: when the bot's own identity cannot be resolved (network
+down at startup, ``auth.test`` returning ``ok:false``, no bot token
+configured), :func:`filter_self_messages` returns ``None`` and the
+scanner refuses to enqueue any row that turn — better silent for one
+tick than spam-spawning ``t3:answerer`` sub-agents against the bot's
+own traffic.
 
 This scanner does NOT post anything back to Slack — recording is its only
 job. The reactive replies (the :eyes: receipt, an ack reaction, a
@@ -30,11 +39,12 @@ independent of both, so a row can be drained, loop-replied, and
 agent-answered without a double reply (#1014).
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from teatree.backends.protocols import MessagingBackend
 from teatree.core.models.pending_chat_injection import PendingChatInjection
 from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.slack_self_filter import OwnSlackIdentity, filter_self_messages, resolve_own_identity
 from teatree.types import RawAPIDict
 
 
@@ -65,14 +75,34 @@ class SlackDmInboundScanner:
     *overlay* tags rows so a multi-overlay deployment can drain per
     overlay; v1 single-overlay use sets ``overlay=""``. The scanner is
     safe to over-poll because the row is keyed on ``(overlay, ts)``.
+
+    ``_cached_identity`` memoises the bot's own Slack identity probed
+    once via :func:`resolve_own_identity`; a successful resolve is
+    cached for the scanner's lifetime so the hot path costs zero Slack
+    API calls beyond the first scan. An unresolved identity is NOT
+    cached so a transient failure that later recovers is re-probed.
     """
 
     backend: MessagingBackend
     overlay: str = ""
     name: str = "slack_dm_inbound"
+    _cached_identity: OwnSlackIdentity | None = field(default=None, init=False, repr=False)
+
+    def _identity(self) -> OwnSlackIdentity | None:
+        if self._cached_identity is not None:
+            return self._cached_identity
+        identity = resolve_own_identity(self.backend)
+        if identity is not None:
+            self._cached_identity = identity
+        return identity
 
     def scan(self) -> list[ScanSignal]:
-        dms = self.backend.fetch_dms()
+        raw = self.backend.fetch_dms()
+        dms = filter_self_messages(raw, self._identity())
+        if dms is None:
+            # Identity unknown — fail closed for this tick rather than
+            # enqueue rows that may include the bot's own outbound DMs.
+            return []
         signals: list[ScanSignal] = []
         for event in dms:
             ts = _event_ts(event)

--- a/src/teatree/loop/scanners/slack_self_filter.py
+++ b/src/teatree/loop/scanners/slack_self_filter.py
@@ -1,0 +1,135 @@
+"""Self-message filter for Slack DM scanners (#1346).
+
+The lowest common helper that BOTH downstream consumers of
+:class:`PendingChatInjection` inherit:
+
+* The reactive Slack-answer cycle (``run_slack_answer_cycle``) — which
+    spawns ``t3:answerer`` sub-agents against unanswered rows.
+* The ``UserPromptSubmit`` injection hook (``handle_inject_pending_chat``
+    in ``hook_router.py``) — which surfaces unconsumed rows as
+    ``additionalContext`` to the next interactive prompt.
+
+The Slack Socket Mode receiver only drops ``subtype=bot_message`` events;
+the bot's own outbound posts from ``chat.postMessage`` arrive as plain
+``message`` events whose ``user`` matches the bot's posted-as user id and
+whose ``bot_id`` matches the bot's bot id. Without a self-filter the bot
+ends up "answering" its own outbound DMs (#1346) and the UserPromptSubmit
+hook injects them as user replies.
+
+This module owns the filter at write-time — applied inside
+:class:`SlackDmInboundScanner.scan` so rows that fail it never reach the
+DB and both downstream consumers benefit for free.
+
+**Fail-closed.** When the bot's own identity cannot be resolved
+(``auth.test`` returned ``ok:false``, no bot token configured, transport
+error), :func:`resolve_own_identity` returns ``None`` and
+:func:`filter_self_messages` returns ``None`` to signal "identity
+unknown — caller must NOT proceed". The scanner refuses to enqueue any
+row that turn — better silent for one tick than spam-spawning
+``t3:answerer`` sub-agents against the bot's own traffic.
+"""
+
+import logging
+from dataclasses import dataclass
+
+from teatree.backends.protocols import MessagingBackend
+from teatree.types import RawAPIDict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class OwnSlackIdentity:
+    """The bot's own Slack identity as seen on inbound message events.
+
+    ``user_id`` is the ``U…`` value Slack uses for the bot's posted-as
+    identity (matches ``message['user']`` on bot-authored events).
+    ``bot_id`` is the ``B…`` value that Slack stamps on bot-authored
+    events (matches ``message['bot_id']``). Either match is sufficient
+    to classify a message as self-authored — a bot's outbound DM may
+    carry only one of them depending on how it was posted.
+    """
+
+    user_id: str
+    bot_id: str
+
+    @property
+    def is_resolvable(self) -> bool:
+        """True iff at least one identifier is non-empty.
+
+        An empty identity (both fields blank) cannot distinguish self
+        from non-self — callers treat it the same as "could not
+        resolve" and fail closed.
+        """
+        return bool(self.user_id or self.bot_id)
+
+
+def resolve_own_identity(backend: MessagingBackend) -> OwnSlackIdentity | None:
+    """Probe ``auth.test`` once and return the bot's own ids, or ``None``.
+
+    ``None`` means "identity unknown" — the call returned ``ok:false``,
+    the bot token is unconfigured (``auth_test`` returned ``{}``), or the
+    transport raised. Callers (the scanner) treat this as a hard
+    fail-closed signal and refuse to enqueue any row that turn.
+
+    The Slack ``auth.test`` response shape:
+    ``{"ok": true, "user_id": "U…", "bot_id": "B…", …}``. Either
+    identifier in isolation is enough — bot-style messages don't always
+    carry both — so the empty-string default for the missing field is
+    intentional.
+    """
+    try:
+        response = backend.auth_test()
+    except Exception as exc:  # noqa: BLE001 — fail-closed on transport failure
+        logger.warning("auth.test raised; cannot resolve own identity for self-filter: %s", exc)
+        return None
+    if not response or not response.get("ok"):
+        return None
+    user_id = response.get("user_id", "")
+    bot_id = response.get("bot_id", "")
+    if not isinstance(user_id, str):
+        user_id = ""
+    if not isinstance(bot_id, str):
+        bot_id = ""
+    identity = OwnSlackIdentity(user_id=user_id, bot_id=bot_id)
+    if not identity.is_resolvable:
+        return None
+    return identity
+
+
+def is_self_authored(message: RawAPIDict, identity: OwnSlackIdentity) -> bool:
+    """True iff *message* was authored by the bot itself.
+
+    Matches either ``message['user'] == identity.user_id`` (the bot's
+    posted-as user id) or ``message['bot_id'] == identity.bot_id``
+    (the bot id Slack stamps on bot-authored events). A match on either
+    field is sufficient — bot-style messages don't always carry both.
+    """
+    user = message.get("user")
+    if identity.user_id and isinstance(user, str) and user == identity.user_id:
+        return True
+    bot_id = message.get("bot_id")
+    return bool(identity.bot_id and isinstance(bot_id, str) and bot_id == identity.bot_id)
+
+
+def filter_self_messages(
+    messages: list[RawAPIDict],
+    identity: OwnSlackIdentity | None,
+) -> list[RawAPIDict] | None:
+    """Drop self-authored messages from *messages*; ``None`` when fail-closed.
+
+    Returns the filtered list when *identity* is resolved; returns
+    ``None`` when *identity* is ``None`` so the caller can refuse to
+    enqueue any row that turn (the fail-closed contract).
+    """
+    if identity is None:
+        return None
+    return [m for m in messages if not is_self_authored(m, identity)]
+
+
+__all__ = [
+    "OwnSlackIdentity",
+    "filter_self_messages",
+    "is_self_authored",
+    "resolve_own_identity",
+]

--- a/tests/teatree_loop/test_slack_dm_inbound.py
+++ b/tests/teatree_loop/test_slack_dm_inbound.py
@@ -57,6 +57,13 @@ class FakeMessaging:
         _ = handle
         return ""
 
+    def auth_test(self) -> RawAPIDict:
+        # The scanner self-filter (#1346) probes this once to learn the
+        # bot's own user / bot ids. Returning a fully-resolved identity
+        # keeps these legacy tests focused on persistence and
+        # idempotency behaviour rather than the self-filter path.
+        return {"ok": True, "user_id": "U_BOT_SELF", "bot_id": "B_BOT_SELF"}
+
 
 class TestScan:
     def test_one_user_message_creates_one_row(self) -> None:

--- a/tests/teatree_loop/test_slack_dm_inbound_self_filter.py
+++ b/tests/teatree_loop/test_slack_dm_inbound_self_filter.py
@@ -1,0 +1,227 @@
+"""Regression: scanner must drop bot's own outbound DMs (#1346).
+
+The Slack inbound bridge enqueues a ``PendingChatInjection`` row for every
+DM the bot's IM channel surfaces. The Socket Mode receiver only filters
+``subtype=bot_message`` — but Slack delivers the bot's own outbound posts
+as regular ``message`` events whose ``user`` matches the bot's user id and
+whose ``bot_id`` matches the bot's bot id. Without a self-filter at the
+scanner the bot's outbound DMs are persisted, the UserPromptSubmit hook
+injects them as "user replies", and the reactive Slack-answer cycle spawns
+``t3:answerer`` sub-agents that try to answer the bot's own message.
+
+The filter must apply at the lowest common helper so BOTH downstream
+consumers — the UserPromptSubmit ``handle_inject_pending_chat`` and the
+reactive ``run_slack_answer_cycle`` — inherit it. Filtering at
+``SlackDmInboundScanner.scan()`` (the write side) achieves that: rows that
+fail the filter never reach the DB.
+
+Fail-closed: when the bot's own identity cannot be resolved (network down
+at startup, auth.test returns ok:false), the scanner refuses to enqueue
+any row that turn — better silent than spam-spawning answerer sub-agents
+against unfiltered traffic.
+"""
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from teatree.core.models import PendingChatInjection
+from teatree.loop.scanners.slack_dm_inbound import SlackDmInboundScanner
+from teatree.types import RawAPIDict
+
+pytestmark = pytest.mark.django_db
+
+_OWN_USER_ID = "U_BOT_SELF"
+_OWN_BOT_ID = "B_BOT_SELF"
+_USER_ID = "U_HUMAN"
+_CHANNEL = "D0B35DKMKFF"
+
+
+@dataclass
+class FakeMessagingWithAuth:
+    """MessagingBackend whose ``auth_test`` returns the bot's own ids."""
+
+    dms: list[RawAPIDict] = field(default_factory=list)
+    auth_response: RawAPIDict = field(
+        default_factory=lambda: {"ok": True, "user_id": _OWN_USER_ID, "bot_id": _OWN_BOT_ID},
+    )
+    auth_test_calls: int = 0
+
+    def fetch_mentions(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return []
+
+    def fetch_dms(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return self.dms
+
+    def fetch_reactions(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return []
+
+    def fetch_message(self, *, channel: str, ts: str) -> RawAPIDict:
+        _ = (channel, ts)
+        return {}
+
+    def fetch_channel_history(self, *, channel: str, limit: int = 50) -> list[RawAPIDict]:
+        _ = (channel, limit)
+        return []
+
+    def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:
+        _ = (channel, text, thread_ts)
+        return {}
+
+    def post_reply(self, *, channel: str, ts: str, text: str) -> RawAPIDict:
+        _ = (channel, ts, text)
+        return {}
+
+    def open_dm(self, user_id: str) -> str:
+        _ = user_id
+        return _CHANNEL
+
+    def get_permalink(self, *, channel: str, ts: str) -> str:
+        _ = (channel, ts)
+        return ""
+
+    def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
+        _ = (channel, ts, emoji)
+        return {}
+
+    def resolve_user_id(self, handle: str) -> str:
+        _ = handle
+        return ""
+
+    def auth_test(self) -> RawAPIDict:
+        self.auth_test_calls += 1
+        return self.auth_response
+
+
+class TestSelfFilter:
+    """The scanner must drop messages authored by the bot itself (#1346)."""
+
+    def test_drops_bot_outbound_when_user_matches_own_user_id(self) -> None:
+        backend = FakeMessagingWithAuth(
+            dms=[
+                {
+                    "ts": "1779823899.073799",
+                    "user": _OWN_USER_ID,
+                    "channel": _CHANNEL,
+                    "text": "teatree#1283 already fixed on main",
+                },
+                {
+                    "ts": "1779823900.000000",
+                    "user": _USER_ID,
+                    "channel": _CHANNEL,
+                    "text": "actual user reply",
+                },
+            ]
+        )
+
+        signals = SlackDmInboundScanner(backend=backend, overlay="demo").scan()
+
+        rows = list(PendingChatInjection.objects.all())
+        assert len(rows) == 1, f"expected only the user message to persist, got {[r.text for r in rows]}"
+        assert rows[0].text == "actual user reply"
+        assert rows[0].user_id == _USER_ID
+        assert [s.payload["ts"] for s in signals] == ["1779823900.000000"]
+
+    def test_drops_bot_outbound_when_bot_id_matches_own_bot_id(self) -> None:
+        """Bot-style messages may carry only ``bot_id`` (no ``user``)."""
+        backend = FakeMessagingWithAuth(
+            dms=[
+                {
+                    "ts": "1.0",
+                    "bot_id": _OWN_BOT_ID,
+                    "channel": _CHANNEL,
+                    "text": "bot post (no user field)",
+                },
+                {
+                    "ts": "2.0",
+                    "user": _USER_ID,
+                    "channel": _CHANNEL,
+                    "text": "real user message",
+                },
+            ]
+        )
+
+        SlackDmInboundScanner(backend=backend, overlay="demo").scan()
+
+        rows = list(PendingChatInjection.objects.all())
+        assert len(rows) == 1
+        assert rows[0].text == "real user message"
+
+    def test_user_messages_still_enqueued(self) -> None:
+        """The filter must not be over-broad — genuine user DMs pass through."""
+        backend = FakeMessagingWithAuth(
+            dms=[
+                {"ts": "1.0", "user": _USER_ID, "channel": _CHANNEL, "text": "hi"},
+                {"ts": "2.0", "user": _USER_ID, "channel": _CHANNEL, "text": "more"},
+            ]
+        )
+
+        SlackDmInboundScanner(backend=backend, overlay="demo").scan()
+
+        assert PendingChatInjection.objects.count() == 2
+
+    def test_fail_closed_when_auth_test_returns_not_ok(self) -> None:
+        """Identity unknown → no rows enqueued (fail-closed: silent > spam)."""
+        backend = FakeMessagingWithAuth(
+            dms=[
+                {"ts": "1.0", "user": _USER_ID, "channel": _CHANNEL, "text": "real user message"},
+            ],
+            auth_response={"ok": False, "error": "invalid_auth"},
+        )
+
+        signals = SlackDmInboundScanner(backend=backend, overlay="demo").scan()
+
+        assert signals == []
+        assert PendingChatInjection.objects.count() == 0
+
+    def test_fail_closed_when_auth_test_returns_empty(self) -> None:
+        """Empty auth.test response (no bot token configured) → no rows."""
+        backend = FakeMessagingWithAuth(
+            dms=[
+                {"ts": "1.0", "user": _USER_ID, "channel": _CHANNEL, "text": "user msg"},
+            ],
+            auth_response={},
+        )
+
+        signals = SlackDmInboundScanner(backend=backend, overlay="demo").scan()
+
+        assert signals == []
+        assert PendingChatInjection.objects.count() == 0
+
+    def test_fail_closed_when_auth_test_raises(self) -> None:
+        """A transport failure in auth.test → no rows (fail-closed)."""
+        transport_error = RuntimeError("transport down")
+
+        @dataclass
+        class RaisingBackend(FakeMessagingWithAuth):
+            def auth_test(self) -> RawAPIDict:
+                raise transport_error
+
+        backend = RaisingBackend(
+            dms=[
+                {"ts": "1.0", "user": _USER_ID, "channel": _CHANNEL, "text": "user msg"},
+            ],
+        )
+
+        signals = SlackDmInboundScanner(backend=backend, overlay="demo").scan()
+
+        assert signals == []
+        assert PendingChatInjection.objects.count() == 0
+
+    def test_auth_test_resolved_once_per_scanner(self) -> None:
+        """Identity is cached on the scanner — repeated scans don't re-probe auth.test."""
+        backend = FakeMessagingWithAuth(
+            dms=[
+                {"ts": "1.0", "user": _USER_ID, "channel": _CHANNEL, "text": "first"},
+            ]
+        )
+        scanner = SlackDmInboundScanner(backend=backend, overlay="demo")
+
+        scanner.scan()
+        scanner.scan()
+        scanner.scan()
+
+        assert backend.auth_test_calls == 1

--- a/tests/test_pending_chat_injection_hook.py
+++ b/tests/test_pending_chat_injection_hook.py
@@ -302,6 +302,12 @@ class TestE2ESlackToInjection:
                 _ = handle
                 return ""
 
+            def auth_test(self) -> RawAPIDict:
+                # #1346 self-filter probe — return a resolved identity so
+                # genuine user messages are not dropped by the fail-closed
+                # path for this round-trip integration test.
+                return {"ok": True, "user_id": "U_BOT_SELF", "bot_id": "B_BOT_SELF"}
+
         _own_loop("owner")
         backend = FakeBackend(
             dms=[


### PR DESCRIPTION
## Summary

Closes #1346.

Filter the bot's own outbound DMs out of the Slack inbound bridge at the lowest common helper — `SlackDmInboundScanner.scan()` — so neither downstream consumer can be tricked into treating them as user replies:

- `run_slack_answer_cycle` no longer spawns a `t3:answerer` sub-agent against the bot's own posts.
- `handle_inject_pending_chat` (UserPromptSubmit hook) no longer injects them as "user replies" into the next prompt.

The Slack Socket Mode receiver only filtered `subtype=bot_message`; the bot's own outbound posts from `chat.postMessage` arrive as plain `message` events whose `user` is the bot's posted-as user id and whose `bot_id` is the bot's bot id. Filtering at the write site means rows that fail the filter never reach the DB.

## Filter helper

New module `src/teatree/loop/scanners/slack_self_filter.py`:

- `resolve_own_identity(backend)` — probes `auth.test` once and caches the bot's `(user_id, bot_id)`; returns `None` when the call returns `ok:false`, returns `{}`, or raises.
- `is_self_authored(message, identity)` — matches `message['user'] == identity.user_id` OR `message['bot_id'] == identity.bot_id`. Either match is sufficient.
- `filter_self_messages(messages, identity)` — returns `None` when `identity is None` so the scanner fails closed (no rows enqueued that turn).

Two callers inherit it via the single write site:

| Consumer | Read path |
|---|---|
| `handle_inject_pending_chat` (UserPromptSubmit hook in `hooks/scripts/hook_router.py`) | `PendingChatInjection.pending()` |
| `run_slack_answer_cycle` (reactive Slack-answer cycle in `teatree.loop.slack_answer.cycle`) | `PendingChatInjection.loop_unreplied()` |

Both read from `PendingChatInjection`. The scanner is the one place that writes to it, so filtering there is the lowest common helper.

## Fail-closed contract

When `auth.test` cannot resolve the bot's identity (network down at startup, `ok:false`, no bot token configured, transport raise), the scanner enqueues **zero** rows that turn — better silent for one tick than spam-spawning `t3:answerer` sub-agents against unfiltered traffic. Verified by `test_fail_closed_when_auth_test_returns_not_ok`, `test_fail_closed_when_auth_test_returns_empty`, `test_fail_closed_when_auth_test_raises`.

## RED -> GREEN evidence

Pre-fix `tests/teatree_loop/test_slack_dm_inbound_self_filter.py::TestSelfFilter::test_drops_bot_outbound_when_user_matches_own_user_id`:

```text
AssertionError: expected only the user message to persist, got ['teatree#1283 already fixed on main', 'actual user reply']
assert 2 == 1
```

Post-fix all 7 cases in the new test file plus the pre-existing 9 in `test_slack_dm_inbound.py` pass.

## Test plan

- [x] New regression suite: `uv run pytest tests/teatree_loop/test_slack_dm_inbound_self_filter.py -v` (7 passed)
- [x] Pre-existing scanner test suite: `uv run pytest tests/teatree_loop/test_slack_dm_inbound.py` (9 passed)
- [x] Loop test sweep: `uv run pytest tests/teatree_loop/` (967 passed)
- [x] Backend + core + integration: `uv run pytest tests/teatree_backends/ tests/teatree_core/ tests/integration/` (2752 passed, 12 skipped)
- [x] Lint: `uv run ruff check` (clean)
- [x] Format: `uv run ruff format` (no changes)
- [x] Type: `uv run ty check` on the new files (clean)
- [x] prek pre-commit hooks (all gates passed at commit time)