### PR TITLE
chore(loops): type TickRequest + build_jobs against real backend Protocols, drop ANN401 noqas

### DIFF
--- a/src/teatree/core/management/commands/loop_tick.py
+++ b/src/teatree/core/management/commands/loop_tick.py
@@ -51,14 +51,17 @@ def _registry_jobs_builder(request: "TickRequest", started_at: dt.datetime) -> l
     from teatree.loops.config import LoopsConfig  # noqa: PLC0415
     from teatree.loops.fanout import build_registry_jobs  # noqa: PLC0415
 
-    scanner_context: dict[str, Any] = {
-        "backends": request.backends,
-        "host": request.host,
-        "messaging": request.messaging,
-        "notion_client": request.notion_client,
-        "ready_labels": request.ready_labels,
-    }
-    return build_registry_jobs(scanner_context, config=LoopsConfig.load(), now=started_at)
+    return build_registry_jobs(
+        {
+            "backends": request.backends,
+            "host": request.host,
+            "messaging": request.messaging,
+            "notion_client": request.notion_client,
+            "ready_labels": request.ready_labels,
+        },
+        config=LoopsConfig.load(),
+        now=started_at,
+    )
 
 
 def _report_to_dict(report: TickReport) -> ReportDict:

--- a/src/teatree/loops/arch_review/loop.py
+++ b/src/teatree/loops/arch_review/loop.py
@@ -1,21 +1,25 @@
 """Architectural-review mini-loop — periodic codebase-wide review cadence."""
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
+
+if TYPE_CHECKING:
+    from teatree.core.backend_factory import OverlayBackends
+    from teatree.loop.tick_jobs import _ScannerJob
 
 
 def _build_jobs(
     *,
-    backends: list[Any] | None = None,
-    **_: Any,  # noqa: ANN401 — orchestrator passes extra context as open kwargs
-) -> list[Any]:
+    backends: "list[OverlayBackends] | None" = None,
+    **_: object,
+) -> "list[_ScannerJob]":
     from teatree.loop.tick_jobs import Domain, jobs_for_domain  # noqa: PLC0415
 
     if not backends:
         return []
     all_backends = tuple(backends)
-    jobs: list[Any] = []
+    jobs: list[_ScannerJob] = []
     for backend in backends:
         jobs.extend(jobs_for_domain(Domain.ARCH_REVIEW, backend, all_backends=all_backends))
     return jobs

--- a/src/teatree/loops/audit/loop.py
+++ b/src/teatree/loops/audit/loop.py
@@ -5,22 +5,26 @@ The legacy global outbound audit scanner stays in the always-on
 per-overlay failed-E2E verifier lives here.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
+
+if TYPE_CHECKING:
+    from teatree.core.backend_factory import OverlayBackends
+    from teatree.loop.tick_jobs import _ScannerJob
 
 
 def _build_jobs(
     *,
-    backends: list[Any] | None = None,
-    **_: Any,  # noqa: ANN401 — orchestrator passes extra context as open kwargs
-) -> list[Any]:
+    backends: "list[OverlayBackends] | None" = None,
+    **_: object,
+) -> "list[_ScannerJob]":
     from teatree.loop.tick_jobs import Domain, jobs_for_domain  # noqa: PLC0415
 
     if not backends:
         return []
     all_backends = tuple(backends)
-    jobs: list[Any] = []
+    jobs: list[_ScannerJob] = []
     for backend in backends:
         jobs.extend(jobs_for_domain(Domain.AUDIT, backend, all_backends=all_backends))
     return jobs

