### PR TITLE
fix(loop/statusline): render all configured loops with per-loop next-tick countdown

### DIFF
--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -208,24 +208,18 @@ def _live_loop_names() -> list[tuple[str, str]]:
     return [(row.name, row.session_id) for row in rows]
 
 
-def _loop_tick_acquired_at() -> datetime | None:
-    """Return the most recent ``acquired_at`` for the ``loop-tick`` lease.
+def _loop_acquired_ats() -> dict[str, datetime]:
+    """Return ``{loop_name: acquired_at}`` for every LoopLease with a timestamp.
 
-    Isolated as a thin DB-read seam (mirrors :func:`_live_loop_names`) so
-    :func:`live_loops_anchor` stays pure and tests stub this directly
-    rather than constructing LoopLease fixtures with timestamps.
-
-    Returns ``None`` when no row exists yet (no tick has ever fired) so
-    the renderer can render a ``last tick: never`` fallback instead of
-    pretending to know.
+    Isolated as a thin DB-read seam so :func:`live_loops_anchor` stays a
+    pure formatter — tests stub this directly rather than constructing
+    LoopLease fixtures with timestamps for each loop name.
     """
     from django.apps import apps  # noqa: PLC0415
 
     lease_model = apps.get_model("core", "LoopLease")
-    row = lease_model.objects.filter(name="loop-tick").values("acquired_at").first()
-    if row is None:
-        return None
-    return row.get("acquired_at")
+    rows = lease_model.objects.exclude(acquired_at=None).values("name", "acquired_at")
+    return {row["name"]: row["acquired_at"] for row in rows}
 
 
 def _cadence_seconds() -> int:
@@ -237,6 +231,50 @@ def _cadence_seconds() -> int:
     from teatree.config import cadence_seconds  # noqa: PLC0415
 
     return cadence_seconds()
+
+
+_LOOP_OWNER_TTL_DEFAULT = 1800
+_SLACK_ANSWER_CADENCE_DEFAULT = 20
+_SELF_IMPROVE_CADENCE_DEFAULT = 1800
+_LOOP_OWNER_TTL_FLOOR = 60
+_SLACK_ANSWER_CADENCE_FLOOR = 15
+_SELF_IMPROVE_CADENCE_FLOOR = 60
+
+
+def _env_int(name: str, *, default: int, floor: int) -> int:
+    raw = os.environ.get(name, str(default)).strip() or str(default)
+    try:
+        return max(floor, int(raw))
+    except ValueError:
+        return default
+
+
+def _cadence_for_loop(name: str) -> int:
+    """Return the cadence in seconds for a named loop.
+
+    Resolves the env-var-driven cadence for each known loop name; unknown
+    names fall back to :func:`_cadence_seconds` so a future loop shows up
+    on the statusline without a code change here.
+    """
+    if name == "loop-slack-answer":
+        return _env_int(
+            "T3_SLACK_ANSWER_CADENCE",
+            default=_SLACK_ANSWER_CADENCE_DEFAULT,
+            floor=_SLACK_ANSWER_CADENCE_FLOOR,
+        )
+    if name == "loop-self-improve":
+        return _env_int(
+            "T3_SELF_IMPROVE_CHEAP_CADENCE",
+            default=_SELF_IMPROVE_CADENCE_DEFAULT,
+            floor=_SELF_IMPROVE_CADENCE_FLOOR,
+        )
+    if name == "loop-owner":
+        return _env_int(
+            "T3_LOOP_OWNER_TTL",
+            default=_LOOP_OWNER_TTL_DEFAULT,
+            floor=_LOOP_OWNER_TTL_FLOOR,
+        )
+    return _cadence_seconds()
 
 
 def loop_owner_anchor(status: "OwnershipStatus", this_session: str) -> tuple[str, str]:
@@ -265,34 +303,29 @@ def loop_owner_anchor(status: "OwnershipStatus", this_session: str) -> tuple[str
 
 
 def live_loops_anchor() -> list[str]:
-    """Return one consolidated dim anchor line summarising live loops.
+    """Return one dim anchor line per live loop with its next-tick countdown.
 
-    Single line, prepended at the top of the statusline so the user's
-    "where is the loop right now?" question is answered with one glance:
+    Each line names a single live :class:`LoopLease` and surfaces when it
+    will next fire:
 
-        ``loop · next tick in 3m12s · 5 loops live``
+        ``loop-owner · next in 28m``
+        ``loop-self-improve · next in 24m05s``
+        ``loop-slack-answer · next in 15s``
+        ``loop-tick · next in 3m12s``
 
-    Components, in order:
+    Per-loop next-tick is ``acquired_at + _cadence_for_loop(name)``:
 
-    *   ``next tick in <duration>`` when the ``loop-tick`` lease has fired
-        at least once and a cadence is configured; the next-tick instant
-        is ``acquired_at + cadence_seconds``. ``next tick due`` when the
-        deadline has already passed (the next ``t3 loop tick`` is overdue
-        but no tick has acquired the lease yet, e.g. cron paused).
-        ``last tick: never`` when no row exists yet (no tick has fired).
-    *   ``<N loops live>`` — the headline number, deduped per-loop.
-        Replaces the prior one-line-per-loop dump (``loop:tick``,
-        ``loop:owner``, …) which the user explicitly did not want at the
-        top of the statusline.
+    *   ``next in <duration>`` when the cadence resolves and the deadline
+        is in the future.
+    *   ``next: due`` when the deadline has already passed (cron paused,
+        tick stuck).
+    *   ``last tick: never`` when no ``acquired_at`` has ever been
+        recorded for this loop.
 
-    Returns ``[]`` when no loop is live — silences the line entirely on
-    a quiet machine. Fails open: any DB / import error degrades to ``[]``
-    so a broken LoopLease read cannot blank the statusline.
-
-    Backward-compat: the return signature is unchanged (``list[str]``)
-    so :func:`_populate_live_loops_anchor` keeps appending whatever lines
-    we return; today it's at most one line, tomorrow it can grow without
-    a caller-side change.
+    Lines render in stable sorted order by loop name. Returns ``[]`` when
+    no loop is live so the statusline stays silent on a quiet machine.
+    Fails open: any DB / import error degrades to ``[]`` rather than
+    blanking the statusline.
     """
     try:
         live_names = _live_loop_names()
