### PR TITLE
fix(triage): detect bare issue refs and make resolution confidence meaningful

### DIFF
--- a/src/teatree/triage.py
+++ b/src/teatree/triage.py
@@ -169,7 +169,11 @@ class DuplicateFinder:
         return matches
 
 
-_ISSUE_REF_IN_TITLE = re.compile(r"\(#(\d+)\)")
+# Matches a ``#N`` issue reference anywhere in a PR title — the canonical
+# parenthesized ``(#N)`` form *and* loose mentions like "fixes #N". The
+# parenthesized form drives the high-confidence verdict (see
+# ``ResolvedIssue.confidence``).
+_ISSUE_REF_IN_TITLE = re.compile(r"(?<![\w/])#(\d+)\b")
 
 
 @dataclass(frozen=True)
@@ -181,7 +185,8 @@ class ResolvedIssue:
 
     @property
     def confidence(self) -> str:
-        return "high" if f"#{self.issue_number})" in self.pr_title else "medium"
+        canonical = f"(#{self.issue_number})"
+        return "high" if canonical in self.pr_title else "medium"
 
 
 @dataclass(frozen=True)
@@ -253,18 +258,17 @@ class TriageScanner:
 
         resolved: list[ResolvedIssue] = []
         for pr in prs:
-            for match in _ISSUE_REF_IN_TITLE.finditer(pr["title"]):
-                ref_number = int(match.group(1))
-                if ref_number in issue_numbers:
-                    issue = issue_by_number[ref_number]
-                    resolved.append(
-                        ResolvedIssue(
-                            issue_number=ref_number,
-                            issue_title=issue["title"],
-                            pr_number=pr["number"],
-                            pr_title=pr["title"],
-                        )
+            ref_numbers = {int(m.group(1)) for m in _ISSUE_REF_IN_TITLE.finditer(pr["title"])}
+            for ref_number in sorted(ref_numbers & issue_numbers):
+                issue = issue_by_number[ref_number]
+                resolved.append(
+                    ResolvedIssue(
+                        issue_number=ref_number,
+                        issue_title=issue["title"],
+                        pr_number=pr["number"],
+                        pr_title=pr["title"],
                     )
+                )
         resolved.sort(key=lambda r: r.issue_number)
         return resolved
 

--- a/tests/test_hook_router_agent_plan_gate.py
+++ b/tests/test_hook_router_agent_plan_gate.py
@@ -48,8 +48,7 @@ def gate_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg))
     monkeypatch.delenv("TEATREE_PLAN_GATE_WINDOW_MINUTES", raising=False)
 
-    ts_file = xdg / "teatree" / "last-plan-skill-ts"
-    yield ts_file
+    yield xdg / "teatree" / "last-plan-skill-ts"
 
     router.STATE_DIR = original_state
 

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -285,7 +285,7 @@ class TestTriageScanner:
             mock_run.return_value = SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0)
             assert TriageScanner("souliane/teatree").find_stale(days=1) == []
 
-    def test_confidence_property(self) -> None:
+    def test_confidence_high_for_parenthesized_reference(self) -> None:
         issues = [_issue_with_age(42, "feat: triage")]
         prs = [_pr_fixture(100, "feat: triage (#42)")]
         with patch("teatree.triage.run_allowed_to_fail") as mock_run:
@@ -294,6 +294,41 @@ class TestTriageScanner:
                 SimpleNamespace(stdout=json.dumps(prs), stderr="", returncode=0),
             ]
             resolved = TriageScanner("souliane/teatree").find_resolved()
