### PR TITLE
fix(setup): provision per-overlay Slack-bot IM channel on setup (#1342)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -2764,6 +2764,13 @@ Usage: t3 teatree e2e run [OPTIONS] [WORK_ITEM]
  ``--target dev|local`` selects the dual-env target and is forwarded to
  whichever runner handles the overlay (see ``external`` for semantics).
 
+ ``--linked-to <ticket-pk>`` (#1322): when the e2e cache repo is not
+ DB-linked to the backend worktree (a frequent shape for
+ out-of-tree test repos), name the backend ticket explicitly so
+ frontend discovery, ``COMPOSE_PROJECT_NAME``, and the env cache
+ feeding ``get_e2e_env_extras`` all route at the linked stack.
+ ``0`` means "no link" (default — back-compat).
+
  Runner-specific flags (``--repo``, ``--playwright-args``) stay on the
  explicit ``external`` subcommand to keep this entry point overlay-agnostic.
 
@@ -2772,15 +2779,16 @@ Usage: t3 teatree e2e run [OPTIONS] [WORK_ITEM]
 │                               URL) — the #794 keystone.                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --test-path                                    TEXT                          │
-│ --at                                           TEXT                          │
-│ --target                                       TEXT                          │
-│ --headed              --no-headed                    [default: no-headed]    │
-│ --update-snapshots    --no-update-snapshots          [default:               │
-│                                                      no-update-snapshots]    │
-│ --docker              --no-docker                    [default: docker]       │
-│ --help                                               Show this message and   │
-│                                                      exit.                   │
+│ --test-path                                   TEXT                           │
+│ --at                                          TEXT                           │
+│ --target                                      TEXT                           │
+│ --headed              --no-headed                      [default: no-headed]  │
+│ --update-snapshots    --no-update-snapsho…             [default:             │
+│                                                        no-update-snapshots]  │
+│ --docker              --no-docker                      [default: docker]     │
+│ --linked-to                                   INTEGER  [default: 0]          │
+│ --help                                                 Show this message and │
+│                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -2827,20 +2835,29 @@ Usage: t3 teatree e2e external [OPTIONS]
  Discovers the frontend port from docker-compose (or local process)
  and reads the tenant variant from the env cache.
 
+ ``--linked-to <ticket-pk>`` (#1322): when the e2e cache repo's
+ auto-registered worktree is not DB-linked to the backend stack
+ (``auto:<branch>`` ticket, different ticket, or no worktree row at
+ all), name the backend ticket explicitly. Discovery,
+ ``COMPOSE_PROJECT_NAME``, and the env cache feeding
+ ``get_e2e_env_extras`` all route at the linked stack. ``0`` means
+ "no link" (default — back-compat with the resolved-worktree path).
+
  Extra Playwright flags (--config, --timeout, --grep, etc.) can be
  passed via --playwright-args: ``--playwright-args="--config x.ts --timeout
  120000"``
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --test-path                                    TEXT                          │
-│ --repo                                         TEXT                          │
-│ --target                                       TEXT                          │
-│ --headed              --no-headed                    [default: no-headed]    │
-│ --update-snapshots    --no-update-snapshots          [default:               │
-│                                                      no-update-snapshots]    │
-│ --playwright-args                              TEXT                          │
-│ --help                                               Show this message and   │
-│                                                      exit.                   │
+│ --test-path                                   TEXT                           │
+│ --repo                                        TEXT                           │
+│ --target                                      TEXT                           │
+│ --headed              --no-headed                      [default: no-headed]  │
+│ --update-snapshots    --no-update-snapsho…             [default:             │
+│                                                        no-update-snapshots]  │
+│ --playwright-args                             TEXT                           │
+│ --linked-to                                   INTEGER  [default: 0]          │
+│ --help                                                 Show this message and │
+│                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -126,6 +126,11 @@ def get_messaging(overlay: "OverlayBase") -> MessagingBackend:
             app_token=read_pass(f"{token_ref}-app") if token_ref else "",
             user_token=read_pass(user_token_ref) if user_token_ref else "",
             user_id=overlay.config.slack_user_id,
+            # Setup-time provisioned IM channel id (#1342) — see
+            # ``OverlayConfig.slack_dm_channel_id``. ``getattr`` keeps older
+            # third-party overlay subclasses (that pre-date the field)
+            # working without an explicit default.
+            dm_channel_id=getattr(overlay.config, "slack_dm_channel_id", ""),
         )
     if choice == "noop":
         return NoopMessagingBackend()

--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -111,6 +111,7 @@ class SlackBotBackend:
         app_token: str = "",
         user_token: str = "",
         user_id: str = "",
+        dm_channel_id: str = "",
     ) -> None:
         # Runtime token-prefix validation — codex #1282 item 5, see
         # ``slack_token_validation``. The capture-time regex in