@@ -301,37 +334,39 @@ def live_loops_anchor() -> list[str]:
     if not live_names:
         return []
 
-    parts: list[str] = ["loop"]
-    parts.extend(_next_tick_parts())
-    parts.append(f"{len(live_names)} loops live")
-    return [" · ".join(parts)]
-
-
-def _next_tick_parts() -> list[str]:
-    """Return the ``next tick in <duration>`` / fallback fragments.
-
-    Empty list when nothing useful is queryable (no cadence, no tick
-    history). Fails open on every DB / config read — the line drops the
-    fragment rather than refusing to render.
-    """
     try:
-        acquired_at = _loop_tick_acquired_at()
+        acquired_ats = _loop_acquired_ats()
     except Exception:  # noqa: BLE001
-        return []
-    if acquired_at is None:
-        return ["last tick: never"]
-    try:
-        cadence = _cadence_seconds()
-    except Exception:  # noqa: BLE001
-        return []
+        acquired_ats = {}
+
+    seen: set[str] = set()
+    unique_names: list[str] = []
+    for name, _session in live_names:
+        if name in seen:
+            continue
+        seen.add(name)
+        unique_names.append(name)
+    unique_names.sort()
+
     from django.utils import timezone  # noqa: PLC0415
 
     now = timezone.now()
+    return [f"{name} · {_next_tick_fragment(name, acquired_ats.get(name), now)}" for name in unique_names]
+
+
+def _next_tick_fragment(name: str, acquired_at: datetime | None, now: datetime) -> str:
+    """Return the per-loop ``next in <duration>`` / fallback fragment."""
+    if acquired_at is None:
+        return "last tick: never"
+    try:
+        cadence = _cadence_for_loop(name)
+    except Exception:  # noqa: BLE001
+        return "last tick: never"
     next_tick_at = acquired_at + timedelta(seconds=cadence)
     delta_seconds = int((next_tick_at - now).total_seconds())
     if delta_seconds <= 0:
-        return ["next tick due"]
-    return [f"next tick in {_format_duration(delta_seconds)}"]
+        return "next: due"
+    return f"next in {_format_duration(delta_seconds)}"
 
 
 _SECONDS_PER_MINUTE = 60

--- a/tests/teatree_loop/test_statusline_multiloop.py
+++ b/tests/teatree_loop/test_statusline_multiloop.py
@@ -6,9 +6,11 @@ History:
     or ``loop-owner=unclaimed`` line plus the foreign-hijack RED line.
 *   #1156 collapsed the dim doctrine into one line per LIVE LoopLease row
     (``loop:tick``, ``loop:owner``, …).
