### PR TITLE
fix(workspace): skip non-startable worktrees in workspace start

### DIFF
--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -10,11 +10,15 @@ from typing import TYPE_CHECKING
 
 from teatree.core.cleanup import _branch_tree_matches_squash, cleanup_worktree
 from teatree.core.models import Worktree
+from teatree.core.worktree_env import write_env_cache
 from teatree.utils import git
-from teatree.utils.run import CommandFailedError, run_allowed_to_fail
+from teatree.utils.db import drop_db
+from teatree.utils.run import CommandFailedError, run_allowed_to_fail, run_checked
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from teatree.core.reconcile import Drift
 
 
 def worktree_map(repo: str) -> dict[str, str]:
@@ -298,3 +302,46 @@ def _raise_on_cleanup_failures(
             write_out(line)
         write_err(f"clean-all: {len(failed)} push/abandon failure(s).")
         raise SystemExit(1)
+
+
+def _fix_drift(drift: "Drift") -> list[str]:
+    """Apply reconciler fixes for one ticket's drift.
+
+    Each fix uses :func:`run_checked` so failures surface — no silent
+    swallow.  Called from ``t3 workspace doctor --fix``.
+    """
+    fixes: list[str] = []
+
+    for c in drift.orphan_containers:
+        run_checked(["docker", "rm", "-f", c.name])
+        fixes.append(f"removed orphan container {c.name}")
+
+    for d in drift.orphan_dbs:
+        drop_db(d.db_name)
+        fixes.append(f"dropped orphan DB {d.db_name}")
+
+    for missing_wt in drift.missing_worktree_dirs:
+        Worktree.objects.filter(pk=missing_wt.worktree_pk).update(extra={})
+        fixes.append(f"cleared worktree_path on wt#{missing_wt.worktree_pk} (path gone: {missing_wt.path})")
+
+    fixes.extend(
+        f"stale worktree dir {stale.path} — remove manually with `git worktree remove`"
+        for stale in drift.stale_worktree_dirs
+    )
+
+    for missing_cache in drift.missing_env_caches:
+        wt = Worktree.objects.get(pk=missing_cache.worktree_pk)
+        write_env_cache(wt)
+        fixes.append(f"regenerated env cache for wt#{missing_cache.worktree_pk}")
+
+    for cache_drift in drift.env_cache_drifts:
+        wt = Worktree.objects.get(pk=cache_drift.worktree_pk)
+        write_env_cache(wt)
+        fixes.append(f"rewrote drifted env cache for wt#{cache_drift.worktree_pk}")
+
+    fixes.extend(
+        f"missing DB {m.db_name} for wt#{m.worktree_pk} — run `t3 <overlay> worktree provision` to re-provision"
+        for m in drift.missing_dbs
+    )
+
+    return fixes

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Annotated, TypedDict, cast
 
 import typer
 from django.db import transaction
+from django_fsm import can_proceed
 from django_typer.management import TyperCommand, command
 
 from teatree.config import load_config
@@ -18,6 +19,7 @@ from teatree.core.dev_repo import resolve_repo_names
 from teatree.core.management.commands import _workspace_helpers as _wh
 from teatree.core.management.commands._workspace_cleanup import (
     _die,
+    _fix_drift,
     _raise_on_cleanup_failures,
     drop_orphan_databases,
     drop_orphaned_stashes,
@@ -30,7 +32,7 @@ from teatree.core.orphan_guard import find_orphans_in_workspace
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.public_identity import StampResult, is_public_github_remote, set_local_noreply_identity
 from teatree.core.readiness import run_and_report_probes
-from teatree.core.reconcile import Drift, reconcile_all, reconcile_ticket
+from teatree.core.reconcile import reconcile_all, reconcile_ticket
 from teatree.core.resolve import WorktreeNotFoundError, _get_user_cwd, resolve_worktree
 from teatree.core.runners import (
     WorktreeProvisioner,
@@ -38,13 +40,12 @@ from teatree.core.runners import (
     WorktreeStartRunner,
     WorktreeTeardownRunner,
 )
-from teatree.core.worktree_env import write_env_cache
 from teatree.utils import git
-from teatree.utils.db import drop_db
-from teatree.utils.run import CommandFailedError, run_checked
+from teatree.utils.run import CommandFailedError
 
 if TYPE_CHECKING:
     from teatree.core.models.types import TicketExtra
+    from teatree.core.overlay import OverlayBase
 
 
 class OrphanEntry(TypedDict):
@@ -105,47 +106,32 @@ def _resolve_workspace_ticket(path: str) -> Ticket:
         raise
 
 
-def _fix_drift(drift: Drift) -> list[str]:
-    """Apply reconciler fixes for one ticket's drift.
+def _report_worktree_probes(
+    worktrees: list[Worktree],
+    overlay: "OverlayBase",
+    write: Callable[[str], None],
+    *,
+    note_empty: bool,
+) -> tuple[int, int]:
+    """Run each worktree's readiness probes; return ``(total, failures)``.
 
-    Each fix uses :func:`run_checked` so failures surface — no silent
-    swallow.  Called from ``t3 workspace doctor --fix``.
+    Shared by ``start`` (probe only the worktrees that started) and
+    ``ready`` (probe every worktree). ``note_empty`` reports a worktree
+    with no probes explicitly (``ready``) or skips it silently (``start``).
     """
-    fixes: list[str] = []
-
-    for c in drift.orphan_containers:
-        run_checked(["docker", "rm", "-f", c.name])
-        fixes.append(f"removed orphan container {c.name}")
-
-    for d in drift.orphan_dbs:
-        drop_db(d.db_name)
-        fixes.append(f"dropped orphan DB {d.db_name}")
-
-    for missing_wt in drift.missing_worktree_dirs:
-        Worktree.objects.filter(pk=missing_wt.worktree_pk).update(extra={})
-        fixes.append(f"cleared worktree_path on wt#{missing_wt.worktree_pk} (path gone: {missing_wt.path})")
-
-    fixes.extend(
-        f"stale worktree dir {stale.path} — remove manually with `git worktree remove`"
-        for stale in drift.stale_worktree_dirs
-    )
-
-    for missing_cache in drift.missing_env_caches:
-        wt = Worktree.objects.get(pk=missing_cache.worktree_pk)
-        write_env_cache(wt)
-        fixes.append(f"regenerated env cache for wt#{missing_cache.worktree_pk}")
-
-    for cache_drift in drift.env_cache_drifts:
-        wt = Worktree.objects.get(pk=cache_drift.worktree_pk)
-        write_env_cache(wt)
-        fixes.append(f"rewrote drifted env cache for wt#{cache_drift.worktree_pk}")
-
-    fixes.extend(
-        f"missing DB {m.db_name} for wt#{m.worktree_pk} — run `t3 <overlay> worktree provision` to re-provision"
-        for m in drift.missing_dbs
-    )
-
-    return fixes
+    total = 0
+    total_failures = 0
+    for wt in worktrees:
+        probes = overlay.get_readiness_probes(wt)
+        if not probes:
+            if note_empty:
+                write(f"  {wt.repo_path}: no probes")
+            continue
+        write(f"  {wt.repo_path}:")
+        summary = run_and_report_probes(probes, write_line=write, indent="    ")
+        total += summary.total
+        total_failures += summary.failures
+    return total, total_failures
 
 
 def _branch_prefix() -> str:
@@ -331,13 +317,25 @@ class Command(TyperCommand):
         overlay = get_overlay(ticket.overlay or None)
 
         worktrees = list(Worktree.objects.filter(ticket=ticket))
+        started: list[Worktree] = []
         failures: list[str] = []
         for wt in worktrees:
+            # The worktrees in one ticket can be in different FSM states
+            # (e.g. a sibling repo whose provision has not run yet is still
+            # CREATED). ``start_services`` only accepts the
+            # ``[PROVISIONED, SERVICES_UP, READY]`` source states; firing it
+            # on a CREATED worktree raises ``TransitionNotAllowed`` and would
+            # crash the whole command, abandoning the worktrees already
+            # started. Skip the ones that can't transition and start the rest.
+            if not can_proceed(wt.start_services):
+                self.stdout.write(f"  Skipping {wt.repo_path} (state: {wt.state}, not ready to start)")
+                continue
             self.stdout.write(f"  Starting {wt.repo_path}…")
             commands = list(overlay.get_run_commands(wt))
             with transaction.atomic():
                 wt.start_services(services=commands)
                 wt.save()
+            started.append(wt)
             result = WorktreeStartRunner(wt, overlay=overlay).run()
             self.stdout.write(f"    {result.detail}")
             if not result.ok:
@@ -345,16 +343,7 @@ class Command(TyperCommand):
         if failures:
             _die(self.stderr.write, f"  Failed: {', '.join(failures)}")
 
-        total = 0
-        total_failures = 0
-        for wt in worktrees:
-            probes = overlay.get_readiness_probes(wt)
-            if not probes:
-                continue
-            self.stdout.write(f"  {wt.repo_path}:")
-            summary = run_and_report_probes(probes, write_line=self.stdout.write, indent="    ")
-            total += summary.total
-            total_failures += summary.failures
+        total, total_failures = _report_worktree_probes(started, overlay, self.stdout.write, note_empty=False)
         if total_failures:
             _die(self.stderr.write, f"  {total_failures} of {total} probe(s) failed")
         return f"started {len(worktrees)} worktree(s)"
@@ -376,17 +365,7 @@ class Command(TyperCommand):
         overlay = get_overlay(ticket.overlay or None)
 
         worktrees = list(Worktree.objects.filter(ticket=ticket))
-        total = 0
-        total_failures = 0
-        for wt in worktrees:
-            probes = overlay.get_readiness_probes(wt)
-            if not probes:
-                self.stdout.write(f"  {wt.repo_path}: no probes")
-                continue
-            self.stdout.write(f"  {wt.repo_path}:")
-            summary = run_and_report_probes(probes, write_line=self.stdout.write, indent="    ")
-            total += summary.total
-            total_failures += summary.failures
+        total, total_failures = _report_worktree_probes(worktrees, overlay, self.stdout.write, note_empty=True)
         if total_failures:
             _die(self.stderr.write, f"  {total_failures} of {total} probe(s) failed")
         return "ok"

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -758,6 +758,87 @@ class TestWorkspaceStartTeardownExitCodes(TestCase):
             assert exc_info.value.code == 1
 
 
+class TestWorkspaceStartMixedState(TestCase):
+    """``workspace start`` tolerates a mixed-state worktree set.
+
+    The command iterates every worktree in the ticket and fires
+    ``Worktree.start_services()``. That transition only accepts the
+    ``[PROVISIONED, SERVICES_UP, READY]`` source states; a worktree still
+    in ``CREATED`` (e.g. a sibling repo whose provision failed/has not run)
+    is not a valid source. Pre-fix the unconditional transition raised
+    ``django_fsm.TransitionNotAllowed`` on the first CREATED worktree and
+    crashed the whole command, leaving the already-startable worktrees in
+    whatever partial state the loop had reached. The fix skips worktrees
+    that are not in a valid source state and starts the rest.
+    """
+
+    def _ticket_with_mixed_worktrees(self, tmp: str) -> tuple[Ticket, Worktree, Worktree, Path]:
+        ticket_dir = Path(tmp) / "1234-feature"
+        ticket_dir.mkdir()
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/1234")
+
+        be_dir = ticket_dir / "backend"
+        be_dir.mkdir()
+        provisioned = Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="backend",
+            branch="1234-feature",
+            extra={"worktree_path": str(be_dir)},
+            state=Worktree.State.PROVISIONED,
+        )
+
+        fe_dir = ticket_dir / "frontend"
+        fe_dir.mkdir()
+        created = Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="frontend",
+            branch="1234-feature",
+            extra={"worktree_path": str(fe_dir)},
+            state=Worktree.State.CREATED,
+        )
+        return ticket, provisioned, created, be_dir
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_start_skips_created_worktree_and_starts_the_rest(self) -> None:
+        """A CREATED sibling must not crash start; the PROVISIONED one still starts."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _ticket, provisioned, created, be_dir = self._ticket_with_mixed_worktrees(tmp)
+            ok = MagicMock()
+            ok.run.return_value = RunnerResult(ok=True, detail="ok")
+            with patch.object(workspace_mod, "WorktreeStartRunner", return_value=ok):
+                # Pre-fix: raises TransitionNotAllowed on the CREATED worktree.
+                call_command("workspace", "start", path=str(be_dir))
+
+            provisioned.refresh_from_db()
+            created.refresh_from_db()
+            # The valid-source worktree DID transition.
+            assert provisioned.state == Worktree.State.SERVICES_UP
+            # The CREATED worktree was skipped, not transitioned or crashed.
+            assert created.state == Worktree.State.CREATED
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_start_does_not_run_start_runner_for_skipped_worktree(self) -> None:
+        """The skipped CREATED worktree must not be handed to the start runner."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _ticket, _provisioned, _created, be_dir = self._ticket_with_mixed_worktrees(tmp)
+            started_repos: list[str] = []
+
+            def _runner_factory(worktree: Worktree, **_kwargs: object) -> MagicMock:
+                started_repos.append(worktree.repo_path)
+                instance = MagicMock()
+                instance.run.return_value = RunnerResult(ok=True, detail="ok")
+                return instance
+
+            with patch.object(workspace_mod, "WorktreeStartRunner", side_effect=_runner_factory):
+                call_command("workspace", "start", path=str(be_dir))
+
+            assert started_repos == ["backend"]
+
+
 class TestWorkspaceMultiOverlayResolution(TestCase):
     """#1310: workspace subcommands disambiguate overlays from the ticket row.
 


### PR DESCRIPTION
## Problem

`workspace start` iterates every worktree in a ticket and fires `Worktree.start_services()`. That transition only accepts the `[PROVISIONED, SERVICES_UP, READY]` source states. When the worktrees in one ticket are in **mixed** states — e.g. a sibling repo still in `CREATED` because its provision has not run yet — the unconditional transition raised `django_fsm.TransitionNotAllowed` on the first `CREATED` worktree and crashed the whole command, abandoning the worktrees that had already started in a partial state.

## Fix

Guard the transition with `can_proceed(wt.start_services)` — the same pattern the loop's mechanical handlers (`loop/mechanical.py`) already use for re-emit-safe transitions. Worktrees not in a valid source state are skipped (with a reported line) and the rest start normally; the command completes cleanly over a mixed-state set. Readiness probes then run only over the worktrees that actually started, not the skipped ones.

The change is localized to the `start` command. The `Worktree` FSM model itself is untouched.

## Housekeeping

To keep `workspace.py` under the module-health LOC cap after the guard:

- The duplicated readiness-probe loop shared by `start` and `ready` is extracted into a `_report_worktree_probes` helper.
- `_fix_drift` (the `doctor --fix` reconciler) moves to the existing `_workspace_cleanup` overflow module.

## Tests

`tests/teatree_core/management_commands/test_workspace.py::TestWorkspaceStartMixedState`:

- `test_start_skips_created_worktree_and_starts_the_rest` — a `CREATED` sibling does not crash `start`; the `PROVISIONED` worktree transitions to `SERVICES_UP` and the `CREATED` one stays `CREATED`.
- `test_start_does_not_run_start_runner_for_skipped_worktree` — the skipped worktree is never handed to the start runner.

Anti-vacuous: with the guard reverted both tests go red with `TransitionNotAllowed`; restored, green. Full suite green at 93.45% coverage.