### PR TITLE
fix(backends): surface X-OAuth-Scopes header from auth_test so the scope guard fires

### DIFF
--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -46,6 +46,7 @@ from typing import cast
 import httpx
 
 from teatree.backends.slack_react_errors import SingleEmojiBodyRefusedError, is_single_emoji_body
+from teatree.backends.slack_scopes import OAUTH_SCOPES_HEADER, attach_granted_scopes
 from teatree.backends.slack_token_policy import SlackOp, channel_token
 from teatree.backends.slack_token_validation import (
     TokenSlotMismatchError,
@@ -483,14 +484,20 @@ class SlackBotBackend:
         return self._cached_bot_id
 
     def auth_test(self) -> RawAPIDict:
-        """Return the raw ``auth.test`` response (``{}`` when no bot token).
+        """Return the ``auth.test`` body with granted scopes from the ``X-OAuth-Scopes`` header.
 
-        A connector preflight calls this to assert the bot token is live
-        and correctly scoped before the loop proceeds — a hard-fail gate
-        rather than discovering ``missing_scope`` mid-tick via a phantom
-        ``post_message`` success.
+        Slack reports the token's scopes in the response header, not the JSON
+        body; they are attached under :data:`GRANTED_SCOPES_KEY` (native keys
+        untouched) so a connector-preflight scope guard can read them. ``{}``
+        when no bot token is configured.
         """
-        return self._post("auth.test", {})
+        if not self._bot_token:
+            return {}
+        headers = {"Authorization": f"Bearer {self._bot_token}", "Content-Type": "application/json; charset=utf-8"}
+        response = httpx.post("https://slack.com/api/auth.test", headers=headers, json={}, timeout=10.0)
+        response.raise_for_status()
+        body = cast("RawAPIDict", response.json())
+        return attach_granted_scopes(body, response.headers.get(OAUTH_SCOPES_HEADER, ""))
 
     def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:
         if is_single_emoji_body(text):

--- a/src/teatree/backends/slack_scopes.py
+++ b/src/teatree/backends/slack_scopes.py
@@ -1,0 +1,37 @@
+"""Slack OAuth-scope surfacing for ``auth.test``.
+
+Slack reports the granted OAuth scopes of a token in the ``X-OAuth-Scopes``
+HTTP *response header*, not in the JSON body. ``SlackBotBackend.auth_test``
+surfaces the parsed set under :data:`GRANTED_SCOPES_KEY` so a scope-preflight
+guard can read it without re-issuing the request. Keeping the parsing here
+(separate from the backend transport) lets both the backend and the
+connector-preflight guard share one source of truth.
+"""
+
+from teatree.types import RawAPIDict
+
+GRANTED_SCOPES_KEY = "_granted_scopes"
+OAUTH_SCOPES_HEADER = "X-OAuth-Scopes"
+
+
+def parse_oauth_scopes(header: str) -> frozenset[str]:
+    """Parse a comma-separated ``X-OAuth-Scopes`` header into a clean scope set."""
+    return frozenset(scope.strip() for scope in header.split(",") if scope.strip())
+
+
+def attach_granted_scopes(body: RawAPIDict, header_value: str) -> RawAPIDict:
+    """Attach the scopes parsed from *header_value* onto *body* under :data:`GRANTED_SCOPES_KEY`.
+
+    *body* (the ``auth.test`` JSON response) is returned mutated in place; its
+    Slack-native keys (``ok`` / ``user_id`` / ``bot_id``) are left untouched.
+    """
+    body[GRANTED_SCOPES_KEY] = sorted(parse_oauth_scopes(header_value))
+    return body
+
+
+__all__ = [
+    "GRANTED_SCOPES_KEY",
+    "OAUTH_SCOPES_HEADER",
+    "attach_granted_scopes",
+    "parse_oauth_scopes",
+]

--- a/src/teatree/core/connector_preflight.py
+++ b/src/teatree/core/connector_preflight.py
@@ -16,9 +16,37 @@ convention (``raise SystemExit``, never ``typer.Exit``).
 
 import logging
 
+from teatree.backends.protocols import MessagingBackend
+from teatree.backends.slack_scopes import GRANTED_SCOPES_KEY
 from teatree.core.overlay_loader import get_all_overlays
 
 logger = logging.getLogger(__name__)
+
+
+def assert_slack_scope(backend: MessagingBackend, scope: str) -> None:
+    """Raise ``RuntimeError`` when *backend*'s token lacks *scope*.
+
+    Reads the granted OAuth scopes that ``auth.test`` surfaces from the
+    ``X-OAuth-Scopes`` response header (under
+    :data:`~teatree.backends.slack_bot.GRANTED_SCOPES_KEY`). An overlay's
+    connector-preflight callable wires this so the loop refuses to continue
+    when a required scope (e.g. ``reactions:write``) is missing — rather than
+    discovering ``missing_scope`` mid-tick via a phantom write success.
+    """
+    response = backend.auth_test()
+    if not response.get("ok"):
+        error = response.get("error", "unknown error")
+        msg = f"Slack auth.test failed: {error}"
+        raise RuntimeError(msg)
+    raw = response.get(GRANTED_SCOPES_KEY)
+    granted = [s for s in raw if isinstance(s, str)] if isinstance(raw, list) else []
+    if scope not in granted:
+        msg = (
+            f"Slack token is missing the {scope!r} scope "
+            f"(granted: {', '.join(granted) or 'none'}). "
+            "Re-run `t3 setup slack-user-token` after updating the app manifest."
+        )
+        raise RuntimeError(msg)
 
 
 def run_connector_preflight(overlay_name: str = "") -> None:
@@ -54,4 +82,4 @@ def run_connector_preflight(overlay_name: str = "") -> None:
                 raise SystemExit(msg) from exc
 
 
-__all__ = ["run_connector_preflight"]
+__all__ = ["assert_slack_scope", "run_connector_preflight"]

--- a/tests/teatree_backends/test_messaging.py
+++ b/tests/teatree_backends/test_messaging.py
@@ -5,7 +5,7 @@ from typing import cast
 import httpx
 import pytest
 
-from teatree.backends import slack_bot
+from teatree.backends import slack_bot, slack_scopes
 from teatree.backends.messaging_noop import NoopMessagingBackend
 from teatree.backends.protocols import MessagingBackend
 from teatree.backends.slack_bot import SlackBotBackend
@@ -101,7 +101,9 @@ def test_slack_auth_test_returns_raw_response(monkeypatch: pytest.MonkeyPatch) -
 
     result = backend.auth_test()
 
-    assert result == {"ok": True, "user_id": "UBOT", "team": "T1"}
+    assert result["ok"] is True
+    assert result["user_id"] == "UBOT"
+    assert result["team"] == "T1"
     assert captured["url"] == "https://slack.com/api/auth.test"
 
 
@@ -116,11 +118,54 @@ def test_slack_auth_test_surfaces_ok_false(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
-    assert backend.auth_test() == {"ok": False, "error": "missing_scope"}
+    result = backend.auth_test()
+    assert result["ok"] is False
+    assert result["error"] == "missing_scope"
 
 
 def test_slack_auth_test_returns_empty_when_no_token() -> None:
     assert SlackBotBackend(bot_token="").auth_test() == {}
+
+
+def test_slack_auth_test_surfaces_granted_scopes_from_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Slack reports granted OAuth scopes in the ``X-OAuth-Scopes`` *header*, not the JSON body.
+
+    A scope guard built on ``auth_test()`` is dead in production unless the
+    backend surfaces what the header carries. This test puts the scope ONLY in
+    the header (never a fabricated JSON ``scopes`` field) and asserts it is
+    surfaced under ``GRANTED_SCOPES_KEY``.
+    """
+
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"X-OAuth-Scopes": "chat:write,reactions:write,users:read"},
+            json={"ok": True, "user_id": "UBOT", "bot_id": "BBOT"},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    backend = SlackBotBackend(bot_token="xoxb-test")
+
+    result = backend.auth_test()
+
+    assert result["ok"] is True
+    assert result["user_id"] == "UBOT"
+    assert result[slack_scopes.GRANTED_SCOPES_KEY] == ["chat:write", "reactions:write", "users:read"]
+
+
+def test_slack_auth_test_surfaces_empty_scopes_when_header_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"ok": True, "user_id": "UBOT"},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    backend = SlackBotBackend(bot_token="xoxb-test")
+
+    assert backend.auth_test()[slack_scopes.GRANTED_SCOPES_KEY] == []
 
 
 def test_slack_post_returns_empty_when_no_token() -> None:

