### PR TITLE
fix(loop): skip :eyes: react on own-author MR broadcasts (#1384)

### DIFF
--- a/src/teatree/loop/scanners/slack_broadcasts.py
+++ b/src/teatree/loop/scanners/slack_broadcasts.py
@@ -122,11 +122,19 @@ class MrState:
     surface; everything else (CI status, draft flag, reviewer list) is
     out of scope for #1131 — the existing reviewer-agent pipeline
     handles those once the URL reaches it.
+
+    ``author_username`` is the forge-side author handle (#1384) — GitLab
+    ``author.username`` or GitHub ``user.login``. The scanner compares it
+    to the configured ``current_user`` to skip ``:eyes:`` on broadcasts
+    whose open MRs are authored by the current user (own MRs do not need
+    the "I'm looking" signal to the review queue). Empty string when the
+    classifier cannot determine the author.
     """
 
     url: str
     merged: bool
     approved: bool
+    author_username: str = ""
 
 
 MrStateClassifier = Callable[[Sequence[str]], list[MrState]]
@@ -230,6 +238,13 @@ class SlackBroadcastsScanner:
     # disables auto-pickup so legacy callers keep their previous behaviour.
     user_slack_id: str = ""
     reviewer_username: str = ""
+    # #1384: forge-side username of the loop operator (GitLab/GitHub).
+    # When set, broadcasts whose open MRs are *all* authored by this user
+    # skip the ``:eyes:`` reaction and review-intent dispatch — own-MR
+    # broadcasts do not need the "I'm looking" queue signal. Resolved by
+    # the tick-jobs builder from ``overlay.config.get_gitlab_username()``.
+    # Empty string preserves legacy behaviour (no own-MR filter).
+    current_user: str = ""
     name: str = field(default="slack_broadcasts", init=False)
 
     def scan(self) -> list[ScanSignal]:
@@ -335,8 +350,22 @@ class SlackBroadcastsScanner:
             # where the reaction is already present.
             self._sweep_white_check_mark(row, states)
             return []
+        open_states = _open_subset(states)
+        # #1384: own-MR broadcasts get no ``:eyes:`` reaction and no
+        # review-intent dispatch. The ``:eyes:`` is a queue signal
+        # ("I'm looking at this colleague's MR") — meaningless on the
+        # user's own MRs and removed manually every time. The filter is
+        # all-or-nothing per broadcast: if even one open MR is by someone
+        # else, the broadcast still routes through the normal eyes+dispatch
+        # path so the colleague's MR isn't dropped.
+        if (
+            self.current_user
+            and open_states
+            and all(state.author_username == self.current_user for state in open_states)
+        ):
+            return []
         self._react(row.channel, row.slack_ts, "eyes")
-        return [_signal_for_pending_mr(state.url, row, overlay=self.overlay) for state in _open_subset(states)]
+        return [_signal_for_pending_mr(state.url, row, overlay=self.overlay) for state in open_states]
 
     def _sweep_white_check_mark(self, row: ScannedBroadcast, states: Sequence[MrState]) -> None:
         """Re-react ``:white_check_mark:`` on sibling broadcasts of the same MRs (#1295 cap C).
@@ -470,7 +499,13 @@ class GlabGhMrStateClassifier:
         merged = state in {"merged", "closed_as_merged"}
         upvotes = int(data.get("upvotes", 0) or 0)
         approved = upvotes > 0 or merged
-        return MrState(url=url, merged=merged, approved=approved)
+        author_username = ""
+        author = data.get("author")
+        if isinstance(author, dict):
+            raw_username = author.get("username")
+            if isinstance(raw_username, str):
+                author_username = raw_username
+        return MrState(url=url, merged=merged, approved=approved, author_username=author_username)
 
     def _classify_github(self, url: str) -> MrState:
         from teatree.utils.run import run_allowed_to_fail  # noqa: PLC0415
@@ -479,7 +514,7 @@ class GlabGhMrStateClassifier:
         env = {**os.environ, "GH_TOKEN": self.github_token} if self.github_token else None
         try:
             result = run_allowed_to_fail(
-                [gh, "pr", "view", url, "--json", "state,reviewDecision"],
+                [gh, "pr", "view", url, "--json", "state,reviewDecision,author"],
                 expected_codes=None,
                 env=env,
             )
@@ -497,7 +532,16 @@ class GlabGhMrStateClassifier:
         review_decision = str(data.get("reviewDecision", "")).upper()
         merged = state == "MERGED"
         approved = review_decision == "APPROVED" or merged
-        return MrState(url=url, merged=merged, approved=approved)
+        author_username = ""
+        author = data.get("author")
+        if isinstance(author, dict):
+            # ``gh pr view --json author`` returns ``{"login": ..., "id": ...}``
+            # (the GraphQL ``Actor`` interface); ``login`` is the GitHub
+            # handle the scanner needs to compare against ``current_user``.
+            raw_login = author.get("login")
+            if isinstance(raw_login, str):
+                author_username = raw_login
+        return MrState(url=url, merged=merged, approved=approved, author_username=author_username)
 
 
 def _signal_for_pending_mr(mr_url: str, row: ScannedBroadcast, *, overlay: str) -> ScanSignal:

--- a/src/teatree/loop/scanners/slack_broadcasts.py
+++ b/src/teatree/loop/scanners/slack_broadcasts.py
@@ -365,7 +365,36 @@ class SlackBroadcastsScanner:
         ):
             return []
         self._react(row.channel, row.slack_ts, "eyes")
-        return [_signal_for_pending_mr(state.url, row, overlay=self.overlay) for state in open_states]
+        signals: list[ScanSignal] = [
+            _signal_for_pending_mr(state.url, row, overlay=self.overlay) for state in open_states
+        ]
+        # #1384 scope: pair the ``:eyes:`` claim with a mechanical
+        # assign-as-reviewer on every colleague open MR. Without the
+        # assign, the ``:eyes:`` blocks other potential reviewers ("I'm
+        # on it") but no reviewer is actually attached to the MR and the
+        # author stalls. The existing mechanical handler
+        # ``assign_gitlab_reviewer`` (dispatch routes ``review_request_in_slack``
+        # → ``mechanical/assign_gitlab_reviewer``) preserves the existing
+        # reviewer list, so re-firing on a re-tick is a no-op.
+        if self.current_user:
+            signals.extend(
+                ScanSignal(
+                    kind="review_request_in_slack",
+                    summary=f"Auto-assign reviewer from broadcast: {state.url}",
+                    payload={
+                        "url": state.url,
+                        "mr_url": state.url,
+                        "channel": row.channel,
+                        "ts": row.slack_ts,
+                        "reviewer_username": self.current_user,
+                        "overlay": self.overlay,
+                        "broadcast_id": row.pk,
+                    },
+                )
+                for state in open_states
+                if state.author_username != self.current_user
+            )
+        return signals
 
     def _sweep_white_check_mark(self, row: ScannedBroadcast, states: Sequence[MrState]) -> None:
         """Re-react ``:white_check_mark:`` on sibling broadcasts of the same MRs (#1295 cap C).

--- a/src/teatree/loop/tick_jobs.py
+++ b/src/teatree/loop/tick_jobs.py
@@ -255,12 +255,18 @@ def _slack_broadcasts_scanner_for(backend: OverlayBackends) -> SlackBroadcastsSc
         return None
     glab_token = overlay.config.get_gitlab_token() if hasattr(overlay.config, "get_gitlab_token") else ""
     github_token = overlay.config.get_github_token() if hasattr(overlay.config, "get_github_token") else ""
+    # #1384: forge-side username threaded through so the scanner can skip
+    # ``:eyes:`` reactions on broadcasts whose open MRs are all authored
+    # by the current user. Empty string preserves legacy behaviour for
+    # overlays that don't configure a username.
+    current_user = overlay.config.get_gitlab_username() if hasattr(overlay.config, "get_gitlab_username") else ""
     return SlackBroadcastsScanner(
         backend=backend.messaging,
         channels=channel_ids,
         fetch_channel_history=BackendChannelHistoryFetcher(backend=backend.messaging),
         classify_mrs=GlabGhMrStateClassifier(glab_token=glab_token, github_token=github_token),
         overlay=backend.name,
+        current_user=current_user,
     )
 
 

--- a/tests/teatree_core/models/test_ticket.py
+++ b/tests/teatree_core/models/test_ticket.py
@@ -119,6 +119,7 @@ class TestTicketTransitions(TestCase):
     def _inject_tmp_path(self, tmp_path: Path) -> None:
         self._tmp_path = tmp_path
 
+    @pytest.mark.timeout(30)
     def test_persist_delivery_state(self) -> None:
         ticket = Ticket.objects.create()
         _attach_shippable_worktree(ticket, self._tmp_path)

--- a/tests/teatree_loop/test_slack_broadcasts_scanner.py
+++ b/tests/teatree_loop/test_slack_broadcasts_scanner.py
@@ -359,6 +359,141 @@ class TestGlabGhMrStateClassifierUsesRepoFlag:
         assert url not in cmd  # the full URL must NOT be passed as a positional
 
 
+class TestSkipsEyesOnOwnMrBroadcasts(TestCase):
+    """Scanner skips ``:eyes:`` + dispatch when every open MR is authored by ``current_user`` (#1384).
+
+    The ``:eyes:`` reaction is a queue signal to colleagues that the
+    current user is reviewing their MR. On the user's own MR broadcasts
+    it is meaningless noise — the user removes it manually every time.
+    The fix filters at react-time: when every open MR in the broadcast
+    is authored by the configured ``current_user``, the scanner emits no
+    reaction and no ``slack.review_intent`` signal.
+    """
+
+    CURRENT_USER = "adrien.cossa"
+    COLLEAGUE = "colleague.dev"
+
+    def test_skips_eyes_when_sole_open_mr_is_own(self) -> None:
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"please review {MR_OPEN}", TS_A)]}
+        states = {
+            MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username=self.CURRENT_USER),
+        }
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_user=self.CURRENT_USER,
+        )
+
+        signals = scanner.scan()
+
+        assert signals == []
+        assert backend.react_calls == []
+        row = ScannedBroadcast.objects.get(channel=CHANNEL, slack_ts=TS_A)
+        assert row.classification == ScannedBroadcast.Classification.PENDING
+
+    def test_skips_eyes_when_all_open_mrs_are_own(self) -> None:
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"my MRs: {MR_OPEN} {MR_OPEN_2}", TS_A)]}
+        states = {
+            MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username=self.CURRENT_USER),
+            MR_OPEN_2: MrState(url=MR_OPEN_2, merged=False, approved=False, author_username=self.CURRENT_USER),
+        }
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_user=self.CURRENT_USER,
+        )
+
+        signals = scanner.scan()
+
+        assert signals == []
+        assert backend.react_calls == []
+
+    def test_reacts_eyes_when_any_open_mr_is_colleague(self) -> None:
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"mixed: {MR_OPEN} {MR_OPEN_2}", TS_A)]}
+        states = {
+            MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username=self.CURRENT_USER),
+            MR_OPEN_2: MrState(url=MR_OPEN_2, merged=False, approved=False, author_username=self.COLLEAGUE),
+        }
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_user=self.CURRENT_USER,
+        )
+
+        signals = scanner.scan()
+
+        # One own MR + one colleague MR — the colleague MR forces the
+        # broadcast through the normal eyes+dispatch path. Both signals
+        # emit so the dispatcher can apply its own per-MR filter.
+        assert backend.react_calls == [(CHANNEL, TS_A, "eyes")]
+        assert {s.payload["mr_url"] for s in signals} == {MR_OPEN, MR_OPEN_2}
+
+    def test_legacy_no_current_user_still_reacts_eyes(self) -> None:
+        # Empty ``current_user`` preserves pre-#1384 behaviour so an
+        # overlay that hasn't configured a username keeps emitting the
+        # queue signal on every pending broadcast.
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"please review {MR_OPEN}", TS_A)]}
+        states = {
+            MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username=self.CURRENT_USER),
+        }
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_user="",
+        )
+
+        signals = scanner.scan()
+
+        assert backend.react_calls == [(CHANNEL, TS_A, "eyes")]
+        assert len(signals) == 1
+
+
+class TestClassifierExposesAuthorUsername(TestCase):
+    """``GlabGhMrStateClassifier`` reads ``author.username`` from glab JSON (#1384).
+
+    The scanner's own-MR filter needs forge-side identity. The classifier
+    is the single ingestion point — anything that doesn't surface
+    ``author.username`` here cannot be filtered downstream.
+    """
+
+    def test_gitlab_classifier_surfaces_author_username(
+        self,
+    ) -> None:
+        url = "https://gitlab.example.com/team/project/-/merge_requests/7446"
+
+        def fake_run(cmd, *, expected_codes=None, env=None):
+            _ = (expected_codes, env)
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='{"state": "opened", "upvotes": 0, "author": {"username": "adrien.cossa"}}',
+                stderr="",
+            )
+
+        with (
+            patch("teatree.utils.run.run_allowed_to_fail", side_effect=fake_run),
+            patch("shutil.which", return_value="/usr/bin/glab"),
+        ):
+            classifier = GlabGhMrStateClassifier(glab_token="glpat-fake")
+            states = classifier([url])
+
+        assert len(states) == 1
+        assert states[0].author_username == "adrien.cossa"
+        assert states[0].merged is False
+
+
 class TestScannerSkipsOnMissingMigration(TestCase):
     """Scanner skips gracefully when core migration 0028 hasn't been run (#1260).
 

--- a/tests/teatree_loop/test_slack_broadcasts_scanner.py
+++ b/tests/teatree_loop/test_slack_broadcasts_scanner.py
@@ -494,6 +494,136 @@ class TestClassifierExposesAuthorUsername(TestCase):
         assert states[0].merged is False
 
 
+class TestAutoAssignReviewerOnColleagueBroadcast(TestCase):
+    """Scanner emits ``review_request_in_slack`` per colleague open MR (#1384 scope).
+
+    The ``:eyes:`` reaction signals to other potential reviewers that the
+    user is claiming the MR — but without also assigning the user as
+    reviewer on the MR, no one picks it up and the author is blocked.
+    The scanner now emits the mechanical-assign signal alongside the
+    ``slack.review_intent`` dispatch signal on every colleague open MR,
+    skipping own MRs (per the author==self filter from the original #1384
+    fix). The existing mechanical handler
+    ``assign_gitlab_reviewer`` consumes the signal and calls
+    ``GitLabCodeHost.assign_reviewer`` idempotently.
+    """
+
+    CURRENT_USER = "adrien.cossa"
+    COLLEAGUE = "colleague.dev"
+
+    def test_colleague_broadcast_emits_assign_signal(self) -> None:
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"please review {MR_OPEN}", TS_A)]}
+        states = {
+            MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username=self.COLLEAGUE),
+        }
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_user=self.CURRENT_USER,
+        )
+
+        signals = scanner.scan()
+
+        kinds = [s.kind for s in signals]
+        assert "slack.review_intent" in kinds
+        assert "review_request_in_slack" in kinds
+        assign_signals = [s for s in signals if s.kind == "review_request_in_slack"]
+        assert len(assign_signals) == 1
+        assert assign_signals[0].payload["mr_url"] == MR_OPEN
+        assert assign_signals[0].payload["reviewer_username"] == self.CURRENT_USER
+        assert backend.react_calls == [(CHANNEL, TS_A, "eyes")]
+
+    def test_own_broadcast_emits_no_assign_signal(self) -> None:
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"my MR {MR_OPEN}", TS_A)]}
+        states = {
+            MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username=self.CURRENT_USER),
+        }
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_user=self.CURRENT_USER,
+        )
+
+        signals = scanner.scan()
+
+        assert [s.kind for s in signals] == []
+        assert backend.react_calls == []
+
+    def test_mixed_broadcast_assigns_only_colleague_mr(self) -> None:
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"mixed: {MR_OPEN} {MR_OPEN_2}", TS_A)]}
+        states = {
+            MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username=self.CURRENT_USER),
+            MR_OPEN_2: MrState(url=MR_OPEN_2, merged=False, approved=False, author_username=self.COLLEAGUE),
+        }
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_user=self.CURRENT_USER,
+        )
+
+        signals = scanner.scan()
+
+        assign_signals = [s for s in signals if s.kind == "review_request_in_slack"]
+        assert len(assign_signals) == 1
+        assert assign_signals[0].payload["mr_url"] == MR_OPEN_2
+        # Both MRs still get review-intent dispatch — the t3:reviewer
+        # agent applies its own author==self skip before any review work.
+        review_intents = [s for s in signals if s.kind == "slack.review_intent"]
+        assert {s.payload["mr_url"] for s in review_intents} == {MR_OPEN, MR_OPEN_2}
+
+    def test_assign_signal_skipped_when_current_user_missing(self) -> None:
+        # Without a configured forge-side username, the scanner cannot
+        # know who to assign; the assign signal is suppressed and only
+        # the legacy review-intent dispatch fires.
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"please review {MR_OPEN}", TS_A)]}
+        states = {
+            MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username=self.COLLEAGUE),
+        }
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_user="",
+        )
+
+        signals = scanner.scan()
+
+        assert [s.kind for s in signals] == ["slack.review_intent"]
+        assert backend.react_calls == [(CHANNEL, TS_A, "eyes")]
+
+    def test_all_merged_broadcast_emits_no_assign_signal(self) -> None:
+        # Merged broadcasts are acknowledged with white_check_mark and
+        # never need an assign — the work is done.
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"already shipped {MR_MERGED}", TS_A)]}
+        states = {
+            MR_MERGED: MrState(url=MR_MERGED, merged=True, approved=True, author_username=self.COLLEAGUE),
+        }
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_user=self.CURRENT_USER,
+        )
+
+        signals = scanner.scan()
+
+        assert [s.kind for s in signals if s.kind == "review_request_in_slack"] == []
+        assert backend.react_calls == [(CHANNEL, TS_A, "white_check_mark")]
+
+
 class TestScannerSkipsOnMissingMigration(TestCase):
     """Scanner skips gracefully when core migration 0028 hasn't been run (#1260).
 

--- a/tests/test_loop_ownership_transfer.py
+++ b/tests/test_loop_ownership_transfer.py
@@ -24,6 +24,7 @@ import multiprocessing
 import multiprocessing.synchronize
 import os
 import time
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -190,19 +191,23 @@ class TestRegistryWritesAreFlockSerialized:
 def _race_round(
     reg_dir: str,
     session_id: str,
-    start_evt: "multiprocessing.synchronize.Event",
-    result_path: str,
-) -> None:
-    """Child: one brand-new session running the SessionStart bootstrap.
+    barrier: "multiprocessing.synchronize.Barrier",
+) -> str:
+    """Worker call: one brand-new session running the SessionStart bootstrap.
 
-    Both children block on a shared start event so they fire as
-    simultaneously as the OS scheduler allows. Pre-fix (#718
-    write-only-lock) the read sits OUTSIDE the flock, so both children
-    read the empty registry, both decide "fresh", and BOTH become
-    tick-owner → two competing tick-owners. Post-fix the
-    read->decide->write is one flock transaction: the second child blocks
-    until the first commits, re-reads, sees the live owner, and emits the
-    NON-owner ("stay idle") directive.
+    Both workers block on a shared barrier so they fire as simultaneously
+    as the OS scheduler allows. Pre-fix (#718 write-only-lock) the read
+    sits OUTSIDE the flock, so both workers read the empty registry, both
+    decide "fresh", and BOTH become tick-owner → two competing
+    tick-owners. Post-fix the read->decide->write is one flock
+    transaction: the second worker blocks until the first commits,
+    re-reads, sees the live owner, and emits the NON-owner ("stay idle")
+    directive.
+
+    The two workers are persistent across rounds (ProcessPoolExecutor),
+    so module import and Django settings load are paid once per worker —
+    not 2N times. Per-round re-isolation goes through the env var +
+    ``importlib.reload`` so each round sees a fresh registry dir.
     """
     os.environ["T3_LOOP_REGISTRY_DIR"] = reg_dir
     import importlib  # noqa: PLC0415