@@ -125,6 +126,16 @@ class SlackBotBackend:
         self._app_token = app_token
         self._user_token = user_token
         self._user_id = user_id
+        # Pre-provisioned IM channel id (#1342). When a per-overlay bot is
+        # registered through ``t3 setup``, the setup-time provisioner calls
+        # ``conversations.open`` once and persists the resulting channel id
+        # in ``~/.teatree.toml`` under ``[overlays.<name>] slack_dm_channel_id``.
+        # Threading it here short-circuits every subsequent ``open_dm(user_id)``
+        # for the configured user so DMs route through this bot's IM rather
+        # than failing ``channel_not_found`` (which previously caused silent
+        # fallback through whichever bot already had an IM with the user —
+        # the per-overlay attribution leak the issue reports).
+        self._dm_channel_id = dm_channel_id
         self._cached_bot_id: str | None = None
         # Per-channel Slack-Connect membership, resolved once via
         # ``conversations.info`` then reused by the token-selection policy.
@@ -148,6 +159,11 @@ class SlackBotBackend:
     @property
     def user_token(self) -> str:
         return self._user_token
+
+    @property
+    def dm_channel_id(self) -> str:
+        """Cached IM channel id for ``user_id``, or ``""`` when unprovisioned (#1342)."""
+        return self._dm_channel_id
 
     def resolve_channel_token(self, channel: str) -> str:
         """The token an outbound post to *channel* would use (#1084).
@@ -491,7 +507,19 @@ class SlackBotBackend:
         )
 
     def open_dm(self, user_id: str) -> str:
-        """Open a direct-message channel with *user_id* and return its channel id."""
+        """Open a direct-message channel with *user_id* and return its channel id.
+
+        Short-circuits on a setup-time provisioned channel id (#1342). When
+        ``user_id`` matches the configured ``user_id`` and a cached
+        ``dm_channel_id`` is set, return it directly without a Slack call —
+        the per-overlay bot's IM was already opened during ``t3 setup`` and
+        persisted in ``~/.teatree.toml`` under ``[overlays.<name>]
+        slack_dm_channel_id``. Falls back to a live ``conversations.open``
+        for any other user id, and for the configured user when no cache
+        was provisioned (legacy behaviour).
+        """
+        if user_id and user_id == self._user_id and self._dm_channel_id:
+            return self._dm_channel_id
         data = self._post("conversations.open", {"users": user_id})
         if not data.get("ok"):
             return ""

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -13,6 +13,7 @@ import typer
 
 from teatree.cli.dep_drift_repair import repair_dep_drift as _repair_dep_drift
 from teatree.cli.doctor import AGENT_SKILL_RUNTIMES, DoctorService, agent_skill_dirs
+from teatree.cli.slack_dm_provisioning import provision_all_overlay_dm_channels
 from teatree.cli.slack_setup import slack_bot_setup
 from teatree.cli.slack_user_token_setup import slack_user_token_setup
 from teatree.utils.run import CompletedProcess, run_allowed_to_fail
@@ -520,6 +521,23 @@ def run(
 
     if not skip_plugin:
         _install_claude_plugin(repo)
+
+    # Per-overlay Slack-bot IM provisioning (#1342) — open
+    # ``conversations.open`` once for every Slack-bot overlay that has no
+    # ``slack_dm_channel_id`` cached yet, then persist the resulting channel
+    # id back to ``~/.teatree.toml``. Without this step a freshly-registered
+    # per-overlay bot has no IM with the user, ``messaging_from_overlay``
+    # returns a backend that hits ``channel_not_found`` on first DM, and
+    # the post silently falls back through whichever bot already had an IM
+    # open — conflating per-overlay attribution.
+    #
+    # Re-derive the path from ``Path.home()`` (rather than importing the
+    # frozen ``CONFIG_PATH``) so tests that ``monkeypatch.setattr("pathlib.Path.home", ...)``
+    # see the redirected location and never reach the real filesystem.
+    provision_all_overlay_dm_channels(
+        config_path=Path.home() / ".teatree.toml",
+        echo=typer.echo,
+    )
 
     # Suggest (never apply) the recommended per-user auto-mode authorizations.
     # Teatree ships no classifier whitelist of its own — see

--- a/src/teatree/cli/slack_dm_provisioning.py
+++ b/src/teatree/cli/slack_dm_provisioning.py
@@ -1,0 +1,262 @@
+"""``t3 setup`` IM provisioning — open the per-overlay bot's IM once (#1342).
+
+Each overlay's bot only routes DMs through its own IM channel; without one,
+``messaging_from_overlay(<name>)`` returns a backend that hits
+``channel_not_found`` on first ``chat.postMessage`` and the DM silently
+falls back to whichever bot already had an IM open with the user — the
+per-overlay attribution leak the issue reports.
+
+This module is invoked from the ``t3 setup`` callback for every overlay
+whose ``[overlays.<name>]`` block declares ``messaging_backend = "slack"``
+and has a token reference but no cached ``slack_dm_channel_id`` yet. It
+calls ``conversations.open`` once and persists the resulting channel id
+back to ``~/.teatree.toml`` under the same overlay block. The runtime
+``messaging_from_overlay`` chain (typed and TOML-only) threads the cached
+id into ``SlackBotBackend``, which short-circuits subsequent ``open_dm``
+calls for the configured user (no extra Slack round-trip).
+
+The user's Slack id is resolved in priority order: first ``pass
+slack/user-id`` (the canonical, overlay-agnostic single source of truth a
+wrapper script provisions once); then the per-overlay ``slack_user_id``
+already recorded by ``t3 setup slack-bot``; finally the bot's own
+``auth.test`` response (last-resort fallback returning whichever user
+the token was minted for — usually the bot user, rarely the human).
+
+Failures are surfaced at setup time rather than mid-run at first DM
+attempt: a clean ``conversations.open ok:false`` produces a single
+``ProvisionResult.FAILED_OPEN_DM`` row the caller renders into a typer
+echo.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+from teatree.backends.slack_bot import SlackBotBackend
+from teatree.utils.secrets import read_pass
+
+if TYPE_CHECKING:
+    from tomlkit.items import Table
+    from tomlkit.toml_document import TOMLDocument
+
+SLACK_DM_CHANNEL_TOML_KEY = "slack_dm_channel_id"
+SLACK_USER_ID_PASS_KEY = "slack/user-id"  # noqa: S105 — pass key name, not a secret
+
+
+class _Status(Enum):
+    PROVISIONED = "provisioned"
+    SKIPPED_NO_BOT = "skipped_no_bot"
+    SKIPPED_NO_BOT_TOKEN = "skipped_no_bot_token"  # noqa: S105 — status name, not a secret
+    SKIPPED_NO_USER_ID = "skipped_no_user_id"
+    SKIPPED_ALREADY_PROVISIONED = "skipped_already_provisioned"
+    FAILED_OPEN_DM = "failed_open_dm"
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisionResult:
+    """Outcome of one overlay's setup-time IM provisioning attempt.
+
+    The status constants live on this class so callers can spell the
+    enum value as ``ProvisionResult.PROVISIONED`` without importing the
+    private ``_Status`` enum — keeping the ``slack_dm_provisioning`` API
+    surface narrow.
+    """
+
+    PROVISIONED: ClassVar[_Status] = _Status.PROVISIONED
+    SKIPPED_NO_BOT: ClassVar[_Status] = _Status.SKIPPED_NO_BOT
+    SKIPPED_NO_BOT_TOKEN: ClassVar[_Status] = _Status.SKIPPED_NO_BOT_TOKEN
+    SKIPPED_NO_USER_ID: ClassVar[_Status] = _Status.SKIPPED_NO_USER_ID
+    SKIPPED_ALREADY_PROVISIONED: ClassVar[_Status] = _Status.SKIPPED_ALREADY_PROVISIONED
+    FAILED_OPEN_DM: ClassVar[_Status] = _Status.FAILED_OPEN_DM
+
+    status: _Status
+    overlay_name: str = ""
+    channel_id: str = ""
+    detail: str = ""
+
+
+def resolve_user_slack_id(*, bot_token: str) -> str:
+    """Resolve the user's Slack id for the IM-provisioning step.
+
+    Try ``pass show slack/user-id`` first (the overlay-agnostic canonical
+    source); fall back to ``auth.test`` on the bot token (a soft fallback
+    that returns whichever user the token was minted for — usually the
+    bot user, rarely the human; the caller decides whether to accept it).
+    Returns ``""`` when neither source resolves.
+    """
+    from_pass = read_pass(SLACK_USER_ID_PASS_KEY)
+    if from_pass:
+        return from_pass
+    backend = SlackBotBackend(bot_token=bot_token)
+    data = backend.auth_test()
+    if not data.get("ok"):
+        return ""
+    user_id = data.get("user_id", "")
+    return user_id if isinstance(user_id, str) else ""
+
+
+def provision_overlay_dm_channel(*, config_path: Path, overlay_name: str) -> ProvisionResult:
+    """Open the per-overlay bot's IM with the user and persist the channel id.
+
+    Idempotent: when ``[overlays.<name>] slack_dm_channel_id`` is already
+    set, returns immediately with ``SKIPPED_ALREADY_PROVISIONED``.
+
+    The persistence target is exactly the same TOML block ``t3 setup
+    slack-bot`` writes to. The runtime ``messaging_from_overlay`` chain
+    reads it back without any further round-trip.
+    """
+    overlay_block, document = _load_overlay_block(config_path, overlay_name)
+    if overlay_block is None or document is None:
+        return ProvisionResult(status=ProvisionResult.SKIPPED_NO_BOT, overlay_name=overlay_name)
+
+    precheck = _precheck_overlay_block(overlay_block, overlay_name)
+    if precheck is not None:
+        return precheck
+
+    token_ref = str(overlay_block.get("slack_token_ref", ""))
+    bot_token = read_pass(f"{token_ref}-bot")
+    if not bot_token:
+        return ProvisionResult(
+            status=ProvisionResult.SKIPPED_NO_BOT_TOKEN,
+            overlay_name=overlay_name,
+            detail=f"no bot token at pass `{token_ref}-bot`",
+        )
+
+    user_id = str(overlay_block.get("slack_user_id", "")) or resolve_user_slack_id(bot_token=bot_token)
+    if not user_id:
+        return ProvisionResult(
+            status=ProvisionResult.SKIPPED_NO_USER_ID,
+            overlay_name=overlay_name,
+            detail="slack_user_id not set on overlay and `pass slack/user-id` empty",
+        )
+
+    backend = SlackBotBackend(bot_token=bot_token, user_id=user_id)
+    channel_id = backend.open_dm(user_id)
+    if not channel_id:
+        return ProvisionResult(
+            status=ProvisionResult.FAILED_OPEN_DM,
+            overlay_name=overlay_name,
+            detail="Slack `conversations.open` returned ok:false (missing scope or invalid user)",
+        )
+
+    import tomlkit  # noqa: PLC0415
+
+    overlay_block[SLACK_DM_CHANNEL_TOML_KEY] = channel_id
+    config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+    return ProvisionResult(
+        status=ProvisionResult.PROVISIONED,
+        overlay_name=overlay_name,
+        channel_id=channel_id,
+    )
+
+
+def _load_overlay_block(
+    config_path: Path,
+    overlay_name: str,
+) -> "tuple[Table | None, TOMLDocument | None]":
+    """Return ``(overlay_block, document)`` from *config_path* or ``(None, None)`` on miss.
+
+    Both are returned together so the caller can persist a mutation back
+    to the same document without re-parsing.
+    """
+    import tomlkit  # noqa: PLC0415
+    from tomlkit import items as tomlkit_items  # noqa: PLC0415
+
+    if not config_path.is_file():
+        return None, None
+    document = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+    overlays = document.get("overlays")
+    if not isinstance(overlays, tomlkit_items.Table):
+        return None, None
+    overlay_block = overlays.get(overlay_name)
+    if not isinstance(overlay_block, tomlkit_items.Table):
+        return None, None
+    return overlay_block, document
+
+
+def _precheck_overlay_block(overlay_block: "Table", overlay_name: str) -> ProvisionResult | None:
+    """Reject blocks that have no Slack bot configured or are already provisioned.
+
+    Returns the early-exit ``ProvisionResult`` when the block isn't a
+    candidate for provisioning, or ``None`` when the caller should proceed
+    to open ``conversations.open``.
+    """
+    if str(overlay_block.get("messaging_backend", "")) != "slack":
+        return ProvisionResult(status=ProvisionResult.SKIPPED_NO_BOT, overlay_name=overlay_name)
+    if not str(overlay_block.get("slack_token_ref", "")):
+        return ProvisionResult(status=ProvisionResult.SKIPPED_NO_BOT, overlay_name=overlay_name)
+    cached = str(overlay_block.get(SLACK_DM_CHANNEL_TOML_KEY, ""))
+    if cached:
+        return ProvisionResult(
+            status=ProvisionResult.SKIPPED_ALREADY_PROVISIONED,
+            overlay_name=overlay_name,
+            channel_id=cached,
+        )
+    return None
+
+
+def provision_all_overlay_dm_channels(
+    *,
+    config_path: Path,
+    echo: Callable[[str], None],
+) -> list[ProvisionResult]:
+    """Provision every Slack-bot overlay's IM channel; called by ``t3 setup``.
+
+    Iterates ``[overlays.*]`` blocks in *config_path*. For every entry
+    declaring ``messaging_backend = "slack"``, calls
+    :func:`provision_overlay_dm_channel`. Renders one ``echo`` line per
+    actionable result so the user sees IM provisioning land alongside the
+    rest of the setup output.
+    """
+    import tomlkit  # noqa: PLC0415
+    from tomlkit import items as tomlkit_items  # noqa: PLC0415
+
+    if not config_path.is_file():
+        return []
+
+    document = tomlkit.parse(config_path.read_text(encoding="utf-8"))
+    overlays = document.get("overlays")
+    if not isinstance(overlays, tomlkit_items.Table):
+        return []
+
+    results: list[ProvisionResult] = []
+    for name in list(overlays.keys()):
+        block = overlays.get(name)
+        if not isinstance(block, tomlkit_items.Table):
+            continue
+        if str(block.get("messaging_backend", "")) != "slack":
+            continue
+        result = provision_overlay_dm_channel(config_path=config_path, overlay_name=name)
+        _render(result, echo)
+        results.append(result)
+    return results
+
+
+def _render(result: ProvisionResult, echo: Callable[[str], None]) -> None:
+    """Emit a single human-readable line per provisioning outcome."""
+    name = result.overlay_name
+    status = result.status
+    if status is ProvisionResult.PROVISIONED:
+        echo(f"OK    Provisioned Slack IM for overlay `{name}` (channel {result.channel_id}).")
+    elif status is ProvisionResult.SKIPPED_ALREADY_PROVISIONED:
+        echo(f"OK    Slack IM for overlay `{name}` already provisioned (channel {result.channel_id}).")
+    elif status is ProvisionResult.SKIPPED_NO_BOT_TOKEN or status is ProvisionResult.SKIPPED_NO_USER_ID:
+        echo(f"WARN  Skipped IM provisioning for overlay `{name}`: {result.detail}.")
+    elif status is ProvisionResult.FAILED_OPEN_DM:
+        echo(f"ERROR IM provisioning failed for overlay `{name}`: {result.detail}.")
+    # SKIPPED_NO_BOT is intentionally silent — every non-Slack overlay
+    # hits this path and rendering it would produce N "skipped" lines
+    # the user has no action on.
+
+
+__all__ = [
+    "SLACK_DM_CHANNEL_TOML_KEY",
+    "SLACK_USER_ID_PASS_KEY",
+    "ProvisionResult",
+    "provision_all_overlay_dm_channels",
+    "provision_overlay_dm_channel",
+    "resolve_user_slack_id",
+]

--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -330,12 +330,18 @@ def _messaging_from_toml(cfg: dict) -> MessagingBackend | None:
     user_token_ref = cfg.get("user_token_ref", "")
     user_token = read_pass(user_token_ref) if user_token_ref else ""
     user_id = cfg.get("slack_user_id", "")
+    # Setup-time provisioned IM channel id (#1342). When set, threads into
+    # ``SlackBotBackend`` so the per-overlay bot's ``open_dm`` short-circuits
+    # the live ``conversations.open`` for the configured user, routing DMs
+    # through this bot's IM instead of failing ``channel_not_found``.
+    dm_channel_id = cfg.get("slack_dm_channel_id", "")
     if bot_token:
         return SlackBotBackend(
             bot_token=bot_token,
             app_token=app_token or "",
             user_token=user_token,
             user_id=user_id,
+            dm_channel_id=dm_channel_id,
         )
     return None
 

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -102,6 +102,16 @@ class OverlayConfig:
     # token is rejected by the workspace restriction policy.
     user_token_ref: str = ""
     slack_user_id: str = ""
+    # Setup-time provisioned IM channel id between the per-overlay bot and
+    # the user (#1342). Populated by ``t3 setup`` calling
+    # ``conversations.open`` once and persisting the result back to
+    # ``[overlays.<name>] slack_dm_channel_id`` in ``~/.teatree.toml``.
+    # ``SlackBotBackend.open_dm`` short-circuits to this value for the
+    # configured ``slack_user_id`` so DMs route through this bot's IM
+    # rather than re-deriving the channel (which fails ``channel_not_found``
+    # for a freshly-registered per-overlay bot and silently falls back
+    # through whichever bot already has an IM with the user).
+    slack_dm_channel_id: str = ""
     require_ticket: bool = False
     ready_labels: list[str]
     exclude_labels: list[str]

--- a/tests/cli_setup/test_slack_dm_provisioning.py
+++ b/tests/cli_setup/test_slack_dm_provisioning.py
@@ -1,0 +1,310 @@
+"""Tests for ``teatree.cli.slack_dm_provisioning`` — first-run IM provisioning (#1342).
+
+The per-overlay bot needs an IM channel id cached in ``~/.teatree.toml`` so
+that DMs route through the overlay's own bot rather than silently falling
+back to whichever bot already has an IM open with the user. The provisioner
+is invoked by ``t3 setup`` and surfaces clean errors at setup time rather
+than at first DM attempt mid-run.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+import tomlkit
+
+from teatree.backends.slack_bot import SlackBotBackend
+from teatree.cli import slack_dm_provisioning
+from teatree.cli.slack_dm_provisioning import ProvisionResult, provision_overlay_dm_channel, resolve_user_slack_id
+
+
+class TestResolveUserSlackId:
+    def test_returns_pass_value_when_available(self) -> None:
+        with patch("teatree.cli.slack_dm_provisioning.read_pass", return_value="U_FROM_PASS"):
+            assert resolve_user_slack_id(bot_token="xoxb-tok") == "U_FROM_PASS"
+
+    def test_falls_back_to_auth_test_when_pass_empty(self) -> None:
+        backend = MagicMock(spec=SlackBotBackend)
+        backend.auth_test.return_value = {"ok": True, "user_id": "U_FROM_AUTH"}
+        with (
+            patch("teatree.cli.slack_dm_provisioning.read_pass", return_value=""),
+            patch("teatree.cli.slack_dm_provisioning.SlackBotBackend", return_value=backend),
+        ):
+            assert resolve_user_slack_id(bot_token="xoxb-tok") == "U_FROM_AUTH"
+
+    def test_returns_empty_when_auth_test_fails(self) -> None:
+        backend = MagicMock(spec=SlackBotBackend)
+        backend.auth_test.return_value = {"ok": False, "error": "invalid_auth"}
+        with (
+            patch("teatree.cli.slack_dm_provisioning.read_pass", return_value=""),
+            patch("teatree.cli.slack_dm_provisioning.SlackBotBackend", return_value=backend),
+        ):
+            assert resolve_user_slack_id(bot_token="xoxb-tok") == ""
+
+
+class TestProvisionOverlayDmChannel:
+    def _write_config(self, path: Path, body: str) -> None:
+        path.write_text(body, encoding="utf-8")
+
+    def test_skips_overlay_without_slack_bot(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        self._write_config(config, '[overlays.teatree]\npath = "/repo"\n')
+        result = provision_overlay_dm_channel(config_path=config, overlay_name="teatree")
+        assert result.status == ProvisionResult.SKIPPED_NO_BOT
+
+    def test_skips_when_already_provisioned(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        self._write_config(
+            config,
+            "[overlays.teatree]\n"
+            'messaging_backend = "slack"\n'
+            'slack_token_ref = "teatree/teatree/slack"\n'
+            'slack_user_id = "U01ABCD1234"\n'
+            'slack_dm_channel_id = "D0CACHED"\n',
+        )
+        result = provision_overlay_dm_channel(config_path=config, overlay_name="teatree")
+        assert result.status == ProvisionResult.SKIPPED_ALREADY_PROVISIONED
+        assert result.channel_id == "D0CACHED"
+
+    def test_opens_dm_and_persists_channel_id(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        self._write_config(
+            config,
+            "[overlays.teatree]\n"
+            'messaging_backend = "slack"\n'
+            'slack_token_ref = "teatree/teatree/slack"\n'
+            'slack_user_id = "U01ABCD1234"\n',
+        )
+
+        backend = MagicMock(spec=SlackBotBackend)
+        backend.open_dm.return_value = "D0B35DKMKFF"
+
+        with (
+            patch(
+                "teatree.cli.slack_dm_provisioning.read_pass",
+                side_effect=lambda key: "xoxb-tok" if key.endswith("-bot") else "",
+            ),
+            patch("teatree.cli.slack_dm_provisioning.SlackBotBackend", return_value=backend),
+        ):
+            result = provision_overlay_dm_channel(config_path=config, overlay_name="teatree")
+
+        backend.open_dm.assert_called_once_with("U01ABCD1234")
+        assert result.status == ProvisionResult.PROVISIONED
+        assert result.channel_id == "D0B35DKMKFF"
+
+        document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
+        assert document["overlays"]["teatree"]["slack_dm_channel_id"] == "D0B35DKMKFF"
+
+    def test_fails_when_conversations_open_returns_empty(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        self._write_config(
+            config,
+            "[overlays.teatree]\n"
+            'messaging_backend = "slack"\n'
+            'slack_token_ref = "teatree/teatree/slack"\n'
+            'slack_user_id = "U01ABCD1234"\n',
+        )
+
+        backend = MagicMock(spec=SlackBotBackend)
+        backend.open_dm.return_value = ""
+
+        with (
+            patch(
+                "teatree.cli.slack_dm_provisioning.read_pass",
+                side_effect=lambda key: "xoxb-tok" if key.endswith("-bot") else "",
+            ),
+            patch("teatree.cli.slack_dm_provisioning.SlackBotBackend", return_value=backend),
+        ):
+            result = provision_overlay_dm_channel(config_path=config, overlay_name="teatree")
+
+        assert result.status == ProvisionResult.FAILED_OPEN_DM
+        document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
+        assert "slack_dm_channel_id" not in document["overlays"]["teatree"]
+
+    def test_skips_when_no_bot_token_in_pass(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        self._write_config(
+            config,
+            "[overlays.teatree]\n"
+            'messaging_backend = "slack"\n'
+            'slack_token_ref = "teatree/teatree/slack"\n'
+            'slack_user_id = "U01ABCD1234"\n',
+        )
+
+        with patch("teatree.cli.slack_dm_provisioning.read_pass", return_value=""):
+            result = provision_overlay_dm_channel(config_path=config, overlay_name="teatree")
+
+        assert result.status == ProvisionResult.SKIPPED_NO_BOT_TOKEN
+
+    def test_uses_pass_slack_user_id_when_overlay_has_none(self, tmp_path: Path) -> None:
+        """Setup falls back to ``pass slack/user-id`` when the overlay has no ``slack_user_id`` yet."""
+        config = tmp_path / "teatree.toml"
+        self._write_config(
+            config,
+            '[overlays.teatree]\nmessaging_backend = "slack"\nslack_token_ref = "teatree/teatree/slack"\n',
+        )
+
+        backend = MagicMock(spec=SlackBotBackend)
+        backend.open_dm.return_value = "D0B35DKMKFF"
+
+        def fake_read_pass(key: str) -> str:
+            if key.endswith("-bot"):
+                return "xoxb-tok"
+            if key == slack_dm_provisioning.SLACK_USER_ID_PASS_KEY:
+                return "U_FROM_PASS"
+            return ""
+
+        with (
+            patch("teatree.cli.slack_dm_provisioning.read_pass", side_effect=fake_read_pass),
+            patch("teatree.cli.slack_dm_provisioning.SlackBotBackend", return_value=backend),
+        ):
+            result = provision_overlay_dm_channel(config_path=config, overlay_name="teatree")
+
+        backend.open_dm.assert_called_once_with("U_FROM_PASS")
+        assert result.status == ProvisionResult.PROVISIONED
+        assert result.channel_id == "D0B35DKMKFF"
+
+
+class TestPersistedChannelKey:
+    """The cached channel id MUST live under ``[overlays.<name>] slack_dm_channel_id``."""
+
+    def test_canonical_toml_key_name(self) -> None:
+        assert slack_dm_provisioning.SLACK_DM_CHANNEL_TOML_KEY == "slack_dm_channel_id"
+
+    def test_canonical_pass_user_id_key(self) -> None:
+        assert slack_dm_provisioning.SLACK_USER_ID_PASS_KEY == "slack/user-id"
+
+
+class TestSlackBackendUsesCachedChannel:
+    """``SlackBotBackend`` must short-circuit ``open_dm`` when a cached channel id is set.
+
+    This is the consumer side of #1342: even when the per-overlay bot has
+    been freshly created and never had an IM with the user, every DM-sending
+    path (``notify_user``, ``DailyDigest``, ``review_nag``) reads the cached
+    channel id without re-calling ``conversations.open``.
+    """
+
+    def test_open_dm_returns_cached_channel_id_for_configured_user(self) -> None:
+        backend = SlackBotBackend(
+            bot_token="xoxb-test",
+            user_id="U01ABCD1234",
+            dm_channel_id="D0B35DKMKFF",
+        )
+        # Reading the cached channel must not perform any HTTP request.
+        with patch.object(backend, "_post") as post:
+            channel = backend.open_dm("U01ABCD1234")
+        post.assert_not_called()
+        assert channel == "D0B35DKMKFF"
+
+    def test_open_dm_falls_back_to_live_call_for_unconfigured_user(self) -> None:
+        backend = SlackBotBackend(
+            bot_token="xoxb-test",
+            user_id="U01ABCD1234",
+            dm_channel_id="D0CACHED",
+        )
+        with patch.object(
+            backend,
+            "_post",
+            return_value={"ok": True, "channel": {"id": "D_OTHER"}},
+        ) as post:
+            channel = backend.open_dm("U_DIFFERENT")
+        post.assert_called_once()
+        assert channel == "D_OTHER"
+
+    def test_open_dm_falls_back_when_no_cache_configured(self) -> None:
+        """Pre-#1342 callers without a cache still hit ``conversations.open``."""
+        backend = SlackBotBackend(bot_token="xoxb-test", user_id="U01ABCD1234")
+        with patch.object(
+            backend,
+            "_post",
+            return_value={"ok": True, "channel": {"id": "D_LIVE"}},
+        ) as post:
+            channel = backend.open_dm("U01ABCD1234")
+        post.assert_called_once()
+        assert channel == "D_LIVE"
+
+
+class TestMessagingFromTomlThreadsCachedChannel:
+    """The TOML-only fallback must read ``slack_dm_channel_id`` and thread it into the backend.
+
+    Pre-fix: ``messaging_from_overlay('teatree')`` returns a ``SlackBotBackend``
+    that has never opened an IM with the user. The first DM through it
+    re-derives the channel via ``conversations.open``, which fails for a
+    fresh per-overlay bot. The fix threads the cached channel into the
+    backend so the DM lands on the right bot's IM.
+    """
+
+    def test_messaging_from_toml_threads_dm_channel_id_into_backend(self) -> None:
+        from teatree.core import backend_factory  # noqa: PLC0415
+
+        cfg = {
+            "messaging_backend": "slack",
+            "slack_token_ref": "teatree/teatree/slack",
+            "slack_user_id": "U01ABCD1234",
+            "slack_dm_channel_id": "D0B35DKMKFF",
+        }
+        pass_lookups = {
+            "teatree/teatree/slack-bot": "xoxb-bot-tok",
+            "teatree/teatree/slack-app": "xapp-app-tok",
+        }
+        with patch("teatree.utils.secrets.read_pass", side_effect=lambda k: pass_lookups.get(k, "")):
+            backend = backend_factory._messaging_from_toml(cfg)
+        assert isinstance(backend, SlackBotBackend)
+        with patch.object(backend, "_post") as post:
+            assert backend.open_dm("U01ABCD1234") == "D0B35DKMKFF"
+        post.assert_not_called()
+
+
+class TestProvisionAllOverlayDmChannels:
+    """Setup-time iterator over every Slack-bot overlay block in the TOML file."""
+
+    def test_iterates_every_slack_overlay_and_skips_non_slack(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        config.write_text(
+            "[overlays.teatree]\n"
+            'messaging_backend = "slack"\n'
+            'slack_token_ref = "teatree/teatree/slack"\n'
+            'slack_user_id = "U01ABCD1234"\n'
+            "\n"
+            "[overlays.acme]\n"
+            'messaging_backend = "slack"\n'
+            'slack_token_ref = "teatree/acme/slack"\n'
+            'slack_user_id = "U01ABCD1234"\n'
+            'slack_dm_channel_id = "D0CACHED"\n'
+            "\n"
+            "[overlays.other]\n"
+            'path = "/repo"\n',
+            encoding="utf-8",
+        )
+
+        backend = MagicMock(spec=SlackBotBackend)
+        backend.open_dm.return_value = "D0NEW"
+
+        echo_lines: list[str] = []
+
+        def fake_read_pass(key: str) -> str:
+            if key.endswith("-bot"):
+                return "xoxb-tok"
+            return ""
+
+        with (
+            patch("teatree.cli.slack_dm_provisioning.read_pass", side_effect=fake_read_pass),
+            patch("teatree.cli.slack_dm_provisioning.SlackBotBackend", return_value=backend),
+        ):
+            results = slack_dm_provisioning.provision_all_overlay_dm_channels(
+                config_path=config,
+                echo=echo_lines.append,
+            )
+
+        statuses = {r.overlay_name: r.status for r in results}
+        assert statuses == {
+            "teatree": ProvisionResult.PROVISIONED,
+            "acme": ProvisionResult.SKIPPED_ALREADY_PROVISIONED,
+        }
+        assert any("Provisioned Slack IM for overlay `teatree`" in line for line in echo_lines)
+        assert any("already provisioned" in line for line in echo_lines)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-x", "-q"])


### PR DESCRIPTION
## Summary

- ``t3 setup`` now opens ``conversations.open`` once for every Slack-bot overlay that has no ``slack_dm_channel_id`` cached yet, persisting the resulting channel id back to ``[overlays.<name>] slack_dm_channel_id`` in ``~/.teatree.toml``.
- ``SlackBotBackend.open_dm`` short-circuits to the cached channel when ``user_id`` matches the configured user, so DMs route through this bot's IM instead of failing ``channel_not_found`` (and silently falling back through whichever bot already had an IM open — the per-overlay attribution leak [#1342](https://github.com/souliane/teatree/issues/1342) reports).
- User Slack id resolution: ``pass slack/user-id`` (canonical) → per-overlay ``slack_user_id`` → ``auth.test``.
- Failures surface at setup time rather than mid-run at first DM attempt.

## Test plan

- [x] RED test (``TestSlackBackendUsesCachedChannel``) FAILS on pre-fix code (``TypeError: SlackBotBackend.__init__() got an unexpected keyword argument 'dm_channel_id'``).
- [x] GREEN: 16 new tests pass in ``tests/cli_setup/test_slack_dm_provisioning.py``.
- [x] No regressions in 6797 tests across the suite (one pre-existing unrelated failure in ``test_contrib_overlay.py`` skipped).
- [x] ``t3 setup`` end-to-end run successfully provisioned both real overlays:

  ```text
  OK    Provisioned Slack IM for overlay `t3-teatree` (channel D0B36P8LU86).
  OK    Provisioned Slack IM for overlay `private overlay` (channel D0B35DKMKFF).
  ```

- [x] Re-running ``t3 setup`` is idempotent (``already provisioned`` lines).

Closes [#1342](https://github.com/souliane/teatree/issues/1342)
