### PR TITLE
fix(workspace): thread a subprocess timeout through probe_host_cli

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -25,7 +25,7 @@ from teatree.core.worktree_recovery import _has_unpushed_commits, capture_recove
 from teatree.utils import git
 from teatree.utils.db import drop_db
 from teatree.utils.postgres_secret import remove_postgres_pass_entry
-from teatree.utils.run import CommandFailedError, run_allowed_to_fail
+from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
 
@@ -185,15 +185,21 @@ def _pr_merge_commit_sha(repo: str, branch: str) -> str:
     )
 
 
-def probe_host_cli(cmd: list[str], repo: str, extract: Callable[[Any], str]) -> str:
+def probe_host_cli(cmd: list[str], repo: str, extract: Callable[[Any], str], *, timeout: float = 30.0) -> str:
     """Invoke a host CLI that may be missing, parse its JSON, extract the SHA.
 
     Swallows ``OSError`` (missing binary, permission denied in sandboxes) and
     JSON/key errors — both are legitimate "no merged PR found" outcomes.
+
+    ``timeout`` bounds the host CLI invocation (seconds): a hung ``gh``/``glab``
+    must not block ``clean-all`` or the loop tick. On expiry the
+    ``subprocess.TimeoutExpired`` is swallowed and ``""`` is returned — the same
+    fail-safe "not found / skip" value as every other failure path, so a timeout
+    can never produce a positive merged signal and never wrongly reaps work.
     """
     try:
-        result = run_allowed_to_fail(cmd, cwd=repo, expected_codes=None)
-    except OSError:
+        result = run_allowed_to_fail(cmd, cwd=repo, expected_codes=None, timeout=timeout)
+    except (OSError, TimeoutExpired):
         return ""
     if result.returncode != 0 or result.stdout.strip() in {"", "[]"}:
         return ""