-*   This refit replaces that per-loop dump with a single consolidated
-    summary line that surfaces time-to-next-tick. The user explicitly
-    asked for "time to next tick" on the first line, not a per-loop list.
+*   #1163 replaced that per-loop dump with a single consolidated summary
+    line carrying time-to-next-tick.
+*   #1400 re-expanded to one dedicated line per live loop, each with its
+    own per-loop next-tick countdown — the consolidated count hid the
+    per-loop schedule once multiple loops were configured.
 
 The #1073 foreign-hijack RED line is preserved unchanged through every
 refit — it is a different code path (``loop_owner_anchor``) and a
@@ -36,44 +38,54 @@ def _make_lease(name: str, *, expires_in: timedelta, session_id: str = "sess-A")
 
 @pytest.mark.django_db
 class TestLiveLoopsAnchor:
-    """``live_loops_anchor()`` returns one consolidated summary line."""
+    """``live_loops_anchor()`` returns one dedicated line per live loop."""
 
-    def test_one_consolidated_line_with_loop_count(self) -> None:
+    def test_one_line_per_live_loop(self) -> None:
         _make_lease("loop-tick", expires_in=timedelta(minutes=30))
         _make_lease("loop-self-improve", expires_in=timedelta(minutes=30))
         _make_lease("loop-slack-answer", expires_in=timedelta(minutes=30))
 
         lines = live_loops_anchor()
 
-        assert len(lines) == 1, repr(lines)
-        line = lines[0]
-        assert line.startswith("loop · "), line
-        assert "3 loops live" in line, line
+        assert len(lines) == 3, repr(lines)
+        joined = "\n".join(lines)
+        assert "loop-tick" in joined
+        assert "loop-self-improve" in joined
+        assert "loop-slack-answer" in joined
 
-    def test_expired_loops_omitted_from_count(self) -> None:
+    def test_expired_loops_omitted(self) -> None:
         _make_lease("loop-tick", expires_in=timedelta(minutes=30))
         _make_lease("loop-self-improve", expires_in=timedelta(minutes=30))
-        # Expired — must not be counted.
+        # Expired — must not appear in the output.
         _make_lease("loop-slack-answer", expires_in=timedelta(seconds=-5))
 
         lines = live_loops_anchor()
 
-        assert len(lines) == 1, repr(lines)
-        assert "2 loops live" in lines[0], lines[0]
+        assert len(lines) == 2, repr(lines)
+        joined = "\n".join(lines)
+        assert "loop-slack-answer" not in joined
 
     def test_per_loop_dump_format_gone(self) -> None:
-        """The pre-refit per-loop dump (``loop:tick`` / ``loop:owner``) is gone."""
+        """The pre-#1156 verbose lines are still gone."""
         _make_lease("loop-owner", expires_in=timedelta(minutes=30), session_id="sess-A")
         _make_lease("loop-tick", expires_in=timedelta(minutes=30), session_id="sess-A")
 
         lines = live_loops_anchor()
         joined = "\n".join(lines)
-        # The verbose pre-#1156 lines are still gone.
         assert "loop-owner=THIS session" not in joined, repr(joined)
         assert "loop-owner=unclaimed" not in joined, repr(joined)
-        # The per-loop dump (``loop:tick`` / ``loop:owner``) is gone too.
+        # ``loop:owner`` / ``loop:tick`` colon-prefixed dump shape.
         assert "loop:tick" not in joined, repr(joined)
         assert "loop:owner" not in joined, repr(joined)
+
+    def test_each_line_carries_next_tick_fragment(self) -> None:
+        _make_lease("loop-tick", expires_in=timedelta(minutes=30))
+        _make_lease("loop-self-improve", expires_in=timedelta(minutes=30))
+
+        lines = live_loops_anchor()
+
+        for line in lines:
+            assert "next " in line, line
 
 
 @pytest.mark.django_db
@@ -94,9 +106,9 @@ class TestForeignHijackStillRed:
 
 @pytest.mark.django_db
 class TestPopulateLoopsAnchorIntegration:
-    """The rendering layer emits the consolidated line for live LoopLease rows."""
+    """The rendering layer emits one anchor line per live LoopLease row."""
 
-    def test_emits_consolidated_line_when_loops_live(self) -> None:
+    def test_emits_one_line_per_loop_when_loops_live(self) -> None:
         from teatree.loop.rendering import _populate_live_loops_anchor  # noqa: PLC0415
 
         _make_lease("loop-tick", expires_in=timedelta(minutes=30))
