### PR TITLE
fix(github): paginate Projects v2 items query (drops items past 100)

### DIFF
--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -218,7 +218,8 @@ _PROJECT_ITEMS_QUERY = """\
 {{
     user(login: "{owner}") {{
         projectV2(number: {project_number}) {{
-            items(first: 100) {{
+            items(first: 100{after}) {{
+                pageInfo {{ hasNextPage endCursor }}
                 nodes {{
                     fieldValueByName(name: "Status") {{
                         ... on ProjectV2ItemFieldSingleSelectValue {{ name }}
@@ -245,16 +246,33 @@ def fetch_project_items(
     *,
     token: str = "",
 ) -> list[ProjectItem]:
-    """Fetch all items from a GitHub Projects v2 board, preserving board order."""
-    data = _gh_graphql(_PROJECT_ITEMS_QUERY.format(owner=owner, project_number=project_number), token=token)
-    # ``dig`` null-guards each hop: GraphQL returns ``null`` (not ``{}``) for a
-    # user/project the token cannot see, where a chained ``.get(k, {})`` would
-    # call ``.get`` on ``None`` and crash the board sync.
-    raw_items = dig(data, "data", "user", "projectV2", "items", "nodes")
-    nodes = raw_items if isinstance(raw_items, list) else []
-    return [
-        item for position, node in enumerate(nodes) if (item := _project_item_from_node(node, position)) is not None
-    ]
+    """Fetch all items from a GitHub Projects v2 board, preserving board order.
+
+    The ``items`` connection caps each page at 100 nodes, so a board with more
+    than 100 items must be walked page by page via the ``pageInfo`` cursor —
+    otherwise every item past the first page is silently dropped from the sync.
+    """
+    items: list[ProjectItem] = []
+    position = 0
+    after = ""
+    while True:
+        query = _PROJECT_ITEMS_QUERY.format(owner=owner, project_number=project_number, after=after)
+        data = _gh_graphql(query, token=token)
+        # ``dig`` null-guards each hop: GraphQL returns ``null`` (not ``{}``) for
+        # a user/project the token cannot see, where a chained ``.get(k, {})``
+        # would call ``.get`` on ``None`` and crash the board sync.
+        raw_items = dig(data, "data", "user", "projectV2", "items", "nodes")
+        nodes = raw_items if isinstance(raw_items, list) else []
+        for node in nodes:
+            if (item := _project_item_from_node(node, position)) is not None:
+                items.append(item)
+            position += 1
+        if dig(data, "data", "user", "projectV2", "items", "pageInfo", "hasNextPage") is not True:
+            return items
+        end_cursor = dig(data, "data", "user", "projectV2", "items", "pageInfo", "endCursor")
+        if not isinstance(end_cursor, str) or not end_cursor:
+            return items
+        after = f', after: "{end_cursor}"'
 
 
 def _project_item_from_node(node: object, position: int) -> ProjectItem | None:

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -294,6 +294,43 @@ class TestFetchProjectItems:
         assert len(items) == 1
         assert items[0].status == ""
 
+    def test_follows_pagination_across_pages(self) -> None:
+        def _page(number: int, *, has_next: bool, cursor: str) -> dict[str, object]:
+            return {
+                "data": {
+                    "user": {
+                        "projectV2": {
+                            "items": {
+                                "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                                "nodes": [
+                                    {
+                                        "fieldValueByName": {"name": "Todo"},
+                                        "content": {
+                                            "number": number,
+                                            "title": f"Issue {number}",
+                                            "url": f"https://github.com/org/repo/issues/{number}",
+                                            "updatedAt": "2026-04-01T00:00:00Z",
+                                            "labels": {"nodes": []},
+                                        },
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                }
+            }
+
+        pages = [
+            _page(1, has_next=True, cursor="CURSOR_PAGE_1"),
+            _page(2, has_next=False, cursor="CURSOR_PAGE_2"),
+        ]
+        with patch.object(github_mod, "_gh_graphql", side_effect=pages) as mock_graphql:
+            items = fetch_project_items("testuser", 1)
+        assert mock_graphql.call_count == 2
+        assert [item.issue_number for item in items] == [1, 2]
+        assert [item.position for item in items] == [0, 1]
+        assert "CURSOR_PAGE_1" in mock_graphql.call_args_list[1].args[0]
+
 
 class TestGitHubCodeHost:
     def test_create_pr(self) -> None:


### PR DESCRIPTION
## Problem

`fetch_project_items` in `src/teatree/backends/github.py` issued a single GraphQL query against a GitHub Projects v2 board with `items(first: 100)` and no pagination — `_gh_graphql` was called exactly once and only the first 100 board items were ever read.

On any board with more than 100 items, every item past the first 100 was silently dropped from the sync: no error, no warning, the affected tickets simply vanished from the synced set.

## Fix

- Add `pageInfo { hasNextPage endCursor }` to the `items` connection and an `after` cursor argument to the query.
- Walk `fetch_project_items` page by page, accumulating nodes and following `endCursor` while `hasNextPage` is true, until the board is exhausted.
- Board order is preserved: `position` stays a monotonic node index across the full accumulated stream.
- The per-hop `dig` null-guards are unchanged, so single-page boards and unseen-project responses behave exactly as before.

## Test

`test_follows_pagination_across_pages` mocks a two-page GraphQL response (page 1: `hasNextPage=true` + `endCursor`; page 2: `hasNextPage=false`) and asserts the sync issues two GraphQL calls, processes items from BOTH pages, follows the page-1 cursor on the second call, and keeps positions monotonic. Observed RED before the fix (`assert 1 == 2` on the call count — only page 1 was read), GREEN after.

Closes #1511