### PR TITLE
fix(loop): bind outbound-audit verifiers to the posting overlay's credentials

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -2764,6 +2764,13 @@ Usage: t3 teatree e2e run [OPTIONS] [WORK_ITEM]
  ``--target dev|local`` selects the dual-env target and is forwarded to
  whichever runner handles the overlay (see ``external`` for semantics).
 
+ ``--linked-to <ticket-pk>`` (#1322): when the e2e cache repo is not
+ DB-linked to the backend worktree (a frequent shape for
+ out-of-tree test repos), name the backend ticket explicitly so
+ frontend discovery, ``COMPOSE_PROJECT_NAME``, and the env cache
+ feeding ``get_e2e_env_extras`` all route at the linked stack.
+ ``0`` means "no link" (default — back-compat).
+
  Runner-specific flags (``--repo``, ``--playwright-args``) stay on the
  explicit ``external`` subcommand to keep this entry point overlay-agnostic.
 
@@ -2772,15 +2779,16 @@ Usage: t3 teatree e2e run [OPTIONS] [WORK_ITEM]
 │                               URL) — the #794 keystone.                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --test-path                                    TEXT                          │
-│ --at                                           TEXT                          │
-│ --target                                       TEXT                          │
-│ --headed              --no-headed                    [default: no-headed]    │
-│ --update-snapshots    --no-update-snapshots          [default:               │
-│                                                      no-update-snapshots]    │
-│ --docker              --no-docker                    [default: docker]       │
-│ --help                                               Show this message and   │
-│                                                      exit.                   │
+│ --test-path                                   TEXT                           │
+│ --at                                          TEXT                           │
+│ --target                                      TEXT                           │
+│ --headed              --no-headed                      [default: no-headed]  │
+│ --update-snapshots    --no-update-snapsho…             [default:             │
+│                                                        no-update-snapshots]  │
+│ --docker              --no-docker                      [default: docker]     │
+│ --linked-to                                   INTEGER  [default: 0]          │
+│ --help                                                 Show this message and │
+│                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -2827,20 +2835,29 @@ Usage: t3 teatree e2e external [OPTIONS]
  Discovers the frontend port from docker-compose (or local process)
  and reads the tenant variant from the env cache.
 
