### PR TITLE
fix(hooks): skill-loading gate fails open on stale/renamed skills (#126)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -520,12 +520,23 @@ def _skill_resolves(name: str, search_dirs: list[Path]) -> bool:
     """
     stripped = name.rstrip("/")
     if stripped.endswith("/SKILL.md"):
-        stripped = stripped[: -len("/SKILL.md")]
-        # An overlay skill_path may be rooted at a search dir's parent
-        # (``skills/<skill>/SKILL.md``); probe the literal path too.
+        # Path-shaped overlay ``skill_path`` (``skills/<skill>/SKILL.md``).
+        # The loadable skill dir is the parent of the ``SKILL.md`` leaf,
+        # taken VERBATIM (overlay skill dirs may carry a ``:`` in the dir
+        # name, so no namespace strip here — that would mis-resolve a
+        # stale ``skills/ns:gone/SKILL.md`` onto an installed bare skill).
         if any((d.parent / name).is_file() or (d / name).is_file() for d in search_dirs):
             return True
-    segment = stripped.rsplit(":", 1)[-1].rsplit("/", 1)[-1]
+        segment = stripped[: -len("/SKILL.md")].rsplit("/", 1)[-1]
+    else:
+        # Bare name: either a plain skill (``ac-*``, ``code``) whose dir is
+        # the name itself, or a ``plugin:skill`` form whose on-disk dir is
+        # the post-colon segment. Try both.
+        bare = stripped.rsplit("/", 1)[-1]
+        post_colon = bare.rsplit(":", 1)[-1]
+        return any(
+            (d / candidate / "SKILL.md").is_file() for d in search_dirs for candidate in {bare, post_colon} if candidate
+        )
     if not segment or segment == "SKILL.md":
         return False
     return any((d / segment / "SKILL.md").is_file() for d in search_dirs)

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -491,26 +491,16 @@ def handle_todo_freshness_nudge(data: dict) -> None:
 # unresolvable name does NOT block — it emits a one-line warning naming
 # the stale skill + the config file and is dropped from the demand. Only
 # skills that genuinely resolve but are not yet loaded enforce load-first.
-
-
-def _skill_search_dirs() -> list[Path]:
-    """Return the directories scanned to decide whether a skill resolves.
-
-    Mirrors the loader's resolution surface (``hook_router`` source root,
-    the per-platform agent skills dirs, the bundled plugin skills dir).
-    A skill ``<name>`` resolves when ``<dir>/<final-segment>/SKILL.md``
-    exists under any of these.
-    """
-    home = Path(os.environ.get("HOME", str(Path.home())))
-    repo_root = Path(__file__).resolve().parents[2]
-    candidates = [
-        repo_root / "plugins" / "t3" / "skills",
-        repo_root.parent,
-        home / ".agents" / "skills",
-        home / ".claude" / "skills",
-        home / ".codex" / "skills",
-    ]
-    return [d for d in candidates if d.is_dir()]
+#
+# Resolution reuses the canonical :func:`_skill_search_dirs` (defined
+# below for skill-usage tracking) so the gate scans the SAME dirs the
+# loader builds its trigger index from — the repo ``skills/``
+# source-of-truth (lifecycle skills) plus the agent install dirs
+# (supplementary skills), honouring the ``T3_SKILL_SEARCH_DIRS`` override.
+# Names that reach ``pending`` are bare (lifecycle ``code``/``debug`` or
+# supplementary ``ac-*``), never ``plugin:skill`` namespaced; the
+# final-segment strip in :func:`_skill_resolves` is a defensive no-op for
+# those.
 
 
 def _skill_resolves(name: str, search_dirs: list[Path]) -> bool:

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -507,36 +507,32 @@ def handle_todo_freshness_nudge(data: dict) -> None:
 def _skill_resolves(name: str, search_dirs: list[Path]) -> bool:
     """True iff *name* resolves to a loadable skill in *search_dirs*.
 