@@ -105,11 +117,12 @@ class TestPopulateLoopsAnchorIntegration:
         zones = StatuslineZones()
         _populate_live_loops_anchor(zones)
 
-        joined = "\n".join(item if isinstance(item, str) else item.text for item in zones.anchors)
-        assert "loop · " in joined, repr(joined)
-        assert "2 loops live" in joined, repr(joined)
+        texts = [item if isinstance(item, str) else item.text for item in zones.anchors]
+        joined = "\n".join(texts)
+        assert "loop-tick" in joined, repr(joined)
+        assert "loop-self-improve" in joined, repr(joined)
         # Verbose dim owner lines must NOT appear.
         assert "loop-owner=THIS session" not in joined, repr(joined)
         assert "loop-owner=unclaimed" not in joined, repr(joined)
-        # Per-loop dump form also gone.
+        # Per-loop colon-prefixed dump form also gone.
         assert "loop:tick" not in joined, repr(joined)

--- a/tests/teatree_loop/test_statusline_next_tick.py
+++ b/tests/teatree_loop/test_statusline_next_tick.py
@@ -1,10 +1,7 @@
-"""Statusline renderer refit — consolidated loop line + state-priority reorder.
+"""Statusline renderer refit — state-priority reorder + anchor cap shape.
 
 Three behaviours regression-locked here:
 
-*   Line 1 of the statusline is the **consolidated loop summary**, not a
-    per-loop dump (``loop:owner``, ``loop:self-improve``, ``loop:tick``).
-    The user explicitly asked for "time to next tick" on the first line.
 *   Anchor state groups render in priority order — actively-shipping work
     first (``started``, ``in_review``, ``ready``) before the long
     ``not_started`` backlog. A 41-deep ``not_started`` no longer pushes
@@ -12,6 +9,8 @@ Three behaviours regression-locked here:
 *   The ``not_started`` cap tightens to 3 with a clear ``(+N more)``
     overflow marker; ``ready:`` and the rest keep the standard
     ``_MAX_PER_STATE`` cap with the same overflow wording.
+*   The per-loop anchor lines (#1400) lead the anchors zone — one line
+    per live loop with its own next-tick countdown.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -50,61 +49,52 @@ def _ready(num: str, *, overlay: str = "ov") -> DispatchAction:
     )
 
 
-class TestConsolidatedLoopAnchor:
-    """Line 1 = ``loop · next tick in <duration> · N loops live``."""
+class TestPerLoopAnchor:
+    """One anchor line per live loop, with a per-loop next-tick countdown (#1400)."""
 
-    def test_includes_time_to_next_tick_when_acquired_at_known(self) -> None:
+    def test_one_line_per_loop_with_next_tick(self) -> None:
         leases = [("loop-tick", "sessA"), ("loop-owner", "sessA")]
-        # Last tick fired 2 minutes ago; cadence 720s → next tick in 10m.
-        acquired_at = datetime.now(UTC) - timedelta(seconds=120)
+        now = datetime.now(UTC)
+        acquired_ats = {
+            "loop-tick": now - timedelta(seconds=120),
+            "loop-owner": now - timedelta(seconds=60),
+        }
         with (
             patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=acquired_at),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value=acquired_ats),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             lines = live_loops_anchor()
-        assert len(lines) == 1, repr(lines)
-        line = lines[0]
-        assert line.startswith("loop · "), line
-        assert "next tick in " in line, line
-        assert "2 loops live" in line, line
+        assert len(lines) == 2, repr(lines)
+        joined = "\n".join(lines)
+        assert "loop-tick" in joined
+        assert "loop-owner" in joined
+        for line in lines:
+            assert "next " in line, line
 
     def test_falls_back_to_last_tick_never_when_no_lease_history(self) -> None:
         leases = [("loop-tick", "sessA")]
         with (
             patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value={}),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             lines = live_loops_anchor()
-        assert lines == ["loop · last tick: never · 1 loops live"], repr(lines)
+        assert lines == ["loop-tick · last tick: never"], repr(lines)
 
-    def test_reports_next_tick_due_when_overdue(self) -> None:
+    def test_reports_due_when_overdue(self) -> None:
         leases = [("loop-tick", "sessA")]
