### PR TITLE
feat(hooks): orchestrator boundary — deny foreground Agent dispatch from main agent (#1442)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -1446,11 +1446,41 @@ def handle_enforce_orchestrator_boundary(data: dict) -> bool:
     hands that implement. Fails open when the transcript cannot
     distinguish the agent (documented limitation), never blocking on an
     ambiguous signal.
+
+    Extension (#1442): the main agent must dispatch ``Agent`` calls with
+    ``run_in_background: true`` — a foreground dispatch blocks the
+    orchestrator for the entire sub-agent runtime (often 30+ min) and is
+    the source of a recurring failure (memory rule
+    ``feedback_always_run_in_background_for_sub_agent_dispatch``). The
+    guard denies main-agent Agent calls when ``run_in_background`` is
+    not ``True``; sub-agents may still dispatch foreground (sidechain
+    sees the unblocked default).
     """
+    tool_name = data.get("tool_name", "")
+    if tool_name == "Agent":
+        sidechain = _active_turn_is_sidechain(data.get("transcript_path", ""))
+        if sidechain is False and data.get("tool_input", {}).get("run_in_background") is not True:
+            json.dump(
+                {
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        "[main-agent-orchestration-guard] Foreground Agent dispatch "
+                        "DENIED in main agent context.\n"
+                        "Pass `run_in_background: true` to every Agent invocation "
+                        "from the main agent.\n"
+                        "Memory rule: "
+                        "feedback_always_run_in_background_for_sub_agent_dispatch "
+                        "(RED CARD recurrence)."
+                    ),
+                },
+                sys.stdout,
+            )
+            return True
+        return False
+
     if _is_orchestration_action(data):
         return False
 
-    tool_name = data.get("tool_name", "")
     is_non_orch = tool_name in _NON_ORCHESTRATION_TOOLS or tool_name == "Bash"
     if not is_non_orch:
         return False

--- a/tests/test_orchestrator_boundary_hook.py
+++ b/tests/test_orchestrator_boundary_hook.py
@@ -311,3 +311,62 @@ class TestSanctionedReadOnlyBashStillAllowed942:
             "transcript_path": _transcript(tmp_path, sidechain=True),
         }
         assert handle_enforce_orchestrator_boundary(data) is False
+
+
+class TestMainAgentForegroundAgentIsBlocked1442:
+    """#1442 — main-agent Agent dispatch must pass ``run_in_background``.
+
+    Foreground Agent calls from the main agent block the orchestrator
+    for the entire sub-agent runtime (often 30+ min) and are the source
+    of a recurring failure (memory rule
+    ``feedback_always_run_in_background_for_sub_agent_dispatch``). The
+    gate denies the call when the main agent dispatches an Agent without
+    ``run_in_background: true``; background calls are allowed, and a
+    sub-agent dispatching its own Agent (sidechain=True) is allowed to
+    pick foreground if it wants.
+    """
+
+    _RULE_CITATION = "feedback_always_run_in_background_for_sub_agent_dispatch"
+
+    def test_agent_foreground_blocked_in_main_agent(self, tmp_path, capsys):
+        data = {
+            "tool_name": "Agent",
+            "tool_input": {"description": "implement X", "run_in_background": False},
+            "transcript_path": _transcript(tmp_path, sidechain=False),
+        }
+        assert handle_enforce_orchestrator_boundary(data) is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+        assert "main-agent-orchestration-guard" in out["permissionDecisionReason"]
+        assert "run_in_background" in out["permissionDecisionReason"]
+        assert self._RULE_CITATION in out["permissionDecisionReason"]
+
+    def test_agent_foreground_blocked_when_field_absent(self, tmp_path, capsys):
+        # Default Agent behavior is foreground when the key is omitted.
+        data = {
+            "tool_name": "Agent",
+            "tool_input": {"description": "implement X"},
+            "transcript_path": _transcript(tmp_path, sidechain=False),
+        }
+        assert handle_enforce_orchestrator_boundary(data) is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+        assert self._RULE_CITATION in out["permissionDecisionReason"]
+
+    def test_agent_background_allowed_in_main_agent(self, tmp_path):
+        data = {
+            "tool_name": "Agent",
+            "tool_input": {"description": "implement X", "run_in_background": True},
+            "transcript_path": _transcript(tmp_path, sidechain=False),
+        }
+        assert handle_enforce_orchestrator_boundary(data) is False
+
+    def test_agent_foreground_allowed_in_sub_agent(self, tmp_path):
+        # Sub-agent dispatching its own Agent — sidechain=True ⇒ allowed
+        # to pick foreground, the guard only governs main-agent dispatch.
+        data = {
+            "tool_name": "Agent",
+            "tool_input": {"description": "nested work", "run_in_background": False},
+            "transcript_path": _transcript(tmp_path, sidechain=True),
+        }
+        assert handle_enforce_orchestrator_boundary(data) is False


### PR DESCRIPTION
Extends `handle_enforce_orchestrator_boundary` (the hook landed under [#836](https://github.com/souliane/teatree/issues/836)) so a main-agent `Agent` dispatch without `run_in_background=True` is denied with an actionable reason that names the memory rule.

Closes [#1442](https://github.com/souliane/teatree/issues/1442).

## Rule

Memory rule `feedback_always_run_in_background_for_sub_agent_dispatch` (BINDING 2026-05-28, RED CARD recurrence): every `Agent` invocation from the main agent must pass `run_in_background: true`. Foreground dispatch blocks the orchestrator for the entire sub-agent runtime (often 30+ min) and was the source of a recurring failure mode. This MR is the structural gate that replaces memory-as-vigilance.

## Behavior

In `handle_enforce_orchestrator_boundary`:

| `tool_name` | `isSidechain` | `run_in_background` | Verdict |
|---|---|---|---|
| `Agent` | `False` (main agent) | not `True` (false / absent) | **DENY** with rule citation |
| `Agent` | `False` (main agent) | `True` | allow |
| `Agent` | `True` (sub-agent) | any | allow |
| `Agent` | `None` (unknown) | any | allow (fail-open, matches existing hook contract) |

The deny reason carries the literal tag `[main-agent-orchestration-guard]` and the memory rule name so a future denial in the wild is greppable.

## Tests (RED→GREEN, all observed RED with the implementation reverted)

| Test | Asserts |
|---|---|
| `test_agent_foreground_blocked_in_main_agent` | main agent + `run_in_background: false` → DENY + rule citation |
| `test_agent_foreground_blocked_when_field_absent` | main agent + key omitted → DENY (default treated as foreground) |
| `test_agent_background_allowed_in_main_agent` | main agent + `run_in_background: true` → allow |
| `test_agent_foreground_allowed_in_sub_agent` | sub-agent (sidechain) + foreground → allow |

The two new denial tests were stash-reverted before the fix and confirmed RED, then GREEN after restore. The two allow tests guard against over-blocking (background dispatch, sub-agent dispatch). All 37 pre-existing `test_orchestrator_boundary_hook.py` tests still pass (41 total in the file).

## Rejected alternatives

- **Bypass comment ("`# allow-foreground-agent`")** — anti-aligned with the rule. Foreground dispatch from the main agent is the failure mode, not a debatable choice; a bypass would just shift the recurrence onto "did I add the comment?".
- **Memory-write carve-out** — needs explicit user sign-off (potential side-effect on the durable-memory write path). Will file a separate issue if the need surfaces; not implemented here.

## Parent

[#836](https://github.com/souliane/teatree/issues/836) — the orchestrator-execution-boundary gate this MR extends.
