### PR TITLE
fix(backends): follow GitLab pagination in MR/issue list methods

### DIFF
--- a/src/teatree/backends/gitlab_api.py
+++ b/src/teatree/backends/gitlab_api.py
@@ -9,7 +9,7 @@ from urllib.parse import urlencode
 
 import httpx
 
-from teatree.backends.types import dig
+from teatree.backends.gitlab_payloads import WORK_ITEM_STATUS_QUERY, status_from_work_item_payload
 from teatree.utils import git
 
 type RawMR = dict[str, object]
@@ -26,30 +26,17 @@ _TTL_USERNAME = 3600
 _HTTP_OK_LOW = 200
 _HTTP_OK_HIGH = 300
 
+# Upper bound on pages walked for an offset-paginated list endpoint. GitLab
+# serves at most 100 items per page; this cap stops a runaway loop if the API
+# ever returns a malformed ``x-next-page`` that never empties.
+_MAX_PAGES = 100
+
 
 class _ReviewerEntry(TypedDict, total=False):
     """Subset of the GitLab reviewer payload teatree reads (#1295 cap B)."""
 
     id: int
     username: str
-
-
-_WORK_ITEM_STATUS_QUERY = """\
-query($projectPath: ID!, $iid: String!) {
-    project(fullPath: $projectPath) {
-        workItems(iids: [$iid]) {
-            nodes {
-                widgets {
-                    type
-                    ... on WorkItemWidgetStatus {
-                        status { name }
-                    }
-                }
-            }
-        }
-    }
-}
-"""
 
 
 def _as_int(value: object) -> int:
@@ -106,6 +93,39 @@ class GitLabHTTPClient:
         )
         response.raise_for_status()
         return cast("dict[str, object] | list[dict[str, object]]", response.json())
+
+    def get_json_paginated(self, endpoint: str) -> list[RawMR]:
+        """Fetch every page of an offset-paginated GitLab list endpoint.
+
+        GitLab returns each list page's continuation in the ``x-next-page``
+        response header — the next page number, or empty on the last page.
+        ``get_json`` reads only the first page, silently truncating any result
+        set larger than ``per_page``; this follows ``x-next-page`` until empty,
+        accumulating every page's items. Returns an empty list when there is no
+        token or a page body is not a JSON array. *endpoint* should already
+        carry the query string; the ``page`` parameter is appended per request.
+        """
+        if not self.token:
+            return []
+        sep = "&" if "?" in endpoint else "?"
+        items: list[RawMR] = []
+        page = 1
+        for _ in range(_MAX_PAGES):
+            response = httpx.get(
+                f"{self.base_url}/{endpoint.lstrip('/')}{sep}page={page}",
+                headers=self._headers(),
+                timeout=10.0,
+            )
+            response.raise_for_status()
+            body = response.json()
+            if not isinstance(body, list):
+                break
+            items.extend(cast("list[RawMR]", body))
+            next_page = response.headers.get("x-next-page", "")
+            if not next_page:
+                break
+            page = int(next_page)
+        return items
 
     def post_json(self, endpoint: str, payload: dict[str, object] | None = None) -> dict[str, object] | None:
         if not self.token:
@@ -190,36 +210,6 @@ class GitLabHTTPClient:
         return cast("dict[str, object]", response.json())
 
 
