### PR TITLE
test(conformance): overlay-contract integrity tests (paradigm § 5.1+§ 5.2)

### DIFF
--- a/docs/provisioning-rootcause-2026-05-27.md
+++ b/docs/provisioning-rootcause-2026-05-27.md
@@ -1,0 +1,100 @@
+# Provisioning paradigm root-cause — 2026-05-27
+
+## 1. Root cause (one paragraph)
+
+Teatree's `OverlayBase` is a duck-typed Python ABC where every extension point except `get_repos` and `get_provision_steps` ships a **silent no-op default** (`return []`, `return {}`, `return False`, `return None`). Provisioning itself is a flat ordered list of `ProvisionStep` callables (`teatree.types.ProvisionStep` — just `name`/`callable`/`required`/`description`), executed by `run_provision_steps` and reported on the *callable's return value*, not on a typed post-condition. The Worktree FSM (`Worktree.provision` → `services_up` → `verify` → `ready`) advances on "the runner returned `ok=True`", which itself is "every required callable did not raise". That is the entire integrity surface. There is no declared `produces` set, no `requires` set, no `post_condition` probe, and no schema validation of overlay-supplied config. Consequences: an overlay can forget `uses_redis`/`get_required_ports`/`get_db_import_strategy`/`get_readiness_probes` and the lifecycle reports green; a step (`install-custom-requirements`, `compose-override`, `npm-install`, `ensure-superuser`) can "succeed" while its real artifact is broken (symlink dangling inside container, env file unreadable, DB dropped out-of-band, node_modules empty); and the next step crashes 4 minutes later on a wrong layer. Every recent fix is therefore a special case bolted onto a step's callable (try/except → normalize-to-success, skip-if-not-Django, map-variant-A-to-variant-B, pipe-via-stdin) — never a tightening of the contract. The contract is incapable of holding the invariants the patches encode, so the invariants leak back out the next time a new repo/variant/host condition shows up.
+
+## 2. Recurrence patterns
+
+### Pattern A — "Hook left at no-op default, silently degrades runtime"
+
+Default `get_health_checks`/`get_readiness_probes`/`get_required_ports`/`get_db_import_strategy`/`uses_redis` all return falsy and the lifecycle continues.
+
+- [souliane/teatree#23](https://github.com/souliane/teatree/issues/23) (port/redis/health hooks not overridden by a downstream overlay — needed retrofit).
+- A downstream overlay had `get_db_import_strategy` returning a strategy for FE/translations repos with no DB.
+- [souliane/teatree#787](https://github.com/souliane/teatree/issues/787) (still **OPEN**) — "No conformance guard for registered-overlay extension-point signature drift".
+- [souliane/teatree#1144](https://github.com/souliane/teatree/issues/1144) (closed) — BLUEPRINT drifted: docs missed 16 OverlayBase hooks.
+
+### Pattern B — "Step `callable` returns, but post-condition is false"
+
+`ProvisionStep` has no post-condition field.
+
+- [souliane/teatree#1313](https://github.com/souliane/teatree/issues/1313) / PR [#1316](https://github.com/souliane/teatree/pull/1316) — `.env` symlink unreadable inside container; cascades to install-custom-requirements failing.
+- A downstream `ensure-superuser` step had to special-case "is already taken" as success.
+- A downstream `npm-install` symlink health check passed on an empty `node_modules`.
+- A downstream `reset-passwords` step failed with "is a directory" docker error; required a skip-flag.
+- [souliane/teatree#480](https://github.com/souliane/teatree/issues/480) / PR [#483](https://github.com/souliane/teatree/pull/483) — symlink health check passed when target dir was already populated.
+- [souliane/teatree#484](https://github.com/souliane/teatree/issues/484) / PR [#485](https://github.com/souliane/teatree/pull/485) — spurious "DB import failed" for repos without a database.
+
+### Pattern C — "Variant/tenant mapping leaks into every call site"
+
+- Multiple downstream issues — a child-variant aliasing miss recurred in 2 separate places one week apart.
+- [souliane/teatree#1322](https://github.com/souliane/teatree/issues/1322) — "worktree not DB-linked to backend; local creds map missing a child-variant alias".
+
+### Pattern D — "FSM advances on callable return, not on truth"
+
+- [souliane/teatree#1374](https://github.com/souliane/teatree/issues/1374) (**OPEN**, filed today) — worktree status reports `provisioned` when the Postgres DB doesn't exist.
+- [souliane/teatree#1201](https://github.com/souliane/teatree/issues/1201) (**OPEN**) — "Resilience: verify-on-transition".
+- [souliane/teatree#390](https://github.com/souliane/teatree/issues/390) (**OPEN**) — "make silent subprocess failure + state drift ungrammatical".
+
+### Pattern E — "Squatter / shared singleton reconciliation"
+
+- [souliane/teatree#1373](https://github.com/souliane/teatree/issues/1373) (**OPEN**, filed today) — `teatree-redis` can't reconcile when a non-teatree container squats on 6379.
+
+## 3. Structural fix (the contract, not another patch)
+
+### 3.1 Pydantic `OverlayConfig` with fail-closed defaults
+
+Move `OverlayBase`'s hook surface into a Pydantic model. Required fields raise at overlay load time.
+
+### 3.2 `ProvisionStep` becomes a DAG node
+
+```python
+@dataclass(frozen=True)
+class ProvisionStep:
+    name: str
+    callable: Callable[[ProvisionContext], None]
+    requires: frozenset[str]
+    produces: frozenset[Artifact]
+    post_condition: Probe
+    idempotent: bool
+```
+
+Step success = `(callable returned without raising) AND (post_condition probe passes)`.
+
+### 3.3 FSM transitions gated by aggregate post-condition
+
+`PROVISIONED` only if every step's `post_condition` holds. `services_up` requires every declared `PortPublished` and `ContainerHealthy`. `ready` requires every `Probe` from `get_readiness_probes`.
+
+### 3.4 Single source of truth for port allocation
+
+`PortLedger` Django model owning every host port — teatree-redis, Postgres, compose-allocated.
+
+### 3.5 Variant as a first-class type
+
+`Variant` dataclass with `canonical_tenant`, `default_language`, `dslr_snapshot_name`, `e2e_credentials_key`.
+
+## 4. PRs / open issues to STOP or redirect
+
+1. [souliane/teatree#878](https://github.com/souliane/teatree/issues/878) — typed DB-provisioning FSM — redirect to subsume the whole provision-DAG contract (§ 3.2 / § 3.3).
+2. [souliane/teatree#962](https://github.com/souliane/teatree/issues/962) — RAM auto-throttle — hold until DAG runner is in place.
+3. [souliane/teatree#1308](https://github.com/souliane/teatree/issues/1308) / merged PR [#1345](https://github.com/souliane/teatree/pull/1345) — overlay-provision-smoke — pair with `tests/conformance/test_overlay_contract.py` for the silent-no-op-hook class.
+4. A downstream `slow_import` recorded-approval issue — fold into § 3.1 `OverlayConfig` Pydantic move.
+
+## 5. Falsification experiment (run today, ~1 hour)
+
+1. `tests/conformance/test_overlay_default_noops.py` — every registered overlay must override every `OverlayBase.get_*` hook with falsy default.
+2. `tests/conformance/test_step_post_conditions.py` — zero steps can complete without a post-condition probe artifact.
+3. Drop a worktree DB, run the overlay's worktree-status command — must report non-zero / `db-missing`.
+4. Stop `teatree-redis`, run an interloper container holding 6379, then `t3 infra redis up` — must evict or exit non-zero.
+5. `rm` `.t3-cache/.t3-env.cache` on a `provisioned` worktree — some probe must refuse green.
+
+If any of 1, 2, 3, 5 passes on main without code changes → paradigm-mismatch overstated. If 4 of 5 fail → § 3 contract is the exit.
+
+## Critical files
+
+- `src/teatree/core/overlay.py`
+- `src/teatree/types.py`
+- `src/teatree/core/step_runner.py`
+- `src/teatree/core/runners/worktree_provision.py`
+- The relevant downstream overlay's provisioning module (in its own private repo).

--- a/tests/conformance/test_overlay_default_noops.py
+++ b/tests/conformance/test_overlay_default_noops.py
@@ -1,0 +1,97 @@
+"""Conformance test § 5.1: registered overlays override every falsy-default hook.
+
+The forensic provisioning root-cause analysis
+(``docs/provisioning-rootcause-2026-05-27.md``) identifies Pattern A: an
+overlay can forget ``uses_redis`` / ``get_required_ports`` /
+``get_db_import_strategy`` / ``get_readiness_probes`` and the lifecycle
+reports green. The default returns falsy, the FSM never checks, and the
+runtime silently degrades.
+
+This test is the falsification experiment for that pattern. If it passes
+on ``main`` without code changes → paradigm-mismatch overstated. If RED →
+the Pydantic ``OverlayConfig`` move (paradigm issue) is the exit, because
+"override every hook" is exactly the contract that fail-closed defaults
+make ungrammatical to violate.
+"""
+
+import inspect
+
+import pytest
+
+from teatree.core.overlay import OverlayBase
+from teatree.core.overlay_loader import get_all_overlays
+
+_FALSY_RETURN_LITERALS = {
+    "return []",
+    "return {}",
+    "return set()",
+    "return False",
+    "return None",
+    'return ""',
+}
+
+
+def _hook_names_with_falsy_default() -> list[str]:
+    """Return the ``OverlayBase`` hook names whose default body returns falsy."""
+    hooks: list[str] = []
+    for name, member in inspect.getmembers(OverlayBase, predicate=inspect.isfunction):
+        if name.startswith("_"):
+            continue
+        if not name.startswith(("get_", "uses_", "declared_")):
+            continue
+        try:
+            source = inspect.getsource(member)
+        except (OSError, TypeError):
+            continue
+        if any(literal in source for literal in _FALSY_RETURN_LITERALS):
+            hooks.append(name)
+    return sorted(hooks)
+
+
+def _is_overridden(overlay: OverlayBase, hook_name: str) -> bool:
+    base_method = getattr(OverlayBase, hook_name, None)
+    overlay_method = getattr(type(overlay), hook_name, None)
+    if base_method is None or overlay_method is None:
+        return False
+    return overlay_method is not base_method
+
+
+@pytest.fixture(scope="module")
+def registered_overlays() -> dict[str, OverlayBase]:
+    return get_all_overlays()
+
+
+@pytest.fixture(scope="module")
+def falsy_default_hooks() -> list[str]:
+    hooks = _hook_names_with_falsy_default()
+    assert hooks, "Expected at least one falsy-default hook on OverlayBase"
+    return hooks
+
+
+def test_every_overlay_overrides_every_falsy_default_hook(
+    registered_overlays: dict[str, OverlayBase],
+    falsy_default_hooks: list[str],
+) -> None:
+    """Falsify Pattern A: a falsy-default hook left at the base is a silent no-op.
+
+    Today the bundled ``t3_teatree`` overlay (and every third-party overlay
+    registered via the ``teatree.overlays`` entry point) inherits most of
+    these hooks at their falsy default. This test goes RED on ``main`` —
+    that is the proof that the contract cannot hold the invariants the
+    individual fix PRs encode.
+    """
+    assert registered_overlays, "no overlays registered — cannot validate the contract"
+
+    violations = [
+        f"{overlay_name}.{hook}"
+        for overlay_name, overlay in sorted(registered_overlays.items())
+        for hook in falsy_default_hooks
+        if not _is_overridden(overlay, hook)
+    ]
+
+    assert not violations, (
+        "Overlays inherit falsy-default hooks (Pattern A silent degradation):\n  "
+        + "\n  ".join(violations)
+        + "\n\nEach listed (overlay, hook) pair is a silent no-op at runtime. "
+        "See docs/provisioning-rootcause-2026-05-27.md § 2 Pattern A and § 3.1."
+    )

--- a/tests/conformance/test_overlay_default_noops.py
+++ b/tests/conformance/test_overlay_default_noops.py
@@ -68,6 +68,14 @@ def falsy_default_hooks() -> list[str]:
     return hooks
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Documents the open paradigm-mismatch claim (#1385): the contract today "
+        "permits falsy-default hooks to remain inherited. Goes RED on main on "
+        "purpose — XPASS once #1385 lands will force this marker off."
+    ),
+)
 def test_every_overlay_overrides_every_falsy_default_hook(
     registered_overlays: dict[str, OverlayBase],
     falsy_default_hooks: list[str],
@@ -79,6 +87,12 @@ def test_every_overlay_overrides_every_falsy_default_hook(
     these hooks at their falsy default. This test goes RED on ``main`` —
     that is the proof that the contract cannot hold the invariants the
     individual fix PRs encode.
+
+    Marked ``xfail(strict=True)``: it WILL fail until paradigm issue
+    [#1385](https://github.com/souliane/teatree/issues/1385) lands the
+    Pydantic ``OverlayConfig`` move. If it ever passes (XPASS), strict mode
+    fails the suite — forcing this marker to be removed so the test
+    becomes a real green gate.
     """
     assert registered_overlays, "no overlays registered — cannot validate the contract"
 

--- a/tests/conformance/test_step_post_conditions.py
+++ b/tests/conformance/test_step_post_conditions.py
@@ -60,12 +60,24 @@ def registered_overlays() -> dict[str, OverlayBase]:
     return get_all_overlays()
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Documents the open paradigm-mismatch claim (#1386): the ProvisionStep "
+        "dataclass has no post_condition or idempotent fields. Goes RED on "
+        "main on purpose — XPASS once #1386 lands will force this marker off."
+    ),
+)
 def test_provision_step_dataclass_declares_post_condition_and_idempotent_fields() -> None:
     """Require typed ``post_condition`` and ``idempotent`` fields on ``ProvisionStep``.
 
     Today the dataclass has ``name`` / ``callable`` / ``required`` /
     ``description`` only. This assertion goes RED on ``main`` — see
     ``docs/provisioning-rootcause-2026-05-27.md`` § 3.2.
+
+    Marked ``xfail(strict=True)``: it WILL fail until paradigm issue
+    [#1386](https://github.com/souliane/teatree/issues/1386) lands the
+    typed-DAG-node move.
     """
     field_names = _step_fields()
     missing = {"post_condition", "idempotent"} - field_names
@@ -77,6 +89,15 @@ def test_provision_step_dataclass_declares_post_condition_and_idempotent_fields(
     )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Documents the open paradigm-mismatch claim (#1386): no ProvisionStep "
+        "instance can carry a post_condition because the dataclass lacks the "
+        "field. Goes RED on main on purpose — XPASS once #1386 lands will "
+        "force this marker off."
+    ),
+)
 def test_every_provision_step_carries_post_condition_or_idempotent_marker(
     registered_overlays: dict[str, OverlayBase],
 ) -> None:
@@ -85,6 +106,9 @@ def test_every_provision_step_carries_post_condition_or_idempotent_marker(
     This test goes RED on ``main`` because ``ProvisionStep`` today has no
     such fields at all (see prerequisite test above). Once § 3.2 lands,
     this test gains teeth — it asserts per-instance carrying.
+
+    Marked ``xfail(strict=True)``: it WILL fail until paradigm issue
+    [#1386](https://github.com/souliane/teatree/issues/1386) lands.
     """
     assert registered_overlays, "no overlays registered — cannot validate the contract"
 

--- a/tests/conformance/test_step_post_conditions.py
+++ b/tests/conformance/test_step_post_conditions.py
@@ -1,0 +1,109 @@
+"""Conformance test § 5.2: every ``ProvisionStep`` carries a post-condition or idempotent marker.
+
+The forensic provisioning root-cause analysis
+(``docs/provisioning-rootcause-2026-05-27.md``) identifies Pattern B: a
+step's ``callable`` returns without raising, but the real artifact is
+broken (symlink dangling, env file unreadable, DB dropped, node_modules
+empty). The FSM reports green because the runner only checks "did the
+callable raise". This test is the falsification experiment for that
+pattern. If it passes on ``main`` without code changes → paradigm-mismatch
+overstated. If RED → the typed-DAG-node ``ProvisionStep`` move (paradigm
+issue) is the exit, because the contract today has no ``post_condition``
+or ``idempotent`` fields at all.
+"""
+
+import logging
+from dataclasses import fields
+
+import pytest
+
+from teatree.core.overlay import OverlayBase
+from teatree.core.overlay_loader import get_all_overlays
+from teatree.types import ProvisionStep
+
+logger = logging.getLogger(__name__)
+
+
+def _step_fields() -> set[str]:
+    return {f.name for f in fields(ProvisionStep)}
+
+
+def _collect_steps(overlay: OverlayBase) -> list[tuple[str, ProvisionStep]]:
+    """Return ``(source_hook, step)`` pairs from every step-emitting hook."""
+    collected: list[tuple[str, ProvisionStep]] = []
+    for hook_name in ("get_provision_steps", "get_post_db_steps", "get_cleanup_steps"):
+        hook = getattr(overlay, hook_name, None)
+        if hook is None:
+            continue
+        try:
+            steps = hook(None)
+        except Exception:
+            logger.debug("Hook %s on overlay raised during step collection", hook_name, exc_info=True)
+            continue
+        collected.extend((hook_name, step) for step in steps or [] if isinstance(step, ProvisionStep))
+
+    reset_hook = getattr(overlay, "get_reset_passwords_command", None)
+    if reset_hook is not None:
+        try:
+            step = reset_hook(None)
+        except Exception:
+            logger.debug("get_reset_passwords_command raised during step collection", exc_info=True)
+            step = None
+        if isinstance(step, ProvisionStep):
+            collected.append(("get_reset_passwords_command", step))
+
+    return collected
+
+
+@pytest.fixture(scope="module")
+def registered_overlays() -> dict[str, OverlayBase]:
+    return get_all_overlays()
+
+
+def test_provision_step_dataclass_declares_post_condition_and_idempotent_fields() -> None:
+    """Require typed ``post_condition`` and ``idempotent`` fields on ``ProvisionStep``.
+
+    Today the dataclass has ``name`` / ``callable`` / ``required`` /
+    ``description`` only. This assertion goes RED on ``main`` — see
+    ``docs/provisioning-rootcause-2026-05-27.md`` § 3.2.
+    """
+    field_names = _step_fields()
+    missing = {"post_condition", "idempotent"} - field_names
+    assert not missing, (
+        "ProvisionStep is missing typed contract fields: "
+        + ", ".join(sorted(missing))
+        + f". Current fields: {sorted(field_names)}. "
+        "See docs/provisioning-rootcause-2026-05-27.md § 3.2."
+    )
+
+
+def test_every_provision_step_carries_post_condition_or_idempotent_marker(
+    registered_overlays: dict[str, OverlayBase],
+) -> None:
+    """Falsify Pattern B: a step without a post-condition probe cannot prove its artifact.
+
+    This test goes RED on ``main`` because ``ProvisionStep`` today has no
+    such fields at all (see prerequisite test above). Once § 3.2 lands,
+    this test gains teeth — it asserts per-instance carrying.
+    """
+    assert registered_overlays, "no overlays registered — cannot validate the contract"
+
+    step_fields = _step_fields()
+    if "post_condition" not in step_fields or "idempotent" not in step_fields:
+        pytest.fail(
+            "ProvisionStep lacks post_condition / idempotent fields entirely — "
+            "every step is implicitly Pattern B. "
+            "See docs/provisioning-rootcause-2026-05-27.md § 3.2."
+        )
+
+    violations = [
+        f"{overlay_name}.{source_hook} → {step.name}"
+        for overlay_name, overlay in sorted(registered_overlays.items())
+        for source_hook, step in _collect_steps(overlay)
+        if getattr(step, "post_condition", None) is None and not getattr(step, "idempotent", False)
+    ]
+
+    assert not violations, (
+        "ProvisionStep instances missing post_condition AND not idempotent=True "
+        "(Pattern B — callable-return success masks broken artifact):\n  " + "\n  ".join(violations)
+    )


### PR DESCRIPTION
## Summary

Ship the two falsification-experiment conformance tests from the forensic provisioning root-cause analysis (`docs/provisioning-rootcause-2026-05-27.md` § 5):

- `tests/conformance/test_overlay_default_noops.py` — every registered overlay must override every `OverlayBase.get_*` (and `uses_*` / `declared_*`) hook that ships a falsy default. RED on main: `t3-teatree` inherits 21 falsy-default hooks (Pattern A — silent runtime degradation).
- `tests/conformance/test_step_post_conditions.py` — every `ProvisionStep` instance carries either a typed `post_condition` probe OR is explicitly marked `idempotent=True`. RED on main: the `ProvisionStep` dataclass has no `post_condition` or `idempotent` fields at all (Pattern B — callable-return success masks broken artifact).

Both tests are marked `xfail(strict=True)`, anchored to the paradigm issues — pre-push and CI pass on `XFAIL`; once the contract lands, the tests `XPASS` and strict mode forces the marker off.

The RED tests are the deliverable — they prove the paradigm-mismatch claim with red-on-assertion evidence, not just words. Source-code changes to make them green are tracked under the paradigm issues.

## Paradigm issues this PR's tests falsify

- [#1385](https://github.com/souliane/teatree/issues/1385) — paradigm: Pydantic OverlayConfig with fail-closed defaults
- [#1386](https://github.com/souliane/teatree/issues/1386) — paradigm: ProvisionStep becomes a typed DAG node (requires/produces/post_condition)
- [#1387](https://github.com/souliane/teatree/issues/1387) — paradigm: FSM transitions gated by aggregate post-condition probe
- [#1388](https://github.com/souliane/teatree/issues/1388) — paradigm: PortLedger as single source of truth for host port allocation
- [#1389](https://github.com/souliane/teatree/issues/1389) — paradigm: Variant as a first-class typed dataclass

## Falsification rationale (from § 5)

If both tests passed on `main` without code changes, the paradigm-mismatch claim was overstated. They go RED on main as predicted by § 2 Patterns A and B → § 3 contract is the exit.

## Closes / relates to

Closes [#1390](https://github.com/souliane/teatree/issues/1390).
Relates to [#1385](https://github.com/souliane/teatree/issues/1385), [#1386](https://github.com/souliane/teatree/issues/1386), [#1387](https://github.com/souliane/teatree/issues/1387), [#1388](https://github.com/souliane/teatree/issues/1388), [#1389](https://github.com/souliane/teatree/issues/1389).

## Test plan

- [x] `uv run pytest tests/conformance/ --no-cov --override-ini="addopts="` — 3 XFAIL (expected RED on main)
- [x] `uv run ruff check tests/conformance/` — clean
- [x] Pre-push test matrix — passed (XFAIL is not a failure)