--- a/tests/teatree_backends/test_slack_scopes.py
+++ b/tests/teatree_backends/test_slack_scopes.py
@@ -1,0 +1,17 @@
+"""Tests for ``teatree.backends.slack_scopes`` (X-OAuth-Scopes header parsing)."""
+
+from teatree.backends.slack_scopes import parse_oauth_scopes
+
+
+def test_parse_oauth_scopes_splits_comma_separated_header() -> None:
+    assert parse_oauth_scopes("chat:write,reactions:write, users:read ") == frozenset(
+        {"chat:write", "reactions:write", "users:read"}
+    )
+
+
+def test_parse_oauth_scopes_empty_header_yields_empty_set() -> None:
+    assert parse_oauth_scopes("") == frozenset()
+
+
+def test_parse_oauth_scopes_drops_blank_segments() -> None:
+    assert parse_oauth_scopes(" , chat:write ,, ") == frozenset({"chat:write"})

--- a/tests/teatree_core/test_connector_preflight.py
+++ b/tests/teatree_core/test_connector_preflight.py
@@ -8,12 +8,57 @@ WHICH connector is down.
 
 from unittest.mock import patch
 
+import httpx
 import pytest
 from django.test import TestCase
 
-from teatree.core.connector_preflight import run_connector_preflight
+from teatree.backends import slack_bot
+from teatree.backends.slack_bot import SlackBotBackend
+from teatree.core.connector_preflight import assert_slack_scope, run_connector_preflight
 from teatree.core.models import Worktree
 from teatree.core.overlay import OverlayBase, ProvisionStep
