### PR TITLE
fix(loop): add per-item fault isolation to the remaining loop scanners

### DIFF
--- a/src/teatree/loop/scanners/active_tickets.py
+++ b/src/teatree/loop/scanners/active_tickets.py
@@ -19,12 +19,15 @@ execution_target=HEADLESS)``. The actual LLM call lives in the
 headless worker — no synchronous LLM in scan().
 """
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from django.apps import apps
 
 from teatree.loop.scanners.base import ScanSignal
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from teatree.core.models import Ticket
@@ -44,31 +47,35 @@ class ActiveTicketsScanner:
             qs = qs.filter(overlay=self.overlay_name)
         signals: list[ScanSignal] = []
         for ticket in qs.only("id", "state", "overlay", "issue_url", "extra", "short_description"):
-            extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-            cached_title = extra.get("issue_title", "") if isinstance(extra, dict) else ""
-            cached_title = cached_title if isinstance(cached_title, str) else ""
-            title = ticket.short_description or cached_title
-            # ``tracker_404`` is the last-observed-404 marker the tracker
-            # client persists on the ticket extras; the renderer drops the
-            # URL when set so dead permalinks don't surface (#1163, #1156).
-            tracker_404 = bool(extra.get("tracker_404", False)) if isinstance(extra, dict) else False
-            issue_url = "" if tracker_404 else ticket.issue_url
-            if not ticket.short_description and cached_title:
-                _enqueue_short_describe(ticket)
-            signals.append(
-                ScanSignal(
-                    kind="ticket.active",
-                    summary=f"#{ticket.ticket_number} {ticket.state}",
-                    payload={
-                        "ticket_id": ticket.pk,
-                        "ticket_number": ticket.ticket_number,
-                        "state": ticket.state,
-                        "issue_url": issue_url,
-                        "title": title,
-                        "tracker_404": tracker_404,
-                    },
-                ),
-            )
+            try:
+                extra = ticket.extra if isinstance(ticket.extra, dict) else {}
+                cached_title = extra.get("issue_title", "") if isinstance(extra, dict) else ""
+                cached_title = cached_title if isinstance(cached_title, str) else ""
+                title = ticket.short_description or cached_title
+                # ``tracker_404`` is the last-observed-404 marker the tracker
+                # client persists on the ticket extras; the renderer drops the
+                # URL when set so dead permalinks don't surface (#1163, #1156).
+                tracker_404 = bool(extra.get("tracker_404", False)) if isinstance(extra, dict) else False
+                issue_url = "" if tracker_404 else ticket.issue_url
+                if not ticket.short_description and cached_title:
+                    _enqueue_short_describe(ticket)
+                signals.append(
+                    ScanSignal(
+                        kind="ticket.active",
+                        summary=f"#{ticket.ticket_number} {ticket.state}",
+                        payload={
+                            "ticket_id": ticket.pk,
+                            "ticket_number": ticket.ticket_number,
+                            "state": ticket.state,
+                            "issue_url": issue_url,
+                            "title": title,
+                            "tracker_404": tracker_404,
+                        },
+                    ),
+                )
+            except Exception:
+                logger.exception("ActiveTicketsScanner failed on ticket %s", ticket.pk)
+                continue
         return signals
 
 

--- a/src/teatree/loop/scanners/issue_implementer.py
+++ b/src/teatree/loop/scanners/issue_implementer.py
@@ -15,6 +15,7 @@ idempotency). Dispatch routing of the emitted signals lands in C4 (#1554);
 C3 stops at claim + signal emission.
 """
 
+import logging
 from dataclasses import dataclass, field
 from typing import cast
 
@@ -22,6 +23,8 @@ from teatree.backends.protocols import CodeHostBackend
 from teatree.core.models import ImplementedIssueMarker
 from teatree.loop.scanners.base import ScanSignal
 from teatree.types import RawAPIDict
+
+logger = logging.getLogger(__name__)
 
 
 def _issue_url(issue: RawAPIDict) -> str:
@@ -94,27 +97,32 @@ class IssueImplementerScanner:
             return []
         signals: list[ScanSignal] = []
         for issue in self._collect_unique_issues(assignees):
