### PR TITLE
fix(lifecycle): advance ticket FSM out of started when its PR merges (#1343)

### DIFF
--- a/src/teatree/core/merge_execution.py
+++ b/src/teatree/core/merge_execution.py
@@ -65,6 +65,7 @@ from urllib.parse import urlparse
 from django.apps import apps
 from django.db import transaction
 from django.utils import timezone
+from django_fsm import TransitionNotAllowed
 
 from teatree.config import discover_overlays
 from teatree.project import find_project_root
@@ -1101,8 +1102,25 @@ def record_merge_and_advance(
         # against a different HEAD.
         session = ticket.resolve_phase_session(agent_id="merge-loop")
         session.visit_phase("merged", agent_id=f"merge-loop@{merged_sha[:12]}")
-        if ticket.state in {"in_review", "merged"}:
-            ticket.mark_merged()
+        # #1343: state-complete reconcile. An authorised, audited PR-merge
+        # is the authority — every pre-merged state (NOT_STARTED through
+        # IN_REVIEW, plus SHIPPED) must advance to MERGED. RETROSPECTED/
+        # DELIVERED are past MERGED and stay where they are; IGNORED is
+        # abandoned. The original ``state in {in_review, merged}`` guard
+        # left STARTED tickets visibly stuck on the statusline after their
+        # PR merged (#1324 follow-up). The FSM source-set on
+        # ``reconcile_merged`` is the single source of truth — catching
+        # ``TransitionNotAllowed`` lets the source list evolve in one
+        # place (the model) without a parallel guard here.
+        try:
+            ticket.reconcile_merged()
+        except TransitionNotAllowed:
+            logger.info(
+                "merge keystone: ticket %s state=%s is past MERGED; FSM unchanged",
+                ticket.pk,
+                ticket.state,
+            )
+        else:
             ticket.save()
         return ticket.state
 

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -76,6 +76,24 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         State.IN_REVIEW,
         State.RETROSPECTED,
     ]
+    # #1343: PR-merge reconcile catches every PRE-MERGED state. The
+    # original guard only fired ``mark_merged()`` from IN_REVIEW/MERGED,
+    # so tickets whose PR landed while the FSM still read STARTED stayed
+    # stuck on the statusline. The merge keystone calls
+    # ``reconcile_merged()``, which targets MERGED from every pre-merged
+    # state (and is idempotent at MERGED). RETROSPECTED/DELIVERED are
+    # past MERGED and must not be dragged backward; IGNORED is abandoned.
+    _MERGED_RECONCILE_SOURCE_STATES: ClassVar[list[str]] = [
+        State.NOT_STARTED,
+        State.SCOPED,
+        State.STARTED,
+        State.CODED,
+        State.TESTED,
+        State.REVIEWED,
+        State.SHIPPED,
+        State.IN_REVIEW,
+        State.MERGED,
+    ]
 
     overlay = models.CharField(max_length=255)
     issue_url = models.URLField(max_length=500, blank=True)
@@ -547,6 +565,34 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         previous teardown reported errors, the operator can re-call
         ``mark_merged()`` to retry. The worker is best-effort and does not
         advance the FSM, so retries are safe.
+        """
+        from teatree.core.tasks import execute_teardown  # noqa: PLC0415
+
+        ticket_pk = int(self.pk)
+        transaction.on_commit(lambda: execute_teardown.enqueue(ticket_pk))
+
+    @transition(
+        field=state,
+        source=_MERGED_RECONCILE_SOURCE_STATES,
+        target=State.MERGED,
+    )
+    def reconcile_merged(self) -> None:
+        """State-complete FSM catch-up to ``MERGED`` on PR-merge (#1343).
+
+        The merge keystone (``merge_execution.record_merge_and_advance``)
+        calls this from its post hook: an authorised, audited PR-merge is
+        the authority — whatever pre-merged state the ticket sat in, the
+        FSM must follow. Mirrors ``reconcile_reviewed`` (#808) — the source
+        is derived from the pre-merged set so a future-added pre-merged
+        state cannot silently re-introduce the stale-``started`` class.
+
+        Post-MERGED states (``RETROSPECTED``/``DELIVERED``) and ``IGNORED``
+        are NOT sources: the keystone must never drag a ticket BACKWARD
+        from a state past MERGED.
+
+        Schedules the same teardown work as ``mark_merged`` so a
+        keystone-driven reconcile cleans up worktrees identically to the
+        normal IN_REVIEW → MERGED path.
         """
         from teatree.core.tasks import execute_teardown  # noqa: PLC0415
 

--- a/tests/teatree_core/test_merge_execution.py
+++ b/tests/teatree_core/test_merge_execution.py
@@ -373,6 +373,49 @@ class TestMergeExecutionEdgeCases(TestCase):
         assert outcome.ticket_state == Ticket.State.RETROSPECTED
         assert MergeAudit.objects.filter(clear=clear).exists()
 
+    def test_record_advance_promotes_started_ticket_to_merged(self) -> None:
+        """#1343: PR-merge keystone advances a ``STARTED`` ticket to ``MERGED``.
+
+        The original guard only fired ``mark_merged()`` when the ticket was
+        already at ``IN_REVIEW``/``MERGED``, so tickets whose PR landed
+        while the FSM still read ``STARTED`` stayed visibly stuck at
+        ``started`` on the statusline. The post hook must reconcile any
+        pre-MERGED non-terminal state to ``MERGED``.
+        """
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.STARTED)
+        clear = _clear(ticket)
+        outcome = _run(clear, _GhStub())
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED, f"PR merged but ticket stuck at {ticket.state} — #1343 regression"
+        assert outcome.ticket_state == Ticket.State.MERGED
+        assert MergeAudit.objects.filter(clear=clear).exists()
+
+    def test_record_advance_promotes_every_pre_merged_state(self) -> None:
+        """State-complete: PR-merge keystone advances EVERY pre-merged state to MERGED.
+
+        Pins the contract so a future-added pre-merged state can't silently
+        re-introduce the ``stale-started`` class. ``RETROSPECTED`` /
+        ``DELIVERED`` / ``IGNORED`` stay where they are (covered by sibling
+        skip-test).
+        """
+        pre_merged = [
+            Ticket.State.NOT_STARTED,
+            Ticket.State.SCOPED,
+            Ticket.State.STARTED,
+            Ticket.State.CODED,
+            Ticket.State.TESTED,
+            Ticket.State.REVIEWED,
+            Ticket.State.SHIPPED,
+            Ticket.State.IN_REVIEW,
+        ]
+        for idx, start_state in enumerate(pre_merged):
+            ticket = Ticket.objects.create(overlay="t3-teatree", state=start_state)
+            clear = _clear(ticket, pr_id=2000 + idx)
+            outcome = _run(clear, _GhStub())
+            ticket.refresh_from_db()
+            assert ticket.state == Ticket.State.MERGED, f"PR merged but {start_state} did not advance to MERGED"
+            assert outcome.ticket_state == Ticket.State.MERGED
+
     def test_merge_response_non_json_falls_back_to_expected_head(self) -> None:
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
         clear = _clear(ticket)

--- a/tests/teatree_core/test_ticket_reconcile_merged.py
+++ b/tests/teatree_core/test_ticket_reconcile_merged.py
@@ -1,0 +1,111 @@
+"""``Ticket.reconcile_merged`` — state-complete FSM catch-up for PR-merge (#1343).
+
+When the keystone merges a PR (``merge_execution.record_merge_and_advance``),
+the linked ticket's FSM must advance to ``MERGED`` regardless of which
+pre-merge state it sat in. The original guard only fired ``mark_merged()``
+when the ticket was already at ``IN_REVIEW``/``MERGED``, so a ticket whose
+PR landed while the FSM still read ``STARTED`` (a common shape when the
+coding agent's session ended before the FSM advanced past coding) stayed
+visibly stuck at ``started`` on the statusline forever.
+
+This transition is the FSM-level expression of "PR merged ⇒ ticket merged":
+any non-past-merged state -> MERGED. Mirrors ``reconcile_reviewed`` (#808).
+"""
+
+import pytest
+from django.test import TestCase
+from django_fsm import TransitionNotAllowed
+
+from teatree.core.models import Ticket
+
+
+class TestReconcileMerged(TestCase):
+    def test_started_reconciles_to_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.STARTED)
+        ticket.reconcile_merged()
+        ticket.save()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_not_started_reconciles_to_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.NOT_STARTED)
+        ticket.reconcile_merged()
+        ticket.save()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_scoped_reconciles_to_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.SCOPED)
+        ticket.reconcile_merged()
+        ticket.save()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_coded_reconciles_to_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.CODED)
+        ticket.reconcile_merged()
+        ticket.save()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_tested_reconciles_to_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.TESTED)
+        ticket.reconcile_merged()
+        ticket.save()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_reviewed_reconciles_to_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.REVIEWED)
+        ticket.reconcile_merged()
+        ticket.save()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_shipped_reconciles_to_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.SHIPPED)
+        ticket.reconcile_merged()
+        ticket.save()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_in_review_reconciles_to_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.IN_REVIEW)
+        ticket.reconcile_merged()
+        ticket.save()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_merged_is_idempotent(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.MERGED)
+        ticket.reconcile_merged()
+        ticket.save()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_retrospected_cannot_reconcile_backwards(self) -> None:
+        """A ticket past MERGED (RETROSPECTED) stays where it is.
+
+        Mirrors the existing ``record_advance_skips_mark_merged`` invariant —
+        the post-merge hook must never drag a ticket BACK from a post-MERGED
+        state to MERGED.
+        """
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.RETROSPECTED)
+        with pytest.raises(TransitionNotAllowed):
+            ticket.reconcile_merged()
+
+    def test_delivered_cannot_reconcile_backwards(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.DELIVERED)
+        with pytest.raises(TransitionNotAllowed):
+            ticket.reconcile_merged()
+
+    def test_ignored_cannot_reconcile_to_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.IGNORED)
+        with pytest.raises(TransitionNotAllowed):
+            ticket.reconcile_merged()
+
+    def test_source_set_partition_is_exhaustive(self) -> None:
+        """Every state is either a reconcile_merged source or refused.
+
+        Structural guard mirroring ``test_source_set_is_complete_partition_of_all_states``
+        on ``reconcile_reviewed``: a future-added State member must be
+        consciously classified here, not silently dropped.
+        """
+        all_states = set(Ticket.State)
+        merge_source = set(Ticket._MERGED_RECONCILE_SOURCE_STATES)
+        refused = {Ticket.State.RETROSPECTED, Ticket.State.DELIVERED, Ticket.State.IGNORED}
+        assert merge_source.isdisjoint(refused), "a state is both reconcile-merged and refused"
+        assert merge_source | refused == all_states, (
+            f"State partition incomplete — unclassified: {all_states - merge_source - refused}"
+        )


### PR DESCRIPTION
## Summary

Fixes [#1343](https://github.com/souliane/teatree/issues/1343) — a ticket whose PR has merged stays visibly stuck at `started` on the statusline because the merge keystone's post hook only fires `mark_merged()` when the FSM already sits at `in_review` / `merged`. The bug is acutely visible after #1324 surfaced the symptom on the bug-snapshot session (`[ov] started: #1317` with the PR already merged).

**Structural path: inline reconciliation** (the canonical t3 pattern — FSM transitions belong to the action that caused them). Picked over a periodic scanner because the merge keystone already runs at the point in time the ticket needs to advance; layering a separate scanner on top duplicates the trigger and widens the window where the statusline lies.

## Implementation

* New FSM transition `Ticket.reconcile_merged()` — state-complete catch-up to `MERGED` from every pre-merged state (`NOT_STARTED` through `IN_REVIEW`, plus `SHIPPED`). `RETROSPECTED` / `DELIVERED` / `IGNORED` are NOT sources: the keystone must never drag a ticket BACKWARD from a state past `MERGED`. Mirrors `reconcile_reviewed` (#808) — the source set is enumerated and pinned by a structural-partition test, so a future-added pre-merged state cannot silently re-introduce the stale-`started` class. Schedules the same `execute_teardown` work as `mark_merged`.

* `merge_execution.record_merge_and_advance` now calls `reconcile_merged()` and catches `TransitionNotAllowed` rather than duplicating the source-state guard. The FSM source-set on the model is the single source of truth.

## Tests

The TDD red was confirmed on the pre-fix code:

```text
INFO teatree.core.merge_execution: merge keystone: souliane/teatree#859 merged at merged0d; ticket state=started
AssertionError: PR merged but ticket stuck at started — #1343 regression
```

After the fix all targeted tests are green; the full suite shows `6956 passed, 13 skipped, 1 deselected, 37 subtests passed` (the deselected `test_in_repo_overlay_resolves_to_three` is a pre-existing failure unrelated to this change, verified by re-running it on `main` HEAD).

## Test plan

- [x] `test_ticket_reconcile_merged.py` — full FSM-level coverage of the new transition (every pre-merged state advances, post-merged states refuse, structural-partition guard).
- [x] `test_record_advance_promotes_started_ticket_to_merged` pins the exact symptom from the issue and is anti-vacuous (RED on pre-fix code, GREEN after).
- [x] `test_record_advance_promotes_every_pre_merged_state` covers every pre-merged source so the contract stays state-complete.
- [x] The existing `test_record_advance_skips_mark_merged_when_state_not_in_review` (RETROSPECTED stays where it is) still passes — backward-drag is still refused.