### PR TITLE
fix(ship): commit PR-create outside the FSM-advance transaction

### DIFF
--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -182,6 +182,15 @@ def execute_ship(ticket_id: int) -> TransitionResult:
     for the same transition — a lost update or a redelivered job must be safe.
 
     On success, advances ``SHIPPED → IN_REVIEW`` via ``request_review()``.
+
+    ``ShipExecutor.run()`` runs OUTSIDE the FSM-advance transaction (#1522):
+    it calls ``host.create_pr()``, whose live forge PR is an external side
+    effect no rollback can undo. Run as a top-level operation, the executor's
+    own ``merge_extra`` records the PR url in its own committed transaction
+    the instant ``create_pr`` returns, so a later rollback of the FSM advance
+    cannot strand the PR. A redelivered job then finds the recorded url and
+    adopts it (``ShipExecutor._recorded_url_for_branch``) instead of
+    re-calling ``create_pr`` and hitting a 409.
     """
     with transaction.atomic():
         ticket = Ticket.objects.select_for_update().get(pk=ticket_id)
@@ -193,11 +202,20 @@ def execute_ship(ticket_id: int) -> TransitionResult:
             )
             return {"ticket_id": ticket_id, "skipped": True, "state": str(ticket.state)}
 
-        result = ShipExecutor(ticket).run()
-        if not result.ok:
-            logger.warning("Ship failed for ticket %s: %s", ticket_id, result.detail)
-            return {"ticket_id": ticket_id, "ok": False, "detail": result.detail}
+    result = ShipExecutor(ticket).run()
+    if not result.ok:
+        logger.warning("Ship failed for ticket %s: %s", ticket_id, result.detail)
+        return {"ticket_id": ticket_id, "ok": False, "detail": result.detail}
 
+    with transaction.atomic():
+        ticket = Ticket.objects.select_for_update().get(pk=ticket_id)
+        if ticket.state != Ticket.State.SHIPPED:
+            logger.info(
+                "execute_ship FSM advance skipped for ticket %s: state=%s (PR already recorded, not SHIPPED)",
+                ticket_id,
+                ticket.state,
+            )
+            return {"ticket_id": ticket_id, "ok": True, "detail": result.detail}
         ticket.request_review()
         ticket.save()
 

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -1,4 +1,6 @@
-from unittest.mock import patch
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import TestCase, override_settings
@@ -308,6 +310,88 @@ class TestExecuteShip(TestCase):
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.SHIPPED
         assert result.return_value == {"ticket_id": ticket.pk, "ok": False, "detail": "push rejected"}
+
+
+class TestExecuteShipOrphanPrWindow(TestCase):
+    """A forge PR opened by ``create_pr`` must never be stranded by a rollback.
+
+    The live PR is an external side effect that no transaction rollback can
+    undo. If the PR-url marker is committed only when the FSM-advance
+    transaction commits, a failure after ``create_pr`` (e.g. the
+    ``request_review`` guard raising) rolls back the marker but leaves the
+    forge PR live — the ticket is stuck SHIPPED with an orphan PR, and a
+    retry re-calls ``create_pr`` and hits a 409.
+    """
+
+    def _shipped_ticket_with_worktree(self) -> Ticket:
+        from teatree.core.models import Worktree  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/77")
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/repo",
+            branch="feat-x",
+            extra={"worktree_path": "/tmp/repo"},
+        )
+        ticket.state = Ticket.State.SHIPPED
+        ticket.save(update_fields=["state"])
+        return ticket
+
+    @contextmanager
+    def _ship_collaborators(self, host: object) -> Iterator[None]:
+        with ExitStack() as stack:
+            stack.enter_context(patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY))
+            stack.enter_context(patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host))
+            stack.enter_context(patch("teatree.core.runners.ship.git.push"))
+            stack.enter_context(patch("teatree.core.runners.ship.git.branch_merged", return_value=False))
+            stack.enter_context(patch("teatree.core.runners.ship.branch_behind_target", return_value=None))
+            stack.enter_context(
+                patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat: x", "body"))
+            )
+            yield
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_pr_url_recorded_when_fsm_advance_raises_after_create_pr(self) -> None:
+        ticket = self._shipped_ticket_with_worktree()
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://example.com/mr/1", "iid": 1}
+        host.current_user.return_value = "souliane"
+
+        with (
+            self._ship_collaborators(host),
+            patch.object(Ticket, "request_review", side_effect=RuntimeError("post-create_pr failure")),
+            pytest.raises(RuntimeError, match="post-create_pr failure"),
+        ):
+            execute_ship.call(ticket.pk)
+
+        ticket.refresh_from_db()
+        # The forge PR is live; its URL MUST survive the FSM-advance rollback.
+        assert ticket.extra.get("pr_urls") == ["https://example.com/mr/1"]
+        assert host.create_pr.call_count == 1
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_retry_after_fsm_advance_failure_adopts_existing_pr(self) -> None:
+        ticket = self._shipped_ticket_with_worktree()
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://example.com/mr/1", "iid": 1}
+        host.current_user.return_value = "souliane"
+
+        with (
+            self._ship_collaborators(host),
+            patch.object(Ticket, "request_review", side_effect=RuntimeError("post-create_pr failure")),
+            pytest.raises(RuntimeError, match="post-create_pr failure"),
+        ):
+            execute_ship.call(ticket.pk)
+
+        # Retry: create_pr must NOT be called again (the recorded URL is adopted),
+        # so the forge never returns a 409 "PR already exists".
+        with self._ship_collaborators(host):
+            execute_ship.call(ticket.pk)
+
+        ticket.refresh_from_db()
+        assert host.create_pr.call_count == 1
+        assert ticket.state == Ticket.State.IN_REVIEW
 
 
 class TestExecuteHeadlessTask(TestCase):


### PR DESCRIPTION
fix(ship): commit PR-create outside the FSM-advance transaction

execute_ship ran host.create_pr() inside the same transaction.atomic()
block that advanced the session FSM. create_pr opens a live forge PR — an
external side effect no rollback can undo — but the pr_urls marker is
written via merge_extra, whose nested atomic() is only a savepoint inside
the outer block, so the marker is not durable until the outer transaction
commits.

Any failure after create_pr (the request_review guard raising, the save,
a select_for_update retry) rolled back the marker while the forge PR
stayed live: the ticket was stuck SHIPPED with an orphan PR, and a retry
re-called create_pr and hit a 409 "PR already exists".

Run ShipExecutor.run() outside the FSM-advance transaction. Its merge_extra
now commits the PR url in its own top-level transaction the instant
create_pr returns, so a later rollback of the FSM advance cannot strand the
PR. A redelivered job then adopts the recorded url
(ShipExecutor._recorded_url_for_branch) instead of re-calling create_pr.
The FSM advance keeps its own locked atomic block with a fresh state guard,
preserving at-least-once idempotency.

Closes #1522