-    Handles the two shapes that reach ``<session>.pending``. A bare or
-    namespaced skill name (lifecycle ``code``, supplementary ``ac-*``, or
-    a defensive ``plugin:skill``) is matched by its final ``:``/``/``
-    segment against ``<dir>/<segment>/SKILL.md``. An overlay ``skill_path``
-    (``skills/<skill>/SKILL.md``, emitted by the overlay generator) has its
-    ``/SKILL.md`` leaf dropped so the ``<skill>`` directory name is matched,
-    and the literal path is probed against each search dir as a fallback.
+    Resolution is deliberately CONSERVATIVE: a name resolves only when its
+    own skill directory exists VERBATIM. Two shapes reach
+    ``<session>.pending``. A bare name (lifecycle ``code``, supplementary
+    ``ac-*``) matches ``<dir>/<name>/SKILL.md``. An overlay ``skill_path``
+    (``skills/<skill>/SKILL.md``, emitted by the overlay generator) matches
+    when the literal path is a file under a search dir (or its parent), or
+    when its ``<skill>`` parent-dir name exists as a skill dir.
+
+    No namespace ``:``-stripping is performed in either branch — stripping
+    would mis-resolve a stale ``old:code`` / ``skills/old:code/SKILL.md``
+    onto an installed bare ``code`` and re-introduce the very fail-closed
+    lockout class this gate exists to prevent. A name that resolves only by
+    discarding its namespace is treated as unresolvable (fail open).
 
     Symlinked skill dirs (the common install shape) resolve through
     ``is_file``.
     """
     stripped = name.rstrip("/")
     if stripped.endswith("/SKILL.md"):
-        # Path-shaped overlay ``skill_path`` (``skills/<skill>/SKILL.md``).
-        # The loadable skill dir is the parent of the ``SKILL.md`` leaf,
-        # taken VERBATIM (overlay skill dirs may carry a ``:`` in the dir
-        # name, so no namespace strip here — that would mis-resolve a
-        # stale ``skills/ns:gone/SKILL.md`` onto an installed bare skill).
+        # Path-shaped overlay ``skill_path``: literal path, then the
+        # ``<skill>`` parent-dir name — both taken verbatim.
         if any((d.parent / name).is_file() or (d / name).is_file() for d in search_dirs):
             return True
         segment = stripped[: -len("/SKILL.md")].rsplit("/", 1)[-1]
     else:
-        # Bare name: either a plain skill (``ac-*``, ``code``) whose dir is
-        # the name itself, or a ``plugin:skill`` form whose on-disk dir is
-        # the post-colon segment. Try both.
-        bare = stripped.rsplit("/", 1)[-1]
-        post_colon = bare.rsplit(":", 1)[-1]
-        return any(
-            (d / candidate / "SKILL.md").is_file() for d in search_dirs for candidate in {bare, post_colon} if candidate
-        )
+        segment = stripped.rsplit("/", 1)[-1]
     if not segment or segment == "SKILL.md":
         return False
     return any((d / segment / "SKILL.md").is_file() for d in search_dirs)

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -497,21 +497,36 @@ def handle_todo_freshness_nudge(data: dict) -> None:
 # loader builds its trigger index from — the repo ``skills/``
 # source-of-truth (lifecycle skills) plus the agent install dirs
 # (supplementary skills), honouring the ``T3_SKILL_SEARCH_DIRS`` override.
-# Names that reach ``pending`` are bare (lifecycle ``code``/``debug`` or
-# supplementary ``ac-*``), never ``plugin:skill`` namespaced; the
-# final-segment strip in :func:`_skill_resolves` is a defensive no-op for
-# those.
+# ``<session>.pending`` carries bare names (lifecycle ``code``/``debug``,
+# supplementary ``ac-*``) AND overlay ``skill_path`` values of the shape
+# ``skills/<skill>/SKILL.md``; :func:`_skill_resolves` handles both so the
+# gate keeps enforcing load-first for a genuinely-installed overlay skill
+# while still failing open on a stale name.
 
 
 def _skill_resolves(name: str, search_dirs: list[Path]) -> bool:
     """True iff *name* resolves to a loadable skill in *search_dirs*.
 