--- a/src/teatree/loops/base.py
+++ b/src/teatree/loops/base.py
@@ -14,7 +14,29 @@ the orchestrator is unchanged, only the *grouping* is new.
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from teatree.backends.protocols import CodeHostBackend, MessagingBackend
+    from teatree.core.backend_factory import OverlayBackends
+    from teatree.loop.scanners.notion_view import NotionLike
+    from teatree.loop.tick_jobs import _ScannerJob
+
+
+class BuildJobsContext(TypedDict, total=False):
+    """The per-tick context the orchestrator spreads into ``build_jobs``.
+
+    Mirrors :class:`teatree.loop.tick.TickRequest`'s fields. ``total=False``
+    because each mini-loop's ``build_jobs`` accepts only the subset of
+    keys it needs (the rest are swallowed by its ``**_`` catch-all), and
+    the live tick's single-overlay path omits ``backends``.
+    """
+
+    backends: "list[OverlayBackends] | None"
+    host: "CodeHostBackend | None"
+    messaging: "MessagingBackend | None"
+    notion_client: "NotionLike | None"
+    ready_labels: tuple[str, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,5 +63,5 @@ class MiniLoop:
 
     name: str
     default_cadence_seconds: int
-    build_jobs: Callable[..., list[Any]]
+    build_jobs: Callable[..., list["_ScannerJob"]]
     always_on: bool = False

--- a/src/teatree/loops/dispatch/loop.py
+++ b/src/teatree/loops/dispatch/loop.py
@@ -1,11 +1,14 @@
 """Dispatch mini-loop definition — always-on global scanners."""
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
 
+if TYPE_CHECKING:
+    from teatree.loop.tick_jobs import _ScannerJob
 
-def _build_jobs(**_: Any) -> list[Any]:  # noqa: ANN401 — orchestrator passes extra context as open kwargs
+
+def _build_jobs(**_: object) -> "list[_ScannerJob]":
     """Build the always-on global scanner triad.
 
     Delegates to the ``Domain.DISPATCH`` slice of the public

--- a/src/teatree/loops/dogfood/loop.py
+++ b/src/teatree/loops/dogfood/loop.py
@@ -1,11 +1,14 @@
 """Dogfood mini-loop — overlay-provision-smoke cadence."""
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
 
+if TYPE_CHECKING:
+    from teatree.loop.tick_jobs import _ScannerJob
 
-def _build_jobs(**_: Any) -> list[Any]:  # noqa: ANN401 — orchestrator passes extra context as open kwargs
+
+def _build_jobs(**_: object) -> "list[_ScannerJob]":
     from teatree.loop.tick_jobs import _dogfood_smoke_scanner, _ScannerJob  # noqa: PLC0415
 
     scanner = _dogfood_smoke_scanner()

--- a/src/teatree/loops/fanout.py
+++ b/src/teatree/loops/fanout.py
@@ -15,16 +15,18 @@ never by importing the registry down into :mod:`teatree.loop`.
 """
 
 import datetime as dt
-from typing import Any
 
 from teatree.loop.tick_jobs import _ScannerJob
+from teatree.loops.base import BuildJobsContext
 from teatree.loops.cadence_ledger import MiniLoopMarker
 from teatree.loops.config import LoopsConfig
 from teatree.loops.gating import elapsed_and_enabled
 from teatree.loops.registry import iter_loops
 
 
-def build_registry_jobs(scanner_context: dict[str, Any], *, config: LoopsConfig, now: dt.datetime) -> list[_ScannerJob]:
+def build_registry_jobs(
+    scanner_context: BuildJobsContext, *, config: LoopsConfig, now: dt.datetime
+) -> list[_ScannerJob]:
     jobs: list[_ScannerJob] = []
     for loop in iter_loops():
         if not elapsed_and_enabled(config, loop, now).should_fire:

--- a/src/teatree/loops/followup/loop.py
+++ b/src/teatree/loops/followup/loop.py
@@ -1,23 +1,28 @@
 """Followup mini-loop — assigned-issue intake + review-nag cadence."""
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
+
+if TYPE_CHECKING:
+    from teatree.backends.protocols import CodeHostBackend
+    from teatree.core.backend_factory import OverlayBackends
+    from teatree.loop.tick_jobs import _ScannerJob
 
 
 def _build_jobs(
     *,
-    backends: list[Any] | None = None,
-    host: Any | None = None,  # noqa: ANN401 — CodeHostBackend, kept loose to avoid backend imports
+    backends: "list[OverlayBackends] | None" = None,
+    host: "CodeHostBackend | None" = None,
     ready_labels: tuple[str, ...] = (),
-    **_: Any,  # noqa: ANN401 — orchestrator passes extra context as open kwargs
-) -> list[Any]:
+    **_: object,
+) -> "list[_ScannerJob]":
     from teatree.loop.scanners import AssignedIssuesScanner  # noqa: PLC0415
     from teatree.loop.tick_jobs import Domain, _ScannerJob, jobs_for_domain  # noqa: PLC0415
 
     if backends:
         all_backends = tuple(backends)
