### PR TITLE
fix: four low-severity backend/gate robustness bugs (#1521)

### DIFF
--- a/src/teatree/backends/gitlab_api.py
+++ b/src/teatree/backends/gitlab_api.py
@@ -399,14 +399,16 @@ class GitLabAPI(GitLabHTTPClient):
                     username = str(user_dict.get("username", ""))
                     if username:  # pragma: no branch
                         names.append(username)
+            left = data.get("approvals_left")
             result_val = {
                 "count": count,
                 "required": int(data.get("approvals_required", 1)),  # type: ignore[arg-type]
                 "approved_by": names,
+                "approvals_left": left if isinstance(left, int) and not isinstance(left, bool) else -1,
             }
             self._set_cached(cache_key, result_val)
             return result_val
-        fallback = {"count": 0, "required": 1, "approved_by": []}
+        fallback = {"count": 0, "required": 1, "approved_by": [], "approvals_left": -1}
         self._set_cached(cache_key, fallback)
         return fallback
 
@@ -452,7 +454,8 @@ class GitLabAPI(GitLabHTTPClient):
     ) -> list[int]:
         cancelled: list[int] = []
         for status in statuses:
-            data = self.get_json(f"projects/{project_id}/pipelines?ref={ref}&status={status}&per_page=10")
+            params = urlencode({"ref": ref, "status": status, "per_page": 10})
+            data = self.get_json(f"projects/{project_id}/pipelines?{params}")
             if not isinstance(data, list):
                 continue
             for pipeline in data:

--- a/src/teatree/backends/gitlab_ci.py
+++ b/src/teatree/backends/gitlab_ci.py
@@ -2,6 +2,7 @@
 
 import re
 from typing import cast
+from urllib.parse import urlencode
 
 from teatree.backends.gitlab_api import GitLabAPI
 
@@ -113,7 +114,8 @@ class GitLabCIService:
         }
 
     def _latest_pipeline(self, project_id: int, ref: str) -> dict[str, object] | None:
-        data = self._client.get_json(f"projects/{project_id}/pipelines?ref={ref}&per_page=1")
+        params = urlencode({"ref": ref, "per_page": 1})
+        data = self._client.get_json(f"projects/{project_id}/pipelines?{params}")
         if isinstance(data, list) and data:
             return data[0]
         return None

--- a/src/teatree/core/privacy_gate.py
+++ b/src/teatree/core/privacy_gate.py
@@ -14,8 +14,11 @@ that is NOT in :attr:`OverlayConfig.public_repos`. A bypass flag
 :func:`scan_for_publication`) authorises an intentional publish.
 """
 
+import logging
 import re
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,7 +96,17 @@ def scan_for_publication(  # noqa: PLR0913 — gate entry-point; each kwarg is a
     for name, pattern in pattern_sources:
         try:
             compiled = re.compile(pattern, flags=re.IGNORECASE | re.MULTILINE)
-        except re.error:
+        except re.error as exc:
+            # Fail closed: a rule we cannot evaluate must block the publish, never
+            # silently pass. Surface it as a match so the gate refuses.
+            logger.warning("privacy gate: unusable block pattern %r (%s) — treating as blocking", pattern, exc)
+            matches.append(
+                PrivacyMatch(
+                    pattern_name=f"{name}:invalid",
+                    matched_text=pattern,
+                    position=0,
+                ),
+            )
             continue
         for match in compiled.finditer(text):
             matches.append(  # noqa: PERF401

--- a/src/teatree/loops/orchestrator.py
+++ b/src/teatree/loops/orchestrator.py
@@ -142,7 +142,12 @@ class Orchestrator:
     def _maybe_send_summary(self, report: OrchestratorReport, started_at: dt.datetime) -> None:
         """Build and send the summary DM honouring the configured policy."""
         utc_day = started_at.date().isoformat()
-        dm = build_summary_dm(report, policy=self.config.summary_dm, utc_day=utc_day)
+        dm = build_summary_dm(
+            report,
+            policy=self.config.summary_dm,
+            utc_day=utc_day,
+            tick_id=started_at.isoformat(),
+        )
         if dm is None:
             return
         try:

--- a/src/teatree/loops/summary.py
+++ b/src/teatree/loops/summary.py
@@ -46,11 +46,17 @@ def build_summary_dm(
     *,
     policy: str,
     utc_day: str,
+    tick_id: str = "",
 ) -> SummaryDM | None:
     """Build a ``SummaryDM`` (or ``None``) honouring *policy*.
 
     *utc_day* is the YYYY-MM-DD string the caller computes once per
     tick — passing it in keeps :func:`build_summary_dm` pure.