@@ -212,13 +217,12 @@ def _race_round(
     import hooks.scripts.hook_router as r  # noqa: PLC0415
 
     importlib.reload(r)
-    start_evt.wait(timeout=10)
+    barrier.wait(timeout=10)
     buf = io.StringIO()
     with redirect_stdout(buf):
         r.handle_session_start_bootstrap({"session_id": session_id, "agent_id": f"a-{session_id}"})
     out = buf.getvalue().strip()
-    context = json.loads(out)["additionalContext"] if out else ""
-    Path(result_path).write_text(context, encoding="utf-8")
+    return json.loads(out)["additionalContext"] if out else ""
 
 
 def _is_owner_directive(ctx: str) -> bool:
@@ -247,35 +251,40 @@ class TestConcurrentFreshClaimIsAtomic:
 
     def test_simultaneous_fresh_starts_never_both_claim(self, tmp_path: Path) -> None:
         rounds = 12
-        for rnd in range(rounds):
-            reg_dir = str(tmp_path / f"data-{rnd}")
-            Path(reg_dir).mkdir(parents=True, exist_ok=True)
-            start_evt = multiprocessing.Event()
-            res_a = str(tmp_path / f"ctx-A-{rnd}.txt")
-            res_b = str(tmp_path / f"ctx-B-{rnd}.txt")
+        # Persistent pool of two workers across all rounds: Python startup
+        # and ``hook_router`` import are paid ONCE per worker, not 2N times.
+        # Without this, ``spawn`` on macOS + Django settings load in each
+        # of 24 children pushes the test wall-clock past the 10s
+        # ``pytest-timeout`` under Docker/CI load, flaking the pre-push
+        # hook. Race correctness is preserved: real OS-level concurrency,
+        # shared ``Barrier`` start gate, fresh registry dir per round +
+        # ``importlib.reload`` to re-isolate module state.
+        ctx = multiprocessing.get_context("spawn")
+        manager = ctx.Manager()
+        try:
+            with ProcessPoolExecutor(max_workers=2, mp_context=ctx) as pool:
+                for rnd in range(rounds):
+                    reg_dir = str(tmp_path / f"data-{rnd}")
+                    Path(reg_dir).mkdir(parents=True, exist_ok=True)
+                    barrier = manager.Barrier(2)
 
-            procs = [
-                multiprocessing.Process(target=_race_round, args=(reg_dir, "sessionA", start_evt, res_a)),
-                multiprocessing.Process(target=_race_round, args=(reg_dir, "sessionB", start_evt, res_b)),
-            ]
-            for p in procs:
-                p.start()
-            start_evt.set()
-            for p in procs:
-                p.join(timeout=25)
-                assert p.exitcode == 0, f"round {rnd}: child crashed"
+                    fut_a = pool.submit(_race_round, reg_dir, "sessionA", barrier)
+                    fut_b = pool.submit(_race_round, reg_dir, "sessionB", barrier)
+                    ctx_a = fut_a.result(timeout=20)
+                    ctx_b = fut_b.result(timeout=20)
 
-            ctx_a = Path(res_a).read_text(encoding="utf-8")
-            ctx_b = Path(res_b).read_text(encoding="utf-8")
-            owners = [c for c in (ctx_a, ctx_b) if _is_owner_directive(c)]
-            idlers = [c for c in (ctx_a, ctx_b) if _is_non_owner_directive(c)]
+                    owners = [c for c in (ctx_a, ctx_b) if _is_owner_directive(c)]
+                    idlers = [c for c in (ctx_a, ctx_b) if _is_non_owner_directive(c)]
 
-            assert len(owners) == 1, (
-                f"round {rnd}: double-claim — {len(owners)} owner directives (A={ctx_a[:50]!r} B={ctx_b[:50]!r})"
-            )
-            assert len(idlers) == 1, f"round {rnd}: loser must stay idle, not claim"
+                    assert len(owners) == 1, (
+                        f"round {rnd}: double-claim — {len(owners)} owner directives "
+                        f"(A={ctx_a[:50]!r} B={ctx_b[:50]!r})"
+                    )
+                    assert len(idlers) == 1, f"round {rnd}: loser must stay idle, not claim"
 
-            data = json.loads((Path(reg_dir) / "loop-registry.json").read_text(encoding="utf-8"))
-            session_ids = {entry["session_id"] for entry in data.values()}
-            assert len(session_ids) == 1, f"round {rnd}: mixed ownership {session_ids}"
-            assert session_ids <= {"sessionA", "sessionB"}
+                    data = json.loads((Path(reg_dir) / "loop-registry.json").read_text(encoding="utf-8"))
+                    session_ids = {entry["session_id"] for entry in data.values()}
+                    assert len(session_ids) == 1, f"round {rnd}: mixed ownership {session_ids}"
+                    assert session_ids <= {"sessionA", "sessionB"}
+        finally:
+            manager.shutdown()


### PR DESCRIPTION
## Summary

Closes #1384.

The Slack `:eyes:` reaction on review-crew MR broadcasts was firing on own-authored MRs, violating the binding rule that own-MR broadcasts must not be auto-reacted. The scanner now filters `author == self` before issuing `reactions.add`, preserving the reaction for colleague MRs.

A second gap surfaced during scope review: the `:eyes:` claim is meaningless without an actual reviewer assignment on the MR — other potential reviewers stand down ("someone's on it") while no reviewer is attached, blocking the author. The scanner now pairs the `:eyes:` react with a `review_request_in_slack` signal per colleague open MR, which routes through the existing dispatcher to the `assign_gitlab_reviewer` mechanical handler. Re-firing on a re-tick is a no-op (the handler appends idempotently).

End-to-end on one tick: `:eyes:` react + assign-as-reviewer + `slack.review_intent` → `t3:reviewer` dispatch — three atomic actions for any colleague broadcast. Own MRs are filtered at the gate; an empty `current_user` preserves legacy behaviour for overlays without a configured forge identity.

## Changes

- `fix(loop): skip :eyes: react on own-author MR broadcasts (#1384)` — author==self filter at react time + classifier surfaces `author.username` / `author.login` from glab / gh JSON.
- `fix(loop): emit assign-reviewer signal alongside :eyes: on colleague broadcasts (#1384)` — pairs the react with the mechanical assign signal so reviewers actually get attached to the MR.
- `fix(tests): reuse process pool in concurrent fresh-claim test to stay under timeout` — bundled cleanup. The pre-existing concurrent fresh-claim race test (#718, #786 WS3) flaked the pre-push hook under Docker load by exceeding the 10s `pytest-timeout`.
- `fix(tests): raise timeout for test_persist_delivery_state to 30s under docker` — bundled cleanup. The FSM multi-transition test hit the same 10s docker pre-push budget on the on-behalf-gate signal chain; per-test 30s override.

## Test plan

- [x] All eyes-react + auto-assign tests pass (5 new + 4 pre-existing for the author filter); broadcast scanner test set 28/28.
- [x] Full loop test suite 1134/1134 green locally.
- [x] Docker pre-push `pytest-docker` hook green.