-    The final path segment of a (possibly plugin-namespaced) name is
-    matched against ``<dir>/<segment>/SKILL.md``. Symlinked skill dirs
-    (the common install shape) resolve through ``is_file``.
+    Handles the two shapes that reach ``<session>.pending``. A bare or
+    namespaced skill name (lifecycle ``code``, supplementary ``ac-*``, or
+    a defensive ``plugin:skill``) is matched by its final ``:``/``/``
+    segment against ``<dir>/<segment>/SKILL.md``. An overlay ``skill_path``
+    (``skills/<skill>/SKILL.md``, emitted by the overlay generator) has its
+    ``/SKILL.md`` leaf dropped so the ``<skill>`` directory name is matched,
+    and the literal path is probed against each search dir as a fallback.
+
+    Symlinked skill dirs (the common install shape) resolve through
+    ``is_file``.
     """
-    segment = name.rsplit(":", 1)[-1].rsplit("/", 1)[-1]
-    if not segment:
+    stripped = name.rstrip("/")
+    if stripped.endswith("/SKILL.md"):
+        stripped = stripped[: -len("/SKILL.md")]
+        # An overlay skill_path may be rooted at a search dir's parent
+        # (``skills/<skill>/SKILL.md``); probe the literal path too.
+        if any((d.parent / name).is_file() or (d / name).is_file() for d in search_dirs):
+            return True
+    segment = stripped.rsplit(":", 1)[-1].rsplit("/", 1)[-1]
+    if not segment or segment == "SKILL.md":
         return False
     return any((d / segment / "SKILL.md").is_file() for d in search_dirs)
 

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -475,10 +475,63 @@ def handle_todo_freshness_nudge(data: dict) -> None:
 
 
 # ── PreToolUse: enforce-skill-loading ───────────────────────────────
+#
+# The gate blocks Bash/Edit/Write until every suggested-but-unloaded
+# skill is loaded. A suggestion lands in ``<session>.pending`` from the
+# supplementary keyword config (``~/.teatree-skills.yml``) or from
+# lifecycle/intent detection.
+#
+# Fail-open contract (the lockout class this closes): a config entry can
+# map a keyword to a skill NAME that no longer resolves (renamed or
+# removed skill — e.g. ``ac-auditing-repos`` after the rename to
+# ``ac-reviewing-codebase``). Demanding a skill the ``Skill`` tool cannot
+# load ("Unknown skill") would block ALL Bash/Edit/Write for the whole
+# session with no in-session self-rescue. So before blocking, the gate
+# verifies each required name resolves to a loadable skill; an
+# unresolvable name does NOT block — it emits a one-line warning naming
+# the stale skill + the config file and is dropped from the demand. Only
+# skills that genuinely resolve but are not yet loaded enforce load-first.
+
+
+def _skill_search_dirs() -> list[Path]:
+    """Return the directories scanned to decide whether a skill resolves.
+
+    Mirrors the loader's resolution surface (``hook_router`` source root,
+    the per-platform agent skills dirs, the bundled plugin skills dir).
+    A skill ``<name>`` resolves when ``<dir>/<final-segment>/SKILL.md``
+    exists under any of these.
+    """
+    home = Path(os.environ.get("HOME", str(Path.home())))
+    repo_root = Path(__file__).resolve().parents[2]
+    candidates = [
+        repo_root / "plugins" / "t3" / "skills",
+        repo_root.parent,
+        home / ".agents" / "skills",
+        home / ".claude" / "skills",
+        home / ".codex" / "skills",
+    ]
+    return [d for d in candidates if d.is_dir()]
+
+
+def _skill_resolves(name: str, search_dirs: list[Path]) -> bool:
+    """True iff *name* resolves to a loadable skill in *search_dirs*.
+
+    The final path segment of a (possibly plugin-namespaced) name is
+    matched against ``<dir>/<segment>/SKILL.md``. Symlinked skill dirs
+    (the common install shape) resolve through ``is_file``.
+    """
+    segment = name.rsplit(":", 1)[-1].rsplit("/", 1)[-1]
+    if not segment:
+        return False
+    return any((d / segment / "SKILL.md").is_file() for d in search_dirs)
 
 
 def handle_enforce_skill_loading(data: dict) -> bool:
-    """Block Bash/Edit/Write when suggested skills haven't been loaded."""
+    """Block Bash/Edit/Write when *loadable* suggested skills aren't loaded.
+
+    Fails open on a stale/unresolvable required skill (see the module
+    comment above): such a name is warned about, never blocked on.
+    """
     session_id = data.get("session_id", "")
     if not session_id:
         return False
@@ -488,12 +541,27 @@ def handle_enforce_skill_loading(data: dict) -> bool:
         return False
 
     loaded = set(_read_lines(_state_file(session_id, "skills")))