+
+
+def _fake_auth_test_post(header_value: str | None):
+    """Return an ``httpx.post`` stub whose ``auth.test`` carries *header_value*.
+
+    The granted scopes are supplied ONLY through the ``X-OAuth-Scopes``
+    response header — never a fabricated JSON ``scopes`` field — so the guard
+    is exercised against the same surface Slack actually uses in production.
+    A ``None`` header value models a response with no scope header at all.
+    """
+    headers = {} if header_value is None else {"X-OAuth-Scopes": header_value}
+
+    def fake_post(url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers=headers,
+            json={"ok": True, "user_id": "UBOT", "bot_id": "BBOT"},
+            request=httpx.Request("POST", url),
+        )
+
+    return fake_post
+
+
+class TestAssertSlackScope(TestCase):
+    def test_passes_when_scope_present_in_header(self) -> None:
+        with patch.object(slack_bot.httpx, "post", _fake_auth_test_post("chat:write,reactions:write,users:read")):
+            assert_slack_scope(SlackBotBackend(bot_token="xoxb-test"), "reactions:write")
+
+    def test_fires_when_scope_missing_from_header(self) -> None:
+        with (
+            patch.object(slack_bot.httpx, "post", _fake_auth_test_post("chat:write,users:read")),
+            pytest.raises(RuntimeError) as excinfo,
+        ):
+            assert_slack_scope(SlackBotBackend(bot_token="xoxb-test"), "reactions:write")
+        assert "reactions:write" in str(excinfo.value)
+
+    def test_fires_when_header_absent_entirely(self) -> None:
+        with (
+            patch.object(slack_bot.httpx, "post", _fake_auth_test_post(None)),
+            pytest.raises(RuntimeError),
+        ):
+            assert_slack_scope(SlackBotBackend(bot_token="xoxb-test"), "reactions:write")
 
 
 class _NoOpOverlay(OverlayBase):


### PR DESCRIPTION
## Problem

Slack reports a token's granted OAuth scopes in the `X-OAuth-Scopes` HTTP
response header, **not** the JSON body. `SlackBotBackend.auth_test()` returned
only `response.json()`, dropping the header. Any connector-preflight that reads
granted scopes from `auth_test()` therefore always saw an empty set, so a
`reactions:write` scope guard built on it could never fire in production — the
guard was effectively dead.

## Fix

- New `slack_scopes` module owns the scope-parsing concern: `parse_oauth_scopes`
  (comma-separated header → clean set), `attach_granted_scopes`, and the
  namespaced `GRANTED_SCOPES_KEY`.
- `auth_test()` now parses the `X-OAuth-Scopes` header and attaches the clean
  scope set under `_granted_scopes`, leaving the native `ok` / `user_id` /
  `bot_id` keys untouched — existing callers (self-filter identity probe, noop
  backend) are unaffected.
- New `connector_preflight.assert_slack_scope(backend, scope)` reads scopes from
  there and raises `RuntimeError` when a required scope is missing, so a
  preflight callable can refuse to continue rather than discover `missing_scope`
  mid-tick.

## Tests (TDD, anti-vacuous)

The regression test puts the scope **only** in the `X-OAuth-Scopes` header
(never a fabricated JSON `scopes` field) and mocks the Slack HTTP response
object with headers:

- `test_slack_auth_test_surfaces_granted_scopes_from_header` — header-only
  scopes are surfaced under the key.
- `TestAssertSlackScope::test_passes_when_scope_present_in_header` — the
  load-bearing RED: observed to FAIL on the pre-fix code, where a present scope
  is reported as `granted: none` and the guard misfires.
- `test_fires_when_scope_missing_from_header` / `..._when_header_absent_entirely`
  — guard raises when `reactions:write` is absent.
- `test_parse_oauth_scopes_*` — pure header-parsing unit tests.

Full suite: 7475 passed, coverage 93.44% (above the 93% floor); the changed
modules are at full coverage.