### PR TITLE
fix(hooks): raw-review-POST gate treats explicit -X GET as a read

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -4798,26 +4798,23 @@ def handle_block_out_of_band_merge(data: dict) -> bool:
 # endpoint is denied; plain GET reads pass through.
 #
 # Conservative by construction: it matches ONLY the review-comment endpoints
-# (discussions / notes / comments) AND only when a write is present (an HTTP
-# method override of POST/PUT/PATCH, or a request-body flag the forge CLIs
-# use to carry a payload — ``-f``/``--field``/``-F``/``--raw-field``/
-# ``--input``/``-d``/``--data``). An EXPLICIT ``-X GET``/``--method GET`` is
-# always a read regardless of any body/query flag: the forge sends ``-f`` as a
-# query parameter on a forced GET, never a body write, so an explicit GET truly
-# cannot create a comment (#1568). A bare read (``glab api .../discussions``)
-# and any non-review endpoint pass through untouched. Fails OPEN on an
-# internal parse error — a gate bug must never wedge the fleet.
+# (discussions / notes / comments) and classifies the command by its EFFECTIVE
+# HTTP method — the one gh (2.87.3) / glab (1.80.4) actually send. Both CLIs
+# resolve repeated ``-X``/``--method`` flags LAST-WINS (empirically verified:
+# ``-X GET -X POST`` POSTs, ``--method GET --method PATCH`` PATCHes), and when
+# NO method flag is given they default to POST if a request-body/field flag is
+# present, else GET. A command is a READ iff its effective method is GET —
+# only then does the forge send ``-f`` as a query parameter rather than a body
+# write, so a comment cannot be created (#1568). Every other effective method
+# (POST/PUT/PATCH/DELETE/…) is a write. A bare read (``glab api
+# .../discussions``) and any non-review endpoint pass through untouched. Fails
+# OPEN on an internal parse error — a gate bug must never wedge the fleet.
 
 _REVIEW_POST_ENDPOINT_RE = re.compile(
     r"(?:merge_requests|pulls|issues)/\d+/(?:discussions|notes|comments)\b",
 )
