### PR TITLE
fix(loop): per-session loop-owner badge in statusline (you ✓ / owner·pid / unclaimed)

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -10,11 +10,17 @@
 #     this hook builds carries NO loop/tick info (#130): loop state has
 #     exactly one home, the loop line.
 #  2. Live per-session info from Claude's stdin JSON: model, context-window %,
-#     5-hour and 7-day rate-limit usage, and skills loaded this session —
-#     the latter populated by hook_router.py into
-#     ${state_dir}/<session_id>.skills. Each loaded skill is expanded to its
-#     resolved `requires:` dependency closure so the segment reflects the
-#     full active set, not just explicitly tool-invoked names.
+#     5-hour and 7-day rate-limit usage, skills loaded this session, and a
+#     per-session loop-owner badge — the latter populated by hook_router.py
+#     into ${state_dir}/<session_id>.skills and from loop-registry.json
+#     respectively. The loop-owner badge shows "you ✓" (green) when this
+#     session owns the loop, "owner·pid<PID>" (yellow, neutral) when a
+#     different session owns it, or "unclaimed" (dim) when the registry has
+#     no live owner. Unlike the shared loop line, this badge is resolved
+#     per-session so every terminal reflects its own ownership context.
+#     Each loaded skill is expanded to its resolved `requires:` dependency
+#     closure so the segment reflects the full active set, not just
+#     explicitly tool-invoked names.
 
 set -u
 
@@ -104,12 +110,38 @@ g_usage=""
 g_updates=""
 g_resource=""
 
+# Per-session loop-owner badge — resolved from loop-registry.json so each
+# terminal shows its own ownership context, not the shared loop-owner chunk
+# that live_loops_anchor() intentionally omits. Gated on jq + session_id;
+# fails open (no badge) on any read error or missing registry.
+_loop_owner_badge=""
+if command -v jq >/dev/null 2>&1 && [ -n "${session_id:-}" ]; then
+    _reg="${T3_LOOP_REGISTRY_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree}/loop-registry.json"
+    if [ -r "$_reg" ]; then
+        _owner_raw=$(jq -r '."t3-loop-tick-owner" | "\(.session_id // "")\t\(.pid // "")"' "$_reg" 2>/dev/null || true)
+        IFS=$'\t' read -r _owner_sid _owner_pid <<< "${_owner_raw:-	}"
+        _owner_sid="${_owner_sid:-}"
+        _owner_pid="${_owner_pid:-}"
+        if [ "$_owner_sid" = "$session_id" ]; then
+            _loop_owner_badge="${_LBL}loop-owner:${_RST} ${_GRN}you ✓${_RST}"
+        elif [ -n "$_owner_sid" ]; then
+            _loop_owner_badge="${_LBL}loop-owner:${_RST} ${_YLW}${_owner_sid:0:8}·pid${_owner_pid}${_RST}"
+        else
+            _loop_owner_badge="${_LBL}loop-owner: unclaimed${_RST}"
+        fi
+    fi
+fi
+
 if [ -n "$model" ]; then
     g_context="${_LBL}model=${_RST}${_GRN}${model}${_RST}"
 fi
 if [ -n "$ctx_pct" ] && [ "$ctx_pct" != "empty" ]; then
     [ -n "$g_context" ] && g_context="${g_context}${isep}"
     g_context="${g_context}${_LBL}ctx=${_RST}$(color_pct "$ctx_pct")"
+fi
+if [ -n "$_loop_owner_badge" ]; then
+    [ -n "$g_context" ] && g_context="${g_context}${isep}"
+    g_context="${g_context}${_loop_owner_badge}"
 fi
 if [ -n "$five_hour_pct" ] && [ "$five_hour_pct" != "empty" ]; then
     g_usage="${_LBL}5h=${_RST}$(color_pct "$five_hour_pct")$(format_reset_time "$five_hour_resets_at")"

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -313,6 +313,16 @@ def live_loops_anchor() -> list[str]:
     if not leases:
         return []
 
