### PR TITLE
feat(e2e): t3 e2e post-evidence — ticket-target, (env,commit)-idempotent, anti-fake gate

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -166,7 +166,7 @@ Every external API concern is a `@runtime_checkable Protocol` in `teatree.backen
 
 | Protocol | Implementations |
 |---|---|
-| `CodeHostBackend` — PR/issue/comment/upload/review-state | `GitHubCodeHost`, `GitLabCodeHost` |
+| `CodeHostBackend` — PR/issue/comment (incl. `list`/`update_issue_comment`)/upload/review-state | `GitHubCodeHost`, `GitLabCodeHost` |
 | `CIService` — pipeline cancel/trigger/quality-check | `GitLabCIService` |
 | `MessagingBackend` — mentions/DMs/post/reply/react | `SlackBotBackend`, `NoopMessagingBackend` |
 
@@ -259,7 +259,7 @@ On every `t3 setup` run, `dep_drift` checks `[project].dependencies` against the
 - `conftest.py` monkeypatches `HOME`, `XDG_*` to `tmp_path`, strips `GIT_*` env vars, isolates overlay env, resets backend + overlay caches between tests
 - Tests mirror `src/` paths under `tests/teatree_core/`, `tests/teatree_agents/`, `tests/teatree_backends/`, `tests/teatree_loop/`, plus top-level cross-cutting suites
 - New tests lean integration / E2E / functional — Django test client, `call_command`, real `git` under `tmp_path`. Unit tests are reserved for pure logic. Mock only unstoppable externals
-- Core has no Playwright suite (no UI). Overlays declare their own via `get_e2e_config()`; `t3 <overlay> e2e {run,external,project}` runs them
+- Core has no Playwright suite (no UI). Overlays declare their own via `get_e2e_config()`; `t3 <overlay> e2e {run,external,project}` runs them. `t3 <overlay> e2e post-evidence` ([#1409](https://github.com/souliane/teatree/issues/1409)) posts ONE structured evidence comment on the **ticket** (never the MR), validation-gated (env ∈ {dev, local} — the deployed-env rule is now machine-enforced, not prose-only — before ≠ after byte-hash anti-fake, commit known + tree clean) and idempotent on a hidden `(env, commit)` marker. Validators + posting live in the sibling `_e2e_evidence` module; on-behalf-gated (#960) like every colleague-visible post
 
 ---
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -2840,12 +2840,14 @@ Usage: t3 teatree e2e [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ run         Run E2E tests — dispatches to project or external runner based   │
-│             on overlay config.                                               │
-│ trigger-ci  Trigger E2E tests on a remote CI pipeline.                       │
-│ external    Run Playwright tests from the external test repo                 │
-│             (T3_PRIVATE_TESTS).                                              │
-│ project     Run E2E tests from the project's own test directory.             │
+│ run            Run E2E tests — dispatches to project or external runner      │
+│                based on overlay config.                                      │
+│ trigger-ci     Trigger E2E tests on a remote CI pipeline.                    │
+│ external       Run Playwright tests from the external test repo              │
+│                (T3_PRIVATE_TESTS).                                           │
+│ project        Run E2E tests from the project's own test directory.          │
+│ post-evidence  Post structured E2E evidence on the ticket (validation-gated, │
+│                idempotent on env+commit).                                    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -2997,6 +2999,33 @@ Usage: t3 teatree e2e project [OPTIONS]
 │                                                      no-update-snapshots]    │
 │ --help                                               Show this message and   │
 │                                                      exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree e2e post-evidence`
