### PR TITLE
fix(review-request): finalize dedup claim after a successful post

### DIFF
--- a/src/teatree/core/management/commands/review_request_post.py
+++ b/src/teatree/core/management/commands/review_request_post.py
@@ -28,6 +28,7 @@ from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError, requi
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 from teatree.core.review_message_cache import persist_review_message
 from teatree.core.review_request_guard import canonical_mr_url, resolve_guard_target, should_post_review_request
+from teatree.loop.review_request_tracker import record_review_request_post
 from teatree.types import RawAPIDict
 
 _ACTION = "review_request_post"
@@ -104,6 +105,18 @@ class Command(TyperCommand):
         resp = messaging.post_message(channel=target.channel_id, text=text, thread_ts="")
         ts = str(resp.get("ts", ""))
         permalink = messaging.get_permalink(channel=target.channel_id, ts=ts)
+
+        # Finalize the guard's claim (#1508). ``should_post_review_request``
+        # took the ``ReviewRequestPost`` get_or_create claim with an empty
+        # ``slack_thread_ts``; without stamping the posted ts here the row
+        # keeps the unposted-orphan shape ``_claim_or_reclaim`` reclaims after
+        # ``_CLAIM_RACE_WINDOW`` — a later re-attempt would post a duplicate
+        # to the review channel (the #1084 incident class).
+        record_review_request_post(
+            mr_url=canonical,
+            slack_channel_id=target.channel_id,
+            slack_thread_ts=ts,
+        )
 
         from django.utils import timezone  # noqa: PLC0415
 

--- a/tests/teatree_core/test_review_request_post_command.py
+++ b/tests/teatree_core/test_review_request_post_command.py
@@ -335,3 +335,63 @@ class TestReviewRequestPostHappyPath(_DataDirMixin, TestCase):
         assert payload["reason"] == "no_messaging_backend"
         # The approval was consumed before the messaging check — single-use.
         assert OnBehalfAudit.objects.count() == 1
+
+
+class TestReviewRequestPostFinalizesClaim(_DataDirMixin, TestCase):
+    """A successful post must finalize the guard's claim row (#1508).
+
+    ``should_post_review_request`` takes the ``ReviewRequestPost``
+    ``get_or_create`` claim before the post (``slack_thread_ts=""``,
+    ``done_at`` unset). If the command never stamps the thread ts after a
+    successful post, the row keeps the *unposted-orphan* shape
+    ``_claim_or_reclaim`` reclaims once older than ``_CLAIM_RACE_WINDOW``
+    — a later re-attempt posts a duplicate to the review channel (the
+    #1084 incident class). After a successful post the row must carry the
+    posted thread ts so it can never be reclaimed as an orphan.
+    """
+
+    def _post_with_real_claim(self) -> _FakeBackend:
+        """Run the happy path with the guard's *real* ``get_or_create`` claim."""
+        OnBehalfApproval.record(
+            target=_MR_URL,
+            action="review_request_post",
+            approver_id="souliane",
+        )
+        backend = _FakeBackend()
+
+        def _real_claim(*, mr_url: str, target: GuardTarget) -> GuardDecision:
+            ReviewRequestPost.objects.get_or_create(
+                mr_url=mr_url,
+                defaults={"slack_channel_id": target.channel_id, "slack_thread_ts": ""},
+            )
+            return GuardDecision(action="post")
+
+        with (
+            patch(f"{_CMD}.resolve_guard_target", return_value=_TARGET),
+            patch(f"{_CMD}.should_post_review_request", side_effect=_real_claim),
+            patch(f"{_CMD}.messaging_from_overlay", return_value=backend),
+        ):
+            code, payload = self._run_or_fail()
+        assert code == 0, payload
+        assert payload["action"] == "post"
+        return backend
+
+    @staticmethod
+    def _run_or_fail() -> tuple[int, dict[str, object]]:
+        return _run("--title", "fix(scope): thing")
+
+    def test_post_stamps_thread_ts_on_claim_row(self) -> None:
+        backend = self._post_with_real_claim()
+        ts = backend.posts and "1.23"
+        post = ReviewRequestPost.objects.get(mr_url=_MR_URL)
+        # The posted thread ts is recorded — the backend returned ts="1.23".
+        assert post.slack_thread_ts == ts
+
+    def test_post_row_no_longer_matches_orphan_reclaim_predicate(self) -> None:
+        self._post_with_real_claim()
+        post = ReviewRequestPost.objects.get(mr_url=_MR_URL)
+        # ``_claim_or_reclaim`` reclaims when this predicate holds (and the
+        # row is stale). A finalized post must break it so no re-attempt
+        # can reclaim the row and post a duplicate.
+        is_unposted_orphan = post.done_at is None and not post.slack_thread_ts
+        assert not is_unposted_orphan


### PR DESCRIPTION
fix(review-request): finalize dedup claim after a successful post

should_post_review_request takes the ReviewRequestPost get_or_create
claim with an empty slack_thread_ts before review_request_post posts.
The command never stamped the posted thread ts, so the row kept the
unposted-orphan shape _claim_or_reclaim reclaims once older than
_CLAIM_RACE_WINDOW (120s) — a stale-MR re-request whose live scan
finds nothing in-window would reclaim it and post a duplicate to the
review channel (the #1084 incident class).

Call record_review_request_post after the post to stamp slack_thread_ts
so the row no longer matches the reclaim predicate. The idempotent
updater leaves last_nag_step/done_at intact.

Closes #1508