### PR TITLE
fix(backends): harden GraphQL/mrkdwn seam parsers against null hops and label-token corruption

### DIFF
--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -8,6 +8,7 @@ from typing import TypedDict, cast
 from urllib.parse import quote_plus, urlparse
 
 from teatree.backends.protocols import ApprovalState, PrOpenState, PullRequestSpec, ReviewState
+from teatree.backends.types import dig
 from teatree.types import RawAPIDict
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError, CompletedProcess, run_checked
@@ -210,41 +211,40 @@ def fetch_project_items(
     token: str = "",
 ) -> list[ProjectItem]:
     """Fetch all items from a GitHub Projects v2 board, preserving board order."""
-    query = _PROJECT_ITEMS_QUERY.format(owner=owner, project_number=project_number)
-    data = _gh_graphql(query, token=token)
-    items: list[ProjectItem] = []
+    data = _gh_graphql(_PROJECT_ITEMS_QUERY.format(owner=owner, project_number=project_number), token=token)
+    # ``dig`` null-guards each hop: GraphQL returns ``null`` (not ``{}``) for a
+    # user/project the token cannot see, where a chained ``.get(k, {})`` would
+    # call ``.get`` on ``None`` and crash the board sync.
+    raw_items = dig(data, "data", "user", "projectV2", "items", "nodes")
+    nodes = raw_items if isinstance(raw_items, list) else []
+    return [
+        item for position, node in enumerate(nodes) if (item := _project_item_from_node(node, position)) is not None
+    ]
 
-    project = data.get("data", {}).get("user", {}).get("projectV2", {})  # type: ignore[union-attr]
-    if not project:
-        return items
 
