### PR TITLE
feat(slack): t3 slack react is the only reaction surface — refuse silent thread-emoji fallback (#1281)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -176,6 +176,8 @@ Request parameters are grouped into frozen `slots=True` dataclasses (`PullReques
 
 **Inbound events.** `t3 slack listen` runs a Socket Mode receiver that writes events to append-only JSONL queues (`slack-events.jsonl`, `slack-reactions.jsonl`) so scanners can drain atomically without racing.
 
+**Reaction surface (#1281).** `t3 slack react` is the only sanctioned reaction surface. `reactions.add` failures (`missing_scope`, `not_in_channel`, `mcp_externally_shared_channel_restricted`, …) raise `SlackReactionError` from `backends/slack_react_errors.py` — never silently return `False` — so callers cannot fall back to a `chat.postMessage(text=":emoji:")` thread reply. The CLI translates the raise into a structured exit-1 message pointing at `t3 setup slack-user-token` and souliane/teatree#1232. `SlackBotBackend.post_message` / `post_reply` reject bodies matching `^:[a-z0-9_+\-]+:$` with `SingleEmojiBodyRefusedError`, foreclosing the failure-mode shape at the backend boundary. FSM-side wrappers (`add_reactions_for_transition`, `add_approval_reaction`) catch the raise locally so Slack auth gaps cannot roll back FSM transitions.
+
 **Sync ABC (`core/sync.py`).** `SyncBackend` is an ABC with `is_configured(overlay)` and `sync(overlay) → SyncResult`. Implementations: `GitHubSyncBackend`, `GitLabSyncBackend`. Both consume `CodeHostBackend` — platform-specific code lives only in the Protocol implementation, not in sync logic.
 
 ---

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1991,9 +1991,22 @@ Usage: t3 slack react [OPTIONS] CHANNEL TS EMOJI
  The personal ``xoxp-…`` token at ``pass slack/user-oauth-token``
  (provisioned by ``t3 setup slack-user-token``) is the only credential
  that reliably reaches user DMs and Slack-Connect externally-shared
- channels for ``reactions.add`` (#1232). Exits 0 on success (including
- the idempotent ``already_reacted`` case), 1 when the token is missing,
- 2 on any other Slack-side failure.
+ channels for ``reactions.add`` (#1232).
+
+ Exit codes:
+
+ - ``0`` — success (including the idempotent ``already_reacted`` case).
+ - ``1`` — token is missing **OR** Slack rejected the call with an
+     ``ok:false`` error (``missing_scope``, ``not_in_channel``,
+     ``mcp_externally_shared_channel_restricted``, …). The structured
+     message prints the error code, the remediation CLI
+     (``t3 setup slack-user-token``), #1232, and the BINDING that
+     forbids a thread-emoji fallback
+     (``feedback_react_not_emoji_thread_comment``).
+ - ``2`` — transport-level failure (HTTP 5xx, ``httpx.HTTPError``).
+
+ A non-zero exit means **stop and surface the gap** — never fall back
+ to ``chat.postMessage(text=":emoji:")`` on the broadcast's thread.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    channel      TEXT  Slack channel id (e.g. `D…` for a DM, `C…` for a     │
@@ -2764,6 +2777,13 @@ Usage: t3 teatree e2e run [OPTIONS] [WORK_ITEM]
  ``--target dev|local`` selects the dual-env target and is forwarded to
  whichever runner handles the overlay (see ``external`` for semantics).
 
+ ``--linked-to <ticket-pk>`` (#1322): when the e2e cache repo is not
+ DB-linked to the backend worktree (a frequent shape for
+ out-of-tree test repos), name the backend ticket explicitly so
+ frontend discovery, ``COMPOSE_PROJECT_NAME``, and the env cache
+ feeding ``get_e2e_env_extras`` all route at the linked stack.
+ ``0`` means "no link" (default — back-compat).
+
  Runner-specific flags (``--repo``, ``--playwright-args``) stay on the
  explicit ``external`` subcommand to keep this entry point overlay-agnostic.
 
@@ -2772,15 +2792,16 @@ Usage: t3 teatree e2e run [OPTIONS] [WORK_ITEM]
 │                               URL) — the #794 keystone.                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --test-path                                    TEXT                          │
-│ --at                                           TEXT                          │
-│ --target                                       TEXT                          │
-│ --headed              --no-headed                    [default: no-headed]    │
-│ --update-snapshots    --no-update-snapshots          [default:               │
-│                                                      no-update-snapshots]    │
-│ --docker              --no-docker                    [default: docker]       │
-│ --help                                               Show this message and   │
-│                                                      exit.                   │
+│ --test-path                                   TEXT                           │
+│ --at                                          TEXT                           │
+│ --target                                      TEXT                           │
+│ --headed              --no-headed                      [default: no-headed]  │
+│ --update-snapshots    --no-update-snapsho…             [default:             │
+│                                                        no-update-snapshots]  │
+│ --docker              --no-docker                      [default: docker]     │
+│ --linked-to                                   INTEGER  [default: 0]          │
+│ --help                                                 Show this message and │
+│                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -2827,20 +2848,29 @@ Usage: t3 teatree e2e external [OPTIONS]
  Discovers the frontend port from docker-compose (or local process)
  and reads the tenant variant from the env cache.
 
+ ``--linked-to <ticket-pk>`` (#1322): when the e2e cache repo's
+ auto-registered worktree is not DB-linked to the backend stack
+ (``auto:<branch>`` ticket, different ticket, or no worktree row at
+ all), name the backend ticket explicitly. Discovery,
+ ``COMPOSE_PROJECT_NAME``, and the env cache feeding
+ ``get_e2e_env_extras`` all route at the linked stack. ``0`` means
+ "no link" (default — back-compat with the resolved-worktree path).
+
  Extra Playwright flags (--config, --timeout, --grep, etc.) can be
  passed via --playwright-args: ``--playwright-args="--config x.ts --timeout
  120000"``
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --test-path                                    TEXT                          │
-│ --repo                                         TEXT                          │
-│ --target                                       TEXT                          │
-│ --headed              --no-headed                    [default: no-headed]    │
-│ --update-snapshots    --no-update-snapshots          [default:               │
-│                                                      no-update-snapshots]    │
-│ --playwright-args                              TEXT                          │
-│ --help                                               Show this message and   │
-│                                                      exit.                   │
+│ --test-path                                   TEXT                           │
+│ --repo                                        TEXT                           │
+│ --target                                      TEXT                           │
+│ --headed              --no-headed                      [default: no-headed]  │
+│ --update-snapshots    --no-update-snapsho…             [default:             │
+│                                                        no-update-snapshots]  │
+│ --playwright-args                             TEXT                           │
+│ --linked-to                                   INTEGER  [default: 0]          │
+│ --help                                                 Show this message and │
+│                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -45,6 +45,7 @@ from typing import cast
 
 import httpx
 
+from teatree.backends.slack_react_errors import SingleEmojiBodyRefusedError, is_single_emoji_body
 from teatree.backends.slack_token_policy import SlackOp, channel_token
 from teatree.backends.slack_token_validation import (
     TokenSlotMismatchError,
@@ -54,7 +55,12 @@ from teatree.backends.slack_token_validation import (
 )
 from teatree.types import RawAPIDict, ScannerError, ScannerErrorClass
 
-__all__ = ["SlackBotBackend", "SlackOp", "TokenSlotMismatchError"]
+__all__ = [
+    "SingleEmojiBodyRefusedError",
+    "SlackBotBackend",
+    "SlackOp",
+    "TokenSlotMismatchError",
+]
 
 
 # Slack ``ok:false`` error codes that indicate the bot/user TOKEN is
@@ -471,12 +477,16 @@ class SlackBotBackend:
         return self._post("auth.test", {})
 
     def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:
+        if is_single_emoji_body(text):
+            raise SingleEmojiBodyRefusedError(text)
         payload: SlackPayload = {"channel": channel, "text": text}
         if thread_ts:
             payload["thread_ts"] = thread_ts
         return self._post("chat.postMessage", payload, token=self._channel_token(channel, op=SlackOp.WRITE))
 
     def post_reply(self, *, channel: str, ts: str, text: str) -> RawAPIDict:
+        if is_single_emoji_body(text):
+            raise SingleEmojiBodyRefusedError(text)
         return self._post(
             "chat.postMessage",
             {"channel": channel, "thread_ts": ts, "text": text},

--- a/src/teatree/backends/slack_react_errors.py
+++ b/src/teatree/backends/slack_react_errors.py
@@ -1,0 +1,106 @@
+r"""Errors that enforce ``t3 slack react`` as the only reaction surface (#1281).
+
+Two structural invariants live here:
+
+1.  :class:`SlackReactionError` — raised when Slack rejects a
+    ``reactions.add`` call with ``ok:false``. The pre-#1281 helpers
+    returned ``False`` on ``missing_scope``, ``not_in_channel``,
+    ``mcp_externally_shared_channel_restricted`` and friends; a caller
+    could then "fall back" to ``chat.postMessage(text=":emoji:")`` on the
+    broadcast's thread. The BINDING memory
+    ``feedback_react_not_emoji_thread_comment`` forbids that fallback.
+    Raising loudly at the helper boundary forecloses the silent swallow.
+2.  :class:`SingleEmojiBodyRefusedError` — raised when
+    ``SlackBotBackend.post_message`` / ``post_reply`` are handed a body
+    whose stripped form matches ``^:[a-z0-9_+\-]+:$``. The single-emoji
+    body is the exact failure-mode shape we want to ban — the substitute
+    the agent produced on 2026-05-20 when ``reactions.add`` failed and the
+    agent thought a thread-comment with ``:white_check_mark:`` as text was
+    "close enough". The error points the caller back at ``t3 slack react``.
+
+The module is intentionally tiny and free of Slack-API imports so every
+caller (CLI, backend, FSM-side helpers, the loop scanners) can depend on
+it without circular-import contortions.
+"""
+
+import re
+
+__all__ = [
+    "SLACK_REACTION_REMEDIATION",
+    "SingleEmojiBodyRefusedError",
+    "SlackReactionError",
+    "build_react_error_message",
+    "is_single_emoji_body",
+]
+
+
+_SINGLE_EMOJI_BODY = re.compile(r"^:[a-z0-9_+\-]+:$")
+
+
+def is_single_emoji_body(text: str) -> bool:
+    """Return ``True`` when *text* stripped is a bare ``:emoji:`` token.
+
+    Empty strings, normal prose, and prose that *contains* an emoji
+    (``"Approved :white_check_mark:."``) all return ``False`` — only the
+    standalone-emoji shape is banned, since prose with an emoji inside it
+    is a legitimate reply that doesn't masquerade as a reaction.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return False
+    return bool(_SINGLE_EMOJI_BODY.match(stripped))
+
+
+SLACK_REACTION_REMEDIATION = (
+    "Fix by re-running `t3 setup slack-user-token` (provisions the personal "
+    "xoxp token with reactions:write; see souliane/teatree#1232). "
+    "Do NOT fall back to posting a `:emoji:` thread reply — that is thread "
+    "spam under the user's name, not a reaction. See BINDING memory "
+    "`feedback_react_not_emoji_thread_comment`."
+)
+
+
+def build_react_error_message(error_code: str, channel: str, ts: str) -> str:
+    """Compose the operator-facing message for a :class:`SlackReactionError`."""
+    return f"Slack reactions.add refused on {channel}/{ts} with error={error_code!r}. {SLACK_REACTION_REMEDIATION}"
+
+
+class SlackReactionError(RuntimeError):
+    """Slack's ``reactions.add`` returned ``ok:false`` (#1281).
+
+    Carries the raw Slack error code (``missing_scope``, ``not_in_channel``,
+    ``mcp_externally_shared_channel_restricted``, etc.) so callers can
+    branch on it without re-parsing the message. The message itself
+    points the operator at the documented remediation and the BINDING
+    that forbids the thread-emoji fallback.
+
+    ``already_reacted`` is **not** raised — it is the idempotent
+    success case (the desired end state is the reaction being present).
+    Callers should treat it as success and never construct this class
+    with that code.
+    """
+
+    def __init__(self, error_code: str, message: str) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class SingleEmojiBodyRefusedError(ValueError):
+    """A ``chat.postMessage`` body of ``:emoji:`` shape is refused (#1281).
+
+    The single-emoji body is the substitute the agent produced when
+    ``reactions.add`` failed (missing_scope, restricted channel). Banning
+    the shape at the backend boundary forecloses the silent fallback
+    path. The CLI surface for an actual reaction is ``t3 slack react``;
+    the error message says so explicitly so any operator (or future
+    agent) hitting this gate is steered to the right tool.
+    """
+
+    def __init__(self, body: str) -> None:
+        super().__init__(
+            f"Refusing to post single-emoji body {body!r} via chat.postMessage. "
+            "A single :emoji: thread reply is thread spam, not a reaction — "
+            "use `t3 slack react <channel> <ts> <emoji>` instead (#1281, "
+            "BINDING `feedback_react_not_emoji_thread_comment`)."
+        )
+        self.body = body

--- a/src/teatree/backends/slack_reactions.py
+++ b/src/teatree/backends/slack_reactions.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 
+from teatree.backends.slack_react_errors import SlackReactionError, build_react_error_message
 from teatree.core.overlay_loader import get_overlay
 
 if TYPE_CHECKING:
@@ -56,11 +57,24 @@ def parse_permalink(permalink: str) -> tuple[str, str] | None:
 
 
 def add_reaction(token: str, channel_id: str, timestamp: str, emoji: str) -> bool:
-    """Call Slack ``reactions.add``. Return True on success, False otherwise.
+    """Call Slack ``reactions.add``. Return True on success.
 
     Treats ``already_reacted`` as success — the desired end state is the
-    emoji being present on the message.  All failures are logged but never
-    raised; Slack outages must not block FSM transitions.
+    emoji being present on the message. Transport-level failures (HTTP
+    5xx, ``httpx.HTTPError``) return ``False`` and are logged: a Slack
+    outage must not block FSM transitions, and there is no auth gap to
+    surface.
+
+    Slack-API-level failures (``ok:false`` — ``missing_scope``,
+    ``not_in_channel``, ``mcp_externally_shared_channel_restricted``, …)
+    raise :class:`SlackReactionError` (#1281). The pre-#1281 silent
+    ``return False`` lets callers fall back to
+    ``chat.postMessage(text=":emoji:")`` on the broadcast's thread —
+    which the BINDING memory ``feedback_react_not_emoji_thread_comment``
+    forbids. Raising loudly forecloses that substitute. FSM-side wrappers
+    (:func:`add_reactions_for_transition`) catch the raise locally so a
+    Slack auth gap during a state transition still degrades to a no-op
+    that retries on the next tick.
     """
     if not (token and channel_id and timestamp and emoji):
         return False
@@ -83,8 +97,7 @@ def add_reaction(token: str, channel_id: str, timestamp: str, emoji: str) -> boo
     error = payload.get("error", "")
     if error == "already_reacted":
         return True
-    logger.warning("Slack reactions.add error: %s", error)
-    return False
+    raise SlackReactionError(error, build_react_error_message(error, channel_id, timestamp))
 
 
 def _iter_pr_permalinks(ticket: "Ticket") -> list[str]:
@@ -141,7 +154,22 @@ def add_reactions_for_transition(ticket: "Ticket", transition_name: str) -> int:
         if not parsed:
             continue
         channel_id, timestamp = parsed
-        if add_reaction(token, channel_id, timestamp, emoji):
+        try:
+            success = add_reaction(token, channel_id, timestamp, emoji)
+        except SlackReactionError as exc:
+            # A Slack auth gap (missing_scope, restricted channel, …)
+            # must surface to a human, but not roll back the FSM
+            # transition — the next tick re-tries. Log + continue so
+            # later permalinks still get their reaction attempted.
+            logger.warning(
+                "Slack reactions.add refused for %s/%s (emoji=%s): %s",
+                channel_id,
+                timestamp,
+                emoji,
+                exc,
+            )
+            continue
+        if success:
             posted += 1
     return posted
 
@@ -179,4 +207,17 @@ def add_approval_reaction(pull_request: "PullRequest") -> int:
         return 0
 
     channel_id, timestamp = parsed
-    return 1 if add_reaction(token, channel_id, timestamp, _APPROVAL_EMOJI) else 0
+    try:
+        success = add_reaction(token, channel_id, timestamp, _APPROVAL_EMOJI)
+    except SlackReactionError as exc:
+        # Approval reaction is FSM-coupled: a Slack auth gap surfaces in
+        # the log but must not roll back the approve() transition.
+        logger.warning(
+            "Slack reactions.add refused for %s/%s (emoji=%s): %s",
+            channel_id,
+            timestamp,
+            _APPROVAL_EMOJI,
+            exc,
+        )
+        return 0
+    return 1 if success else 0

--- a/src/teatree/cli/slack_listen.py
+++ b/src/teatree/cli/slack_listen.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import httpx
 import typer
 
+from teatree.backends.slack_react_errors import SlackReactionError, build_react_error_message
 from teatree.backends.slack_receiver import default_queue_path, run_listener
 from teatree.cli.slack_user_token_setup import USER_TOKEN_PASS_KEY
 from teatree.utils.secrets import read_pass
@@ -34,11 +35,18 @@ def post_reaction(*, token: str, channel: str, ts: str, emoji: str) -> bool:
     """Call Slack ``reactions.add`` with *token* and return success.
 
     Treats ``already_reacted`` as success — the desired end state is the
-    emoji being present on the message. Network and API failures are
-    logged but never raised: a Slack outage must not break a fast loop
-    tick. Mirrors :func:`teatree.backends.slack_reactions.add_reaction`
-    but kept inline here so the CLI surface does not pull the FSM-side
-    transition-reaction module just for an HTTP POST.
+    emoji being present on the message. Transport-level failures (HTTP
+    5xx, ``httpx.HTTPError``) return ``False`` and are logged: there is
+    no auth gap to surface, just a network blip.
+
+    Slack-API-level failures (``ok:false`` — ``missing_scope``,
+    ``not_in_channel``, ``mcp_externally_shared_channel_restricted``, …)
+    raise :class:`SlackReactionError` (#1281). The pre-#1281 silent
+    ``return False`` let callers fall back to
+    ``chat.postMessage(text=":emoji:")`` on the broadcast's thread —
+    which the BINDING memory ``feedback_react_not_emoji_thread_comment``
+    forbids. The CLI ``react`` command translates the raise into a
+    structured exit-1 message pointing at the documented remediation.
     """
     if not (token and channel and ts and emoji):
         return False
@@ -61,8 +69,7 @@ def post_reaction(*, token: str, channel: str, ts: str, emoji: str) -> bool:
     error = payload.get("error", "")
     if error == "already_reacted":
         return True
-    logging.getLogger(__name__).warning("Slack reactions.add error: %s", error)
-    return False
+    raise SlackReactionError(error, build_react_error_message(error, channel, ts))
 
 
 def _resolve_overlays(restrict: str) -> list[tuple[str, str, str]]:
@@ -181,7 +188,19 @@ def _ack_messages(messages: list[dict[str, str]]) -> None:
     for msg in messages:
         channel = msg.get("channel", "")
         ts = msg.get("ts", "")
-        post_reaction(token=token, channel=channel, ts=ts, emoji="eyes")
+        try:
+            post_reaction(token=token, channel=channel, ts=ts, emoji="eyes")
+        except SlackReactionError as exc:
+            # ``t3 slack check`` runs from a fast cron — a Slack auth gap
+            # on a single ack must not break the whole tick. Surface the
+            # gap in the log; the next ``react`` invocation (or the
+            # operator's own re-run) gets the same structured hint.
+            logging.getLogger(__name__).warning(
+                "Skipping :eyes: ack on %s/%s: %s",
+                channel,
+                ts,
+                exc,
+            )
 
 
 @slack_app.command("react")
@@ -195,9 +214,22 @@ def react_command(
     The personal ``xoxp-…`` token at ``pass slack/user-oauth-token``
     (provisioned by ``t3 setup slack-user-token``) is the only credential
     that reliably reaches user DMs and Slack-Connect externally-shared
-    channels for ``reactions.add`` (#1232). Exits 0 on success (including
-    the idempotent ``already_reacted`` case), 1 when the token is missing,
-    2 on any other Slack-side failure.
+    channels for ``reactions.add`` (#1232).
+
+    Exit codes:
+
+    - ``0`` — success (including the idempotent ``already_reacted`` case).
+    - ``1`` — token is missing **OR** Slack rejected the call with an
+        ``ok:false`` error (``missing_scope``, ``not_in_channel``,
+        ``mcp_externally_shared_channel_restricted``, …). The structured
+        message prints the error code, the remediation CLI
+        (``t3 setup slack-user-token``), #1232, and the BINDING that
+        forbids a thread-emoji fallback
+        (``feedback_react_not_emoji_thread_comment``).
+    - ``2`` — transport-level failure (HTTP 5xx, ``httpx.HTTPError``).
+
+    A non-zero exit means **stop and surface the gap** — never fall back
+    to ``chat.postMessage(text=":emoji:")`` on the broadcast's thread.
     """
     token = _resolve_reaction_token()
     if not token:
@@ -206,7 +238,12 @@ def react_command(
             "Run `t3 setup slack-user-token` first."
         )
         raise typer.Exit(code=1)
-    if post_reaction(token=token, channel=channel, ts=ts, emoji=emoji):
+    try:
+        success = post_reaction(token=token, channel=channel, ts=ts, emoji=emoji)
+    except SlackReactionError as exc:
+        typer.echo(f"ERROR {exc}")
+        raise typer.Exit(code=1) from exc
+    if success:
         typer.echo(f"OK    Reacted :{emoji}: on {channel}/{ts}")
         return
     typer.echo(f"ERROR reactions.add failed for {channel}/{ts}; see logs.")

--- a/tests/teatree_backends/test_slack_react_only_gate.py
+++ b/tests/teatree_backends/test_slack_react_only_gate.py
@@ -1,0 +1,265 @@
+r"""``t3 slack react`` is the only sanctioned reaction surface (#1281).
+
+Two structural invariants land here:
+
+1.  ``reactions.add`` failures raise :class:`SlackReactionError` — never
+    silently return False — so callers cannot accidentally fall back to a
+    ``chat.postMessage`` thread reply containing the emoji. The
+    ``missing_scope`` case is the primary trigger (BINDING memory
+    ``feedback_react_not_emoji_thread_comment``) but every Slack-side
+    ``ok:false`` is loud.
+2.  ``SlackBotBackend.post_message`` / ``post_reply`` reject a body that
+    is a single ``:emoji:`` token (``^:[a-z0-9_+\-]+:$``) with
+    :class:`SingleEmojiBodyRefusedError`, pointing at ``t3 slack react``.
+    A single-emoji body is the failure-mode shape — banning it forecloses
+    the silent fallback path that produced thread spam on three colleague
+    broadcasts on 2026-05-20.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from teatree.backends import slack_reactions
+from teatree.backends.slack_bot import SlackBotBackend
+from teatree.backends.slack_react_errors import SingleEmojiBodyRefusedError, SlackReactionError, is_single_emoji_body
+from teatree.cli.slack_listen import post_reaction, slack_app
+
+runner = CliRunner()
+
+
+def _response(*, status: int = 200, payload: dict[str, object] | None = None) -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.is_success = status < 400
+    response.status_code = status
+    response.json.return_value = payload or {"ok": True}
+    return response
+
+
+class TestPostReactionRaisesOnSlackError:
+    """``cli/slack_listen.post_reaction`` raises on every Slack ``ok:false``.
+
+    The pre-#1281 helper returned ``False`` on ``missing_scope`` and any
+    other API-level error. A caller could then "fall back" to posting
+    ``chat.postMessage(text=":emoji:")`` on the same broadcast's thread.
+    The BINDING memory ``feedback_react_not_emoji_thread_comment`` forbids
+    that fallback. The structural fix is to make the failure loud at the
+    helper boundary so no caller can swallow it.
+    """
+
+    def test_missing_scope_raises(self) -> None:
+        payload = {"ok": False, "error": "missing_scope"}
+        with (
+            patch("teatree.cli.slack_listen.httpx.post", return_value=_response(payload=payload)),
+            pytest.raises(SlackReactionError) as exc_info,
+        ):
+            post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes")
+
+        assert exc_info.value.error_code == "missing_scope"
+        message = str(exc_info.value)
+        assert "missing_scope" in message
+        # The message MUST steer the operator to the documented remediation —
+        # the scope provisioner CLI and #1232 (the scope-gap issue).
+        assert "t3 setup slack-user-token" in message
+        assert "1232" in message
+        # And it MUST reference the BINDING that forbids the thread-emoji
+        # fallback, so any reader of the traceback knows why we raise.
+        assert "feedback_react_not_emoji_thread_comment" in message
+
+    def test_not_in_channel_raises(self) -> None:
+        payload = {"ok": False, "error": "not_in_channel"}
+        with (
+            patch("teatree.cli.slack_listen.httpx.post", return_value=_response(payload=payload)),
+            pytest.raises(SlackReactionError) as exc_info,
+        ):
+            post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes")
+        assert exc_info.value.error_code == "not_in_channel"
+
+    def test_connect_restricted_raises(self) -> None:
+        payload = {"ok": False, "error": "mcp_externally_shared_channel_restricted"}
+        with (
+            patch("teatree.cli.slack_listen.httpx.post", return_value=_response(payload=payload)),
+            pytest.raises(SlackReactionError) as exc_info,
+        ):
+            post_reaction(token="xoxp-1", channel="C-shared", ts="1.0", emoji="white_check_mark")
+        assert exc_info.value.error_code == "mcp_externally_shared_channel_restricted"
+
+    def test_already_reacted_does_not_raise(self) -> None:
+        payload = {"ok": False, "error": "already_reacted"}
+        with patch("teatree.cli.slack_listen.httpx.post", return_value=_response(payload=payload)):
+            assert post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes") is True
+
+    def test_ok_response_does_not_raise(self) -> None:
+        with patch("teatree.cli.slack_listen.httpx.post", return_value=_response()):
+            assert post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes") is True
+
+
+class TestAddReactionRaisesOnSlackError:
+    """``backends.slack_reactions.add_reaction`` raises on every Slack ``ok:false``.
+
+    Same rule as the CLI helper. The FSM-side wrapper
+    (``add_reactions_for_transition``) catches the exception and continues
+    so a Slack outage cannot block an FSM transition — but the helper
+    itself raises so no future caller can silently swallow the error and
+    substitute a thread-emoji post.
+    """
+
+    def test_missing_scope_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        post = lambda *_a, **_kw: _response(payload={"ok": False, "error": "missing_scope"})  # noqa: E731
+        monkeypatch.setattr(slack_reactions.httpx, "post", post)
+        with pytest.raises(SlackReactionError) as exc_info:
+            slack_reactions.add_reaction("xoxp", "C1", "1.0", "tada")
+        assert exc_info.value.error_code == "missing_scope"
+        assert "feedback_react_not_emoji_thread_comment" in str(exc_info.value)
+
+    def test_already_reacted_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        post = lambda *_a, **_kw: _response(payload={"ok": False, "error": "already_reacted"})  # noqa: E731
+        monkeypatch.setattr(slack_reactions.httpx, "post", post)
+        assert slack_reactions.add_reaction("xoxp", "C1", "1.0", "tada") is True
+
+    def test_ok_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(slack_reactions.httpx, "post", lambda *_a, **_kw: _response())
+        assert slack_reactions.add_reaction("xoxp", "C1", "1.0", "tada") is True
+
+    def test_fsm_wrapper_swallows_react_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``add_reactions_for_transition`` keeps FSM transitions resilient.
+
+        The helper raises loudly, but the FSM-side wrapper must NOT
+        propagate the raise — a Slack outage during a state transition
+        must not roll back the transition. The wrapper counts the failed
+        reaction as a no-op (0 in the return) and the next tick re-tries.
+        """
+        from types import SimpleNamespace  # noqa: PLC0415
+
+        class _Cfg:
+            def get_slack_token(self) -> str:
+                return "xoxp"
+
+            def get_transition_emojis(self) -> dict[str, str]:
+                return {"mark_merged": "tada"}
+
+        overlay = SimpleNamespace(config=_Cfg())
+        monkeypatch.setattr(slack_reactions, "get_overlay", lambda name=None: overlay)
+
+        def _raise(*_a: object, **_kw: object) -> bool:
+            code = "missing_scope"
+            msg = f"Slack reactions.add refused: {code}"
+            raise SlackReactionError(code, msg)
+
+        monkeypatch.setattr(slack_reactions, "add_reaction", _raise)
+
+        ticket = SimpleNamespace(
+            extra={"prs": {"a": {"review_permalink": "https://t.slack.com/archives/C1/p1700000000000100"}}},
+            overlay="",
+            role="author",
+        )
+        # No exception propagates; FSM treats it as 0 successful reactions.
+        assert slack_reactions.add_reactions_for_transition(ticket, "mark_merged") == 0
+
+
+class TestReactCommandSurfaceMissingScope:
+    """``t3 slack react`` exits 1 on ``missing_scope`` with a structured hint.
+
+    Pre-#1281 the CLI exited 2 with the generic ``reactions.add failed``
+    message regardless of the underlying error. The structured hint at
+    exit 1 is required so any operator who hits the scope gap is
+    immediately pointed at the documented remediation — never at a
+    chat.postMessage fallback.
+    """
+
+    def test_missing_scope_exits_1_with_pointer(self) -> None:
+        payload = {"ok": False, "error": "missing_scope"}
+        with (
+            patch("teatree.cli.slack_listen._resolve_reaction_token", return_value="xoxp-1"),
+            patch("teatree.cli.slack_listen.httpx.post", return_value=_response(payload=payload)),
+        ):
+            result = runner.invoke(slack_app, ["react", "D1", "1.0", "eyes"])
+
+        assert result.exit_code == 1, result.stdout
+        # Surface the error code, the remediation CLI, and #1232.
+        assert "missing_scope" in result.stdout
+        assert "t3 setup slack-user-token" in result.stdout
+        assert "1232" in result.stdout
+
+
+class TestSlackBotBackendRejectsSingleEmojiBody:
+    """``SlackBotBackend.post_message`` / ``post_reply`` refuse ``^:[a-z_]+:$`` bodies.
+
+    The failure-mode shape this guards against: an agent that wanted to
+    react but couldn't (missing_scope, restricted channel) substituting a
+    ``chat.postMessage(text=":white_check_mark:")``. Banning the shape
+    forecloses the substitute and forces the operator back to
+    ``reactions.add`` (i.e. ``t3 slack react``).
+    """
+
+    def _backend(self) -> SlackBotBackend:
+        return SlackBotBackend(bot_token="xoxb-test", user_id="U1")
+
+    def test_post_message_rejects_single_emoji(self) -> None:
+        backend = self._backend()
+        with pytest.raises(SingleEmojiBodyRefusedError) as exc_info:
+            backend.post_message(channel="C1", text=":white_check_mark:")
+        msg = str(exc_info.value)
+        assert "t3 slack react" in msg
+        assert ":white_check_mark:" in msg
+
+    def test_post_reply_rejects_single_emoji(self) -> None:
+        backend = self._backend()
+        with pytest.raises(SingleEmojiBodyRefusedError):
+            backend.post_reply(channel="C1", ts="1700000000.000100", text=":eyes:")
+
+    def test_post_reply_rejects_single_emoji_with_whitespace(self) -> None:
+        """Leading/trailing whitespace must not bypass the gate."""
+        backend = self._backend()
+        with pytest.raises(SingleEmojiBodyRefusedError):
+            backend.post_reply(channel="C1", ts="1700000000.000100", text="  :tada:  ")
+
+    def test_post_message_allows_normal_text(self) -> None:
+        backend = self._backend()
+        with patch.object(backend, "_post", return_value={"ok": True}) as posted:
+            backend.post_message(channel="C1", text="Approved, posted :white_check_mark:.")
+        # Normal body passes through to Slack.
+        posted.assert_called_once()
+
+    def test_post_message_allows_empty_text(self) -> None:
+        """An empty body is not a single-emoji body; the guard does not fire here."""
+        backend = self._backend()
+        with patch.object(backend, "_post", return_value={"ok": True}):
+            backend.post_message(channel="C1", text="")
+
+
+class TestIsSingleEmojiBody:
+    """The pure predicate behind the single-emoji guard."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            ":white_check_mark:",
+            ":eyes:",
+            ":tada:",
+            "  :white_check_mark:  ",
+            "\t:eyes:\n",
+            ":thumbsup:",
+            ":+1:",
+            ":-1:",
+        ],
+    )
+    def test_matches_single_emoji(self, body: str) -> None:
+        assert is_single_emoji_body(body) is True
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "",
+            "Approved.",
+            "Approved :white_check_mark:.",
+            ":white_check_mark: :tada:",
+            "  hello  ",
+            ":not closed",
+            "not opened:",
+        ],
+    )
+    def test_does_not_match_normal_text(self, body: str) -> None:
+        assert is_single_emoji_body(body) is False

--- a/tests/teatree_backends/test_slack_reactions.py
+++ b/tests/teatree_backends/test_slack_reactions.py
@@ -74,7 +74,17 @@ class TestAddReaction:
         monkeypatch.setattr(slack_reactions.httpx, "post", post)
         assert add_reaction("xoxb", "C1", "1.0", "tada") is True
 
-    def test_other_error_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_other_error_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """#1281: any Slack ``ok:false`` raises :class:`SlackReactionError`.
+
+        Pre-#1281 the helper returned ``False`` on every non-``already_reacted``
+        error — that let callers silently substitute a
+        ``chat.postMessage(text=":emoji:")`` thread reply, which the BINDING
+        memory ``feedback_react_not_emoji_thread_comment`` forbids. Raising
+        loudly at the helper boundary forecloses the silent swallow.
+        """
+        from teatree.backends.slack_react_errors import SlackReactionError  # noqa: PLC0415
+
         post = _FakePost(
             responses=[
                 httpx.Response(
@@ -85,7 +95,9 @@ class TestAddReaction:
             ],
         )
         monkeypatch.setattr(slack_reactions.httpx, "post", post)
-        assert add_reaction("xoxb", "C1", "1.0", "tada") is False
+        with pytest.raises(SlackReactionError) as exc_info:
+            add_reaction("xoxb", "C1", "1.0", "tada")
+        assert exc_info.value.error_code == "channel_not_found"
 
     def test_http_error_swallowed_and_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def _raise(*_a: object, **_kw: object) -> httpx.Response:

--- a/tests/test_slack_listen.py
+++ b/tests/test_slack_listen.py
@@ -289,10 +289,23 @@ class TestPostReaction:
         with patch("teatree.cli.slack_listen.httpx.post", return_value=self._response(payload=payload)):
             assert post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes") is True
 
-    def test_missing_scope_is_failure(self) -> None:
+    def test_missing_scope_raises(self) -> None:
+        """#1281: ``missing_scope`` raises :class:`SlackReactionError`.
+
+        Pre-#1281 the helper returned ``False`` and a caller could
+        silently substitute a ``chat.postMessage(text=":emoji:")`` thread
+        reply. The BINDING memory ``feedback_react_not_emoji_thread_comment``
+        forbids that fallback. Raising loudly forecloses the swallow.
+        """
+        from teatree.backends.slack_react_errors import SlackReactionError  # noqa: PLC0415
+
         payload = {"ok": False, "error": "missing_scope"}
-        with patch("teatree.cli.slack_listen.httpx.post", return_value=self._response(payload=payload)):
-            assert post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes") is False
+        with (
+            patch("teatree.cli.slack_listen.httpx.post", return_value=self._response(payload=payload)),
+            pytest.raises(SlackReactionError) as exc_info,
+        ):
+            post_reaction(token="xoxp-1", channel="D1", ts="1.0", emoji="eyes")
+        assert exc_info.value.error_code == "missing_scope"
 
     def test_transport_error_is_failure(self) -> None:
         with patch("teatree.cli.slack_listen.httpx.post", side_effect=httpx.ConnectError("nope")):


### PR DESCRIPTION
## Summary

Fixes #1281 — `t3 slack react` is the only sanctioned reaction surface; on `missing_scope` (or any other `ok:false`) the code raises a specific error instead of silently letting callers fall back to a `chat.postMessage(text=":emoji:")` thread reply. The structural fix forecloses the 2026-05-20 thread-spam path documented in BINDING memory `feedback_react_not_emoji_thread_comment`.

- `reactions.add` helpers (`cli/slack_listen.post_reaction`, `backends/slack_reactions.add_reaction`) raise `SlackReactionError` on every Slack `ok:false`. The error carries the raw error code, points at `t3 setup slack-user-token`, references #1232 (the scope gap), and cites the BINDING.
- `t3 slack react` translates the raise into exit-1 with the structured message; transport-level failures keep exit-2.
- FSM-side wrappers (`add_reactions_for_transition`, `add_approval_reaction`) catch the raise locally so Slack auth gaps cannot roll back FSM transitions.
- `SlackBotBackend.post_message` / `post_reply` reject bodies matching `^:[a-z0-9_+\-]+:$` with `SingleEmojiBodyRefusedError`, foreclosing the failure-mode shape at the backend boundary. Normal prose (including prose that contains an emoji) passes through unchanged.

The new exception classes live in a tiny pure module `backends/slack_react_errors.py` (no Slack-API imports) so every caller — CLI, backend, FSM helpers, loop scanners — can depend on it without circular-import contortions.

## Test plan

- [x] New `tests/teatree_backends/test_slack_react_only_gate.py` (30 tests) covers: `missing_scope`/`not_in_channel`/`mcp_externally_shared_channel_restricted` all raise; `already_reacted` and `ok:true` do not; the FSM wrapper swallows the raise; `t3 slack react` exits 1 with the structured pointer; `post_message`/`post_reply` reject single-emoji bodies; the `is_single_emoji_body` predicate matches every standalone-emoji shape and rejects every prose.
- [x] Pre-fix RED proof: stashing the src changes makes `TestPostReactionRaisesOnSlackError::test_missing_scope_raises` fail with `Failed: DID NOT RAISE <class 'teatree.backends.slack_react_errors.SlackReactionError'>`. Stash restored — fix re-applied.
- [x] Updated pre-existing regression tests (`test_other_error_raises` in `test_slack_reactions.py`, `test_missing_scope_raises` in `test_slack_listen.py`) that pinned the pre-#1281 silent-`False` contract — they now pin the raise.
- [x] Full suite: 6971 passed (1 unrelated pre-existing failure in `test_contrib_overlay.py` re. `max_concurrent_auto_starts`, fails on `origin/main` without these changes).
- [x] `prek run --files` on changed files: all hooks pass (ruff, ty-check, banned-terms, editorconfig, blueprint-sync, …).