### PR TITLE
fix(workspace): ship pushes the worktree's actual branch and reconciles the DB row

### DIFF
--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -129,7 +129,14 @@ class ShipExecutor(RunnerBase):
             return RunnerResult(ok=False, detail="no code host configured")
 
         repo_path = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
-        branch = worktree.branch
+        # #1519: the DB-recorded branch is minted as ``<N>-ticket`` at
+        # ``workspace ticket`` time; agents then rename the git branch to the
+        # ``<N>-<type>-<desc>`` convention. Ship the worktree's ACTUAL current
+        # git branch — that is what exists in the worktree — and reconcile the
+        # stale DB rows so the worktree↔branch mapping stops desyncing.
+        # (Minting the convention name upfront — option 1 — is a separate
+        # design decision deliberately left out of this fix.)
+        branch = self._resolve_and_reconcile_branch(ticket, worktree, repo_path)
 
         # #1263: short-circuit only when THIS branch already has a PR.
         # The legacy truthiness check fired on any prior ``pr_urls`` entry,
@@ -164,6 +171,55 @@ class ShipExecutor(RunnerBase):
         git.push(repo=repo_path, remote="origin", branch=branch)
         spec = self._build_pr_spec(ticket, host, repo_path, branch, extra)
         return self._open_pr_and_record(ticket, extra, host, spec, branch)
