### PR TITLE
fix(loop): isolate per-PR failures in PrSweepScanner

### DIFF
--- a/src/teatree/loop/scanners/pr_sweep.py
+++ b/src/teatree/loop/scanners/pr_sweep.py
@@ -202,7 +202,13 @@ class PrSweepScanner:
         signals: list[ScanSignal] = []
         for slug in self.repos:
             for pr in self._safe_list(slug):
-                attempt = self._evaluate(pr)
+                try:
+                    attempt = self._evaluate(pr)
+                except ScannerError:
+                    raise  # auth/rate-limit escalation (#1287) — surface to the dispatcher
+                except Exception:
+                    logger.exception("pr_sweep failed to evaluate %s#%s", slug, getattr(pr, "number", "?"))
+                    continue
                 signals.append(_signal_from_attempt(attempt, overlay=self.overlay))
                 logger.info(
                     "pr_sweep %s#%d decision=%s reason=%s merged=%s",

--- a/tests/teatree_loop/test_pr_sweep_scanner.py
+++ b/tests/teatree_loop/test_pr_sweep_scanner.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 import pytest
 
 from teatree.core.models.merge_clear import ClearRequest, MergeClear
+from teatree.loop.scanners.base import ScannerError, ScannerErrorClass
 from teatree.loop.scanners.pr_sweep import CheckResult, NullMergeNotifier, PrSummary, PrSweepScanner
 
 pytestmark = pytest.mark.django_db
@@ -462,3 +463,53 @@ class TestErrorIsolation:
 
         assert signals == []
         assert api.calls == 1
+
+    def test_evaluate_failure_on_one_pr_does_not_prevent_sibling_from_merging(self) -> None:
+        """A runtime error in _evaluate for PR A must not skip PR B (#1596)."""
+        clear_b = _issue_clear(pr_id=7777)
+        pr_a = _open_pr(pr_id=6230)
+        pr_b = _open_pr(pr_id=7777)
+
+        @dataclass(slots=True)
+        class _BoomFirstKeystone:
+            calls: list[int] = field(default_factory=list)
+
+            def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str]:
+                self.calls.append(clear_id)
+                if not self.calls or (self.calls == [clear_id] and len(self.calls) == 1):
+                    # First call: inject a fault to simulate a merge conflict / DB error
+                    msg = "simulated keystone failure"
+                    raise RuntimeError(msg)
+                return True, MAIN_SHA, ""  # pragma: no cover
+
+        # Issue a CLEAR for both PRs so _evaluate reaches _merge for each.
+        _issue_clear(pr_id=6230)
+        keystone = _BoomFirstKeystone()
+        api = FakePrApiClient(prs_by_slug={SLUG: [pr_a, pr_b]})
+        scanner, _ = _scanner(api=api, keystone=keystone)
+
+        signals = scanner.scan()
+
+        # PR A failed — its signal must be absent; PR B succeeded.
+        assert len(signals) == 1
+        assert signals[0].payload["pr_id"] == int(clear_b.pr_id)
+        assert signals[0].kind == "pr_sweep.merged"
+
+    def test_scanner_error_from_evaluate_propagates_out_of_scan(self) -> None:
+        """A ScannerError raised inside _evaluate must not be swallowed (#1596)."""
+        _issue_clear()
+
+        @dataclass(slots=True)
+        class _AuthErrorKeystone:
+            def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str]:
+                raise ScannerError(
+                    scanner="pr_sweep",
+                    error_class=ScannerErrorClass.AUTH,
+                    detail="token revoked",
+                )
+
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr()]})
+        scanner, _ = _scanner(api=api, keystone=_AuthErrorKeystone())
+
+        with pytest.raises(ScannerError):
+            scanner.scan()


### PR DESCRIPTION
## Problem

`PrSweepScanner.scan()` called `self._evaluate(pr)` without a per-PR guard. A runtime error from any one PR (merge conflict, forge API error, gate refusal, transient DB/network fault) propagated out of `scan()`, causing the entire sweep to return zero signals. Every other green/mergeable PR was skipped for that tick and all subsequent ticks until the loop restarted.

## Fix

Wrap `self._evaluate(pr)` in the same per-PR try/except pattern used by the `_safe_list` guard and the [#1592 fix for GitLabApprovalsScanner](https://github.com/souliane/teatree/issues/1593):

- Generic exceptions: log + `continue` (sibling PRs still processed)
- `ScannerError`: re-raised so auth/rate-limit faults still surface to the dispatcher ([#1287](https://github.com/souliane/teatree/issues/1287))

## Tests

Two regression tests added to `TestErrorIsolation`:

- `test_evaluate_failure_on_one_pr_does_not_prevent_sibling_from_merging` — two open PRs, keystone raises for the first; asserts the second still produces a merged signal. Fails on the unfixed code, passes after.
- `test_scanner_error_from_evaluate_propagates_out_of_scan` — keystone raises `ScannerError`; asserts it propagates out of `scan()`.

Part of the systemic per-item fault-isolation audit [#1597](https://github.com/souliane/teatree/issues/1597).

Closes [#1596](https://github.com/souliane/teatree/issues/1596)