+    # Exclude the loop-owner lease: it is a session-ownership token, not a
+    # work loop, and its countdown is meaningless in the shared zones file
+    # (every terminal would show the same "owner Nm" chunk regardless of
+    # which session is actually the owner). The per-session owner badge in
+    # statusline.sh replaces that signal with a context-aware you ✓ /
+    # owner·pid / unclaimed display.
+    leases = [(name, acquired_at) for name, acquired_at in leases if name != "loop-owner"]
+    if not leases:
+        return []
+
     chunks = list(starmap(_loop_chunk, leases))
     parts = ["loop running", *chunks]
     waiting = _waiting_clause()

--- a/tests/teatree_loop/test_statusline_next_tick.py
+++ b/tests/teatree_loop/test_statusline_next_tick.py
@@ -55,7 +55,9 @@ class TestConsolidatedLoopAnchor:
 
     def test_includes_relative_minutes_when_acquired_at_known(self) -> None:
         # Each lease carries its own acquire instant; 2 minutes elapsed of
-        # the 720s cadence → next tick in 10m.
+        # the 720s cadence → next tick in 10m. The loop-owner lease is
+        # excluded from the shared loop line — its badge is per-session in
+        # statusline.sh instead.
         acquired_at = datetime.now(UTC) - timedelta(seconds=120)
         leases = [("loop-tick", acquired_at), ("loop-owner", acquired_at)]
         with (
@@ -69,7 +71,8 @@ class TestConsolidatedLoopAnchor:
         # Per-loop name + relative minutes, no headline count.
         assert "loops live" not in line, line
         assert "tick 10m" in line, line
-        assert "owner 10m" in line, line
+        # loop-owner is excluded from the shared line (per-session badge in sh).
+        assert "owner" not in line, line
 
     def test_names_only_when_no_lease_history(self) -> None:
         leases = [("loop-tick", None)]
@@ -186,6 +189,8 @@ class TestZonesForIntegration:
 
     def test_line_one_is_per_loop_summary(self, tmp_path: Path) -> None:
         acquired_at = datetime.now(UTC) - timedelta(seconds=60)
+        # The loop-owner lease is present but excluded from the shared line
+        # (it is rendered as a per-session badge in statusline.sh instead).
         leases = [("loop-tick", acquired_at), ("loop-owner", acquired_at)]
         with (
             patch("teatree.loop.statusline._live_loop_leases", return_value=leases),
@@ -197,9 +202,9 @@ class TestZonesForIntegration:
         body = target.read_text()
         first_line = body.splitlines()[0]
         assert first_line.startswith("loop running · "), repr(first_line)
-        # 60s elapsed of 720s → next tick in 11m; each loop named.
+        # 60s elapsed of 720s → next tick in 11m; loop-tick appears, loop-owner absent.
         assert "tick 11m" in first_line, first_line
-        assert "owner 11m" in first_line, first_line
+        assert "owner" not in first_line, first_line
         assert "loops live" not in first_line, first_line
         # Per-loop tokens removed at the top.
         assert "\nloop:tick" not in body

--- a/tests/teatree_loop/test_statusline_refinements_1163.py
+++ b/tests/teatree_loop/test_statusline_refinements_1163.py
@@ -221,6 +221,8 @@ class TestLiveLoopsAnchor:
     """
 
     def test_returns_one_line_naming_each_loop(self) -> None:
+        # loop-owner is excluded from the shared line — its badge is
+        # per-session in statusline.sh. The other two loops appear.
         leases = [
             ("loop-tick", None),
             ("loop-slack-answer", None),
@@ -236,7 +238,8 @@ class TestLiveLoopsAnchor:
         assert "loops live" not in lines[0]
         assert "tick" in lines[0]
         assert "slack-answer" in lines[0]
-        assert "owner" in lines[0]
+        # loop-owner excluded from the shared line (per-session badge in sh).
+        assert "owner" not in lines[0]
 
     def test_no_live_leases_returns_empty(self) -> None:
         # Empty list → no lines (no statusline noise when no loop is live).
@@ -254,6 +257,8 @@ class TestZonesForIntegratesLoopsAnchor:
     """``zones_for`` surfaces the consolidated loop summary in the anchors zone."""
 
     def test_zones_for_appends_consolidated_loop_line(self, tmp_path: Path) -> None:
+        # loop-owner lease present but excluded from the shared line
+        # (per-session badge in statusline.sh replaces it).
         with (
             patch(
                 "teatree.loop.statusline._live_loop_leases",
@@ -268,7 +273,8 @@ class TestZonesForIntegratesLoopsAnchor:
         assert "loop running · " in body
         assert "loops live" not in body
         assert "tick" in body
-        assert "owner" in body
+        # loop-owner absent from the shared zones file.
+        assert "owner" not in body
         # Per-loop dump tokens absent.
         assert "loop:tick" not in body
         assert "loop:owner" not in body

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -1088,16 +1088,15 @@ class TestLoopOwnerAnchorWiring(django.test.TestCase):
             sl = Path(d) / "sl.txt"
             with patch.dict("os.environ", {"CLAUDE_SESSION_ID": "owner-sess"}):
                 run_tick(TickRequest(scanners=[]), statusline_path=sl)
-            # A live LoopLease row surfaces in the consolidated loop line
-            # — ``loop running · <name> <Nm> · …`` — at the top of the
-            # statusline, listing each live loop by its short name. The
-            # pre-refit one-line-per-loop dump (``loop:owner``,
-            # ``loop:tick``, …) and the later useless ``N loops live`` count
-            # were both removed at the user's explicit request.
+            # loop-owner is excluded from the shared consolidated loop line;
+            # its badge is rendered per-session in statusline.sh instead
+            # (you ✓ / owner·pid / unclaimed). With only the owner lease live
+            # and no actual work loop, the loop line is intentionally absent
+            # from the shared zones file.
             body = sl.read_text(encoding="utf-8")
-            assert "loop running · " in body, body
             assert "loops live" not in body, body
-            assert "owner" in body.splitlines()[0], body
+            assert "loop running · " not in body, body
+            assert "owner" not in body, body
 
     def test_normal_path_flags_foreign_owner_in_red_zone(self) -> None:
         import tempfile  # noqa: PLC0415

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -25,11 +25,19 @@ def _strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text)
 
 
-def _run(payload: dict, *, state_dir: Path, statusline_file: Path | None = None) -> subprocess.CompletedProcess:
+def _run(
+    payload: dict,
+    *,
+    state_dir: Path,
+    statusline_file: Path | None = None,
+    registry_dir: Path | None = None,
+) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env["TEATREE_CLAUDE_STATUSLINE_STATE_DIR"] = str(state_dir)
     if statusline_file is not None:
         env["TEATREE_STATUSLINE_FILE"] = str(statusline_file)
+    if registry_dir is not None:
+        env["T3_LOOP_REGISTRY_DIR"] = str(registry_dir)
     return subprocess.run(
         [str(SCRIPT)],
         input=json.dumps(payload),
@@ -334,3 +342,115 @@ class TestFreshnessInlineRefresh:
         result = _run({"model": {"display_name": "Claude Opus"}}, state_dir=state_dir, statusline_file=sl)
         plain = _strip_ansi(result.stdout)
         assert "old=5" in plain
+
+
+class TestLoopOwnerBadge:
+    """Per-session loop-owner badge in the g_context header group.
+
+    The badge reads ``loop-registry.json`` at display time so each terminal
+    reflects its own session's ownership relationship — unlike the shared
+    loop line written by the loop owner.
+    """
+
+    def _write_registry(self, registry_dir: Path, *, session_id: str, pid: int = 4242) -> None:
+        registry_dir.mkdir(parents=True, exist_ok=True)
+        reg = registry_dir / "loop-registry.json"
+        reg.write_text(
+            json.dumps({"t3-loop-tick-owner": {"session_id": session_id, "pid": pid}}),
+            encoding="utf-8",
+        )
+
+    def test_you_badge_when_owner_matches_session(self, tmp_path: Path) -> None:
+        """Same session owns the loop → green ``loop-owner: you ✓``."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        registry_dir = tmp_path / "registry"
+        self._write_registry(registry_dir, session_id="my-session-abc", pid=1234)
+
+        result = _run(
+            {"session_id": "my-session-abc", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            registry_dir=registry_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "loop-owner: you ✓" in plain, plain
+        # Confirm it is in the header (first line).
+        header = plain.splitlines()[0]
+        assert "loop-owner: you ✓" in header, header
+        # Green SGR present in the raw (non-stripped) output.
+        assert "\033[1;32m" in result.stdout, "expected green SGR for owner=you"
+
+    def test_foreign_owner_badge_shows_short_sid_and_pid(self, tmp_path: Path) -> None:
+        """Different session owns the loop → yellow ``abcdef01·pid4242``."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        registry_dir = tmp_path / "registry"
+        self._write_registry(registry_dir, session_id="abcdef0123456789", pid=4242)
+
+        result = _run(
+            {"session_id": "other-session", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            registry_dir=registry_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "abcdef01·pid4242" in plain, plain
+        assert "loop-owner:" in plain, plain
+        # Yellow SGR present (neutral — a foreign owner is normal from a non-owner terminal).
+        assert "\033[1;33m" in result.stdout, "expected yellow SGR for foreign owner"
+
+    def test_unclaimed_badge_when_registry_has_no_owner(self, tmp_path: Path) -> None:
+        """Readable registry but no owner key → dim ``loop-owner: unclaimed``."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        registry_dir = tmp_path / "registry"
+        registry_dir.mkdir()
+        reg = registry_dir / "loop-registry.json"
+        reg.write_text(json.dumps({}), encoding="utf-8")
+
+        result = _run(
+            {"session_id": "any-session", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            registry_dir=registry_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "loop-owner: unclaimed" in plain, plain
+
+    def test_badge_absent_when_registry_missing(self, tmp_path: Path) -> None:
+        """No registry file → NO badge (fail-open)."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        registry_dir = tmp_path / "empty-registry"
+        # Directory does NOT exist — registry file unreadable.
+
+        result = _run(
+            {"session_id": "any-session", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            registry_dir=registry_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "loop-owner" not in plain, plain
+
+    def test_badge_absent_when_no_session_id(self, tmp_path: Path) -> None:
+        """No session_id in payload → NO badge (cannot determine ownership)."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        registry_dir = tmp_path / "registry"
+        self._write_registry(registry_dir, session_id="some-session", pid=999)
+
+        result = _run(
+            {"model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            registry_dir=registry_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "loop-owner" not in plain, plain


### PR DESCRIPTION
## Summary

- `live_loops_anchor()` now filters `loop-owner` out of the shared zones
  file — it was a session-ownership token showing an identical countdown on
  every terminal regardless of which session actually held the lock
- `statusline.sh` reads `loop-registry.json` at display time and renders a
  per-session badge in the `g_context` header:
  - **you ✓** (green) — this session is the loop owner
  - **`<short8>·pid<N>`** (yellow/neutral) — another session holds it
  - **`loop-owner: unclaimed`** (dim) — registry readable, no owner set
  - badge absent when registry is unreadable or `session_id` unset (fail-open)
- Tests updated: 5 new `TestLoopOwnerBadge` tests in `test_claude_statusline.py`;
  existing tests in `test_statusline_refinements_1163.py`,
  `test_statusline_next_tick.py`, and `test_tick.py` updated to reflect the new
  contract (loop-owner absent from shared file)

## Test plan

- [ ] `uv run pytest --no-cov -q tests/teatree_loop tests/test_claude_statusline.py` — 1449 passed
- [ ] `uv run ruff check && uv run ruff format --check` — clean
- [ ] All pre-commit hooks passed on commit
- [ ] All pre-push hooks passed (including pytest Docker matrix)