### PR TITLE
fix(gates): repair gate-over-deny lockouts across four safety gates (#126)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -466,7 +466,7 @@ Usage: t3 review [OPTIONS] COMMAND [ARGS]...
 │                      published.                                              │
 │ resolve-discussion   Mark a GitLab MR discussion thread resolved or          │
 │                      unresolved.                                             │
-│ approve-live-post    Mint a Slack-recorded :class:`LivePostApproval` for     │
+│ approve-live-post    Mint a single-use :class:`LivePostApproval` for         │
 │                      ``<mr-url>``.                                           │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -827,9 +827,11 @@ Usage: t3 review resolve-discussion [OPTIONS] REPO MR DISCUSSION_ID
 ```
 Usage: t3 review approve-live-post [OPTIONS] MR_URL
 
- Mint a Slack-recorded :class:`LivePostApproval` for ``<mr-url>``.
+ Mint a single-use :class:`LivePostApproval` for ``<mr-url>``.
 
- After this command writes the row, the next
+ Authorization arrives through ``--slack-ts`` (verify the user's
+ DM) OR ``--from-on-behalf`` (accept a recorded on-behalf
+ approval). After this command writes the row, the next
  ``t3 review post-comment <mr-url> ... --live`` invocation
  publishes (single-use, consumed by that call); any subsequent
  live post against the same MR requires a fresh approval.
@@ -844,15 +846,20 @@ Usage: t3 review approve-live-post [OPTIONS] MR_URL
 │                        [required]                                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ *  --slack-ts        TEXT  Slack timestamp (e.g. ``1700000000.0001``) of the │
-│                            user's DM authorising the live post. The helper   │
-│                            fetches that message, refuses unless it was       │
-│                            authored by the configured user, is recent        │
-│                            (within the TTL window), and contains an explicit │
-│                            approval phrase (``post live`` / ``submit it`` /  │
-│                            ``go ahead``).                                    │
-│                            [required]                                        │
-│    --help                  Show this message and exit.                       │
+│ --slack-ts              TEXT  Slack timestamp (e.g. ``1700000000.0001``) of  │
+│                               the user's DM authorising the live post. The   │
+│                               helper fetches that message, refuses unless it │
+│                               was authored by the configured user, is recent │
+│                               (within the TTL window), and contains an       │
+│                               approval phrase. Alternative to                │
+│                               --from-on-behalf; one of the two is required.  │
+│ --from-on-behalf              Authorize from a recorded on-behalf approval   │
+│                               instead of a Slack DM. Accepts an unconsumed   │
+│                               `t3 review approve-on-behalf <mr-url>          │
+│                               post_comment` token for this exact MR as the   │
+│                               human authorization (#126). Alternative to     │
+│                               --slack-ts; one of the two is required.        │
+│ --help                        Show this message and exit.                    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -931,32 +931,163 @@ def _load_protected_branches() -> set[str]:
     return branches
 
 
-def handle_protect_default_branch(data: dict) -> bool:
-    """Block Edit/Write on files that live on a protected branch."""
-    tool_name = data.get("tool_name", "")
-    if tool_name not in _FILE_PATH_TOOLS:
-        return False
+# Agent-harness state dirs that may sit UNDER a git repo's working tree
+# (e.g. ``~/.claude`` inside a dotfiles repo) but whose files are never
+# repo source. A Write here must never be blocked by the protected-branch
+# gate — editing agent memory / todos / per-project state on `main` is
+# exactly what the agent is supposed to do. Mirrors ``_KEEP_PATTERNS``.
+_AGENT_STATE_PATH_RE = re.compile(
+    r"/\.(claude|codex|cursor|copilot)/(projects/.*/memory/|memory/|todos/|statsig/|.*\.log$)",
+)
 
-    file_path = data.get("tool_input", {}).get("file_path", "")
-    if not file_path:
-        return False
 
-    parent = str(Path(file_path).parent)
+def _is_agent_state_path(file_path: str) -> bool:
+    """True iff *file_path* is agent-harness state, not repo source.
+
+    Resolved to an absolute, symlink-free path first so a relative or
+    ``..``-laden path can't dodge the pattern. A resolution failure (a
+    path under a missing dir) falls back to the raw string — the regex
+    is anchored on the harness-dir segment, which survives either form.
+    """
     try:
-        branch = subprocess.check_output(  # noqa: S603
-            ["git", "-C", parent, "--no-optional-locks", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
+        resolved = str(Path(file_path).expanduser().resolve())
+    except (OSError, RuntimeError):
+        resolved = file_path
+    return _AGENT_STATE_PATH_RE.search(resolved) is not None
+
+
+def _file_is_inside_worktree(repo_root: str, file_path: str) -> bool:
+    """True iff *file_path* resolves to a path inside *repo_root*'s working tree.
+
+    ``git -C <parent> rev-parse`` walks UP to the nearest enclosing
+    ``.git``, so the resolved repo root can be an ANCESTOR of the file
+    (a dotfiles/home repo the file merely sits under). Confirming the
+    file is genuinely within that root is what scopes the gate to the
+    TARGET FILE's repo rather than whatever happens to enclose its parent
+    dir (#126). A resolution failure means we cannot confirm containment —
+    fail open (return ``False``, do not block).
+    """
+    try:
+        file_resolved = Path(file_path).expanduser().resolve()
+        root_resolved = Path(repo_root).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return False
+    try:
+        file_resolved.relative_to(root_resolved)
+    except ValueError:
+        return False
+    return True
+
+
+def _repo_root_is_teatree_managed(repo_root: str) -> bool:
+    """True iff *repo_root* is a teatree-MANAGED source repo.
+
+    The protected-branch gate guards only teatree core + the active
+    overlay's registered repos (``~/.teatree.toml``
+    ``workspace_repos`` / ``frontend_repos`` / ``public_repos`` slugs,
+    plus each overlay ``path``) — NOT every git repo (#126). An unmanaged
+    repo on ``main`` (a dotfiles repo, an unrelated clone) must not block,
+    so this returns ``False`` for any repo the managed-signal set does not
+    cover, and ``False`` on any classification error (fail OPEN — the
+    gate-over-deny class this whole change closes).
+
+    Reuses :func:`_overlay_managed_repo_signals` (the same signal source
+    as the out-of-band-merge gate) and ``publish_surface._slug_for_cwd``
+    so the slug shape matches the rest of the managed-repo machinery.
+    """
+    slugs, paths = _overlay_managed_repo_signals()
+    try:
+        root_resolved = Path(repo_root).expanduser().resolve()
+    except (OSError, RuntimeError):
+        return False
+    for base in paths:
+        with contextlib.suppress(OSError, RuntimeError):
+            root_resolved.relative_to(base)
+            return True
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    added = False
+    try:
+        if str(src_dir) not in sys.path:
+            sys.path.insert(0, str(src_dir))
+            added = True
+        from teatree.hooks import publish_surface  # noqa: PLC0415
+
+        slug = publish_surface._slug_for_cwd(root_resolved).lower()  # noqa: SLF001
+    except Exception:  # noqa: BLE001
+        return False
+    finally:
+        if added:
+            with contextlib.suppress(ValueError):
+                sys.path.remove(str(src_dir))
+    return any(entry in slug for entry in slugs) if slug else False
+
+
+def _resolve_branch_and_root(parent: str) -> tuple[str, str] | None:
+    """Return ``(branch, repo_root)`` for the repo enclosing *parent*, or ``None``.
+
+    ``None`` when *parent* is not inside a git repo, on a git error, or on
+    a timeout — every one of which fails the gate open. ``git -C`` walks UP
+    to the nearest ``.git``, so the returned root can be an ancestor of the
+    file; :func:`_file_is_inside_worktree` is what re-scopes it.
+    """
+
+    def _rev_parse(*flags: str) -> str:
+        return subprocess.check_output(  # noqa: S603
+            ["git", "-C", parent, "--no-optional-locks", "rev-parse", *flags],  # noqa: S607
             text=True,
             timeout=3,
             stderr=subprocess.DEVNULL,
         ).strip()
+
+    try:
+        return _rev_parse("--abbrev-ref", "HEAD"), _rev_parse("--show-toplevel")
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def handle_protect_default_branch(data: dict) -> bool:
+    """Block Edit/Write on a source file in a teatree-MANAGED protected-branch repo.
+
+    Scoped to the TARGET FILE's own repo, never to the cwd's branch and
+    never to "any git repo" (#126). The block fires only when ALL hold:
+
+    1. the tool is ``Edit``/``Write``/``Read`` with a ``file_path``;
+    2. the path is NOT agent-harness state (memory / todos / per-project
+        state) — those are git-tracked scratch state, never protected
+        source, so they are exempt even on ``main``;
+    3. the file's enclosing git repo is on a protected branch;
+    4. the file genuinely lives inside that repo's working tree;
+    5. that repo is teatree-MANAGED (core + the active overlay's
+        registered repos) — an unmanaged repo on ``main`` (a dotfiles
+        clone, an unrelated project) is NOT this gate's concern.
+
+    Any condition unmet → allow (fail open). A git error, an
+    unresolvable repo, or an unclassifiable slug all allow — the
+    gate-over-deny class this change closes means uncertainty errs toward
+    letting the write through, not blocking it.
+    """
+    tool_name = data.get("tool_name", "")
+    file_path = data.get("tool_input", {}).get("file_path", "")
+    # Agent-harness state is never repo source — allow it even on `main`.
+    if tool_name not in _FILE_PATH_TOOLS or not file_path or _is_agent_state_path(file_path):
         return False
 
-    if branch in _load_protected_branches():
-        return emit_pretooluse_deny(
-            f"BLOCKED: file is on protected branch '{branch}'. Create a worktree first with `t3 workspace ticket`."
-        )
-    return False
+    resolved = _resolve_branch_and_root(str(Path(file_path).parent))
+    if resolved is None:
+        return False
+    branch, repo_root = resolved
+
+    if (
+        branch not in _load_protected_branches()
+        or not _file_is_inside_worktree(repo_root, file_path)
+        or not _repo_root_is_teatree_managed(repo_root)
+    ):
+        return False
+
+    return emit_pretooluse_deny(
+        f"BLOCKED: file is on protected branch '{branch}' in a teatree-managed repo. "
+        "Create a worktree first with `t3 workspace ticket`."
+    )
 
 
 # ── PreToolUse: validate-mr-metadata ────────────────────────────────

--- a/src/teatree/cli/review_live_approval.py
+++ b/src/teatree/cli/review_live_approval.py
@@ -1,19 +1,31 @@
-r"""Slack-DM-verified approval CLI for the ``--live`` post-comment gate (#1207).
+r"""Authorization CLI for the ``--live`` post-comment gate (#1207, #126).
 
-``t3 review approve-live-post <mr-url> --slack-ts <ts>`` is the single
-satisfier for the :class:`~teatree.core.live_post_gate.LivePostBlockedError`
-gate. It walks the Slack DM at ``<ts>``, refuses unless:
+``t3 review approve-live-post <mr-url>`` is the satisfier for the
+:class:`~teatree.core.live_post_gate.LivePostBlockedError` gate. The
+human authorization can arrive through EITHER of two durable channels —
+the gate must not fail-closed against a legitimate one (#126):
 
-* the message was authored by the configured user (``slack_user_id``),
-* the message is fresh — within
+* ``--slack-ts <ts>`` — verify the user's Slack DM at that timestamp.
+    Refuses unless the message was authored by the configured user
+    (``slack_user_id``), is fresh (within
     :data:`~teatree.core.models.live_post_approval.LIVE_POST_APPROVAL_TTL_MINUTES`
-    minutes of now,
-* the message body contains a whole-word, case-insensitive approval
-    phrase (``"post live"`` / ``"submit it"`` / ``"go ahead"``) — the
-    matcher uses ``\b``-anchored regex against each phrase, so a
-    negated form such as ``"don't post live"`` does NOT match. Single-
-    pattern matching with no fuzzy NLP; sentence-aware NLP is tracked
-    as a class-C enforcement follow-up.
+    minutes), and contains a whole-word, case-insensitive, unnegated
+    approval phrase. The phrase list is the natural wording the user
+    actually types ("post the findings", "approved", "ship it", ...),
+    not three magic strings — a negated form such as ``"don't post
+    live"`` still does NOT match (clause-scope negation, no fuzzy NLP).
+
+* ``--from-on-behalf`` — accept a recorded
+    :class:`~teatree.core.models.on_behalf_approval.OnBehalfApproval`
+    for ``(<scope>, post_comment)`` as the authorization. The on-behalf
+    approval IS the human authorization, recorded durably by
+    ``t3 review approve-on-behalf <scope> post_comment --approver <id>``;
+    requiring a *separate* fresh Slack ts on top of it was the lockout
+    this closes (a user who already recorded the on-behalf token could
+    not get the live post out).
+
+With neither channel satisfied the gate stays blocked — no approval of
+any kind, no token.
 
 On success the helper mints a single-use
 :class:`~teatree.core.models.live_post_approval.LivePostApproval` row
@@ -44,7 +56,27 @@ class SlackMessage(TypedDict, total=False):
     text: str
 
 
-APPROVAL_PHRASES: tuple[str, ...] = ("post live", "submit it", "go ahead")
+APPROVAL_PHRASES: tuple[str, ...] = (
+    "post live",
+    "submit it",
+    "go ahead",
+    # Natural approval wording the user actually types (#126): the
+    # original three-phrase whitelist rejected ordinary approvals
+    # and forced the user to learn one of three magic strings. Each
+    # phrase is matched whole-word and is still rejected when negated
+    # in the same clause (see :func:`_clause_has_phrase`).
+    "post the findings",
+    "post them",
+    "post it",
+    "approved",
+    "approve it",
+    "ship it",
+)
+
+# Action name an :class:`OnBehalfApproval` must carry to authorize a
+# live post — the live, colleague-visible comment is a ``post_comment``
+# on-behalf action, so a recorded approval for it IS the authorization.
+_ON_BEHALF_POST_ACTION = "post_comment"
 
 
 def _user_channel() -> str:
@@ -185,6 +217,76 @@ def _verify_slack_message(*, slack_ts: str, user_id: str, channel: str) -> tuple
     return text, ""
 
 
+def _verify_on_behalf_authorization(*, scope: str) -> tuple[str, str]:
+    """Resolve a recorded on-behalf approval for ``(scope, post_comment)``.
+
+    Returns ``(approval_ref, "")`` when an unconsumed
+    :class:`~teatree.core.models.on_behalf_approval.OnBehalfApproval`
+    exists for this exact MR scope and the ``post_comment`` action — the
+    durable human authorization is sufficient to mint the live-post
+    token, no Slack ts required (#126). Returns ``("", reason)`` when no
+    matching approval exists; the caller then refuses.
+
+    The approval is matched (and read) but NOT consumed here: the
+    :class:`LivePostApproval` is the single-use token that the live
+    post consumes. The on-behalf approval's pk is recorded on the live
+    token as the audit reference for which durable authorization minted
+    it.
+    """
+    from teatree.core.models.on_behalf_approval import OnBehalfApproval  # noqa: PLC0415
+
+    approval = (
+        OnBehalfApproval.objects.filter(
+            target=scope,
+            action=_ON_BEHALF_POST_ACTION,
+            consumed_at__isnull=True,
+        )
+        .order_by("-created_at")
+        .first()
+    )
+    if approval is None:
+        return "", (
+            f"no recorded on-behalf approval for ({scope!r}, {_ON_BEHALF_POST_ACTION!r}) — "
+            f"record one with `t3 review approve-on-behalf {scope} {_ON_BEHALF_POST_ACTION} "
+            f"--approver <id>`, or pass --slack-ts <ts> with the user's DM"
+        )
+    return f"on-behalf-approval#{approval.pk}", ""
+
+
+def _resolve_authorization(*, mr_url: str, slack_ts: str, from_on_behalf: bool, user_id: str) -> tuple[str, str, str]:
+    """Resolve the authorization channel into ``(slack_ts_for_token, ref, error)``.
+
+    Tries the on-behalf channel first when ``--from-on-behalf`` is set,
+    then the Slack-ts channel. Returns ``(ts, ref, "")`` on success
+    (``ts`` is the value persisted on the token — the Slack ts, or the
+    on-behalf approval ref when there is no DM) or ``("", "", reason)``
+    when neither channel authorizes. The caller mints the token only on
+    an empty error.
+    """
+    from teatree.core.models.live_post_approval import canonical_mr_scope  # noqa: PLC0415
+
+    scope = canonical_mr_scope(mr_url)
+    if from_on_behalf:
+        ref, error = _verify_on_behalf_authorization(scope=scope)
+        if not error:
+            return ref, ref, ""
+        if not slack_ts:
+            return "", "", error
+    if not slack_ts:
+        return (
+            "",
+            "",
+            (
+                "no authorization provided — pass --slack-ts <ts> (the user's approval DM) "
+                "or --from-on-behalf (a recorded `t3 review approve-on-behalf` token)"
+            ),
+        )
+    _approval_text, error = _verify_slack_message(slack_ts=slack_ts, user_id=user_id, channel=_user_channel())
+    if error:
+        return "", "", error
+    return slack_ts, slack_ts, ""
+
+
 def register(review_app: typer.Typer) -> None:
     """Register the ``approve-live-post`` command on the review typer app.
 
@@ -205,19 +307,32 @@ def register(review_app: typer.Typer) -> None:
         ),
         *,
         slack_ts: str = typer.Option(
-            ...,
+            "",
             "--slack-ts",
             help=(
                 "Slack timestamp (e.g. ``1700000000.0001``) of the user's DM authorising "
                 "the live post. The helper fetches that message, refuses unless it was "
                 "authored by the configured user, is recent (within the TTL window), and "
-                "contains an explicit approval phrase (``post live`` / ``submit it`` / ``go ahead``)."
+                "contains an approval phrase. Alternative to --from-on-behalf; one of the "
+                "two is required."
+            ),
+        ),
+        from_on_behalf: bool = typer.Option(
+            False,
+            "--from-on-behalf",
+            help=(
+                "Authorize from a recorded on-behalf approval instead of a Slack DM. "
+                "Accepts an unconsumed `t3 review approve-on-behalf <mr-url> post_comment` "
+                "token for this exact MR as the human authorization (#126). Alternative to "
+                "--slack-ts; one of the two is required."
             ),
         ),
     ) -> None:
-        """Mint a Slack-recorded :class:`LivePostApproval` for ``<mr-url>``.
+        """Mint a single-use :class:`LivePostApproval` for ``<mr-url>``.
 
-        After this command writes the row, the next
+        Authorization arrives through ``--slack-ts`` (verify the user's
+        DM) OR ``--from-on-behalf`` (accept a recorded on-behalf
+        approval). After this command writes the row, the next
         ``t3 review post-comment <mr-url> ... --live`` invocation
         publishes (single-use, consumed by that call); any subsequent
         live post against the same MR requires a fresh approval.
@@ -241,10 +356,11 @@ def register(review_app: typer.Typer) -> None:
             typer.echo("Refused: no Slack user_id configured — set `teatree.slack_user_id` first")
             raise typer.Exit(code=1)
 
-        _approval_text, error = _verify_slack_message(
+        token_ts, _ref, error = _resolve_authorization(
+            mr_url=mr_url,
             slack_ts=slack_ts,
+            from_on_behalf=from_on_behalf,
             user_id=user_id,
-            channel=_user_channel(),
         )
         if error:
             typer.echo(f"Refused: {error}")
@@ -252,7 +368,7 @@ def register(review_app: typer.Typer) -> None:
 
         scope = canonical_mr_scope(mr_url)
         try:
-            approval = LivePostApproval.record(mr_url=scope, slack_ts=slack_ts, slack_user_id=user_id)
+            approval = LivePostApproval.record(mr_url=scope, slack_ts=token_ts, slack_user_id=user_id)
         except LivePostApprovalError as err:
             typer.echo(f"Refused: {err}")
             raise typer.Exit(code=1) from None

--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -17,9 +17,12 @@ The parser walks a Bash command string in two passes:
     command segment and pull out body-flag values, heredoc-style content,
     and attached short-option payloads (``-d'{...}'``).
 
-Indirect body sources we cannot inspect (``gh api --input -``, missing
-files, opaque ``-d @file`` references) fail closed via a sentinel
-string that downstream scanning treats as a HIGH match.
+Indirect body sources we cannot inspect (``gh api --input -``, opaque
+``-d @file`` references, a missing ``git commit -F`` message file) fail
+closed via a sentinel string that downstream scanning treats as a HIGH
+match. A missing ``gh``/``glab`` ``--body-file`` is the one exception:
+an absent drafted PR/issue body is "needs-inline", not a leak, so it
+contributes no payload rather than a fail-closed HIGH (#126).
 """
 
 import json
