### PR TITLE
fix(loop): isolate per-PR failures in GitLabApprovalsScanner

### DIFF
--- a/src/teatree/loop/scanners/gitlab_approvals.py
+++ b/src/teatree/loop/scanners/gitlab_approvals.py
@@ -3,9 +3,9 @@
 The webhook path (``IncomingEventsScanner`` + ``SCHEDULE_MERGE``) already
 drives the sanctioned auto-merge keystone when GitLab fires an
 ``approved`` webhook to ``/hooks/gitlab/``. That path is blocked for
-Slack Connect workspaces (the OperCodeReviewBot ``#the-review-crew``
-channel is Connect-only, the bot cannot join), and other deployments
-have not enabled the GitLab webhook at all. This scanner is the
+Slack Connect workspaces where the bot cannot join the overlay's
+review channel, and other deployments that have not enabled the GitLab
+webhook at all. This scanner is the
 poll-driven complement: every tick it walks the active user's open MRs,
 asks GitLab for the approval state, and — when the merge guard says yes
 — emits the same ``incoming_event.merge_*`` signal the dispatcher
@@ -68,7 +68,16 @@ class GitLabApprovalsScanner:
             return []
         signals: list[ScanSignal] = []
         for pr in self._collect_unique_prs(authors):
-            signal = self._scan_one(pr)
+            try:
+                signal = self._scan_one(pr)
+            except ScannerError:
+                raise  # auth/network escalation — must surface to the dispatcher
+            except Exception:
+                logger.exception(
+                    "GitLabApprovalsScanner: _scan_one failed for %s",
+                    _str_field(pr, "web_url", "html_url"),
+                )
+                continue
             if signal is not None:
                 signals.append(signal)
         return signals

--- a/tests/teatree_loop/test_gitlab_approvals_scanner.py
+++ b/tests/teatree_loop/test_gitlab_approvals_scanner.py
@@ -11,12 +11,14 @@ from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import patch
 
+import pytest
 from django.test import TestCase
 
 import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.backends.protocols import ApprovalState, ReviewState
 from teatree.core.merge_guard import MergeGuard
 from teatree.core.models import Ticket
+from teatree.loop.scanners.base import ScannerError, ScannerErrorClass
 from teatree.loop.scanners.gitlab_approvals import GitLabApprovalsScanner
 from teatree.types import RawAPIDict
 
@@ -413,6 +415,80 @@ class TestGitLabApprovalsScanner(TestCase):
         signals = scanner.scan()
 
         assert len(signals) == 1
+
+
+class TestPerPrIsolation(TestCase):
+    """Regression tests for per-PR exception isolation (#1592)."""
+
+    def test_sibling_pr_still_emits_when_first_raises_value_error(self) -> None:
+        """overlay.can_auto_merge raising for the first PR must not suppress the second.
+
+        Before the fix, the ValueError propagated out of scan(), returning zero
+        signals. After the fix, the first PR failure is logged and skipped; the
+        second PR emits its signal normally.
+        """
+        host = FakeCodeHost(
+            my_prs=[
+                _gitlab_mr(iid=201, sha="bad-mr", project="acme/backend"),
+                _gitlab_mr(iid=202, sha="good-mr", project="acme/backend"),
+            ],
+            approvals={
+                ("acme/backend", 201): ApprovalState(
+                    approvals_left=0,
+                    approved_by=["bob"],
+                    unresolved_resolvable=0,
+                ),
+                ("acme/backend", 202): ApprovalState(
+                    approvals_left=0,
+                    approved_by=["bob"],
+                    unresolved_resolvable=0,
+                ),
+            },
+        )
+
+        call_count = 0
+
+        class _RaisingFirstOverlay:
+            """Raises ValueError for the first MR, allows the second."""
+
+            def can_auto_merge(self, *, target_ref: str, thread_ref: str) -> MergeGuard:
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    msg = "description does not match canonical format"
+                    raise ValueError(msg)
+                return MergeGuard(allowed=True, reason="", escalate=False)
+
+        scanner = GitLabApprovalsScanner(host=host)
+        with patch.object(overlay_loader_mod, "get_overlay", return_value=_RaisingFirstOverlay()):
+            signals = scanner.scan()
+
+        assert len(signals) == 1
+        assert signals[0].kind == "incoming_event.merge_needed"
+        assert "merge_requests/202" in signals[0].payload["thread_ref"]
+
+    def test_scanner_error_from_scan_one_propagates(self) -> None:
+        """A ScannerError (auth/network) raised by _scan_one must escape scan().
+
+        ScannerError is the structured escalation path — the dispatcher must
+        see it to DM the user. The per-PR isolation must re-raise it.
+        """
+
+        class _ScannerErrorHost(FakeCodeHost):
+            def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState:
+                raise ScannerError(
+                    scanner="gitlab_approvals",
+                    error_class=ScannerErrorClass.AUTH,
+                    detail="401 Unauthorized",
+                )
+
+        host = _ScannerErrorHost(
+            my_prs=[_gitlab_mr(iid=203, sha="auth-fail")],
+        )
+        scanner = GitLabApprovalsScanner(host=host)
+
+        with pytest.raises(ScannerError):
+            scanner.scan()
 
 
 class TestHelperFunctions(TestCase):


### PR DESCRIPTION
## Problem

In `GitLabApprovalsScanner.scan()`, any exception from `_scan_one()` — in
particular a `ValueError` raised by `OverlayBase.can_auto_merge()` when an MR
description does not match the overlay's expected format — propagated out of
the loop and caused `scan()` to return zero signals. One bad MR suppressed
auto-merge signals for every other approved MR on every subsequent tick.

The sibling scanner `IncomingEventsScanner` already isolates per-event
failures correctly; this PR brings `GitLabApprovalsScanner` to the same
standard.

## Fix

Wrap the `_scan_one(pr)` call in a `try/except`:

- `ScannerError` is re-raised so auth/network escalation still reaches the
  dispatcher (the user-notify path).
- All other exceptions are logged at ERROR level and the loop continues to the
  next PR.

Also removes an overlay-scoped Slack channel name from the module docstring
that the overlay-leak gate now catches (pre-existing, surfaced by the [#1590](https://github.com/souliane/teatree/pull/1590)
full-tree scan).

## Tests

Two regression tests added to `TestPerPrIsolation`:

- `test_sibling_pr_still_emits_when_first_raises_value_error` — two approved
  PRs; overlay raises `ValueError` for the first, allows the second. Asserts
  one `merge_needed` signal is emitted. **Fails before the fix, passes after.**
- `test_scanner_error_from_scan_one_propagates` — a `ScannerError` from the
  backend still escapes `scan()` via `pytest.raises`. Verifies the escalation
  path is preserved.

Closes [#1592](https://github.com/souliane/teatree/issues/1592).