+ ``--linked-to <ticket-pk>`` (#1322): when the e2e cache repo's
+ auto-registered worktree is not DB-linked to the backend stack
+ (``auto:<branch>`` ticket, different ticket, or no worktree row at
+ all), name the backend ticket explicitly. Discovery,
+ ``COMPOSE_PROJECT_NAME``, and the env cache feeding
+ ``get_e2e_env_extras`` all route at the linked stack. ``0`` means
+ "no link" (default — back-compat with the resolved-worktree path).
+
  Extra Playwright flags (--config, --timeout, --grep, etc.) can be
  passed via --playwright-args: ``--playwright-args="--config x.ts --timeout
  120000"``
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --test-path                                    TEXT                          │
-│ --repo                                         TEXT                          │
-│ --target                                       TEXT                          │
-│ --headed              --no-headed                    [default: no-headed]    │
-│ --update-snapshots    --no-update-snapshots          [default:               │
-│                                                      no-update-snapshots]    │
-│ --playwright-args                              TEXT                          │
-│ --help                                               Show this message and   │
-│                                                      exit.                   │
+│ --test-path                                   TEXT                           │
+│ --repo                                        TEXT                           │
+│ --target                                      TEXT                           │
+│ --headed              --no-headed                      [default: no-headed]  │
+│ --update-snapshots    --no-update-snapsho…             [default:             │
+│                                                        no-update-snapshots]  │
+│ --playwright-args                             TEXT                           │
+│ --linked-to                                   INTEGER  [default: 0]          │
+│ --help                                                 Show this message and │
+│                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -271,8 +271,14 @@ def _record_github_note_claim(
     race) is swallowed. The publish has already succeeded by the time we
     get here — failing to audit it must not turn that success into a
     user-visible failure.
+
+    Stamps ``extra["overlay"]`` from ``T3_OVERLAY_NAME`` (#1275) so the
+    audit verifier can re-read the comment through the same overlay's
+    GitHub token that posted it — not a process-global resolver that may
+    land on a different identity in multi-overlay setups.
     """
     import hashlib  # noqa: PLC0415 — stdlib, cheap, used only here
+    import os  # noqa: PLC0415 — defer stdlib import out of module load
 
     try:
         from django.db import (  # noqa: PLC0415 — keep Django out of module-load if bootstrap fails
@@ -286,6 +292,7 @@ def _record_github_note_claim(
         return
 
     digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    overlay_name = os.environ.get("T3_OVERLAY_NAME", "") or ""
     idempotency_key = f"github_note:{repo}#{target_number}:{comment_id}"
     try:
         with transaction.atomic():
@@ -299,6 +306,7 @@ def _record_github_note_claim(
                         "target_number": target_number,
                         "artifact_id": str(comment_id),
                         "payload_digest": digest,
+                        "overlay": overlay_name,
                     },
                 },
             )

--- a/src/teatree/cli/review_audit.py
+++ b/src/teatree/cli/review_audit.py
@@ -45,7 +45,12 @@ def record_note_claim(
     kind: str = "gitlab_note",
     **extra: str | int | bool,
 ) -> None:
-    """Audit one successful outward review action for the drift verifier."""
+    """Audit one successful outward review action for the drift verifier.
+
+    ``record_claim`` stamps ``extra["overlay"]`` from ``T3_OVERLAY_NAME``
+    so the audit scanner re-reads the artifact through the same overlay's
+    credentials that posted it (#1275).
+    """
     from teatree.outbound_claim import record_claim  # noqa: PLC0415
 
     record_claim(

--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -252,7 +252,10 @@ def _record_outbound_claim(
     ignores it), so adding a return value would be dead code — a future
     sibling-sync pass should not "fix" this asymmetry.
     """
+    import os  # noqa: PLC0415 — defer stdlib import out of module load
+
     session_id = current_session_id()
+    overlay_name = os.environ.get("T3_OVERLAY_NAME", "") or ""
     try:
         with transaction.atomic():
             OutboundClaim.objects.get_or_create(
@@ -261,7 +264,11 @@ def _record_outbound_claim(
                     "kind": OutboundClaim.Kind.SLACK_DM.value,
                     "target_url": target_url,
                     "agent_session_id": session_id,
-                    "extra": {"channel": channel, "ts": posted_ts},
+                    "extra": {
+                        "channel": channel,
+                        "ts": posted_ts,
+                        "overlay": overlay_name,
+                    },
                 },
             )
     except IntegrityError:

--- a/src/teatree/loop/scanners/outbound_audit.py
+++ b/src/teatree/loop/scanners/outbound_audit.py
@@ -26,14 +26,38 @@ import datetime as dt
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from http import HTTPStatus
 from typing import TYPE_CHECKING, ClassVar, cast
 
-import httpx
 from django.apps import apps
 from django.utils import timezone
 
 from teatree.loop.scanners.base import ScanSignal
+
+# Overlay-aware verifier factories — defined in a sibling module so this
+# file stays under the module-health LOC cap. Re-exported here as
+# module-level names because the test suite patches them via the
+# ``teatree.loop.scanners.outbound_audit.<name>`` path, and the sibling
+# module's lazy ``from outbound_audit import _xxx`` imports therefore see
+# the patched values (#1275). The sibling defers its ``VerifyResult`` /
+# private-helper imports back to this module to avoid a cycle at import time.
+from teatree.loop.scanners.outbound_audit_overlay_verifiers import (
+    github_note_verifier_for_overlay as _github_note_verifier_for_overlay,
+)
+from teatree.loop.scanners.outbound_audit_overlay_verifiers import (
+    gitlab_api_for_overlay as _gitlab_api_for_overlay,  # noqa: F401 — re-exported for test patching
+)
+from teatree.loop.scanners.outbound_audit_overlay_verifiers import (
+    gitlab_approve_verifier_for_overlay as _gitlab_approve_verifier_for_overlay,
+)
+from teatree.loop.scanners.outbound_audit_overlay_verifiers import (
+    gitlab_note_verifier_for_overlay as _gitlab_note_verifier_for_overlay,
+)
+from teatree.loop.scanners.outbound_audit_overlay_verifiers import (
+    resolve_github_token_for_overlay as _resolve_github_token_for_overlay,  # noqa: F401 — re-exported for test patching
+)
+from teatree.loop.scanners.outbound_audit_overlay_verifiers import (
+    slack_dm_verifier_for_overlay as _slack_dm_verifier_for_overlay,
+)
 
 if TYPE_CHECKING:
     from teatree.core.models import OutboundClaim as OutboundClaimModel
@@ -115,9 +139,15 @@ class OutboundAuditScanner:
         signals: list[ScanSignal] = []
         candidates = self._candidate_claims(model, now)
         for claim in candidates:
-            verifier = self.verifiers.get(claim.kind) or _default_verifier_for(claim.kind)
+            # Explicit injected verifier wins (test path); else resolve the
+            # production verifier bound to the overlay that posted the
+            # claim (#1275). Per-claim resolution is the load-bearing
+            # change: the same scanner instance now picks up the right
+            # backend for each row, not whichever credential a single
+            # global resolver landed on at scanner construction.
+            verifier = self.verifiers.get(claim.kind) or _default_verifier_for_claim(claim)
             if verifier is None:
-                logger.debug("No verifier for kind=%s — skipping claim %s", claim.kind, claim.pk)
+                signals.append(_audit_skipped_signal(claim))
                 continue
             try:
                 result = verifier(claim)
@@ -205,12 +235,12 @@ class OutboundAuditScanner:
 
 
 def _default_verifier_for(kind: str) -> Verifier | None:
-    """Lazy production-default verifiers built from overlay factory clients.
+    """Lazy production-default verifiers built from the default overlay.
 
     Returns ``None`` when no production verifier exists for the kind — the
-    scanner then skips the row (no alert). Tests inject explicit verifiers
-    via :class:`OutboundAuditScanner`'s ``verifiers`` dict, so the
-    production path here is intentionally minimal and never raises.
+    scanner then skips the row (no alert). Kept as the legacy single-
+    overlay entry point and exercised by the dispatcher tests; per-claim
+    overlay-bound resolution is :func:`_default_verifier_for_claim`.
     """
     if kind == "gitlab_note":
         return _gitlab_note_verifier()
@@ -223,37 +253,59 @@ def _default_verifier_for(kind: str) -> Verifier | None:
     return None
 
 
+def _default_verifier_for_claim(claim: "OutboundClaimModel") -> Verifier | None:
+    """Build a production verifier bound to the overlay that posted the claim.
+
+    Reads ``claim.extra["overlay"]`` and constructs the right backend
+    from THAT overlay's credentials (#1275). When the overlay name is
+    absent (legacy rows recorded before the overlay-stamping change), or
+    the credential pipeline for that overlay returns nothing, the result
+    is ``None`` — the scanner then emits ``outbound.audit_skipped`` so
+    the silent backlog is observable, never re-classified as drift.
+    """
+    overlay = str(claim.extra.get("overlay", ""))
+    kind = claim.kind
+    if kind == "slack_dm":
+        return _slack_dm_verifier_for_overlay(overlay)
+    if kind == "gitlab_note":
+        return _gitlab_note_verifier_for_overlay(overlay)
+    if kind == "gitlab_approve":
+        return _gitlab_approve_verifier_for_overlay(overlay)
+    if kind == "github_note":
+        return _github_note_verifier_for_overlay(overlay)
+    return None
+
+
+def _audit_skipped_signal(claim: "OutboundClaimModel") -> ScanSignal:
+    """Build an ``outbound.audit_skipped`` ScanSignal for an unverifiable claim.
+
+    Emitted when no verifier resolves for a claim's (kind, overlay) pair
+    — the credential is missing for the recorded overlay. Distinct from
+    ``outbound.drift`` so the dispatcher and statusline can surface the
+    backlog separately rather than mis-classifying a credential gap as
+    a missing artifact (#1275).
+    """
+    overlay = str(claim.extra.get("overlay", ""))
+    return ScanSignal(
+        kind="outbound.audit_skipped",
+        summary=f"No verifier for {claim.kind} overlay={overlay or '<default>'}",
+        payload={
+            "claim_id": claim.pk,
+            "claim_kind": claim.kind,
+            "overlay": overlay,
+            "target_url": claim.target_url,
+        },
+    )
+
+
 def _gitlab_note_verifier() -> Verifier | None:
-    """Build a GitLab-note verifier from the overlay's GitLab credentials."""
-    try:
-        from teatree.backends.gitlab_api import GitLabAPI  # noqa: PLC0415
-    except Exception:  # noqa: BLE001
-        return None
-    try:
-        api = GitLabAPI()
-    except Exception:  # noqa: BLE001
-        return None
+    """Legacy single-overlay GitLab-note verifier — delegates to the overlay-aware sibling.
 
-    def _verify(claim: "OutboundClaimModel") -> VerifyResult:
-        repo = str(claim.extra.get("repo", ""))
-        mr = claim.extra.get("mr")
-        artifact_id = str(claim.extra.get("artifact_id", ""))
-        endpoint = str(claim.extra.get("endpoint", "notes"))
-        if not (repo and isinstance(mr, int) and artifact_id):
-            return VerifyResult.ok()
-        encoded = repo.replace("/", "%2F")
-        sub = "draft_notes" if "draft_notes" in endpoint else "notes"
-        if not artifact_id.isdigit():
-            return VerifyResult.ok()
-        try:
-            api.get_json(f"projects/{encoded}/merge_requests/{mr}/{sub}/{artifact_id}")
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == HTTPStatus.NOT_FOUND:
-                return VerifyResult.drift(f"GitLab note {artifact_id} not found on !{mr}")
-            raise
-        return VerifyResult.ok()
-
-    return _verify
+    Kept so existing patch-based tests pinning the factory's import-
+    guard and constructor-raise paths keep working. Production code
+    paths go through :func:`_default_verifier_for_claim` (#1275).
+    """
+    return _gitlab_note_verifier_for_overlay("")
 
 
 def _resolve_github_token() -> str:
@@ -283,61 +335,14 @@ def _resolve_github_token() -> str:
 
 
 def _github_note_verifier() -> Verifier | None:
-    """Build a GitHub-note verifier with the overlay's GitHub credentials (#1198).
+    """Legacy single-overlay GitHub-note verifier — delegates to the overlay-aware sibling.
 
-    Confirms via ``GET repos/<repo>/issues/comments/<id>`` that the
-    comment claimed in ``extra`` still exists and that its body hash
-    matches the recorded ``payload_digest``. The endpoint covers both PR
-    review comments and issue comments — GitHub returns the same shape
-    under ``issues/comments`` for both.
-
-    Mirrors :func:`_gitlab_note_verifier`'s error doctrine: a 404 → drift
-    (the comment is genuinely missing); any other transport-level error
-    is re-raised so the scanner can skip the row silently rather than
-    spamming DMs on a temporary GitHub-API outage.
-
-    Token-aware (#1198 codex finding): the verifier resolves the
-    posting token via :func:`_resolve_github_token` and passes it into
-    ``_gh_api_get``. Without an explicit token, ``gh api`` against a
-    private repo can return a 404 that is really "no auth", which the
-    verifier would otherwise mis-classify as drift. Empty-token →
-    return ``None`` and the scanner skips ``github_note`` rows silently.
+    Kept so existing patch-based tests pinning the factory's
+    import-guard, missing-token, and verifier-behaviour paths keep
+    working. Production code paths go through
+    :func:`_default_verifier_for_claim` (#1275).
     """
-    try:
-        from teatree.backends.github import _gh_api_get  # noqa: PLC0415
-    except Exception:  # noqa: BLE001
-        return None
-    token = _resolve_github_token()
-    if not token:
-        return None
-
-    def _verify(claim: "OutboundClaimModel") -> VerifyResult:
-        repo = str(claim.extra.get("repo", ""))
-        artifact_id = str(claim.extra.get("artifact_id", ""))
-        expected_digest = str(claim.extra.get("payload_digest", ""))
-        if not (repo and artifact_id and artifact_id.isdigit()):
-            return VerifyResult.ok()
-        try:
-            data = _gh_api_get(f"repos/{repo}/issues/comments/{artifact_id}", token=token)
-        except Exception as exc:
-            if _is_github_not_found(exc):
-                return VerifyResult.drift(
-                    f"GitHub comment {artifact_id} not found on {repo}",
-                )
-            raise
-        if not isinstance(data, dict):
-            return VerifyResult.drift(
-                f"GitHub comment {artifact_id} on {repo} returned non-dict payload",
-            )
-        if expected_digest:
-            actual_body = str(cast("RawAPIDict", data).get("body", ""))
-            if _hash_body(actual_body) != expected_digest:
-                return VerifyResult.drift(
-                    f"GitHub comment {artifact_id} body digest mismatch on {repo}",
-                )
-        return VerifyResult.ok()
-
-    return _verify
+    return _github_note_verifier_for_overlay("")
 
 
 def _is_github_not_found(exc: BaseException) -> bool:
@@ -384,87 +389,19 @@ def _usernames_from_approvers(approved_by: list[object]) -> set[str]:
 
 
 def _gitlab_approve_verifier() -> Verifier | None:
-    """Build a GitLab-approval verifier from the overlay's GitLab credentials."""
-    try:
-        from teatree.backends.gitlab_api import GitLabAPI  # noqa: PLC0415
-    except Exception:  # noqa: BLE001
-        return None
-    try:
-        api = GitLabAPI()
-        my_username = api.current_username()
-    except Exception:  # noqa: BLE001
-        return None
-    if not my_username:
-        return None
-
-    def _verify(claim: "OutboundClaimModel") -> VerifyResult:
-        repo = str(claim.extra.get("repo", ""))
-        mr = claim.extra.get("mr")
-        endpoint = str(claim.extra.get("endpoint", "approve"))
-        if not (repo and isinstance(mr, int)):
-            return VerifyResult.ok()
-        encoded = repo.replace("/", "%2F")
-        try:
-            approvals = api.get_json(f"projects/{encoded}/merge_requests/{mr}/approvals")
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == HTTPStatus.NOT_FOUND:
-                return VerifyResult.drift(f"GitLab MR !{mr} approvals endpoint 404")
-            raise
-        raw_approved = approvals.get("approved_by") if isinstance(approvals, dict) else None
-        approved_by: list[object] = list(raw_approved) if isinstance(raw_approved, list) else []
-        names = _usernames_from_approvers(approved_by)
-        present = my_username in names
-        if endpoint == "approve" and not present:
-            return VerifyResult.drift(
-                f"Approval by {my_username} not present on !{mr} (claimed approve)",
-            )
-        if endpoint == "unapprove" and present:
-            return VerifyResult.drift(
-                f"Approval by {my_username} still present on !{mr} (claimed unapprove)",
-            )
-        return VerifyResult.ok()
-
-    return _verify
+    """Legacy single-overlay GitLab-approve verifier — delegates to the overlay-aware sibling."""
+    return _gitlab_approve_verifier_for_overlay("")
 
 
 def _slack_dm_verifier() -> Verifier | None:
-    """Build a Slack-DM verifier from the overlay messaging backend.
+    """Build a Slack-DM verifier from the default overlay's messaging backend.
 
-    Confirms via ``chat.getPermalink`` that the ``(channel, ts)`` recorded
-    in the claim's ``extra`` still resolves to a permalink. Mirrors the
-    GitLab verifier's error doctrine:
-
-    - An empty permalink (the backend's "ok=false" / 404-equivalent
-        return shape: ``channel_not_found`` / ``message_not_found``)
-        → :class:`VerifyResult.drift` — the message did not land.
-    - Any transport-level exception (``httpx.HTTPStatusError`` for HTTP
-        5xx, ``httpx.NetworkError`` for connection failures, etc.)
-        → re-raise. ``scan()`` catches and skips the row silently so we
-        do not spam drift DMs on a temporary backend outage.
+    Legacy single-overlay entry. The overlay-bound sibling
+    :func:`_slack_dm_verifier_for_overlay` (#1275) supersedes this on the
+    per-claim path; tests still construct this directly to exercise the
+    underlying verifier behaviour.
     """
-    try:
-        from teatree.core.backend_factory import messaging_from_overlay  # noqa: PLC0415
-    except Exception:  # noqa: BLE001
-        return None
-    backend = messaging_from_overlay()
-    if backend is None:
-        return None
-
-    def _verify(claim: "OutboundClaimModel") -> VerifyResult:
-        channel = str(claim.extra.get("channel", ""))
-        ts = str(claim.extra.get("ts", ""))
-        if not (channel and ts):
-            return VerifyResult.ok()
-        # Let httpx.* and any other transport-layer exception propagate
-        # so ``scan()`` can skip the row silently — drift is reserved for
-        # "the backend told us the artifact is gone", not "we could not
-        # reach the backend".
-        permalink = backend.get_permalink(channel=channel, ts=ts)
-        if not permalink:
-            return VerifyResult.drift(f"Slack message {ts} not found in {channel}")
-        return VerifyResult.ok()
-
-    return _verify
+    return _slack_dm_verifier_for_overlay("")
 
 
 __all__ = [

--- a/src/teatree/loop/scanners/outbound_audit_overlay_verifiers.py
+++ b/src/teatree/loop/scanners/outbound_audit_overlay_verifiers.py
@@ -1,0 +1,364 @@
+"""Overlay-bound verifier factories for the outbound-audit scanner (#1275).
+
+The outbound-audit scanner (``loop.scanners.outbound_audit``) routes each
+claim through a verifier built with the SAME overlay's credentials that
+posted it. This module owns the per-overlay factories so the scanner
+file stays under the module-health LOC cap.
+
+Failure mode this addresses: pre-#1275 the verifier factories called
+``GitLabAPI()`` / ``messaging_from_overlay()`` / ``_resolve_github_token()``
+with no overlay arg, so multi-overlay setups (one overlay with
+``github_token_ref="github/work-token"``, another with
+``github_token_ref="github/personal"``) silently picked whichever
+credential the process-global resolver landed on. On a repo readable
+only by the non-default token, the GitHub/GitLab API returned 404 →
+false drift DM. This module fixes that by reading
+``claim.extra["overlay"]`` and binding each verifier to that overlay's
+own credential pipeline.
+
+Legacy single-overlay factories live in :mod:`outbound_audit` and now
+delegate here with ``overlay_name=""`` so the pre-#1275 contract still
+holds for callers that don't record overlay context.
+"""
+
+from http import HTTPStatus
+from typing import TYPE_CHECKING, cast
+
+import httpx
+
+if TYPE_CHECKING:
+    from teatree.core.models import OutboundClaim as OutboundClaimModel
+    from teatree.loop.scanners.outbound_audit import Verifier
+    from teatree.types import RawAPIDict
+
+
+def slack_dm_verifier_for_overlay(overlay_name: str) -> "Verifier | None":
+    """Build a Slack-DM verifier bound to a specific overlay's messaging backend.
+
+    ``overlay_name`` is the value recorded on ``OutboundClaim.extra["overlay"]``
+    at post time. Empty string is the canonical single-overlay default
+    (the same key ``messaging_from_overlay`` uses when no overlay is
+    explicitly selected).
+
+    Mirrors the legacy verifier's error doctrine:
+
+    - An empty permalink (the backend's "ok=false" / 404-equivalent
+        return shape: ``channel_not_found`` / ``message_not_found``)
+        → :class:`VerifyResult.drift` — the message did not land.
+    - Any transport-level exception (``httpx.HTTPStatusError`` for HTTP
+        5xx, ``httpx.NetworkError`` for connection failures, etc.)
+        → re-raise. ``scan()`` catches and skips the row silently so we
+        do not spam drift DMs on a temporary backend outage.
+
+    Returns ``None`` (no verifier) when the overlay's messaging backend
+    can't be constructed — the scanner emits ``outbound.audit_skipped``
+    rather than treating that as drift.
+    """
+    from teatree.loop.scanners.outbound_audit import VerifyResult  # noqa: PLC0415
+
+    try:
+        from teatree.core.backend_factory import messaging_from_overlay  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+    backend = messaging_from_overlay(overlay_name=overlay_name or None)
+    if backend is None:
+        return None
+
+    def _verify(claim: "OutboundClaimModel") -> "VerifyResult":
+        channel = str(claim.extra.get("channel", ""))
+        ts = str(claim.extra.get("ts", ""))
+        if not (channel and ts):
+            return VerifyResult.ok()
+        # Let httpx.* and any other transport-layer exception propagate
+        # so ``scan()`` can skip the row silently — drift is reserved for
+        # "the backend told us the artifact is gone", not "we could not
+        # reach the backend".
+        permalink = backend.get_permalink(channel=channel, ts=ts)
+        if not permalink:
+            return VerifyResult.drift(f"Slack message {ts} not found in {channel}")
+        return VerifyResult.ok()
+
+    return _verify
+
+
+def gitlab_api_for_overlay(overlay_name: str) -> object | None:
+    """Build a ``GitLabAPI`` instance using the named overlay's credentials.
+
+    Returns ``None`` when the overlay can't be resolved, its GitLab token
+    doesn't resolve, or the ``GitLabAPI`` module isn't importable.
+    Mirrors the legacy ``GitLabAPI()`` constructor's resolve-or-skip
+    contract, but reads the token from the matching overlay rather than
+    the process-global env/pass fallback.
+    """
+    try:
+        from teatree.backends.gitlab_api import GitLabAPI  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+    token, base_url = _overlay_gitlab_credentials(overlay_name)
+    try:
+        if token:
+            return GitLabAPI(token=token, base_url=base_url)
+        # Legacy fallback: empty overlay or unregistered overlay name —
+        # use the process-global default resolver (same shape pre-#1275).
+        return GitLabAPI()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _overlay_gitlab_credentials(overlay_name: str) -> tuple[str, str]:
+    """Return ``(token, base_url)`` for the named overlay's GitLab config.
+
+    Empty overlay name (or an unresolvable name) returns ``("", "")`` so
+    the caller falls back to the legacy single-overlay default. Reading
+    through the overlay config is the load-bearing change — a wrapper
+    script that opts an overlay into a non-default ``gitlab_token_ref``
+    now drives the audit verifier through THAT token.
+    """
+    if not overlay_name:
+        return ("", "")
+    try:
+        from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return ("", "")
+    try:
+        overlay = get_overlay(overlay_name)
+    except Exception:  # noqa: BLE001
+        # TOML overlay (no Python class) — try the raw config table.
+        return _overlay_gitlab_credentials_from_toml(overlay_name)
+    try:
+        token = overlay.config.get_gitlab_token()
+    except Exception:  # noqa: BLE001
+        token = ""
+    base_url = getattr(overlay.config, "gitlab_url", "https://gitlab.com/api/v4")
+    return (token or "", base_url or "https://gitlab.com/api/v4")
+
+
+def _overlay_gitlab_credentials_from_toml(overlay_name: str) -> tuple[str, str]:
+    """Resolve a TOML-only overlay's ``gitlab_token_ref`` via ``pass``.
+
+    Path-only overlays (no Python class, opted in via
+    ``[overlays.<name>]`` in ``~/.teatree.toml``) keep their credentials
+    in the TOML table, mirroring ``backend_factory._hosts_from_toml``.
+    """
+    try:
+        from teatree.config import load_config  # noqa: PLC0415
+        from teatree.utils.secrets import read_pass  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return ("", "")
+    overlays = load_config().raw.get("overlays") or {}
+    cfg = overlays.get(overlay_name)
+    if not isinstance(cfg, dict):
+        return ("", "")
+    token_ref = str(cfg.get("gitlab_token_ref", ""))
+    base_url = str(cfg.get("gitlab_url", "https://gitlab.com")).rstrip("/")
+    if not token_ref:
+        return ("", "")
+    if not base_url.endswith("/api/v4"):
+        base_url = f"{base_url}/api/v4"
+    try:
+        token = read_pass(token_ref)
+    except Exception:  # noqa: BLE001
+        token = ""
+    return (token or "", base_url)
+
+
+def gitlab_note_verifier_for_overlay(overlay_name: str) -> "Verifier | None":
+    """Build a GitLab-note verifier from the named overlay's GitLab token."""
+    from teatree.loop.scanners.outbound_audit import VerifyResult, _gitlab_api_for_overlay  # noqa: PLC0415
+
+    api = _gitlab_api_for_overlay(overlay_name)
+    if api is None:
+        return None
+
+    def _verify(claim: "OutboundClaimModel") -> "VerifyResult":
+        repo = str(claim.extra.get("repo", ""))
+        mr = claim.extra.get("mr")
+        artifact_id = str(claim.extra.get("artifact_id", ""))
+        endpoint = str(claim.extra.get("endpoint", "notes"))
+        if not (repo and isinstance(mr, int) and artifact_id):
+            return VerifyResult.ok()
+        encoded = repo.replace("/", "%2F")
+        sub = "draft_notes" if "draft_notes" in endpoint else "notes"
+        if not artifact_id.isdigit():
+            return VerifyResult.ok()
+        try:
+            api.get_json(f"projects/{encoded}/merge_requests/{mr}/{sub}/{artifact_id}")  # type: ignore[attr-defined]
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == HTTPStatus.NOT_FOUND:
+                return VerifyResult.drift(f"GitLab note {artifact_id} not found on !{mr}")
+            raise
+        return VerifyResult.ok()
+
+    return _verify
+
+
+def gitlab_approve_verifier_for_overlay(overlay_name: str) -> "Verifier | None":
+    """Build a GitLab-approve verifier from the named overlay's credentials."""
+    from teatree.loop.scanners.outbound_audit import (  # noqa: PLC0415
+        VerifyResult,
+        _gitlab_api_for_overlay,
+        _usernames_from_approvers,
+    )
+
+    api = _gitlab_api_for_overlay(overlay_name)
+    if api is None:
+        return None
+    try:
+        my_username = api.current_username()  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001
+        return None
+    if not my_username:
+        return None
+
+    def _verify(claim: "OutboundClaimModel") -> "VerifyResult":
+        repo = str(claim.extra.get("repo", ""))
+        mr = claim.extra.get("mr")
+        endpoint = str(claim.extra.get("endpoint", "approve"))
+        if not (repo and isinstance(mr, int)):
+            return VerifyResult.ok()
+        encoded = repo.replace("/", "%2F")
+        try:
+            approvals = api.get_json(f"projects/{encoded}/merge_requests/{mr}/approvals")  # type: ignore[attr-defined]
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == HTTPStatus.NOT_FOUND:
+                return VerifyResult.drift(f"GitLab MR !{mr} approvals endpoint 404")
+            raise
+        raw_approved = approvals.get("approved_by") if isinstance(approvals, dict) else None
+        approved_by: list[object] = list(raw_approved) if isinstance(raw_approved, list) else []
+        names = _usernames_from_approvers(approved_by)
+        present = my_username in names
+        if endpoint == "approve" and not present:
+            return VerifyResult.drift(
+                f"Approval by {my_username} not present on !{mr} (claimed approve)",
+            )
+        if endpoint == "unapprove" and present:
+            return VerifyResult.drift(
+                f"Approval by {my_username} still present on !{mr} (claimed unapprove)",
+            )
+        return VerifyResult.ok()
+
+    return _verify
+
+
+def resolve_github_token_for_overlay(overlay_name: str) -> str:
+    """Resolve a GitHub PAT bound to ``overlay_name``'s config.
+
+    Empty overlay name (or an unresolvable name) falls through to the
+    legacy resolver (env → ``pass`` default keys). A registered overlay
+    with its own ``github_token_ref`` (or ``github_pat`` getter) takes
+    precedence — this is the credential pipeline that #1275 binds
+    verifiers to.
+    """
+    from teatree.loop.scanners.outbound_audit import _resolve_github_token  # noqa: PLC0415
+
+    if not overlay_name:
+        return _resolve_github_token()
+    token = _github_token_from_registered_overlay(overlay_name)
+    if token:
+        return token
+    token = _github_token_from_toml_overlay(overlay_name)
+    if token:
+        return token
+    return _resolve_github_token()
+
+
+def _github_token_from_registered_overlay(overlay_name: str) -> str:
+    """Read the GitHub token off a Python-class-registered overlay."""
+    try:
+        from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+
+        overlay = get_overlay(overlay_name)
+    except Exception:  # noqa: BLE001
+        return ""
+    try:
+        return overlay.config.get_github_token() or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _github_token_from_toml_overlay(overlay_name: str) -> str:
+    """Read the GitHub token off a path-only TOML overlay.
+
+    Mirrors ``backend_factory._hosts_from_toml`` so path-only overlays
+    keep one credential pipeline shared with the loop's host scanners.
+    """
+    try:
+        from teatree.config import load_config  # noqa: PLC0415
+        from teatree.utils.secrets import read_pass  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return ""
+    overlays = load_config().raw.get("overlays") or {}
+    cfg = overlays.get(overlay_name)
+    if not isinstance(cfg, dict):
+        return ""
+    token_ref = str(cfg.get("github_token_ref", ""))
+    if not token_ref:
+        return ""
+    try:
+        return read_pass(token_ref) or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def github_note_verifier_for_overlay(overlay_name: str) -> "Verifier | None":
+    """Build a GitHub-note verifier with the named overlay's GitHub token.
+
+    Mirrors the legacy verifier's error doctrine but resolves the token
+    through ``overlay_name``'s credential pipeline so multi-overlay
+    setups don't cross-talk. Empty-token → ``None`` and the scanner
+    emits ``outbound.audit_skipped`` for the row (never drift — an
+    unauthenticated 404 on a private repo is ambiguous and must not
+    become a false alert).
+    """
+    from teatree.loop.scanners.outbound_audit import (  # noqa: PLC0415
+        VerifyResult,
+        _hash_body,
+        _is_github_not_found,
+        _resolve_github_token_for_overlay,
+    )
+
+    try:
+        from teatree.backends.github import _gh_api_get  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+    token = _resolve_github_token_for_overlay(overlay_name)
+    if not token:
+        return None
+
+    def _verify(claim: "OutboundClaimModel") -> "VerifyResult":
+        repo = str(claim.extra.get("repo", ""))
+        artifact_id = str(claim.extra.get("artifact_id", ""))
+        expected_digest = str(claim.extra.get("payload_digest", ""))
+        if not (repo and artifact_id and artifact_id.isdigit()):
+            return VerifyResult.ok()
+        try:
+            data = _gh_api_get(f"repos/{repo}/issues/comments/{artifact_id}", token=token)
+        except Exception as exc:
+            if _is_github_not_found(exc):
+                return VerifyResult.drift(
+                    f"GitHub comment {artifact_id} not found on {repo}",
+                )
+            raise
+        if not isinstance(data, dict):
+            return VerifyResult.drift(
+                f"GitHub comment {artifact_id} on {repo} returned non-dict payload",
+            )
+        if expected_digest:
+            actual_body = str(cast("RawAPIDict", data).get("body", ""))
+            if _hash_body(actual_body) != expected_digest:
+                return VerifyResult.drift(
+                    f"GitHub comment {artifact_id} body digest mismatch on {repo}",
+                )
+        return VerifyResult.ok()
+
+    return _verify
+
+
+__all__ = [
+    "github_note_verifier_for_overlay",
+    "gitlab_api_for_overlay",
+    "gitlab_approve_verifier_for_overlay",
+    "gitlab_note_verifier_for_overlay",
+    "resolve_github_token_for_overlay",
+    "slack_dm_verifier_for_overlay",
+]

--- a/src/teatree/outbound_claim.py
+++ b/src/teatree/outbound_claim.py
@@ -13,6 +13,7 @@ so an outage of the audit ledger does not cascade into the CLI turn.
 """
 
 import logging
+import os
 from typing import Any
 
 from django.db import DatabaseError, IntegrityError, transaction
@@ -21,6 +22,16 @@ from teatree.core.models import OutboundClaim
 from teatree.core.session_identity import current_session_id as _resolve_agent_session_id
 
 logger = logging.getLogger(__name__)
+
+
+def _active_overlay_name() -> str:
+    """Read the active overlay name from the env (``T3_OVERLAY_NAME``).
+
+    Empty string is the canonical single-overlay default — record helpers
+    stamp that on the claim's ``extra["overlay"]`` so the audit scanner
+    knows which credential pipeline to re-read with (#1275).
+    """
+    return os.environ.get("T3_OVERLAY_NAME", "") or ""
 
 
 def record_claim(
@@ -39,9 +50,18 @@ def record_claim(
     degrade to ``None`` + a logger warning. The caller's publish has
     already succeeded by the time we get here; failing to audit it must
     not turn that success into a user-visible failure.
+
+    Stamps ``extra["overlay"]`` from ``T3_OVERLAY_NAME`` so the audit
+    verifier can re-read the artifact through THAT overlay's credentials —
+    not whichever credential a process-global resolver lands on (#1275).
+    Callers that already have an explicit overlay in mind pass it in the
+    ``extra`` dict directly (``extra={"overlay": "client-A", ...}``); that
+    value wins over the env-var fallback.
     """
     kind_value = OutboundClaim.Kind(kind) if not isinstance(kind, OutboundClaim.Kind) else kind
     session_id = agent_session_id or _resolve_agent_session_id()
+    final_extra: dict[str, Any] = dict(extra or {})
+    final_extra.setdefault("overlay", _active_overlay_name())
     try:
         with transaction.atomic():
             claim, _created = OutboundClaim.objects.get_or_create(
@@ -50,7 +70,7 @@ def record_claim(
                     "kind": kind_value.value,
                     "target_url": target_url,
                     "agent_session_id": session_id,
-                    "extra": extra or {},
+                    "extra": final_extra,
                 },
             )
     except IntegrityError:

--- a/tests/teatree_core/test_outbound_claim.py
+++ b/tests/teatree_core/test_outbound_claim.py
@@ -22,7 +22,9 @@ class RecordClaimTests(TestCase):
         row = OutboundClaim.objects.get(idempotency_key="gitlab_note:repo!1:42")
         assert row.kind == OutboundClaim.Kind.GITLAB_NOTE
         assert row.target_url.endswith("/merge_requests/1")
-        assert row.extra == {"repo": "repo", "mr": 1}
+        # ``record_claim`` stamps the active overlay name on extra (#1275).
+        # No env override here -> empty string (default overlay).
+        assert row.extra == {"repo": "repo", "mr": 1, "overlay": ""}
         assert row.verified_at is None
         assert row.drift_detected is False
         assert row.drift_alerted_at is None

--- a/tests/teatree_loop/test_outbound_audit.py
+++ b/tests/teatree_loop/test_outbound_audit.py
@@ -136,14 +136,19 @@ class OutboundAuditScannerTests(TestCase):
         scanner.scan()
         assert calls == []
 
-    def test_unknown_kind_without_verifier_is_skipped(self) -> None:
+    def test_unknown_kind_without_verifier_emits_audit_skipped(self) -> None:
         _aged_claim(kind=OutboundClaim.Kind.NOTION_EDIT, key="unknown-kind")
 
         # No verifier configured for notion_edit and no production default
-        # registered — scanner skips silently rather than crashing.
+        # registered — scanner emits ``outbound.audit_skipped`` so the
+        # backlog is observable instead of silently growing (#1275).
+        # Never a drift signal: an unverifiable kind is not a missing
+        # artifact.
         scanner = OutboundAuditScanner(verifiers={})
         signals = scanner.scan()
-        assert signals == []
+        assert len(signals) == 1
+        assert signals[0].kind == "outbound.audit_skipped"
+        assert all(s.kind != "outbound.drift" for s in signals)
 
     def test_verifier_exception_does_not_break_tick(self) -> None:
         _aged_claim(kind=OutboundClaim.Kind.SLACK_DM, key="raises")

--- a/tests/teatree_loop/test_outbound_audit_overlay_binding.py
+++ b/tests/teatree_loop/test_outbound_audit_overlay_binding.py
@@ -1,0 +1,281 @@
+"""Behaviour tests for overlay-bound outbound-audit verifiers (#1275).
+
+The outbound-audit scanner verifies each :class:`OutboundClaim` by
+contacting the third-party system that originally received the post.
+Multi-overlay setups configure different credentials per overlay
+(`github_token_ref = "github/work-token"` on one overlay,
+`github_token_ref = "github/personal"` on another); a verifier built
+with a process-global resolver lands on the wrong identity for at least
+one of them, producing a false 404 → false drift DM (failure mode #1)
+or no token at all → silent claim-skipping with `kind=slack_dm —
+skipping claim N` debug noise (failure mode #3).
+
+These tests pin the new contract:
+
+- Every record helper stamps ``overlay`` on ``extra`` at claim-time.
+- The scanner uses ``claim.extra["overlay"]`` to build a verifier
+    scoped to that overlay's credentials.
+- A claim whose overlay can't resolve credentials surfaces as an
+    ``outbound.audit_skipped`` ScanSignal — observable, never drift.
+"""
+
+import datetime as dt
+import os
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.models import OutboundClaim
+from teatree.loop.scanners.outbound_audit import OutboundAuditScanner, kind_settling_seconds
+
+
+def _aged_claim(*, kind: OutboundClaim.Kind, key: str, **extra: object) -> OutboundClaim:
+    age = max(kind_settling_seconds.values(), default=30) + 30
+    return OutboundClaim.objects.create(
+        kind=kind,
+        idempotency_key=key,
+        target_url="https://example.com/artifact",
+        claim_ts=timezone.now() - dt.timedelta(seconds=age),
+        extra=extra or {},
+    )
+
+
+class OverlayBoundVerifierDispatchTests(TestCase):
+    """Scanner routes each claim through its recorded-overlay's verifier."""
+
+    def test_slack_dm_verifier_uses_recorded_overlay_messaging_backend(self) -> None:
+        """A claim recorded under overlay 'work' verifies through that overlay's backend.
+
+        ``messaging_from_overlay(overlay_name='work')`` resolves the
+        backend; the default overlay's backend is never consulted.
+        """
+        _aged_claim(
+            kind=OutboundClaim.Kind.SLACK_DM,
+            key="overlay-work:slack:1",
+            overlay="work",
+            channel="C_WORK",
+            ts="1700000000.0001",
+        )
+
+        work_backend = MagicMock()
+        work_backend.get_permalink.return_value = "https://slack.example/archives/C_WORK/p1"
+        default_backend = MagicMock()
+
+        def _factory(overlay_name: str | None = None) -> object:
+            if overlay_name == "work":
+                return work_backend
+            return default_backend
+
+        with patch(
+            "teatree.core.backend_factory.messaging_from_overlay",
+            side_effect=_factory,
+        ):
+            scanner = OutboundAuditScanner()
+            signals = scanner.scan()
+
+        work_backend.get_permalink.assert_called_once_with(channel="C_WORK", ts="1700000000.0001")
+        default_backend.get_permalink.assert_not_called()
+        assert signals == []
+
+    def test_github_note_verifier_uses_overlay_specific_token(self) -> None:
+        """Two GitHub overlays send their own token to ``_gh_api_get`` per claim.
+
+        Each overlay has its own ``github_token_ref``; the verifier
+        resolves the right token for each claim independently.
+        """
+        _aged_claim(
+            kind=OutboundClaim.Kind.GITHUB_NOTE,
+            key="github_note:org/work#5:42",
+            overlay="work",
+            repo="org/work",
+            artifact_id="42",
+            token_ref="github/work-token",
+        )
+        _aged_claim(
+            kind=OutboundClaim.Kind.GITHUB_NOTE,
+            key="github_note:org/personal#7:99",
+            overlay="personal",
+            repo="org/personal",
+            artifact_id="99",
+            token_ref="github/personal",
+        )
+
+        seen_tokens: list[str] = []
+
+        def _resolve(overlay_name: str) -> str:
+            return f"tok-for-{overlay_name}"
+
+        def _gh_get(_endpoint: str, *, token: str = "") -> object:
+            seen_tokens.append(token)
+            return {"id": 42, "body": ""}
+
+        with (
+            patch(
+                "teatree.loop.scanners.outbound_audit._resolve_github_token_for_overlay",
+                side_effect=_resolve,
+            ),
+            patch("teatree.backends.github._gh_api_get", side_effect=_gh_get),
+        ):
+            scanner = OutboundAuditScanner()
+            scanner.scan()
+
+        assert "tok-for-work" in seen_tokens
+        assert "tok-for-personal" in seen_tokens
+
+    def test_gitlab_note_verifier_uses_recorded_overlay_credentials(self) -> None:
+        """A GitLab note claim built under overlay 'client-A' verifies through that overlay.
+
+        The verifier calls ``_gitlab_api_for_overlay('client-A')`` to
+        build the GitLabAPI instance — client-A's token and URL apply.
+        """
+        _aged_claim(
+            kind=OutboundClaim.Kind.GITLAB_NOTE,
+            key="gitlab_note:org/proj!1:7",
+            overlay="client-A",
+            repo="org/proj",
+            mr=1,
+            artifact_id="7",
+            endpoint="notes",
+        )
+
+        seen_overlays: list[str] = []
+        fake_api = MagicMock()
+        fake_api.get_json.return_value = {"id": 7, "body": "x"}
+
+        def _build_api(overlay_name: str) -> object:
+            seen_overlays.append(overlay_name)
+            return fake_api
+
+        with patch(
+            "teatree.loop.scanners.outbound_audit._gitlab_api_for_overlay",
+            side_effect=_build_api,
+        ):
+            scanner = OutboundAuditScanner()
+            scanner.scan()
+
+        assert seen_overlays == ["client-A"]
+        fake_api.get_json.assert_called_once()
+
+
+class NoVerifierForKindObservabilityTests(TestCase):
+    """Unresolvable overlay credentials emit ``outbound.audit_skipped``.
+
+    Never silent skipping (the legacy log-debug behaviour) and never
+    classified as drift — the credential gap is its own observable
+    backlog signal.
+    """
+
+    def test_unresolvable_overlay_credentials_emit_audit_skipped(self) -> None:
+        _aged_claim(
+            kind=OutboundClaim.Kind.SLACK_DM,
+            key="overlay-missing:slack:1",
+            overlay="archived-overlay",
+            channel="C123",
+            ts="1.1",
+        )
+
+        notify = MagicMock()
+        with patch(
+            "teatree.core.backend_factory.messaging_from_overlay",
+            return_value=None,
+        ):
+            scanner = OutboundAuditScanner(notifier=notify)
+            signals = scanner.scan()
+
+        # Drift was NOT emitted — that would have spammed a false alert.
+        assert all(s.kind != "outbound.drift" for s in signals)
+        # Observability: at least one signal of the new kind is emitted.
+        kinds = {s.kind for s in signals}
+        assert "outbound.audit_skipped" in kinds
+        notify.assert_not_called()
+
+
+class RecordClaimStampsOverlayTests(TestCase):
+    """Every record helper writes the active overlay name into ``extra``."""
+
+    def test_record_claim_stamps_active_overlay(self) -> None:
+        from teatree.outbound_claim import record_claim  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"T3_OVERLAY_NAME": "work"}, clear=False):
+            row = record_claim(
+                kind=OutboundClaim.Kind.SLACK_DM,
+                idempotency_key="rcs:1",
+                extra={"channel": "C1", "ts": "1.1"},
+            )
+
+        assert row is not None
+        assert row.extra["overlay"] == "work"
+        # Pre-existing extra survives.
+        assert row.extra["channel"] == "C1"
+        assert row.extra["ts"] == "1.1"
+
+    def test_record_claim_with_explicit_overlay_wins_over_env(self) -> None:
+        """An explicit overlay in ``extra`` wins over ``T3_OVERLAY_NAME``."""
+        from teatree.outbound_claim import record_claim  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"T3_OVERLAY_NAME": "env-overlay"}, clear=False):
+            row = record_claim(
+                kind=OutboundClaim.Kind.GITLAB_NOTE,
+                idempotency_key="rcs:2",
+                extra={
+                    "repo": "org/proj",
+                    "mr": 1,
+                    "artifact_id": "1",
+                    "overlay": "explicit-overlay",
+                },
+            )
+
+        assert row is not None
+        assert row.extra["overlay"] == "explicit-overlay"
+
+    def test_record_note_claim_stamps_overlay(self) -> None:
+        from teatree.cli.review_audit import record_note_claim  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"T3_OVERLAY_NAME": "gitlab-overlay"}, clear=False):
+            record_note_claim(
+                lambda: "https://gitlab.example/api/v4",
+                "org/proj",
+                1,
+                42,
+                endpoint="notes",
+            )
+
+        row = OutboundClaim.objects.get(idempotency_key="gitlab_note:org/proj!1:42")
+        assert row.extra["overlay"] == "gitlab-overlay"
+
+    def test_record_github_note_claim_stamps_overlay(self) -> None:
+        from teatree.backends.github import _record_github_note_claim  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"T3_OVERLAY_NAME": "gh-overlay"}, clear=False):
+            _record_github_note_claim(
+                repo="org/repo",
+                target_number=5,
+                comment_id=42,
+                body="lgtm",
+                target_url="https://github.com/org/repo/issues/5#issuecomment-42",
+            )
+
+        row = OutboundClaim.objects.get(idempotency_key="github_note:org/repo#5:42")
+        assert row.extra["overlay"] == "gh-overlay"
+
+    def test_notify_user_stamps_overlay_on_recorded_slack_dm_claim(self) -> None:
+        """``notify_user`` records a SLACK_DM claim with the active overlay.
+
+        Lets the audit verifier re-read with the same credentials that
+        posted the DM, closing the multi-overlay drift gap.
+        """
+        from teatree.core.notify import _record_outbound_claim  # noqa: PLC0415
+
+        with patch.dict(os.environ, {"T3_OVERLAY_NAME": "slack-overlay"}, clear=False):
+            _record_outbound_claim(
+                idempotency_key="slack_dm:notify-1",
+                target_url="https://slack.example/p/1",
+                channel="C123",
+                posted_ts="1.1",
+            )
+
+        row = OutboundClaim.objects.get(idempotency_key="slack_dm:notify-1")
+        assert row.extra["overlay"] == "slack-overlay"
+        assert row.extra["channel"] == "C123"
+        assert row.extra["ts"] == "1.1"

--- a/tests/teatree_loop/test_outbound_audit_overlay_binding.py
+++ b/tests/teatree_loop/test_outbound_audit_overlay_binding.py
@@ -595,3 +595,119 @@ class OverlayCredentialResolutionTests(TestCase):
             side_effect=RuntimeError("network failed at construction"),
         ):
             assert gitlab_api_for_overlay("") is None
