### PR TITLE
chore(loop): add default-OFF IssueImplementerScanner reachable via jobs_for_domain

### DIFF
--- a/src/teatree/loop/scanners/__init__.py
+++ b/src/teatree/loop/scanners/__init__.py
@@ -16,6 +16,7 @@ from teatree.loop.scanners.base import Scanner, ScanSignal
 from teatree.loop.scanners.codex_review import CodexReviewScanner, GhCodexPrApi
 from teatree.loop.scanners.gitlab_approvals import GitLabApprovalsScanner
 from teatree.loop.scanners.incoming_events import IncomingEventsScanner
+from teatree.loop.scanners.issue_implementer import IssueImplementerScanner
 from teatree.loop.scanners.my_prs import MyPrsScanner
 from teatree.loop.scanners.notion_view import NotionViewScanner
 from teatree.loop.scanners.outbound_audit import OutboundAuditScanner
@@ -60,6 +61,7 @@ __all__ = [
     "GitLabApprovalsScanner",
     "GlabGhMrStateClassifier",
     "IncomingEventsScanner",
+    "IssueImplementerScanner",
     "MyPrsScanner",
     "NotionViewScanner",
     "NullMergeNotifier",

--- a/src/teatree/loop/scanners/issue_implementer.py
+++ b/src/teatree/loop/scanners/issue_implementer.py
@@ -1,0 +1,138 @@
+"""Discover open, labelled issues and claim them for auto-implementation (#1553).
+
+The always-on issue-implementer loop (default-OFF behind the
+``issue_implementer_enabled`` gate) picks up issues that carry the
+configured ``issue_implementer_label`` and are not already in flight. The
+scanner is the discovery + claim half: it lists the user's open issues via
+the code-host backend, keeps the ones carrying the label, and claims each
+through the TOCTOU-safe :meth:`ImplementedIssueMarker.claim` so two
+concurrent ticks never double-dispatch the same issue.
+
+Whether the scanner runs at all is decided one layer up by
+:func:`teatree.loop.tick_jobs._issue_implementer_scanner_for` — the triple
+gate (enabled flag, in-flight concurrency budget, per-issue claim
+idempotency). Dispatch routing of the emitted signals lands in C4 (#1554);
+C3 stops at claim + signal emission.
+"""
+
+from dataclasses import dataclass, field
+from typing import cast
+
+from teatree.backends.protocols import CodeHostBackend
+from teatree.core.models import ImplementedIssueMarker
+from teatree.loop.scanners.base import ScanSignal
+from teatree.types import RawAPIDict
+
+
+def _issue_url(issue: RawAPIDict) -> str:
+    for name in ("web_url", "html_url"):
+        value = issue.get(name)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _issue_title(issue: RawAPIDict) -> str:
+    title = issue.get("title")
+    return title if isinstance(title, str) else ""
+
+
+def _issue_labels(issue: RawAPIDict) -> list[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return []
+    out: list[str] = []
+    for item in labels:
+        if isinstance(item, str):
+            out.append(item)
+        elif isinstance(item, dict):
+            name = cast("RawAPIDict", item).get("name")
+            if isinstance(name, str):
+                out.append(name)
+    return out
+
+
+def _issue_is_open(issue: RawAPIDict) -> bool:
+    """Treat an issue as open unless the backend explicitly reports otherwise.
+
+    The forge issue-search the backends use already filters to open issues
+    (``is:open``), so a missing ``state`` is open by construction; a present
+    ``state`` of ``closed`` is the only thing that excludes an issue.
+    """
+    state = issue.get("state")
+    return not (isinstance(state, str) and state.lower() == "closed")
+
+
+@dataclass(slots=True)
+class IssueImplementerScanner:
+    """Claim open, labelled issues for the auto-implementer pipeline (#1553).
+
+    Lists the configured *identities*' open issues on *host*, keeps the ones
+    carrying *label*, and claims each via the TOCTOU-safe
+    :meth:`ImplementedIssueMarker.claim`. A claim that returns ``None`` (the
+    row already exists — another tick or overlay took it) is skipped
+    silently, so the scanner never double-dispatches. Each newly claimed
+    issue surfaces one ``issue_implementer.claimed`` signal; the C4 dispatch
+    layer routes those into the implementation pipeline.
+
+    ``identities`` opts the scanner into a multi-alias union query (matching
+    :class:`AssignedIssuesScanner`); empty falls back to
+    ``host.current_user()``.
+    """
+
+    host: CodeHostBackend
+    label: str
+    overlay_name: str = ""
+    identities: tuple[str, ...] = field(default_factory=tuple)
+    name: str = "issue_implementer"
+
+    def scan(self) -> list[ScanSignal]:
+        if not self.label:
+            return []
+        assignees = self._resolve_identities()
+        if not assignees:
+            return []
+        signals: list[ScanSignal] = []
+        for issue in self._collect_unique_issues(assignees):
+            if not _issue_is_open(issue):
+                continue
+            if self.label not in _issue_labels(issue):
+                continue
+            url = _issue_url(issue)
+            if not url:
+                continue
+            marker = ImplementedIssueMarker.objects.claim(url, overlay=self.overlay_name)
+            if marker is None:
+                continue
+            signals.append(
+                ScanSignal(
+                    kind="issue_implementer.claimed",
+                    summary=f"Claimed for auto-implement: {_issue_title(issue)}",
+                    payload={
+                        "url": url,
+                        "raw": issue,
+                        "overlay": self.overlay_name,
+                    },
+                )
+            )
+        return signals
+
+    def _resolve_identities(self) -> tuple[str, ...]:
+        if self.identities:
+            return tuple(dict.fromkeys(self.identities))
+        user = self.host.current_user()
+        return (user,) if user else ()
+
+    def _collect_unique_issues(self, assignees: tuple[str, ...]) -> list[RawAPIDict]:
+        """Union assigned issues across *assignees*, deduped by URL."""
+        seen_urls: set[str] = set()
+        issues: list[RawAPIDict] = []
+        for assignee in assignees:
+            for issue in self.host.list_assigned_issues(assignee=assignee):
+                url = _issue_url(issue)
+                if url and url in seen_urls:
+                    continue
+                if url:
+                    seen_urls.add(url)
+                issues.append(issue)
+        return issues

--- a/src/teatree/loop/tick_jobs.py
+++ b/src/teatree/loop/tick_jobs.py
@@ -23,6 +23,7 @@ from teatree.core.clone_paths import find_clone_path
 if TYPE_CHECKING:
     from teatree.config import UserSettings
 from teatree.core.backend_factory import OverlayBackends
+from teatree.core.models import ImplementedIssueMarker
 from teatree.loop.scanners import (
     ActiveTicketsScanner,
     ArchitecturalReviewScanner,
@@ -35,6 +36,7 @@ from teatree.loop.scanners import (
     GitLabApprovalsScanner,
     GlabGhMrStateClassifier,
     IncomingEventsScanner,
+    IssueImplementerScanner,
     MyPrsScanner,
     NotionViewScanner,
     NullMergeNotifier,
@@ -98,6 +100,7 @@ class Domain(StrEnum):
     ARCH_REVIEW = "arch_review"
     AUDIT = "audit"
     HOUSEKEEPING = "housekeeping"
+    ISSUE_IMPLEMENTER = "issue_implementer"
     DISPATCH = "dispatch"
 
 
@@ -114,6 +117,7 @@ PER_OVERLAY_DOMAINS: tuple[Domain, ...] = (
     Domain.ARCH_REVIEW,
     Domain.AUDIT,
     Domain.HOUSEKEEPING,
+    Domain.ISSUE_IMPLEMENTER,
 )
 
 
@@ -468,6 +472,45 @@ def _architectural_review_scanner_for(backend: OverlayBackends) -> Architectural
         skill=settings.architectural_review_skill,
         cadence_hours=settings.architectural_review_cadence_hours,
         after_merge_count=settings.architectural_review_after_merge_count,
+    )
+
+
+def _issue_implementer_scanner_for(backend: OverlayBackends) -> IssueImplementerScanner | None:
+    """Build a per-overlay issue-implementer scanner behind the triple gate (#1553).
+
+    Returns a scanner ONLY when the always-on issue-implementer loop is
+    opted in for this overlay AND the in-flight budget has room. Two of the
+    triple gate's three checks live here; the third lives in the scanner.
+
+    The master gate is ``issue_implementer_enabled`` (default False) — the
+    loop is a hard no-op until an overlay flips it on. The concurrency gate
+    is ``ImplementedIssueMarker.in_flight_count(overlay) <
+    issue_implementer_max_concurrent`` — a full budget emits no scanner, so
+    no further issue is picked up this tick.
+
+    The third gate — per-issue claim idempotency — lives inside the scanner
+    itself (:meth:`ImplementedIssueMarker.claim` returns ``None`` for an
+    already-claimed issue, which the scanner skips).
+
+    Returns ``None`` (no job emitted) whenever either gate is shut, so with
+    the default-OFF config neither ``build_registry_jobs`` nor
+    ``build_default_jobs`` emits anything for this domain — the registry
+    fan-out stays byte-for-byte unchanged until an overlay opts in. Dispatch
+    routing of the emitted signals lands in C4 (#1554).
+    """
+    settings = _effective_settings_for_overlay(backend.name)
+    if not settings.issue_implementer_enabled:
+        return None
+    code_host = backend.host
+    if code_host is None:
+        return None
+    if ImplementedIssueMarker.objects.in_flight_count(backend.name) >= settings.issue_implementer_max_concurrent:
+        return None
+    return IssueImplementerScanner(
+        host=code_host,
+        label=settings.issue_implementer_label,
+        overlay_name=backend.name,
+        identities=backend.identities,
     )
 
 
@@ -990,6 +1033,20 @@ def _housekeeping_jobs_for_overlay(backend: OverlayBackends) -> list[_ScannerJob
     return [_ScannerJob(scanner=scanner, overlay=backend.name)]
 
 
+def _issue_implementer_jobs_for_overlay(backend: OverlayBackends) -> list[_ScannerJob]:
+    """Per-overlay issue-implementer scanner behind the default-OFF triple gate (#1553).
+
+    Empty by default — :func:`_issue_implementer_scanner_for` returns
+    ``None`` unless the overlay opts in and has in-flight budget — so this
+    domain slice contributes nothing to either fan-out path until an overlay
+    enables the loop, keeping the registry/legacy parity green.
+    """
+    scanner = _issue_implementer_scanner_for(backend)
+    if scanner is None:
+        return []
+    return [_ScannerJob(scanner=scanner, overlay=backend.name)]
+
+
 def _identity_groups_for_overlay(backend: OverlayBackends) -> tuple[tuple[str, ...], ...]:
     """Resolve disposition identity-alias groups with the multi-identity self-group fallback (#1113)."""
     groups = _identity_alias_groups_for_overlay(backend.name, backend)
@@ -1015,6 +1072,7 @@ _PER_OVERLAY_DOMAIN_BUILDERS: dict[Domain, _OverlayDomainBuilder] = {
     Domain.ARCH_REVIEW: _arch_review_jobs_for_overlay,
     Domain.AUDIT: _audit_jobs_for_overlay,
     Domain.HOUSEKEEPING: _housekeeping_jobs_for_overlay,
+    Domain.ISSUE_IMPLEMENTER: _issue_implementer_jobs_for_overlay,
 }
 
 

--- a/tests/teatree_loop/test_issue_implementer_scanner.py
+++ b/tests/teatree_loop/test_issue_implementer_scanner.py
@@ -1,0 +1,114 @@
+"""Behaviour tests for ``IssueImplementerScanner`` — label filter + claim idempotency (#1553).
+
+The scanner is the discovery + claim half of the always-on issue-implementer
+loop. It lists the user's open issues via the code-host backend, keeps the
+ones carrying the configured label, and claims each through the TOCTOU-safe
+:meth:`ImplementedIssueMarker.claim` so a re-tick (or a concurrent overlay)
+never double-dispatches the same issue.
+"""
+
+from dataclasses import dataclass, field
+
+from django.test import TestCase
+
+from teatree.core.models import ImplementedIssueMarker
+from teatree.loop.scanners.issue_implementer import IssueImplementerScanner
+from teatree.types import RawAPIDict
+
+
+@dataclass
+class _Host:
+    """Minimal CodeHostBackend stub — only the methods the scanner calls."""
+
+    user: str = "alice"
+    issues: list[RawAPIDict] = field(default_factory=list)
+
+    def current_user(self) -> str:
+        return self.user
+
+    def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:
+        _ = assignee
+        return self.issues
+
+
+class IssueImplementerScannerTests(TestCase):
+    OVERLAY = "acme"
+    LABEL = "auto-implement"
+    URL_A = "https://github.com/souliane/teatree/issues/100"
+    URL_B = "https://github.com/souliane/teatree/issues/101"
+
+    def _scanner(self, host: _Host, *, label: str = LABEL) -> IssueImplementerScanner:
+        return IssueImplementerScanner(host=host, label=label, overlay_name=self.OVERLAY)
+
+    @staticmethod
+    def _issue(url: str, *, labels: list[str], title: str = "do it", state: str = "open") -> RawAPIDict:
+        return {"web_url": url, "title": title, "labels": labels, "state": state}
+
+    def test_labelled_open_issue_is_claimed_and_emitted(self) -> None:
+        host = _Host(issues=[self._issue(self.URL_A, labels=[self.LABEL])])
+        signals = self._scanner(host).scan()
+        assert [s.kind for s in signals] == ["issue_implementer.claimed"]
+        assert signals[0].payload["url"] == self.URL_A
+        marker = ImplementedIssueMarker.objects.get(issue_url=self.URL_A, overlay=self.OVERLAY)
+        assert marker.state == ImplementedIssueMarker.State.DISPATCHED
+
+    def test_only_labelled_issues_are_actionable(self) -> None:
+        host = _Host(
+            issues=[
+                self._issue(self.URL_A, labels=[self.LABEL]),
+                self._issue(self.URL_B, labels=["something-else"]),
+            ]
+        )
+        signals = self._scanner(host).scan()
+        assert {s.payload["url"] for s in signals} == {self.URL_A}
+        assert not ImplementedIssueMarker.objects.filter(issue_url=self.URL_B).exists()
+
+    def test_closed_labelled_issue_is_skipped(self) -> None:
+        host = _Host(issues=[self._issue(self.URL_A, labels=[self.LABEL], state="closed")])
+        assert self._scanner(host).scan() == []
+        assert not ImplementedIssueMarker.objects.filter(issue_url=self.URL_A).exists()
+
+    def test_second_claim_of_same_issue_is_skipped(self) -> None:
+        """``claim`` idempotency: a re-tick on an already-claimed issue emits nothing."""
+        host = _Host(issues=[self._issue(self.URL_A, labels=[self.LABEL])])
+        first = self._scanner(host).scan()
+        assert len(first) == 1
+        second = self._scanner(host).scan()
+        assert second == []
+        assert ImplementedIssueMarker.objects.filter(issue_url=self.URL_A, overlay=self.OVERLAY).count() == 1
+
+    def test_empty_label_claims_nothing(self) -> None:
+        """Defence-in-depth: an empty label never picks up any issue."""
+        host = _Host(issues=[self._issue(self.URL_A, labels=[self.LABEL])])
+        assert self._scanner(host, label="").scan() == []
+        assert not ImplementedIssueMarker.objects.exists()
+
+    def test_no_identity_resolves_to_no_scan(self) -> None:
+        host = _Host(user="", issues=[self._issue(self.URL_A, labels=[self.LABEL])])
+        assert self._scanner(host).scan() == []
+        assert not ImplementedIssueMarker.objects.exists()
+
+    def test_explicit_identities_union_dedupes_by_url(self) -> None:
+        host = _Host(issues=[self._issue(self.URL_A, labels=[self.LABEL])])
+        scanner = IssueImplementerScanner(
+            host=host,
+            label=self.LABEL,
+            overlay_name=self.OVERLAY,
+            identities=("alice", "alice-bot"),
+        )
+        signals = scanner.scan()
+        assert len(signals) == 1
+        assert ImplementedIssueMarker.objects.filter(issue_url=self.URL_A).count() == 1
+
+    def test_missing_state_field_treated_as_open(self) -> None:
+        host = _Host(issues=[{"web_url": self.URL_A, "title": "t", "labels": [self.LABEL]}])
+        assert len(self._scanner(host).scan()) == 1
+
+    def test_issue_without_url_is_skipped(self) -> None:
+        host = _Host(issues=[{"title": "no url", "labels": [self.LABEL]}])
+        assert self._scanner(host).scan() == []
+        assert not ImplementedIssueMarker.objects.exists()
+
+    def test_dict_shaped_labels_are_matched(self) -> None:
+        host = _Host(issues=[{"web_url": self.URL_A, "title": "t", "labels": [{"name": self.LABEL}]}])
+        assert len(self._scanner(host).scan()) == 1

--- a/tests/teatree_loop/test_issue_implementer_wiring.py
+++ b/tests/teatree_loop/test_issue_implementer_wiring.py
@@ -1,0 +1,109 @@
+"""The issue-implementer tick-job builder is gated by the default-OFF triple gate (#1553).
+
+``_issue_implementer_scanner_for`` returns a scanner ONLY when the loop is
+opted in for the overlay AND the in-flight concurrency budget has room;
+otherwise ``None`` (no job emitted). With the default-OFF config it always
+returns ``None``, so the per-overlay ``ISSUE_IMPLEMENTER`` domain slice is
+empty and the registry/legacy fan-out stays byte-for-byte unchanged.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from teatree.backends.protocols import CodeHostBackend
+from teatree.config import UserSettings
+from teatree.core.backend_factory import OverlayBackends
+from teatree.loop.scanners.issue_implementer import IssueImplementerScanner
+from teatree.loop.tick_jobs import Domain, _issue_implementer_scanner_for, jobs_for_domain
+from tests.factories import ImplementedIssueMarkerFactory
+
+_PATCH_TARGET = "teatree.loop.tick_jobs._effective_settings_for_overlay"
+
+
+def _backend(name: str = "acme") -> OverlayBackends:
+    return OverlayBackends(
+        name=name,
+        hosts=(MagicMock(spec=CodeHostBackend),),
+        messaging=None,
+        ready_labels=(),
+        identities=("alice",),
+    )
+
+
+def _settings(**overrides: object) -> UserSettings:
+    return UserSettings(**overrides)
+
+
+class IssueImplementerGateTests(TestCase):
+    def test_disabled_by_default_emits_no_scanner(self) -> None:
+        with patch(_PATCH_TARGET, return_value=_settings()):
+            assert _issue_implementer_scanner_for(_backend()) is None
+
+    def test_enabled_with_budget_builds_scanner(self) -> None:
+        with patch(
+            _PATCH_TARGET,
+            return_value=_settings(issue_implementer_enabled=True, issue_implementer_label="auto-implement"),
+        ):
+            scanner = _issue_implementer_scanner_for(_backend())
+        assert isinstance(scanner, IssueImplementerScanner)
+        assert scanner.label == "auto-implement"
+        assert scanner.overlay_name == "acme"
+        assert scanner.identities == ("alice",)
+
+    def test_concurrency_at_max_emits_no_scanner(self) -> None:
+        ImplementedIssueMarkerFactory(overlay="acme")
+        with patch(
+            _PATCH_TARGET,
+            return_value=_settings(
+                issue_implementer_enabled=True,
+                issue_implementer_label="auto-implement",
+                issue_implementer_max_concurrent=1,
+            ),
+        ):
+            assert _issue_implementer_scanner_for(_backend()) is None
+
+    def test_abandoned_marker_does_not_consume_budget(self) -> None:
+        ImplementedIssueMarkerFactory(overlay="acme", abandoned=True)
+        with patch(
+            _PATCH_TARGET,
+            return_value=_settings(
+                issue_implementer_enabled=True,
+                issue_implementer_label="auto-implement",
+                issue_implementer_max_concurrent=1,
+            ),
+        ):
+            assert _issue_implementer_scanner_for(_backend()) is not None
+
+    def test_budget_is_overlay_scoped(self) -> None:
+        ImplementedIssueMarkerFactory(overlay="other")
+        with patch(
+            _PATCH_TARGET,
+            return_value=_settings(
+                issue_implementer_enabled=True,
+                issue_implementer_label="auto-implement",
+                issue_implementer_max_concurrent=1,
+            ),
+        ):
+            assert _issue_implementer_scanner_for(_backend("acme")) is not None
+
+    def test_hostless_backend_emits_no_scanner(self) -> None:
+        backend = OverlayBackends(name="acme", hosts=(), messaging=None, ready_labels=())
+        with patch(
+            _PATCH_TARGET,
+            return_value=_settings(issue_implementer_enabled=True, issue_implementer_label="auto-implement"),
+        ):
+            assert _issue_implementer_scanner_for(backend) is None
+
+    def test_domain_slice_empty_when_disabled(self) -> None:
+        with patch(_PATCH_TARGET, return_value=_settings()):
+            assert jobs_for_domain(Domain.ISSUE_IMPLEMENTER, _backend()) == []
+
+    def test_domain_slice_emits_one_scanner_when_enabled(self) -> None:
+        with patch(
+            _PATCH_TARGET,
+            return_value=_settings(issue_implementer_enabled=True, issue_implementer_label="auto-implement"),
+        ):
+            jobs = jobs_for_domain(Domain.ISSUE_IMPLEMENTER, _backend())
+        assert [job.scanner.name for job in jobs] == ["issue_implementer"]
+        assert jobs[0].overlay == "acme"

--- a/tests/teatree_loop/test_jobs_for_domain.py
+++ b/tests/teatree_loop/test_jobs_for_domain.py
@@ -12,12 +12,13 @@ turns the exhaustiveness assertion RED.
 import dataclasses
 from collections import Counter
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import TestCase
 
 from teatree.backends.protocols import CodeHostBackend, MessagingBackend
+from teatree.config import UserSettings
 from teatree.core.backend_factory import OverlayBackends
 from teatree.loop.tick_jobs import PER_OVERLAY_DOMAINS, Domain, _jobs_for_overlay_backend, jobs_for_domain
 
@@ -137,3 +138,68 @@ class JobsForDomainTodoSweepTestCase(TestCase):
         backend = self._backend_with_python_overlay()
         tickets_names = {job.scanner.name for job in jobs_for_domain(Domain.TICKETS, backend)}
         assert "todo_sweep" in tickets_names
+
+
+_SETTINGS_PATCH_TARGET = "teatree.loop.tick_jobs._effective_settings_for_overlay"
+
+
+class IssueImplementerDomainPartitionTestCase(TestCase):
+    """``ISSUE_IMPLEMENTER`` joins the partition without breaking it (#1553).
+
+    The domain is default-OFF: :func:`_issue_implementer_scanner_for`
+    returns ``None`` unless an overlay opts in, so the per-overlay sum stays
+    byte-for-byte equal to the legacy builder by default (the parity
+    invariant). When enabled it owns exactly the one scanner the partition
+    seam emits — the single source both fan-out paths consume.
+    """
+
+    @staticmethod
+    def _backend() -> OverlayBackends:
+        host = MagicMock(spec=CodeHostBackend)
+        return OverlayBackends(
+            name="teatree",
+            hosts=(host,),
+            messaging=MagicMock(spec=MessagingBackend),
+            ready_labels=("ready",),
+            identities=("alice",),
+        )
+
+    def test_member_of_per_overlay_partition(self) -> None:
+        assert Domain.ISSUE_IMPLEMENTER in PER_OVERLAY_DOMAINS
+
+    def test_disabled_slice_is_empty_so_partition_sum_is_unchanged(self) -> None:
+        backend = self._backend()
+        with patch(_SETTINGS_PATCH_TARGET, return_value=UserSettings()):
+            assert jobs_for_domain(Domain.ISSUE_IMPLEMENTER, backend) == []
+            partitioned: list[Any] = []
+            for domain in PER_OVERLAY_DOMAINS:
+                partitioned.extend(jobs_for_domain(domain, backend, all_backends=(backend,)))
+            legacy = _jobs_for_overlay_backend(backend, all_backends=(backend,))
+        assert sorted(map(_signature, partitioned), key=repr) == sorted(map(_signature, legacy), key=repr)
+
+    def test_enabled_slice_owns_exactly_the_issue_implementer_scanner(self) -> None:
+        backend = self._backend()
+        with patch(
+            _SETTINGS_PATCH_TARGET,
+            return_value=UserSettings(issue_implementer_enabled=True, issue_implementer_label="auto-implement"),
+        ):
+            slice_jobs = jobs_for_domain(Domain.ISSUE_IMPLEMENTER, backend)
+            legacy = _jobs_for_overlay_backend(backend, all_backends=(backend,))
+        assert [job.scanner.name for job in slice_jobs] == ["issue_implementer"]
+        # Enabled, the legacy aggregator carries exactly the one slice scanner —
+        # both fan-out paths derive from this same partition slice (no divergence).
+        legacy_ii = [j for j in legacy if j.scanner.name == "issue_implementer"]
+        assert len(legacy_ii) == 1
+        assert _signature(legacy_ii[0]) == _signature(slice_jobs[0])
+
+    def test_enabled_partition_still_disjoint(self) -> None:
+        backend = self._backend()
+        with patch(
+            _SETTINGS_PATCH_TARGET,
+            return_value=UserSettings(issue_implementer_enabled=True, issue_implementer_label="auto-implement"),
+        ):
+            counts: Counter[tuple[Any, ...]] = Counter()
+            for domain in PER_OVERLAY_DOMAINS:
+                for job in jobs_for_domain(domain, backend, all_backends=(backend,)):
+                    counts[_signature(job)] += 1
+        assert not {sig for sig, n in counts.items() if n > 1}

--- a/tests/teatree_loops/test_fanout.py
+++ b/tests/teatree_loops/test_fanout.py
@@ -183,6 +183,22 @@ class RegistryLegacyParityTestCase(TestCase):
         assert len(legacy_nags) == 1
         assert len(nags) == 1
 
+    def test_default_off_issue_implementer_keeps_parity_and_emits_nothing(self) -> None:
+        """The default-OFF ``ISSUE_IMPLEMENTER`` domain leaves both fan-out paths unchanged (#1553).
+
+        With ``issue_implementer_enabled`` defaulting to False the per-overlay
+        slice is empty, so neither the registry path nor the legacy path emits
+        the scanner — the byte-for-byte parity guard stays green even though the
+        new domain is a partition member.
+        """
+        backends = [self._production_backend()]
+        legacy = build_default_jobs(backends=backends)
+        MiniLoopMarker.objects.all().delete()
+        registry = build_registry_jobs(_context(backends), config=LoopsConfig(), now=NOW)
+        assert _signature_multiset(registry) == _signature_multiset(legacy)
+        assert "issue_implementer" not in {j.scanner.name for j in legacy}
+        assert "issue_implementer" not in {j.scanner.name for j in registry}
+
     def test_my_prs_and_reviewer_prs_carry_url_attribution(self) -> None:
         """The ship/review domain slices pass the same non-empty URL-attribution the legacy fan-out does.
 


### PR DESCRIPTION
## What

Phase C3 of the always-on, config-gated issue-implementer loop ([#1553](https://github.com/souliane/teatree/issues/1553)). Adds an `IssueImplementerScanner` reachable through the `jobs_for_domain` seam, **default-OFF behind a triple gate**, so the registry fan-out is byte-for-byte unchanged until an overlay opts in.

- `ISSUE_IMPLEMENTER` is now a member of the `Domain` StrEnum and the `PER_OVERLAY_DOMAINS` partition, with a `_issue_implementer_jobs_for_overlay` domain builder and the `_issue_implementer_scanner_for` gate builder in `teatree.loop.tick_jobs`.
- `_issue_implementer_scanner_for` returns a scanner **only when** `config.issue_implementer_enabled` is True **and** `ImplementedIssueMarker.in_flight_count(overlay) < config.issue_implementer_max_concurrent` (and the overlay resolves a host); otherwise `None`, so no job is emitted. The third gate — per-issue claim idempotency — lives in the scanner.
- `IssueImplementerScanner` lists the user's open issues via the code-host backend, keeps the ones carrying `config.issue_implementer_label`, and claims each via the TOCTOU-safe `ImplementedIssueMarker.claim()` — skipping silently when `claim()` returns `None` (already taken by another tick or overlay).

No dispatch routing or mini-loop registration yet — that is C4 ([#1554](https://github.com/souliane/teatree/issues/1554)). This is the scanner + gate + partition member + tests only.

## Why

The substrate (the `jobs_for_domain` seam [#1482](https://github.com/souliane/teatree/issues/1482), the config fields, and the `ImplementedIssueMarker` model) is already merged. C3 adds the scanner that consumes that substrate while keeping the loop a hard no-op by default.

**Parity invariant.** Because `issue_implementer_enabled` defaults to False, the gate returns `None`, the domain slice is empty, and neither `build_registry_jobs` nor `build_default_jobs` emits anything for this domain — `RegistryLegacyParityTestCase` and the partition exhaustive/disjoint guards stay green. The partition stays the single source both fan-out paths derive from, so no path can diverge.

## Tests

- Scanner behaviour: labelled-open issue claimed + emitted, label filtering, closed-issue skip, `claim()` idempotency (second claim returns `None`, skipped), empty-label no-op, identity union dedupe.
- Triple gate: disabled-by-default emits nothing, enabled+budget builds the scanner, concurrency-at-max emits nothing, abandoned markers don't consume budget, budget is overlay-scoped, hostless backend emits nothing.
- Partition: `ISSUE_IMPLEMENTER` is a `PER_OVERLAY_DOMAINS` member; disabled-slice keeps the legacy sum unchanged; enabled-slice owns exactly the one scanner the legacy aggregator carries; partition stays disjoint when enabled.
- Full-path parity: registry vs legacy fan-out stays byte-for-byte equal with the domain present-but-disabled.

Full suite green (8861 passed), `tach check` green, `ty check` green (no `Any`, no ANN401 noqas), `ruff check` + `ruff format --check` clean, coverage 93.95%.

Closes [#1553](https://github.com/souliane/teatree/issues/1553).