### PR TITLE
fix(loop): drop outbound.audit_skipped from statusline rendering (#1372)

### DIFF
--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -84,6 +84,14 @@ _STATUSLINE_ZONE_BY_KIND: dict[str, str] = {
     "incoming_event.recorded": "in_flight",
 }
 
+# Diagnostic signal kinds that intentionally do NOT render to the statusline.
+# ``outbound.audit_skipped`` is emitted once per unverifiable claim per tick —
+# without this drop, N unverifiable claims fill the in_flight zone with N
+# identical rows ("No verifier for <kind> overlay=<overlay>") and crowd out
+# real signal (#1372). The signal is still emitted so internal counts work;
+# only the statusline rendering is suppressed.
+_STATUSLINE_DROP_KINDS: frozenset[str] = frozenset({"outbound.audit_skipped"})
+
 _PR_URL_RE = re.compile(r"https?://[^\s>|]+/(?:merge_requests|pull|pulls)/\d+")
 
 
@@ -315,6 +323,8 @@ def _claim_red_mr_fix(signal: ScanSignal) -> bool:
 
 
 def _dispatch_one(signal: ScanSignal) -> list[DispatchAction]:
+    if signal.kind in _STATUSLINE_DROP_KINDS:
+        return []
     conditional = _conditional_dispatch(signal)
     if conditional is not None:
         return conditional

--- a/tests/teatree_loop/test_dispatch.py
+++ b/tests/teatree_loop/test_dispatch.py
@@ -134,6 +134,22 @@ def test_unknown_kind_falls_back_to_in_flight() -> None:
     assert actions[0].zone == "in_flight"
 
 
+def test_outbound_audit_skipped_does_not_render_to_statusline() -> None:
+    """``outbound.audit_skipped`` is a credential-gap diagnostic, not user-actionable.
+
+    Without the drop, every unverifiable claim renders one statusline row per
+    tick — at scale, the in_flight zone fills with N copies of "No verifier
+    for <kind> overlay=<overlay>" and crowds out real signal (#1372).
+    """
+    signal = ScanSignal(
+        kind="outbound.audit_skipped",
+        summary="No verifier for slack_dm overlay=<default>",
+        payload={"claim_id": 1, "claim_kind": "slack_dm", "overlay": ""},
+    )
+    actions = dispatch([signal])
+    assert actions == []
+
+
 def test_payload_propagates_through_dispatch() -> None:
     payload: dict[str, object] = {"url": "https://example.com/mr/1"}
     actions = dispatch([ScanSignal(kind="reviewer_pr.new_sha", summary="x", payload=payload)])


### PR DESCRIPTION
The signal is a credential-gap diagnostic emitted once per unverifiable claim per tick. Without an explicit drop the dispatcher falls back to `in_flight`, and N unverifiable claims fill the statusline with N identical `No verifier for <kind> overlay=<overlay>` rows that crowd out real signal.

Adds an explicit `_STATUSLINE_DROP_KINDS` set and a guard at the top of `_dispatch_one`. The ScanSignal is still emitted so internal counts work; only the rendering is suppressed.

Closes #1372