+
+    def test_overlay_gitlab_credentials_returns_blank_when_loader_import_fails(self) -> None:
+        """``overlay_loader`` import failure → ``("", "")`` graceful fallback."""
+        import builtins  # noqa: PLC0415
+
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import _overlay_gitlab_credentials  # noqa: PLC0415
+
+        real_import = builtins.__import__
+
+        def _blocked(name: str, *args: object, **kwargs: object) -> object:
+            if name == "teatree.core.overlay_loader":
+                msg = "synthetic import block"
+                raise ImportError(msg)
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_blocked):
+            assert _overlay_gitlab_credentials("x") == ("", "")
+
+    def test_overlay_gitlab_credentials_from_toml_blank_when_config_import_fails(self) -> None:
+        """``teatree.config`` import failure inside the TOML helper → blank pair."""
+        import builtins  # noqa: PLC0415
+
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            _overlay_gitlab_credentials_from_toml,
+        )
+
+        real_import = builtins.__import__
+
+        def _blocked(name: str, *args: object, **kwargs: object) -> object:
+            if name == "teatree.config":
+                msg = "config blocked"
+                raise ImportError(msg)
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_blocked):
+            assert _overlay_gitlab_credentials_from_toml("x") == ("", "")
+
+    def test_github_token_from_toml_overlay_blank_when_imports_fail(self) -> None:
+        """Import failure inside the TOML GitHub token helper → empty string."""
+        import builtins  # noqa: PLC0415
+
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            _github_token_from_toml_overlay,
+        )
+
+        real_import = builtins.__import__
+
+        def _blocked(name: str, *args: object, **kwargs: object) -> object:
+            if name == "teatree.config":
+                msg = "config blocked"
+                raise ImportError(msg)
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_blocked):
+            assert _github_token_from_toml_overlay("x") == ""
+
+    def test_gitlab_approve_verifier_returns_none_when_current_username_raises(self) -> None:
+        """``api.current_username()`` raising → ``None`` from the factory."""
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            gitlab_approve_verifier_for_overlay,
+        )
+
+        fake_api = MagicMock()
+        fake_api.current_username.side_effect = RuntimeError("token expired")
+        with patch(
+            "teatree.loop.scanners.outbound_audit._gitlab_api_for_overlay",
+            return_value=fake_api,
+        ):
+            assert gitlab_approve_verifier_for_overlay("any") is None
+
+
+class DefaultVerifierForClaimGitlabApproveBranchTests(TestCase):
+    """The ``gitlab_approve`` branch of ``_default_verifier_for_claim``."""
+
+    def test_gitlab_approve_kind_dispatches_to_overlay_factory(self) -> None:
+        """A claim with ``kind="gitlab_approve"`` routes through the approve factory."""
+        from teatree.loop.scanners.outbound_audit import _default_verifier_for_claim  # noqa: PLC0415
+
+        claim = MagicMock()
+        claim.kind = "gitlab_approve"
+        claim.extra = {"overlay": "client-A"}
+
+        sentinel: object = object()
+        with patch(
+            "teatree.loop.scanners.outbound_audit._gitlab_approve_verifier_for_overlay",
+            return_value=sentinel,
+        ) as factory:
+            result = _default_verifier_for_claim(claim)
+
+        assert result is sentinel
+        factory.assert_called_once_with("client-A")
+
+
+class ResolveGithubTokenSecretsImportFailureTests(TestCase):
+    """``_resolve_github_token`` graceful handling when secrets import fails."""
+
+    def test_returns_blank_when_secrets_module_unimportable(self) -> None:
+        """No env token + ``teatree.utils.secrets`` unimportable → empty string."""
+        import builtins  # noqa: PLC0415
+        import os  # noqa: PLC0415
+
+        from teatree.loop.scanners.outbound_audit import _resolve_github_token  # noqa: PLC0415
+
+        real_import = builtins.__import__
+
+        def _blocked(name: str, *args: object, **kwargs: object) -> object:
+            if name == "teatree.utils.secrets":
+                msg = "secrets blocked"
+                raise ImportError(msg)
+            return real_import(name, *args, **kwargs)
+
+        with (
+            patch.dict(os.environ, {"GH_TOKEN": "", "GITHUB_TOKEN": ""}, clear=False),
+            patch("builtins.__import__", side_effect=_blocked),
+        ):
+            assert _resolve_github_token() == ""

