### PR TITLE
fix(backends): paginate GitHub PR-comment listing so dedup sees the full history

### DIFF
--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TypedDict, cast
 from urllib.parse import quote_plus, urlparse
 
+from teatree.backends.github_claims import record_github_note_claim as _record_github_note_claim
 from teatree.backends.protocols import ApprovalState, PrOpenState, PullRequestSpec, ReviewState
 from teatree.backends.types import dig
 from teatree.types import RawAPIDict
@@ -132,6 +133,40 @@ def _gh_api_get(endpoint: str, *, token: str = "") -> object:
     return json.loads(result.stdout)
 
 
+def _gh_api_get_paginated(endpoint: str, *, token: str = "") -> list[RawAPIDict]:
+    """Fetch EVERY page of a list endpoint and return one flat list.
+
+    A plain ``gh api`` GET returns only the first page — GitHub's default
+    page size silently caps the result, so a comment older than the most
+    recent page goes unseen and the find-then-update dedup re-posts a
+    duplicate. ``--paginate`` follows the ``Link`` header to the last page;
+    ``--slurp`` wraps each page's JSON array into one outer array
+    (``[[page1…], [page2…]]``), which this flattens into a single list.
+
+    Non-list pages (a single-object body, an error payload) are skipped so
+    a malformed page can never raise. Returns ``[]`` when the outer payload
+    is not an array.
+    """
+    result = _run_gh(
+        "gh",
+        "api",
+        endpoint,
+        "--paginate",
+        "--slurp",
+        "--header",
+        "Accept: application/vnd.github+json",
+        token=token,
+    )
+    pages = json.loads(result.stdout)
+    if not isinstance(pages, list):
+        return []
+    flattened: list[RawAPIDict] = []
+    for page in pages:
+        if isinstance(page, list):
+            flattened.extend(cast("list[RawAPIDict]", page))
+    return flattened
+
+
 def _gh_api_post(endpoint: str, payload: dict[str, object], *, token: str = "") -> object:
     """Call ``gh api`` (POST) and return parsed JSON."""
     cmd = [
@@ -245,75 +280,6 @@ def _project_item_from_node(node: object, position: int) -> ProjectItem | None:
         labels=labels,
         updated_at=str(dig(node, "content", "updatedAt") or ""),
     )
-
-
-def _record_github_note_claim(
-    *,
-    repo: str,
-    target_number: int,
-    comment_id: int,
-    body: str,
-    target_url: str,
-) -> None:
-    """Audit one successful GitHub-comment publish for the drift verifier (#1198).
-
-    Mirrors :func:`teatree.cli.review_audit.record_note_claim` for the
-    GitLab side: best-effort write, never raises into the caller.
-    ``payload_digest`` lets the verifier detect silent body-divergence
-    without storing the full body in the claim row.
-
-    The idempotency key encodes ``repo``, target number (PR or issue —
-    GitHub uses the same ``/issues/<n>/comments`` endpoint for both), and
-    the server-assigned ``comment_id`` so a retried POST that the API
-    collapsed to the same comment no-ops at the ledger layer.
-
-    Best-effort: any exception (Django not booted, DB outage, integrity
-    race) is swallowed. The publish has already succeeded by the time we
-    get here — failing to audit it must not turn that success into a
-    user-visible failure.
-
-    Stamps ``extra["overlay"]`` from ``T3_OVERLAY_NAME`` (#1275) so the
-    audit verifier can re-read the comment through the same overlay's
-    GitHub token that posted it — not a process-global resolver that may
-    land on a different identity in multi-overlay setups.
-    """
-    import hashlib  # noqa: PLC0415 — stdlib, cheap, used only here
-    import os  # noqa: PLC0415 — defer stdlib import out of module load
-
-    try:
-        from django.db import (  # noqa: PLC0415 — keep Django out of module-load if bootstrap fails
-            DatabaseError,
-            IntegrityError,
-            transaction,
-        )
-
-        from teatree.core.models import OutboundClaim  # noqa: PLC0415
-    except Exception:  # noqa: BLE001 — must never break the publish path
-        return
-
-    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
-    overlay_name = os.environ.get("T3_OVERLAY_NAME", "") or ""
-    idempotency_key = f"github_note:{repo}#{target_number}:{comment_id}"
-    try:
-        with transaction.atomic():
-            OutboundClaim.objects.get_or_create(
-                idempotency_key=idempotency_key,
-                defaults={
-                    "kind": OutboundClaim.Kind.GITHUB_NOTE.value,
-                    "target_url": target_url,
-                    "extra": {
-                        "repo": repo,
-                        "target_number": target_number,
-                        "artifact_id": str(comment_id),
-                        "payload_digest": digest,
-                        "overlay": overlay_name,
-                    },
-                },
-            )
-    except (IntegrityError, DatabaseError):
-        return
-    except Exception:  # noqa: BLE001 — must never break the publish path
-        return
 
 
 class GitHubCodeHost:
@@ -430,8 +396,10 @@ class GitHubCodeHost:
         return cast("RawAPIDict", data) if isinstance(data, dict) else {}
 
     def list_pr_comments(self, *, repo: str, pr_iid: int) -> list[RawAPIDict]:
-        data = _gh_api_get(f"repos/{repo}/issues/{pr_iid}/comments", token=self._token)
-        return cast("list[RawAPIDict]", data) if isinstance(data, list) else []
+        # Paginate: a busy PR has >30 comments (GitHub's default page size),
+        # and a non-paginated GET would hide the ``## Test Plan`` note the
+        # evidence-poster looks up to UPDATE — re-posting a duplicate instead.
+        return _gh_api_get_paginated(f"repos/{repo}/issues/{pr_iid}/comments?per_page=100", token=self._token)
 
     def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:
         query = quote_plus(f"is:issue is:open assignee:{assignee}")

--- a/src/teatree/backends/github_claims.py
+++ b/src/teatree/backends/github_claims.py
@@ -1,0 +1,81 @@
+"""Outbound-claim audit recording for GitHub comment publishes (#1198/#1275).
+
+Split from :mod:`teatree.backends.github` so the code-host module stays
+under the module-health LOC cap. :func:`record_github_note_claim` is the
+GitHub-side parallel of :func:`teatree.cli.review_audit.record_note_claim`
+for the GitLab side: a best-effort write of one :class:`OutboundClaim`
+row in the same logical step as a successful comment POST, so the drift
+verifier can later confirm the artifact actually exists on the forge.
+
+Every dependency is imported lazily inside the function body so importing
+the code-host module never eagerly boots Django.
+"""
+
+
+def record_github_note_claim(
+    *,
+    repo: str,
+    target_number: int,
+    comment_id: int,
+    body: str,
+    target_url: str,
+) -> None:
+    """Audit one successful GitHub-comment publish for the drift verifier (#1198).
+
+    Mirrors :func:`teatree.cli.review_audit.record_note_claim` for the
+    GitLab side: best-effort write, never raises into the caller.
+    ``payload_digest`` lets the verifier detect silent body-divergence
+    without storing the full body in the claim row.
+
+    The idempotency key encodes ``repo``, target number (PR or issue —
+    GitHub uses the same ``/issues/<n>/comments`` endpoint for both), and
+    the server-assigned ``comment_id`` so a retried POST that the API
+    collapsed to the same comment no-ops at the ledger layer.
+
+    Best-effort: any exception (Django not booted, DB outage, integrity
+    race) is swallowed. The publish has already succeeded by the time we
+    get here — failing to audit it must not turn that success into a
+    user-visible failure.
+
+    Stamps ``extra["overlay"]`` from ``T3_OVERLAY_NAME`` (#1275) so the
+    audit verifier can re-read the comment through the same overlay's
+    GitHub token that posted it — not a process-global resolver that may
+    land on a different identity in multi-overlay setups.
+    """
+    import hashlib  # noqa: PLC0415 — stdlib, cheap, used only here
+    import os  # noqa: PLC0415 — defer stdlib import out of module load
+
+    try:
+        from django.db import (  # noqa: PLC0415 — keep Django out of module-load if bootstrap fails
+            DatabaseError,
+            IntegrityError,
+            transaction,
+        )
+
+        from teatree.core.models import OutboundClaim  # noqa: PLC0415
+    except Exception:  # noqa: BLE001 — must never break the publish path
+        return
+
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    overlay_name = os.environ.get("T3_OVERLAY_NAME", "") or ""
+    idempotency_key = f"github_note:{repo}#{target_number}:{comment_id}"
+    try:
+        with transaction.atomic():
+            OutboundClaim.objects.get_or_create(
+                idempotency_key=idempotency_key,
+                defaults={
+                    "kind": OutboundClaim.Kind.GITHUB_NOTE.value,
+                    "target_url": target_url,
+                    "extra": {
+                        "repo": repo,
+                        "target_number": target_number,
+                        "artifact_id": str(comment_id),
+                        "payload_digest": digest,
+                        "overlay": overlay_name,
+                    },
+                },
+            )
+    except (IntegrityError, DatabaseError):
+        return
+    except Exception:  # noqa: BLE001 — must never break the publish path
+        return

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -12,6 +12,7 @@ from teatree.backends.github import (
     GitHubCodeHost,
     ProjectItem,
     _gh_api_get,
+    _gh_api_get_paginated,
     _gh_api_patch,
     _gh_api_post,
     _gh_graphql,
@@ -62,6 +63,45 @@ class TestGhApiGet:
             mock_run.return_value = MagicMock(stdout="{}")
             _gh_api_get("/test", token="tok")
         assert mock_run.call_args[1]["token"] == "tok"
+
+
+class TestGhApiGetPaginated:
+    def test_flattens_slurped_pages(self) -> None:
+        pages = [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+        with patch.object(github_mod, "_run_gh") as mock_run:
+            mock_run.return_value = MagicMock(stdout=json.dumps(pages))
+            result = _gh_api_get_paginated("repos/o/r/issues/5/comments?per_page=100")
+        argv = mock_run.call_args.args
+        assert "--paginate" in argv
+        assert "--slurp" in argv
+        assert "repos/o/r/issues/5/comments?per_page=100" in argv
+        assert result == [{"id": 1}, {"id": 2}, {"id": 3}]
+
+    def test_passes_token(self) -> None:
+        with patch.object(github_mod, "_run_gh") as mock_run:
+            mock_run.return_value = MagicMock(stdout="[]")
+            _gh_api_get_paginated("repos/o/r/issues/5/comments", token="tok")
+        assert mock_run.call_args.kwargs["token"] == "tok"
+
+    def test_empty_pages_return_empty_list(self) -> None:
+        with patch.object(github_mod, "_run_gh") as mock_run:
+            mock_run.return_value = MagicMock(stdout="[]")
+            result = _gh_api_get_paginated("repos/o/r/issues/5/comments")
+        assert result == []
+
+    def test_non_array_outer_payload_returns_empty_list(self) -> None:
+        # A single-object endpoint accidentally passed here must not explode;
+        # ``--slurp`` always yields an outer array, but guard defensively.
+        with patch.object(github_mod, "_run_gh") as mock_run:
+            mock_run.return_value = MagicMock(stdout='{"message": "Not Found"}')
+            result = _gh_api_get_paginated("repos/o/r/issues/5/comments")
+        assert result == []
+
+    def test_skips_non_list_pages(self) -> None:
+        with patch.object(github_mod, "_run_gh") as mock_run:
+            mock_run.return_value = MagicMock(stdout=json.dumps([[{"id": 1}], {"oops": True}]))
+            result = _gh_api_get_paginated("repos/o/r/issues/5/comments")
+        assert result == [{"id": 1}]
 
 
 class TestGhApiPost:
@@ -479,14 +519,43 @@ class TestGitHubCodeHost:
         assert result == {}
 
     def test_list_pr_comments(self) -> None:
+        # ``--slurp`` wraps each page in an outer array; one page → one inner list.
         notes = [{"id": 1, "body": "comment"}]
-        with patch.object(github_mod, "_gh_api_get", return_value=notes):
+        with patch.object(github_mod, "_gh_api_get_paginated", return_value=notes):
             host = GitHubCodeHost()
             result = host.list_pr_comments(repo="org/repo", pr_iid=5)
         assert result == notes
 
     def test_list_pr_comments_returns_empty_for_non_list(self) -> None:
-        with patch.object(github_mod, "_gh_api_get", return_value={"error": "bad"}):
+        with patch.object(github_mod, "_gh_api_get_paginated", return_value=[]):
+            host = GitHubCodeHost()
+            result = host.list_pr_comments(repo="org/repo", pr_iid=5)
+        assert result == []
+
+    def test_list_pr_comments_paginates_beyond_the_first_page(self) -> None:
+        # A PR with >30 comments: GitHub's default page size silently caps a
+        # non-paginated GET at 30, so a ``## Test Plan`` note older than the 30
+        # most-recent comments goes unseen and the evidence-poster duplicates
+        # it every run. ``gh api --paginate --slurp`` returns every page as an
+        # outer array of per-page arrays; the helper flattens them so the
+        # dedup search sees the full comment history.
+        page_one = [{"id": i, "body": f"c{i}"} for i in range(100)]
+        page_two = [{"id": 100, "body": "## Test Plan"}]
+        slurped_pages = json.dumps([page_one, page_two])
+        with patch.object(github_mod, "_run_gh") as mock_run:
+            mock_run.return_value = MagicMock(stdout=slurped_pages)
+            host = GitHubCodeHost()
+            result = host.list_pr_comments(repo="org/repo", pr_iid=5)
+        argv = mock_run.call_args.args
+        assert "--paginate" in argv
+        assert "--slurp" in argv
+        assert result == [*page_one, *page_two]
+        assert {"id": 100, "body": "## Test Plan"} in result
+
+    def test_list_pr_comments_returns_empty_when_slurp_yields_no_pages(self) -> None:
+        # No comments → ``--slurp`` emits ``[]`` (zero pages) → empty result.
+        with patch.object(github_mod, "_run_gh") as mock_run:
+            mock_run.return_value = MagicMock(stdout="[]")
             host = GitHubCodeHost()
             result = host.list_pr_comments(repo="org/repo", pr_iid=5)
         assert result == []


### PR DESCRIPTION
fix(backends): paginate GitHub PR-comment listing so dedup sees the full history

GitHubCodeHost.list_pr_comments did a non-paginated gh api GET, which
GitHub caps at the default 30 comments per page. The evidence-poster
(core/management/commands/pr.py) lists comments to find an existing
'## Test Plan' note and UPDATE it; on a busy PR with >30 comments that
note falls off the first page, so the lookup misses it and a duplicate
note is posted on every run. The GitLab backend already reads per_page=100.

Add _gh_api_get_paginated (gh api --paginate --slurp, flattening the outer
array of per-page arrays, skipping any non-list page) and route
list_pr_comments through it with per_page=100.

Extract record_github_note_claim into github_claims.py to keep github.py
under the module-health LOC cap after the new helper.