-        jobs: list[Any] = []
+        jobs: list[_ScannerJob] = []
         for backend in backends:
             jobs.extend(jobs_for_domain(Domain.FOLLOWUP, backend, all_backends=all_backends))
         return jobs

--- a/src/teatree/loops/housekeeping/loop.py
+++ b/src/teatree/loops/housekeeping/loop.py
@@ -1,15 +1,19 @@
 """Housekeeping mini-loop — editable self-update + work-repo main clone."""
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
+
+if TYPE_CHECKING:
+    from teatree.core.backend_factory import OverlayBackends
+    from teatree.loop.tick_jobs import _ScannerJob
 
 
 def _build_jobs(
     *,
-    backends: list[Any] | None = None,
-    **_: Any,  # noqa: ANN401 — orchestrator passes extra context as open kwargs
-) -> list[Any]:
+    backends: "list[OverlayBackends] | None" = None,
+    **_: object,
+) -> "list[_ScannerJob]":
     """Wire the global self-update job + each overlay's pull-main-clone slice.
 
     Self-update is a global (``overlay=""``) job — it fast-forwards the
@@ -19,7 +23,7 @@ def _build_jobs(
     """
     from teatree.loop.tick_jobs import Domain, _ScannerJob, _self_update_scanner, jobs_for_domain  # noqa: PLC0415
 
-    jobs: list[Any] = []
+    jobs: list[_ScannerJob] = []
     self_update = _self_update_scanner()
     if self_update is not None:
         jobs.append(_ScannerJob(scanner=self_update, overlay=""))

--- a/src/teatree/loops/inbox/loop.py
+++ b/src/teatree/loops/inbox/loop.py
@@ -5,18 +5,24 @@ mentions/DMs, RED CARD signals, Notion view items. Default cadence is
 short because user-facing inbox lag is felt within seconds.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
