### PR TITLE
fix(scanners): nag scanner sees manually-broadcast MRs (#1256)

### DIFF
--- a/src/teatree/loop/scanners/slack_broadcasts.py
+++ b/src/teatree/loop/scanners/slack_broadcasts.py
@@ -178,6 +178,35 @@ def _open_subset(states: Sequence[MrState]) -> list[MrState]:
     return [state for state in states if not state.merged]
 
 
+def _seed_review_request_posts(
+    *,
+    channel: str,
+    ts: str,
+    states: Sequence[MrState],
+) -> None:
+    """Seed a ``ReviewRequestPost`` for every open MR in a broadcast (#1256).
+
+    The ``ReviewNagScanner`` walks ``ReviewRequestPost`` rows; before #1256
+    only the bot's review-request flow wrote those rows, so manually-posted
+    MRs in the review channel escaped the +1/+2/+3/+5d nag cadence. Seeding
+    here closes that gap — the broadcast scanner is the single ingestion
+    point for any colleague- or author-broadcast.
+
+    Idempotent on ``mr_url`` via ``record_review_request_post``: a re-scan
+    refreshes the channel/thread reference but preserves ``last_nag_step``
+    and ``done_at`` so the nag state machine is not reset. Merged URLs are
+    skipped — only open MRs need nagging.
+    """
+    from teatree.loop.review_request_tracker import record_review_request_post  # noqa: PLC0415
+
+    for state in _open_subset(states):
+        record_review_request_post(
+            mr_url=state.url,
+            slack_channel_id=channel,
+            slack_thread_ts=ts,
+        )
+
+
 @dataclass(slots=True)
 class SlackBroadcastsScanner:
     """Scan one or more Slack channels for MR-broadcast messages.
@@ -252,6 +281,11 @@ class SlackBroadcastsScanner:
         row = ScannedBroadcast.record(observation)
         if row is None:
             return []
+        # #1256: seed a ReviewRequestPost for every open MR in the broadcast
+        # so the ReviewNagScanner picks them up — manual broadcasts in the
+        # review channel were previously invisible to the nag train because
+        # only the bot's review-request flow wrote ReviewRequestPost rows.
+        _seed_review_request_posts(channel=row.channel, ts=row.slack_ts, states=states)
         signals = self._apply_classification(row, states)
         # #1295 cap B: detect ``<@user_slack_id>`` mentions so the
         # mechanical assigner picks up the MR without waiting for a

--- a/tests/teatree_loop/test_review_nag_covers_manual_broadcasts.py
+++ b/tests/teatree_loop/test_review_nag_covers_manual_broadcasts.py
@@ -1,0 +1,147 @@
+"""ReviewNagScanner must nag both bot-tracked AND manually-broadcast MRs (#1256).
+
+The ``ReviewNagScanner`` walks ``ReviewRequestPost`` rows on every tick.
+Before #1256 the only writers of those rows were the bot's review-request
+flow (``record_review_request_post``); a manual post in the review channel
+(detected by ``SlackBroadcastsScanner``) created a ``ScannedBroadcast`` row
+but no ``ReviewRequestPost`` row, leaving the nag scanner blind to it.
+
+The fix wires ``SlackBroadcastsScanner`` to also seed a ``ReviewRequestPost``
+for every open MR it ingests, so both paths feed the same nag pipeline.
+"""
+
+import datetime as dt
+from dataclasses import dataclass, field
+from typing import Any
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.models import ReviewRequestPost
+from teatree.loop.review_request_tracker import record_review_request_post
+from teatree.loop.scanners.review_nag import ReviewNagScanner
+from teatree.loop.scanners.slack_broadcasts import MrState, SlackBroadcastsScanner
+from teatree.types import RawAPIDict
+
+CHANNEL = "C0AM3TENTLK"
+BOT_THREAD_TS = "1700000000.001"
+MANUAL_TS = "1700000099.999"
+MR_BOT = "https://gitlab.example.com/team/project/-/merge_requests/7400"
+MR_MANUAL = "https://gitlab.example.com/team/project/-/merge_requests/7437"
+
+
+@dataclass
+class FakeSlack:
+    """In-memory messaging backend recording posts and reacts."""
+
+    posts: list[dict[str, Any]] = field(default_factory=list)
+    react_calls: list[tuple[str, str, str]] = field(default_factory=list)
+    usergroup_id: str = ""
+    dm_channel: str = "D-USER"
+
+    def fetch_mentions(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return []
+
+    def fetch_dms(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return []
+
+    def fetch_reactions(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        return []
+
+    def fetch_message(self, *, channel: str, ts: str) -> RawAPIDict:
+        _ = (channel, ts)
+        return {}
+
+    def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:
+        self.posts.append({"channel": channel, "text": text, "thread_ts": thread_ts})
+        return {"ok": True, "ts": f"reply.{len(self.posts)}"}
+
+    def post_reply(self, *, channel: str, ts: str, text: str) -> RawAPIDict:
+        return self.post_message(channel=channel, text=text, thread_ts=ts)
+
+    def open_dm(self, user_id: str) -> str:
+        _ = user_id
+        return self.dm_channel
+
+    def get_permalink(self, *, channel: str, ts: str) -> str:
+        return f"https://slack.example/{channel}/p{ts.replace('.', '')}"
+
+    def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
+        self.react_calls.append((channel, ts, emoji))
+        return {"ok": True}
+
+    def resolve_user_id(self, handle: str) -> str:
+        if handle == "engineers":
+            return self.usergroup_id
+        return ""
+
+    def auth_test(self) -> RawAPIDict:
+        return {"ok": True}
+
+
+def _fetcher(messages: dict[str, list[RawAPIDict]]):
+    def fetch(*, channel: str) -> list[RawAPIDict]:
+        return list(messages.get(channel, []))
+
+    return fetch
+
+
+def _classifier(states: dict[str, MrState]):
+    def classify(urls):
+        return [states[url] for url in urls]
+
+    return classify
+
+
+class TestReviewNagCoversBothPaths(TestCase):
+    """Both bot-tracked AND manually-broadcast rows must get nagged."""
+
+    def test_nag_fires_on_bot_tracked_and_manually_broadcast_mr(self) -> None:
+        # --- 1. Bot-created row (the existing path) ---
+        record_review_request_post(
+            mr_url=MR_BOT,
+            slack_channel_id=CHANNEL,
+            slack_thread_ts=BOT_THREAD_TS,
+        )
+
+        # --- 2. Manually-posted row (the gap #1256 closes) ---
+        # A colleague (or the user) hand-posts an MR in the review channel,
+        # outside the teatree review-request flow. The broadcast scanner
+        # ingests it on the next tick — and must seed a ReviewRequestPost
+        # row so the nag scanner can find it.
+        backend = FakeSlack()
+        history = {
+            CHANNEL: [{"text": f"please review {MR_MANUAL}", "ts": MANUAL_TS, "user": "USRG", "type": "message"}]
+        }
+        states = {MR_MANUAL: MrState(url=MR_MANUAL, merged=False, approved=False)}
+        SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+        ).scan()
+
+        # The broadcast scanner must have seeded a ReviewRequestPost for
+        # the manually-posted MR.
+        assert ReviewRequestPost.objects.filter(mr_url=MR_MANUAL).exists(), (
+            "SlackBroadcastsScanner did not seed a ReviewRequestPost for the "
+            "manually-broadcast MR — the nag scanner is blind to it (#1256)."
+        )
+
+        # --- 3. Both rows are now > 24h old ---
+        old = timezone.now() - dt.timedelta(days=1, hours=2)
+        ReviewRequestPost.objects.filter(mr_url__in=[MR_BOT, MR_MANUAL]).update(created_at=old)
+
+        # --- 4. The nag scanner must fire on BOTH ---
+        nag_slack = FakeSlack()
+        signals = ReviewNagScanner(messaging=nag_slack, user_slack_id="U_ME").scan()
+
+        assert any(MR_BOT in p["text"] for p in nag_slack.posts), "ReviewNagScanner did not nag the bot-tracked MR"
+        assert any(MR_MANUAL in p["text"] for p in nag_slack.posts), (
+            "ReviewNagScanner did not nag the manually-broadcast MR (#1256)"
+        )
+        kinds = [s.kind for s in signals]
+        assert kinds.count("review_nag.ping") == 2, f"expected two pings, got {kinds}"


### PR DESCRIPTION
## Summary

`ReviewNagScanner` was blind to manually-posted MRs in the review channel — it only nagged rows the bot itself created via `record_review_request_post`. Closes #1256.

`SlackBroadcastsScanner` already polls the review channel and writes a `ScannedBroadcast` ledger row, but it never touched `ReviewRequestPost`. The nag scanner's `filter(done_at__isnull=True)` walked an empty shadow of the channel for every colleague- or user-broadcast.

This change adds a single seed call inside `SlackBroadcastsScanner._handle_message`: for every open MR in a broadcast, write (or refresh) a `ReviewRequestPost` via `record_review_request_post`. Both ingestion paths now feed the same nag pipeline.

## Behavior

- Bot-posted MR (`record_review_request_post`): unchanged — already worked.
- Manually-posted MR (any human in the review channel): now seeds `ReviewRequestPost` on the next broadcast tick, then the nag scanner picks it up at +1/+2/+3/+5d as designed.
- Re-scans are idempotent on `mr_url`: `record_review_request_post` updates the channel/thread reference but preserves `last_nag_step` and `done_at`, so the nag state machine is not reset.
- Merged MRs are skipped (`_open_subset`) — nothing to nag on.

## Files changed

- `src/teatree/loop/scanners/slack_broadcasts.py` — new `_seed_review_request_posts` helper, called from `_handle_message` after the `ScannedBroadcast` row is recorded.
- `tests/teatree_loop/test_review_nag_covers_manual_broadcasts.py` — integration test: one bot-tracked row + one manually-broadcast row, both > 24h old, scanner emits two `review_nag.ping` signals.

## Test plan

- [x] RED test pre-fix: `tests/teatree_loop/test_review_nag_covers_manual_broadcasts.py` fails on the manual-broadcast assertion
- [x] GREEN post-fix: same test passes
- [x] Full suite: 6942 passed, 13 skipped (one unrelated pre-existing failure unrelated to this change)
- [x] prek run on changed files: all hooks pass