### PR TITLE
fix(cli): infer review-request overlay from MR URL when cwd resolution is blank

### DIFF
--- a/src/teatree/cli/review_request.py
+++ b/src/teatree/cli/review_request.py
@@ -1,5 +1,6 @@
 """``t3 review-request`` — batch review request commands."""
 
+import os
 from pathlib import Path
 
 import typer
@@ -35,6 +36,41 @@ def _active_project() -> tuple[Path, str]:
     return project, (active.name if active else "")
 
 
+def _overlay_name_for_mr(mr_url: str) -> str:
+    """Resolve the overlay that owns *mr_url* for a review-request dispatch.
+
+    Prefers the cwd/env resolution of :func:`_active_project` (``T3_OVERLAY_NAME``
+    env, then cwd-``manage.py`` dev fallback, then the single configured
+    overlay). When that yields no overlay — the common case when ``t3`` is
+    run from a clone whose directory name is not an overlay name (e.g. the
+    teatree clone) on a multi-overlay install — fall back to inferring the
+    owner from the MR URL via :func:`infer_overlay_for_url`.
+
+    Without this fallback the dispatch ran with an empty ``T3_OVERLAY_NAME``,
+    so the command subprocess hit ``get_overlay()``'s multi-overlay
+    ambiguity, ``resolve_guard_target()`` returned ``None``, and every
+    cross-overlay review request suppressed with
+    ``no_review_channel_or_token`` regardless of cwd (#1471).
+
+    Inference instantiates the registered overlays, so it needs the Django
+    app registry. The ``review-request`` Typer group is otherwise
+    Django-free (it only dispatches to a ``python -m teatree`` subprocess),
+    so ``django.setup()`` is run here — idempotent — before inferring,
+    matching the other DB-touching CLI wrappers.
+    """
+    _, overlay_name = _active_project()
+    if overlay_name:
+        return overlay_name
+
+    import django  # noqa: PLC0415
+
+    from teatree.core.overlay_loader import infer_overlay_for_url  # noqa: PLC0415
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+    django.setup()
+    return infer_overlay_for_url(mr_url)
+
+
 @review_request_app.command()
 def discover() -> None:
     """Discover open merge requests awaiting review."""