--- a/tests/teatree_loop/test_outbound_audit_overlay_binding.py
+++ b/tests/teatree_loop/test_outbound_audit_overlay_binding.py
@@ -279,3 +279,319 @@ class RecordClaimStampsOverlayTests(TestCase):
         assert row.extra["overlay"] == "slack-overlay"
         assert row.extra["channel"] == "C123"
         assert row.extra["ts"] == "1.1"
+
+
+class OverlayCredentialResolutionTests(TestCase):
+    """Per-overlay credential resolution drives the verifier factories.
+
+    Covers the resolver helpers in
+    ``outbound_audit_overlay_verifiers``: registered-overlay path
+    (``get_overlay`` succeeds, ``config.get_gitlab_token`` /
+    ``config.get_github_token`` returns the token), the TOML-only
+    fallback path (overlay lives in ``[overlays.<name>]`` without a
+    Python class, so ``get_overlay`` raises and the resolver re-reads
+    via ``load_config`` + ``read_pass``), and the empty-overlay legacy
+    branch (delegates to the process-global resolver).
+    """
+
+    def test_gitlab_credentials_from_registered_overlay(self) -> None:
+        """Registered overlay: ``get_overlay(name).config`` provides token + URL."""
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import _overlay_gitlab_credentials  # noqa: PLC0415
+
+        fake_overlay = MagicMock()
+        fake_overlay.config.get_gitlab_token.return_value = "glpat-overlay-A"
+        fake_overlay.config.gitlab_url = "https://gitlab.example.com/api/v4"
+
+        with patch(
+            "teatree.core.overlay_loader.get_overlay",
+            return_value=fake_overlay,
+        ):
+            token, base_url = _overlay_gitlab_credentials("overlay-A")
+
+        assert token == "glpat-overlay-A"
+        assert base_url == "https://gitlab.example.com/api/v4"
+
+    def test_gitlab_credentials_falls_back_to_toml_when_get_overlay_raises(self) -> None:
+        """Path-only TOML overlay: ``get_overlay`` raises; resolver re-reads TOML."""
+        from teatree.config import TeaTreeConfig  # noqa: PLC0415
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import _overlay_gitlab_credentials  # noqa: PLC0415
+
+        toml_config = TeaTreeConfig(
+            raw={
+                "overlays": {
+                    "toml-only": {
+                        "gitlab_token_ref": "gitlab/toml-only-token",
+                        "gitlab_url": "https://gitlab.example.org",
+                    },
+                },
+            },
+        )
+        with (
+            patch(
+                "teatree.core.overlay_loader.get_overlay",
+                side_effect=LookupError("no python class"),
+            ),
+            patch("teatree.config.load_config", return_value=toml_config),
+            patch("teatree.utils.secrets.read_pass", return_value="glpat-from-pass"),
+        ):
+            token, base_url = _overlay_gitlab_credentials("toml-only")
+
+        assert token == "glpat-from-pass"
+        assert base_url == "https://gitlab.example.org/api/v4"
+
+    def test_gitlab_credentials_empty_name_returns_blank_pair(self) -> None:
+        """Empty overlay name short-circuits — legacy global-resolver path."""
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import _overlay_gitlab_credentials  # noqa: PLC0415
+
+        assert _overlay_gitlab_credentials("") == ("", "")
+
+    def test_gitlab_credentials_overlay_config_get_token_raises(self) -> None:
+        """``config.get_gitlab_token`` raising returns empty token + default URL."""
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import _overlay_gitlab_credentials  # noqa: PLC0415
+
+        broken = MagicMock()
+        broken.config.get_gitlab_token.side_effect = RuntimeError("vault unavailable")
+        broken.config.gitlab_url = "https://gitlab.com/api/v4"
+
+        with patch(
+            "teatree.core.overlay_loader.get_overlay",
+            return_value=broken,
+        ):
+            token, base_url = _overlay_gitlab_credentials("broken-overlay")
+
+        assert token == ""
+        assert base_url == "https://gitlab.com/api/v4"
+
+    def test_gitlab_credentials_toml_missing_overlay_returns_blank(self) -> None:
+        """TOML fallback: overlay name absent from config → empty pair."""
+        from teatree.config import TeaTreeConfig  # noqa: PLC0415
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            _overlay_gitlab_credentials_from_toml,
+        )
+
+        with patch(
+            "teatree.config.load_config",
+            return_value=TeaTreeConfig(raw={"overlays": {}}),
+        ):
+            assert _overlay_gitlab_credentials_from_toml("absent") == ("", "")
+
+    def test_gitlab_credentials_toml_missing_token_ref_returns_blank(self) -> None:
+        """TOML fallback: overlay present but no ``gitlab_token_ref`` → empty."""
+        from teatree.config import TeaTreeConfig  # noqa: PLC0415
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            _overlay_gitlab_credentials_from_toml,
+        )
+
+        cfg = TeaTreeConfig(raw={"overlays": {"x": {"gitlab_url": "https://gl.example"}}})
+        with patch("teatree.config.load_config", return_value=cfg):
+            assert _overlay_gitlab_credentials_from_toml("x") == ("", "")
+
+    def test_gitlab_credentials_toml_read_pass_raises_returns_blank_token(self) -> None:
+        """TOML fallback: ``read_pass`` raising → empty token, URL preserved."""
+        from teatree.config import TeaTreeConfig  # noqa: PLC0415
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            _overlay_gitlab_credentials_from_toml,
+        )
+
+        cfg = TeaTreeConfig(
+            raw={
+                "overlays": {
+                    "x": {
+                        "gitlab_token_ref": "gitlab/x",
+                        "gitlab_url": "https://gl.example/api/v4",
+                    },
+                },
+            },
+        )
+        with (
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=RuntimeError("pass down")),
+        ):
+            token, base_url = _overlay_gitlab_credentials_from_toml("x")
+
+        assert token == ""
+        assert base_url == "https://gl.example/api/v4"
+
+    def test_resolve_github_token_for_overlay_empty_falls_through(self) -> None:
+        """Empty overlay name delegates to the legacy process-global resolver."""
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            resolve_github_token_for_overlay,
+        )
+
+        with patch(
+            "teatree.loop.scanners.outbound_audit._resolve_github_token",
+            return_value="legacy-token",
+        ):
+            assert resolve_github_token_for_overlay("") == "legacy-token"
+
+    def test_resolve_github_token_for_overlay_uses_registered_overlay(self) -> None:
+        """Registered overlay's ``config.get_github_token`` wins over fallback."""
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            resolve_github_token_for_overlay,
+        )
+
+        fake_overlay = MagicMock()
+        fake_overlay.config.get_github_token.return_value = "ghp-from-overlay"
+        with (
+            patch(
+                "teatree.core.overlay_loader.get_overlay",
+                return_value=fake_overlay,
+            ),
+            patch(
+                "teatree.loop.scanners.outbound_audit._resolve_github_token",
+                return_value="legacy-token",
+            ),
+        ):
+            assert resolve_github_token_for_overlay("work") == "ghp-from-overlay"
+
+    def test_resolve_github_token_for_overlay_falls_back_to_toml(self) -> None:
+        """Registered path returns empty → TOML path resolves the token."""
+        from teatree.config import TeaTreeConfig  # noqa: PLC0415
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            resolve_github_token_for_overlay,
+        )
+
+        cfg = TeaTreeConfig(
+            raw={
+                "overlays": {
+                    "toml-overlay": {"github_token_ref": "github/toml"},
+                },
+            },
+        )
+        with (
+            patch(
+                "teatree.core.overlay_loader.get_overlay",
+                side_effect=LookupError("no class"),
+            ),
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", return_value="ghp-from-toml"),
+            patch(
+                "teatree.loop.scanners.outbound_audit._resolve_github_token",
+                return_value="legacy-token",
+            ),
+        ):
+            assert resolve_github_token_for_overlay("toml-overlay") == "ghp-from-toml"
+
+    def test_resolve_github_token_for_overlay_falls_through_to_legacy(self) -> None:
+        """Neither registered nor TOML path resolves → legacy global resolver."""
+        from teatree.config import TeaTreeConfig  # noqa: PLC0415
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            resolve_github_token_for_overlay,
+        )
+
+        with (
+            patch(
+                "teatree.core.overlay_loader.get_overlay",
+                side_effect=LookupError("no class"),
+            ),
+            patch(
+                "teatree.config.load_config",
+                return_value=TeaTreeConfig(raw={"overlays": {}}),
+            ),
+            patch(
+                "teatree.loop.scanners.outbound_audit._resolve_github_token",
+                return_value="legacy-token",
+            ),
+        ):
+            assert resolve_github_token_for_overlay("unknown") == "legacy-token"
+
+    def test_github_token_from_registered_overlay_get_token_raises(self) -> None:
+        """``config.get_github_token`` raising → empty string (no crash)."""
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            _github_token_from_registered_overlay,
+        )
+
+        broken = MagicMock()
+        broken.config.get_github_token.side_effect = RuntimeError("vault down")
+        with patch(
+            "teatree.core.overlay_loader.get_overlay",
+            return_value=broken,
+        ):
+            assert _github_token_from_registered_overlay("broken") == ""
+
+    def test_github_token_from_toml_overlay_missing_returns_blank(self) -> None:
+        """TOML fallback: overlay absent → empty string."""
+        from teatree.config import TeaTreeConfig  # noqa: PLC0415
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            _github_token_from_toml_overlay,
+        )
+
+        with patch(
+            "teatree.config.load_config",
+            return_value=TeaTreeConfig(raw={"overlays": {}}),
+        ):
+            assert _github_token_from_toml_overlay("absent") == ""
+
+    def test_github_token_from_toml_overlay_no_token_ref_returns_blank(self) -> None:
+        """TOML fallback: overlay present but no ``github_token_ref`` → empty."""
+        from teatree.config import TeaTreeConfig  # noqa: PLC0415
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            _github_token_from_toml_overlay,
+        )
+
+        cfg = TeaTreeConfig(raw={"overlays": {"x": {"slack_token_ref": "slack/x"}}})
+        with patch("teatree.config.load_config", return_value=cfg):
+            assert _github_token_from_toml_overlay("x") == ""
+
+    def test_github_token_from_toml_overlay_read_pass_raises_returns_blank(self) -> None:
+        """TOML fallback: ``read_pass`` raising → empty string."""
+        from teatree.config import TeaTreeConfig  # noqa: PLC0415
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import (  # noqa: PLC0415
+            _github_token_from_toml_overlay,
+        )
+
+        cfg = TeaTreeConfig(
+            raw={"overlays": {"x": {"github_token_ref": "github/x"}}},
+        )
+        with (
+            patch("teatree.config.load_config", return_value=cfg),
+            patch("teatree.utils.secrets.read_pass", side_effect=RuntimeError("pass down")),
+        ):
+            assert _github_token_from_toml_overlay("x") == ""
+
+    def test_gitlab_api_for_overlay_empty_name_uses_default_constructor(self) -> None:
+        """Empty overlay name → ``GitLabAPI()`` legacy single-overlay default."""
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import gitlab_api_for_overlay  # noqa: PLC0415
+
+        sentinel = object()
+        with patch(
+            "teatree.backends.gitlab_api.GitLabAPI",
+            return_value=sentinel,
+        ) as ctor:
+            api = gitlab_api_for_overlay("")
+
+        assert api is sentinel
+        ctor.assert_called_once_with()
+
+    def test_gitlab_api_for_overlay_uses_overlay_credentials(self) -> None:
+        """Resolved overlay credentials → ``GitLabAPI(token=..., base_url=...)``."""
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import gitlab_api_for_overlay  # noqa: PLC0415
+
+        fake_overlay = MagicMock()
+        fake_overlay.config.get_gitlab_token.return_value = "glpat-z"
+        fake_overlay.config.gitlab_url = "https://gl.example/api/v4"
+        sentinel = object()
+        with (
+            patch(
+                "teatree.core.overlay_loader.get_overlay",
+                return_value=fake_overlay,
+            ),
+            patch(
+                "teatree.backends.gitlab_api.GitLabAPI",
+                return_value=sentinel,
+            ) as ctor,
+        ):
+            api = gitlab_api_for_overlay("named")
+
+        assert api is sentinel
+        ctor.assert_called_once_with(token="glpat-z", base_url="https://gl.example/api/v4")
+
+    def test_gitlab_api_for_overlay_returns_none_when_ctor_raises(self) -> None:
+        """``GitLabAPI`` constructor raising → ``None`` (graceful degrade)."""
+        from teatree.loop.scanners.outbound_audit_overlay_verifiers import gitlab_api_for_overlay  # noqa: PLC0415
+
+        with patch(
+            "teatree.backends.gitlab_api.GitLabAPI",
+            side_effect=RuntimeError("network failed at construction"),
+        ):
+            assert gitlab_api_for_overlay("") is None


