### PR TITLE
fix(workspace): reap merged-but-unmatchable worktrees via canonical forge PR-state check (#1578)

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -205,6 +205,45 @@ def probe_host_cli(cmd: list[str], repo: str, extract: Callable[[Any], str]) -> 
     return sha or ""
 
 
+def _branch_pr_is_merged(repo: str, branch: str) -> bool:
+    """Whether the forge canonically reports ``branch``'s PR/MR as merged (#1578).
+
+    The subject-match classifier and :func:`_branch_tree_matches_squash` both
+    break down for branches that diverged long before they were squash-merged:
+    the squash creates a new SHA on the default branch (so no subject matches and
+    the branch's own SHAs are absent from every remote) and the branch tip tree
+    no longer equals the squash commit tree (main moved on). Such a worktree is
+    fully merged yet looks ``genuinely_ahead`` / "commits on NO remote", so the
+    guards refuse it forever.
+
+    This asks the forge directly — the canonical truth, not a heuristic. A merged
+    PR/MR whose source branch matches ``branch`` means the work shipped, however
+    far the local branch has since diverged. GitHub marks a squash-merged PR
+    ``state=merged``; GitLab marks the MR ``merged`` — both are covered by the
+    same ``--state merged`` / ``--merged`` queries the squash-commit probe uses,
+    so this reuses :func:`probe_host_cli` (which swallows a missing ``gh``/``glab``
+    binary and any parse error as "not found").
+
+    **Fail-safe to skip.** Returns ``True`` only on a positive merged signal;
+    every uncertain outcome (no merged PR, CLI absent, probe/JSON failure) returns
+    ``False`` so the caller keeps the conservative refuse-and-report — ambiguity
+    never reaps real work.
+    """
+    found = probe_host_cli(
+        ["gh", "pr", "list", "--head", branch, "--state", "merged", "--json", "number", "--limit", "1"],
+        repo,
+        lambda data: str(data[0]["number"]),
+    )
+    if found:
+        return True
+    found = probe_host_cli(
+        ["glab", "mr", "list", "--merged", "--source-branch", branch, "--output", "json", "-P", "1"],
+        repo,
+        lambda data: str(data[0]["iid"]),
+    )
+    return bool(found)
+
+
 def _branch_tree_matches_squash(repo: str, branch: str) -> bool:
     """Return ``True`` when the PR's merge commit has the same tree as the branch tip.
 
@@ -223,11 +262,14 @@ def _raise_if_genuinely_ahead(repo_main: str, worktree: Worktree) -> None:
     """Raise ``RuntimeError`` when the branch carries commits not on ``origin/main``.
 
     Merge commits and squash-merged commits are ignored — only ``genuinely_ahead``
-    work blocks cleanup. As a fallback, the PR's merge commit tree is compared
-    against the branch tip: an empty diff means the cumulative branch content
-    is already captured in the squash (typical for post-merge retro commits),
-    so cleanup proceeds. The error message lists up to ``_SUBJECT_PREVIEW_LIMIT``
-    commit subjects so the caller can decide whether to push or abandon.
+    work blocks cleanup. Two fallbacks run before refusing, both confirming the
+    work already shipped: first the PR's merge commit tree is compared against the
+    branch tip (an empty diff means the cumulative content is captured in the
+    squash, typical for post-merge retro commits); then, for branches that
+    diverged so far the squash tree no longer matches, the forge is asked
+    canonically whether the branch's PR is merged (#1578). The error message
+    lists up to ``_SUBJECT_PREVIEW_LIMIT`` commit subjects so the caller can
+    decide whether to push or abandon.
     """
     unsynced = git.unsynced_commits(repo_main, worktree.branch)
     if not unsynced:
@@ -236,6 +278,8 @@ def _raise_if_genuinely_ahead(repo_main: str, worktree: Worktree) -> None:
     if not classification.genuinely_ahead:
         return
     if _branch_tree_matches_squash(repo_main, worktree.branch):
+        return
+    if _branch_pr_is_merged(repo_main, worktree.branch):
         return
     preview = classification.genuinely_ahead[:_SUBJECT_PREVIEW_LIMIT]
     subjects = ", ".join(c.subject for c in preview)
@@ -269,6 +313,14 @@ def _raise_if_unpushed(repo_main: str, worktree: Worktree) -> None:
     corrupt repo, any ``git log`` failure) it raises ``CommandFailedError``;
     we translate that into a refusal rather than proceeding, because an
     inconclusive probe means we cannot prove the commits are pushed.
+
+    **Canonical merged override (#1578).** A squash-merge creates a new SHA on
+    the default branch and deletes the source ref, so the branch's own commits
+    are absent from every remote even though the work shipped. Before refusing,
+    the forge is asked whether the branch's PR is merged; a positive answer is
+    the ground truth that the content is safe on the default branch, so teardown
+    proceeds. The check fails safe to skip — only a positive merged signal
+    overrides; any uncertainty keeps the refusal.
     """
     try:
         unpushed = git.commits_absent_from_all_remotes(repo_main, worktree.branch)
@@ -280,6 +332,8 @@ def _raise_if_unpushed(repo_main: str, worktree: Worktree) -> None:
         )
         raise RuntimeError(msg) from exc
     if not unpushed:
+        return
+    if _branch_pr_is_merged(repo_main, worktree.branch):
         return
     preview = unpushed[:_SUBJECT_PREVIEW_LIMIT]
     shas = ", ".join(preview)

--- a/tests/teatree_core/cleanup/test_branch_pr_is_merged.py
+++ b/tests/teatree_core/cleanup/test_branch_pr_is_merged.py
@@ -1,0 +1,62 @@
+"""``_branch_pr_is_merged`` — the canonical forge merged-PR probe (#1578).
+
+The fallback the residual-worktree reaper consults when subject-matching and
+the squash-tree heuristic both break down on a long-diverged branch. It must
+answer ``True`` only on a positive merged signal from the forge and fail safe
+to ``False`` on every uncertainty (no merged PR, CLI missing, parse error) so
+the conservative refuse-and-report stands. The subprocess CLI is mocked exactly
+like :func:`is_squash_merged`'s tests in ``test_workspace.py``.
+"""
+
+import subprocess
+from collections.abc import Callable
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from teatree.core.cleanup import _branch_pr_is_merged
+
+
+def _dispatch(gh_stdout: str, glab_stdout: str) -> Callable[..., subprocess.CompletedProcess[str]]:
+    """Return mock stdout for ``gh`` vs ``glab`` based on the invoked binary."""
+
+    def _side_effect(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        cmd = args[0] if args else ""
+        return subprocess.CompletedProcess([], 0, stdout=gh_stdout if cmd == "gh" else glab_stdout)
+
+    return _side_effect
+
+
+class TestBranchPrIsMerged(TestCase):
+    def test_true_when_github_reports_merged_pr(self) -> None:
+        with patch(
+            "teatree.utils.run.subprocess.run",
+            return_value=subprocess.CompletedProcess([], 0, stdout='[{"number":7}]'),
+        ):
+            assert _branch_pr_is_merged("/repo", "1206-feat-review-run") is True
+
+    def test_true_when_gitlab_reports_merged_mr(self) -> None:
+        with patch(
+            "teatree.utils.run.subprocess.run",
+            side_effect=_dispatch(gh_stdout="[]", glab_stdout='[{"iid":5,"merge_commit_sha":"abc"}]'),
+        ):
+            assert _branch_pr_is_merged("/repo", "s-repo-99-fix") is True
+
+    def test_false_when_no_merged_pr_on_either_forge(self) -> None:
+        with patch(
+            "teatree.utils.run.subprocess.run",
+            side_effect=_dispatch(gh_stdout="[]", glab_stdout="[]"),
+        ):
+            assert _branch_pr_is_merged("/repo", "1234-feat-pending") is False
+
+    def test_false_when_host_cli_is_missing_or_blocked(self) -> None:
+        for exc in (FileNotFoundError("gh"), PermissionError("blocked")):
+            with patch("teatree.utils.run.subprocess.run", side_effect=exc):
+                assert _branch_pr_is_merged("/repo", "1234-feat-pending") is False
+
+    def test_false_when_payload_is_unparsable(self) -> None:
+        with patch(
+            "teatree.utils.run.subprocess.run",
+            side_effect=_dispatch(gh_stdout="not-json", glab_stdout="also-not-json"),
+        ):
+            assert _branch_pr_is_merged("/repo", "1234-feat-pending") is False

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -331,6 +331,143 @@ class TestCleanupWorktree(TestCase):
         mock_git.worktree_remove.assert_called_once()
         mock_git.branch_delete.assert_called_once()
 
+    @_patch_classify
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_reaps_genuinely_ahead_branch_when_forge_says_pr_merged(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+        mock_classify: MagicMock,
+    ) -> None:
+        """#1578 — a long-diverged branch whose PR the forge reports MERGED is reaped.
+
+        The subject-match classifier reports ``genuinely_ahead`` and the squash
+        tree no longer matches the branch tip (the branch diverged long ago), so
+        the prior guards refuse. The canonical forge PR-state check overrides:
+        a merged PR is the ground truth that the work shipped.
+        """
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = ["abc123 feat: shipped via squash long ago"]
+        mock_classify.return_value = BranchClassification(
+            genuinely_ahead=[BranchCommit(sha="abc123", subject="feat: shipped via squash long ago", is_merge=False)]
+        )
+        mock_git.check.return_value = False  # tree differs — branch tip diverged from squash
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        with (
+            patch("teatree.core.cleanup._pr_merge_commit_sha", return_value="squash123"),
+            patch("teatree.core.cleanup._branch_pr_is_merged", return_value=True),
+        ):
+            cleanup_worktree(wt)
+
+        mock_git.worktree_remove.assert_called_once()
+        mock_git.branch_delete.assert_called_once()
+
+    @_patch_classify
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_refuses_genuinely_ahead_branch_when_no_merged_pr(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+        mock_classify: MagicMock,
+    ) -> None:
+        """#1578 load-bearing safety test — real pending work (no merged PR) is still refused.
+
+        The forge canonically reports no merged PR for the branch, so the
+        conservative refuse-and-report stands: genuinely-ahead work is never
+        auto-discarded.
+        """
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = ["abc123 feat: genuine unpushed work"]
+        mock_classify.return_value = BranchClassification(
+            genuinely_ahead=[BranchCommit(sha="abc123", subject="feat: genuine unpushed work", is_merge=False)]
+        )
+        mock_git.check.return_value = False  # tree differs — not captured by any squash
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        with (
+            patch("teatree.core.cleanup._pr_merge_commit_sha", return_value=""),
+            patch("teatree.core.cleanup._branch_pr_is_merged", return_value=False),
+            pytest.raises(RuntimeError, match="unsynced commit"),
+        ):
+            cleanup_worktree(wt)
+
+        mock_git.worktree_remove.assert_not_called()
+        mock_git.branch_delete.assert_not_called()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_reaps_unpushed_branch_when_forge_says_pr_merged(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """#1578 — a branch flagged 'commits on NO remote' is reaped when its PR is MERGED.
+
+        Squash-merge creates a new SHA on main, so the branch's own SHAs are
+        absent from every remote ref — the #706 data-loss guard fires. But the
+        forge canonically reports the branch's PR merged, so the content shipped
+        and the worktree is safe to reap.
+        """
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = []
+        mock_git.commits_absent_from_all_remotes.return_value = ["abc1234 feat: squashed onto main"]
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        with patch("teatree.core.cleanup._branch_pr_is_merged", return_value=True):
+            cleanup_worktree(wt)
+
+        mock_git.worktree_remove.assert_called_once()
+        mock_git.branch_delete.assert_called_once()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_refuses_unpushed_branch_when_forge_lookup_uncertain(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """#1578 fail-safe — an unpushed branch with no/uncertain merged PR is still refused.
+
+        The forge lookup returning ``False`` (no merged PR found, CLI missing,
+        or any probe failure) leaves the #706 data-loss guard in force: ambiguity
+        never reaps.
+        """
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.commits_absent_from_all_remotes.return_value = ["abc1234 feat: never pushed, no PR"]
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        with (
+            patch("teatree.core.cleanup._branch_pr_is_merged", return_value=False),
+            pytest.raises(RuntimeError, match=r"on NO remote \(data loss\)"),
+        ):
+            cleanup_worktree(wt)
+
+        mock_git.worktree_remove.assert_not_called()
+        mock_git.branch_delete.assert_not_called()
+
     @_patch_overlay
     @_patch_git
     @_patch_config


### PR DESCRIPTION
## Problem

[PR #1561](https://github.com/souliane/teatree/pull/1561) reaped gone-remote+clean worktrees, but a residual class survives: worktrees whose work shipped via squash-merge (new SHA on the default branch) yet whose local commits are neither gone-remote nor subject-matchable. The classifier reports them `genuinely_ahead` / "N commits on NO remote (data loss)" and refuses to reap them forever — so ~46 worktrees accumulate. The refuse-and-report is the safe direction, but the sprawl is the exact problem this set out to solve.

## Fix

Add `_branch_pr_is_merged(repo, branch)` in `core/cleanup.py` — a canonical forge probe (`gh pr list --head <branch> --state merged` / `glab mr list --merged --source-branch <branch>`) consulted as a final fallback inside the two existing guards:

- `_raise_if_genuinely_ahead` — after the cheap local squash-tree check fails.
- `_raise_if_unpushed` — after the local absent-from-all-remotes check finds unpushed commits.

A merged PR/MR is ground truth that the work shipped, however far the local branch has since diverged — it beats subject-matching for old/diverged branches.

**Cost-bound.** The forge lookup runs ONLY for the residual skipped set (after the cheap local checks already failed), never once-per-worktree.

**Fail-safe to skip.** Returns `True` only on a positive merged signal; every uncertain outcome (no merged PR, missing `gh`/`glab`, any probe/JSON failure) returns `False`, so the conservative refuse-and-report stands — genuinely-ahead work is never auto-discarded on ambiguity.

## Tests

- A `genuinely_ahead` worktree whose branch PR is MERGED → now reaped.
- A worktree with NO merged PR (real pending work) → still refused (the load-bearing safety test).
- An unpushed branch whose PR is MERGED → reaped despite the [#706](https://github.com/souliane/teatree/issues/706) data-loss guard.
- Forge lookup uncertain / no merged PR on an unpushed branch → still refused (no reap, no crash).
- `_branch_pr_is_merged` unit tests: GitHub-merged, GitLab-merged, no-PR, missing/blocked CLI, unparsable payload.

Full suite green (9167 passed), coverage 93.97%, tach/ty/ruff/makemigrations clean.

Closes [#1578](https://github.com/souliane/teatree/issues/1578)

🤖 Generated with [Claude Code](https://claude.com/claude-code)