### PR TITLE
feat(ship): generate canonical PR titles via overlay hook + fail-closed metadata gate (#1439)

### DIFF
--- a/docs/generated/overlay-extension-points.json
+++ b/docs/generated/overlay-extension-points.json
@@ -83,6 +83,12 @@
       "signature": "(title: str, description: str) -> teatree.types.ValidationResult"
     },
     {
+      "description": "Produce the PR title from structured ticket data (default: the commit subject).",
+      "name": "metadata.build_pr_title",
+      "required": false,
+      "signature": "(*, branch: str, subject: str, body: str, issue_url: str) -> str"
+    },
+    {
       "description": "Return the active overlay skill path and remote match patterns.",
       "name": "metadata.get_skill_metadata",
       "required": false,

--- a/docs/generated/overlay-extension-points.md
+++ b/docs/generated/overlay-extension-points.md
@@ -18,6 +18,7 @@ Base class: `teatree.core.overlay.OverlayBase`
 | `get_base_images` | No | `(worktree: 'Worktree') -> list[teatree.types.BaseImageConfig]` | Declare Docker base images teatree builds once and shares across worktrees. |
 | `get_docker_services` | No | `(worktree: 'Worktree') -> set[str]` | Declare service names that MUST run in Docker — enforced at `worktree provision`. |
 | `metadata.validate_pr` | No | `(title: str, description: str) -> teatree.types.ValidationResult` | Return PR validation problems for this overlay. |
+| `metadata.build_pr_title` | No | `(*, branch: str, subject: str, body: str, issue_url: str) -> str` | Produce the PR title from structured ticket data (default: the commit subject). |
 | `metadata.get_skill_metadata` | No | `() -> teatree.types.SkillMetadata` | Return the active overlay skill path and remote match patterns. |
 | `metadata.get_ci_project_path` | No | `() -> str` | Return the GitLab project path for CI operations. |
 | `metadata.get_e2e_config` | No | `() -> dict[str, str]` | Return E2E runner configuration (runner, test_dir, settings_module, project_path, ref). |

--- a/docs/overlay-api.md
+++ b/docs/overlay-api.md
@@ -71,6 +71,7 @@ Project metadata, CI integration, MR validation, and skill registration live on 
 | Method | Default | Purpose |
 |--------|---------|---------|
 | `validate_pr(title, description)` | no errors/warnings | Validate PR title and description against project conventions |
+| `build_pr_title(branch, subject, body, issue_url)` | the commit `subject` | Produce the PR title from structured ticket data so the ship path generates a compliant title instead of copying a raw subject |
 | `get_followup_repos()` | `[]` | Repos to check during follow-up sync |
 | `get_skill_metadata()` | `{}` | Skill path, remote patterns, trigger index for the overlay's companion skills |
 | `get_ci_project_path()` | `""` | CI project path for pipeline triggers and evidence posting |

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -1008,11 +1008,51 @@ def _mr_validate_argv() -> list[str] | None:
     return None
 
 
+_MR_VALIDATE_BROKEN_ENV_DENY = (
+    "Cannot validate MR title/description — the overlay validator "
+    "(`t3 tool validate-mr`) is not resolvable or crashed. Refusing to create "
+    "the MR with unvalidated metadata (fail closed). Fix the environment, or "
+    "set T3_MR_VALIDATE_ALLOW_BROKEN_ENV=1 to deliberately bypass."
+)
+
+
+def _handle_broken_validate_env() -> bool:
+    """Decide the gate's action when the validator can't run.
+
+    The MR-metadata gate FAILS CLOSED by default (deny): a non-compliant title
+    must never reach GitLab just because the env could not validate it. The
+    explicit ``T3_MR_VALIDATE_ALLOW_BROKEN_ENV`` opt-in is the operator's
+    self-rescue — deliberately fall back to fail-open (allow) so a genuinely
+    broken environment is not a hard deadlock.
+    """
+    if os.environ.get("T3_MR_VALIDATE_ALLOW_BROKEN_ENV", "").strip().lower() in {"1", "true", "yes"}:
+        return False
+    return emit_pretooluse_deny(_MR_VALIDATE_BROKEN_ENV_DENY)
+
+
+def _run_mr_validator(argv: list[str], title: str, description: str) -> "subprocess.CompletedProcess[str] | None":
+    """Run the validator, or ``None`` if the env is broken (timeout/missing)."""
+    try:
+        return subprocess.run(  # noqa: S603
+            [*argv, "--title", title, "--description", description],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
 def handle_validate_mr_metadata(data: dict) -> bool:
     """Block a non-compliant ``glab mr create/update`` before it runs.
 
     Validates by default via the active overlay's ``validate_pr`` (no
-    env-var opt-in) so the pre-push gate is always live (#119 Part 3).
+    env-var opt-in) so the pre-push gate is always live (#119 Part 3). When
+    the validator cannot be resolved or crashes, the gate FAILS CLOSED — a
+    non-compliant title must never slip onto GitLab on a broken env. The
+    explicit ``T3_MR_VALIDATE_ALLOW_BROKEN_ENV`` opt-in restores fail-open as
+    a deliberate self-rescue.
     """
     fields = _extract_mr_fields(data)
     if fields is None:
@@ -1021,18 +1061,11 @@ def handle_validate_mr_metadata(data: dict) -> bool:
 
     argv = _mr_validate_argv()
     if argv is None:
-        return False
+        return _handle_broken_validate_env()
 
-    try:
-        result = subprocess.run(  # noqa: S603
-            [*argv, "--title", title, "--description", description],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=10,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return False
+    result = _run_mr_validator(argv, title, description)
+    if result is None:
+        return _handle_broken_validate_env()
 
     if result.returncode != 0:
         return emit_pretooluse_deny(

--- a/src/teatree/core/docgen.py
+++ b/src/teatree/core/docgen.py
@@ -24,6 +24,7 @@ _OVERLAY_HOOK_ORDER = (
 
 _METADATA_HOOK_ORDER = (
     "validate_pr",
+    "build_pr_title",
     "get_skill_metadata",
     "get_ci_project_path",
     "get_e2e_config",
@@ -48,6 +49,7 @@ _OVERLAY_HOOK_DESCRIPTIONS = {
 
 _METADATA_HOOK_DESCRIPTIONS = {
     "validate_pr": "Return PR validation problems for this overlay.",
+    "build_pr_title": "Produce the PR title from structured ticket data (default: the commit subject).",
     "get_skill_metadata": "Return the active overlay skill path and remote match patterns.",
     "get_ci_project_path": "Return the GitLab project path for CI operations.",
     "get_e2e_config": "Return E2E runner configuration (runner, test_dir, settings_module, project_path, ref).",

--- a/src/teatree/core/management/commands/_pr_preview.py
+++ b/src/teatree/core/management/commands/_pr_preview.py
@@ -37,9 +37,15 @@ class PrValidationError(TypedDict):
 def ship_preview(ticket: Ticket, worktree: Worktree) -> tuple[str, str, str]:
     """Return ``(repo_path, title, description)`` previewed from the last commit.
 
-    Sanitizes the TITLE first, then builds the description's first line from
-    that exact sanitized string. Applying close-keyword sanitization only to
-    the description (the old behaviour) silently diverged it from the title
+    The title is PRODUCED by the overlay (``metadata.build_pr_title``), not
+    copied verbatim from the commit subject: an overlay enforcing a title
+    grammar assembles a canonical title from the branch + subject + ticket so
+    a non-canonical subject can never reach the MR. The default overlay hook
+    returns the subject unchanged, preserving prior behaviour.
+
+    The TITLE is sanitized first, then the description's first line is built
+    from that exact sanitized string. Applying close-keyword sanitization only
+    to the description (the old behaviour) silently diverged it from the title
     whenever the title carried a close-keyword (e.g. the ``Resolve <url>``
     fallback, or a ``fix: resolve X`` subject) — the title/description
     divergence class. Reusing the sanitized title makes the first line ==
@@ -47,11 +53,18 @@ def ship_preview(ticket: Ticket, worktree: Worktree) -> tuple[str, str, str]:
     """
     repo_path = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
     subject, body = git.last_commit_message(repo=repo_path)
+    overlay = get_overlay()
+    generated = overlay.metadata.build_pr_title(
+        branch=worktree.branch or "",
+        subject=subject,
+        body=body or "",
+        issue_url=ticket.issue_url or "",
+    )
     close_ticket = should_close_ticket(
         ticket.extra or {},
-        setting_enabled=get_overlay().config.mr_close_ticket,
+        setting_enabled=overlay.config.mr_close_ticket,
     )
-    title = sanitize_close_keywords(subject or f"Resolve {ticket.issue_url}", close_ticket=close_ticket)
+    title = sanitize_close_keywords(generated or f"Resolve {ticket.issue_url}", close_ticket=close_ticket)
     raw_body = sanitize_close_keywords(body, close_ticket=close_ticket) if body else ""
     description = f"{title}\n\n{raw_body}" if raw_body else title
     return repo_path, title, description

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -158,6 +158,7 @@ class Command(TyperCommand):
         title: str = "",
         dry_run: bool = False,
         skip_validation: bool = False,
+        skip_mr_format_check: bool = False,
         skip_visual_qa: str = "",
         sync: bool = False,
     ) -> (
@@ -189,6 +190,12 @@ class Command(TyperCommand):
 
         ``--title`` overrides the PR title (default: last commit subject).
         Stored on ``ticket.extra['pr_title_override']`` so the ship reads it.
+
+        ``--skip-validation`` skips the heavy ship gates (visual QA, branch
+        currency, FSM phase check) but STILL runs the cheap MR
+        title/description format check. ``--skip-mr-format-check`` is the
+        separate, explicit opt-in that disables that format check too — needed
+        only in the rare case where a non-canonical title must ship anyway.
         """
         try:
             ticket = resolve_ticket(ticket_id)
@@ -245,6 +252,15 @@ class Command(TyperCommand):
             # FSM must follow the authorization or ship() is structurally
             # impossible from a non-REVIEWED state (#748).
             reconcile_fsm_for_ship(ticket)
+            # --skip-validation skips the HEAVY gates (visual QA, branch
+            # currency, FSM phase check) — but NOT the cheap, deterministic
+            # MR title/description format check. A non-compliant title must
+            # not slip onto GitLab via the bypass; only the explicit
+            # --skip-mr-format-check opt-in disables the format check too.
+            if not skip_mr_format_check:
+                format_error = validate_pr_metadata(ticket, worktree)
+                if format_error is not None:
+                    return format_error
 
         return _dispatch_ship(ticket, worktree, title=title, dry_run=dry_run, sync=sync)
 

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -307,6 +307,20 @@ class OverlayMetadata:
     def validate_pr(self, title: str, description: str) -> ValidationResult:
         return {"errors": [], "warnings": []}
 
+    def build_pr_title(self, *, branch: str, subject: str, body: str, issue_url: str) -> str:
+        """Produce the PR title from structured data instead of copying the subject.
+
+        The default returns ``subject`` unchanged — historic behaviour, so an
+        overlay that does not override it is unaffected. An overlay enforcing a
+        title grammar (e.g. ``type(scope): … [flag] (ticket_url)``) overrides
+        this to ASSEMBLE a canonical title from ``branch`` / ``subject`` /
+        ``issue_url``. This closes the gap where a coder agent's non-canonical
+        commit subject (e.g. ``test(insurance): …``) flowed straight onto the
+        MR: the factory now produces a compliant title rather than letting the
+        validator merely reject the copied one after the fact.
+        """
+        return subject
+
     def get_followup_repos(self) -> list[str]:
         return []
 

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -275,13 +275,28 @@ class ShipExecutor(RunnerBase):
     ) -> PullRequestSpec:
         title_override = str(extra.get("pr_title_override") or "")
         subject, body = git.last_commit_message(repo=repo_path)
-        title = title_override or subject or f"Resolve {ticket.issue_url}"
-        raw_description = f"{subject}\n\n{body}" if subject and body else (subject or body)
+        overlay = get_overlay()
+        # PRODUCE the title from structured data unless the user pinned one
+        # via --title. The overlay default returns the subject unchanged.
+        generated = overlay.metadata.build_pr_title(
+            branch=branch,
+            subject=subject,
+            body=body or "",
+            issue_url=ticket.issue_url or "",
+        )
+        title = title_override or generated or f"Resolve {ticket.issue_url}"
         close_ticket = should_close_ticket(
             extra,
-            setting_enabled=get_overlay().config.mr_close_ticket,
+            setting_enabled=overlay.config.mr_close_ticket,
         )
-        description = sanitize_close_keywords(raw_description, close_ticket=close_ticket)
+        # Build the description's FIRST LINE from the (sanitized) title, not the
+        # raw subject — otherwise a canonical generated title diverges from the
+        # raw-subject first line, the exact title/description divergence that
+        # blocks the release-notes pipeline.
+        sanitized_title = sanitize_close_keywords(title, close_ticket=close_ticket)
+        title = sanitized_title
+        sanitized_body = sanitize_close_keywords(body, close_ticket=close_ticket) if body else ""
+        description = f"{sanitized_title}\n\n{sanitized_body}" if sanitized_body else sanitized_title
         description = apply_publish_gate(
             description,
             repo=repo_path,

--- a/tests/teatree_core/pr_command/test_create_sync_ship.py
+++ b/tests/teatree_core/pr_command/test_create_sync_ship.py
@@ -121,6 +121,63 @@ class TestPrCreateSyncShip(TestCase):
         ticket.refresh_from_db()
         assert ticket.state in {Ticket.State.SHIPPED, Ticket.State.REVIEWED}
 
+    def test_skip_validation_still_enforces_mr_format_check(self) -> None:
+        """Skip the heavy gates, still enforce the MR format check.
+
+        ``--skip-validation`` skips the HEAVY gates but NOT the cheap,
+        deterministic MR title/description format check — a non-compliant
+        title must not slip onto GitLab via the bypass. Only the explicit
+        ``--skip-mr-format-check`` opt-in disables the format check too.
+        """
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.STARTED)
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/backend",
+            branch="feature-branch",
+            extra={"worktree_path": "/tmp/backend"},
+        )
+        ship_mock = MagicMock()
+        ship_mock.call.return_value = {"ticket_id": ticket.pk, "ok": True, "detail": "PR opened"}
+        fmt_error = pr_command.PrValidationError(error="PR validation failed", details=["bad title"])
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command, "validate_pr_metadata", return_value=fmt_error) as fmt,
+            patch("teatree.core.tasks.execute_ship", ship_mock),
+        ):
+            result = cast(
+                "dict[str, object]",
+                call_command("pr", "create", str(ticket.id), sync=True, skip_validation=True),
+            )
+        fmt.assert_called_once()
+        assert result == fmt_error
+        ship_mock.call.assert_not_called()
+
+    def test_skip_mr_format_check_disables_the_format_check_too(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.STARTED)
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/backend",
+            branch="feature-branch",
+            extra={"worktree_path": "/tmp/backend"},
+        )
+        ship_mock = MagicMock()
+        ship_mock.call.return_value = {"ticket_id": ticket.pk, "ok": True, "detail": "PR opened"}
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command, "validate_pr_metadata") as fmt,
+            patch("teatree.core.tasks.execute_ship", ship_mock),
+        ):
+            result = cast(
+                "dict[str, object]",
+                call_command(
+                    "pr", "create", str(ticket.id), sync=True, skip_validation=True, skip_mr_format_check=True
+                ),
+            )
+        fmt.assert_not_called()
+        assert result["ok"] is True
+
     def test_sync_illegal_transition_without_skip_is_structured_failure(self) -> None:
         # Validation NOT skipped, no attested session -> the gate blocks
         # with a structured failure, never a raw TransitionNotAllowed (#694).

--- a/tests/teatree_core/test_pr_preview.py
+++ b/tests/teatree_core/test_pr_preview.py
@@ -13,10 +13,22 @@ from django.test import TestCase
 from teatree.core.management.commands import _pr_preview
 from teatree.core.management.commands._pr_preview import ship_preview
 from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay import OverlayMetadata
 from teatree.core.overlay_loader import reset_overlay_cache
 from tests.teatree_core.conftest import CommandOverlay
 
 _MOCK_OVERLAY = {"test": CommandOverlay()}
+
+
+class _GeneratingMetadata(OverlayMetadata):
+    """An overlay metadata that REPLACES a non-canonical subject with a fixed title."""
+
+    def build_pr_title(self, *, branch: str, subject: str, body: str, issue_url: str) -> str:
+        return "fix(corridor): canonical generated title [none] (proj#119)"
+
+
+class _GenOverlay(CommandOverlay):
+    metadata = _GeneratingMetadata()
 
 
 @pytest.fixture(autouse=True)
@@ -101,3 +113,42 @@ class TestShipPreviewTitleDescriptionInvariant(TestCase):
             _, title, description = ship_preview(ticket, ticket.worktrees.first())
         # Title and first line are both the *sanitized* string -> still equal.
         assert self._first_line(description) == title
+
+
+class TestShipPreviewUsesOverlayGeneratedTitle(TestCase):
+    """The title is PRODUCED by the overlay, not copied from the subject.
+
+    An overlay enforcing a title grammar must be able to REPLACE a
+    non-canonical commit subject (e.g. ``test(insurance): …``) with a
+    compliant generated title — and the description first line must follow it
+    so the two never diverge.
+    """
+
+    def _ticket_with_worktree(self) -> Ticket:
+        ticket = Ticket.objects.create(
+            overlay="gen",
+            state=Ticket.State.REVIEWED,
+            issue_url="https://github.com/souliane/teatree/issues/119",
+        )
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="gen",
+            repo_path="/tmp/backend",
+            branch="119-fix-corridor-margin",
+            extra={"worktree_path": "/tmp/backend"},
+        )
+        return ticket
+
+    def test_overlay_generated_title_replaces_subject_and_first_line_follows(self) -> None:
+        ticket = self._ticket_with_worktree()
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value={"gen": _GenOverlay()}),
+            patch.object(
+                _pr_preview.git,
+                "last_commit_message",
+                return_value=("test(insurance): add coverage", "Body paragraph.\n"),
+            ),
+        ):
+            _, title, description = ship_preview(ticket, ticket.worktrees.first())
+        assert title == "fix(corridor): canonical generated title [none] (proj#119)"
+        assert description.split("\n", 1)[0] == title

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -590,6 +590,9 @@ class TestShipExecutorHonorsAutoCloseSetting(TestCase):
         cfg = MagicMock()
         cfg.config.mr_close_ticket = setting_enabled
         cfg.config.pr_auto_labels = []
+        # The default title hook returns the subject unchanged; mirror that so
+        # this auto-close test exercises sanitization, not title generation.
+        cfg.metadata.build_pr_title.side_effect = lambda *, branch, subject, body, issue_url: subject
         with (
             patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
             patch("teatree.core.runners.ship.get_overlay", return_value=cfg),

--- a/tests/test_validate_mr_metadata_hook.py
+++ b/tests/test_validate_mr_metadata_hook.py
@@ -60,12 +60,47 @@ class TestDefaultOverlayValidation:
         data = {"tool_name": "Bash", "tool_input": {"command": "ls -la"}}
         assert handle_validate_mr_metadata(data) is False
 
-    def test_noop_when_t3_not_on_path(self, monkeypatch):
+    def test_fails_closed_when_t3_not_on_path(self, monkeypatch, capsys):
+        # No validator resolvable -> the gate FAILS CLOSED (deny), not open:
+        # a non-compliant title must never reach GitLab just because the env
+        # could not validate it. The escape hatch is the explicit env var.
         monkeypatch.delenv("T3_MR_VALIDATE_SCRIPT", raising=False)
+        monkeypatch.delenv("T3_MR_VALIDATE_ALLOW_BROKEN_ENV", raising=False)
         monkeypatch.setattr(router.shutil, "which", lambda _: None)
-        # No t3 binary -> cannot validate -> fail open (don't block the agent
-        # on a broken environment), same posture as other t3-shelling hooks.
+        blocked = handle_validate_mr_metadata(_glab_create("bad", "bad"))
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+        assert "validate" in out["permissionDecisionReason"].lower()
+
+    def test_broken_env_escape_hatch_fails_open(self, monkeypatch):
+        # The deliberate self-rescue opt-in: when the operator sets
+        # T3_MR_VALIDATE_ALLOW_BROKEN_ENV, an unresolvable validator falls
+        # back to fail-open so a genuinely broken env is not a hard deadlock.
+        monkeypatch.delenv("T3_MR_VALIDATE_SCRIPT", raising=False)
+        monkeypatch.setenv("T3_MR_VALIDATE_ALLOW_BROKEN_ENV", "1")
+        monkeypatch.setattr(router.shutil, "which", lambda _: None)
         assert handle_validate_mr_metadata(_glab_create("bad", "bad")) is False
+
+    def test_fails_closed_when_validator_times_out(self, monkeypatch, capsys):
+        monkeypatch.delenv("T3_MR_VALIDATE_SCRIPT", raising=False)
+        monkeypatch.delenv("T3_MR_VALIDATE_ALLOW_BROKEN_ENV", raising=False)
+        monkeypatch.setattr(router.shutil, "which", lambda _: "/usr/local/bin/t3")
+        with patch.object(router.subprocess, "run", side_effect=subprocess.TimeoutExpired(cmd="t3", timeout=10)):
+            blocked = handle_validate_mr_metadata(_glab_create("fix: x (p#1)", "fix: x (p#1)"))
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+
+    def test_fails_closed_when_validator_binary_missing(self, monkeypatch, capsys):
+        monkeypatch.delenv("T3_MR_VALIDATE_SCRIPT", raising=False)
+        monkeypatch.delenv("T3_MR_VALIDATE_ALLOW_BROKEN_ENV", raising=False)
+        monkeypatch.setattr(router.shutil, "which", lambda _: "/usr/local/bin/t3")
+        with patch.object(router.subprocess, "run", side_effect=FileNotFoundError):
+            blocked = handle_validate_mr_metadata(_glab_create("fix: x (p#1)", "fix: x (p#1)"))
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
 
     def test_missing_title_is_validated_not_skipped(self, monkeypatch, capsys):
         # An MR create with no --title is exactly the bad metadata the gate


### PR DESCRIPTION
Closes #1439.

## Problem

Agent-created PR titles relied on dispatch-prompt vigilance, which failed often: the ship path copied the raw commit subject verbatim onto the PR title (`ship_preview`, `_build_pr_spec`), so a non-canonical subject reached the platform and only failed release-notes CI afterward. The validate choke-points were also escapable — the PreToolUse `validate-mr-metadata` hook failed OPEN on a broken env, and `--skip-validation` skipped the cheap metadata check along with the heavy gates.

## Approach: produce-correct over reject-wrong

Rather than a parallel `mr_title_regex` config + a separate reject-only gate (the literal #1439 proposal), this reuses the existing `validate_pr` machinery and adds a GENERATOR so the title is right *by construction*:

- New overlay hook `OverlayMetadata.build_pr_title(branch, subject, body, issue_url)`. The default returns `subject` unchanged, so overlays that don't override it are unaffected.
- `ship_preview` and `_build_pr_spec` now call it to PRODUCE the title, and build the description's first line from the resulting (sanitized) title — so title and first line can never diverge (the existing divergence invariant now holds for generated titles too).
- The PreToolUse `validate-mr-metadata` hook FAILS CLOSED when the validator can't run (unresolvable / timeout / missing) instead of fail-open. The explicit `T3_MR_VALIDATE_ALLOW_BROKEN_ENV` opt-in is the deliberate self-rescue so a genuinely broken env is never a hard deadlock.
- `--skip-validation` still runs the cheap title/description format check; only the new explicit `--skip-mr-format-check` disables it too.
- The generated-docs registry + `overlay-api.md` list the new metadata hook; generated extension-point docs regenerated.

## Tests

RED-first for every new behaviour. Full core suite green (2548 passed). Pairs with the overlay-side PR that overrides `build_pr_title` to emit titles passing its own release-notes validator (verified end to end).