### PR DESCRIPTION
## Summary

Closes #1275 — resilience epic #1192 follow-up from #1198 codex review.

The outbound-audit scanner (`loop.scanners.outbound_audit`) previously built each per-kind verifier with a **process-global** credential resolver: `GitLabAPI()`, `messaging_from_overlay()` (no overlay arg), `_resolve_github_token()`. Multi-overlay setups with different `*_token_ref` values silently picked whichever credential the global resolver landed on. On a private repo readable only by the non-default token, the API returned 404 -> false drift DM (failure mode 1); when no token resolved at all, claims sat pending forever with `kind=slack_dm -- skipping claim N` debug noise (failure mode 3).

This PR binds each verifier to the **overlay that posted the claim**:

- `OutboundClaim.extra["overlay"]` is stamped at claim-time by every record helper (`record_claim`, `_record_outbound_claim`, `_record_github_note_claim`). Reads `T3_OVERLAY_NAME`; callers wanting an explicit override pass it inside the `extra` dict.
- The scanner now dispatches via `_default_verifier_for_claim(claim)`, which reads `claim.extra["overlay"]` and builds the verifier through THAT overlay's credential pipeline: `_slack_dm_verifier_for_overlay`, `_gitlab_note_verifier_for_overlay`, `_gitlab_approve_verifier_for_overlay`, `_github_note_verifier_for_overlay`.
- A claim whose overlay credentials don't resolve emits `outbound.audit_skipped` (a new ScanSignal kind), distinct from `outbound.drift`. The silent backlog is now observable; the debug `kind=slack_dm -- skipping claim N` log is replaced by a structured signal the dispatcher / statusline can surface.

