### PR TITLE
fix(cli): pr ensure-pr sources title/body from the branch's own commit

### DIFF
--- a/src/teatree/core/management/commands/_ensure_pr.py
+++ b/src/teatree/core/management/commands/_ensure_pr.py
@@ -63,8 +63,30 @@ def _ticket_extra_for_branch(branch_name: str) -> dict | None:
     return ticket.extra if isinstance(ticket.extra, dict) else None
 
 
+def _branch_own_commit_message(repo_path: str, branch_name: str) -> tuple[str, str]:
+    """Return ``(subject, body)`` of the branch's OWN first (oldest) commit.
+
+    #1534: the PR title/body must describe the work being shipped — the
+    branch's own commit — never the default branch's head. Reading
+    ``HEAD`` (the former behaviour) could pick up an unrelated, already-
+    merged commit when the wrong ref was checked out or ``--repo`` was a
+    slug, opening a PR titled after a stale default-branch commit. Sourcing
+    explicitly from ``origin/<default>..<branch>`` makes the title
+    independent of the working tree and matches the squash-PR-title
+    convention (the branch's first own commit). The oldest unique commit is
+    the canonical title when the branch has several. No unique commit yields
+    ``("", "")`` so the caller keeps its safe ``WIP:`` fallback rather than
+    mislabelling the PR after the default-branch head.
+    """
+    try:
+        default = git.default_branch(repo=repo_path)
+    except (CommandFailedError, RuntimeError, ValueError):
+        default = "main"
+    return git.first_commit_message(repo=repo_path, range_spec=f"origin/{default}..{branch_name}")
+
+
 def create_or_defer_pr(repo_path: str, branch_name: str) -> EnsurePrResult:
-    """Build the PR spec from the last commit and create it, or defer (#792).
+    """Build the PR spec from the branch's own commit and create it, or defer (#792).
 
     The "no commits between" create failure is the pre-push stale-remote
     race (the remote ref still lags this in-flight push); deferring it lets
@@ -75,7 +97,7 @@ def create_or_defer_pr(repo_path: str, branch_name: str) -> EnsurePrResult:
     if host is None:
         return EnsurePrResult(error="no code host configured")
 
