### PR TITLE
fix(hooks): extend banned-terms carve-out to gh/glab create on known-private target

### DIFF
--- a/src/teatree/hooks/publish_surface.py
+++ b/src/teatree/hooks/publish_surface.py
@@ -395,9 +395,17 @@ def posting_command_targets_private_repo(
 ) -> bool:
     """Return True iff the gh/glab posting command's target repo is known-private.
 
-    Resolves the target repo slug by:
-    1. Parsing ``--repo``/``-R`` from the command (explicit target takes priority).
-    2. Falling back to the CWD origin slug when no flag is present.
+    Resolves the target repo slug, mirroring how ``gh``/``glab`` themselves
+    resolve their target, in priority order:
+
+    - ``--repo``/``-R`` from the command (explicit flag always wins).
+    - For ``gh`` ONLY: the ``GH_REPO`` env var, when no flag is present.
+        ``gh`` reads ``GH_REPO`` as its default target, so a flagless
+        ``gh pr create`` with ``GH_REPO`` exported posts there -- NOT to the
+        CWD repo. The hook shares the process environment ``gh`` inherits, so
+        ``os.environ`` reflects the same value. ``glab`` has no equivalent
+        env var, so this step is skipped for it.
+    - The CWD origin slug, as the final fallback.
 
     An explicit ``--repo owner/name`` slug has no host prefix; it is matched
     against the allowlist as-is, then passed to the visibility probe directly
@@ -408,9 +416,12 @@ def posting_command_targets_private_repo(
     """
     words = first_segment_words(command)
     explicit_repo = _extract_repo_flag(words)
+    is_gh = bool(words) and words[0] == "gh"
 
     if explicit_repo:
         slug = explicit_repo
+    elif is_gh and os.environ.get("GH_REPO", ""):
+        slug = os.environ["GH_REPO"]
     elif cwd is not None:
         slug = _slug_for_cwd(cwd)
     else:

--- a/src/teatree/hooks/publish_surface.py
+++ b/src/teatree/hooks/publish_surface.py
@@ -1,7 +1,7 @@
 """Publish-surface classification for the pre-publish gates (#126).
 
 The quote-scanner (#1213) and banned-terms (#1415) gates exist to stop
-leaks on PUBLIC surfaces — public-repo issues/PRs, Slack, public REST
+leaks on PUBLIC surfaces -- public-repo issues/PRs, Slack, public REST
 posts. A ``git commit`` to a PRIVATE repo is not a public surface: a
 private repo's own customer/domain terms are exactly what its commits are
 supposed to carry, and hard-blocking them forced an
@@ -11,24 +11,34 @@ This module classifies a Bash command into one of two surface classes
 so the gates can DOWNGRADE from hard-block to warn for the private-repo
 commit case ONLY, while leaving every public surface hard-blocked:
 
-``is_git_commit_command`` decides the command is a ``git commit`` — the
-one surface eligible for the private-repo carve-out. Public posting
-commands (``gh issue create``, ``glab mr note``, ``gh api`` / ``glab
-api`` REST, Slack) are never eligible.
+``is_git_commit_command`` decides the command is a ``git commit`` -- the
+one surface eligible for the private-repo carve-out.
+
+``is_gh_glab_posting_command`` decides the command is a structured
+``gh``/``glab`` PR/issue create-or-comment command (NOT ``gh api`` /
+``glab api`` raw REST, NOT ``curl``/Slack) that posts to a specific
+repo target. These are eligible for the carve-out ONLY when the target
+repo is POSITIVELY known-private (resolved from ``--repo``/``-R`` flag
+first, then CWD fallback). Unknown or public targets stay hard-blocked.
 
 ``commit_targets_private_repo`` decides the commit's repo (resolved from
 the harness ``cwd``) is known-private, via an offline allowlist
 (``[teatree] private_repos`` slug substrings in ``~/.teatree.toml``)
 first, then a cached ``gh``/``glab`` visibility probe.
 
+``posting_command_targets_private_repo`` applies the same privacy
+decision to a ``gh``/``glab`` posting command: the target repo slug is
+extracted from ``--repo``/``-R`` in the command first; if absent, the
+CWD repo is used as a fallback. Unknown/unresolvable => NOT private.
+
 Detection is conservative and offline-first: the allowlist needs no
 network and is the recommended way to declare private repos; the cached
 probe is a best-effort fallback. An unknown/unresolvable repo is treated
-as NOT private — the gate stays hard-blocking, never weakened by a
+as NOT private -- the gate stays hard-blocking, never weakened by a
 detection failure.
 
 Secrets (API keys, tokens) are blocked on EVERY surface regardless of
-the carve-out — see :func:`contains_secret`.
+the carve-out -- see :func:`contains_secret`.
 """
 
 import json
@@ -51,7 +61,7 @@ class _VisibilityEntry(TypedDict):
 
 
 # A leading ``KEY=value`` token is an inline env assignment, not the
-# command name — bash applies it to the command's environment. Skipped
+# command name -- bash applies it to the command's environment. Skipped
 # so ``FOO=1 git commit`` is still classified as a ``git commit``.
 _ENV_ASSIGNMENT_RE: Final[re.Pattern[str]] = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=.*")
 
