### PR TITLE
fix(loop/statusline): per-loop next-tick line, drop self_update cruft, terse MR topics

### DIFF
--- a/src/teatree/core/management/commands/loop_tick.py
+++ b/src/teatree/core/management/commands/loop_tick.py
@@ -30,6 +30,13 @@ from django_typer.management import TyperCommand
 
 from teatree.loop.tick import TickReport
 
+# The persistent ``loop-owner`` claim TTL reader lives in
+# ``teatree.loop.tick_piggyback`` alongside its sibling per-loop cadence
+# readers so the statusline's per-loop next-tick countdown (#1400) can reach
+# it without ``teatree.loop`` importing back into ``teatree.core.management``.
+# Re-exported here so this command (and its tests) keep the original name.
+from teatree.loop.tick_piggyback import _loop_owner_ttl_seconds
+
 type ReportDict = dict[str, Any]
 
 
@@ -65,28 +72,6 @@ def _skipped_report_dict(started_at: dt.datetime, reason: str) -> ReportDict:
         "skipped": True,
         "skipped_reason": reason,
     }
-
-
-_LOOP_OWNER_TTL_DEFAULT = 1800
-
-
-def _loop_owner_ttl_seconds() -> int:
-    """The persistent ``loop-owner`` claim TTL (``T3_LOOP_OWNER_TTL``, default 1800s).
-
-    Parsed defensively like ``cli.loop._cadence_for_loop_slot``: a blank
-    or non-integer override degrades to the default rather than crashing
-    the tick; the floor of 60s keeps a fat-fingered tiny TTL from making
-    the owner lapse mid-tick.
-    """
-    import os  # noqa: PLC0415
-
-    raw = os.environ.get("T3_LOOP_OWNER_TTL", str(_LOOP_OWNER_TTL_DEFAULT)).strip()
-    if not raw:
-        return _LOOP_OWNER_TTL_DEFAULT
-    try:
-        return max(60, int(raw))
-    except ValueError:
-        return _LOOP_OWNER_TTL_DEFAULT
 
 
 class Command(TyperCommand):