+
+if TYPE_CHECKING:
+    from teatree.backends.protocols import MessagingBackend
+    from teatree.core.backend_factory import OverlayBackends
+    from teatree.loop.scanners.notion_view import NotionLike
+    from teatree.loop.tick_jobs import _ScannerJob
 
 
 def _build_jobs(
     *,
-    backends: list[Any] | None = None,
-    notion_client: Any | None = None,  # noqa: ANN401 — NotionLike, kept loose
-    messaging: Any | None = None,  # noqa: ANN401 — MessagingBackend, kept loose
-    **_: Any,  # noqa: ANN401 — orchestrator passes extra context as open kwargs
-) -> list[Any]:
+    backends: "list[OverlayBackends] | None" = None,
+    notion_client: "NotionLike | None" = None,
+    messaging: "MessagingBackend | None" = None,
+    **_: object,
+) -> "list[_ScannerJob]":
     """Consume the per-overlay ``Domain.INBOX`` slice plus the global notion job.
 
     ``Domain.INBOX`` owns the per-overlay inbound Slack scanners
@@ -29,7 +35,7 @@ def _build_jobs(
     from teatree.loop.scanners import NotionViewScanner  # noqa: PLC0415
     from teatree.loop.tick_jobs import Domain, _ScannerJob, jobs_for_domain  # noqa: PLC0415
 
-    jobs: list[Any] = []
+    jobs: list[_ScannerJob] = []
     if backends:
         all_backends = tuple(backends)
         for backend in backends:
@@ -41,7 +47,7 @@ def _build_jobs(
     return jobs
 
 
-def _single_overlay_messaging_jobs(messaging: Any) -> list[Any]:  # noqa: ANN401
+def _single_overlay_messaging_jobs(messaging: "MessagingBackend") -> "list[_ScannerJob]":
     from teatree.loop.scanners import (  # noqa: PLC0415
         RedCardScanner,
         SlackDmInboundScanner,

--- a/src/teatree/loops/news/loop.py
+++ b/src/teatree/loops/news/loop.py
@@ -1,11 +1,14 @@
 """News mini-loop — daily ``scanning_news`` cadence anchor."""
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
 
+if TYPE_CHECKING:
+    from teatree.loop.tick_jobs import _ScannerJob
 
-def _build_jobs(**_: Any) -> list[Any]:  # noqa: ANN401 — orchestrator passes extra context as open kwargs
+
+def _build_jobs(**_: object) -> "list[_ScannerJob]":
     from teatree.loop.tick_jobs import _ScannerJob, _scanning_news_scanner  # noqa: PLC0415
 
     scanner = _scanning_news_scanner()

--- a/src/teatree/loops/orchestrator.py
+++ b/src/teatree/loops/orchestrator.py
@@ -26,14 +26,22 @@ import datetime as dt
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING
 
-from teatree.loops.base import MiniLoop
+from teatree.loops.base import BuildJobsContext, MiniLoop
 from teatree.loops.cadence_ledger import MiniLoopMarker
 from teatree.loops.config import LoopsConfig
 from teatree.loops.gating import elapsed_and_enabled
 from teatree.loops.registry import iter_loops
 from teatree.loops.summary import OrchestratorReport, build_summary_dm
+
+if TYPE_CHECKING:
+    from teatree.backends.protocols import CodeHostBackend, MessagingBackend
+    from teatree.core.backend_factory import OverlayBackends
+    from teatree.loop.dispatch import DispatchAction
+    from teatree.loop.scanners.base import ScanSignal
+    from teatree.loop.scanners.notion_view import NotionLike
+    from teatree.loop.tick_jobs import _ScannerJob
 
 logger = logging.getLogger(__name__)
 
@@ -42,19 +50,19 @@ logger = logging.getLogger(__name__)
 class TickRequest:
     """Per-tick context propagated to every mini-loop's ``build_jobs``.
 
-    Mirrors :class:`teatree.loop.tick.TickRequest` so the mini-loop
-    ``build_jobs`` callable can pick the kwargs it needs. Kept as
-    ``Any``-typed to avoid pulling backend types into this surface.
+    Mirrors :class:`teatree.loop.tick.TickRequest` — same backend
+    Protocols on every field so the orchestrator surface carries the
+    same compile-time contract as the live tick path.
     """
 
-    backends: list[Any] | None = None
-    host: Any | None = None
-    messaging: Any | None = None
-    notion_client: Any | None = None
+    backends: list["OverlayBackends"] | None = None
+    host: "CodeHostBackend | None" = None
+    messaging: "MessagingBackend | None" = None
+    notion_client: "NotionLike | None" = None
     ready_labels: tuple[str, ...] = ()
 
 
-def _default_dispatch(jobs: list[Any]) -> list[Any]:
+def _default_dispatch(jobs: "list[_ScannerJob]") -> "list[DispatchAction]":
     """Default dispatch — runs the legacy job pipeline.
 
     Imports lazily so the orchestrator stays importable from contexts
@@ -67,7 +75,7 @@ def _default_dispatch(jobs: list[Any]) -> list[Any]:
     from teatree.loop.dispatch import dispatch  # noqa: PLC0415
     from teatree.loop.tick_jobs import _run_job  # noqa: PLC0415
 
-    signals: list[Any] = []
+    signals: list[ScanSignal] = []
     with ThreadPoolExecutor(max_workers=max(1, len(jobs))) as pool:
         for _label, sigs, _err in pool.map(_run_job, jobs):
             signals.extend(sigs)
@@ -93,7 +101,7 @@ class Orchestrator:
     config: LoopsConfig
     registry_fn: Callable[[], tuple[MiniLoop, ...]] = field(default=iter_loops)
     clock: Callable[[], dt.datetime] = field(default=_utc_clock)
