### PR TITLE
fix(loop): evict stale LoopLease owner on session rotation (#1107 follow-up)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -2365,6 +2365,46 @@ def _tick_owner_record(session_id: str, agent_id: str) -> dict[str, dict]:
     }
 
 
+def _evict_stale_db_lease_owner(session_id: str) -> None:
+    """Orphan any ``LoopLease`` ``loop-owner`` row not held by ``session_id``.
+
+    #1380 (#1107 follow-up). Context compaction rotates the Claude
+    ``session_id``. The file registry's ``t3-loop-tick-owner`` slot is
+    rewritten to the new id, but the DB ``LoopLease`` row name=
+    ``loop-owner`` still carries the OLD id with an unexpired
+    ``lease_expires_at``. ``CLAUDE_SESSION_ID`` is empty in Bash-tool
+    subprocesses (#1107) so the next ``t3 loop tick`` resolves the NEW
+    id via the registry fallback and the ``claim_ownership`` CAS fails
+    (DB row's session != new session, lease not expired) — the same
+    session can never own its own loop until ``t3 loop claim
+    --take-over`` runs manually.
+
+    Compaction is the natural eviction point. Whenever the SessionStart
+    handler records a new session as the tick-owner, any stale DB row
+    (session_id != new id, including the empty-string baseline) is
+    orphaned so the new session's next tick CAS-claims it cleanly. The
+    lease stays the authoritative liveness source; the registry is the
+    discovery channel.
+
+    Best-effort: any Django bootstrap / DB error fails open. The hook
+    must never block the SessionStart directive over a DB hiccup.
+    """
+    if not _bootstrap_teatree_django():
+        return
+    try:
+        from teatree.core.models import LoopLease  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return
+    try:
+        LoopLease.objects.filter(name="loop-owner").exclude(session_id=session_id).update(
+            session_id="",
+            acquired_at=None,
+            lease_expires_at=None,
+        )
+    except Exception:  # noqa: BLE001
+        return
+
+
 def _autocompact_kill_switch_advisory() -> str | None:
     """Return the #980 advisory text when the harness kill-switch trips.
 
@@ -2423,6 +2463,7 @@ def handle_session_start_bootstrap(data: dict) -> None:
         return
     agent_id = data.get("agent_id", "")
 
+    became_owner_after_rotation = False
     with _loop_registry_txn() as box:
         registry = _prune_dead_owner(box[0])
         owner = registry.get(_OWNER_LOOP)
@@ -2440,9 +2481,27 @@ def handle_session_start_bootstrap(data: dict) -> None:
             # No live owner, or this session already owns it (incl. the
             # post-compaction same-session restart — nothing to re-spawn,
             # the cron keeps ticking). This session is the tick-owner.
+            # ``owner is None`` here = a fresh machine OR a dead-owner
+            # prune; both can leave a stale DB lease behind. The
+            # ``same-session refresh`` case (``owner.session_id ==
+            # session_id``) does not need eviction — gating on this flag
+            # spares those SessionStarts the Django startup cost.
+            became_owner_after_rotation = owner is None
             box[0] = _tick_owner_record(session_id, owner.get("agent_id", "") if owner else agent_id or "")
             context = _TICK_DISPATCH_OWNER_DIRECTIVE
             emit_osc = True
+
+    # #1380: orphan any stale DB ``loop-owner`` row from a rotated session
+    # (compaction rotated the Claude ``session_id``, leaving the DB lease
+    # under the previous id with an unexpired ``lease_expires_at``). The
+    # lease stays the authoritative liveness source; this aligns it with
+    # the file registry we just rewrote so the new session's next
+    # ``t3 loop tick`` CAS-claims cleanly without ``--take-over``. Outside
+    # the flock — the DB has its own CAS serialization; holding the
+    # registry flock across a Django bootstrap would needlessly stall
+    # sibling SessionStart hooks.
+    if became_owner_after_rotation:
+        _evict_stale_db_lease_owner(session_id)
 
     # OSC write is a tty side effect, not registry state — keep it out of
     # the flock critical section.

--- a/tests/test_session_start_bootstrap_hook.py
+++ b/tests/test_session_start_bootstrap_hook.py
@@ -12,9 +12,12 @@ owner-only / interactive-TTY-gated.
 
 import json
 import os
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
+from django.test import TestCase
+from django.utils import timezone
 
 import hooks.scripts.hook_router as router
 from hooks.scripts.hook_router import (
@@ -416,3 +419,109 @@ class TestAutocompactAdvisoryIntegration:
 
         payload = json.loads(capsys.readouterr().out)
         assert "AUTO-COMPACT SILENT KILL-SWITCH" not in payload["additionalContext"]
+
+
+# ── Issue #1380: evict stale LoopLease owner on session rotation (#1107 follow-up) ──
+
+
+class TestStaleLeaseEvictionOnSessionRotation(TestCase):
+    """SessionStart evicts a stale ``LoopLease`` owner on rotation.
+
+    Compaction rotates the session id. The hook updates the file
+    registry to the new id, but the live ``LoopLease`` row name=
+    ``loop-owner`` still carries the OLD id with an unexpired
+    ``lease_expires_at``. ``CLAUDE_SESSION_ID`` is empty in Bash-tool
+    subprocesses (#1107), so the next ``t3 loop tick`` resolves the new
+    id via the file registry and the CAS in ``claim_ownership`` fails:
+    DB session != new session, lease not expired. The session can never
+    own its own loop until ``t3 loop claim --take-over`` runs manually.
+
+    Fix: when ``handle_session_start_bootstrap`` records a new session as
+    the tick-owner, orphan any stale DB row (``session_id != new_id``)
+    so the next tick CAS-claims it cleanly.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _hook_isolation(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        reg_dir = tmp_path / "data"
+        reg_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", str(reg_dir))
+        monkeypatch.setattr(router, "_TTY_PATH", str(tmp_path / "fake-tty"))
+
+    def test_new_session_evicts_stale_db_lease(self) -> None:
+        from teatree.core.models import LoopLease  # noqa: PLC0415
+
+        LoopLease.objects.claim_ownership("loop-owner", session_id="old-session")
+        assert LoopLease.objects.get(name="loop-owner").session_id == "old-session"
+
+        handle_session_start_bootstrap({"session_id": "new-session", "agent_id": "a"})
+
+        # The stale lease is orphaned so the next tick from the new
+        # session CAS-claims it cleanly.
+        row = LoopLease.objects.get(name="loop-owner")
+        assert row.session_id == ""
+        assert row.acquired_at is None
+        assert row.lease_expires_at is None
+
+    def test_same_session_restart_does_not_evict_own_lease(self) -> None:
+        from teatree.core.models import LoopLease  # noqa: PLC0415
+
+        LoopLease.objects.claim_ownership("loop-owner", session_id="owner-1")
+        expiry_before = LoopLease.objects.get(name="loop-owner").lease_expires_at
+
+        handle_session_start_bootstrap({"session_id": "owner-1", "agent_id": "a"})
+
+        # Same-session restart (post-compaction-same-id, or hook re-fire):
+        # the session keeps its own claim, no orphaning.
+        row = LoopLease.objects.get(name="loop-owner")
+        assert row.session_id == "owner-1"
+        assert row.lease_expires_at == expiry_before
+
+    def test_non_owner_session_does_not_touch_db_lease(self) -> None:
+        from teatree.core.models import LoopLease  # noqa: PLC0415
+
+        # A different live session already holds the file-registry owner
+        # slot. The new session is told to stay idle — it must NOT
+        # orphan the DB row (only an *owner* writes the DB).
+        _write_loop_registry({_OWNER_LOOP: {"session_id": "live-owner", "agent_id": "a", "pid": os.getpid()}})
+        LoopLease.objects.claim_ownership("loop-owner", session_id="live-owner")
+
+        handle_session_start_bootstrap({"session_id": "outsider", "agent_id": "b"})
+
+        # Non-owner branch fired (registry shows the existing owner) —
+        # the DB row is untouched.
+        assert LoopLease.objects.get(name="loop-owner").session_id == "live-owner"
+
+    def test_eviction_after_rotation_unblocks_claim_ownership(self) -> None:
+        """End-to-end repro of the #1107 follow-up bug.
+
+        Pre-fix sequence:
+
+        1. ``old-session`` holds an unexpired DB ``loop-owner`` claim.
+        2. Compaction rotates the live session id to ``new-session``.
+        3. ``SessionStart`` writes the new id to the file registry.
+        4. ``t3 loop tick`` resolves ``new-session`` via the registry
+            fallback (#1107) and calls
+            ``claim_ownership("loop-owner", session_id="new-session")``
+            — DB still says ``old-session``, lease unexpired, CAS fails.
+        5. Tick skips ("loop not owned by this session"); the user must
+            run ``t3 loop claim --take-over`` to recover.
+
+        Post-fix: step 3 also orphans the DB row, so step 4 wins.
+        """
+        from teatree.core.models import LoopLease  # noqa: PLC0415
+
+        # (1) old session is the DB lease holder, unexpired
+        LoopLease.objects.claim_ownership("loop-owner", session_id="old-session", ttl_seconds=1800)
+        row = LoopLease.objects.get(name="loop-owner")
+        assert row.session_id == "old-session"
+        assert row.lease_expires_at is not None
+        assert row.lease_expires_at > timezone.now() + timedelta(seconds=60)
+
+        # (3) hook records the new session as tick-owner
+        handle_session_start_bootstrap({"session_id": "new-session", "agent_id": "a"})
+
+        # (4) new session's first tick CAS-claims cleanly (no take-over)
+        won, owner = LoopLease.objects.claim_ownership("loop-owner", session_id="new-session")
+        assert won is True
+        assert owner == "new-session"


### PR DESCRIPTION
fix(loop): evict stale LoopLease owner on session rotation (#1107 follow-up)

Closes #1380.

After context compaction the Claude session_id rotates. The SessionStart
hook rewrites loop-registry.json's t3-loop-tick-owner slot to the new
id, but the live LoopLease row name=loop-owner still carries the
previous session's id with an unexpired lease_expires_at. Inside
Bash-tool subprocesses CLAUDE_SESSION_ID is empty (#1107), so the next
t3 loop tick resolves the new id via the registry fallback and
claim_ownership's CAS fails: the DB session no longer matches and the
lease is not expired. The same session can never own its own loop until
the user runs t3 loop claim --take-over manually.

Compaction is the natural eviction point. When handle_session_start_
bootstrap records a new session as the tick-owner (fresh machine or a
pruned-dead-owner reclaim — both can leave a stale DB row behind), the
DB row name=loop-owner whose session_id differs is orphaned so the new
session's next tick CAS-claims it cleanly. The lease remains the
authoritative liveness source; the registry is the discovery channel.

Eviction runs outside the registry flock (the DB has its own CAS
serialization; holding the flock across a Django bootstrap would
needlessly stall sibling SessionStart hooks) and is best-effort — any
Django/DB error fails open so the hook never blocks the SessionStart
directive over a DB hiccup. Gated on the rotation case so a same-session
restart does not pay the Django startup cost on every SessionStart.