### PR TITLE
fix(notify): honor never-raise contract on DatabaseError (not just IntegrityError)

### DIFF
--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -142,6 +142,11 @@ def notify_user(  # noqa: PLR0913 — single notification egress; each kwarg is 
             )
     except IntegrityError:
         logger.debug("notify_user race on key=%s — already audited", idempotency_key)
+    except DatabaseError as exc:
+        # The DM has already landed; a locked/failed audit write must
+        # never escape and break the caller's FSM transition (the
+        # never-raise contract). Mirror ``_record_outbound_claim``.
+        logger.warning("notify_user audit write failed for key=%s: %s", idempotency_key, exc)
 
     _maybe_stamp_answered(
         idempotency_key=idempotency_key,
@@ -377,6 +382,8 @@ def _record_noop(*, idempotency_key: str, kind: NotifyKind, text: str, reason: s
             )
     except IntegrityError:
         logger.debug("notify_user noop race on key=%s", idempotency_key)
+    except DatabaseError as exc:
+        logger.warning("notify_user noop audit write failed for key=%s: %s", idempotency_key, exc)
 
 
 def _record_failed(*, idempotency_key: str, kind: NotifyKind, text: str, error: str) -> None:
@@ -391,6 +398,8 @@ def _record_failed(*, idempotency_key: str, kind: NotifyKind, text: str, error: 
             )
     except IntegrityError:
         logger.debug("notify_user failed-row race on key=%s", idempotency_key)
+    except DatabaseError as exc:
+        logger.warning("notify_user failed-row audit write failed for key=%s: %s", idempotency_key, exc)
 
 
 __all__ = ["NotifyKind", "notify_user"]

--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -85,13 +85,22 @@ def notify_user(  # noqa: PLR0913 — single notification egress; each kwarg is 
     # able to retry under the same key (#1306). We delete the recoverable
     # row so the verify-by-re-read invariant still holds: the terminal
     # ledger entry reflects the eventual outcome, not a transient miss.
-    existing = BotPing.objects.filter(idempotency_key=idempotency_key).first()
-    if existing is not None:
-        if existing.status == BotPing.Status.SENT:
-            logger.debug("notify_user idempotent no-op for key=%s", idempotency_key)
-            return True
-        logger.info("notify_user retrying key=%s (prior status=%s)", idempotency_key, existing.status)
-        existing.delete()
+    #
+    # The ledger lookup/cleanup is a DB read+delete before any delivery;
+    # a DatabaseError here (e.g. SQLite "database is locked") must not
+    # escape the never-raise contract. We fail closed — return False
+    # without delivering — so the caller's FSM transition keeps moving.
+    try:
+        existing = BotPing.objects.filter(idempotency_key=idempotency_key).first()
+        if existing is not None:
+            if existing.status == BotPing.Status.SENT:
+                logger.debug("notify_user idempotent no-op for key=%s", idempotency_key)
+                return True
+            logger.info("notify_user retrying key=%s (prior status=%s)", idempotency_key, existing.status)
+            existing.delete()
+    except DatabaseError as exc:
+        logger.warning("notify_user idempotency-ledger access failed for key=%s: %s", idempotency_key, exc)
+        return False
 
     resolved_backend = backend if backend is not None else messaging_from_overlay()
     resolved_user_id = user_id if user_id is not None else _resolve_user_id()

--- a/tests/teatree_core/test_notify.py
+++ b/tests/teatree_core/test_notify.py
@@ -287,14 +287,31 @@ class TestNotifyUserNeverRaises(TestCase):
     """The never-raise contract holds for any DatabaseError, not just IntegrityError.
 
     ``notify_user`` runs inside FSM transitions and the public docstring
-    promises it never raises into the CLI turn. The SENT-audit write
-    previously caught only ``IntegrityError``, so an ``OperationalError``
-    (e.g. SQLite "database is locked") raised by the ``BotPing`` create —
-    after the DM had already landed — escaped and broke the caller's
-    transition. The most-defensive sibling (``_record_outbound_claim``)
-    already swallows the full ``DatabaseError`` breadth; the audit writes
-    must match it.
+    promises it never raises into the CLI turn. Pre-fix the SENT-audit
+    write caught only ``IntegrityError``, so an ``OperationalError`` (e.g.
+    SQLite "database is locked") raised by the ``BotPing`` create — after
+    the DM had already landed — escaped and broke the caller's transition.
+    The same too-narrow catch applied to the NOOP/FAILED audit writes and
+    to the early idempotency-ledger read+delete. The most-defensive
+    sibling (``_record_outbound_claim``) already swallows the full
+    ``DatabaseError`` breadth; every DB access in ``notify_user`` must
+    match it so no ``DatabaseError`` reaches the caller.
     """
+
+    def test_operational_error_on_idempotency_ledger_read_is_swallowed(self) -> None:
+        backend = _backend()
+        with patch.object(BotPing.objects, "filter", side_effect=_DB_LOCKED):
+            sent = notify_user(
+                "ledger read under lock contention",
+                kind=NotifyKind.INFO,
+                idempotency_key="db-locked-ledger",
+                backend=backend,
+                user_id="U_ME",
+            )
+
+        # Fail closed: no delivery, no propagation, caller keeps moving.
+        assert sent is False
+        backend.post_message.assert_not_called()
 
     def test_operational_error_on_sent_audit_is_swallowed(self) -> None:
         backend = _backend()

--- a/tests/teatree_core/test_notify.py
+++ b/tests/teatree_core/test_notify.py
@@ -2,10 +2,13 @@
 
 from unittest.mock import MagicMock, patch
 
+from django.db import OperationalError
 from django.test import TestCase
 
 from teatree.core.models import BotPing
 from teatree.notify import NotifyKind, notify_user
+
+_DB_LOCKED = OperationalError("database is locked")
 
 
 def _backend(*, permalink: str = "https://acme.slack.com/archives/D-USER/p1700000000000000") -> MagicMock:
@@ -278,6 +281,73 @@ class TestNotifyUser(TestCase):
         assert sent is False
         backend.open_dm.assert_not_called()
         assert not BotPing.objects.filter(idempotency_key="disabled").exists()
+
+
+class TestNotifyUserNeverRaises(TestCase):
+    """The never-raise contract holds for any DatabaseError, not just IntegrityError.
+
+    ``notify_user`` runs inside FSM transitions and the public docstring
+    promises it never raises into the CLI turn. The SENT-audit write
+    previously caught only ``IntegrityError``, so an ``OperationalError``
+    (e.g. SQLite "database is locked") raised by the ``BotPing`` create —
+    after the DM had already landed — escaped and broke the caller's
+    transition. The most-defensive sibling (``_record_outbound_claim``)
+    already swallows the full ``DatabaseError`` breadth; the audit writes
+    must match it.
+    """
+
+    def test_operational_error_on_sent_audit_is_swallowed(self) -> None:
+        backend = _backend()
+        create = BotPing.objects.create
+        with patch.object(BotPing.objects, "create", autospec=True) as mock_create:
+
+            def _raise_on_sent(*args: object, **kwargs: object) -> BotPing:
+                if kwargs.get("status") == BotPing.Status.SENT:
+                    raise _DB_LOCKED
+                return create(*args, **kwargs)
+
+            mock_create.side_effect = _raise_on_sent
+
+            sent = notify_user(
+                "lock contention on the audit write",
+                kind=NotifyKind.INFO,
+                idempotency_key="db-locked-sent",
+                backend=backend,
+                user_id="U_ME",
+            )
+
+        # DM landed; the failed audit write must not propagate or flip the result.
+        assert sent is True
+        backend.post_message.assert_called_once()
+
+    def test_operational_error_on_noop_audit_is_swallowed(self) -> None:
+        with (
+            patch("teatree.core.notify.messaging_from_overlay", return_value=None),
+            patch.object(BotPing.objects, "create", side_effect=_DB_LOCKED),
+        ):
+            sent = notify_user(
+                "no backend, locked audit",
+                kind=NotifyKind.QUESTION,
+                idempotency_key="db-locked-noop",
+                backend=None,
+                user_id="U_ME",
+            )
+
+        assert sent is False
+
+    def test_operational_error_on_failed_audit_is_swallowed(self) -> None:
+        backend = _backend()
+        backend.post_message.side_effect = RuntimeError("slack timeout")
+        with patch.object(BotPing.objects, "create", side_effect=_DB_LOCKED):
+            sent = notify_user(
+                "delivery failed, locked audit",
+                kind=NotifyKind.INFO,
+                idempotency_key="db-locked-failed",
+                backend=backend,
+                user_id="U_ME",
+            )
+
+        assert sent is False
 
 
 class TestNotifyUserLinkify(TestCase):


### PR DESCRIPTION
## Problem

`teatree.core.notify.notify_user` documents a strict never-raise contract — the public module docstring states it "never raises into the CLI turn", and `notify_user` runs inside FSM transitions where the only correct failure mode is to log-and-swallow and return `False`.

The `BotPing` audit writes (SENT, NOOP, FAILED) and the early idempotency-ledger read+delete caught only `IntegrityError`. A `django.db.OperationalError` (a sibling of `IntegrityError` under `DatabaseError` — e.g. SQLite "database is locked" under concurrent writes) was therefore not caught and propagated out of `notify_user`, breaking the caller's FSM transition. On the SENT path the escape happened *after* the DM had already landed, so the caller could leave a dispatch row non-terminal or retry and double-post.

The sibling helper `_record_outbound_claim` in the same module already handles the full breadth (`IntegrityError` race no-op, then `DatabaseError`, then best-effort `Exception`). The other DB accesses should mirror that so the never-raise contract actually holds.

## Fix

- Broaden the three `BotPing.objects.create` handlers (SENT-audit, `_record_noop`, `_record_failed`) to also catch `DatabaseError`, logging a warning and swallowing.
- Guard the early idempotency-ledger lookup + recoverable-row delete (which run before any delivery) with the same `DatabaseError` catch, failing closed (return `False`, no delivery) so the caller's transition keeps moving. This gap was caught in an independent cold review of the first commit.

Every explicit ORM access in `notify_user` is now `DatabaseError`-safe.

## Tests

Added `TestNotifyUserNeverRaises` covering the ledger read, the SENT audit (DM already landed → still returns `True`), and the NOOP/FAILED audit writes — each patched to raise `OperationalError`. All observed RED before the fix, GREEN after.

Blast class: logic / resilience. No schema or API change.

Closes #1512
