### PR TITLE
fix(paths): make worktree-anchor detection robust + add doctor entrypoint guard

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -193,5 +193,11 @@ The `t3` CLI uses this to auto-detect which Django settings module to use.
   Otherwise you risk accidentally modifying framework code.
 - Same rules apply to the overlay package.
 
+It also **FAILs when the installed `t3` is anchored to a git worktree**
+instead of the primary clone (a stale editable `.pth`): the worktree-resident
+code auto-isolates onto a per-worktree DB while the loop and canonical state
+live in the canonical DB, so work silently diverges. The fix is to re-anchor
+the editable install at the primary clone (re-run `t3 setup` from it).
+
 These checks run automatically on `t3 doctor check` and as a Django
 system check (warns on every `t3` invocation if misconfigured).

--- a/src/teatree/cli/_doctor_checks.py
+++ b/src/teatree/cli/_doctor_checks.py
@@ -23,6 +23,39 @@ def _check_single_db() -> bool:
     return False
 
 
+def _check_entrypoint_is_primary_clone() -> bool:
+    """FAIL when the running ``t3`` entrypoint is anchored to a worktree (#1507).
+
+    The installed long-lived ``t3`` must import ``teatree`` from the primary
+    clone. A stale editable ``.pth`` anchored to a worktree makes the resident
+    code resolve a per-worktree isolated DB (``paths.DATA_DIR_AUTO_ISOLATED``
+    is then ``True``) while the loop and canonical state live in the true
+    canonical DB — work silently vanishes. This is a hard FAIL, not a WARN,
+    naming the offending worktree, both DB paths, and the remediation.
+
+    Reads the live :mod:`teatree.paths` attributes (resolved at that module's
+    import time from the entrypoint's on-disk location), so it reports the
+    state of the process actually running ``t3 doctor``.
+    """
+    import teatree  # noqa: PLC0415
+    from teatree import paths  # noqa: PLC0415
+
+    if not paths.DATA_DIR_AUTO_ISOLATED:
+        return True
+    # ``teatree.__file__`` is ``<repo>/src/teatree/__init__.py``; the repo root
+    # is its third parent (matches ``paths._code_repo_root``).
+    repo_root = Path(teatree.__file__).resolve().parents[2]
+    isolated_db = paths.DATA_DIR / "db.sqlite3"
+    typer.echo(
+        f"FAIL  Entrypoint is anchored to a worktree, not the primary clone: {repo_root}. "
+        f"The installed t3 resolves the isolated DB {isolated_db} instead of the canonical "
+        f"DB {paths.TRUE_CANONICAL_DB} — loop state and merges silently diverge. Re-anchor "
+        f"the editable install at the primary clone: re-run `t3 setup` from the primary "
+        f"clone (or fix the stale `.pth`), then re-run `t3 doctor check`.",
+    )
+    return False
+
+
 def _check_singletons() -> bool:
     """Clean up stale pid files for known singleton processes."""
     from teatree.utils.singleton import default_pid_path, read_pid  # noqa: PLC0415

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -21,6 +21,7 @@ import typer
 
 from teatree.cli._doctor_checks import (
     _check_editable_sanity,
+    _check_entrypoint_is_primary_clone,
     _check_legacy_overlay_alias,
     _check_single_db,
     _check_singletons,
@@ -56,6 +57,7 @@ __all__ = (
     "IntrospectionHelpers",
     "PackageNotFoundError",
     "_check_editable_sanity",
+    "_check_entrypoint_is_primary_clone",
     "_check_legacy_overlay_alias",
     "_check_single_db",
     "_check_singletons",
@@ -525,6 +527,10 @@ def check() -> bool:
             typer.echo(f"FAIL  Required tool not found: {tool}")
             ok = False
 
+    # Must precede _check_editable_sanity: under contribute=true that check can
+    # auto-make-editable against the cwd worktree, creating the exact stale
+    # worktree-anchored install this guard exists to catch (#1507).
+    ok = _check_entrypoint_is_primary_clone() and ok
     ok = _check_editable_sanity() and ok
     ok = _check_skills() and ok
     ok = _check_single_db() and ok

--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -239,13 +239,34 @@ def update_repo(name: str, repo: Path) -> RepoUpdate:
     return RepoUpdate(name, UpdateStatus.UPDATED, old_sha=old_sha, new_sha=new_sha)
 
 
+def _running_clone() -> Path | None:
+    """The git work-tree the *running* interpreter imports ``teatree`` from.
+
+    Resolved from ``teatree.__file__`` — independent of cwd/``T3_REPO``. A
+    stale editable ``.pth`` anchored to a worktree makes this differ from the
+    configured main clone, which is exactly the silent-isolation case the
+    currency gate must catch (#1507).
+    """
+    import teatree  # noqa: PLC0415
+
+    pkg = teatree.__file__
+    if pkg is None:
+        return None
+    return _git_toplevel(Path(pkg).resolve().parent)
+
+
 def _collect_repos() -> list[tuple[str, Path]]:
-    """Discover teatree core and every registered overlay repo.
+    """Discover teatree core, the running clone, and every registered overlay repo.
 
     Core is resolved via the same ``T3_REPO``/cwd logic ``t3 setup`` uses.
-    Overlays come from ``discover_overlays()`` (the ``teatree.overlays`` entry
-    points merged with ``[overlays.*]`` TOML config); each entry's
-    ``project_path`` is walked up to its containing git work tree.
+    The *running* clone — the work-tree the interpreter actually imports
+    ``teatree`` from — is collected separately so the clone-currency gate
+    audits the code the process runs, not just the configured main clone: a
+    worktree-anchored editable install would otherwise sail past the #948 gate
+    (#1507). Overlays come from ``discover_overlays()`` (the
+    ``teatree.overlays`` entry points merged with ``[overlays.*]`` TOML
+    config); each entry's ``project_path`` is walked up to its containing git
+    work tree.
     """
     from teatree.cli.setup import _find_main_clone  # noqa: PLC0415
     from teatree.config import discover_overlays  # noqa: PLC0415
@@ -258,6 +279,11 @@ def _collect_repos() -> list[tuple[str, Path]]:
         resolved = core.resolve()
         repos.append(("teatree", resolved))
         seen.add(resolved)
+
+    running = _running_clone()
+    if running is not None and running not in seen:
+        seen.add(running)
+        repos.append(("teatree (running)", running))
 
     for entry in discover_overlays():
         if entry.project_path is None:

--- a/src/teatree/paths.py
+++ b/src/teatree/paths.py
@@ -16,6 +16,7 @@ at the true canonical DB is a hard error.
 import fcntl
 import hashlib
 import os
+import re
 import sqlite3
 import tempfile
 from collections.abc import Iterator
@@ -59,6 +60,35 @@ class CanonicalDBFromWorktreeError(RuntimeError):
 def running_from_worktree(repo_root: Path) -> bool:
     """A git worktree has a ``.git`` *file*; a primary clone has a ``.git`` *dir*."""
     return (repo_root / ".git").is_file()
+
+
+def resolve_main_clone(repo_root: Path) -> Path | None:
+    """Resolve *repo_root* to its primary clone, following a worktree pointer.
+
+    A primary clone (``.git`` is a *dir*) resolves to itself. A git worktree
+    (``.git`` is a *file* holding ``gitdir: <main>/.git/worktrees/<name>``)
+    resolves back to the main clone the pointer names. Returns ``None`` when
+    ``.git`` is neither, or the pointer cannot be parsed back to a ``.git``
+    dir. The single source of truth mirrored by ``cli/setup.py`` and
+    ``cli/_doctor_plugin_repair.py`` (#1507).
+    """
+    git = repo_root / ".git"
+    if git.is_dir():
+        return repo_root
+    if git.is_file():
+        match = re.match(r"^gitdir:\s*(.+)$", git.read_text().strip())
+        if not match:
+            return None
+        # A relative ``gitdir:`` is resolved against the ``.git`` file's own
+        # directory (git's gitfile convention), not the process cwd.
+        pointer = Path(match.group(1))
+        if not pointer.is_absolute():
+            pointer = (repo_root / pointer).resolve()
+        # `.git` points at `<main-clone>/.git/worktrees/<name>`; step up to the clone.
+        main_git = pointer.parent.parent
+        if main_git.name == ".git" and main_git.is_dir():
+            return main_git.parent
+    return None
 
 
 def _code_repo_root() -> Path:

--- a/src/teatree/project.py
+++ b/src/teatree/project.py
@@ -1,15 +1,21 @@
 from pathlib import Path
 
+from teatree.paths import resolve_main_clone
+
 
 def find_project_root() -> Path | None:
     """Walk up from this package looking for the teatree project root.
 
     Returns the first ancestor containing both ``.git`` and ``pyproject.toml``,
-    or ``None`` when running from a non-source install.
+    or ``None`` when running from a non-source install. When that ancestor is a
+    git *worktree* (``.git`` is a pointer file), resolves back to the primary
+    clone it points at — a worktree-anchored import must not bind skills or the
+    editable repo to the worktree, which silently isolates the control DB
+    (#1507).
     """
     current = Path(__file__).resolve().parent
     while current != current.parent:
         if (current / ".git").exists() and (current / "pyproject.toml").is_file():
-            return current
+            return resolve_main_clone(current) or current
         current = current.parent
     return None

--- a/tests/cli_doctor/test_doctor_check_command.py
+++ b/tests/cli_doctor/test_doctor_check_command.py
@@ -16,6 +16,7 @@ from typer.testing import CliRunner
 import teatree.cli.doctor as teatree_cli_doctor
 import teatree.cli.update as teatree_cli_update
 import teatree.core.overlay_loader as teatree_overlay_loader
+import teatree.paths as teatree_paths
 from teatree.cli import app
 from teatree.cli.doctor import IntrospectionHelpers
 
@@ -25,20 +26,22 @@ runner = CliRunner()
 
 
 @pytest.fixture(autouse=True)
-def _isolate_clone_currency(monkeypatch):
-    """Pin the pre-investigation clone-currency gate (#948) to "no repos".
+def _isolate_environment_dependent_gates(monkeypatch):
+    """Pin the doctor gates that depend on the runner's real on-disk location.
 
-    The gate calls ``_collect_repos()`` → real ``git fetch origin`` and
-    ``rev-list HEAD..origin/<default>`` against whatever clone the test
-    runner happens to live in.  In a CI checkout that lags behind
-    ``origin/main`` (e.g. a feature branch cut weeks ago) this surfaces
-    a real ``FAIL`` line and makes the doctor smoke tests non-deterministic.
-    The doctor wiring itself is exercised end-to-end in
-    ``tests/teatree_core/test_clone_guard.py``; here we only assert that
-    ``t3 doctor check`` aggregates check results, so an empty repo list
-    is the right boundary.
+    Two gates read the environment the test runner happens to live in and would
+    otherwise make the doctor smoke tests non-deterministic. The clone-currency
+    gate (#948) shells out to real ``git fetch`` / ``rev-list`` against whatever
+    clone the runner lives in (a lagging checkout surfaces a real FAIL), and the
+    entrypoint-is-primary-clone gate (#1507) FAILs when the runner executes from
+    a worktree (``paths.DATA_DIR_AUTO_ISOLATED`` is True) — exactly the case
+    here. Both are exercised end-to-end in their own dedicated modules
+    (``test_clone_guard.py`` and ``test_entrypoint_primary_clone.py``); here we
+    only assert that ``t3 doctor check`` aggregates results, so pinning each to
+    its primary-clone boundary is correct.
     """
     monkeypatch.setattr(teatree_cli_update, "_collect_repos", list)
+    monkeypatch.setattr(teatree_paths, "DATA_DIR_AUTO_ISOLATED", False)
 
 
 class TestDoctorCheckCommand:
@@ -51,6 +54,36 @@ class TestDoctorCheckCommand:
 
     def _write_noop_toml(self, home: Path) -> None:
         _write_teatree_toml(home / ".teatree.toml", "[teatree]\ncontribute = false\n")
+
+    def test_entrypoint_guard_runs_before_editable_autorepair(self, tmp_path, monkeypatch):
+        """The entrypoint guard must fire before editable auto-repair (#1507).
+
+        Under ``contribute=true`` the editable-sanity check can auto-make the
+        cwd worktree editable — the exact stale anchor the guard catches. If it
+        ran first it would create the bad install before the guard fails.
+        """
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
+
+        order: list[str] = []
+
+        def _entry() -> bool:
+            order.append("entrypoint")
+            return True
+
+        def _editable() -> bool:
+            order.append("editable")
+            return True
+
+        with (
+            patch.object(teatree_cli_doctor.shutil, "which", side_effect=lambda t: f"/usr/bin/{t}"),
+            patch.object(teatree_cli_doctor, "_check_entrypoint_is_primary_clone", side_effect=_entry),
+            patch.object(teatree_cli_doctor, "_check_editable_sanity", side_effect=_editable),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+        ):
+            runner.invoke(app, ["doctor", "check"])
+
+        assert order.index("entrypoint") < order.index("editable")
 
     def test_reports_all_checks_passed(self, tmp_path, monkeypatch):
         _stage_home(tmp_path, monkeypatch)

--- a/tests/cli_doctor/test_entrypoint_primary_clone.py
+++ b/tests/cli_doctor/test_entrypoint_primary_clone.py
@@ -1,0 +1,55 @@
+"""``_check_entrypoint_is_primary_clone`` — the silent-isolation guard (#1507).
+
+The installed ``t3`` must run from the primary clone. When a stale editable
+``.pth`` anchors the entrypoint to a worktree, ``paths.DATA_DIR_AUTO_ISOLATED``
+is ``True`` and the process reads a per-worktree isolated DB while the loop and
+canonical state live elsewhere. This guard FAILs that case at session start.
+"""
+
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import teatree
+import teatree.paths as paths_mod
+from teatree.cli._doctor_checks import _check_entrypoint_is_primary_clone
+
+
+def _run() -> tuple[bool, str]:
+    out = io.StringIO()
+    with redirect_stdout(out):
+        ok = _check_entrypoint_is_primary_clone()
+    return ok, out.getvalue()
+
+
+class TestCheckEntrypointIsPrimaryClone:
+    def test_passes_on_primary_clone(self) -> None:
+        """A primary-clone entrypoint (not auto-isolated) passes."""
+        with patch.object(paths_mod, "DATA_DIR_AUTO_ISOLATED", new=False):
+            ok, message = _run()
+        assert ok is True
+        assert "FAIL" not in message
+
+    def test_fails_when_entrypoint_auto_isolated(self, tmp_path: Path) -> None:
+        """An auto-isolated worktree entrypoint FAILs, naming the DBs + remedy."""
+        worktree_root = tmp_path / "wt"
+        pkg_init = worktree_root / "src" / "teatree" / "__init__.py"
+        pkg_init.parent.mkdir(parents=True)
+        pkg_init.touch()
+        isolated_dir = tmp_path / "teatree-worktrees" / "abc123"
+        canonical = tmp_path / "share" / "teatree" / "db.sqlite3"
+        with (
+            patch.object(paths_mod, "DATA_DIR_AUTO_ISOLATED", new=True),
+            patch.object(paths_mod, "DATA_DIR", new=isolated_dir),
+            patch.object(paths_mod, "TRUE_CANONICAL_DB", new=canonical),
+            patch.object(teatree, "__file__", new=str(pkg_init)),
+        ):
+            ok, message = _run()
+        assert ok is False
+        assert "FAIL" in message
+        # Exact repo root, not the ``src`` sub-dir — guards the parents[] depth.
+        assert f": {worktree_root}." in message
+        assert str(isolated_dir / "db.sqlite3") in message
+        assert str(canonical) in message
+        assert "setup" in message

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -374,11 +374,35 @@ class TestCollectRepos:
         ovl = _clone(tmp_path, ovl_bare, "ovl-clone")
 
         monkeypatch.setattr(setup_mod, "_find_main_clone", lambda: None)
+        monkeypatch.setattr(update_mod, "_running_clone", lambda: None)
         monkeypatch.setattr(config_mod, "discover_overlays", lambda: [_Result("ovl", ovl)])
 
         repos = _collect_repos()
 
         assert repos == [("ovl", ovl.resolve())]
+
+    def test_includes_the_clone_the_interpreter_runs_from(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A worktree-anchored entrypoint is audited for currency (#1507).
+
+        ``_find_main_clone`` reports the *configured* main clone (cwd/T3_REPO),
+        but the editable ``.pth`` can be anchored to a worktree the interpreter
+        actually imports from. Unless the running clone is collected, a stale
+        worktree-anchored install sails past the #948 clone-currency gate.
+        """
+        core_bare = _make_remote(tmp_path, "core")
+        core = _clone(tmp_path, core_bare, "core-clone")
+        running_bare = _make_remote(tmp_path, "running")
+        running = _clone(tmp_path, running_bare, "running-clone").resolve()
+
+        monkeypatch.setattr(setup_mod, "_find_main_clone", lambda: core)
+        monkeypatch.setattr(config_mod, "discover_overlays", list)
+        monkeypatch.setattr(update_mod, "_running_clone", lambda: running)
+
+        repos = _collect_repos()
+
+        assert ("teatree (running)", running) in repos
 
 
 class TestReinstallAndResetup:

--- a/tests/test_find_project_root.py
+++ b/tests/test_find_project_root.py
@@ -1,10 +1,36 @@
 """Tests for teatree.find_project_root."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
 import teatree.project
 from teatree import find_project_root
+
+
+def _git(repo: Path, *args: str) -> None:
+    # Trusted fixed argv (literal "git" + test-controlled flags).
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)  # noqa: S607
+
+
+def _make_clone_with_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a real primary clone and a linked git worktree under *tmp_path*.
+
+    Returns ``(main_clone, worktree)``. The worktree's ``.git`` is a real
+    ``gitdir:`` pointer file, so resolution back to the main clone exercises
+    the same path the installed ``t3`` hits from a worktree checkout.
+    """
+    main_clone = tmp_path / "teatree"
+    main_clone.mkdir()
+    _git(main_clone, "init", "-b", "main")
+    _git(main_clone, "config", "user.email", "t@example.com")
+    _git(main_clone, "config", "user.name", "t")
+    (main_clone / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
+    _git(main_clone, "add", "pyproject.toml")
+    _git(main_clone, "commit", "-m", "init")
+    worktree = tmp_path / "wt"
+    _git(main_clone, "worktree", "add", str(worktree), "-b", "feature")
+    return main_clone, worktree
 
 
 class TestFindProjectRoot:
@@ -32,3 +58,37 @@ class TestFindProjectRoot:
         deep.touch()
         with patch.object(teatree.project, "__file__", str(deep)):
             assert find_project_root() == tmp_path
+
+    def test_resolves_worktree_to_main_clone(self, tmp_path: Path) -> None:
+        """From a worktree checkout, find_project_root returns the main clone.
+
+        A worktree's ``.git`` is a *file* (a ``gitdir:`` pointer), not a dir.
+        The naive ``.exists()`` check matched the worktree itself and bound
+        skills / the editable repo to the worktree, isolating the DB (#1507).
+        """
+        main_clone, worktree = _make_clone_with_worktree(tmp_path)
+        pkg_file = worktree / "src" / "teatree" / "project.py"
+        pkg_file.parent.mkdir(parents=True)
+        pkg_file.touch()
+        with patch.object(teatree.project, "__file__", str(pkg_file)):
+            assert find_project_root() == main_clone
+
+    def test_resolves_relative_gitdir_pointer(self, tmp_path: Path) -> None:
+        """A relative ``gitdir:`` pointer resolves against the .git file's dir.
+
+        ``git worktree add --relative-paths`` (and older git) writes a relative
+        pointer; resolving it against the process cwd returns the wrong clone
+        (or None → fallback to the worktree, reintroducing the bad anchor).
+        """
+        main_clone = tmp_path / "teatree"
+        (main_clone / ".git" / "worktrees" / "wt").mkdir(parents=True)
+        (main_clone / "pyproject.toml").write_text("[project]\n")
+        worktree = tmp_path / "wt"
+        (worktree / "src" / "teatree").mkdir(parents=True)
+        (worktree / "pyproject.toml").write_text("[project]\n")
+        # Relative pointer, as `git worktree add --relative-paths` writes it.
+        (worktree / ".git").write_text("gitdir: ../teatree/.git/worktrees/wt\n")
+        pkg_file = worktree / "src" / "teatree" / "project.py"
+        pkg_file.touch()
+        with patch.object(teatree.project, "__file__", str(pkg_file)):
+            assert find_project_root() == main_clone


### PR DESCRIPTION
fix(paths): make worktree-anchor detection robust + add doctor entrypoint guard

A worktree-anchored teatree import silently binds the long-lived entrypoint to a per-worktree isolated DB while the loop and canonical state read the true canonical DB — work appears to vanish (the failure that broke the bug-hunt session itself). Three independent gaps let this happen silently; this closes all three.

## What changed

- **`find_project_root()`** treated a worktree `.git` *file* as a project root (`.exists()` matches both a clone dir and a worktree file, unlike `running_from_worktree()` which uses `.is_file()`). It now follows the `gitdir:` pointer back to the main clone via a new shared `paths.resolve_main_clone()` helper (mirrors `cli/setup._find_main_clone` and `cli/_doctor_plugin_repair._resolve_main_clone`). Relative `gitdir:` pointers are resolved against the `.git` file's own directory, per git's gitfile convention.
- **`t3 doctor check`** gained `_check_entrypoint_is_primary_clone()`, a hard FAIL when the running entrypoint is auto-isolated (`paths.DATA_DIR_AUTO_ISOLATED`), naming the worktree, the isolated DB, the canonical DB (`paths.TRUE_CANONICAL_DB`), and the re-anchor remedy. It runs **before** the editable-sanity auto-repair, which under `contribute=true` could otherwise create the exact stale anchor the guard catches.
- **`update._collect_repos()`** now also includes the clone the interpreter actually runs from (`teatree (running)`, resolved from `teatree.__file__`), so the #948 clone-currency gate audits the running clone instead of only the configured main clone — a stale worktree-anchored `.pth` no longer sails past it.

## Acceptance criteria

- [x] `find_project_root()` returns the main clone when invoked from a worktree checkout (absolute + relative `gitdir:` pointers).
- [x] `t3 doctor check` FAILs (naming worktree + both DB paths + remediation) when the entrypoint is auto-isolated, and passes from a primary clone; the guard runs before editable auto-repair.
- [x] `_collect_repos()` includes the running clone so clone-currency audits the clone the interpreter runs from.
- [x] Regression tests for each part, each observed RED before its fix.

docs: install.md updated to describe the new `t3 doctor check` worktree-anchor FAIL.

Closes #1507