-def _status_from_work_item_payload(data: object) -> str | None:
-    """Extract the Status-widget name from a work-item GraphQL payload.
-
-    Returns ``None`` for any missing/null hop. GraphQL returns ``null`` (not
-    an empty object) for a project the token cannot see / that no longer
-    exists, and likewise for an absent ``workItems`` — a chained
-    ``.get(..., {})`` does NOT substitute the default when the key is
-    present-but-null, so each hop must be isinstance-guarded or ``None.get``
-    would crash the whole label sync.
-    """
-    nodes = dig(data, "data", "project", "workItems", "nodes")
-    if not isinstance(nodes, list) or not nodes:
-        return None
-    first_node = nodes[0]
-    if not isinstance(first_node, Mapping):
-        return None
-    widgets = cast("Mapping[str, object]", first_node).get("widgets", [])
-    if not isinstance(widgets, list):
-        return None
-    for widget in widgets:
-        if not isinstance(widget, Mapping):
-            continue
-        widget_dict = cast("Mapping[str, object]", widget)
-        if widget_dict.get("type") == "STATUS":
-            status = widget_dict.get("status")
-            if isinstance(status, Mapping):
-                return str(cast("Mapping[str, object]", status).get("name", ""))
-    return None
-
-
 class GitLabAPI(GitLabHTTPClient):
     def get_work_item_status(self, project_path: str, iid: int) -> str | None:
         """Fetch the Status widget value for a GitLab work item via GraphQL."""
@@ -227,8 +217,8 @@ class GitLabAPI(GitLabHTTPClient):
         cached = self._get_cached(cache_key, _TTL_WORK_ITEM)
         if cached is not None:
             return cached  # type: ignore[return-value]
-        data = self.graphql(_WORK_ITEM_STATUS_QUERY, {"projectPath": project_path, "iid": str(iid)})
-        result = _status_from_work_item_payload(data)
+        data = self.graphql(WORK_ITEM_STATUS_QUERY, {"projectPath": project_path, "iid": str(iid)})
+        result = status_from_work_item_payload(data)
         self._set_cached(cache_key, result)
         return result
 
@@ -278,9 +268,7 @@ class GitLabAPI(GitLabHTTPClient):
         if updated_after:
             query["updated_after"] = updated_after
         params = urlencode(query)
-        data = self.get_json(f"merge_requests?{params}")
-        if not isinstance(data, list):
-            return []
+        data = self.get_json_paginated(f"merge_requests?{params}")
         if include_draft:
             return data
         return [mr for mr in data if not mr.get("draft")]
@@ -302,8 +290,7 @@ class GitLabAPI(GitLabHTTPClient):
         if updated_after:
             query["updated_after"] = updated_after
         params = urlencode(query)