+        assert resolved[0].confidence == "high"
+
+    def test_finds_resolved_issue_from_bare_reference(self) -> None:
+        issues = [_issue_with_age(42, "broken thing")]
+        prs = [_pr_fixture(100, "fix: thing, fixes #42")]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.side_effect = [
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(prs), stderr="", returncode=0),
+            ]
+            resolved = TriageScanner("souliane/teatree").find_resolved()
+        assert len(resolved) == 1
+        assert resolved[0].issue_number == 42
+
+    def test_confidence_medium_for_bare_reference(self) -> None:
+        issues = [_issue_with_age(42, "broken thing")]
+        prs = [_pr_fixture(100, "fix: thing, fixes #42")]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.side_effect = [
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(prs), stderr="", returncode=0),
+            ]
+            resolved = TriageScanner("souliane/teatree").find_resolved()
+        assert resolved[0].confidence == "medium"
+
+    def test_repeated_reference_yields_single_resolution(self) -> None:
+        issues = [_issue_with_age(42, "broken thing")]
+        prs = [_pr_fixture(100, "fix: thing, fixes #42 (#42)")]
+        with patch("teatree.triage.run_allowed_to_fail") as mock_run:
+            mock_run.side_effect = [
+                SimpleNamespace(stdout=json.dumps(issues), stderr="", returncode=0),
+                SimpleNamespace(stdout=json.dumps(prs), stderr="", returncode=0),
+            ]
+            resolved = TriageScanner("souliane/teatree").find_resolved()
+        assert len(resolved) == 1
         assert resolved[0].confidence == "high"
 
     def test_gh_failure_returns_empty(self) -> None:


### PR DESCRIPTION
## Bug-hunt + quick-win pass

A focused pass on `teatree.triage` (the resolved-but-open / stale issue scanner) plus one lint fixup. Full test suite was green on `main` (7395 passed); these are real logic bugs found by reading the code, each with an anti-vacuous regression test.

### Fixes

**1. Resolved-issue scanner missed bare `#N` references (false negatives).**
`find_resolved` only matched the parenthesized `(#N)` form in merged-PR titles. A PR titled `fix: thing, fixes #42` never linked back to issue #42, so a genuinely-resolved issue stayed open (and was never auto-closed under `--close-resolved`). The reference regex now matches `#N` anywhere in the title, with a lookbehind that still rejects `abc#42`, `path/#42`, and hex colors like `#fff`.
- Test: `test_finds_resolved_issue_from_bare_reference`

**2. `ResolvedIssue.confidence` was vacuously always `"high"`.**
Because the finder only ever matched titles already containing `(#N)`, the property's looser `#N)` substring check could never be false, so the user-visible `[high]`/`[medium]` label (rendered by `t3 tools triage-issues`) was meaningless and the `"medium"` branch was dead code. `confidence` now returns `"high"` for the canonical `(#N)` form and `"medium"` for a bare `#N` mention, so the signal does real work alongside fix #1.
- Test: `test_confidence_medium_for_bare_reference` (and the existing high-confidence case, renamed)

**3. Duplicate resolutions from a title carrying both forms.**
With the broadened regex, a title like `fixes #42 (#42)` would have produced two identical `ResolvedIssue` entries. References are now deduped per PR.
- Test: `test_repeated_reference_yields_single_resolution`

**4. Lint: `ruff check` was red (RUF070).**
A test fixture assigned `ts_file` then immediately yielded it; inlined the yield so `ruff check` passes clean again.

### Verification

- `uv run pytest` (full suite): **7397 passed, 13 skipped, 37 subtests passed**; total coverage **93.35%** (floor 93%).
- `uv run ruff check`: clean. `uv run ruff format --check`: clean. `uv run ty check`: clean.
- Each fix verified anti-vacuous: reverting the source change turns the new test(s) red, restoring turns them green.

### Left alone (noted, not changed)

- `update_check.py` compares versions with `==`, so if the local build is *ahead* of the latest release it would still show an "upgrade" notice. Not currently reachable (the package version is pinned and there are no semver release tags), and a correct fix means semver comparison + a dependency-declaration decision — out of scope for an unattended pass.
- `url_title_fetcher.fetch_titles` relies on the `ThreadPoolExecutor` `with` block, whose exit waits for in-flight futures, so `TOTAL_BUDGET` is not a hard ceiling. `cancel_futures=True` would tighten it, but a deterministic regression test would be clock/timing-dependent and flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)