### PR TITLE
fix(db): runtime-resolved self-DB migrate self-rescue + doctor settings (#126)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3120,6 +3120,8 @@ Usage: t3 teatree db [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ migrate          Apply pending migrations to the runtime self-DB             │
+│                  (non-destructive self-rescue).                              │
 │ refresh          Re-import the worktree database from dump/DSLR.             │
 │ restore-ci       Restore database from the latest CI dump.                   │
 │ reset-passwords  Reset all user passwords to a known dev value.              │
@@ -3127,6 +3129,35 @@ Usage: t3 teatree db [OPTIONS] COMMAND [ARGS]...
 │                  as JSON.                                                    │
 │ shell            Drop into a Django shell against the resolved (gate)        │
 │                  control DB.                                                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree db migrate`
+
+```
+Usage: t3 teatree db migrate [OPTIONS]
+
+ Apply pending migrations to the runtime self-DB, non-destructively.
+
+ The always-available self-rescue for a stale runtime control DB —
+ the exact gap that locks out the sanctioned merge path
+ (``ticket clear``/``merge`` refuse on ANY pending migration). It
+ delegates to :func:`teatree.core.schema_guard.migrate_self_db`, which
+ runs ``migrate --no-input`` *in this process* against the same
+ connection the merge gate reads, so "migrate then re-check"
+ converges on one DB.
+
+ Unlike ``resetdb`` this drops nothing — live ticket/session/lease
+ rows survive. Unlike the old ``uv --directory <clone>`` wrapper it
+ cannot target a different (auto-isolated) DB than the runtime
+ resolves. Dispatched via teatree-core (``python -m teatree``) so it
+ reaches the runtime self-DB regardless of which overlay invokes it.
+
+ Fail-closed: a real migrate failure exits non-zero with the captured
+ error, never leaving a half-migrated DB look like a success.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -3305,18 +3336,26 @@ Usage: t3 teatree pr create [OPTIONS] TICKET_ID
  ``--title`` overrides the PR title (default: last commit subject).
  Stored on ``ticket.extra['pr_title_override']`` so the ship reads it.
 
+ ``--skip-validation`` skips the heavy ship gates (visual QA, branch
+ currency, FSM phase check) but STILL runs the cheap MR
+ title/description format check. ``--skip-mr-format-check`` is the
+ separate, explicit opt-in that disables that format check too — needed
+ only in the rare case where a non-canonical title must ship anyway.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    ticket_id      TEXT  [required]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --title                                      TEXT                            │
-│ --dry-run            --no-dry-run                  [default: no-dry-run]     │
-│ --skip-validation    --no-skip-validation          [default:                 │
-│                                                    no-skip-validation]       │
-│ --skip-visual-qa                             TEXT                            │
-│ --sync               --no-sync                     [default: no-sync]        │
-│ --help                                             Show this message and     │
-│                                                    exit.                     │
+│ --title                                          TEXT                        │
+│ --dry-run                --no-dry-run                  [default: no-dry-run] │
+│ --skip-validation        --no-skip-validation          [default:             │
+│                                                        no-skip-validation]   │
+│ --skip-mr-format-che…    --no-skip-mr-format…          [default:             │
+│                                                        no-skip-mr-format-ch… │
+│ --skip-visual-qa                                 TEXT                        │
+│ --sync                   --no-sync                     [default: no-sync]    │
+│ --help                                                 Show this message and │
+│                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/management-commands.md
+++ b/docs/management-commands.md
@@ -36,6 +36,7 @@ Database operations on worktrees.
 
 | Subcommand | Arguments | Returns | Description |
 |------------|-----------|---------|-------------|
+| `migrate` | — | string | Applies pending migrations to the runtime self-DB in-process (non-destructive self-rescue for a stale control DB; the always-available unblock when the merge path refuses on unapplied migrations) |
 | `refresh` | `--path`, `--dslr-snapshot`, `--dump-path`, `--force` | string | Re-imports the worktree database from DSLR snapshot or dump, runs post-DB steps and password reset |
 | `restore-ci` | `--path` | string | Restores the worktree database from the latest CI dump |
 | `reset-passwords` | `--path` | string | Resets all user passwords to a known dev value via the overlay's reset command |

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -42,13 +42,21 @@ hard-fails.
 
 ## Self-DB Migrations
 
-`t3 update` probes the teatree self-DB with `manage.py migrate --check`
-and, when migrations are pending, applies them **non-destructively** (the
-`uv --directory <clone> run python manage.py migrate --no-input` path, no
-DB drop). This is the sanctioned first-class alternative to the
-destructive `resetdb` (which discards all local ticket/session/lease
-state) and the raw `manage.py migrate` the PreToolUse hook router
-discourages.
+`t3 update` probes the teatree self-DB and, when migrations are pending,
+applies them **non-destructively** (no DB drop). Both the probe and the
+migrate run **in the runtime interpreter** (`python -m teatree migrate`),
+so they target the exact control DB the running `t3` resolves — not a
+`uv --directory <clone>` sibling DB, which for a worktree-anchored editable
+install auto-isolates onto a different DB and silently reports
+"already migrated" while the runtime DB stays stale (#126). This is the
+sanctioned first-class alternative to the destructive `resetdb` (which
+discards all local ticket/session/lease state).
+
+For an on-demand, always-available self-rescue of a stale runtime self-DB —
+e.g. when the sanctioned merge path refuses with "unapplied migration(s)" —
+run `t3 teatree db migrate`. It applies pending migrations in-process against
+the same DB the merge gate reads, is idempotent and non-destructive, and is
+reachable even while the merge gate is refusing.
 
 The migration is gated on **whether migrations are actually pending —
 not on whether a repo advanced this run** (#929). An interrupted prior

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -1,0 +1,214 @@
+"""Overlay Django command-group catalogue.
+
+The static description of every ``t3 <overlay> <group> <sub>`` command tree
+(``DjangoGroup`` + the ``DJANGO_GROUPS`` table), split out of ``overlay.py`` so
+the app-builder logic and this data catalogue each stay a focused module.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DjangoGroup:
+    """One overlay sub-app group description.
+
+    ``core_dispatch`` flags groups whose subcommands live in
+    ``teatree.core.management.commands`` (not in any overlay-owned
+    ``manage.py``). When ``True``, :meth:`OverlayAppBuilder._bridge_subcommand`
+    dispatches via :func:`managepy_core` (``python -m teatree``) so the call
+    never reaches an overlay's ``manage.py`` whose settings module may not
+    register the command (#1318 follow-up to #1312).
+
+    ``core_subcommands`` is the *per-subcommand* variant for a mixed group:
+    most subcommands route through the overlay ``manage.py`` (they drive the
+    overlay's own behaviour) but a named few must run in the teatree-core
+    runtime. ``db`` is the canonical case — ``refresh``/``restore-ci`` need
+    the overlay's ``db_import`` strategy, but ``migrate`` must migrate the
+    teatree-core control DB the merge gate reads, in the runtime process
+    (#126).
+    """
+
+    help_text: str
+    subcommands: list[tuple[str, str]]
+    core_dispatch: bool = False
+    core_subcommands: frozenset[str] = frozenset()
+
+    def dispatches_to_core(self, sub_name: str) -> bool:
+        """True iff *sub_name* must dispatch via teatree-core, not overlay manage.py."""
+        return self.core_dispatch or sub_name in self.core_subcommands
+
+
+DJANGO_GROUPS: dict[str, DjangoGroup] = {
+    "worktree": DjangoGroup(
+        "Per-worktree FSM operations.",
+        [
+            ("provision", "Run DB import + env cache + direnv + prek + overlay setup steps for one worktree."),
+            ("start", "Boot ``docker compose up`` for one worktree."),
+            ("verify", "Run overlay health checks for one worktree."),
+            ("ready", "Run runtime readiness probes for one worktree."),
+            ("teardown", "Stop docker, drop DB, remove git worktree, delete row."),
+            ("status", "Report FSM state, branch, and allocated host ports for one worktree."),
+            ("diagnose", "Print a structured health checklist for one worktree."),
+            ("smoke-test", "Quick health check: overlay loads, CLI responds, imports OK."),
+            ("diagram", "Print a state diagram as Mermaid. Models: worktree, ticket, task."),
+        ],
+    ),
+    "workspace": DjangoGroup(
+        "Ticket-level workspace operations (every worktree in the ticket).",
+        [
+            ("ticket", "Create or update a ticket and trigger worktree provisioning."),
+            ("provision", "Provision every worktree in the current ticket workspace."),
+            ("start", "Start docker for every worktree in the current ticket workspace."),
+            ("ready", "Run readiness probes for every worktree in the ticket workspace."),
+            ("teardown", "Tear down every worktree in the current ticket workspace."),
+            ("finalize", "Squash worktree commits and rebase on the default branch."),
+            ("doctor", "Detect state drift across every store; optionally fix it."),
+            ("clean-merged", "Tear down every worktree whose ticket is already MERGED."),
+            ("clean-all", "Prune merged worktrees, stale branches, orphaned stashes, orphan DBs, old DSLR snapshots."),
+            ("list-orphans", "List orphan branches (commits not on main, no open PR)."),
+        ],
+    ),
+    "run": DjangoGroup(
+        "Run services.",
+        [
+            ("verify", "Verify worktree state and return URLs."),
+            ("services", "Return configured run commands."),
+            ("backend", "Start the backend dev server."),
+            ("frontend", "Start the frontend dev server."),
+            ("build-frontend", "Build the frontend for production/testing."),
+            ("tests", "Run the project test suite."),
+        ],
+    ),
+    "e2e": DjangoGroup(
+        "E2E test commands.",
+        [
+            ("run", "Run E2E tests — dispatches to project or external runner based on overlay config."),
+            ("trigger-ci", "Trigger E2E tests on a remote CI pipeline."),
+            ("external", "Run Playwright tests from the external test repo (T3_PRIVATE_TESTS)."),
+            ("project", "Run E2E tests from the project's own test directory."),
+            (
+                "post-evidence",
+                "Post structured E2E evidence on the ticket (validation-gated, idempotent on env+commit).",
+            ),
+        ],
+    ),
+    "db": DjangoGroup(
+        "Database operations.",
+        [
+            ("migrate", "Apply pending migrations to the runtime self-DB (non-destructive self-rescue)."),
+            ("refresh", "Re-import the worktree database from dump/DSLR."),
+            ("restore-ci", "Restore database from the latest CI dump."),
+            ("reset-passwords", "Reset all user passwords to a known dev value."),
+            ("query", "Run a read-only SQL query against the control DB; emit rows as JSON."),
+            ("shell", "Drop into a Django shell against the resolved (gate) control DB."),
+        ],
+        # `migrate` migrates the teatree-core control DB the merge gate reads,
+        # so it must run in the runtime process (#126); its siblings keep
+        # routing through the overlay manage.py.
+        core_subcommands=frozenset({"migrate"}),
+    ),
+    "pr": DjangoGroup(
+        "Pull request helpers.",
+        [
+            ("create", "Create a pull request for the ticket's branch."),
+            ("ensure-pr", "Create a PR for an orphan branch (idempotent)."),
+            ("check-gates", "Check whether session gates allow a phase transition."),
+            ("fetch-issue", "Fetch issue details from the configured tracker."),
+            ("detect-tenant", "Detect the current tenant variant from the overlay."),
+            ("post-evidence", "Post test evidence as a PR comment."),
+            ("sweep", "List your open PRs across the forge for the /t3:sweeping-prs skill."),
+        ],
+    ),
+    "tasks": DjangoGroup(
+        "Async task queue.",
+        [
+            ("cancel", "Cancel a task by ID."),
+            ("claim", "Claim the next available task."),
+            ("complete", "Mark a claimed task COMPLETED for work finished out-of-band."),
+            ("create", "Enqueue the next-phase task for a ticket."),
+            ("list", "List tasks with optional filters."),
+            ("start", "Claim and run the next interactive task in the current terminal."),
+            ("work-next-sdk", "Claim and execute an headless task."),
+            ("work-next-user-input", "Claim and execute a user input task."),
+        ],
+    ),
+    "followup": DjangoGroup(
+        "Follow-up snapshots.",
+        [
+            ("refresh", "Return counts of tickets and tasks."),
+            ("sync", "Synchronize followup data from MRs."),
+            ("discover-mrs", "List the user's open non-draft PRs/MRs awaiting a review request."),
+            ("remind", "Return list of pending user input tasks."),
+        ],
+        core_dispatch=True,
+    ),
+    "standup": DjangoGroup(
+        "Auto-generated daily update (read-only).",
+        [
+            ("generate", "Generate a standup from transition + attempt data (read-only)."),
+            ("stale", "List tickets with no activity past the staleness threshold (read-only)."),
+        ],
+    ),
+    "lifecycle": DjangoGroup(
+        "Session lifecycle and phase tracking.",
+        [
+            ("visit-phase", "Mark a phase as visited on the ticket's latest session."),
+            ("clear-ledger", "Clear a reused ticket's stale phase ledger (sanctioned session-retire)."),
+        ],
+    ),
+    "env": DjangoGroup(
+        "Inspect and mutate the worktree env cache.",
+        [
+            ("show", "Print the env cache as the DB would render it."),
+            ("set-var", "Persist an override on the worktree and refresh the cache."),
+            ("unset", "Delete an override row and refresh the cache."),
+            ("overrides", "List user-declared overrides for this worktree."),
+            ("check", "Exit non-zero if the on-disk cache diverges from the DB render."),
+            ("migrate-secrets", "Move POSTGRES_PASSWORD literals out of .t3-env.cache into pass."),
+        ],
+    ),
+    "ticket": DjangoGroup(
+        "Ticket state management.",
+        [
+            ("transition", "Transition a ticket to a new state."),
+            ("clear", "Issue a per-diff CLEAR — the orchestrator's only merge output (BLUEPRINT §17.4.2)."),
+            ("merge", "Execute the IN_REVIEW → MERGED keystone transition (BLUEPRINT §17.4)."),
+            ("list", "List tickets, optionally filtered by state and/or overlay."),
+            ("sync-completions", "Check post-ship tickets against upstream issues and advance completed ones."),
+            ("comment", "Post a comment to an issue or work item by its URL."),
+            ("context", "Durable per-ticket knowledge store: show / add / edit (#627)."),
+        ],
+        core_dispatch=True,
+    ),
+    "availability": DjangoGroup(
+        "24/7 dual question-mode (#58, BLUEPRINT §17.1 invariant 9).",
+        [
+            ("away", "Set manual away-mode override (questions queue as DeferredQuestion rows)."),
+            ("present", "Set manual present-mode override (questions ask interactively)."),
+            ("auto", "Clear manual override and fall back to schedule/default."),
+            ("show", "Print the currently resolved mode and source (override/schedule/default)."),
+        ],
+    ),
+    "questions": DjangoGroup(
+        "Manage the away-mode deferred-question backlog (#58).",
+        [
+            ("record", "Record a deferred question (used by the PreToolUse away-mode hook)."),
+            ("list", "List pending deferred questions, oldest first."),
+            ("answer", "Resolve a pending question with a user answer."),
+            ("dismiss", "Dismiss a pending question without answering it."),
+        ],
+    ),
+    "pending_chat": DjangoGroup(
+        "Manage the inbound Slack-DM queue (#1063).",
+        [
+            ("list", "List inbound rows from the last hour (or --all)."),
+            ("mark-answered", "Stamp ``answered_at`` on rows matching a Slack ts."),
+        ],
+    ),
+    "notify": DjangoGroup(
+        "Bot→user Slack DM from the shell (#1030).",
+        [
+            ("send", "DM the user; exit 0 on delivery, 1 otherwise (sub-agent direct notify)."),
+        ],
+    ),
+}

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -61,6 +61,7 @@ __all__ = (
     "_check_singletons",
     "_check_skills",
     "_do_ensure_plugin_registered",
+    "_ensure_django",
     "_ensure_plugin_registered",
     "_find_host_project_root",
     "_find_teatree_pyproject_from_cwd",
@@ -80,6 +81,21 @@ __all__ = (
 def agent_skill_dirs() -> list[tuple[str, Path]]:
     """Return (runtime_label, skills_dir) pairs, resolved against the current HOME."""
     return [(name, Path.home() / f".{name}" / "skills") for name in AGENT_SKILL_RUNTIMES]
+
+
+def _ensure_django() -> None:
+    """Configure Django so DB-touching doctor checks can inspect the self-DB.
+
+    ``check`` is reached through the Django-free Typer group, so no
+    ``django.setup()`` has run.  The self-DB schema guard reads the ORM
+    connection and would otherwise raise ``ImproperlyConfigured`` (#126).
+    Idempotent — mirrors the canonical ``_ensure_django`` in sibling CLI
+    modules (``cli/tools.py``).
+    """
+    import django  # noqa: PLC0415
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+    django.setup()
 
 
 _DEV_SOURCES_FILE = ".t3-dev-sources"
@@ -495,6 +511,13 @@ def check() -> bool:
     ok = _check_editable_sanity() and ok
     ok = _check_skills() and ok
     ok = _check_single_db() and ok
+
+    # ``check`` is a plain Typer command in the Django-free CLI group, so
+    # Django is not configured by the time the self-DB schema guard runs.
+    # Without this the inspection hit ``ImproperlyConfigured`` and silently
+    # WARNed, masking a stale runtime self-DB that locks out the merge path
+    # (#126). Configure Django first so the guard reports the REAL state.
+    _ensure_django()
 
     from teatree.core.schema_guard import doctor_check_self_db_migrations  # noqa: PLC0415
 

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -5,16 +5,21 @@ import logging
 import os
 import shutil
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 
 import typer
 
+from teatree.cli.django_groups import DJANGO_GROUPS, DjangoGroup
 from teatree.cli.teatree_gate import register_gate_commands
 from teatree.utils.run import run_streamed, spawn
 from teatree.utils.singleton import AlreadyRunningError, singleton
 
 logger = logging.getLogger(__name__)
+
+# Re-exported for consumers that import the catalogue from this module
+# (the CLI reference generator, tests): the data lives in
+# ``teatree.cli.django_groups`` but ``overlay`` stays its public home.
+__all__ = ["DJANGO_GROUPS", "OVERLAY_PROXY_COMMANDS", "DjangoGroup", "OverlayAppBuilder", "managepy", "managepy_core"]
 
 OVERLAY_PROXY_COMMANDS: dict[str, tuple[str, str]] = {}
 """Maps proxy callback ``__name__`` -> ``(django_group, django_sub)``.
@@ -25,194 +30,6 @@ CLI reference generator to swap the proxy's stub help for the underlying
 reassigned per-leaf (``_run_{group}_{sub}``); object identity is not stable
 across Typer's ``get_command`` conversion.
 """
-
-
-@dataclass(frozen=True)
-class DjangoGroup:
-    """One overlay sub-app group description.
-
-    ``core_dispatch`` flags groups whose subcommands live in
-    ``teatree.core.management.commands`` (not in any overlay-owned
-    ``manage.py``). When ``True``, :meth:`OverlayAppBuilder._bridge_subcommand`
-    dispatches via :func:`managepy_core` (``python -m teatree``) so the call
-    never reaches an overlay's ``manage.py`` whose settings module may not
-    register the command (#1318 follow-up to #1312).
-    """
-
-    help_text: str
-    subcommands: list[tuple[str, str]]
-    core_dispatch: bool = False
-
-
-DJANGO_GROUPS: dict[str, DjangoGroup] = {
-    "worktree": DjangoGroup(
-        "Per-worktree FSM operations.",
-        [
-            ("provision", "Run DB import + env cache + direnv + prek + overlay setup steps for one worktree."),
-            ("start", "Boot ``docker compose up`` for one worktree."),
-            ("verify", "Run overlay health checks for one worktree."),
-            ("ready", "Run runtime readiness probes for one worktree."),
-            ("teardown", "Stop docker, drop DB, remove git worktree, delete row."),
-            ("status", "Report FSM state, branch, and allocated host ports for one worktree."),
-            ("diagnose", "Print a structured health checklist for one worktree."),
-            ("smoke-test", "Quick health check: overlay loads, CLI responds, imports OK."),
-            ("diagram", "Print a state diagram as Mermaid. Models: worktree, ticket, task."),
-        ],
-    ),
-    "workspace": DjangoGroup(
-        "Ticket-level workspace operations (every worktree in the ticket).",
-        [
-            ("ticket", "Create or update a ticket and trigger worktree provisioning."),
-            ("provision", "Provision every worktree in the current ticket workspace."),
-            ("start", "Start docker for every worktree in the current ticket workspace."),
-            ("ready", "Run readiness probes for every worktree in the ticket workspace."),
-            ("teardown", "Tear down every worktree in the current ticket workspace."),
-            ("finalize", "Squash worktree commits and rebase on the default branch."),
-            ("doctor", "Detect state drift across every store; optionally fix it."),
-            ("clean-merged", "Tear down every worktree whose ticket is already MERGED."),
-            ("clean-all", "Prune merged worktrees, stale branches, orphaned stashes, orphan DBs, old DSLR snapshots."),
-            ("list-orphans", "List orphan branches (commits not on main, no open PR)."),
-        ],
-    ),
-    "run": DjangoGroup(
-        "Run services.",
-        [
-            ("verify", "Verify worktree state and return URLs."),
-            ("services", "Return configured run commands."),
-            ("backend", "Start the backend dev server."),
-            ("frontend", "Start the frontend dev server."),
-            ("build-frontend", "Build the frontend for production/testing."),
-            ("tests", "Run the project test suite."),
-        ],
-    ),
-    "e2e": DjangoGroup(
-        "E2E test commands.",
-        [
-            ("run", "Run E2E tests — dispatches to project or external runner based on overlay config."),
-            ("trigger-ci", "Trigger E2E tests on a remote CI pipeline."),
-            ("external", "Run Playwright tests from the external test repo (T3_PRIVATE_TESTS)."),
-            ("project", "Run E2E tests from the project's own test directory."),
-            (
-                "post-evidence",
-                "Post structured E2E evidence on the ticket (validation-gated, idempotent on env+commit).",
-            ),
-        ],
-    ),
-    "db": DjangoGroup(
-        "Database operations.",
-        [
-            ("refresh", "Re-import the worktree database from dump/DSLR."),
-            ("restore-ci", "Restore database from the latest CI dump."),
-            ("reset-passwords", "Reset all user passwords to a known dev value."),
-            ("query", "Run a read-only SQL query against the control DB; emit rows as JSON."),
-            ("shell", "Drop into a Django shell against the resolved (gate) control DB."),
-        ],
-    ),
-    "pr": DjangoGroup(
-        "Pull request helpers.",
-        [
-            ("create", "Create a pull request for the ticket's branch."),
-            ("ensure-pr", "Create a PR for an orphan branch (idempotent)."),
-            ("check-gates", "Check whether session gates allow a phase transition."),
-            ("fetch-issue", "Fetch issue details from the configured tracker."),
-            ("detect-tenant", "Detect the current tenant variant from the overlay."),
-            ("post-evidence", "Post test evidence as a PR comment."),
-            ("sweep", "List your open PRs across the forge for the /t3:sweeping-prs skill."),
-        ],
-    ),
-    "tasks": DjangoGroup(
-        "Async task queue.",
-        [
-            ("cancel", "Cancel a task by ID."),
-            ("claim", "Claim the next available task."),
-            ("complete", "Mark a claimed task COMPLETED for work finished out-of-band."),
-            ("create", "Enqueue the next-phase task for a ticket."),
-            ("list", "List tasks with optional filters."),
-            ("start", "Claim and run the next interactive task in the current terminal."),
-            ("work-next-sdk", "Claim and execute an headless task."),
-            ("work-next-user-input", "Claim and execute a user input task."),
-        ],
-    ),
-    "followup": DjangoGroup(
-        "Follow-up snapshots.",
-        [
-            ("refresh", "Return counts of tickets and tasks."),
-            ("sync", "Synchronize followup data from MRs."),
-            ("discover-mrs", "List the user's open non-draft PRs/MRs awaiting a review request."),
-            ("remind", "Return list of pending user input tasks."),
-        ],
-        core_dispatch=True,
-    ),
-    "standup": DjangoGroup(
-        "Auto-generated daily update (read-only).",
-        [
-            ("generate", "Generate a standup from transition + attempt data (read-only)."),
-            ("stale", "List tickets with no activity past the staleness threshold (read-only)."),
-        ],
-    ),
-    "lifecycle": DjangoGroup(
-        "Session lifecycle and phase tracking.",
-        [
-            ("visit-phase", "Mark a phase as visited on the ticket's latest session."),
-            ("clear-ledger", "Clear a reused ticket's stale phase ledger (sanctioned session-retire)."),
-        ],
-    ),
-    "env": DjangoGroup(
-        "Inspect and mutate the worktree env cache.",
-        [
-            ("show", "Print the env cache as the DB would render it."),
-            ("set-var", "Persist an override on the worktree and refresh the cache."),
-            ("unset", "Delete an override row and refresh the cache."),
-            ("overrides", "List user-declared overrides for this worktree."),
-            ("check", "Exit non-zero if the on-disk cache diverges from the DB render."),
-            ("migrate-secrets", "Move POSTGRES_PASSWORD literals out of .t3-env.cache into pass."),
-        ],
-    ),
-    "ticket": DjangoGroup(
-        "Ticket state management.",
-        [
-            ("transition", "Transition a ticket to a new state."),
-            ("clear", "Issue a per-diff CLEAR — the orchestrator's only merge output (BLUEPRINT §17.4.2)."),
-            ("merge", "Execute the IN_REVIEW → MERGED keystone transition (BLUEPRINT §17.4)."),
-            ("list", "List tickets, optionally filtered by state and/or overlay."),
-            ("sync-completions", "Check post-ship tickets against upstream issues and advance completed ones."),
-            ("comment", "Post a comment to an issue or work item by its URL."),
-            ("context", "Durable per-ticket knowledge store: show / add / edit (#627)."),
-        ],
-        core_dispatch=True,
-    ),
-    "availability": DjangoGroup(
-        "24/7 dual question-mode (#58, BLUEPRINT §17.1 invariant 9).",
-        [
-            ("away", "Set manual away-mode override (questions queue as DeferredQuestion rows)."),
-            ("present", "Set manual present-mode override (questions ask interactively)."),
-            ("auto", "Clear manual override and fall back to schedule/default."),
-            ("show", "Print the currently resolved mode and source (override/schedule/default)."),
-        ],
-    ),
-    "questions": DjangoGroup(
-        "Manage the away-mode deferred-question backlog (#58).",
-        [
-            ("record", "Record a deferred question (used by the PreToolUse away-mode hook)."),
-            ("list", "List pending deferred questions, oldest first."),
-            ("answer", "Resolve a pending question with a user answer."),
-            ("dismiss", "Dismiss a pending question without answering it."),
-        ],
-    ),
-    "pending_chat": DjangoGroup(
-        "Manage the inbound Slack-DM queue (#1063).",
-        [
-            ("list", "List inbound rows from the last hour (or --all)."),
-            ("mark-answered", "Stamp ``answered_at`` on rows matching a Slack ts."),
-        ],
-    ),
-    "notify": DjangoGroup(
-        "Bot→user Slack DM from the shell (#1030).",
-        [
-            ("send", "DM the user; exit 0 on delivery, 1 otherwise (sub-agent direct notify)."),
-        ],
-    ),
-}
 
 
 def uv_cmd(project_path: Path, *args: str) -> list[str]:
@@ -334,7 +151,13 @@ class OverlayAppBuilder:
         for group_name, dj_group in DJANGO_GROUPS.items():
             group = typer.Typer(no_args_is_help=True, help=dj_group.help_text)
             for sub_name, sub_help in dj_group.subcommands:
-                self._bridge_subcommand(group, group_name, sub_name, sub_help, core_dispatch=dj_group.core_dispatch)
+                self._bridge_subcommand(
+                    group,
+                    group_name,
+                    sub_name,
+                    sub_help,
+                    core_dispatch=dj_group.dispatches_to_core(sub_name),
+                )
             self.overlay_app.add_typer(group, name=group_name)
 
         self._register_overlay_tools()

--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -12,10 +12,13 @@ For teatree core (``$T3_REPO``) and every registered overlay repo, this:
     tracked-dirty tree (loudly). Untracked-only files do not block it.
 4. Otherwise ``git pull --ff-only`` — fast-forward only, never merge/rebase.
 5. Reinstalls advanced editable installs, then runs ``t3 setup``.
-6. Probes the teatree self-DB (``manage.py migrate --check``) and applies
-    pending migrations non-destructively — gated on *migrations actually
-    pending*, NOT on whether a repo advanced this run, so an interrupted
-    prior run / out-of-band ff-pull can't leave a stale self-DB (#929).
+6. Probes the teatree self-DB (``python -m teatree migrate --check`` in the
+    *runtime* interpreter) and applies pending migrations non-destructively
+    — gated on *migrations actually pending*, NOT on whether a repo advanced
+    this run, so an interrupted prior run / out-of-band ff-pull can't leave a
+    stale self-DB (#929). Running in the runtime process (not ``uv
+    --directory <clone>``) guarantees it migrates the DB the runtime ``t3``
+    actually resolves, not an auto-isolated sibling DB (#126).
 7. Prints a per-repo summary; exits non-zero on a hard repo failure OR a
     self-DB left unmigrated (fail-closed, consistent with #870).
 
@@ -27,6 +30,7 @@ codes").  Precedent: ``cli/setup.py`` ``_validate_repo`` → ``raise typer.Exit`
 """
 
 import enum
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -277,46 +281,72 @@ def _git_toplevel(path: Path) -> Path | None:
     return Path(result.stdout.strip()).resolve()
 
 
-def _self_db_has_pending_migrations(uv_bin: str, source: Path) -> bool:
-    """Probe whether the teatree self-DB has unapplied migrations.
+def _self_db_migrate_env() -> dict[str, str]:
+    """Env for the runtime-interpreter self-DB migrate.
 
-    Runs ``manage.py migrate --check --no-input``: Django exits 0 when
-    the DB is fully migrated and non-zero when migrations are pending.
-    This decouples "should we migrate?" from "did a repo advance *this
-    run*?" — an interrupted prior ``t3 update`` or an out-of-band ``git
-    pull`` can leave the SHA already current with a stale self-DB
-    (#929), so the per-run ``UPDATED`` flag is the wrong gate.
+    Strips an inherited ``DJANGO_SETTINGS_MODULE`` (a worktree-specific value
+    leaking from the caller would crash the subprocess with
+    ``ModuleNotFoundError`` — the #959 class) and pins ``teatree.settings``,
+    so the migrate always targets the teatree-core control DB the runtime
+    ``t3`` resolves.
+    """
+    env = {k: v for k, v in os.environ.items() if k != "DJANGO_SETTINGS_MODULE"}
+    env["DJANGO_SETTINGS_MODULE"] = "teatree.settings"
+    return env
+
+
+def _self_db_migrate_cmd(*args: str) -> list[str]:
+    """``python -m teatree <args>`` using the *running* interpreter.
+
+    Running in the runtime process — not ``uv --directory <clone>`` — is the
+    #126 fix: a worktree-anchored editable install resolves its control DB by
+    the *code's* on-disk location, so ``uv --directory <clone>`` auto-isolates
+    onto a sibling DB the runtime never reads, while ``python -m teatree``
+    (this interpreter, this installed package) resolves the exact DB the merge
+    gate inspects.
+    """
+    return [sys.executable, "-m", "teatree", *args]
+
+
+def _self_db_has_pending_migrations() -> bool:
+    """Probe whether the runtime teatree self-DB has unapplied migrations.
+
+    Runs ``python -m teatree migrate --check --no-input`` in the runtime
+    interpreter: Django exits 0 when the DB is fully migrated and non-zero
+    when migrations are pending. This decouples "should we migrate?" from
+    "did a repo advance *this run*?" — an interrupted prior ``t3 update`` or
+    an out-of-band ``git pull`` can leave the SHA already current with a
+    stale self-DB (#929), so the per-run ``UPDATED`` flag is the wrong gate.
     """
     result = run_allowed_to_fail(
-        [uv_bin, "--directory", str(source), "run", "python", "manage.py", "migrate", "--check", "--no-input"],
+        _self_db_migrate_cmd("migrate", "--check", "--no-input"),
+        env=_self_db_migrate_env(),
         expected_codes=None,
     )
     return result.returncode != 0
 
 
-def _migrate_self_db(source: Path) -> None:
-    """Apply pending teatree self-DB migrations non-destructively.
+def _migrate_self_db() -> None:
+    """Apply pending teatree self-DB migrations non-destructively, in-process.
 
-    A teatree git-pull can land new migrations; ``t3 update`` must apply
-    them or the sanctioned merge path breaks against the now-stale
-    self-DB. Runs the same ``uv --directory <clone> run python manage.py
-    migrate --no-input`` wrapper ``resetdb`` uses internally — WITHOUT
-    the destructive DB drop, so live ticket/session/lease state is
-    preserved. This is the first-class t3 alternative to the destructive
-    ``resetdb`` and the hook-discouraged raw ``manage.py migrate``.
+    A teatree git-pull can land new migrations; ``t3 update`` must apply them
+    or the sanctioned merge path breaks against the now-stale self-DB. Runs
+    ``python -m teatree migrate --no-input`` in the *running* interpreter so
+    the DB it migrates is exactly the one the runtime ``t3`` (and the merge
+    gate) resolves — never a ``uv --directory <clone>`` sibling DB (#126).
+    Non-destructive: live ticket/session/lease state is preserved. This is
+    the first-class t3 alternative to the destructive ``resetdb`` and the
+    hook-discouraged raw ``manage.py migrate``.
 
     A failure is **fail-closed** (#929): it raises ``typer.Exit(code=1)``
     rather than swallowing a WARN, so ``t3 update`` can never exit 0 with
     a half-migrated self-DB and silently break #870's
     fail-closed-on-unmigrated-self-DB guarantee.
     """
-    uv_bin = shutil.which("uv")
-    if uv_bin is None:
-        typer.echo("WARN  `uv` not on PATH — skipping self-DB migration.")
-        return
-    typer.echo("Applying teatree self-DB migrations (non-destructive) ...")
+    typer.echo("Applying teatree self-DB migrations (non-destructive, runtime self-DB) ...")
     result = run_allowed_to_fail(
-        [uv_bin, "--directory", str(source), "run", "python", "manage.py", "migrate", "--no-input"],
+        _self_db_migrate_cmd("migrate", "--no-input"),
+        env=_self_db_migrate_env(),
         expected_codes=None,
     )
     if result.returncode != 0:
@@ -330,37 +360,8 @@ def _migrate_self_db(source: Path) -> None:
     typer.echo("OK    self-DB migrations applied.")
 
 
-def _self_db_source() -> Path | None:
-    """Resolve the teatree clone whose self-DB ``t3 update`` must migrate.
-
-    Prefers the editable source recorded in uv's tool receipt (the clone
-    the running ``t3`` is actually anchored on); falls back to the
-    configured main clone.  Returns ``None`` when neither resolves (a
-    non-editable install with no discoverable clone) — nothing to
-    migrate from.
-    """
-    uv_bin = shutil.which("uv")
-    if uv_bin is not None:
-        from teatree.cli.setup import _current_editable_source  # noqa: PLC0415
-
-        source = _current_editable_source(uv_bin)
-        if source is not None and source.is_dir():
-            return source
-    main_clone = _find_main_clone()
-    if main_clone is not None and main_clone.is_dir():
-        return main_clone
-    return None
-
-
-def _find_main_clone() -> Path | None:
-    """Thin indirection over ``setup._find_main_clone`` (test seam)."""
-    from teatree.cli.setup import _find_main_clone as _impl  # noqa: PLC0415
-
-    return _impl()
-
-
 def _ensure_self_db_migrated() -> bool:
-    """Migrate the teatree self-DB iff migrations are actually pending.
+    """Migrate the runtime teatree self-DB iff migrations are actually pending.
 
     Probe-gated and fully decoupled from whether a repo advanced *this
     run* (#929): an interrupted prior ``t3 update`` or an out-of-band
@@ -369,24 +370,15 @@ def _ensure_self_db_migrated() -> bool:
     unmigrated (caller exits non-zero — fail-closed, #870); ``False``
     when nothing was pending or the migration succeeded.
 
-    A missing ``uv`` or an unresolvable clone can't be probed or
-    migrated: warn loudly but don't hard-fail the whole run (preserving
-    #925's tolerance), since "unverifiable" differs from "verified
-    unmigrated".
+    Both probe and migrate run in the runtime interpreter (``python -m
+    teatree``), so they always target the DB the runtime resolves — there
+    is no clone to resolve and no ``uv`` dependency for this path (#126).
     """
-    uv_bin = shutil.which("uv")
-    if uv_bin is None:
-        typer.echo("WARN  `uv` not on PATH — skipping self-DB migration check.")
-        return False
-    source = _self_db_source()
-    if source is None:
-        typer.echo("WARN  no editable teatree clone resolved — skipping self-DB migration check.")
-        return False
-    if not _self_db_has_pending_migrations(uv_bin, source):
+    if not _self_db_has_pending_migrations():
         typer.echo("OK    self-DB already migrated.")
         return False
     try:
-        _migrate_self_db(source)
+        _migrate_self_db()
     except typer.Exit:
         return True
     return False

--- a/src/teatree/core/management/commands/db.py
+++ b/src/teatree/core/management/commands/db.py
@@ -1,4 +1,4 @@
-"""Database operations: refresh, restore from CI, reset passwords, introspect."""
+"""Database operations: migrate, refresh, restore from CI, reset passwords, introspect."""
 
 import json
 import os
@@ -12,6 +12,7 @@ from django_typer.management import TyperCommand, command
 from teatree.core.db_approval_gate import ApprovalScope, require_approval
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import resolve_worktree
+from teatree.core.schema_guard import SelfDbMigrationError, migrate_self_db
 from teatree.types import SqlRow
 from teatree.utils.approval import ApprovalRefusedError
 
@@ -106,6 +107,37 @@ def _run_read_only(sql: str) -> list[SqlRow]:
 
 
 class Command(TyperCommand):
+    @command()
+    def migrate(self) -> None:
+        """Apply pending migrations to the runtime self-DB, non-destructively.
+
+        The always-available self-rescue for a stale runtime control DB —
+        the exact gap that locks out the sanctioned merge path
+        (``ticket clear``/``merge`` refuse on ANY pending migration). It
+        delegates to :func:`teatree.core.schema_guard.migrate_self_db`, which
+        runs ``migrate --no-input`` *in this process* against the same
+        connection the merge gate reads, so "migrate then re-check"
+        converges on one DB.
+
+        Unlike ``resetdb`` this drops nothing — live ticket/session/lease
+        rows survive. Unlike the old ``uv --directory <clone>`` wrapper it
+        cannot target a different (auto-isolated) DB than the runtime
+        resolves. Dispatched via teatree-core (``python -m teatree``) so it
+        reaches the runtime self-DB regardless of which overlay invokes it.
+
+        Fail-closed: a real migrate failure exits non-zero with the captured
+        error, never leaving a half-migrated DB look like a success.
+        """
+        try:
+            applied = migrate_self_db()
+        except SelfDbMigrationError as exc:
+            self.stderr.write(str(exc))
+            raise SystemExit(1) from exc
+        if not applied:
+            self.stdout.write("Self-DB already current — no migrations to apply.")
+            return
+        self.stdout.write(f"Applied {len(applied)} migration(s): {', '.join(applied)}")
+
     @command()
     def refresh(  # noqa: PLR0913 — django-typer command: every param is a CLI flag mapped 1:1 to the public `db refresh` surface (path/dslr/dump/force/fresh-dump/user-authorized); the arg list IS the CLI contract, not an internal design smell (same rationale as ticket.py:clear).
         self,

--- a/src/teatree/core/schema_guard.py
+++ b/src/teatree/core/schema_guard.py
@@ -12,25 +12,36 @@ tickets, that opaque failure blocks the *entire* merge pipeline with no
 actionable signal. This module provides a cheap pre-flight that converts
 the silent traceback into a clear, sanctioned-remediation error and a
 ``t3 doctor`` check that surfaces the gap proactively at session start.
+
+The merge gate deliberately *refuses* (it does not auto-migrate): mutating
+the schema as a side effect of a merge command is surprising and unsafe if
+the migration itself fails partway. Instead :func:`migrate_self_db` (exposed
+as ``t3 teatree db migrate``) is the explicit, always-available, in-process
+self-rescue — reachable even while the gate is refusing, since it is a
+separate command not gated by the merge path (#126).
 """
 
 import typer
+from django.core.management import call_command
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.executor import MigrationExecutor
 
 _REMEDIATION = (
-    "Run the sanctioned non-destructive migrate:\n"
-    "  uv --directory <teatree-clone> run python manage.py migrate --no-input\n"
+    "Run the sanctioned non-destructive migrate against the runtime self-DB:\n"
+    "  t3 teatree db migrate\n"
     "(or `t3 <overlay> resetdb` only if losing all local ticket/session state "
     "is acceptable). `t3 doctor check` flags this gap at session start."
 )
 
 
 class SelfDbMigrationError(RuntimeError):
-    """Raised when the teatree self-DB has unapplied migrations.
+    """Raised when the teatree self-DB has unapplied migrations or a migrate fails.
 
-    Carries the unapplied migration labels so the caller can render an
-    actionable message instead of a raw ``OperationalError`` traceback.
+    On the read path it carries the unapplied migration labels so the caller
+    can render an actionable message instead of a raw ``OperationalError``
+    traceback. On the write path (:func:`migrate_self_db`) it wraps the
+    underlying migrate failure so the consumer fails *closed* rather than
+    proceeding against a half-migrated DB.
     """
 
 
@@ -45,6 +56,41 @@ def pending_migrations(alias: str = DEFAULT_DB_ALIAS) -> list[str]:
     targets = executor.loader.graph.leaf_nodes()
     plan = executor.migration_plan(targets)
     return [f"{migration.app_label}.{migration.name}" for migration, _backwards in plan]
+
+
+def migrate_self_db(alias: str = DEFAULT_DB_ALIAS) -> list[str]:
+    """Apply pending migrations to the runtime-resolved control DB in-process.
+
+    The always-available, non-destructive self-rescue for a stale runtime
+    self-DB. It runs ``migrate --no-input`` *in the running process* against
+    the connection named by *alias* — the exact connection
+    :func:`pending_migrations` reads — so "migrate then re-check" converges on
+    the same DB. This is the structural fix for the lockout: every prior
+    migrate wrapper either targeted a different DB than the runtime resolves
+    (``uv --directory <clone>`` auto-isolates a worktree-anchored editable
+    install onto a sibling DB) or was destructive (``resetdb``).
+
+    Returns the ``"<app>.<name>"`` labels that were pending (and are now
+    applied); an empty list when the DB was already current (idempotent
+    no-op). Existing rows are preserved — ``migrate`` never drops live data.
+
+    Fail-closed: a genuine migrate failure is re-raised as
+    :class:`SelfDbMigrationError` (never swallowed), so a consumer that
+    migrates-then-proceeds cannot proceed against a half-migrated DB.
+    """
+    pending = pending_migrations(alias)
+    if not pending:
+        return []
+    try:
+        call_command("migrate", "--no-input", database=alias, verbosity=0)
+    except Exception as exc:
+        msg = (
+            f"teatree self-DB migrate failed on alias {alias!r} "
+            f"({len(pending)} pending): {exc.__class__.__name__}: {exc}. "
+            f"The DB is left UNMIGRATED; the sanctioned merge path stays fail-closed (#870)."
+        )
+        raise SelfDbMigrationError(msg) from exc
+    return pending
 
 
 def require_current_schema(alias: str = DEFAULT_DB_ALIAS) -> None:
@@ -84,7 +130,6 @@ def doctor_check_self_db_migrations(alias: str = DEFAULT_DB_ALIAS) -> bool:
         return True
     typer.echo(
         f"FAIL  teatree self-DB has {len(pending)} unapplied migration(s): {', '.join(pending)}. "
-        f"The sanctioned merge path needs a current schema — run "
-        f"`uv --directory <teatree-clone> run python manage.py migrate --no-input`."
+        f"The sanctioned merge path needs a current schema — run `t3 teatree db migrate`."
     )
     return False

--- a/tests/cli_doctor/test_doctor_check_command.py
+++ b/tests/cli_doctor/test_doctor_check_command.py
@@ -147,6 +147,48 @@ class TestDoctorCheckCommand:
 
         assert "WARN" in result.output
 
+    def test_configures_django_before_self_db_inspection(self, tmp_path, monkeypatch):
+        """``t3 doctor check`` must configure Django before inspecting the self-DB.
+
+        Regression (#126): ``check()`` is a plain Typer command in a
+        Django-free group, so without an explicit ``django.setup()`` the
+        self-DB schema inspection hit ``ImproperlyConfigured: DJANGO_
+        SETTINGS_MODULE not set`` and silently WARNed — masking a real stale
+        runtime self-DB that would have locked out the merge path. The check
+        must run the canonical ``_ensure_django`` step (``django.setup`` +
+        ``DJANGO_SETTINGS_MODULE``) before reaching the schema guard, so it
+        reports the REAL pending-migration state.
+        """
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
+
+        order: list[str] = []
+
+        def _record_setup() -> None:
+            order.append("ensure_django")
+
+        def _record_check(*_args, **_kwargs) -> bool:
+            order.append("self_db_check")
+            return True
+
+        with (
+            patch.object(teatree_cli_doctor.shutil, "which", side_effect=lambda t: f"/usr/bin/{t}"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+            patch.object(teatree_cli_doctor, "_ensure_django", side_effect=_record_setup),
+            patch(
+                "teatree.core.schema_guard.doctor_check_self_db_migrations",
+                side_effect=_record_check,
+            ),
+        ):
+            result = runner.invoke(app, ["doctor", "check"])
+
+        assert result.exit_code == 0, result.output
+        # Django must be configured BEFORE the self-DB schema inspection runs.
+        assert "ensure_django" in order, "doctor check must call _ensure_django (#126)"
+        assert order.index("ensure_django") < order.index("self_db_check")
+        assert "Could not inspect self-DB migrations: ImproperlyConfigured" not in result.output
+
     def test_fails_on_import_error(self):
         import builtins  # noqa: PLC0415
 

--- a/tests/teatree_core/test_db_migrate_command.py
+++ b/tests/teatree_core/test_db_migrate_command.py
@@ -1,0 +1,65 @@
+"""``t3 <overlay> db migrate`` — in-process self-DB migrate command (#126).
+
+The sanctioned merge path refuses on a stale runtime self-DB, but no
+sanctioned, non-destructive migrate targeted *that* DB: ``t3 update`` ran
+``uv --directory <clone> run migrate`` (a different, auto-isolated DB for a
+worktree-anchored editable install) and ``resetdb`` is destructive. This
+command closes the gap — it delegates to
+:func:`teatree.core.schema_guard.migrate_self_db`, which migrates the exact
+connection the gate reads, in the running process.
+"""
+
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.db import connection
+from django.test import TransactionTestCase
+
+from teatree.core.models import Ticket
+
+
+class DbMigrateCommandTest(TransactionTestCase):
+    """``db migrate`` brings the live (gate) connection current, non-destructively."""
+
+    def test_migrate_reports_already_current_when_nothing_pending(self) -> None:
+        out = StringIO()
+        call_command("db", "migrate", stdout=out)
+        # The test DB is at head, so nothing is pending — the command must
+        # report a clean no-op, not error.
+        assert "already" in out.getvalue().lower() or "current" in out.getvalue().lower()
+
+    def test_migrate_delegates_to_in_process_self_rescue(self) -> None:
+        # The command must route through migrate_self_db (the in-process
+        # rescue against the live connection), never a subprocess wrapper.
+        with patch(
+            "teatree.core.management.commands.db.migrate_self_db",
+            return_value=["core.0041_resource_pressure_marker"],
+        ) as mocked:
+            out = StringIO()
+            call_command("db", "migrate", stdout=out)
+        assert mocked.called
+        assert "core.0041_resource_pressure_marker" in out.getvalue()
+
+    def test_migrate_preserves_existing_rows(self) -> None:
+        # Non-destructive: a row written before migrate survives it. On a
+        # head DB this is a no-op migrate, but it still must not drop data.
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.STARTED)
+        call_command("db", "migrate", stdout=StringIO())
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.STARTED
+        assert connection.vendor == "sqlite"
+
+    def test_migrate_fails_closed_when_underlying_migrate_errors(self) -> None:
+        import pytest  # noqa: PLC0415
+
+        from teatree.core.schema_guard import SelfDbMigrationError  # noqa: PLC0415
+
+        with (
+            patch(
+                "teatree.core.management.commands.db.migrate_self_db",
+                side_effect=SelfDbMigrationError("disk I/O error"),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            call_command("db", "migrate", stdout=StringIO(), stderr=StringIO())

--- a/tests/teatree_core/test_overlay_core_dispatch.py
+++ b/tests/teatree_core/test_overlay_core_dispatch.py
@@ -150,6 +150,51 @@ class TestTicketGroupCoreDispatch:
         assert "merge" in cmd
 
 
+class TestDbMigrateCoreDispatch:
+    """``db migrate`` routes through ``python -m teatree`` (core); siblings do not.
+
+    ``db migrate`` migrates the teatree-core control DB the merge gate reads,
+    so it must run in the runtime process (``python -m teatree``). The sibling
+    ``db`` subcommands (``refresh``/``restore-ci``/``reset-passwords``) drive
+    the overlay's own ``db_import`` strategy and must keep routing through the
+    overlay's ``manage.py``. So ``db`` is a *per-subcommand* core-dispatch
+    group, not a wholesale one (#126).
+    """
+
+    def test_db_migrate_is_marked_core_dispatch_per_subcommand(self) -> None:
+        entry = DJANGO_GROUPS["db"]
+        assert "migrate" in getattr(entry, "core_subcommands", frozenset()), (
+            f"db.migrate must opt into per-subcommand core dispatch (#126), got {entry!r}"
+        )
+        # The group itself must NOT be wholesale core_dispatch — refresh et al.
+        # still need the overlay manage.py.
+        assert getattr(entry, "core_dispatch", False) is False
+
+    def test_db_migrate_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["db", "migrate"])
+        assert result.exit_code == 0, result.output
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"db migrate must dispatch via python -m teatree, got {cmd!r}"
+        assert "teatree" in cmd, f"db migrate must dispatch via python -m teatree, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd), f"db migrate must NOT route through manage.py, got {cmd!r}"
+        assert "db" in cmd
+        assert "migrate" in cmd
+
+    def test_db_refresh_still_uses_overlay_manage_py(self, overlay_clone_path: Path) -> None:
+        # The sibling stays on the overlay manage.py path — only migrate is
+        # core-dispatched.
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["db", "refresh"])
+        assert result.exit_code == 0, result.output
+        cmd = run_streamed.call_args.args[0]
+        assert "manage.py" in " ".join(cmd), f"db refresh must route through the overlay manage.py, got {cmd!r}"
+
+
 class TestShortcutCoreDispatch:
     """``full-status`` and ``daily`` shortcut to followup commands — same dispatch rule."""
 

--- a/tests/teatree_core/test_schema_guard.py
+++ b/tests/teatree_core/test_schema_guard.py
@@ -112,7 +112,9 @@ class UnmigratedSelfDbTest(TransactionTestCase):
         message = str(exc.value)
         assert "unapplied migration" in message
         assert "ticket clear/merge" in message
-        assert "manage.py migrate" in message
+        # The remediation points at the in-process self-rescue, not the old
+        # `uv --directory <clone>` wrapper that resolved a different DB (#126).
+        assert "t3 teatree db migrate" in message
 
     def test_ticket_clear_command_fails_closed_with_remediation(self) -> None:
         result = cast(
@@ -129,7 +131,7 @@ class UnmigratedSelfDbTest(TransactionTestCase):
         )
         assert result["issued"] is False
         assert "unapplied migration" in str(result["error"])
-        assert "manage.py migrate" in str(result["error"])
+        assert "t3 teatree db migrate" in str(result["error"])
 
     def test_ticket_merge_command_fails_closed_with_remediation(self) -> None:
         result = cast(

--- a/tests/teatree_core/test_schema_guard_migrate.py
+++ b/tests/teatree_core/test_schema_guard_migrate.py
@@ -1,0 +1,118 @@
+"""In-process self-DB migrate — the always-available stale-runtime-DB rescue (#126).
+
+The sanctioned merge path refuses when ``pending_migrations()`` reports a
+stale runtime self-DB, but every migrate wrapper before this either targeted
+a *different* DB than the runtime process resolves (``t3 update`` ran
+``uv --directory <clone> run migrate``, which auto-isolates to a sibling DB
+for a worktree-anchored editable install) or was destructive (``resetdb``).
+``migrate_self_db`` closes the gap: it applies migrations **in the running
+process, against the exact connection** ``pending_migrations()`` reads — so
+"migrate then re-check" is guaranteed to converge on the same DB. It is
+non-destructive (rows survive), idempotent (a no-op on a current DB), and
+fail-closed (a real migrate error raises).
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.db import OperationalError, connection, connections
+from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.recorder import MigrationRecorder
+from django.test import TransactionTestCase
+
+from teatree.core.schema_guard import SelfDbMigrationError, migrate_self_db, pending_migrations
+
+# A short contiguous tail to roll back so the DB is genuinely stale: the
+# executor only reports a gap when no *descendant* is recorded, so we
+# un-record from a fixed point through the leaf.
+_ROLLBACK_FROM = "0040_miniloopmarker"
+
+
+def _core_tail_from(name: str) -> list[str]:
+    """Applied core migration ledger names ``>= name``, ascending."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT name FROM django_migrations WHERE app = 'core' AND name >= %s ORDER BY name",
+            [name],
+        )
+        return [row[0] for row in cursor.fetchall()]
+
+
+class MigrateSelfDbInProcessTest(TransactionTestCase):
+    """``migrate_self_db`` converges the live test connection.
+
+    It targets the same connection ``pending_migrations()`` inspects, so the
+    migrate-then-recheck round-trip is guaranteed to converge on one DB.
+    """
+
+    def _make_stale(self) -> list[str]:
+        """Roll the live DB back to before ``_ROLLBACK_FROM`` and return the gap.
+
+        Reverses the migrations rather than just deleting ledger rows so the
+        schema is genuinely behind (tables/columns absent), matching the real
+        stale-runtime-DB state ``schema_guard`` guards against.
+        """
+        tail = _core_tail_from(_ROLLBACK_FROM)
+        executor = MigrationExecutor(connection)
+        # Migrate core back to the state just before the rollback point.
+        target = ("core", _previous_core_migration(_ROLLBACK_FROM))
+        executor.migrate([target])
+        return tail
+
+    def _restore_head(self) -> None:
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()
+        core_leaves = [node for node in executor.loader.graph.leaf_nodes() if node[0] == "core"]
+        executor.migrate(core_leaves)
+
+    def test_stale_db_is_brought_current(self) -> None:
+        self.addCleanup(self._restore_head)
+        self._make_stale()
+        assert pending_migrations() != [], "precondition: DB must be stale"
+
+        applied = migrate_self_db()
+
+        assert pending_migrations() == [], "migrate_self_db must converge the live connection"
+        assert applied, "must report the migration labels it applied"
+        assert any(_ROLLBACK_FROM in label for label in applied)
+
+    def test_idempotent_noop_on_current_db(self) -> None:
+        # A current DB yields nothing pending; migrate returns an empty list
+        # and does not error.
+        assert pending_migrations() == []
+        assert migrate_self_db() == []
+        assert pending_migrations() == []
+
+    def test_rows_survive_migrate(self) -> None:
+        from teatree.core.models import Ticket  # noqa: PLC0415
+
+        self.addCleanup(self._restore_head)
+        ticket = Ticket.objects.create(overlay="t3-teatree", issue_url="https://example.com/issues/126")
+        self._make_stale()
+
+        migrate_self_db()
+
+        ticket.refresh_from_db()
+        assert ticket.issue_url == "https://example.com/issues/126", "non-destructive: existing rows survive"
+
+    def test_fails_closed_when_migrate_errors(self) -> None:
+        # A genuine migrate failure must raise SelfDbMigrationError, never be
+        # swallowed — the consumer relies on a non-zero outcome to fail closed.
+        self.addCleanup(self._restore_head)
+        self._make_stale()  # ensure pending != [] so call_command is reached
+        with (
+            patch(
+                "teatree.core.schema_guard.call_command",
+                side_effect=OperationalError("disk I/O error"),
+            ),
+            pytest.raises(SelfDbMigrationError) as exc,
+        ):
+            migrate_self_db()
+        assert "disk I/O error" in str(exc.value)
+
+
+def _previous_core_migration(name: str) -> str:
+    """The applied core migration immediately preceding *name* in the ledger."""
+    recorder = MigrationRecorder(connections["default"])
+    applied = sorted(m_name for (app, m_name) in recorder.applied_migrations() if app == "core" and m_name < name)
+    return applied[-1]

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -468,66 +468,50 @@ class TestSelfDbMigrationOnUpdate:
     must fail closed (non-zero exit) when it cannot.
     """
 
-    def test_migrate_self_db_runs_sanctioned_non_destructive_migrate(
+    def test_migrate_self_db_runs_in_runtime_interpreter_not_uv_directory(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        source = tmp_path / "clone"
-        source.mkdir()
+        # #126: the migrate must run in the RUNTIME process (python -m
+        # teatree), resolving the runtime self-DB — NOT `uv --directory
+        # <clone>`, which for a worktree-anchored editable install
+        # auto-isolates onto a sibling DB the runtime never reads.
         calls: list[list[str]] = []
 
         def _run(cmd: list[str], **_kw: object) -> _Proc:
             calls.append(cmd)
             return _Proc(0, "No migrations to apply.", "")
 
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
         monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
 
-        update_mod._migrate_self_db(source)
+        update_mod._migrate_self_db()
 
         assert len(calls) == 1
         cmd = calls[0]
-        assert cmd[:2] == ["/usr/bin/uv", "--directory"]
-        assert str(source) in cmd
-        assert cmd[-3:] == ["manage.py", "migrate", "--no-input"]
+        assert cmd[0] == update_mod.sys.executable, "must use the running interpreter"
+        assert cmd[1:4] == ["-m", "teatree", "migrate"], f"must be `python -m teatree migrate`, got {cmd!r}"
+        assert "--no-input" in cmd
+        assert "--directory" not in cmd, "must NOT route through `uv --directory <clone>`"
 
-    def test_migrate_self_db_skips_when_uv_missing(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    def test_migrate_self_db_does_not_inherit_caller_settings_module(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        source = tmp_path / "clone"
-        source.mkdir()
-        monkeypatch.setattr(update_mod.shutil, "which", lambda _name: None)
+        # Mirrors #959: a worktree-specific DJANGO_SETTINGS_MODULE in the
+        # caller env must not leak into the migrate subprocess (it would
+        # crash with ModuleNotFoundError). The runtime self-DB migrate
+        # always runs against teatree.settings.
+        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "worktree_only.settings_local")
+        captured: list[dict[str, str]] = []
 
-        update_mod._migrate_self_db(source)  # must not raise
+        def _run(cmd: list[str], *, env: dict[str, str] | None = None, **_kw: object) -> _Proc:
+            captured.append(dict(env or {}))
+            return _Proc(0, "", "")
 
-        assert "skipping self-DB migration" in capsys.readouterr().out
+        monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
 
-    def test_self_db_source_prefers_editable_clone(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        editable = tmp_path / "editable"
-        editable.mkdir()
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
-        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: editable)
+        update_mod._migrate_self_db()
 
-        assert update_mod._self_db_source() == editable
-
-    def test_self_db_source_falls_back_to_main_clone(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        main_clone = tmp_path / "main"
-        main_clone.mkdir()
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
-        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: None)
-        monkeypatch.setattr(update_mod, "_find_main_clone", lambda: main_clone)
-
-        assert update_mod._self_db_source() == main_clone
-
-    def test_self_db_source_none_when_nothing_resolves(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(update_mod.shutil, "which", lambda _name: None)
-        monkeypatch.setattr(update_mod, "_find_main_clone", lambda: None)
-
-        assert update_mod._self_db_source() is None
-
-    def test_find_main_clone_delegates_to_setup(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(setup_mod, "_find_main_clone", lambda: tmp_path)
-
-        assert update_mod._find_main_clone() == tmp_path
+        assert captured, "migrate subprocess was not invoked"
+        assert captured[0].get("DJANGO_SETTINGS_MODULE") == "teatree.settings"
 
     def test_migrate_self_db_fails_closed_on_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -535,20 +519,14 @@ class TestSelfDbMigrationOnUpdate:
         # #929: a swallowed WARN left t3 update exiting 0 with a
         # half-migrated self-DB, breaking the sanctioned merge path
         # (#870). The failure must now raise (fail-closed).
-        source = tmp_path / "clone"
-        source.mkdir()
-
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
         monkeypatch.setattr(update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(1, "", "locked"))
 
         with pytest.raises((SystemExit, click.exceptions.Exit)):
-            update_mod._migrate_self_db(source)
+            update_mod._migrate_self_db()
 
         assert "self-DB migration" in capsys.readouterr().out
 
-    def test_self_db_probe_reports_pending_migrations(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        source = tmp_path / "clone"
-        source.mkdir()
+    def test_self_db_probe_reports_pending_migrations(self, monkeypatch: pytest.MonkeyPatch) -> None:
         calls: list[list[str]] = []
 
         def _run(cmd: list[str], **_kw: object) -> _Proc:
@@ -556,29 +534,23 @@ class TestSelfDbMigrationOnUpdate:
             # Django `migrate --check` exits 1 when migrations are pending.
             return _Proc(1, "", "")
 
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
         monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
 
-        assert _self_db_has_pending_migrations("/usr/bin/uv", source) is True
-        assert calls[0][-3:] == ["migrate", "--check", "--no-input"]
+        assert _self_db_has_pending_migrations() is True
+        cmd = calls[0]
+        assert cmd[0] == update_mod.sys.executable
+        assert cmd[1:4] == ["-m", "teatree", "migrate"]
+        assert cmd[-3:] == ["migrate", "--check", "--no-input"]
 
-    def test_self_db_probe_reports_clean_when_up_to_date(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        source = tmp_path / "clone"
-        source.mkdir()
-
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+    def test_self_db_probe_reports_clean_when_up_to_date(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(0, "", ""))
 
-        assert _self_db_has_pending_migrations("/usr/bin/uv", source) is False
+        assert _self_db_has_pending_migrations() is False
 
-    def test_ensure_migrates_even_when_no_repo_advanced_this_run(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_ensure_migrates_even_when_no_repo_advanced_this_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # The #929 regression: SHA already current (no UPDATED this
         # run) but the self-DB is behind. `t3 update` MUST still migrate
         # — the migration is probe-gated, not advance-gated.
-        source = tmp_path / "editable-src"
-        source.mkdir()
         calls: list[list[str]] = []
 
         def _run(cmd: list[str], **_kw: object) -> _Proc:
@@ -589,81 +561,42 @@ class TestSelfDbMigrationOnUpdate:
                 return _Proc(1, "", "")
             return _Proc(0, "Applying ...", "")
 
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
-        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: source)
         monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
 
         failed = _ensure_self_db_migrated()
 
         assert failed is False
-        migrate_calls = [c for c in calls if c[-3:] == ["manage.py", "migrate", "--no-input"]]
+        migrate_calls = [c for c in calls if c[-2:] == ["migrate", "--no-input"]]
         assert len(migrate_calls) == 1
-        assert str(source) in migrate_calls[0]
+        assert migrate_calls[0][0] == update_mod.sys.executable
 
-    def test_ensure_skips_migrate_when_probe_reports_clean(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        source = tmp_path / "editable-src"
-        source.mkdir()
+    def test_ensure_skips_migrate_when_probe_reports_clean(self, monkeypatch: pytest.MonkeyPatch) -> None:
         calls: list[list[str]] = []
 
         def _run(cmd: list[str], **_kw: object) -> _Proc:
             calls.append(cmd)
             return _Proc(0, "", "")  # probe: nothing pending
 
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
-        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: source)
         monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
 
         failed = _ensure_self_db_migrated()
 
         assert failed is False
-        assert not [c for c in calls if c[-3:] == ["manage.py", "migrate", "--no-input"]]
+        assert not [c for c in calls if c[-2:] == ["migrate", "--no-input"]]
 
     def test_ensure_returns_failed_when_migration_fails_closed(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        source = tmp_path / "editable-src"
-        source.mkdir()
-
         def _run(cmd: list[str], **_kw: object) -> _Proc:
             if "--check" in cmd:
                 return _Proc(1, "", "")  # pending
             return _Proc(1, "", "db locked")  # migrate fails
 
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
-        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: source)
         monkeypatch.setattr(update_mod, "run_allowed_to_fail", _run)
 
         failed = _ensure_self_db_migrated()
 
         assert failed is True
-        assert "self-DB" in capsys.readouterr().out
-
-    def test_ensure_warns_and_passes_when_uv_missing(
-        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        # Can't probe or migrate without uv — preserve #925 tolerance:
-        # warn loudly, don't fail the whole run.
-        monkeypatch.setattr(update_mod.shutil, "which", lambda _name: None)
-
-        failed = _ensure_self_db_migrated()
-
-        assert failed is False
-        assert "self-DB migration" in capsys.readouterr().out
-
-    def test_ensure_warns_and_passes_when_no_editable_source(
-        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        # Non-editable install with no resolvable core clone → nothing
-        # to migrate from; warn, don't hard-fail.
-        monkeypatch.setattr(update_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
-        monkeypatch.setattr(setup_mod, "_current_editable_source", lambda _uv: None)
-        monkeypatch.setattr(update_mod, "_find_main_clone", lambda: None)
-
-        failed = _ensure_self_db_migrated()
-
-        assert failed is False
         assert "self-DB" in capsys.readouterr().out
 
     def test_reinstall_flow_no_longer_migrates_self_db(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

The sanctioned merge path (`ticket clear` / `merge`) refuses when the
runtime self-DB has pending migrations, but there was no sanctioned,
non-destructive way to migrate the DB the runtime *actually resolves*, so
the refusal could become a dead end. Root cause + fixes in #1495.

## Fixes

- **`schema_guard.migrate_self_db(alias)`** — applies migrations in-process
  against the exact connection `pending_migrations()` reads, so
  migrate-then-recheck converges on one DB. Non-destructive, idempotent,
  fail-closed (a real migrate failure raises `SelfDbMigrationError`).
- **`t3 <overlay> db migrate`** — the always-available self-rescue,
  dispatched in the runtime process (`python -m teatree`, per-subcommand
  core dispatch) so it targets the DB the merge gate reads. Reachable even
  while the merge gate is refusing.
- **`t3 update`** — the self-DB probe + migrate now run in the runtime
  interpreter (`python -m teatree migrate`) instead of `uv --directory
  <clone> run`. For a worktree-anchored editable install the latter
  auto-isolated onto a sibling DB and reported "already migrated" while the
  runtime DB stayed stale. Strips an inherited `DJANGO_SETTINGS_MODULE`,
  pins `teatree.settings`.
- **`t3 doctor check`** — runs `_ensure_django()` before the self-DB schema
  inspection, so it reports the REAL pending-migration state instead of
  `WARN  Could not inspect self-DB migrations: ImproperlyConfigured`.
- Merge gate keeps the hard refuse (does not auto-migrate — mutating schema
  as a merge side effect is unsafe if the migrate fails partway); the
  explicit `db migrate` is the rescue. Remediation message + docs updated.
- Extracted `DjangoGroup` + `DJANGO_GROUPS` into `cli/django_groups.py`
  (by-concern split; keeps `overlay.py` under the module-health LOC cap).

## Tests

Integration-style against a real stale self-DB:

- `migrate_self_db` brings a stale DB current — idempotent, non-destructive
  (rows survive), fail-closed on a real migrate error.
- `t3 update` probe + migrate run in the runtime interpreter and do not
  inherit the caller's `DJANGO_SETTINGS_MODULE`.
- `t3 teatree db migrate` delegates to the in-process rescue and fails
  closed on error; routes via core dispatch (not the overlay manage.py).
- `t3 doctor check` configures Django before the self-DB inspection.

prek + full suite green (8105 passed, coverage 93.5%).

Relates to #126.
Closes #1495.