-        # Last tick was 1 hour ago; cadence 12 minutes → due now.
         acquired_at = datetime.now(UTC) - timedelta(hours=1)
         with (
             patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=acquired_at),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch(
+                "teatree.loop.statusline._loop_acquired_ats",
+                return_value={"loop-tick": acquired_at},
+            ),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             lines = live_loops_anchor()
-        assert lines == ["loop · next tick due · 1 loops live"], repr(lines)
-
-    def test_no_per_loop_lines_anymore(self) -> None:
-        """The pre-refit one-line-per-loop shape is gone (user explicitly opted out)."""
-        leases = [("loop-tick", "sessA"), ("loop-owner", "sessA"), ("loop-self-improve", "sessA")]
-        with (
-            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
-        ):
-            lines = live_loops_anchor()
-        assert len(lines) == 1, repr(lines)
-        # No ``loop:owner`` / ``loop:tick`` / ``loop:self-improve`` tokens.
-        assert "loop:owner" not in lines[0], lines[0]
-        assert "loop:tick" not in lines[0], lines[0]
-        assert "loop:self-improve" not in lines[0], lines[0]
+        assert lines == ["loop-tick · next: due"], repr(lines)
 
     def test_empty_when_no_loops_live(self) -> None:
         with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
@@ -183,24 +173,26 @@ class TestReadyOverflowPhrasing:
 
 
 class TestZonesForIntegration:
-    """End-to-end: ``zones_for`` + ``render`` produces the new top-line shape."""
+    """End-to-end: ``zones_for`` + ``render`` produces one anchor line per loop."""
 
-    def test_line_one_is_consolidated_loop_summary(self, tmp_path: Path) -> None:
+    def test_loop_lines_lead_anchors_zone(self, tmp_path: Path) -> None:
         leases = [("loop-tick", "sessA"), ("loop-owner", "sessA")]
-        acquired_at = datetime.now(UTC) - timedelta(seconds=60)
+        now = datetime.now(UTC)
+        acquired_ats = {
+            "loop-tick": now - timedelta(seconds=60),
+            "loop-owner": now - timedelta(seconds=30),
+        }
         with (
             patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=acquired_at),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value=acquired_ats),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             zones = zones_for([], colorize=False)
         target = tmp_path / "statusline.txt"
         render(zones, target=target, colorize=False)
         body = target.read_text()
-        first_line = body.splitlines()[0]
-        assert first_line.startswith("loop · "), repr(first_line)
-        assert "next tick in " in first_line, first_line
-        assert "2 loops live" in first_line, first_line
-        # Per-loop tokens removed at the top.
+        assert "loop-tick" in body
+        assert "loop-owner" in body
+        # ``loop:tick`` / ``loop:owner`` colon-prefixed dump form gone.
         assert "\nloop:tick" not in body
         assert "\nloop:owner" not in body

