### PR TITLE
fix(workspace): reap squash-merged gone-remote worktrees in clean-all

### DIFF
--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 from teatree.core.cleanup import _branch_tree_matches_squash, cleanup_worktree
 from teatree.core.models import Worktree
-from teatree.core.worktree_env import write_env_cache
+from teatree.core.worktree_env import CACHE_DIRNAME, CACHE_FILENAME, write_env_cache
 from teatree.utils import git
 from teatree.utils.db import drop_db
 from teatree.utils.run import CommandFailedError, run_allowed_to_fail, run_checked
@@ -20,6 +20,18 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from teatree.core.reconcile import Drift
+    from teatree.utils.run import CompletedProcess
+
+# Regenerable artifacts a clean-working-tree probe must ignore: provisioning
+# writes the env cache into every worktree (``worktree_env.write_env_cache``).
+# In teatree's own clone these are gitignored, but an overlay repo may track
+# them as untracked, so a porcelain status that lists only these is still
+# "clean" for the gone-remote prune decision.
+_REGENERABLE_WORKTREE_PATHS = (CACHE_FILENAME, f"{CACHE_DIRNAME}/")
+
+# ``git status --porcelain`` prefixes each path with a two-char ``XY`` status
+# code plus a space, e.g. ``?? path`` or `` M path``.
+_PORCELAIN_STATUS_PREFIX_WIDTH = 3
 
 
 def worktree_map(repo: str) -> dict[str, str]:
@@ -40,23 +52,41 @@ def worktree_branches(repo: str) -> set[str]:
     return set(worktree_map(repo))
 
 
+def _run_host_cli(cmd: list[str], repo: str) -> "CompletedProcess[str] | None":
+    """Run a host CLI that may be missing, returning ``None`` when it cannot run.
+
+    ``gh`` / ``glab`` are optional — absent in CI without auth and blocked in
+    sandboxes (a denied binary raises ``PermissionError``, a missing one
+    ``FileNotFoundError``; both are ``OSError``). Swallowing ``OSError`` lets
+    :func:`is_squash_merged` fall back to the diff check instead of crashing the
+    whole ``clean-all`` run — the exact condition under which merged worktrees
+    were left unpruned.
+    """
+    try:
+        return run_allowed_to_fail(cmd, cwd=repo, expected_codes=None)
+    except OSError:
+        return None
+
+
 def is_squash_merged(repo: str, branch: str, default: str) -> bool:
     # GitHub: ask if a PR for this branch was merged.