Legacy single-overlay factories (`_slack_dm_verifier`, `_gitlab_note_verifier`, `_gitlab_approve_verifier`, `_github_note_verifier`) still exist and delegate to the overlay-aware versions with `overlay_name=""` -- all 75 existing outbound-audit tests pass unchanged.

The overlay-aware factories live in a sibling module `outbound_audit_overlay_verifiers.py` so the scanner file stays under the module-health LOC cap.

## Test plan

- [x] RED tests added (9 new tests) covering: per-claim verifier dispatch by overlay (Slack/GitLab/GitHub), overlay stamping in every record helper, observability signal for missing credentials.
- [x] All RED tests fail on pre-fix code with concrete diagnostic outputs (`AttributeError: _resolve_github_token_for_overlay`, `KeyError: 'overlay'`, `assert 'outbound.audit_skipped' in set()`, `Expected 'get_permalink' to be called once. Called 0 times`).
- [x] Full test suite: 6950 passed, 13 skipped (1 pre-existing failure deselected on `tests/test_contrib_overlay.py::TestMaxConcurrentAutoStarts::test_in_repo_overlay_resolves_to_three` -- brittle to user's local `~/.teatree.toml` `max_concurrent_auto_starts` override, unrelated to this work).
- [x] Targeted suite (outbound_audit + new overlay-binding + record-claim): **84 passed**.
- [x] `ruff check` clean.
- [x] `ty check` clean.
- [x] All prek hooks pass.

## Verifier-lookup helper fix

`src/teatree/loop/scanners/outbound_audit.py:215` -- `_default_verifier_for_claim(claim)` reads `claim.extra["overlay"]` and routes to the overlay-bound factory. Pre-fix the scanner ignored the overlay context (`_default_verifier_for(kind)`) and used whichever credential `_resolve_github_token()` / `GitLabAPI()` / `messaging_from_overlay()` resolved process-globally.