--- a/tests/teatree_loop/test_statusline_per_loop_next_tick.py
+++ b/tests/teatree_loop/test_statusline_per_loop_next_tick.py
@@ -1,0 +1,244 @@
+"""Per-loop next-tick countdowns in the anchors zone (#1400).
+
+The pre-#1400 ``live_loops_anchor()`` collapsed every live loop into one
+consolidated ``loop · next tick in <duration> · N loops live`` line, which
+hid the per-loop schedule. With multiple configured loops (``loop-tick``,
+``loop-owner``, ``loop-slack-answer``, ``loop-self-improve``, …) the
+operator could not tell when each one would next fire.
+
+This module locks the new shape: one anchor line per live loop, each with
+its own ``next in <duration>`` countdown computed from
+``acquired_at + cadence_for_loop(name)``.
+"""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from teatree.loop.rendering import zones_for
+from teatree.loop.statusline import live_loops_anchor, render
+
+
+class TestPerLoopAnchorLine:
+    """One anchor line per live loop, each with its own next-tick countdown."""
+
+    def test_one_line_per_live_loop(self) -> None:
+        leases = [
+            ("loop-tick", "sessA"),
+            ("loop-slack-answer", "sessA"),
+            ("loop-self-improve", "sessA"),
+            ("loop-owner", "sessA"),
+        ]
+        now = datetime.now(UTC)
+        acquired_ats = {
+            "loop-tick": now - timedelta(seconds=60),
+            "loop-slack-answer": now - timedelta(seconds=5),
+            "loop-self-improve": now - timedelta(seconds=600),
+            "loop-owner": now - timedelta(seconds=120),
+        }
+        cadences = {
+            "loop-tick": 720,
+            "loop-slack-answer": 20,
+            "loop-self-improve": 1800,
+            "loop-owner": 1800,
+        }
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value=acquired_ats),
+            patch(
+                "teatree.loop.statusline._cadence_for_loop",
+                side_effect=lambda name: cadences.get(name, 720),
+            ),
+        ):
+            lines = live_loops_anchor()
+
+        assert len(lines) == 4, repr(lines)
+        joined = "\n".join(lines)
+        assert "loop-tick" in joined
+        assert "loop-slack-answer" in joined
+        assert "loop-self-improve" in joined
+        assert "loop-owner" in joined
+        # Each line carries a per-loop next-tick fragment.
+        for line in lines:
+            assert "next " in line, line
+
+    def test_per_loop_countdown_uses_per_loop_cadence(self) -> None:
+        now = datetime.now(UTC)
+        leases = [("loop-tick", "sessA"), ("loop-slack-answer", "sessA")]
+        acquired_ats = {
+            "loop-tick": now - timedelta(seconds=120),
+            "loop-slack-answer": now - timedelta(seconds=5),
+        }
+        cadences = {"loop-tick": 720, "loop-slack-answer": 20}
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value=acquired_ats),
+            patch(
+                "teatree.loop.statusline._cadence_for_loop",
+                side_effect=lambda name: cadences[name],
+            ),
+        ):
+            lines = live_loops_anchor()
+
+        tick_line = next(line for line in lines if "loop-tick" in line)
+        slack_line = next(line for line in lines if "loop-slack-answer" in line)
+
+        # loop-tick: 720 - 120 = 600s → 9m59s or 10m (depending on clock jitter).
+        assert ("10m" in tick_line) or ("9m" in tick_line), tick_line
+        # loop-slack-answer: 20 - 5 = 15s.
+        assert ("15s" in slack_line) or ("14s" in slack_line), slack_line
+
+    def test_overdue_loop_reports_due(self) -> None:
+        now = datetime.now(UTC)
+        leases = [("loop-tick", "sessA")]
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch(
+                "teatree.loop.statusline._loop_acquired_ats",
+                return_value={"loop-tick": now - timedelta(hours=1)},
+            ),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
+        ):
+            lines = live_loops_anchor()
+
+        assert len(lines) == 1
+        assert "loop-tick" in lines[0]
+        assert "due" in lines[0], lines[0]
+
+    def test_no_acquired_at_yet_reports_never(self) -> None:
+        leases = [("loop-tick", "sessA")]
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value={}),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
+        ):
+            lines = live_loops_anchor()
+
+        assert len(lines) == 1
+        assert "loop-tick" in lines[0]
+        assert "never" in lines[0], lines[0]
+
+    def test_lines_sorted_stable_by_loop_name(self) -> None:
+        leases = [
+            ("loop-tick", "sessA"),
+            ("loop-owner", "sessA"),
+            ("loop-self-improve", "sessA"),
+            ("loop-slack-answer", "sessA"),
+        ]
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value={}),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
+        ):
+            lines = live_loops_anchor()
+
+        names = [line.split(" ", 1)[0] for line in lines]
+        assert names == sorted(names), names
+
+    def test_no_consolidated_loops_live_summary(self) -> None:
+        leases = [("loop-tick", "sessA"), ("loop-owner", "sessA")]
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value={}),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
+        ):
+            lines = live_loops_anchor()
+
+        joined = "\n".join(lines)
+        assert "loops live" not in joined, joined
+
+    def test_empty_when_no_live_loops(self) -> None:
+        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+            assert live_loops_anchor() == []
+
+    def test_fails_open_on_db_error(self) -> None:
+        with patch(
+            "teatree.loop.statusline._live_loop_names",
+            side_effect=RuntimeError("db down"),
+        ):
+            assert live_loops_anchor() == []
+
+    def test_fails_open_on_acquired_ats_error(self) -> None:
+        leases = [("loop-tick", "sessA")]
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch(
+                "teatree.loop.statusline._loop_acquired_ats",
+                side_effect=RuntimeError("db down"),
+            ),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
+        ):
+            lines = live_loops_anchor()
+        # Degrades to "never" rather than blanking the line entirely.
+        assert len(lines) == 1
+        assert "loop-tick" in lines[0]
+
+
+class TestCadenceForLoop:
+    """``_cadence_for_loop(name)`` resolves the per-loop cadence."""
+
+    def test_loop_tick_uses_loop_cadence(self) -> None:
+        from teatree.loop.statusline import _cadence_for_loop  # noqa: PLC0415
+
+        with patch("teatree.loop.statusline._cadence_seconds", return_value=720):
+            assert _cadence_for_loop("loop-tick") == 720
+
+    def test_loop_slack_answer_uses_slack_answer_cadence(self, monkeypatch) -> None:
+        from teatree.loop.statusline import _cadence_for_loop  # noqa: PLC0415
+
+        monkeypatch.setenv("T3_SLACK_ANSWER_CADENCE", "20")
+        assert _cadence_for_loop("loop-slack-answer") == 20
+
+    def test_loop_self_improve_uses_self_improve_cadence(self, monkeypatch) -> None:
+        from teatree.loop.statusline import _cadence_for_loop  # noqa: PLC0415
+
+        monkeypatch.setenv("T3_SELF_IMPROVE_CHEAP_CADENCE", "1800")
+        assert _cadence_for_loop("loop-self-improve") == 1800
+
+    def test_loop_owner_uses_loop_owner_ttl(self, monkeypatch) -> None:
+        from teatree.loop.statusline import _cadence_for_loop  # noqa: PLC0415
+
+        monkeypatch.setenv("T3_LOOP_OWNER_TTL", "1800")
+        assert _cadence_for_loop("loop-owner") == 1800
+
+    def test_unknown_loop_falls_back_to_default_cadence(self) -> None:
+        from teatree.loop.statusline import _cadence_for_loop  # noqa: PLC0415
+
+        with patch("teatree.loop.statusline._cadence_seconds", return_value=720):
+            assert _cadence_for_loop("loop-future-feature") == 720
+
+
+class TestZonesForIntegration:
+    """``zones_for`` + ``render`` produce one anchor line per live loop."""
+
+    def test_renders_all_configured_loops(self, tmp_path: Path) -> None:
+        leases = [
+            ("loop-tick", "sessA"),
+            ("loop-slack-answer", "sessA"),
+            ("loop-self-improve", "sessA"),
+        ]
+        now = datetime.now(UTC)
+        acquired_ats = {
+            "loop-tick": now - timedelta(seconds=60),
+            "loop-slack-answer": now - timedelta(seconds=5),
+            "loop-self-improve": now - timedelta(seconds=600),
+        }
+        cadences = {"loop-tick": 720, "loop-slack-answer": 20, "loop-self-improve": 1800}
+        with (
+            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value=acquired_ats),
+            patch(
+                "teatree.loop.statusline._cadence_for_loop",
+                side_effect=lambda name: cadences[name],
+            ),
+        ):
+            zones = zones_for([], colorize=False)
+
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=False)
+        body = target.read_text()
+        assert "loop-tick" in body
+        assert "loop-slack-answer" in body
+        assert "loop-self-improve" in body
+        # The old consolidated summary is gone.
+        assert "loops live" not in body