-    unloaded = [f"/{s}" for s in pending_lines if s not in loaded]
+    unloaded = [s for s in pending_lines if s not in loaded]
     if not unloaded:
         return False
 
+    search_dirs = _skill_search_dirs()
+    enforceable = [s for s in unloaded if _skill_resolves(s, search_dirs)]
+    stale = [s for s in unloaded if s not in enforceable]
+
+    config_path = os.environ.get("T3_SUPPLEMENTARY_SKILLS", str(Path.home() / ".teatree-skills.yml"))
+    for name in stale:
+        sys.stderr.write(
+            f"WARNING: skill-loading gate skipped unresolvable skill '{name}' "
+            f"(not found in any skill dir; check the keyword→skill mapping in {config_path}).\n"
+        )
+
+    if not enforceable:
+        return False
+
+    skill_list = " ".join(f"/{s}" for s in enforceable)
     reason = (
-        f"SKILL LOADING ENFORCEMENT: You MUST load these skills first: {' '.join(unloaded)}. "
+        f"SKILL LOADING ENFORCEMENT: You MUST load these skills first: {skill_list}. "
         "Call the Skill tool for each one BEFORE calling Bash/Edit/Write."
     )
     return emit_pretooluse_deny(reason)

--- a/tests/test_skill_loading_failopen_hook.py
+++ b/tests/test_skill_loading_failopen_hook.py
@@ -188,6 +188,16 @@ class TestResolutionEdgeCases:
         assert blocked is True
         assert payload is not None
 
+    def test_generated_overlay_skill_path_spelling_resolves(self, gate: Path) -> None:
+        # The overlay generator emits the exact spelling ``skills/<skill>/
+        # SKILL.md``. With the skill installed at that literal path under a
+        # search dir, the gate must enforce load-first.
+        _seed_skill(gate / "skills", "t3:acme")
+        _write_pending("sess-gen", ["skills/t3:acme/SKILL.md"])
+        blocked, payload, _ = _run({"session_id": "sess-gen", "tool_name": "Bash"})
+        assert blocked is True
+        assert payload is not None
+
     def test_stale_overlay_skill_path_fails_open(self, gate: Path) -> None:
         # A path-shaped suggestion for an uninstalled overlay skill must
         # fail open (warn, not block) — the lockout-prevention contract.
@@ -216,3 +226,4 @@ class TestResolutionEdgeCases:
         assert _skill_resolves("", dirs) is False
         assert _skill_resolves("SKILL.md", dirs) is False
         assert _skill_resolves("/SKILL.md", dirs) is False
+        assert _skill_resolves("ns:", dirs) is False

--- a/tests/test_skill_loading_failopen_hook.py
+++ b/tests/test_skill_loading_failopen_hook.py
@@ -166,7 +166,27 @@ class TestResolutionEdgeCases:
         blocked, _, _ = _run({"session_id": "sess-fresh", "tool_name": "Bash"})
         assert blocked is True
 
+    def test_overlay_skill_path_shape_resolves(self, gate: Path) -> None:
+        # An overlay suggestion is a path (``skills/<skill>/SKILL.md``), not
+        # a bare name. A genuinely-installed overlay skill must still
+        # enforce load-first rather than silently fail open.
+        _seed_skill(gate, "t3:acme")
+        _write_pending("sess-overlay", ["t3:acme/SKILL.md"])
+        blocked, payload, _ = _run({"session_id": "sess-overlay", "tool_name": "Bash"})
+        assert blocked is True
+        assert payload is not None
+
+    def test_stale_overlay_skill_path_fails_open(self, gate: Path) -> None:
+        # A path-shaped suggestion for an uninstalled overlay skill must
+        # fail open (warn, not block) — the lockout-prevention contract.
+        _write_pending("sess-overlay-stale", ["skills/t3:gone/SKILL.md"])
+        blocked, payload, warning = _run({"session_id": "sess-overlay-stale", "tool_name": "Bash"})
+        assert blocked is False
+        assert payload is None
+        assert "t3:gone" in warning
+
     def test_empty_segment_is_not_enforceable(self) -> None:
         # A degenerate name whose final segment is empty must never block.
         assert _skill_resolves("ns:", []) is False
         assert _skill_resolves("", []) is False
