### PR TITLE
docs: add subdirectory CLAUDE.md pointer files (#1020)

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -1,0 +1,8 @@
+# e2e — local conventions
+
+See the root [`CLAUDE.md`](../CLAUDE.md) for the code-quality bar. This file adds only what is specific to `e2e/`.
+
+- **Load `/t3:e2e` before working here.** It covers Playwright test writing, running, visual snapshots, evidence posting, and the pre-push visual QA gate.
+- **Full worktree per PR (non-negotiable).** Each PR under test gets its own backend + frontend via `t3 <overlay> worktree provision` + `t3 <overlay> worktree start`. Never mix one worktree's backend with another's frontend; never hand-patch an incomplete worktree — delete and recreate.
+- **Evidence comes from the deployed environment**, never from local builds or `localhost` screenshots (`/t3:rules` § "Evidence Comes From the Deployed Environment").
+- **Never blindly accept snapshot baselines** — verify the captured PNG shows the asserted state before updating (`/t3:e2e` visual QA gate).

--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -1,0 +1,13 @@
+# hooks — local conventions
+
+See the root [`CLAUDE.md`](../CLAUDE.md) for the code-quality bar. This file adds only what is specific to `hooks/`.
+
+- **One router, many events.** `scripts/hook_router.py` dispatches on `--event`. Registered events: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `PreCompact`, `SessionEnd`, `InstructionsLoaded`. Wiring lives in `hooks.json`.
+- **Adding a gate** = a new handler branch in `hook_router.py` for an existing event (usually `PreToolUse` or `Stop`). To **deny** a tool call, write the harness directive to stdout and exit 0:
+
+  ```python
+  json.dump({"permissionDecision": "deny", "permissionDecisionReason": reason}, sys.stdout)
+  ```
+
+- **Hooks must be crash-proof and fast.** `hooks.json` sets tight timeouts (3–5s); a hook that raises or hangs blocks the user. Fail open and stay silent on the happy path.
+- **Statusline state** is regenerated, not authored: `/tmp/claude-statusline/<session>.<suffix>` (override dir via `TEATREE_CLAUDE_STATUSLINE_STATE_DIR`). Never read it as a source of truth.

--- a/skills/CLAUDE.md
+++ b/skills/CLAUDE.md
@@ -1,0 +1,11 @@
+# skills — local conventions
+
+See the root [`CLAUDE.md`](../CLAUDE.md) for the code-quality bar. This is the source-of-truth skills tree (`plugins/t3/skills` is a symlink to here). This file adds only what is specific to skill authoring.
+
+- **One skill per directory**, each with a `SKILL.md`. Frontmatter keys: `name`, `description`, `compatibility`, `metadata` (with `version`, `subagent_safe`) — plus the relationship keys:
+  - `requires:` — skills auto-loaded *with* this one (hard dependency).
+  - `companions:` — generic methodology skills loaded alongside (e.g. `test-driven-development`).
+  - `triggers:` — phrases that auto-load the skill via the `UserPromptSubmit` hook.
+- **Never slim a skill.** Don't move SKILL.md prose into `references/` to save tokens — agents don't reliably load reference files on demand. Add a `references/` file only for genuinely optional deep-dive material; keep load-bearing rules inline. (`/t3:rules` § "Never Slim Skills".)
+- **`subagent_safe: true`** only for pure methodology that needs no shell functions, MCP, or cross-skill state.
+- Skill-system spec: BLUEPRINT.md § 11.

--- a/src/teatree/core/CLAUDE.md
+++ b/src/teatree/core/CLAUDE.md
@@ -1,0 +1,8 @@
+# teatree core — local conventions
+
+See the root [`CLAUDE.md`](../../../CLAUDE.md) for the code-quality bar and how to run things. This file adds only what is specific to `src/teatree/core/`.
+
+- **Overlay-agnostic.** Core never imports or hard-codes an overlay. Overlay behaviour is reached only through the `OverlayBase` ABC (`overlay.py`) — its `get_*` extension hooks are the contract. Adding a hook means giving every registered overlay a default and updating each registered overlay (see `/t3:rules` § "Teatree Extension Point Changes Must Update All Registered Overlays").
+- **Models live in the `models/` package**, one model per module (`ticket.py`, `worktree.py`, `session.py`, `pull_request.py`, …). `Ticket` carries the session FSM — add lifecycle states/transitions on the model, not in callers.
+- **Composition over mixins** (root bar) is load-bearing here: `OverlayBase` composes `OverlayConfig` + `OverlayMetadata`; follow that shape for new overlay surface.
+- **Overlay system + FSM spec:** BLUEPRINT.md § 6 (Overlay System). Don't re-derive the contract from a single module — read § 6 before changing the ABC or the state graph.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,8 @@
+# tests — local conventions
+
+See the root [`CLAUDE.md`](../CLAUDE.md) for the code-quality bar. This file adds only what is specific to `tests/`.
+
+- **Run:** `uv run pytest --no-cov -x -q` for a fast inner loop. The full coverage gate is **93% branch, non-negotiable** (`fail_under = 93, branch = true`; migrations omitted). New code ships with its tests in the same commit.
+- **Tests mirror `src/`.** Test path mirrors the module under test; classes/methods describe behaviour, not implementation.
+- **Lean integration / functional.** Prefer the Django test client, `call_command`, and real `git` under `tmp_path`. Reserve unit tests for pure logic (parsers, formatters, branch-name builders). Mock only unstoppable externals (network, clock, third-party subprocesses). Full rule + review gate: `AGENTS.md` § "Test-Writing Doctrine".
+- **A regression test must be observed RED before the fix.** A test that passes on the buggy code guards nothing — see `/t3:code` § TDD Discipline.


### PR DESCRIPTION
Closes [#1020](https://github.com/souliane/teatree/issues/1020) (tracker [#1019](https://github.com/souliane/teatree/issues/1019)).

Adds short pointer `CLAUDE.md` files so an agent walking up the directory tree picks up local conventions without reading the whole [`BLUEPRINT.md`](../blob/main/BLUEPRINT.md). Each file is a one-line pointer to the root `CLAUDE.md` plus only the directory-specific gotchas — no BLUEPRINT prose is duplicated.

| File | Local conventions captured |
|------|----------------------------|
| `src/teatree/core/CLAUDE.md` | overlay-agnostic `OverlayBase` contract, `models/` package, FSM pointer to BLUEPRINT § 6 |
| `hooks/CLAUDE.md` | hook event list, the `permissionDecision: deny` shape, statusline state path |
| `skills/CLAUDE.md` | frontmatter spec, `requires` / `companions` / `triggers`, "Never Slim Skills" |
| `tests/CLAUDE.md` | `uv run pytest --no-cov -x -q`, 93% branch gate, integration-leaning doctrine |
| `e2e/CLAUDE.md` | pointer to `/t3:e2e`, worktree-per-PR, deployed-environment evidence rule |

### Path notes
- The issue listed `plugins/t3/skills/CLAUDE.md`. `plugins/t3` is a symlink to the repo root and `plugins/` is in `.claudeignore`, so the git-tracked canonical path is `skills/CLAUDE.md` (which `plugins/t3/skills` resolves to).
- `e2e/CLAUDE.md` is the first git-tracked file under `e2e/` (the dir previously held only caches and gitignored run artifacts).
- The issue's "eight Django models" figure is stale (the `models/` package now has many more), so the core file points at the package generically rather than asserting a count.

`prek run` passes on all five files (markdownlint, ty-check, banned-terms, codespell, "no overlay names" all green).