### PR TITLE
fix(cli): mark ticket group core_dispatch so non-core overlays reach core merge path

### DIFF
--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -179,6 +179,7 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("comment", "Post a comment to an issue or work item by its URL."),
             ("context", "Durable per-ticket knowledge store: show / add / edit (#627)."),
         ],
+        core_dispatch=True,
     ),
     "availability": DjangoGroup(
         "24/7 dual question-mode (#58, BLUEPRINT §17.1 invariant 9).",

--- a/tests/teatree_core/test_overlay_core_dispatch.py
+++ b/tests/teatree_core/test_overlay_core_dispatch.py
@@ -101,6 +101,55 @@ class TestFollowupGroupCoreDispatch:
         assert "manage.py" not in " ".join(cmd)
 
 
+class TestTicketGroupCoreDispatch:
+    """``ticket clear/merge`` route through ``python -m teatree`` (core), not the overlay manage.py.
+
+    ``ticket`` subcommands live in ``teatree.core.management.commands.ticket``
+    (delegating to ``teatree.core.merge_execution``) — teatree CORE, not any
+    overlay-owned ``manage.py``. A non-core overlay clone has its own
+    ``manage.py`` with no ``ticket`` command, so without the ``core_dispatch``
+    marker the sanctioned merge path crashes with ``Unknown command: 'ticket'``
+    — the same #1312/#1318 lockout class as ``followup`` and ``review-request``.
+    """
+
+    def test_ticket_group_is_marked_core_dispatch(self) -> None:
+        """``DJANGO_GROUPS['ticket']`` carries the ``core_dispatch`` marker."""
+        entry = DJANGO_GROUPS["ticket"]
+        assert getattr(entry, "core_dispatch", False) is True, (
+            f"ticket group must opt into core dispatch — its clear/merge commands live in "
+            f"teatree.core, not an overlay manage.py, got {entry!r}"
+        )
+
+    def test_ticket_clear_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        """``t3 <overlay> ticket clear`` must dispatch to core, never the overlay manage.py."""
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["ticket", "clear", "15"])
+        assert result.exit_code == 0, result.output
+        assert run_streamed.called
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"ticket clear must dispatch via python -m teatree, got {cmd!r}"
+        assert "teatree" in cmd, f"ticket clear must dispatch via python -m teatree, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd), f"ticket clear must NOT route through manage.py, got {cmd!r}"
+        assert "ticket" in cmd
+        assert "clear" in cmd
+
+    def test_ticket_merge_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        """``t3 <overlay> ticket merge`` must dispatch to core, never the overlay manage.py."""
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["ticket", "merge", "abc123"])
+        assert result.exit_code == 0, result.output
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"ticket merge must use core dispatch, got {cmd!r}"
+        assert "teatree" in cmd, f"ticket merge must use core dispatch, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd), f"ticket merge must NOT route through manage.py, got {cmd!r}"
+        assert "ticket" in cmd
+        assert "merge" in cmd
+
+
 class TestShortcutCoreDispatch:
     """``full-status`` and ``daily`` shortcut to followup commands — same dispatch rule."""
 


### PR DESCRIPTION
## Problem

The `ticket` DjangoGroup in `src/teatree/cli/overlay.py` lacked `core_dispatch=True`, while its `clear`/`merge` subcommands live in teatree **CORE** (`teatree.core.management.commands.ticket` → `teatree.core.merge_execution`), not in any overlay-owned `manage.py`.

From a **non-core overlay** whose clone has its own `manage.py`, `t3 <overlay> ticket clear/merge` routed through `managepy` → the overlay's `manage.py` → `Unknown command: 'ticket'`. This locked out the **sanctioned merge path** for every non-core overlay — the orchestrator's only merge output (BLUEPRINT §17.4.2) could not run.

Same #1312/#1318 `core_dispatch` lockout class already fixed for `followup` and `review-request`. `t3 teatree ticket` worked only because core's own `manage.py` registers the command.

## Fix

Add `core_dispatch=True` to the `ticket` group so its commands dispatch via `python -m teatree` (teatree-native core), never an overlay's `manage.py`.

## Test

Adds `TestTicketGroupCoreDispatch` to `tests/teatree_core/test_overlay_core_dispatch.py`, mirroring the existing `followup` core-dispatch tests. The 3 new tests were observed **RED** on pre-fix code (dispatch resolved to `uv --directory <overlay-clone> run python manage.py ticket clear ...`) and **GREEN** after the one-line fix. Full `tests/teatree_core/` + CLI suite green (2568 passed).