-_REVIEW_POST_METHOD_WRITE_RE = re.compile(
-    r"(?:-X|--method)[\s=]+['\"]?(?:POST|PUT|PATCH)\b",
-    re.IGNORECASE,
-)
-_REVIEW_POST_METHOD_READ_RE = re.compile(
-    r"(?:-X|--method)[\s=]+['\"]?GET\b",
-    re.IGNORECASE,
+_REVIEW_POST_METHOD_RE = re.compile(
+    r"(?:-X|--method)[\s=]+['\"]?([A-Za-z]+)\b",
 )
 _REVIEW_POST_BODY_FLAG_RE = re.compile(
     r"(?:^|\s)(?:-f|--field|-F|--raw-field|--input|-d|--data)\b",
@@ -4836,19 +4833,25 @@ def _is_raw_review_write(command: str) -> bool:
     """Whether *command* is a raw forge REST WRITE to a review-comment endpoint.
 
     True only when the command targets a ``.../discussions``, ``.../notes``,
-    or ``.../comments`` endpoint AND carries a write signal (a POST/PUT/PATCH
-    method override or a request-body flag). An explicit ``-X GET``/
-    ``--method GET`` is always classified read — a forced GET sends body flags
-    as query params and cannot create a comment (#1568). A plain GET read
-    returns False.
+    or ``.../comments`` endpoint AND its EFFECTIVE HTTP method is not GET. The
+    effective method models gh/glab semantics: the LAST ``-X``/``--method``
+    value wins (so ``-X GET -X POST`` is a POST write, ``-X POST -X GET`` is a
+    GET read); with no method flag the forge defaults to POST when a body/field
+    flag is present, else GET. A forced GET sends body flags as query params
+    and cannot create a comment, so it is the only read (#1568).
     """
     if "glab api" not in command and "gh api" not in command:
         return False
     if not _REVIEW_POST_ENDPOINT_RE.search(command):
         return False
-    if _REVIEW_POST_METHOD_READ_RE.search(command):
-        return False
-    return bool(_REVIEW_POST_METHOD_WRITE_RE.search(command) or _REVIEW_POST_BODY_FLAG_RE.search(command))
+    methods = [m.upper() for m in _REVIEW_POST_METHOD_RE.findall(command)]
+    if methods:
+        is_read = methods[-1] == "GET"
+    elif _REVIEW_POST_BODY_FLAG_RE.search(command):
+        is_read = False
+    else:
+        is_read = True
+    return not is_read
 
 
 def handle_block_raw_review_post(data: dict) -> bool:
@@ -4856,10 +4859,11 @@ def handle_block_raw_review_post(data: dict) -> bool:
 
     Forces the sanctioned ``t3 <overlay> review post-comment`` /
     ``post-draft-note`` path (draft-default + dedup + on-behalf approval),
-    which a direct REST POST skips. Conservative: only clear review-write
-    POSTs are denied — bare reads, explicit ``-X GET``/``--method GET`` reads,
-    and non-review endpoints pass through. Returns True when a deny was emitted
-    (caller stops the handler chain).
+    which a direct REST write skips. Conservative: a command is denied only
+    when its effective HTTP method (last ``-X``/``--method`` wins; default POST
+    when a body flag is present) is not GET. Reads — bare, explicit-GET, or
+    write-then-GET — and non-review endpoints pass through. Returns True when a
+    deny was emitted (caller stops the handler chain).
     """
     if data.get("tool_name") != "Bash":
         return False

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -4801,7 +4801,10 @@ def handle_block_out_of_band_merge(data: dict) -> bool:
 # (discussions / notes / comments) AND only when a write is present (an HTTP
 # method override of POST/PUT/PATCH, or a request-body flag the forge CLIs
 # use to carry a payload — ``-f``/``--field``/``-F``/``--raw-field``/
-# ``--input``/``-d``/``--data``). A bare read (``glab api .../discussions``)
+# ``--input``/``-d``/``--data``). An EXPLICIT ``-X GET``/``--method GET`` is
+# always a read regardless of any body/query flag: the forge sends ``-f`` as a
+# query parameter on a forced GET, never a body write, so an explicit GET truly
+# cannot create a comment (#1568). A bare read (``glab api .../discussions``)
 # and any non-review endpoint pass through untouched. Fails OPEN on an
 # internal parse error — a gate bug must never wedge the fleet.
 
@@ -4810,6 +4813,10 @@ _REVIEW_POST_ENDPOINT_RE = re.compile(
 )
 _REVIEW_POST_METHOD_WRITE_RE = re.compile(
     r"(?:-X|--method)[\s=]+['\"]?(?:POST|PUT|PATCH)\b",
+    re.IGNORECASE,
+)
+_REVIEW_POST_METHOD_READ_RE = re.compile(
+    r"(?:-X|--method)[\s=]+['\"]?GET\b",
     re.IGNORECASE,
 )
 _REVIEW_POST_BODY_FLAG_RE = re.compile(
@@ -4830,11 +4837,16 @@ def _is_raw_review_write(command: str) -> bool:
 
     True only when the command targets a ``.../discussions``, ``.../notes``,
     or ``.../comments`` endpoint AND carries a write signal (a POST/PUT/PATCH
-    method override or a request-body flag). A plain GET read returns False.
+    method override or a request-body flag). An explicit ``-X GET``/
+    ``--method GET`` is always classified read — a forced GET sends body flags
+    as query params and cannot create a comment (#1568). A plain GET read
+    returns False.
     """
     if "glab api" not in command and "gh api" not in command:
         return False
     if not _REVIEW_POST_ENDPOINT_RE.search(command):
+        return False
+    if _REVIEW_POST_METHOD_READ_RE.search(command):
         return False
     return bool(_REVIEW_POST_METHOD_WRITE_RE.search(command) or _REVIEW_POST_BODY_FLAG_RE.search(command))
 
@@ -4845,8 +4857,9 @@ def handle_block_raw_review_post(data: dict) -> bool:
     Forces the sanctioned ``t3 <overlay> review post-comment`` /
     ``post-draft-note`` path (draft-default + dedup + on-behalf approval),
     which a direct REST POST skips. Conservative: only clear review-write
-    POSTs are denied — bare reads and non-review endpoints pass through.
-    Returns True when a deny was emitted (caller stops the handler chain).
+    POSTs are denied — bare reads, explicit ``-X GET``/``--method GET`` reads,
+    and non-review endpoints pass through. Returns True when a deny was emitted
+    (caller stops the handler chain).
     """
     if data.get("tool_name") != "Bash":
         return False

--- a/tests/test_hook_router_raw_review_post.py
+++ b/tests/test_hook_router_raw_review_post.py
@@ -45,6 +45,11 @@ class TestDeniesRawReviewWrites:
             "gh api repos/o/r/pulls/12/comments -f body='please fix'",
             "gh api repos/o/r/issues/12/comments --method POST -f body=x",
             "gh api repos/o/r/pulls/12/comments -X POST --raw-field body=@note.txt",
+            # Body flag with NO explicit method — still a write (#1568).
+            "glab api projects/42/merge_requests/7/discussions -f body=hi",
+            # Explicit non-GET write methods stay writes even with a body flag.
+            "glab api projects/42/merge_requests/7/comments --method PATCH -f body=x",
+            "glab api projects/42/merge_requests/7/notes -X PUT -f body=x",
         ],
     )
     def test_raw_review_write_is_denied(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
@@ -76,6 +81,12 @@ class TestAllowsReadsAndUnrelated:
             "glab api projects/42/merge_requests/7/discussions",
             "glab api projects/42/merge_requests/7/notes --paginate",
             "gh api repos/o/r/pulls/12/comments",
+            # Explicit GET read with a body flag carrying a query param (#1568):
+            # `-X GET`/`--method GET` forces a GET, so `-f` is a query param,
+            # never a body write — must NOT be denied.
+            "glab api projects/42/merge_requests/7/discussions -X GET -f sort=asc",
+            "glab api projects/42/merge_requests/7/discussions --method GET -f sort=asc",
+            "gh api repos/o/r/pulls/12/notes --method=GET -f per_page=100",
             # Non-review forge reads/writes.
             "glab api projects/42/merge_requests/7",
             "glab api projects/42/merge_requests/7/approvals -X POST",

--- a/tests/test_hook_router_raw_review_post.py
+++ b/tests/test_hook_router_raw_review_post.py
@@ -45,11 +45,18 @@ class TestDeniesRawReviewWrites:
             "gh api repos/o/r/pulls/12/comments -f body='please fix'",
             "gh api repos/o/r/issues/12/comments --method POST -f body=x",
             "gh api repos/o/r/pulls/12/comments -X POST --raw-field body=@note.txt",
-            # Body flag with NO explicit method — still a write (#1568).
+            # Body flag with NO explicit method — gh/glab default to POST (#1568).
             "glab api projects/42/merge_requests/7/discussions -f body=hi",
             # Explicit non-GET write methods stay writes even with a body flag.
             "glab api projects/42/merge_requests/7/comments --method PATCH -f body=x",
             "glab api projects/42/merge_requests/7/notes -X PUT -f body=x",
+            # Repeated method flags resolve LAST-WINS in gh (2.87.3) / glab
+            # (1.80.4): a GET token followed by a write method is a genuine
+            # write, not a read — the bypass the cold-review flagged (#1568).
+            "gh api repos/o/r/pulls/12/comments -X GET -X POST -f body=hi",
+            "glab api projects/42/merge_requests/7/discussions --method=GET --method PATCH -f body=x",
+            # DELETE is a write — an effective GET is the ONLY read.
+            "glab api projects/42/merge_requests/7/notes -X DELETE -f x",
         ],
     )
     def test_raw_review_write_is_denied(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
@@ -87,6 +94,9 @@ class TestAllowsReadsAndUnrelated:
             "glab api projects/42/merge_requests/7/discussions -X GET -f sort=asc",
             "glab api projects/42/merge_requests/7/discussions --method GET -f sort=asc",
             "gh api repos/o/r/pulls/12/notes --method=GET -f per_page=100",
+            # Repeated method flags, GET LAST — effective method is GET, so a
+            # write-then-GET command is a read (last-wins, no false-deny).
+            "gh api repos/o/r/pulls/12/comments -X POST -X GET",
             # Non-review forge reads/writes.
             "glab api projects/42/merge_requests/7",
             "glab api projects/42/merge_requests/7/approvals -X POST",


### PR DESCRIPTION
## Edge

`_is_raw_review_write` (`hooks/scripts/hook_router.py`) treated ANY request-body flag (`-f`/`--field`/`-F`/`--raw-field`/`--input`/`-d`/`--data`) as a write. So an explicit READ like `glab api .../discussions -X GET -f sort=asc` or `gh api .../notes --method GET -f per_page=100` was wrongly DENIED — even though `-X GET` forces a GET (the forge sends `-f` as a query param on a GET, never a body write). Real-world risk is negligible (reads idiomatically use `-X GET`/`--paginate`/path query, not body flags), but the discrimination should be provably sound.

## Fix

Fail-safe direction — flips to read ONLY on an EXPLICIT GET:

- New `_REVIEW_POST_METHOD_READ_RE` mirroring the existing write-method regex, matching `-X GET`/`--method GET` (case-insensitive).
- In `_is_raw_review_write`, after the endpoint check and before the write check, short-circuit `return False` when an explicit GET is present. An explicit `-X GET` truly cannot create a comment, so this cannot be a bypass.
- The existing `return bool(METHOD_WRITE or BODY_FLAG)` is unchanged: a command with NO explicit GET and a body flag (`-f body=...`) is STILL a write (denied); `-X POST/PUT/PATCH` is STILL a write.
- Docstrings + the module comment block now note that an explicit `-X GET`/`--method GET` is always classified read.

## Test evidence

RED before the fix: `glab api .../discussions -X GET -f sort=asc` was denied (observed failing). GREEN after. New cases cover `--method GET`, `--method=GET`, and the negative-space regressions (`-f body=hi` with no explicit GET, `-X POST`, `--method PATCH`, `-X PUT` all still denied).

```
$ uv run pytest --no-cov -q tests/test_hook_router_raw_review_post.py
============================== 27 passed in 0.28s ==============================
$ uv run ruff check hooks/scripts/hook_router.py tests/test_hook_router_raw_review_post.py
All checks passed!
$ uv run ruff format --check hooks/scripts/hook_router.py tests/test_hook_router_raw_review_post.py
2 files already formatted
```

Follow-up to the raw-review-POST deny gate ([PR #1566](https://github.com/souliane/teatree/pull/1566) / [issue #1164](https://github.com/souliane/teatree/issues/1164)).

Closes [#1568](https://github.com/souliane/teatree/issues/1568)
