### PR TITLE
fix(loop): skip :eyes: react on own-author MR broadcasts (#1384)

### DIFF
--- a/src/teatree/loop/scanners/slack_broadcasts.py
+++ b/src/teatree/loop/scanners/slack_broadcasts.py
@@ -122,11 +122,17 @@ class MrState:
     surface; everything else (CI status, draft flag, reviewer list) is
     out of scope for #1131 — the existing reviewer-agent pipeline
     handles those once the URL reaches it.
+
+    ``author_username`` carries the MR author's forge username (GitLab
+    ``author.username`` / GitHub ``user.login``) so the scanner can skip
+    the ``:eyes:`` review reaction on the user's own MR broadcasts (#1384).
+    Empty when the classifier could not read it — treated as "not mine".
     """
 
     url: str
     merged: bool
     approved: bool
+    author_username: str = ""
 
 
 MrStateClassifier = Callable[[Sequence[str]], list[MrState]]
@@ -230,6 +236,12 @@ class SlackBroadcastsScanner:
     # disables auto-pickup so legacy callers keep their previous behaviour.
     user_slack_id: str = ""
     reviewer_username: str = ""
+    # #1384: the current user's forge username. When every open MR in a
+    # broadcast is authored by this username the ``:eyes:`` review reaction
+    # and reviewer-dispatch signals are skipped — you don't review your own
+    # MR. Empty disables the filter (legacy callers keep reacting on every
+    # pending broadcast). Sibling of #1321's review-sweep own-author exclusion.
+    current_gitlab_username: str = ""
     name: str = field(default="slack_broadcasts", init=False)
 
     def scan(self) -> list[ScanSignal]:
@@ -335,8 +347,27 @@ class SlackBroadcastsScanner:
             # where the reaction is already present.
             self._sweep_white_check_mark(row, states)
             return []
+        open_states = _open_subset(states)
+        if self._all_authored_by_me(open_states):
+            # #1384: every open MR in this broadcast is the user's own — the
+            # ``:eyes:`` reaction ("I'm looking at this colleague's MR") is
+            # meaningless noise on one's own MR, and there is nothing to
+            # dispatch a reviewer for. Skip both. Sibling of #1321.
+            return []
         self._react(row.channel, row.slack_ts, "eyes")
-        return [_signal_for_pending_mr(state.url, row, overlay=self.overlay) for state in _open_subset(states)]
+        return [_signal_for_pending_mr(state.url, row, overlay=self.overlay) for state in open_states]
+
+    def _all_authored_by_me(self, open_states: Sequence[MrState]) -> bool:
+        """True when every open MR in the broadcast is authored by the current user (#1384).
+
+        Returns ``False`` when the filter is disabled (no
+        ``current_gitlab_username`` configured) or there are no open MRs, so
+        the legacy react-on-every-pending behaviour is preserved for callers
+        that don't supply the username.
+        """
+        if not self.current_gitlab_username or not open_states:
+            return False
+        return all(state.author_username == self.current_gitlab_username for state in open_states)
 
     def _sweep_white_check_mark(self, row: ScannedBroadcast, states: Sequence[MrState]) -> None:
         """Re-react ``:white_check_mark:`` on sibling broadcasts of the same MRs (#1295 cap C).
@@ -470,7 +501,9 @@ class GlabGhMrStateClassifier:
         merged = state in {"merged", "closed_as_merged"}
         upvotes = int(data.get("upvotes", 0) or 0)
         approved = upvotes > 0 or merged
-        return MrState(url=url, merged=merged, approved=approved)
+        author = data.get("author")
+        author_username = str(author.get("username", "")) if isinstance(author, dict) else ""
+        return MrState(url=url, merged=merged, approved=approved, author_username=author_username)
 
     def _classify_github(self, url: str) -> MrState:
         from teatree.utils.run import run_allowed_to_fail  # noqa: PLC0415
@@ -479,7 +512,7 @@ class GlabGhMrStateClassifier:
         env = {**os.environ, "GH_TOKEN": self.github_token} if self.github_token else None
         try:
             result = run_allowed_to_fail(
-                [gh, "pr", "view", url, "--json", "state,reviewDecision"],
+                [gh, "pr", "view", url, "--json", "state,reviewDecision,author"],
                 expected_codes=None,
                 env=env,
             )
@@ -497,7 +530,9 @@ class GlabGhMrStateClassifier:
         review_decision = str(data.get("reviewDecision", "")).upper()
         merged = state == "MERGED"
         approved = review_decision == "APPROVED" or merged
-        return MrState(url=url, merged=merged, approved=approved)
+        author = data.get("author")
+        author_username = str(author.get("login", "")) if isinstance(author, dict) else ""
+        return MrState(url=url, merged=merged, approved=approved, author_username=author_username)
 
 
 def _signal_for_pending_mr(mr_url: str, row: ScannedBroadcast, *, overlay: str) -> ScanSignal:

--- a/src/teatree/loop/tick_jobs.py
+++ b/src/teatree/loop/tick_jobs.py
@@ -256,12 +256,19 @@ def _slack_broadcasts_scanner_for(backend: OverlayBackends) -> SlackBroadcastsSc
         return None
     glab_token = overlay.config.get_gitlab_token() if hasattr(overlay.config, "get_gitlab_token") else ""
     github_token = overlay.config.get_github_token() if hasattr(overlay.config, "get_github_token") else ""
+    # #1384: pass the user's forge username so the scanner skips :eyes: on
+    # their own-author MR broadcasts. Empty (no getter / unconfigured) leaves
+    # the filter off, preserving react-on-every-pending for legacy overlays.
+    current_gitlab_username = (
+        overlay.config.get_gitlab_username() if hasattr(overlay.config, "get_gitlab_username") else ""
+    )
     return SlackBroadcastsScanner(
         backend=backend.messaging,
         channels=channel_ids,
         fetch_channel_history=BackendChannelHistoryFetcher(backend=backend.messaging),
         classify_mrs=GlabGhMrStateClassifier(glab_token=glab_token, github_token=github_token),
         overlay=backend.name,
+        current_gitlab_username=current_gitlab_username,
     )
 
 

--- a/tests/teatree_loop/test_slack_broadcasts_scanner.py
+++ b/tests/teatree_loop/test_slack_broadcasts_scanner.py
@@ -178,6 +178,78 @@ class TestClassificationBehaviour(TestCase):
         assert backend.react_calls == [(CHANNEL, TS_A, "eyes")]
 
 
+class TestSkipsEyesOnOwnMrBroadcasts(TestCase):
+    """Own-author MR broadcasts must not get the ``:eyes:`` review reaction (#1384).
+
+    The ``:eyes:`` reaction signals "I'm looking at this colleague's MR". On a
+    broadcast whose every open MR is authored by the current user it is
+    meaningless noise the user has to remove by hand. The scanner skips both
+    the reaction and the reviewer-dispatch signals when ``current_gitlab_username``
+    matches the author of every open MR in the broadcast (sibling of #1321's
+    review-sweep own-author exclusion). BINDING
+    ``feedback_no_eyes_react_on_own_mr_broadcasts``.
+    """
+
+    def test_sole_own_mr_broadcast_skips_eyes_and_dispatch(self) -> None:
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"please review {MR_OPEN}", TS_A)]}
+        states = {MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username="me")}
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_gitlab_username="me",
+        )
+
+        signals = scanner.scan()
+
+        assert signals == []
+        assert backend.react_calls == []
+        row = ScannedBroadcast.objects.get(channel=CHANNEL, slack_ts=TS_A)
+        assert row.classification == ScannedBroadcast.Classification.PENDING
+
+    def test_colleague_mr_broadcast_still_reacts_eyes(self) -> None:
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"please review {MR_OPEN}", TS_A)]}
+        states = {MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username="colleague")}
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_gitlab_username="me",
+        )
+
+        signals = scanner.scan()
+
+        assert [s.payload["mr_url"] for s in signals] == [MR_OPEN]
+        assert backend.react_calls == [(CHANNEL, TS_A, "eyes")]
+
+    def test_mixed_authorship_open_subset_still_reacts_eyes(self) -> None:
+        # One own MR + one colleague MR open in the same broadcast: a
+        # colleague MR still needs review, so the broadcast is not "all mine"
+        # and the :eyes: react + dispatch for the colleague's MR must fire.
+        backend = FakeMessaging()
+        history = {CHANNEL: [_message(f"{MR_OPEN} {MR_OPEN_2}", TS_A)]}
+        states = {
+            MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False, author_username="me"),
+            MR_OPEN_2: MrState(url=MR_OPEN_2, merged=False, approved=False, author_username="colleague"),
+        }
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+            current_gitlab_username="me",
+        )
+
+        signals = scanner.scan()
+
+        assert {s.payload["mr_url"] for s in signals} == {MR_OPEN, MR_OPEN_2}
+        assert backend.react_calls == [(CHANNEL, TS_A, "eyes")]
+
+
 class TestIdempotency(TestCase):
     def test_idempotent_rescan_is_a_noop(self) -> None:
         backend = FakeMessaging()
