### PR TITLE
fix(tool): resolve validate-mr overlay by repo instead of crashing on ambiguity

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1167,6 +1167,24 @@ Usage: t3 tool validate-mr [OPTIONS]
  bad title/description is rejected BEFORE the push — no env-var opt-in
  (#119).
 
+ Overlay resolution is deterministic and never crashes on ambiguity
+ (#1526). Order:
+
+ 1.  Single overlay, or an explicit ``T3_OVERLAY_NAME`` — use it exactly
+     as before (``get_overlay()``).
+ 2.  Multiple overlays — resolve by the repo the command runs in
+     (``get_overlay_for_repo``): the overlay whose configured repos own
+     the cwd's ``origin`` remote.
+ 3.  Still ambiguous — validate against EACH overlay and PASS if ANY
+     accepts. A metadata check is advisory; it must never hard-deny just
+     because we cannot tell which overlay owns the MR. Only deny when ALL
+     registered overlays reject.
+ 4.  No overlay resolvable at all — skip (exit 0) with a stderr note.
+     Under no path does this command exit via an unhandled
+     ``ImproperlyConfigured`` traceback, which the pre-push hook would
+     mis-read as a "metadata invalid" verdict and use to block every MR
+     create/update (the lockout this fix closes).
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --title              TEXT  MR/PR title                                       │
 │ --description        TEXT  MR/PR description                                 │

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -4,11 +4,15 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 
-from teatree.core.overlay_loader import get_overlay
+from teatree.core.overlay_loader import get_all_overlays, get_overlay, get_overlay_for_repo
 from teatree.utils.run import run_allowed_to_fail
+
+if TYPE_CHECKING:
+    from teatree.core.overlay import OverlayBase
 
 tool_app = typer.Typer(no_args_is_help=True, help="Standalone utilities.")
 
@@ -67,6 +71,13 @@ def privacy_scan(
     ToolRunner.run_script("privacy_scan", path)
 
 
+def _deny_with_errors(errors: list[str]) -> None:
+    """Print each validation error to stderr and exit 1 (deny)."""
+    for err in errors:
+        typer.echo(err, err=True)
+    raise typer.Exit(code=1)
+
+
 @tool_app.command("validate-mr")
 def validate_mr(
     title: str = typer.Option("", "--title", help="MR/PR title"),
@@ -79,14 +90,55 @@ def validate_mr(
     the metadata is invalid. The pre-push hook invokes this by default so a
     bad title/description is rejected BEFORE the push — no env-var opt-in
     (#119).
+
+    Overlay resolution is deterministic and never crashes on ambiguity
+    (#1526). Order:
+
+    1.  Single overlay, or an explicit ``T3_OVERLAY_NAME`` — use it exactly
+        as before (``get_overlay()``).
+    2.  Multiple overlays — resolve by the repo the command runs in
+        (``get_overlay_for_repo``): the overlay whose configured repos own
+        the cwd's ``origin`` remote.
+    3.  Still ambiguous — validate against EACH overlay and PASS if ANY
+        accepts. A metadata check is advisory; it must never hard-deny just
+        because we cannot tell which overlay owns the MR. Only deny when ALL
+        registered overlays reject.
+    4.  No overlay resolvable at all — skip (exit 0) with a stderr note.
+        Under no path does this command exit via an unhandled
+        ``ImproperlyConfigured`` traceback, which the pre-push hook would
+        mis-read as a "metadata invalid" verdict and use to block every MR
+        create/update (the lockout this fix closes).
     """
     _ensure_django()
-    result = get_overlay().metadata.validate_pr(title, description)
-    errors = result.get("errors", [])
-    if errors:
-        for err in errors:
-            typer.echo(err, err=True)
-        raise typer.Exit(code=1)
+    from django.core.exceptions import ImproperlyConfigured  # noqa: PLC0415
+
+    try:
+        overlay = get_overlay()
+    except ImproperlyConfigured:
+        overlay = get_overlay_for_repo(".")
+
+    if overlay is not None:
+        errors = _validation_errors(overlay, title, description)
+        if errors:
+            _deny_with_errors(errors)
+        return
+
+    overlays = get_all_overlays()
+    if not overlays:
+        typer.echo("validate-mr: no overlay resolvable for this repo; skipping metadata check.", err=True)
+        return
+
+    per_overlay_errors = [_validation_errors(ov, title, description) for ov in overlays.values()]
+    if any(not errs for errs in per_overlay_errors):
+        return
+    # Every overlay rejected — surface the first overlay's errors.
+    _deny_with_errors(per_overlay_errors[0])
+
+
+def _validation_errors(overlay: "OverlayBase", title: str, description: str) -> list[str]:
+    """Return the overlay's ``validate_pr`` errors for ``title``/``description``."""
+    result = overlay.metadata.validate_pr(title, description)
+    return list(result.get("errors", []))
 
 
 @tool_app.command("repo-mode")

--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -45,6 +45,47 @@ def get_overlay(name: str | None = None) -> "OverlayBase":
     raise ImproperlyConfigured(msg)
 
 
+def get_overlay_for_repo(repo: str = ".") -> "OverlayBase | None":
+    """Return the overlay whose workspace repos own the git repo at ``repo``.
+
+    Resolves the ``origin`` remote slug (``owner/name``) of the repo at
+    ``repo`` and matches it against each registered overlay's
+    ``get_workspace_repos()`` — the same repo-ownership relation
+    :func:`infer_overlay_for_url` uses for a URL. This lets a caller in an
+    ambiguous multi-overlay environment pick the overlay that actually owns
+    the current repository instead of crashing on ambiguity.
+
+    Returns ``None`` when the slug is empty (no ``origin``) or matches zero
+    or more than one overlay, so the caller can fall back deterministically
+    rather than guess wrong. An overlay whose ``get_workspace_repos()``
+    raises is skipped so one broken overlay can't poison resolution.
+    """
+    from teatree.utils.git import remote_slug  # noqa: PLC0415
+
+    slug = remote_slug(repo=repo)
+    if not slug:
+        return None
+
+    matches: list[OverlayBase] = []
+    for name, overlay in get_all_overlays().items():
+        getter = getattr(overlay, "get_workspace_repos", None)
+        if not callable(getter):
+            continue
+        try:
+            repo_slugs = getter()
+        except Exception:
+            logger.warning("Overlay %r get_workspace_repos() failed during repo resolution", name, exc_info=True)
+            continue
+        for repo_slug in repo_slugs or []:
+            if isinstance(repo_slug, str) and repo_slug and repo_slug in slug:
+                matches.append(overlay)
+                break
+
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
 def get_all_overlays() -> "dict[str, OverlayBase]":
     return dict(_discover_overlays())
 

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -13,9 +13,12 @@ import teatree.cli as teatree_cli
 from scripts.privacy_scan import PRIVACY_FINDINGS_EXIT_CODE
 from teatree.cli import app
 from teatree.cli.tools import ToolRunner
+from teatree.core.overlay import OverlayBase, OverlayMetadata
 from teatree.repo_mode import RepoMode
 
 runner = CliRunner()
+
+_GIT = shutil.which("git") or "git"
 
 
 class TestToolRunner:
@@ -396,6 +399,122 @@ class TestValidateMrCommand:
         assert proc.returncode == 0, f"validate-mr crashed:\n{proc.stdout}\n{proc.stderr}"
         assert "ImproperlyConfigured" not in proc.stderr
         assert "AppRegistryNotReady" not in proc.stderr
+
+
+class _OverlayMeta(OverlayMetadata):
+    def __init__(self, errors: list[str]) -> None:
+        self._errors = errors
+
+    def validate_pr(self, title: str, description: str):
+        del title, description
+        return {"errors": list(self._errors), "warnings": []}
+
+
+class _AcceptingOverlay(OverlayBase):
+    """Overlay whose ``validate_pr`` always passes, owning fixed repo slugs."""
+
+    def __init__(self, repos: list[str]) -> None:
+        self._repos = repos
+        self.metadata = _OverlayMeta([])
+
+    def get_repos(self) -> list[str]:
+        return self._repos
+
+    def get_provision_steps(self, worktree):
+        return []
+
+
+class _RejectingOverlay(OverlayBase):
+    """Overlay whose ``validate_pr`` always rejects with fixed errors."""
+
+    def __init__(self, repos: list[str], errors: list[str]) -> None:
+        self._repos = repos
+        self.metadata = _OverlayMeta(errors)
+
+    def get_repos(self) -> list[str]:
+        return self._repos
+
+    def get_provision_steps(self, worktree):
+        return []
+
+
+class TestValidateMrMultipleOverlays:
+    """`t3 tool validate-mr` must not crash when >1 overlay is registered (#1526).
+
+    Before the fix ``validate_mr`` called ``get_overlay()`` with no name; with
+    two overlays installed and no ``T3_OVERLAY_NAME`` that raised
+    ``ImproperlyConfigured``. The pre-push hook treated the traceback (exit 1)
+    as a "metadata invalid" verdict and hard-blocked every MR create/update —
+    a lockout. The command now resolves the overlay by repo, and when still
+    ambiguous validates leniently (PASS if ANY overlay accepts) so an advisory
+    metadata check never hard-denies on ambiguity.
+
+    Real overlay instances are registered via ``_discover_overlays`` (the live
+    registry both ``get_overlay`` and ``get_all_overlays`` route through);
+    nothing about overlay resolution is mocked.
+    """
+
+    def _register(self, monkeypatch, overlays: dict):
+        # The test suite pins T3_OVERLAY_NAME=t3-teatree for determinism; drop
+        # it so the ambiguity path (multiple overlays, no explicit name) runs.
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        return patch("teatree.core.overlay_loader._discover_overlays", return_value=overlays)
+
+    def test_valid_metadata_exits_zero_with_two_overlays(self, monkeypatch):
+        # RED before the fix: crashes ImproperlyConfigured (exit != 0).
+        overlays = {
+            "alpha": _AcceptingOverlay(["acme/alpha"]),
+            "bravo": _AcceptingOverlay(["acme/bravo"]),
+        }
+        with self._register(monkeypatch, overlays):
+            result = runner.invoke(
+                app,
+                ["tool", "validate-mr", "--title", "fix: x", "--description", "fix: x\n\nbody"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "ImproperlyConfigured" not in result.output
+
+    def test_resolvable_by_repo_uses_that_overlays_verdict(self, monkeypatch, tmp_path):
+        # cwd repo belongs to exactly one overlay -> use ITS verdict, including
+        # the deny path (no regression in rejection when resolution is sharp).
+        repo = tmp_path / "alpha"
+        repo.mkdir()
+        subprocess.run([_GIT, "init", "-q"], cwd=repo, check=True)
+        subprocess.run([_GIT, "remote", "add", "origin", "git@github.com:acme/alpha.git"], cwd=repo, check=True)
+        monkeypatch.chdir(repo)
+        overlays = {
+            "alpha": _RejectingOverlay(["acme/alpha"], ["Title is invalid."]),
+            "bravo": _AcceptingOverlay(["acme/bravo"]),
+        }
+        with self._register(monkeypatch, overlays):
+            result = runner.invoke(app, ["tool", "validate-mr", "--title", "bad", "--description", "bad"])
+        assert result.exit_code == 1
+        assert "Title is invalid." in result.output
+
+    def test_lenient_pass_when_any_overlay_accepts(self, monkeypatch):
+        # Unresolvable by repo + multiple overlays: PASS if ANY accepts.
+        overlays = {
+            "alpha": _RejectingOverlay(["acme/alpha"], ["nope"]),
+            "bravo": _AcceptingOverlay(["acme/bravo"]),
+        }
+        with self._register(monkeypatch, overlays):
+            result = runner.invoke(app, ["tool", "validate-mr", "--title", "fix: x", "--description", "fix: x"])
+        assert result.exit_code == 0, result.output
+
+    def test_deny_when_all_overlays_reject(self, monkeypatch):
+        overlays = {
+            "alpha": _RejectingOverlay(["acme/alpha"], ["alpha rejects"]),
+            "bravo": _RejectingOverlay(["acme/bravo"], ["bravo rejects"]),
+        }
+        with self._register(monkeypatch, overlays):
+            result = runner.invoke(app, ["tool", "validate-mr", "--title", "bad", "--description", "bad"])
+        assert result.exit_code == 1
+        assert "alpha rejects" in result.output or "bravo rejects" in result.output
+
+    def test_no_overlays_skips_fail_open(self, monkeypatch):
+        with self._register(monkeypatch, {}):
+            result = runner.invoke(app, ["tool", "validate-mr", "--title", "anything", "--description", "x"])
+        assert result.exit_code == 0
 
 
 class TestToMarkdownCommand:

--- a/tests/test_overlay_loader.py
+++ b/tests/test_overlay_loader.py
@@ -1,12 +1,17 @@
 """Tests for teatree.core.overlay_loader — TOML-based overlay discovery."""
 
+import shutil
+import subprocess
+from pathlib import Path
 from typing import ClassVar
 from unittest.mock import patch
 
 import teatree.config as config_mod
 from teatree.config import TeaTreeConfig
 from teatree.core.overlay import OverlayBase
-from teatree.core.overlay_loader import _discover_toml_overlays, infer_overlay_for_url
+from teatree.core.overlay_loader import _discover_toml_overlays, get_overlay_for_repo, infer_overlay_for_url
+
+_GIT = shutil.which("git") or "git"
 
 
 def _make_config(overlays: dict) -> TeaTreeConfig:
@@ -137,6 +142,107 @@ class TestInferOverlayForUrl:
         ):
             assert infer_overlay_for_url("https://gitlab.com/acme/widgets/-/issues/7") == "ok"
         assert "failed during inference" in caplog.text
+
+
+def _init_repo_with_origin(path: Path, origin_url: str) -> None:
+    """Create a real git repo at ``path`` with ``origin`` set to ``origin_url``."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run([_GIT, "init", "-q"], cwd=path, check=True)
+    subprocess.run([_GIT, "remote", "add", "origin", origin_url], cwd=path, check=True)
+
+
+class _RepoOverlay(OverlayBase):
+    """Concrete overlay exposing a fixed workspace-repo slug list."""
+
+    def __init__(self, repos: list[str]) -> None:
+        self._repos = repos
+
+    def get_repos(self) -> list[str]:
+        return self._repos
+
+    def get_provision_steps(self, worktree):
+        return []
+
+
+class TestGetOverlayForRepo:
+    """``get_overlay_for_repo`` maps the cwd git repo to its owning overlay (#1526).
+
+    Resolves the overlay deterministically by the ``origin`` remote slug of
+    the repo at the given path, matched against each registered overlay's
+    ``get_workspace_repos()``. Returns ``None`` when the slug matches zero or
+    more than one overlay so the caller can fall back without crashing.
+    """
+
+    def test_matches_repo_to_its_owning_overlay(self, tmp_path):
+        repo = tmp_path / "widgets"
+        _init_repo_with_origin(repo, "git@github.com:acme/widgets.git")
+        overlays = {
+            "a": _RepoOverlay(["acme/widgets"]),
+            "b": _RepoOverlay(["other/repo"]),
+        }
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
+            resolved = get_overlay_for_repo(str(repo))
+        assert resolved is overlays["a"]
+
+    def test_no_match_returns_none(self, tmp_path):
+        repo = tmp_path / "ghost"
+        _init_repo_with_origin(repo, "git@github.com:acme/ghost.git")
+        overlays = {
+            "a": _RepoOverlay(["acme/widgets"]),
+            "b": _RepoOverlay(["other/repo"]),
+        }
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
+            assert get_overlay_for_repo(str(repo)) is None
+
+    def test_ambiguous_match_returns_none(self, tmp_path):
+        repo = tmp_path / "shared"
+        _init_repo_with_origin(repo, "git@github.com:acme/shared.git")
+        overlays = {
+            "a": _RepoOverlay(["acme/shared"]),
+            "b": _RepoOverlay(["acme/shared"]),
+        }
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
+            assert get_overlay_for_repo(str(repo)) is None
+
+    def test_repo_without_origin_returns_none(self, tmp_path):
+        repo = tmp_path / "no-origin"
+        repo.mkdir()
+        subprocess.run([_GIT, "init", "-q"], cwd=repo, check=True)
+        overlays = {"a": _RepoOverlay(["acme/widgets"])}
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
+            assert get_overlay_for_repo(str(repo)) is None
+
+    def test_non_overlay_entry_is_skipped(self, tmp_path):
+        repo = tmp_path / "widgets"
+        _init_repo_with_origin(repo, "git@github.com:acme/widgets.git")
+
+        class _Bare:
+            config = None
+
+        overlays = {"bare": _Bare(), "a": _RepoOverlay(["acme/widgets"])}
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
+            assert get_overlay_for_repo(str(repo)) is overlays["a"]
+
+    def test_raising_overlay_does_not_block_others(self, tmp_path, caplog):
+        repo = tmp_path / "widgets"
+        _init_repo_with_origin(repo, "git@github.com:acme/widgets.git")
+
+        class _Broken(OverlayBase):
+            def get_repos(self) -> list[str]:
+                msg = "boom"
+                raise RuntimeError(msg)
+
+            def get_workspace_repos(self) -> list[str]:
+                msg = "boom"
+                raise RuntimeError(msg)
+
+            def get_provision_steps(self, worktree):
+                return []
+
+        overlays = {"broken": _Broken(), "a": _RepoOverlay(["acme/widgets"])}
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
+            assert get_overlay_for_repo(str(repo)) is overlays["a"]
+        assert "failed during repo resolution" in caplog.text
 
 
 # ── Test helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
fix(tool): resolve validate-mr overlay by repo instead of crashing on ambiguity

`t3 tool validate-mr` called `get_overlay()` with no name. With more than
one overlay registered and no `T3_OVERLAY_NAME` set, that raised
`ImproperlyConfigured`. The pre-push hook `handle_validate_mr_metadata`
could not distinguish that traceback (exit 1) from a genuine
"metadata invalid" verdict, so every MR create/update from a workspace
with two overlays registered was hard-blocked — a lockout.

Resolve the overlay deterministically instead of crashing:

- Add `get_overlay_for_repo()` to `overlay_loader`: it maps the cwd git
  repo (via the `origin` remote slug) to the overlay whose configured
  repos own it, reusing the same repo-ownership relation as
  `infer_overlay_for_url`. Returns None on zero/ambiguous matches.
- `validate_mr()` resolution order: explicit `T3_OVERLAY_NAME` / single
  overlay (unchanged) -> repo-match -> if still ambiguous, validate
  against each overlay and PASS if any accepts (an advisory metadata
  check must never hard-deny on ambiguity) -> if no overlay resolvable,
  skip (exit 0) with a stderr note.

Under no path does `validate_mr` exit via an unhandled
`ImproperlyConfigured`. Single-overlay and `T3_OVERLAY_NAME` behaviour
is preserved exactly.

The pre-push hook's own crash-vs-verdict distinction
(`_run_mr_validator` / `handle_validate_mr_metadata`) is substrate and
is left for a separate PR.

Closes #1526