### PR TITLE
fix(cleanup): refuse force teardown when recovery capture fails on unsaved work

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -361,20 +361,24 @@ def _remove_git_worktree(
     except Exception as exc:
         # #1506 — under force the recovery artifact is the ONLY protection, so a
         # capture failure must not silently fall through to the destructive
-        # remove. Re-check (with the same fail-open probe the capture uses)
-        # whether this worktree actually had work to lose; if so, abort the
-        # remove for it — leave it on disk, keep its branch — rather than
-        # destroying unrecoverable commits/edits. #835's non-blocking intent is
-        # preserved for the safe case: a clean + fully-pushed worktree (where
-        # the failed capture was a no-op anyway) is still reaped.
+        # remove. Re-check (with the fail-closed probe) whether this worktree
+        # actually had work to lose; if so, refuse the teardown for it just like
+        # the non-force #706 guard does — raise before the destructive
+        # remove + the ``worktree.delete()`` DB-row drop, so the worktree is
+        # left intact on disk AND still tracked (no orphaned-on-disk row). #835's
+        # non-blocking intent is preserved for the safe case: a clean +
+        # fully-pushed worktree (where the failed capture was a no-op anyway)
+        # falls through and is still reaped.
         logger.exception("recovery capture failed for %s (%s)", worktree.repo_path, worktree.branch)
-        errors.append(f"recovery capture failed for {worktree.branch}: {exc}")
         if _worktree_has_work_to_lose(repo_main, wt_path, worktree):
-            errors.append(
-                f"recovery capture failed for {worktree.branch} and it has unrecoverable "
-                f"work — kept it on disk at {wt_path}; restore or push it, then re-run cleanup"
+            msg = (
+                f"{worktree.repo_path} ({worktree.branch}): "
+                f"refused teardown — recovery capture failed ({exc}) and the worktree has "
+                f"unrecoverable work (dirty or unpushed). Kept it on disk at {wt_path}; "
+                f"restore or push it, then re-run cleanup."
             )
-            return errors
+            raise RuntimeError(msg) from exc
+        errors.append(f"recovery capture failed for {worktree.branch}: {exc}")
     if not git.worktree_remove(str(repo_main), wt_path):
         errors.append(f"git worktree remove failed for {wt_path}")
     if not git.branch_delete(str(repo_main), worktree.branch):
@@ -385,15 +389,32 @@ def _remove_git_worktree(
 def _worktree_has_work_to_lose(repo_main: Path, wt_path: str, worktree: Worktree) -> bool:
     """Whether removing this worktree would destroy unrecoverable work.
 
-    Mirrors :func:`capture_recovery_artifact`'s own dirty/unpushed decision so a
-    failed capture is re-evaluated against the same criteria: a dirty working
-    tree (uncommitted edits/untracked files) or commits absent from every remote
-    ref. Fails *closed* (returns ``True``) on an inconclusive probe — the
-    conservative branch, since the destructive remove is irreversible.
+    Re-evaluates the same dirty/unpushed criteria :func:`capture_recovery_artifact`
+    uses, but **fails closed** at every step: this guards an irreversible
+    ``branch -D`` + ``worktree remove`` after the recovery capture already
+    failed, so "couldn't determine" must mean "might lose work", not "safe".
+
+    Unpushed commits are checked first via the same fail-open probe the capture
+    uses (it returns ``True`` on an inconclusive ``git log``). Those commits
+    live in the main clone's object store, so a missing worktree dir does not
+    make them safe — the branch is the only copy.
+
+    The dirty working-tree check runs only when the dir is present and uses the
+    strict porcelain probe; an inconclusive ``git status`` (lock contention,
+    corrupt index) raises and is treated as "might be dirty".
+
+    Returns ``False`` only when both checks positively confirm there is nothing
+    to lose — a clean (or already-gone) worktree whose branch is fully pushed,
+    the safe case #835's non-blocking intent still reaps.
     """
+    if _has_unpushed_commits(repo_main, worktree.branch):
+        return True
     if not Path(wt_path).is_dir():
         return False
-    return bool(git.status_porcelain(wt_path)) or _has_unpushed_commits(repo_main, worktree.branch)
+    try:
+        return bool(git.status_porcelain_strict(wt_path))
+    except CommandFailedError:
+        return True
 
 
 def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> CleanupResult:
@@ -420,6 +441,15 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene:
     backends and interactive ``clean-all`` keep this on; the automated FSM
     teardown path passes ``strict_hygiene=False`` (the ticket is MERGED and the
     branch is already on its remote).
+
+    Recovery-capture backstop (#1506, ``force=True`` only): when the #706/#835
+    guards are bypassed by force, the recovery capture is the only protection.
+    If that capture *fails* and the worktree still has work to lose (dirty or
+    unpushed, determined fail-closed), this raises ``RuntimeError`` too — before
+    the destructive remove and the DB-row delete — so the worktree is left
+    intact and tracked rather than silently destroyed. A proven clean+pushed
+    worktree whose (no-op) capture failed is still reaped, with the failure in
+    ``result.errors``.
 
     Pass ``force=True`` only from trusted callers (explicit operator override,
     tests, programmatic API).

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -21,7 +21,7 @@ from teatree.config import load_config
 from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_overlay
-from teatree.core.worktree_recovery import capture_recovery_artifact
+from teatree.core.worktree_recovery import _has_unpushed_commits, capture_recovery_artifact
 from teatree.utils import git
 from teatree.utils.db import drop_db
 from teatree.utils.postgres_secret import remove_postgres_pass_entry
@@ -355,19 +355,45 @@ def _remove_git_worktree(
     # completed-but-uncommitted change set): a dirty or unpushed worktree gets a
     # restorable bundle + working-tree diff under the system temp dir first. A
     # clean, fully-pushed worktree captures nothing — the hard-delete path is
-    # unchanged. A capture failure is surfaced (not raised): blocking the prune
-    # would re-create the stuck-cleanup state #835 explicitly rejects, so we log
-    # loudly, record the error, and still remove the worktree.
+    # unchanged.
     try:
         capture_recovery_artifact(repo_main, wt_path, worktree)
     except Exception as exc:
+        # #1506 — under force the recovery artifact is the ONLY protection, so a
+        # capture failure must not silently fall through to the destructive
+        # remove. Re-check (with the same fail-open probe the capture uses)
+        # whether this worktree actually had work to lose; if so, abort the
+        # remove for it — leave it on disk, keep its branch — rather than
+        # destroying unrecoverable commits/edits. #835's non-blocking intent is
+        # preserved for the safe case: a clean + fully-pushed worktree (where
+        # the failed capture was a no-op anyway) is still reaped.
         logger.exception("recovery capture failed for %s (%s)", worktree.repo_path, worktree.branch)
         errors.append(f"recovery capture failed for {worktree.branch}: {exc}")
+        if _worktree_has_work_to_lose(repo_main, wt_path, worktree):
+            errors.append(
+                f"recovery capture failed for {worktree.branch} and it has unrecoverable "
+                f"work — kept it on disk at {wt_path}; restore or push it, then re-run cleanup"
+            )
+            return errors
     if not git.worktree_remove(str(repo_main), wt_path):
         errors.append(f"git worktree remove failed for {wt_path}")
     if not git.branch_delete(str(repo_main), worktree.branch):
         errors.append(f"git branch -D failed for {worktree.branch}")
     return errors
+
+
+def _worktree_has_work_to_lose(repo_main: Path, wt_path: str, worktree: Worktree) -> bool:
+    """Whether removing this worktree would destroy unrecoverable work.
+
+    Mirrors :func:`capture_recovery_artifact`'s own dirty/unpushed decision so a
+    failed capture is re-evaluated against the same criteria: a dirty working
+    tree (uncommitted edits/untracked files) or commits absent from every remote
+    ref. Fails *closed* (returns ``True``) on an inconclusive probe — the
+    conservative branch, since the destructive remove is irreversible.
+    """
+    if not Path(wt_path).is_dir():
+        return False
+    return bool(git.status_porcelain(wt_path)) or _has_unpushed_commits(repo_main, worktree.branch)
 
 
 def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> CleanupResult:

--- a/src/teatree/core/worktree_recovery.py
+++ b/src/teatree/core/worktree_recovery.py
@@ -93,8 +93,9 @@ def capture_recovery_artifact(repo_main: Path, wt_path: str, worktree: Worktree)
     except Exception:
         # A half-written artifact is worse than none and a stray empty temp dir
         # is litter — drop our own partial dir, then re-raise so the caller logs
-        # and surfaces the failure (it still proceeds with the prune; #835
-        # rejects blocking cleanup on capture trouble).
+        # and surfaces the failure. The caller (#1506) re-checks whether the
+        # worktree actually had work to lose and aborts the prune for it if so;
+        # only a proven clean+pushed worktree is still reaped on capture failure.
         shutil.rmtree(recovery_dir, ignore_errors=True)
         raise
 

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -68,6 +68,19 @@ def status_porcelain(repo: str = ".") -> str:
     return run(repo=repo, args=["status", "--porcelain"])
 
 
+def status_porcelain_strict(repo: str = ".") -> str:
+    """Like :func:`status_porcelain` but raises on a non-zero ``git status`` exit.
+
+    :func:`status_porcelain` swallows git errors and returns whatever (possibly
+    empty) stdout it got, so an inconclusive status (lock contention, corrupt
+    index, missing dir) is indistinguishable from a genuinely clean tree. For a
+    data-loss decision that must fail closed, use this variant: a git error
+    raises ``CommandFailedError`` so the caller can treat "couldn't determine"
+    as "might be dirty" rather than "clean".
+    """
+    return run_strict(repo=repo, args=["status", "--porcelain"])
+
+
 def soft_reset(repo: str = ".", target: str = "") -> None:
     run_strict(repo=repo, args=["reset", "--soft", target])
 

--- a/tests/teatree_core/cleanup/test_recovery.py
+++ b/tests/teatree_core/cleanup/test_recovery.py
@@ -237,14 +237,20 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
         assert (restore / "base.txt").read_text(encoding="utf-8") == "base\nDIRTY EDIT\n"
         assert (restore / "newfile.txt").read_text(encoding="utf-8") == "brand new\n"
 
-    def test_capture_failure_surfaced_and_prune_still_proceeds(self) -> None:
-        """#835/#877 — a capture failure must NOT block the prune (stuck-cleanup).
+    def test_capture_failure_on_dirty_worktree_aborts_removal(self) -> None:
+        """#1506 — capture failure on a DIRTY worktree must NOT destroy the work.
+
+        Under ``force=True`` the data-loss guards are skipped, so the recovery
+        artifact is the only protection. When that capture itself fails (disk
+        full, bundle error) the prior behaviour fell through to ``worktree
+        remove`` + ``branch -D``, destroying the very commits/edits the capture
+        was meant to save. The corrected contract: re-check whether the worktree
+        actually had work to lose and, if so, abort the destructive removal for
+        this worktree — leave it on disk, keep its branch, surface the error.
 
         Drives the production seam (``cleanup_worktree`` → ``_remove_git_worktree``)
         with the real on-disk worktree; only the (unstoppable, deliberately
-        failing) capture is patched to raise. The ticket mandates: do not raise,
-        still remove the worktree, surface the failure in ``errors`` (#877 —
-        the structured channel, not a swallowed label string).
+        failing) capture is patched to raise.
         """
         (self.wt_path / "base.txt").write_text("base\nDIRTY EDIT\n", encoding="utf-8")
         wt = self._make_worktree()
@@ -259,7 +265,43 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
             mock_overlay.return_value.get_cleanup_steps.return_value = []
             result = cleanup_worktree(wt, force=True)  # must NOT raise
 
-        assert not self.wt_path.exists(), "worktree must still be removed despite capture failure"
+        assert self.wt_path.exists(), "dirty worktree must NOT be removed when capture failed"
+        branches = subprocess.run(
+            [_GIT, "-C", str(self.repo_main), "branch", "--format=%(refname:short)"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+        ).stdout.split()
+        assert self.branch in branches, "branch must survive when capture failed on dirty work"
+        assert result.clean is False
+        assert any(f"recovery capture failed for {self.branch}" in e for e in result.errors)
+        assert any("disk full while bundling" in e for e in result.errors)
+        assert any("kept it on disk" in e for e in result.errors), "abort must be surfaced"
+
+    def test_capture_failure_on_clean_pushed_worktree_still_reaped(self) -> None:
+        """#1506/#835 — capture failure on a CLEAN+PUSHED worktree still reaps.
+
+        Capture is a no-op for a clean, fully-pushed worktree (nothing to lose),
+        so a failure of that no-op must not block the prune — preserving #835's
+        non-blocking-cleanup intent for the safe case. The worktree is removed
+        and its branch deleted; the capture error is still surfaced.
+        """
+        _run_git("push", "-q", "origin", f"{self.branch}:main", cwd=self.repo_main)
+        _run_git("fetch", "-q", "origin", cwd=self.repo_main)
+        wt = self._make_worktree()
+        boom = RuntimeError("disk full while bundling")
+
+        with (
+            patch("teatree.core.cleanup.load_config") as mock_config,
+            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.capture_recovery_artifact", side_effect=boom),
+        ):
+            mock_config.return_value.user.workspace_dir = self.workspace
+            mock_overlay.return_value.get_cleanup_steps.return_value = []
+            result = cleanup_worktree(wt, force=True)  # must NOT raise
+
+        assert not self.wt_path.exists(), "clean+pushed worktree must still be reaped"
         assert result.clean is False
         assert any(f"recovery capture failed for {self.branch}" in e for e in result.errors)
         assert any("disk full while bundling" in e for e in result.errors)

--- a/tests/teatree_core/cleanup/test_recovery.py
+++ b/tests/teatree_core/cleanup/test_recovery.py
@@ -96,6 +96,16 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
             mock_overlay.return_value.get_cleanup_steps.return_value = []
             return cleanup_worktree(worktree, force=True)
 
+    def _branch_exists(self) -> bool:
+        branches = subprocess.run(
+            [_GIT, "-C", str(self.repo_main), "branch", "--format=%(refname:short)"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+        ).stdout.split()
+        return self.branch in branches
+
     def test_uncommitted_changes_recovered_before_prune(self) -> None:
         # Uncommitted work in the worktree: an edit + a brand-new file.
         (self.wt_path / "base.txt").write_text("base\nDIRTY EDIT\n", encoding="utf-8")
@@ -245,8 +255,9 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
         full, bundle error) the prior behaviour fell through to ``worktree
         remove`` + ``branch -D``, destroying the very commits/edits the capture
         was meant to save. The corrected contract: re-check whether the worktree
-        actually had work to lose and, if so, abort the destructive removal for
-        this worktree — leave it on disk, keep its branch, surface the error.
+        actually had work to lose and, if so, refuse the teardown (raise, like
+        the non-force #706 guard) — leaving the worktree on disk, its branch,
+        and its tracking DB row all intact.
 
         Drives the production seam (``cleanup_worktree`` → ``_remove_git_worktree``)
         with the real on-disk worktree; only the (unstoppable, deliberately
@@ -263,21 +274,12 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
             mock_overlay.return_value.get_cleanup_steps.return_value = []
-            result = cleanup_worktree(wt, force=True)  # must NOT raise
+            with pytest.raises(RuntimeError, match="refused teardown"):
+                cleanup_worktree(wt, force=True)
 
         assert self.wt_path.exists(), "dirty worktree must NOT be removed when capture failed"
-        branches = subprocess.run(
-            [_GIT, "-C", str(self.repo_main), "branch", "--format=%(refname:short)"],
-            check=True,
-            capture_output=True,
-            text=True,
-            env=_clean_env(),
-        ).stdout.split()
-        assert self.branch in branches, "branch must survive when capture failed on dirty work"
-        assert result.clean is False
-        assert any(f"recovery capture failed for {self.branch}" in e for e in result.errors)
-        assert any("disk full while bundling" in e for e in result.errors)
-        assert any("kept it on disk" in e for e in result.errors), "abort must be surfaced"
+        assert self._branch_exists(), "branch must survive when capture failed on dirty work"
+        assert Worktree.objects.filter(branch=self.branch).exists(), "DB row must survive (not orphaned on disk)"
 
     def test_capture_failure_on_clean_pushed_worktree_still_reaped(self) -> None:
         """#1506/#835 — capture failure on a CLEAN+PUSHED worktree still reaps.
@@ -306,6 +308,94 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
         assert any(f"recovery capture failed for {self.branch}" in e for e in result.errors)
         assert any("disk full while bundling" in e for e in result.errors)
         assert _recovery_dirs(self.temp_root) == [], "no artifact when capture itself failed"
+
+    def test_capture_failure_on_clean_unpushed_worktree_aborts_removal(self) -> None:
+        """#1506 — a clean working tree with UNPUSHED commits still aborts.
+
+        The branch holds the only copy of the committed work; a clean working
+        tree does not make it safe. Capture-failure must abort the destructive
+        ``branch -D`` so the commits survive.
+        """
+        (self.wt_path / "feature.txt").write_text("feature work\n", encoding="utf-8")
+        _run_git("add", "-A", cwd=self.wt_path)
+        _run_git("commit", "-q", "-m", "feat: unpushed feature", cwd=self.wt_path)
+        wt = self._make_worktree()
+        boom = RuntimeError("disk full while bundling")
+
+        with (
+            patch("teatree.core.cleanup.load_config") as mock_config,
+            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.capture_recovery_artifact", side_effect=boom),
+        ):
+            mock_config.return_value.user.workspace_dir = self.workspace
+            mock_overlay.return_value.get_cleanup_steps.return_value = []
+            with pytest.raises(RuntimeError, match="refused teardown"):
+                cleanup_worktree(wt, force=True)
+
+        assert self._branch_exists(), "branch with unpushed commits must survive"
+        assert Worktree.objects.filter(branch=self.branch).exists()
+
+    def test_capture_failure_with_missing_dir_and_unpushed_commits_aborts(self) -> None:
+        """#1506 — a gone worktree dir does NOT make unpushed branch commits safe.
+
+        The unpushed-commit probe must run independently of the worktree dir's
+        existence; the commits live in the main clone's object store. With the
+        dir already removed but the branch unpushed, ``branch -D`` must still be
+        aborted.
+        """
+        (self.wt_path / "feature.txt").write_text("feature work\n", encoding="utf-8")
+        _run_git("add", "-A", cwd=self.wt_path)
+        _run_git("commit", "-q", "-m", "feat: unpushed feature", cwd=self.wt_path)
+        # Remove the worktree dir out-of-band (the capture-failure re-check then
+        # sees a missing dir but a branch that is still unpushed).
+        _run_git("worktree", "remove", "--force", str(self.wt_path), cwd=self.repo_main)
+        assert not self.wt_path.exists()
+        wt = self._make_worktree()
+        boom = RuntimeError("disk full while bundling")
+
+        with (
+            patch("teatree.core.cleanup.load_config") as mock_config,
+            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.capture_recovery_artifact", side_effect=boom),
+        ):
+            mock_config.return_value.user.workspace_dir = self.workspace
+            mock_overlay.return_value.get_cleanup_steps.return_value = []
+            with pytest.raises(RuntimeError, match="refused teardown"):
+                cleanup_worktree(wt, force=True)
+
+        assert self._branch_exists(), "unpushed branch must survive a gone-dir capture failure"
+        assert Worktree.objects.filter(branch=self.branch).exists()
+
+    def test_capture_failure_with_inconclusive_status_aborts(self) -> None:
+        """#1506 — an inconclusive ``git status`` must fail closed (might be dirty).
+
+        Branch is pushed (no unpushed commits), but the strict dirty probe
+        raises (lock contention / corrupt index). The re-check must treat the
+        un-determinable working-tree state as "might have work to lose" and
+        abort the destructive remove rather than assume clean.
+        """
+        _run_git("push", "-q", "origin", self.branch, cwd=self.repo_main)
+        _run_git("fetch", "-q", "origin", cwd=self.repo_main)
+        wt = self._make_worktree()
+        boom = RuntimeError("disk full while bundling")
+
+        with (
+            patch("teatree.core.cleanup.load_config") as mock_config,
+            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.capture_recovery_artifact", side_effect=boom),
+            patch(
+                "teatree.core.cleanup.git.status_porcelain_strict",
+                side_effect=CommandFailedError(["git"], 128, "", "index.lock"),
+            ),
+        ):
+            mock_config.return_value.user.workspace_dir = self.workspace
+            mock_overlay.return_value.get_cleanup_steps.return_value = []
+            with pytest.raises(RuntimeError, match="refused teardown"):
+                cleanup_worktree(wt, force=True)
+
+        assert self.wt_path.exists(), "inconclusive status must abort the remove (fail closed)"
+        assert self._branch_exists()
+        assert Worktree.objects.filter(branch=self.branch).exists()
 
     def test_clean_merged_worktree_hard_deletes_with_no_artifact(self) -> None:
         # Branch tip == origin/main, clean working tree: nothing to lose.

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1057,6 +1057,10 @@ class TestWorkspaceCleanAll(TestCase):
                 patch.object(cleanup_mod, "load_config", return_value=mock_config),
                 patch.object(cleanup_mod, "git") as mock_git,
                 patch.object(cleanup_mod, "get_overlay") as mock_overlay,
+                # The fake repo (.git is a bare dir) can't satisfy a real
+                # ``git bundle``; isolate the recovery-capture seam so this test
+                # exercises the clean+pushed reap path, not the capture itself.
+                patch.object(cleanup_mod, "capture_recovery_artifact", return_value=None),
             ):
                 mock_overlay.return_value.get_cleanup_steps.return_value = []
                 mock_git.status_porcelain.return_value = ""
@@ -1355,6 +1359,10 @@ class TestWorkspaceCleanAll(TestCase):
                 patch.object(cleanup_mod, "git") as mock_git,
                 patch.object(cleanup_mod, "get_overlay") as mock_overlay,
                 patch.object(cleanup_mod, "classify_branch_commits", side_effect=_classify),
+                # Isolate the recovery-capture seam — the fake repos (.git is a
+                # bare dir) can't satisfy a real ``git bundle``; this test
+                # targets the origin/main hygiene refusal, not capture.
+                patch.object(cleanup_mod, "capture_recovery_artifact", return_value=None),
             ):
                 mock_overlay.return_value.get_cleanup_steps.return_value = []
                 mock_git.status_porcelain.return_value = ""

--- a/tests/teatree_core/test_runners_teardown.py
+++ b/tests/teatree_core/test_runners_teardown.py
@@ -242,11 +242,15 @@ class TestWorktreeTeardownUnpushedGuard(TestCase):
         assert self.wt_path.exists(), "worktree destroyed despite an inconclusive data-loss probe"
         assert Worktree.objects.filter(branch="branch-git-never-heard-of").exists()
 
-    def test_force_still_overrides_when_probe_would_error(self) -> None:
-        """Force bypasses the probe entirely.
+    def test_force_with_inconclusive_probe_and_capture_failure_keeps_worktree(self) -> None:
+        """#1506 — force skips the *guard* but the recovery capture still protects.
 
-        The explicit force escape hatch skips the data-loss probe, so an
-        unknown branch does not block a forced teardown.
+        Force bypasses the pre-remove data-loss guard, but the recovery capture
+        becomes the only safety net. When the branch is unknown to git the
+        capture (a ``git bundle`` of that branch) fails, and the post-failure
+        re-check cannot prove there is nothing to lose — so it fails closed and
+        the worktree is kept rather than hard-deleted. (Pre-#1506 this forced
+        teardown destroyed the worktree on a capture failure.)
         """
         ticket = Ticket.objects.create(
             overlay="test",
@@ -263,5 +267,5 @@ class TestWorktreeTeardownUnpushedGuard(TestCase):
 
         result = self._teardown(ticket, force=True)
 
-        assert result.ok is True, result.detail
-        assert not self.wt_path.exists()
+        assert result.ok is False, result.detail
+        assert self.wt_path.exists(), "inconclusive capture must fail closed, not destroy the worktree"


### PR DESCRIPTION
## Problem

`_remove_git_worktree(force=True)` in `src/teatree/core/cleanup.py` skips the #706/#835 data-loss guards by design (the non-blocking-cleanup intent). Under force, the recovery artifact written by `capture_recovery_artifact()` is the only protection against losing a dirty or unpushed worktree. A capture **failure** (disk full, bundle error) was caught and logged but execution fell through to `git.worktree_remove` + `git branch -D`, destroying the unpushed/dirty commits the capture was meant to save.

## Fix

On a capture exception under force, re-probe whether the worktree actually had work to lose and, if so, refuse the teardown by raising `RuntimeError` (mirroring the non-force #706 guard) **before** the destructive remove and the `worktree.delete()` DB-row drop — leaving the worktree on disk, its branch, and its tracking row all intact. The `WorktreeTeardown` runner reports `ok=False` so the FSM stays put. A proven clean+pushed worktree whose (no-op) capture failed is still reaped, preserving #835's intent for the safe case.

The re-probe **fails closed** at every step: it checks unpushed commits first (independent of the worktree dir's existence — the branch is the only copy), and uses a new `git.status_porcelain_strict` so an inconclusive `git status` is treated as "might be dirty" rather than "clean".

## Scope vs #1506

- Force teardown of a dirty/unpushed worktree whose capture raises does NOT delete the branch/worktree — recorded + kept recoverable. ✅
- Force teardown of a clean+pushed worktree whose capture is a no-op is still reaped (no #835 regression). ✅

## Tests

Updates the test that enshrined the buggy fall-through and adds fail-closed regression tests (missing-dir-with-unpushed-commits, inconclusive-status, clean-but-unpushed); updates the `test_runners_teardown` force-override and two `clean-all` seam tests to the corrected contract.

docs: n/a — bug fix, contract documented in the touched docstrings

Closes #1506