-            if not _issue_is_open(issue):
-                continue
-            if self.label not in _issue_labels(issue):
-                continue
-            url = _issue_url(issue)
-            if not url:
-                continue
-            marker = ImplementedIssueMarker.objects.claim(url, overlay=self.overlay_name)
-            if marker is None:
-                continue
-            signals.append(
-                ScanSignal(
-                    kind="issue_implementer.claimed",
-                    summary=f"Claimed for auto-implement: {_issue_title(issue)}",
-                    payload={
-                        "url": url,
-                        "raw": issue,
-                        "overlay": self.overlay_name,
-                    },
+            url = _issue_url(issue) or "<unknown>"
+            try:
+                if not _issue_is_open(issue):
+                    continue
+                if self.label not in _issue_labels(issue):
+                    continue
+                url = _issue_url(issue)
+                if not url:
+                    continue
+                marker = ImplementedIssueMarker.objects.claim(url, overlay=self.overlay_name)
+                if marker is None:
+                    continue
+                signals.append(
+                    ScanSignal(
+                        kind="issue_implementer.claimed",
+                        summary=f"Claimed for auto-implement: {_issue_title(issue)}",
+                        payload={
+                            "url": url,
+                            "raw": issue,
+                            "overlay": self.overlay_name,
+                        },
+                    )
                 )
-            )
+            except Exception:
+                logger.exception("IssueImplementerScanner failed on issue %s", url)
+                continue
         return signals
 
     def _resolve_identities(self) -> tuple[str, ...]:

--- a/src/teatree/loop/scanners/red_card.py
+++ b/src/teatree/loop/scanners/red_card.py
@@ -116,12 +116,22 @@ class RedCardScanner:
         signals: list[ScanSignal] = []
 
         for event in self._drain_reactions():
-            signal = self._handle_reaction(event, target_user)
+            ts = _event_ts(event)
+            try:
+                signal = self._handle_reaction(event, target_user)
+            except Exception:
+                logger.exception("RedCardScanner failed on reaction event %s", ts)
+                continue
             if signal is not None:
                 signals.append(signal)
 
         for event in self._drain_dms():
-            signal = self._handle_dm(event, target_user)
+            ts = _event_ts(event)
+            try:
+                signal = self._handle_dm(event, target_user)
+            except Exception:
+                logger.exception("RedCardScanner failed on DM event %s", ts)
+                continue
             if signal is not None:
                 signals.append(signal)
 

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -11,6 +11,7 @@ The cache lives on ``Ticket(role="reviewer")`` rows in ``extra``
 then deleted — no migration command required.
 """
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
@@ -18,6 +19,8 @@ from teatree.backends.protocols import CodeHostBackend, PrOpenState, ReviewState
 from teatree.core.review_candidate import should_review_candidate_reasons
 from teatree.loop.scanners.base import ScanSignal
 from teatree.types import RawAPIDict
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from teatree.core.models import Ticket as _Ticket
@@ -210,7 +213,11 @@ def _orphaned_task_signals(
     candidates = candidates.exclude(issue_url="").exclude(issue_url__in=scanned_urls).distinct()
     signals: list[ScanSignal] = []
     for ticket in candidates:
-        state = host.get_pr_open_state(pr_url=ticket.issue_url)
+        try:
+            state = host.get_pr_open_state(pr_url=ticket.issue_url)
+        except Exception:
+            logger.exception("ReviewerPrsScanner failed to get PR state for %s", ticket.issue_url)
+            continue
         if state not in {PrOpenState.MERGED, PrOpenState.CLOSED}:
             # OPEN → live review still owed; UNKNOWN → fail open. Never reap.
             continue
@@ -291,32 +298,36 @@ class ReviewerPrsScanner:
             url = _pr_url(pr)
             if not url or not self._url_allowed(url):
                 continue
-            # #1321 (post-#1328 rewire): the 4 review-candidate skip-conditions
-            # belong on the colleague-MR review-sweep path — exactly this loop.
-            # ``list_review_requested_prs`` can return MRs the agent must not
-            # dispatch ``t3:reviewer`` on (self-authored, self-approved,
-            # self-noted, or already merged/closed); filter them here BEFORE
-            # adding the URL to ``scanned_urls`` so the orphan-task sweep
-            # still reaps the corresponding ticket via ``get_pr_open_state``
-            # when the MR is genuinely merged/closed. The full identity set
-            # (not just the primary alias) is matched so an MR authored under
-            # any of the user's github/gitlab aliases is recognised as own
-            # work (#1321 multi-identity).
-            reasons = should_review_candidate_reasons(pr, current_user=primary_reviewer, self_identities=reviewers)
-            if reasons:
-                # #1321: a reviewing task already created for a self-authored
-                # OPEN MR (before this gate, or via another path) lingers
-                # forever — the orphan sweep only reaps MERGED/CLOSED PRs.
-                # Emit a reconciliation signal so the queue self-heals on the
-                # next tick. Other skip reasons (already-approved, merged,
-                # broadcast-reacted) are handled by the existing orphan sweep
-                # or are genuinely review-engaged, so only ``author_is_self``
-                # drives reconciliation here.
-                if "author_is_self" in reasons:
-                    signals.extend(self._self_authored_reconcile_signals(url, ticket_model))
+            try:
+                # #1321 (post-#1328 rewire): the 4 review-candidate skip-conditions
+                # belong on the colleague-MR review-sweep path — exactly this loop.
+                # ``list_review_requested_prs`` can return MRs the agent must not
+                # dispatch ``t3:reviewer`` on (self-authored, self-approved,
+                # self-noted, or already merged/closed); filter them here BEFORE
+                # adding the URL to ``scanned_urls`` so the orphan-task sweep
+                # still reaps the corresponding ticket via ``get_pr_open_state``
+                # when the MR is genuinely merged/closed. The full identity set
+                # (not just the primary alias) is matched so an MR authored under
+                # any of the user's github/gitlab aliases is recognised as own
+                # work (#1321 multi-identity).
+                reasons = should_review_candidate_reasons(pr, current_user=primary_reviewer, self_identities=reviewers)
+                if reasons:
+                    # #1321: a reviewing task already created for a self-authored
+                    # OPEN MR (before this gate, or via another path) lingers
+                    # forever — the orphan sweep only reaps MERGED/CLOSED PRs.
+                    # Emit a reconciliation signal so the queue self-heals on the
+                    # next tick. Other skip reasons (already-approved, merged,
+                    # broadcast-reacted) are handled by the existing orphan sweep
+                    # or are genuinely review-engaged, so only ``author_is_self``
+                    # drives reconciliation here.
+                    if "author_is_self" in reasons:
+                        signals.extend(self._self_authored_reconcile_signals(url, ticket_model))
+                    continue
+                scanned_urls.add(url)
+                signals.extend(self._signals_for_pr(pr, url, cache, ticket_model, primary_reviewer))
+            except Exception:
+                logger.exception("ReviewerPrsScanner failed on PR %s", url)
                 continue
-            scanned_urls.add(url)
-            signals.extend(self._signals_for_pr(pr, url, cache, ticket_model, primary_reviewer))
         signals.extend(_orphaned_task_signals(ticket_model, scanned_urls, self.host, self.overlay_name))
         return signals
 

--- a/src/teatree/loop/scanners/slack_broadcasts.py
+++ b/src/teatree/loop/scanners/slack_broadcasts.py
@@ -270,7 +270,14 @@ class SlackBroadcastsScanner:
     def _scan_channel(self, channel: str) -> list[ScanSignal]:
         signals: list[ScanSignal] = []
         for message in self.fetch_channel_history(channel=channel):
-            signals.extend(self._handle_message(channel, message))
+            ts = message.get("ts", "<unknown>")
+            try:
+                signals.extend(self._handle_message(channel, message))
+            except ConnectChannelBotRestrictedError:
+                raise
+            except Exception:
+                logger.exception("SlackBroadcastsScanner failed on message %s in %s", ts, channel)
+                continue
         return signals
 
     def _handle_message(self, channel: str, message: RawAPIDict) -> list[ScanSignal]:

--- a/src/teatree/loop/scanners/slack_dm_inbound.py
+++ b/src/teatree/loop/scanners/slack_dm_inbound.py
@@ -39,6 +39,7 @@ independent of both, so a row can be drained, loop-replied, and
 agent-answered without a double reply (#1014).
 """
 
+import logging
 from dataclasses import dataclass, field
 
 from teatree.backends.protocols import MessagingBackend
@@ -46,6 +47,8 @@ from teatree.core.models.pending_chat_injection import PendingChatInjection
 from teatree.loop.scanners.base import ScanSignal
 from teatree.loop.scanners.slack_self_filter import OwnSlackIdentity, filter_self_messages, resolve_own_identity
 from teatree.types import RawAPIDict
+
+logger = logging.getLogger(__name__)
 
 
 def _event_ts(event: RawAPIDict) -> str:
@@ -106,34 +109,38 @@ class SlackDmInboundScanner:
         signals: list[ScanSignal] = []
         for event in dms:
             ts = _event_ts(event)
-            text = _event_text(event)
-            if not ts or not text.strip():
-                continue
-            channel = _event_channel(event)
-            user_id = _event_user(event)
-            row = PendingChatInjection.record(
-                channel=channel,
-                slack_ts=ts,
-                text=text,
-                overlay=self.overlay,
-                user_id=user_id,
-            )
-            if row is None:
-                # Duplicate ``ts`` — the scanner over-polled. Skip the
-                # signal so the dispatcher doesn't re-route a row that
-                # the previous tick already queued.
-                continue
-            signals.append(
-                ScanSignal(
-                    kind="slack.user_reply",
-                    summary=f"Slack user reply {ts}: {text[:80]}",
-                    payload={
-                        "ts": ts,
-                        "channel": channel,
-                        "user_id": user_id,
-                        "text": text,
-                        "overlay": self.overlay,
-                    },
+            try:
+                text = _event_text(event)
+                if not ts or not text.strip():
+                    continue
+                channel = _event_channel(event)
+                user_id = _event_user(event)
+                row = PendingChatInjection.record(
+                    channel=channel,
+                    slack_ts=ts,
+                    text=text,
+                    overlay=self.overlay,
+                    user_id=user_id,
                 )
-            )
+                if row is None:
+                    # Duplicate ``ts`` — the scanner over-polled. Skip the
+                    # signal so the dispatcher doesn't re-route a row that
+                    # the previous tick already queued.
+                    continue
+                signals.append(
+                    ScanSignal(
+                        kind="slack.user_reply",
+                        summary=f"Slack user reply {ts}: {text[:80]}",
+                        payload={
+                            "ts": ts,
+                            "channel": channel,
+                            "user_id": user_id,
+                            "text": text,
+                            "overlay": self.overlay,
+                        },
+                    )
+                )
+            except Exception:
+                logger.exception("SlackDmInboundScanner failed on DM event %s", ts)
+                continue
         return signals

--- a/src/teatree/loop/scanners/slack_review_intent.py
+++ b/src/teatree/loop/scanners/slack_review_intent.py
@@ -87,7 +87,12 @@ class SlackReviewIntentScanner:
 
         reactions, drained_file = self._drain_reactions()
         for event in reactions:
-            signal = self._handle_reaction(event, target_user)
+            ts = event.get("ts") or event.get("event_ts", "<unknown>")
+            try:
+                signal = self._handle_reaction(event, target_user)
+            except Exception:
+                logger.exception("SlackReviewIntentScanner failed on reaction event %s", ts)
+                continue
             if signal is not None:
                 signals.append(signal)
         if drained_file:
@@ -99,7 +104,12 @@ class SlackReviewIntentScanner:
             commit_reactions_drain()
 
         for event in self._drain_mentions():
-            signal = self._handle_mention(event, target_user)
+            ts = event.get("ts") or event.get("event_ts", "<unknown>")
+            try:
+                signal = self._handle_mention(event, target_user)
+            except Exception:
+                logger.exception("SlackReviewIntentScanner failed on mention event %s", ts)
+                continue
             if signal is not None:
                 signals.append(signal)
 

--- a/src/teatree/loop/scanners/ticket_completion.py
+++ b/src/teatree/loop/scanners/ticket_completion.py
@@ -53,42 +53,46 @@ class TicketCompletionScanner:
     def scan(self) -> list[ScanSignal]:
         signals: list[ScanSignal] = []
         for ticket in self._candidate_tickets():
-            if _has_draft_mrs(ticket):
-                signals.append(
-                    ScanSignal(
-                        kind="ticket.reopen_needed",
-                        summary=f"Ticket {ticket.ticket_number} — draft MRs exist, reopening",
-                        payload={
-                            "ticket_id": ticket.pk,
-                            "ticket_state": ticket.state,
-                            "issue_url": ticket.issue_url,
-                        },
-                    ),
-                )
-                continue
-
-            host = get_code_host_for_url(self.overlay, ticket.issue_url)
-            if host is None:
-                continue
             try:
-                issue_data = host.get_issue(ticket.issue_url)
-            except Exception:  # noqa: BLE001
-                logger.warning("Failed to fetch issue for ticket %s (%s), skipping", ticket.pk, ticket.issue_url)
+                if _has_draft_mrs(ticket):
+                    signals.append(
+                        ScanSignal(
+                            kind="ticket.reopen_needed",
+                            summary=f"Ticket {ticket.ticket_number} — draft MRs exist, reopening",
+                            payload={
+                                "ticket_id": ticket.pk,
+                                "ticket_state": ticket.state,
+                                "issue_url": ticket.issue_url,
+                            },
+                        ),
+                    )
+                    continue
+
+                host = get_code_host_for_url(self.overlay, ticket.issue_url)
+                if host is None:
+                    continue
+                try:
+                    issue_data = host.get_issue(ticket.issue_url)
+                except Exception:  # noqa: BLE001
+                    logger.warning("Failed to fetch issue for ticket %s (%s), skipping", ticket.pk, ticket.issue_url)
+                    continue
+                if not isinstance(issue_data, dict) or "error" in issue_data:
+                    continue
+                if self.overlay.is_issue_done(issue_data):
+                    signals.append(
+                        ScanSignal(
+                            kind="ticket.completion_detected",
+                            summary=f"Ticket {ticket.ticket_number} — issue done upstream",
+                            payload={
+                                "ticket_id": ticket.pk,
+                                "ticket_state": ticket.state,
+                                "issue_url": ticket.issue_url,
+                            },
+                        ),
+                    )
+            except Exception:
+                logger.exception("TicketCompletionScanner failed on ticket %s", ticket.pk)
                 continue
-            if not isinstance(issue_data, dict) or "error" in issue_data:
-                continue
-            if self.overlay.is_issue_done(issue_data):
-                signals.append(
-                    ScanSignal(
-                        kind="ticket.completion_detected",
-                        summary=f"Ticket {ticket.ticket_number} — issue done upstream",
-                        payload={
-                            "ticket_id": ticket.pk,
-                            "ticket_state": ticket.state,
-                            "issue_url": ticket.issue_url,
-                        },
-                    ),
-                )
         return signals
 
     def _candidate_tickets(self) -> Iterable["Ticket"]:

--- a/src/teatree/loop/scanners/todo_sweep.py
+++ b/src/teatree/loop/scanners/todo_sweep.py
@@ -66,10 +66,14 @@ class TodoSweepScanner:
         signals: list[ScanSignal] = []
         now = timezone.now()
         for task in self._candidate_tasks(now):
-            if not self._claim_for_sweep(task_id=task.pk, now=now):
-                # Another concurrent tick won the atomic stamp — skip this task.
+            try:
+                if not self._claim_for_sweep(task_id=task.pk, now=now):
+                    # Another concurrent tick won the atomic stamp — skip this task.
+                    continue
+                signal = self._verify(task)
+            except Exception:
+                logger.exception("TodoSweepScanner failed on task %s", task.pk)
                 continue
-            signal = self._verify(task)
             if signal is not None:
                 signals.append(signal)
         return signals

--- a/tests/teatree_loop/test_per_item_fault_isolation_1597.py
+++ b/tests/teatree_loop/test_per_item_fault_isolation_1597.py
@@ -1,0 +1,728 @@
+"""Per-item fault isolation across loop scanners (#1597).
+
+Each test verifies that when one item in a scanner's loop raises an
+unexpected exception, sibling items still produce their signals. A test
+written against the unfixed code is first confirmed RED (the second item's
+signal is missing), then becomes GREEN after the per-item try/except guard
+is added.
+
+Covered scanners:
+- ReviewerPrsScanner (main PR loop + orphan ticket loop)
+- ActiveTicketsScanner
+- SlackBroadcastsScanner (per-message, with ConnectChannelBotRestrictedError escalation)
+- TicketCompletionScanner
+- RedCardScanner (reaction loop + DM loop)
+- SlackReviewIntentScanner (reaction loop + mention loop)
+- TodoSweepScanner
+- IssueImplementerScanner
+- SlackDmInboundScanner
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.backends.protocols import PrOpenState, ReviewState
+from teatree.core.models import ImplementedIssueMarker
+from teatree.core.models.session import Session
+from teatree.core.models.task import Task
+from teatree.core.models.ticket import Ticket
+from teatree.core.overlay import OverlayBase
+from teatree.loop.scanners.active_tickets import ActiveTicketsScanner
+from teatree.loop.scanners.issue_implementer import IssueImplementerScanner
+from teatree.loop.scanners.red_card import RedCardScanner
+from teatree.loop.scanners.reviewer_prs import ReviewerPrsScanner
+from teatree.loop.scanners.slack_broadcasts import ConnectChannelBotRestrictedError, MrState, SlackBroadcastsScanner
+from teatree.loop.scanners.slack_dm_inbound import SlackDmInboundScanner
+from teatree.loop.scanners.slack_review_intent import SlackReviewIntentScanner
+from teatree.loop.scanners.ticket_completion import TicketCompletionScanner
+from teatree.loop.scanners.todo_sweep import TodoSweepScanner
+from teatree.types import RawAPIDict
+
+# ---------------------------------------------------------------------------
+# Shared fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCodeHost:
+    user: str = "alice"
+    my_prs: list[RawAPIDict] = field(default_factory=list)
+    review_requested_prs: list[RawAPIDict] = field(default_factory=list)
+    assigned_issues: list[RawAPIDict] = field(default_factory=list)
+    review_state_by_url: dict[str, ReviewState] = field(default_factory=dict)
+    pr_open_state_by_url: dict[str, PrOpenState] = field(default_factory=dict)
+    pr_open_state_default: PrOpenState = PrOpenState.UNKNOWN
+    raise_on_pr_url: str = ""
+    raise_on_open_state_url: str = ""
+
+    def current_user(self) -> str:
+        return self.user
+
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
+        return self.my_prs
+
+    def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (reviewer, updated_after)
+        return self.review_requested_prs
+
+    def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:
+        _ = assignee
+        return self.assigned_issues
+
+    def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState:
+        _ = reviewer
+        if pr_url == self.raise_on_pr_url:
+            msg = "simulated network failure"
+            raise RuntimeError(msg)
+        return self.review_state_by_url.get(pr_url, ReviewState.NONE)
+
+    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState:
+        if pr_url == self.raise_on_open_state_url:
+            msg = "simulated network failure"
+            raise RuntimeError(msg)
+        return self.pr_open_state_by_url.get(pr_url, self.pr_open_state_default)
+
+    def create_pr(self, spec: Any) -> RawAPIDict:
+        _ = spec
+        return {}
+
+    def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict:
+        _ = (repo, pr_iid, body)
+        return {}
+
+    def update_pr_comment(self, *, repo: str, pr_iid: int, comment_id: int, body: str) -> RawAPIDict:
+        _ = (repo, pr_iid, comment_id, body)
+        return {}
+
+    def list_pr_comments(self, *, repo: str, pr_iid: int) -> list[RawAPIDict]:
+        _ = (repo, pr_iid)
+        return []
+
+    def upload_file(self, *, repo: str, filepath: str) -> RawAPIDict:
+        _ = (repo, filepath)
+        return {}
+
+    def get_issue(self, issue_url: str) -> RawAPIDict:
+        _ = issue_url
+        return {}
+
+
+@dataclass
+class _FakeMessaging:
+    user_id: str = "U0A72P7CK0A"
+    reactions: list[RawAPIDict] = field(default_factory=list)
+    mentions: list[RawAPIDict] = field(default_factory=list)
+    dms: list[RawAPIDict] = field(default_factory=list)
+    messages_by_ts: dict[tuple[str, str], RawAPIDict] = field(default_factory=dict)
+    react_calls: list[tuple[str, str, str]] = field(default_factory=list)
+    react_raises: BaseException | None = None
+
+    def fetch_mentions(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        events, self.mentions = self.mentions, []
+        return events
+
+    def fetch_dms(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        events, self.dms = self.dms, []
+        return events
+
+    def fetch_reactions(self, *, since: str = "") -> list[RawAPIDict]:
+        _ = since
+        events, self.reactions = self.reactions, []
+        return events
+
+    def fetch_message(self, *, channel: str, ts: str) -> RawAPIDict:
+        return self.messages_by_ts.get((channel, ts), {})
+
+    def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:
+        _ = (channel, text, thread_ts)
+        return {}
+
+    def post_reply(self, *, channel: str, ts: str, text: str) -> RawAPIDict:
+        _ = (channel, ts, text)
+        return {}
+
+    def open_dm(self, user_id: str) -> str:
+        _ = user_id
+        return ""
+
+    def get_permalink(self, *, channel: str, ts: str) -> str:
+        _ = (channel, ts)
+        return ""
+
+    def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
+        if self.react_raises is not None:
+            raise self.react_raises
+        self.react_calls.append((channel, ts, emoji))
+        return {"ok": True}
+
+    def resolve_user_id(self, handle: str) -> str:
+        _ = handle
+        return ""
+
+    def auth_test(self) -> RawAPIDict:
+        return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# ReviewerPrsScanner — main PR loop
+# ---------------------------------------------------------------------------
+
+CHANNEL = "C0AM3TENTLK"
+URL_A = "https://gitlab.example.com/team/project/-/merge_requests/100"
+URL_B = "https://gitlab.example.com/team/project/-/merge_requests/101"
+
+
+class TestReviewerPrsIsolation(TestCase):
+    """Sibling PR survives when _signals_for_pr raises on the first PR."""
+
+    def _pr(self, url: str, author: str = "bob") -> RawAPIDict:
+        return {"web_url": url, "sha": "abc", "author": {"username": author}, "state": "opened"}
+
+    def test_failing_first_pr_does_not_suppress_second_pr_signal(self) -> None:
+        host = _FakeCodeHost(
+            user="alice",
+            review_requested_prs=[self._pr(URL_A), self._pr(URL_B)],
+        )
+        scanner = ReviewerPrsScanner(host=host)
+
+        call_count = [0]
+        original_signals_for_pr = ReviewerPrsScanner._signals_for_pr
+
+        def _raising_signals_for_pr(self_inner, pr: RawAPIDict, url: str, *args: Any, **kwargs: Any) -> list:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated failure for first PR"
+                raise RuntimeError(msg)
+            return original_signals_for_pr(self_inner, pr, url, *args, **kwargs)
+
+        with patch.object(ReviewerPrsScanner, "_signals_for_pr", _raising_signals_for_pr):
+            signals = scanner.scan()
+
+        kinds = [s.kind for s in signals]
+        assert any("review" in k for k in kinds), "second PR must emit a signal even though the first PR raised"
+        urls = [s.payload.get("mr_url") or s.payload.get("url", "") for s in signals]
+        assert not any(URL_A in u for u in urls), "first (failing) PR must not produce a signal"
+        assert any(URL_B in u for u in urls), "second (healthy) PR must produce its signal"
+
+
+# ---------------------------------------------------------------------------
+# ReviewerPrsScanner — orphaned ticket loop
+# ---------------------------------------------------------------------------
+
+
+class TestReviewerPrsOrphanIsolation(TestCase):
+    """Sibling orphaned ticket survives when the first ticket's get_pr_open_state raises."""
+
+    def test_failing_first_ticket_does_not_suppress_second_orphan_signal(self) -> None:
+        ticket_a = Ticket.objects.create(overlay="acme", issue_url=URL_A, role="reviewer")
+        ticket_b = Ticket.objects.create(overlay="acme", issue_url=URL_B, role="reviewer")
+        session_a = Session.objects.create(overlay="acme", ticket=ticket_a, agent_id="a")
+        session_b = Session.objects.create(overlay="acme", ticket=ticket_b, agent_id="b")
+        Task.objects.create(ticket=ticket_a, session=session_a, phase="reviewing")
+        Task.objects.create(ticket=ticket_b, session=session_b, phase="reviewing")
+
+        host = _FakeCodeHost(
+            user="alice",
+            raise_on_open_state_url=URL_A,
+            pr_open_state_by_url={URL_B: PrOpenState.MERGED},
+        )
+        scanner = ReviewerPrsScanner(host=host)
+        signals = scanner.scan()
+        orphan_signals = [s for s in signals if s.kind == "reviewer_pr.task_orphaned"]
+        assert len(orphan_signals) == 1, "second ticket must be reaped even though first raised"
+        assert orphan_signals[0].payload["url"] == URL_B
+
+
+# ---------------------------------------------------------------------------
+# ActiveTicketsScanner
+# ---------------------------------------------------------------------------
+
+
+class TestActiveTicketsIsolation(TestCase):
+    """Sibling ticket still emits signal when processing the first ticket raises."""
+
+    def test_failing_first_ticket_does_not_suppress_second_ticket_signal(self) -> None:
+        ticket_a = Ticket.objects.create(overlay="acme", issue_url="https://x/1", state="started")
+        Ticket.objects.create(overlay="acme", issue_url="https://x/2", state="coded")
+
+        # Make _enqueue_short_describe raise on ticket_a by giving it a cached
+        # title (triggering the enqueue path) and making Session.objects.create raise.
+        Ticket.objects.filter(pk=ticket_a.pk).update(
+            extra={"issue_title": "something"},
+        )
+
+        original_create = Session.objects.create
+        call_count = [0]
+
+        def _raising_create(**kwargs: Any) -> Any:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated DB error on first ticket"
+                raise RuntimeError(msg)
+            return original_create(**kwargs)
+
+        with patch("teatree.core.models.session.Session.objects.create", side_effect=_raising_create):
+            signals = ActiveTicketsScanner().scan()
+
+        assert len(signals) == 1, "second ticket must emit its signal even though first raised"
+        assert signals[0].payload["state"] == "coded"
+
+
+# ---------------------------------------------------------------------------
+# SlackBroadcastsScanner — per-message isolation + ConnectChannelBotRestrictedError propagation
+# ---------------------------------------------------------------------------
+
+MR_OPEN_A = "https://gitlab.example.com/team/project/-/merge_requests/200"
+MR_OPEN_B = "https://gitlab.example.com/team/project/-/merge_requests/201"
+TS_A = "1779201478.501469"
+TS_B = "1779201499.123456"
+
+
+def _fetcher(messages_by_channel: dict[str, list[RawAPIDict]]):
+    def fetch(*, channel: str) -> list[RawAPIDict]:
+        return list(messages_by_channel.get(channel, []))
+
+    return fetch
+
+
+def _classifier(states: dict[str, MrState]):
+    def classify(urls: list[str]) -> list[MrState]:
+        return [states[url] for url in urls]
+
+    return classify
+
+
+def _message(text: str, ts: str) -> RawAPIDict:
+    return {"text": text, "ts": ts, "user": "USRG", "type": "message"}
+
+
+class TestSlackBroadcastsMessageIsolation(TestCase):
+    """Second message survives when _handle_message raises on the first."""
+
+    def test_failing_first_message_does_not_suppress_second_message_signal(self) -> None:
+        backend = _FakeMessaging()
+        history = {
+            CHANNEL: [
+                _message(f"review {MR_OPEN_A}", TS_A),
+                _message(f"review {MR_OPEN_B}", TS_B),
+            ]
+        }
+        states = {
+            MR_OPEN_A: MrState(url=MR_OPEN_A, merged=False, approved=False),
+            MR_OPEN_B: MrState(url=MR_OPEN_B, merged=False, approved=False),
+        }
+        call_count = [0]
+        original_handle = SlackBroadcastsScanner._handle_message
+
+        def _raising_handle(self_inner, channel: str, message: RawAPIDict) -> list:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated processing failure"
+                raise RuntimeError(msg)
+            return original_handle(self_inner, channel, message)
+
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+        )
+        with patch.object(SlackBroadcastsScanner, "_handle_message", _raising_handle):
+            signals = scanner.scan()
+
+        assert len(signals) >= 1, "second message must still produce its signal"
+        assert any(s.payload.get("mr_url") == MR_OPEN_B for s in signals)
+
+
+class TestSlackBroadcastsConnectChannelEscalation(TestCase):
+    """ConnectChannelBotRestrictedError still propagates through the per-message guard."""
+
+    def test_connect_channel_error_propagates_out_of_scan(self) -> None:
+        backend = _FakeMessaging(react_raises=RuntimeError("Slack API not_in_channel"))
+        history = {CHANNEL: [_message(f"{MR_OPEN_A}", TS_A)]}
+        states = {MR_OPEN_A: MrState(url=MR_OPEN_A, merged=False, approved=False)}
+        scanner = SlackBroadcastsScanner(
+            backend=backend,
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier(states),
+        )
+        with pytest.raises(ConnectChannelBotRestrictedError):
+            scanner.scan()
+
+
+# ---------------------------------------------------------------------------
+# TicketCompletionScanner
+# ---------------------------------------------------------------------------
+
+
+class _Overlay(OverlayBase):
+    def get_repos(self) -> list[str]:
+        return ["acme-repo"]
+
+    def get_provision_steps(self, worktree: Any) -> list:
+        _ = worktree
+        return []
+
+    def is_issue_done(self, issue_data: dict[str, object]) -> bool:
+        return issue_data.get("state") in {"closed", "completed", "merged"}
+
+
+class TestTicketCompletionIsolation(TestCase):
+    """Sibling ticket still emits when processing the first ticket raises."""
+
+    def test_failing_first_ticket_does_not_suppress_second_ticket_completion(self) -> None:
+        Ticket.objects.create(overlay="acme", issue_url="https://x/shipped/1", state="shipped")
+        Ticket.objects.create(overlay="acme", issue_url="https://x/shipped/2", state="shipped")
+
+        call_count = [0]
+
+        def _patched_get_code_host(overlay: Any, url: str) -> Any:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated host lookup failure"
+                raise RuntimeError(msg)
+            host = _FakeCodeHost()
+            host.get_issue = lambda issue_url: {"state": "closed"}  # type: ignore[assignment]
+            return host
+
+        scanner = TicketCompletionScanner(overlay=_Overlay(), overlay_name="acme")
+        with patch("teatree.loop.scanners.ticket_completion.get_code_host_for_url", _patched_get_code_host):
+            signals = scanner.scan()
+
+        assert len(signals) == 1, "second ticket must still emit completion_detected"
+        assert signals[0].kind == "ticket.completion_detected"
+
+
+# ---------------------------------------------------------------------------
+# RedCardScanner — reaction loop
+# ---------------------------------------------------------------------------
+
+REACTION_TS_A = "1779180557.000100"
+REACTION_TS_B = "1779180558.000200"
+RC_CHANNEL = "C09D25ZHCRJ"
+DM_CHANNEL = "D0B36P8LU86"
+USER = "U0A72P7CK0A"
+
+
+def _reaction_event(ts: str, channel: str = RC_CHANNEL) -> RawAPIDict:
+    return {
+        "type": "reaction_added",
+        "user": USER,
+        "reaction": "red_circle",
+        "item": {"type": "message", "channel": channel, "ts": ts},
+        "event_ts": ts,
+    }
+
+
+def _dm_event(ts: str, text: str = "RED CARD") -> RawAPIDict:
+    return {"ts": ts, "text": text, "channel": DM_CHANNEL, "user": USER}
+
+
+class TestRedCardReactionIsolation(TestCase):
+    """Second reaction event still produces a signal when the first raises."""
+
+    def test_failing_first_reaction_does_not_suppress_second_reaction_signal(self) -> None:
+        backend = _FakeMessaging(
+            user_id=USER,
+            reactions=[_reaction_event(REACTION_TS_A), _reaction_event(REACTION_TS_B)],
+            messages_by_ts={
+                (RC_CHANNEL, REACTION_TS_A): {"text": "agent msg a"},
+                (RC_CHANNEL, REACTION_TS_B): {"text": "agent msg b"},
+            },
+        )
+        scanner = RedCardScanner(backend=backend, overlay="acme")
+
+        call_count = [0]
+        original_handle = RedCardScanner._handle_reaction
+
+        def _raising_handle(self_inner, event: RawAPIDict, target_user: str) -> Any:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated failure on reaction 1"
+                raise RuntimeError(msg)
+            return original_handle(self_inner, event, target_user)
+
+        with patch.object(RedCardScanner, "_handle_reaction", _raising_handle):
+            signals = scanner.scan()
+
+        assert len(signals) == 1, "second reaction must still produce its signal"
+        assert signals[0].kind == "red_card.signal"
+
+
+class TestRedCardDmIsolation(TestCase):
+    """Second DM event still produces a signal when the first raises."""
+
+    def test_failing_first_dm_does_not_suppress_second_dm_signal(self) -> None:
+        backend = _FakeMessaging(
+            user_id=USER,
+            dms=[_dm_event("1779.001"), _dm_event("1779.002")],
+        )
+        scanner = RedCardScanner(backend=backend, overlay="acme")
+
+        call_count = [0]
+        original_handle = RedCardScanner._handle_dm
+
+        def _raising_handle(self_inner, event: RawAPIDict, target_user: str) -> Any:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated failure on DM 1"
+                raise RuntimeError(msg)
+            return original_handle(self_inner, event, target_user)
+
+        with patch.object(RedCardScanner, "_handle_dm", _raising_handle):
+            signals = scanner.scan()
+
+        assert len(signals) == 1, "second DM must still produce its signal"
+        assert signals[0].kind == "red_card.signal"
+
+
+# ---------------------------------------------------------------------------
+# SlackReviewIntentScanner — reaction + mention loops
+# ---------------------------------------------------------------------------
+
+MR_URL = "https://gitlab.com/owner/repo/-/merge_requests/42"
+RI_TS_A = "1779180558.000300"
+RI_TS_B = "1779180558.000400"
+RI_CHANNEL = "C0REVIEW"
+
+
+def _review_reaction(ts: str) -> RawAPIDict:
+    return {
+        "type": "reaction_added",
+        "user": USER,
+        "reaction": "eyes",
+        "item": {"type": "message", "channel": RI_CHANNEL, "ts": ts},
+        "event_ts": ts,
+    }
+
+
+def _mention_event(ts: str) -> RawAPIDict:
+    return {"ts": ts, "text": f"<@{USER}> please review {MR_URL}", "channel": RI_CHANNEL}
+
+
+class TestSlackReviewIntentReactionIsolation(TestCase):
+    """Second reaction still produces a signal when the first raises."""
+
+    def test_failing_first_reaction_does_not_suppress_second_reaction_signal(self) -> None:
+        backend = _FakeMessaging(
+            user_id=USER,
+            reactions=[_review_reaction(RI_TS_A), _review_reaction(RI_TS_B)],
+            messages_by_ts={
+                (RI_CHANNEL, RI_TS_A): {"text": f"review {MR_URL}"},
+                (RI_CHANNEL, RI_TS_B): {"text": f"review {MR_URL}"},
+            },
+        )
+        scanner = SlackReviewIntentScanner(backend=backend, overlay="acme")
+
+        call_count = [0]
+        original_handle = SlackReviewIntentScanner._handle_reaction
+
+        def _raising_handle(self_inner, event: RawAPIDict, target_user: str) -> Any:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated failure"
+                raise RuntimeError(msg)
+            return original_handle(self_inner, event, target_user)
+
+        with (
+            patch.object(SlackReviewIntentScanner, "_handle_reaction", _raising_handle),
+            patch("teatree.backends.slack_receiver.drain_reactions_queue", return_value=[]),
+        ):
+            signals = scanner.scan()
+
+        assert len(signals) == 1, "second reaction must still produce its signal"
+
+
+class TestSlackReviewIntentMentionIsolation(TestCase):
+    """Second mention still produces a signal when the first raises."""
+
+    def test_failing_first_mention_does_not_suppress_second_mention_signal(self) -> None:
+        backend = _FakeMessaging(
+            user_id=USER,
+            mentions=[_mention_event(RI_TS_A), _mention_event(RI_TS_B)],
+        )
+        scanner = SlackReviewIntentScanner(backend=backend, overlay="acme")
+
+        call_count = [0]
+        original_handle = SlackReviewIntentScanner._handle_mention
+
+        def _raising_handle(self_inner, event: RawAPIDict, target_user: str) -> Any:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated failure"
+                raise RuntimeError(msg)
+            return original_handle(self_inner, event, target_user)
+
+        with (
+            patch.object(SlackReviewIntentScanner, "_handle_mention", _raising_handle),
+            patch("teatree.backends.slack_receiver.drain_reactions_queue", return_value=[]),
+        ):
+            signals = scanner.scan()
+
+        assert len(signals) == 1, "second mention must still produce its signal"
+
+
+# ---------------------------------------------------------------------------
+# TodoSweepScanner
+# ---------------------------------------------------------------------------
+
+
+class _TodoOverlay(OverlayBase):
+    def get_repos(self) -> list[str]:
+        return []
+
+    def get_provision_steps(self, worktree: Any) -> list:
+        _ = worktree
+        return []
+
+    def is_issue_done(self, issue_data: dict[str, object]) -> bool:
+        return issue_data.get("state") == "closed"
+
+
+URL_SWEEP_A = "https://example.com/issues/sweep/1"
+URL_SWEEP_B = "https://example.com/issues/sweep/2"
+
+
+class TestTodoSweepIsolation(TestCase):
+    """Second task still produces a signal when _verify raises on the first."""
+
+    def test_failing_first_task_does_not_suppress_second_task_signal(self) -> None:
+        overlay = _TodoOverlay()
+        ticket_a = Ticket.objects.create(overlay="acme", issue_url=URL_SWEEP_A)
+        ticket_b = Ticket.objects.create(overlay="acme", issue_url=URL_SWEEP_B)
+        session_a = Session.objects.create(overlay="acme", ticket=ticket_a, agent_id="a")
+        session_b = Session.objects.create(overlay="acme", ticket=ticket_b, agent_id="b")
+        Task.objects.create(ticket=ticket_a, session=session_a, phase="coding")
+        Task.objects.create(ticket=ticket_b, session=session_b, phase="coding")
+
+        scanner = TodoSweepScanner(overlay=overlay, overlay_name="acme")
+
+        call_count = [0]
+        original_verify = TodoSweepScanner._verify
+
+        def _raising_verify(self_inner, task: Any) -> Any:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated verify failure"
+                raise RuntimeError(msg)
+            return original_verify(self_inner, task)
+
+        host_b = _FakeCodeHost()
+        host_b.get_issue = lambda url: {"state": "closed"}  # type: ignore[assignment]
+
+        with (
+            patch.object(TodoSweepScanner, "_verify", _raising_verify),
+            patch("teatree.loop.scanners.todo_sweep.get_code_host_for_url", return_value=host_b),
+        ):
+            signals = scanner.scan()
+
+        assert len(signals) == 1, "second task must still produce its signal"
+
+
+# ---------------------------------------------------------------------------
+# IssueImplementerScanner
+# ---------------------------------------------------------------------------
+
+
+class _ImplementerHost:
+    user: str = "alice"
+    issues: list[RawAPIDict]
+
+    def __init__(self, issues: list[RawAPIDict]) -> None:
+        self.issues = issues
+
+    def current_user(self) -> str:
+        return self.user
+
+    def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:
+        _ = assignee
+        return self.issues
+
+
+IMPL_LABEL = "auto-implement"
+IMPL_URL_A = "https://github.com/acme/repo/issues/1"
+IMPL_URL_B = "https://github.com/acme/repo/issues/2"
+
+
+class TestIssueImplementerIsolation(TestCase):
+    def _issue(self, url: str) -> RawAPIDict:
+        return {"web_url": url, "title": "do it", "labels": [IMPL_LABEL], "state": "open"}
+
+    def test_failing_first_issue_does_not_suppress_second_issue_signal(self) -> None:
+        host = _ImplementerHost(issues=[self._issue(IMPL_URL_A), self._issue(IMPL_URL_B)])
+        scanner = IssueImplementerScanner(host=host, label=IMPL_LABEL, overlay_name="acme")
+
+        call_count = [0]
+        original_claim = ImplementedIssueMarker.objects.claim
+
+        def _raising_claim(url: str, *, overlay: str) -> Any:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated DB failure"
+                raise RuntimeError(msg)
+            return original_claim(url, overlay=overlay)
+
+        with patch.object(ImplementedIssueMarker.objects, "claim", _raising_claim):
+            signals = scanner.scan()
+
+        assert len(signals) == 1, "second issue must still be claimed and emitted"
+        assert signals[0].payload["url"] == IMPL_URL_B
+
+
+# ---------------------------------------------------------------------------
+# SlackDmInboundScanner
+# ---------------------------------------------------------------------------
+
+
+class TestSlackDmInboundIsolation(TestCase):
+    """Second DM still produces a signal when processing the first raises."""
+
+    def test_failing_first_dm_does_not_suppress_second_dm_signal(self) -> None:
+        dm_ts_a = "1779180560.000100"
+        dm_ts_b = "1779180560.000200"
+        dm_ch = "D0DIRECT"
+
+        backend = _FakeMessaging(
+            user_id=USER,
+            dms=[
+                {"ts": dm_ts_a, "text": "hello agent", "channel": dm_ch, "user": USER},
+                {"ts": dm_ts_b, "text": "another message", "channel": dm_ch, "user": USER},
+            ],
+        )
+        scanner = SlackDmInboundScanner(backend=backend, overlay="acme")
+
+        call_count = [0]
+        from teatree.core.models.pending_chat_injection import PendingChatInjection  # noqa: PLC0415
+
+        original_record = PendingChatInjection.record
+
+        def _raising_record(**kwargs: Any) -> Any:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                msg = "simulated record failure"
+                raise RuntimeError(msg)
+            return original_record(**kwargs)
+
+        with (
+            patch.object(PendingChatInjection, "record", _raising_record),
+            patch(
+                "teatree.loop.scanners.slack_dm_inbound.resolve_own_identity",
+                return_value=None,
+            ),
+            patch(
+                "teatree.loop.scanners.slack_dm_inbound.filter_self_messages",
+                side_effect=lambda events, identity: events,
+            ),
+        ):
+            signals = scanner.scan()
+
+        assert len(signals) == 1, "second DM must still produce its signal"
+        assert signals[0].payload["ts"] == dm_ts_b


### PR DESCRIPTION
fix(loop): add per-item fault isolation to the remaining loop scanners

Wraps each scanner's inner iteration body in try/except so a single
bad item logs an error and continues rather than aborting all siblings.
Covers: active_tickets, issue_implementer, red_card (reactions + DMs),
reviewer_prs (PR loop + orphan loop), slack_broadcasts (per-message,
ConnectChannelBotRestrictedError escalation preserved), slack_dm_inbound,
slack_review_intent (reactions + mentions), ticket_completion, todo_sweep.

Closes #1597