-        data = self.get_json(f"issues?{params}")
-        return data if isinstance(data, list) else []
+        return self.get_json_paginated(f"issues?{params}")
 
     def list_open_mrs_as_reviewer(
         self,
@@ -323,10 +310,7 @@ class GitLabAPI(GitLabHTTPClient):
         if updated_after:
             query["updated_after"] = updated_after
         params = urlencode(query)
-        data = self.get_json(f"merge_requests?{params}")
-        if not isinstance(data, list):
-            return []
-        return data
+        return self.get_json_paginated(f"merge_requests?{params}")
 
     def list_recently_merged_mrs(
         self,
@@ -374,10 +358,7 @@ class GitLabAPI(GitLabHTTPClient):
         if updated_after:
             query["updated_after"] = updated_after
         params = urlencode(query)
-        data = self.get_json(f"merge_requests?{params}")
-        if not isinstance(data, list):
-            return []
-        return data
+        return self.get_json_paginated(f"merge_requests?{params}")
 
     def get_mr_pipeline(self, project_id: int, mr_iid: int) -> dict[str, str | None]:
         """Return the latest pipeline status and URL for an MR."""

--- a/src/teatree/backends/gitlab_payloads.py
+++ b/src/teatree/backends/gitlab_payloads.py
@@ -1,0 +1,51 @@
+from collections.abc import Mapping
+from typing import cast
+
+from teatree.backends.types import dig
+
+WORK_ITEM_STATUS_QUERY = """\
+query($projectPath: ID!, $iid: String!) {
+    project(fullPath: $projectPath) {
+        workItems(iids: [$iid]) {
+            nodes {
+                widgets {
+                    type
+                    ... on WorkItemWidgetStatus {
+                        status { name }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+def status_from_work_item_payload(data: object) -> str | None:
+    """Extract the Status-widget name from a work-item GraphQL payload.
+
+    Returns ``None`` for any missing/null hop. GraphQL returns ``null`` (not
+    an empty object) for a project the token cannot see / that no longer
+    exists, and likewise for an absent ``workItems`` — a chained
+    ``.get(..., {})`` does NOT substitute the default when the key is
+    present-but-null, so each hop must be isinstance-guarded or ``None.get``
+    would crash the whole label sync.
+    """
+    nodes = dig(data, "data", "project", "workItems", "nodes")
+    if not isinstance(nodes, list) or not nodes:
+        return None
+    first_node = nodes[0]
+    if not isinstance(first_node, Mapping):
+        return None
+    widgets = cast("Mapping[str, object]", first_node).get("widgets", [])
+    if not isinstance(widgets, list):
+        return None
+    for widget in widgets:
+        if not isinstance(widget, Mapping):
+            continue
+        widget_dict = cast("Mapping[str, object]", widget)
+        if widget_dict.get("type") == "STATUS":
+            status = widget_dict.get("status")
+            if isinstance(status, Mapping):
+                return str(cast("Mapping[str, object]", status).get("name", ""))
+    return None

--- a/tests/utils/test_gitlab_api_client.py
+++ b/tests/utils/test_gitlab_api_client.py
@@ -37,6 +37,9 @@ def test_gitlab_api_helpers_cover_http_paths_and_failures(monkeypatch: pytest.Mo
         requests.append(url)
 
         class Response:
+            def __init__(self) -> None:
+                self.headers = {"x-next-page": ""}
+
             def raise_for_status(self) -> None:
                 return None
 
@@ -82,7 +85,7 @@ def test_gitlab_api_helpers_cover_http_paths_and_failures(monkeypatch: pytest.Mo
     assert client.list_all_open_mrs("adrien") == [{"iid": 1, "draft": False}, {"iid": 2, "draft": True}]
     assert client.list_all_open_mrs("adrien", include_draft=False) == [{"iid": 1, "draft": False}]
     assert client.cancel_pipelines(42, "feature") == [101, 101]
-    monkeypatch.setattr(client, "get_json", lambda endpoint: None)
+    monkeypatch.setattr(client, "get_json_paginated", lambda endpoint: [])
     assert client.list_all_open_mrs("adrien") == []
     monkeypatch.setattr(client, "get_json", lambda endpoint: {"oops": "bad"})
     assert client.cancel_pipelines(42, "feature") == []

--- a/tests/utils/test_gitlab_api_queries.py
+++ b/tests/utils/test_gitlab_api_queries.py
@@ -3,11 +3,166 @@ import pytest
 from teatree.backends import gitlab_api
 
 
+class _PagedResponse:
+    """Minimal httpx.Response stand-in for a single GitLab REST list page."""
+
+    def __init__(self, body: list[dict[str, object]], next_page: str) -> None:
+        self._body = body
+        self.headers = {"x-next-page": next_page}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> list[dict[str, object]]:
+        return self._body
+
+
+def _two_page_httpx_get(
+    pages: dict[str, _PagedResponse],
+    requested: list[str],
+) -> object:
+    """Build a fake ``httpx.get`` that serves *pages* keyed by ``page=`` value.
+
+    Page 1 is served when no explicit ``page=`` query is present (GitLab
+    defaults to page 1); later pages match on the ``page=N`` parameter.
+    """
+
+    def fake_get(url: str, *, headers: dict[str, str], timeout: float) -> object:
+        requested.append(url)
+        if "page=2" in url:
+            return pages["2"]
+        return pages["1"]
+
+    return fake_get
+
+
+def test_get_json_paginated_returns_empty_without_token() -> None:
+    client = gitlab_api.GitLabAPI(token="")
+
+    assert client.get_json_paginated("merge_requests?per_page=100") == []
+
+
+def test_get_json_paginated_breaks_on_non_list_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-array page body (e.g. a GitLab error object) stops the walk."""
+
+    class _ErrorResponse:
+        def __init__(self) -> None:
+            self.headers = {"x-next-page": "2"}
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"message": "403 Forbidden"}
+
+    monkeypatch.setattr(gitlab_api.httpx, "get", lambda url, *, headers, timeout: _ErrorResponse())
+    client = gitlab_api.GitLabAPI(token="test-token")
+
+    assert client.get_json_paginated("merge_requests?per_page=100") == []
+
+
+def test_get_json_paginated_appends_page_with_question_mark_separator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the endpoint already has a query string, ``page`` joins with ``&``."""
+    requested: list[str] = []
+
+    def fake_get(url: str, *, headers: dict[str, str], timeout: float) -> object:
+        requested.append(url)
+        return _PagedResponse([{"iid": 1}], next_page="")
+
+    monkeypatch.setattr(gitlab_api.httpx, "get", fake_get)
+    client = gitlab_api.GitLabAPI(token="test-token")
+    client.get_json_paginated("issues")
+
+    assert requested[0].endswith("issues?page=1")
+
+
+def test_get_json_paginated_stops_at_max_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A never-emptying ``x-next-page`` is bounded by ``_MAX_PAGES``."""
+    requested: list[str] = []
+
+    def fake_get(url: str, *, headers: dict[str, str], timeout: float) -> object:
+        requested.append(url)
+        return _PagedResponse([{"iid": 1}], next_page="999")
+
+    monkeypatch.setattr(gitlab_api.httpx, "get", fake_get)
+    client = gitlab_api.GitLabAPI(token="test-token")
+    result = client.get_json_paginated("merge_requests?per_page=100")
+
+    assert len(requested) == gitlab_api._MAX_PAGES
+    assert len(result) == gitlab_api._MAX_PAGES
+
+
+def test_list_all_open_mrs_follows_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_all_open_mrs accumulates items from every page, not just page 1.
+
+    RED on the pre-fix code (which read only the first page via get_json):
+    only the two page-1 items were returned, so the page-2 item (iid 3) was
+    silently dropped. GREEN after the method follows ``x-next-page``.
+    """
+    requested: list[str] = []
+    pages = {
+        "1": _PagedResponse([{"iid": 1, "draft": False}, {"iid": 2, "draft": False}], next_page="2"),
+        "2": _PagedResponse([{"iid": 3, "draft": False}], next_page=""),
+    }
+    monkeypatch.setattr(gitlab_api.httpx, "get", _two_page_httpx_get(pages, requested))
+
+    client = gitlab_api.GitLabAPI(token="test-token")
+    result = client.list_all_open_mrs("adrien")
+
+    assert [mr["iid"] for mr in result] == [1, 2, 3]
+    assert any("page=2" in url for url in requested)
+
+
+def test_list_open_issues_for_assignee_follows_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_open_issues_for_assignee returns issues from both pages."""
+    requested: list[str] = []
+    pages = {
+        "1": _PagedResponse([{"iid": 10}, {"iid": 11}], next_page="2"),
+        "2": _PagedResponse([{"iid": 12}], next_page=""),
+    }
+    monkeypatch.setattr(gitlab_api.httpx, "get", _two_page_httpx_get(pages, requested))
+
+    client = gitlab_api.GitLabAPI(token="test-token")
+    result = client.list_open_issues_for_assignee("adrien")
+
+    assert [issue["iid"] for issue in result] == [10, 11, 12]
+
+
+def test_list_open_mrs_as_reviewer_follows_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_open_mrs_as_reviewer returns reviewer MRs from both pages."""
+    requested: list[str] = []
+    pages = {
+        "1": _PagedResponse([{"iid": 20}, {"iid": 21}], next_page="2"),
+        "2": _PagedResponse([{"iid": 22}], next_page=""),
+    }
+    monkeypatch.setattr(gitlab_api.httpx, "get", _two_page_httpx_get(pages, requested))
+
+    client = gitlab_api.GitLabAPI(token="test-token")
+    result = client.list_open_mrs_as_reviewer("adrien")
+
+    assert [mr["iid"] for mr in result] == [20, 21, 22]
+
+
+def test_list_recently_merged_mrs_follows_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_list_terminal_mrs (via list_recently_merged_mrs) returns both pages."""
+    requested: list[str] = []
+    pages = {
+        "1": _PagedResponse([{"iid": 30}, {"iid": 31}], next_page="2"),
+        "2": _PagedResponse([{"iid": 32}], next_page=""),
+    }
+    monkeypatch.setattr(gitlab_api.httpx, "get", _two_page_httpx_get(pages, requested))
+
+    client = gitlab_api.GitLabAPI(token="test-token")
+    result = client.list_recently_merged_mrs("adrien")
+
+    assert [mr["iid"] for mr in result] == [30, 31, 32]
+
+
 def test_list_all_open_mrs_with_updated_after(monkeypatch: pytest.MonkeyPatch) -> None:
     client = gitlab_api.GitLabAPI(token="test-token")
     monkeypatch.setattr(
         client,
-        "get_json",
+        "get_json_paginated",
         lambda endpoint: [{"iid": 1, "draft": False}],
     )
 
@@ -24,7 +179,7 @@ def test_list_open_mrs_as_reviewer(monkeypatch: pytest.MonkeyPatch) -> None:
         captured_endpoints.append(endpoint)
         return [{"iid": 5, "web_url": "https://gitlab.com/org/repo/-/merge_requests/5"}]
 
-    monkeypatch.setattr(client, "get_json", _capture)
+    monkeypatch.setattr(client, "get_json_paginated", _capture)
 
     result = client.list_open_mrs_as_reviewer("adrien")
 
@@ -41,7 +196,7 @@ def test_list_open_issues_for_assignee(monkeypatch: pytest.MonkeyPatch) -> None:
         captured_endpoints.append(endpoint)
         return [{"iid": 42, "web_url": "https://gitlab.com/org/repo/-/issues/42"}]
 
-    monkeypatch.setattr(client, "get_json", _capture)
+    monkeypatch.setattr(client, "get_json_paginated", _capture)
 
     result = client.list_open_issues_for_assignee("adrien", updated_after="2024-01-01T00:00:00Z")
 
@@ -52,9 +207,9 @@ def test_list_open_issues_for_assignee(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "updated_after=2024-01-01T00%3A00%3A00Z" in captured_endpoints[0]
 
 
-def test_list_open_issues_for_assignee_returns_empty_on_non_list(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_list_open_issues_for_assignee_returns_empty_on_no_pages(monkeypatch: pytest.MonkeyPatch) -> None:
     client = gitlab_api.GitLabAPI(token="test-token")
-    monkeypatch.setattr(client, "get_json", lambda _endpoint: None)
+    monkeypatch.setattr(client, "get_json_paginated", lambda _endpoint: [])
 
     assert client.list_open_issues_for_assignee("adrien") == []
 
@@ -63,7 +218,7 @@ def test_list_recently_merged_mrs_returns_data(monkeypatch: pytest.MonkeyPatch) 
     client = gitlab_api.GitLabAPI(token="test-token")
     monkeypatch.setattr(
         client,
-        "get_json",
+        "get_json_paginated",
         lambda endpoint: [{"iid": 10, "state": "merged"}],
     )
 
@@ -80,7 +235,7 @@ def test_list_recently_merged_mrs_with_updated_after(monkeypatch: pytest.MonkeyP
         captured_endpoints.append(endpoint)
         return [{"iid": 10}]
 
-    monkeypatch.setattr(client, "get_json", capture_get_json)
+    monkeypatch.setattr(client, "get_json_paginated", capture_get_json)
 
     result = client.list_recently_merged_mrs("adrien", updated_after="2024-06-01T00:00:00Z")
 
@@ -88,9 +243,9 @@ def test_list_recently_merged_mrs_with_updated_after(monkeypatch: pytest.MonkeyP
     assert "updated_after" in captured_endpoints[0]
 
 
-def test_list_recently_merged_mrs_returns_empty_when_not_a_list(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_list_recently_merged_mrs_returns_empty_when_no_pages(monkeypatch: pytest.MonkeyPatch) -> None:
     client = gitlab_api.GitLabAPI(token="test-token")
-    monkeypatch.setattr(client, "get_json", lambda endpoint: {"error": "bad"})
+    monkeypatch.setattr(client, "get_json_paginated", lambda endpoint: [])
 
     result = client.list_recently_merged_mrs("adrien")
 
@@ -105,7 +260,7 @@ def test_list_recently_closed_mrs_queries_state_closed(monkeypatch: pytest.Monke
         captured.append(endpoint)
         return [{"iid": 77, "state": "closed"}]
 
-    monkeypatch.setattr(client, "get_json", capture_get_json)
+    monkeypatch.setattr(client, "get_json_paginated", capture_get_json)
 
     result = client.list_recently_closed_mrs("adrien", updated_after="2024-06-01T00:00:00Z")
 
@@ -115,9 +270,9 @@ def test_list_recently_closed_mrs_queries_state_closed(monkeypatch: pytest.Monke
     assert "updated_after" in captured[0]
 
 
-def test_list_recently_closed_mrs_returns_empty_when_not_a_list(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_list_recently_closed_mrs_returns_empty_when_no_pages(monkeypatch: pytest.MonkeyPatch) -> None:
     client = gitlab_api.GitLabAPI(token="test-token")
-    monkeypatch.setattr(client, "get_json", lambda _endpoint: {"error": "bad"})
+    monkeypatch.setattr(client, "get_json_paginated", lambda _endpoint: [])
 
     assert client.list_recently_closed_mrs("adrien") == []
 


### PR DESCRIPTION
## Problem

The GitLab list helpers (`list_all_open_mrs`, `list_open_issues_for_assignee`, `list_open_mrs_as_reviewer`, and `_list_terminal_mrs`) request `per_page=100` but read only the first page through `get_json`, which discards the HTTP response headers. Any result set larger than 100 items was silently truncated — a sweep over an identity with more than 100 open or terminal MRs/issues across accessible projects missed everything past the first page, with no error.

## Fix

Add `GitLabHTTPClient.get_json_paginated`, which follows GitLab's `x-next-page` response header (offset pagination): it requests `page=1`, appends each page's items, and continues to the next page number until `x-next-page` is empty. A page cap bounds the loop against a malformed never-emptying header. A non-array page body (e.g. a GitLab error object) stops the walk and yields what was collected so far. The four list methods now route through it; `per_page=100` is unchanged.

To keep `gitlab_api.py` under the module-health LOC ceiling once the new method lands, the work-item GraphQL query and its payload parser move to a new `gitlab_payloads` module.

## Tests

- `test_list_all_open_mrs_follows_pagination`, `test_list_open_issues_for_assignee_follows_pagination`, `test_list_open_mrs_as_reviewer_follows_pagination`, `test_list_recently_merged_mrs_follows_pagination` — mock a 2-page HTTP response (page 1 full + `x-next-page: 2`, page 2 partial) at the `httpx` layer and assert items from both pages are returned. Observed RED on the pre-fix code (only page-1 items returned) and GREEN after.
- `test_get_json_paginated_returns_empty_without_token`, `test_get_json_paginated_breaks_on_non_list_body`, `test_get_json_paginated_appends_page_with_question_mark_separator`, `test_get_json_paginated_stops_at_max_pages` cover the helper's own branches.

Full suite green, branch coverage 93.45% (floor 93%).