@@ -363,48 +366,62 @@ def _walk_body_file_flags(
     while i < n:
         word = words[i]
         if word in _BODY_FILE_FLAG_NAMES and i + 1 < n:
-            _append_file_payload(words[i + 1], payloads, heredoc_files)
+            _append_file_payload(words[i + 1], payloads, heredoc_files, fail_closed=False)
             i += 2
             continue
         attached: str | None = None
         for flag in _BODY_FILE_FLAG_NAMES:
             attached = _attached_value(word, flag + "=")
             if attached is not None:
-                _append_file_payload(attached, payloads, heredoc_files)
+                _append_file_payload(attached, payloads, heredoc_files, fail_closed=False)
                 break
         if attached is not None:
             i += 1
             continue
         if is_git and word == "-F" and i + 1 < n:
-            _append_file_payload(words[i + 1], payloads, heredoc_files)
+            _append_file_payload(words[i + 1], payloads, heredoc_files, fail_closed=True)
             i += 2
             continue
         if is_git:
             attached = _attached_value(word, "-F")
             if attached is not None:
-                _append_file_payload(attached, payloads, heredoc_files)
+                _append_file_payload(attached, payloads, heredoc_files, fail_closed=True)
                 i += 1
                 continue
         i += 1
 
 
-def _append_file_payload(path: str, payloads: list[str], heredoc_files: dict[str, str]) -> None:
+def _append_file_payload(path: str, payloads: list[str], heredoc_files: dict[str, str], *, fail_closed: bool) -> None:
     """Append the body referenced by a ``-F``/``--file``/``--body-file`` path.
 
     Resolution order: the on-disk file, then an in-command heredoc that
-    writes to that path (``cat > path <<EOF … EOF``), then the fail-closed
-    sentinel. The heredoc fallback closes the #126 false positive where a
-    body written to a temp file and committed via ``-F`` in the same
-    command was unreadable at PreToolUse scan time (the hook runs BEFORE
-    the file is created).
+    writes to that path (``cat > path <<EOF … EOF``), then the
+    ``fail_closed`` branch. The heredoc fallback closes the #126 false
+    positive where a body written to a temp file and committed via ``-F``
+    in the same command was unreadable at PreToolUse scan time (the hook
+    runs BEFORE the file is created).
+
+    ``fail_closed`` selects what an unresolvable path does:
+
+    * ``True`` (``git commit -F <path>``) — append the fail-closed
+        sentinel. A commit message cannot be amended post-push without a
+        force-push we do not permit, so an unreadable commit-message file
+        must hard-block, matching the #1207 rationale.
+    * ``False`` (``gh``/``glab`` ``--body-file`` / ``--description-file``
+        / ``--file``) — append NOTHING. A drafted PR/issue body file that
+        does not exist at scan time is "needs-inline", not a leak: there
+        is nothing to scan, and a public post that genuinely carries a
+        quote still reaches the gate via its inline ``--body`` text.
+        Treating an absent draft file as a HIGH match denied every such
+        publish (#126).
     """
     content = _read_file_arg(path)
     if content is None:
         content = heredoc_files.get(path)
-    if content is None:
-        payloads.append(FAIL_CLOSED_SENTINEL)
-    else:
+    if content is not None:
         payloads.append(content)
+    elif fail_closed:
+        payloads.append(FAIL_CLOSED_SENTINEL)
 
 
 def _handle_api_input(arg: str, payloads: list[str]) -> None:

--- a/src/teatree/hooks/banned_terms_scanner.py
+++ b/src/teatree/hooks/banned_terms_scanner.py
@@ -93,12 +93,22 @@ def has_override(tool_name: str, tool_input: ToolInput) -> bool:
     The ``--allow-banned-term`` flag is honoured only when it appears as a
     token in the FIRST command segment (anything after a command-separator
     metacharacter is a separate command and must not bypass the gate).
-    ``ALLOW_BANNED_TERM=1`` in the tool-input env mapping also bypasses.
+
+    ``ALLOW_BANNED_TERM=1`` is honoured from the process environment
+    (``os.environ``). The Claude Code PreToolUse payload for a ``Bash``
+    tool carries NO ``env`` block, so the agent's ``ALLOW_BANNED_TERM=1``
+    lives in the hook subprocess's own environment; reading only
+    ``tool_input["env"]`` meant the documented override never reached the
+    wrapper and forced numeric-id + paraphrase workarounds (#126).
+    ``tool_input["env"]`` is still consulted for any harness build that
+    DOES populate it. Mirrors ``quote_scanner.has_quote_ok_override``.
     """
     if tool_name == "Bash":
         command = tool_input.get("command", "")
         if _OVERRIDE_FLAG in _first_segment_words(command):
             return True
+    if os.environ.get(_OVERRIDE_ENV, "").strip() == "1":
+        return True
     env = tool_input.get("env") or {}
     return env.get(_OVERRIDE_ENV, "").strip() == "1"
 

--- a/src/teatree/hooks/quote_scanner.py
+++ b/src/teatree/hooks/quote_scanner.py
@@ -357,7 +357,7 @@ def extract_publish_payload(tool_name: str, tool_input: ToolInput) -> str | None
 def has_quote_ok_override(tool_name: str, tool_input: ToolInput) -> bool:
     """Return True iff the caller explicitly opted out of the gate.
 
-    Two surfaces are accepted. The flag ``--quote-ok`` may appear as a
+    Three surfaces are accepted. The flag ``--quote-ok`` may appear as a
     standalone token in the FIRST shell command segment — any
     ``--quote-ok`` that lives after a command-separator metacharacter
     (``;`` / ``|`` / ``&`` / ``&&`` / ``||`` / literal newline) is part
@@ -366,13 +366,21 @@ def has_quote_ok_override(tool_name: str, tool_input: ToolInput) -> bool:
     (``cmd "x";echo --quote-ok``) so the first-segment rule holds
     regardless of whitespace.
 
-    The env mapping on the tool input may set ``QUOTE_OK=1`` (the
-    harness exposes the env block separately from the command string).
+    ``QUOTE_OK=1`` is honoured from the process environment
+    (``os.environ``) — the documented env escape (#1213 AC §3). The
+    Claude Code PreToolUse payload for a ``Bash`` tool carries NO ``env``
+    block, so the agent's ``QUOTE_OK=1`` lives in the hook subprocess's
+    own environment; reading only ``tool_input["env"]`` meant the
+    documented escape never reached the wrapper and the gate could only
+    be cleared by paraphrasing (#126). ``tool_input["env"]`` is still
+    consulted for any harness build that DOES populate it.
     """
     if tool_name == "Bash":
         command = tool_input.get("command", "")
         if "--quote-ok" in _first_segment_words(command):
             return True
+    if os.environ.get("QUOTE_OK", "").strip() == "1":
+        return True
     env = tool_input.get("env") or {}
     return env.get("QUOTE_OK", "").strip() == "1"
 

--- a/tests/teatree_cli/test_review_live_approval_eval.py
+++ b/tests/teatree_cli/test_review_live_approval_eval.py
@@ -1,0 +1,234 @@
+r"""Eval matrix for the live-post-approval authorization gate (#1207, #126).
+
+The gate-over-deny lockout this guards against: ``t3 review
+approve-live-post`` historically minted the live-post token ONLY from a
+fresh Slack-DM ts carrying one of three hard-coded phrases. A user who
+approved the post four times in chat + an AskUserQuestion AND recorded a
+durable on-behalf approval token still could not get a live post out —
+the gate fail-closed against every legitimate authorization channel that
+was not the one narrow Slack-ts path.
+
+This matrix asserts the four authorization scenarios as a unit:
+
+* a recorded on-behalf approval (the durable human authorization minted
+    by ``t3 review approve-on-behalf <scope> post_comment``) is sufficient
+    to mint the live-post token — no Slack ts required;
+* a natural approval phrase in the Slack DM (``"post the findings"`` /
+    ``"post them"`` / ``"approved"`` / ``"ship it"``) is accepted;
+* the original explicit phrase (``"go ahead"`` etc.) still works;
+* NO approval of any kind → still blocked (the genuine guard).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from django.utils import timezone
+from typer.testing import CliRunner
+
+from teatree.cli import app
+from teatree.config import OnBehalfPostMode
+from teatree.core.models.live_post_approval import LivePostApproval
+from teatree.core.models.on_behalf_approval import OnBehalfApproval
+
+pytestmark = pytest.mark.django_db
+
+_runner = CliRunner()
+
+
+def _write_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, user_id: str = "U-OPERATOR") -> None:
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text(
+        f'[teatree]\nslack_user_id = "{user_id}"\non_behalf_post_mode = "{OnBehalfPostMode.IMMEDIATE.value}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+
+
+class TestLivePostApprovalAuthorizationMatrix:
+    """The four authorization scenarios for minting a live-post token."""
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_cfg(tmp_path, monkeypatch)
+        self.tmp_path = tmp_path
+        self.monkeypatch = monkeypatch
+
+    def _wire_slack_backend(self, *, message: dict[str, object] | None) -> MagicMock:
+        backend = MagicMock()
+        backend.open_dm.return_value = "D-OPERATOR"
+        backend.fetch_message.return_value = message
+        self.monkeypatch.setattr(
+            "teatree.core.backend_factory.messaging_from_overlay",
+            lambda: backend,
+        )
+        return backend
+
+    def _fresh_ts(self) -> str:
+        return f"{timezone.now().timestamp():.4f}"
+
+    # ── ALLOW: recorded on-behalf approval mints the token ──────────
+
+    def test_recorded_on_behalf_approval_mints_live_token(self) -> None:
+        # The durable human authorization (id=N) IS sufficient — no Slack
+        # ts, no phrase. This is the lockout the issue describes.
+        OnBehalfApproval.record(target="org/repo!7", action="post_comment", approver_id="U-OPERATOR")
+
+        result = _runner.invoke(
+            app,
+            ["review", "approve-live-post", "org/repo!7", "--from-on-behalf"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "OK recorded live-post approval" in result.output
+        row = LivePostApproval.objects.get(mr_url="org/repo!7")
+        assert row.consumed_at is None
+
+    def test_on_behalf_approval_accepts_gitlab_url_scope(self) -> None:
+        OnBehalfApproval.record(target="org/repo!7", action="post_comment", approver_id="U-OPERATOR")
+
+        result = _runner.invoke(
+            app,
+            [
+                "review",
+                "approve-live-post",
+                "https://gitlab.com/org/repo/-/merge_requests/7",
+                "--from-on-behalf",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert LivePostApproval.objects.filter(mr_url="org/repo!7").exists()
+
+    def test_from_on_behalf_without_recorded_approval_is_blocked(self) -> None:
+        # No on-behalf row for this scope → the durable-authorization
+        # path cannot mint a token. Genuine guard preserved.
+        result = _runner.invoke(
+            app,
+            ["review", "approve-live-post", "org/repo!7", "--from-on-behalf"],
+        )
+
+        assert result.exit_code == 1
+        assert "Refused" in result.output
+        assert LivePostApproval.objects.count() == 0
+
+    def test_on_behalf_approval_for_other_mr_does_not_authorize(self) -> None:
+        OnBehalfApproval.record(target="org/repo!1", action="post_comment", approver_id="U-OPERATOR")
+
+        result = _runner.invoke(
+            app,
+            ["review", "approve-live-post", "org/repo!2", "--from-on-behalf"],
+        )
+
+        assert result.exit_code == 1
+        assert LivePostApproval.objects.filter(mr_url="org/repo!2").count() == 0
+
+    # ── ALLOW: natural approval wording in the Slack DM ─────────────
+
+    @pytest.mark.parametrize(
+        "phrase",
+        ["post the findings", "post them", "approved", "ship it"],
+    )
+    def test_natural_approval_phrase_is_accepted(self, phrase: str) -> None:
+        ts = self._fresh_ts()
+        self._wire_slack_backend(message={"user": "U-OPERATOR", "text": phrase})
+
+        result = _runner.invoke(
+            app,
+            ["review", "approve-live-post", "org/repo!7", "--slack-ts", ts],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert LivePostApproval.objects.filter(mr_url="org/repo!7").exists()
+
+    # ── ALLOW: the original explicit phrase still works ─────────────
+
+    @pytest.mark.parametrize("phrase", ["go ahead", "post live", "submit it"])
+    def test_explicit_phrase_still_accepted(self, phrase: str) -> None:
+        ts = self._fresh_ts()
+        self._wire_slack_backend(message={"user": "U-OPERATOR", "text": phrase})
+
+        result = _runner.invoke(
+            app,
+            ["review", "approve-live-post", "org/repo!7", "--slack-ts", ts],
+        )
+
+        assert result.exit_code == 0, result.output
+
+    # ── BLOCK: no approval of any kind ──────────────────────────────
+
+    def test_no_authorization_at_all_is_blocked(self) -> None:
+        # Neither --slack-ts nor --from-on-behalf, no recorded row.
+        result = _runner.invoke(
+            app,
+            ["review", "approve-live-post", "org/repo!7"],
+        )
+
+        assert result.exit_code == 1
+        assert "Refused" in result.output
+        assert LivePostApproval.objects.count() == 0
+
+    def test_slack_ts_without_any_approval_phrase_is_blocked(self) -> None:
+        ts = self._fresh_ts()
+        self._wire_slack_backend(message={"user": "U-OPERATOR", "text": "thumbs up"})
+
+        result = _runner.invoke(
+            app,
+            ["review", "approve-live-post", "org/repo!7", "--slack-ts", ts],
+        )
+
+        assert result.exit_code == 1
+        assert "Refused" in result.output
+        assert LivePostApproval.objects.count() == 0
+
+    def test_from_on_behalf_falls_through_to_slack_when_no_token(self) -> None:
+        # --from-on-behalf with NO recorded approval but a valid --slack-ts
+        # falls through to the Slack-DM channel (both flags passed; the
+        # on-behalf miss is not fatal when a DM authorization exists).
+        ts = self._fresh_ts()
+        self._wire_slack_backend(message={"user": "U-OPERATOR", "text": "go ahead"})
+
+        result = _runner.invoke(
+            app,
+            ["review", "approve-live-post", "org/repo!7", "--from-on-behalf", "--slack-ts", ts],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert LivePostApproval.objects.filter(mr_url="org/repo!7").exists()
+
+    def test_no_user_id_configured_is_refused(self) -> None:
+        # A config with no slack_user_id cannot verify any authorization.
+        cfg = self.tmp_path / ".teatree.toml"
+        cfg.write_text(f'[teatree]\non_behalf_post_mode = "{OnBehalfPostMode.IMMEDIATE.value}"\n', encoding="utf-8")
+        self.monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+        self.monkeypatch.setattr("teatree.core.notify._resolve_user_id", lambda: "")
+
+        result = _runner.invoke(
+            app,
+            ["review", "approve-live-post", "org/repo!7", "--from-on-behalf"],
+        )
+
+        assert result.exit_code == 1
+        assert "Refused" in result.output
+        assert "user_id" in result.output
+
+    # ── FAIL-OPEN on a broken env never silently AUTHORIZES ─────────
+
+    def test_broken_slack_backend_blocks_not_authorizes(self) -> None:
+        # A missing backend must REFUSE (fail closed on the authorization
+        # decision) rather than mint a token — fail-open here means "do
+        # not grant", the conservative direction for a publish gate.
+        self.monkeypatch.setattr(
+            "teatree.core.backend_factory.messaging_from_overlay",
+            lambda: None,
+        )
+        ts = self._fresh_ts()
+
+        result = _runner.invoke(
+            app,
+            ["review", "approve-live-post", "org/repo!7", "--slack-ts", ts],
+        )
+
+        assert result.exit_code == 1
+        assert "Refused" in result.output
+        assert LivePostApproval.objects.count() == 0

--- a/tests/test_banned_terms_env_override_eval.py
+++ b/tests/test_banned_terms_env_override_eval.py
@@ -1,0 +1,102 @@
+"""Eval matrix for the banned-terms egress-wrapper escape hatch (#1415, #126).
+
+The gate-over-deny lockout this guards against: the documented
+``--allow-banned-term`` / ``ALLOW_BANNED_TERM=1`` override did NOT
+propagate through the wrapper. The override check read ONLY
+``tool_input["env"]``, but the Claude Code PreToolUse payload for a
+``Bash`` tool carries no ``env`` block — the agent's
+``ALLOW_BANNED_TERM=1`` process env var (inherited by the hook
+subprocess via ``os.environ``) never reached the gate, forcing
+numeric-id + paraphrase workarounds all session.
+
+Scenario matrix:
+
+* the ``ALLOW_BANNED_TERM=1`` override in the process env → ALLOW;
+* no override + a banned term in a POST → BLOCK;
+* fails OPEN on a broken env (no config / unreadable env).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hooks.scripts.hook_router import handle_banned_terms_pretool
+from teatree.hooks.banned_terms_scanner import has_override, scan_text
+
+
+@pytest.fixture
+def _term_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin a one-term banned-list config so the shell scanner has something to flag."""
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text('[teatree]\nbanned_terms = ["acmecorp"]\n', encoding="utf-8")
+    monkeypatch.setenv("T3_BANNED_TERMS_CONFIG", str(cfg))
+    return cfg
+
+
+def _bash(command: str) -> dict[str, object]:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class TestAllowBannedTermEnvReachesWrapper:
+    """``ALLOW_BANNED_TERM=1`` in the process env bypasses the gate."""
+
+    def test_process_env_override_is_honoured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ALLOW_BANNED_TERM", "1")
+        cmd = 'gh issue create --title t --body "mention of acmecorp here"'
+        assert has_override("Bash", {"command": cmd}) is True
+
+    def test_process_env_override_zero_does_not_bypass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ALLOW_BANNED_TERM", "0")
+        cmd = 'gh issue create --title t --body "mention of acmecorp here"'
+        assert has_override("Bash", {"command": cmd}) is False
+
+    def test_tool_input_env_still_honoured(self) -> None:
+        cmd = 'gh issue create --title t --body "acmecorp"'
+        assert has_override("Bash", {"command": cmd, "env": {"ALLOW_BANNED_TERM": "1"}}) is True
+
+    def test_flag_in_first_segment_still_honoured(self) -> None:
+        cmd = 'gh issue create --title t --body "acmecorp" --allow-banned-term'
+        assert has_override("Bash", {"command": cmd}) is True
+
+    @pytest.mark.usefixtures("_term_config")
+    def test_process_env_override_bypasses_block_end_to_end(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("ALLOW_BANNED_TERM", "1")
+        data = _bash('gh issue create --title t --body "acmecorp ships next week"')
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+
+class TestBannedTermGenuineGuardIntact:
+    """The override must not weaken the real block on a genuine violation."""
+
+    @pytest.mark.usefixtures("_term_config")
+    def test_banned_term_in_post_without_override_is_blocked(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("ALLOW_BANNED_TERM", raising=False)
+        data = _bash('gh issue create --title t --body "acmecorp ships next week"')
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+        assert "acmecorp" in out["permissionDecisionReason"]
+
+    def test_clean_body_is_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ALLOW_BANNED_TERM", raising=False)
+        cmd = 'gh issue create --title t --body "acmecorp"'
+        # No override env, no flag → no bypass (the block decision is then
+        # made by the scanner against the config).
+        assert has_override("Bash", {"command": cmd}) is False
+
+
+class TestBannedTermFailsOpenOnBrokenEnv:
+    """A missing config / unreadable scanner must fail OPEN (no block)."""
+
+    def test_no_config_fails_open(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_BANNED_TERMS_CONFIG", str(tmp_path / "does-not-exist.toml"))
+        # No config ⇒ scan_text returns None ⇒ the gate never blocks.
+        assert scan_text("acmecorp leak") is None

--- a/tests/test_protect_default_branch_target_eval.py
+++ b/tests/test_protect_default_branch_target_eval.py
@@ -1,0 +1,164 @@
+"""Eval matrix for the protected-branch Write/Edit gate (#126).
+
+The gate-over-deny lockout this guards against: the gate keyed on the
+branch of whatever repo ENCLOSES the target file's parent dir
+(``git -C <parent> rev-parse``). ``git`` walks UP the directory tree to
+the nearest ``.git``, so a Write to the agent memory dir
+(``~/.claude/projects/*/memory/*.md``) — which is itself inside a git
+repo on ``main`` (the agent-config dotfiles repo) — was blocked as "on
+protected branch 'main'", even though the memory file is agent scratch
+state, never protected source.
+
+The sharpened scope: the gate protects ONLY teatree-MANAGED source
+repos (teatree core + the active overlay's registered repos, read from
+``~/.teatree.toml`` ``workspace_repos`` / ``frontend_repos`` /
+``public_repos`` plus each overlay ``path``). It keys on the TARGET
+FILE's repo, never on the cwd's branch, and never on "is the file in
+ANY git repo". An unmanaged git repo on ``main`` is allowed; the agent
+memory dir is explicitly exempt even when git-tracked.
+
+Scenario matrix:
+
+* Write to a tracked file in a teatree-MANAGED repo on main → BLOCK;
+* Write to the agent memory dir (git-tracked, on main) → ALLOW;
+* Write to a file in an UNMANAGED git repo on main → ALLOW;
+* Write to a file OUTSIDE any git repo → ALLOW;
+* a write on a feature branch (managed repo) → ALLOW;
+* fails OPEN on a broken git env → ALLOW.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hooks.scripts.hook_router import handle_protect_default_branch
+
+_GIT = shutil.which("git")
+
+# A remote whose slug is teatree-managed (core's own slug is always
+# managed per ``_overlay_managed_repo_signals``).
+_MANAGED_REMOTE = "git@github.com:souliane/teatree.git"
+# A remote that no overlay registers — an ordinary unrelated repo.
+_UNMANAGED_REMOTE = "git@github.com:someone-else/unrelated-tool.git"
+
+
+def _git(repo: Path, *args: str) -> None:
+    assert _GIT is not None
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@e",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e",
+    }
+    subprocess.run([_GIT, "-C", str(repo), *args], check=True, capture_output=True, env=env)
+
+
+def _repo_on_branch(root: Path, branch: str, *, remote: str, name: str = "repo") -> Path:
+    repo = root / name
+    repo.mkdir()
+    assert _GIT is not None
+    env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
+    subprocess.run([_GIT, "init", "-b", branch], cwd=repo, check=True, capture_output=True, env=env)
+    _git(repo, "remote", "add", "origin", remote)
+    (repo / "tracked.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", "tracked.py")
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
+def _write(file_path: str) -> dict[str, object]:
+    return {"tool_name": "Write", "tool_input": {"file_path": file_path}}
+
+
+@pytest.fixture(autouse=True)
+def _no_overlay_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin HOME to an empty dir so only teatree-core's own slug is managed.
+
+    Keeps the managed-repo classification deterministic — it does not
+    pick up the developer's real ``~/.teatree.toml`` overlay repos.
+    """
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+
+
+@pytest.mark.skipif(_GIT is None, reason="git not on PATH")
+class TestProtectedBranchManagedScoping:
+    """The gate blocks only teatree-managed source on a protected branch."""
+
+    def test_managed_repo_tracked_file_on_main_is_blocked(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = _repo_on_branch(tmp_path, "main", remote=_MANAGED_REMOTE)
+        blocked = handle_protect_default_branch(_write(str(repo / "tracked.py")))
+        assert blocked is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+        assert "protected branch" in out["permissionDecisionReason"]
+
+    def test_managed_repo_new_source_file_on_main_is_blocked(self, tmp_path: Path) -> None:
+        repo = _repo_on_branch(tmp_path, "main", remote=_MANAGED_REMOTE)
+        assert handle_protect_default_branch(_write(str(repo / "newfile.py"))) is True
+
+    def test_unmanaged_repo_on_main_is_allowed(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # A git repo on `main` that no overlay registers must NOT block —
+        # the gate guards teatree-managed source only, not every repo.
+        repo = _repo_on_branch(tmp_path, "main", remote=_UNMANAGED_REMOTE)
+        blocked = handle_protect_default_branch(_write(str(repo / "tracked.py")))
+        assert blocked is False, "an unmanaged repo on main must not be blocked"
+        assert capsys.readouterr().out == ""
+
+    def test_memory_dir_in_managed_repo_on_main_is_allowed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The reproduction: the agent memory dir is git-tracked and on
+        # `main`, inside a teatree-managed repo — it is still agent
+        # scratch state, never protected source.
+        repo = _repo_on_branch(tmp_path, "main", remote=_MANAGED_REMOTE)
+        memory = repo / ".claude" / "projects" / "proj" / "memory"
+        memory.mkdir(parents=True)
+        blocked = handle_protect_default_branch(_write(str(memory / "MEMORY.md")))
+        assert blocked is False, "agent memory dir must be exempt even in a managed repo on main"
+        assert capsys.readouterr().out == ""
+
+    def test_codex_memory_dir_is_allowed(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        repo = _repo_on_branch(tmp_path, "main", remote=_MANAGED_REMOTE)
+        memory = repo / ".codex" / "projects" / "x" / "memory"
+        memory.mkdir(parents=True)
+        assert handle_protect_default_branch(_write(str(memory / "topic.md"))) is False
+        assert capsys.readouterr().out == ""
+
+    def test_file_outside_any_repo_is_allowed(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        target = tmp_path / "scratch" / "note.txt"
+        target.parent.mkdir()
+        assert handle_protect_default_branch(_write(str(target))) is False
+        assert capsys.readouterr().out == ""
+
+    def test_managed_repo_on_feature_branch_is_allowed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = _repo_on_branch(tmp_path, "feature-x", remote=_MANAGED_REMOTE)
+        assert handle_protect_default_branch(_write(str(repo / "tracked.py"))) is False
+        assert capsys.readouterr().out == ""
+
+    def test_broken_git_env_fails_open(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_protect_default_branch(_write(str(tmp_path / "ghost" / "file.txt"))) is False
+        assert capsys.readouterr().out == ""
+
+    def test_managed_via_overlay_path_is_blocked(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A repo with no managed slug, but whose working tree is under an
+        # overlay's registered ``path``, is managed too.
+        home = tmp_path / "home2"
+        home.mkdir(exist_ok=True)
+        repo = _repo_on_branch(tmp_path, "main", remote=_UNMANAGED_REMOTE, name="overlay-repo")
+        cfg = home / ".teatree.toml"
+        cfg.write_text(f'[overlays.x]\npath = "{repo}"\n', encoding="utf-8")
+        monkeypatch.setenv("HOME", str(home))
+        assert handle_protect_default_branch(_write(str(repo / "tracked.py"))) is True

--- a/tests/test_quote_scanner_env_override_eval.py
+++ b/tests/test_quote_scanner_env_override_eval.py
@@ -1,0 +1,120 @@
+"""Eval matrix for the quote-scanner egress-wrapper escape hatch (#1213, #126).
+
+The gate-over-deny lockout this guards against: the documented
+``QUOTE_OK=1`` escape did NOT propagate to the egress wrapper. The
+override check read ONLY ``tool_input["env"]`` — but the Claude Code
+PreToolUse payload for a ``Bash`` tool carries no ``env`` block, so the
+agent's ``QUOTE_OK=1`` process env var (which the hook subprocess
+inherits via ``os.environ``) never reached the gate. The escape was
+documented in every block message yet structurally unreachable, forcing
+paraphrase workarounds all session.
+
+Scenario matrix (accepts a legitimately-authorized action / still
+blocks a genuine violation / the documented escape actually works /
+fails-OPEN on a broken env):
+
+* a clean body → ALLOW;
+* ``QUOTE_OK=1`` in the process env (``os.environ``) → ALLOW;
+* an actual user-verbatim quote, no override → BLOCK;
+* the body in a file the scanner cannot read → NOT auto-denied
+    (treat as needs-inline, scan what it can — a missing draft file is
+    not a leak).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hooks.scripts.hook_router import handle_quote_scanner_pretool
+from teatree.hooks.quote_scanner import extract_publish_payload, has_quote_ok_override, scan_text
+
+
+@pytest.fixture(autouse=True)
+def _isolated_ledger(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("T3_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _bash(command: str) -> dict[str, object]:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class TestQuoteOkEnvReachesWrapper:
+    """``QUOTE_OK=1`` in the process env bypasses the gate (the documented escape)."""
+
+    def test_process_env_quote_ok_is_honoured_by_override_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("QUOTE_OK", "1")
+        cmd = 'gh pr create --title t --body "the user said: ship it now"'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is True
+
+    def test_process_env_quote_ok_zero_does_not_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("QUOTE_OK", "0")
+        cmd = 'gh pr create --title t --body "the user said: ship it now"'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+    def test_process_env_quote_ok_bypasses_high_match_end_to_end(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("QUOTE_OK", "1")
+        data = _bash('gh pr create --title t --body "## User mandate\nfoo"')
+        blocked = handle_quote_scanner_pretool(data)
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_tool_input_env_still_honoured(self) -> None:
+        # The legacy ``tool_input["env"]`` surface keeps working — a
+        # harness that DOES populate it is not regressed.
+        cmd = 'gh pr create --title t --body "the user said: foo"'
+        assert has_quote_ok_override("Bash", {"command": cmd, "env": {"QUOTE_OK": "1"}}) is True
+
+
+class TestQuoteScannerGenuineGuardsIntact:
+    """The override must not weaken the real block / clean-allow contract."""
+
+    def test_clean_body_is_allowed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        data = _bash('gh pr create --title t --body "Refactored the config loader."')
+        assert handle_quote_scanner_pretool(data) is False
+        assert capsys.readouterr().err == ""
+
+    def test_actual_user_quote_without_override_is_blocked(self, capsys: pytest.CaptureFixture[str]) -> None:
+        data = _bash('gh pr create --title t --body "## User mandate\nplease ship now"')
+        assert handle_quote_scanner_pretool(data) is True
+        out = json.loads(capsys.readouterr().out)
+        assert out["permissionDecision"] == "deny"
+
+    def test_no_env_var_means_no_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("QUOTE_OK", raising=False)
+        cmd = 'gh pr create --title t --body "the user said: foo"'
+        assert has_quote_ok_override("Bash", {"command": cmd}) is False
+
+
+class TestUnreadableBodyFileIsNotAutoDenied:
+    """A ``--body-file`` the scanner cannot read is needs-inline, not a leak (#126)."""
+
+    def test_missing_gh_body_file_does_not_fail_closed(self) -> None:
+        # A drafted ``--body-file`` that does not exist at scan time (the
+        # agent writes it later, or it was a typo) carries no body — the
+        # gate must NOT manufacture a fail-closed HIGH finding out of an
+        # absent file. Nothing to scan ⇒ no leak.
+        cmd = "gh pr create --title t --body-file /nonexistent/draft-126.md"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        scan = scan_text(payload)
+        assert not scan.has_high, f"a missing --body-file must not auto-deny; findings={scan.findings!r}"
+
+    def test_missing_gh_body_file_end_to_end_does_not_block(self, capsys: pytest.CaptureFixture[str]) -> None:
+        data = _bash("gh pr create --title t --body-file /nonexistent/draft-126.md")
+        blocked = handle_quote_scanner_pretool(data)
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_readable_body_file_with_quote_still_blocks(self, tmp_path: Path) -> None:
+        # The carve-out is ONLY for an unreadable file — a readable
+        # body-file carrying a verbatim quote still trips the gate.
+        body_path = tmp_path / "pr.md"
+        body_path.write_text("## User directive\nbody\n", encoding="utf-8")
+        cmd = f"gh pr create --title t --body-file {body_path}"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert scan_text(payload).has_high


### PR DESCRIPTION
## Summary

Repairs the teatree **gate-over-deny / lockout class** (#126): four safety gates fail-closed against *legitimately user-authorized* actions, deadlocking the autonomous factory. Each gate keeps its genuine safety block on real violations and fails OPEN on a broken/unreadable env — the fix is to stop rejecting the legitimate path, not to weaken the guard. Every gate gets an eval-style parametrized regression matrix: accepts a legit action / still blocks a genuine violation / the documented escape actually works / fails open on a broken env.

## Gates fixed (priority order)

1. **#1207 LivePostApproval** (`cli/review_live_approval.py`) — minting the live-post token required one of three magic Slack phrases via a fresh DM ts, and ignored a recorded on-behalf approval token. Now:
   - a recorded `OnBehalfApproval` for `(scope, post_comment)` authorizes via `--from-on-behalf` (the on-behalf token IS the durable human authorization);
   - `APPROVAL_PHRASES` broadened to natural wording (`post the findings`, `post them`, `approved`, `ship it`, …), still whole-word + negation-rejecting;
   - no approval of any kind still blocks.

2. **#1213 quote-scanner** (`hooks/quote_scanner.py`, `hooks/_command_parser.py`) — the documented `QUOTE_OK=1` escape never reached the wrapper (the PreToolUse Bash payload has no `env` block; the var lives in `os.environ`). Now `has_quote_ok_override` reads the process env. A missing `gh`/`glab` `--body-file` is treated as needs-inline (no payload) rather than a fail-closed HIGH — `git commit -F` keeps fail-closed (commit messages can't be amended post-push), and `--input -`/`@file` stay fail-closed.

3. **#1415 banned-terms** (`hooks/banned_terms_scanner.py`) — same wrapper-propagation gap: `ALLOW_BANNED_TERM=1` now honoured from `os.environ`, ending the numeric-id + paraphrase workarounds.

4. **protected-branch Write/Edit gate** (`hooks/scripts/hook_router.py`) — keyed on whatever repo *enclosed* the file's parent dir, so a Write to the agent memory dir (git-tracked, on `main`) was blocked. Now scoped to the TARGET FILE's repo: blocks only **teatree-managed** source (core + the active overlay's registered repos) on a protected branch, exempts the agent memory dir, and allows files outside any repo / in unmanaged repos. Fails open on any git error.

## Eval coverage

- `tests/teatree_cli/test_review_live_approval_eval.py` — on-behalf token / natural phrase / explicit phrase / nothing → BLOCK / fall-through / no-user-id / broken-backend.
- `tests/test_quote_scanner_env_override_eval.py` — `QUOTE_OK` via process env, genuine quote still blocks, missing body-file not auto-denied.
- `tests/test_banned_terms_env_override_eval.py` — `ALLOW_BANNED_TERM` via process env, genuine term still blocks, no-config fails open.
- `tests/test_protect_default_branch_target_eval.py` — managed-repo source on main → BLOCK, memory dir / unmanaged repo / outside-any-repo → ALLOW, broken git → fail open.

Each regression test was observed RED on the pre-fix code before the fix.

## Status

- Full suite green (8152 passed, 14 skipped, 3 xfailed); coverage gate 93.50% >= 93.0%.
- `prek` green on all changed files; ruff check + format clean.
- Rebased on latest `origin/main` (#1486 / #1478) — no conflicts (the gate functions are disjoint from #1486's `handle_validate_mr_metadata`).
- Do NOT merge — needs independent review.