+
+    *tick_id* is a per-tick identifier (the caller's tick timestamp).
+    Under ``policy="always"`` it is folded into the idempotency key so
+    every tick can send. The ``errors`` path keeps a day-granular key on
+    purpose: a broken scanner spams once per day, not once per tick.
     """
     if policy not in _VALID_POLICIES:
         policy = "errors"
@@ -67,9 +73,10 @@ def build_summary_dm(
             text=_format_error_dm(report),
             idempotency_key=f"loops_tick_errors:{utc_day}",
         )
+    suffix = f":{tick_id}" if (policy == "always" and tick_id) else ""
     return SummaryDM(
         text=_format_signals_dm(report),
-        idempotency_key=f"loops_tick_summary:{utc_day}",
+        idempotency_key=f"loops_tick_summary:{utc_day}{suffix}",
     )
 
 

--- a/tests/teatree_backends/test_gitlab_ci.py
+++ b/tests/teatree_backends/test_gitlab_ci.py
@@ -168,6 +168,30 @@ def test_fetch_pipeline_errors_returns_message_for_no_pipeline() -> None:
     assert result == ["No pipeline found for ref: main"]
 
 
+def test_latest_pipeline_url_encodes_ref_with_plus() -> None:
+    # A '+' in a ref decodes to a space server-side, so it must be percent-encoded.
+    client, mock = _make_client(project=_project())
+    mock.get_json.return_value = [{"id": 900}]
+    service = GitLabCIService(client=client)
+
+    service.quality_check(project="org/repo", ref="release+1.2")
+
+    endpoint = mock.get_json.call_args_list[0][0][0]
+    assert "ref=release%2B1.2" in endpoint
+    assert "ref=release+1.2" not in endpoint
+
+
+def test_latest_pipeline_url_encodes_ref_with_slash() -> None:
+    client, mock = _make_client(project=_project())
+    mock.get_json.return_value = [{"id": 901}]
+    service = GitLabCIService(client=client)
+
+    service.quality_check(project="org/repo", ref="feature/abc")
+
+    endpoint = mock.get_json.call_args_list[0][0][0]
+    assert "ref=feature%2Fabc" in endpoint
+
+
 def test_fetch_pipeline_errors_returns_empty_when_jobs_not_a_list() -> None:
     client, mock = _make_client(project=_project())
     mock.get_json.side_effect = [

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -708,3 +708,41 @@ def test_assign_reviewer_swallows_exception_and_returns_false() -> None:
     host = GitLabCodeHost(client=client)
 
     assert host.assign_reviewer(pr_url="https://gitlab.com/org/repo/-/merge_requests/9", username="alice") is False
+
+
+def test_get_mr_approvals_uses_canonical_approvals_left_not_fallback() -> None:
+    # On a multi-rule repo the upstream approvals_left is authoritative.
+    # required - count (here 1 - 1 = 0) would wrongly say "no approvals left".
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_mr_approvals.return_value = {
+        "count": 1,
+        "required": 1,
+        "approved_by": ["reviewer1"],
+        "approvals_left": 2,
+    }
+    client.get_mr_discussions.return_value = []
+    host = GitLabCodeHost(client=client)
+
+    state = host.get_mr_approvals(repo="org/repo", pr_iid=12)
+
+    assert state["approvals_left"] == 2
+
+
+def test_get_mr_approvals_falls_back_when_left_absent() -> None:
+    # When the payload omits approvals_left (sentinel -1), the code-host
+    # recomputes required - count.
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_mr_approvals.return_value = {
+        "count": 1,
+        "required": 3,
+        "approved_by": ["reviewer1"],
+        "approvals_left": -1,
+    }
+    client.get_mr_discussions.return_value = []
+    host = GitLabCodeHost(client=client)
+
+    state = host.get_mr_approvals(repo="org/repo", pr_iid=12)
+
+    assert state["approvals_left"] == 2

--- a/tests/teatree_core/test_privacy_gate.py
+++ b/tests/teatree_core/test_privacy_gate.py
@@ -6,6 +6,8 @@ text for the overlay's redact-terms + the default quote-anchor
 patterns, and refuses when any match fires.
 """
 
+import pytest
+
 from teatree.core.privacy_gate import format_refusal, scan_for_publication
 
 PUBLIC = "souliane/teatree"
@@ -96,16 +98,37 @@ def test_custom_block_patterns_match() -> None:
     assert any(m.pattern_name.startswith("block:") for m in result.matches)
 
 
-def test_invalid_regex_in_block_patterns_skipped_gracefully() -> None:
-    """A malformed pattern logs nothing and just gets skipped — never crashes."""
+def test_invalid_regex_in_block_patterns_fails_closed(caplog: pytest.LogCaptureFixture) -> None:
+    """A malformed pattern must fail closed — block the publish and log, never silently pass."""
+    import logging  # noqa: PLC0415
+
+    with caplog.at_level(logging.WARNING, logger="teatree.core.privacy_gate"):
+        result = scan_for_publication(
+            text="Body content",
+            target_repo=PUBLIC,
+            public_repos=[PUBLIC],
+            block_patterns=["[unclosed", ""],
+        )
+
+    # Fail-closed: a rule that can't be evaluated blocks rather than passes.
+    assert result.refused
+    assert any(m.pattern_name.startswith("block:") for m in result.matches)
+    assert "[unclosed" in caplog.text
+
+
+def test_invalid_default_pattern_does_not_break_valid_matches() -> None:
+    """A bad block pattern fails closed but valid patterns still surface their own matches."""
     result = scan_for_publication(
-        text="Body content",
+        text="secret token ABC-12345 leaked here",
         target_repo=PUBLIC,
         public_repos=[PUBLIC],
-        block_patterns=["[unclosed", ""],
+        block_patterns=[r"ABC-\d{5}", "(unbalanced"],
     )
-    # Invalid pattern is skipped; empty pattern filtered by the comprehension.
-    assert not result.refused
+    assert result.refused
+    names = {m.pattern_name for m in result.matches}
+    # Both the valid match and the fail-closed bad-pattern marker are present.
+    assert any(n.startswith("block:ABC") for n in names)
+    assert any("unbalanced" in n for n in names)
 
 
 def test_format_refusal_renders_matches_block() -> None:

--- a/tests/teatree_loops/test_orchestrator.py
+++ b/tests/teatree_loops/test_orchestrator.py
@@ -177,3 +177,30 @@ class OrchestratorTestCase(TestCase):
         text, key = sent[0]
         assert "inbox" in text
         assert "loops_tick_errors" in key
+
+    def test_always_policy_two_same_day_ticks_get_distinct_keys(self) -> None:
+        # policy=always must DM every tick; the idempotency key carries the tick
+        # timestamp so the second same-day tick is not deduped away.
+        sent: list[tuple[str, str]] = []
+
+        def _send(text: str, *, idempotency_key: str) -> None:
+            sent.append((text, idempotency_key))
+
+        ticks = iter(
+            [
+                dt.datetime(2026, 5, 28, 12, 0, tzinfo=dt.UTC),
+                dt.datetime(2026, 5, 28, 12, 1, tzinfo=dt.UTC),
+            ],
+        )
+        loop = _loop("inbox", jobs=[])
+        orch = Orchestrator(
+            config=LoopsConfig(summary_dm="always"),
+            registry_fn=lambda: (loop,),
+            clock=lambda: next(ticks),
+            dispatch_fn=list,
+        )
+        orch._notify = _send  # type: ignore[method-assign]
+        orch.tick(TickRequest())
+        orch.tick(TickRequest())
+        assert len(sent) == 2
+        assert sent[0][1] != sent[1][1]

--- a/tests/teatree_loops/test_summary_silent_when_idle.py
+++ b/tests/teatree_loops/test_summary_silent_when_idle.py
@@ -55,6 +55,16 @@ class TestPolicyErrors:
         assert b is not None
         assert a.idempotency_key != b.idempotency_key
 
+    def test_errors_key_stays_daily_even_with_distinct_tick_id(self) -> None:
+        # A broken scanner must still spam once per day, not once per tick — the
+        # tick-unique component only applies to the always-mode signals path.
+        report = OrchestratorReport(errors={"inbox": "boom"})
+        a = build_summary_dm(report, policy="errors", utc_day="2026-05-28", tick_id="2026-05-28T10:00:00+00:00")
+        b = build_summary_dm(report, policy="errors", utc_day="2026-05-28", tick_id="2026-05-28T10:01:00+00:00")
+        assert a is not None
+        assert b is not None
+        assert a.idempotency_key == b.idempotency_key
+
 
 class TestPolicyAlways:
     def test_quiet_tick_still_emits(self) -> None:
@@ -70,6 +80,16 @@ class TestPolicyAlways:
         assert "5 signals" in dm.text
         assert "3 actions" in dm.text
         assert "inbox" in dm.text
+
+    def test_two_ticks_same_day_get_distinct_keys(self) -> None:
+        # policy=always means "DM every tick". A day-granular key would dedup the
+        # second tick away. Each tick must carry a distinct idempotency key.
+        report = OrchestratorReport(signals_count=0, errors={})
+        first = build_summary_dm(report, policy="always", utc_day="2026-05-28", tick_id="2026-05-28T10:00:00+00:00")
+        second = build_summary_dm(report, policy="always", utc_day="2026-05-28", tick_id="2026-05-28T10:01:00+00:00")
+        assert first is not None
+        assert second is not None
+        assert first.idempotency_key != second.idempotency_key
 
 
 class TestUnknownPolicyFallsBackToErrors:

--- a/tests/utils/test_gitlab_api_queries.py
+++ b/tests/utils/test_gitlab_api_queries.py
@@ -316,12 +316,32 @@ def test_get_mr_approvals_returns_counts(monkeypatch: pytest.MonkeyPatch) -> Non
         lambda endpoint: {
             "approved_by": [{"user": {"username": "reviewer1"}}, {"user": {"username": "reviewer2"}}],
             "approvals_required": 2,
+            "approvals_left": 0,
         },
     )
 
     result = client.get_mr_approvals(42, 1)
 