@@ -357,6 +429,75 @@ class TestGlabGhMrStateClassifierUsesRepoFlag:
         assert cmd[r_idx + 1] == "team/project"
         assert "7446" in cmd
         assert url not in cmd  # the full URL must NOT be passed as a positional
+
+
+class TestClassifierReadsAuthorUsername:
+    """``GlabGhMrStateClassifier`` surfaces the MR author username (#1384).
+
+    The own-MR ``:eyes:`` skip needs the author identity. GitLab JSON
+    carries it under ``author.username``; GitHub under ``author.login``.
+    A missing/malformed author block degrades to an empty username, which
+    the scanner treats as "not mine".
+    """
+
+    def test_gitlab_reads_author_username(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        url = "https://gitlab.example.com/team/project/-/merge_requests/7446"
+
+        def fake_run(cmd, *, expected_codes=None, env=None):
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='{"state": "opened", "upvotes": 0, "author": {"username": "me"}}',
+                stderr="",
+            )
+
+        monkeypatch.setattr("teatree.utils.run.run_allowed_to_fail", fake_run)
+        monkeypatch.setattr("shutil.which", lambda _arg: "/usr/bin/glab")
+
+        states = GlabGhMrStateClassifier(glab_token="glpat-fake")([url])
+
+        assert states[0].author_username == "me"
+        assert states[0].merged is False
+
+    def test_gitlab_missing_author_block_yields_empty_username(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        url = "https://gitlab.example.com/team/project/-/merge_requests/7446"
+
+        def fake_run(cmd, *, expected_codes=None, env=None):
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='{"state": "opened", "upvotes": 0}',
+                stderr="",
+            )
+
+        monkeypatch.setattr("teatree.utils.run.run_allowed_to_fail", fake_run)
+        monkeypatch.setattr("shutil.which", lambda _arg: "/usr/bin/glab")
+
+        states = GlabGhMrStateClassifier(glab_token="glpat-fake")([url])
+
+        assert states[0].author_username == ""
+
+    def test_github_reads_author_login(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        url = "https://github.com/owner/repo/pull/42"
+        captured: list[list[str]] = []
+
+        def fake_run(cmd, *, expected_codes=None, env=None):
+            captured.append(list(cmd))
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='{"state": "OPEN", "reviewDecision": "", "author": {"login": "me"}}',
+                stderr="",
+            )
+
+        monkeypatch.setattr("teatree.utils.run.run_allowed_to_fail", fake_run)
+        monkeypatch.setattr("shutil.which", lambda _arg: "/usr/bin/gh")
+
+        states = GlabGhMrStateClassifier(github_token="ghp-fake")([url])
+
+        assert states[0].author_username == "me"
+        # The author field must be in the requested json columns.
+        assert "state,reviewDecision,author" in captured[0]
 
 
 class TestScannerSkipsOnMissingMigration(TestCase):