--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -92,6 +92,23 @@ _STATUSLINE_ZONE_BY_KIND: dict[str, str] = {
 # only the statusline rendering is suppressed.
 _STATUSLINE_DROP_KINDS: frozenset[str] = frozenset({"outbound.audit_skipped"})
 
+# Signal-kind *prefixes* whose every outcome is internal scanner state, not
+# user-facing statusline content. The ``self_update.*`` family
+# (``cadence_not_elapsed``, ``up_to_date``, ``updated``, ``skipped``,
+# ``failed``) is the auto-update scanner's per-repo bookkeeping; its
+# ``reason`` payload (e.g. ``recent_marker``) used to leak into the
+# statusline as a mystery ``recent_marker: ?`` row because the renderer
+# treats any ``reason``-bearing action as a ticket disposition. The
+# update outcome is logged and persisted on ``SelfUpdateMarker`` — the
+# statusline is the wrong surface for it.
+_STATUSLINE_DROP_PREFIXES: tuple[str, ...] = ("self_update.",)
+
+
+def _is_statusline_dropped(kind: str) -> bool:
+    """True when *kind* is diagnostic-only and must not reach the statusline."""
+    return kind in _STATUSLINE_DROP_KINDS or kind.startswith(_STATUSLINE_DROP_PREFIXES)
+
+
 _PR_URL_RE = re.compile(r"https?://[^\s>|]+/(?:merge_requests|pull|pulls)/\d+")
 
 
@@ -323,7 +340,7 @@ def _claim_red_mr_fix(signal: ScanSignal) -> bool:
 
 
 def _dispatch_one(signal: ScanSignal) -> list[DispatchAction]:
-    if signal.kind in _STATUSLINE_DROP_KINDS:
+    if _is_statusline_dropped(signal.kind):
         return []
     conditional = _conditional_dispatch(signal)
     if conditional is not None:

--- a/src/teatree/loop/rendering_items.py
+++ b/src/teatree/loop/rendering_items.py
@@ -12,6 +12,7 @@ the same look without each render path re-implementing description truncation
 or comma joining.
 """
 
+import re
 from dataclasses import dataclass, field
 from typing import Protocol
 
@@ -20,27 +21,41 @@ class _LinkFn(Protocol):
     def __call__(self, text: str, url: object, *, colorize: bool) -> str: ...
 
 
-# Canonical item-shape description width (#1015): ``#N (short desc) (!M)``.
-# 40 chars is wide enough for a useful title chunk on a single-line
-# statusline but narrow enough that three tickets per state line still
-# fit a typical terminal. Truncated descriptions are tail-elided with a
-# single-codepoint Unicode ellipsis so the visible width stays predictable.
-_ITEM_DESC_LEN = 40
+# Canonical statusline chip shape: ``#N (terse topic) !M1 !M2``. The
+# ``(topic)`` chunk is a 2-3 word gist, not the full commit subject —
+# a chip is a glance-target, not a changelog. The full title still lives
+# on the OSC-8 hyperlink target, so nothing is lost.
+_TOPIC_WORDS = 3
+_TOPIC_MAX_LEN = 24
+
+# Conventional-commit / scoped prefix (``fix:``, ``feat(loop):``,
+# ``techdebt:``) carries no topic signal on a chip — every chip is already
+# work-in-flight — so it is stripped before the word budget is applied.
+_CC_PREFIX_RE = re.compile(r"^[a-z][\w-]*(?:\([^)]*\))?!?:\s*", re.IGNORECASE)
 
 
 def _short_desc(title: str) -> str:
-    """Return *title* truncated to the canonical item-shape width.
+    """Return a terse 2-3 word topic for *title* (the chip ``(topic)`` chunk).
 
     Empty input → empty output (caller suppresses the ``(desc)`` chunk).
-    Titles within budget pass through verbatim; longer ones are tail-elided
-    with a Unicode ellipsis so the rendered width never exceeds
-    ``_ITEM_DESC_LEN``.
+    The leading conventional-commit prefix (``fix:``, ``feat(loop):``,
+    ``techdebt:``) is dropped, then the first :data:`_TOPIC_WORDS` words are
+    kept and capped at :data:`_TOPIC_MAX_LEN` chars with a single-codepoint
+    Unicode ellipsis — so a long commit subject like
+    ``techdebt: refactor PLW0717 try-clause-too-long across modules``
+    collapses to ``refactor PLW0717 try-clause-…`` rather than a 40-char
+    slice of the whole subject.
     """
     if not title:
         return ""
-    if len(title) <= _ITEM_DESC_LEN:
-        return title
-    return title[: _ITEM_DESC_LEN - 1] + "…"
+    stripped = _CC_PREFIX_RE.sub("", title, count=1).strip()
+    if not stripped:
+        stripped = title.strip()
+    words = stripped.split()
+    topic = " ".join(words[:_TOPIC_WORDS])
+    if len(topic) > _TOPIC_MAX_LEN:
+        return topic[: _TOPIC_MAX_LEN - 1].rstrip() + "…"
+    return topic
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -3,6 +3,7 @@ import re
 import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from itertools import starmap
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -192,47 +193,53 @@ def availability_anchor(mode: str, queued: int) -> str:
     return "mode=away"
 
 
-def _live_loop_names() -> list[tuple[str, str]]:
-    """Return ``(loop_name, session_id)`` for every currently-live LoopLease.
+def _live_loop_leases() -> list[tuple[str, datetime | None]]:
+    """Return ``(loop_name, acquired_at)`` for every currently-live LoopLease.
 
     Isolated as a thin DB-read seam so :func:`live_loops_anchor` stays a
     pure formatter — tests stub this function rather than constructing
     LoopLease fixtures, and the renderer keeps a single try/except gate
-    around it for fail-open semantics.
+    around it for fail-open semantics. ``acquired_at`` is ``None`` for a
+    lease row that has never recorded an acquire (no tick yet); the
+    renderer then drops the per-loop countdown for that loop.
     """
     from django.apps import apps  # noqa: PLC0415
     from django.utils import timezone  # noqa: PLC0415
 
     lease_model = apps.get_model("core", "LoopLease")
-    rows = lease_model.objects.filter(lease_expires_at__gt=timezone.now()).only("name", "session_id").order_by("name")
-    return [(row.name, row.session_id) for row in rows]
+    rows = lease_model.objects.filter(lease_expires_at__gt=timezone.now()).only("name", "acquired_at").order_by("name")
+    return [(row.name, row.acquired_at) for row in rows]
 
 
-def _loop_tick_acquired_at() -> datetime | None:
-    """Return the most recent ``acquired_at`` for the ``loop-tick`` lease.
+# Per-loop cadence resolution (#1400). Each named loop ticks on its own
+# schedule, so the next-tick countdown is ``acquired_at + cadence`` with the
+# loop's own cadence — not a single shared value. Unknown / future loops fall
+# back to the ``loop-tick`` cadence so a newly-added loop surfaces without a
+# code change here. The per-loop cadence readers live next to each loop's
+# owning module; this is the single place that maps a loop name to its reader.
+def _cadence_for_loop(name: str) -> int:
+    """Return the cadence in seconds for the named loop (``loop-tick`` fallback)."""
+    if name == "loop-slack-answer":
+        from teatree.loop.tick_piggyback import _slack_answer_cadence_seconds  # noqa: PLC0415
 
-    Isolated as a thin DB-read seam (mirrors :func:`_live_loop_names`) so
-    :func:`live_loops_anchor` stays pure and tests stub this directly
-    rather than constructing LoopLease fixtures with timestamps.
+        return _slack_answer_cadence_seconds()
+    if name == "loop-self-improve":
+        from teatree.loop.tick_piggyback import _self_improve_cadence_seconds  # noqa: PLC0415
 
-    Returns ``None`` when no row exists yet (no tick has ever fired) so
-    the renderer can render a ``last tick: never`` fallback instead of
-    pretending to know.
-    """
-    from django.apps import apps  # noqa: PLC0415
+        return _self_improve_cadence_seconds()
+    if name == "loop-owner":
+        from teatree.loop.tick_piggyback import _loop_owner_ttl_seconds  # noqa: PLC0415
 
-    lease_model = apps.get_model("core", "LoopLease")
-    row = lease_model.objects.filter(name="loop-tick").values("acquired_at").first()
-    if row is None:
-        return None
-    return row.get("acquired_at")
+        return _loop_owner_ttl_seconds()
+    return _cadence_seconds()
 
 
 def _cadence_seconds() -> int:
-    """Return the resolved loop cadence in seconds.
+    """Return the resolved ``loop-tick`` cadence in seconds.
 
     Isolated as a seam so tests can stub it without spinning up the
     full config layer; production reads :func:`teatree.config.cadence_seconds`.
+    Doubles as the fallback cadence for loops with no dedicated reader.
     """
     from teatree.config import cadence_seconds  # noqa: PLC0415
 
@@ -265,25 +272,31 @@ def loop_owner_anchor(status: "OwnershipStatus", this_session: str) -> tuple[str
 
 
 def live_loops_anchor() -> list[str]:
-    """Return one consolidated dim anchor line summarising live loops.
+    """Return one dedicated dim anchor line listing every live loop (#1400).
 
     Single line, prepended at the top of the statusline so the user's
-    "where is the loop right now?" question is answered with one glance:
+    "which loops are live and when do they tick?" question is answered
+    with one glance:
 
-        ``loop · next tick in 3m12s · 5 loops live``
+        ``loop · my-prs 11m · tickets 11m · slack-answer 1m``
 
-    Components, in order:
+    Each live :class:`~teatree.core.models.LoopLease` contributes one
+    ``<short-name> <next-tick>`` chunk:
 
-    *   ``next tick in <duration>`` when the ``loop-tick`` lease has fired
-        at least once and a cadence is configured; the next-tick instant
-        is ``acquired_at + cadence_seconds``. ``next tick due`` when the
-        deadline has already passed (the next ``t3 loop tick`` is overdue
-        but no tick has acquired the lease yet, e.g. cron paused).
-        ``last tick: never`` when no row exists yet (no tick has fired).
-    *   ``<N loops live>`` — the headline number, deduped per-loop.
-        Replaces the prior one-line-per-loop dump (``loop:tick``,
-        ``loop:owner``, …) which the user explicitly did not want at the
-        top of the statusline.
+    *   ``<short-name>`` — the lease name with its ``loop-`` prefix
+        stripped (``loop-my-prs`` → ``my-prs``), so the user reads which
+        loops are running, not an opaque count.
+    *   ``<next-tick>`` — the time until that loop's next tick as a
+        RELATIVE duration in whole minutes (``11m``), never a clock time.
+        Each loop has its own cadence (:func:`_cadence_for_loop`), so a
+        fast reactive loop and a slow self-improve loop show different
+        countdowns. The chunk is name-only when the lease has no recorded
+        ``acquired_at`` yet (no tick fired) so we never invent a number we
+        can't compute. ``due`` replaces the duration when overdue.
+
+    The prior ``next tick in <duration> · N loops live`` shape is gone:
+    the bare count said neither *which* loops nor *when* they tick, and the
+    single duration sat detached from the loops it described.
 
     Returns ``[]`` when no loop is live — silences the line entirely on
     a quiet machine. Fails open: any DB / import error degrades to ``[]``
@@ -295,43 +308,50 @@ def live_loops_anchor() -> list[str]:
     a caller-side change.
     """
     try:
-        live_names = _live_loop_names()
+        leases = _live_loop_leases()
     except Exception:  # noqa: BLE001
         return []
-    if not live_names:
+    if not leases:
         return []
 
-    parts: list[str] = ["loop"]
-    parts.extend(_next_tick_parts())
-    parts.append(f"{len(live_names)} loops live")
-    return [" · ".join(parts)]
+    chunks = list(starmap(_loop_chunk, leases))
+    return [" · ".join(["loop", *chunks])]
 
 
-def _next_tick_parts() -> list[str]:
-    """Return the ``next tick in <duration>`` / fallback fragments.
+def _short_loop_name(name: str) -> str:
+    """Strip the ``loop-`` prefix so ``loop-my-prs`` reads as ``my-prs``."""
+    return name.removeprefix("loop-")
 
-    Empty list when nothing useful is queryable (no cadence, no tick
-    history). Fails open on every DB / config read — the line drops the
-    fragment rather than refusing to render.
+
+def _loop_chunk(name: str, acquired_at: datetime | None) -> str:
+    """Render one ``<short-name> <next-tick>`` chunk for a live loop."""
+    tick = _next_tick_minutes(name, acquired_at)
+    suffix = f" {tick}" if tick else ""
+    return f"{_short_loop_name(name)}{suffix}"
+
+
+def _next_tick_minutes(name: str, acquired_at: datetime | None) -> str:
+    """Return *name*'s relative next-tick as whole minutes (``11m`` / ``due``).
+
+    Empty string when nothing useful is queryable (no acquire timestamp, no
+    resolvable cadence) — the caller then renders a name-only chunk rather
+    than invent a duration. Fails open on every config read.
     """
-    try:
-        acquired_at = _loop_tick_acquired_at()
-    except Exception:  # noqa: BLE001
-        return []
     if acquired_at is None:
-        return ["last tick: never"]
+        return ""
     try:
-        cadence = _cadence_seconds()
+        cadence = _cadence_for_loop(name)
     except Exception:  # noqa: BLE001
-        return []
+        return ""
     from django.utils import timezone  # noqa: PLC0415
 
     now = timezone.now()
     next_tick_at = acquired_at + timedelta(seconds=cadence)
     delta_seconds = int((next_tick_at - now).total_seconds())
     if delta_seconds <= 0:
-        return ["next tick due"]
-    return [f"next tick in {_format_duration(delta_seconds)}"]
+        return "due"
+    minutes = max(1, round(delta_seconds / _SECONDS_PER_MINUTE))
+    return f"{minutes}m"
 
 
 _SECONDS_PER_MINUTE = 60

--- a/src/teatree/loop/tick_piggyback.py
+++ b/src/teatree/loop/tick_piggyback.py
@@ -54,6 +54,29 @@ def _self_improve_cadence_seconds() -> int:
         return 1800
 
 
+_LOOP_OWNER_TTL_DEFAULT = 1800
+
+
+def _loop_owner_ttl_seconds() -> int:
+    """The persistent ``loop-owner`` claim TTL (``T3_LOOP_OWNER_TTL``, default 1800s, floor 60).
+
+    Lives here next to its sibling per-loop cadence readers (the
+    ``teatree.loop`` layer) so the statusline's per-loop next-tick
+    countdown (#1400) and the ``loop_tick`` owner-claim can both reach it
+    without ``teatree.loop`` importing back into ``teatree.core.management``.
+    A blank or non-integer override degrades to the default rather than
+    crashing the tick; the 60s floor keeps a fat-fingered tiny TTL from
+    making the owner lapse mid-tick.
+    """
+    raw = os.environ.get("T3_LOOP_OWNER_TTL", str(_LOOP_OWNER_TTL_DEFAULT)).strip()
+    if not raw:
+        return _LOOP_OWNER_TTL_DEFAULT
+    try:
+        return max(60, int(raw))
+    except ValueError:
+        return _LOOP_OWNER_TTL_DEFAULT
+
+
 def _piggyback_slack_answer() -> None:
     """Drive one reactive Slack-answer cycle behind the dedicated lease CAS."""
     from teatree.core.models import LoopLease  # noqa: PLC0415

--- a/tests/teatree_loop/test_statusline_canonical_item_shape.py
+++ b/tests/teatree_loop/test_statusline_canonical_item_shape.py
@@ -3,15 +3,16 @@
 Every state line (anchor ``ready:``/``started:``/``tested:`` rows and the
 action-needed ``ready:`` row) renders items in the same canonical shape so
 the operator never has to mentally translate between two formats. The
-description comes from the cached tracker title (``ticket.extra
-["issue_title"]``) truncated to 40 chars with a Unicode ellipsis; the MR
-chunk is comma-separated and every number is a hyperlink.
+description is a terse 2-3 word topic derived from the cached tracker title
+(``ticket.extra["issue_title"]``) — the conventional-commit prefix stripped,
+the first few words kept, capped with a Unicode ellipsis; the MR chunk is
+space-separated and every number is a hyperlink.
 
 These tests pin the canonical shape on the anchor row (replaces the old
 ``coded: #N`` bare form), the canonical shape on the ``ready:`` action row,
-graceful degradation when ``title`` is empty (just ``#N (!M)``), description
-truncation at 40 chars with the ellipsis, and the ``ActiveTicketsScanner``
-plumbing ``extra['issue_title']`` through the payload.
+graceful degradation when ``title`` is empty (just ``#N (!M)``), the terse
+topic collapse for long titles, and the ``ActiveTicketsScanner`` plumbing
+``extra['issue_title']`` through the payload.
 """
 
 from django.test import TestCase
@@ -73,22 +74,29 @@ def _ready(num: str, *, title: str = "", overlay: str = "teatree") -> DispatchAc
 
 
 class TestShortDescHelper:
-    def test_passes_short_titles_through_unchanged(self) -> None:
+    def test_passes_short_topics_through_unchanged(self) -> None:
+        # A title already 2-3 words within budget reads verbatim.
         assert _short_desc("short title") == "short title"
 
     def test_returns_empty_for_empty_input(self) -> None:
         assert _short_desc("") == ""
 
-    def test_truncates_long_titles_with_ellipsis_at_40_chars(self) -> None:
+    def test_collapses_long_titles_to_terse_topic(self) -> None:
+        # A long single token is tail-elided at the terse 24-char budget,
+        # not the prior 40-char commit-subject slice.
         long = "x" * 60
         out = _short_desc(long)
-        assert len(out) == 40
+        assert len(out) <= 24
         assert out.endswith("…")
-        assert out == "x" * 39 + "…"
+        assert out == "x" * 23 + "…"
 
-    def test_keeps_titles_at_budget_unchanged(self) -> None:
-        exactly_40 = "x" * 40
-        assert _short_desc(exactly_40) == exactly_40
+    def test_keeps_first_three_words_only(self) -> None:
+        # Beyond three words the topic is gist, not the full subject.
+        assert _short_desc("add the canonical item shape everywhere") == "add the canonical"
+
+    def test_strips_conventional_commit_prefix(self) -> None:
+        assert _short_desc("feat(loop): multi loop anchors") == "multi loop anchors"
+        assert _short_desc("techdebt: refactor module") == "refactor module"
 
 
 class TestAnchorCanonicalShape:
@@ -101,18 +109,18 @@ class TestAnchorCanonicalShape:
         )
         text = _blob(zones.anchors)
         # Terse format (#1377) drops the ``state:`` prefix — ``#10`` reads
-        # bare under the overlay tag.
+        # bare under the overlay tag. The topic keeps the first three words.
         assert "#10" in text
         assert "coded:" not in text
-        assert "(Add canonical item shape)" in text, repr(text)
+        assert "(Add canonical item)" in text, repr(text)
 
-    def test_anchor_truncates_long_titles(self) -> None:
+    def test_anchor_collapses_long_titles_to_terse_topic(self) -> None:
         zones = zones_for(
             [_active("10", "coded", title="x" * 60)],
             colorize=False,
         )
         text = _blob(zones.anchors)
-        assert "(" + ("x" * 39) + "…)" in text, repr(text)
+        assert "(" + ("x" * 23) + "…)" in text, repr(text)
 
     def test_anchor_no_desc_chunk_when_title_empty(self) -> None:
         zones = zones_for([_active("10", "coded", title="")], colorize=False)
@@ -293,10 +301,10 @@ class TestReadyRowCanonicalShape:
         assert "#99" in text
         assert "(Add identity aliases)" in text, repr(text)
 
-    def test_ready_row_truncates_long_titles(self) -> None:
+    def test_ready_row_collapses_long_titles_to_terse_topic(self) -> None:
         zones = zones_for([_ready("99", title="x" * 60)], colorize=False)
         text = _blob(zones.action_needed)
-        assert "(" + ("x" * 39) + "…)" in text, repr(text)
+        assert "(" + ("x" * 23) + "…)" in text, repr(text)
 
     def test_ready_row_falls_back_to_no_desc_when_title_missing(self) -> None:
         zones = zones_for([_ready("99", title="")], colorize=False)

--- a/tests/teatree_loop/test_statusline_loop_line_cleanup.py
+++ b/tests/teatree_loop/test_statusline_loop_line_cleanup.py
@@ -1,0 +1,200 @@
+"""Statusline loop-line cleanup — one dedicated loop line, per-loop ticks, no cruft.
+
+Regression-locks four complaints about the rendered statusline:
+
+1.  Loop info lives on exactly ONE dedicated line — there is no second
+    ``loops: tick(Nm)`` fragment elsewhere in the output.
+2.  The useless ``N loops live`` headline count is gone. Each live loop
+    shows its short name + next tick as a RELATIVE duration in minutes
+    (``my-prs 11m · tickets 11m``), never a clock time, never a bare count.
+3.  The ``recent_marker: ?`` mystery row (the ``self_update`` scanner's
+    internal cadence-gate reason) never reaches the statusline.
+4.  MR chips render a terse topic, not the full truncated commit subject —
+    a long ``techdebt: refactor PLW0717 try-clause-too-long`` collapses to a
+    2-3 word topic.
+"""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from teatree.loop.dispatch import DispatchAction, dispatch
+from teatree.loop.rendering import zones_for
+from teatree.loop.rendering_items import _short_desc
+from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.statusline import live_loops_anchor, render
+
+
+def _pr_action(*, url: str, iid: int, title: str, overlay: str = "acme") -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="in_flight",
+        detail=f"PR #{iid} {title}",
+        payload={"url": url, "iid": iid, "title": title, "overlay": overlay},
+    )
+
+
+class TestPerLoopRelativeTicks:
+    """Complaint 2: per-loop name + relative-minutes tick, not ``N loops live``."""
+
+    def test_each_loop_name_and_relative_minutes(self) -> None:
+        # Each lease carries its own acquire timestamp; 60s elapsed of the
+        # 720s cadence → next tick in 11m (rounded).
+        acquired_at = datetime.now(UTC) - timedelta(seconds=60)
+        leases = [("loop-my-prs", acquired_at), ("loop-tickets", acquired_at), ("loop-tick", acquired_at)]
+        with (
+            patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
+        ):
+            lines = live_loops_anchor()
+        assert len(lines) == 1, repr(lines)
+        line = lines[0]
+        # The useless headline count is gone.
+        assert "loops live" not in line, line
+        # Each live loop's short name appears (the ``loop-`` prefix stripped).
+        assert "my-prs" in line, line
+        assert "tickets" in line, line
+        # Relative minutes, not a clock time. 60s elapsed of 720s → 11m left.
+        assert "11m" in line, line
+        # No clock-time form (HH:MM) leaked into the line.
+        assert ":" not in line.replace("·", ""), line
+
+    def test_per_loop_cadence_yields_different_countdowns(self) -> None:
+        # A fast reactive loop and a slow self-improve loop show different
+        # countdowns from the same acquire instant (#1400).
+        acquired_at = datetime.now(UTC) - timedelta(seconds=60)
+        leases = [("loop-slack-answer", acquired_at), ("loop-self-improve", acquired_at)]
+
+        def _cadence(name: str) -> int:
+            return 20 if name == "loop-slack-answer" else 1800
+
+        with (
+            patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline._cadence_for_loop", side_effect=_cadence),
+        ):
+            lines = live_loops_anchor()
+        line = lines[0]
+        # slack-answer: 20s cadence, 60s elapsed → already due.
+        assert "slack-answer due" in line, line
+        # self-improve: 1800s cadence, 60s elapsed → 29m left.
+        assert "self-improve 29m" in line, line
+
+    def test_names_only_when_no_tick_history(self) -> None:
+        leases = [("loop-my-prs", None), ("loop-tickets", None)]
+        with (
+            patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
+        ):
+            lines = live_loops_anchor()
+        assert lines == ["loop · my-prs · tickets"], repr(lines)
+
+    def test_empty_when_no_loops_live(self) -> None:
+        with patch("teatree.loop.statusline._live_loop_leases", return_value=[]):
+            assert live_loops_anchor() == []
+
+    def test_fails_open_on_db_error(self) -> None:
+        with patch("teatree.loop.statusline._live_loop_leases", side_effect=RuntimeError("db down")):
+            assert live_loops_anchor() == []
+
+
+class TestSingleLoopLine:
+    """Complaint 1: loop info on exactly one line — no duplicate fragment."""
+
+    def test_only_one_loop_line_in_full_render(self, tmp_path: Path) -> None:
+        acquired_at = datetime.now(UTC) - timedelta(seconds=60)
+        leases = [("loop-my-prs", acquired_at), ("loop-tickets", acquired_at), ("loop-tick", acquired_at)]
+        with (
+            patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
+        ):
+            zones = zones_for([], colorize=False)
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=False)
+        body = target.read_text()
+        loop_lines = [ln for ln in body.splitlines() if ln.startswith("loop")]
+        assert len(loop_lines) == 1, body
+        # The legacy top-zone ``loops: tick(Nm)`` fragment must not appear.
+        assert "loops: tick(" not in body, body
+        assert "loops live" not in body, body
+
+
+class TestRecentMarkerNotRendered:
+    """Complaint 3: the ``self_update`` cadence reason never reaches the statusline."""
+
+    def test_recent_marker_dropped(self, tmp_path: Path) -> None:
+        signal = ScanSignal(
+            kind="self_update.cadence_not_elapsed",
+            summary="self-update teatree: cadence_not_elapsed (recent_marker)",
+            payload={
+                "repo": "teatree",
+                "outcome": "cadence_not_elapsed",
+                "reason": "recent_marker",
+                "old_sha": "",
+                "new_sha": "",
+            },
+        )
+        actions = dispatch([signal])
+        with patch("teatree.loop.statusline._live_loop_leases", return_value=[]):
+            zones = zones_for(actions, colorize=False)
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=False)
+        body = target.read_text()
+        assert "recent_marker" not in body, body
+        assert "self-update" not in body, body
+        assert "self_update" not in body, body
+
+    def test_all_self_update_outcomes_dropped(self) -> None:
+        for outcome, reason in (
+            ("cadence_not_elapsed", "recent_marker"),
+            ("up_to_date", ""),
+            ("updated", ""),
+            ("skipped", "branch=feature!=main"),
+            ("failed", "fetch:boom"),
+        ):
+            signal = ScanSignal(
+                kind=f"self_update.{outcome}",
+                summary=f"self-update teatree: {outcome}",
+                payload={"repo": "teatree", "outcome": outcome, "reason": reason},
+            )
+            assert dispatch([signal]) == [], (outcome, dispatch([signal]))
+
+
+class TestTerseMrTopic:
+    """Complaint 4: MR chips show a terse 2-3 word topic, not the full subject."""
+
+    def test_long_commit_subject_collapses_to_topic(self) -> None:
+        title = "techdebt: refactor PLW0717 try-clause-too-long across modules"
+        topic = _short_desc(title)
+        # The terse topic must be short — a few words, not a 40-char truncation
+        # of the full commit subject.
+        assert len(topic) <= 24, repr(topic)
+        assert "across modules" not in topic, repr(topic)
+        # The leading conventional-commit type prefix is dropped.
+        assert not topic.startswith("techdebt:"), repr(topic)
+
+    def test_terse_topic_in_rendered_chip(self, tmp_path: Path) -> None:
+        actions = [
+            _pr_action(
+                url="https://gitlab.com/x/-/merge_requests/7494",
+                iid=7494,
+                title="techdebt: refactor PLW0717 try-clause-too-long across modules",
+            ),
+        ]
+        with patch("teatree.loop.statusline._live_loop_leases", return_value=[]):
+            zones = zones_for(actions, colorize=False)
+        target = tmp_path / "statusline.txt"
+        render(zones, target=target, colorize=False)
+        body = target.read_text()
+        assert "!7494" in body, body
+        # The full truncated subject is gone; no tail-ellipsis of the subject.
+        assert "try-clause-t…" not in body, body
+        assert "across modules" not in body, body
+
+    def test_short_title_passes_through(self) -> None:
+        # A title already terse keeps its words (conventional-commit prefix
+        # still stripped for consistency).
+        assert _short_desc("loop line cleanup") == "loop line cleanup"
+        assert _short_desc("fix: loop line cleanup") == "loop line cleanup"
+
+    def test_empty_title_stays_empty(self) -> None:
+        assert _short_desc("") == ""

--- a/tests/teatree_loop/test_statusline_mr_format.py
+++ b/tests/teatree_loop/test_statusline_mr_format.py
@@ -1,7 +1,10 @@
-"""Tests for the ``!N (MR title)`` rendering (#1156).
+"""Tests for the ``!N (terse topic)`` rendering (#1156).
 
 Pre-#1156: bare ``!1234`` ref, comma-joined when multiple.
 Post-#1156: ``!1234 (MR title)`` ref, space-separated when multiple.
+Later: the ``(…)`` chunk is a terse 2-3 word topic, not the full commit
+subject — the conventional-commit prefix is stripped and only the first
+few words are kept. The full subject still lives on the OSC-8 link target.
 """
 
 import pytest
@@ -32,7 +35,7 @@ def _render_blob(actions: list[DispatchAction]) -> str:
 
 
 class TestMrLineIncludesTitle:
-    def test_mr_line_includes_title(self) -> None:
+    def test_mr_line_includes_terse_topic(self) -> None:
         actions = [
             _pr_action(
                 url="https://example.com/p/1/merge_requests/123",
@@ -42,13 +45,14 @@ class TestMrLineIncludesTitle:
         ]
         blob = _render_blob(actions)
 
-        # The MR ref now carries its title — under NO_COLOR the rendered
-        # form is ``!N <url> (title)`` because the iid is wrapped in the
-        # plain-text URL fallback.
+        # The MR ref carries a terse topic — the ``feat(loop):`` prefix is
+        # stripped and the first three words kept.
         assert "!123" in blob, repr(blob)
-        assert "(feat(loop): add multi-loop anchors)" in blob, repr(blob)
-        # The title chunk must come *after* the iid.
-        assert blob.index("!123") < blob.index("(feat(loop): add multi-loop anchors)"), repr(blob)
+        assert "(add multi-loop anchors)" in blob, repr(blob)
+        # The full conventional-commit prefix must NOT render on the chip.
+        assert "feat(loop):" not in blob, repr(blob)
+        # The topic chunk must come *after* the iid.
+        assert blob.index("!123") < blob.index("(add multi-loop anchors)"), repr(blob)
 
     def test_multiple_open_mrs_space_separated(self) -> None:
         actions = [
@@ -79,9 +83,10 @@ class TestMrLineIncludesTitle:
         )
         blob = _render_blob([action])
 
-        # Title appears alongside the existing annotation.
+        # Terse topic (``wip:`` prefix stripped) appears alongside the
+        # existing annotation.
         assert "!200" in blob, repr(blob)
-        assert "wip: experimental" in blob, repr(blob)
+        assert "(experimental)" in blob, repr(blob)
 
 
 @pytest.mark.django_db

--- a/tests/teatree_loop/test_statusline_multiloop.py
+++ b/tests/teatree_loop/test_statusline_multiloop.py
@@ -6,9 +6,12 @@ History:
     or ``loop-owner=unclaimed`` line plus the foreign-hijack RED line.
 *   #1156 collapsed the dim doctrine into one line per LIVE LoopLease row
     (``loop:tick``, ``loop:owner``, …).
-*   This refit replaces that per-loop dump with a single consolidated
-    summary line that surfaces time-to-next-tick. The user explicitly
-    asked for "time to next tick" on the first line, not a per-loop list.
+*   A later refit replaced that per-loop dump with a single consolidated
+    ``loop · next tick in <d> · N loops live`` summary line.
+*   This refit drops the useless ``N loops live`` count: each live loop
+    now lists its short name + next tick as a relative duration in minutes
+    (``loop · my-prs 11m · tickets 11m``). The user explicitly opted out of
+    the bare count — it said neither which loops nor when they tick.
 
 The #1073 foreign-hijack RED line is preserved unchanged through every
 refit — it is a different code path (``loop_owner_anchor``) and a
@@ -36,9 +39,9 @@ def _make_lease(name: str, *, expires_in: timedelta, session_id: str = "sess-A")
 
 @pytest.mark.django_db
 class TestLiveLoopsAnchor:
-    """``live_loops_anchor()`` returns one consolidated summary line."""
+    """``live_loops_anchor()`` returns one per-loop-named summary line."""
 
-    def test_one_consolidated_line_with_loop_count(self) -> None:
+    def test_one_line_lists_each_live_loop_by_name(self) -> None:
         _make_lease("loop-tick", expires_in=timedelta(minutes=30))
         _make_lease("loop-self-improve", expires_in=timedelta(minutes=30))
         _make_lease("loop-slack-answer", expires_in=timedelta(minutes=30))
@@ -48,18 +51,24 @@ class TestLiveLoopsAnchor:
         assert len(lines) == 1, repr(lines)
         line = lines[0]
         assert line.startswith("loop · "), line
-        assert "3 loops live" in line, line
+        # The useless headline count is gone; each loop's short name appears.
+        assert "loops live" not in line, line
+        assert "tick" in line, line
+        assert "self-improve" in line, line
+        assert "slack-answer" in line, line
 
-    def test_expired_loops_omitted_from_count(self) -> None:
+    def test_expired_loops_omitted(self) -> None:
         _make_lease("loop-tick", expires_in=timedelta(minutes=30))
         _make_lease("loop-self-improve", expires_in=timedelta(minutes=30))
-        # Expired — must not be counted.
+        # Expired — must not appear in the line.
         _make_lease("loop-slack-answer", expires_in=timedelta(seconds=-5))
 
         lines = live_loops_anchor()
 
         assert len(lines) == 1, repr(lines)
-        assert "2 loops live" in lines[0], lines[0]
+        assert "slack-answer" not in lines[0], lines[0]
+        assert "tick" in lines[0], lines[0]
+        assert "self-improve" in lines[0], lines[0]
 
     def test_per_loop_dump_format_gone(self) -> None:
         """The pre-refit per-loop dump (``loop:tick`` / ``loop:owner``) is gone."""
@@ -107,7 +116,10 @@ class TestPopulateLoopsAnchorIntegration:
 
         joined = "\n".join(item if isinstance(item, str) else item.text for item in zones.anchors)
         assert "loop · " in joined, repr(joined)
-        assert "2 loops live" in joined, repr(joined)
+        # Each live loop is named; the bare count is gone.
+        assert "loops live" not in joined, repr(joined)
+        assert "tick" in joined, repr(joined)
+        assert "self-improve" in joined, repr(joined)
         # Verbose dim owner lines must NOT appear.
         assert "loop-owner=THIS session" not in joined, repr(joined)
         assert "loop-owner=unclaimed" not in joined, repr(joined)

--- a/tests/teatree_loop/test_statusline_next_tick.py
+++ b/tests/teatree_loop/test_statusline_next_tick.py
@@ -51,53 +51,52 @@ def _ready(num: str, *, overlay: str = "ov") -> DispatchAction:
 
 
 class TestConsolidatedLoopAnchor:
-    """Line 1 = ``loop · next tick in <duration> · N loops live``."""
+    """Line 1 = ``loop · <name> <Nm> · <name> <Nm>`` (per-loop relative ticks)."""
 
-    def test_includes_time_to_next_tick_when_acquired_at_known(self) -> None:
-        leases = [("loop-tick", "sessA"), ("loop-owner", "sessA")]
-        # Last tick fired 2 minutes ago; cadence 720s → next tick in 10m.
+    def test_includes_relative_minutes_when_acquired_at_known(self) -> None:
+        # Each lease carries its own acquire instant; 2 minutes elapsed of
+        # the 720s cadence → next tick in 10m.
         acquired_at = datetime.now(UTC) - timedelta(seconds=120)
+        leases = [("loop-tick", acquired_at), ("loop-owner", acquired_at)]
         with (
-            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=acquired_at),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             lines = live_loops_anchor()
         assert len(lines) == 1, repr(lines)
         line = lines[0]
         assert line.startswith("loop · "), line
-        assert "next tick in " in line, line
-        assert "2 loops live" in line, line
+        # Per-loop name + relative minutes, no headline count.
+        assert "loops live" not in line, line
+        assert "tick 10m" in line, line
+        assert "owner 10m" in line, line
 
-    def test_falls_back_to_last_tick_never_when_no_lease_history(self) -> None:
-        leases = [("loop-tick", "sessA")]
+    def test_names_only_when_no_lease_history(self) -> None:
+        leases = [("loop-tick", None)]
         with (
-            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             lines = live_loops_anchor()
-        assert lines == ["loop · last tick: never · 1 loops live"], repr(lines)
+        assert lines == ["loop · tick"], repr(lines)
 
-    def test_reports_next_tick_due_when_overdue(self) -> None:
-        leases = [("loop-tick", "sessA")]
-        # Last tick was 1 hour ago; cadence 12 minutes → due now.
+    def test_reports_due_when_overdue(self) -> None:
+        # Acquired 1 hour ago; cadence 12 minutes → due now.
         acquired_at = datetime.now(UTC) - timedelta(hours=1)
+        leases = [("loop-tick", acquired_at)]
         with (
-            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=acquired_at),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             lines = live_loops_anchor()
-        assert lines == ["loop · next tick due · 1 loops live"], repr(lines)
+        assert lines == ["loop · tick due"], repr(lines)
 
     def test_no_per_loop_lines_anymore(self) -> None:
         """The pre-refit one-line-per-loop shape is gone (user explicitly opted out)."""
-        leases = [("loop-tick", "sessA"), ("loop-owner", "sessA"), ("loop-self-improve", "sessA")]
+        leases = [("loop-tick", None), ("loop-owner", None), ("loop-self-improve", None)]
         with (
-            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             lines = live_loops_anchor()
         assert len(lines) == 1, repr(lines)
@@ -107,11 +106,11 @@ class TestConsolidatedLoopAnchor:
         assert "loop:self-improve" not in lines[0], lines[0]
 
     def test_empty_when_no_loops_live(self) -> None:
-        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+        with patch("teatree.loop.statusline._live_loop_leases", return_value=[]):
             assert live_loops_anchor() == []
 
     def test_fails_open_on_db_error(self) -> None:
-        with patch("teatree.loop.statusline._live_loop_names", side_effect=RuntimeError("db down")):
+        with patch("teatree.loop.statusline._live_loop_leases", side_effect=RuntimeError("db down")):
             assert live_loops_anchor() == []
 
 
@@ -142,7 +141,7 @@ class TestAnchorStatePriorityOrder:
             _active_ticket("100", "coded", overlay="ov"),
             _active_ticket("200", "started", overlay="ov"),
         ]
-        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+        with patch("teatree.loop.statusline._live_loop_leases", return_value=[]):
             zones = zones_for(actions, colorize=False)
         target = tmp_path / "statusline.txt"
         render(zones, target=target, colorize=False)
@@ -158,7 +157,7 @@ class TestActiveStateOverflowCap:
 
     def test_started_caps_at_five(self, tmp_path: Path) -> None:
         actions = [_active_ticket(str(i), "started", overlay="ov") for i in range(1, 11)]
-        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+        with patch("teatree.loop.statusline._live_loop_leases", return_value=[]):
             zones = zones_for(actions, colorize=False)
         target = tmp_path / "statusline.txt"
         render(zones, target=target, colorize=False)
@@ -174,7 +173,7 @@ class TestReadyOverflowPhrasing:
 
     def test_ready_overflow_says_more(self, tmp_path: Path) -> None:
         actions = [_ready(str(i), overlay="ov") for i in range(10)]
-        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+        with patch("teatree.loop.statusline._live_loop_leases", return_value=[]):
             zones = zones_for(actions, colorize=False)
         target = tmp_path / "statusline.txt"
         render(zones, target=target, colorize=False)
@@ -185,13 +184,12 @@ class TestReadyOverflowPhrasing:
 class TestZonesForIntegration:
     """End-to-end: ``zones_for`` + ``render`` produces the new top-line shape."""
 
-    def test_line_one_is_consolidated_loop_summary(self, tmp_path: Path) -> None:
-        leases = [("loop-tick", "sessA"), ("loop-owner", "sessA")]
+    def test_line_one_is_per_loop_summary(self, tmp_path: Path) -> None:
         acquired_at = datetime.now(UTC) - timedelta(seconds=60)
+        leases = [("loop-tick", acquired_at), ("loop-owner", acquired_at)]
         with (
-            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=acquired_at),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             zones = zones_for([], colorize=False)
         target = tmp_path / "statusline.txt"
@@ -199,8 +197,10 @@ class TestZonesForIntegration:
         body = target.read_text()
         first_line = body.splitlines()[0]
         assert first_line.startswith("loop · "), repr(first_line)
-        assert "next tick in " in first_line, first_line
-        assert "2 loops live" in first_line, first_line
+        # 60s elapsed of 720s → next tick in 11m; each loop named.
+        assert "tick 11m" in first_line, first_line
+        assert "owner 11m" in first_line, first_line
+        assert "loops live" not in first_line, first_line
         # Per-loop tokens removed at the top.
         assert "\nloop:tick" not in body
         assert "\nloop:owner" not in body

--- a/tests/teatree_loop/test_statusline_refinements_1163.py
+++ b/tests/teatree_loop/test_statusline_refinements_1163.py
@@ -131,7 +131,8 @@ class TestItemFormatDescriptionAlwaysShown:
         render(zones, target=target, colorize=False)
         body = target.read_text()
         assert "#500" in body
-        assert "(add new scanner guard)" in body
+        # Terse topic keeps the first three words of the title.
+        assert "(add new scanner)" in body
 
 
 class TestNo404Links:
@@ -211,38 +212,41 @@ class TestDedupAcrossOverlays:
 
 
 class TestLiveLoopsAnchor:
-    """Refinement 5 (revised): one consolidated summary line for live loops.
+    """Refinement 5 (revised): one per-loop-named summary line for live loops.
 
-    The original refinement returned one line per live loop. The user
-    asked instead for a single first-line summary with time-to-next-tick;
-    this rewrites the tests to lock the consolidated shape.
+    The original refinement returned one line per live loop, then a later
+    refit collapsed to a single ``… · N loops live`` count. The user asked
+    instead for one line that names each live loop with its next tick; this
+    locks that shape (the bare count is gone).
     """
 
-    def test_returns_one_consolidated_summary_line(self) -> None:
+    def test_returns_one_line_naming_each_loop(self) -> None:
         leases = [
-            ("loop-tick", "sessA"),
-            ("loop-slack-answer", "sessB"),
-            ("loop-owner", "sessA"),
+            ("loop-tick", None),
+            ("loop-slack-answer", None),
+            ("loop-owner", None),
         ]
         with (
-            patch("teatree.loop.statusline._live_loop_names", return_value=leases),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             lines = live_loops_anchor()
         assert len(lines) == 1
         assert lines[0].startswith("loop · ")
-        assert "3 loops live" in lines[0]
+        assert "loops live" not in lines[0]
+        assert "tick" in lines[0]
+        assert "slack-answer" in lines[0]
+        assert "owner" in lines[0]
 
     def test_no_live_leases_returns_empty(self) -> None:
         # Empty list → no lines (no statusline noise when no loop is live).
-        with patch("teatree.loop.statusline._live_loop_names", return_value=[]):
+        with patch("teatree.loop.statusline._live_loop_leases", return_value=[]):
             assert live_loops_anchor() == []
 
     def test_fails_open_on_query_error(self) -> None:
         # When the underlying DB read raises, callers see [] — a broken
         # LoopLease query must never blank the statusline.
-        with patch("teatree.loop.statusline._live_loop_names", side_effect=RuntimeError("db down")):
+        with patch("teatree.loop.statusline._live_loop_leases", side_effect=RuntimeError("db down")):
             assert live_loops_anchor() == []
 
 
@@ -252,18 +256,19 @@ class TestZonesForIntegratesLoopsAnchor:
     def test_zones_for_appends_consolidated_loop_line(self, tmp_path: Path) -> None:
         with (
             patch(
-                "teatree.loop.statusline._live_loop_names",
-                return_value=[("loop-tick", "sessA"), ("loop-owner", "sessA")],
+                "teatree.loop.statusline._live_loop_leases",
+                return_value=[("loop-tick", None), ("loop-owner", None)],
             ),
-            patch("teatree.loop.statusline._loop_tick_acquired_at", return_value=None),
-            patch("teatree.loop.statusline._cadence_seconds", return_value=720),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
         ):
             zones: StatuslineZones = zones_for([], colorize=False)
         target = tmp_path / "statusline.txt"
         render(zones, target=target, colorize=False)
         body = target.read_text()
         assert "loop · " in body
-        assert "2 loops live" in body
+        assert "loops live" not in body
+        assert "tick" in body
+        assert "owner" in body
         # Per-loop dump tokens absent.
         assert "loop:tick" not in body
         assert "loop:owner" not in body

--- a/tests/teatree_loop/test_statusline_short_description.py
+++ b/tests/teatree_loop/test_statusline_short_description.py
@@ -76,14 +76,14 @@ class TestShortDescriptionInScanner:
 
 
 class TestShortDescriptionTruncation:
-    """The canonical-item shape truncates description at the existing 40-char limit."""
+    """The canonical-item shape collapses the description to a terse topic."""
 
-    def test_description_truncated_at_40(self) -> None:
+    def test_description_collapsed_to_terse_topic(self) -> None:
         long_title = "a" * 80
         blob = _render_blob([_ticket_active_action(number="100", title=long_title)])
 
-        # Truncation budget is 40 chars including the ellipsis.
-        truncated = "a" * 39 + "…"
+        # Terse topic budget is 24 chars including the ellipsis.
+        truncated = "a" * 23 + "…"
         assert truncated in blob, repr(blob)
         # The full 80-char title must NOT appear.
         assert long_title not in blob, repr(blob)

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -1085,15 +1085,16 @@ class TestLoopOwnerAnchorWiring(django.test.TestCase):
             sl = Path(d) / "sl.txt"
             with patch.dict("os.environ", {"CLAUDE_SESSION_ID": "owner-sess"}):
                 run_tick(TickRequest(scanners=[]), statusline_path=sl)
-            # A live LoopLease row surfaces in the consolidated summary
-            # line — ``loop · … · N loops live`` — at the top of the
-            # statusline. The pre-refit one-line-per-loop dump
-            # (``loop:owner``, ``loop:tick``, …) was removed at the user's
-            # explicit request; the count carries the same signal in less
-            # vertical space.
+            # A live LoopLease row surfaces in the consolidated loop line
+            # — ``loop · <name> <Nm> · …`` — at the top of the statusline,
+            # listing each live loop by its short name. The pre-refit
+            # one-line-per-loop dump (``loop:owner``, ``loop:tick``, …) and
+            # the later useless ``N loops live`` count were both removed at
+            # the user's explicit request.
             body = sl.read_text(encoding="utf-8")
             assert "loop · " in body, body
-            assert "1 loops live" in body, body
+            assert "loops live" not in body, body
+            assert "owner" in body.splitlines()[0], body
 
     def test_normal_path_flags_foreign_owner_in_red_zone(self) -> None:
         import tempfile  # noqa: PLC0415


### PR DESCRIPTION
## Why

Four complaints about the rendered statusline.

## Before

```
loop · next tick in 10m59s · 3 loops live
recent_marker: ?

[acme] !7494 <https://example.com/x/-/merge_requests/7494> (techdebt: refactor PLW0717 try-clause-t…)
```

## After

```
loop · my-prs 11m · tick 11m · slack-answer due · self-improve 29m

[acme] !7494 <https://example.com/x/-/merge_requests/7494> (refactor PLW0717 try-cl…)
```

## What changed

**1 + 2 — one dedicated loop line with per-loop next-tick.** The useless `N loops live` count said neither which loops were live nor when they tick. It is replaced by one line naming each live loop with its own next-tick countdown in relative minutes. Each loop's countdown uses its own cadence (`_cadence_for_loop`): a fast reactive loop and a slow self-improve loop show different countdowns, falling back to the `loop-tick` cadence for loops without a dedicated reader. The countdown is name-only when a lease has no recorded `acquired_at` yet, and reads `due` when overdue. The `loop-owner` TTL reader moved to `tick_piggyback` (the `teatree.loop` layer) so the statusline can reach it without `teatree.loop` importing back into `teatree.core.management` (tach boundary). Closes #1400.

**3 — drop `recent_marker: ?` cruft.** The `self_update.*` scanner family fell through to a statusline action whose `reason` payload (`recent_marker`) was misread as a ticket disposition and rendered as a mystery `recent_marker: ?` row. The update outcome is internal bookkeeping (logged + persisted on `SelfUpdateMarker`), not user-facing — the whole family is now dropped from the statusline via a prefix-matched drop set. Closes #1365.

**4 — terse MR/ticket topics.** Chips rendered a 40-char slice of the full commit subject. `_short_desc` now yields a terse 2-3 word topic: the conventional-commit prefix is stripped and only the first few words are kept, capped at 24 chars. The full title still lives on the OSC-8 hyperlink target. Closes #1363.

## Tests

New `tests/teatree_loop/test_statusline_loop_line_cleanup.py` asserts: the loop line lists each loop with per-loop relative ticks (incl. different cadences yielding different countdowns), exactly one loop line in the full render, `recent_marker`/`self_update` never reach the statusline (every outcome dropped), and chips collapse to a terse topic. Existing statusline tests updated to the new shapes.

Full suite green (7330 passed, 13 skipped); coverage 93.29% (gate 93%). The one pre-existing failure (`test_in_repo_overlay_resolves_to_three`) is environment-dependent on the local `~/.teatree.toml` and reproduces on `main` untouched by this change.