+
+```
+Usage: t3 teatree e2e post-evidence [OPTIONS]
+
+ Post structured E2E evidence on the **ticket** (work item / bug), never the
+ MR.
+
+ Validation-gated (env ∈ {dev, local}, before ≠ after anti-fake,
+ commit known + tree clean, ticket resolvable) and idempotent on the
+ hidden ``(env, commit)`` marker — a re-run on the same env + commit
+ edits in place, a different env/commit posts anew. ``--ticket`` and
+ ``--commit`` auto-detect from the worktree. See
+ :mod:`._e2e_evidence` for the validators and the SKILL for usage.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --ticket           TEXT                                                      │
+│ --env              TEXT                                                      │
+│ --commit           TEXT                                                      │
+│ --before           TEXT                                                      │
+│ --after            TEXT                                                      │
+│ --video            TEXT                                                      │
+│ --assertion        TEXT                                                      │
+│ --help                   Show this message and exit.                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/management-commands.md
+++ b/docs/management-commands.md
@@ -115,6 +115,7 @@ End-to-end test execution.
 | `trigger-ci` | `branch` | dict | Triggers E2E tests on a remote CI pipeline via the overlay's E2E config |
 | `external` | `test_path`, `--headed`, `--update-snapshots` | string | Runs Playwright tests from the external test repo (`T3_PRIVATE_TESTS`). Auto-discovers frontend port and tenant variant. |
 | `project` | `test_path`, `--headed`, `--docker` | string | Runs E2E tests from the project's own test directory, via docker or directly |
+| `post-evidence` | `--ticket`, `--env`, `--commit`, `--before`, `--after`, `--video`, `--assertion` | dict | Posts ONE structured evidence comment on the ticket (not the MR). Validation-gated (env ∈ {dev, local}, before ≠ after, known + clean commit) and idempotent on `(ticket, env, commit)` via a hidden marker. |
 
 ## `tool`
 

--- a/skills/e2e/SKILL.md
+++ b/skills/e2e/SKILL.md
@@ -104,11 +104,30 @@ Sometimes a **separate test repo** reduces friction — no conflicts with the QA
 - Structure tests by app and feature: `tests/<app>/<feature-area>/<test-file>`
 - Store artifacts (screenshots, recordings) in a git-tracked `artifacts/<TICKET>/` directory.
 
-## Post Testing Evidence on PR
+## Post Testing Evidence on the Ticket
 
-**Use `t3 <overlay> pr post-evidence` first.** If the CLI command handles uploading and posting, use it instead of manual API calls.
+**Use `t3 <overlay> e2e post-evidence` first.** It posts ONE structured comment on the **ticket** (work item / bug) — never on the MR, even when MRs are open. The deployed-environment proof belongs to the issue the work closes and stays attached after the MR merges.
 
-After confirming a feature works, embed screenshot(s) and video(s) **directly in the test plan comment** — not as a separate comment.
+The command refuses bad evidence before any upload or post:
+
+- missing `--before` / `--after` artifact
+- identical before == after (same path, or two paths with byte-identical contents)
+- `--env` outside `{dev, local}`
+- an unknown commit, or a dirty working tree (uncommitted changes ⇒ not reproducible)
+
+Flags (all keyword-only):
+
+| Flag | Required | Auto-detection |
+|---|---|---|
+| `--ticket` | no | pk / issue number / issue URL; falls back to the resolved worktree's ticket |
+| `--env` | yes | none — must be `dev` or `local` |
+| `--commit` | no | `git HEAD` of the resolved worktree |
+| `--before` | yes | none — path to the before artifact |
+| `--after` | yes | none — path to the after artifact |
+| `--video` | no | none — optional video artifact |
+| `--assertion` | yes | none — the feature claim the evidence proves |
+
+After confirming a feature works, embed screenshot(s) and video(s) **directly in the evidence comment** — not as a separate comment.
 
 ### Visual Comparison Format
 
@@ -135,12 +154,14 @@ With a design mockup available, use 3 columns:
 - Screenshots go below the section they verify, not at the bottom.
 - Write in first person, casual tone ("Tested on local...", "Works as expected").
 - Evidence must read as manual testing — no mentions of automation, E2E, Playwright, or scripts.
-- **Update the existing test plan** — never post a second evidence comment.
+- **Idempotent on `(ticket, env, commit)`.** Each comment carries a hidden marker `<!-- t3-e2e-evidence env=<env> commit=<sha> -->` (renders invisibly). Re-running with the same env + commit edits that comment in place; a different commit or env posts a new comment. You never have to hand-dedup — the marker does it.
 - **Match evidence type to PR type.** UI screenshots for frontend PRs; backend evidence (test output, API diffs) for backend PRs.
 
 ### Evidence Source Integrity (Non-Negotiable)
 
 Evidence posted on tickets or MRs MUST come from the **deployed environment** (dev/staging), never from local builds. Violation is grounds for termination — it exposes the team to compliance and trust failures.
+
+The `dev`/`local` gate is now **machine-enforced** by `t3 <overlay> e2e post-evidence`: an `--env` outside `{dev, local}`, a missing/identical before-after pair, or an unknown/dirty commit is refused before any upload or post — so a fake or mislabelled evidence pair never reaches the ticket.
 
 **Prohibited evidence sources:**
 

--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -494,6 +494,43 @@ class GitHubCodeHost:
             )
         return result
 
+    def list_issue_comments(self, *, issue_url: str) -> list[RawAPIDict]:
+        """List the comments on a GitHub issue.
+
+        Supports ``https://github.com/<owner>/<repo>/issues/<number>``.
+        Returns an empty list when the URL is not a recognised GitHub issue
+        URL — the caller treats "no comments" and "unresolvable" identically.
+        """
+        path = urlparse(issue_url).path
+        match = _ISSUE_URL_RE.match(path)
+        if match is None:
+            return []
+
+        repo = f"{match['owner']}/{match['repo']}"
+        data = _gh_api_get(f"repos/{repo}/issues/{match['number']}/comments?per_page=100", token=self._token)
+        return cast("list[RawAPIDict]", data) if isinstance(data, list) else []
+
+    def update_issue_comment(self, *, issue_url: str, comment_id: int, body: str) -> RawAPIDict:
+        """Edit an existing GitHub issue comment in place.
+
+        GitHub issue-comment ids are globally unique within a repo, edited
+        via ``/repos/{repo}/issues/comments/{id}`` (the issue number is not
+        part of the path). Returns ``{"error": ...}`` when the URL is not a
+        recognised GitHub issue URL.
+        """
+        path = urlparse(issue_url).path
+        match = _ISSUE_URL_RE.match(path)
+        if match is None:
+            return {"error": f"Not a GitHub issue URL: {issue_url}"}
+
+        repo = f"{match['owner']}/{match['repo']}"
+        data = _gh_api_patch(
+            f"repos/{repo}/issues/comments/{comment_id}",
+            {"body": body},
+            token=self._token,
+        )
+        return cast("RawAPIDict", data) if isinstance(data, dict) else {}
+
     @staticmethod
     def get_mr_approvals(*, repo: str, pr_iid: int) -> ApprovalState:
         """Out of scope for #936 — GitLab-only approval polling for now.

--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -322,6 +322,55 @@ class GitLabCodeHost:
             or {}
         )
 
+    def list_issue_comments(self, *, issue_url: str) -> list[RawAPIDict]:
+        """List the notes on a GitLab issue or work item.
+
+        Accepts the same ``…/-/issues/<iid>`` and ``…/-/work_items/<iid>``
+        forms as :meth:`post_issue_comment` (GitLab serves the same iid and
+        notes API under both). Returns an empty list when the URL is not a
+        recognised GitLab issue URL or the project cannot be resolved — the
+        caller treats "no comments" and "unresolvable" identically (it will
+        create a fresh comment either way).
+        """
+        path = urlparse(issue_url).path
+        match = _ISSUE_OR_WORKITEM_URL_RE.match(path)
+        if match is None:
+            return []
+
+        project = self._client.resolve_project(match["path"])
+        if project is None:
+            return []
+
+        data = self._client.get_json(
+            f"projects/{project.project_id}/issues/{int(match['iid'])}/notes?per_page=100",
+        )
+        return cast("list[RawAPIDict]", data) if isinstance(data, list) else []
+
+    def update_issue_comment(self, *, issue_url: str, comment_id: int, body: str) -> RawAPIDict:
+        """Edit an existing note on a GitLab issue or work item in place.
+
+        Used by ``e2e post-evidence`` to keep a single evidence comment
+        per ``(ticket, env, commit)`` rather than appending a new one on
+        re-run. Returns ``{"error": ...}`` when the URL is not a recognised
+        GitLab issue URL or the project cannot be resolved.
+        """
+        path = urlparse(issue_url).path
+        match = _ISSUE_OR_WORKITEM_URL_RE.match(path)
+        if match is None:
+            return {"error": f"Not a GitLab issue URL: {issue_url}"}
+
+        project = self._client.resolve_project(match["path"])
+        if project is None:
+            return {"error": f"Could not resolve project: {match['path']}"}
+
+        return (
+            self._client.put_json(
+                f"projects/{project.project_id}/issues/{int(match['iid'])}/notes/{comment_id}",
+                {"body": body},
+            )
+            or {}
+        )
+
     def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState:
         """Return the approval state for an MR — used by ``GitLabApprovalsScanner`` (#936).
 

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -142,6 +142,16 @@ class CodeHostBackend(Protocol):
 
     def post_issue_comment(self, *, issue_url: str, body: str) -> RawAPIDict: ...  # pragma: no branch
 
+    def list_issue_comments(self, *, issue_url: str) -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def update_issue_comment(
+        self,
+        *,
+        issue_url: str,
+        comment_id: int,
+        body: str,
+    ) -> RawAPIDict: ...  # pragma: no branch
+
     def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]: ...  # pragma: no branch
 
     def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState: ...  # pragma: no branch

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -91,6 +91,10 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("trigger-ci", "Trigger E2E tests on a remote CI pipeline."),
             ("external", "Run Playwright tests from the external test repo (T3_PRIVATE_TESTS)."),
             ("project", "Run E2E tests from the project's own test directory."),
+            (
+                "post-evidence",
+                "Post structured E2E evidence on the ticket (validation-gated, idempotent on env+commit).",
+            ),
         ],
     ),
     "db": DjangoGroup(

--- a/src/teatree/core/management/commands/_e2e_evidence.py
+++ b/src/teatree/core/management/commands/_e2e_evidence.py
@@ -1,0 +1,440 @@
+"""Validators and comment builder for ``e2e post-evidence``.
+
+Split out of ``e2e.py`` (mirroring the ``_e2e_discovery`` split) so the
+validation logic — env enum, artifact-presence, anti-fake before≠after,
+commit known-and-clean — is independently unit-testable as pure functions.
+
+The command method in ``e2e.py`` orchestrates: it calls these validators
+in order (env → artifacts → before≠after → commit → ticket-resolvable),
+catches the typed errors they raise, writes the message to stderr and
+exits non-zero. None of these functions know about Typer or the CLI.
+
+The evidence comment is posted on the **ticket** (work item / bug), never
+on an MR — the deployed-environment proof belongs to the issue the work
+closes, and stays attached even after the MR merges. Idempotency is keyed
+on a hidden HTML-comment marker carrying ``(env, commit)`` so a re-run on
+the same environment + commit edits the existing comment in place instead
+of appending a new one.
+"""
+
+import hashlib
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import TypedDict
+
+from teatree.backends.protocols import CodeHostBackend
+from teatree.core.models import Ticket, Worktree
+from teatree.core.on_behalf_gate_recorded import require_on_behalf_approval
+from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
+from teatree.core.overlay_loader import get_overlay
+from teatree.core.resolve import WorktreeNotFoundError, resolve_worktree
+from teatree.types import RawAPIDict
+from teatree.utils import git
+from teatree.utils.run import CommandFailedError
+
+_ON_BEHALF_ACTION = "post_e2e_evidence"
+
+# Mirror of ``backends/gitlab_sync_prs.py`` ``_E2E_EVIDENCE_RE`` in spirit:
+# a single source-of-truth regex matching the hidden idempotency marker
+# embedded at the top of every evidence comment. Named groups expose the
+# env + commit so the idempotency lookup is a pure regex parse.
+_E2E_MARKER_RE = re.compile(r"<!--\s*t3-e2e-evidence\s+env=(?P<env>\S+)\s+commit=(?P<commit>\S+)\s*-->")
+
+
+class EvidenceEnv(StrEnum):
+    """The only environments E2E evidence may come from.
+
+    The dev/local gate is machine-enforced here (it used to be a prose-only
+    rule in the e2e skill): a deployed dev environment or a teatree-managed
+    local stack. Staging/prod evidence is out of scope for this command.
+    """
+
+    DEV = "dev"
+    LOCAL = "local"
+
+
+class EvidenceValidationError(ValueError):
+    """A pre-post evidence validation failed — the comment must NOT be posted.
+
+    Raised by the pure validators below; the command method catches it,
+    writes ``str(error)`` to stderr and raises ``SystemExit(1)`` so no
+    upload or comment side effect ever runs on invalid evidence.
+    """
+
+
+class EvidenceResolutionError(EvidenceValidationError):
+    """The ticket the evidence should post on could not be resolved.
+
+    A subclass of :class:`EvidenceValidationError` so the command's single
+    ``except EvidenceValidationError`` arm catches resolution and validation
+    failures alike — both must exit non-zero with no host side effect.
+    """
+
+
+def coerce_env(env: str) -> EvidenceEnv:
+    """Coerce a ``--env`` string to :class:`EvidenceEnv` or raise.
+
+    Empty or anything outside ``{dev, local}`` fails — the command requires
+    an explicit, machine-checked environment.
+    """
+    try:
+        return EvidenceEnv(env.strip().lower())
+    except ValueError:
+        allowed = ", ".join(e.value for e in EvidenceEnv)
+        msg = f"--env must be one of {{{allowed}}}, got {env!r}."
+        raise EvidenceValidationError(msg) from None
+
+
+def validate_assertion(assertion: str) -> None:
+    """The feature-claim text is required — empty evidence proves nothing."""
+    if not assertion.strip():
+        msg = "--assertion is required (the feature claim the evidence proves)."
+        raise EvidenceValidationError(msg)
+
+
+def validate_artifacts_present(*, before: str, after: str) -> tuple[Path, Path]:
+    """Both before/after must be non-empty paths pointing at real files.
+
+    Separate messages per side so the user knows which artifact is missing.
+    Returns the resolved ``(before_path, after_path)`` for downstream checks.
+    """
+    if not before:
+        msg = "--before is required (path to the before screenshot/artifact)."
+        raise EvidenceValidationError(msg)
+    if not after:
+        msg = "--after is required (path to the after screenshot/artifact)."
+        raise EvidenceValidationError(msg)
+    before_path = Path(before)
+    after_path = Path(after)
+    if not before_path.is_file():
+        msg = f"--before is not a file: {before}"
+        raise EvidenceValidationError(msg)
+    if not after_path.is_file():
+        msg = f"--after is not a file: {after}"
+        raise EvidenceValidationError(msg)
+    return before_path, after_path
+
+
+def _file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def validate_before_differs_from_after(*, before: Path, after: Path) -> None:
+    """Anti-fake gate: before and after must not be the same bytes.
+
+    Same path, or two distinct paths whose bytes hash identically, both
+    fail — a before/after pair that is byte-identical is not evidence of
+    any change. For images this is a byte-level (not perceptual) compare:
+    Pillow is intentionally not a dependency, so two visually-identical PNGs
+    re-encoded differently would pass here; the byte-hash catches the common
+    fake (the same file submitted twice).
+    """
+    if before.resolve() == after.resolve():
+        msg = "--before and --after point at the same file; evidence must show a change."
+        raise EvidenceValidationError(msg)
+    if _file_sha256(before) == _file_sha256(after):
+        msg = "--before and --after are byte-identical; evidence must show a change."
+        raise EvidenceValidationError(msg)
+
+
+def resolve_and_validate_commit(*, commit: str, repo: str) -> str:
+    """Resolve the code-under-test SHA and confirm it is known + the tree is clean.
+
+    Empty ``commit`` auto-detects via ``git.head_sha(repo)``; an empty result
+    (not a git repo / no HEAD) fails. A supplied SHA must resolve via
+    ``git rev-parse --verify <sha>^{commit}``. A dirty working tree
+    (``git status --porcelain`` non-empty) fails — uncommitted changes mean
+    the evidence is not reproducible from the recorded commit.
+
+    Returns the full resolved SHA.
+    """
+    resolved = commit.strip()
+    if not resolved:
+        try:
+            resolved = git.head_sha(repo=repo)
+        except CommandFailedError:
+            resolved = ""
+        if not resolved:
+            msg = f"Could not resolve a commit SHA (no --commit and git HEAD unavailable in {repo!r})."
+            raise EvidenceValidationError(msg)
+    elif not git.check(repo=repo, args=["rev-parse", "--verify", f"{resolved}^{{commit}}"]):
+        msg = f"--commit {commit!r} is not a known commit in {repo!r}."
+        raise EvidenceValidationError(msg)
+
+    if git.status_porcelain(repo=repo).strip():
+        msg = f"Working tree in {repo!r} is dirty; commit or stash changes so the evidence is reproducible."
+        raise EvidenceValidationError(msg)
+    return resolved
+
+
+def evidence_marker(*, env: EvidenceEnv, commit: str) -> str:
+    """The hidden HTML-comment idempotency marker for ``(env, commit)``.
+
+    Renders invisibly in GitLab/GitHub markdown; matched by
+    :data:`_E2E_MARKER_RE` to find a prior evidence comment to update.
+    """
+    return f"<!-- t3-e2e-evidence env={env.value} commit={commit} -->"
+
+
+def find_matching_comment(
+    comments: list[RawAPIDict],
+    *,
+    env: EvidenceEnv,
+    commit: str,
+) -> int | None:
+    """Return the id of an existing evidence comment matching THIS (env, commit).
+
+    A comment whose marker carries a *different* env or commit is left alone
+    (the caller posts a new comment). Returns the first matching comment's
+    integer id, or ``None`` when none match.
+    """
+    for comment in comments:
+        body = str(comment.get("body", ""))
+        match = _E2E_MARKER_RE.search(body)
+        if match is None:
+            continue
+        if match.group("env") == env.value and match.group("commit") == commit:
+            raw_id = comment.get("id")
+            if isinstance(raw_id, int):
+                return raw_id
+            if isinstance(raw_id, str) and raw_id.isdigit():
+                return int(raw_id)
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceComment:
+    """The data the evidence comment body is rendered from.
+
+    Bundles the rendering inputs so :func:`build_evidence_body` stays a
+    single-argument function (below the project's per-function arg cap) and
+    the call site reads as one named record rather than six positionals.
+    """
+
+    env: EvidenceEnv
+    commit: str
+    before_md: str
+    after_md: str
+    assertion: str
+    video_md: str = ""
+
+
+def build_evidence_body(comment: EvidenceComment) -> str:
+    """Render the evidence comment body.
+
+    Order: hidden marker, environment banner, commit tested, the
+    Before/After table (plus a Video row when a video embed is given),
+    then the feature-claim assertion text.
+    """
+    lines = [
+        evidence_marker(env=comment.env, commit=comment.commit),
+        f"## E2E Evidence — environment: **{comment.env.value.upper()}**",
+        "",
+        f"Commit tested: `{comment.commit}`",
+        "",
+        "| Before | After |",
+        "|---|---|",
+        f"| {comment.before_md} | {comment.after_md} |",
+    ]
+    if comment.video_md:
+        lines.append(f"| Video | {comment.video_md} |")
+    lines.extend(["", comment.assertion])
+    return "\n".join(lines)
+
+
+class PostEvidenceResult(TypedDict):
+    """Return shape of ``e2e post-evidence`` — the posted evidence comment.
+
+    ``action`` is ``"created"`` when a new comment was posted and
+    ``"updated"`` when an existing comment matching the same ``(env, commit)``
+    marker was edited in place.
+    """
+
+    issue_url: str
+    comment_id: int
+    env: str
+    commit: str
+    action: str
+
+
+@dataclass(frozen=True, slots=True)
+class EvidencePost:
+    """Validated inputs for :func:`post_evidence_comment`.
+
+    Every field is a post-validation value: the resolved env enum, the
+    resolved-and-clean commit SHA, the issue URL the evidence lands on, the
+    on-disk artifact paths, and the feature-claim text. Bundled so the
+    posting function takes one record rather than eight positionals.
+    """
+
+    issue_url: str
+    repo: str
+    env: EvidenceEnv
+    commit: str
+    before_path: Path
+    after_path: Path
+    assertion: str
+    video: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceFlags:
+    """The raw CLI flags for ``e2e post-evidence``, before validation.
+
+    Mirrors the command's keyword-only parameters so the command method
+    forwards one record into :func:`build_validated_post` rather than
+    threading eight positionals through the validators.
+    """
+
+    ticket: str = ""
+    env: str = ""
+    commit: str = ""
+    before: str = ""
+    after: str = ""
+    video: str = ""
+    assertion: str = ""
+
+
+def _resolve_worktree_or_none() -> Worktree | None:
+    """Resolve the current worktree, or ``None`` when not inside one."""
+    try:
+        return resolve_worktree()
+    except WorktreeNotFoundError:
+        return None
+
+
+def _resolve_issue_url(ticket: str, worktree: Worktree | None) -> str:
+    """Resolve the issue URL the evidence posts on, from ``--ticket`` or the worktree.
+
+    ``--ticket`` (a pk, issue number, or full issue URL) wins; otherwise the
+    resolved worktree's ticket supplies it. Raises
+    :class:`EvidenceResolutionError` when neither resolves to a ticket
+    carrying an ``issue_url``.
+    """
+    if ticket:
+        try:
+            resolved = Ticket.objects.resolve(ticket)
+        except Ticket.DoesNotExist:
+            msg = f"No ticket matching {ticket!r} (looked up by pk and issue_url)."
+            raise EvidenceResolutionError(msg) from None
+    elif worktree is not None and worktree.ticket is not None:
+        resolved = worktree.ticket
+    else:
+        msg = "Could not determine the ticket: pass --ticket <pk|number|url> or run from inside a worktree."
+        raise EvidenceResolutionError(msg)
+    if not resolved.issue_url:
+        msg = f"Ticket {resolved} has no issue_url to post evidence on."
+        raise EvidenceResolutionError(msg)
+    return str(resolved.issue_url)
+
+
+def build_validated_post(flags: EvidenceFlags) -> EvidencePost:
+    """Run every validator in order and return a fully-validated :class:`EvidencePost`.
+
+    Order: env → artifacts present → before≠after → commit known+clean →
+    assertion present → ticket resolvable. Any failure raises
+    :class:`EvidenceValidationError` (or its
+    :class:`EvidenceResolutionError` subclass) so the caller exits non-zero
+    before any host side effect. The repo for artifact upload comes from the
+    overlay's CI project path; the commit repo comes from the resolved
+    worktree's on-disk path (cwd fallback).
+    """
+    worktree = _resolve_worktree_or_none()
+    repo_dir = worktree.worktree_path if worktree is not None and worktree.worktree_path else "."
+
+    env = coerce_env(flags.env)
+    before_path, after_path = validate_artifacts_present(before=flags.before, after=flags.after)
+    validate_before_differs_from_after(before=before_path, after=after_path)
+    commit = resolve_and_validate_commit(commit=flags.commit, repo=repo_dir)
+    validate_assertion(flags.assertion)
+
+    return EvidencePost(
+        issue_url=_resolve_issue_url(flags.ticket, worktree),
+        repo=get_overlay().metadata.get_ci_project_path(),
+        env=env,
+        commit=commit,
+        before_path=before_path,
+        after_path=after_path,
+        assertion=flags.assertion,
+        video=flags.video,
+    )
+
+
+def _comment_id(result: RawAPIDict) -> int:
+    """Extract the integer comment id from a host create response."""
+    raw = result.get("id")
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str) and raw.isdigit():
+        return int(raw)
+    return 0
+
+
+def _upload_artifact(host: CodeHostBackend, *, repo: str, filepath: str, label: str) -> str:
+    """Upload one artifact and return its markdown embed.
+
+    Falls back to a bare ``[label](filepath)`` link when the host's upload
+    returns no markdown (keeps the table well-formed).
+    """
+    result = host.upload_file(repo=repo, filepath=filepath)
+    markdown = str(result.get("markdown", ""))
+    return markdown or f"[{label}]({filepath})"
+
+
+def post_evidence_comment(host: CodeHostBackend, post: EvidencePost) -> PostEvidenceResult:
+    """Gate, upload artifacts, build the body, then create-or-update the comment.
+
+    Runs only after every validator passed. The on-behalf gate is the last
+    check before any side effect: a BLOCK with no recorded approval raises
+    :class:`OnBehalfPostBlockedError`, which the command surfaces as a
+    non-zero exit rather than publishing unattended. Idempotency is keyed on
+    the hidden ``(env, commit)`` marker: a matching prior comment is edited
+    in place (``action="updated"``); otherwise a new comment is created.
+    """
+    require_on_behalf_approval(target=post.issue_url, action=_ON_BEHALF_ACTION)
+
+    before_md = _upload_artifact(host, repo=post.repo, filepath=str(post.before_path), label="before")
+    after_md = _upload_artifact(host, repo=post.repo, filepath=str(post.after_path), label="after")
+    video_md = _upload_artifact(host, repo=post.repo, filepath=post.video, label="video") if post.video else ""
+
+    body = build_evidence_body(
+        EvidenceComment(
+            env=post.env,
+            commit=post.commit,
+            before_md=before_md,
+            after_md=after_md,
+            assertion=post.assertion,
+            video_md=video_md,
+        ),
+    )
+
+    match_id = find_matching_comment(
+        host.list_issue_comments(issue_url=post.issue_url),
+        env=post.env,
+        commit=post.commit,
+    )
+    if match_id is not None:
+        result = host.update_issue_comment(issue_url=post.issue_url, comment_id=match_id, body=body)
+        action = "updated"
+        comment_id = match_id
+    else:
+        result = host.post_issue_comment(issue_url=post.issue_url, body=body)
+        action = "created"
+        comment_id = _comment_id(result)
+
+    notify_user_on_behalf_post(
+        target=post.issue_url,
+        action=_ON_BEHALF_ACTION,
+        destination=post.issue_url,
+        artifact_url=str(result.get("web_url") or result.get("html_url") or post.issue_url),
+        summary=f"E2E evidence ({post.env.value}, {post.commit[:8]}) on {post.issue_url}",
+    )
+    return PostEvidenceResult(
+        issue_url=post.issue_url,
+        comment_id=comment_id,
+        env=post.env.value,
+        commit=post.commit,
+        action=action,
+    )

--- a/src/teatree/core/management/commands/_e2e_runners.py
+++ b/src/teatree/core/management/commands/_e2e_runners.py
@@ -1,0 +1,103 @@
+"""External/private-test repo resolution and Playwright env construction.
+
+Split out of ``e2e.py`` (mirroring the ``_e2e_discovery`` and
+``_e2e_evidence`` splits) to keep that module under the project's per-file
+LOC cap. These are the pure helpers the ``external``/``project`` runners
+lean on: cloning the external test repo, resolving the private-tests
+directory, and building the Playwright environment dict.
+"""
+
+import os
+from pathlib import Path
+
+from teatree.config import E2ERepo
+from teatree.core.overlay_loader import get_overlay
+from teatree.core.resolve import _find_env_cache, _get_user_cwd, _parse_env_file
+from teatree.paths import get_data_dir
+from teatree.utils.run import run_checked
+
+
+def clone_or_update_e2e_repo(repo: E2ERepo) -> Path:
+    """Clone or update an external E2E repo to the local cache and return the playwright root.
+
+    On first run: ``git clone --branch <branch> --depth 1 <url> <cache_path>``.
+    On subsequent runs: ``git fetch origin <branch>`` + ``git reset --hard FETCH_HEAD``.
+
+    Returns ``cache_path / repo.e2e_dir`` — the directory passed as ``cwd`` to Playwright.
+    """
+    cache_path = get_data_dir("e2e-repos") / repo.name
+    if not cache_path.exists():
+        run_checked(
+            ["git", "clone", "--branch", repo.branch, "--depth", "1", repo.url, str(cache_path)],
+        )
+    else:
+        run_checked(["git", "-C", str(cache_path), "fetch", "origin", repo.branch])
+        run_checked(["git", "-C", str(cache_path), "reset", "--hard", "FETCH_HEAD"])
+    return cache_path / repo.e2e_dir
+
+
+def resolve_private_tests_path() -> Path | None:
+    """Resolve the private tests directory from env or config."""
+    from teatree.config import load_config  # noqa: PLC0415
+
+    private_tests = os.environ.get("T3_PRIVATE_TESTS", "")
+    if not private_tests:
+        private_tests = load_config().raw.get("teatree", {}).get("private_tests", "")
+    if not private_tests:
+        return None
+    path = Path(private_tests).expanduser()
+    return path if path.is_dir() else None
+
+
+def build_e2e_env(
+    frontend_url: str | None = None,
+    *,
+    headed: bool,
+    target: str,
+    compose_project: str | None = None,
+    env_cache_override: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build environment dict for Playwright: ``BASE_URL``, overlay extras, ``CI``.
+
+    When *frontend_url* is given it overrides ``BASE_URL``.
+    When it is ``None`` the existing ``BASE_URL`` env var is preserved (DEV / staging mode).
+
+    *target* is the resolved dual-env target (``"dev"`` or ``"local"``); it is
+    exported as ``T3_E2E_TARGET`` so a single dual-mode spec can branch on
+    ``process.env.T3_E2E_TARGET === 'dev'`` instead of re-deriving the target
+    from a ``BASE_URL`` host regex.
+
+    *compose_project* is the teatree-managed docker-compose project of the
+    resolved worktree (``compose_project(worktree)``) for a local target. It
+    is exported as ``COMPOSE_PROJECT_NAME`` — the variable ``docker compose``
+    natively honours — so a spec that resolves the backend via a bare
+    ``docker compose port web 8000`` / ``docker compose exec -T web`` (run
+    from the backend repo dir, no ``-p``) deterministically targets the
+    teatree stack whose ``web`` container has the restored-Postgres
+    ``DATABASE_URL`` injected, instead of defaulting to the directory
+    basename and missing it. ``None`` (dev target) leaves it unset.
+
+    Overlay-specific env vars (e.g. ``CUSTOMER``) come from
+    :meth:`OverlayBase.get_e2e_env_extras` — core only knows about ``BASE_URL``,
+    ``T3_E2E_TARGET``, ``COMPOSE_PROJECT_NAME`` and ``CI``.
+    """
+    env = {**os.environ}
+    if frontend_url is not None:
+        env["BASE_URL"] = frontend_url
+    env["T3_E2E_TARGET"] = target
+    if compose_project:
+        env["COMPOSE_PROJECT_NAME"] = compose_project
+
+    if env_cache_override is not None:
+        env_cache = env_cache_override
+    else:
+        envfile = _find_env_cache(_get_user_cwd())
+        env_cache = _parse_env_file(envfile) if envfile is not None else {}
+    for key, value in get_overlay().get_e2e_env_extras(env_cache).items():
+        env.setdefault(key, value)
+
+    if headed:
+        env.pop("CI", None)
+    else:
+        env["CI"] = "1"
+    return env

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -8,14 +8,17 @@ from typing import Annotated
 import typer
 from django_typer.management import TyperCommand, command
 
-from teatree.config import E2ERepo, load_e2e_repos
+from teatree.config import load_e2e_repos
+from teatree.core.backend_factory import code_host_from_overlay
 from teatree.core.management.commands import _e2e_discovery as _disc
+from teatree.core.management.commands import _e2e_evidence as _evidence
+from teatree.core.management.commands import _e2e_runners as _runners
 from teatree.core.models import Ticket
+from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError
 from teatree.core.overlay_loader import get_overlay
-from teatree.core.resolve import _find_env_cache, _get_user_cwd, _parse_env_file, resolve_worktree
+from teatree.core.resolve import resolve_worktree
 from teatree.core.runners.worktree_start import compose_project
-from teatree.paths import get_data_dir
-from teatree.utils.run import run_checked, run_streamed
+from teatree.utils.run import run_streamed
 
 # Re-exports for back-compat with tests and external callers (#1322 split).
 _ticket_frontend_projects = _disc.ticket_frontend_projects
@@ -24,6 +27,9 @@ _resolve_linked_worktree = _disc.resolve_linked_worktree
 _linked_env_cache = _disc.linked_env_cache
 _compose_frontend_port = _disc.compose_frontend_port
 _detect_local_port = _disc.detect_local_port
+_clone_or_update_e2e_repo = _runners.clone_or_update_e2e_repo
+_resolve_private_tests_path = _runners.resolve_private_tests_path
+_build_e2e_env = _runners.build_e2e_env
 
 
 @dataclass
@@ -62,92 +68,6 @@ class PlaywrightOptions:
             args.append("--headed")
         args.extend(self.extra)
         return args
-
-
-def _clone_or_update_e2e_repo(repo: E2ERepo) -> Path:
-    """Clone or update an external E2E repo to the local cache and return the playwright root.
-
-    On first run: ``git clone --branch <branch> --depth 1 <url> <cache_path>``.
-    On subsequent runs: ``git fetch origin <branch>`` + ``git reset --hard FETCH_HEAD``.
-
-    Returns ``cache_path / repo.e2e_dir`` — the directory passed as ``cwd`` to Playwright.
-    """
-    cache_path = get_data_dir("e2e-repos") / repo.name
-    if not cache_path.exists():
-        run_checked(
-            ["git", "clone", "--branch", repo.branch, "--depth", "1", repo.url, str(cache_path)],
-        )
-    else:
-        run_checked(["git", "-C", str(cache_path), "fetch", "origin", repo.branch])
-        run_checked(["git", "-C", str(cache_path), "reset", "--hard", "FETCH_HEAD"])
-    return cache_path / repo.e2e_dir
-
-
-def _resolve_private_tests_path() -> Path | None:
-    """Resolve the private tests directory from env or config."""
-    from teatree.config import load_config  # noqa: PLC0415
-
-    private_tests = os.environ.get("T3_PRIVATE_TESTS", "")
-    if not private_tests:
-        private_tests = load_config().raw.get("teatree", {}).get("private_tests", "")
-    if not private_tests:
-        return None
-    path = Path(private_tests).expanduser()
-    return path if path.is_dir() else None
-
-
-def _build_e2e_env(
-    frontend_url: str | None = None,
-    *,
-    headed: bool,
-    target: str,
-    compose_project: str | None = None,
-    env_cache_override: dict[str, str] | None = None,
-) -> dict[str, str]:
-    """Build environment dict for Playwright: ``BASE_URL``, overlay extras, ``CI``.
-
-    When *frontend_url* is given it overrides ``BASE_URL``.
-    When it is ``None`` the existing ``BASE_URL`` env var is preserved (DEV / staging mode).
-
-    *target* is the resolved dual-env target (``"dev"`` or ``"local"``); it is
-    exported as ``T3_E2E_TARGET`` so a single dual-mode spec can branch on
-    ``process.env.T3_E2E_TARGET === 'dev'`` instead of re-deriving the target
-    from a ``BASE_URL`` host regex.
-
-    *compose_project* is the teatree-managed docker-compose project of the
-    resolved worktree (``compose_project(worktree)``) for a local target. It
-    is exported as ``COMPOSE_PROJECT_NAME`` — the variable ``docker compose``
-    natively honours — so a spec that resolves the backend via a bare
-    ``docker compose port web 8000`` / ``docker compose exec -T web`` (run
-    from the backend repo dir, no ``-p``) deterministically targets the
-    teatree stack whose ``web`` container has the restored-Postgres
-    ``DATABASE_URL`` injected, instead of defaulting to the directory
-    basename and missing it. ``None`` (dev target) leaves it unset.
-
-    Overlay-specific env vars (e.g. ``CUSTOMER``) come from
-    :meth:`OverlayBase.get_e2e_env_extras` — core only knows about ``BASE_URL``,
-    ``T3_E2E_TARGET``, ``COMPOSE_PROJECT_NAME`` and ``CI``.
-    """
-    env = {**os.environ}
-    if frontend_url is not None:
-        env["BASE_URL"] = frontend_url
-    env["T3_E2E_TARGET"] = target
-    if compose_project:
-        env["COMPOSE_PROJECT_NAME"] = compose_project
-
-    if env_cache_override is not None:
-        env_cache = env_cache_override
-    else:
-        envfile = _find_env_cache(_get_user_cwd())
-        env_cache = _parse_env_file(envfile) if envfile is not None else {}
-    for key, value in get_overlay().get_e2e_env_extras(env_cache).items():
-        env.setdefault(key, value)
-
-    if headed:
-        env.pop("CI", None)
-    else:
-        env["CI"] = "1"
-    return env
 
 
 class Command(TyperCommand):
@@ -571,3 +491,41 @@ class Command(TyperCommand):
             return "E2E passed."
         self.stderr.write(f"E2E failed (exit {rc}).")
         raise SystemExit(rc)
+
+    @command(name="post-evidence")
+    def post_evidence(  # noqa: PLR0913
+        self,
+        *,
+        ticket: str = "",
+        env: str = "",
+        commit: str = "",
+        before: str = "",
+        after: str = "",
+        video: str = "",
+        assertion: str = "",
+    ) -> _evidence.PostEvidenceResult:
+        """Post structured E2E evidence on the **ticket** (work item / bug), never the MR.
+
+        Validation-gated (env ∈ {dev, local}, before ≠ after anti-fake,
+        commit known + tree clean, ticket resolvable) and idempotent on the
+        hidden ``(env, commit)`` marker — a re-run on the same env + commit
+        edits in place, a different env/commit posts anew. ``--ticket`` and
+        ``--commit`` auto-detect from the worktree. See
+        :mod:`._e2e_evidence` for the validators and the SKILL for usage.
+        """
+        host = code_host_from_overlay()
+        if host is None:
+            self.stderr.write("No code host configured (check overlay GitLab/GitHub token).")
+            raise SystemExit(1)
+
+        flags = _evidence.EvidenceFlags(
+            ticket=ticket, env=env, commit=commit, before=before, after=after, video=video, assertion=assertion
+        )
+        try:
+            post = _evidence.build_validated_post(flags)
+            result = _evidence.post_evidence_comment(host, post)
+        except (_evidence.EvidenceValidationError, OnBehalfPostBlockedError) as err:
+            self.stderr.write(str(err))
+            raise SystemExit(1) from err
+        self.stdout.write(f"  Evidence {result['action']} on {post.issue_url} (comment {result['comment_id']}).")
+        return result

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -437,6 +437,128 @@ def test_post_issue_comment_returns_empty_dict_when_post_returns_none() -> None:
     assert result == {}
 
 
+def test_list_issue_comments_hits_notes_endpoint() -> None:
+    """list_issue_comments GETs the issue notes endpoint with per_page=100."""
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_json.return_value = [{"id": 1, "body": "a"}, {"id": 2, "body": "b"}]
+    host = GitLabCodeHost(client=client)
+
+    result = host.list_issue_comments(issue_url="https://gitlab.com/org/repo/-/issues/7")
+
+    assert result == [{"id": 1, "body": "a"}, {"id": 2, "body": "b"}]
+    client.get_json.assert_called_once_with("projects/42/issues/7/notes?per_page=100")
+
+
+def test_list_issue_comments_supports_work_items_url() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_json.return_value = []
+    host = GitLabCodeHost(client=client)
+
+    result = host.list_issue_comments(issue_url="https://gitlab.com/group/sub/repo/-/work_items/469")
+
+    assert result == []
+    client.resolve_project.assert_called_once_with("group/sub/repo")
+    client.get_json.assert_called_once_with("projects/42/issues/469/notes?per_page=100")
+
+
+def test_list_issue_comments_returns_empty_on_non_issue_url() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    host = GitLabCodeHost(client=client)
+
+    result = host.list_issue_comments(issue_url="https://gitlab.com/org/repo/-/merge_requests/12")
+
+    assert result == []
+    client.get_json.assert_not_called()
+
+
+def test_list_issue_comments_returns_empty_when_project_unresolved() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = None
+    host = GitLabCodeHost(client=client)
+
+    result = host.list_issue_comments(issue_url="https://gitlab.com/org/repo/-/issues/7")
+
+    assert result == []
+    client.get_json.assert_not_called()
+
+
+def test_list_issue_comments_returns_empty_when_get_returns_non_list() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_json.return_value = {"error": "boom"}
+    host = GitLabCodeHost(client=client)
+
+    result = host.list_issue_comments(issue_url="https://gitlab.com/org/repo/-/issues/7")
+
+    assert result == []
+
+
+def test_update_issue_comment_puts_to_note_endpoint() -> None:
+    """update_issue_comment PUTs the new body to the note's endpoint."""
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.put_json.return_value = {"id": 55, "body": "new"}
+    host = GitLabCodeHost(client=client)
+
+    result = host.update_issue_comment(
+        issue_url="https://gitlab.com/org/repo/-/issues/7",
+        comment_id=55,
+        body="new",
+    )
+
+    assert result == {"id": 55, "body": "new"}
+    client.put_json.assert_called_once_with(
+        "projects/42/issues/7/notes/55",
+        {"body": "new"},
+    )
+
+
+def test_update_issue_comment_rejects_non_issue_url() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    host = GitLabCodeHost(client=client)
+
+    result = host.update_issue_comment(
+        issue_url="https://gitlab.com/org/repo/-/merge_requests/12",
+        comment_id=55,
+        body="new",
+    )
+
+    assert result == {"error": "Not a GitLab issue URL: https://gitlab.com/org/repo/-/merge_requests/12"}
+    client.put_json.assert_not_called()
+
+
+def test_update_issue_comment_returns_error_when_project_unresolved() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = None
+    host = GitLabCodeHost(client=client)
+
+    result = host.update_issue_comment(
+        issue_url="https://gitlab.com/org/repo/-/issues/7",
+        comment_id=55,
+        body="new",
+    )
+
+    assert result == {"error": "Could not resolve project: org/repo"}
+    client.put_json.assert_not_called()
+
+
+def test_update_issue_comment_returns_empty_dict_when_put_returns_none() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.put_json.return_value = None
+    host = GitLabCodeHost(client=client)
+
+    result = host.update_issue_comment(
+        issue_url="https://gitlab.com/org/repo/-/issues/7",
+        comment_id=55,
+        body="new",
+    )
+
+    assert result == {}
+
+
 def test_get_pr_open_state_maps_opened_to_open() -> None:
     from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
 

--- a/tests/teatree_backends/test_protocols.py
+++ b/tests/teatree_backends/test_protocols.py
@@ -88,6 +88,14 @@ class _FakeCodeHost:
         _ = (issue_url, body)
         return {}
 
+    def list_issue_comments(self, *, issue_url: str) -> list[dict[str, object]]:
+        _ = issue_url
+        return []
+
+    def update_issue_comment(self, *, issue_url: str, comment_id: int, body: str) -> dict[str, object]:
+        _ = (issue_url, comment_id, body)
+        return {}
+
     def list_assigned_issues(self, *, assignee: str) -> list[dict[str, object]]:
         _ = assignee
         return []

--- a/tests/teatree_core/e2e_command/test_post_evidence.py
+++ b/tests/teatree_core/e2e_command/test_post_evidence.py
@@ -1,0 +1,365 @@
+"""Tests for ``t3 <overlay> e2e post-evidence`` (souliane/teatree#1409).
+
+Mirrors ``tests/teatree_core/pr_command/test_post_evidence_and_sweep.py``:
+``TestCase`` + ``call_command`` + a ``MagicMock`` host, with the
+``disable_on_behalf_gate`` fixture so the transport-mechanics tests don't
+trip the on-behalf gate.
+
+The hard-fail half asserts the validators refuse bad evidence with no host
+side effect; the idempotency half asserts the (env, commit) hidden-marker
+create-or-update flow; the pure-validator half exercises the regex / hash /
+enum helpers directly.
+"""
+
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.management.commands import _e2e_evidence as _evidence
+from teatree.core.management.commands import e2e as e2e_command
+from teatree.core.management.commands._e2e_evidence import EvidenceEnv
+from tests.teatree_core.conftest import CommandOverlay
+
+_MOCK_OVERLAY = {"test": CommandOverlay()}
+_ISSUE_URL = "https://gitlab.com/org/repo/-/issues/1409"
+
+
+def _write_png(path, payload: bytes) -> str:
+    """Write a tiny distinct PNG-ish blob and return its path string."""
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + payload)
+    return str(path)
+
+
+class _EvidenceTestBase(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        self._monkeypatch = monkeypatch
+        self._tmp = tmp_path
+
+    @pytest.fixture(autouse=True)
+    def _no_on_behalf_gate(
+        self,
+        tmp_path_factory: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from tests.teatree_core._on_behalf_gate_helpers import disable_on_behalf_gate  # noqa: PLC0415
+
+        disable_on_behalf_gate(tmp_path_factory, monkeypatch)
+
+    def _clean_repo(self) -> None:
+        """Make the commit validators deterministic: known SHA + clean tree."""
+        self._monkeypatch.setattr(_evidence.git, "head_sha", lambda repo=".": "a" * 40)
+        self._monkeypatch.setattr(_evidence.git, "status_porcelain", lambda repo=".": "")
+        self._monkeypatch.setattr(
+            _evidence.git,
+            "check",
+            lambda *, repo=".", args: True,
+        )
+
+    def _patch_host(self, host: MagicMock) -> None:
+        self._monkeypatch.setattr(e2e_command, "code_host_from_overlay", lambda: host)
+        # No worktree resolvable from the test cwd → ticket comes from --ticket.
+        self._monkeypatch.setattr(
+            _evidence,
+            "resolve_worktree",
+            MagicMock(side_effect=_evidence.WorktreeNotFoundError("none")),
+        )
+
+    def _before_after(self) -> tuple[str, str]:
+        before = _write_png(self._tmp / "before.png", b"BEFORE")
+        after = _write_png(self._tmp / "after.png", b"AFTER")
+        return before, after
+
+
+class TestHardFail(_EvidenceTestBase):
+    """Each invalid input exits non-zero and posts/uploads nothing."""
+
+    def _run_expecting_exit(self, host: MagicMock, **kwargs: str) -> None:
+        # A real ticket exists, so the ONLY failure path is the validator
+        # under test — never an unresolvable-ticket false positive.
+        from teatree.core.models import Ticket  # noqa: PLC0415
+
+        Ticket.objects.create(overlay="test", issue_url=_ISSUE_URL)
+        self._patch_host(host)
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            pytest.raises(SystemExit),
+        ):
+            call_command("e2e", "post-evidence", **kwargs)
+        host.upload_file.assert_not_called()
+        host.post_issue_comment.assert_not_called()
+        host.update_issue_comment.assert_not_called()
+
+    def test_bad_env(self) -> None:
+        self._clean_repo()
+        before, after = self._before_after()
+        host = MagicMock()
+        self._run_expecting_exit(
+            host,
+            ticket=_ISSUE_URL,
+            env="staging",
+            before=before,
+            after=after,
+            assertion="It works",
+        )
+
+    def test_missing_before(self) -> None:
+        self._clean_repo()
+        _, after = self._before_after()
+        host = MagicMock()
+        self._run_expecting_exit(
+            host,
+            ticket=_ISSUE_URL,
+            env="dev",
+            before="",
+            after=after,
+            assertion="It works",
+        )
+
+    def test_missing_after(self) -> None:
+        self._clean_repo()
+        before, _ = self._before_after()
+        host = MagicMock()
+        self._run_expecting_exit(
+            host,
+            ticket=_ISSUE_URL,
+            env="dev",
+            before=before,
+            after="",
+            assertion="It works",
+        )
+
+    def test_identical_before_after_same_path(self) -> None:
+        self._clean_repo()
+        before, _ = self._before_after()
+        host = MagicMock()
+        self._run_expecting_exit(
+            host,
+            ticket=_ISSUE_URL,
+            env="dev",
+            before=before,
+            after=before,
+            assertion="It works",
+        )
+
+    def test_byte_identical_distinct_paths(self) -> None:
+        self._clean_repo()
+        before = _write_png(self._tmp / "before.png", b"SAME")
+        after = _write_png(self._tmp / "after.png", b"SAME")
+        host = MagicMock()
+        self._run_expecting_exit(
+            host,
+            ticket=_ISSUE_URL,
+            env="local",
+            before=before,
+            after=after,
+            assertion="It works",
+        )
+
+    def test_dirty_tree(self) -> None:
+        self._monkeypatch.setattr(_evidence.git, "head_sha", lambda repo=".": "a" * 40)
+        self._monkeypatch.setattr(_evidence.git, "status_porcelain", lambda repo=".": " M src/x.py")
+        before, after = self._before_after()
+        host = MagicMock()
+        self._run_expecting_exit(
+            host,
+            ticket=_ISSUE_URL,
+            env="dev",
+            before=before,
+            after=after,
+            assertion="It works",
+        )
+
+    def test_unknown_commit(self) -> None:
+        self._monkeypatch.setattr(_evidence.git, "status_porcelain", lambda repo=".": "")
+        self._monkeypatch.setattr(_evidence.git, "check", lambda *, repo=".", args: False)
+        before, after = self._before_after()
+        host = MagicMock()
+        self._run_expecting_exit(
+            host,
+            ticket=_ISSUE_URL,
+            env="dev",
+            commit="deadbeef",
+            before=before,
+            after=after,
+            assertion="It works",
+        )
+
+
+class TestIdempotency(_EvidenceTestBase):
+    """The (env, commit) hidden-marker create-or-update flow (gate disabled)."""
+
+    def _ticket(self) -> None:
+        from teatree.core.models import Ticket  # noqa: PLC0415
+
+        Ticket.objects.create(overlay="test", issue_url=_ISSUE_URL)
+
+    def _run(self, host: MagicMock, **kwargs: str) -> dict[str, object]:
+        self._clean_repo()
+        self._patch_host(host)
+        host.upload_file.return_value = {"markdown": "![x](u)"}
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            return cast("dict[str, object]", call_command("e2e", "post-evidence", **kwargs))
+
+    def _existing_comment(self, *, env: str, commit: str, comment_id: int) -> dict[str, object]:
+        marker = f"<!-- t3-e2e-evidence env={env} commit={commit} -->"
+        return {"id": comment_id, "body": f"{marker}\n## old"}
+
+    def test_creates_new_when_list_empty(self) -> None:
+        self._ticket()
+        before, after = self._before_after()
+        host = MagicMock()
+        host.list_issue_comments.return_value = []
+        host.post_issue_comment.return_value = {"id": 77, "web_url": "u"}
+
+        result = self._run(
+            host,
+            ticket=_ISSUE_URL,
+            env="dev",
+            before=before,
+            after=after,
+            assertion="The thing works",
+        )
+
+        assert result["action"] == "created"
+        assert result["comment_id"] == 77
+        assert result["env"] == "dev"
+        host.post_issue_comment.assert_called_once()
+        host.update_issue_comment.assert_not_called()
+        body = host.post_issue_comment.call_args.kwargs["body"]
+        assert "t3-e2e-evidence env=dev commit=" + "a" * 40 in body
+        assert "The thing works" in body
+
+    def test_updates_when_marker_env_and_commit_match(self) -> None:
+        self._ticket()
+        before, after = self._before_after()
+        host = MagicMock()
+        host.list_issue_comments.return_value = [
+            self._existing_comment(env="dev", commit="a" * 40, comment_id=33),
+        ]
+        host.update_issue_comment.return_value = {"id": 33, "web_url": "u"}
+
+        result = self._run(
+            host,
+            ticket=_ISSUE_URL,
+            env="dev",
+            before=before,
+            after=after,
+            assertion="works",
+        )
+
+        assert result["action"] == "updated"
+        assert result["comment_id"] == 33
+        host.update_issue_comment.assert_called_once()
+        host.post_issue_comment.assert_not_called()
+
+    def test_new_comment_when_commit_differs(self) -> None:
+        self._ticket()
+        before, after = self._before_after()
+        host = MagicMock()
+        host.list_issue_comments.return_value = [
+            self._existing_comment(env="dev", commit="b" * 40, comment_id=33),
+        ]
+        host.post_issue_comment.return_value = {"id": 88}
+
+        result = self._run(
+            host,
+            ticket=_ISSUE_URL,
+            env="dev",
+            before=before,
+            after=after,
+            assertion="works",
+        )
+
+        assert result["action"] == "created"
+        host.post_issue_comment.assert_called_once()
+        host.update_issue_comment.assert_not_called()
+
+    def test_new_comment_when_env_differs(self) -> None:
+        self._ticket()
+        before, after = self._before_after()
+        host = MagicMock()
+        host.list_issue_comments.return_value = [
+            self._existing_comment(env="local", commit="a" * 40, comment_id=33),
+        ]
+        host.post_issue_comment.return_value = {"id": 99}
+
+        result = self._run(
+            host,
+            ticket=_ISSUE_URL,
+            env="dev",
+            before=before,
+            after=after,
+            assertion="works",
+        )
+
+        assert result["action"] == "created"
+        host.post_issue_comment.assert_called_once()
+        host.update_issue_comment.assert_not_called()
+
+
+class TestPureValidators:
+    """The pure helpers in ``_e2e_evidence`` are independently testable."""
+
+    def test_marker_regex_round_trip(self) -> None:
+        marker = _evidence.evidence_marker(env=EvidenceEnv.DEV, commit="c" * 40)
+        match = _evidence._E2E_MARKER_RE.search(f"prefix {marker} suffix")
+        assert match is not None
+        assert match.group("env") == "dev"
+        assert match.group("commit") == "c" * 40
+
+    def test_before_after_hash_compare(self, tmp_path) -> None:
+        a = tmp_path / "a.png"
+        b = tmp_path / "b.png"
+        a.write_bytes(b"AAA")
+        b.write_bytes(b"BBB")
+        # Distinct bytes pass.
+        _evidence.validate_before_differs_from_after(before=a, after=b)
+        # Same bytes (distinct path) fail.
+        b.write_bytes(b"AAA")
+        with pytest.raises(_evidence.EvidenceValidationError):
+            _evidence.validate_before_differs_from_after(before=a, after=b)
+
+    def test_env_enum_coercion(self) -> None:
+        assert _evidence.coerce_env("DEV") is EvidenceEnv.DEV
+        assert _evidence.coerce_env(" local ") is EvidenceEnv.LOCAL
+        with pytest.raises(_evidence.EvidenceValidationError):
+            _evidence.coerce_env("")
+        with pytest.raises(_evidence.EvidenceValidationError):
+            _evidence.coerce_env("prod")
+
+    def test_find_matching_comment_ignores_other_markers(self) -> None:
+        comments = [
+            {"id": 1, "body": "<!-- t3-e2e-evidence env=dev commit=zzz -->\nx"},
+            {"id": 2, "body": "no marker here"},
+            {"id": 3, "body": "<!-- t3-e2e-evidence env=local commit=yyy -->\nx"},
+        ]
+        assert _evidence.find_matching_comment(comments, env=EvidenceEnv.DEV, commit="zzz") == 1
+        assert _evidence.find_matching_comment(comments, env=EvidenceEnv.DEV, commit="nope") is None
+
+    def test_build_body_includes_video_row_only_when_given(self) -> None:
+        without = _evidence.build_evidence_body(
+            _evidence.EvidenceComment(
+                env=EvidenceEnv.LOCAL,
+                commit="d" * 40,
+                before_md="![b](b)",
+                after_md="![a](a)",
+                assertion="claim",
+            ),
+        )
+        assert "Video" not in without
+        assert "environment: **LOCAL**" in without
+        with_video = _evidence.build_evidence_body(
+            _evidence.EvidenceComment(
+                env=EvidenceEnv.LOCAL,
+                commit="d" * 40,
+                before_md="![b](b)",
+                after_md="![a](a)",
+                assertion="claim",
+                video_md="[vid](v)",
+            ),
+        )
+        assert "| Video | [vid](v) |" in with_video

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -17,6 +17,7 @@ from django.utils.module_loading import import_string
 import teatree.config as config_mod
 import teatree.core.backend_factory as backend_factory_mod
 import teatree.core.management.commands._e2e_discovery as e2e_disc_mod
+import teatree.core.management.commands._e2e_runners as e2e_runners_mod
 import teatree.core.management.commands.e2e as e2e_mod
 import teatree.utils.run as utils_run_mod
 from teatree.core.models import Ticket, Worktree
@@ -914,7 +915,7 @@ class TestCloneOrUpdateE2eRepo(TestCase):
             cache_path = tmp_path / "e2e-repos" / "demo-svc"
 
             with (
-                patch.object(e2e_mod, "get_data_dir", return_value=tmp_path / "e2e-repos"),
+                patch.object(e2e_runners_mod, "get_data_dir", return_value=tmp_path / "e2e-repos"),
                 patch.object(utils_run_mod.subprocess, "run", return_value=MagicMock(returncode=0)) as mock_run,
             ):
                 e2e_mod._clone_or_update_e2e_repo(self._make_repo())
@@ -938,7 +939,7 @@ class TestCloneOrUpdateE2eRepo(TestCase):
                 return MagicMock(returncode=0)
 
             with (
-                patch.object(e2e_mod, "get_data_dir", return_value=tmp_path / "e2e-repos"),
+                patch.object(e2e_runners_mod, "get_data_dir", return_value=tmp_path / "e2e-repos"),
                 patch.object(utils_run_mod.subprocess, "run", side_effect=capture_run),
             ):
                 e2e_mod._clone_or_update_e2e_repo(self._make_repo())
@@ -953,7 +954,7 @@ class TestCloneOrUpdateE2eRepo(TestCase):
             (tmp_path / "e2e-repos" / "demo-svc").mkdir(parents=True)
 
             with (
-                patch.object(e2e_mod, "get_data_dir", return_value=tmp_path / "e2e-repos"),
+                patch.object(e2e_runners_mod, "get_data_dir", return_value=tmp_path / "e2e-repos"),
                 patch.object(utils_run_mod.subprocess, "run", return_value=MagicMock(returncode=0)),
             ):
                 result = e2e_mod._clone_or_update_e2e_repo(self._make_repo(e2e_dir="playwright"))
@@ -1051,8 +1052,8 @@ class TestE2EResolveTarget(TestCase):
 
     def test_build_env_exports_t3_e2e_target(self) -> None:
         with (
-            patch.object(e2e_mod, "get_overlay") as get_overlay,
-            patch.object(e2e_mod, "_find_env_cache", return_value=None),
+            patch.object(e2e_runners_mod, "get_overlay") as get_overlay,
+            patch.object(e2e_runners_mod, "_find_env_cache", return_value=None),
         ):
             get_overlay.return_value.get_e2e_env_extras.return_value = {}
             env = e2e_mod._build_e2e_env("http://localhost:4200", headed=False, target="local")

--- a/tests/teatree_core/test_provisioning_contract.py
+++ b/tests/teatree_core/test_provisioning_contract.py
@@ -364,8 +364,8 @@ class E2eEnvMergeContractTests(TestCase):
 
     def _build(self) -> dict[str, str]:
         with (
-            patch("teatree.core.management.commands.e2e.get_overlay", return_value=_FixedExtrasOverlay()),
-            patch("teatree.core.management.commands.e2e._find_env_cache", return_value=None),
+            patch("teatree.core.management.commands._e2e_runners.get_overlay", return_value=_FixedExtrasOverlay()),
+            patch("teatree.core.management.commands._e2e_runners._find_env_cache", return_value=None),
         ):
             return _build_e2e_env(None, headed=False, target="local")
 

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -447,6 +447,39 @@ class TestGitHubCodeHost:
             result = host.list_pr_comments(repo="org/repo", pr_iid=5)
         assert result == []
 
+    def test_list_issue_comments_returns_payload(self) -> None:
+        notes = [{"id": 1, "body": "x"}]
+        with patch.object(github_mod, "_gh_api_get", return_value=notes) as mock_get:
+            host = GitHubCodeHost()
+            result = host.list_issue_comments(issue_url="https://github.com/souliane/teatree/issues/7")
+        assert result == notes
+        assert "repos/souliane/teatree/issues/7/comments" in mock_get.call_args.args[0]
+
+    def test_list_issue_comments_returns_empty_for_non_issue_url(self) -> None:
+        host = GitHubCodeHost()
+        result = host.list_issue_comments(issue_url="https://github.com/souliane/teatree/pull/7")
+        assert result == []
+
+    def test_update_issue_comment_patches_comment_endpoint(self) -> None:
+        with patch.object(github_mod, "_gh_api_patch", return_value={"id": 99}) as mock_patch:
+            host = GitHubCodeHost()
+            result = host.update_issue_comment(
+                issue_url="https://github.com/souliane/teatree/issues/7",
+                comment_id=99,
+                body="new",
+            )
+        assert result == {"id": 99}
+        assert mock_patch.call_args.args[0] == "repos/souliane/teatree/issues/comments/99"
+
+    def test_update_issue_comment_rejects_non_issue_url(self) -> None:
+        host = GitHubCodeHost()
+        result = host.update_issue_comment(
+            issue_url="https://github.com/souliane/teatree/pull/7",
+            comment_id=99,
+            body="new",
+        )
+        assert "error" in result
+
     def test_upload_file_raises(self) -> None:
         host = GitHubCodeHost()
         import pytest  # noqa: PLC0415


### PR DESCRIPTION
Adds a new `t3 <overlay> e2e post-evidence` core command — the enforcement artifact for the recurring E2E-evidence trust failures tracked in #1409.

## What it does

Posts ONE structured evidence comment on the **ticket** (work item / bug), never on the MR — even when MRs are open. The deployed-environment proof belongs to the issue the work closes and stays attached after the MR merges.

It is validation-gated and refuses bad evidence before any upload or post:

- `--env` must be `dev` or `local` — the previously prose-only "evidence comes from the deployed environment" rule is now machine-enforced.
- `--before` / `--after` must be present and not byte-identical (anti-fake; same path or same SHA-256 bytes both fail). Byte-level compare only — Pillow is intentionally not pulled in.
- the commit must be known (`git rev-parse --verify`) and the working tree clean (`git status --porcelain` empty) so the evidence is reproducible.

Idempotency is keyed on a hidden HTML-comment marker `<!-- t3-e2e-evidence env=<env> commit=<sha> -->`: a re-run on the same `(env, commit)` edits the existing comment in place (`action="updated"`); a different env or commit posts a new comment (`action="created"`).

On-behalf-gated (#960) like every colleague-visible post, with the after-receipt user DM.

## Backend seam

New `CodeHostBackend` protocol methods `list_issue_comments` / `update_issue_comment`, implemented for GitLab (issue notes `GET` / `PUT`) and GitHub (issue comments `GET` / `PATCH`).

## Structure

Heavy logic lives in sibling modules so e2e.py stays under the LOC cap and the validators are independently unit-tested:

- `_e2e_evidence.py` — env enum, artifact-presence, before≠after, commit known+clean validators, the hidden-marker regex, the comment-body builder, and the create-or-update posting orchestration.
- `_e2e_runners.py` — the external-test-repo clone and Playwright-env helpers extracted out of e2e.py (mirrors the existing `_e2e_discovery` split).

## Tests

New `tests/teatree_core/e2e_command/test_post_evidence.py` (hard-fail validators with no host side effect, the create/update idempotency matrix, pure-validator units) plus GitLab and GitHub backend tests for the two new methods.

## Docs

BLUEPRINT.md, management-commands.md, the generated CLI reference, and the e2e SKILL ("Post Testing Evidence on the Ticket") all updated. The SKILL now documents the machine-enforced dev/local gate and the (ticket, env, commit) marker idempotency.

Closes #1409