### PR TITLE
chore(scanners): extract shared classify_gh_stderr to base

### DIFF
--- a/src/teatree/loop/scanners/base.py
+++ b/src/teatree/loop/scanners/base.py
@@ -16,9 +16,37 @@ __all__ = [
     "ScannerError",
     "ScannerErrorClass",
     "SignalPayload",
+    "classify_gh_stderr",
 ]
 
 type SignalPayload = dict[str, Any]
+
+
+def classify_gh_stderr(stderr: str) -> ScannerErrorClass:
+    """Classify a non-zero ``gh`` stderr into a :class:`ScannerErrorClass` (#1287).
+
+    The classifier reads gh's well-known error wording: auth-required
+    prompts (``gh auth login``, ``GH_TOKEN``, ``Bad credentials``, ``401``),
+    GitHub rate-limit messages (``API rate limit exceeded``, ``rate
+    limit``, ``secondary rate limit``), and network failures (``dial
+    tcp``, ``no such host``, ``Could not resolve``). Anything else falls
+    through to :attr:`ScannerErrorClass.UNKNOWN` so the dispatcher still
+    surfaces the failure rather than masking it.
+
+    Shared by every ``gh``-backed scanner (pr_sweep, codex_review, …) so
+    the marker lists stay in one place.
+    """
+    lower = stderr.lower()
+    rate_limit_markers = ("rate limit", "rate-limit", "secondary rate")
+    auth_markers = ("gh auth login", "gh_token", "bad credentials", "401")
+    network_markers = ("no such host", "could not resolve", "dial tcp", "network is unreachable")
+    if any(marker in lower for marker in rate_limit_markers):
+        return ScannerErrorClass.RATE_LIMIT
+    if any(marker in lower for marker in auth_markers):
+        return ScannerErrorClass.AUTH
+    if any(marker in lower for marker in network_markers):
+        return ScannerErrorClass.NETWORK
+    return ScannerErrorClass.UNKNOWN
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/teatree/loop/scanners/codex_review.py
+++ b/src/teatree/loop/scanners/codex_review.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass
 from typing import Protocol, TypedDict, cast, runtime_checkable
 
 from teatree.core.models.codex_review_marker import CodexReviewMarker
-from teatree.loop.scanners.base import ScannerError, ScannerErrorClass, ScanSignal
+from teatree.loop.scanners.base import ScannerError, ScanSignal, classify_gh_stderr
 from teatree.utils.run import run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
@@ -275,19 +275,7 @@ def _as_str(value: object) -> str:
     return value if isinstance(value, str) else ""
 
 
-def _classify_gh_stderr(stderr: str) -> ScannerErrorClass:
-    """Classify a non-zero ``gh`` stderr — mirrors :func:`pr_sweep._classify_gh_stderr`."""
-    lower = stderr.lower()
-    rate_limit_markers = ("rate limit", "rate-limit", "secondary rate")
-    auth_markers = ("gh auth login", "gh_token", "bad credentials", "401")
-    network_markers = ("no such host", "could not resolve", "dial tcp", "network is unreachable")
-    if any(marker in lower for marker in rate_limit_markers):
-        return ScannerErrorClass.RATE_LIMIT
-    if any(marker in lower for marker in auth_markers):
-        return ScannerErrorClass.AUTH
-    if any(marker in lower for marker in network_markers):
-        return ScannerErrorClass.NETWORK
-    return ScannerErrorClass.UNKNOWN
+_classify_gh_stderr = classify_gh_stderr
 
 
 __all__ = [

--- a/src/teatree/loop/scanners/pr_sweep.py
+++ b/src/teatree/loop/scanners/pr_sweep.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass, field
 from typing import Protocol, TypedDict, cast, runtime_checkable
 
 from teatree.core.models.merge_clear import MergeClear
-from teatree.loop.scanners.base import ScannerError, ScannerErrorClass, ScanSignal
+from teatree.loop.scanners.base import ScannerError, ScanSignal, classify_gh_stderr
 from teatree.utils.run import run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
@@ -404,28 +404,7 @@ def _as_str(value: object) -> str:
     return value if isinstance(value, str) else ""
 
 
-def _classify_gh_stderr(stderr: str) -> ScannerErrorClass:
-    """Classify a non-zero ``gh`` stderr into a :class:`ScannerErrorClass` (#1287).
-
-    The classifier reads gh's well-known error wording: auth-required
-    prompts (``gh auth login``, ``GH_TOKEN``, ``Bad credentials``, ``401``),
-    GitHub rate-limit messages (``API rate limit exceeded``, ``rate
-    limit``, ``secondary rate limit``), and network failures (``dial
-    tcp``, ``no such host``, ``Could not resolve``). Anything else falls
-    through to :attr:`ScannerErrorClass.UNKNOWN` so the dispatcher still
-    surfaces the failure rather than masking it.
-    """
-    lower = stderr.lower()
-    rate_limit_markers = ("rate limit", "rate-limit", "secondary rate")
-    auth_markers = ("gh auth login", "gh_token", "bad credentials", "401")
-    network_markers = ("no such host", "could not resolve", "dial tcp", "network is unreachable")
-    if any(marker in lower for marker in rate_limit_markers):
-        return ScannerErrorClass.RATE_LIMIT
-    if any(marker in lower for marker in auth_markers):
-        return ScannerErrorClass.AUTH
-    if any(marker in lower for marker in network_markers):
-        return ScannerErrorClass.NETWORK
-    return ScannerErrorClass.UNKNOWN
+_classify_gh_stderr = classify_gh_stderr
 
 
 def _signal_from_attempt(attempt: MergeAttempt, *, overlay: str) -> ScanSignal:


### PR DESCRIPTION
## Summary

Tech-debt cleanup surfaced by an architectural review of the 2026-05-26/27 commits.

`_classify_gh_stderr` was duplicated **verbatim** between two scanners added/maintained in that window:
- `src/teatree/loop/scanners/pr_sweep.py` (#1287)
- `src/teatree/loop/scanners/codex_review.py` (#1254) — whose docstring already admitted it "mirrors `pr_sweep._classify_gh_stderr`"

Both bodies were byte-identical (same marker tuples, same branch order). This moves the single implementation to `scanners/base.classify_gh_stderr` (the natural shared home — `base.py` already owns `ScanSignal`/`Scanner`/`ScannerErrorClass`) and keeps a thin module-level alias `_classify_gh_stderr = classify_gh_stderr` in each scanner so existing call sites and the test that imports `codex_review._classify_gh_stderr` stay valid. Also drops the now-unused `ScannerErrorClass` import from both scanners.

Net: one classifier instead of two; future gh-marker additions land in one place.

## Test plan
- `tests/teatree_loop/test_codex_review_scanner.py` + `tests/teatree_loop/test_pr_sweep_scanner.py` — 60 passed
- ruff clean on all three files; pre-commit (ty-check, tach, module-health, blueprint-sync) green
- Import smoke: both aliases are identity-equal to `base.classify_gh_stderr`; all four classification branches verified

No endpoint/model/command/config change — internal dedup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)