@@ -66,19 +76,36 @@ _MIN_SLUG_PARTS: Final[int] = 2
 # tolerating the occasional flip.
 _VISIBILITY_TTL_S: Final[int] = 24 * 60 * 60
 
-# Visibility probe budget — a hook that hangs blocks the user, so the
+# Visibility probe budget -- a hook that hangs blocks the user, so the
 # network call gets a tight timeout and any failure falls back to
 # "unknown" (treated as NOT private).
 _PROBE_TIMEOUT_S: Final[int] = 5
 
+# Eligible ``gh`` sub-command pairs: (tool, verb) where "tool" is the
+# second word (pr/issue) and "verb" is the third word (create/comment).
+# ``gh api`` is NOT in this set -- raw REST can target arbitrary surfaces.
+_GH_ELIGIBLE_VERBS: Final[frozenset[tuple[str, str]]] = frozenset(
+    {
+        ("pr", "create"),
+        ("pr", "comment"),
+        ("issue", "create"),
+        ("issue", "comment"),
+    }
+)
+
+# Eligible ``glab`` sub-command pairs. ``glab api`` is NOT in this set.
+_GLAB_ELIGIBLE_VERBS: Final[frozenset[tuple[str, str]]] = frozenset(
+    {
+        ("mr", "create"),
+        ("mr", "note"),
+        ("issue", "create"),
+        ("issue", "note"),
+    }
+)
+
 
 def is_git_commit_command(command: str) -> bool:
     """Return True iff the first command segment is a ``git commit``.
-
-    The private-repo carve-out applies ONLY to ``git commit`` — it is the
-    single publish surface that writes to a repo rather than to a public
-    posting surface. ``gh``/``glab``/``curl``/Slack publishes and the
-    ``gh api`` / ``glab api`` REST paths are never eligible.
 
     A leading inline env assignment (``FOO=1 git commit``) is skipped so
     the command name resolves to ``git``.
@@ -87,6 +114,32 @@ def is_git_commit_command(command: str) -> bool:
     while words and _ENV_ASSIGNMENT_RE.fullmatch(words[0]):
         words = words[1:]
     return len(words) >= _COMMIT_WORD_COUNT and words[0] == "git" and words[1] == "commit"
+
+
+def is_gh_glab_posting_command(command: str) -> bool:
+    """Return True iff the first command segment is an eligible ``gh``/``glab`` posting verb.
+
+    Eligible: ``gh pr create``, ``gh pr comment``, ``gh issue create``,
+    ``gh issue comment``, ``glab mr create``, ``glab mr note``,
+    ``glab issue create``, ``glab issue note``.
+
+    NOT eligible: ``gh api`` / ``glab api`` (raw REST -- can target any
+    surface), ``gh repo view``, ``glab mr list``, or anything that is not
+    a structured create-or-comment verb against a single repo target.
+
+    The carve-out uses this to gate which posting commands may be
+    downgraded from hard-block to warn when the target repo is positively
+    known-private.
+    """
+    words = first_segment_words(command)
+    if len(words) < 3:  # noqa: PLR2004
+        return False
+    tool, sub, verb = words[0], words[1], words[2]
+    if tool == "gh":
+        return (sub, verb) in _GH_ELIGIBLE_VERBS
+    if tool == "glab":
+        return (sub, verb) in _GLAB_ELIGIBLE_VERBS
+    return False
 
 
 def _config_path() -> Path:
@@ -151,7 +204,7 @@ def _cache_root() -> Path:
 
     The historical default ``~/.teatree`` is the shell-sourceable config
     FILE in this environment, so a cache write under it raised "Not a
-    directory" and the verdict could never persist — every commit re-probed.
+    directory" and the verdict could never persist -- every commit re-probed.
     Honour ``T3_DATA_DIR`` when set, else use the XDG cache dir (matching
     ``url_title_fetcher``'s ``~/.cache/teatree``). If the chosen root already
     exists as a non-directory, fall back to a sibling so the write still
@@ -216,7 +269,7 @@ def _probe_visibility(slug: str) -> str | None:
 
     Returns ``"PRIVATE"`` / ``"PUBLIC"`` (upper-cased) or ``None`` when
     the tool is unavailable, the slug is unrecognised, or the probe
-    errors. ``None`` is the fail-safe "unknown" — the caller then treats
+    errors. ``None`` is the fail-safe "unknown" -- the caller then treats
     the repo as NOT private and the gate stays hard-blocking.
     """
     parts = slug.split("/")
@@ -268,7 +321,7 @@ def _probe_glab(repo_path: str) -> str | None:
 
 
 def _slug_is_private(slug: str) -> bool:
-    """Resolve whether ``slug`` is a private repo (cache → probe → cache write)."""
+    """Resolve whether ``slug`` is a private repo (cache -> probe -> cache write)."""
     cached = _read_visibility_cache(slug)
     if cached is not None:
         return cached == "PRIVATE"
@@ -279,6 +332,12 @@ def _slug_is_private(slug: str) -> bool:
     return verdict == "PRIVATE"
 
 