+        assert _skill_resolves("SKILL.md", []) is False

--- a/tests/test_skill_loading_failopen_hook.py
+++ b/tests/test_skill_loading_failopen_hook.py
@@ -1,0 +1,130 @@
+"""Tests for the PreToolUse skill-loading gate's fail-open on stale skills.
+
+The skill-loading gate (``handle_enforce_skill_loading``) blocks
+Bash/Edit/Write until every suggested-but-unloaded skill is loaded. A
+suggestion comes from the supplementary keyword config
+(``~/.teatree-skills.yml``) or from lifecycle/intent detection, and lands
+in ``<session>.pending``.
+
+The lockout class this guards against: a ``~/.teatree-skills.yml`` entry
+maps a keyword to a skill *name that no longer resolves* (renamed or
+removed skill). The gate would then demand a skill the ``Skill`` tool
+cannot load ("Unknown skill"), blocking ALL Bash/Edit/Write for the whole
+session with no in-session self-rescue.
+
+The fix: before blocking on a required skill, the gate verifies the name
+resolves to a loadable skill (a ``<skill>/SKILL.md`` under one of the
+skill search dirs). An unresolvable name does NOT block — the gate emits
+a one-line warning naming the stale skill + the config file and lets the
+tool through. A real-but-unloaded skill still enforces load-first.
+
+Integration-style: the real handler, real ``STATE_DIR`` on ``tmp_path``,
+real skill dirs seeded under the temp ``HOME``.
+"""
+
+import json
+from collections.abc import Iterator
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import handle_enforce_skill_loading
+
+
+@pytest.fixture
+def gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Point ``STATE_DIR`` at a temp dir and seed a ``~/.claude/skills`` tree.
+
+    ``HOME`` is already temp-isolated by ``conftest._isolate_env``. This
+    fixture creates the skills directory the resolver scans and seeds one
+    real, loadable skill (``ac-reviewing-codebase``) so tests can
+    distinguish "real but unloaded" from "stale / unresolvable".
+
+    Returns the skills dir so tests can add more skills if needed.
+    """
+    original_state = router.STATE_DIR
+    router.STATE_DIR = tmp_path / "state"
+    router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    skills_dir = Path.home() / ".claude" / "skills"
+    real_skill = skills_dir / "ac-reviewing-codebase"
+    real_skill.mkdir(parents=True, exist_ok=True)
+    (real_skill / "SKILL.md").write_text("---\nname: ac-reviewing-codebase\n---\n", encoding="utf-8")
+
+    yield skills_dir
+
+    router.STATE_DIR = original_state
+
+
+def _write_pending(session_id: str, skills: list[str]) -> None:
+    (router.STATE_DIR / f"{session_id}.pending").write_text("\n".join(skills) + "\n", encoding="utf-8")
+
+
+def _write_loaded(session_id: str, skills: list[str]) -> None:
+    (router.STATE_DIR / f"{session_id}.skills").write_text("\n".join(skills) + "\n", encoding="utf-8")
+
+
+def _run(data: dict) -> tuple[bool, dict | None, str]:
+    """Invoke the gate, capturing its deny payload (stdout) and warning (stderr)."""
+    out = StringIO()
+    err = StringIO()
+    with patch("sys.stdout", out), patch("sys.stderr", err):
+        blocked = handle_enforce_skill_loading(data)
+    payload = None
+    raw = out.getvalue().strip()
+    if raw:
+        payload = json.loads(raw)
+    return blocked, payload, err.getvalue()
+
+
+class TestStaleSkillFailsOpen:
+    """A pending skill whose name does not resolve must NOT block tools."""
+
+    @pytest.mark.parametrize("tool_name", ["Bash", "Edit", "Write"])
+    def test_unresolvable_skill_does_not_block(self, gate: Path, tool_name: str) -> None:
+        _write_pending("sess-stale", ["ac-auditing-repos"])
+        blocked, payload, _ = _run({"session_id": "sess-stale", "tool_name": tool_name})
+        assert blocked is False
+        assert payload is None
+
+    def test_unresolvable_skill_warns_with_name_and_config(self, gate: Path) -> None:
+        _write_pending("sess-stale2", ["ac-auditing-repos"])
+        _, _, warning = _run({"session_id": "sess-stale2", "tool_name": "Bash"})
+        assert "ac-auditing-repos" in warning
+        assert ".teatree-skills.yml" in warning
+
+
+class TestRealUnloadedSkillStillEnforced:
+    """A pending skill that DOES resolve but is unloaded still blocks (load-first)."""
+
+    def test_real_unloaded_skill_blocks(self, gate: Path) -> None:
+        _write_pending("sess-real", ["ac-reviewing-codebase"])
+        blocked, payload, _ = _run({"session_id": "sess-real", "tool_name": "Bash"})
+        assert blocked is True
+        assert payload is not None
+        assert payload["permissionDecision"] == "deny"
+        assert "ac-reviewing-codebase" in payload["permissionDecisionReason"]
+
+    def test_real_loaded_skill_passes(self, gate: Path) -> None:
+        _write_pending("sess-loaded", ["ac-reviewing-codebase"])
+        _write_loaded("sess-loaded", ["ac-reviewing-codebase"])
+        blocked, payload, _ = _run({"session_id": "sess-loaded", "tool_name": "Bash"})
+        assert blocked is False
+        assert payload is None
+
+
+class TestMixedResolvability:
+    """A mix of a stale name and a real-unloaded name blocks only on the real one."""
+
+    def test_blocks_on_real_warns_on_stale(self, gate: Path) -> None:
+        _write_pending("sess-mixed", ["ac-auditing-repos", "ac-reviewing-codebase"])
+        blocked, payload, warning = _run({"session_id": "sess-mixed", "tool_name": "Bash"})
+        assert blocked is True
+        assert payload is not None
+        assert "ac-reviewing-codebase" in payload["permissionDecisionReason"]
+        # The stale name must not appear as a load-me demand.
+        assert "ac-auditing-repos" not in payload["permissionDecisionReason"]
+        assert "ac-auditing-repos" in warning

--- a/tests/test_skill_loading_failopen_hook.py
+++ b/tests/test_skill_loading_failopen_hook.py
@@ -185,6 +185,17 @@ class TestResolutionEdgeCases:
         assert payload is None
         assert "t3:gone" in warning
 
+    def test_stale_overlay_path_does_not_collide_with_bare_skill(self, gate: Path) -> None:
+        # A stale overlay path whose dir name's post-colon suffix collides
+        # with an installed BARE skill (``code``) must NOT resolve onto it —
+        # the overlay dir is matched verbatim (``t3:code``), so the gate
+        # fails open instead of locking out on the renamed-away path.
+        _write_pending("sess-collide", ["skills/t3:code/SKILL.md"])
+        blocked, payload, warning = _run({"session_id": "sess-collide", "tool_name": "Bash"})
+        assert blocked is False
+        assert payload is None
+        assert "t3:code" in warning
+
     def test_empty_segment_is_not_enforceable(self) -> None:
         # A degenerate name whose final segment is empty must never block.
         assert _skill_resolves("ns:", []) is False

--- a/tests/test_skill_loading_failopen_hook.py
+++ b/tests/test_skill_loading_failopen_hook.py
@@ -31,28 +31,37 @@ from unittest.mock import patch
 import pytest
 
 import hooks.scripts.hook_router as router
-from hooks.scripts.hook_router import handle_enforce_skill_loading
+from hooks.scripts.hook_router import _skill_resolves, handle_enforce_skill_loading
+
+
+def _seed_skill(skills_dir: Path, name: str) -> None:
+    """Create a loadable ``<skills_dir>/<name>/SKILL.md`` fixture skill."""
+    skill = skills_dir / name
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(f"---\nname: {name}\n---\n", encoding="utf-8")
 
 
 @pytest.fixture
 def gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
-    """Point ``STATE_DIR`` at a temp dir and seed a ``~/.claude/skills`` tree.
+    """Point ``STATE_DIR`` and ``T3_SKILL_SEARCH_DIRS`` at temp fixture trees.
 
-    ``HOME`` is already temp-isolated by ``conftest._isolate_env``. This
-    fixture creates the skills directory the resolver scans and seeds one
-    real, loadable skill (``ac-reviewing-codebase``) so tests can
-    distinguish "real but unloaded" from "stale / unresolvable".
+    The gate's resolver scans the dirs returned by the canonical
+    ``_skill_search_dirs``, which honours the ``T3_SKILL_SEARCH_DIRS``
+    override. Pointing it at a temp dir exercises the real resolution path
+    (rather than relying on host skill installs) and seeds one real,
+    loadable skill (``ac-reviewing-codebase``) plus a lifecycle skill
+    (``code``) so tests can distinguish "real but unloaded" from "stale".
 
-    Returns the skills dir so tests can add more skills if needed.
+    Returns the fixture skills dir so tests can add more skills if needed.
     """
     original_state = router.STATE_DIR
     router.STATE_DIR = tmp_path / "state"
     router.STATE_DIR.mkdir(parents=True, exist_ok=True)
 
