### PR TITLE
fix(loop): collapse todo.orphaned needs-operator-review rows to one statusline line

### DIFF
--- a/src/teatree/loop/rendering_classification.py
+++ b/src/teatree/loop/rendering_classification.py
@@ -181,48 +181,89 @@ def _classify_disposition(c: _ClassifiedActions, overlay: str, payload: Payload,
     c.disposition_refs.setdefault(overlay, {}).setdefault(reason, []).append(ref)
 
 
+def _is_orphaned_task(payload: Payload) -> bool:
+    """True when *payload* belongs to a ``todo.orphaned`` operator-review advisory.
+
+    The scanner emits one signal per unverifiable task; without collapse,
+    N orphaned tasks produce N identical-shaped rows in ``action_needed``
+    and flood the statusline. The classifier intercepts them and collapses
+    the whole batch to one summary line (``N tasks need operator review``).
+    The ScanSignals themselves are preserved for non-statusline consumers;
+    only the rendered view collapses.
+    """
+    return isinstance(payload.get("task_id"), int)
+
+
+def _emit_orphaned_summaries(
+    c: _ClassifiedActions,
+    orphaned_counts: dict[str, int],
+) -> None:
+    """Append one collapsed ``N tasks need operator review`` entry per overlay."""
+    for overlay, count in sorted(orphaned_counts.items()):
+        prefix = f"[{overlay}] " if overlay else ""
+        label = "task needs" if count == 1 else "tasks need"
+        c.other.append(("action_needed", StatuslineEntry(text=f"{prefix}{count} {label} operator review")))
+
+
+def _classify_one(c: _ClassifiedActions, action: DispatchAction) -> None:
+    """Route one statusline action into the right classified bucket.
+
+    Pre-condition: ``action.kind == "statusline"``, not a slack user reply,
+    and not a ``todo.orphaned`` advisory (both filtered by the caller).
+    """
+    payload = action.payload if isinstance(action.payload, dict) else {}
+    url_str = _str_field(payload, "url")
+    overlay = _str_field(payload, "overlay")
+    prefix = f"[{overlay}] " if overlay else ""
+
+    state = payload.get("state")
+    ticket_number = payload.get("ticket_number")
+    if action.zone == "anchors" and isinstance(state, str) and isinstance(ticket_number, str):
+        c.active_tickets.setdefault(overlay, []).append(
+            _active_ticket_tuple(ticket_number=ticket_number, state=state, payload=payload),
+        )
+        return
+    if payload.get("stale") is True:
+        c.stale_refs.setdefault(overlay, []).append(
+            _issue_ref_from(
+                issue_url=_str_field(payload, "issue_url"),
+                ticket_number=_str_field(payload, "ticket_number"),
+            ),
+        )
+        return
+    reason = payload.get("reason")
+    if isinstance(reason, str):
+        _classify_disposition(c, overlay, payload, reason)
+        return
+    if action.zone == "action_needed" and action.detail.startswith("Ready to start:"):
+        c.ready_refs.setdefault(overlay, []).append(
+            _issue_ref_from(
+                url=_str_field(payload, "url"),
+                issue_url=_str_field(payload, "issue_url"),
+                ticket_number=_str_field(payload, "ticket_number"),
+                title=_str_field(payload, "title"),
+            ),
+        )
+        return
+    if _is_dm_action(action, payload):
+        c.dms.setdefault(overlay, []).append(_dm_ref_from(payload))
+        return
+    ref = _pr_ref(action)
+    if ref is not None:
+        bucket = c.action_prs if action.zone == "action_needed" else c.inflight_prs
+        bucket.setdefault(overlay, []).append(ref)
+        return
+    c.other.append((action.zone, StatuslineEntry(text=f"{prefix}{action.detail}", url=url_str)))
+
+
 def _classify_actions(actions: list[DispatchAction]) -> _ClassifiedActions:
     c = _ClassifiedActions()
+    orphaned_counts: dict[str, int] = {}
     for action in actions:
-        payload = action.payload if isinstance(action.payload, dict) else {}
-        url_str = _str_field(payload, "url")
-        overlay = _str_field(payload, "overlay")
-        prefix = f"[{overlay}] " if overlay else ""
-
         if action.kind != "statusline":
             continue
-        state = payload.get("state")
-        ticket_number = payload.get("ticket_number")
-        if action.zone == "anchors" and isinstance(state, str) and isinstance(ticket_number, str):
-            c.active_tickets.setdefault(overlay, []).append(
-                _active_ticket_tuple(ticket_number=ticket_number, state=state, payload=payload),
-            )
-            continue
-        if payload.get("stale") is True:
-            c.stale_refs.setdefault(overlay, []).append(
-                _issue_ref_from(
-                    issue_url=_str_field(payload, "issue_url"),
-                    ticket_number=_str_field(payload, "ticket_number"),
-                ),
-            )
-            continue
-        reason = payload.get("reason")
-        if isinstance(reason, str):
-            _classify_disposition(c, overlay, payload, reason)
-            continue
-        if action.zone == "action_needed" and action.detail.startswith("Ready to start:"):
-            c.ready_refs.setdefault(overlay, []).append(
-                _issue_ref_from(
-                    url=_str_field(payload, "url"),
-                    issue_url=_str_field(payload, "issue_url"),
-                    ticket_number=_str_field(payload, "ticket_number"),
-                    title=_str_field(payload, "title"),
-                ),
-            )
-            continue
-        if _is_dm_action(action, payload):
-            c.dms.setdefault(overlay, []).append(_dm_ref_from(payload))
-            continue
+        payload = action.payload if isinstance(action.payload, dict) else {}
+        overlay = _str_field(payload, "overlay")
         if _is_slack_user_reply(action, payload):
             # #1113 Defect 2 defense-in-depth: raw Slack reply text + ts must
             # never reach ``c.other`` and render verbatim, even if the
@@ -230,12 +271,11 @@ def _classify_actions(actions: list[DispatchAction]) -> _ClassifiedActions:
             # Slack-answer loop (``teatree.loop.slack_answer``); the
             # statusline never surfaces it.
             continue
-        ref = _pr_ref(action)
-        if ref is not None:
-            bucket = c.action_prs if action.zone == "action_needed" else c.inflight_prs
-            bucket.setdefault(overlay, []).append(ref)
+        if action.zone == "action_needed" and _is_orphaned_task(payload):
+            orphaned_counts[overlay] = orphaned_counts.get(overlay, 0) + 1
             continue
-        c.other.append((action.zone, StatuslineEntry(text=f"{prefix}{action.detail}", url=url_str)))
+        _classify_one(c, action)
+    _emit_orphaned_summaries(c, orphaned_counts)
     _dedup_classified(c)
     return c
 

--- a/tests/teatree_loop/test_rendering_audit.py
+++ b/tests/teatree_loop/test_rendering_audit.py
@@ -248,6 +248,59 @@ class TestInflightPrRows:
         assert "(pipeline failed)" not in text, repr(text)
 
 
+def _orphaned(task_id: int, overlay: str = "teatree") -> DispatchAction:
+    """Build a ``todo.orphaned`` statusline action as the dispatcher emits it."""
+    return DispatchAction(
+        kind="statusline",
+        zone="action_needed",
+        detail=f"Task {task_id} — artifact state unverifiable, needs operator review",
+        payload={
+            "task_id": task_id,
+            "ticket_id": task_id + 1000,
+            "issue_url": f"https://example.com/issues/{task_id}",
+            "overlay": overlay,
+        },
+    )
+
+
+class TestOrphanedTaskCollapse:
+    """N ``todo.orphaned`` signals collapse to ONE summary line in action_needed."""
+
+    def test_single_orphaned_task_renders_one_summary_line(self) -> None:
+        zones = zones_for([_orphaned(42)], colorize=False)
+        text = _blob(zones.action_needed)
+        assert "task needs operator review" in text, repr(text)
+        assert "1 task" in text, repr(text)
+
+    def test_many_orphaned_tasks_render_exactly_one_summary_line(self) -> None:
+        actions = [_orphaned(i) for i in range(1, 12)]
+        zones = zones_for(actions, colorize=False)
+        lines = [item if isinstance(item, str) else item.text for item in zones.action_needed]
+        # Exactly one line mentions operator review — not 11 separate rows.
+        review_lines = [ln for ln in lines if "operator review" in ln]
+        assert len(review_lines) == 1, repr(lines)
+        assert "11 tasks need operator review" in review_lines[0], repr(review_lines[0])
+
+    def test_orphaned_task_summary_includes_count(self) -> None:
+        actions = [_orphaned(i) for i in range(1, 4)]
+        zones = zones_for(actions, colorize=False)
+        text = _blob(zones.action_needed)
+        assert "3 tasks need operator review" in text, repr(text)
+
+    def test_orphaned_tasks_from_different_overlays_each_get_one_line(self) -> None:
+        actions = [
+            _orphaned(1, overlay="overlay-a"),
+            _orphaned(2, overlay="overlay-a"),
+            _orphaned(3, overlay="overlay-b"),
+        ]
+        zones = zones_for(actions, colorize=False)
+        lines = [item if isinstance(item, str) else item.text for item in zones.action_needed]
+        review_lines = [ln for ln in lines if "operator review" in ln]
+        assert len(review_lines) == 2, repr(lines)
+        assert any("overlay-a" in ln and "2 tasks" in ln for ln in review_lines), repr(review_lines)
+        assert any("overlay-b" in ln and "1 task" in ln for ln in review_lines), repr(review_lines)
+
+
 class TestNoRunningTasksLine(django.test.TestCase):
     """The DB-backed ``agents:`` row is gone post-#1156.
 


### PR DESCRIPTION
## Problem

When N tasks reach the `todo.orphaned` state (artifact state unverifiable), the scanner emits one `todo.orphaned` `ScanSignal` per task. Each signal dispatches to a `statusline/action_needed` action, and each action produced its own row in the statusline `action_needed` zone — resulting in N identical-shaped lines like `[overlay] Task NNN — artifact state unverifiable, needs operator review`.

With 11 orphaned tasks the entire statusline was dominated by this one repeated message, making every other signal invisible.

## Fix

In [`rendering_classification.py`](src/teatree/loop/rendering_classification.py), `_classify_actions` now intercepts `todo.orphaned` actions (identified by `action.zone == "action_needed"` and `isinstance(payload["task_id"], int)`) before routing them to `_classify_one`. It accumulates a count per overlay, then `_emit_orphaned_summaries` appends exactly one collapsed entry per overlay group:

```
[overlay] 11 tasks need operator review
```

`ScanSignals` themselves are preserved for non-statusline consumers. Only the rendered statusline view collapses.

The `_classify_one` extraction (pulled out of the now-simpler `_classify_actions`) also keeps both functions within ruff's `C901`/`PLR0911` complexity limits.

## Tests

Four new cases in `TestOrphanedTaskCollapse` (in `tests/teatree_loop/test_rendering_audit.py`):

- single orphaned task → `1 task needs operator review`
- 11 orphaned tasks → exactly one line, `11 tasks need operator review`
- N tasks → count present in text
- tasks from two overlays → two separate summary lines, one per overlay

All 96 tests pass (`uv run pytest --no-cov -q`).