### PR TITLE
fix(hooks): snapshot Agent-tool background sub-agents in PreCompact (#778)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -50,7 +50,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|Write|Edit|Read|Grep|Glob|TodoWrite",
+        "matcher": "Bash|Write|Edit|Read|Grep|Glob|TodoWrite|Agent",
         "hooks": [
           {
             "type": "command",

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -1669,6 +1669,98 @@ def handle_track_todos(data: dict) -> None:
     todos_file.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
 
 
+# ── PostToolUse: capture Agent-tool sub-agent dispatches ───────────
+#
+# Issue #778 (reopened): the PreCompact snapshot pinned the loop
+# tick-owner (#786 WS3) but NOT ad-hoc background sub-agents an
+# orchestrator dispatches via the ``Agent`` tool. The dispatched
+# agentId is the handle ``SendMessage`` needs to resume/steer/collect a
+# running agent; it lives only in the conversation and is lost on
+# auto-compaction, orphaning the agent. Mirror the #970 ``TodoWrite``
+# capture: on every ``Agent`` PostToolUse, append the agentId + its
+# role/description to ``<session>.agents`` so the snapshot can quote the
+# roster back. Each line is ``<agentId>\t<role>`` — append-only, deduped
+# on agentId, so a multi-agent fan-out accumulates rather than clobbers.
+
+
+_AGENT_ID_KEYS = ("agentId", "agent_id", "id")
+
+
+def _agent_id_from_response(tool_response: object) -> str:
+    """Extract the dispatched agentId from an ``Agent`` PostToolUse payload.
+
+    The harness response shape is not contractually fixed, so probe the
+    known id-bearing keys on a dict response (``agentId`` / ``agent_id``
+    / ``id``). Returns ``""`` when none is present — the caller then
+    falls back to scanning the harness tasks dir.
+    """
+    from typing import cast  # noqa: PLC0415
+
+    if not isinstance(tool_response, dict):
+        return ""
+    response = cast("dict[str, object]", tool_response)
+    for key in _AGENT_ID_KEYS:
+        value = response.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _newest_task_agent_id() -> str:
+    """Scan the harness tasks output dir for the newest ``a*`` task id.
+
+    Fallback used only when the PostToolUse payload does not expose the
+    agentId. The harness writes one ``<agentId>.output`` file per
+    dispatched task under ``CLAUDE_TASKS_DIR`` (or
+    ``~/.claude/tasks``); the dispatched sub-agent's id is ``a``-prefixed.
+    Returns the most-recently-modified match, or ``""`` when the dir is
+    absent / has no match. Never raises — capture must never block the
+    orchestrator.
+    """
+    tasks_dir = Path(os.environ.get("CLAUDE_TASKS_DIR", str(Path.home() / ".claude" / "tasks")))
+    try:
+        candidates = [p for p in tasks_dir.glob("a*.output") if p.is_file()]
+    except OSError:
+        return ""
+    if not candidates:
+        return ""
+    newest = max(candidates, key=lambda p: p.stat().st_mtime)
+    return newest.stem
+
+
+def handle_track_agents(data: dict) -> None:
+    """Persist a dispatched ``Agent`` sub-agent's id + role to ``<session>.agents``.
+
+    No-op for any other tool name. Prefers the agentId carried on the
+    PostToolUse ``tool_response`` (``tool_result`` as a secondary
+    payload key); falls back to the newest ``a*`` id under the harness
+    tasks dir when the payload omits it. Append-only and deduped on
+    agentId so a parallel fan-out of sub-agents all survive compaction.
+    """
+    if data.get("tool_name") != "Agent":
+        return
+    session_id = data.get("session_id", "")
+    if not session_id:
+        return
+
+    agent_id = _agent_id_from_response(data.get("tool_response"))
+    if not agent_id:
+        agent_id = _agent_id_from_response(data.get("tool_result"))
+    if not agent_id:
+        agent_id = _newest_task_agent_id()
+    if not agent_id:
+        return
+
+    tool_input = data.get("tool_input", {})
+    role = str(tool_input.get("description") or tool_input.get("subagent_type") or "(no description)").strip()
+
+    _ensure_state_dir()
+    agents_file = _state_file(session_id, "agents")
+    if any(line.split("\t", 1)[0] == agent_id for line in _read_lines(agents_file)):
+        return
+    _append_line(agents_file, f"{agent_id}\t{role}")
+
+
 # ── PreCompact: retro-before-compact ──────────────────────────────
 
 
@@ -1848,6 +1940,22 @@ def _durable_session_snapshot(session_id: str, data: dict | None = None) -> str:
         for _name, entry in sorted(owned):
             agent_id = entry.get("agent_id") or "(agent id not recorded)"
             lines.append(f"- tick-owner agentId `{agent_id}` (pid {entry.get('pid', '?')})")
+
+    dispatched = _read_lines(_state_file(session_id, "agents"))
+    if dispatched:
+        lines += [
+            "",
+            "## Dispatched background sub-agents",
+            (
+                "Ad-hoc `Agent`-tool sub-agents dispatched this session "
+                "(#778). Their agentIds are the handle `SendMessage` needs "
+                "to resume / steer / collect a still-running agent — reuse "
+                "them rather than re-dispatching duplicate work."
+            ),
+        ]
+        for line in dispatched:
+            agent_id, _, role = line.partition("\t")
+            lines.append(f"- agentId `{agent_id}` — {role or '(no description)'}")
 
     todos = _read_lines(_state_file(session_id, "todos"))
     if todos:
@@ -4218,6 +4326,7 @@ _HANDLERS: dict[str, list] = {
         handle_track_cron_jobs,
         handle_read_dedup,
         handle_track_todos,
+        handle_track_agents,
         handle_track_plan_invocation,
         handle_track_plan_skill_timestamp,
         handle_track_workspace_source_read,

--- a/tests/test_pre_compact_snapshot_enriched.py
+++ b/tests/test_pre_compact_snapshot_enriched.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 
 import hooks.scripts.hook_router as router
-from hooks.scripts.hook_router import _T3_TEMP_PREFIX, handle_pre_compact, handle_track_todos
+from hooks.scripts.hook_router import _T3_TEMP_PREFIX, handle_pre_compact, handle_track_agents, handle_track_todos
 
 
 @pytest.fixture(autouse=True)
@@ -245,6 +245,107 @@ class TestTodoCaptureAndSnapshot:
         assert "Pending TODOs" in body
         assert "fix snapshot" in body
         assert "push PR" in body
+
+
+class TestAgentDispatchCaptureAndSnapshot:
+    """Background sub-agents dispatched via the Agent tool must survive compaction.
+
+    Issue #778 (reopened): the PreCompact snapshot captured the loop
+    tick-owner (#786 WS3) but NOT ad-hoc background sub-agents an
+    orchestrator dispatches via the ``Agent`` tool. Those agentIds — the
+    handle ``SendMessage`` needs to resume/steer/collect a running agent
+    — live only in the conversation and are lost on auto-compaction,
+    orphaning the running agents. Mirror the #970 ``TodoWrite`` capture:
+    a PostToolUse on ``Agent`` appends the dispatched agentId + its role
+    to ``<session>.agents`` so the snapshot can quote the roster back.
+    """
+
+    def test_agent_dispatch_captured_to_session_agents_file(self) -> None:
+        session_id = "sess-agent-capture"
+        handle_track_agents(
+            {
+                "session_id": session_id,
+                "tool_name": "Agent",
+                "tool_input": {"description": "implement #778 fix", "subagent_type": "t3-coder"},
+                "tool_response": {"agentId": "a1b2c3d4"},
+            }
+        )
+        agents_file = router.STATE_DIR / f"{session_id}.agents"
+        assert agents_file.is_file()
+        text = agents_file.read_text(encoding="utf-8")
+        assert "a1b2c3d4" in text
+        assert "implement #778 fix" in text
+
+    def test_non_agent_tool_does_not_write_agents_file(self) -> None:
+        session_id = "sess-agent-noclobber"
+        handle_track_agents({"session_id": session_id, "tool_name": "Read", "tool_input": {"file_path": "x"}})
+        assert not (router.STATE_DIR / f"{session_id}.agents").is_file()
+
+    def test_multiple_dispatches_accumulate_not_clobber(self) -> None:
+        session_id = "sess-agent-accumulate"
+        handle_track_agents(
+            {
+                "session_id": session_id,
+                "tool_name": "Agent",
+                "tool_input": {"description": "first agent"},
+                "tool_response": {"agentId": "aaaa1111"},
+            }
+        )
+        handle_track_agents(
+            {
+                "session_id": session_id,
+                "tool_name": "Agent",
+                "tool_input": {"description": "second agent"},
+                "tool_response": {"agentId": "bbbb2222"},
+            }
+        )
+        text = (router.STATE_DIR / f"{session_id}.agents").read_text(encoding="utf-8")
+        assert "aaaa1111" in text
+        assert "bbbb2222" in text
+        assert "first agent" in text
+        assert "second agent" in text
+
+    def test_snapshot_renders_dispatched_agents_roster(self) -> None:
+        session_id = "sess-agent-render"
+        handle_track_agents(
+            {
+                "session_id": session_id,
+                "tool_name": "Agent",
+                "tool_input": {"description": "fix snapshot regression", "subagent_type": "t3-coder"},
+                "tool_response": {"agentId": "deadbeef"},
+            }
+        )
+
+        handle_pre_compact({"session_id": session_id})
+
+        body = _snapshot_for(session_id).read_text(encoding="utf-8")
+        assert "deadbeef" in body
+        assert "fix snapshot regression" in body
+
+    def test_agent_dispatch_capture_falls_back_to_tasks_dir_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # When the PostToolUse payload does not expose the agentId directly,
+        # the handler scans the harness tasks output dir for the newest
+        # ``a*``-prefixed id (the SendMessage handle).
+        session_id = "sess-agent-fallback"
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir(parents=True)
+        (tasks_dir / "afeedface.output").write_text("running\n", encoding="utf-8")
+        monkeypatch.setenv("CLAUDE_TASKS_DIR", str(tasks_dir))
+
+        handle_track_agents(
+            {
+                "session_id": session_id,
+                "tool_name": "Agent",
+                "tool_input": {"description": "no-id agent"},
+                "tool_response": {},
+            }
+        )
+
+        text = (router.STATE_DIR / f"{session_id}.agents").read_text(encoding="utf-8")
+        assert "afeedface" in text
+        assert "no-id agent" in text
 
 
 class TestSnapshotResilience:


### PR DESCRIPTION
## Problem

The PreCompact durable-state snapshot (`_durable_session_snapshot`) captures the loop **tick-owner** ([#786](https://github.com/souliane/teatree/issues/786) WS3) and the [#970](https://github.com/souliane/teatree/issues/970) recovery context (cwd, git state, open PRs, TODOs). It did **not** capture ad-hoc background sub-agents an orchestrator dispatches via the `Agent` tool.

Those `agentId`s are the handle `SendMessage` needs to resume, steer, or collect a still-running agent. They live only in the conversation transcript and are lost on auto-compaction, orphaning the running agents — a regression of the closed issue [#778](https://github.com/souliane/teatree/issues/778).

## Fix

Mirror the [#970](https://github.com/souliane/teatree/issues/970) `TodoWrite` capture pattern:

1. **PostToolUse capture on `Agent`** (`handle_track_agents`) appends the dispatched sub-agent's `agentId` + its `description`/`subagent_type` role to a durable per-session `<session>.agents` file (parallel to `<session>.todos`). Registered in `hooks.json` (added `Agent` to the PostToolUse matcher) and routed in `hook_router.py`.
   - Prefers the `agentId` exposed on the PostToolUse `tool_response` (`tool_result` as a secondary key).
   - Falls back to scanning the harness tasks output dir (`CLAUDE_TASKS_DIR`) for the newest `a*`-prefixed id when the payload omits it.
   - Append-only and deduped on `agentId`, so a parallel fan-out of sub-agents all survive compaction.
2. **Snapshot roster** — `_durable_session_snapshot` renders a "Dispatched background sub-agents" section (agentId + role) so the recovery snapshot carries the handles; a compacted orchestrator reuses them rather than re-dispatching duplicate work.

## Test

Extended `tests/test_pre_compact_snapshot_enriched.py` with `TestAgentDispatchCaptureAndSnapshot` (5 cases): capture, no-op on non-Agent tools, accumulation across dispatches, snapshot rendering, and the tasks-dir fallback.

Observed RED before the fix (import error + `agents_file.is_file()` assertion failure with the capture disabled), GREEN after. Full suite green apart from one pre-existing, config-isolation failure unrelated to this change (`test_contrib_overlay.py::TestMaxConcurrentAutoStarts::test_in_repo_overlay_resolves_to_three`, which reads the live local overlay config).

Closes #778