### PR TITLE
fix(cleanup): parse stash and gone-branch markers robustly so orphan reaping is correct

### DIFF
--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -143,7 +143,7 @@ def prune_branches(repo: str) -> list[str]:
     for line in git.run(repo=repo, args=["branch", "-v", "--no-color"]).splitlines():
         if "[gone]" not in line:
             continue
-        name = line.strip().removeprefix("+ ").split()[0]
+        name = line.strip().removeprefix("* ").removeprefix("+ ").split()[0]
         if name in protected or name in wt_branches:
             continue
         git.branch_delete(repo, name)

--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -5,6 +5,7 @@ stays under the module-health LOC cap. Functions are kept private (``_``
 prefix) because the only public surface is the ``clean-all`` subcommand.
 """
 
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -175,6 +176,30 @@ def prune_branches(repo: str) -> list[str]:
     return cleaned
 
 
+# A ``git stash list`` line is ``stash@{N}: <subject>`` where git writes the
+# subject as ``WIP on <branch>: ...`` (auto-stash) or ``On <branch>: ...``
+# (``git stash push -m``). The branch is the text between the anchored
+# ``[WIP ]on `` prefix and the first ``:`` that follows it. A naive split on
+# ``" on "`` both missed the capital-``On`` (explicit-message) form entirely and
+# mis-parsed any stash whose message contained the word "on", dropping stashes
+# that still belonged to an existing branch.
+_STASH_BRANCH_RE = re.compile(r"^stash@\{\d+\}:\s+(?:WIP on|On)\s+(?P<branch>[^:]+):")
+
+
+def _stash_branch(line: str) -> str:
+    """Return the branch a ``git stash list`` line belongs to, or ``""`` if unparsable.
+
+    A stash taken on a detached HEAD reads ``On (no branch): ...`` — there is no
+    owning branch to compare against, so it is reported as unparsable and the
+    stash is kept rather than reaped.
+    """
+    match = _STASH_BRANCH_RE.match(line)
+    if not match:
+        return ""
+    branch = match.group("branch").strip()
+    return "" if branch == "(no branch)" else branch
+
+
 def drop_orphaned_stashes(repo: str) -> list[str]:
     """Drop stashes whose branch no longer exists."""
     stash_list = git.run(repo=repo, args=["stash", "list"])
@@ -190,12 +215,11 @@ def drop_orphaned_stashes(repo: str) -> list[str]:
     entries = stash_list.splitlines()
     for i in range(len(entries) - 1, -1, -1):
         line = entries[i]
-        if " on " not in line:
+        branch = _stash_branch(line)
+        if not branch or branch in existing:
             continue
-        branch_part = line.split(" on ", 1)[1].split(":")[0].strip()
-        if branch_part not in existing:
-            git.run(repo=repo, args=["stash", "drop", f"stash@{{{i}}}"])
-            cleaned.append(f"Dropped orphaned stash: {line.split(':')[0]} (was on {branch_part})")
+        git.run(repo=repo, args=["stash", "drop", f"stash@{{{i}}}"])
+        cleaned.append(f"Dropped orphaned stash: {line.split(':')[0]} (was on {branch})")
 
     return cleaned
 

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1848,8 +1848,11 @@ class TestPruneBranchesPassOneAndTwo(TestCase):
         ):
             ws_cleanup_mod.prune_branches("/repo")
 
-        for call in mock_del.call_args_list:
-            assert call.args[1] != "*", "branch marker '*' leaked into branch_delete"
+        # The marker must resolve to "feature", which is the protected current
+        # branch — so nothing is deleted at all. The buggy parser yielded "*",
+        # which is unprotected, so it reached branch_delete (and "*" is a
+        # dangerous refspec glob). assert_not_called covers both failures.
+        mock_del.assert_not_called()
 
 
 class TestDropOrphanedStashes(TestCase):

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1823,6 +1823,34 @@ class TestPruneBranchesPassOneAndTwo(TestCase):
 
         mock_del.assert_not_called()
 
+    def test_pass1_strips_current_branch_marker_on_gone_branch(self) -> None:
+        # `git branch -v` prefixes the checked-out branch with "* ". A gone
+        # current branch reads "* feature abc123 [gone] ...". Parsing must
+        # recover "feature" (which is protected as the current branch), never
+        # the literal "*" — passing "*" to branch_delete is both wrong and
+        # dangerous (git interprets it as a refspec glob).
+        def fake_run(*, repo: str = ".", args: list[str]) -> str:
+            if args == ["branch", "-v", "--no-color"]:
+                return "* feature abc123 [gone] some work"
+            if args == ["branch", "--merged", "origin/main", "--no-color"]:
+                return ""
+            if args == ["branch", "--no-color"]:
+                return "* feature"
+            return ""
+
+        with (
+            patch.object(git_mod, "run", side_effect=fake_run),
+            patch.object(git_mod, "current_branch", return_value="feature"),
+            patch.object(git_mod, "default_branch", return_value="main"),
+            patch.object(git_mod, "branch_delete") as mock_del,
+            patch.object(ws_cleanup_mod, "worktree_branches", return_value=set()),
+            patch.object(ws_cleanup_mod, "worktree_map", return_value={}),
+        ):
+            ws_cleanup_mod.prune_branches("/repo")
+
+        for call in mock_del.call_args_list:
+            assert call.args[1] != "*", "branch marker '*' leaked into branch_delete"
+
 
 class TestDropOrphanedStashes(TestCase):
     def test_drops_stash_for_deleted_branch(self) -> None:

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1882,6 +1882,88 @@ class TestDropOrphanedStashes(TestCase):
 
         assert result == []
 
+    def test_drops_explicit_message_stash_for_deleted_branch(self) -> None:
+        # `git stash push -m "msg"` produces "On <branch>: <msg>" (capital On,
+        # no lowercase " on " token). The branch is deleted, so this is a
+        # genuine orphan that must be dropped.
+        stash_output = "stash@{0}: On deleted-branch: refactor parser"
+        branches_output = "* main"
+        calls: list[list[str]] = []
+
+        def fake_run(*, repo: str = ".", args: list[str]) -> str:
+            calls.append(args)
+            if args == ["stash", "list"]:
+                return stash_output
+            if args == ["branch", "--no-color"]:
+                return branches_output
+            return ""
+
+        with patch.object(git_mod, "run", side_effect=fake_run):
+            result = ws_cleanup_mod.drop_orphaned_stashes("/repo")
+
+        assert len(result) == 1
+        assert "deleted-branch" in result[0]
+        assert ["stash", "drop", "stash@{0}"] in calls
+
+    def test_keeps_stash_for_existing_branch_with_on_in_message(self) -> None:
+        # The stash message contains the word "on"; a naive split on " on "
+        # mis-parses the branch as "the login flow" and would drop a stash that
+        # still belongs to the existing branch.
+        stash_output = "stash@{0}: On kept-branch: working on the login flow"
+        branches_output = "* main\n  kept-branch"
+        calls: list[list[str]] = []
+
+        def fake_run(*, repo: str = ".", args: list[str]) -> str:
+            calls.append(args)
+            if args == ["stash", "list"]:
+                return stash_output
+            if args == ["branch", "--no-color"]:
+                return branches_output
+            return ""
+
+        with patch.object(git_mod, "run", side_effect=fake_run):
+            result = ws_cleanup_mod.drop_orphaned_stashes("/repo")
+
+        assert result == []
+        assert not any(a[:2] == ["stash", "drop"] for a in calls)
+
+    def test_keeps_detached_head_stash(self) -> None:
+        # A stash taken on a detached HEAD reads "On (no branch): ..." — there
+        # is no owning branch, so it must be kept rather than reaped.
+        stash_output = "stash@{0}: On (no branch): detached work"
+        branches_output = "* main"
+        calls: list[list[str]] = []
+
+        def fake_run(*, repo: str = ".", args: list[str]) -> str:
+            calls.append(args)
+            if args == ["stash", "list"]:
+                return stash_output
+            if args == ["branch", "--no-color"]:
+                return branches_output
+            return ""
+
+        with patch.object(git_mod, "run", side_effect=fake_run):
+            result = ws_cleanup_mod.drop_orphaned_stashes("/repo")
+
+        assert result == []
+        assert not any(a[:2] == ["stash", "drop"] for a in calls)
+
+
+class TestStashBranch(TestCase):
+    def test_parses_wip_auto_stash(self) -> None:
+        line = "stash@{0}: WIP on feature-x: abc123 init"
+        assert ws_cleanup_mod._stash_branch(line) == "feature-x"
+
+    def test_parses_explicit_message_stash(self) -> None:
+        line = "stash@{2}: On feature-x: working on the parser"
+        assert ws_cleanup_mod._stash_branch(line) == "feature-x"
+
+    def test_unparseable_line_returns_empty(self) -> None:
+        assert ws_cleanup_mod._stash_branch("stash@{0}: Some unusual format") == ""
+
+    def test_detached_head_returns_empty(self) -> None:
+        assert ws_cleanup_mod._stash_branch("stash@{0}: On (no branch): detached work") == ""
+
 
 class TestDropOrphanDatabasesFailure(TestCase):
     def test_returns_empty_when_psql_fails(self) -> None:


### PR DESCRIPTION
fix(cleanup): parse stash and gone-branch markers robustly so orphan reaping is correct

`drop_orphaned_stashes` split each `git stash list` line on the lowercase
token " on " to recover the owning branch, which (a) missed the
capital-`On <branch>:` shape that `git stash push -m` emits, silently
skipping explicit-message stashes, and (b) mis-split any stash whose
message contained the word "on", dropping a stash that still belonged to
an existing branch — data loss. Replaced with an anchored regex matching
both `WIP on <branch>:` and `On <branch>:`, treating `On (no branch):`
(detached HEAD) as unparsable so it is kept.

The neighbouring `prune_branches` Pass-1 gone-branch parser stripped only
the worktree marker (`+ `) before splitting out the branch name, not the
current-branch marker (`* `). A checked-out branch that is also gone read
`* feature ...` and parsed as the literal `*`, which is unprotected and
was passed to `git branch -D` as a refspec glob. Mirror the sibling
parsers and strip `* ` too.

Tests cover both stash shapes, the "on"-in-message and detached-HEAD
cases, and a current+gone branch (RED→GREEN: the buggy parser reaped the
protected current branch; the fix never calls branch_delete).

docs: n/a — bug fix preserving existing contract

Closes #1503