-    commit_subject, commit_body = git.last_commit_message(repo=repo_path)
+    commit_subject, commit_body = _branch_own_commit_message(repo_path, branch_name)
     title = commit_subject or f"WIP: {branch_name}"
     raw_description = (
         f"{commit_subject}\n\n{commit_body}"

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -268,6 +268,33 @@ def last_commit_message(repo: str = ".") -> tuple[str, str]:
     return subject, body
 
 
+def first_commit_message(repo: str = ".", range_spec: str = "") -> tuple[str, str]:
+    """Return ``(subject, body)`` of the OLDEST commit in *range_spec*.
+
+    The canonical PR title for a branch is its first (oldest) own commit —
+    the same commit a squash-merge keeps as the squash title. Unlike
+    :func:`last_commit_message` (which reads ``HEAD`` and so can pick up the
+    default branch's head when the wrong ref is checked out), this sources
+    explicitly from a range like ``origin/main..my-branch`` and is therefore
+    independent of the working tree. An empty/missing range, or a range with
+    no commits, yields ``("", "")`` so the caller can fall back safely
+    instead of mislabelling the PR.
+
+    A ``%x1f`` unit separator splits subject from body and a ``%x1e`` record
+    separator splits commits, so a body containing blank lines never bleeds
+    into the next commit.
+    """
+    if not range_spec:
+        return "", ""
+    unit_sep, record_sep = "\x1f", "\x1e"
+    output = run(repo=repo, args=["log", "--reverse", range_spec, f"--format=%s{unit_sep}%b{record_sep}"])
+    records = [chunk for chunk in output.split(record_sep) if chunk.strip()]
+    if not records:
+        return "", ""
+    subject, _, body = records[0].lstrip("\n").partition(unit_sep)
+    return subject.strip(), body.strip()
+
+
 def commit_messages(repo: str = ".", range_spec: str = "") -> list[str]:
     """Return the full message (subject + body) of each commit in *range_spec*.
 

--- a/tests/teatree_core/pr_command/test_ensure_pr.py
+++ b/tests/teatree_core/pr_command/test_ensure_pr.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock, patch
 
@@ -7,7 +8,9 @@ from django.test import TestCase
 
 from teatree.core.management.commands import _ensure_pr as ensure_pr_mod
 from teatree.core.management.commands import pr as pr_command
+from teatree.core.management.commands._ensure_pr import create_or_defer_pr
 from teatree.core.orphan_guard import BranchReport, BranchStatus
+from tests.teatree_core.cleanup._shared import _run_git
 
 from ._shared import _MOCK_OVERLAY
 
@@ -101,7 +104,7 @@ class TestEnsurePr(TestCase):
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
             patch.object(pr_command.git, "current_branch", return_value="feat-q"),
             patch.object(ensure_pr_mod.git, "remote_url", return_value="git@github.com:souliane/teatree.git"),
-            patch.object(ensure_pr_mod.git, "last_commit_message", return_value=("feat: cool thing", "body")),
+            patch.object(ensure_pr_mod, "_branch_own_commit_message", return_value=("feat: cool thing", "body")),
             patch.object(
                 pr_command,
                 "classify_branch",
@@ -150,7 +153,7 @@ class TestEnsurePr(TestCase):
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
             patch.object(pr_command.git, "current_branch", return_value="feat-q"),
             patch.object(ensure_pr_mod.git, "remote_url", return_value="git@github.com:souliane/teatree.git"),
-            patch.object(ensure_pr_mod.git, "last_commit_message", return_value=("feat: cool thing", "body")),
+            patch.object(ensure_pr_mod, "_branch_own_commit_message", return_value=("feat: cool thing", "body")),
             patch.object(
                 pr_command,
                 "classify_branch",
@@ -187,7 +190,7 @@ class TestEnsurePr(TestCase):
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
             patch.object(pr_command.git, "current_branch", return_value="feat-q"),
             patch.object(ensure_pr_mod.git, "remote_url", return_value="git@github.com:souliane/teatree.git"),
-            patch.object(ensure_pr_mod.git, "last_commit_message", return_value=("feat: x", "body")),
+            patch.object(ensure_pr_mod, "_branch_own_commit_message", return_value=("feat: x", "body")),
             patch.object(
                 pr_command,
                 "classify_branch",
@@ -201,3 +204,98 @@ class TestEnsurePr(TestCase):
             pytest.raises(CommandFailedError, match="rate limit"),
         ):
             call_command("pr", "ensure-pr")
+
+
+class TestCreatePrTitleSourcing(TestCase):
+    """#1534: the PR title/body must come from the branch's OWN commit.
+
+    Real git under ``tmp_path`` — only the forge ``create_pr`` is mocked.
+    ``origin/main`` carries an unrelated, already-merged commit ``M``; the
+    feature branch carries its own work ``B``. The repo's WORKING TREE is left
+    checked out on the default branch at ``M`` (the main-clone / wrong-ref /
+    slug condition #1534 describes), so the former ``HEAD``-based sourcing
+    would title the PR after ``M``. The opened PR must be titled after ``B``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        self._monkeypatch = monkeypatch
+        self._tmp_path = tmp_path
+
+    @staticmethod
+    def _set_identity(clone: Path) -> None:
+        """Give the tmp clone a commit identity (the Docker CI image has none)."""
+        _run_git("config", "user.email", "t@t", cwd=clone)
+        _run_git("config", "user.name", "t", cwd=clone)
+
+    def _origin_and_feature(self, branch_commits: list[str], *, default_branch: str = "main") -> Path:
+        origin = self._tmp_path / "origin.git"
+        _run_git("init", "-q", "--bare", "-b", default_branch, str(origin), cwd=self._tmp_path)
+        clone = self._tmp_path / "clone"
+        _run_git("clone", "-q", str(origin), str(clone), cwd=self._tmp_path)
+        self._set_identity(clone)
+        _run_git("commit", "--allow-empty", "-q", "-m", "feat(lifecycle): unrelated already-merged (#1426)", cwd=clone)
+        # M (the unrelated, already-merged head) IS origin/<default>. The
+        # branch is built on a side ref and the working tree is then returned
+        # to the default branch at M — the main-clone / wrong-ref condition
+        # where HEAD-based sourcing wrongly picks M.
+        _run_git("push", "-q", "origin", default_branch, cwd=clone)
+        # Point ``origin`` at the GitHub slug so the spec carries the real
+        # repo; the bare-origin push above already populated origin/<default>.
+        _run_git("remote", "set-url", "origin", "git@github.com:souliane/teatree.git", cwd=clone)
+        _run_git("checkout", "-q", "-b", "1534-fix-the-real-work", cwd=clone)
+        for subject in branch_commits:
+            _run_git("commit", "--allow-empty", "-q", "-m", subject, cwd=clone)
+        _run_git("checkout", "-q", default_branch, cwd=clone)
+        return clone
+
+    def _host(self) -> MagicMock:
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://github.com/souliane/teatree/pull/1"}
+        host.current_user.return_value = "souliane"
+        self._monkeypatch.setattr(ensure_pr_mod, "code_host_from_overlay", lambda: host)
+        return host
+
+    def test_title_derives_from_branch_commit_not_default_head(self) -> None:
+        clone = self._origin_and_feature(["fix(y): the real work"])
+        host = self._host()
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = create_or_defer_pr(str(clone), "1534-fix-the-real-work")
+
+        assert result["url"] == "https://github.com/souliane/teatree/pull/1"
+        (spec,) = host.create_pr.call_args.args
+        assert spec.title == "fix(y): the real work"
+        assert "1426" not in spec.title
+        assert "1426" not in spec.description
+
+    def test_oldest_unique_commit_is_the_title_for_multi_commit_branch(self) -> None:
+        clone = self._origin_and_feature(["fix(y): the real work", "fix(y): a follow-up commit", "fix(y): one more"])
+        host = self._host()
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            create_or_defer_pr(str(clone), "1534-fix-the-real-work")
+
+        (spec,) = host.create_pr.call_args.args
+        assert spec.title == "fix(y): the real work"
+
+    def test_no_unique_commit_falls_back_to_wip_not_default_head(self) -> None:
+        """Guard: a branch with no commits over origin/<default> must NOT title after M."""
+        origin = self._tmp_path / "origin.git"
+        _run_git("init", "-q", "--bare", "-b", "main", str(origin), cwd=self._tmp_path)
+        clone = self._tmp_path / "clone"
+        _run_git("clone", "-q", str(origin), str(clone), cwd=self._tmp_path)
+        self._set_identity(clone)
+        _run_git("commit", "--allow-empty", "-q", "-m", "feat(lifecycle): unrelated already-merged (#1426)", cwd=clone)
+        _run_git("push", "-q", "origin", "main", cwd=clone)
+        _run_git("remote", "set-url", "origin", "git@github.com:souliane/teatree.git", cwd=clone)
+        # Feature branch sits exactly on origin/main — zero unique commits.
+        _run_git("checkout", "-q", "-b", "empty-branch", cwd=clone)
+        host = self._host()
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            create_or_defer_pr(str(clone), "empty-branch")
+
+        (spec,) = host.create_pr.call_args.args
+        assert spec.title == "WIP: empty-branch"
+        assert "1426" not in spec.title

--- a/tests/utils/test_git_core.py
+++ b/tests/utils/test_git_core.py
@@ -1,9 +1,11 @@
+from pathlib import Path
 from subprocess import CompletedProcess
 
 import pytest
 
 from teatree.utils import git
 from teatree.utils import run as utils_run_mod
+from tests.teatree_core.cleanup._shared import _run_git
 
 
 def test_default_branch_prefers_symbolic_ref_and_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -248,6 +250,47 @@ def test_last_commit_message_subject_only(monkeypatch: pytest.MonkeyPatch) -> No
     subject, body = git.last_commit_message()
     assert subject == "feat: add feature"
     assert body == ""
+
+
+def _origin_with_branch(tmp_path: Path, branch_commits: list[tuple[str, str]]) -> Path:
+    """An ``origin/main`` clone with a ``feature`` branch carrying ``branch_commits``.
+
+    The shared ``GIT_*``-stripped runner keeps the tmp repo isolated from the
+    outer ``git commit`` hook env (#288).
+    """
+    origin = tmp_path / "origin.git"
+    _run_git("init", "-q", "--bare", "-b", "main", str(origin), cwd=tmp_path)
+    clone = tmp_path / "clone"
+    _run_git("clone", "-q", str(origin), str(clone), cwd=tmp_path)
+    _run_git("config", "user.email", "t@t", cwd=clone)
+    _run_git("config", "user.name", "t", cwd=clone)
+    _run_git("commit", "--allow-empty", "-q", "-m", "feat(lifecycle): unrelated already-merged", cwd=clone)
+    _run_git("push", "-q", "origin", "main", cwd=clone)
+    _run_git("checkout", "-q", "-b", "feature", cwd=clone)
+    for subject, body in branch_commits:
+        message = f"{subject}\n\n{body}" if body else subject
+        _run_git("commit", "--allow-empty", "-q", "-m", message, cwd=clone)
+    return clone
+
+
+def test_first_commit_message_returns_oldest_branch_commit_not_default_head(tmp_path: Path) -> None:
+    clone = _origin_with_branch(
+        tmp_path,
+        [("fix(y): the real work", "Body line.\n\nSecond paragraph."), ("fix(y): a follow-up", "")],
+    )
+    subject, body = git.first_commit_message(repo=str(clone), range_spec="origin/main..feature")
+    assert subject == "fix(y): the real work"
+    assert body == "Body line.\n\nSecond paragraph."
+
+
+def test_first_commit_message_empty_when_no_commits_in_range(tmp_path: Path) -> None:
+    clone = _origin_with_branch(tmp_path, [("fix(y): work", "")])
+    assert git.first_commit_message(repo=str(clone), range_spec="origin/main..origin/main") == ("", "")
+
+
+def test_first_commit_message_empty_range_spec_yields_empty(tmp_path: Path) -> None:
+    clone = _origin_with_branch(tmp_path, [("fix(y): work", "")])
+    assert git.first_commit_message(repo=str(clone), range_spec="") == ("", "")
 
 
 def test_worktree_add_with_and_without_create_branch(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Root cause

`t3 <overlay> pr ensure-pr` (the orphan-branch PR-open helper) built the PR title/body from `git.last_commit_message(repo=repo_path)`, which reads whatever `HEAD` resolves to. When `repo_path` is a main clone checked out on the default branch (or `--repo` was passed as a slug, or any wrong ref), `HEAD` is the default branch's head — so the PR opened with an unrelated, already-merged title (observed: a PR titled after the lifecycle commit that closed [#1426](https://github.com/souliane/teatree/issues/1426)), defeating the MR-title/scope conventions and the `Closes #N` cross-check.

## Fix

The PR title/body now derive from the branch's OWN work commit, sourced explicitly from the branch ref and independent of the working tree:

- New `git.first_commit_message(repo, range_spec)` returns the subject+body of the OLDEST commit in a range (e.g. `origin/main..<branch>`), using a unit/record separator so multi-line bodies never bleed across commits. Empty/missing range yields `("", "")`.
- `_ensure_pr._branch_own_commit_message` resolves the default branch robustly (`git.default_branch`, falling back to `main`) and reads `origin/<default>..<branch>`. The oldest unique commit is the canonical title — matching the squash-PR-title convention.
- If the branch has NO unique commits over `origin/<default>` (the no-unique-commit guard), the existing safe fallback (`WIP: <branch>` / track-branch body) is kept rather than silently titling after the default-branch head.
- The pre-push "no commits between" deferral path (the [#792](https://github.com/souliane/teatree/issues/792) deadlock fix) is unchanged.

## Test evidence

RED→GREEN integration tests with real git under `tmp_path` (only the forge `create_pr` is mocked): `origin/main` carries an unrelated already-merged commit M while the branch carries its own work B; the working tree is left on the default branch at M (the mis-sourcing condition). On the buggy code all three new title tests failed by picking up M; with the fix they pick B / fall back to `WIP:`.

```
$ uv run pytest --no-cov -q tests/teatree_core/pr_command/test_ensure_pr.py tests/teatree_core/test_ensure_pr.py tests/utils/test_git_core.py
============================== 41 passed in 1.77s ==============================

$ uv run ruff check .
All checks passed!
```

Closes [#1534](https://github.com/souliane/teatree/issues/1534)