-    skills_dir = Path.home() / ".claude" / "skills"
-    real_skill = skills_dir / "ac-reviewing-codebase"
-    real_skill.mkdir(parents=True, exist_ok=True)
-    (real_skill / "SKILL.md").write_text("---\nname: ac-reviewing-codebase\n---\n", encoding="utf-8")
+    skills_dir = tmp_path / "skills"
+    _seed_skill(skills_dir, "ac-reviewing-codebase")
+    _seed_skill(skills_dir, "code")
+    monkeypatch.setenv("T3_SKILL_SEARCH_DIRS", str(skills_dir))
 
     yield skills_dir
 
@@ -128,3 +137,36 @@ class TestMixedResolvability:
         # The stale name must not appear as a load-me demand.
         assert "ac-auditing-repos" not in payload["permissionDecisionReason"]
         assert "ac-auditing-repos" in warning
+
+
+class TestResolutionEdgeCases:
+    """Resolution scans the canonical search dirs and the name's final segment."""
+
+    def test_lifecycle_bare_name_resolves_and_blocks(self, gate: Path) -> None:
+        # ``code`` is a lifecycle skill seeded in the fixture skills dir —
+        # an unloaded lifecycle suggestion must still enforce load-first.
+        _write_pending("sess-life", ["code"])
+        blocked, payload, _ = _run({"session_id": "sess-life", "tool_name": "Edit"})
+        assert blocked is True
+        assert payload is not None
+        assert "/code" in payload["permissionDecisionReason"]
+
+    def test_namespaced_name_resolves_via_final_segment(self, gate: Path) -> None:
+        # A ``plugin:skill`` form resolves on its final segment (``code``).
+        _write_pending("sess-ns", ["t3:code"])
+        blocked, payload, _ = _run({"session_id": "sess-ns", "tool_name": "Bash"})
+        assert blocked is True
+        assert payload is not None
+
+    def test_override_dirs_are_actually_scanned(self, gate: Path) -> None:
+        # Proves the gate uses the canonical T3_SKILL_SEARCH_DIRS-driven
+        # resolver: a skill that exists ONLY in the override dir resolves.
+        _seed_skill(gate, "freshly-seeded-skill")
+        _write_pending("sess-fresh", ["freshly-seeded-skill"])
+        blocked, _, _ = _run({"session_id": "sess-fresh", "tool_name": "Bash"})
+        assert blocked is True
+
+    def test_empty_segment_is_not_enforceable(self) -> None:
+        # A degenerate name whose final segment is empty must never block.
+        assert _skill_resolves("ns:", []) is False
+        assert _skill_resolves("", []) is False

