### PR TITLE
feat(review): structured-evidence schema for review findings (#1280)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -216,6 +216,8 @@ Posting discipline (#1207): `t3 review post-comment` defaults to creating a DRAF
 
 Review-shape audit (#1206): `t3 review run <MR_URL>` is the read-only entry point reviewer sub-agents call before scanning a diff. It fetches MR metadata, classifies complexity, counts existing-review state (open discussions + draft notes + approvals), and emits a structured JSON summary so every reviewer starts from the same shape rather than improvising. The command never publishes — it stays outside the on-behalf surface. GitHub PR URLs return `unsupported_forge` (exit 2) deterministically until a parallel GitHub backend lands.
 
+Structured-evidence gate (#1280): `t3 review post-comment` and `post-draft-note` refuse a finding whose body matches an "X is missing/wrong/broken/stale" pattern unless an accompanying `FindingEvidence` record (passed via `--evidence-json '{...}'`) carries verified receipts. The schema fields are `master_check_paths`, `ticket_dep_refs`, `helper_indirection_paths`, `recent_merge_sweep_query`, and `confidence` (`verified` | `speculative`); the gate passes only when `confidence='verified'` AND at least one of `master_check_paths` or `ticket_dep_refs` is non-empty. Implemented in `teatree.cli.review_evidence_gate`; runs alongside the on-behalf (#960), colleague-MR shape (#1114), and TODO-anchor (#1186) sibling gates inside `ReviewService._run_pre_publish_gates`.
+
 ---
 
 ## 10. Configuration

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -448,18 +448,31 @@ Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
 │ *    note      TEXT     Comment text (markdown) [required]                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --file           TEXT     File path for inline comment — REQUIRED unless     │
-│                           --general is passed.                               │
-│ --line           INTEGER  Line number in the new file (must be an added      │
-│                           line) — REQUIRED unless --general is passed.       │
-│ --general                 Post a general (MR-wide) note instead of an inline │
-│                           one. Mutually exclusive with --file/--line.        │
-│                           Without this flag, --file AND --line are both      │
-│                           required — omitting either is refused upfront so a │
-│                           missed-flag invocation can no longer silently      │
-│                           degrade an intended-inline draft into a general    │
-│                           note (souliane/teatree#72).                        │
-│ --help                    Show this message and exit.                        │
+│ --file                 TEXT     File path for inline comment — REQUIRED      │
+│                                 unless --general is passed.                  │
+│ --line                 INTEGER  Line number in the new file (must be an      │
+│                                 added line) — REQUIRED unless --general is   │
+│                                 passed.                                      │
+│ --general                       Post a general (MR-wide) note instead of an  │
+│                                 inline one. Mutually exclusive with          │
+│                                 --file/--line. Without this flag, --file AND │
+│                                 --line are both required — omitting either   │
+│                                 is refused upfront so a missed-flag          │
+│                                 invocation can no longer silently degrade an │
+│                                 intended-inline draft into a general note    │
+│                                 (souliane/teatree#72).                       │
+│ --evidence-json        TEXT     Structured-evidence record (JSON) for a      │
+│                                 'missing/wrong/broken' finding               │
+│                                 (souliane/teatree#1280). Required when the   │
+│                                 note asserts something is                    │
+│                                 missing/wrong/broken/stale or does not       │
+│                                 exist. JSON keys: master_check_paths (list), │
+│                                 ticket_dep_refs (list),                      │
+│                                 helper_indirection_paths (list),             │
+│                                 recent_merge_sweep_query (str), confidence   │
+│                                 ('verified'|'speculative'). Schema:          │
+│                                 teatree.cli.review_evidence_gate.FindingEvi… │
+│ --help                          Show this message and exit.                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -485,16 +498,30 @@ Usage: t3 review post-comment [OPTIONS] REPO MR NOTE
 │ *    note      TEXT     Comment text (markdown) [required]                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --file        TEXT     File path for inline comment (omit for general note)  │
-│ --line        INTEGER  Line number in the new file (must be an added line)   │
-│                        [default: 0]                                          │
-│ --live                 Publish a colleague-visible comment directly instead  │
-│                        of creating a draft. Requires a single-use            │
-│                        Slack-recorded approval token minted via `t3 review   │
-│                        approve-live-post <mr-url> --slack-ts <ts>` (#1207).  │
-│                        The default (no flag) creates a DRAFT and DMs the     │
-│                        user the link — safe-by-default.                      │
-│ --help                 Show this message and exit.                           │
+│ --file                 TEXT     File path for inline comment (omit for       │
+│                                 general note)                                │
+│ --line                 INTEGER  Line number in the new file (must be an      │
+│                                 added line)                                  │
+│                                 [default: 0]                                 │
+│ --live                          Publish a colleague-visible comment directly │
+│                                 instead of creating a draft. Requires a      │
+│                                 single-use Slack-recorded approval token     │
+│                                 minted via `t3 review approve-live-post      │
+│                                 <mr-url> --slack-ts <ts>` (#1207). The       │
+│                                 default (no flag) creates a DRAFT and DMs    │
+│                                 the user the link — safe-by-default.         │
+│ --evidence-json        TEXT     Structured-evidence record (JSON) for a      │
+│                                 'missing/wrong/broken' finding               │
+│                                 (souliane/teatree#1280). Required when the   │
+│                                 note asserts something is                    │
+│                                 missing/wrong/broken/stale or does not       │
+│                                 exist. JSON keys: master_check_paths (list), │
+│                                 ticket_dep_refs (list),                      │
+│                                 helper_indirection_paths (list),             │
+│                                 recent_merge_sweep_query (str), confidence   │
+│                                 ('verified'|'speculative'). Schema:          │
+│                                 teatree.cli.review_evidence_gate.FindingEvi… │
+│ --help                          Show this message and exit.                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -2764,6 +2791,13 @@ Usage: t3 teatree e2e run [OPTIONS] [WORK_ITEM]
  ``--target dev|local`` selects the dual-env target and is forwarded to
  whichever runner handles the overlay (see ``external`` for semantics).
 
+ ``--linked-to <ticket-pk>`` (#1322): when the e2e cache repo is not
+ DB-linked to the backend worktree (a frequent shape for
+ out-of-tree test repos), name the backend ticket explicitly so
+ frontend discovery, ``COMPOSE_PROJECT_NAME``, and the env cache
+ feeding ``get_e2e_env_extras`` all route at the linked stack.
+ ``0`` means "no link" (default — back-compat).
+
  Runner-specific flags (``--repo``, ``--playwright-args``) stay on the
  explicit ``external`` subcommand to keep this entry point overlay-agnostic.
 
@@ -2772,15 +2806,16 @@ Usage: t3 teatree e2e run [OPTIONS] [WORK_ITEM]
 │                               URL) — the #794 keystone.                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --test-path                                    TEXT                          │
-│ --at                                           TEXT                          │
-│ --target                                       TEXT                          │
-│ --headed              --no-headed                    [default: no-headed]    │
-│ --update-snapshots    --no-update-snapshots          [default:               │
-│                                                      no-update-snapshots]    │
-│ --docker              --no-docker                    [default: docker]       │
-│ --help                                               Show this message and   │
-│                                                      exit.                   │
+│ --test-path                                   TEXT                           │
+│ --at                                          TEXT                           │
+│ --target                                      TEXT                           │
+│ --headed              --no-headed                      [default: no-headed]  │
+│ --update-snapshots    --no-update-snapsho…             [default:             │
+│                                                        no-update-snapshots]  │
+│ --docker              --no-docker                      [default: docker]     │
+│ --linked-to                                   INTEGER  [default: 0]          │
+│ --help                                                 Show this message and │
+│                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -2827,20 +2862,29 @@ Usage: t3 teatree e2e external [OPTIONS]
  Discovers the frontend port from docker-compose (or local process)
  and reads the tenant variant from the env cache.
 
+ ``--linked-to <ticket-pk>`` (#1322): when the e2e cache repo's
+ auto-registered worktree is not DB-linked to the backend stack
+ (``auto:<branch>`` ticket, different ticket, or no worktree row at
+ all), name the backend ticket explicitly. Discovery,
+ ``COMPOSE_PROJECT_NAME``, and the env cache feeding
+ ``get_e2e_env_extras`` all route at the linked stack. ``0`` means
+ "no link" (default — back-compat with the resolved-worktree path).
+
  Extra Playwright flags (--config, --timeout, --grep, etc.) can be
  passed via --playwright-args: ``--playwright-args="--config x.ts --timeout
  120000"``
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --test-path                                    TEXT                          │
-│ --repo                                         TEXT                          │
-│ --target                                       TEXT                          │
-│ --headed              --no-headed                    [default: no-headed]    │
-│ --update-snapshots    --no-update-snapshots          [default:               │
-│                                                      no-update-snapshots]    │
-│ --playwright-args                              TEXT                          │
-│ --help                                               Show this message and   │
-│                                                      exit.                   │
+│ --test-path                                   TEXT                           │
+│ --repo                                        TEXT                           │
+│ --target                                      TEXT                           │
+│ --headed              --no-headed                      [default: no-headed]  │
+│ --update-snapshots    --no-update-snapsho…             [default:             │
+│                                                        no-update-snapshots]  │
+│ --playwright-args                             TEXT                           │
+│ --linked-to                                   INTEGER  [default: 0]          │
+│ --help                                                 Show this message and │
+│                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -30,6 +30,7 @@ from teatree.cli.review_approval import identity_has_reviewed, identity_in_appro
 from teatree.cli.review_audit import ReviewAfterReceipt, notify_review_after_receipt, record_note_claim
 from teatree.cli.review_diff import find_added_line, resolve_inline_position
 from teatree.cli.review_drafts import register as _register_drafts
+from teatree.cli.review_evidence_gate import FindingEvidence, check_finding_evidence
 from teatree.cli.review_on_behalf import check_on_behalf, on_behalf_gate_active
 from teatree.cli.review_on_behalf import register as _register_on_behalf
 from teatree.cli.review_shape_gate import check_review_shape
@@ -39,8 +40,13 @@ from teatree.utils.run import run_allowed_to_fail
 # Re-exports — keep monkeypatch targets under the ``review`` namespace
 # after extraction to :mod:`teatree.cli.review_diff` /
 # :mod:`teatree.cli.review_on_behalf` for module-health LOC reasons.
+# ``resolve_inline_position`` is re-exported here so the existing
+# ``monkeypatch.setattr(review_mod, "resolve_inline_position", …)`` test
+# pattern keeps working after the impl bodies moved to
+# :mod:`teatree.cli.review_post_impl` (#1280).
 _find_added_line = find_added_line
 _on_behalf_gate_active = on_behalf_gate_active
+_resolve_inline_position = resolve_inline_position
 
 review_app = typer.Typer(no_args_is_help=True, help="Code review helpers.")
 _TOKEN_PARTS_COUNT = 2
@@ -93,44 +99,21 @@ class ReviewService:
             return os.environ.get("GITLAB_URL", "https://gitlab.com/api/v4")
 
     def _post_draft_note_impl(self, repo: str, mr: int, note: str, *, file: str, line: int) -> tuple[str, int]:
-        """The pre-gate-passed body of :meth:`post_draft_note` (see docstring)."""
-        api = self._get_api()
-        encoded = repo.replace("/", "%2F")
-        endpoint = f"projects/{encoded}/merge_requests/{mr}/draft_notes"
+        """The pre-gate-passed body of :meth:`post_draft_note` (extracted to :mod:`review_post_impl`)."""
+        from teatree.cli.review_post_impl import post_draft_note_impl  # noqa: PLC0415
 
-        if not (file and line):
-            result = api.post_json(endpoint, {"note": note})
-            if not result:
-                return "Failed to post draft note", 1
-            note_id = dict(result).get("id")
-            record_note_claim(self._resolve_base_url, repo, mr, note_id, endpoint="draft_notes")
-            return f"OK draft_note_id={note_id}", 0
+        return post_draft_note_impl(self, repo, mr, note, file=file, line=line)
 
-        position, error = resolve_inline_position(api, encoded, mr, file, line)
-        if position is None:
-            return error, 1
-
-        result = api.post_json(endpoint, {"note": note, "position": position})
-        if not result:
-            return "Failed to post draft note", 1
-        result_dict = dict(result) if isinstance(result, dict) else {}
-        note_id = result_dict.get("id")
-        line_code = result_dict.get("line_code")
-        if line_code:
-            record_note_claim(self._resolve_base_url, repo, mr, note_id, endpoint="draft_notes", file=file, line=line)
-            return f"OK draft_note_id={note_id}\nline_code={line_code}", 0
-
-        if isinstance(note_id, int):
-            api.delete(f"{endpoint}/{note_id}")
-        return (
-            f"GitLab refused to anchor the draft on {file}:{line} (line_code came back null). "
-            "This usually means the file diff is collapsed because of its size; the draft_notes "
-            "API cannot anchor on collapsed-diff files. Workaround: "
-            f"`t3 review post-comment {repo} {mr} ... --file {file} --line {line}` "
-            "(creates an immediate non-draft inline discussion)."
-        ), 1
-
-    def post_draft_note(self, repo: str, mr: int, note: str, *, file: str = "", line: int = 0) -> tuple[str, int]:
+    def post_draft_note(  # noqa: PLR0913 — public service method whose params map 1:1 to the ``t3 review post-draft-note`` CLI flags; ``evidence`` is the #1280 structured-evidence record and must stay a kwarg on this surface.
+        self,
+        repo: str,
+        mr: int,
+        note: str,
+        *,
+        file: str = "",
+        line: int = 0,
+        evidence: FindingEvidence | None = None,
+    ) -> tuple[str, int]:
         """Post a draft note. Returns (message, exit_code).
 
         For inline notes (file+line), validates that the target line is an added
@@ -139,95 +122,52 @@ class ReviewService:
         (anchor refused, usually because the file diff is collapsed) are
         deleted and surfaced as an error so they cannot be published silently.
 
-        Gated by ``on_behalf_post_mode`` (#960). Under
-        :attr:`~teatree.config.OnBehalfPostMode.IMMEDIATE` posts directly.
-        Under :attr:`~teatree.config.OnBehalfPostMode.DRAFT_OR_ASK` (the
-        new default) posts the draft autonomously and DMs the user with
-        the publish/delete commands — drafts are colleague-invisible and
-        revocable, so the post proceeds without a recorded approval.
-        Under :attr:`~teatree.config.OnBehalfPostMode.ASK` the call is
-        refused without any GitLab side effect when no recorded
-        :class:`OnBehalfApproval` matches
-        ``(<repo>!<mr>, "post_draft_note")``.
+        Gated by the pre-publish chain in :meth:`_run_pre_publish_gates` —
+        ``on_behalf_post_mode`` (#960), colleague-MR shape (#1114), TODO-anchor
+        (#1186), and structured-evidence (#1280, requires ``evidence`` on
+        ``missing/wrong/broken`` finding bodies).
         """
-        blocked = check_on_behalf(repo, mr, "post_draft_note")
+        refusal = self._run_pre_publish_gates(
+            repo=repo, mr=mr, note=note, file=file, line=line, action="post_draft_note", evidence=evidence
+        )
+        if refusal:
+            return refusal, 1
+        return self._post_draft_note_impl(repo, mr, note, file=file, line=line)
+
+    def _run_pre_publish_gates(  # noqa: PLR0913
+        self,
+        *,
+        repo: str,
+        mr: int,
+        note: str,
+        file: str,
+        line: int,
+        action: str,
+        evidence: FindingEvidence | None,
+    ) -> str:
+        """Run on-behalf (#960) → shape (#1114) → TODO-anchor (#1186) → evidence (#1280); first refusal or ``""``."""
+        blocked = check_on_behalf(repo, mr, action)
         if blocked:
-            return blocked, 1
+            return blocked
         encoded = repo.replace("/", "%2F")
         api = self._get_api()
         shape_error = check_review_shape(api=api, encoded_repo=encoded, mr=mr, body=note, inline=bool(file and line))
         if shape_error:
-            return shape_error, 1
+            return shape_error
         todo_error = check_todo_anchor(
             api=api, encoded_repo=encoded, mr=mr, body=note, anchor=InlineAnchor(file=file, line=line)
         )
         if todo_error:
-            return todo_error, 1
-        return self._post_draft_note_impl(repo, mr, note, file=file, line=line)
+            return todo_error
+        return check_finding_evidence(body=note, evidence=evidence)
 
-    def _post_comment_impl(
-        self,
-        repo: str,
-        mr: int,
-        note: str,
-        *,
-        file: str,
-        line: int,
-    ) -> tuple[str, int]:
-        """The pre-gate-passed body of :meth:`post_comment` (see docstring)."""
-        api = self._get_api()
-        encoded = repo.replace("/", "%2F")
+    def _post_comment_impl(self, repo: str, mr: int, note: str, *, file: str, line: int) -> tuple[str, int]:
+        """The pre-gate-passed body of :meth:`post_comment` (extracted to :mod:`review_post_impl`)."""
+        from teatree.cli.review_post_impl import post_comment_impl  # noqa: PLC0415
 
-        if not (file and line):
-            result = api.post_json(f"projects/{encoded}/merge_requests/{mr}/notes", {"body": note})
-            if not result:
-                return "Failed to post comment", 1
-            result_dict = dict(result) if isinstance(result, dict) else {}
-            note_id = result_dict.get("id")
-            record_note_claim(self._resolve_base_url, repo, mr, note_id, endpoint="notes")
-            notify_review_after_receipt(
-                self._resolve_base_url,
-                repo,
-                mr,
-                review_action=ReviewAfterReceipt(
-                    action="post_comment",
-                    summary=f"posted comment note_id={note_id} on {repo}!{mr}",
-                    note_web_url=str(result_dict.get("web_url", "")),
-                ),
-            )
-            return f"OK note_id={note_id}", 0
+        return post_comment_impl(self, repo, mr, note, file=file, line=line)
 
-        position, error = resolve_inline_position(api, encoded, mr, file, line)
-        if position is None:
-            return error, 1
-
-        result = api.post_json(
-            f"projects/{encoded}/merge_requests/{mr}/discussions",
-            {"body": note, "position": position},
-        )
-        if not result:
-            return "Failed to post comment", 1
-        result_dict = dict(result) if isinstance(result, dict) else {}
-        discussion_id = result_dict.get("id")
-        notes = result_dict.get("notes")
-        first_note = notes[0] if isinstance(notes, list) and notes else {}
-        note_type = first_note.get("type") if isinstance(first_note, dict) else None
-        if note_type != "DiffNote":
-            return f"Comment posted but not anchored inline (type={note_type!r}). discussion_id={discussion_id}", 1
-        record_note_claim(self._resolve_base_url, repo, mr, discussion_id, endpoint="discussions", file=file, line=line)
-        notify_review_after_receipt(
-            self._resolve_base_url,
-            repo,
-            mr,
-            review_action=ReviewAfterReceipt(
-                action="post_comment",
-                summary=f"posted inline comment discussion_id={discussion_id} on {repo}!{mr}",
-                note_web_url=str(first_note.get("web_url", "")) if isinstance(first_note, dict) else "",
-            ),
-        )
-        return f"OK discussion_id={discussion_id} (inline DiffNote)", 0
-
-    def post_comment(  # noqa: PLR0913 — public service method whose params map 1:1 to the ``t3 review post-comment`` CLI flags; ``live`` is the load-bearing #1207 default-flip and must stay a kwarg on this surface.
+    def post_comment(  # noqa: PLR0913 — public service method whose params map 1:1 to the ``t3 review post-comment`` CLI flags; ``live`` (#1207 default-flip) and ``evidence`` (#1280) must stay kwargs on this surface.
         self,
         repo: str,
         mr: int,
@@ -236,32 +176,30 @@ class ReviewService:
         file: str = "",
         line: int = 0,
         live: bool = False,
+        evidence: FindingEvidence | None = None,
     ) -> tuple[str, int]:
         """Post an MR comment — DRAFT by default; ``--live`` needs a Slack-recorded LivePostApproval (#1207).
 
         Default path routes through :meth:`post_draft_note` (draft-form on-behalf carve-out).
         ``--live`` requires both a ``post_comment`` on-behalf approval and a LivePostApproval.
+
+        Also gated by the structured-evidence pre-publish gate (#1280):
+        when ``note`` matches an "X is missing/wrong/broken" pattern, the
+        ``evidence`` kwarg must carry a verified
+        :class:`~teatree.cli.review_evidence_gate.FindingEvidence` record.
         """
         from teatree.cli.review_default_draft import check_live_post, notify_draft_created  # noqa: PLC0415
 
         if not live:
-            msg, code = self.post_draft_note(repo, mr, note, file=file, line=line)
+            msg, code = self.post_draft_note(repo, mr, note, file=file, line=line, evidence=evidence)
             if code == 0:
                 notify_draft_created(repo=repo, mr=mr, body=note, message=msg)
             return msg, code
-        blocked = check_on_behalf(repo, mr, "post_comment")
-        if blocked:
-            return blocked, 1
-        encoded = repo.replace("/", "%2F")
-        api = self._get_api()
-        shape_error = check_review_shape(api=api, encoded_repo=encoded, mr=mr, body=note, inline=bool(file and line))
-        if shape_error:
-            return shape_error, 1
-        todo_error = check_todo_anchor(
-            api=api, encoded_repo=encoded, mr=mr, body=note, anchor=InlineAnchor(file=file, line=line)
+        refusal = self._run_pre_publish_gates(
+            repo=repo, mr=mr, note=note, file=file, line=line, action="post_comment", evidence=evidence
         )
-        if todo_error:
-            return todo_error, 1
+        if refusal:
+            return refusal, 1
         blocked_live = check_live_post(repo=repo, mr=mr)
         if blocked_live:
             return blocked_live, 1

--- a/src/teatree/cli/review_commands.py
+++ b/src/teatree/cli/review_commands.py
@@ -7,9 +7,14 @@ thin shims around :class:`teatree.cli.review.ReviewService`; the
 service class owns the gating + ledger logic.
 """
 
+from typing import TYPE_CHECKING
+
 import typer
 
 from teatree.cli.review import ReviewService, review_app
+
+if TYPE_CHECKING:
+    from teatree.cli.review_evidence_gate import FindingEvidence
 
 
 def _require_token() -> ReviewService:
@@ -31,8 +36,32 @@ def _require_token() -> ReviewService:
     return ReviewService(token)
 
 
+_EVIDENCE_JSON_HELP = (
+    "Structured-evidence record (JSON) for a 'missing/wrong/broken' "
+    "finding (souliane/teatree#1280). Required when the note asserts something "
+    "is missing/wrong/broken/stale or does not exist. JSON keys: "
+    "master_check_paths (list[str]), ticket_dep_refs (list[str]), "
+    "helper_indirection_paths (list[str]), recent_merge_sweep_query (str), "
+    "confidence ('verified'|'speculative'). Schema: "
+    "teatree.cli.review_evidence_gate.FindingEvidence."
+)
+
+
+def _parse_evidence(raw: str) -> "FindingEvidence | None":
+    """Build a :class:`FindingEvidence` from a CLI JSON string, or ``None`` when omitted."""
+    from teatree.cli.review_evidence_gate import FindingEvidence  # noqa: PLC0415
+
+    if not raw:
+        return None
+    try:
+        return FindingEvidence.from_json(raw)
+    except ValueError as e:
+        typer.echo(str(e))
+        raise typer.Exit(code=1) from e
+
+
 @review_app.command(name="post-draft-note")
-def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI flag mapped 1:1 to the public `review post-draft-note` surface (repo/mr/note/file/line/general). The `--general` flag is load-bearing — it closes the #72 silent-degradation foot-gun by making the inline-vs-general decision explicit. The arg list IS the CLI contract, not an internal design smell (same rationale as ticket.clear / db.refresh / pr.create).
+def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI flag mapped 1:1 to the public `review post-draft-note` surface (repo/mr/note/file/line/general/evidence-json). The `--general` flag is load-bearing — it closes the #72 silent-degradation foot-gun by making the inline-vs-general decision explicit. `--evidence-json` is load-bearing — it's the #1280 structured-evidence CLI plumbing.
     repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
     mr: int = typer.Argument(help="Merge request IID"),
     note: str = typer.Argument(help="Comment text (markdown)"),
@@ -56,6 +85,7 @@ def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI fl
             "(souliane/teatree#72)."
         ),
     ),
+    evidence_json: str = typer.Option("", "--evidence-json", help=_EVIDENCE_JSON_HELP),
 ) -> None:
     """Post a draft note on a GitLab MR (inline or general).
 
@@ -80,14 +110,15 @@ def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI fl
     )
     service = _require_token()
     validate_inline_or_general(file=file, line=line, general=general)
-    msg, code = service.post_draft_note(repo, mr, note, file=file, line=line or 0)
+    evidence = _parse_evidence(evidence_json)
+    msg, code = service.post_draft_note(repo, mr, note, file=file, line=line or 0, evidence=evidence)
     typer.echo(msg)
     if code:
         raise typer.Exit(code=code)
 
 
 @review_app.command(name="post-comment")
-def post_comment(  # noqa: PLR0913 — typer command: every param is a CLI flag mapped 1:1 to the public ``review post-comment`` surface (repo/mr/note/file/line/live). ``--live`` is load-bearing — its absence is the safe-by-default draft path (#1207).
+def post_comment(  # noqa: PLR0913 — typer command: every param is a CLI flag mapped 1:1 to the public ``review post-comment`` surface (repo/mr/note/file/line/live/evidence-json). ``--live`` is load-bearing — its absence is the safe-by-default draft path (#1207). ``--evidence-json`` is load-bearing — it's the #1280 structured-evidence CLI plumbing.
     repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
     mr: int = typer.Argument(help="Merge request IID"),
     note: str = typer.Argument(help="Comment text (markdown)"),
@@ -104,6 +135,7 @@ def post_comment(  # noqa: PLR0913 — typer command: every param is a CLI flag 
             "(no flag) creates a DRAFT and DMs the user the link — safe-by-default."
         ),
     ),
+    evidence_json: str = typer.Option("", "--evidence-json", help=_EVIDENCE_JSON_HELP),
 ) -> None:
     """Post a comment on a GitLab MR — DRAFT by default, ``--live`` requires Slack approval.
 
@@ -115,7 +147,8 @@ def post_comment(  # noqa: PLR0913 — typer command: every param is a CLI flag 
     for the MR (mint via ``t3 review approve-live-post``).
     """
     service = _require_token()
-    msg, code = service.post_comment(repo, mr, note, file=file, line=line, live=live)
+    evidence = _parse_evidence(evidence_json)
+    msg, code = service.post_comment(repo, mr, note, file=file, line=line, live=live, evidence=evidence)
     typer.echo(msg)
     if code:
         raise typer.Exit(code=code)

--- a/src/teatree/cli/review_evidence_gate.py
+++ b/src/teatree/cli/review_evidence_gate.py
@@ -1,0 +1,258 @@
+"""Structured-evidence pre-publish gate for review findings (souliane/teatree#1280).
+
+When a reviewer posts a finding via :class:`teatree.cli.review.ReviewService`
+whose body matches a ``"X is missing/wrong/broken"`` pattern, the gate refuses
+the post unless an accompanying :class:`FindingEvidence` record carries the
+typed receipts the reviewer used to derive the claim.
+
+Sibling gates on the same publishing flow:
+
+* :mod:`teatree.cli.review_on_behalf` — recorded-approval gate (#960).
+* :mod:`teatree.cli.review_shape_gate` — colleague-MR shape gate (#1114).
+* :mod:`teatree.cli.review_todo_gate` — author-marked TODO/FIXME anchor gate (#1186).
+
+All four run on every publishing call that takes a body, in this order:
+on-behalf → shape → TODO-anchor → evidence. The evidence gate is the last one
+because it is the most expensive to satisfy (the reviewer must do the master
+check / ticket-dep scan / helper indirection lookup work) — earlier gates
+should refuse the cheap mistakes first.
+
+Refusal contract (mirrors the sibling gates):
+
+* The gate function returns ``""`` to proceed, or a non-empty refusal string
+    to refuse. The caller short-circuits the GitLab API call with
+    ``(message, 1)`` — same shape every other gate uses.
+* The refusal names the schema (``FindingEvidence``), the missing field, and
+    the recovery path so the agent knows exactly how to satisfy the gate.
+
+Schema extension path:
+
+The schema starts with a minimal set of fields covering the four common
+review-finding shapes named in #1280 (missing file, missing function, wrong
+API signature, stale documentation). New fields are additive — extend
+:class:`FindingEvidence` with default ``[]`` / ``""`` values, then teach
+:func:`check_finding_evidence` to consult them where appropriate. The
+existing fields never change shape (no rename, no list→dict, no required→
+optional flip) because they are the public CLI surface — instead, add new
+fields alongside.
+"""
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+
+# Confidence values the schema accepts. ``verified`` is the only value that
+# can pass the gate; ``speculative`` is documented so the agent has a way to
+# express "I think this is missing but I have not checked master" — and then
+# the gate drops the finding entirely (silence on a checked claim is correct,
+# per the issue body).
+Confidence = Literal["verified", "speculative"]
+_ALLOWED_CONFIDENCE: frozenset[str] = frozenset({"verified", "speculative"})
+
+# Pattern detection. Anchored on word boundaries so an incidental
+# "the brokerage" or "wrongdoer" does not trip. Two sub-patterns:
+#
+# 1. ``<noun> is/are (missing|wrong|broken|stale)`` — the canonical issue-body
+#    shape ("the helper is missing", "the API signature is wrong").
+# 2. Standalone negation-of-existence phrases — "does not exist", "cannot find",
+#    "there is no", "should not exist", "no such", "missing from" — which
+#    convey the same claim shape without the copula.
+_EVIDENCE_CLAIM_RE = re.compile(
+    r"\b(?:"
+    r"is\s+(?:missing|wrong|broken|stale|incorrect)|"
+    r"are\s+(?:missing|wrong|broken|stale|incorrect)|"
+    r"does\s+not\s+exist|"
+    r"do\s+not\s+exist|"
+    r"doesn'?t\s+exist|"
+    r"don'?t\s+exist|"
+    r"cannot\s+find|"
+    r"can'?t\s+find|"
+    r"there\s+is\s+no\s+(?:such\s+)?[a-z_]+|"
+    r"should\s+not\s+exist|"
+    r"shouldn'?t\s+exist|"
+    r"no\s+such\s+(?:function|method|symbol|file|module|helper|class)|"
+    r"missing\s+from|"
+    r"stale\s+reference"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class FindingEvidence:
+    """Typed evidence record for a review finding (souliane/teatree#1280).
+
+    Each field captures one of the receipts a reviewer used to derive an
+    "X is missing/wrong/broken" claim. The combination is consumed by
+    :func:`check_finding_evidence` to decide whether the publish is allowed.
+
+    Field semantics:
+
+    ``master_check_paths``
+        Files (optionally with ``:LINE`` or ``:START-END`` suffix) the
+        reviewer inspected on ``origin/<default>`` before concluding the
+        thing was absent or wrong. Example: ``"src/teatree/cli/foo.py:42"``.
+
+    ``ticket_dep_refs``
+        Ticket IDs the reviewed MR explicitly cited as upstream
+        dependencies that should already carry the missing piece. Example:
+        ``["souliane/teatree#1234"]``.
+
+    ``helper_indirection_paths``
+        Helper modules the reviewer consulted to confirm the consumer
+        reads the canonical list/registry by indirection (so an apparent
+        local miss does not contradict a non-local registration). May be
+        empty when no helper indirection applies.
+
+    ``recent_merge_sweep_query``
+        The literal ``git log --grep`` / ``gh pr list`` / ``glab mr list``
+        query the reviewer ran to confirm no recent sibling merge added
+        the symbol since the MR's base. May be empty when not applicable
+        (e.g. when ``master_check_paths`` already pins the receipt).
+
+    ``confidence``
+        ``"verified"`` (the reviewer ran the checks and they support the
+        claim) or ``"speculative"`` (the reviewer thinks something is
+        wrong but has not verified). Only ``"verified"`` ever passes the
+        gate — ``"speculative"`` is documented as an explicit escape
+        hatch for the agent to express uncertainty, and the gate drops
+        the finding when it sees this value.
+
+    Extension path (per #1280 "extensible — start with a minimal field
+    set"): add new fields with default values — never change the shape
+    of these five. See module docstring.
+    """
+
+    master_check_paths: list[str] = field(default_factory=list)
+    ticket_dep_refs: list[str] = field(default_factory=list)
+    helper_indirection_paths: list[str] = field(default_factory=list)
+    recent_merge_sweep_query: str = ""
+    confidence: Confidence = "verified"
+
+    @classmethod
+    def from_json(cls, raw: str) -> "FindingEvidence":
+        """Construct from a JSON string (the CLI flag plumbing path).
+
+        Raises :class:`ValueError` when ``raw`` is not valid JSON, is not
+        a JSON object, or names a ``confidence`` outside the
+        ``verified|speculative`` literal set. Unknown keys are ignored
+        (forward-compat with future schema extensions).
+        """
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError as e:
+            msg = f"FindingEvidence.from_json: invalid json: {e}"
+            raise ValueError(msg) from e
+        if not isinstance(obj, dict):
+            msg = "FindingEvidence.from_json: invalid json: expected a JSON object"
+            raise ValueError(msg)  # noqa: TRY004 — uniform ValueError surface for CLI plumbing
+        confidence_raw = obj.get("confidence", "verified")
+        if confidence_raw not in _ALLOWED_CONFIDENCE:
+            msg = (
+                f"FindingEvidence.from_json: confidence={confidence_raw!r} is not one of {sorted(_ALLOWED_CONFIDENCE)}"
+            )
+            raise ValueError(msg)
+        return cls(
+            master_check_paths=_string_list(obj.get("master_check_paths", [])),
+            ticket_dep_refs=_string_list(obj.get("ticket_dep_refs", [])),
+            helper_indirection_paths=_string_list(obj.get("helper_indirection_paths", [])),
+            recent_merge_sweep_query=str(obj.get("recent_merge_sweep_query", "")),
+            confidence=confidence_raw,
+        )
+
+
+def _string_list(value: object) -> list[str]:
+    """Coerce a JSON list value to ``list[str]`` (drop non-strings rather than crash)."""
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if isinstance(item, str)]
+
+
+def looks_like_evidence_claim(body: str) -> bool:
+    """Whether ``body`` reads as an 'X is missing/wrong/broken' claim.
+
+    True when the body matches any of the canonical claim phrases — the
+    pattern set is biased to flag (a false-positive costs the reviewer
+    one structured evidence record; a false-negative recurs the #1280
+    failure mode).
+    """
+    if not body:
+        return False
+    return _EVIDENCE_CLAIM_RE.search(body) is not None
+
+
+def check_finding_evidence(*, body: str, evidence: object) -> str:
+    """Return a non-empty refusal when a claim-shaped post lacks valid evidence.
+
+    Returns ``""`` (proceed) when any of these hold:
+
+    * ``body`` is empty (other gates own the empty-body refusal).
+    * ``body`` does not look like an "X is missing/wrong/broken" claim
+        (no schema needed for a nit or a non-claim observation).
+    * ``evidence`` is a :class:`FindingEvidence` with ``confidence ==
+        "verified"`` AND at least one of ``master_check_paths`` or
+        ``ticket_dep_refs`` is non-empty.
+
+    Returns an actionable refusal string otherwise. The caller short-
+    circuits the GitLab API call with ``(message, 1)`` — same shape every
+    sibling gate uses.
+
+    The ``evidence`` parameter is typed ``object`` rather than
+    ``FindingEvidence | None`` so the CLI plumbing can pass either a
+    dataclass instance or ``None`` without a type-narrow at every
+    caller. Anything that is not a :class:`FindingEvidence` is treated
+    as "no evidence supplied".
+    """
+    if not body:
+        return ""
+    if not looks_like_evidence_claim(body):
+        return ""
+    if not isinstance(evidence, FindingEvidence):
+        return _refusal_missing()
+    if evidence.confidence == "speculative":
+        return _refusal_speculative()
+    if not evidence.master_check_paths and not evidence.ticket_dep_refs:
+        return _refusal_empty_signals()
+    return ""
+
+
+def _refusal_missing() -> str:
+    """Refusal when no evidence record was supplied at all."""
+    return (
+        "Refusing 'missing/wrong/broken' finding without evidence (souliane/teatree#1280):\n"
+        "The body asserts something is missing, wrong, or broken — a structured\n"
+        'FindingEvidence record is required. Pass --evidence-json \'{"master_check_paths":\n'
+        '[...], "ticket_dep_refs": [...], "confidence": "verified"}\' on the CLI, or\n'
+        "downgrade the finding to a non-claim observation (a nit, a question, a\n"
+        "cross-reference). Speculative findings on master-state should drop entirely —\n"
+        "silence on a checked claim is correct.\n"
+        "Schema: teatree.cli.review_evidence_gate.FindingEvidence.\n"
+        "See: https://github.com/souliane/teatree/issues/1280"
+    )
+
+
+def _refusal_speculative() -> str:
+    """Refusal when ``confidence == 'speculative'``."""
+    return (
+        "Refusing speculative 'missing/wrong/broken' finding (souliane/teatree#1280):\n"
+        "FindingEvidence(confidence='speculative') means the reviewer has not verified\n"
+        "the claim against master, the ticket dependencies, or a recent-merge sweep.\n"
+        "Speculative findings drop entirely — silence on a checked claim is correct.\n"
+        "To publish: re-run the checks, populate master_check_paths or ticket_dep_refs,\n"
+        "and set confidence='verified'."
+    )
+
+
+def _refusal_empty_signals() -> str:
+    """Refusal when ``confidence='verified'`` but both signal lists are empty."""
+    return (
+        "Refusing 'missing/wrong/broken' finding with empty evidence signals\n"
+        "(souliane/teatree#1280):\n"
+        "FindingEvidence.confidence='verified' but BOTH master_check_paths and\n"
+        "ticket_dep_refs are empty. At least one must carry an entry:\n"
+        "  - master_check_paths: file(:line) on origin/<default> you inspected, or\n"
+        "  - ticket_dep_refs: ticket IDs the MR cites as upstream dependencies.\n"
+        "A 'verified' tag without either signal is not evidence — it is an assertion\n"
+        "without receipts, which is the #1280 failure mode."
+    )

--- a/src/teatree/cli/review_post_impl.py
+++ b/src/teatree/cli/review_post_impl.py
@@ -1,0 +1,141 @@
+"""Pre-gate-passed publishing bodies for :class:`teatree.cli.review.ReviewService`.
+
+Extracted from :mod:`teatree.cli.review` to keep that file under the
+module-health LOC budget (souliane/teatree#1280). The functions here run
+*after* the pre-publish gate chain in
+:meth:`ReviewService._run_pre_publish_gates` — they never re-check the
+gates and they are not part of the public CLI surface.
+
+Signature: each function takes the ``ReviewService`` instance as the
+first argument (the methods on the class are thin shims that call these).
+SLF001 (private member access) is muted module-wide via per-file-ignores
+because this module IS the extracted implementation of those methods.
+"""
+# ruff: noqa: SLF001 — sibling-module extraction of ReviewService method bodies (#1280).
+
+from typing import TYPE_CHECKING
+
+from teatree.cli.review_audit import ReviewAfterReceipt, notify_review_after_receipt, record_note_claim
+
+
+def _resolve_inline_position(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+    """Indirection so test monkeypatches on ``teatree.cli.review.resolve_inline_position`` apply here too."""
+    from teatree.cli import review as review_mod  # noqa: PLC0415
+
+    return review_mod.resolve_inline_position(*args, **kwargs)
+
+
+resolve_inline_position = _resolve_inline_position
+
+if TYPE_CHECKING:
+    from teatree.cli.review import ReviewService
+
+
+def post_draft_note_impl(  # noqa: PLR0913 — every kwarg maps 1:1 to a public CLI flag on `review post-draft-note`.
+    service: "ReviewService",
+    repo: str,
+    mr: int,
+    note: str,
+    *,
+    file: str,
+    line: int,
+) -> tuple[str, int]:
+    """The pre-gate-passed body of :meth:`ReviewService.post_draft_note`."""
+    api = service._get_api()
+    encoded = repo.replace("/", "%2F")
+    endpoint = f"projects/{encoded}/merge_requests/{mr}/draft_notes"
+
+    if not (file and line):
+        result = api.post_json(endpoint, {"note": note})
+        if not result:
+            return "Failed to post draft note", 1
+        note_id = dict(result).get("id")
+        record_note_claim(service._resolve_base_url, repo, mr, note_id, endpoint="draft_notes")
+        return f"OK draft_note_id={note_id}", 0
+
+    position, error = resolve_inline_position(api, encoded, mr, file, line)
+    if position is None:
+        return error, 1
+
+    result = api.post_json(endpoint, {"note": note, "position": position})
+    if not result:
+        return "Failed to post draft note", 1
+    result_dict = dict(result) if isinstance(result, dict) else {}
+    note_id = result_dict.get("id")
+    line_code = result_dict.get("line_code")
+    if line_code:
+        record_note_claim(service._resolve_base_url, repo, mr, note_id, endpoint="draft_notes", file=file, line=line)
+        return f"OK draft_note_id={note_id}\nline_code={line_code}", 0
+
+    if isinstance(note_id, int):
+        api.delete(f"{endpoint}/{note_id}")
+    return (
+        f"GitLab refused to anchor the draft on {file}:{line} (line_code came back null). "
+        "This usually means the file diff is collapsed because of its size; the draft_notes "
+        "API cannot anchor on collapsed-diff files. Workaround: "
+        f"`t3 review post-comment {repo} {mr} ... --file {file} --line {line}` "
+        "(creates an immediate non-draft inline discussion)."
+    ), 1
+
+
+def post_comment_impl(  # noqa: PLR0913 — every kwarg maps 1:1 to a public CLI flag on `review post-comment`.
+    service: "ReviewService",
+    repo: str,
+    mr: int,
+    note: str,
+    *,
+    file: str,
+    line: int,
+) -> tuple[str, int]:
+    """The pre-gate-passed body of :meth:`ReviewService.post_comment` (live path)."""
+    api = service._get_api()
+    encoded = repo.replace("/", "%2F")
+
+    if not (file and line):
+        result = api.post_json(f"projects/{encoded}/merge_requests/{mr}/notes", {"body": note})
+        if not result:
+            return "Failed to post comment", 1
+        result_dict = dict(result) if isinstance(result, dict) else {}
+        note_id = result_dict.get("id")
+        record_note_claim(service._resolve_base_url, repo, mr, note_id, endpoint="notes")
+        notify_review_after_receipt(
+            service._resolve_base_url,
+            repo,
+            mr,
+            review_action=ReviewAfterReceipt(
+                action="post_comment",
+                summary=f"posted comment note_id={note_id} on {repo}!{mr}",
+                note_web_url=str(result_dict.get("web_url", "")),
+            ),
+        )
+        return f"OK note_id={note_id}", 0
+
+    position, error = resolve_inline_position(api, encoded, mr, file, line)
+    if position is None:
+        return error, 1
+
+    result = api.post_json(
+        f"projects/{encoded}/merge_requests/{mr}/discussions",
+        {"body": note, "position": position},
+    )
+    if not result:
+        return "Failed to post comment", 1
+    result_dict = dict(result) if isinstance(result, dict) else {}
+    discussion_id = result_dict.get("id")
+    notes = result_dict.get("notes")
+    first_note = notes[0] if isinstance(notes, list) and notes else {}
+    note_type = first_note.get("type") if isinstance(first_note, dict) else None
+    if note_type != "DiffNote":
+        return f"Comment posted but not anchored inline (type={note_type!r}). discussion_id={discussion_id}", 1
+    record_note_claim(service._resolve_base_url, repo, mr, discussion_id, endpoint="discussions", file=file, line=line)
+    notify_review_after_receipt(
+        service._resolve_base_url,
+        repo,
+        mr,
+        review_action=ReviewAfterReceipt(
+            action="post_comment",
+            summary=f"posted inline comment discussion_id={discussion_id} on {repo}!{mr}",
+            note_web_url=str(first_note.get("web_url", "")) if isinstance(first_note, dict) else "",
+        ),
+    )
+    return f"OK discussion_id={discussion_id} (inline DiffNote)", 0

--- a/tests/teatree_cli/test_review_evidence_gate.py
+++ b/tests/teatree_cli/test_review_evidence_gate.py
@@ -1,0 +1,570 @@
+"""Structured-evidence pre-publish gate for review findings (souliane/teatree#1280).
+
+When a reviewer posts a finding that asserts something "is missing", "is wrong",
+"is broken", "does not exist", etc. via ``t3 review post-comment`` or
+``post-draft-note``, the gate refuses the post unless a structured
+:class:`teatree.cli.review_evidence_gate.FindingEvidence` record accompanies the
+call. The evidence record carries the typed receipts a reviewer used to derive
+the claim — file:line on master, ticket dependency refs, helper indirections
+consulted, recent-merge sweep query, and a ``verified|speculative`` confidence
+tag.
+
+The gate refuses when:
+
+* The body matches the missing/wrong/broken pattern, AND
+* No evidence record is supplied, OR
+* ``confidence == "speculative"``, OR
+* Neither ``master_check_paths`` nor ``ticket_dep_refs`` carries at least one
+    entry (a verified claim must have looked at master or have a documented
+    upstream ticket — both empty = no evidence at all).
+
+The gate is independent of the sibling gates (on-behalf, shape, TODO-anchor) —
+all four run on every publishing call that takes a body.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from teatree.cli.review import ReviewService
+from teatree.cli.review_evidence_gate import FindingEvidence, check_finding_evidence, looks_like_evidence_claim
+from teatree.config import OnBehalfPostMode
+
+pytestmark = pytest.mark.django_db
+
+
+def _gate_immediate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin on-behalf gate to IMMEDIATE so it does not also block the call."""
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text(
+        f'[teatree]\non_behalf_post_mode = "{OnBehalfPostMode.IMMEDIATE.value}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+
+
+def _disable_other_gates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the colleague-MR shape and TODO-anchor gates so refusals come from the evidence gate only."""
+    from teatree.cli import review as review_mod  # noqa: PLC0415
+
+    monkeypatch.setattr(review_mod, "check_review_shape", lambda **_kw: "")
+    monkeypatch.setattr(review_mod, "check_todo_anchor", lambda **_kw: "")
+
+
+def _build_diff_with_added_line(target_line: int) -> str:
+    """Build a unified diff with every line from ``target_line - 5`` to ``+5`` added.
+
+    Mirrors the helper in :mod:`tests.teatree_cli.test_review_todo_gate` so the
+    anchor line under test is reliably an added (``+``) line in the synthetic diff.
+    """
+    start = max(1, target_line - 5)
+    end = target_line + 5
+    lines = [f"@@ -{start},{end - start + 1} +{start},{end - start + 1} @@"]
+    lines.extend(f"+    code_at_{ln}()" for ln in range(start, end + 1))
+    return "\n".join(lines) + "\n"
+
+
+class _StubAPI:
+    """Stand-in for GitLabAPI — records calls and returns a passing-stub response."""
+
+    def __init__(self, mr_author: str = "carol", target_line: int = 42) -> None:
+        self.calls: list[tuple[str, str, Any]] = []
+        self._mr_author = mr_author
+        self._diff = _build_diff_with_added_line(target_line)
+
+    def post_json(self, endpoint: str, payload: object) -> dict[str, object]:
+        self.calls.append(("post_json", endpoint, payload))
+        return {"id": 1, "notes": [{"type": "DiffNote"}], "web_url": "", "line_code": "abc_42_42"}
+
+    def post_status(self, endpoint: str) -> int:
+        self.calls.append(("post_status", endpoint, None))
+        return 200
+
+    def delete(self, endpoint: str) -> int:
+        self.calls.append(("delete", endpoint, None))
+        return 204
+
+    def get_json(self, endpoint: str) -> object:
+        self.calls.append(("get_json", endpoint, None))
+        if "/changes" in endpoint:
+            return {
+                "changes": [
+                    {"new_path": "x.py", "old_path": "x.py", "diff": self._diff},
+                ],
+            }
+        if "/merge_requests/" in endpoint:
+            return {
+                "author": {"username": self._mr_author},
+                "diff_refs": {"base_sha": "b", "head_sha": "h", "start_sha": "s"},
+            }
+        return {}
+
+    def current_username(self) -> str:
+        return "alice"
+
+
+def _service_with_stub(stub: _StubAPI) -> ReviewService:
+    service = ReviewService(token="t")
+    service._get_api = lambda: stub  # type: ignore[method-assign]
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Unit tests on the schema and gate function (no Django, no API round-trips).
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeEvidenceClaim:
+    """The pattern detector flags 'X is missing/wrong/broken' shapes."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "This helper is missing from the module.",
+            "The enum value is missing.",
+            "The function name is wrong here.",
+            "API signature is wrong.",
+            "Documentation is broken — references a removed symbol.",
+            "This is broken: the import does not exist.",
+            "The constant does not exist in the canonical list.",
+            "Cannot find the helper anywhere in the codebase.",
+            "There is no such function in master.",
+            "This file should not exist.",
+            "Stale reference to a removed module.",
+        ],
+    )
+    def test_canonical_claim_phrases_are_flagged(self, body: str) -> None:
+        assert looks_like_evidence_claim(body), f"must flag claim shape: {body!r}"
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Nit: prefer a shorter name.",
+            "Tracked at #1234.",
+            "LGTM.",
+            "Consider renaming this for clarity.",
+            "Why this choice over the sibling pattern?",
+            "Nit: blank line above.",
+        ],
+    )
+    def test_non_claim_phrases_are_not_flagged(self, body: str) -> None:
+        assert not looks_like_evidence_claim(body), f"must NOT flag non-claim: {body!r}"
+
+
+class TestCheckFindingEvidenceUnit:
+    """Direct unit tests on ``check_finding_evidence`` — no ReviewService round-trip."""
+
+    def test_non_claim_body_proceeds_without_evidence(self) -> None:
+        """A body that does not match the claim pattern bypasses the gate entirely."""
+        assert check_finding_evidence(body="Nit: rename for clarity.", evidence=None) == ""
+
+    def test_claim_body_without_evidence_is_refused(self) -> None:
+        """A 'missing/wrong/broken' claim without an evidence record is refused."""
+        msg = check_finding_evidence(
+            body="This helper is missing from the module.",
+            evidence=None,
+        )
+        assert msg, "expected a refusal string"
+        assert "evidence" in msg.lower()
+
+    def test_claim_body_with_speculative_evidence_is_refused(self) -> None:
+        """A claim tagged ``speculative`` is refused — speculative findings must drop entirely."""
+        ev = FindingEvidence(
+            master_check_paths=["src/foo.py"],
+            ticket_dep_refs=["souliane/teatree#100"],
+            helper_indirection_paths=[],
+            recent_merge_sweep_query="",
+            confidence="speculative",
+        )
+        msg = check_finding_evidence(
+            body="This helper is missing from the module.",
+            evidence=ev,
+        )
+        assert msg, "expected a refusal string"
+        assert "speculative" in msg.lower()
+
+    def test_claim_body_with_verified_but_empty_signals_is_refused(self) -> None:
+        """Verified but both master_check_paths and ticket_dep_refs empty = no evidence at all."""
+        ev = FindingEvidence(
+            master_check_paths=[],
+            ticket_dep_refs=[],
+            helper_indirection_paths=["src/helper.py"],
+            recent_merge_sweep_query="git log --grep=foo",
+            confidence="verified",
+        )
+        msg = check_finding_evidence(
+            body="The enum value is missing from the canonical list.",
+            evidence=ev,
+        )
+        assert msg, "expected a refusal string"
+        assert "master_check_paths" in msg or "ticket_dep_refs" in msg
+
+    def test_claim_body_with_verified_master_check_is_accepted(self) -> None:
+        """Verified + at least one master check path → proceed."""
+        ev = FindingEvidence(
+            master_check_paths=["src/foo.py:42"],
+            ticket_dep_refs=[],
+            helper_indirection_paths=[],
+            recent_merge_sweep_query="",
+            confidence="verified",
+        )
+        assert (
+            check_finding_evidence(
+                body="The helper is missing from src/foo.py.",
+                evidence=ev,
+            )
+            == ""
+        )
+
+    def test_claim_body_with_verified_ticket_dep_is_accepted(self) -> None:
+        """Verified + at least one ticket dependency reference → proceed."""
+        ev = FindingEvidence(
+            master_check_paths=[],
+            ticket_dep_refs=["souliane/teatree#1234"],
+            helper_indirection_paths=[],
+            recent_merge_sweep_query="",
+            confidence="verified",
+        )
+        assert (
+            check_finding_evidence(
+                body="The API signature is wrong here.",
+                evidence=ev,
+            )
+            == ""
+        )
+
+    def test_empty_body_proceeds(self) -> None:
+        """An empty body never trips the gate (other gates own the empty-body refusal)."""
+        assert check_finding_evidence(body="", evidence=None) == ""
+
+
+# ---------------------------------------------------------------------------
+# Schema fields cover the common finding shapes documented in the issue.
+# ---------------------------------------------------------------------------
+
+
+class TestFindingEvidenceSchema:
+    """The schema's fields cover the four common review-finding shapes."""
+
+    def test_missing_file_evidence_shape(self) -> None:
+        """Missing-file finding: master_check_paths names the master path that was looked at."""
+        ev = FindingEvidence(
+            master_check_paths=["src/teatree/cli/foo.py"],
+            ticket_dep_refs=[],
+            helper_indirection_paths=[],
+            recent_merge_sweep_query="",
+            confidence="verified",
+        )
+        assert ev.confidence == "verified"
+        assert ev.master_check_paths == ["src/teatree/cli/foo.py"]
+
+    def test_missing_function_evidence_shape(self) -> None:
+        """Missing-function finding: master_check_paths names file:line of the search."""
+        ev = FindingEvidence(
+            master_check_paths=["src/teatree/cli/review.py:42-100"],
+            ticket_dep_refs=[],
+            helper_indirection_paths=[],
+            recent_merge_sweep_query="",
+            confidence="verified",
+        )
+        assert "src/teatree/cli/review.py:42-100" in ev.master_check_paths
+
+    def test_wrong_api_signature_evidence_shape(self) -> None:
+        """Wrong-API-signature finding: helper_indirection_paths shows where the canonical signature lives."""
+        ev = FindingEvidence(
+            master_check_paths=["src/teatree/backends/gitlab_api.py:200"],
+            ticket_dep_refs=[],
+            helper_indirection_paths=["src/teatree/cli/review_diff.py"],
+            recent_merge_sweep_query="",
+            confidence="verified",
+        )
+        assert ev.helper_indirection_paths == ["src/teatree/cli/review_diff.py"]
+
+    def test_stale_doc_evidence_shape(self) -> None:
+        """Stale-doc finding: ticket_dep_refs cites the ticket that landed the change."""
+        ev = FindingEvidence(
+            master_check_paths=["BLUEPRINT.md:1200"],
+            ticket_dep_refs=["souliane/teatree#999"],
+            helper_indirection_paths=[],
+            recent_merge_sweep_query="git log --grep='(#999)' origin/main",
+            confidence="verified",
+        )
+        assert ev.recent_merge_sweep_query.startswith("git log")
+        assert ev.ticket_dep_refs == ["souliane/teatree#999"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: ReviewService.post_draft_note / post_comment route through the gate.
+# ---------------------------------------------------------------------------
+
+
+class TestPostDraftNoteRefusesClaimWithoutEvidence:
+    """ReviewService.post_draft_note refuses a 'missing/wrong/broken' body when no evidence is supplied."""
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _gate_immediate(tmp_path, monkeypatch)
+        _disable_other_gates(monkeypatch)
+
+    def test_claim_body_without_evidence_refused(self) -> None:
+        stub = _StubAPI()
+        service = _service_with_stub(stub)
+
+        msg, code = service.post_draft_note(
+            "org/repo",
+            7,
+            "This helper is missing from src/foo.py.",
+            file="x.py",
+            line=42,
+        )
+
+        assert code == 1, f"claim-without-evidence must refuse: code={code} msg={msg!r}"
+        assert "evidence" in msg.lower()
+        assert not any(c[0] == "post_json" and "/draft_notes" in c[1] for c in stub.calls), (
+            "no GitLab POST must fire when the gate refuses"
+        )
+
+    def test_claim_body_with_verified_evidence_publishes(self) -> None:
+        stub = _StubAPI()
+        service = _service_with_stub(stub)
+        ev = FindingEvidence(
+            master_check_paths=["src/foo.py:1-100"],
+            ticket_dep_refs=[],
+            helper_indirection_paths=[],
+            recent_merge_sweep_query="",
+            confidence="verified",
+        )
+
+        msg, code = service.post_draft_note(
+            "org/repo",
+            7,
+            "This helper is missing from src/foo.py.",
+            file="x.py",
+            line=42,
+            evidence=ev,
+        )
+
+        assert code == 0, f"claim with verified evidence must pass: code={code} msg={msg!r}"
+        assert any(c[0] == "post_json" and "/draft_notes" in c[1] for c in stub.calls)
+
+    def test_claim_body_with_speculative_evidence_refused(self) -> None:
+        stub = _StubAPI()
+        service = _service_with_stub(stub)
+        ev = FindingEvidence(
+            master_check_paths=["src/foo.py"],
+            ticket_dep_refs=["souliane/teatree#100"],
+            helper_indirection_paths=[],
+            recent_merge_sweep_query="",
+            confidence="speculative",
+        )
+
+        msg, code = service.post_draft_note(
+            "org/repo",
+            7,
+            "This helper is missing from src/foo.py.",
+            file="x.py",
+            line=42,
+            evidence=ev,
+        )
+
+        assert code == 1, f"speculative finding must drop: code={code} msg={msg!r}"
+        assert "speculative" in msg.lower()
+        assert not any(c[0] == "post_json" and "/draft_notes" in c[1] for c in stub.calls)
+
+
+class TestPostDraftNoteAllowsNonClaimsWithoutEvidence:
+    """A non-claim body (no missing/wrong/broken assertion) bypasses the evidence gate."""
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _gate_immediate(tmp_path, monkeypatch)
+        _disable_other_gates(monkeypatch)
+
+    def test_nit_body_publishes_without_evidence(self) -> None:
+        stub = _StubAPI()
+        service = _service_with_stub(stub)
+
+        msg, code = service.post_draft_note(
+            "org/repo",
+            7,
+            "Nit: rename for clarity.",
+            file="x.py",
+            line=42,
+        )
+
+        assert code == 0, f"nit body must publish without evidence: code={code} msg={msg!r}"
+        assert any(c[0] == "post_json" and "/draft_notes" in c[1] for c in stub.calls)
+
+
+class TestPostCommentRoutesThroughEvidenceGate:
+    """post_comment (default-draft path) also routes through the evidence gate."""
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _gate_immediate(tmp_path, monkeypatch)
+        _disable_other_gates(monkeypatch)
+
+    def test_default_draft_path_refuses_claim_without_evidence(self) -> None:
+        stub = _StubAPI()
+        service = _service_with_stub(stub)
+
+        msg, code = service.post_comment(
+            "org/repo",
+            7,
+            "The API signature is wrong here.",
+            file="x.py",
+            line=42,
+        )
+
+        assert code == 1, f"default-draft path must refuse claim without evidence: code={code}"
+        assert "evidence" in msg.lower()
+        assert not any(c[0] == "post_json" and "/draft_notes" in c[1] for c in stub.calls)
+
+    def test_default_draft_path_accepts_claim_with_verified_evidence(self) -> None:
+        stub = _StubAPI()
+        service = _service_with_stub(stub)
+        ev = FindingEvidence(
+            master_check_paths=["src/foo.py"],
+            ticket_dep_refs=[],
+            helper_indirection_paths=[],
+            recent_merge_sweep_query="",
+            confidence="verified",
+        )
+
+        msg, code = service.post_comment(
+            "org/repo",
+            7,
+            "The API signature is wrong here.",
+            file="x.py",
+            line=42,
+            evidence=ev,
+        )
+
+        assert code == 0, f"verified evidence must publish: code={code} msg={msg!r}"
+
+
+# ---------------------------------------------------------------------------
+# Vacuity guard: the RED test goes red on the PRE-fix code.
+# ---------------------------------------------------------------------------
+
+
+class TestGateIsAntiVacuous:
+    """A claim-shaped body without evidence MUST be rejected.
+
+    This is the canonical RED test for #1280 — it asserts the gate IS the
+    enforcement, not a memory rule. Reverting :func:`check_finding_evidence`
+    in :class:`ReviewService.post_draft_note` makes this test fail (claim
+    publishes without evidence) — proving the gate guards the contract.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _gate_immediate(tmp_path, monkeypatch)
+        _disable_other_gates(monkeypatch)
+
+    def test_unprotected_claim_post_is_blocked_with_actionable_message(self) -> None:
+        stub = _StubAPI()
+        service = _service_with_stub(stub)
+
+        msg, code = service.post_draft_note(
+            "org/repo",
+            7,
+            "The enum value is missing from the canonical list.",
+            file="x.py",
+            line=42,
+        )
+
+        assert code == 1
+        assert "FindingEvidence" in msg, f"refusal must name the schema: {msg!r}"
+        assert "confidence" in msg.lower() or "evidence" in msg.lower()
+        assert "#1280" in msg or "evidence" in msg.lower()
+        # Critical receipt: no POST hit the wire.
+        post_calls = [c for c in stub.calls if c[0] == "post_json" and "/draft_notes" in c[1]]
+        assert post_calls == [], f"the gate failed — POST leaked through: {post_calls!r}"
+
+
+# ---------------------------------------------------------------------------
+# Schema serialization — the agent passes evidence via JSON on the CLI surface.
+# ---------------------------------------------------------------------------
+
+
+class TestFindingEvidenceFromJSON:
+    """The schema can be reconstructed from a JSON string (CLI plumbing path)."""
+
+    def test_from_json_roundtrip(self) -> None:
+        raw = (
+            '{"master_check_paths": ["src/foo.py:42"],'
+            ' "ticket_dep_refs": ["souliane/teatree#100"],'
+            ' "helper_indirection_paths": [],'
+            ' "recent_merge_sweep_query": "git log --grep=foo",'
+            ' "confidence": "verified"}'
+        )
+        ev = FindingEvidence.from_json(raw)
+        assert ev.master_check_paths == ["src/foo.py:42"]
+        assert ev.ticket_dep_refs == ["souliane/teatree#100"]
+        assert ev.helper_indirection_paths == []
+        assert ev.recent_merge_sweep_query == "git log --grep=foo"
+        assert ev.confidence == "verified"
+
+    def test_from_json_rejects_unknown_confidence(self) -> None:
+        raw = (
+            '{"master_check_paths": [],'
+            ' "ticket_dep_refs": [],'
+            ' "helper_indirection_paths": [],'
+            ' "recent_merge_sweep_query": "",'
+            ' "confidence": "maybe"}'
+        )
+        with pytest.raises(ValueError, match="confidence"):
+            FindingEvidence.from_json(raw)
+
+    def test_from_json_rejects_malformed(self) -> None:
+        with pytest.raises(ValueError, match="json"):
+            FindingEvidence.from_json("not json at all")
+
+
+# ---------------------------------------------------------------------------
+# The gate runs independently of the on-behalf, shape, and TODO-anchor gates.
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceGateOrdering:
+    """The evidence gate runs after on-behalf but before the API call — same shape as the sibling gates."""
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _gate_immediate(tmp_path, monkeypatch)
+        _disable_other_gates(monkeypatch)
+
+    def test_no_api_get_when_evidence_gate_refuses(self) -> None:
+        """The gate short-circuits — no GitLab GET fires when the body is a claim without evidence."""
+        stub = _StubAPI()
+        service = _service_with_stub(stub)
+
+        _msg, code = service.post_draft_note(
+            "org/repo",
+            7,
+            "The helper does not exist in master.",
+            file="x.py",
+            line=42,
+        )
+
+        assert code == 1
+        # No POST fires.
+        assert not any(c[0] == "post_json" for c in stub.calls)
+
+
+class TestCheckFindingEvidenceFromCast:
+    """The gate accepts ``Any``-typed evidence (CLI passes dict; from_json mints dataclass)."""
+
+    def test_dict_shaped_evidence_via_from_json(self) -> None:
+        ev = FindingEvidence.from_json(
+            '{"master_check_paths": ["src/x.py"], "ticket_dep_refs": [],'
+            ' "helper_indirection_paths": [], "recent_merge_sweep_query": "",'
+            ' "confidence": "verified"}'
+        )
+        msg = check_finding_evidence(
+            body="The helper is missing from src/x.py.",
+            evidence=cast("Any", ev),
+        )
+        assert msg == ""


### PR DESCRIPTION
## Summary

- Add `FindingEvidence` dataclass + `check_finding_evidence` pre-publish gate (souliane/teatree#1280) refusing review findings whose body matches an "X is missing/wrong/broken" pattern unless verified evidence (master check path or ticket dep ref) accompanies the call.
- CLI surface: `--evidence-json '{...}'` on `t3 review post-comment` / `post-draft-note`. Schema lives at `teatree.cli.review_evidence_gate.FindingEvidence`.
- Consolidated the four pre-publish gates (on-behalf #960, colleague-MR shape #1114, TODO-anchor #1186, evidence #1280) behind `ReviewService._run_pre_publish_gates`; extracted the publish-impl bodies to `review_post_impl.py` to keep `review.py` under the module-health LOC ceiling.

Closes souliane/teatree#1280.

## Pre-publish gate ordering (`ReviewService._run_pre_publish_gates`)

```
on-behalf (#960)  ->  shape (#1114)  ->  TODO-anchor (#1186)  ->  evidence (#1280)
```

The evidence gate is last because it is the most expensive to satisfy.

## Test plan

- [x] 40 new tests in `tests/teatree_cli/test_review_evidence_gate.py` covering schema, pattern detector, gate, JSON deserialiser, and integration through `ReviewService.post_draft_note` / `post_comment`.
- [x] RED-test anti-vacuity verified: removing the `check_finding_evidence` call from `ReviewService.post_draft_note` makes `TestGateIsAntiVacuous::test_unprotected_claim_post_is_blocked_with_actionable_message` fail with `assert 0 == 1` (post leaks through).
- [x] Full suite: 6980 pass, 13 skipped, 2 deselected (1 pre-existing unrelated failure on `origin/main`).
- [x] `prek run` clean.