--- a/tests/teatree_core/test_ci_only_branches.py
+++ b/tests/teatree_core/test_ci_only_branches.py
@@ -9,6 +9,7 @@ designed to prevent, but only if the targeted branches are reachable from
 the test suite at all.
 """
 
+import subprocess
 from operator import itemgetter
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -138,6 +139,93 @@ class TestProbeHostCliEmptyResults:
             return_value=CompletedProcess(args=[], returncode=0, stdout="[]", stderr=""),
         ):
             assert cleanup.probe_host_cli(["gh", "pr"], "/tmp", itemgetter("sha")) == ""
+
+
+class TestProbeHostCliTimeout:
+    """``probe_host_cli`` bounds the host CLI and fails safe on expiry — #1580.
+
+    A hung ``gh``/``glab`` must not block ``clean-all`` or the loop tick. The
+    ``timeout`` is forwarded to ``run_allowed_to_fail`` (and thus
+    ``subprocess.run``); when it expires the ``TimeoutExpired`` is swallowed and
+    ``""`` (fail-safe "skip") is returned, so a timeout never yields a positive
+    merged signal.
+    """
+
+    def test_returns_empty_string_when_subprocess_times_out(self) -> None:
+        from teatree.core import cleanup  # noqa: PLC0415
+
+        with patch.object(
+            cleanup,
+            "run_allowed_to_fail",
+            side_effect=subprocess.TimeoutExpired(cmd=["gh", "pr"], timeout=30.0),
+        ):
+            assert cleanup.probe_host_cli(["gh", "pr"], "/tmp", itemgetter("oid")) == ""
+
+    def test_returns_empty_string_when_real_subprocess_run_times_out(self) -> None:
+        from teatree.core import cleanup  # noqa: PLC0415
+
+        # Patch the actual subprocess.run reached through run_allowed_to_fail so
+        # the fail-safe is exercised against the real probe + wrapper, not a
+        # shallow stub of the wrapper itself.
+        with patch(
+            "teatree.utils.run.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["gh", "pr"], timeout=5.0),
+        ):
+            assert cleanup.probe_host_cli(["gh", "pr"], "/tmp", itemgetter("oid"), timeout=5.0) == ""
+
+    def test_forwards_timeout_to_run_allowed_to_fail(self) -> None:
+        from teatree.core import cleanup  # noqa: PLC0415
+
+        with patch.object(
+            cleanup,
+            "run_allowed_to_fail",
+            return_value=CompletedProcess(args=[], returncode=0, stdout="[]", stderr=""),
+        ) as run_mock:
+            cleanup.probe_host_cli(["gh", "pr"], "/tmp", itemgetter("oid"), timeout=12.5)
+
+        assert run_mock.call_args.kwargs["timeout"] == pytest.approx(12.5)
+
+    def test_defaults_timeout_to_thirty_seconds(self) -> None:
+        from teatree.core import cleanup  # noqa: PLC0415
+
+        with patch.object(
+            cleanup,
+            "run_allowed_to_fail",
+            return_value=CompletedProcess(args=[], returncode=0, stdout="[]", stderr=""),
+        ) as run_mock:
+            cleanup.probe_host_cli(["gh", "pr"], "/tmp", itemgetter("oid"))
+
+        assert run_mock.call_args.kwargs["timeout"] == pytest.approx(30.0)
+
+
+class TestProbeHostCliFailSafePaths:
+    """The non-timeout failure/success paths still resolve correctly — #1580 regression guard."""
+
+    def test_returns_empty_string_when_binary_is_missing(self) -> None:
+        from teatree.core import cleanup  # noqa: PLC0415
+
+        with patch.object(cleanup, "run_allowed_to_fail", side_effect=OSError("no gh")):
+            assert cleanup.probe_host_cli(["gh", "pr"], "/tmp", itemgetter("oid")) == ""
+
+    def test_returns_empty_string_on_malformed_json(self) -> None:
+        from teatree.core import cleanup  # noqa: PLC0415
+
+        with patch.object(
+            cleanup,
+            "run_allowed_to_fail",
+            return_value=CompletedProcess(args=[], returncode=0, stdout="not json", stderr=""),
+        ):
+            assert cleanup.probe_host_cli(["gh", "pr"], "/tmp", itemgetter("oid")) == ""
+
+    def test_extracts_value_on_happy_path(self) -> None:
+        from teatree.core import cleanup  # noqa: PLC0415
+
+        with patch.object(
+            cleanup,
+            "run_allowed_to_fail",
+            return_value=CompletedProcess(args=[], returncode=0, stdout='[{"oid": "abc123"}]', stderr=""),
+        ):
+            assert cleanup.probe_host_cli(["gh", "pr"], "/tmp", lambda data: data[0]["oid"]) == "abc123"
 
 
 class TestResolveCandidatePathsMacosSymlinks:


### PR DESCRIPTION
## Root cause

`probe_host_cli` (`src/teatree/core/cleanup.py`) called `run_allowed_to_fail` with no timeout, so a hung `gh`/`glab` invocation blocked `clean-all` (and the loop tick) indefinitely. Surfaced as a cold-review follow-up from [#1579](https://github.com/souliane/teatree/pull/1579). Used by four call sites: `_pr_merge_commit_sha`, `_branch_pr_is_merged` (the [#1579](https://github.com/souliane/teatree/pull/1579) reaper), and `find_open_pr` in `orphan_guard.py`.

## Fix

- Add a keyword-only `timeout: float = 30.0` to `probe_host_cli`, forwarded to `run_allowed_to_fail` — which already accepts `timeout` and forwards it to `subprocess.run`, so no change was needed in `utils/run.py`.
- Catch the surfaced `TimeoutExpired` alongside the existing `OSError` and return `""` — the same fail-safe "not found / skip" value as every other failure path. A timeout can never return a positive merged signal, so it can never cause a wrongful reap; the data-loss axis stays safe (liveness-only).
- The four call sites are unchanged — the default timeout keeps them all working.

## Test evidence

`tests/teatree_core/test_ci_only_branches.py` — new `TestProbeHostCliTimeout` (timeout fail-safe via both a patched wrapper and the real `subprocess.run`; `timeout` forwarding; 30s default) and `TestProbeHostCliFailSafePaths` (regression guard for the missing-binary / bad-JSON / happy paths). The timeout test was observed RED against the pre-fix `except OSError:` clause.

```
============================== 17 passed in 0.37s ==============================
```

`uv run ruff check` -> `All checks passed!`

Closes [#1580](https://github.com/souliane/teatree/issues/1580)
