### PR TITLE
fix(loop/news): require per-article ask gate before ticket creation (#1391)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -2210,6 +2210,7 @@ Usage: t3 teatree [OPTIONS] COMMAND [ARGS]...
 │ questions     Manage the away-mode deferred-question backlog (#58).          │
 │ pending_chat  Manage the inbound Slack-DM queue (#1063).                     │
 │ notify        Bot→user Slack DM from the shell (#1030).                      │
+│ news          Manage the news-scan ask-gate queue (#1391).                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -4322,5 +4323,72 @@ Usage: t3 teatree notify send [OPTIONS] BODY
 │    --overlay                TEXT  Set T3_OVERLAY_NAME for the call           │
 │                                   (per-overlay bot routing).                 │
 │    --help                         Show this message and exit.                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 teatree news`
+
+```
+Usage: t3 teatree news [OPTIONS] COMMAND [ARGS]...
+
+ Manage the news-scan ask-gate queue (#1391).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ pending  List undecided article suggestions, oldest first.                   │
+│ approve  Approve a suggestion — files the GitHub issue and stamps the row.   │
+│ reject   Reject a suggestion — no issue is created.                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree news pending`
+
+```
+Usage: t3 teatree news pending [OPTIONS]
+
+ List news-scan suggestions awaiting user decision.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --all     --pending      Include approved/rejected rows. [default: pending]  │
+│ --help                   Show this message and exit.                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree news approve`
+
+```
+Usage: t3 teatree news approve [OPTIONS] SUGGESTION_ID
+
+ Approve a pending suggestion — files the GitHub issue.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    suggestion_id      INTEGER  [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --decider        TEXT  Identity of the approver (audit trail).               │
+│ --repo           TEXT  GitHub repo for the new issue.                        │
+│                        [default: souliane/teatree]                           │
+│ --label          TEXT  Issue label. [default: from-news-scan]                │
+│ --help                 Show this message and exit.                           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree news reject`
+
+```
+Usage: t3 teatree news reject [OPTIONS] SUGGESTION_ID
+
+ Reject a pending suggestion — no issue is created.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    suggestion_id      INTEGER  [required]                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --reason         TEXT  Why the candidate is dropped (audit trail).           │
+│                        [default: not relevant]                               │
+│ --decider        TEXT  Identity of the rejecter (audit trail).               │
+│ --help                 Show this message and exit.                           │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/skills/scanning-news/SKILL.md
+++ b/skills/scanning-news/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 ## Non-Negotiables
 
-1. **Per-article ask gate is mandatory (#1391).** Never call `gh issue create` directly for a scanned article. Every candidate goes through `teatree.core.article_ingestion_gate.enqueue_candidates_and_notify`, which records a `PendingArticleSuggestion` row, sends the user a batch DM, and waits for explicit approval via `t3 manage news approve <id>`. The user pilots the backlog — silent ticket creation from any third-party-prose scanner is banned.
+1. **Per-article ask gate is mandatory (#1391).** Never call `gh issue create` directly for a scanned article. Every candidate goes through `teatree.core.article_ingestion_gate.enqueue_candidates_and_notify`, which records a `PendingArticleSuggestion` row, sends the user a batch DM, and waits for explicit approval via `t3 teatree news approve <id>`. The user pilots the backlog — silent ticket creation from any third-party-prose scanner is banned.
 2. **Date-of-edition verification is mandatory.** Before processing any newsletter, read the issue date verbatim from the page header and compare it to today's workspace date. If they do not match, do not proceed — either re-fetch with a stricter prompt, fall back to the latest published edition, or abort that source. Never silently treat yesterday's edition as today's.
 3. **Aggregator-detection is mandatory.** TLDR's `tldr.tech/<track>/<date>` page can return a kitchen-sink summary that lists stories from every TLDR track (Tech, AI, Dev, Product, IT, Marketing, Design, Infosec, Crypto, Founders, DevOps, Data, Fintech). The real per-issue newsletter is 5–9 stories grouped under named sections. If the fetch returns >15 stories or contains track-names that are not the requested track, the prompt drifted — re-fetch with the stricter prompt before continuing.
 4. **Idempotency via `url_hash`.** The ask-gate skips already-queued URLs. A second scan of the same edition is a no-op.
@@ -40,9 +40,9 @@ enqueue_candidates_and_notify([
 "
 
 # Inspect / decide
-t3 manage news pending
-t3 manage news approve <id>
-t3 manage news reject <id> --reason "<one-line>"
+t3 teatree news pending
+t3 teatree news approve <id>
+t3 teatree news reject <id> --reason "<one-line>"
 
 # Dedupe check (still useful before enqueueing — gate is idempotent on URL hash)
 gh --repo souliane/teatree issue list --label from-news-scan --state all --search "<article URL>"
@@ -108,7 +108,7 @@ When invoked with `--periodic` (from the teatree loop's periodic dispatcher, or 
 
 - Non-interactive — no user confirmation prompts inside the scan itself.
 - Candidates are queued via the ask gate (never auto-filed).
-- DM listing the batch is automatic; ticket creation waits on `t3 manage news approve <id>`.
+- DM listing the batch is automatic; ticket creation waits on `t3 teatree news approve <id>`.
 - Print a summary to stdout for log capture.
 
 ## Scheduling via the teatree main loop

--- a/skills/scanning-news/SKILL.md
+++ b/skills/scanning-news/SKILL.md
@@ -20,23 +20,32 @@ metadata:
 
 ## Non-Negotiables
 
-1. **Date-of-edition verification is mandatory.** Before processing any newsletter, read the issue date verbatim from the page header and compare it to today's workspace date. If they do not match, do not proceed — either re-fetch with a stricter prompt, fall back to the latest published edition, or abort that source. Never silently treat yesterday's edition as today's.
-2. **Aggregator-detection is mandatory.** TLDR's `tldr.tech/<track>/<date>` page can return a kitchen-sink summary that lists stories from every TLDR track (Tech, AI, Dev, Product, IT, Marketing, Design, Infosec, Crypto, Founders, DevOps, Data, Fintech). The real per-issue newsletter is 5–9 stories grouped under named sections. If the fetch returns >15 stories or contains track-names that are not the requested track, the prompt drifted — re-fetch with the stricter prompt before continuing.
-3. **Dedupe tickets by source URL** before filing. Existing `from-news-scan` issues already cite the article URL in their body.
-4. **No AI signature** on issues or DMs (per `t3:rules`).
-5. **Never invent stories.** If a source fetch fails, omit that source from the DM and note the failure.
+1. **Per-article ask gate is mandatory (#1391).** Never call `gh issue create` directly for a scanned article. Every candidate goes through `teatree.core.article_ingestion_gate.enqueue_candidates_and_notify`, which records a `PendingArticleSuggestion` row, sends the user a batch DM, and waits for explicit approval via `t3 manage news approve <id>`. The user pilots the backlog — silent ticket creation from any third-party-prose scanner is banned.
+2. **Date-of-edition verification is mandatory.** Before processing any newsletter, read the issue date verbatim from the page header and compare it to today's workspace date. If they do not match, do not proceed — either re-fetch with a stricter prompt, fall back to the latest published edition, or abort that source. Never silently treat yesterday's edition as today's.
+3. **Aggregator-detection is mandatory.** TLDR's `tldr.tech/<track>/<date>` page can return a kitchen-sink summary that lists stories from every TLDR track (Tech, AI, Dev, Product, IT, Marketing, Design, Infosec, Crypto, Founders, DevOps, Data, Fintech). The real per-issue newsletter is 5–9 stories grouped under named sections. If the fetch returns >15 stories or contains track-names that are not the requested track, the prompt drifted — re-fetch with the stricter prompt before continuing.
+4. **Idempotency via `url_hash`.** The ask-gate skips already-queued URLs. A second scan of the same edition is a no-op.
+5. **No AI signature** on issues or DMs (per `t3:rules`).
+6. **Never invent stories.** If a source fetch fails, omit that source from the DM and note the failure.
 
 ## Command Reference
 
 ```bash
-# Issue creation
-gh --repo souliane/teatree issue create --title "<title>" --body "<body>" --label "from-news-scan"
+# Enqueue candidates (the only sanctioned path — replaces direct gh issue create)
+python -c "
+import django; django.setup()
+from teatree.core.article_ingestion_gate import enqueue_candidates_and_notify, ArticleCandidate
+enqueue_candidates_and_notify([
+    ArticleCandidate(url='<url>', title='<title>', summary='<why-interesting>', source='tldr-ai'),
+])
+"
 
-# Dedupe check
+# Inspect / decide
+t3 manage news pending
+t3 manage news approve <id>
+t3 manage news reject <id> --reason "<one-line>"
+
+# Dedupe check (still useful before enqueueing — gate is idempotent on URL hash)
 gh --repo souliane/teatree issue list --label from-news-scan --state all --search "<article URL>"
-
-# Slack DM via overlay router (teatree bot)
-python -c "from teatree.messaging import messaging_from_overlay; m = messaging_from_overlay(overlay_name='teatree'); m.dm_owner('<text>')"
 ```
 
 ## Workflow
@@ -85,21 +94,21 @@ For each deep-read article, ask: *is there a concrete, scoped change to teatree 
 
 Bias toward filing in borderline cases — duplicates are triaged later, missed ideas vanish.
 
-### 7. File tickets
+### 7. Enqueue candidates (NOT file tickets)
 
-After the dedupe check returns no match, file the issue using the body template in `references/ticket-template.md`. One issue per *idea*, not per article — three articles inspiring one idea collapse to one issue citing all three URLs.
+For each relevant idea, build an `ArticleCandidate(url, title, summary, source)` and pass the batch through `enqueue_candidates_and_notify(...)`. The gate writes one `PendingArticleSuggestion` per new URL and DMs the user the batch. **Do not call `gh issue create` from this skill.** One suggestion per *idea*, not per article — three articles inspiring one idea collapse to one suggestion citing all three URLs in the summary.
 
 ### 8. Post the Slack DM
 
-Format defined in `references/slack-format.md`. Always post even when zero items are interesting — a "0 items, 0 tickets" DM is the honest signal that the scan ran.
+The batch DM is sent by the gate itself (`enqueue_candidates_and_notify`). When zero candidates are interesting, post a separate "0 items, 0 suggestions" DM directly so the honest signal still fires.
 
 ## Periodic Mode
 
 When invoked with `--periodic` (from the teatree loop's periodic dispatcher, or cron):
 
-- Non-interactive — no user confirmation prompts.
-- Ticket filing automatic (dedupe gate prevents spam).
-- DM automatic.
+- Non-interactive — no user confirmation prompts inside the scan itself.
+- Candidates are queued via the ask gate (never auto-filed).
+- DM listing the batch is automatic; ticket creation waits on `t3 manage news approve <id>`.
 - Print a summary to stdout for log capture.
 
 ## Scheduling via the teatree main loop
@@ -119,9 +128,9 @@ If the loop scanner is not yet wired on an older install, the fallback path is d
 
 ## Rules
 
-- Dedupe before filing.
-- One issue per idea.
-- Label every filed issue `from-news-scan`.
+- Route every candidate through `enqueue_candidates_and_notify` — never `gh issue create` directly.
+- One suggestion per idea.
+- The gate labels every approved issue `from-news-scan` automatically.
 - Use the workspace clock; never trust a date interpolated by an upstream caller.
 - No AI signature on posts.
 

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -206,6 +206,14 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("send", "DM the user; exit 0 on delivery, 1 otherwise (sub-agent direct notify)."),
         ],
     ),
+    "news": DjangoGroup(
+        "Manage the news-scan ask-gate queue (#1391).",
+        [
+            ("pending", "List undecided article suggestions, oldest first."),
+            ("approve", "Approve a suggestion — files the GitHub issue and stamps the row."),
+            ("reject", "Reject a suggestion — no issue is created."),
+        ],
+    ),
 }
 
 

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -195,6 +195,7 @@ OVERLAY_OVERRIDABLE_SETTINGS: dict[str, Callable[[Any], Any]] = {
     "scanning_news_disabled": bool,
     "scanning_news_skill": str,
     "scanning_news_cadence_hours": int,
+    "ask_before_creating_news_tickets": bool,
     "dogfood_smoke_disabled": bool,
     "dogfood_smoke_skill": str,
     "dogfood_smoke_cadence_hours": int,
@@ -353,6 +354,13 @@ class UserSettings:
     scanning_news_disabled: bool = False
     scanning_news_skill: str = "scanning-news"
     scanning_news_cadence_hours: int = 24
+    # #1391 Per-article ask gate for the scanning-news scanner (and any
+    # sibling third-party-prose scanner). When True, scanners queue
+    # candidate articles into ``PendingArticleSuggestion`` rows + DM
+    # the user the batch instead of auto-filing issues. Approval flow
+    # is ``t3 manage news approve <id>`` / ``... news reject <id>``.
+    # Default ON — the user pilots the backlog (BINDING 2026-05-27).
+    ask_before_creating_news_tickets: bool = True
     # #1308 Periodic provision-smoke scanner — CORE always-on with a
     # 24h cadence by default. Queues a ``dogfood_smoke`` task per cadence
     # window so the loop exercises the active overlay's provision path
@@ -432,6 +440,7 @@ def load_config(path: Path | None = None) -> TeaTreeConfig:
         scanning_news_disabled=bool(teatree.get("scanning_news_disabled", False)),
         scanning_news_skill=str(teatree.get("scanning_news_skill", "scanning-news")),
         scanning_news_cadence_hours=int(teatree.get("scanning_news_cadence_hours", 24)),
+        ask_before_creating_news_tickets=bool(teatree.get("ask_before_creating_news_tickets", True)),
         dogfood_smoke_disabled=bool(teatree.get("dogfood_smoke_disabled", False)),
         dogfood_smoke_skill=str(teatree.get("dogfood_smoke_skill", "dogfood-smoke")),
         dogfood_smoke_cadence_hours=int(teatree.get("dogfood_smoke_cadence_hours", 24)),

--- a/src/teatree/core/article_ingestion_gate.py
+++ b/src/teatree/core/article_ingestion_gate.py
@@ -1,0 +1,239 @@
+"""Per-article approval gate for scanner-ingested third-party prose (#1391).
+
+This module is the **single helper** the ``scanning-news`` skill (and any
+sibling third-party-prose scanner) calls instead of ``gh issue create``.
+The flow:
+
+1. Scanner triages candidate articles into a list of
+    :class:`ArticleCandidate` dicts.
+2. Caller invokes :func:`enqueue_candidates_and_notify` — this writes
+    one :class:`PendingArticleSuggestion` per new URL (idempotent on
+    ``url_hash``) and DMs the user the batch via
+    :func:`teatree.core.notify.notify_user`.
+3. The user reviews the batch and calls
+    ``t3 manage news approve <id>`` / ``t3 manage news reject <id>``
+    to act on individual suggestions.
+4. ``approve`` is the only path that calls ``gh issue create`` on
+    ``souliane/teatree`` with the ``from-news-scan`` label.
+
+The gate is **config-overridable**: when
+``[teatree] ask_before_creating_news_tickets = false`` resolves to
+``False`` the scanner falls back to direct ticket creation (the legacy
+behaviour). The default is ``True`` (gate on).
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from teatree.core.models import PendingArticleSuggestion
+from teatree.utils.run import CommandFailedError, run_checked
+
+if TYPE_CHECKING:
+    from teatree.backends.protocols import MessagingBackend
+
+logger = logging.getLogger(__name__)
+
+#: Label every ask-gate-approved issue carries, matching the legacy
+#: skill behaviour so dedup queries keep working.
+APPROVED_ISSUE_LABEL = "from-news-scan"
+
+#: Repo the scanning-news skill files to. Hardcoded because the skill
+#: is teatree-specific (it mines TLDR/Rundown for teatree improvements).
+APPROVED_ISSUE_REPO = "souliane/teatree"
+
+
+@dataclass(frozen=True, slots=True)
+class ArticleCandidate:
+    """One triaged article the scanner wants the user to consider.
+
+    ``url`` is the canonical link to the article. ``title`` is the
+    human-readable headline. ``summary`` is the short
+    "why-this-looks-interesting" blurb the scanner produced. ``source``
+    names the producing newsletter (``"tldr-ai"``, ``"rundown-ai"``,
+    etc.) and gates per-source rate-limiting if added later.
+    """
+
+    url: str
+    title: str
+    summary: str
+    source: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class EnqueueResult:
+    """Outcome of :func:`enqueue_candidates_and_notify`."""
+
+    new_suggestion_ids: list[int]
+    skipped_duplicate_urls: list[str]
+    dm_sent: bool
+
+
+def enqueue_candidates_and_notify(
+    candidates: list[ArticleCandidate],
+    *,
+    backend: "MessagingBackend | None" = None,
+    user_id: str | None = None,
+    idempotency_prefix: str = "news-scan-batch",
+) -> EnqueueResult:
+    """Record candidates and DM the user the pending batch.
+
+    Each new URL becomes one :class:`PendingArticleSuggestion` row;
+    URLs whose ``url_hash`` is already on file are reported as
+    ``skipped_duplicate_urls`` (no second DM, no second row). The DM
+    listing names every newly-recorded suggestion by id + title with a
+    pointer to ``t3 manage news approve <id>`` / ``... reject <id>``.
+    """
+    new_ids: list[int] = []
+    skipped: list[str] = []
+    for candidate in candidates:
+        row = PendingArticleSuggestion.record_if_new(
+            url=candidate.url,
+            summary=candidate.summary,
+            title=candidate.title,
+            source=candidate.source,
+        )
+        if row is None:
+            skipped.append(candidate.url)
+        else:
+            new_ids.append(row.pk)
+
+    if not new_ids:
+        return EnqueueResult(new_suggestion_ids=[], skipped_duplicate_urls=skipped, dm_sent=False)
+
+    dm_text = _format_batch_dm(new_ids)
+    sent = _notify_user(
+        text=dm_text,
+        backend=backend,
+        user_id=user_id,
+        idempotency_key=f"{idempotency_prefix}:{'-'.join(str(i) for i in new_ids)}",
+    )
+    if sent:
+        PendingArticleSuggestion.mark_batch_presented(new_ids)
+    return EnqueueResult(
+        new_suggestion_ids=new_ids,
+        skipped_duplicate_urls=skipped,
+        dm_sent=sent,
+    )
+
+
+def _format_batch_dm(suggestion_ids: list[int]) -> str:
+    rows = PendingArticleSuggestion.objects.filter(pk__in=suggestion_ids).order_by("created_at")
+    lines = [f":newspaper: *{len(rows)} candidate article(s) from news-scan*"]
+    for row in rows:
+        title = row.title or row.url
+        lines.extend([f"  #{row.pk}: {title}", f"     {row.url}"])
+        if row.summary:
+            lines.append(f"     {row.summary}")
+    lines.extend(
+        [
+            "",
+            "Approve: `t3 manage news approve <id>` — Reject: `t3 manage news reject <id>`",
+        ],
+    )
+    return "\n".join(lines)
+
+
+def _notify_user(
+    *,
+    text: str,
+    backend: "MessagingBackend | None",
+    user_id: str | None,
+    idempotency_key: str,
+) -> bool:
+    """Send the batch DM via the canonical bot→user helper.
+
+    Imported lazily so this module stays importable in tests that don't
+    pre-build the Django + messaging machinery.
+    """
+    from teatree.core.notify import NotifyKind, notify_user  # noqa: PLC0415
+
+    return notify_user(
+        text,
+        kind=NotifyKind.INFO,
+        idempotency_key=idempotency_key,
+        backend=backend,
+        user_id=user_id,
+    )
+
+
+def approve_and_create_ticket(
+    suggestion_id: int,
+    *,
+    decider_id: str = "",
+    repo: str = APPROVED_ISSUE_REPO,
+    label: str = APPROVED_ISSUE_LABEL,
+    extra_body_lines: list[str] | None = None,
+) -> PendingArticleSuggestion | None:
+    """Approve a suggestion and create the corresponding GitHub issue.
+
+    Calls ``gh issue create`` once and stamps the resulting URL on the
+    :class:`PendingArticleSuggestion` row inside the same atomic step.
+    Returns the consumed row on success, ``None`` when the suggestion
+    is missing or already decided. Raises
+    :class:`teatree.utils.run.CommandFailedError` when ``gh`` exits
+    non-zero — the row stays pending so the caller can retry after
+    fixing the gh state.
+    """
+    row = PendingArticleSuggestion.objects.filter(pk=suggestion_id).first()
+    if row is None or not row.is_pending:
+        return None
+    title = (row.title or row.url)[:200]
+    body_lines = [
+        f"Source: {row.url}",
+        "",
+        row.summary,
+    ]
+    if extra_body_lines:
+        body_lines.extend(["", *extra_body_lines])
+    body = "\n".join(body_lines)
+    ticket_url = _gh_issue_create(repo=repo, title=title, body=body, label=label)
+    return PendingArticleSuggestion.approve(
+        suggestion_id,
+        decider_id=decider_id,
+        ticket_url=ticket_url,
+    )
+
+
+def _gh_issue_create(*, repo: str, title: str, body: str, label: str) -> str:
+    """Thin shell around ``gh issue create`` returning the issue URL.
+
+    Separated so tests monkeypatch this single chokepoint instead of
+    the surrounding business logic.
+    """
+    try:
+        result = run_checked(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--repo",
+                repo,
+                "--title",
+                title,
+                "--body",
+                body,
+                "--label",
+                label,
+            ],
+        )
+    except CommandFailedError:
+        logger.exception("gh issue create failed for repo=%s title=%s", repo, title[:60])
+        raise
+    stdout = (result.stdout or "").strip()
+    if not stdout:
+        return ""
+    return stdout.splitlines()[-1].strip()
+
+
+def ask_gate_enabled() -> bool:
+    """Resolve the ``ask_before_creating_news_tickets`` setting (default True).
+
+    The gate is on by default; users who explicitly opt back into legacy
+    behaviour set ``[teatree] ask_before_creating_news_tickets = false``
+    in ``~/.teatree.toml``. Per-overlay overrides are supported via the
+    standard ``OVERLAY_OVERRIDABLE_SETTINGS`` chain.
+    """
+    from teatree.config import get_effective_settings  # noqa: PLC0415
+
+    return bool(get_effective_settings().ask_before_creating_news_tickets)

--- a/src/teatree/core/article_ingestion_gate.py
+++ b/src/teatree/core/article_ingestion_gate.py
@@ -11,7 +11,7 @@ The flow:
     ``url_hash``) and DMs the user the batch via
     :func:`teatree.core.notify.notify_user`.
 3. The user reviews the batch and calls
-    ``t3 manage news approve <id>`` / ``t3 manage news reject <id>``
+    ``t3 teatree news approve <id>`` / ``t3 teatree news reject <id>``
     to act on individual suggestions.
 4. ``approve`` is the only path that calls ``gh issue create`` on
     ``souliane/teatree`` with the ``from-news-scan`` label.
@@ -82,7 +82,7 @@ def enqueue_candidates_and_notify(
     URLs whose ``url_hash`` is already on file are reported as
     ``skipped_duplicate_urls`` (no second DM, no second row). The DM
     listing names every newly-recorded suggestion by id + title with a
-    pointer to ``t3 manage news approve <id>`` / ``... reject <id>``.
+    pointer to ``t3 teatree news approve <id>`` / ``... reject <id>``.
     """
     new_ids: list[int] = []
     skipped: list[str] = []
@@ -128,7 +128,7 @@ def _format_batch_dm(suggestion_ids: list[int]) -> str:
     lines.extend(
         [
             "",
-            "Approve: `t3 manage news approve <id>` — Reject: `t3 manage news reject <id>`",
+            "Approve: `t3 teatree news approve <id>` — Reject: `t3 teatree news reject <id>`",
         ],
     )
     return "\n".join(lines)

--- a/src/teatree/core/management/commands/news.py
+++ b/src/teatree/core/management/commands/news.py
@@ -1,0 +1,125 @@
+"""``manage.py news`` — operate on the news-scan ask-gate queue (#1391).
+
+Three subcommands act on the durable
+:class:`teatree.core.models.PendingArticleSuggestion` queue populated by
+the scanning-news skill instead of direct ``gh issue create`` calls:
+
+* ``news pending`` — list undecided suggestions, oldest first.
+* ``news approve <id>`` — file the GitHub issue and stamp the row
+    APPROVED with the new issue URL.
+* ``news reject <id> [--reason ...]`` — drop the candidate (no issue
+    is created) and stamp the row REJECTED.
+
+The user pilots the backlog: nothing in this flow auto-creates a
+ticket without a deliberate ``news approve`` call.
+"""
+
+from typing import Annotated
+
+import typer
+from django_typer.management import TyperCommand, command, initialize
+
+from teatree.core.article_ingestion_gate import APPROVED_ISSUE_LABEL, APPROVED_ISSUE_REPO, approve_and_create_ticket
+from teatree.core.models import PendingArticleSuggestion
+
+
+def _format_row(row: PendingArticleSuggestion) -> str:
+    age = row.created_at.isoformat() if row.created_at is not None else "?"
+    title = row.title or row.url
+    lines = [
+        f"  #{row.pk} [{row.decision}] {age}",
+        f"     {title}",
+        f"     {row.url}",
+    ]
+    if row.summary:
+        lines.append(f"     {row.summary}")
+    if row.source:
+        lines.append(f"     source: {row.source}")
+    if row.created_ticket_url:
+        lines.append(f"     ticket: {row.created_ticket_url}")
+    return "\n".join(lines)
+
+
+class Command(TyperCommand):
+    @initialize()
+    def init(self) -> None:
+        """``t3 manage news`` group root."""
+
+    @command(name="pending")
+    def list_pending(
+        self,
+        *,
+        all_rows: Annotated[
+            bool,
+            typer.Option("--all/--pending", help="Include approved/rejected rows."),
+        ] = False,
+    ) -> str:
+        """List news-scan suggestions awaiting user decision."""
+        if all_rows:
+            rows = list(PendingArticleSuggestion.objects.order_by("-created_at"))
+        else:
+            rows = list(PendingArticleSuggestion.pending())
+        if not rows:
+            return "no pending article suggestions."
+        lines = [f"{len(rows)} article suggestion(s):"]
+        lines.extend(_format_row(row) for row in rows)
+        return "\n".join(lines)
+
+    @command()
+    def approve(
+        self,
+        suggestion_id: int,
+        decider_id: Annotated[
+            str,
+            typer.Option("--decider", help="Identity of the approver (audit trail)."),
+        ] = "",
+        repo: Annotated[
+            str,
+            typer.Option("--repo", help="GitHub repo for the new issue."),
+        ] = APPROVED_ISSUE_REPO,
+        label: Annotated[
+            str,
+            typer.Option("--label", help="Issue label."),
+        ] = APPROVED_ISSUE_LABEL,
+    ) -> str:
+        """Approve a pending suggestion — files the GitHub issue."""
+        row = approve_and_create_ticket(
+            suggestion_id,
+            decider_id=decider_id,
+            repo=repo,
+            label=label,
+        )
+        if row is None:
+            self.stderr.write(
+                f"suggestion #{suggestion_id} not found or already decided",
+            )
+            raise SystemExit(1)
+        if row.created_ticket_url:
+            return f"approved #{row.pk} — issue: {row.created_ticket_url}"
+        return f"approved #{row.pk} (ticket URL not captured from gh output)"
+
+    @command()
+    def reject(
+        self,
+        suggestion_id: int,
+        reason: Annotated[
+            str,
+            typer.Option("--reason", help="Why the candidate is dropped (audit trail)."),
+        ] = "not relevant",
+        decider_id: Annotated[
+            str,
+            typer.Option("--decider", help="Identity of the rejecter (audit trail)."),
+        ] = "",
+    ) -> str:
+        """Reject a pending suggestion — no issue is created."""
+        row = PendingArticleSuggestion.reject(
+            suggestion_id,
+            decider_id=decider_id,
+            reason=reason.strip() or "not relevant",
+        )
+        if row is None:
+            self.stderr.write(
+                f"suggestion #{suggestion_id} not found or already decided",
+            )
+            raise SystemExit(1)
+        return f"rejected #{row.pk}."

--- a/src/teatree/core/management/commands/news.py
+++ b/src/teatree/core/management/commands/news.py
@@ -43,7 +43,7 @@ def _format_row(row: PendingArticleSuggestion) -> str:
 class Command(TyperCommand):
     @initialize()
     def init(self) -> None:
-        """``t3 manage news`` group root."""
+        """``t3 teatree news`` group root."""
 
     @command(name="pending")
     def list_pending(

--- a/src/teatree/core/migrations/0037_pendingarticlesuggestion.py
+++ b/src/teatree/core/migrations/0037_pendingarticlesuggestion.py
@@ -1,0 +1,47 @@
+# Generated for #1391 — per-article ask gate for the scanning-news scanner.
+
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0036_codexreviewmarker"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PendingArticleSuggestion",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(default=django.utils.timezone.now)),
+                ("url", models.URLField(max_length=2048)),
+                ("url_hash", models.CharField(max_length=64, unique=True)),
+                ("title", models.TextField(blank=True, default="")),
+                ("summary", models.TextField()),
+                ("source", models.CharField(blank=True, default="", max_length=64)),
+                ("presented", models.BooleanField(default=False)),
+                ("presented_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "decision",
+                    models.CharField(
+                        choices=[
+                            ("pending", "pending"),
+                            ("approved", "approved"),
+                            ("rejected", "rejected"),
+                        ],
+                        default="pending",
+                        max_length=16,
+                    ),
+                ),
+                ("decided_at", models.DateTimeField(blank=True, null=True)),
+                ("decider_id", models.CharField(blank=True, default="", max_length=255)),
+                ("decision_reason", models.TextField(blank=True, default="")),
+                ("created_ticket_url", models.URLField(blank=True, default="", max_length=2048)),
+            ],
+            options={
+                "db_table": "teatree_pending_article_suggestion",
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/src/teatree/core/models/__init__.py
+++ b/src/teatree/core/models/__init__.py
@@ -17,6 +17,7 @@ from teatree.core.models.loop_lease import LoopLease
 from teatree.core.models.merge_clear import ClearIssuanceError, ClearRequest, MergeAudit, MergeClear
 from teatree.core.models.on_behalf_approval import OnBehalfApproval, OnBehalfApprovalError, OnBehalfAudit
 from teatree.core.models.outbound_claim import OutboundClaim
+from teatree.core.models.pending_article_suggestion import PendingArticleSuggestion, PendingArticleSuggestionError
 from teatree.core.models.pending_chat_injection import PendingChatInjection
 from teatree.core.models.pull_request import PullRequest
 from teatree.core.models.red_card_signal import RedCardIntent, RedCardSignal
@@ -65,6 +66,8 @@ __all__ = [
     "OnBehalfApprovalError",
     "OnBehalfAudit",
     "OutboundClaim",
+    "PendingArticleSuggestion",
+    "PendingArticleSuggestionError",
     "PendingChatInjection",
     "Ports",
     "PullRequest",

--- a/src/teatree/core/models/pending_article_suggestion.py
+++ b/src/teatree/core/models/pending_article_suggestion.py
@@ -9,8 +9,8 @@ directly after triaging an edition. That auto-create pattern treats
 This model is the durable buffer between **scanner triage** and
 **ticket creation**: a scanner records one
 :class:`PendingArticleSuggestion` per candidate article, the user reviews
-the batch (via DM or ``t3 news pending``), and only the user-approved
-suggestions become real GitHub issues — via ``t3 news approve <id>``.
+the batch (via DM or ``t3 teatree news pending``), and only the user-approved
+suggestions become real GitHub issues — via ``t3 teatree news approve <id>``.
 
 The model mirrors the ``DeferredQuestion`` / ``OnBehalfApproval`` shape:
 

--- a/src/teatree/core/models/pending_article_suggestion.py
+++ b/src/teatree/core/models/pending_article_suggestion.py
@@ -1,0 +1,255 @@
+"""Per-article approval gate for scanner-ingested third-party prose (#1391).
+
+The ``scanning-news`` skill (and any sibling RSS / arxiv / vendor-blog
+scanner) historically called ``gh issue create --label from-news-scan``
+directly after triaging an edition. That auto-create pattern treats
+"interesting article" as a strong signal to ticketize, and the user
+(correctly) treats this as backlog pollution: most articles are noise.
+
+This model is the durable buffer between **scanner triage** and
+**ticket creation**: a scanner records one
+:class:`PendingArticleSuggestion` per candidate article, the user reviews
+the batch (via DM or ``t3 news pending``), and only the user-approved
+suggestions become real GitHub issues — via ``t3 news approve <id>``.
+
+The model mirrors the ``DeferredQuestion`` / ``OnBehalfApproval`` shape:
+
+* guarded factory :meth:`PendingArticleSuggestion.record` is the only
+    path that writes a row, and it refuses empty payloads (no silent drop);
+* :meth:`approve` / :meth:`reject` atomically claim and stamp
+    ``decided_at`` so the same row can never be acted on twice;
+* ``url_hash`` is the idempotency key — a second scanner pass on the
+    same URL is a no-op via :meth:`record_if_new`.
+
+Unlike ``OnBehalfApproval`` (which guards a *publication*), this row
+guards a *backlog ingestion*. The shape is the same — durable,
+single-use, scoped, audited — so the team can reason about all the
+gates as one primitive family.
+"""
+
+import hashlib
+from typing import ClassVar
+
+from django.db import models, transaction
+from django.utils import timezone
+
+
+class PendingArticleSuggestionError(ValueError):
+    """A :class:`PendingArticleSuggestion` was rejected at record time."""
+
+
+class PendingArticleSuggestion(models.Model):
+    """One candidate article queued for user approval before ticket creation.
+
+    ``url_hash`` is the SHA-256 of the canonical article URL; a second
+    scan that lands on the same URL is a no-op (the
+    :meth:`record_if_new` factory enforces this via a unique-index
+    short-circuit). ``source`` names the scanner that produced the row
+    (e.g. ``"tldr-ai"``, ``"rundown-ai"``) for batch-level dedup and
+    audit.
+    """
+
+    DECISION_PENDING = "pending"
+    DECISION_APPROVED = "approved"
+    DECISION_REJECTED = "rejected"
+
+    created_at = models.DateTimeField(default=timezone.now)
+    url = models.URLField(max_length=2048)
+    url_hash = models.CharField(max_length=64, unique=True)
+    title = models.TextField(blank=True, default="")
+    summary = models.TextField()
+    source = models.CharField(max_length=64, blank=True, default="")
+    presented = models.BooleanField(default=False)
+    presented_at = models.DateTimeField(null=True, blank=True)
+    decision = models.CharField(
+        max_length=16,
+        choices=[
+            (DECISION_PENDING, "pending"),
+            (DECISION_APPROVED, "approved"),
+            (DECISION_REJECTED, "rejected"),
+        ],
+        default=DECISION_PENDING,
+    )
+    decided_at = models.DateTimeField(null=True, blank=True)
+    decider_id = models.CharField(max_length=255, blank=True, default="")
+    decision_reason = models.TextField(blank=True, default="")
+    created_ticket_url = models.URLField(max_length=2048, blank=True, default="")
+
+    class Meta:
+        db_table = "teatree_pending_article_suggestion"
+        ordering: ClassVar = ["-created_at"]
+
+    def __str__(self) -> str:
+        title = self.title or self.url
+        return f"pending-article<{self.pk}:{self.decision} '{title[:60]}'>"
+
+    @property
+    def is_pending(self) -> bool:
+        return self.decision == self.DECISION_PENDING
+
+    @staticmethod
+    def hash_url(url: str) -> str:
+        """Canonical idempotency key for a candidate article URL."""
+        return hashlib.sha256(url.strip().encode("utf-8")).hexdigest()
+
+    @classmethod
+    def record(
+        cls,
+        *,
+        url: str,
+        summary: str,
+        title: str = "",
+        source: str = "",
+    ) -> "PendingArticleSuggestion":
+        """The single guarded factory; raises if URL/summary are empty.
+
+        Construction is atomic so a rejected record leaves no partial row.
+        Callers that want the idempotent "skip if already presented"
+        behaviour should use :meth:`record_if_new` instead.
+        """
+        clean_url = url.strip()
+        clean_summary = summary.strip()
+        if not clean_url:
+            msg = "url is required (#1391)"
+            raise PendingArticleSuggestionError(msg)
+        if not clean_summary:
+            msg = "summary is required (#1391)"
+            raise PendingArticleSuggestionError(msg)
+        with transaction.atomic():
+            return cls.objects.create(
+                url=clean_url,
+                url_hash=cls.hash_url(clean_url),
+                title=title.strip(),
+                summary=clean_summary,
+                source=source.strip(),
+            )
+
+    @classmethod
+    def record_if_new(
+        cls,
+        *,
+        url: str,
+        summary: str,
+        title: str = "",
+        source: str = "",
+    ) -> "PendingArticleSuggestion | None":
+        """Record a candidate, returning ``None`` if its URL is already queued.
+
+        Idempotency on ``url_hash`` is the load-bearing invariant — a
+        scanner that double-fires on the same edition must not produce
+        duplicate suggestions. Returns the row on first record; returns
+        ``None`` when a row with the same ``url_hash`` already exists
+        regardless of its decision state (a previously-rejected URL is
+        not re-presented).
+        """
+        clean_url = url.strip()
+        if not clean_url:
+            return None
+        url_hash = cls.hash_url(clean_url)
+        if cls.objects.filter(url_hash=url_hash).exists():
+            return None
+        try:
+            return cls.record(url=clean_url, summary=summary, title=title, source=source)
+        except PendingArticleSuggestionError:
+            return None
+
+    @classmethod
+    def pending(cls, *, using: str | None = None) -> models.QuerySet["PendingArticleSuggestion"]:
+        """Return the undecided queue, oldest first."""
+        manager = cls.objects.using(using) if using else cls.objects
+        return manager.filter(decision=cls.DECISION_PENDING).order_by("created_at")
+
+    @classmethod
+    def mark_batch_presented(cls, ids: list[int]) -> int:
+        """Stamp ``presented=True`` / ``presented_at`` on the listed rows.
+
+        Called by the scanner after the batch DM has been sent so the
+        next tick doesn't re-DM the same suggestions.
+        """
+        if not ids:
+            return 0
+        now = timezone.now()
+        return cls.objects.filter(pk__in=ids, presented=False).update(
+            presented=True,
+            presented_at=now,
+        )
+
+    @classmethod
+    def approve(
+        cls,
+        suggestion_id: int,
+        *,
+        decider_id: str = "",
+        ticket_url: str = "",
+        using: str | None = None,
+    ) -> "PendingArticleSuggestion | None":
+        """Atomically claim the row as APPROVED and stamp the ticket URL.
+
+        Returns the consumed row (so the caller can chain the issue
+        creation), or ``None`` when the suggestion is missing or already
+        decided. The ``ticket_url`` is recorded on the suggestion so the
+        audit trail shows which approval produced which issue.
+        """
+        return cls._consume(
+            suggestion_id,
+            decision=cls.DECISION_APPROVED,
+            decider_id=decider_id,
+            ticket_url=ticket_url,
+            reason="",
+            using=using,
+        )
+
+    @classmethod
+    def reject(
+        cls,
+        suggestion_id: int,
+        *,
+        decider_id: str = "",
+        reason: str = "",
+        using: str | None = None,
+    ) -> "PendingArticleSuggestion | None":
+        """Atomically claim the row as REJECTED with an optional reason."""
+        return cls._consume(
+            suggestion_id,
+            decision=cls.DECISION_REJECTED,
+            decider_id=decider_id,
+            ticket_url="",
+            reason=reason,
+            using=using,
+        )
+
+    @classmethod
+    def _consume(  # noqa: PLR0913 — single chokepoint for all decision transitions; each kwarg is a documented audit field.
+        cls,
+        suggestion_id: int,
+        *,
+        decision: str,
+        decider_id: str,
+        ticket_url: str,
+        reason: str,
+        using: str | None,
+    ) -> "PendingArticleSuggestion | None":
+        manager = cls.objects.using(using) if using else cls.objects
+        with transaction.atomic(using=using):
+            row = manager.select_for_update().filter(pk=suggestion_id, decision=cls.DECISION_PENDING).first()
+            if row is None:
+                return None
+            now = timezone.now()
+            row.decision = decision
+            row.decided_at = now
+            row.decider_id = decider_id
+            if ticket_url:
+                row.created_ticket_url = ticket_url
+            if reason:
+                row.decision_reason = reason
+            row.save(
+                update_fields=[
+                    "decision",
+                    "decided_at",
+                    "decider_id",
+                    "created_ticket_url",
+                    "decision_reason",
+                ],
+                using=using,
+            )
+            return row

--- a/tests/teatree_core/management_commands/test_news_command.py
+++ b/tests/teatree_core/management_commands/test_news_command.py
@@ -1,0 +1,78 @@
+"""Tests for ``t3 manage news`` (pending / approve / reject) — #1391."""
+
+from io import StringIO
+from unittest import mock
+
+import pytest
+from django.core.management import call_command
+
+from teatree.core.models import PendingArticleSuggestion
+
+pytestmark = pytest.mark.django_db
+
+
+def _call(*args: str) -> str:
+    buf = StringIO()
+    call_command(*args, stdout=buf)
+    return buf.getvalue()
+
+
+class TestNewsPendingCommand:
+    def test_pending_lists_only_undecided_rows(self) -> None:
+        a = PendingArticleSuggestion.record(url="https://example.com/a", summary="why A", title="A")
+        PendingArticleSuggestion.record(url="https://example.com/b", summary="why B", title="B")
+        c = PendingArticleSuggestion.record(url="https://example.com/c", summary="why C", title="C")
+        PendingArticleSuggestion.reject(c.pk, reason="dup")
+
+        out = _call("news", "pending")
+        assert f"#{a.pk}" in out
+        assert f"#{c.pk}" not in out
+        assert "A" in out
+        assert "https://example.com/a" in out
+
+    def test_pending_with_all_includes_decided(self) -> None:
+        a = PendingArticleSuggestion.record(url="https://example.com/a", summary="why A")
+        PendingArticleSuggestion.reject(a.pk, reason="dup")
+        out = _call("news", "pending", "--all")
+        assert f"#{a.pk}" in out
+        assert "rejected" in out
+
+    def test_pending_handles_empty_queue(self) -> None:
+        out = _call("news", "pending")
+        assert "no pending article suggestions" in out
+
+
+class TestNewsApproveCommand:
+    def test_approve_calls_gh_and_stamps_url(self) -> None:
+        row = PendingArticleSuggestion.record(
+            url="https://example.com/a",
+            summary="why this article matters",
+            title="An interesting article",
+        )
+        with mock.patch(
+            "teatree.core.article_ingestion_gate._gh_issue_create",
+            return_value="https://github.com/souliane/teatree/issues/9001",
+        ) as gh_mock:
+            out = _call("news", "approve", str(row.pk), "--decider", "adrien")
+        gh_mock.assert_called_once()
+        row.refresh_from_db()
+        assert row.decision == PendingArticleSuggestion.DECISION_APPROVED
+        assert row.created_ticket_url == "https://github.com/souliane/teatree/issues/9001"
+        assert "9001" in out
+
+    def test_approve_unknown_id_exits_nonzero(self) -> None:
+        with pytest.raises(SystemExit):
+            _call("news", "approve", "999999")
+
+
+class TestNewsRejectCommand:
+    def test_reject_stamps_decision_with_reason(self) -> None:
+        row = PendingArticleSuggestion.record(url="https://example.com/a", summary="why")
+        _call("news", "reject", str(row.pk), "--reason", "copycat article")
+        row.refresh_from_db()
+        assert row.decision == PendingArticleSuggestion.DECISION_REJECTED
+        assert row.decision_reason == "copycat article"
+
+    def test_reject_unknown_id_exits_nonzero(self) -> None:
+        with pytest.raises(SystemExit):
+            _call("news", "reject", "999999")

--- a/tests/teatree_core/test_pending_article_suggestion_model.py
+++ b/tests/teatree_core/test_pending_article_suggestion_model.py
@@ -1,0 +1,230 @@
+"""Tests for :class:`PendingArticleSuggestion` and the ask-gate helper (#1391).
+
+The ask gate is the single chokepoint between news-scan triage and
+ticket creation. The tests assert:
+
+* the durable model is the only path to a row (guarded factory),
+* idempotency on ``url_hash`` is load-bearing (second scan = no-op),
+* the gate enqueues + DMs without calling ``gh issue create`` until
+    an explicit approval happens,
+* ``approve_and_create_ticket`` calls ``gh issue create`` exactly once,
+    stamps the row APPROVED, and records the new issue URL.
+"""
+
+from unittest import mock
+
+import pytest
+
+from teatree.core.article_ingestion_gate import (
+    APPROVED_ISSUE_LABEL,
+    APPROVED_ISSUE_REPO,
+    ArticleCandidate,
+    approve_and_create_ticket,
+    enqueue_candidates_and_notify,
+)
+from teatree.core.models import PendingArticleSuggestion
+from teatree.core.models.pending_article_suggestion import PendingArticleSuggestionError
+
+pytestmark = pytest.mark.django_db
+
+
+class TestPendingArticleSuggestionRecord:
+    def test_record_creates_a_pending_row_with_hash(self) -> None:
+        row = PendingArticleSuggestion.record(
+            url="https://example.com/a",
+            summary="why interesting",
+            title="An article",
+            source="tldr-ai",
+        )
+        assert row.pk is not None
+        assert row.is_pending is True
+        assert row.decision == PendingArticleSuggestion.DECISION_PENDING
+        assert row.url_hash == PendingArticleSuggestion.hash_url("https://example.com/a")
+        assert row.title == "An article"
+        assert row.source == "tldr-ai"
+        assert row.created_ticket_url == ""
+
+    def test_record_strips_and_requires_url(self) -> None:
+        with pytest.raises(PendingArticleSuggestionError, match="url is required"):
+            PendingArticleSuggestion.record(url="   ", summary="x")
+
+    def test_record_strips_and_requires_summary(self) -> None:
+        with pytest.raises(PendingArticleSuggestionError, match="summary is required"):
+            PendingArticleSuggestion.record(url="https://example.com/a", summary="   ")
+
+
+class TestRecordIfNewIdempotency:
+    def test_first_record_succeeds_second_is_noop(self) -> None:
+        first = PendingArticleSuggestion.record_if_new(
+            url="https://example.com/a",
+            summary="why",
+            title="Article A",
+        )
+        second = PendingArticleSuggestion.record_if_new(
+            url="https://example.com/a",
+            summary="why again",
+            title="Article A (dup)",
+        )
+        assert first is not None
+        assert second is None
+        assert (
+            PendingArticleSuggestion.objects.filter(
+                url_hash=PendingArticleSuggestion.hash_url("https://example.com/a"),
+            ).count()
+            == 1
+        )
+
+    def test_record_if_new_skips_already_rejected_url(self) -> None:
+        row = PendingArticleSuggestion.record_if_new(
+            url="https://example.com/a",
+            summary="why",
+        )
+        assert row is not None
+        PendingArticleSuggestion.reject(row.pk, decider_id="adrien", reason="not relevant")
+        assert PendingArticleSuggestion.record_if_new(url="https://example.com/a", summary="why") is None
+
+
+class TestApproveRejectSingleUse:
+    def test_approve_stamps_decision_and_ticket_url(self) -> None:
+        row = PendingArticleSuggestion.record(url="https://example.com/a", summary="why")
+        consumed = PendingArticleSuggestion.approve(
+            row.pk,
+            decider_id="adrien",
+            ticket_url="https://github.com/souliane/teatree/issues/1234",
+        )
+        assert consumed is not None
+        assert consumed.decision == PendingArticleSuggestion.DECISION_APPROVED
+        assert consumed.created_ticket_url == "https://github.com/souliane/teatree/issues/1234"
+        assert consumed.decided_at is not None
+        assert consumed.decider_id == "adrien"
+
+    def test_reject_stamps_decision_and_reason(self) -> None:
+        row = PendingArticleSuggestion.record(url="https://example.com/a", summary="why")
+        consumed = PendingArticleSuggestion.reject(
+            row.pk,
+            decider_id="adrien",
+            reason="copycat article",
+        )
+        assert consumed is not None
+        assert consumed.decision == PendingArticleSuggestion.DECISION_REJECTED
+        assert consumed.decision_reason == "copycat article"
+        assert consumed.decided_at is not None
+
+    def test_decisions_are_single_use(self) -> None:
+        row = PendingArticleSuggestion.record(url="https://example.com/a", summary="why")
+        assert PendingArticleSuggestion.approve(row.pk, ticket_url="x") is not None
+        assert PendingArticleSuggestion.approve(row.pk, ticket_url="y") is None
+        assert PendingArticleSuggestion.reject(row.pk) is None
+
+
+class TestEnqueueCandidatesAndNotify:
+    def test_no_ticket_is_created_on_scan(self) -> None:
+        with (
+            mock.patch(
+                "teatree.core.article_ingestion_gate._notify_user",
+                return_value=True,
+            ) as notify_mock,
+            mock.patch(
+                "teatree.core.article_ingestion_gate._gh_issue_create",
+            ) as gh_mock,
+        ):
+            result = enqueue_candidates_and_notify(
+                [
+                    ArticleCandidate(
+                        url="https://example.com/a",
+                        title="A",
+                        summary="reason A",
+                        source="tldr-ai",
+                    ),
+                    ArticleCandidate(
+                        url="https://example.com/b",
+                        title="B",
+                        summary="reason B",
+                        source="rundown-ai",
+                    ),
+                ],
+            )
+        # Neither candidate became a GitHub issue.
+        gh_mock.assert_not_called()
+        # Two pending rows landed in the durable queue.
+        assert len(result.new_suggestion_ids) == 2
+        assert result.skipped_duplicate_urls == []
+        assert result.dm_sent is True
+        notify_mock.assert_called_once()
+        # The DM listed every new suggestion id.
+        dm_text = notify_mock.call_args.kwargs["text"]
+        assert "#" + str(result.new_suggestion_ids[0]) in dm_text
+        assert "https://example.com/a" in dm_text
+        assert "https://example.com/b" in dm_text
+        # The presented stamp moved so the next tick won't re-DM.
+        for sid in result.new_suggestion_ids:
+            row = PendingArticleSuggestion.objects.get(pk=sid)
+            assert row.presented is True
+            assert row.presented_at is not None
+
+    def test_duplicate_urls_are_skipped_idempotently(self) -> None:
+        # Pre-existing row for URL A.
+        existing = PendingArticleSuggestion.record(url="https://example.com/a", summary="x")
+        with (
+            mock.patch(
+                "teatree.core.article_ingestion_gate._notify_user",
+                return_value=True,
+            ),
+            mock.patch("teatree.core.article_ingestion_gate._gh_issue_create"),
+        ):
+            result = enqueue_candidates_and_notify(
+                [
+                    ArticleCandidate(url="https://example.com/a", title="A", summary="x"),
+                    ArticleCandidate(url="https://example.com/b", title="B", summary="y"),
+                ],
+            )
+        # Only B is new; A is reported as a skipped duplicate.
+        assert result.skipped_duplicate_urls == ["https://example.com/a"]
+        assert len(result.new_suggestion_ids) == 1
+        # Existing row is unchanged.
+        existing.refresh_from_db()
+        assert existing.decision == PendingArticleSuggestion.DECISION_PENDING
+
+    def test_empty_batch_does_not_dm(self) -> None:
+        with mock.patch(
+            "teatree.core.article_ingestion_gate._notify_user",
+            return_value=True,
+        ) as notify_mock:
+            result = enqueue_candidates_and_notify([])
+        notify_mock.assert_not_called()
+        assert result.dm_sent is False
+        assert result.new_suggestion_ids == []
+
+
+class TestApproveAndCreateTicket:
+    def test_approve_calls_gh_with_label_and_stamps_url(self) -> None:
+        row = PendingArticleSuggestion.record(
+            url="https://example.com/a",
+            summary="why this is interesting",
+            title="An article",
+        )
+        with mock.patch(
+            "teatree.core.article_ingestion_gate._gh_issue_create",
+            return_value="https://github.com/souliane/teatree/issues/9999",
+        ) as gh_mock:
+            consumed = approve_and_create_ticket(row.pk, decider_id="adrien")
+        assert consumed is not None
+        assert consumed.decision == PendingArticleSuggestion.DECISION_APPROVED
+        assert consumed.created_ticket_url == "https://github.com/souliane/teatree/issues/9999"
+        gh_mock.assert_called_once()
+        kwargs = gh_mock.call_args.kwargs
+        assert kwargs["repo"] == APPROVED_ISSUE_REPO
+        assert kwargs["label"] == APPROVED_ISSUE_LABEL
+        # The body cites the source URL — preserves the dedupe contract
+        # the legacy skill relied on.
+        assert "https://example.com/a" in kwargs["body"]
+
+    def test_approve_missing_row_returns_none(self) -> None:
+        assert approve_and_create_ticket(999_999) is None
+
+    def test_approve_already_decided_row_returns_none_and_does_not_call_gh(self) -> None:
+        row = PendingArticleSuggestion.record(url="https://example.com/a", summary="x")
+        PendingArticleSuggestion.reject(row.pk, decider_id="adrien", reason="dup")
+        with mock.patch("teatree.core.article_ingestion_gate._gh_issue_create") as gh_mock:
+            assert approve_and_create_ticket(row.pk) is None
+        gh_mock.assert_not_called()


### PR DESCRIPTION
## Summary

The scanning-news skill previously called `gh issue create --label from-news-scan` directly after triaging each candidate. That auto-create pattern treats "interesting article" as a strong signal to ticketize and pollutes the backlog with low-signal copycat tickets. Closes [#1391](https://github.com/souliane/teatree/issues/1391).

## Changes

- New `PendingArticleSuggestion` model (sibling of `DeferredQuestion` / `OnBehalfApproval`):
  - SHA-256 `url_hash` for idempotency (a second scan on the same URL is a no-op).
  - `PENDING` / `APPROVED` / `REJECTED` decision state with single-use atomic transitions.
  - Guarded factory + `record_if_new` for the scanner-call shape.
- `teatree.core.article_ingestion_gate` is the new single chokepoint scanners call instead of `gh issue create`:
  - `enqueue_candidates_and_notify` writes one row per new URL and DMs the user the batch via the canonical bot->user notify helper.
  - `approve_and_create_ticket` is the only path that calls `gh issue create` — invoked from `t3 teatree news approve`.
- Three management subcommands registered under `t3 teatree news`:
  - `t3 teatree news pending` — list undecided suggestions.
  - `t3 teatree news approve <id>` — files the GitHub issue.
  - `t3 teatree news reject <id> --reason "<line>"` — drops the candidate.
- `[teatree] ask_before_creating_news_tickets` setting (default `true`, per-overlay overridable).
- scanning-news SKILL.md updated: direct `gh issue create` is banned; candidates must route through the gate.
- Migration `0037_pendingarticlesuggestion`.

## Test plan

- [x] `tests/teatree_core/test_pending_article_suggestion_model.py` — model contract (record / record_if_new / approve / reject single-use), the gate's no-ticket-on-scan invariant, idempotency on duplicate URLs.
- [x] `tests/teatree_core/management_commands/test_news_command.py` — three subcommands end-to-end via `call_command` with mocked `gh`.
- [x] `tests/test_skill_t3_invocations.py` passes (SKILL.md cites resolvable paths).
- [x] `uv run pytest --no-cov -x -q tests/config` (settings load OK with the new field).
- [x] `uv run python manage.py makemigrations --dry-run --check` clean.
- [x] `uv run ruff check` clean across new and edited files.

## Notes for reviewers

The gate is **on by default** (`ask_before_creating_news_tickets = true`). The `from-news-scan` label is preserved on approved issues so the legacy dedup query keeps working. Per-overlay opt-out is supported via the standard `OVERLAY_OVERRIDABLE_SETTINGS` chain.