--- a/tests/teatree_loop/test_statusline_refinements_1163.py
+++ b/tests/teatree_loop/test_statusline_refinements_1163.py
@@ -211,14 +211,16 @@ class TestDedupAcrossOverlays:
 
 
 class TestLiveLoopsAnchor:
-    """Refinement 5 (revised): one consolidated summary line for live loops.
+    """Refinement 5 (revised twice): one dedicated line per live loop (#1400).
 
-    The original refinement returned one line per live loop. The user
-    asked instead for a single first-line summary with time-to-next-tick;
-    this rewrites the tests to lock the consolidated shape.
+    History — #1163 first returned one line per live loop, then collapsed
+    into a single consolidated summary, then re-expanded to one line per
+    loop with per-loop next-tick countdowns. The per-loop schedule was
+    invisible under the consolidated form once multiple loops ran in
+    parallel.
     """
 
-    def test_returns_one_consolidated_summary_line(self) -> None:
+    def test_returns_one_line_per_live_loop(self) -> None:
         leases = [
             ("loop-tick", "sessA"),
             ("loop-slack-answer", "sessB"),
@@ -226,13 +228,15 @@ class TestLiveLoopsAnchor:
         ]
         with (
             patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value={}),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             lines = live_loops_anchor()
-        assert len(lines) == 1
-        assert lines[0].startswith("loop · ")
-        assert "3 loops live" in lines[0]
+        assert len(lines) == 3
+        joined = "\n".join(lines)
+        assert "loop-tick" in joined
+        assert "loop-slack-answer" in joined
+        assert "loop-owner" in joined
 
     def test_no_live_leases_returns_empty(self) -> None:
         # Empty list → no lines (no statusline noise when no loop is live).
@@ -247,23 +251,23 @@ class TestLiveLoopsAnchor:
 
 
 class TestZonesForIntegratesLoopsAnchor:
-    """``zones_for`` surfaces the consolidated loop summary in the anchors zone."""
+    """``zones_for`` surfaces one per-loop anchor line in the anchors zone."""
 
-    def test_zones_for_appends_consolidated_loop_line(self, tmp_path: Path) -> None:
+    def test_zones_for_appends_one_anchor_per_loop(self, tmp_path: Path) -> None:
         with (
             patch(
                 "teatree.loop.statusline._live_loop_names",
                 return_value=[("loop-tick", "sessA"), ("loop-owner", "sessA")],
             ),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._loop_acquired_ats", return_value={}),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             zones: StatuslineZones = zones_for([], colorize=False)
         target = tmp_path / "statusline.txt"
         render(zones, target=target, colorize=False)
         body = target.read_text()
-        assert "loop · " in body
-        assert "2 loops live" in body
-        # Per-loop dump tokens absent.
+        assert "loop-tick" in body
+        assert "loop-owner" in body
+        # Per-loop colon-prefixed dump tokens absent.
         assert "loop:tick" not in body
         assert "loop:owner" not in body

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -1085,15 +1085,11 @@ class TestLoopOwnerAnchorWiring(django.test.TestCase):
             sl = Path(d) / "sl.txt"
             with patch.dict("os.environ", {"CLAUDE_SESSION_ID": "owner-sess"}):
                 run_tick(TickRequest(scanners=[]), statusline_path=sl)
-            # A live LoopLease row surfaces in the consolidated summary
-            # line — ``loop · … · N loops live`` — at the top of the
-            # statusline. The pre-refit one-line-per-loop dump
-            # (``loop:owner``, ``loop:tick``, …) was removed at the user's
-            # explicit request; the count carries the same signal in less
-            # vertical space.
+            # Each live LoopLease row surfaces as its own anchor line
+            # with a per-loop next-tick countdown (#1400).
             body = sl.read_text(encoding="utf-8")
-            assert "loop · " in body, body
-            assert "1 loops live" in body, body
+            assert "loop-owner" in body, body
+            assert "next " in body, body
 
     def test_normal_path_flags_foreign_owner_in_red_zone(self) -> None:
         import tempfile  # noqa: PLC0415


### PR DESCRIPTION
## Summary

The consolidated `loop · next tick in <duration> · N loops live` anchor hid the per-loop schedule. With multiple loops running in parallel (`loop-tick`, `loop-owner`, `loop-slack-answer`, `loop-self-improve`, …), the operator could not tell when each one would next fire.

This PR re-expands the anchor to one line per live loop, each with its own next-tick countdown:

```
loop-owner · next in 27m59s
loop-self-improve · next in 24m59s
loop-slack-answer · next in 14s
loop-tick · next in 3m11s
```

## Per-loop cadence resolution

Per-loop next-tick = `acquired_at + _cadence_for_loop(name)`:

- `loop-tick`: `cadence_seconds()` (env `T3_LOOP_CADENCE`, then `loop_cadence_seconds` in `~/.teatree.toml`, default 720).
- `loop-slack-answer`: env `T3_SLACK_ANSWER_CADENCE`, default 20s.
- `loop-self-improve`: env `T3_SELF_IMPROVE_CHEAP_CADENCE`, default 1800s.
- `loop-owner`: env `T3_LOOP_OWNER_TTL`, default 1800s (TTL doubles as refresh cadence).
- Unknown loops: fall back to the `loop-tick` cadence so future loops surface without a code change.

Overdue deadline → `next: due`. No `acquired_at` recorded yet → `last tick: never`. Lines render in stable sorted order. Empty / fail-open semantics preserved (no live loops → `[]`, any DB error → `[]`).

## Test plan

- [x] New `tests/teatree_loop/test_statusline_per_loop_next_tick.py` — 15 tests cover the per-loop shape, per-loop cadence resolution, due/never fallbacks, sorted order, and fail-open paths.
- [x] Old tests asserting the consolidated single-line shape updated to the new per-loop shape (`test_statusline_multiloop.py`, `test_statusline_next_tick.py`, `test_statusline_refinements_1163.py`, `test_tick.py`).
- [x] Full `tests/teatree_loop/` suite passes (1139 tests).
- [x] `ruff check` + `ruff format --check` clean.
- [x] Sanity-checked the rendered output against a real `live_loops_anchor()` invocation.

Fixes #1400