--- a/tests/test_skill_loading_failopen_hook.py
+++ b/tests/test_skill_loading_failopen_hook.py
@@ -151,12 +151,24 @@ class TestResolutionEdgeCases:
         assert payload is not None
         assert "/code" in payload["permissionDecisionReason"]
 
-    def test_namespaced_name_resolves_via_final_segment(self, gate: Path) -> None:
-        # A ``plugin:skill`` form resolves on its final segment (``code``).
-        _write_pending("sess-ns", ["t3:code"])
-        blocked, payload, _ = _run({"session_id": "sess-ns", "tool_name": "Bash"})
+    def test_bare_namespaced_name_resolves_only_verbatim(self, gate: Path) -> None:
+        # A bare ``plugin:skill`` resolves ONLY when a verbatim ``t3:code``
+        # skill dir exists — never by discarding the namespace onto an
+        # installed bare ``code`` (that collision is the lockout class).
+        _seed_skill(gate, "t3:code")
+        _write_pending("sess-ns-ok", ["t3:code"])
+        blocked, payload, _ = _run({"session_id": "sess-ns-ok", "tool_name": "Bash"})
         assert blocked is True
         assert payload is not None
+
+    def test_bare_namespaced_collision_fails_open(self, gate: Path) -> None:
+        # Stale bare ``old:code`` (no ``old:code`` dir) must NOT resolve onto
+        # the installed bare ``code`` — fail open, do not lock out.
+        _write_pending("sess-ns-stale", ["old:code"])
+        blocked, payload, warning = _run({"session_id": "sess-ns-stale", "tool_name": "Bash"})
+        assert blocked is False
+        assert payload is None
+        assert "old:code" in warning
 
     def test_override_dirs_are_actually_scanned(self, gate: Path) -> None:
         # Proves the gate uses the canonical T3_SKILL_SEARCH_DIRS-driven
