### PR TITLE
fix(gitlab_sync): narrow update_ticket set_keys to {prs} so concurrent extra keys survive

### DIFF
--- a/src/teatree/backends/gitlab_sync_prs.py
+++ b/src/teatree/backends/gitlab_sync_prs.py
@@ -227,19 +227,22 @@ def update_ticket(
                 pr_entry[key] = prev[key]
 
     prs[pr_url] = pr_entry
-    extra["prs"] = prs
 
     repos = ticket.repos if isinstance(ticket.repos, list) else []
     if repo_short not in repos:
         repos = [*repos, repo_short]
 
-    # #800 N3: canonical locked RMW; extra + repos (+ optional state)
-    # stay one atomic write via also_set (no split).
+    # #800 N3: canonical locked RMW; narrow set_keys to the only top-level
+    # key this fn mutates (prs) so merge_extra's locked re-read does not
+    # clobber a concurrent writer's sibling key from the stale snapshot
+    # (#1505). repos (+ optional state) ride along via also_set in the
+    # same atomic write (no split).
     also_set: TicketSiblingFields = {"repos": repos}
     if inferred_state and _STATE_ORDER.index(inferred_state) > _STATE_ORDER.index(ticket.state):
         also_set["state"] = inferred_state
 
-    ticket.merge_extra(set_keys=cast("TicketExtra", dict(extra)), also_set=also_set)
+    set_keys = cast("TicketExtra", {"prs": prs})
+    ticket.merge_extra(set_keys=set_keys, also_set=also_set)
 
 
 def infer_state_from_prs(prs_data: dict[str, PREntryDict]) -> str:

--- a/tests/teatree_core/sync/test_ticket_extras.py
+++ b/tests/teatree_core/sync/test_ticket_extras.py
@@ -53,6 +53,45 @@ class TestUpdateTicket(TestCase):
         assert mr["review_permalink"] == "https://slack.com/archives/C123/p456"
         assert mr["e2e_test_plan_url"] == "https://gitlab.com/org/repo/-/merge_requests/50#note_789"
 
+    def test_does_not_clobber_a_concurrent_writers_extra_key(self) -> None:
+        """A concurrent writer's top-level extra key survives a sync from a stale ticket.
+
+        update_ticket only mutates the top-level ``prs`` key, so it must
+        pass ``set_keys={"prs": ...}`` to ``merge_extra`` -- not the whole
+        stale ``extra`` snapshot. Passing the whole snapshot makes
+        ``merge_extra``'s locked re-read overwrite every sibling key
+        (reviewed_sha, last_approval_sha, pr_urls, visual_qa) with the
+        stale value, defeating the lock (the #800 lost-update class).
+
+        Modelled as the canonical lost-update race: a stale in-memory
+        ticket read first, then the reviewer path commits ``reviewed_sha``
+        via the same locked primitive (bare autocommit, the prod shape),
+        then the sync runs from the stale handle.
+        """
+        mr_url = "https://gitlab.com/org/repo/-/merge_requests/50"
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://gitlab.com/org/repo/-/issues/210",
+            repos=["repo"],
+            extra={"reviewed_sha": "old_sha", "prs": {mr_url: {"url": mr_url, "repo": "repo", "title": "old"}}},
+        )
+
+        # Stale handle read BEFORE the concurrent writer commits.
+        stale = Ticket.objects.get(pk=ticket.pk)
+
+        # Concurrent reviewer-path writer stamps a fresh reviewed_sha.
+        ticket.merge_extra(set_keys={"reviewed_sha": "new_sha"})
+
+        # The sync runs from the stale in-memory ticket.
+        new_mr_entry: PREntryDict = {"url": mr_url, "repo": "repo", "title": "new title"}
+        update_ticket(stale, new_mr_entry, mr_url, "repo")
+
+        stale.refresh_from_db()
+        # The concurrent writer's key must survive (the lock did its job).
+        assert stale.extra["reviewed_sha"] == "new_sha"
+        # The sync's own mutation still landed.
+        assert stale.extra["prs"][mr_url]["title"] == "new title"
+
 
 class TestMergeTicketExtras(TestCase):
     def test_combines_mrs_and_repos(self) -> None:


### PR DESCRIPTION
fix(gitlab_sync): narrow update_ticket set_keys to {prs} so concurrent extra keys survive

update_ticket passed the whole stale extra snapshot as merge_extra's
set_keys, so the locked re-read's merged.update(set_keys) overwrote every
top-level key (reviewed_sha, last_approval_sha, pr_urls, visual_qa) with
the stale value, defeating the lock the #800 RMW provides. Narrow set_keys
to {"prs": prs} -- the only top-level key this fn mutates -- mirroring the
sibling sync fns (merge_ticket_extras, apply_merged_status,
apply_closed_status). The _SKILL_WRITTEN_FIELDS carry-forward writes into
the nested prs[pr_url] entry, so it stays inside the prs value.

Closes #1505

docs: n/a — bug fix preserving the existing extra-merge contract