-    nodes = project.get("items", {}).get("nodes", [])
-    for position, node in enumerate(nodes):
-        if not isinstance(node, dict):
-            continue
-        content = node.get("content")
-        if not isinstance(content, dict) or "number" not in content:
-            continue  # skip draft items or non-issue content
+def _project_item_from_node(node: object, position: int) -> ProjectItem | None:
+    """Build a :class:`ProjectItem` from one board node, or ``None`` to skip.
 
-        status_field = node.get("fieldValueByName")
-        status = status_field.get("name", "") if isinstance(status_field, dict) else ""
-
-        label_nodes = content.get("labels", {}).get("nodes", [])
-        labels = [ln["name"] for ln in label_nodes if isinstance(ln, dict) and "name" in ln]
-
-        items.append(
-            ProjectItem(
-                issue_number=int(content["number"]),
-                title=str(content.get("title", "")),
-                url=str(content.get("url", "")),
-                status=status,
-                position=position,
-                labels=labels,
-                updated_at=str(content.get("updatedAt", "")),
-            ),
-        )
-
-    return items
+    Every field read goes through :func:`dig`, which null-guards each hop and
+    returns ``object`` — so a draft item (no ``content``) or a node the token
+    cannot fully see degrades to a skip rather than crashing the board sync.
+    """
+    number = dig(node, "content", "number")
+    if not isinstance(number, int):
+        return None  # draft item or non-issue content
+    status_name = dig(node, "fieldValueByName", "name")
+    raw_labels = dig(node, "content", "labels", "nodes")
+    label_nodes = raw_labels if isinstance(raw_labels, list) else []
+    labels = [str(name) for ln in label_nodes if isinstance(name := dig(ln, "name"), str)]
+    return ProjectItem(
+        issue_number=number,
+        title=str(dig(node, "content", "title") or ""),
+        url=str(dig(node, "content", "url") or ""),
+        status=str(status_name or ""),
+        position=position,
+        labels=labels,
+        updated_at=str(dig(node, "content", "updatedAt") or ""),
+    )
 
 
 def _record_github_note_claim(

--- a/src/teatree/backends/gitlab_api.py
+++ b/src/teatree/backends/gitlab_api.py
@@ -9,6 +9,7 @@ from urllib.parse import urlencode
 
 import httpx
 
+from teatree.backends.types import dig
 from teatree.utils import git
 
 type RawMR = dict[str, object]
@@ -189,6 +190,36 @@ class GitLabHTTPClient:
         return cast("dict[str, object]", response.json())
 
 
+def _status_from_work_item_payload(data: object) -> str | None:
+    """Extract the Status-widget name from a work-item GraphQL payload.
+
+    Returns ``None`` for any missing/null hop. GraphQL returns ``null`` (not
+    an empty object) for a project the token cannot see / that no longer
+    exists, and likewise for an absent ``workItems`` — a chained
+    ``.get(..., {})`` does NOT substitute the default when the key is
+    present-but-null, so each hop must be isinstance-guarded or ``None.get``
+    would crash the whole label sync.
+    """
+    nodes = dig(data, "data", "project", "workItems", "nodes")
+    if not isinstance(nodes, list) or not nodes:
+        return None
+    first_node = nodes[0]
+    if not isinstance(first_node, Mapping):
+        return None
+    widgets = cast("Mapping[str, object]", first_node).get("widgets", [])
+    if not isinstance(widgets, list):
+        return None
+    for widget in widgets:
+        if not isinstance(widget, Mapping):
+            continue
+        widget_dict = cast("Mapping[str, object]", widget)
+        if widget_dict.get("type") == "STATUS":
+            status = widget_dict.get("status")
+            if isinstance(status, Mapping):
+                return str(cast("Mapping[str, object]", status).get("name", ""))
+    return None
+
+
 class GitLabAPI(GitLabHTTPClient):
     def get_work_item_status(self, project_path: str, iid: int) -> str | None:
         """Fetch the Status widget value for a GitLab work item via GraphQL."""
@@ -197,28 +228,9 @@ class GitLabAPI(GitLabHTTPClient):
         if cached is not None:
             return cached  # type: ignore[return-value]
         data = self.graphql(_WORK_ITEM_STATUS_QUERY, {"projectPath": project_path, "iid": str(iid)})
-        if not isinstance(data, dict):
-            self._set_cached(cache_key, None)
-            return None
-        nodes = (
-            data.get("data", {}).get("project", {}).get("workItems", {}).get("nodes", [])  # type: ignore[union-attr]
-        )
-        if not isinstance(nodes, list) or not nodes:
-            self._set_cached(cache_key, None)
-            return None
-        widgets = nodes[0].get("widgets", [])
-        if not isinstance(widgets, list):
-            self._set_cached(cache_key, None)
-            return None
-        for widget in widgets:
-            if isinstance(widget, dict) and widget.get("type") == "STATUS":
-                status = widget.get("status")
-                if isinstance(status, dict):
-                    result = str(status.get("name", ""))
-                    self._set_cached(cache_key, result)
-                    return result
-        self._set_cached(cache_key, None)
-        return None
+        result = _status_from_work_item_payload(data)
+        self._set_cached(cache_key, result)
+        return result
 
     def resolve_project(self, repo_path: str) -> ProjectInfo | None:
         if repo_path in self._project_cache:

--- a/src/teatree/backends/types.py
+++ b/src/teatree/backends/types.py
@@ -5,7 +5,24 @@ protocol implementations.  They do NOT replace the Protocol signatures
 (which remain ``dict[str, object]`` for structural typing compatibility).
 """
 
-from typing import TypedDict
+from collections.abc import Mapping
+from typing import TypedDict, cast
+
+
+def dig(data: object, *keys: str) -> object:
+    """Walk nested mapping *keys*, returning ``None`` on any missing/null hop.
+
+    Unlike a chained ``dict.get(k, {})`` this tolerates a key that is present
+    but ``null`` — the shape GraphQL returns for an inaccessible user / project
+    / work item — where the chained-default form would call ``.get`` on
+    ``None`` and crash. Shared by the GitHub and GitLab GraphQL parsers.
+    """
+    current = data
+    for key in keys:
+        if not isinstance(current, Mapping):
+            return None
+        current = cast("Mapping[str, object]", current).get(key)
+    return current
 
 
 class PullRequestResponse(TypedDict, total=False):

--- a/src/teatree/slack_mrkdwn.py
+++ b/src/teatree/slack_mrkdwn.py
@@ -99,7 +99,15 @@ def slack_linkify(
     text = _INLINE_CODE_RE.sub(_stash, text)
     text = _MRKDWN_LINK_RE.sub(_stash, text)
 
-    text = _MD_LINK_RE.sub(_rewrite_md_link, text)
+    # Stash each rewritten ``[label](url)`` → ``<url|label>`` link immediately:
+    # without protection a bare ``#N`` / ``!N`` inside the label (e.g.
+    # ``[issue #5](url)``) would be matched by the bare-token resolvers below
+    # and corrupted into a nested ``<url|… <url|#5>>`` link.
+    def _stash_md_link(match: re.Match[str]) -> str:
+        protected.append(_rewrite_md_link(match))
+        return f"\x00{len(protected) - 1}\x00"
+
+    text = _MD_LINK_RE.sub(_stash_md_link, text)
 
     if mr_resolver is not None:
         text = _BARE_MR_RE.sub(_make_token_rewriter("!", mr_resolver), text)

--- a/tests/teatree_backends/test_types.py
+++ b/tests/teatree_backends/test_types.py
@@ -1,4 +1,7 @@
+import pytest
+
 import teatree.backends.types as _types
+from teatree.backends.types import dig
 
 
 def test_typed_responses_importable() -> None:
@@ -13,3 +16,26 @@ def test_typed_responses_importable() -> None:
     ):
         td = getattr(_types, name)
         assert issubclass(td, dict)
+
+
+class TestDig:
+    def test_returns_nested_value(self) -> None:
+        assert dig({"a": {"b": {"c": 7}}}, "a", "b", "c") == 7
+
+    def test_returns_intermediate_mapping(self) -> None:
+        assert dig({"a": {"b": {"c": 7}}}, "a", "b") == {"c": 7}
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {"a": None},
+            {"a": {"b": None}},
+            {"a": "scalar"},
+            {},
+            None,
+        ],
+    )
+    def test_returns_none_on_missing_or_null_hop(self, data: object) -> None:
+        # The bug class this guards: a chained ``.get(k, {})`` calls ``.get`` on
+        # a present-but-null value and crashes; ``dig`` returns ``None`` instead.
+        assert dig(data, "a", "b", "c") is None

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -4,6 +4,8 @@ import json
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import teatree.backends.github as github_mod
 import teatree.utils.run as utils_run_mod
 from teatree.backends.github import (
@@ -155,6 +157,48 @@ class TestFetchProjectItems:
         with patch.object(github_mod, "_gh_graphql", return_value={"data": {"user": {}}}):
             items = fetch_project_items("testuser", 1)
         assert items == []
+
+    @pytest.mark.parametrize(
+        "graphql_response",
+        [
+            {"data": {"user": None}},
+            {"data": {"user": {"projectV2": None}}},
+            {"data": {"user": {"projectV2": {"items": None}}}},
+            {"data": {"user": {"projectV2": {"items": {"nodes": None}}}}},
+            {"data": None},
+        ],
+    )
+    def test_returns_empty_when_graphql_hop_is_null(self, graphql_response: dict[str, object]) -> None:
+        with patch.object(github_mod, "_gh_graphql", return_value=graphql_response):
+            items = fetch_project_items("testuser", 1)
+        assert items == []
+
+    def test_handles_null_labels_block(self) -> None:
+        graphql_response = {
+            "data": {
+                "user": {
+                    "projectV2": {
+                        "items": {
+                            "nodes": [
+                                {
+                                    "fieldValueByName": {"name": "Todo"},
+                                    "content": {
+                                        "number": 7,
+                                        "title": "No labels block",
+                                        "url": "https://github.com/org/repo/issues/7",
+                                        "labels": None,
+                                    },
+                                },
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        with patch.object(github_mod, "_gh_graphql", return_value=graphql_response):
+            items = fetch_project_items("testuser", 1)
+        assert len(items) == 1
+        assert items[0].labels == []
 
     def test_skips_non_dict_nodes(self) -> None:
         graphql_response = {"data": {"user": {"projectV2": {"items": {"nodes": [None, "invalid"]}}}}}

--- a/tests/test_slack_mrkdwn.py
+++ b/tests/test_slack_mrkdwn.py
@@ -82,6 +82,23 @@ class TestSlackLinkifyMarkdownLinks:
         out = slack_linkify("see [the PR](https://example.com/pr/1)")
         assert out == "see <https://example.com/pr/1|the PR>"
 
+    def test_bare_token_inside_link_label_is_not_rewritten(self) -> None:
+        # A ``#N`` / ``!N`` inside a markdown link label must survive verbatim:
+        # the freshly-built ``<url|label>`` link is protected before the bare-
+        # token resolvers run, so the label is never corrupted into a nested
+        # ``<url|… <url|#5>>`` link Slack renders as garbage.
+        out = slack_linkify(
+            "See [issue #1011](https://example.com/issues/1011) now",
+            issue_resolver=_issue,
+        )
+        assert out == "See <https://example.com/issues/1011|issue #1011> now"
+
+    def test_bare_token_outside_link_still_resolved_with_md_link_present(self) -> None:
+        out = slack_linkify("fixes #1011 in [the PR](https://example.com/pr/1)", issue_resolver=_issue)
+        assert out == (
+            "fixes <https://github.com/souliane/teatree/issues/1011|#1011> in <https://example.com/pr/1|the PR>"
+        )
+
     def test_label_with_pipe_inside_is_escaped(self) -> None:
         # Slack mrkdwn doesn't support pipes in labels; the helper substitutes
         # them with a unicode bar so the label stays readable rather than the

--- a/tests/utils/test_gitlab_api_client.py
+++ b/tests/utils/test_gitlab_api_client.py
@@ -246,6 +246,27 @@ def test_get_work_item_status_returns_none_when_widgets_not_a_list(monkeypatch: 
     assert result is None
 
 
+@pytest.mark.parametrize(
+    "graphql_response",
+    [
+        {"data": {"project": None}},
+        {"data": {"project": {"workItems": None}}},
+        {"data": {"project": {"workItems": {"nodes": None}}}},
+        {"data": {"project": {"workItems": {"nodes": ["not-a-dict"]}}}},
+        {"data": None},
+        {},
+    ],
+)
+def test_get_work_item_status_returns_none_when_graphql_hop_is_null(
+    graphql_response: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = gitlab_api.GitLabAPI(token="test-token")
+    monkeypatch.setattr(client, "graphql", lambda query, variables: graphql_response)
+
+    assert client.get_work_item_status("org/repo", 42) is None
+
+
 def test_get_work_item_status_returns_none_when_status_value_not_dict(monkeypatch: pytest.MonkeyPatch) -> None:
     client = gitlab_api.GitLabAPI(token="test-token")
     monkeypatch.setattr(


### PR DESCRIPTION
Second bug-hunt wave focused on the cross-module **seams** — where one parser's output is another module's input — in the clients/formatters subsystems. Three real defects found and fixed, each on a payload shape the upstream API genuinely returns.

## Fixes

**1. GitLab `get_work_item_status` crashed on a null project (fail-closed crash)**
GitLab GraphQL returns `{"data": {"project": null}}` when the token loses access to a work item's project or the project is deleted. The chained `data.get("data", {}).get("project", {}).get(...)` does **not** substitute the `{}` default for a present-but-null key, so `.get` was called on `None` → `AttributeError`. The label-sync loop (`fetch_issue_labels`) has no try/except around the loop body, so **one inaccessible work item aborted the label sweep for every remaining ticket**. Extracted a pure `_status_from_work_item_payload` helper that null-guards each hop.

**2. GitHub `fetch_project_items` had the identical crash**
Same chained `.get(k, {})` pattern over `data → user → projectV2 → items → labels`. A null `user`/`projectV2`/`labels` (org not found, no access) surfaced as a confusing `'NoneType' object has no attribute 'get'` board-sync error instead of an empty board. Extracted a pure `_project_item_from_node` helper that routes every field read through the null-guarding traversal.

**3. `slack_linkify` corrupted markdown links whose label contained a bare ref**
A label like `[issue #5](url)` was rewritten to `<url|issue #5>`, but the freshly-built mrkdwn link was not protected before the bare-`#N`/`!N` resolvers ran — so the `#5` inside the label was rewritten too, producing a nested `<url|issue <url|#5>>` link that Slack renders as garbage. This is on the outbound bot→user DM linkify path. Now the rewritten link is stashed immediately, like the other protected spans (code fences, inline code, existing mrkdwn links).

Factored the shared null-tolerant traversal into `teatree.backends.types.dig` so the GitHub and GitLab GraphQL parsers share one implementation.

## Tests
Each fix ships an anti-vacuous regression test, observed RED on the unpatched parser and GREEN after:
- `test_get_work_item_status_returns_none_when_graphql_hop_is_null` (parametrized)
- `test_returns_empty_when_graphql_hop_is_null` + `test_handles_null_labels_block`
- `test_bare_token_inside_link_label_is_not_rewritten` + `test_bare_token_outside_link_still_resolved_with_md_link_present`
- `TestDig` covers the shared helper directly

Full suite: 7465 passed, 13 skipped. Coverage 93.44% (≥93 floor). ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)