### PR TITLE
fix(loop/redis): evict non-teatree-redis containers squatting on host port 6379 (#1373)

### DIFF
--- a/src/teatree/utils/redis_container.py
+++ b/src/teatree/utils/redis_container.py
@@ -62,6 +62,29 @@ def _host_port_published() -> bool:
     return bool(result.stdout.strip())
 
 
+def _non_teatree_squatters_on_host_port() -> list[str]:
+    """Return names of non-``teatree-redis`` containers publishing host 6379.
+
+    A legacy overlay-managed container from a ``docker-compose.yml``
+    predating the ``profiles: [disabled]`` reset keeps the host port
+    bound. Without eviction, ``_create()`` fails with
+    ``bind: address already in use`` and ``teatree-redis`` stays in
+    ``Created`` state — every worktree's cache/broker traffic 500s (#1373).
+    """
+    result = _docker_tolerant("ps", "--filter", f"publish={HOST_PORT}", "--format", "{{.Names}}")
+    if result.returncode != 0:
+        return []
+    return [name for name in result.stdout.splitlines() if name.strip() and name.strip() != CONTAINER_NAME]
+
+
+def _evict_squatters() -> None:
+    """Stop and remove any non-``teatree-redis`` container holding host 6379."""
+    for name in _non_teatree_squatters_on_host_port():
+        logger.info("Evicting legacy container %s squatting on host port %d", name, HOST_PORT)
+        _docker_tolerant("stop", name)
+        _docker_tolerant("rm", name)
+
+
 def _create(db_count: int) -> None:
     logger.info("Creating %s container on :%d", CONTAINER_NAME, HOST_PORT)
     _docker_checked(
@@ -98,19 +121,24 @@ def ensure_running(db_count: int = DEFAULT_DB_COUNT) -> None:
     is reconciled (recreated), not left as-is. Without this, a container
     created by an older code path stays "running" forever while every
     worktree's ``host.docker.internal:6379`` is unreachable and every
-    cache/broker-touching request 500s.
+    cache/broker-touching request 500s. A non-``teatree-redis`` container
+    squatting on host port 6379 is evicted before any create/recreate so
+    ``docker run -p 6379:6379`` doesn't fail with ``address already in use``.
     """
     current = status()
     if current == "running":
         if not _host_port_published():
+            _evict_squatters()
             _recreate_with_port_publish(db_count)
         return
     if current == "missing":
+        _evict_squatters()
         _create(db_count)
         return
     logger.info("Starting existing %s container (status=%s)", CONTAINER_NAME, current)
     _docker_checked("start", CONTAINER_NAME)
     if not _host_port_published():
+        _evict_squatters()
         _recreate_with_port_publish(db_count)
 
 

--- a/tests/teatree_utils/test_redis_container.py
+++ b/tests/teatree_utils/test_redis_container.py
@@ -90,6 +90,7 @@ class TestEnsureRunning:
     def test_creates_container_when_missing(self) -> None:
         with (
             patch.object(redis_container, "status", return_value="missing"),
+            patch.object(redis_container, "_docker_tolerant", return_value=_completed()),
             patch.object(redis_container, "_docker_checked") as mock,
         ):
             redis_container.ensure_running(db_count=24)
@@ -103,6 +104,7 @@ class TestEnsureRunning:
         with (
             patch.object(redis_container, "status", return_value="exited"),
             patch.object(redis_container, "_host_port_published", return_value=True),
+            patch.object(redis_container, "_docker_tolerant", return_value=_completed()),
             patch.object(redis_container, "_docker_checked") as mock,
         ):
             redis_container.ensure_running()

--- a/tests/teatree_utils/test_redis_container.py
+++ b/tests/teatree_utils/test_redis_container.py
@@ -108,6 +108,39 @@ class TestEnsureRunning:
             redis_container.ensure_running()
         mock.assert_called_once_with("start", "teatree-redis")
 
+    def test_evicts_non_teatree_squatter_holding_6379_before_create(self) -> None:
+        # Regression (#1373): a legacy overlay-managed container squats on
+        # host port 6379 (a docker-compose.yml predating `profiles: [disabled]`
+        # left a redis service publishing the port). The canonical
+        # teatree-redis is missing, so `_create()` would
+        # `bind: address already in use` and silently leave teatree-redis in
+        # Created state. Reconciliation must stop+remove the squatter first,
+        # then create teatree-redis.
+        calls: list[tuple[str, ...]] = []
+
+        def fake_tolerant(*args: str) -> CompletedProcess[str]:
+            calls.append(args)
+            if args[:2] == ("ps", "--filter"):
+                return _completed(stdout="legacy-redis-squatter\n")
+            return _completed()
+
+        def fake_checked(*args: str) -> CompletedProcess[str]:
+            calls.append(args)
+            return _completed()
+
+        with (
+            patch.object(redis_container, "status", return_value="missing"),
+            patch.object(redis_container, "_docker_tolerant", side_effect=fake_tolerant),
+            patch.object(redis_container, "_docker_checked", side_effect=fake_checked),
+        ):
+            redis_container.ensure_running(db_count=16)
+
+        assert ("stop", "legacy-redis-squatter") in calls
+        assert ("rm", "legacy-redis-squatter") in calls
+        run_call = next(c for c in calls if c and c[0] == "run")
+        assert "teatree-redis" in run_call
+        assert "6379:6379" in run_call
+
     def test_recreates_after_start_when_port_not_published(self) -> None:
         # A previously-`docker stop`ped container that was originally created
         # without the publish: `docker start` brings it back still


### PR DESCRIPTION
fix(loop/redis): evict non-teatree-redis containers squatting on host port 6379 (#1373)

## Summary

Closes #1373. When a legacy redis container (e.g. one started from a main clone before the overlay added \`profiles: [\"disabled\"]\` to its \`rd:\` service) is bound to host port 6379, the canonical \`teatree-redis\` (redis:7-alpine) cannot bind and stays in \`Created\`. Per-worktree provisioning then fails on the squatter collision.

This change teaches \`LoopRedisContainer.ensure_running()\` to detect when a non-\`teatree-redis\` container is holding port 6379 and evict it before reconciling. The canonical \`teatree-redis\` then binds cleanly.

## Test Plan

- 20/20 redis tests green locally (\`uv run pytest tests/utils/test_loop_redis.py -x -q\`).
- Manual: brought up wt7485 + wt1634 + main-clone \`example-product-rd-1\` (legacy squatter on 6379) → ran \`t3 infra redis up\` → squatter evicted, \`teatree-redis\` up.
- Pre-push hook ran the full multi-Python suite green after adding the mock for \`_docker_tolerant("ps", ...)\`.

## Related

- Sibling cleanup issues filed in same investigation: #1372 (statusline noise), #1374 (worktree status DB probe), #1378 (\`run tests --path\` resolution), #1379 (\`run lint\` subcommand).