-    dispatch_fn: Callable[[list[Any]], list[Any]] = field(default=_default_dispatch)
+    dispatch_fn: "Callable[[list[_ScannerJob]], list[DispatchAction]]" = field(default=_default_dispatch)
 
     def tick(self, request: TickRequest) -> "TickOutcome":
         """Run one orchestrator tick — gate, dispatch, summarise."""
@@ -161,7 +169,7 @@ class Orchestrator:
         notify_with_fallback(text, kind=NotifyKind.INFO, idempotency_key=idempotency_key)
 
 
-def _kwargs_for_request(request: TickRequest) -> dict[str, Any]:
+def _kwargs_for_request(request: TickRequest) -> BuildJobsContext:
     return {
         "backends": request.backends,
         "host": request.host,

--- a/src/teatree/loops/resource_pressure/loop.py
+++ b/src/teatree/loops/resource_pressure/loop.py
@@ -9,14 +9,17 @@ matching the legacy per-tick construction rather than the hourly
 housekeeping cadence.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
+
+if TYPE_CHECKING:
+    from teatree.loop.tick_jobs import _ScannerJob
 
 _REGISTRY_CADENCE_FLOOR = 60
 
 
-def _build_jobs(**_: Any) -> list[Any]:  # noqa: ANN401 — orchestrator passes extra context as open kwargs
+def _build_jobs(**_: object) -> "list[_ScannerJob]":
     from teatree.loop.tick_jobs import _resource_pressure_scanner, _ScannerJob  # noqa: PLC0415
 
     scanner = _resource_pressure_scanner()

--- a/src/teatree/loops/review/loop.py
+++ b/src/teatree/loops/review/loop.py
@@ -5,24 +5,29 @@ colleague pushes a new SHA, the loop fires once, the work is done) so
 sub-minute polling buys nothing.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
+
+if TYPE_CHECKING:
+    from teatree.backends.protocols import CodeHostBackend
+    from teatree.core.backend_factory import OverlayBackends
+    from teatree.loop.tick_jobs import _ScannerJob
 
 
 def _build_jobs(
     *,
-    backends: list[Any] | None = None,
-    host: Any | None = None,  # noqa: ANN401 — CodeHostBackend, kept loose
-    **_: Any,  # noqa: ANN401 — orchestrator passes extra context as open kwargs
-) -> list[Any]:
+    backends: "list[OverlayBackends] | None" = None,
+    host: "CodeHostBackend | None" = None,
+    **_: object,
+) -> "list[_ScannerJob]":
     """Build per-overlay reviewer-PR + companion review-related scanners."""
     from teatree.loop.scanners import ReviewerPrsScanner  # noqa: PLC0415
     from teatree.loop.tick_jobs import Domain, _ScannerJob, jobs_for_domain  # noqa: PLC0415
 
     if backends:
         all_backends = tuple(backends)
-        jobs: list[Any] = []
+        jobs: list[_ScannerJob] = []
         for backend in backends:
             jobs.extend(jobs_for_domain(Domain.REVIEW, backend, all_backends=all_backends))
         return jobs

--- a/src/teatree/loops/ship/loop.py
+++ b/src/teatree/loops/ship/loop.py
@@ -1,23 +1,28 @@
 """Ship mini-loop — own-author PR + GitLab approvals."""
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
+
+if TYPE_CHECKING:
+    from teatree.backends.protocols import CodeHostBackend
+    from teatree.core.backend_factory import OverlayBackends
+    from teatree.loop.tick_jobs import _ScannerJob
 
 
 def _build_jobs(
     *,
-    backends: list[Any] | None = None,
-    host: Any | None = None,  # noqa: ANN401 — CodeHostBackend, kept loose
-    **_: Any,  # noqa: ANN401 — orchestrator passes extra context as open kwargs
-) -> list[Any]:
+    backends: "list[OverlayBackends] | None" = None,
+    host: "CodeHostBackend | None" = None,
+    **_: object,
+) -> "list[_ScannerJob]":
     """Build per-host MyPrsScanner + optional GitLab approvals scanner."""
     from teatree.loop.scanners import MyPrsScanner  # noqa: PLC0415
     from teatree.loop.tick_jobs import Domain, _ScannerJob, jobs_for_domain  # noqa: PLC0415
 
     if backends:
         all_backends = tuple(backends)
