### PR TITLE
fix(loop/statusline): terse `[overlay] #N (topic !chip …)` format, strip agent-added decoration

### DIFF
--- a/src/teatree/loop/rendering_items.py
+++ b/src/teatree/loop/rendering_items.py
@@ -123,6 +123,16 @@ class _OverlayActionRefs:
     stale_refs: list[_IssueRef] = field(default_factory=list)
 
 
+def _chip_prefix(url: str) -> str:
+    """Return ``#`` for GitHub PR URLs, ``!`` otherwise (#1377).
+
+    GitHub PR URLs contain ``/pull/`` or ``/pulls/``; everything else
+    (GitLab MRs, unknown / blank URLs) gets the ``!`` default so the
+    pre-existing GitLab behaviour is preserved when the URL is missing.
+    """
+    return "#" if "/pull/" in url or "/pulls/" in url else "!"
+
+
 def _render_canonical_item(
     *,
     label: str,
@@ -131,51 +141,31 @@ def _render_canonical_item(
     child_refs: list[_PRRef],
     ctx: _LinkCtx,
 ) -> str:
-    """Render one item in the canonical statusline shape (#1015, #1156).
+    """Render one item in the terse statusline shape (#1377, binding spec).
 
-    ``#N (short desc) !M1 (MR1 title) !M2 (MR2 title)`` — every number
-    is a hyperlink, the description is omitted when empty, each MR
-    carries its title (#1156), and MRs are space-separated. The MRs are
-    no longer wrapped in an outer ``(…)`` group — the per-MR title chunk
-    is already parenthesised, so an outer group would double-bracket.
-
-    *ctx* bundles the renderer-side link formatter (OSC-8 vs.
-    ``text <url>`` fallback) with the ``colorize`` flag, so this module
-    stays free of the rendering module's colorize toggling.
+    ``#N (topic !M1 !M2 …)`` — every number is a hyperlink, topic and
+    chips share one pair of parens, and the parens are suppressed when
+    both topic and chips are absent so a bare ticket reads ``#N`` with no
+    trailing decoration. GitHub PRs render with the ``#`` chip prefix;
+    GitLab MRs keep ``!``. Per the binding spec the renderer adds no
+    per-MR title, no annotation chunk, and no review-permalink suffix —
+    richer per-MR signal belongs in dedicated zones.
     """
     text = ctx.link(label, url, colorize=ctx.colorize)
-    desc = _short_desc(title)
-    if desc:
-        text += f" ({desc})"
-    if child_refs:
-        text += " " + " ".join(_format_mr_ref(r, ctx) for r in child_refs)
-    # #1113 enhancement: append a clickable Slack permalink chunk per child
-    # MR whose ``ReviewRequestPost`` row recorded a thread post, so the
-    # operator can jump from the statusline straight to the review thread.
-    review_links = [
-        ctx.link(f"review !{r.iid}", r.review_permalink, colorize=ctx.colorize)
-        for r in child_refs
-        if r.review_permalink
-    ]
-    if review_links:
-        text += f" ({', '.join(review_links)})"
+    topic = _short_desc(title)
+    chips = " ".join(_format_mr_ref(r, ctx) for r in child_refs)
+    inner = " ".join(part for part in (topic, chips) if part)
+    if inner:
+        text += f" ({inner})"
     return text
 
 
 def _format_mr_ref(ref: _PRRef, ctx: _LinkCtx) -> str:
-    """Render one MR ref in the ``!N (title)`` shape (#1156).
+    """Render one MR/PR chip as a bare clickable ``!<iid>`` or ``#<iid>`` (#1377).
 
-    The ``(title)`` chunk is appended *outside* the clickable ``!N`` so the
-    hyperlink target stays small and the title is readable when ANSI
-    sequences are stripped. ``title`` is truncated to the canonical 40-char
-    budget via :func:`_short_desc`. The legacy annotation (``draft_count``,
-    ``pipeline status``) survives as a separate ``(annotation)`` chunk so a
-    titled draft renders as ``!N (title) (1 notes)``.
+    Per the binding spec the chip is just the number — no title, no
+    annotation, no Slack permalink suffix. GitHub PR URLs render with
+    the ``#`` prefix; GitLab MR URLs render with ``!``.
     """
-    rendered = ctx.link(f"!{ref.iid}", ref.url, colorize=ctx.colorize)
-    title = _short_desc(ref.title)
-    if title:
-        rendered += f" ({title})"
-    if ref.annotation:
-        rendered += f" ({ref.annotation})"
-    return rendered
+    chip = f"{_chip_prefix(ref.url)}{ref.iid}"
+    return ctx.link(chip, ref.url, colorize=ctx.colorize)

--- a/src/teatree/loop/rendering_zones.py
+++ b/src/teatree/loop/rendering_zones.py
@@ -99,20 +99,12 @@ def _render_pr_group(
 
     ctx = _LinkCtx(colorize=colorize, link=_link)
 
-    def _label(ref: _PRRef) -> str:
-        rendered = _format_mr_ref(ref, ctx)
-        # #1113 enhancement: surface the review-channel post permalink so the
-        # operator can jump from the statusline straight to the thread.
-        if ref.review_permalink:
-            rendered += " " + _link("(review)", ref.review_permalink, colorize=colorize)
-        return rendered
-
     chunks: list[str] = []
     for tnum in sorted(by_ticket):
-        bucket = " ".join(_label(r) for r in by_ticket[tnum])
+        bucket = " ".join(_format_mr_ref(r, ctx) for r in by_ticket[tnum])
         chunks.append(f"#{tnum}: {bucket}")
     if orphans:
-        chunks.append(" ".join(_label(r) for r in orphans))
+        chunks.append(" ".join(_format_mr_ref(r, ctx) for r in orphans))
     return f"{prefix}{' · '.join(chunks)}"
 
 

--- a/tests/teatree_loop/test_pr_ticket_index.py
+++ b/tests/teatree_loop/test_pr_ticket_index.py
@@ -391,10 +391,9 @@ class TestZonesForGroupsByParentTicket(TestCase):
         zones = zones_for(actions)
         text = zones.action_needed[0] if isinstance(zones.action_needed[0], str) else zones.action_needed[0].text
         assert "#855:" in text
-        # #1156: NO_COLOR renders the MR ref with the URL between iid and
-        # the annotation chunk — assert each piece separately.
         assert "!370" in text
-        assert "(3 notes)" in text
+        # Annotation chunk removed by #1377 — chip is bare.
+        assert "(3 notes)" not in text, repr(text)
 
     def test_orphan_pr_renders_under_overlay_without_ticket_prefix(self) -> None:
         from teatree.loop.rendering import zones_for  # noqa: PLC0415

--- a/tests/teatree_loop/test_rendering.py
+++ b/tests/teatree_loop/test_rendering.py
@@ -523,13 +523,14 @@ class TestTicketExtraPrsResolvesMrToTicket:
 
 
 @pytest.mark.django_db
-class TestPostedReviewRequestPermalink:
-    """#1113 enhancement — a posted review-request renders a clickable link.
+class TestPostedReviewRequestPermalinkNotInChip:
+    """#1377: the chip is bare — review-permalink suffix removed from the chip.
 
-    A ``ReviewRequestPost`` row records the review-channel post's channel +
-    thread ts. The ticket whose MR was posted should surface the clickable
-    Slack permalink as an extra ref chunk. Pre-fix nothing reads
-    ``ReviewRequestPost`` into the render path.
+    A ``ReviewRequestPost`` row still records the review-channel post's
+    channel + thread ts (the data path is unchanged), but the statusline
+    chip no longer surfaces the permalink in-line. Per the binding spec
+    the chip is just ``!<iid>``; richer per-MR signal belongs in
+    dedicated zones, not on the chip.
     """
 
     URL = "https://gitlab.com/souliane/teatree/-/merge_requests/145"
@@ -560,10 +561,13 @@ class TestPostedReviewRequestPermalink:
             ),
         ]
 
-    def test_posted_review_request_surfaces_clickable_permalink(self) -> None:
+    def test_chip_has_no_slack_permalink_suffix(self) -> None:
         self._seed()
         blob = _render_blob(self._actions())
-        assert "slack.com/archives/C9" in blob, repr(blob)
+        assert "!145" in blob, repr(blob)
+        # Slack permalink suffix removed from the chip in #1377.
+        assert "slack.com/archives/C9" not in blob, repr(blob)
+        assert "(review" not in blob, repr(blob)
 
 
 @pytest.mark.django_db
@@ -603,11 +607,13 @@ class TestNoAgentsLineInInFlight:
         assert "agents:" not in blob, repr(blob)
 
 
-def test_canonical_item_renders_review_permalink_chunk() -> None:
-    """Canonical item appends a ``(review)`` chunk per child MR with a permalink.
+def test_canonical_item_drops_review_permalink_chunk() -> None:
+    """#1377: canonical item omits the ``(review)`` permalink suffix.
 
-    When a state-line item's child MR has a recorded permalink, the
-    canonical item shape adds the clickable ``(review)`` chunk.
+    Even when a child MR has a ``review_permalink`` recorded, the chip
+    renders as a bare ``!<iid>`` — the Slack permalink does not appear
+    on the chip. Per the binding spec the chip is just the number;
+    richer per-MR signal belongs in dedicated zones.
     """
     from teatree.loop.rendering_items import _LinkCtx, _PRRef, _render_canonical_item  # noqa: PLC0415
 
@@ -629,4 +635,6 @@ def test_canonical_item_renders_review_permalink_chunk() -> None:
         ],
         ctx=_LinkCtx(colorize=False, link=_link),
     )
-    assert "review !145 <https://slack.com/archives/C9/p17790001>" in rendered, rendered
+    assert "!145 <https://x/mr/145>" in rendered, rendered
+    assert "slack.com" not in rendered, rendered
+    assert "review !145" not in rendered, rendered

--- a/tests/teatree_loop/test_rendering_audit.py
+++ b/tests/teatree_loop/test_rendering_audit.py
@@ -237,13 +237,13 @@ class TestInflightPrRows:
         text = _blob(zones.in_flight)
         assert text.count("!123") == 1, repr(text)
 
-    def test_in_flight_pr_failed_annotation_renders_once(self) -> None:
+    def test_in_flight_pr_failed_renders_bare_chip_no_annotation(self) -> None:
+        """Per #1377 the chip is bare ``!N`` — ``(pipeline failed)`` removed."""
         zones = zones_for([_my_pr(456, zone="action_needed", status="failed")], colorize=False)
         text = _blob(zones.action_needed)
-        # #1156: NO_COLOR renders ``!N <url>`` plus the annotation chunk.
         assert "!456" in text, repr(text)
-        assert "(pipeline failed)" in text, repr(text)
-        assert text.count("(pipeline failed)") == 1, repr(text)
+        # Annotation decoration removed by #1377.
+        assert "(pipeline failed)" not in text, repr(text)
 
 
 class TestNoRunningTasksLine(django.test.TestCase):

--- a/tests/teatree_loop/test_statusline_canonical_item_shape.py
+++ b/tests/teatree_loop/test_statusline_canonical_item_shape.py
@@ -131,12 +131,12 @@ class TestAnchorCanonicalShape:
         # Ensure no "()" (empty desc) bug.
         assert "()" not in text, repr(text)
 
-    def test_anchor_emits_canonical_pr_chunk_space_separated(self) -> None:
-        """Multiple MRs claiming a ticket render space-separated (#1156).
+    def test_anchor_renders_topic_and_chips_inside_one_paren_group(self) -> None:
+        """#1377 binding spec: topic AND chips share ONE pair of parens.
 
-        #1156 swapped the pre-existing comma join for a single space —
-        each MR now carries its own ``(title)`` chunk so a comma would
-        visually collide with the parens.
+        ``[overlay] #N (topic !M1 !M2)`` — not ``#N (topic) !M1 !M2``.
+        Per the user-spec, every chip is a bare ``!<iid>`` — no per-MR
+        title chunk, no annotation, no comma separator.
         """
         # ``build_ticket_index`` parses ``Closes #N`` from the MR
         # description (nested under ``payload['raw']['description']`` — the
@@ -167,14 +167,16 @@ class TestAnchorCanonicalShape:
         zones = zones_for([action_active, action_pr1, action_pr2], colorize=False)
         anchor = _blob(zones.anchors)
         assert "#44" in anchor, repr(anchor)
-        assert "(Tickety tick)" in anchor, repr(anchor)
-        # Both MRs render, and the comma join is gone.
+        # Topic and chips share ONE pair of parens — ``(Tickety tick) !1``
+        # (chips outside) is the banned shape.
+        assert "(Tickety tick) !1" not in anchor, repr(anchor)
+        assert "(Tickety tick !1" in anchor, repr(anchor)
         assert "!1" in anchor, repr(anchor)
         assert "!2" in anchor, repr(anchor)
         assert ", !2" not in anchor, repr(anchor)
 
     def test_anchor_renders_canonical_shape_under_colorize(self) -> None:
-        """Under OSC8 the MR chunk also uses space separation (#1156)."""
+        """Under OSC8 the chips stay inside the topic parens (#1377)."""
         action_active = _active("44", "coded", title="Tickety tick")
         action_pr1 = DispatchAction(
             kind="statusline",
@@ -217,7 +219,7 @@ class TestCanonicalShapeSurvivesTickSplitMerge:
     behaviours turns this RED.
     """
 
-    def test_full_canonical_shape_with_clickable_numbers_and_space_mrs(self) -> None:
+    def test_full_canonical_shape_with_clickable_numbers_and_inner_chips(self) -> None:
         import re  # noqa: PLC0415
 
         zones = zones_for(
@@ -256,10 +258,10 @@ class TestCanonicalShapeSurvivesTickSplitMerge:
         assert "\033]8;;https://gitlab.example.com/g/p/-/merge_requests/1\033\\" in anchor, repr(anchor)
         assert "\033]8;;https://gitlab.example.com/g/p/-/merge_requests/2\033\\" in anchor, repr(anchor)
         # (3) Strip OSC8 sequences to recover the visible text and pin the
-        #     #1156 canonical shape: ``#44 (Tickety tick) !1 !2`` —
-        #     description in single parens, MRs space-joined (no outer parens).
+        #     #1377 terse shape: ``#44 (Tickety tick !1 !2)`` — topic and
+        #     chips share ONE pair of parens.
         visible = re.sub(r"\033]8;;[^\033]*\033\\", "", anchor)
-        assert re.search(r"#44 \(Tickety tick\) !1 !2", visible), repr(visible)
+        assert re.search(r"#44 \(Tickety tick !1 !2\)", visible), repr(visible)
 
     def test_description_chunk_omitted_when_title_empty(self) -> None:
         import re  # noqa: PLC0415

--- a/tests/teatree_loop/test_statusline_mr_format.py
+++ b/tests/teatree_loop/test_statusline_mr_format.py
@@ -1,10 +1,8 @@
-"""Tests for the ``!N (terse topic)`` rendering (#1156).
+"""Tests for the bare ``!N`` / ``#N`` chip rendering (#1377).
 
-Pre-#1156: bare ``!1234`` ref, comma-joined when multiple.
-Post-#1156: ``!1234 (MR title)`` ref, space-separated when multiple.
-Later: the ``(…)`` chunk is a terse 2-3 word topic, not the full commit
-subject — the conventional-commit prefix is stripped and only the first
-few words are kept. The full subject still lives on the OSC-8 link target.
+Per the binding spec the chip is just the number — no per-MR title
+chunk, no annotation, no review-permalink suffix. Earlier shapes
+(``!N (title)``, ``!N (title) (1 notes)``) are gone.
 """
 
 import pytest
@@ -34,8 +32,8 @@ def _render_blob(actions: list[DispatchAction]) -> str:
     )
 
 
-class TestMrLineIncludesTitle:
-    def test_mr_line_includes_terse_topic(self) -> None:
+class TestMrChipIsBare:
+    def test_chip_is_bare_iid_no_title_chunk(self) -> None:
         actions = [
             _pr_action(
                 url="https://example.com/p/1/merge_requests/123",
@@ -45,14 +43,10 @@ class TestMrLineIncludesTitle:
         ]
         blob = _render_blob(actions)
 
-        # The MR ref carries a terse topic — the ``feat(loop):`` prefix is
-        # stripped and the first three words kept.
         assert "!123" in blob, repr(blob)
-        assert "(add multi-loop anchors)" in blob, repr(blob)
-        # The full conventional-commit prefix must NOT render on the chip.
+        # Per #1377 the title chunk is removed from the chip — no decoration.
+        assert "(add multi-loop anchors)" not in blob, repr(blob)
         assert "feat(loop):" not in blob, repr(blob)
-        # The topic chunk must come *after* the iid.
-        assert blob.index("!123") < blob.index("(add multi-loop anchors)"), repr(blob)
 
     def test_multiple_open_mrs_space_separated(self) -> None:
         actions = [
@@ -61,14 +55,16 @@ class TestMrLineIncludesTitle:
         ]
         blob = _render_blob(actions)
 
-        # Both MRs render with their title. They are joined by a single
-        # space, never ``, `` (comma-joining was the pre-#1156 form).
-        assert "(alpha) !101" in blob, repr(blob)
-        # Comma-joining must be gone (no ``, !101``).
+        assert "!100" in blob, repr(blob)
+        assert "!101" in blob, repr(blob)
+        # Comma-joining stayed gone; chips space-separated.
         assert ", !101" not in blob, repr(blob)
+        # Per #1377 no per-MR title chunks.
+        assert "(alpha)" not in blob, repr(blob)
+        assert "(beta)" not in blob, repr(blob)
 
-    def test_drafts_included(self) -> None:
-        """A draft MR (annotation present) still renders with its title."""
+    def test_draft_chip_has_no_annotation(self) -> None:
+        """A draft MR's ``(N notes)`` annotation is gone per #1377."""
         action = DispatchAction(
             kind="statusline",
             zone="in_flight",
@@ -83,10 +79,10 @@ class TestMrLineIncludesTitle:
         )
         blob = _render_blob([action])
 
-        # Terse topic (``wip:`` prefix stripped) appears alongside the
-        # existing annotation.
         assert "!200" in blob, repr(blob)
-        assert "(experimental)" in blob, repr(blob)
+        # Annotation chunk and title chunk both gone per #1377.
+        assert "(experimental)" not in blob, repr(blob)
+        assert "(1 notes)" not in blob, repr(blob)
 
 
 @pytest.mark.django_db

--- a/tests/teatree_loop/test_statusline_terse_chips_spec.py
+++ b/tests/teatree_loop/test_statusline_terse_chips_spec.py
@@ -1,0 +1,150 @@
+"""Statusline terse-chips spec (#1377, binding format).
+
+Pins the literal user-spec shape ``[overlay] #N (topic !chip1 !chip2 …)``:
+
+- Topic and chips share ONE pair of parentheses.
+- Chips are bare ``!<iid>`` (GitLab MR) or ``#<n>`` (GitHub PR) — no
+    per-MR title chunk, no annotation chunk, no review-permalink suffix.
+- No empty ``()`` when both topic and chips are absent — the parens
+    are suppressed entirely.
+
+Example shape (overlay name sanitised for this public repo):
+``[acme-fleet] #8495 (extra margin !6264 !7491 !7490 !7487)``
+"""
+
+import re
+
+from teatree.loop.dispatch import DispatchAction
+from teatree.loop.rendering import zones_for
+
+
+def _blob(zone: list[object]) -> str:
+    return "\n".join(item if isinstance(item, str) else item.text for item in zone)
+
+
+def _active(num: str, *, title: str, overlay: str, issue_url: str) -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="anchors",
+        detail=f"#{num} started",
+        payload={
+            "ticket_number": num,
+            "state": "started",
+            "overlay": overlay,
+            "issue_url": issue_url,
+            "title": title,
+        },
+    )
+
+
+def _pr(*, iid: int, url: str, overlay: str, ticket_num: str) -> DispatchAction:
+    return DispatchAction(
+        kind="statusline",
+        zone="in_flight",
+        detail=f"PR !{iid}",
+        payload={
+            "iid": iid,
+            "url": url,
+            "overlay": overlay,
+            "raw": {"description": f"Closes #{ticket_num}"},
+        },
+    )
+
+
+def _visible(text: str) -> str:
+    """Recover the bare visible glyphs a user reads in their terminal.
+
+    Strips OSC8 hyperlink wrappers and ANSI CSI escapes so the assertion
+    sees only what the user actually sees — the link URL lives inside
+    the OSC8 envelope, not in the visible text.
+    """
+    text = re.sub(r"\x1b\]8;;[^\x1b\x07]*(?:\x1b\\|\x07)", "", text)
+    return re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text)
+
+
+class TestAnchorWithFourGitlabMrsMatchesShape:
+    """The anchor must render `[overlay] #N (topic !a !b !c !d)` exactly."""
+
+    def test_overlay_ticket_8495_with_four_gitlab_mrs(self) -> None:
+        ticket_url = "https://gitlab.example.com/acme-fleet/-/issues/8495"
+        base = "https://gitlab.example.com/acme-fleet/-/merge_requests"
+        actions = [
+            _active(
+                "8495",
+                title="extra margin",
+                overlay="acme-fleet",
+                issue_url=ticket_url,
+            ),
+            _pr(iid=6264, url=f"{base}/6264", overlay="acme-fleet", ticket_num="8495"),
+            _pr(iid=7491, url=f"{base}/7491", overlay="acme-fleet", ticket_num="8495"),
+            _pr(iid=7490, url=f"{base}/7490", overlay="acme-fleet", ticket_num="8495"),
+            _pr(iid=7487, url=f"{base}/7487", overlay="acme-fleet", ticket_num="8495"),
+        ]
+        zones = zones_for(actions, colorize=True)
+        anchor = _visible(_blob(zones.anchors))
+        anchor_line = next((line for line in anchor.splitlines() if line.startswith("[acme-fleet]")), "")
+        assert anchor_line == "[acme-fleet] #8495 (extra margin !6264 !7491 !7490 !7487)", repr(anchor_line)
+
+
+class TestGithubChipsUseHash:
+    """A teatree ticket with two GitHub PRs renders ``#N`` chips, not ``!N``."""
+
+    def test_teatree_ticket_with_two_github_prs_renders_hash_chips(self) -> None:
+        ticket_url = "https://github.com/souliane/teatree/issues/97"
+        actions = [
+            _active(
+                "97",
+                title="terse chips spec",
+                overlay="teatree",
+                issue_url=ticket_url,
+            ),
+            _pr(
+                iid=1377,
+                url="https://github.com/souliane/teatree/pull/1377",
+                overlay="teatree",
+                ticket_num="97",
+            ),
+            _pr(
+                iid=1399,
+                url="https://github.com/souliane/teatree/pull/1399",
+                overlay="teatree",
+                ticket_num="97",
+            ),
+        ]
+        zones = zones_for(actions, colorize=True)
+        anchor = _visible(_blob(zones.anchors))
+        anchor_line = next((line for line in anchor.splitlines() if line.startswith("[teatree]")), "")
+        assert anchor_line == "[teatree] #97 (terse chips spec #1377 #1399)", repr(anchor_line)
+
+
+class TestNoMrsNoEmptyParens:
+    """A ticket with no MRs renders ``[ov] #N (topic)`` (no trailing space, no empty parens)."""
+
+    def test_ticket_with_topic_and_no_mrs_has_no_trailing_decoration(self) -> None:
+        actions = [
+            _active(
+                "100",
+                title="some topic",
+                overlay="acme-fleet",
+                issue_url="https://gitlab.example.com/acme-fleet/-/issues/100",
+            ),
+        ]
+        zones = zones_for(actions, colorize=True)
+        anchor = _visible(_blob(zones.anchors))
+        anchor_line = next((line for line in anchor.splitlines() if line.startswith("[acme-fleet]")), "")
+        assert anchor_line == "[acme-fleet] #100 (some topic)", repr(anchor_line)
+
+    def test_ticket_with_no_topic_and_no_mrs_has_no_parens_at_all(self) -> None:
+        actions = [
+            _active(
+                "100",
+                title="",
+                overlay="acme-fleet",
+                issue_url="https://gitlab.example.com/acme-fleet/-/issues/100",
+            ),
+        ]
+        zones = zones_for(actions, colorize=True)
+        anchor = _visible(_blob(zones.anchors))
+        anchor_line = next((line for line in anchor.splitlines() if line.startswith("[acme-fleet]")), "")
+        # Bare ``[acme-fleet] #100`` — no parens, no trailing space.
+        assert anchor_line == "[acme-fleet] #100", repr(anchor_line)

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -573,7 +573,8 @@ def test_zones_groups_prs_per_overlay_on_one_line() -> None:
     assert "!7370" in text
 
 
-def test_zones_pr_annotations_show_notes_and_failures() -> None:
+def test_zones_pr_chips_are_bare_no_annotation_decoration() -> None:
+    """Per #1377 the chip is just the number — no ``(N notes)`` / ``(pipeline …)``."""
     from teatree.loop.dispatch import DispatchAction  # noqa: PLC0415
     from teatree.loop.rendering import zones_for as _zones_for  # noqa: PLC0415
 
@@ -593,11 +594,11 @@ def test_zones_pr_annotations_show_notes_and_failures() -> None:
     ]
     zones = _zones_for(actions)
     text = zones.action_needed[0] if isinstance(zones.action_needed[0], str) else zones.action_needed[0].text
-    # #1156: NO_COLOR puts the URL between the iid and annotation chunks.
     assert "!330" in text
-    assert "(7 notes)" in text
     assert "!99" in text
-    assert "(pipeline failed)" in text
+    # The annotation chunks are gone — bare chips only.
+    assert "(7 notes)" not in text, repr(text)
+    assert "(pipeline failed)" not in text, repr(text)
 
 
 def test_active_tickets_shown_in_anchors() -> None:
@@ -881,7 +882,8 @@ def test_tick_multi_overlay_prefixes_summary(tmp_path: Path) -> None:
     run_tick(TickRequest(backends=backends), statusline_path=statusline, colorize=False)
     contents = statusline.read_text(encoding="utf-8")
     assert "[teatree]" in contents
-    assert "!545" in contents
+    # GitHub PR URL → ``#545`` chip glyph (#1377). GitLab URLs use ``!``.
+    assert "#545" in contents
 
 
 def test_repos_from_toml_extracts_path_and_workspace_repos(
@@ -1067,8 +1069,9 @@ def test_reviewer_pr_signal_surfaces_in_statusline() -> None:
     zones = zones_for(actions)
     rendered = "\n".join(item if isinstance(item, str) else item.text for item in zones.action_needed)
     assert "!371" in rendered
-    assert "review" in rendered
     assert "[acme]" in rendered
+    # #1377: the chip is bare — no ``(review)`` annotation suffix.
+    assert "(review)" not in rendered, repr(rendered)
 
 
 class TestLoopOwnerAnchorWiring(django.test.TestCase):


### PR DESCRIPTION
Closes #1377.

## What changed

`teatree.loop.rendering_items` and `teatree.loop.rendering_zones` now render every statusline anchor item in the terse shape:

```
[overlay] #N (topic !chip1 !chip2 …)
```

Topic and chips share **one** pair of parens. Chips are bare `!<iid>` (GitLab MR) or `#<iid>` (GitHub PR) — no per-MR title chunk, no `(N notes)` / `(pipeline failed)` annotation, no `(review)` Slack permalink suffix. When both topic and chips are absent the parens are suppressed entirely so a bare ticket reads `[overlay] #N` with no trailing decoration.

The data paths that produce those signals (draft count, pipeline status, `ReviewRequestPost`) are **unchanged** — only the chip renderer drops them. Richer per-MR signal belongs in dedicated zones, not on the anchor chip.

## Why

Recurring user complaint over the past two days: the anchor row kept growing per-MR decoration (`(techdebt(extra_margin): tighten origina…)`, `(N notes)`, `(pipeline failed)`, `(review …)`) that the user neither asked for nor wants. The format was specified in the user's binding feedback memory (`feedback_statusline_format_terse_ticket_mr_chips`) and #1377; this PR lands it as a deterministic gate (assertions + negative assertions in tests).

## Shape assertion (PR-level acceptance check)

Render of an overlay ticket #8495 with four GitLab MRs `!6264 !7491 !7490 !7487` produces exactly:

```
[<overlay>] #8495 (extra margin !6264 !7491 !7490 !7487)
```

Pinned in `tests/teatree_loop/test_statusline_terse_chips_spec.py::TestAnchorWithFourGitlabMrsMatchesShape::test_overlay_ticket_8495_with_four_gitlab_mrs` (overlay name sanitised for this public repo; the shape is identical to the user-binding example).

Sibling assertions:

- `test_teatree_ticket_with_two_github_prs_renders_hash_chips` — GitHub PR URLs render with the `#` chip glyph: `[teatree] #97 (terse chips spec #1377 #1399)`.
- `test_ticket_with_topic_and_no_mrs_has_no_trailing_decoration` — `[<overlay>] #100 (some topic)` (no trailing space, no empty parens).
- `test_ticket_with_no_topic_and_no_mrs_has_no_parens_at_all` — `[<overlay>] #100` (no parens at all when both topic and chips are empty).

## Anti-vacuous proof

Reverted the renderer change and re-ran the new tests: the four-chip GitLab anchor and the GitHub-chips tests both went RED with the exact diff the spec rejects (`(extra margin) !6264 !7491 !7490 !7487` — chips outside the parens). Restored the fix → GREEN.

## Test sweep

Six existing tests pinned the now-banned `(title)`, `(annotation)`, and `(review)` chunks plus the chips-outside-parens shape. Each was updated to assert the new contract with a negative assertion guarding the regression:

- `tests/teatree_loop/test_statusline_canonical_item_shape.py` — chips inside the topic parens.
- `tests/teatree_loop/test_statusline_mr_format.py` — chip is bare, no `(title)`, no `(N notes)`.
- `tests/teatree_loop/test_rendering_audit.py` — `(pipeline failed)` removed from the chip.
- `tests/teatree_loop/test_rendering.py` — `(review)` Slack permalink suffix removed from the chip; `_render_canonical_item` drops the permalink chunk.
- `tests/teatree_loop/test_pr_ticket_index.py` — `(3 notes)` annotation removed.
- `tests/teatree_loop/test_tick.py` — `(7 notes)`, `(pipeline failed)`, `(review)` removed; GitHub PR URL renders with `#` chip glyph.

Full loop test suite: 1176 passed. Full repo: 7486 passed (one unrelated concurrency-timeout flake on `test_loop_ownership_transfer.py::TestConcurrentFreshClaimIsAtomic`, passes in isolation).