-    result = run_allowed_to_fail(
+    result = _run_host_cli(
         ["gh", "pr", "list", "--head", branch, "--state", "merged", "--json", "number", "--limit", "1"],
-        cwd=repo,
-        expected_codes=None,
+        repo,
     )
-    if result.returncode == 0 and result.stdout.strip() not in {"", "[]"}:
+    if result is not None and result.returncode == 0 and result.stdout.strip() not in {"", "[]"}:
         return True
 
     # GitLab: glab mr list output lines for found MRs start with "!" (e.g. "!5  Title  (branch)").
-    result = run_allowed_to_fail(
+    result = _run_host_cli(
         ["glab", "mr", "list", "--merged", "--source-branch", branch, "--limit", "1"],
-        cwd=repo,
-        expected_codes=None,
+        repo,
     )
-    if result.returncode == 0 and any(line.lstrip().startswith("!") for line in result.stdout.splitlines()):
+    if (
+        result is not None
+        and result.returncode == 0
+        and any(line.lstrip().startswith("!") for line in result.stdout.splitlines())
+    ):
         return True
 
     diff = git.run(repo=repo, args=["diff", f"origin/{default}...{branch}", "--stat"])
@@ -127,6 +157,92 @@ def prune_squash_merged(repo: str, name: str, wt_map: dict[str, str]) -> str:
     return f"Pruned squash-merged branch: {name}"
 
 
+def _origin_ref_exists(repo: str, branch: str) -> bool:
+    """Whether ``refs/remotes/origin/<branch>`` still exists after ``fetch --prune``.
+
+    A branch whose remote tracking ref is gone is "gone-remote" — the branch was
+    deleted on origin, the normal terminal state of a squash-merged PR (the merge
+    creates a new commit on the default branch and deletes the source ref). A
+    branch still on origin is open work and must be kept.
+    """
+    return git.check(repo=repo, args=["show-ref", "--verify", "--quiet", f"refs/remotes/origin/{branch}"])
+
+
+def _worktree_clean(wt_path: str) -> bool:
+    """Whether the worktree has no uncommitted changes (ignoring regenerable files).
+
+    Provisioning seeds each worktree with the env cache; a status that lists only
+    those regenerable artifacts is still clean for prune purposes. Any other dirty
+    entry — staged, modified, or untracked real work — keeps the worktree.
+    """
+    if not Path(wt_path).is_dir():
+        return False
+    for line in git.status_porcelain(wt_path).splitlines():
+        entry = line[_PORCELAIN_STATUS_PREFIX_WIDTH:].strip()
+        if entry and not entry.startswith(_REGENERABLE_WORKTREE_PATHS):
+            return False
+    return True
+
+
+def _prune_gone_worktree(repo: str, name: str, wt_path: str) -> str:
+    """Remove the working tree of a gone-remote branch, keeping the branch ref.
+
+    A branch whose ``origin/<branch>`` ref was pruned (squash-merged + deleted on
+    origin) never appears as an ancestor of ``origin/main`` — the squash creates a
+    new SHA — so the merged-ancestor and ``[gone]``-marker passes leave its
+    worktree behind. This closes that gap.
+
+    The operation is **non-destructive of commits**: only the on-disk working
+    tree is removed (``git worktree remove``); the branch ref is deliberately
+    kept, so the worktree is fully recoverable with ``git worktree add <path>
+    <branch>`` and no committed work can be lost even if the gone-remote
+    classification were wrong. This is why the by-SHA ``_refuse_if_unpushed``
+    data-loss guard (which protects branch-ref *deletion*, and which a
+    squash-merged branch always trips because the squash is a new SHA) is not
+    applied here — we never delete the ref. The only loss a clean removal could
+    cause is uncommitted working-tree changes, which the clean check forbids.
+
+    As defense-in-depth a clean worktree is still kept when its branch carries
+    commits ahead of ``origin/main`` that are not captured by a squash-merge —
+    active post-merge work in progress. The probe is conservative in the safe
+    direction: when it cannot confirm the content is merged it keeps the
+    worktree, never removes it.
+
+    Returns a one-line outcome — a removal, or a SKIPPED line when the worktree
+    is kept (uncommitted changes / genuinely-ahead work) or the removal failed.
+    """
+    if not _worktree_clean(wt_path):
+        return f"SKIPPED '{name}': worktree has uncommitted changes — keeping {wt_path}"
+    unsynced = git.unsynced_commits(repo, name)
+    if unsynced and not _branch_tree_matches_squash(repo, name):
+        return f"SKIPPED '{name}': {len(unsynced)} commit(s) ahead of origin/main — keeping {wt_path}"
+    if git.worktree_remove(repo, wt_path):
+        git.run(repo=repo, args=["worktree", "prune"])
+        return f"Removed gone-remote worktree (branch kept): {name}"
+    return f"SKIPPED '{name}': git worktree remove failed for {wt_path}"
+
+
+def _prune_gone_remote_worktrees(repo: str, wt_map: dict[str, str], protected: set[str]) -> list[str]:
+    """Reap worktrees of gone-remote branches; mark their refs protected.
+
+    Worktree-linked branches whose ``origin/<branch>`` ref is gone (squash-merged
+    + branch-deleted) are skipped by every branch-deletion pass — they have a live
+    worktree. Reap the working tree (keep the branch ref) when it is clean and not
+    genuinely ahead of ``origin/main``; otherwise keep both. Either way this pass
+    is the authoritative handler for these branches, so it adds each one to
+    ``protected`` (mutated in place): the later squash-merge pass would
+    ``--force``-remove even a dirty worktree, and a reaped worktree is recoverable
+    via ``git worktree add`` only while its ref survives.
+    """
+    cleaned: list[str] = []
+    for name, wt_path in sorted(wt_map.items()):
+        if name in protected or _origin_ref_exists(repo, name):
+            continue
+        cleaned.append(_prune_gone_worktree(repo, name, wt_path))
+        protected.add(name)
+    return cleaned
+
+
 def prune_branches(repo: str) -> list[str]:
     """Delete local branches that are gone or merged, including squash-merged."""
     cleaned: list[str] = []
@@ -148,6 +264,8 @@ def prune_branches(repo: str) -> list[str]:
             continue
         git.branch_delete(repo, name)
         cleaned.append(f"Pruned gone branch: {name}")
+
+    cleaned.extend(_prune_gone_remote_worktrees(repo, wt_map, protected))
 
     for line in git.run(repo=repo, args=["branch", "--merged", f"origin/{default}", "--no-color"]).splitlines():
         name = line.strip().removeprefix("* ").removeprefix("+ ")

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1604,6 +1604,21 @@ class TestPruneBranches(TestCase):
         with _gh_no_pr, patch.object(git_mod, "run", return_value=" file.py | 1 +"):
             assert ws_cleanup_mod.is_squash_merged("/repo", "feature", "main") is False
 
+    def test_falls_back_to_diff_when_host_cli_is_blocked(self) -> None:
+        # A blocked/missing gh/glab raises OSError (PermissionError in a sandbox,
+        # FileNotFoundError when absent) — clean-all must not crash, it falls
+        # back to the diff check rather than propagating the error.
+        with (
+            patch("teatree.utils.run.subprocess.run", side_effect=PermissionError("blocked")),
+            patch.object(git_mod, "run", return_value=""),
+        ):
+            assert ws_cleanup_mod.is_squash_merged("/repo", "feature", "main") is True
+        with (
+            patch("teatree.utils.run.subprocess.run", side_effect=FileNotFoundError("gh")),
+            patch.object(git_mod, "run", return_value=" file.py | 1 +"),
+        ):
+            assert ws_cleanup_mod.is_squash_merged("/repo", "feature", "main") is False
+
     def test_worktree_map_parses_porcelain(self) -> None:
         porcelain = (
             "worktree /home/user/main\n"
@@ -2345,3 +2360,170 @@ class TestPruneSquashMergedDataLossGuard(TestCase):
             assert "SKIPPED 'feature'" in result
             assert "could not verify" in result
             assert tip  # tip captured for clarity; branch must survive
+
+
+class TestPruneGoneRemoteWorktree(TestCase):
+    """#1558 — clean-all must reap worktrees of squash-merged (gone-remote) branches.
+
+    A project PR is squash-merged with branch deletion, so the merged branch's
+    tip is never an ancestor of ``origin/main`` (squash creates a new SHA) and
+    the remote ``origin/<branch>`` ref is gone. Uses a real on-disk git repo so
+    the gone-remote classification is exercised against actual git behaviour.
+
+    The squash-merge tree-match probe (``_pr_merge_commit_sha`` →
+    ``_branch_tree_matches_squash``) needs a host CLI that is absent under test,
+    so the squash commit SHA is injected (the existing data-loss-guard tests do
+    the same) — hermetic regardless of commit timestamps (#915).
+    """
+
+    def _squash_merge_and_delete_remote(self, work: Path, branch: str) -> tuple[str, str]:
+        """Squash-merge ``branch`` into main, push main, delete the remote ref.
+
+        Returns ``(worktree_path, squash_sha)``. Leaves the local ``branch`` ref
+        present (the worktree holds it) but ``fetch --prune`` removes
+        ``refs/remotes/origin/<branch>`` — the gone-remote terminal state of a
+        squash-merged + branch-deleted PR. ``squash_sha`` (the commit on main,
+        whose tree equals the branch tip) is fed to ``_pr_merge_commit_sha`` so
+        the tree-match classification is deterministic.
+        """
+        _git(work, "checkout", "-q", "-b", branch)
+        (work / f"{branch}.py").write_text("work\n", encoding="utf-8")
+        _git(work, "add", f"{branch}.py")
+        _git(work, "commit", "-q", "-m", f"feat: {branch} (#1558)")
+        _git(work, "push", "-q", "origin", branch)
+        _git(work, "checkout", "-q", "main")
+        _git(work, "merge", "-q", "--squash", branch)
+        _git(work, "commit", "-q", "-m", f"feat: {branch} (#1558)")
+        squash_sha = _git(work, "rev-parse", "main")
+        _git(work, "push", "-q", "origin", "main")
+        # Delete the source branch on the remote, then prune the local ref.
+        _git(work, "push", "-q", "origin", "--delete", branch)
+        _git(work, "fetch", "-q", "--prune", "origin")
+        wt_path = work.parent / f"wt-{branch}"
+        _git(work, "worktree", "add", "-q", str(wt_path), branch)
+        return str(wt_path), squash_sha
+
+    def test_gone_remote_clean_worktree_is_pruned_branch_kept(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            _remote, work = _init_repo_with_remote(tmp)
+            wt_path, squash_sha = self._squash_merge_and_delete_remote(work, "feature")
+
+            with patch.object(cleanup_mod, "_pr_merge_commit_sha", return_value=squash_sha):
+                cleaned = ws_cleanup_mod.prune_branches(str(work))
+
+            assert not Path(wt_path).is_dir(), f"gone-remote worktree should be removed, got: {cleaned!r}"
+            assert any("feature" in c and "gone-remote" in c.lower() for c in cleaned), cleaned
+            # The branch ref must survive — only the working tree is reaped.
+            assert "feature" in _git(work, "branch", "--format=%(refname:short)").split(), (
+                f"branch ref must be kept (recoverable), got: {cleaned!r}"
+            )
+
+    def test_gone_remote_dirty_worktree_is_kept(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            _remote, work = _init_repo_with_remote(tmp)
+            wt_path, squash_sha = self._squash_merge_and_delete_remote(work, "feature")
+            # Uncommitted change in the worktree → must be kept.
+            (Path(wt_path) / "dirty.py").write_text("local edit\n", encoding="utf-8")
+
+            with patch.object(cleanup_mod, "_pr_merge_commit_sha", return_value=squash_sha):
+                cleaned = ws_cleanup_mod.prune_branches(str(work))
+
+            assert Path(wt_path).is_dir(), f"dirty worktree must be kept, got: {cleaned!r}"
+            assert any("feature" in c and "uncommitted" in c.lower() for c in cleaned), cleaned
+            assert "feature" in _git(work, "branch", "--format=%(refname:short)").split()
+
+    def test_gone_remote_worktree_with_only_regenerable_file_is_pruned(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            _remote, work = _init_repo_with_remote(tmp)
+            wt_path, squash_sha = self._squash_merge_and_delete_remote(work, "feature")
+            # A regenerable env cache is not real work — the worktree is clean.
+            (Path(wt_path) / ".t3-env.cache").write_text("POSTGRES_USER=x\n", encoding="utf-8")
+
+            with patch.object(cleanup_mod, "_pr_merge_commit_sha", return_value=squash_sha):
+                cleaned = ws_cleanup_mod.prune_branches(str(work))
+
+            assert not Path(wt_path).is_dir(), (
+                f"worktree with only regenerable files should be pruned, got: {cleaned!r}"
+            )
+            assert "feature" in _git(work, "branch", "--format=%(refname:short)").split()
+
+    def test_branch_still_on_origin_is_kept(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            _remote, work = _init_repo_with_remote(tmp)
+            # Pushed branch, NOT merged, remote ref intact → open work, keep it.
+            _git(work, "checkout", "-q", "-b", "feature")
+            (work / "f.py").write_text("work\n", encoding="utf-8")
+            _git(work, "add", "f.py")
+            _git(work, "commit", "-q", "-m", "feat: open work (#1558)")
+            _git(work, "push", "-q", "origin", "feature")
+            _git(work, "checkout", "-q", "main")
+            _git(work, "fetch", "-q", "--prune", "origin")
+            wt_path = tmp / "wt-feature"
+            _git(work, "worktree", "add", "-q", str(wt_path), "feature")
+
+            cleaned = ws_cleanup_mod.prune_branches(str(work))
+
+            assert wt_path.is_dir(), f"branch still on origin must be kept, got: {cleaned!r}"
+            assert not any("gone-remote" in c.lower() for c in cleaned), cleaned
+            assert "feature" in _git(work, "branch", "--format=%(refname:short)").split()
+
+    def test_gone_remote_genuinely_ahead_worktree_is_kept(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            _remote, work = _init_repo_with_remote(tmp)
+            wt_path, squash_sha = self._squash_merge_and_delete_remote(work, "feature")
+            # A commit added in the worktree after merge that is NOT captured by
+            # the squash (its tree diverges from the squash SHA) — active WIP, so
+            # the worktree must be kept even though the branch ref is recoverable.
+            (Path(wt_path) / "extra.py").write_text("more work\n", encoding="utf-8")
+            _git(Path(wt_path), "add", "extra.py")
+            _git(Path(wt_path), "commit", "-q", "-m", "feat: extra unmerged work")
+
+            with patch.object(cleanup_mod, "_pr_merge_commit_sha", return_value=squash_sha):
+                cleaned = ws_cleanup_mod.prune_branches(str(work))
+
+            assert Path(wt_path).is_dir(), f"genuinely-ahead worktree must be kept, got: {cleaned!r}"
+            assert any("feature" in c and "ahead of origin/main" in c for c in cleaned), cleaned
+            assert "feature" in _git(work, "branch", "--format=%(refname:short)").split()
+
+    def test_origin_ref_exists_helper(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            _remote, work = _init_repo_with_remote(tmp)
+            assert ws_cleanup_mod._origin_ref_exists(str(work), "main") is True
+            assert ws_cleanup_mod._origin_ref_exists(str(work), "never-existed") is False
+
+    def test_worktree_clean_helper_ignores_regenerable_and_missing_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            _remote, work = _init_repo_with_remote(tmp)
+            wt_path = tmp / "wt-clean"
+            _git(work, "worktree", "add", "-q", str(wt_path), "-b", "side")
+            assert ws_cleanup_mod._worktree_clean(str(wt_path)) is True
+            (wt_path / ".t3-env.cache").write_text("X=1\n", encoding="utf-8")
+            assert ws_cleanup_mod._worktree_clean(str(wt_path)) is True
+            (wt_path / "real.py").write_text("real\n", encoding="utf-8")
+            assert ws_cleanup_mod._worktree_clean(str(wt_path)) is False
+            assert ws_cleanup_mod._worktree_clean(str(tmp / "does-not-exist")) is False
+
+    def test_prune_gone_worktree_reports_when_removal_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            _remote, work = _init_repo_with_remote(tmp)
+            wt_path, squash_sha = self._squash_merge_and_delete_remote(work, "feature")
+
+            with (
+                patch.object(cleanup_mod, "_pr_merge_commit_sha", return_value=squash_sha),
+                patch.object(git_mod, "worktree_remove", return_value=False),
+            ):
+                result = ws_cleanup_mod._prune_gone_worktree(str(work), "feature", wt_path)
+
+            assert "SKIPPED 'feature'" in result
+            assert "git worktree remove failed" in result
+            # Removal failed → the working tree and branch ref both survive.
+            assert Path(wt_path).is_dir()
+            assert "feature" in _git(work, "branch", "--format=%(refname:short)").split()


### PR DESCRIPTION
## Problem

`t3 <overlay> workspace clean-all` left merged worktrees unpruned. `prune_branches` only removed a worktree-linked branch when its tip was an ancestor of `origin/main`. Squash-merged PRs delete the source branch, so a merged branch's tip is never an ancestor of main (the squash is a new SHA) — it becomes *gone-remote* (no `origin/<branch>` ref). Both the ancestor pass and the `[gone]`-marker pass skip worktree-linked branches, so merged worktrees accumulated unpruned (observed: 322 of 360).

## Fix

`prune_branches` now has a dedicated pass over worktree-linked branches whose `origin/<branch>` ref is gone. It reaps such a worktree when:

- the working tree is clean (ignoring the regenerable `.t3-env.cache` / `.t3-cache/`), **and**
- the branch is not genuinely ahead of `origin/main` (defense-in-depth via the existing squash-merge tree-match classifier).

Only the working tree is removed (`git worktree remove`) — **the branch ref is kept**, so no committed work is lost and the worktree is recoverable with `git worktree add`. Dirty, still-on-origin, locked/detached, and genuinely-ahead worktrees are kept.

Also hardens `is_squash_merged`: a blocked or missing `gh`/`glab` raised `OSError` and crashed the whole `clean-all` run; it now falls back to the diff check — the exact condition under which merged worktrees were left unpruned.

## Tests

New real-git regression tests in `TestPruneGoneRemoteWorktree`: gone-remote + clean → pruned (branch ref kept); dirty → kept; still-on-origin → kept; genuinely-ahead → kept; only-regenerable-file → pruned; removal-failure path; plus host-CLI-blocked fallback for `is_squash_merged`. All observed RED on the unmodified code first.

Full suite green (Docker matrix), `ty`/`tach`/`ruff` clean, coverage 93.96%.

Closes [#1558](https://github.com/souliane/teatree/issues/1558)