### PR TITLE
fix(ship): cross-check Closes/Fixes/Resolves #N against the real target issue

### DIFF
--- a/src/teatree/core/management/commands/_closes_issue_crosscheck.py
+++ b/src/teatree/core/management/commands/_closes_issue_crosscheck.py
@@ -1,0 +1,204 @@
+"""Pre-push gate: cross-check ``Closes/Fixes/Resolves #N`` against the real issue.
+
+teatree's internal TaskList uses integer ids (``#45``, ``#66``, …) that are
+NOT GitHub/GitLab issue numbers. A ``Closes #<task-id>`` trailer therefore
+mis-targets whatever unrelated issue happens to carry that number — observed:
+a closed PR, a docs issue — auto-closing it the instant the PR merges (#83).
+
+This gate runs alongside the auto-close-rewrite path (``sanitize_close_keywords``)
+and is its mirror image: ``_close_keyword_gate`` REJECTS trailers for overlays
+that forbid them, while this gate VALIDATES the trailers that overlays which
+DO auto-close (``config.mr_close_ticket``) are about to ship. For every
+``#N`` referenced after a close keyword it resolves the sibling issue URL on
+the **target repo** (derived from the ticket's own ``issue_url``) and fetches
+the issue via the code host.
+
+BLOCK (``SystemExit``) when the issue is closed or missing — a closed or
+absent target is the task-id-vs-issue-number symptom. WARN (logged,
+non-blocking) when the issue is open but its title shares no token with the
+branch name — a weak "probably the wrong issue" signal.
+
+Detection uses the same close-keyword verb set as
+``teatree.core.runners.ship.CLOSE_KEYWORD_RE`` (the auto-close single source
+of truth, #1090), narrowed to the *bare* ``#N`` form — full-URL references
+already name their target repo, so they carry no task-id collision hazard.
+Unverifiable inputs (no code host, an unparsable ticket URL, a git failure)
+fail OPEN: the gate skips rather than block on an unknown, matching
+``_scan_sources`` and ``PrOpenState.UNKNOWN``.
+"""
+
+import logging
+import re
+from urllib.parse import urlparse
+
+from teatree.core.backend_factory import code_host_from_overlay
+from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay_loader import get_overlay
+from teatree.types import RawAPIDict
+from teatree.utils import git
+from teatree.utils.run import CommandFailedError
+
+logger = logging.getLogger(__name__)
+
+# A close keyword followed by a *bare* ``#N`` — the form that carries the
+# task-id-vs-issue-number hazard. Full-URL references already name their
+# target repo explicitly, so they are out of scope here (the close-keyword
+# gate covers the forbidding overlays; auto-close handles the rest).
+_BARE_REF_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?::\s*|\s+)#(?P<number>\d+)",
+    re.IGNORECASE,
+)
+
+# A GitHub-/GitLab-style issue URL whose trailing ``/<number>`` we swap for the
+# referenced ``#N`` to build the sibling issue URL on the same repo. Matches
+# both ``…/issues/<n>`` (GitHub) and ``…/-/issues/<n>`` (GitLab web form).
+_ISSUE_PATH_RE = re.compile(r"^(?P<prefix>.*/issues)/\d+/?$")
+
+_MIN_TOKEN_LEN = 3
+_OPEN_STATES = frozenset({"open", "opened"})
+_CLOSED_STATES = frozenset({"closed", "close"})
+
+
+def _tokens(text: str) -> set[str]:
+    """Lowercased alphanumeric tokens of *text*, dropping short / numeric ones.
+
+    A leading issue number (``83-gate-…``) and 1-2 char fragments carry no
+    intent signal, so they are excluded from the cross-relevance comparison.
+    """
+    raw = re.split(r"[^0-9a-z]+", text.lower())
+    return {tok for tok in raw if len(tok) >= _MIN_TOKEN_LEN and not tok.isdigit()}
+
+
+def _shares_token(issue_title: str, branch: str) -> bool:
+    """Whether *issue_title* and *branch* share any meaningful token.
+
+    Returns ``True`` when the branch has no comparable tokens — a token-less
+    branch is undecidable, and the gate must never escalate an undecidable
+    case to a warning.
+    """
+    branch_tokens = _tokens(branch)
+    if not branch_tokens:
+        return True
+    return bool(branch_tokens & _tokens(issue_title))
+
+
+def _issue_url_for_ref(ticket_issue_url: str, number: str) -> str:
+    """Build the sibling issue URL for ``#number`` on the ticket's own repo.
+
+    The ticket's ``issue_url`` names the repo a bare ``#N`` resolves against;
+    swap its trailing issue number for *number*. Returns ``""`` when the
+    ticket URL is not a recognisable issue URL (the gate then fails open).
+    """
+    parsed = urlparse(ticket_issue_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    match = _ISSUE_PATH_RE.match(parsed.path)
+    if match is None:
+        return ""
+    return f"{parsed.scheme}://{parsed.netloc}{match['prefix']}/{number}"
+
+
+def _referenced_numbers(worktree: Worktree) -> list[str]:
+    """Bare ``#N`` numbers referenced after a close keyword, de-duplicated.
+
+    Scans the same author-intent sources as ``_close_keyword_gate``: the raw
+    last-commit message (the MR description's source) plus every branch commit
+    body. A git failure is unverifiable — return what was collected so far
+    rather than block on an unknown.
+    """
+    repo = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
+    branch = worktree.branch
+    if not repo or not branch:
+        return []
+    sources: list[str] = []
+    try:
+        subject, body = git.last_commit_message(repo=repo)
+        sources.append(f"{subject}\n\n{body}" if body else subject)
+        base = f"origin/{git.default_branch(repo=repo)}"
+        sources.extend(git.commit_messages(repo=repo, range_spec=f"{base}..{branch}"))
+    except (CommandFailedError, RuntimeError, ValueError):
+        pass
+    numbers: list[str] = []
+    for source in sources:
+        for match in _BARE_REF_RE.finditer(source):
+            number = match["number"]
+            if number not in numbers:
+                numbers.append(number)
+    return numbers
+
+
+def _issue_state(issue: RawAPIDict) -> str:
+    state = issue.get("state")
+    return state.lower() if isinstance(state, str) else ""
+
+
+def _issue_title(issue: RawAPIDict) -> str:
+    title = issue.get("title")
+    return title if isinstance(title, str) else ""
+
+
+def _issue_missing(issue: RawAPIDict) -> bool:
+    return "error" in issue or _issue_state(issue) not in (_OPEN_STATES | _CLOSED_STATES)
+
+
+def run_closes_issue_crosscheck(ticket: Ticket, worktree: Worktree) -> None:
+    """Cross-check every ``Closes #N`` trailer against the real target issue.
+
+    No-op unless the active overlay sets ``config.mr_close_ticket`` (only
+    then does ``Closes #N`` survive into the merged PR and auto-close the
+    issue). Raises ``SystemExit`` when a referenced issue is closed or
+    missing; logs a WARNING when an open issue's title shares no token with
+    the branch. Fails OPEN on any unverifiable input.
+    """
+    if not get_overlay().config.mr_close_ticket:
+        return
+
+    numbers = _referenced_numbers(worktree)
+    if not numbers:
+        return
+
+    host = code_host_from_overlay()
+    if host is None:
+        return
+
+    branch = worktree.branch
+    blockers: list[str] = []
+    for number in numbers:
+        url = _issue_url_for_ref(ticket.issue_url, number)
+        if not url:
+            # Ticket URL is not a recognisable issue URL — can't resolve the
+            # target repo for a bare ``#N``; unverifiable, skip.
+            continue
+        issue = host.get_issue(url)
+        if _issue_missing(issue):
+            blockers.append(
+                f"  - #{number} → {url}\n    issue is missing or unreadable on the target repo "
+                "(a teatree task id is NOT an issue number — did you mean a real open issue?)"
+            )
+            continue
+        if _issue_state(issue) in _CLOSED_STATES:
+            blockers.append(
+                f"  - #{number} → {url}\n    issue is already CLOSED — merging would re-close it spuriously"
+            )
+            continue
+        if not _shares_token(_issue_title(issue), branch):
+            logger.warning(
+                "Closes #%s targets %r whose title %r shares no token with branch %r — "
+                "verify this is the intended issue, not a stray task-id collision.",
+                number,
+                url,
+                _issue_title(issue),
+                branch,
+            )
+
+    if blockers:
+        bullets = "\n".join(blockers)
+        msg = (
+            "Refusing to ship: a `Closes/Fixes/Resolves #N` trailer references an issue that is "
+            "not a real open issue on the target repo. teatree task ids are NOT issue numbers, so "
+            "a stray trailer mis-targets an unrelated issue and auto-closes it on merge:\n"
+            f"{bullets}\n"
+            "Fix the trailer to reference a real OPEN issue, or rewrite it to `Relates to #N` "
+            "(no auto-close), then retry `pr create`."
+        )
+        raise SystemExit(msg)

--- a/src/teatree/core/management/commands/_ship_gates.py
+++ b/src/teatree/core/management/commands/_ship_gates.py
@@ -1,0 +1,263 @@
+"""Pre-ship gate helpers, extracted from ``pr.py`` by concern.
+
+The ``pr create`` command runs a sequence of deterministic gates before it
+advances the FSM to SHIPPED: branch-currency auto-merge (#940), the
+phase/shipping gate (#694), the overlay-scoped close-keyword gates (#1012 /
+#83), the visual-QA browser sanity gate, and the PR-metadata validator. Those
+leaf gates plus their failure payloads live here so ``pr.py`` stays within the
+module-health LOC bar; ``pr.py`` re-imports them and keeps the ``_run_ship_gates``
+orchestrator (so the existing ``patch.object(pr, "_run_visual_qa_gate")`` test
+seams keep resolving against ``pr``'s namespace).
+"""
+
+from typing import TypedDict, cast
+
+from teatree import visual_qa
+from teatree.core.branch_currency import require_current_branch
+from teatree.core.management.commands._ship_exec import ShippingGateFailure
+from teatree.core.management.commands._ship_fsm import reconcile_fsm_for_ship
+from teatree.core.models import Session, Ticket, Worktree
+from teatree.core.models.types import TicketExtra, VisualQASummary
+from teatree.core.overlay_loader import get_overlay
+from teatree.core.phases import normalize_phase
+from teatree.core.runners.ship import resolve_ship_worktree
+from teatree.utils import git
+from teatree.utils.run import CommandFailedError
+
+
+class VisualQAGateFailure(TypedDict):
+    allowed: bool
+    error: str
+    visual_qa: VisualQASummary
+    report_markdown: str
+    hint: str
+
+
+class BranchCurrencyFailure(TypedDict):
+    """Pre-ship branch-currency gate refusal (#940).
+
+    Returned when ``origin/<target>`` has advanced past the branch
+    point and ``git merge`` produced conflicts. The branch must be
+    manually merged + resolved before the cold reviewer attests the
+    post-merge SHA — otherwise the release pipeline certifies a stale
+    base.
+    """
+
+    allowed: bool
+    error: str
+    hint: str
+    branch: str
+    target: str
+
+
+class NoCommitsAheadError(TypedDict):
+    error: str
+    branch: str
+    base: str
+
+
+def assert_commits_ahead_of_base(worktree: Worktree) -> NoCommitsAheadError | None:
+    """Block a hollow ship: the branch must have ≥1 commit ahead of base (#788).
+
+    The phase gate answers "is the work attested?"; this answers "is
+    there actually anything to ship?". Without it, a
+    reviewer-approved-but-uncommitted (or committed-elsewhere) branch
+    produced a hollow ``state: shipped`` — the CLI reported success, the
+    FSM advanced, then ``execute_ship`` later failed with "No commits
+    between main and branch", deferring the real failure into the async
+    worker where it is easy to miss.
+
+    Blocks **only on a confirmed zero** (``rev_count(base..branch) ==
+    0``), naming the branch and the base it was compared against. If git
+    introspection cannot be performed (no real repo, base undetectable,
+    git error) the state is *unverifiable* — distinct from the
+    confirmed-zero bug — so the prior behaviour (proceed) is preserved
+    rather than blocking on an unknown.
+    """
+    repo = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
+    branch = worktree.branch
+    if not repo or not branch:
+        return None
+    try:
+        base = f"origin/{git.default_branch(repo=repo)}"
+        ahead = git.rev_count(repo=repo, range_spec=f"{base}..{branch}")
+    except (CommandFailedError, RuntimeError, ValueError):
+        return None  # unverifiable ≠ the confirmed-zero bug — do not block
+    if ahead > 0:
+        return None
+    return NoCommitsAheadError(
+        error=(
+            f"Refusing to ship: branch {branch!r} has 0 commits ahead of {base} — "
+            f"nothing to push (work uncommitted or committed elsewhere). "
+            f"Commit the work on {branch!r}, then retry `pr create`."
+        ),
+        branch=branch,
+        base=base,
+    )
+
+
+def resolve_target_branch(ticket: Ticket, repo: str) -> str:
+    """Stacked-PR target resolver (#940).
+
+    Reads ``ticket.extra['target_branch']`` first (stacked PRs base on
+    a different branch than ``origin/main``); falls back to
+    ``origin/<default>`` — the same resolver shape
+    :func:`assert_commits_ahead_of_base` uses.
+    """
+    extra = ticket.extra or {}
+    explicit = str(extra.get("target_branch") or "").strip()
+    if explicit:
+        return explicit if "/" in explicit else f"origin/{explicit}"
+    try:
+        return f"origin/{git.default_branch(repo=repo)}"
+    except (CommandFailedError, RuntimeError, ValueError):
+        return "origin/main"
+
+
+def run_branch_currency_gate(
+    ticket: Ticket,
+    worktree: Worktree,
+) -> BranchCurrencyFailure | None:
+    """Auto-merge ``target`` into the feature branch before the rest of the gates (#940).
+
+    Placed FIRST in :func:`_run_ship_gates` so the visual-QA gate, the
+    phase gate, and the eventual cold-review attestation all run
+    against the post-merge tree — not a stale base whose target-branch
+    fixes are missing. On zero-conflict the new HEAD is recorded as
+    ``ship_invoking_branch``'s post-merge sha so the cold reviewer
+    attests the SHA the loop will actually push. On conflict the gate
+    refuses cleanly (``git merge --abort`` already restored the tree).
+    Fetch failures (offline, auth) are inconclusive — same posture as
+    :mod:`teatree.core.clone_guard`.
+    """
+    repo = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
+    branch = worktree.branch
+    if not repo or not branch:
+        return None
+    target = resolve_target_branch(ticket, repo)
+
+    result = require_current_branch(repo, branch, target=target)
+    if result["error"]:
+        return BranchCurrencyFailure(
+            allowed=False,
+            error=result["error"],
+            hint=result["hint"] or "",
+            branch=branch,
+            target=target,
+        )
+    post_sha = result["post_merge_sha"]
+    if result["auto_merged"] and post_sha:
+        # #800 N3: canonical locked RMW — record the post-merge HEAD so
+        # the cold reviewer's attestation binds to the tree the loop
+        # will actually push, not the pre-merge stale base.
+        ticket.merge_extra(set_keys={"branch_currency_post_merge_sha": post_sha})
+    return None
+
+
+def check_shipping_gate(ticket: Ticket) -> ShippingGateFailure | None:
+    """Reconcile ``ticket.state`` from the session, or block with missing phases.
+
+    ``Session.visited_phases`` is the single source of truth (#694). When the
+    required phases are present this auto-walks the FSM to REVIEWED so
+    ``ticket.ship()`` is legal — the gate and ``ticket.state`` can no longer
+    disagree. When phases are missing it returns structured JSON with the
+    exact ``missing`` list so the calling agent can satisfy the gate rather
+    than hitting a raw ``TransitionNotAllowed``.
+    """
+    from teatree.core.models.errors import QualityGateError  # noqa: PLC0415
+
+    # #801 SSOT: canonical earliest selection (was -pk-latest); the
+    # gate only READS — create=False so a gate check never mints a
+    # session as a side effect.
+    session = ticket.find_phase_session()
+    if session is None:
+        # No session => no attested work; nothing to reconcile. Returning
+        # ``None`` here would let ``ticket.ship()`` raise a raw
+        # ``TransitionNotAllowed`` from a non-REVIEWED state, breaking the
+        # "pr create never raises a raw TransitionNotAllowed" invariant.
+        required = Session._REQUIRED_PHASES.get("shipping", [])  # noqa: SLF001
+        return ShippingGateFailure(
+            allowed=False,
+            error="No session: no attested work to reconcile.",
+            missing=list(required),
+            hint="Run the work through the loop (or `lifecycle visit-phase`) so the phases are recorded, then retry.",
+        )
+    try:
+        # Single source of truth = the union of phase records across ALL
+        # the ticket's sessions, not just the latest (#694). FSM-advancing
+        # `visit-phase` forks fresh sessions by design; the required phases
+        # are legitimately scattered across the ticket lifecycle.
+        session.check_gate_across_ticket("shipping")
+    except QualityGateError as exc:
+        # #1118: normalize the visited list before comparing — ``_check_phases``
+        # normalizes both sides (#782), so an unnormalized comparison here
+        # would name a phase as missing that the gate itself accepted.
+        visited, _ = ticket.aggregate_phase_records()
+        canonical_visited = {normalize_phase(phase) for phase in visited}
+        required = Session._REQUIRED_PHASES.get("shipping", [])  # noqa: SLF001
+        missing = [p for p in required if p not in canonical_visited]
+        return ShippingGateFailure(
+            allowed=False,
+            error=f"Gate check failed: {exc}",
+            missing=missing,
+            hint="Spawn a review sub-agent to satisfy the reviewing gate, then retry.",
+        )
+
+    # Gate passed -> the work is attested. Reconcile the FSM so ``ship()``
+    # is legal and drain any orphan reviewing task (gate-verified only).
+    reconcile_fsm_for_ship(ticket, consume_reviewing_tasks=True)
+    return None
+
+
+def resolve_base_url(worktree: Worktree | None) -> str:
+    """Return the frontend URL recorded by ``Worktree.verify()``.
+
+    Prefers ``urls['frontend']`` (what users browse) over ``urls['backend']``.
+    Falls back to ``http://127.0.0.1:8000`` when no URLs are recorded yet.
+    """
+    if worktree is None:
+        return "http://127.0.0.1:8000"
+    urls = worktree.get_extra().get("urls", {})
+    return urls.get("frontend") or urls.get("backend") or "http://127.0.0.1:8000"
+
+
+def run_visual_qa_gate(ticket: Ticket, *, skip_reason: str = "") -> VisualQAGateFailure | None:
+    """Run the pre-push browser sanity gate before PR creation.
+
+    Records a JSON summary on ``ticket.extra['visual_qa']`` when the gate
+    actually ran (i.e. not skipped for env/flag reasons) so the result
+    survives in the FSM history.  Returns an error dict when blocking
+    findings are present so the caller can refuse PR creation, or
+    ``None`` when the gate passes / is skipped.
+    """
+    # #776 N1: resolve the INVOKING worktree (same root cause as the
+    # ship-branch fix) — a reused multi-workstream ticket must run visual
+    # QA against the current workstream's repo, not the stale earliest
+    # `worktrees.first()` row. The `ship_invoking_branch` hint is recorded
+    # by `create()` before the gates run, so the canonical resolver has
+    # the data here too.
+    extra = cast("TicketExtra", ticket.extra or {})
+    worktree = resolve_ship_worktree(ticket, extra)
+    repo_path = worktree.repo_path if worktree else "."
+    base_url = resolve_base_url(worktree)
+
+    overlay = get_overlay()
+    diff = visual_qa.changed_files(repo=repo_path)
+    report = visual_qa.evaluate(diff=diff, overlay=overlay, base_url=base_url, skip_reason=skip_reason)
+
+    # Only persist when the gate produced a meaningful signal — skipping a
+    # no-op run keeps the FSM history readable.
+    if report.pages or report.has_errors:
+        # #800 N3: canonical locked RMW — concurrent pr_urls (ship
+        # worker) writer no longer clobbers visual_qa.
+        ticket.merge_extra(set_keys={"visual_qa": report.summary()})
+
+    if not report.has_errors:
+        return None
+    return VisualQAGateFailure(
+        allowed=False,
+        error=f"Visual QA found {report.total_errors} blocking finding(s).",
+        visual_qa=report.summary(),
+        report_markdown=visual_qa.format_report(report),
+        hint="Fix the findings, or pass --skip-visual-qa <reason> to bypass.",
+    )

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -7,15 +7,14 @@ returns the PR URL once the worker completes.
 """
 
 import re
-from typing import TypedDict, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 from django_typer.management import TyperCommand, command
 
-from teatree import visual_qa
 from teatree.core.backend_factory import code_host_from_overlay
-from teatree.core.branch_currency import require_current_branch
 from teatree.core.db_anchor import assert_lifecycle_db_is_canonical
 from teatree.core.management.commands._close_keyword_gate import run_close_keyword_gate
+from teatree.core.management.commands._closes_issue_crosscheck import run_closes_issue_crosscheck
 from teatree.core.management.commands._ensure_pr import EnsurePrResult, create_or_defer_pr
 from teatree.core.management.commands._pr_preview import (
     PrValidationError,
@@ -36,8 +35,12 @@ from teatree.core.management.commands._ship_exec import (
     _ship_sync,
 )
 from teatree.core.management.commands._ship_fsm import reconcile_fsm_for_ship
-from teatree.core.models import Session, Ticket, Worktree
-from teatree.core.models.types import TicketExtra, VisualQASummary
+from teatree.core.management.commands._ship_gates import BranchCurrencyFailure, NoCommitsAheadError, VisualQAGateFailure
+from teatree.core.management.commands._ship_gates import assert_commits_ahead_of_base as _assert_commits_ahead_of_base
+from teatree.core.management.commands._ship_gates import check_shipping_gate as _check_shipping_gate
+from teatree.core.management.commands._ship_gates import run_branch_currency_gate as _run_branch_currency_gate
+from teatree.core.management.commands._ship_gates import run_visual_qa_gate as _run_visual_qa_gate
+from teatree.core.models import Ticket, Worktree
 from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError, require_on_behalf_approval
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 from teatree.core.orphan_guard import BranchStatus, classify_branch
@@ -47,32 +50,17 @@ from teatree.core.public_identity import MergeResult
 from teatree.core.runners.ship import resolve_ship_worktree
 from teatree.types import RawAPIDict
 from teatree.utils import git
-from teatree.utils.run import CommandFailedError
 
+if TYPE_CHECKING:
+    from teatree.core.models.types import TicketExtra
 
-class VisualQAGateFailure(TypedDict):
-    allowed: bool
-    error: str
-    visual_qa: VisualQASummary
-    report_markdown: str
-    hint: str
-
-
-class BranchCurrencyFailure(TypedDict):
-    """Pre-ship branch-currency gate refusal (#940).
-
-    Returned when ``origin/<target>`` has advanced past the branch
-    point and ``git merge`` produced conflicts. The branch must be
-    manually merged + resolved before the cold reviewer attests the
-    post-merge SHA — otherwise the release pipeline certifies a stale
-    base.
-    """
-
-    allowed: bool
-    error: str
-    hint: str
-    branch: str
-    target: str
+# VisualQAGateFailure / BranchCurrencyFailure / NoCommitsAheadError and the
+# pre-ship gate helpers live in ``_ship_gates`` (extracted by concern,
+# re-imported above under their legacy underscore names) so external importers
+# of ``pr.VisualQAGateFailure`` / ``pr._run_visual_qa_gate`` keep working and
+# ``pr.py`` stays within the module-health LOC bar. ``_run_ship_gates`` stays
+# here so the ``patch.object(pr, "_run_visual_qa_gate")`` test seams resolve
+# against this module's namespace.
 
 
 # ShipDryRun / PrValidationError live in ``_pr_preview`` (re-exported below)
@@ -89,12 +77,6 @@ class WorktreeMissingError(TypedDict):
     error: str
 
 
-class NoCommitsAheadError(TypedDict):
-    error: str
-    branch: str
-    base: str
-
-
 # ShipEnqueued / ShipExecuted / ShippingGateFailure and the ship-execution
 # helpers live in ``_ship_exec`` (extracted by concern, re-exported above)
 # so external importers of ``pr.ShipExecuted`` etc. keep working and
@@ -106,213 +88,6 @@ class NoCommitsAheadError(TypedDict):
 
 _IMAGE_URL_RE = re.compile(r"!\[([^\]]*)\]\((/uploads/[^\)]+)\)")
 _EXTERNAL_LINK_RE = re.compile(r"https?://(?:www\.)?(?:notion\.so|linear\.app|jira\.\S+)/\S+")
-
-
-def _assert_commits_ahead_of_base(worktree: Worktree) -> NoCommitsAheadError | None:
-    """Block a hollow ship: the branch must have ≥1 commit ahead of base (#788).
-
-    The phase gate answers "is the work attested?"; this answers "is
-    there actually anything to ship?". Without it, a
-    reviewer-approved-but-uncommitted (or committed-elsewhere) branch
-    produced a hollow ``state: shipped`` — the CLI reported success, the
-    FSM advanced, then ``execute_ship`` later failed with "No commits
-    between main and branch", deferring the real failure into the async
-    worker where it is easy to miss.
-
-    Blocks **only on a confirmed zero** (``rev_count(base..branch) ==
-    0``), naming the branch and the base it was compared against. If git
-    introspection cannot be performed (no real repo, base undetectable,
-    git error) the state is *unverifiable* — distinct from the
-    confirmed-zero bug — so the prior behaviour (proceed) is preserved
-    rather than blocking on an unknown.
-    """
-    repo = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
-    branch = worktree.branch
-    if not repo or not branch:
-        return None
-    try:
-        base = f"origin/{git.default_branch(repo=repo)}"
-        ahead = git.rev_count(repo=repo, range_spec=f"{base}..{branch}")
-    except (CommandFailedError, RuntimeError, ValueError):
-        return None  # unverifiable ≠ the confirmed-zero bug — do not block
-    if ahead > 0:
-        return None
-    return NoCommitsAheadError(
-        error=(
-            f"Refusing to ship: branch {branch!r} has 0 commits ahead of {base} — "
-            f"nothing to push (work uncommitted or committed elsewhere). "
-            f"Commit the work on {branch!r}, then retry `pr create`."
-        ),
-        branch=branch,
-        base=base,
-    )
-
-
-def _resolve_target_branch(ticket: Ticket, repo: str) -> str:
-    """Stacked-PR target resolver (#940).
-
-    Reads ``ticket.extra['target_branch']`` first (stacked PRs base on
-    a different branch than ``origin/main``); falls back to
-    ``origin/<default>`` — the same resolver shape
-    :func:`_assert_commits_ahead_of_base` uses.
-    """
-    extra = ticket.extra or {}
-    explicit = str(extra.get("target_branch") or "").strip()
-    if explicit:
-        return explicit if "/" in explicit else f"origin/{explicit}"
-    try:
-        return f"origin/{git.default_branch(repo=repo)}"
-    except (CommandFailedError, RuntimeError, ValueError):
-        return "origin/main"
-
-
-def _run_branch_currency_gate(
-    ticket: Ticket,
-    worktree: Worktree,
-) -> BranchCurrencyFailure | None:
-    """Auto-merge ``target`` into the feature branch before the rest of the gates (#940).
-
-    Placed FIRST in :func:`_run_ship_gates` so the visual-QA gate, the
-    phase gate, and the eventual cold-review attestation all run
-    against the post-merge tree — not a stale base whose target-branch
-    fixes are missing. On zero-conflict the new HEAD is recorded as
-    ``ship_invoking_branch``'s post-merge sha so the cold reviewer
-    attests the SHA the loop will actually push. On conflict the gate
-    refuses cleanly (``git merge --abort`` already restored the tree).
-    Fetch failures (offline, auth) are inconclusive — same posture as
-    :mod:`teatree.core.clone_guard`.
-    """
-    repo = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
-    branch = worktree.branch
-    if not repo or not branch:
-        return None
-    target = _resolve_target_branch(ticket, repo)
-
-    result = require_current_branch(repo, branch, target=target)
-    if result["error"]:
-        return BranchCurrencyFailure(
-            allowed=False,
-            error=result["error"],
-            hint=result["hint"] or "",
-            branch=branch,
-            target=target,
-        )
-    post_sha = result["post_merge_sha"]
-    if result["auto_merged"] and post_sha:
-        # #800 N3: canonical locked RMW — record the post-merge HEAD so
-        # the cold reviewer's attestation binds to the tree the loop
-        # will actually push, not the pre-merge stale base.
-        ticket.merge_extra(set_keys={"branch_currency_post_merge_sha": post_sha})
-    return None
-
-
-def _check_shipping_gate(ticket: Ticket) -> ShippingGateFailure | None:
-    """Reconcile ``ticket.state`` from the session, or block with missing phases.
-
-    ``Session.visited_phases`` is the single source of truth (#694). When the
-    required phases are present this auto-walks the FSM to REVIEWED so
-    ``ticket.ship()`` is legal — the gate and ``ticket.state`` can no longer
-    disagree. When phases are missing it returns structured JSON with the
-    exact ``missing`` list so the calling agent can satisfy the gate rather
-    than hitting a raw ``TransitionNotAllowed``.
-    """
-    from teatree.core.models.errors import QualityGateError  # noqa: PLC0415
-
-    # #801 SSOT: canonical earliest selection (was -pk-latest); the
-    # gate only READS — create=False so a gate check never mints a
-    # session as a side effect.
-    session = ticket.find_phase_session()
-    if session is None:
-        # No session => no attested work; nothing to reconcile. Returning
-        # ``None`` here would let ``ticket.ship()`` raise a raw
-        # ``TransitionNotAllowed`` from a non-REVIEWED state, breaking the
-        # "pr create never raises a raw TransitionNotAllowed" invariant.
-        required = Session._REQUIRED_PHASES.get("shipping", [])  # noqa: SLF001
-        return ShippingGateFailure(
-            allowed=False,
-            error="No session: no attested work to reconcile.",
-            missing=list(required),
-            hint="Run the work through the loop (or `lifecycle visit-phase`) so the phases are recorded, then retry.",
-        )
-    try:
-        # Single source of truth = the union of phase records across ALL
-        # the ticket's sessions, not just the latest (#694). FSM-advancing
-        # `visit-phase` forks fresh sessions by design; the required phases
-        # are legitimately scattered across the ticket lifecycle.
-        session.check_gate_across_ticket("shipping")
-    except QualityGateError as exc:
-        # #1118: normalize the visited list before comparing — ``_check_phases``
-        # normalizes both sides (#782), so an unnormalized comparison here
-        # would name a phase as missing that the gate itself accepted.
-        visited, _ = ticket.aggregate_phase_records()
-        canonical_visited = {normalize_phase(phase) for phase in visited}
-        required = Session._REQUIRED_PHASES.get("shipping", [])  # noqa: SLF001
-        missing = [p for p in required if p not in canonical_visited]
-        return ShippingGateFailure(
-            allowed=False,
-            error=f"Gate check failed: {exc}",
-            missing=missing,
-            hint="Spawn a review sub-agent to satisfy the reviewing gate, then retry.",
-        )
-
-    # Gate passed -> the work is attested. Reconcile the FSM so ``ship()``
-    # is legal and drain any orphan reviewing task (gate-verified only).
-    reconcile_fsm_for_ship(ticket, consume_reviewing_tasks=True)
-    return None
-
-
-def _resolve_base_url(worktree: Worktree | None) -> str:
-    """Return the frontend URL recorded by ``Worktree.verify()``.
-
-    Prefers ``urls['frontend']`` (what users browse) over ``urls['backend']``.
-    Falls back to ``http://127.0.0.1:8000`` when no URLs are recorded yet.
-    """
-    if worktree is None:
-        return "http://127.0.0.1:8000"
-    urls = worktree.get_extra().get("urls", {})
-    return urls.get("frontend") or urls.get("backend") or "http://127.0.0.1:8000"
-
-
-def _run_visual_qa_gate(ticket: Ticket, *, skip_reason: str = "") -> VisualQAGateFailure | None:
-    """Run the pre-push browser sanity gate before PR creation.
-
-    Records a JSON summary on ``ticket.extra['visual_qa']`` when the gate
-    actually ran (i.e. not skipped for env/flag reasons) so the result
-    survives in the FSM history.  Returns an error dict when blocking
-    findings are present so the caller can refuse PR creation, or
-    ``None`` when the gate passes / is skipped.
-    """
-    # #776 N1: resolve the INVOKING worktree (same root cause as the
-    # ship-branch fix) — a reused multi-workstream ticket must run visual
-    # QA against the current workstream's repo, not the stale earliest
-    # `worktrees.first()` row. The `ship_invoking_branch` hint is recorded
-    # by `create()` before the gates run, so the canonical resolver has
-    # the data here too.
-    extra = cast("TicketExtra", ticket.extra or {})
-    worktree = resolve_ship_worktree(ticket, extra)
-    repo_path = worktree.repo_path if worktree else "."
-    base_url = _resolve_base_url(worktree)
-
-    overlay = get_overlay()
-    diff = visual_qa.changed_files(repo=repo_path)
-    report = visual_qa.evaluate(diff=diff, overlay=overlay, base_url=base_url, skip_reason=skip_reason)
-
-    # Only persist when the gate produced a meaningful signal — skipping a
-    # no-op run keeps the FSM history readable.
-    if report.pages or report.has_errors:
-        # #800 N3: canonical locked RMW — concurrent pr_urls (ship
-        # worker) writer no longer clobbers visual_qa.
-        ticket.merge_extra(set_keys={"visual_qa": report.summary()})
-
-    if not report.has_errors:
-        return None
-    return VisualQAGateFailure(
-        allowed=False,
-        error=f"Visual QA found {report.total_errors} blocking finding(s).",
-        visual_qa=report.summary(),
-        report_markdown=visual_qa.format_report(report),
-        hint="Fix the findings, or pass --skip-visual-qa <reason> to bypass.",
-    )
 
 
 def _run_ship_gates(
@@ -338,6 +113,11 @@ def _run_ship_gates(
     # Overlay-scoped (#1012): no-op unless the overlay forbids auto-close
     # trailers; raises SystemExit with the offending line otherwise.
     run_close_keyword_gate(ticket, worktree)
+    # Overlay-scoped (#83): for overlays that auto-close via ``Closes #N``,
+    # cross-check each referenced issue is real + open on the target repo —
+    # a teatree task id is not an issue number. Raises SystemExit on a
+    # closed/missing target; warns (non-blocking) on an unrelated title.
+    run_closes_issue_crosscheck(ticket, worktree)
     visual_qa_error = _run_visual_qa_gate(ticket, skip_reason=skip_visual_qa)
     if visual_qa_error is not None:
         return visual_qa_error

--- a/tests/teatree_core/management_commands/_overlays.py
+++ b/tests/teatree_core/management_commands/_overlays.py
@@ -144,6 +144,21 @@ class ForbidCloseKeywordsOverlay(FullOverlay):
         self.config.forbid_close_keywords = True
 
 
+class CloseTicketOverlay(FullOverlay):
+    """teatree-style overlay that auto-closes its issue via ``Closes #N``.
+
+    Sets ``config.mr_close_ticket`` so the closes-issue cross-check gate (#83)
+    enforces. ``FullOverlay`` leaves it at the ``False`` default, so the gate
+    is a no-op there.
+    """
+
+    config = OverlayConfig()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.config.mr_close_ticket = True
+
+
 class _MinimalMetadata(OverlayMetadata):
     def get_tool_commands(self) -> list[ToolCommand]:
         return []
@@ -304,6 +319,9 @@ FULL_OVERLAY = "tests.teatree_core.management_commands._overlays.FullOverlay"
 
 
 FORBID_CLOSE_KEYWORDS_OVERLAY = "tests.teatree_core.management_commands._overlays.ForbidCloseKeywordsOverlay"
+
+
+CLOSE_TICKET_OVERLAY = "tests.teatree_core.management_commands._overlays.CloseTicketOverlay"
 
 
 NESTED_OVERLAY = "tests.teatree_core.management_commands._overlays.NestedRepoOverlay"

--- a/tests/teatree_core/management_commands/test_closes_issue_crosscheck.py
+++ b/tests/teatree_core/management_commands/test_closes_issue_crosscheck.py
@@ -1,0 +1,345 @@
+"""Pre-push cross-check for ``Closes/Fixes/Resolves #N`` trailers (#83).
+
+teatree's internal TaskList uses integer ids that are NOT GitHub issue
+numbers, so a ``Closes #<task-id>`` trailer mis-targets an unrelated issue
+that happens to carry that number. This gate cross-checks every close-keyword
+reference in the MR description / commit bodies against the real issue on the
+target repo: it BLOCKS when the referenced issue is closed or missing, and
+WARNS (non-blocking) when the issue title shares no token with the branch
+name. Scoped to overlays whose ``config.mr_close_ticket`` is set — exactly the
+teatree case where ``Closes #N`` is emitted and auto-closes on merge.
+
+Driven through the real ``pr create`` entrypoint; only the unstoppable git
+subprocess + visual-QA + GitHub/GitLab network boundaries are patched.
+"""
+
+import contextlib
+from collections.abc import Iterator
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+import teatree.core.management.commands._closes_issue_crosscheck as crosscheck_mod
+import teatree.core.management.commands.pr as pr_mod
+from teatree.core.management.commands._closes_issue_crosscheck import (
+    _issue_url_for_ref,
+    _referenced_numbers,
+    _shares_token,
+    _tokens,
+)
+from teatree.core.models import Session, Ticket, Worktree
+from tests.teatree_core.management_commands._overlays import (
+    CLOSE_TICKET_OVERLAY,
+    FULL_OVERLAY,
+    SETTINGS,
+    _patch_overlays,
+)
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:In Typer, only the parameter 'autocompletion' is supported.*:DeprecationWarning",
+)
+
+_ISSUE_URL = "https://github.com/souliane/teatree/issues/70"
+
+
+def _shippable_ticket(
+    *,
+    repo: str = "/tmp/wt",
+    branch: str = "83-gate-closes-issue-crosscheck",
+    issue_url: str = _ISSUE_URL,
+) -> Ticket:
+    ticket = Ticket.objects.create(
+        overlay="test",
+        state=Ticket.State.REVIEWED,
+        issue_url=issue_url,
+    )
+    session = Session.objects.create(overlay="test", ticket=ticket)
+    for phase in ("testing", "reviewing", "retro"):
+        session.visit_phase(phase)
+    Worktree.objects.create(
+        overlay="test",
+        ticket=ticket,
+        repo_path=repo,
+        branch=branch,
+        extra={"worktree_path": repo},
+    )
+    return ticket
+
+
+@contextlib.contextmanager
+def _git_boundary(
+    *,
+    subject: str = "feat: x",
+    body: str = "",
+    commit_bodies: list[str] | None = None,
+) -> Iterator[None]:
+    """Patch the git boundary the gate + ``ship_preview`` reach.
+
+    Mirrors ``test_close_keyword_gate._git_boundary``: ``last_commit_message``
+    is the raw MR-description source, ``commit_messages`` feeds the
+    branch-commit scan, ``default_branch`` lets the range be built. Visual QA
+    is patched out (browser boundary).
+    """
+    with (
+        patch.object(pr_mod, "_run_visual_qa_gate", return_value=None),
+        patch(
+            "teatree.core.management.commands._closes_issue_crosscheck.git.last_commit_message",
+            return_value=(subject, body),
+        ),
+        patch(
+            "teatree.core.management.commands._pr_preview.git.last_commit_message",
+            return_value=(subject, body),
+        ),
+        patch(
+            "teatree.core.management.commands._closes_issue_crosscheck.git.default_branch",
+            return_value="main",
+        ),
+        patch(
+            "teatree.core.management.commands._closes_issue_crosscheck.git.commit_messages",
+            return_value=list(commit_bodies or []),
+        ),
+    ):
+        yield
+
+
+@contextlib.contextmanager
+def _stub_issue(issue: dict[str, object]) -> Iterator[None]:
+    """Patch the code-host so ``get_issue`` returns *issue* (the network boundary)."""
+
+    class _Host:
+        def get_issue(self, issue_url: str) -> dict[str, object]:
+            return issue
+
+    with patch.object(crosscheck_mod, "code_host_from_overlay", return_value=_Host()):
+        yield
+
+
+class TestClosesIssueCrosscheckBlocks(TestCase):
+    """Overlay with ``mr_close_ticket=True`` (teatree-style): the gate enforces."""
+
+    @_patch_overlays(CLOSE_TICKET_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_blocks_when_referenced_issue_is_closed(self) -> None:
+        ticket = _shippable_ticket()
+        with (
+            pytest.raises(SystemExit) as ctx,
+            _git_boundary(subject="feat: gate closes-issue cross-check (#70)", body="Closes #70"),
+            _stub_issue({"state": "closed", "title": "gate closes-issue cross-check"}),
+        ):
+            call_command("pr", "create", str(ticket.pk))
+        assert ctx.value.code != 0
+        assert "#70" in str(ctx.value)
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED
+
+    @_patch_overlays(CLOSE_TICKET_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_blocks_when_referenced_issue_is_missing(self) -> None:
+        ticket = _shippable_ticket()
+        with (
+            pytest.raises(SystemExit) as ctx,
+            _git_boundary(subject="feat: x", body="Closes #999"),
+            _stub_issue({"error": "Issue not found: ...#999"}),
+        ):
+            call_command("pr", "create", str(ticket.pk))
+        assert ctx.value.code != 0
+        assert "#999" in str(ctx.value)
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED
+
+    @_patch_overlays(CLOSE_TICKET_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_passes_when_open_issue_title_matches_branch(self) -> None:
+        ticket = _shippable_ticket()
+        with (
+            _git_boundary(subject="feat: gate closes-issue cross-check (#70)", body="Closes #70"),
+            _stub_issue({"state": "open", "title": "Add closes-issue cross-check gate"}),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert "error" not in result
+
+    @_patch_overlays(CLOSE_TICKET_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_warns_but_proceeds_on_unrelated_open_title(self) -> None:
+        ticket = _shippable_ticket(branch="83-gate-closes-issue-crosscheck")
+        with (
+            self.assertLogs(crosscheck_mod.logger, level="WARNING") as logs,
+            _git_boundary(subject="feat: x (#70)", body="Closes #70"),
+            _stub_issue({"state": "open", "title": "Refactor database connection pooling"}),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert "error" not in result
+        assert any("#70" in line for line in logs.output)
+
+
+class TestClosesIssueCrosscheckScope(TestCase):
+    """The gate is scoped to ``mr_close_ticket`` overlays and skips otherwise."""
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_skips_when_overlay_does_not_close_via_keyword(self) -> None:
+        # FullOverlay leaves mr_close_ticket=False, so a Closes #N never
+        # survives into the merged PR (sanitize_close_keywords rewrites it);
+        # the cross-check gate must not even call get_issue.
+        ticket = _shippable_ticket()
+        called: list[str] = []
+
+        class _Host:
+            def get_issue(self, issue_url: str) -> dict[str, object]:
+                called.append(issue_url)
+                return {}
+
+        with (
+            _git_boundary(subject="feat: x", body="Closes #999"),
+            patch.object(crosscheck_mod, "code_host_from_overlay", return_value=_Host()),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert "error" not in result
+        assert called == []
+
+    @_patch_overlays(CLOSE_TICKET_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_no_close_keyword_is_a_noop(self) -> None:
+        ticket = _shippable_ticket()
+        called: list[str] = []
+
+        class _Host:
+            def get_issue(self, issue_url: str) -> dict[str, object]:
+                called.append(issue_url)
+                return {}
+
+        with (
+            _git_boundary(subject="feat: no trailer here", body="Relates to #70"),
+            patch.object(crosscheck_mod, "code_host_from_overlay", return_value=_Host()),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert "error" not in result
+        assert called == []
+
+
+class TestClosesIssueCrosscheckFailOpen(TestCase):
+    """Unverifiable inputs (no host, no ticket repo) fail OPEN rather than block."""
+
+    @_patch_overlays(CLOSE_TICKET_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_no_code_host_skips(self) -> None:
+        ticket = _shippable_ticket()
+        with (
+            _git_boundary(subject="feat: x", body="Closes #999"),
+            patch.object(crosscheck_mod, "code_host_from_overlay", return_value=None),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert "error" not in result
+
+    @_patch_overlays(CLOSE_TICKET_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_unparsable_ticket_url_skips(self) -> None:
+        ticket = _shippable_ticket(issue_url="ticket-without-url")
+        called: list[str] = []
+
+        class _Host:
+            def get_issue(self, issue_url: str) -> dict[str, object]:
+                called.append(issue_url)
+                return {}
+
+        with (
+            _git_boundary(subject="feat: x", body="Closes #999"),
+            patch.object(crosscheck_mod, "code_host_from_overlay", return_value=_Host()),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", str(ticket.pk)))
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert "error" not in result
+        assert called == []
+
+
+class TestTokenHelpers(TestCase):
+    """Pure helpers: tokenization, overlap, and issue-URL construction."""
+
+    def test_tokens_lowercases_and_splits_on_nonalnum(self) -> None:
+        assert _tokens("83-gate-closes-issue-crosscheck") == {
+            "gate",
+            "closes",
+            "issue",
+            "crosscheck",
+        }
+
+    def test_tokens_drops_short_and_numeric_tokens(self) -> None:
+        # Leading issue number and 1-2 char fragments carry no intent signal.
+        assert "83" not in _tokens("83-gate")
+        assert _tokens("a-bb-ccc") == {"ccc"}
+
+    def test_shares_token_true_on_overlap(self) -> None:
+        assert _shares_token("Add closes-issue cross-check gate", "83-gate-closes-crosscheck")
+
+    def test_shares_token_false_on_no_overlap(self) -> None:
+        assert not _shares_token("Refactor database pooling", "83-gate-closes-crosscheck")
+
+    def test_shares_token_true_when_branch_has_no_tokens(self) -> None:
+        # A token-less branch (only the leading number) can't be cross-checked;
+        # treat as related so the gate never blocks on an undecidable case.
+        assert _shares_token("anything at all", "83")
+
+    def test_issue_url_for_ref_builds_sibling_issue_url(self) -> None:
+        assert (
+            _issue_url_for_ref("https://github.com/souliane/teatree/issues/70", "42")
+            == "https://github.com/souliane/teatree/issues/42"
+        )
+
+    def test_issue_url_for_ref_handles_gitlab_dash_issues(self) -> None:
+        assert (
+            _issue_url_for_ref("https://gitlab.com/grp/proj/-/issues/9", "42")
+            == "https://gitlab.com/grp/proj/-/issues/42"
+        )
+
+    def test_issue_url_for_ref_returns_empty_for_unparsable(self) -> None:
+        assert _issue_url_for_ref("not-a-url", "42") == ""
+
+    def test_issue_url_for_ref_returns_empty_for_non_issue_path(self) -> None:
+        # A real http URL whose path is not an ``.../issues/<n>`` form can't
+        # resolve the target repo for a bare ``#N`` — fail open (empty).
+        assert _issue_url_for_ref("https://github.com/souliane/teatree/pull/70", "42") == ""
+
+
+class TestReferencedNumbers(TestCase):
+    """``_referenced_numbers`` — bare ``#N`` extraction over the git boundary."""
+
+    def test_no_repo_or_branch_returns_empty(self) -> None:
+        worktree = Worktree(overlay="test", repo_path="", branch="")
+        assert _referenced_numbers(worktree) == []
+
+    def test_git_failure_returns_collected_sources_only(self) -> None:
+        worktree = Worktree(overlay="test", repo_path="/tmp/wt", branch="feat")
+        with (
+            patch.object(crosscheck_mod.git, "last_commit_message", return_value=("Closes #70", "")),
+            patch.object(
+                crosscheck_mod.git,
+                "default_branch",
+                side_effect=crosscheck_mod.CommandFailedError(["git", "branch"], 128, "", "boom"),
+            ),
+        ):
+            # The last-commit source was collected before the failure; the
+            # branch-range scan is skipped (unverifiable, not a block).
+            assert _referenced_numbers(worktree) == ["70"]
+
+    def test_dedups_repeated_reference(self) -> None:
+        worktree = Worktree(overlay="test", repo_path="/tmp/wt", branch="feat")
+        with (
+            patch.object(crosscheck_mod.git, "last_commit_message", return_value=("Closes #70", "Fixes #70")),
+            patch.object(crosscheck_mod.git, "default_branch", return_value="main"),
+            patch.object(crosscheck_mod.git, "commit_messages", return_value=["Resolves #70"]),
+        ):
+            assert _referenced_numbers(worktree) == ["70"]

--- a/tests/teatree_core/pr_command/test_helpers.py
+++ b/tests/teatree_core/pr_command/test_helpers.py
@@ -4,12 +4,8 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from teatree import visual_qa
-from teatree.core.management.commands.pr import (
-    _assert_commits_ahead_of_base,
-    _check_shipping_gate,
-    _resolve_base_url,
-    _run_visual_qa_gate,
-)
+from teatree.core.management.commands._ship_gates import resolve_base_url as _resolve_base_url
+from teatree.core.management.commands.pr import _assert_commits_ahead_of_base, _check_shipping_gate, _run_visual_qa_gate
 from teatree.core.models import Session, Ticket, Worktree
 
 from ._shared import _MOCK_OVERLAY


### PR DESCRIPTION
fix(ship): cross-check Closes/Fixes/Resolves #N against the real target issue

## Problem

teatree's internal TaskList uses integer ids that are not GitHub/GitLab issue
numbers. A stray `Closes #<task-id>` trailer therefore mis-targets whatever
unrelated issue happens to carry that number and auto-closes it the instant the
PR merges. (Concrete example on this very repo: a bare `#83` resolves to a
long-closed, unrelated issue.)

## Change

A pre-PR-creation gate `run_closes_issue_crosscheck`, wired into `_run_ship_gates`
right after the existing close-keyword gate. For overlays that auto-close via
`Closes #N` (`config.mr_close_ticket`), it resolves each bare `#N` to the
sibling issue URL on the target repo (derived from the ticket's own `issue_url`)
and fetches it through the code host:

- BLOCK (`SystemExit`) when the referenced issue is closed or missing — the
  task-id-vs-issue-number symptom.
- WARN (logged, non-blocking) when an open issue's title shares no token with
  the branch name — a weak wrong-issue signal.

Unverifiable inputs (no code host, an unparsable ticket URL, a git failure)
fail open, matching the close-keyword gate's `_scan_sources` / `PrOpenState.UNKNOWN`
posture. It is the mirror image of `_close_keyword_gate`: that gate rejects
close-keywords for overlays that forbid them; this one validates the
close-keywords overlays that do auto-close are about to ship.

The pre-ship gate helpers and failure payloads move from `pr.py` into a new
`_ship_gates.py` (split-by-concern, mirroring `_ship_exec` / `_ship_fsm`) so
`pr.py` stays under the module-health LOC bar; `_run_ship_gates` stays in
`pr.py` so the existing test seams keep resolving against `pr`'s namespace.

## Tests

TDD: the three enforcing tests (closed-issue block, missing-issue block,
unrelated-title warn) were observed RED with the gate disabled, then green after
wiring. 100% line+branch coverage on the new module. Full suite green
(7415 passed).