### PR TITLE
fix(hooks): orchestrator-boundary anchor catches uvx/wrapper-prefixed pytest

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -2286,15 +2286,21 @@ _ORCHESTRATION_TOOLS = {
 # x-pytest`` / ``uv add pytest-django`` (#1178 cold-review false-deny).
 # So anchor it to a command head: start-of-string OR a shell separator
 # (``;`` ``&&`` ``||`` ``|`` newline ``(`` ``{``), then optional env-var
-# assignments and an optional Python runner prefix (``uv/uvx/poetry/pdm/
-# hatch run`` or ``python[3] -m``), then ``pytest`` NOT followed by a word
-# char or hyphen. The separator branch keeps the shell-grammar bypass
-# guard intact (``git status && pytest`` still denies).
+# assignments, optional (possibly-stacked) command-wrapper prefixes
+# (``command``/``exec``/``time``/``nice``), and an optional Python runner
+# prefix — note ``uvx`` runs a tool DIRECTLY with no ``run`` (``uvx
+# pytest``), while ``uv``/``poetry``/``pdm``/``hatch`` DO need ``run``, and
+# ``python[3] -m`` — then ``pytest`` NOT followed by a word char or hyphen.
+# The separator branch keeps the shell-grammar bypass guard intact (``git
+# status && pytest`` still denies); the trailing ``(?![\w-])`` keeps the
+# match pinned to ``pytest`` so wrapper prefixes never widen to other tools
+# (``uvx ruff`` / ``command ls`` stay ALLOWED).
 _PYTEST_VERB_RE = (
     r"(?:^|[;&|\n(){}])"
     r"\s*"
     r"(?:\w+=\S+\s+)*"
-    r"(?:(?:uv|uvx|poetry|pdm|hatch)\s+run\s+|python3?\s+-m\s+)?"
+    r"(?:(?:command|exec|time|nice)\s+)*"
+    r"(?:uvx\s+|(?:uv|poetry|pdm|hatch)\s+run\s+|python3?\s+-m\s+)?"
     r"pytest(?![\w-])"
 )
 
@@ -2436,7 +2442,9 @@ def _deny_heavy_main_agent_bash(data: dict) -> bool:
     tool_input = data.get("tool_input", {})
     if tool_input.get("run_in_background") is True:
         return False
-    command = tool_input.get("command", "")
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return False
     if _FG_OK_RE.search(command) or not _ORCHESTRATOR_HEAVY_BASH_RE.search(command):
         return False
     return emit_pretooluse_deny(

--- a/tests/test_orchestrator_boundary_hook.py
+++ b/tests/test_orchestrator_boundary_hook.py
@@ -225,6 +225,84 @@ class TestPytestSubstringFalseDenyFixed:
         assert handle_enforce_orchestrator_boundary(_main_agent_bash(command)) is True
 
 
+class TestPytestUvxAndWrapperPrefixesAnchored:
+    r"""``uvx pytest`` and wrapper-prefixed ``pytest`` are now anchored (#1576).
+
+    The runner-prefix group previously required ``run`` after EVERY runner,
+    so ``uvx pytest`` (uvx takes no ``run``) slipped to the foreground; and
+    common command wrappers (``command``/``exec``/``time``/``nice``) were
+    absent, so ``command pytest`` etc. also slipped. Both are folded into
+    the verb anchor in the safe deny-more direction. The trailing
+    ``pytest(?![\\w-])`` keeps the match pinned to ``pytest`` — wrapper
+    prefixes never widen to other tools.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "uvx pytest",
+            "uvx pytest tests/",
+            "command pytest",
+            "exec pytest",
+            "time pytest",
+            "nice pytest",
+            "command exec time nice pytest",
+            "time uvx pytest",
+            "pdm run pytest",
+            "hatch run pytest",
+        ],
+    )
+    def test_uvx_and_wrapper_prefixed_pytest_now_denied(self, command: str) -> None:
+        assert handle_enforce_orchestrator_boundary(_main_agent_bash(command)) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "uvx ruff",
+            "uvx ruff check",
+            "command ls",
+            "exec ls -la",
+            "time git status",
+            "nice cat README.md",
+        ],
+    )
+    def test_wrapper_prefixes_do_not_widen_beyond_pytest(self, command: str) -> None:
+        assert handle_enforce_orchestrator_boundary(_main_agent_bash(command)) is False
+
+    def test_uvx_pytest_fg_ok_escape_still_works(self) -> None:
+        assert handle_enforce_orchestrator_boundary(_main_agent_bash("uvx pytest [fg-ok: targeted run]")) is False
+
+    def test_uvx_pytest_run_in_background_still_allowed(self) -> None:
+        assert handle_enforce_orchestrator_boundary(_main_agent_bash("uvx pytest", run_in_background=True)) is False
+
+    @pytest.mark.parametrize("command", ["pytest_helper.py", "pytest-django setup", "x-pytest"])
+    def test_pytest_followed_by_word_or_hyphen_not_denied(self, command: str) -> None:
+        assert handle_enforce_orchestrator_boundary(_main_agent_bash(command)) is False
+
+
+class TestHandlerCrashProofOnMissingOrNonStrCommand:
+    """The handler self-guards a missing / ``None`` / non-``str`` command (#1576).
+
+    The router's per-handler try/except already makes a ``TypeError`` net
+    fail-open, but the handler's docstring implies it is self-crash-proof.
+    The in-function ``isinstance`` guard returns the clean allow value
+    (no match) WITHOUT relying on the outer catch — no ``TypeError``.
+    """
+
+    @pytest.mark.parametrize(
+        "tool_input",
+        [
+            {"command": None},
+            {},
+            {"command": 123},
+            {"command": ["pytest"]},
+        ],
+    )
+    def test_non_str_or_missing_command_fails_open(self, tool_input: dict) -> None:
+        data = {"tool_name": "Bash", "tool_input": tool_input}
+        assert handle_enforce_orchestrator_boundary(data) is False
+
+
 class TestMarginalSlowPatternsAdded:
     """The #1178-additive shapes the gate previously lacked are now denied.
 


### PR DESCRIPTION
Two small fail-safe-direction nits from [PR #1574](https://github.com/souliane/teatree/pull/1574)'s cold-review on the orchestrator-boundary / slow-bash gate. Both ADD matches in the safe (deny-more) direction or make the handler self-crash-proof — no existing behavior widens unsafely.

## Fix 1 — `_PYTEST_VERB_RE` prefix gaps (`hooks/scripts/hook_router.py`)

The optional runner-prefix group required `run` after EVERY runner, but `uvx <tool>` runs a tool directly with NO `run`, so `uvx pytest` was not anchored and ALLOWed (slipped to foreground). It also missed common command-wrapper prefixes (`command`/`exec`/`time`/`nice`), so `command pytest` / `exec pytest` / `time pytest` / `nice pytest` ALLOWed.

The fix splits `uvx` out (no `run`) from `uv`/`poetry`/`pdm`/`hatch` (which do need `run`), keeps `python[3] -m`, and adds an optional, possibly-stacked wrapper-prefix group before the runner. The trailing `pytest(?![\w-])` anchor, the leading separator boundary, and the env-assignment group are all unchanged, so the match stays pinned to `pytest` (`uvx ruff` / `command ls` stay ALLOWed) and the `git status && pytest` separator-bypass guard still DENIES.

## Fix 2 — in-function None/non-str guard

`_deny_heavy_main_agent_bash` (the `_ORCHESTRATOR_HEAVY_BASH_RE` handler) raised `TypeError` on `tool_input={"command": None}`. Net behavior was already fail-open via the router's per-handler try/except, but the docstring implies the handler is self-crash-proof. Added an in-function `isinstance` guard that returns the clean allow value WITHOUT relying on the outer catch. No other behavior changed.

## Test evidence

Extended `tests/test_orchestrator_boundary_hook.py` (RED→GREEN: `uvx`/wrapper-prefixed `pytest` ALLOWed pre-fix). New coverage: `uvx`/`command`/`exec`/`time`/`nice`/stacked-wrapper/`pdm run`/`hatch run` pytest now DENY; `uvx ruff` / `command ls` / `pytest_helper.py` / `pytest-django` stay ALLOW; `uvx pytest [fg-ok:]` and `run_in_background` escapes still work; `command=None`/missing/non-str fail open with no `TypeError`. All existing orchestrator-boundary tests stay green.

```
============================= 140 passed in 0.50s ==============================
```

```
$ uv run ruff check hooks/scripts/hook_router.py tests/test_orchestrator_boundary_hook.py
All checks passed!
$ uv run ruff format --check ...
2 files already formatted
```

Closes [#1576](https://github.com/souliane/teatree/issues/1576)