### PR DESCRIPTION
## Problem

`SlackBroadcastsScanner` reacted `:eyes:` on every pending review-crew broadcast it saw — including broadcasts for MRs authored by the current user. The `:eyes:` reaction means "I'm looking at this colleague's MR"; on one's own MR it is meaningless noise the user has to remove by hand. This is the sibling-of-#1321 enforcement for the reaction-add path (#1321 covered the review-sweep own-author exclusion).

## Fix

- Extend `MrState` with an `author_username` field.
- `GlabGhMrStateClassifier` reads `author.username` from `glab mr view` JSON and `author.login` from `gh pr view` (the `gh` `--json` column list gains `author`).
- In `_apply_classification`, when **every** open MR in the broadcast is authored by `current_gitlab_username`, skip both the `:eyes:` reaction and the reviewer-dispatch signals.
- Inject `current_gitlab_username` into the scanner via `overlay.config.get_gitlab_username()` in the `tick_jobs` builder. Empty username leaves the filter off, so legacy overlays keep reacting on every pending broadcast.

A mixed-authorship broadcast (one own MR + one colleague MR still open) is not "all mine", so the `:eyes:` react + dispatch still fire — a colleague MR always needs review.

## Tests (TDD)

`tests/teatree_loop/test_slack_broadcasts_scanner.py`:

- `TestSkipsEyesOnOwnMrBroadcasts` — sole own-MR broadcast produces no `:eyes:` and no review-intent signal; colleague-MR and mixed-authorship broadcasts still react.
- `TestClassifierReadsAuthorUsername` — classifier surfaces `author.username` (GitLab) / `author.login` (GitHub) and degrades to empty on a missing author block.

Anti-vacuous verified: neutering the filter turns `test_sole_own_mr_broadcast_skips_eyes_and_dispatch` RED while the colleague/mixed cases stay green; restoring it returns to green (20 passed). Full loop suite: 1143 passed.

Closes #1384