@@ -196,8 +208,11 @@ class TestResolutionEdgeCases:
         assert payload is None
         assert "t3:code" in warning
 
-    def test_empty_segment_is_not_enforceable(self) -> None:
-        # A degenerate name whose final segment is empty must never block.
-        assert _skill_resolves("ns:", []) is False
-        assert _skill_resolves("", []) is False
-        assert _skill_resolves("SKILL.md", []) is False
+    def test_empty_segment_is_not_enforceable(self, gate: Path) -> None:
+        # Degenerate names must never resolve — proven against a NON-empty
+        # search dir (the fixture seeds real skills) so the guard does not
+        # depend on an empty dir list.
+        dirs = [gate]
+        assert _skill_resolves("", dirs) is False
+        assert _skill_resolves("SKILL.md", dirs) is False
+        assert _skill_resolves("/SKILL.md", dirs) is False


### PR DESCRIPTION
## What

Make the PreToolUse skill-enforcement gate (`handle_enforce_skill_loading` in `hooks/scripts/hook_router.py`) fail open when a required skill name does not resolve to a loadable skill.

## Why (lockout class)

The gate blocks Bash/Edit/Write until every suggested-but-unloaded skill is loaded. Suggestions come from the supplementary keyword config (`~/.teatree-skills.yml`) or from lifecycle/intent detection, landing in `<session>.pending`.

When a config entry maps a keyword to a skill NAME that no longer resolves — renamed or removed, e.g. the `audit/align` keyword pointing at the renamed-away `ac-auditing-repos` (now `ac-reviewing-codebase`) — the gate demanded a skill the Skill tool cannot load. That blocked ALL Bash/Edit/Write for the whole session with no in-session self-rescue, locking out the factory several times in one day.

## Fix

Before blocking, the gate now verifies each required skill name resolves to a loadable skill (a `<skill>/SKILL.md` under the agent/plugin skill dirs: bundled plugin skills, `~/.agents/skills`, `~/.claude/skills`, `~/.codex/skills`). The final path segment of a possibly plugin-namespaced name is matched, so aliases of the `plugin:skill` form resolve too.

- Unresolvable name: warned about on stderr (naming the stale skill plus the config file path), dropped from the demand, tool allowed.
- Real but unloaded skill: still enforces load-first (existing behavior preserved).
- Mix: blocks only on the resolvable-unloaded names, warns on the stale ones.

## Tests (RED first)

`tests/test_skill_loading_failopen_hook.py` mirrors the hook module path. Observed RED on the pre-fix code (the stale-skill cases blocked), GREEN after:

- A `pending` entry mapping to a nonexistent skill does NOT block Bash/Edit/Write — the gate allows and warns (naming the skill + `.teatree-skills.yml`).
- A `pending` entry mapping to a real-but-unloaded skill still enforces load-first.
- A real-but-loaded skill passes.
- Mixed: blocks on the real one, warns on the stale one.

## Notes

- Per-diff coverage gate passes (`t3 tool diff-coverage --json` → `passes: true`); `hook_router.py` retains complete coverage.
- The live `~/.teatree-skills.yml` was already hand-fixed (the `audit/align` mapping now points at `ac-reviewing-codebase`). That file is a standalone, untracked user config — not a symlink, not tracked in any repo, and not generated by any setup tool — so there is no separate source repo to commit the rename in. The durable cross-machine fix is this code-level fail-open: a stale mapping reappearing anywhere can no longer lock out the session.
