### PR TITLE
feat(hooks): deny raw glab/gh api review-comment POSTs, force review CLI (#1164)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -4617,6 +4617,76 @@ def handle_block_out_of_band_merge(data: dict) -> bool:
     return emit_pretooluse_deny(_OUT_OF_BAND_MERGE_REASON)
 
 
+# ── PreToolUse: block-raw-review-post (#1164) ────────────────────────
+#
+# Sub-agents have repeatedly posted MR/PR review comments by shelling out
+# to a raw forge REST POST — ``glab api projects/.../merge_requests/<n>/
+# discussions -X POST`` (or ``.../notes``, or the GitHub ``.../pulls/<n>/
+# comments``) — bypassing the sanctioned ``t3 <overlay> review post-comment``
+# / ``post-draft-note`` path that enforces draft-default (#1207), dedup, and
+# on-behalf approval (#960). RED-CARD, 5x recurrence. This gate closes the
+# bypass at the Bash boundary: a WRITE to a review discussion/notes/comments
+# endpoint is denied; plain GET reads pass through.
+#
+# Conservative by construction: it matches ONLY the review-comment endpoints
+# (discussions / notes / comments) AND only when a write is present (an HTTP
+# method override of POST/PUT/PATCH, or a request-body flag the forge CLIs
+# use to carry a payload — ``-f``/``--field``/``-F``/``--raw-field``/
+# ``--input``/``-d``/``--data``). A bare read (``glab api .../discussions``)
+# and any non-review endpoint pass through untouched. Fails OPEN on an
+# internal parse error — a gate bug must never wedge the fleet.
+
+_REVIEW_POST_ENDPOINT_RE = re.compile(
+    r"(?:merge_requests|pulls|issues)/\d+/(?:discussions|notes|comments)\b",
+)
+_REVIEW_POST_METHOD_WRITE_RE = re.compile(
+    r"(?:-X|--method)[\s=]+['\"]?(?:POST|PUT|PATCH)\b",
+    re.IGNORECASE,
+)
+_REVIEW_POST_BODY_FLAG_RE = re.compile(
+    r"(?:^|\s)(?:-f|--field|-F|--raw-field|--input|-d|--data)\b",
+)
+_REVIEW_POST_DENY_REASON = (
+    "BLOCKED: raw `glab api`/`gh api` POST to a review discussion/notes/comments "
+    "endpoint bypasses the sanctioned review-post CLI. Use "
+    "`t3 <overlay> review post-comment` (draft by default, #1207) or "
+    "`t3 <overlay> review post-draft-note` — the CLI enforces draft-default, "
+    "dedup, and on-behalf approval, which a direct REST write skips entirely. "
+    "Read-only `glab api`/`gh api` GETs are unaffected."
+)
+
+
+def _is_raw_review_write(command: str) -> bool:
+    """Whether *command* is a raw forge REST WRITE to a review-comment endpoint.
+
+    True only when the command targets a ``.../discussions``, ``.../notes``,
+    or ``.../comments`` endpoint AND carries a write signal (a POST/PUT/PATCH
+    method override or a request-body flag). A plain GET read returns False.
+    """
+    if "glab api" not in command and "gh api" not in command:
+        return False
+    if not _REVIEW_POST_ENDPOINT_RE.search(command):
+        return False
+    return bool(_REVIEW_POST_METHOD_WRITE_RE.search(command) or _REVIEW_POST_BODY_FLAG_RE.search(command))
+
+
+def handle_block_raw_review_post(data: dict) -> bool:
+    """Deny a raw ``glab api``/``gh api`` WRITE to a review-comment endpoint.
+
+    Forces the sanctioned ``t3 <overlay> review post-comment`` /
+    ``post-draft-note`` path (draft-default + dedup + on-behalf approval),
+    which a direct REST POST skips. Conservative: only clear review-write
+    POSTs are denied — bare reads and non-review endpoints pass through.
+    Returns True when a deny was emitted (caller stops the handler chain).
+    """
+    if data.get("tool_name") != "Bash":
+        return False
+    command = data.get("tool_input", {}).get("command", "")
+    if not command or not _is_raw_review_write(command):
+        return False
+    return emit_pretooluse_deny(_REVIEW_POST_DENY_REASON)
+
+
 # ── PreToolUse: mirror-question-to-slack ─────────────────────────────
 
 
@@ -5496,6 +5566,7 @@ _HANDLERS: dict[str, list] = {
         handle_enforce_skill_loading,
         handle_block_direct_commands,
         handle_block_out_of_band_merge,
+        handle_block_raw_review_post,
         handle_validate_mr_metadata,
         handle_block_ai_signature,
         handle_block_uncovered_diff,

--- a/tests/test_hook_router_raw_review_post.py
+++ b/tests/test_hook_router_raw_review_post.py
@@ -1,0 +1,102 @@
+"""Tests for the raw-review-post deny gate in hook_router (#1164).
+
+Sub-agents have repeatedly posted MR/PR review comments by shelling out to a
+raw forge REST POST (``glab api .../merge_requests/<n>/discussions -X POST``,
+``.../notes``, or the GitHub ``.../pulls/<n>/comments``), bypassing the
+sanctioned ``t3 <overlay> review post-comment`` / ``post-draft-note`` path
+(draft-default + dedup + on-behalf approval). This gate HARD-DENIES those
+writes at the Bash boundary while letting plain GET reads through.
+
+The gate is conservative: it denies ONLY clear review-write POSTs and never a
+bare read or a non-review endpoint, so a no-false-deny guard accompanies every
+deny case.
+"""
+
+import json
+
+import pytest
+
+from hooks.scripts.hook_router import handle_block_raw_review_post
+
+
+def _bash_event(command: str, tool_name: str = "Bash") -> dict:
+    return {
+        "session_id": "sess-review-post",
+        "tool_name": tool_name,
+        "tool_input": {"command": command},
+    }
+
+
+def _parse_deny(capsys: pytest.CaptureFixture[str]) -> dict | None:
+    output = capsys.readouterr().out.strip()
+    return json.loads(output) if output else None
+
+
+class TestDeniesRawReviewWrites:
+    """Raw forge REST writes to a review-comment endpoint are denied."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "glab api projects/42/merge_requests/7/discussions -X POST -f body='looks good'",
+            "glab api projects/42/merge_requests/7/discussions --method POST -f body=x",
+            "glab api projects/42/merge_requests/7/notes -X POST -f body='nit'",
+            "glab api projects/42/issues/9/notes --method POST --field body=hi",
+            "gh api repos/o/r/pulls/12/comments -f body='please fix'",
+            "gh api repos/o/r/issues/12/comments --method POST -f body=x",
+            "gh api repos/o/r/pulls/12/comments -X POST --raw-field body=@note.txt",
+        ],
+    )
+    def test_raw_review_write_is_denied(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_raw_review_post(_bash_event(command)) is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert deny["permissionDecision"] == "deny"
+
+    def test_deny_message_names_the_sanctioned_cli(self, capsys: pytest.CaptureFixture[str]) -> None:
+        command = "glab api projects/42/merge_requests/7/discussions -X POST -f body='hi'"
+        handle_block_raw_review_post(_bash_event(command))
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        reason = deny["permissionDecisionReason"]
+        assert "review post-comment" in reason
+        assert "post-draft-note" in reason
+        assert "draft" in reason
+        assert "dedup" in reason
+        assert "on-behalf approval" in reason
+
+
+class TestAllowsReadsAndUnrelated:
+    """Bare reads and non-review commands pass through with no false-deny."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GET read of a review endpoint — no write flags.
+            "glab api projects/42/merge_requests/7/discussions",
+            "glab api projects/42/merge_requests/7/notes --paginate",
+            "gh api repos/o/r/pulls/12/comments",
+            # Non-review forge reads/writes.
+            "glab api projects/42/merge_requests/7",
+            "glab api projects/42/merge_requests/7/approvals -X POST",
+            "gh api repos/o/r/pulls/12 -f title='x'",
+            "gh api repos/o/r/labels -f name=bug",
+            # Unrelated commands.
+            "git status",
+            "ls -la",
+            "echo 'glab api discussions -X POST is just a string here'",
+            "t3 teatree review post-comment 7 --file a.py --line 3 --body x",
+        ],
+    )
+    def test_command_is_allowed(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_raw_review_post(_bash_event(command)) is not True
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_ignores_non_bash_tools(self, capsys: pytest.CaptureFixture[str]) -> None:
+        command = "glab api projects/42/merge_requests/7/discussions -X POST -f body=x"
+        assert handle_block_raw_review_post(_bash_event(command, tool_name="Read")) is not True
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_empty_command_passes_through(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_raw_review_post(_bash_event("")) is not True
+        assert capsys.readouterr().out.strip() == ""


### PR DESCRIPTION
Closes [#1164](https://github.com/souliane/teatree/issues/1164)

## What
A new `PreToolUse` Bash handler `handle_block_raw_review_post` (`hooks/scripts/hook_router.py`) HARD-denies a raw `glab api`/`gh api` WRITE to a review-comment endpoint — `.../merge_requests/<n>/discussions`, `.../<n>/notes`, the GitHub `.../pulls/<n>/comments` / `.../issues/<n>/comments`. A write is detected as a `POST`/`PUT`/`PATCH` method override (`-X`/`--method`) or a request-body flag (`-f`/`--field`/`-F`/`--raw-field`/`--input`/`-d`/`--data`).

## Why
Sub-agents have repeatedly posted MR/PR review comments by shelling out to a direct REST POST, bypassing the sanctioned `t3 <overlay> review post-comment` / `post-draft-note` path that enforces draft-default, dedup, and on-behalf approval. The deny message names that CLI as the remediation.

## Discrimination
- Matches ONLY the review-comment endpoints AND only when a write signal is present.
- A bare GET read (`glab api .../discussions` with no write flags) passes through.
- Non-review endpoints (`.../approvals`, `.../pulls/<n>` itself, labels) pass through.
- Fails OPEN on an internal parse error — a gate bug must never wedge the fleet.

Registered as one line in `_HANDLERS["PreToolUse"]`; no shared code refactored.