### PR TITLE
fix(provision): guard native redis squatter and route linked worktree to backend stack

### DIFF
--- a/src/teatree/core/management/commands/_e2e_discovery.py
+++ b/src/teatree/core/management/commands/_e2e_discovery.py
@@ -93,19 +93,42 @@ def discover_frontend_port(worktree: Worktree, *, linked_ticket: Ticket | None =
     return None
 
 
+def _runs_backend_stack(worktree: Worktree) -> bool:
+    """True when this worktree's compose project runs the backend (``web``) service.
+
+    Overlay-agnostic signal: the overlay returns a non-empty compose file only
+    for the worktree that owns the backend stack (a frontend / data-only repo
+    returns ``""``). ``docker compose exec web`` and the exported
+    ``COMPOSE_PROJECT_NAME`` must target *that* worktree.
+    """
+    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+
+    try:
+        return bool(get_overlay().get_compose_file(worktree))
+    except Exception:  # noqa: BLE001 — a misbehaving overlay hook must not break routing
+        return False
+
+
 def resolve_linked_worktree(linked_ticket: Ticket) -> Worktree | None:
     """Pick the worktree that owns the backend stack for ``linked_ticket``.
 
     The env cache that feeds ``get_e2e_env_extras`` and the
     ``COMPOSE_PROJECT_NAME`` exported for ``docker compose`` calls both live
-    on this worktree. Prefer the first stored-path worktree (deterministic
-    order by pk); fall back to any sibling so a freshly-provisioned ticket
-    with no recorded ``worktree_path`` still routes.
+    on this worktree. A multi-repo ticket has several siblings, and the first
+    by pk is often the *frontend* worktree — exporting its compose project as
+    ``COMPOSE_PROJECT_NAME`` makes ``docker compose exec web`` fail with
+    "service web is not running" (#1322). Prefer the sibling that actually
+    runs the backend stack (non-empty overlay compose file); fall back to the
+    first stored-path worktree, then any sibling so a freshly-provisioned
+    ticket with no recorded ``worktree_path`` still routes.
     """
     siblings = list(Worktree.objects.filter(ticket=linked_ticket).order_by("pk"))
-    for wt in siblings:
-        if (wt.extra or {}).get("worktree_path"):
+    stored = [wt for wt in siblings if (wt.extra or {}).get("worktree_path")]
+    for wt in stored:
+        if _runs_backend_stack(wt):
             return wt
+    if stored:
+        return stored[0]
     return siblings[0] if siblings else None
 
 

--- a/src/teatree/utils/redis_container.py
+++ b/src/teatree/utils/redis_container.py
@@ -20,6 +20,10 @@ IMAGE = "redis:7-alpine"
 HOST_PORT = 6379
 
 
+class NativeRedisSquatterError(RuntimeError):
+    """A non-Docker process holds host 6379, so ``teatree-redis`` cannot bind it."""
+
+
 DEFAULT_DB_COUNT = 16
 
 
@@ -85,6 +89,63 @@ def _evict_squatters() -> None:
         _docker_tolerant("rm", name)
 
 
+def _native_host_listeners() -> list[str]:
+    """Return ``pid/command`` strings for native (non-Docker) listeners on host 6379.
+
+    ``_evict_squatters`` only handles *container* squatters. A native
+    ``redis-server`` started by Homebrew/systemd binds the host port directly,
+    so ``docker run -p 6379:6379`` fails with ``bind: address already in
+    use`` and ``teatree-redis`` is left in ``Created`` state — every worktree's
+    cache/broker traffic then 500s (#1373 sibling). ``lsof`` is the portable
+    probe (macOS + Linux); Docker's own port forwarder (``com.docker`` /
+    ``docker-pr`` / ``dockerd``) is excluded so the shared container's own
+    publish isn't mistaken for a squatter.
+    """
+    if shutil.which("lsof") is None:
+        return []
+    result = run_allowed_to_fail(
+        ["lsof", "-nP", f"-iTCP:{HOST_PORT}", "-sTCP:LISTEN", "-F", "pc"],
+        expected_codes=None,
+    )
+    listeners: list[str] = []
+    pid = ""
+    for line in result.stdout.splitlines():
+        if line.startswith("p"):
+            pid = line[1:].strip()
+        elif line.startswith("c"):
+            command = line[1:].strip()
+            if command and not _is_docker_forwarder(command):
+                listeners.append(f"{pid}/{command}")
+    return listeners
+
+
+def _is_docker_forwarder(command: str) -> bool:
+    """True when *command* is Docker's own port-publish proxy, not a native squatter."""
+    lowered = command.lower()
+    return any(token in lowered for token in ("docker", "vpnkit", "com.docke"))
+
+
+def _guard_native_squatter() -> None:
+    """Raise an actionable error when a native process holds host 6379.
+
+    Eviction is deliberately not attempted: a native ``redis-server`` is
+    almost always a user-managed service (Homebrew/systemd) whose silent kill
+    would surprise the user and lose data. Naming the ``pid/command`` lets the
+    user stop it (``brew services stop redis`` / ``kill <pid>``) and re-run.
+    """
+    listeners = _native_host_listeners()
+    if listeners:
+        joined = ", ".join(listeners)
+        msg = (
+            f"A native (non-Docker) process is listening on host port {HOST_PORT} "
+            f"[{joined}], so the shared '{CONTAINER_NAME}' container cannot bind it "
+            "(docker run would fail with 'address already in use'). Stop the native "
+            "service (e.g. `brew services stop redis` or `kill <pid>`) and re-run, or "
+            "let teatree manage Redis exclusively."
+        )
+        raise NativeRedisSquatterError(msg)
+
+
 def _create(db_count: int) -> None:
     logger.info("Creating %s container on :%d", CONTAINER_NAME, HOST_PORT)
     _docker_checked(
@@ -124,21 +185,27 @@ def ensure_running(db_count: int = DEFAULT_DB_COUNT) -> None:
     cache/broker-touching request 500s. A non-``teatree-redis`` container
     squatting on host port 6379 is evicted before any create/recreate so
     ``docker run -p 6379:6379`` doesn't fail with ``address already in use``.
+    A *native* (non-Docker) ``redis-server`` holding the port cannot be safely
+    evicted, so it raises :class:`NativeRedisSquatterError` naming the process
+    instead of letting ``docker run`` fail with a cryptic bind error.
     """
     current = status()
     if current == "running":
         if not _host_port_published():
             _evict_squatters()
+            _guard_native_squatter()
             _recreate_with_port_publish(db_count)
         return
     if current == "missing":
         _evict_squatters()
+        _guard_native_squatter()
         _create(db_count)
         return
     logger.info("Starting existing %s container (status=%s)", CONTAINER_NAME, current)
     _docker_checked("start", CONTAINER_NAME)
     if not _host_port_published():
         _evict_squatters()
+        _guard_native_squatter()
         _recreate_with_port_publish(db_count)
 
 

--- a/tests/teatree_core/test_e2e_frontend_discovery.py
+++ b/tests/teatree_core/test_e2e_frontend_discovery.py
@@ -1,5 +1,8 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 
+from teatree.core.management.commands._e2e_discovery import resolve_linked_worktree
 from teatree.core.management.commands.e2e import _ticket_frontend_projects
 from teatree.core.models import Ticket, Worktree
 from teatree.core.runners.worktree_start import compose_project
@@ -63,3 +66,91 @@ class TicketFrontendProjectsTests(TestCase):
         assert compose_project(backend_wt) in projects
         # The resolved-worktree ticket's siblings are bypassed when a link is given.
         assert "webapp-wt147" not in projects
+
+
+class ResolveLinkedWorktreeTests(TestCase):
+    """``--linked-to`` must route at the backend-stack worktree, not the FE.
+
+    Defect 2 of souliane/teatree#1322: ``resolve_linked_worktree`` picked the
+    first sibling by pk that had a ``worktree_path``. For a multi-repo ticket
+    whose frontend worktree sorts before the backend, that exported the FE's
+    ``COMPOSE_PROJECT_NAME`` and ``docker compose exec web`` failed with
+    "service web is not running". The resolver must prefer the sibling whose
+    overlay returns a non-empty compose file (the backend stack owner).
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.ticket = Ticket.objects.create(overlay="demo", issue_url="https://example.test/issues/1322")
+        # Frontend worktree is created FIRST (lower pk) — it sorts before the
+        # backend, reproducing the bug's ordering.
+        cls.frontend_wt = Worktree.objects.create(
+            ticket=cls.ticket,
+            overlay="demo",
+            repo_path="frontend-repo",
+            branch="b",
+            extra={"worktree_path": "/ws/1322/frontend-repo"},
+        )
+        cls.backend_wt = Worktree.objects.create(
+            ticket=cls.ticket,
+            overlay="demo",
+            repo_path="backend-repo",
+            branch="b",
+            extra={"worktree_path": "/ws/1322/backend-repo"},
+        )
+
+    def _overlay_with_backend(self, backend_repo_path: str):
+        def get_compose_file(worktree: Worktree) -> str:
+            return "/ws/1322/backend-repo/docker-compose.yml" if worktree.repo_path == backend_repo_path else ""
+
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        overlay = MagicMock()
+        overlay.get_compose_file.side_effect = get_compose_file
+        return overlay
+
+    def test_prefers_backend_stack_owner_over_first_pk(self) -> None:
+        with patch(
+            "teatree.core.overlay_loader.get_overlay",
+            return_value=self._overlay_with_backend("backend-repo"),
+        ):
+            resolved = resolve_linked_worktree(self.ticket)
+
+        assert resolved == self.backend_wt
+
+    def test_falls_back_to_first_stored_when_no_backend_signal(self) -> None:
+        # A misbehaving / empty overlay (no compose file for any repo) must
+        # still route to a worktree — the first stored-path sibling by pk.
+        with patch(
+            "teatree.core.overlay_loader.get_overlay",
+            return_value=self._overlay_with_backend("does-not-exist"),
+        ):
+            resolved = resolve_linked_worktree(self.ticket)
+
+        assert resolved == self.frontend_wt
+
+    def test_returns_none_when_no_siblings(self) -> None:
+        empty = Ticket.objects.create(overlay="demo")
+        assert resolve_linked_worktree(empty) is None
+
+    def test_routes_unstored_sibling_when_none_have_paths(self) -> None:
+        ticket = Ticket.objects.create(overlay="demo")
+        wt = Worktree.objects.create(ticket=ticket, overlay="demo", repo_path="solo", branch="b")
+        with patch(
+            "teatree.core.overlay_loader.get_overlay",
+            return_value=self._overlay_with_backend("solo"),
+        ):
+            assert resolve_linked_worktree(ticket) == wt
+
+    def test_falls_back_when_overlay_hook_raises(self) -> None:
+        # A misbehaving overlay hook must not break routing — the resolver
+        # treats a raising ``get_compose_file`` as "not the backend" and falls
+        # back to the first stored-path sibling.
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        overlay = MagicMock()
+        overlay.get_compose_file.side_effect = RuntimeError("overlay boom")
+        with patch("teatree.core.overlay_loader.get_overlay", return_value=overlay):
+            resolved = resolve_linked_worktree(self.ticket)
+
+        assert resolved == self.frontend_wt

--- a/tests/teatree_utils/test_redis_container.py
+++ b/tests/teatree_utils/test_redis_container.py
@@ -161,6 +161,68 @@ class TestEnsureRunning:
         assert "6379:6379" in run_call
 
 
+class TestNativeSquatterDetection:
+    # lsof -F pc output: each field is prefixed with its type char, so a
+    # `redis-server` command appears as the line `credis-server` and a `p<pid>`
+    # line precedes it.
+    def test_reports_native_redis_listener(self) -> None:
+        with (
+            patch("shutil.which", return_value="/usr/bin/lsof"),
+            patch.object(
+                redis_container,
+                "run_allowed_to_fail",
+                return_value=_completed(stdout="p4242\ncredis-server\n"),
+            ),
+        ):
+            assert redis_container._native_host_listeners() == ["4242/redis-server"]
+
+    def test_ignores_docker_port_forwarder(self) -> None:
+        # Docker's own publish proxy holds the port on behalf of teatree-redis —
+        # that is not a native squatter and must not be reported. The lsof
+        # command field for `com.docker.backend` prints as `ccom.docker.backend`.
+        with (
+            patch("shutil.which", return_value="/usr/bin/lsof"),
+            patch.object(
+                redis_container,
+                "run_allowed_to_fail",
+                return_value=_completed(stdout="p99\nccom.docker.backend\n"),
+            ),
+        ):
+            assert redis_container._native_host_listeners() == []
+
+    def test_returns_empty_when_lsof_absent(self) -> None:
+        with patch("shutil.which", return_value=None):
+            assert redis_container._native_host_listeners() == []
+
+
+class TestNativeSquatterGuard:
+    def test_ensure_running_raises_when_native_redis_holds_port(self) -> None:
+        # Regression (#1373 sibling): a native `redis-server` binds host 6379,
+        # so `_create()` would fail with `bind: address already in use` and
+        # leave teatree-redis in Created state. _evict_squatters only handles
+        # container squatters, so provision must fail loud naming the process.
+        with (
+            patch.object(redis_container, "status", return_value="missing"),
+            patch.object(redis_container, "_non_teatree_squatters_on_host_port", return_value=[]),
+            patch.object(redis_container, "_native_host_listeners", return_value=["4242/redis-server"]),
+            patch.object(redis_container, "_docker_checked") as mock_create,
+            pytest.raises(redis_container.NativeRedisSquatterError, match="4242/redis-server"),
+        ):
+            redis_container.ensure_running(db_count=16)
+        mock_create.assert_not_called()
+
+    def test_ensure_running_creates_when_no_native_listener(self) -> None:
+        with (
+            patch.object(redis_container, "status", return_value="missing"),
+            patch.object(redis_container, "_non_teatree_squatters_on_host_port", return_value=[]),
+            patch.object(redis_container, "_native_host_listeners", return_value=[]),
+            patch.object(redis_container, "_docker_tolerant", return_value=_completed()),
+            patch.object(redis_container, "_docker_checked", return_value=_completed()) as mock_create,
+        ):
+            redis_container.ensure_running(db_count=16)
+        assert mock_create.call_args.args[0] == "run"
+
+
 class TestStop:
     def test_no_op_when_container_missing(self) -> None:
         with (


### PR DESCRIPTION
fix(provision): guard native redis squatter and route linked worktree to backend stack

Two provisioning defects surfaced during a Baurecht local-stack E2E run:

- redis_container only evicts container squatters on host 6379, so a native
  redis-server (Homebrew/systemd) makes docker run -p 6379:6379 fail with
  'address already in use' and leaves teatree-redis in Created state (#1373
  sibling). Detect the native listener via lsof and fail loud naming the
  pid/command instead of letting docker run fail cryptically; Docker's own
  port forwarder is excluded so the shared container's publish is not
  mistaken for a squatter.

- resolve_linked_worktree (--linked-to, #1322) picked the first sibling by
  pk with a worktree_path — often the frontend worktree on a multi-repo
  ticket — so the exported COMPOSE_PROJECT_NAME pointed at the FE project and
  docker compose exec web failed with 'service web is not running'. Prefer
  the sibling that runs the backend stack, detected overlay-agnostic via a
  non-empty overlay get_compose_file; fall back to the prior order.