### PR TITLE
feat(statusline): show free disk space after RAM usage

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -207,7 +207,25 @@ elif [ -r /proc/meminfo ]; then
     _ram_total_gb=$(awk "BEGIN{printf \"%.0f\", $_ram_total_kb / 1048576}")
     _ram_segment="${_LBL}ram=${_RST}$(color_pct "$_ram_pct")${_LBL} ${_ram_used_gb}/${_ram_total_gb}G${_RST}"
 fi
+
+# Free disk space on the volume holding $HOME (cross-platform via POSIX df).
+# Colored by used% so it goes red as the disk fills, mirroring the RAM segment.
+_disk_segment=""
+_df_out=$(df -Pk "$HOME" 2>/dev/null)
+if [ -n "$_df_out" ]; then
+    _disk_avail_kb=$(awk 'NR==2{print $4}' <<< "$_df_out")
+    _disk_used_pct=$(awk 'NR==2{gsub(/%/,"",$5); print $5}' <<< "$_df_out")
+    if [[ "$_disk_avail_kb" =~ ^[0-9]+$ ]] && [[ "$_disk_used_pct" =~ ^[0-9]+$ ]]; then
+        _disk_free_gb=$(awk "BEGIN{printf \"%.0f\", $_disk_avail_kb / 1048576}")
+        _disk_segment="${_LBL}disk=${_RST}$(color_pct "$_disk_used_pct")${_LBL} ${_disk_free_gb}G free${_RST}"
+    fi
+fi
+
 g_resource="$_ram_segment"
+if [ -n "$_disk_segment" ]; then
+    [ -n "$g_resource" ] && g_resource="${g_resource}${isep}"
+    g_resource="${g_resource}${_disk_segment}"
+fi
 
 # Next tick countdown from tick-meta.json
 _tick_meta="${target%.txt}-meta.json"

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -108,6 +108,42 @@ class TestStatuslineHook:
         assert "model=Claude Sonnet" in plain
         assert "ctx=41%" in plain
 
+    def test_renders_free_disk_segment_after_ram(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        result = _run(
+            {"session_id": "s-disk", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        match = re.search(r"disk=\d+% \d+G free", plain)
+        assert match is not None, plain
+        # The disk segment follows the RAM segment within the resource group.
+        assert plain.index("ram=") < match.start()
+
+    def test_disk_segment_omitted_when_df_target_unreadable(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        env = os.environ.copy()
+        env["TEATREE_CLAUDE_STATUSLINE_STATE_DIR"] = str(state_dir)
+        env["HOME"] = str(tmp_path / "does-not-exist")
+
+        result = subprocess.run(
+            [str(SCRIPT)],
+            input=json.dumps({"session_id": "s-nodisk", "model": {"display_name": "Claude Opus"}}),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+            cwd=REPO_ROOT,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "disk=" not in _strip_ansi(result.stdout)
+
     def test_appends_pre_rendered_loop_zones_file(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"
         state_dir.mkdir()


### PR DESCRIPTION
## What

Adds a `disk=` segment to the statusline's resource group, right after the existing `ram=` segment. It shows free space on the volume holding `\$HOME`.

Rendered example (resource group):

```
ram=69% 16.6/24G · disk=100% 1G free
```

## Details

- Computed cross-platform with POSIX `df -Pk "\$HOME"` — available KB from column 4, used% from column 5.
- Colored by **used%** via the existing `color_pct` helper, so it turns red as the disk fills, mirroring how the RAM segment colors by used%.
- Joined to the RAM segment with the existing intra-group mid-dot separator (`isep`), matching the other resource sub-segments.
- Fail-open: any `df` failure (or a non-numeric value) leaves the segment empty, so the statusline always renders. Verified by temporarily pointing `\$HOME` at a nonexistent path — segment absent, exit 0, no stderr.

## Tests

Two new integration tests in `tests/test_claude_statusline.py`:
- `test_renders_free_disk_segment_after_ram` — asserts the `disk=N% NG free` shape and that it follows `ram=`.
- `test_disk_segment_omitted_when_df_target_unreadable` — asserts fail-open when the `df` target is unreadable.

All 18 tests in the file pass locally via `uv run pytest --no-cov`. `bash -n` syntax check passes.

The Docker test matrix pre-push hook was skipped locally (Docker unavailable in this environment); CI runs the full matrix on this PR.