+
+    @staticmethod
+    def _resolve_and_reconcile_branch(ticket: "Ticket", worktree: "Worktree", repo_path: str) -> str:
+        """Return the worktree's actual git branch, reconciling the DB to it.
+
+        #1519: ``Worktree.branch`` is minted as ``<N>-ticket`` and the agent
+        renames the real git branch to ``<N>-<type>-<desc>``. Ship must push
+        what exists, so read ``git rev-parse --abbrev-ref HEAD`` in the
+        worktree dir and adopt it — but only when it is a real branch that
+        belongs to this ticket. A detached ``HEAD`` or an unrelated branch
+        (not prefixed ``<ticket_id>-``) falls back to the recorded branch
+        and logs a WARNING, never silently pushing an unrelated ref.
+
+        On a genuine drift the recorded ``Worktree.branch`` (and the
+        ticket-level ``extra['branch']`` when it matched the old name) are
+        updated to the current branch so every later reader — the merge
+        path, ``_recorded_url_for_branch``, the provisioner — sees the same
+        branch. Reconciling BEFORE the recorded-url lookup keeps the #1522
+        idempotency intact: a redelivered job resolves the same current
+        branch and finds the url recorded under it.
+        """
+        recorded = worktree.branch
+        current = git.current_branch(repo=repo_path)
+        prefix = f"{ticket.ticket_number}-"
+        if not current or current == "HEAD" or not current.startswith(prefix):
+            if current and current != recorded:
+                logger.warning(
+                    "Ship branch resolution for ticket %s: worktree at %s is on %r "
+                    "(detached or not prefixed %r) — falling back to recorded branch %r",
+                    ticket.ticket_number,
+                    repo_path,
+                    current,
+                    prefix,
+                    recorded,
+                )
+            return recorded
+        if current != recorded:
+            logger.info(
+                "Ship reconciling ticket %s worktree branch %r → %r (renamed in the worktree)",
+                ticket.ticket_number,
+                recorded,
+                current,
+            )
+            worktree.branch = current
+            worktree.save(update_fields=["branch"])
+            extra = ticket.extra or {}
+            if extra.get("branch") == recorded:
+                ticket.merge_extra(set_keys={"branch": current})
+        return current
 
     def _open_pr_and_record(
         self,

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -5,7 +5,10 @@ the heavy I/O (push, MR creation) onto a ``@task`` worker. The worker runs
 ``ShipExecutor`` and on success advances ``SHIPPED → IN_REVIEW``.
 """
 
+import shutil
+import subprocess
 from collections.abc import Iterator
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,6 +29,12 @@ def _clear_overlay_cache() -> Iterator[None]:
 
 
 _MOCK_OVERLAY = {"test": CommandOverlay()}
+
+_GIT = shutil.which("git") or "git"
+
+
+def _run_git(*args: str, cwd: Path) -> None:
+    subprocess.run([_GIT, "-C", str(cwd), *args], check=True, capture_output=True)
 
 
 class TestShipExecutor(TestCase):
@@ -474,6 +483,184 @@ class TestShipMultiWorkstreamStaleUrlGuard(TestCase):
 
         ticket.refresh_from_db()
         assert ticket.extra["pr_url_by_branch"]["s-1263-pr-b-current"] == "https://example.com/pr/b-new"
+
+
+class TestShipReconcilesWorktreeBranch(TestCase):
+    """#1519: ship pushes the worktree's ACTUAL git branch and reconciles the DB.
+
+    ``workspace ticket <N>`` mints ``Worktree.branch`` as ``<N>-ticket``;
+    the agent renames the git branch in the worktree to the
+    ``<N>-<type>-<desc>`` convention. ``ShipExecutor`` pushed the
+    DB-recorded (stale) ref and left the worktree↔branch DB mapping
+    desynced. The fix resolves the current git branch, pushes that, and
+    reconciles ``Worktree.branch`` (and ``Ticket.extra['branch']``) — but
+    only for a real branch that belongs to this ticket; a detached HEAD or
+    an unrelated branch falls back to the recorded branch.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _tmp_repo(self, tmp_path: Path) -> None:
+        self.repo = tmp_path / "repo"
+        self.repo.mkdir()
+        _run_git("init", "-q", "-b", "main", cwd=self.repo)
+        _run_git("config", "user.email", "t@t", cwd=self.repo)
+        _run_git("config", "user.name", "t", cwd=self.repo)
+        _run_git("commit", "--allow-empty", "-q", "-m", "initial", cwd=self.repo)
+
+    def _checkout(self, branch: str) -> None:
+        (self.repo / "f.txt").write_text(branch, encoding="utf-8")
+        _run_git("checkout", "-q", "-b", branch, cwd=self.repo)
+        _run_git("add", "f.txt", cwd=self.repo)
+        _run_git("commit", "-q", "-m", f"work on {branch}", cwd=self.repo)
+
+    def _ticket(self, *, recorded_branch: str, extra: dict | None = None) -> Ticket:
+        merged = {"branch": recorded_branch, **(extra or {})}
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://github.com/souliane/teatree/issues/1519",
+            extra=merged,
+        )
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path=str(self.repo),
+            branch=recorded_branch,
+            extra={"worktree_path": str(self.repo)},
+        )
+        return ticket
+
+    def _host(self) -> MagicMock:
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://example.com/pr/1519"}
+        host.current_user.return_value = "souliane"
+        return host
+
+    def test_pushes_actual_branch_and_reconciles_db_on_drift(self) -> None:
+        self._checkout("1519-fix-foo")
+        ticket = self._ticket(recorded_branch="1519-ticket")
+        host = self._host()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+            patch("teatree.core.runners.ship.branch_behind_target", return_value=None),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is True
+        # (a) pushes the REAL branch, not the stale recorded one.
+        push.assert_called_once_with(repo=str(self.repo), remote="origin", branch="1519-fix-foo")
+        (spec,) = host.create_pr.call_args.args
+        assert spec.branch == "1519-fix-foo"
+        # (b) the DB rows are reconciled to the current branch.
+        ticket.refresh_from_db()
+        assert ticket.worktrees.get().branch == "1519-fix-foo"
+        assert ticket.extra["branch"] == "1519-fix-foo"
+
+    def test_no_drift_leaves_db_unchanged(self) -> None:
+        self._checkout("1519-fix-foo")
+        ticket = self._ticket(recorded_branch="1519-fix-foo")
+        host = self._host()
+        worktree = ticket.worktrees.get()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+            patch("teatree.core.runners.ship.branch_behind_target", return_value=None),
+            patch.object(Worktree, "save", autospec=True) as wt_save,
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is True
+        push.assert_called_once_with(repo=str(self.repo), remote="origin", branch="1519-fix-foo")
+        # No spurious reconcile write when the names already agree.
+        wt_save.assert_not_called()
+        worktree.refresh_from_db()
+        assert worktree.branch == "1519-fix-foo"
+
+    def test_detached_head_falls_back_to_recorded_branch(self) -> None:
+        self._checkout("1519-fix-foo")
+        sha = subprocess.run(
+            [_GIT, "-C", str(self.repo), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        _run_git("checkout", "-q", sha, cwd=self.repo)  # detached HEAD
+        ticket = self._ticket(recorded_branch="1519-ticket")
+        host = self._host()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+            patch("teatree.core.runners.ship.branch_behind_target", return_value=None),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is True
+        # Falls back to the recorded branch — never pushes the bare SHA / HEAD.
+        push.assert_called_once_with(repo=str(self.repo), remote="origin", branch="1519-ticket")
+        ticket.refresh_from_db()
+        assert ticket.worktrees.get().branch == "1519-ticket"
+
+    def test_unrelated_branch_falls_back_and_is_not_pushed(self) -> None:
+        self._checkout("9999-someone-elses-branch")  # not prefixed 1519-
+        ticket = self._ticket(recorded_branch="1519-ticket")
+        host = self._host()
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push") as push,
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+            patch("teatree.core.runners.ship.branch_behind_target", return_value=None),
+        ):
+            result = ShipExecutor(ticket).run()
+
+        assert result.ok is True
+        push.assert_called_once_with(repo=str(self.repo), remote="origin", branch="1519-ticket")
+        (spec,) = host.create_pr.call_args.args
+        assert spec.branch == "1519-ticket"
+        ticket.refresh_from_db()
+        assert ticket.worktrees.get().branch == "1519-ticket"
+
+    def test_redelivery_adopts_recorded_url_after_reconcile(self) -> None:
+        """#1522 idempotency holds: a second run adopts the recorded PR url.
+
+        The first run reconciles the branch and records the url under the
+        ACTUAL branch; the redelivered job resolves the same branch and
+        short-circuits on the recorded url instead of re-creating the PR.
+        """
+        self._checkout("1519-fix-foo")
+        ticket = self._ticket(recorded_branch="1519-ticket")
+        host = self._host()
+
+        patches = (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push"),
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+            patch("teatree.core.runners.ship.branch_behind_target", return_value=None),
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            first = ShipExecutor(ticket).run()
+        assert first.ok is True
+        assert host.create_pr.call_count == 1
+
+        ticket.refresh_from_db()
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            second = ShipExecutor(ticket).run()
+
+        assert second.ok is True
+        assert second.detail == "https://example.com/pr/1519"
+        # No second PR — the recorded url for the reconciled branch is adopted.
+        assert host.create_pr.call_count == 1
 
 
 class TestSanitizeCloseKeywords:


### PR DESCRIPTION
## Root cause

`workspace ticket <N>` mints the worktree branch as a generic `<N>-ticket`.
Agents then rename the git branch to the `<N>-<type>-<desc>` convention, but
`ShipExecutor` (behind `execute_ship`) pushed the **DB-recorded**
`Worktree.branch` — still `<N>-ticket`. It pushed (or failed to push) a stale
ref, and the worktree↔branch DB mapping desynced. Hit by 6 independent
fix-agent runs in one session — systematic, not a one-off.

## The fix (option 2 + reconcile)

`ShipExecutor.run` now resolves the worktree's **actual** current git branch
via the existing `teatree.utils.git.current_branch` helper
(`git rev-parse --abbrev-ref HEAD` in the worktree dir):

- **Guard.** Adopt the current branch only when it is a real branch (not
  detached `HEAD`) AND belongs to this ticket (prefixed `<N>-`). A detached
  `HEAD` or an unrelated branch falls back to the DB-recorded `Worktree.branch`
  and logs a `WARNING` — it never silently pushes an unrelated ref.
- **Push** the resolved (guarded) branch — what actually exists in the worktree.
- **Reconcile** the DB on drift: update `Worktree.branch` and, when it matched
  the old name, `Ticket.extra['branch']` to the current branch through the
  locked `merge_extra` primitive, so the merge path, `_recorded_url_for_branch`,
  and the provisioner all read the same branch.

The reconcile-then-look-up ordering preserves the
[#1522](https://github.com/souliane/teatree/issues/1522) /
[#1524](https://github.com/souliane/teatree/issues/1524) idempotency: a
redelivered job resolves the same current branch and adopts the url recorded
under it (`_recorded_url_for_branch`) instead of re-creating the PR.

## Deliberately out of scope

Upfront-minting a convention name from the issue title at `workspace ticket`
creation (option 1) is a separate design decision and is **not** built here.

## Test evidence

Real `git` under `tmp_path`, mocking only the forge `create_pr`. New
`TestShipReconcilesWorktreeBranch` covers: drift → pushes the real branch +
reconciles the DB rows (RED on current code); no-drift → no spurious DB write;
detached `HEAD` and unrelated branch → fall back, do not push the wrong ref;
redelivery → adopts the recorded PR url, no re-create.

```
$ uv run pytest --no-cov -q tests/teatree_core/test_runners_ship.py
============================== 55 passed in 1.95s ==============================
$ uv run ruff check src/ tests/
All checks passed!
```

Closes [#1519](https://github.com/souliane/teatree/issues/1519)