+def _slug_is_allowlisted_private(slug: str, config_path: Path | None) -> bool:
+    """Return True iff ``slug`` matches the offline allowlist."""
+    lowered = slug.lower()
+    return any(entry in lowered for entry in _private_repo_allowlist(config_path))
+
+
 def commit_targets_private_repo(cwd: Path | None, *, config_path: Path | None = None) -> bool:
     """Return True iff a commit in ``cwd`` targets a known-private repo.
 
@@ -286,7 +345,7 @@ def commit_targets_private_repo(cwd: Path | None, *, config_path: Path | None = 
     allowlist is consulted before any network probe, so a fully-offline
     session still gets the carve-out for declared repos. The cached
     ``gh``/``glab`` visibility probe is the fallback. An unresolvable repo
-    is NOT private (the gate stays hard-blocking) — detection failure
+    is NOT private (the gate stays hard-blocking) -- detection failure
     never weakens the gate.
     """
     if cwd is None:
@@ -294,17 +353,70 @@ def commit_targets_private_repo(cwd: Path | None, *, config_path: Path | None = 
     slug = _slug_for_cwd(cwd)
     if not slug:
         return False
-    lowered = slug.lower()
-    for entry in _private_repo_allowlist(config_path):
-        if entry in lowered:
-            return True
+    if _slug_is_allowlisted_private(slug, config_path):
+        return True
     return _slug_is_private(slug)
 
 
-# ── Always-on secret detection ──────────────────────────────────────
+def _extract_repo_flag(words: list[str]) -> str:
+    """Extract ``--repo``/``-R`` value from a word list, or return ``""``.
+
+    Handles both ``--repo owner/name`` and ``--repo=owner/name`` forms,
+    and the short ``-R owner/name`` alias used by both ``gh`` and ``glab``.
+    Returns the first match; ``""`` when the flag is absent.
+    """
+    i = 0
+    while i < len(words):
+        w = words[i]
+        if w in {"--repo", "-R"} and i + 1 < len(words):
+            return words[i + 1]
+        if w.startswith("--repo="):
+            return w[len("--repo=") :]
+        i += 1
+    return ""
+
+
+def posting_command_targets_private_repo(
+    command: str,
+    cwd: Path | None,
+    *,
+    config_path: Path | None = None,
+) -> bool:
+    """Return True iff the gh/glab posting command's target repo is known-private.
+
+    Resolves the target repo slug by:
+    1. Parsing ``--repo``/``-R`` from the command (explicit target takes priority).
+    2. Falling back to the CWD origin slug when no flag is present.
+
+    An explicit ``--repo owner/name`` slug has no host prefix; it is matched
+    against the allowlist as-is, then passed to the visibility probe directly
+    (``gh`` probe for GitHub slugs, ``glab`` probe requires the host to detect
+    GitLab; a bare ``owner/name`` defaults to the GitHub probe path).
+
+    Unknown/unresolvable target => NOT private (default-deny preserved).
+    """
+    words = first_segment_words(command)
+    explicit_repo = _extract_repo_flag(words)
+
+    if explicit_repo:
+        slug = explicit_repo
+    elif cwd is not None:
+        slug = _slug_for_cwd(cwd)
+    else:
+        return False
+
+    if not slug:
+        return False
+
+    if _slug_is_allowlisted_private(slug, config_path):
+        return True
+    return _slug_is_private(slug)
+
+
+# -- Always-on secret detection -----------------------------------------------
 
 # High-confidence secret shapes. These are blocked on EVERY surface,
-# including a private-repo commit — the carve-out is about a repo's own
+# including a private-repo commit -- the carve-out is about a repo's own
 # domain words, never about leaking a live credential into git history.
 # The patterns are intentionally narrow (recognisable provider prefixes
 # + length) to avoid false positives on ordinary prose.
@@ -349,21 +461,19 @@ def carve_out_applies(
 ) -> bool:
     """Return True iff a HIGH/banned match on ``payload`` should DOWNGRADE.
 
-    The private-repo carve-out (#126) applies when ALL hold: the tool is
-    ``Bash`` (the only surface a commit reaches); the command is a ``git
-    commit`` (public posting surfaces excluded); the commit targets a
-    known-private repo (offline allowlist first, cached visibility probe
-    second); the payload was actually resolved (the fail-closed sentinel
-    means the scanner could not read the body, so it must still hard-
-    block); and the payload carries no high-confidence secret (credentials
-    leak on every surface, private repos included).
+    The private-repo carve-out applies when ALL hold:
 
-    Any other surface (public-repo issue/PR, ``gh api`` / ``glab api``
-    REST, Slack) returns ``False`` so the gate stays hard-blocking.
+    - The tool is ``Bash``.
+    - The payload was actually resolved (fail-closed sentinel => hard-block).
+    - The payload carries no high-confidence secret (credentials always leak).
+    - The command is a ``git commit`` to a known-private CWD repo, OR a
+        structured ``gh``/``glab`` create-or-comment command whose RESOLVED
+        TARGET is positively known-private (--repo/-R first, CWD fallback).
+
+    Ineligible regardless: ``gh api`` / ``glab api`` raw REST, ``curl``,
+    Slack, and any non-structured verb. Public/unknown targets stay blocked.
     """
     if tool_name != "Bash":
-        return False
-    if not is_git_commit_command(command):
         return False
     from teatree.hooks._command_parser import is_fail_closed_sentinel  # noqa: PLC0415
 
@@ -371,4 +481,11 @@ def carve_out_applies(
         return False
     if contains_secret(payload):
         return False
-    return commit_targets_private_repo(cwd, config_path=config_path)
+
+    if is_git_commit_command(command):
+        return commit_targets_private_repo(cwd, config_path=config_path)
+
+    if is_gh_glab_posting_command(command):
+        return posting_command_targets_private_repo(command, cwd, config_path=config_path)
+
+    return False

--- a/src/teatree/hooks/publish_surface.py
+++ b/src/teatree/hooks/publish_surface.py
@@ -359,21 +359,32 @@ def commit_targets_private_repo(cwd: Path | None, *, config_path: Path | None = 
 
 
 def _extract_repo_flag(words: list[str]) -> str:
-    """Extract ``--repo``/``-R`` value from a word list, or return ``""``.
+    """Extract the EFFECTIVE ``--repo``/``-R`` value, or return ``""``.
 
-    Handles both ``--repo owner/name`` and ``--repo=owner/name`` forms,
-    and the short ``-R owner/name`` alias used by both ``gh`` and ``glab``.
-    Returns the first match; ``""`` when the flag is absent.
+    ``gh`` and ``glab`` resolve a repeated ``--repo``/``-R`` flag LAST-WINS
+    (the same effective-resolution rule as ``-X GET -X POST`` for the HTTP
+    method). Reading the FIRST match would let a crafted command claim a
+    private slug while the tool actually posts to a trailing PUBLIC slug --
+    a leak that defeats the carve-out's load-bearing safety property. So
+    this scans the WHOLE word list and keeps the LAST occurrence.
+
+    All four forms are recognised and the last one anywhere wins regardless
+    of form: ``--repo X``, ``--repo=X``, ``-R X``, ``-R=X``.
     """
+    found = ""
     i = 0
     while i < len(words):
         w = words[i]
         if w in {"--repo", "-R"} and i + 1 < len(words):
-            return words[i + 1]
+            found = words[i + 1]
+            i += 2
+            continue
         if w.startswith("--repo="):
-            return w[len("--repo=") :]
+            found = w[len("--repo=") :]
+        elif w.startswith("-R="):
+            found = w[len("-R=") :]
         i += 1
-    return ""
+    return found
 
 
 def posting_command_targets_private_repo(

--- a/tests/test_banned_terms_scanner.py
+++ b/tests/test_banned_terms_scanner.py
@@ -290,14 +290,31 @@ class TestPrivateRepoCarveOut:
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
-    def test_public_posting_command_with_banned_term_still_blocks(
+    def test_private_repo_posting_command_with_cwd_target_downgrades(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        # Even from inside a private repo, gh issue create is a PUBLIC surface.
+        # gh issue create (no --repo flag) from a private CWD resolves the
+        # target from the CWD origin and applies the carve-out.
         repo = _private_repo(tmp_path)
         data = {
             "tool_name": "Bash",
             "tool_input": {"command": 'gh issue create --title t --body "ship to acmecorp"'},
+            "cwd": str(repo),
+        }
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is False  # downgraded to warn, not denied
+        assert capsys.readouterr().out == ""  # no deny JSON on stdout
+
+    def test_posting_command_with_explicit_public_repo_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # An explicit --repo pointing at a PUBLIC repo must never be carved out
+        # regardless of what the CWD is. This is the load-bearing safety test.
+        repo = _private_repo(tmp_path)
+        monkeypatch.setattr(publish_surface, "_probe_visibility", lambda _slug: "PUBLIC")
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'gh pr create --repo souliane/teatree --title t --body "ship to acmecorp"'},
             "cwd": str(repo),
         }
         blocked = handle_banned_terms_pretool(data)

--- a/tests/test_publish_surface.py
+++ b/tests/test_publish_surface.py
@@ -184,6 +184,51 @@ class TestIsGhGlabPostingCommand:
         assert publish_surface.is_gh_glab_posting_command("echo hi && gh pr create --title x") is False
 
 
+class TestExtractRepoFlag:
+    """``_extract_repo_flag`` must mirror gh/glab's LAST-WINS resolution.
+
+    gh/glab resolve a repeated ``--repo``/``-R`` flag by taking the LAST
+    value, exactly like the ``-X GET -X POST`` method case. Reading the
+    FIRST match would let a crafted command claim a private slug while gh
+    actually posts to the trailing public one -- a leak.
+    """
+
+    def test_single_long_flag(self) -> None:
+        assert publish_surface._extract_repo_flag(["--repo", "owner/name"]) == "owner/name"
+
+    def test_single_equals_form(self) -> None:
+        assert publish_surface._extract_repo_flag(["--repo=owner/name"]) == "owner/name"
+
+    def test_single_short_flag(self) -> None:
+        assert publish_surface._extract_repo_flag(["-R", "owner/name"]) == "owner/name"
+
+    def test_short_equals_form(self) -> None:
+        assert publish_surface._extract_repo_flag(["-R=owner/name"]) == "owner/name"
+
+    def test_absent_flag_returns_empty(self) -> None:
+        assert publish_surface._extract_repo_flag(["gh", "pr", "create", "--title", "x"]) == ""
+
+    def test_repeated_long_flags_last_wins(self) -> None:
+        words = ["--repo", "first/private", "--repo", "second/public"]
+        assert publish_surface._extract_repo_flag(words) == "second/public"
+
+    def test_repeated_equals_form_last_wins(self) -> None:
+        words = ["--repo=first/private", "--repo=second/public"]
+        assert publish_surface._extract_repo_flag(words) == "second/public"
+
+    def test_mixed_long_then_short_last_wins(self) -> None:
+        words = ["--repo=first/public", "-R", "second/private"]
+        assert publish_surface._extract_repo_flag(words) == "second/private"
+
+    def test_mixed_short_then_long_last_wins(self) -> None:
+        words = ["-R", "first/private", "--repo=second/public"]
+        assert publish_surface._extract_repo_flag(words) == "second/public"
+
+    def test_short_equals_form_last_wins(self) -> None:
+        words = ["-R=first/private", "-R=second/public"]
+        assert publish_surface._extract_repo_flag(words) == "second/public"
+
+
 class TestPrivateRepoAllowlist:
     def test_namespace_substring_matches_repo_slug(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path, ["acmecorp-engineering"])
@@ -492,3 +537,82 @@ class TestCarveOutApplies:
             "Write", "git commit", "acmewidget", private_repo, config_path=private_cfg
         )
         assert verdict is False
+
+    # SAFETY TEST (the spoof): a crafted command that lists a private repo
+    # FIRST and a PUBLIC repo LAST resolves (last-wins, like gh/glab) to the
+    # PUBLIC repo, so the carve-out MUST NOT apply -- it stays hard-blocked.
+    # Reading the first flag would leak the banned term to public teatree.
+    def test_repeated_repo_private_then_public_stays_hard_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_cwd = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git")
+        # No probe tool -> the trailing public slug is unknown -> NOT private.
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create --repo acmecorp-engineering/acmecorp-product --repo souliane/teatree --title x",
+                "acmewidget fix",
+                private_cwd,
+                config_path=cfg,
+            )
+            is False
+        )
+
+    def test_repeated_repo_public_then_private_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reverse of the spoof: public FIRST, private LAST -> effective target
+        # is the private repo (last-wins) -> downgrade. Proves last-wins both ways.
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        unrelated_cwd = _repo_with_remote(tmp_path / "r", "git@github.com:some/unrelated-repo.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create --repo souliane/teatree --repo acmecorp-engineering/acmecorp-product --title x",
+                "acmewidget fix",
+                unrelated_cwd,
+                config_path=cfg,
+            )
+            is True
+        )
+
+    def test_mixed_forms_public_equals_then_private_short_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``--repo=souliane/teatree -R acmecorp-engineering/...`` -> the short
+        # ``-R`` private slug is LAST -> wins -> downgrade.
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        unrelated_cwd = _repo_with_remote(tmp_path / "r", "git@github.com:some/unrelated-repo.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create --repo=souliane/teatree -R acmecorp-engineering/acmecorp-product --title x",
+                "acmewidget fix",
+                unrelated_cwd,
+                config_path=cfg,
+            )
+            is True
+        )
+
+    def test_mixed_forms_private_short_then_public_equals_stays_hard_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``-R acmecorp-engineering/... --repo=souliane/teatree`` -> the public
+        # ``--repo=`` slug is LAST -> wins -> stays hard-blocked.
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_cwd = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create -R acmecorp-engineering/acmecorp-product --repo=souliane/teatree --title x",
+                "acmewidget fix",
+                private_cwd,
+                config_path=cfg,
+            )
+            is False
+        )

--- a/tests/test_publish_surface.py
+++ b/tests/test_publish_surface.py
@@ -616,3 +616,105 @@ class TestCarveOutApplies:
             )
             is False
         )
+
+    # SAFETY TEST (the GH_REPO env leak): gh resolves its target from the
+    # GH_REPO env var when no --repo flag is given. A public GH_REPO + a
+    # flagless ``gh pr create`` from a PRIVATE CWD must NOT carve out -- gh
+    # posts to the PUBLIC GH_REPO, so the banned term would leak. The hook
+    # MUST honour GH_REPO BEFORE the CWD fallback, mirroring gh.
+    def test_gh_env_repo_public_with_private_cwd_stays_hard_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_cwd = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git")
+        # No probe tool -> the public GH_REPO slug is unknown -> NOT private.
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        monkeypatch.setenv("GH_REPO", "souliane/teatree")
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create --body x",
+                "acmewidget fix",
+                private_cwd,
+                config_path=cfg,
+            )
+            is False
+        )
+
+    def test_gh_env_repo_private_with_unknown_cwd_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # GH_REPO points at a known-private repo, no --repo flag -> the env
+        # target wins over the CWD fallback -> downgrade.
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        unknown_cwd = _repo_with_remote(tmp_path / "r", "git@github.com:some/unknown-repo.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        monkeypatch.setenv("GH_REPO", "acmecorp-engineering/acmecorp-product")
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create --body x",
+                "acmewidget fix",
+                unknown_cwd,
+                config_path=cfg,
+            )
+            is True
+        )
+
+    def test_gh_env_repo_unset_falls_back_to_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # GH_REPO unset -> behaviour is exactly the CWD fallback: a private
+        # CWD with no --repo flag downgrades, as before this fix.
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_cwd = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        monkeypatch.delenv("GH_REPO", raising=False)
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create --body x",
+                "acmewidget fix",
+                private_cwd,
+                config_path=cfg,
+            )
+            is True
+        )
+
+    def test_explicit_repo_flag_wins_over_gh_env_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An explicit ``--repo`` always wins over GH_REPO (gh ignores the env
+        # var when the flag is present). ``--repo souliane/teatree`` (public)
+        # + GH_REPO private -> the flag's public target wins -> stays blocked.
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_cwd = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        monkeypatch.setenv("GH_REPO", "acmecorp-engineering/acmecorp-product")
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create --repo souliane/teatree --body x",
+                "acmewidget fix",
+                private_cwd,
+                config_path=cfg,
+            )
+            is False
+        )
+
+    def test_glab_ignores_gh_env_repo_and_falls_back_to_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # glab does NOT honour GH_REPO. A flagless ``glab mr create`` with a
+        # public GH_REPO exported must IGNORE GH_REPO and use the CWD origin.
+        # Private CWD -> downgrade (GH_REPO public is irrelevant to glab).
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_cwd = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        monkeypatch.setenv("GH_REPO", "souliane/teatree")
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "glab mr create --title x",
+                "acmewidget fix",
+                private_cwd,
+                config_path=cfg,
+            )
+            is True
+        )

--- a/tests/test_publish_surface.py
+++ b/tests/test_publish_surface.py
@@ -8,6 +8,12 @@ carrying a secret. Detection is offline-first (a ``[teatree]
 private_repos`` allowlist) with a cached ``gh``/``glab`` visibility probe
 fallback.
 
+Extended in #1594: structured ``gh``/``glab`` PR/issue create-or-comment
+commands are ALSO eligible when their RESOLVED TARGET repo is positively
+known-private (via ``--repo``/``-R`` flag, or CWD fallback). Raw REST
+(``gh api``, ``glab api``) and ``curl``/Slack remain ineligible. An
+unknown or public target stays hard-blocked.
+
 Tests use a real ``git init`` repo under ``tmp_path`` with a rewritten
 remote URL, plus a fake ``gh`` on PATH for the probe dimension.
 """
@@ -137,6 +143,47 @@ class TestIsGitCommitCommand:
         assert publish_surface.is_git_commit_command('echo hi && git commit -m "x"') is False
 
 
+class TestIsGhGlabPostingCommand:
+    def test_gh_pr_create_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("gh pr create --title x") is True
+
+    def test_gh_issue_create_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("gh issue create --body x") is True
+
+    def test_gh_issue_comment_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("gh issue comment 1 --body x") is True
+
+    def test_gh_pr_comment_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("gh pr comment 1 --body x") is True
+
+    def test_glab_mr_create_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("glab mr create --title x") is True
+
+    def test_glab_issue_create_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("glab issue create --title x") is True
+
+    def test_glab_mr_note_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("glab mr note 1 --message x") is True
+
+    def test_gh_api_is_not_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("gh api repos/owner/repo/issues") is False
+
+    def test_glab_api_is_not_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("glab api projects/owner%2Frepo") is False
+
+    def test_gh_repo_view_is_not_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("gh repo view owner/repo") is False
+
+    def test_glab_mr_list_is_not_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("glab mr list") is False
+
+    def test_git_commit_is_not_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command('git commit -m "x"') is False
+
+    def test_command_after_separator_does_not_count(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("echo hi && gh pr create --title x") is False
+
+
 class TestPrivateRepoAllowlist:
     def test_namespace_substring_matches_repo_slug(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path, ["acmecorp-engineering"])
@@ -147,8 +194,8 @@ class TestPrivateRepoAllowlist:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         cfg = _config(tmp_path, ["acmecorp-engineering"])
-        repo = _repo_with_remote(tmp_path / "r", "https://github.com/some/public.git")
-        # No allowlist hit and no probe tool on PATH → unknown → NOT private.
+        repo = _repo_with_remote(tmp_path / "r", "git@github.com:some/public-repo.git")
+        # No allowlist hit and no probe tool on PATH -> unknown -> NOT private.
         monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
         assert publish_surface.commit_targets_private_repo(repo, config_path=cfg) is False
 
@@ -170,8 +217,8 @@ class TestVisibilityProbeFallback:
         monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "data"))
 
     def test_private_visibility_probe_marks_repo_private(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        cfg = _config(tmp_path, [])  # empty allowlist → must use the probe
-        repo = _repo_with_remote(tmp_path / "r", "https://github.com/acme/secret.git")
+        cfg = _config(tmp_path, [])  # empty allowlist -> must use the probe
+        repo = _repo_with_remote(tmp_path / "r", "git@github.com:acme/secret-repo.git")
         bin_dir = tmp_path / "bin"
         _make_gh_shim(bin_dir, "PRIVATE")
         monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
@@ -181,7 +228,7 @@ class TestVisibilityProbeFallback:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         cfg = _config(tmp_path, [])
-        repo = _repo_with_remote(tmp_path / "r", "https://github.com/acme/open.git")
+        repo = _repo_with_remote(tmp_path / "r", "git@github.com:acme/open-repo.git")
         bin_dir = tmp_path / "bin"
         _make_gh_shim(bin_dir, "PUBLIC")
         monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
@@ -189,12 +236,12 @@ class TestVisibilityProbeFallback:
 
     def test_probe_verdict_is_cached(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         cfg = _config(tmp_path, [])
-        repo = _repo_with_remote(tmp_path / "r", "https://github.com/acme/cached.git")
+        repo = _repo_with_remote(tmp_path / "r", "git@github.com:acme/cached-repo.git")
         bin_dir = tmp_path / "bin"
         _make_gh_shim(bin_dir, "PRIVATE")
         monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
         assert publish_surface.commit_targets_private_repo(repo, config_path=cfg) is True
-        # Remove the shim — a fresh resolution must still answer from cache
+        # Remove the shim -- a fresh resolution must still answer from cache
         # (git stays available so the slug still resolves).
         (bin_dir / "gh").unlink()
         monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "gitonly"))
@@ -203,9 +250,9 @@ class TestVisibilityProbeFallback:
     def test_gitlab_private_probe_parses_json_without_jq(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # Bug 1: ``glab api`` has no ``--jq`` flag. The probe must request the
         # bare project JSON and parse ``.visibility`` in Python; passing
-        # ``--jq`` (the old code) would make glab exit 1 → None → NOT private.
+        # ``--jq`` (the old code) would make glab exit 1 -> None -> NOT private.
         cfg = _config(tmp_path, [])
-        repo = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acme/secret.git")
+        repo = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acme/secret-repo.git")
         bin_dir = tmp_path / "bin"
         _make_glab_shim(bin_dir, "private")
         monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
@@ -213,7 +260,7 @@ class TestVisibilityProbeFallback:
 
     def test_gitlab_public_probe_parses_json_without_jq(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         cfg = _config(tmp_path, [])
-        repo = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acme/open.git")
+        repo = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acme/open-repo.git")
         bin_dir = tmp_path / "bin"
         _make_glab_shim(bin_dir, "public")
         monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
@@ -223,7 +270,7 @@ class TestVisibilityProbeFallback:
 class TestVisibilityCachePathCollision:
     """Bug 2: the cache must persist even when ``~/.teatree`` is a FILE.
 
-    The historical default rooted the cache at ``~/.teatree`` — but that
+    The historical default rooted the cache at ``~/.teatree`` -- but that
     path is the shell-sourceable config FILE, not a directory, so every
     cache write raised "Not a directory" (swallowed as OSError) and the
     verdict could never persist. The default now lives under the XDG cache
@@ -315,13 +362,105 @@ class TestCarveOutApplies:
             is True
         )
 
-    def test_public_posting_command_never_downgrades(self, private_cfg: Path, private_repo: Path) -> None:
-        # A gh issue create from inside a private repo is STILL a public surface.
+    # SAFETY TEST: This test is load-bearing. A public-repo target MUST always
+    # stay hard-blocked, regardless of CWD or allowlist.
+    def test_gh_pr_create_explicit_public_repo_stays_hard_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_cwd = _repo_with_remote(tmp_path / "r", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git")
+        # No probe tool -> souliane/teatree is unknown -> treated as NOT private.
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
         assert (
             publish_surface.carve_out_applies(
-                "Bash", 'gh issue create --body "acmewidget"', "acmewidget", private_repo, config_path=private_cfg
+                "Bash",
+                "gh pr create --repo souliane/teatree --title x",
+                "acmewidget fix",
+                private_cwd,
+                config_path=cfg,
             )
             is False
+        )
+
+    def test_gh_pr_create_explicit_private_repo_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # gh pr create targeting a known-private repo via --repo should downgrade.
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        # CWD repo is irrelevant when --repo is explicit; use an unrelated CWD.
+        unrelated_cwd = _repo_with_remote(tmp_path / "r", "git@github.com:some/unrelated-repo.git")
+        # No probe tool; acmecorp-engineering is in the allowlist -> private.
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create --repo acmecorp-engineering/acmecorp-product --title x",
+                "acmewidget fix",
+                unrelated_cwd,
+                config_path=cfg,
+            )
+            is True
+        )
+
+    def test_gh_pr_create_no_repo_flag_unknown_cwd_stays_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No --repo and CWD unknown (no probe tool) -> default-deny, stays hard-blocked.
+        cfg = _config(tmp_path, [])  # empty allowlist
+        unknown_cwd = _repo_with_remote(tmp_path / "r", "git@github.com:some/unknown-repo.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create --title x",
+                "acmewidget fix",
+                unknown_cwd,
+                config_path=cfg,
+            )
+            is False
+        )
+
+    def test_gh_api_is_not_eligible_for_carve_out(self, private_cfg: Path, private_repo: Path) -> None:
+        # gh api (raw REST) is never eligible, even targeting a private repo.
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh api repos/acmecorp-engineering/acmecorp-product/issues --field body=x",
+                "acmewidget",
+                private_repo,
+                config_path=private_cfg,
+            )
+            is False
+        )
+
+    def test_glab_mr_create_explicit_private_repo_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        unrelated_cwd = _repo_with_remote(tmp_path / "r", "git@github.com:some/unrelated-repo.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "glab mr create --repo acmecorp-engineering/acmecorp-product --title x",
+                "acmewidget fix",
+                unrelated_cwd,
+                config_path=cfg,
+            )
+            is True
+        )
+
+    def test_gh_pr_create_no_repo_cwd_private_downgrades(self, private_cfg: Path, private_repo: Path) -> None:
+        # gh pr create with no --repo falls back to CWD; private CWD -> downgrade.
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                "gh pr create --title x",
+                "acmewidget fix",
+                private_repo,
+                config_path=private_cfg,
+            )
+            is True
         )
 
     def test_secret_in_body_blocks_carve_out(self, private_cfg: Path, private_repo: Path) -> None:
@@ -341,8 +480,8 @@ class TestCarveOutApplies:
 
     def test_public_repo_commit_does_not_downgrade(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         cfg = _config(tmp_path, ["acmecorp-engineering"])
-        repo = _repo_with_remote(tmp_path / "r", "https://github.com/some/public.git")
-        # No probe tool resolvable → unknown → NOT private.
+        repo = _repo_with_remote(tmp_path / "r", "git@github.com:some/public-repo.git")
+        # No probe tool resolvable -> unknown -> NOT private.
         monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
         assert (
             publish_surface.carve_out_applies("Bash", 'git commit -m "x"', "acmewidget", repo, config_path=cfg) is False

--- a/tests/test_quote_scanner.py
+++ b/tests/test_quote_scanner.py
@@ -21,7 +21,7 @@ import pytest
 
 import hooks.scripts.hook_router as router
 from hooks.scripts.hook_router import handle_quote_scanner_pretool
-from teatree.hooks import quote_scanner
+from teatree.hooks import publish_surface, quote_scanner
 from teatree.hooks._command_parser import FAIL_CLOSED_SENTINEL, is_fail_closed_sentinel
 from teatree.hooks.quote_scanner import Finding, ScanResult, extract_publish_payload, has_quote_ok_override, scan_text
 
@@ -1017,16 +1017,38 @@ class TestPrivateRepoCarveOut:
         assert "WARNING" in captured.err
         assert _ledger_lines(tmp_path)[-1]["decision"] == "warn-private-repo"
 
-    def test_public_surface_from_private_repo_still_denies(
+    def test_private_repo_posting_command_with_cwd_target_downgrades(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         repo = tmp_path / "repo"
         repo.mkdir()
         _git_init_remote(repo, "git@gitlab.com:acmecorp-engineering/product.git")
-        # gh issue create is a PUBLIC surface even from inside a private repo.
+        # gh issue create (no --repo) from a private CWD resolves the target
+        # from the CWD origin and applies the carve-out.
         data = {
             "tool_name": "Bash",
             "tool_input": {"command": 'gh issue create --title t --body "the user said: ship it now"'},
+            "cwd": str(repo),
+        }
+        blocked = handle_quote_scanner_pretool(data)
+        assert blocked is False  # downgraded, not denied
+        captured = capsys.readouterr()
+        assert captured.out == ""  # no deny JSON
+        assert "WARNING" in captured.err
+
+    def test_explicit_public_repo_still_denies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git_init_remote(repo, "git@gitlab.com:acmecorp-engineering/product.git")
+        # An explicit --repo pointing at a public repo must never be carved out.
+        monkeypatch.setattr(publish_surface, "_probe_visibility", lambda _slug: "PUBLIC")
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": 'gh pr create --repo souliane/teatree --title t --body "the user said: ship it now"'
+            },
             "cwd": str(repo),
         }
         blocked = handle_quote_scanner_pretool(data)


### PR DESCRIPTION
## Problem

`carve_out_applies()` only carved out `git commit` to a private repo.
Every `gh`/`glab` posting command was treated as a public surface and
hard-blocked, even when the resolved target repo was positively known
to be private.

This blocked the factory when a private overlay repo's slug contained a
configured banned-domain term — the clickable URL in the payload carried
the term, triggering the gate on every legitimate posting command.

## Solution

Extend `carve_out_applies()` to downgrade `gh`/`glab` posting commands
when their resolved target is positively known private:

1. **`is_gh_glab_posting_command()`** — returns `True` only for the
   eligible verb set; `gh api` / `glab api` and all raw REST remain
   ineligible.
2. **`_extract_repo_flag()`** — parses `--repo`/`-R owner/name` from
   the first shell segment.
3. **`posting_command_targets_private_repo()`** — resolves target: explicit
   `--repo` flag first, CWD-derived slug as fallback; checks allowlist then
   probes visibility. Returns `False` (default-deny) when target cannot be
   positively determined private.

### Eligible verbs (gh)
`pr create`, `pr comment`, `issue create`, `issue comment`

### Eligible verbs (glab)
`mr create`, `mr note`, `issue create`, `issue note`

### Not eligible (preserved hard-block)
`gh api`, `glab api`, `curl`, raw REST calls, any unrecognised verb

## Safety properties preserved

- Default-deny: if `--repo` is absent and CWD is unknown/unresolvable,
  the command stays **HARD-BLOCKED**.
- A public repo target stays **HARD-BLOCKED** regardless of CWD
  (tested by `test_gh_pr_create_explicit_public_repo_stays_hard_blocked`).
- `gh api` / `glab api` are **NOT eligible** for the carve-out.

Closes [#1594](https://github.com/souliane/teatree/issues/1594)