-    assert result == {"count": 2, "required": 2, "approved_by": ["reviewer1", "reviewer2"]}
+    assert result == {"count": 2, "required": 2, "approved_by": ["reviewer1", "reviewer2"], "approvals_left": 0}
+
+
+def test_get_mr_approvals_passes_through_approvals_left(monkeypatch: pytest.MonkeyPatch) -> None:
+    # On multi-rule repos the upstream approvals_left is canonical and must not be
+    # recomputed from required - count. The client must surface it to callers.
+    client = gitlab_api.GitLabAPI(token="test-token")
+    monkeypatch.setattr(
+        client,
+        "get_json",
+        lambda endpoint: {
+            "approved_by": [{"user": {"username": "reviewer1"}}],
+            "approvals_required": 2,
+            "approvals_left": 3,
+        },
+    )
+
+    result = client.get_mr_approvals(42, 1)
+
+    assert result["approvals_left"] == 3
 
 
 def test_get_mr_approvals_returns_defaults_when_not_a_dict(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -330,7 +350,7 @@ def test_get_mr_approvals_returns_defaults_when_not_a_dict(monkeypatch: pytest.M
 
     result = client.get_mr_approvals(42, 1)
 
-    assert result == {"count": 0, "required": 1, "approved_by": []}
+    assert result == {"count": 0, "required": 1, "approved_by": [], "approvals_left": -1}
 
 
 def test_get_mr_approvals_handles_non_list_approved_by(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -343,7 +363,7 @@ def test_get_mr_approvals_handles_non_list_approved_by(monkeypatch: pytest.Monke
 
     result = client.get_mr_approvals(42, 1)
 
-    assert result == {"count": 0, "required": 1, "approved_by": []}
+    assert result == {"count": 0, "required": 1, "approved_by": [], "approvals_left": -1}
 
 
 def test_get_mr_approvals_skips_non_dict_entry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -363,7 +383,24 @@ def test_get_mr_approvals_skips_non_dict_entry(monkeypatch: pytest.MonkeyPatch) 
 
     result = client.get_mr_approvals(42, 1)
 
-    assert result == {"count": 2, "required": 1, "approved_by": ["reviewer1"]}
+    assert result == {"count": 2, "required": 1, "approved_by": ["reviewer1"], "approvals_left": -1}
+
+
+def test_cancel_pipelines_url_encodes_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A '+' in a ref decodes to a space server-side, so it must be percent-encoded.
+    client = gitlab_api.GitLabAPI(token="test-token")
+    seen: list[str] = []
+
+    def fake_get_json(endpoint: str) -> list[dict[str, object]]:
+        seen.append(endpoint)
+        return []
+
+    monkeypatch.setattr(client, "get_json", fake_get_json)
+
+    client.cancel_pipelines(42, "release+1.2", statuses=("running",))
+
+    assert "ref=release%2B1.2" in seen[0]
+    assert "ref=release+1.2" not in seen[0]
 
 
 def test_get_issue_returns_issue_dict(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #1521

Four independent low-severity robustness bugs, fixed together in one MR. Each fix ships with a regression test observed RED before the fix.

### 1. URL-encode the GitLab pipeline-lookup ref
`GitLabCIService._latest_pipeline` and `GitLabAPI.cancel_pipelines` interpolated the git ref straight into the `?ref=...` query string. A `+` decoded to a space server-side and a `/` was mis-parsed, so the lookup returned "no pipeline found" for valid refs. Now encoded via `urlencode`.

### 2. Surface `approvals_left` from `get_mr_approvals`
The `GitLabAPI.get_mr_approvals` client result omitted the upstream `approvals_left` field, so the code-host layer never saw it and always recomputed `required - count` — wrong on repos with multiple approval rules. The canonical `approvals_left` is now passed through (sentinel `-1` when absent, so the existing fallback still applies when the field is genuinely missing).

### 3. Privacy gate fails closed on unusable block patterns
`scan_for_publication` caught a `re.error` on a malformed block pattern and `continue`d, silently skipping it — text it was meant to catch slipped through. It now fails closed: logs the bad pattern at WARNING and surfaces it as a match so the gate refuses.

### 4. `summary_dm` policy=always sends every tick
`build_summary_dm` used a day-granular idempotency key, so under `policy=always` the dedup layer suppressed every tick after the first one each day. A per-tick `tick_id` (the tick timestamp) is now folded into the always-mode signals key. The errors path keeps its day-granular key on purpose so a broken scanner spams once per day, not once per tick.