### PR TITLE
fix(slack_receiver): persist inbound mentions before unlinking the drain file

### DIFF
--- a/src/teatree/backends/slack_receiver.py
+++ b/src/teatree/backends/slack_receiver.py
@@ -70,13 +70,33 @@ def _enqueue(path: Path, overlay: str, event: dict) -> None:
 
 
 def drain_event_queue(path: Path | None = None) -> list[dict]:
+    """Read queued events into memory using recover-then-drain ordering.
+
+    A previous drain that crashed before its caller durably persisted leaves
+    its ``.draining`` file on disk; this drain recovers those events first,
+    then folds in any newly enqueued live events. The ``.draining`` file is
+    left in place — the caller unlinks it via :func:`commit_drain` only after
+    the durable persist succeeds. A crash in the window between this return
+    and the persist therefore loses nothing: the next drain recovers it.
+    Slack never retries ``app_mention`` delivery, so this ordering is the
+    only thing preventing permanent mention loss.
+    """
     path = path or default_queue_path()
-    if not path.is_file():
-        return []
     tmp = path.with_suffix(".draining")
-    try:
-        path.rename(tmp)
-    except OSError:
+    if not tmp.exists():
+        # No leftover from a crashed drain: claim the live queue atomically.
+        # If there is no live file either, there is nothing to drain.
+        if not path.is_file():
+            return []
+        try:
+            path.rename(tmp)
+        except OSError:
+            return []
+    # A leftover ``.draining`` is drained as-is; the live file (if any) is
+    # left untouched and claimed on the next drain after ``commit_drain``.
+    # Recovery therefore stays a pure atomic rename — no live-file copy that
+    # could drop a concurrent ``_enqueue``.
+    if not tmp.is_file():
         return []
     events = []
     for line in tmp.read_text(encoding="utf-8").strip().splitlines():
@@ -84,8 +104,18 @@ def drain_event_queue(path: Path | None = None) -> list[dict]:
             events.append(json.loads(line))
         except json.JSONDecodeError:
             continue
-    tmp.unlink(missing_ok=True)
     return events
+
+
+def commit_drain(path: Path | None = None) -> None:
+    """Discard the drained backing file after the caller durably persisted.
+
+    Call this only once the events returned by :func:`drain_event_queue` are
+    safely persisted; until then the ``.draining`` file must stay so a crash
+    is recoverable.
+    """
+    path = path or default_queue_path()
+    path.with_suffix(".draining").unlink(missing_ok=True)
 
 
 def drain_reactions_queue(path: Path | None = None) -> list[dict]:
@@ -97,6 +127,14 @@ def drain_reactions_queue(path: Path | None = None) -> list[dict]:
     (atomic rename) stays scoped per file.
     """
     return drain_event_queue(path or default_reactions_queue_path())
+
+
+def commit_reactions_drain(path: Path | None = None) -> None:
+    """Discard the drained reactions backing file after a durable persist.
+
+    Reactions counterpart of :func:`commit_drain` (#1047).
+    """
+    commit_drain(path or default_reactions_queue_path())
 
 
 def _run_single_overlay(

--- a/src/teatree/cli/slack_listen.py
+++ b/src/teatree/cli/slack_listen.py
@@ -144,7 +144,7 @@ def check_command() -> None:
     """
     import json  # noqa: PLC0415
 
-    from teatree.backends.slack_receiver import drain_event_queue  # noqa: PLC0415
+    from teatree.backends.slack_receiver import commit_drain, drain_event_queue  # noqa: PLC0415
 
     events = drain_event_queue()
     messages: list[dict[str, str]] = []
@@ -162,8 +162,14 @@ def check_command() -> None:
             ts = event.get("ts", "")
             messages.append({"overlay": overlay, "user": user, "text": text, "ts": ts, "channel": channel})
     if not messages:
+        # Nothing actionable to emit, but the drained file must still be
+        # discarded so empty/bot-only events don't replay on every drain.
+        commit_drain()
         raise typer.Exit(code=1)
     _ack_messages(messages)
+    # Discard the backing file only after acking — a crash before this point
+    # leaves it for the next drain to recover (Slack never retries mentions).
+    commit_drain()
     for msg in messages:
         typer.echo(json.dumps(msg))
 

--- a/src/teatree/loop/scanners/slack_mentions.py
+++ b/src/teatree/loop/scanners/slack_mentions.py
@@ -85,20 +85,7 @@ class SlackMentionsScanner:
         mentions = self.backend.fetch_mentions(since=cursors.get("mentions", ""))
         dms = self.backend.fetch_dms(since=cursors.get("dms", ""))
 
-        from teatree.backends.slack_receiver import drain_event_queue  # noqa: PLC0415
-
-        for queued in drain_event_queue():
-            event = queued.get("event", {})
-            event_type = event.get("type", "")
-            if event_type == "app_mention":
-                mentions.append(event)
-            elif event_type == "message":
-                channel_type = event.get("channel_type", "")
-                if channel_type == "im":
-                    dms.append(event)
-            # ``reaction_added`` events land in ``slack-reactions.jsonl``
-            # (drained by ``SlackReviewIntentScanner``, #1047) — handled by
-            # the receiver-side routing in ``_run_single_overlay``.
+        drained_any = self._drain_queue_into(mentions, dms)
 
         signals: list[ScanSignal] = []
         for event in mentions:
@@ -128,7 +115,37 @@ class SlackMentionsScanner:
                 cursors["dms"] = max(cursors.get("dms", ""), ts)
         if signals:
             _write_cursors(self.cursor_path, cursors)
+        if drained_any:
+            # Discard the backing file only after the durable persist
+            # (cursor advance + review-intent rows) above. A crash before
+            # this point leaves the ``.draining`` file for the next drain to
+            # recover, so no mention is lost (Slack never retries them).
+            from teatree.backends.slack_receiver import commit_drain  # noqa: PLC0415
+
+            commit_drain()
         return signals
+
+    @staticmethod
+    def _drain_queue_into(mentions: list[RawAPIDict], dms: list[RawAPIDict]) -> bool:
+        """Fold queued Socket Mode events into the fetched mention/DM lists.
+
+        Returns whether the JSONL queue yielded anything, so :meth:`scan`
+        commits the backing file only after persisting. ``reaction_added``
+        events land in ``slack-reactions.jsonl`` (drained by
+        ``SlackReviewIntentScanner``, #1047) and never reach here.
+        """
+        from teatree.backends.slack_receiver import drain_event_queue  # noqa: PLC0415
+
+        drained_any = False
+        for queued in drain_event_queue():
+            drained_any = True
+            event = queued.get("event", {})
+            event_type = event.get("type", "")
+            if event_type == "app_mention":
+                mentions.append(event)
+            elif event_type == "message" and event.get("channel_type", "") == "im":
+                dms.append(event)
+        return drained_any
 
     def _record_review_intent(self, event: RawAPIDict) -> None:
         """Persist a ``ReviewAssignment`` row and post ``:eyes:`` for MR-bearing mentions.

--- a/src/teatree/loop/scanners/slack_review_intent.py
+++ b/src/teatree/loop/scanners/slack_review_intent.py
@@ -85,10 +85,18 @@ class SlackReviewIntentScanner:
         target_user = getattr(self.backend, "user_id", "")
         signals: list[ScanSignal] = []
 
-        for event in self._drain_reactions():
+        reactions, drained_file = self._drain_reactions()
+        for event in reactions:
             signal = self._handle_reaction(event, target_user)
             if signal is not None:
                 signals.append(signal)
+        if drained_file:
+            # Discard the backing file only after the reactions above are
+            # handled (rows persisted) — a crash before this point leaves it
+            # for the next drain to recover (#1047).
+            from teatree.backends.slack_receiver import commit_reactions_drain  # noqa: PLC0415
+
+            commit_reactions_drain()
 
         for event in self._drain_mentions():
             signal = self._handle_mention(event, target_user)
@@ -97,25 +105,29 @@ class SlackReviewIntentScanner:
 
         return signals
 
-    def _drain_reactions(self) -> list[RawAPIDict]:
-        """Drain reaction events.
+    def _drain_reactions(self) -> tuple[list[RawAPIDict], bool]:
+        """Drain reaction events; flag whether the file-backed queue had any.
 
         Production path: pop from ``slack-reactions.jsonl`` via
         :func:`drain_reactions_queue`. Test path: pop from the backend's
         in-memory ``fetch_reactions`` (used by ``FakeMessaging`` so unit
-        tests stay file-system free).
+        tests stay file-system free). The returned flag is true when the
+        JSONL queue yielded events, so :meth:`scan` knows to commit the
+        backing file only after the rows are persisted.
         """
         from teatree.backends.slack_receiver import drain_reactions_queue  # noqa: PLC0415
 
         events: list[RawAPIDict] = []
+        drained_file = False
         for queued in drain_reactions_queue():
+            drained_file = True
             event = queued.get("event", {})
             if isinstance(event, dict):
                 events.append(event)
         fetch_reactions = getattr(self.backend, "fetch_reactions", None)
         if callable(fetch_reactions):
             events.extend(fetch_reactions())
-        return events
+        return events, drained_file
 
     def _drain_mentions(self) -> list[RawAPIDict]:
         """Drain mention events without consuming the JSONL queue.

--- a/tests/teatree_backends/test_slack_receiver.py
+++ b/tests/teatree_backends/test_slack_receiver.py
@@ -9,6 +9,7 @@ from teatree.backends.slack_receiver import (
     QueuePaths,
     _enqueue,
     _run_single_overlay,
+    commit_drain,
     default_queue_path,
     default_reactions_queue_path,
     drain_event_queue,
@@ -100,6 +101,77 @@ class TestDrainEventQueue:
 
         events = drain_event_queue(queue)
         assert events == []
+
+
+class TestDrainCommitRecovery:
+    """Recover-then-drain keeps the backing file alive until the caller commits.
+
+    The file survives a crash between the in-memory drain and the caller's
+    durable persist, so mentions are not lost (Slack never retries
+    ``app_mention`` delivery).
+    """
+
+    def test_drain_leaves_backing_file_until_committed(self, tmp_path: Path) -> None:
+        queue = tmp_path / "events.jsonl"
+        _enqueue(queue, "ov1", {"type": "app_mention", "text": "hi"})
+
+        events = drain_event_queue(queue)
+
+        assert len(events) == 1
+        # Live queue is renamed away, but the drained data still lives on disk
+        # (in the .draining file) until the caller commits after persisting.
+        assert not queue.is_file()
+        assert queue.with_suffix(".draining").is_file()
+
+    def test_crash_after_drain_before_persist_recovers_events(self, tmp_path: Path) -> None:
+        queue = tmp_path / "events.jsonl"
+        _enqueue(queue, "ov1", {"type": "app_mention", "text": "hi"})
+        _enqueue(queue, "ov2", {"type": "app_mention", "text": "hey"})
+
+        # First drain reads the events into memory. The process crashes here,
+        # before the caller persists them durably — commit_drain is never reached.
+        first = drain_event_queue(queue)
+        assert len(first) == 2
+
+        # Next tick: the events must be recoverable, not lost.
+        recovered = drain_event_queue(queue)
+        assert len(recovered) == 2
+        assert {e["overlay"] for e in recovered} == {"ov1", "ov2"}
+
+    def test_commit_drain_removes_backing_file(self, tmp_path: Path) -> None:
+        queue = tmp_path / "events.jsonl"
+        _enqueue(queue, "ov1", {"type": "app_mention", "text": "hi"})
+
+        events = drain_event_queue(queue)
+        assert len(events) == 1
+
+        commit_drain(queue)
+
+        # Once committed (after durable persist), the data is gone and a
+        # subsequent drain returns nothing.
+        assert not queue.with_suffix(".draining").is_file()
+        assert drain_event_queue(queue) == []
+
+    def test_new_event_during_recovery_is_not_lost(self, tmp_path: Path) -> None:
+        queue = tmp_path / "events.jsonl"
+        _enqueue(queue, "ov1", {"type": "app_mention", "text": "first"})
+
+        # Crash after draining ov1 (no commit) — ov1 sits in the .draining file.
+        drain_event_queue(queue)
+
+        # A new event arrives on the live queue before the next drain.
+        _enqueue(queue, "ov2", {"type": "app_mention", "text": "second"})
+
+        # Recovery drains only the leftover and never touches the live file,
+        # so the concurrent enqueue cannot be dropped.
+        recovered = drain_event_queue(queue)
+        assert {e["overlay"] for e in recovered} == {"ov1"}
+        assert queue.is_file()
+
+        # After committing the recovered batch, the live event drains next.
+        commit_drain(queue)
+        follow_up = drain_event_queue(queue)
+        assert {e["overlay"] for e in follow_up} == {"ov2"}
 
 
 class TestRunSingleOverlay:

--- a/tests/teatree_loop/test_slack_review_intent.py
+++ b/tests/teatree_loop/test_slack_review_intent.py
@@ -389,8 +389,34 @@ class TestProductionDrainPath:
         signals = SlackReviewIntentScanner(backend=backend, overlay="teatree").scan()
 
         assert [s.kind for s in signals] == ["slack.review_intent"]
-        # File was atomically renamed and consumed.
+        # File was atomically renamed, consumed, and committed after persist.
         assert not queue.is_file()
+        assert not queue.with_suffix(".draining").is_file()
+
+    def test_reaction_queue_recovers_after_crash_before_persist(self, tmp_path, monkeypatch) -> None:
+        import json  # noqa: PLC0415
+
+        from teatree.backends import slack_receiver  # noqa: PLC0415
+
+        queue = tmp_path / "slack-reactions.jsonl"
+        event = _reaction_event()
+        queue.write_text(json.dumps({"overlay": "teatree", "event": event}) + "\n", encoding="utf-8")
+
+        def fake_default() -> "object":
+            return queue
+
+        monkeypatch.setattr(slack_receiver, "default_reactions_queue_path", fake_default)
+
+        # First drain reads the event but the process "crashes" before commit:
+        # drain_reactions_queue leaves the .draining file in place.
+        drained = slack_receiver.drain_reactions_queue()
+        assert len(drained) == 1
+
+        # Next scan must recover the reaction rather than lose it.
+        backend = FakeMessaging(messages_by_ts={(CHANNEL, TS): _message()})
+        signals = SlackReviewIntentScanner(backend=backend, overlay="teatree").scan()
+        assert [s.kind for s in signals] == ["slack.review_intent"]
+        assert not queue.with_suffix(".draining").is_file()
 
 
 class TestBackendWithoutMentionsApi:

--- a/tests/test_slack_listen.py
+++ b/tests/test_slack_listen.py
@@ -185,6 +185,45 @@ class TestCheckCommand:
         assert result.exit_code == 0
         posted.assert_not_called()
 
+    def test_commits_backing_file_after_ack(self, tmp_path: Path, monkeypatch) -> None:
+        """The drained file is discarded only after acking the messages."""
+        import json  # noqa: PLC0415
+
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        queue = tmp_path / "teatree" / "slack-events.jsonl"
+        queue.parent.mkdir(parents=True, exist_ok=True)
+        queue.write_text(
+            json.dumps({"overlay": "ov", "event": {"type": "message", "user": "U1", "text": "hi", "ts": "1.0"}}) + "\n",
+            encoding="utf-8",
+        )
+
+        with (
+            patch("teatree.cli.slack_listen._resolve_reaction_token", return_value="xoxp-test"),
+            patch("teatree.cli.slack_listen.post_reaction", return_value=True),
+        ):
+            result = runner.invoke(slack_app, ["check"])
+
+        assert result.exit_code == 0
+        assert not queue.is_file()
+        assert not queue.with_suffix(".draining").is_file()
+
+    def test_empty_queue_commits_so_bot_events_do_not_replay(self, tmp_path: Path, monkeypatch) -> None:
+        """Bot-only events still discard the backing file (no infinite replay)."""
+        import json  # noqa: PLC0415
+
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        queue = tmp_path / "teatree" / "slack-events.jsonl"
+        queue.parent.mkdir(parents=True, exist_ok=True)
+        queue.write_text(
+            json.dumps({"overlay": "ov", "event": {"type": "message", "bot_id": "B1", "text": "bot"}}) + "\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(slack_app, ["check"])
+
+        assert result.exit_code == 1
+        assert not queue.with_suffix(".draining").is_file()
+
 
 class TestListenCommand:
     def test_exits_when_no_overlays(self, tmp_path: Path) -> None:


### PR DESCRIPTION
fix(slack_receiver): persist inbound mentions before unlinking the drain file

drain_event_queue read queued Slack events into memory and unlinked the
backing .draining file before the caller had durably persisted them. A
crash in that window lost the events permanently — Slack never retries
app_mention delivery.

Adopt recover-then-drain ordering: drain_event_queue recovers a leftover
.draining file from a previously crashed drain (left untouched so recovery
stays a pure atomic rename — the live queue is claimed only after commit,
never copied, so a concurrent enqueue can't be dropped). The file is left
on disk; a new commit_drain (and commit_reactions_drain for #1047) unlinks
it, called by each drain caller only after its durable persist succeeds.
A crash between drain and persist now leaves the file for the next drain
to recover.

Closes #1513