### PR TITLE
fix(loop): give changes-requested review a terminal disposition so the reviewer stops re-dispatching forever (#1606)

### DIFF
--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -88,6 +88,9 @@ _ALLOWED_TRANSITIONS = {
     # #1077: reviewer concludes an external review with no postable/
     # approvable action — terminal disposition for the reviewing task.
     "mark_review_no_action",
+    # #1606: reviewer requests changes — terminal disposition for the
+    # reviewing task so the scanner stops re-dispatching at a fixed head SHA.
+    "mark_review_changes_requested",
     # #1118: phase-driven catch-up to REVIEWED. The FSM exposes it via
     # ``get_available_FIELD_transitions`` from every non-terminal state
     # (#808); the CLI must mirror the FSM-table surface so a ticket
@@ -104,7 +107,7 @@ class Command(TyperCommand):
 
         Accepts any of the allowed transition names: scope, start, code, test,
         review, ship, request_review, mark_merged, retrospect, mark_delivered,
-        rework, mark_review_no_action.
+        rework, mark_review_no_action, mark_review_changes_requested.
         """
         if transition_name not in _ALLOWED_TRANSITIONS:
             return {"error": f"Unknown transition: {transition_name}"}

--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -207,11 +207,26 @@ class Task(models.Model):
             Ticket.State.TESTED,
             Ticket.State.REVIEWED,
         }
+        # #1606: an honest non-approval disposition (CHANGES_REQUESTED /
+        # REVIEWED_NO_ACTION) already recorded on ``extra`` must never be
+        # overwritten with APPROVED by a stray task completion. The state
+        # guard below already covers the normal path (those transitions move
+        # the ticket to DELIVERED, out of the source set), but recording the
+        # invariant explicitly keeps it true even if a future path leaves the
+        # ticket in a source state with the disposition stamped.
+        from teatree.backends.protocols import ReviewState  # noqa: PLC0415
+
+        non_approval_dispositions = {
+            ReviewState.CHANGES_REQUESTED.value,
+            ReviewState.REVIEWED_NO_ACTION.value,
+        }
+        already_dispositioned = (ticket.extra or {}).get("last_review_state") in non_approval_dispositions
         with transaction.atomic():
             if (
                 phase == "reviewing"
                 and ticket.role == Ticket.Role.REVIEWER
                 and ticket.state in mark_reviewed_externally_source_states
+                and not already_dispositioned
             ):
                 ticket.mark_reviewed_externally()
                 ticket.save()

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -524,6 +524,50 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
             self.merge_extra(set_keys={"reviewed_sha": sha, "last_review_state": ReviewState.REVIEWED_NO_ACTION.value})
         self._consume_pending_phase_tasks("reviewing")
 
+    @transition(
+        field=state,
+        source=[
+            State.NOT_STARTED,
+            State.SCOPED,
+            State.STARTED,
+            State.CODED,
+            State.TESTED,
+            State.REVIEWED,
+        ],
+        target=State.DELIVERED,
+        conditions=[lambda t: t.role == Ticket.Role.REVIEWER],
+    )
+    def mark_review_changes_requested(self) -> None:
+        """Reviewer-role terminal disposition for a changes-requested review.
+
+        Sibling of :meth:`mark_review_no_action` for the case the reviewer
+        posts review feedback requesting changes. Like the no-action case,
+        ``CHANGES_REQUESTED`` had no FSM transition: the only terminal path
+        was ``Task.complete()`` -> ``mark_reviewed_externally`` (APPROVED),
+        so ``ReviewState.CHANGES_REQUESTED`` was never recorded and was
+        absent from the ``_already_reviewed_at_head`` dedup set. The
+        reviewing Task therefore re-dispatched the same changes-requested
+        PR every Stop-hook pump forever (the #1077-class loop, for the
+        changes-requested outcome -- #1606).
+
+        Driven directly via ``t3 ticket transition <id>
+        mark_review_changes_requested`` while the reviewing task is still
+        PENDING, so it consumes that task itself. It records
+        ``last_review_state = CHANGES_REQUESTED`` (NEVER APPROVED): the
+        disposition is honest -- the review is *not* an approval -- yet
+        ``_already_reviewed_at_head`` treats a changes-requested observation
+        at the current head SHA as "already handled" so the task is not
+        re-queued while the author has not addressed the feedback. A head-SHA
+        move drops ``last_review_state`` (the existing #959 reset) so the
+        revised PR is reviewed again -- no lost obligation.
+        """
+        from teatree.backends.protocols import ReviewState  # noqa: PLC0415
+
+        sha = str(self._extra().get("reviewed_sha", ""))
+        if self.issue_url and sha:
+            self.merge_extra(set_keys={"reviewed_sha": sha, "last_review_state": ReviewState.CHANGES_REQUESTED.value})
+        self._consume_pending_phase_tasks("reviewing")
+
     @transition(field=state, source=[State.REVIEWED, State.SHIPPED], target=State.SHIPPED)
     def ship(self) -> None:
         """Schedule push + PR creation.

--- a/src/teatree/loop/persistence.py
+++ b/src/teatree/loop/persistence.py
@@ -140,17 +140,19 @@ def _already_reviewed_at_head(ticket: Ticket, head_sha: str) -> bool:
     loop reviewing Task, so there is no open/completed Task to key on) is
     the reviewer ticket's ``last_review_state``/``reviewed_sha`` pair —
     written by ``Ticket.mark_reviewed_externally`` / ``mark_review_no_action``
-    and the ``ReviewerPrsScanner`` cache. A terminal state at the current
-    head ⇒ the review already happened; re-enqueueing would duplicate it
-    every tick. Two terminal states suppress: ``APPROVED`` (a genuine
-    approving review — the existing #959 behaviour) and
-    ``REVIEWED_NO_ACTION`` (the reviewer concluded there was nothing to
-    post/approve on a bot MR — before #1077 there was no terminal state
-    for this, so the reviewing task re-dispatched every Stop-hook pump
-    forever). ``REVIEWED_NO_ACTION`` is intentionally *not* APPROVED so a
-    future genuine review is never hidden; suppression is keyed on the
+    / ``mark_review_changes_requested`` and the ``ReviewerPrsScanner`` cache.
+    A terminal state at the current head ⇒ the review already happened;
+    re-enqueueing would duplicate it every tick. Three terminal states
+    suppress: ``APPROVED`` (a genuine approving review — the existing #959
+    behaviour), ``REVIEWED_NO_ACTION`` (the reviewer concluded there was
+    nothing to post/approve on a bot MR — before #1077 there was no terminal
+    state for this, so the reviewing task re-dispatched every Stop-hook pump
+    forever) and ``CHANGES_REQUESTED`` (the reviewer requested changes — same
+    #1077-class loop for the changes-requested outcome, #1606). Neither
+    ``REVIEWED_NO_ACTION`` nor ``CHANGES_REQUESTED`` is APPROVED, so a future
+    genuine approving review is never hidden; suppression is keyed on the
     head SHA, and a SHA move drops ``last_review_state`` (the #959 reset
-    in ``_handle_reviewer``) so a new revision is still reviewed.
+    in ``_handle_reviewer``) so the revised PR is reviewed again.
 
     A blank ``head_sha`` is treated as "cannot confirm parity" so review
     is NOT suppressed (fail-open — never silently skip a real review).
@@ -160,7 +162,11 @@ def _already_reviewed_at_head(ticket: Ticket, head_sha: str) -> bool:
     from teatree.backends.protocols import ReviewState  # noqa: PLC0415
 
     extra = ticket.extra or {}
-    terminal = {ReviewState.APPROVED.value, ReviewState.REVIEWED_NO_ACTION.value}
+    terminal = {
+        ReviewState.APPROVED.value,
+        ReviewState.REVIEWED_NO_ACTION.value,
+        ReviewState.CHANGES_REQUESTED.value,
+    }
     return extra.get("last_review_state") in terminal and extra.get("reviewed_sha") == head_sha
 
 

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -484,6 +484,26 @@ class TestTicketCommand(TestCase):
         ticket.refresh_from_db()
         assert ticket.extra["last_review_state"] == "reviewed_no_action"
 
+    def test_transition_mark_review_changes_requested_delivers_reviewer_ticket(self) -> None:
+        """#1606: the changes-requested disposition is reachable via the CLI transition."""
+        from teatree.backends.protocols import ReviewState  # noqa: PLC0415
+        from teatree.core.models.ticket import schedule_external_review  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://gitlab/x/-/merge_requests/1606c",
+            role=Ticket.Role.REVIEWER,
+            extra={"reviewed_sha": "sha1"},
+        )
+        schedule_external_review(ticket)
+        result = cast(
+            "dict[str, object]",
+            call_command("ticket", "transition", ticket.pk, "mark_review_changes_requested"),
+        )
+        assert result["state"] == Ticket.State.DELIVERED
+        ticket.refresh_from_db()
+        assert ticket.extra["last_review_state"] == ReviewState.CHANGES_REQUESTED.value
+
     def test_list_returns_all_tickets(self) -> None:
         Ticket.objects.create(overlay="test")
         Ticket.objects.create(overlay="other")

--- a/tests/teatree_core/test_ticket_role.py
+++ b/tests/teatree_core/test_ticket_role.py
@@ -144,3 +144,100 @@ class TestMarkReviewNoAction(TestCase):
         assert ticket.state == Ticket.State.DELIVERED
         assert task.status == Task.Status.COMPLETED
         assert "last_review_state" not in (ticket.extra or {})
+
+
+class TestMarkReviewChangesRequested(TestCase):
+    """#1606: terminal disposition for a changes-requested external review."""
+
+    def test_consumes_pending_task_and_records_changes_requested_state(self) -> None:
+        """The PENDING reviewing task is terminated and the real outcome stamped.
+
+        Anti-vacuity anchor: without the fix there is no
+        ``mark_review_changes_requested`` transition, so this test cannot even
+        resolve the attribute -- RED by ``AttributeError``. With the fix:
+        ticket -> DELIVERED, the reviewing Task is COMPLETED (no longer
+        PENDING -- the infinite re-queue stops), and ``last_review_state`` is
+        ``changes_requested`` (NEVER ``approved``, so a later approving review
+        at a new SHA is not suppressed).
+        """
+        from teatree.backends.protocols import ReviewState  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(
+            overlay="acme",
+            issue_url="https://gitlab/x/-/merge_requests/1606",
+            role=Ticket.Role.REVIEWER,
+            extra={"reviewed_sha": "sha1"},
+        )
+        task = schedule_external_review(ticket)
+        assert task.status == Task.Status.PENDING
+
+        ticket.mark_review_changes_requested()
+        ticket.save()
+
+        ticket.refresh_from_db()
+        task.refresh_from_db()
+        assert ticket.state == Ticket.State.DELIVERED
+        assert task.status == Task.Status.COMPLETED
+        assert ticket.extra["last_review_state"] == ReviewState.CHANGES_REQUESTED.value
+        assert ticket.extra["last_review_state"] != ReviewState.APPROVED.value
+        assert ticket.extra["reviewed_sha"] == "sha1"
+
+    def test_refuses_author_role_ticket(self) -> None:
+        from django_fsm import TransitionNotAllowed  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(
+            overlay="acme",
+            issue_url="https://example.com/issues/8",
+            extra={"reviewed_sha": "sha1"},
+        )
+        with pytest.raises(TransitionNotAllowed):
+            ticket.mark_review_changes_requested()
+
+    def test_no_extra_write_when_url_or_sha_missing(self) -> None:
+        """Body's ``if self.issue_url and sha`` guard -- still terminal, no stamp."""
+        ticket = Ticket.objects.create(
+            overlay="acme",
+            issue_url="https://gitlab/x/-/merge_requests/1607",
+            role=Ticket.Role.REVIEWER,
+        )
+        task = schedule_external_review(ticket)
+
+        ticket.mark_review_changes_requested()
+        ticket.save()
+
+        ticket.refresh_from_db()
+        task.refresh_from_db()
+        assert ticket.state == Ticket.State.DELIVERED
+        assert task.status == Task.Status.COMPLETED
+        assert "last_review_state" not in (ticket.extra or {})
+
+    def test_task_completion_does_not_overwrite_changes_requested_with_approved(self) -> None:
+        """A completed reviewing task must not stamp APPROVED over a changes-requested disposition.
+
+        The task-completion auto-approve path (``Task._apply_phase_transition``)
+        fires ``mark_reviewed_externally`` (-> APPROVED) for a reviewing task on
+        a ticket still in a pre-DELIVERED source state. ``mark_review_changes_requested``
+        moves the ticket to DELIVERED (out of that source set) and consumes the
+        pending task, so a later orphan-sweep completion must NOT resurrect an
+        APPROVED stamp on top of the honest ``changes_requested`` outcome.
+        """
+        from teatree.backends.protocols import ReviewState  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(
+            overlay="acme",
+            issue_url="https://gitlab/x/-/merge_requests/1608",
+            role=Ticket.Role.REVIEWER,
+            extra={"reviewed_sha": "sha1"},
+        )
+        task = schedule_external_review(ticket)
+
+        ticket.mark_review_changes_requested()
+        ticket.save()
+
+        # A stray completion of the (already consumed) reviewing task must not
+        # overwrite the recorded disposition.
+        task.complete()
+
+        ticket.refresh_from_db()
+        assert ticket.extra["last_review_state"] == ReviewState.CHANGES_REQUESTED.value
+        assert ticket.extra["last_review_state"] != ReviewState.APPROVED.value

--- a/tests/teatree_loop/test_persistence.py
+++ b/tests/teatree_loop/test_persistence.py
@@ -210,6 +210,71 @@ class TestPersistReviewer(TestCase):
         assert len(created) == 1
         assert created[0].phase == "reviewing"
 
+    def test_changes_requested_disposition_stops_infinite_requeue_at_same_head(self) -> None:
+        """#1606 liveness: a changes-requested review is not re-dispatched at head.
+
+        A reviewer requests changes on a PR. The scanner keeps emitting the
+        same ``t3:reviewer`` action every tick. With the fix, the reviewer
+        records the terminal disposition via ``mark_review_changes_requested``
+        (``last_review_state = CHANGES_REQUESTED``, NEVER ``APPROVED``), the
+        reviewing Task is consumed, and a subsequent ``_handle_reviewer`` at
+        the SAME head SHA returns None (no re-dispatch).
+
+        Anti-vacuity: without the fix there is no
+        ``mark_review_changes_requested`` transition and ``CHANGES_REQUESTED``
+        is absent from the ``_already_reviewed_at_head`` terminal set, so the
+        disposition cannot be recorded / does not suppress and the second call
+        re-creates a reviewing Task — RED.
+        """
+        url = "https://gitlab/x/-/merge_requests/1606a"
+        first = persist_agent_actions([self._action(url=url, head_sha="sha1")])
+        assert len(first) == 1
+
+        ticket = Ticket.objects.get(issue_url=url)
+        ticket.mark_review_changes_requested()
+        ticket.save()
+        ticket.refresh_from_db()
+
+        assert ticket.extra["last_review_state"] == ReviewState.CHANGES_REQUESTED.value
+        assert ticket.extra["last_review_state"] != ReviewState.APPROVED.value
+        assert not Task.objects.filter(
+            ticket=ticket,
+            phase="reviewing",
+            status__in=(Task.Status.PENDING, Task.Status.CLAIMED),
+        ).exists()
+
+        # Same url + same head SHA on the next tick -> NO re-dispatch.
+        second = persist_agent_actions([self._action(url=url, head_sha="sha1")])
+        assert second == []
+        assert (
+            Task.objects.filter(
+                ticket=ticket,
+                phase="reviewing",
+                status__in=(Task.Status.PENDING, Task.Status.CLAIMED),
+            ).count()
+            == 0
+        )
+
+    def test_changes_requested_disposition_re_dispatches_on_new_head(self) -> None:
+        """#1606 no-lost-obligation: a head-SHA move re-schedules the review.
+
+        After a changes-requested disposition at SHA1, the author pushes SHA2
+        addressing the feedback. The recorded ``changes_requested`` belonged
+        to SHA1 -- the new revision MUST be reviewed again (the #959 SHA-move
+        reset drops the stale state), so ``_handle_reviewer``
+        re-``schedule_external_review``.
+        """
+        url = "https://gitlab/x/-/merge_requests/1606b"
+        persist_agent_actions([self._action(url=url, head_sha="sha1")])
+        ticket = Ticket.objects.get(issue_url=url)
+        ticket.mark_review_changes_requested()
+        ticket.save()
+
+        created = persist_agent_actions([self._action(url=url, head_sha="sha2")])
+
+        assert len(created) == 1
+        assert created[0].phase == "reviewing"
+
 
 class TestPersistOrchestrator(TestCase):
     def _action(


### PR DESCRIPTION
fix(loop): give changes-requested review a terminal disposition so the reviewer stops re-dispatching forever (#1606)

## Why

A reviewer that requests changes had no honest terminal disposition. ReviewState.CHANGES_REQUESTED existed in the enum but no FSM transition recorded it, and it was absent from the _already_reviewed_at_head dedup terminal set, so the scanner re-scheduled a reviewing task for the same changes-requested PR on every scan forever (the [#1077](https://github.com/souliane/teatree/issues/1077)-class re-dispatch loop, for the changes-requested outcome).

## What

- Add a mark_review_changes_requested FSM transition (reviewer role -> DELIVERED) mirroring mark_review_no_action: records last_review_state = CHANGES_REQUESTED + reviewed_sha = <head> and consumes the pending reviewing task.
- Add CHANGES_REQUESTED to the _already_reviewed_at_head terminal set so re-dispatch is suppressed while the head SHA is unchanged but re-triggers once the author pushes a new commit (the head-SHA-move reset in _handle_reviewer already pops last_review_state).
- Guard the task-completion auto-approve path so a recorded non-approval disposition (changes_requested / reviewed_no_action) is never overwritten with APPROVED by a stray task completion.
- Expose mark_review_changes_requested through the ticket transition CLI allow-list.

docs: n/a -- bug fix preserving the existing contract (no new state, no new top-level command)