-        jobs: list[Any] = []
+        jobs: list[_ScannerJob] = []
         for backend in backends:
             jobs.extend(jobs_for_domain(Domain.SHIP, backend, all_backends=all_backends))
         return jobs

--- a/src/teatree/loops/tickets/loop.py
+++ b/src/teatree/loops/tickets/loop.py
@@ -1,21 +1,25 @@
 """Tickets mini-loop — local Ticket DB scanners + per-host disposition/completion."""
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from teatree.loops.base import MiniLoop
+
+if TYPE_CHECKING:
+    from teatree.core.backend_factory import OverlayBackends
+    from teatree.loop.tick_jobs import _ScannerJob
 
 
 def _build_jobs(
     *,
-    backends: list[Any] | None = None,
-    **_: Any,  # noqa: ANN401 — orchestrator passes extra context as open kwargs
-) -> list[Any]:
+    backends: "list[OverlayBackends] | None" = None,
+    **_: object,
+) -> "list[_ScannerJob]":
     from teatree.loop.tick_jobs import Domain, jobs_for_domain  # noqa: PLC0415
 
     if not backends:
         return []
     all_backends = tuple(backends)
-    jobs: list[Any] = []
+    jobs: list[_ScannerJob] = []
     for backend in backends:
         jobs.extend(jobs_for_domain(Domain.TICKETS, backend, all_backends=all_backends))
     return jobs


### PR DESCRIPTION
## What

`teatree.loops` was the one corner of `src/teatree/` opting out of strict typing: the orchestrator passed its per-tick context (`backends`/`host`/`messaging`/`notion_client`) as `Any`, every `MiniLoop.build_jobs` took `**_: Any`, and `TickRequest` in `loops/orchestrator.py` was `Any`-typed on every field — silenced by inline `# noqa: ANN401` suppressions. The backend types are already real, importable Protocols (`CodeHostBackend`, `MessagingBackend`, `NotionLike`, `OverlayBackends`) used precisely everywhere else in `loop/`.

This types the surface against those real Protocols, mirroring the live `teatree.loop.tick.TickRequest`:

- `TickRequest` fields and every `loops/*/loop.py::_build_jobs` signature now use `list[OverlayBackends] | None`, `CodeHostBackend | None`, `MessagingBackend | None`, `NotionLike | None`, and return `list[_ScannerJob]`.
- A `BuildJobsContext` `TypedDict` (in `loops/base.py`) names the per-tick context bundle the orchestrator and the registry fan-out spread into `build_jobs`, replacing the untyped kwargs bag.
- Open catch-all kwargs are typed `object` instead of `Any`.
- Every `# noqa: ANN401` under `loops/` is removed (`grep -rn "noqa: ANN401" src/teatree/loops/` returns nothing).

Protocol imports are `TYPE_CHECKING`-only, so the runtime import graph is unchanged — the values arrive via the orchestrator kwargs at runtime — keeping the `tach` `loops -> backends` boundary clean.

## Why

Per [#1483](https://github.com/souliane/teatree/issues/1483): keeping these `Any` is an internal typing gap, not the sanctioned "untyped third-party code" exception, and 24-ish inline `ANN401` suppressions papered over it. The mirror-`TickRequest`-as-`Any` choice meant the orchestrator surface could be passed the wrong shape with no type-checker signal. Typing it precisely lets the `loops` package re-join the strictly-typed core and gain the same compile-time contract the live tick path has.

## Tests

Types only — no behaviour change, so the fan-out output stays byte-for-byte identical:

- `RegistryLegacyParityTestCase::test_registry_matches_legacy_scanner_signatures`, all of `tests/teatree_loops/test_fanout.py`, and `tests/teatree_loop/test_jobs_for_domain.py` stay green.
- Full suite: 8838 passed, coverage 93.93% (gate 93%). `tach check`, `ruff check`, `ruff format --check`, `ty check` (`error-on-warning = true`), and prek all green.

Closes [#1483](https://github.com/souliane/teatree/issues/1483)