### PR TITLE
fix(worktree): refresh ticket FK after variant update in provision

### DIFF
--- a/src/teatree/core/management/commands/worktree.py
+++ b/src/teatree/core/management/commands/worktree.py
@@ -145,6 +145,12 @@ class Command(TyperCommand):
         ticket = Ticket.objects.get(pk=worktree.ticket.pk)
 
         _update_ticket_variant(ticket, variant)
+        # _update_ticket_variant mutated the ticket + worktree rows through
+        # separate instances; reload so this worktree's cached ticket FK and
+        # db_name reflect the new variant before provision() and the env render
+        # read them (otherwise WT_VARIANT renders blank and db_name loses its
+        # variant suffix).
+        worktree.refresh_from_db()
         resolved_overlay = get_overlay()
         if resolved_overlay.uses_redis():
             redis_container.ensure_running(db_count=load_config().user.redis_db_count)

--- a/tests/teatree_core/management_commands/test_lifecycle.py
+++ b/tests/teatree_core/management_commands/test_lifecycle.py
@@ -129,6 +129,44 @@ class TestLifecycleSetup(TestCase):
             ticket.refresh_from_db()
             assert ticket.variant == "testcustomer"
 
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_variant_propagates_to_db_name_and_env_cache(self) -> None:
+        """`--variant` must reach db_name and the rendered WT_VARIANT/WT_DB_NAME.
+
+        The in-scope worktree resolved by the command holds a cached ``ticket``
+        FK loaded before the variant update. When ``_build_db_name`` and the env
+        render read that stale FK, ``WT_VARIANT`` renders blank and ``db_name``
+        loses its variant suffix — so the DB import targets the wrong name. The
+        command must refresh the FK so both reflect the new variant.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/91", variant="")
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/backend",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+            )
+
+            with patch.object(utils_run_mod.subprocess, "run"):
+                worktree_id = cast(
+                    "int",
+                    call_command("worktree", "provision", path=str(wt_dir), variant="acmebank"),
+                )
+
+            worktree = Worktree.objects.get(pk=worktree_id)
+            assert worktree.db_name == "wt_91_acmebank"
+
+            cache_file = tmp_path / ".t3-cache" / ".t3-env.cache"
+            cache_body = cache_file.read_text(encoding="utf-8")
+            assert "WT_VARIANT=acmebank" in cache_body
+            assert "WT_DB_NAME=wt_91_acmebank" in cache_body
+
     @_patch_overlays(FAILING_IMPORT_OVERLAY)
     @override_settings(**SETTINGS)
     def test_continues_on_db_import_failure(self) -> None:


### PR DESCRIPTION
## Problem

`t3 <overlay> worktree provision --variant <name>` updated the ticket variant through a freshly fetched `Ticket` instance, but the worktree resolved at the top of the command keeps a **cached** `ticket` foreign key loaded *before* the update (variant still `""`). Both `Worktree._build_db_name()` and the env-cache render read that stale FK:

- `WT_VARIANT` rendered **blank**.
- `WT_DB_NAME` (and `worktree.db_name`) lost its `_<variant>` suffix.

With the wrong/blank `db_name`, the provision runner's DB import targeted the wrong name, and the later migrate step then ran against a database that was never created for the requested variant. So provisioning with a variant silently produced an environment with the variant unset and a mismatched DB.

## Fix

After `_update_ticket_variant(...)`, reload the in-scope worktree from the DB (`worktree.refresh_from_db()`). This clears the cached `ticket` relation and reloads `db_name`, so `provision()` and the env render both see the new variant. Minimal and targeted — the provision flow is otherwise unchanged.

## Test

`TestLifecycleSetup::test_variant_propagates_to_db_name_and_env_cache` drives the real `worktree provision` command with a variant under `tmp_path` (only `subprocess` mocked), then asserts:

- `worktree.db_name == "wt_91_<variant>"` (variant suffix present)
- the written `.t3-env.cache` contains `WT_VARIANT=<variant>` and `WT_DB_NAME=wt_91_<variant>`

Anti-vacuous: the test was observed RED on the pre-fix code (`'wt_91' != 'wt_91_<variant>'`) and GREEN after the fix; a clean revert of the `refresh_from_db()` line reproduces the RED.

Full suite green (7424 passed, 13 skipped).