### PR TITLE
fix(checking): scope merged group by resolved repo + gate PR URLs on owner/repo

### DIFF
--- a/src/teatree/core/checking.py
+++ b/src/teatree/core/checking.py
@@ -26,7 +26,7 @@ from datetime import datetime
 from typing import TypedDict
 
 from teatree.core.models.deferred_question import DeferredQuestion
-from teatree.core.models.merge_clear import MergeAudit
+from teatree.core.models.merge_clear import MergeAudit, MergeClear
 from teatree.core.models.task import TaskAttempt
 from teatree.core.models.ticket import Ticket
 from teatree.core.models.transition import TicketTransition
@@ -152,27 +152,49 @@ class CheckingReport:
 
 
 def build_pr_url(*, slug: str, pr_id: int, code_host: str) -> str:
-    """Build a clickable PR/MR web URL from a ``owner/name`` slug + id.
+    """Build a clickable PR/MR web URL from a real ``owner/repo`` slug + id.
 
     GitLab uses ``/-/merge_requests/<id>``; GitHub (and the default) uses
-    ``/pull/<id>``. Returns ``""`` when the slug is blank — a caller with no
-    slug falls back to the ticket's issue URL rather than emitting a guessed
-    link, so a reader never gets a wrong-host link.
+    ``/pull/<id>``. Returns ``""`` unless *slug* is a genuine ``owner/repo``
+    identifier (per :func:`merge_execution._looks_like_owner_repo`): a CLEAR's
+    ``slug`` is a *workstream* slug (e.g. ``statusline-stale-wakeup``) or a
+    branch name (``fix/foo``), never a repo, so emitting
+    ``github.com/<workstream>/pull/<id>`` would be a wrong-host, unclickable
+    link (#1559). A caller with no real repo slug falls back to the stored PR
+    URL or the ticket's issue URL instead.
     """
+    from teatree.core.merge_execution import _looks_like_owner_repo  # noqa: PLC0415
+
     clean = slug.strip().strip("/")
-    if not clean:
+    if not _looks_like_owner_repo(clean):
         return ""
     if code_host.strip().lower() == "gitlab":
         return f"https://gitlab.com/{clean}/-/merge_requests/{pr_id}"
     return f"https://github.com/{clean}/pull/{pr_id}"
 
 
-def gather_checking_report(
+@dataclass(frozen=True, slots=True)
+class _MergedScope:
+    """How the merged group is scoped to one overlay (#1559).
+
+    ``overlay_name`` is the ticket-FK back-compat scope for ticket-bearing
+    CLEARs; ``overlay_repos`` (``owner/repo`` or bare ``repo``) is the
+    resolved-repo scope for NULL-ticket ceremony CLEARs; ``code_host`` picks
+    the PR URL shape.
+    """
+
+    overlay_name: str
+    code_host: str
+    overlay_repos: list[str]
+
+
+def gather_checking_report(  # noqa: PLR0913 — read-report entry-point; each kwarg is a documented window/scope input.
     *,
     since: datetime,
     now: datetime,
     overlay_name: str = "",
     code_host: str = "",
+    overlay_repos: list[str] | None = None,
     cap: int = DEFAULT_CAP,
 ) -> CheckingReport:
     """Build a :class:`CheckingReport` for the window ``[since, now)``.
@@ -182,22 +204,32 @@ def gather_checking_report(
     window is half-open — ``merged_at``/``created_at``/``ended_at`` in
     ``[since, now)`` — and every group except pending questions is scoped to
     *overlay_name*.
+
+    ``overlay_repos`` are the overlay's ``owner/repo`` (or bare ``repo``)
+    identifiers used to scope a NULL-ticket ceremony merge to this overlay by
+    its resolved repo — the ceremony ``ticket clear`` is normally issued
+    without ``--ticket-id``, so a ticket-FK JOIN would silently drop it. The
+    caller resolves the list from the active overlay; an empty list scopes the
+    merged group to ticket-bearing CLEARs only (the back-compat behaviour).
     """
+    scope = _MergedScope(overlay_name=overlay_name, code_host=code_host, overlay_repos=overlay_repos or [])
     return CheckingReport(
         since=since,
-        merged=_merged_group(since=since, now=now, overlay_name=overlay_name, code_host=code_host, cap=cap),
+        merged=_merged_group(since=since, now=now, scope=scope, cap=cap),
         in_flight=_in_flight_group(since=since, now=now, overlay_name=overlay_name, cap=cap),
         needs_you=_needs_you_group(since=since, now=now, overlay_name=overlay_name, cap=cap),
     )
 
 
-def _pr_url_for(ticket: Ticket | None, *, slug: str, pr_id: int, code_host: str) -> str:
+def _pr_url_for(ticket: Ticket | None, *, repo_slug: str, pr_id: int, code_host: str) -> str:
     """Prefer an exact stored PR URL, else a host-aware built URL, else issue URL.
 
     A stored ``extra['pr_urls']`` entry that mentions the pr_id is the exact
     forge web_url/html_url and wins. Otherwise the host-aware builder produces
-    a slug-based URL; if even the slug is blank, fall back to the ticket's
-    issue URL so the reference is still clickable.
+    a URL from *repo_slug* — but only when it is a real ``owner/repo`` (a
+    workstream/branch slug yields ``""`` from :func:`build_pr_url`, #1559). If
+    no real repo is known, fall back to the ticket's issue URL so the reference
+    is still clickable rather than a wrong-host link.
     """
     if ticket is not None:
         stored = (ticket.extra or {}).get("pr_urls") or []
@@ -205,35 +237,96 @@ def _pr_url_for(ticket: Ticket | None, *, slug: str, pr_id: int, code_host: str)
             for url in stored:
                 if isinstance(url, str) and url and str(pr_id) in url:
                     return url
-    built = build_pr_url(slug=slug, pr_id=pr_id, code_host=code_host)
+    built = build_pr_url(slug=repo_slug, pr_id=pr_id, code_host=code_host)
     if built:
         return built
     return ticket.issue_url if ticket is not None else ""
 
 
-def _merged_group(*, since: datetime, now: datetime, overlay_name: str, code_host: str, cap: int) -> CheckGroup:
+def _resolved_repo_slug(clear: MergeClear) -> str:
+    """The real ``owner/repo`` for *clear*'s PR, or ``""`` when unresolvable.
+
+    Wraps :func:`merge_execution.resolve_pr_repo_slug` (the same resolver the
+    sanctioned merge keystone uses): an ``owner/repo``-shaped CLEAR slug as-is,
+    else the ticket's ``issue_url`` repo, else the running clone's ``origin``.
+    The resolver fails closed with :class:`MergePreconditionError` when nothing
+    resolves; this read path swallows that into ``""`` so a catch-up report is
+    never wedged by a single unresolvable row.
+    """
+    from teatree.core.merge_execution import MergePreconditionError, resolve_pr_repo_slug  # noqa: PLC0415
+
+    try:
+        return resolve_pr_repo_slug(clear)
+    except MergePreconditionError:
+        return ""
+
+
+def _repo_in_overlay(repo_slug: str, overlay_repos: list[str]) -> bool:
+    """True when *repo_slug* (a resolved ``owner/repo``) belongs to the overlay.
+
+    An overlay declares its repos either as ``owner/repo`` (an exact match) or
+    as a bare ``repo`` name (matching any owner, since a self-hosted namespace
+    varies) — the same two shapes :mod:`teatree.loop.tick_resolvers` honours.
+    """
+    if not repo_slug:
+        return False
+    repo_name = repo_slug.rsplit("/", 1)[-1]
+    for declared in overlay_repos:
+        if not declared:
+            continue
+        if "/" in declared:
+            if declared == repo_slug:
+                return True
+        elif declared == repo_name:
+            return True
+    return False
+
+
+def _merged_group(*, since: datetime, now: datetime, scope: _MergedScope, cap: int) -> CheckGroup:
     qs = (
         MergeAudit.objects.filter(merged_at__gte=since, merged_at__lt=now)
         .select_related("clear", "clear__ticket")
         .order_by("-merged_at")
     )
-    if overlay_name:
-        qs = qs.filter(clear__ticket__overlay=overlay_name)
-    audits = list(qs)
+    # Resolve each merge's real repo once (the resolver may read a git remote),
+    # then scope and render from the cached slug — never re-resolving per field.
+    scoped: list[tuple[MergeAudit, str]] = []
+    for audit in qs:
+        repo_slug = _resolved_repo_slug(audit.clear)
+        if _audit_in_overlay(audit, repo_slug=repo_slug, scope=scope):
+            scoped.append((audit, repo_slug))
     items = [
         CheckItem(
-            label=f"{audit.clear.slug}#{audit.clear.pr_id}",
+            label=f"{repo_slug or audit.clear.slug}#{audit.clear.pr_id}",
             url=_pr_url_for(
                 audit.clear.ticket,
-                slug=audit.clear.slug,
+                repo_slug=repo_slug,
                 pr_id=audit.clear.pr_id,
-                code_host=code_host,
+                code_host=scope.code_host,
             ),
             detail=(audit.clear.ticket.short_description if audit.clear.ticket else ""),
         )
-        for audit in audits[:cap]
+        for audit, repo_slug in scoped[:cap]
     ]
-    return CheckGroup(title="Merged", items=items, total=len(audits))
+    return CheckGroup(title="Merged", items=items, total=len(scoped))
+
+
+def _audit_in_overlay(audit: MergeAudit, *, repo_slug: str, scope: _MergedScope) -> bool:
+    """Whether *audit*'s merge belongs to the scoped overlay (#1559).
+
+    An unscoped report (no ``overlay_name``) includes every merge. Otherwise a
+    merge is in scope when EITHER its CLEAR's ticket is linked to this overlay
+    (the precise back-compat path for ticket-bearing CLEARs) OR — the ceremony
+    case — the CLEAR has no ticket and its already-resolved repo belongs to
+    this overlay. A NULL-ticket CLEAR whose repo belongs to a *different*
+    overlay is excluded; a blanket ``ticket IS NULL`` rule would over-report it.
+    """
+    if not scope.overlay_name:
+        return True
+    ticket = audit.clear.ticket
+    if ticket is not None:
+        return ticket.overlay == scope.overlay_name
+    return _repo_in_overlay(repo_slug, scope.overlay_repos)
 
 
 def _in_flight_group(*, since: datetime, now: datetime, overlay_name: str, cap: int) -> CheckGroup:

--- a/src/teatree/core/management/commands/checking.py
+++ b/src/teatree/core/management/commands/checking.py
@@ -57,6 +57,7 @@ class Command(TyperCommand):
             now=now,
             overlay_name=overlay_name,
             code_host=self._resolve_code_host(),
+            overlay_repos=self._resolve_overlay_repos(),
         )
         # Advance only on the default path: an explicit --since or --no-advance
         # is an inspection that must not move the user's last-checked marker.
@@ -83,3 +84,22 @@ class Command(TyperCommand):
             return get_overlay().config.code_host or ""
         except Exception:  # noqa: BLE001 — config read must never wedge a read-only report
             return ""
+
+    @staticmethod
+    def _resolve_overlay_repos() -> list[str]:
+        """Resolve the overlay's repo identifiers used to scope NULL-ticket merges (#1559).
+
+        Unions ``get_followup_repos()`` (``owner/repo``) with ``get_repos()``
+        (often a bare ``repo`` name) so a ceremony CLEAR whose resolved repo
+        matches either shape is scoped to this overlay. A missing or unloadable
+        overlay (or a hook that raises) degrades to an empty list — the merged
+        group then keeps the ticket-bearing back-compat scope only.
+        """
+        try:
+            from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+
+            overlay = get_overlay()
+            repos = list(overlay.metadata.get_followup_repos()) + list(overlay.get_repos())
+            return [repo for repo in repos if isinstance(repo, str) and repo]
+        except Exception:  # noqa: BLE001 — config read must never wedge a read-only report
+            return []

--- a/tests/teatree_core/management_commands/test_checking.py
+++ b/tests/teatree_core/management_commands/test_checking.py
@@ -122,6 +122,32 @@ class TestCheckingShow:
         labels = [item["label"] for item in payload["merged"]["items"]]
         assert labels == ["acme/widgets#10"]
 
+    def test_null_ticket_ceremony_merge_scoped_by_resolved_repo(
+        self, checkpoint_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A NULL-ticket ceremony merge surfaces when its repo is the overlay's (#1559).
+
+        Runs against the real bundled ``t3-teatree`` overlay so the command's
+        own ``_resolve_overlay_repos`` derives the repo set (``souliane/teatree``)
+        — the ticket-FK JOIN that previously dropped every NULL-ticket CLEAR is
+        gone, while a foreign-repo merge stays excluded.
+        """
+        monkeypatch.setenv("T3_OVERLAY_NAME", "t3-teatree")
+        for pr_id, slug in ((50, "souliane/teatree"), (51, "other-org/other-repo")):
+            clear = MergeClear.objects.create(
+                ticket=None,
+                pr_id=pr_id,
+                slug=slug,
+                reviewed_sha=_SHA,
+                reviewer_identity="cold-reviewer",
+                gh_verify_result=MergeClear.VerifyResult.GREEN,
+                blast_class=MergeClear.BlastClass.LOGIC,
+            )
+            MergeAudit.objects.create(clear=clear, merged_sha=_SHA, required_checks_status="success")
+        out = _call("checking", "show", "--json")
+        labels = [item["label"] for item in json.loads(out)["merged"]["items"]]
+        assert labels == ["souliane/teatree#50"]
+
     def test_second_run_after_advance_reports_nothing(self, checkpoint_file: Path) -> None:
         """Gather-then-advance: an immediate second run sees an empty window."""
         _merged_ticket()

--- a/tests/teatree_core/test_checking.py
+++ b/tests/teatree_core/test_checking.py
@@ -13,6 +13,7 @@ are omitted, and an all-empty report collapses to one line.
 import json
 import re
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.utils import timezone
@@ -123,13 +124,98 @@ class TestMergedGroup(CheckingTestBase):
         report = gather_checking_report(since=self.since, now=self.now, overlay_name=self.OVERLAY, code_host="gitlab")
         assert report.merged.items[0].url == "https://gitlab.com/acme/widgets/-/merge_requests/9"
 
-    def test_blank_slug_falls_back_to_issue_url(self) -> None:
-        # No slug and no stored pr_url: the builder yields nothing, so the
-        # reference falls back to the ticket's issue URL (still clickable).
-        ticket = self._ticket()
-        self._merge(ticket, pr_id=7, slug="", hours_ago=2)
-        report = gather_checking_report(since=self.since, now=self.now, overlay_name=self.OVERLAY)
+    def test_unresolvable_repo_falls_back_to_issue_url(self) -> None:
+        # No owner/repo-shaped slug, a ticket whose issue_url is not a
+        # recognisable forge repo, and no clone-origin remote: no real repo
+        # resolves, so the reference falls back to the ticket's issue URL
+        # (still clickable) rather than a wrong-host workstream link (#1559).
+        ticket = Ticket.objects.create(
+            overlay=self.OVERLAY,
+            issue_url="https://example.invalid/not-an-issue",
+            state=Ticket.State.IN_REVIEW,
+            short_description="ticket work",
+        )
+        self._merge(ticket, pr_id=7, slug="some-workstream-name", hours_ago=2)
+        with patch("teatree.core.merge_execution._project_repo_slug", return_value=""):
+            report = gather_checking_report(since=self.since, now=self.now, overlay_name=self.OVERLAY)
         assert report.merged.items[0].url == ticket.issue_url
+
+    def test_workstream_slug_never_builds_wrong_host_url(self) -> None:
+        # A ticket-bearing CLEAR whose slug is a workstream slug must resolve
+        # the ticket's real repo, never emit ``github.com/<workstream>/...``
+        # (#1559 bug 2).
+        ticket = self._ticket()
+        self._merge(ticket, pr_id=7, slug="statusline-stale-wakeup", hours_ago=2)
+        report = gather_checking_report(since=self.since, now=self.now, overlay_name=self.OVERLAY, code_host="github")
+        item = report.merged.items[0]
+        assert item.url == "https://github.com/acme/widgets/pull/7"
+        assert "statusline-stale-wakeup" not in item.url
+        assert item.label == "acme/widgets#7"
+
+
+class TestMergedGroupNullTicketRepoScope(CheckingTestBase):
+    """A NULL-ticket ceremony merge is scoped to the overlay by its repo (#1559 bug 1).
+
+    The ceremony ``ticket clear`` is issued without ``--ticket-id``, so
+    ``MergeClear.ticket`` is NULL for nearly every CLEAR. A ticket-FK JOIN
+    silently drops those, leaving the merged group almost always empty. The
+    read-side scope must instead match the CLEAR's RESOLVED repo against the
+    overlay's repo set — without over-reporting a different overlay's merges.
+    """
+
+    def _null_ticket_merge(self, *, pr_id: int, slug: str, hours_ago: float) -> MergeAudit:
+        clear = MergeClear.objects.create(
+            ticket=None,
+            pr_id=pr_id,
+            slug=slug,
+            reviewed_sha=_SHA,
+            reviewer_identity=_REVIEWER,
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.LOGIC,
+        )
+        audit = MergeAudit.objects.create(clear=clear, merged_sha=_SHA, required_checks_status="success")
+        MergeAudit.objects.filter(pk=audit.pk).update(merged_at=self.now - timedelta(hours=hours_ago))
+        return audit
+
+    def test_null_ticket_merge_in_overlay_repo_appears(self) -> None:
+        # owner/repo-shaped slug resolves to itself; the repo belongs to the
+        # overlay, so the NULL-ticket merge surfaces.
+        self._null_ticket_merge(pr_id=12, slug="acme/widgets", hours_ago=2)
+        report = gather_checking_report(
+            since=self.since, now=self.now, overlay_name=self.OVERLAY, overlay_repos=["acme/widgets"]
+        )
+        assert [item.label for item in report.merged.items] == ["acme/widgets#12"]
+
+    def test_null_ticket_merge_in_overlay_matched_by_bare_repo_name(self) -> None:
+        # An overlay that declares a bare ``repo`` name (no owner) still scopes
+        # a resolved ``owner/repo`` whose repo segment matches.
+        self._null_ticket_merge(pr_id=13, slug="acme/widgets", hours_ago=2)
+        report = gather_checking_report(
+            since=self.since, now=self.now, overlay_name=self.OVERLAY, overlay_repos=["widgets"]
+        )
+        assert [item.label for item in report.merged.items] == ["acme/widgets#13"]
+
+    def test_null_ticket_merge_in_other_overlay_repo_excluded(self) -> None:
+        # A NULL-ticket merge whose resolved repo is NOT in this overlay's repo
+        # set must NOT appear — no blanket ``ticket IS NULL`` over-reporting.
+        self._null_ticket_merge(pr_id=14, slug="other-org/other-repo", hours_ago=2)
+        report = gather_checking_report(
+            since=self.since, now=self.now, overlay_name=self.OVERLAY, overlay_repos=["acme/widgets"]
+        )
+        assert report.merged.total == 0
+
+    def test_null_ticket_and_ticket_bearing_merges_both_scoped(self) -> None:
+        # The ticket-bearing CLEAR keeps its precise overlay link; the
+        # NULL-ticket CLEAR is scoped by repo. Both land; a foreign one drops.
+        ticket = self._ticket(number=5)
+        self._merge(ticket, pr_id=20, slug="acme/widgets", hours_ago=3)
+        self._null_ticket_merge(pr_id=21, slug="acme/widgets", hours_ago=2)
+        self._null_ticket_merge(pr_id=22, slug="other-org/other-repo", hours_ago=1)
+        report = gather_checking_report(
+            since=self.since, now=self.now, overlay_name=self.OVERLAY, overlay_repos=["acme/widgets"]
+        )
+        labels = {item.label for item in report.merged.items}
+        assert labels == {"acme/widgets#20", "acme/widgets#21"}
 
 
 class TestInFlightGroup(CheckingTestBase):


### PR DESCRIPTION
Closes [#1559](https://github.com/souliane/teatree/issues/1559)

Two read-path bugs in `src/teatree/core/checking.py`, found dogfooding `t3 <overlay> checking show` (the report said "Nothing since …" while PRs had merged in the window). Both are logic-class — no model field, no migration.

## Bug 1 — merged group dropped every NULL-ticket ceremony merge
`_merged_group` scoped via the `clear__ticket__overlay` JOIN. The ceremony `ticket clear` is issued without `--ticket-id`, so `MergeClear.ticket` is NULL for nearly every CLEAR — the JOIN silently excluded them and the merged group was almost always empty.

Fix: a ticket-bearing CLEAR keeps its precise overlay link; a NULL-ticket CLEAR is now scoped by its **resolved repo** (`merge_execution.resolve_pr_repo_slug`, the same resolver the merge keystone uses) matched against the overlay's repo set (`get_followup_repos()` union `get_repos()`, honouring both `owner/repo` and bare `repo` shapes — the two shapes `tick_resolvers` already honours). A NULL-ticket merge whose repo belongs to a *different* overlay stays excluded — no blanket `ticket IS NULL` over-reporting.

## Bug 2 — wrong PR URLs from workstream slugs
`build_pr_url` treated the CLEAR's workstream/branch slug as `owner/repo`, emitting a wrong-host, unclickable `github.com/<workstream>/pull/N`. It now gates on `merge_execution._looks_like_owner_repo` and emits a URL only for a real `owner/repo`; `_pr_url_for` resolves the real repo first and otherwise falls back to the stored `pr_urls` entry or the ticket's issue URL.

## Where
- `checking.py`: `build_pr_url` (owner/repo gate), `_pr_url_for` (resolve real repo), new `_resolved_repo_slug`/`_repo_in_overlay`/`_audit_in_overlay`/`_MergedScope`, `_merged_group` (repo-scoped).
- `management/commands/checking.py`: `_resolve_overlay_repos()` derives the overlay repo set and threads it into `gather_checking_report`.

## Tests
- A NULL-ticket merge whose resolved repo is in the overlay → appears; not in → excluded (exact-`owner/repo` and bare-`repo` match). Ticket-bearing + NULL-ticket merges both scoped in one report.
- Workstream-slug CLEAR renders a valid `https://github.com/<owner>/<repo>/pull/<id>`, never `github.com/<workstream>/...`. Genuinely unresolvable repo falls back to the issue URL.
- Command-level test exercises the scope end-to-end through the real bundled overlay's repo resolution.
- Existing checking tests stay green (one updated: blank/unresolvable-slug fallback now genuinely requires no resolvable repo).

Gates: full suite green (8875 passed), `ty`/`tach`/`ruff`/`ruff format` clean, coverage 93.95%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)