@@ -53,7 +89,7 @@ def check(mr_url: str = typer.Option(..., "--mr-url", help="Canonical MR/PR URL 
     ``ReviewRequestPost`` claim (``peek_should_post_review_request``), so
     it can never leave an orphan that wedges a later real post (#1103).
     """
-    _, overlay_name = _active_project()
+    overlay_name = _overlay_name_for_mr(mr_url)
     managepy_core("review_request_check", "--mr-url", mr_url, overlay_name=overlay_name)
 
 
@@ -70,7 +106,7 @@ def post(
     the only way to satisfy it), then the post. Refuses with the exact
     ``approve-on-behalf`` remediation when no recorded approval matches.
     """
-    _, overlay_name = _active_project()
+    overlay_name = _overlay_name_for_mr(mr_url)
     extra = ("--title", title) if title else ()
     managepy_core(
         "review_request_post",

--- a/tests/teatree_core/test_review_request_cli.py
+++ b/tests/teatree_core/test_review_request_cli.py
@@ -26,12 +26,13 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from teatree.cli.review_request import _active_project, review_request_app
+from teatree.cli.review_request import _active_project, _overlay_name_for_mr, review_request_app
 from teatree.config import OverlayEntry
 
 _TEATREE_PATH = Path("/workspace/teatree")
 _OTHER_PATH = Path("/workspace/acme-overlay")
 _OTHER_NAME = "acme-overlay"
+_MR_URL = "https://gitlab.com/acme-org/acme-repo/-/merge_requests/385"
 
 
 def _two_overlays() -> list[OverlayEntry]:
@@ -59,6 +60,66 @@ class TestActiveProjectOverlayRouting:
             from teatree.cli.review_request import post  # noqa: PLC0415
 
             post(mr_url="https://gitlab.com/org/repo/-/merge_requests/385", approver="souliane", title="")
+        assert managepy_core.call_args.kwargs["overlay_name"] == _OTHER_NAME
+
+
+class TestOverlayInferenceFromMrUrl:
+    """``check``/``post`` fall back to MR-URL inference when cwd resolution is blank (#1471).
+
+    Bug: run from a clone whose directory name is not an overlay name (the
+    teatree clone is dir ``teatree`` while the entry point is ``t3-teatree``)
+    on a multi-overlay install, ``_active_project()`` returns an empty
+    overlay name. The dispatch then ran with no ``T3_OVERLAY_NAME``, so the
+    command subprocess hit ``get_overlay()`` multi-overlay ambiguity,
+    ``resolve_guard_target()`` returned ``None``, and the request suppressed
+    with ``no_review_channel_or_token``. The MR URL is the authoritative
+    owner signal and must drive the routing when cwd/env yields nothing.
+    """
+
+    def test_blank_active_project_falls_back_to_url_inference(self) -> None:
+        with (
+            patch("teatree.cli.review_request._active_project", return_value=(_OTHER_PATH, "")),
+            patch("django.setup"),
+            patch("teatree.core.overlay_loader.infer_overlay_for_url", return_value=_OTHER_NAME) as infer,
+        ):
+            resolved = _overlay_name_for_mr(_MR_URL)
+        infer.assert_called_once_with(_MR_URL)
+        assert resolved == _OTHER_NAME
+
+    def test_resolved_active_project_wins_over_url_inference(self) -> None:
+        """A cwd/env-resolved overlay name short-circuits — URL inference is never consulted."""
+        with (
+            patch("teatree.cli.review_request._active_project", return_value=(_OTHER_PATH, _OTHER_NAME)),
+            patch("django.setup") as setup,
+            patch("teatree.core.overlay_loader.infer_overlay_for_url") as infer,
+        ):
+            resolved = _overlay_name_for_mr(_MR_URL)
+        infer.assert_not_called()
+        setup.assert_not_called()
+        assert resolved == _OTHER_NAME
+
+    def test_check_threads_url_inferred_overlay_when_cwd_blank(self) -> None:
+        with (
+            patch("teatree.cli.review_request._active_project", return_value=(_OTHER_PATH, "")),
+            patch("django.setup"),
+            patch("teatree.core.overlay_loader.infer_overlay_for_url", return_value=_OTHER_NAME),
+            patch("teatree.cli.review_request.managepy_core") as managepy_core,
+        ):
+            from teatree.cli.review_request import check  # noqa: PLC0415
+
+            check(mr_url=_MR_URL)
+        assert managepy_core.call_args.kwargs["overlay_name"] == _OTHER_NAME
+
+    def test_post_threads_url_inferred_overlay_when_cwd_blank(self) -> None:
+        with (
+            patch("teatree.cli.review_request._active_project", return_value=(_OTHER_PATH, "")),
+            patch("django.setup"),
+            patch("teatree.core.overlay_loader.infer_overlay_for_url", return_value=_OTHER_NAME),
+            patch("teatree.cli.review_request.managepy_core") as managepy_core,
+        ):
+            from teatree.cli.review_request import post  # noqa: PLC0415
+
+            post(mr_url=_MR_URL, approver="souliane", title="")
         assert managepy_core.call_args.kwargs["overlay_name"] == _OTHER_NAME
 
 


### PR DESCRIPTION
## Problem

`t3 review-request check`/`post` resolved the owning overlay only from the cwd (the `manage.py` ancestor dir name) or the single-install fallback, ignoring the MR URL entirely. When `t3` runs from a clone whose directory name is not an overlay name (the teatree clone is dir `teatree` while the entry point is `t3-teatree`) on a multi-overlay install, the resolution yields an empty overlay name. The dispatch then runs with no `T3_OVERLAY_NAME`, the command subprocess hits `get_overlay()` multi-overlay ambiguity, `resolve_guard_target()` returns `None`, and every cross-overlay review request suppresses with `no_review_channel_or_token` regardless of cwd.

## Fix

Add `_overlay_name_for_mr(mr_url)`. It keeps the existing cwd/env resolution first (`T3_OVERLAY_NAME` env, then cwd-`manage.py` dev fallback, then single configured overlay), and when that yields nothing it infers the owning overlay from the MR URL via `infer_overlay_for_url` — the URL is the authoritative owner signal. `django.setup()` runs before inference (idempotent) since the otherwise-Django-free Typer group needs the app registry to instantiate overlays. `check` and `post` now route through this resolver.

## Tests

- `_overlay_name_for_mr` falls back to URL inference when cwd resolution is blank
- A resolved cwd/env overlay short-circuits, so URL inference and `django.setup()` are never consulted
- `check` and `post` thread the URL-inferred overlay when cwd is blank

Module suite (10 tests) green. Broader `tests/teatree_core/` run green (2509 passed). ruff/ty clean. Pre-push Docker test matrix green (7786 passed).
