### PR TITLE
fix(loop): scanner/messaging fail-safe gaps (never-raise, no-silent-drop)

### DIFF
--- a/src/teatree/loop/scanners/gitlab_approvals.py
+++ b/src/teatree/loop/scanners/gitlab_approvals.py
@@ -333,12 +333,12 @@ def _already_emitted_at(url: str, head_sha: str) -> bool:
 
 
 def _record_emission(url: str, head_sha: str) -> None:
-    """Persist the head SHA of the latest emission on a ``Ticket`` row.
+    """Persist the head SHA of the latest emission on an existing ``Ticket`` row.
 
-    Uses ``get_or_create`` to upsert a tracking-only row when the URL has
-    no existing ticket — the existing reviewer-prs cache pattern. Best
-    effort: a DB error is logged but never blocks scanner output (the
-    cost of failing to dedup is one extra signal, not a wrong merge).
+    Only updates a row that already exists — never creates a phantom
+    blank-overlay Ticket for a URL that has no real ticket. Best effort:
+    a DB error or a missing ticket are both non-fatal (the cost of failing
+    to dedup is one extra signal, not a wrong merge).
     """
     if not url:
         return
@@ -346,10 +346,9 @@ def _record_emission(url: str, head_sha: str) -> None:
     if ticket_model is None:
         return
     try:
-        ticket, _ = ticket_model.objects.get_or_create(
-            issue_url=url,
-            defaults={"overlay": "", "role": "author"},
-        )
+        ticket = ticket_model.objects.filter(issue_url=url).first()
+        if ticket is None:
+            return
         ticket.merge_extra(set_keys={"last_approval_sha": head_sha})
     except Exception:
         logger.exception("GitLabApprovalsScanner: could not persist last_approval_sha for %s", url)

--- a/src/teatree/loop/scanners/pr_sweep.py
+++ b/src/teatree/loop/scanners/pr_sweep.py
@@ -496,7 +496,9 @@ class GhPrApiClient:
         rc, out, _ = self._run_gh(
             ["pr", "view", str(pr_id), "--repo", slug, "--json", "mergeCommit", "--jq", ".mergeCommit.oid"],
         )
-        return True, out.strip() if rc == 0 else ""
+        if rc == 0 and out.strip():
+            return True, out.strip()
+        return True, "sha-unavailable"
 
     def _run_gh(self, argv: list[str]) -> tuple[int, str, str]:
         gh = shutil.which("gh") or "gh"

--- a/src/teatree/loop/scanners/review_nag.py
+++ b/src/teatree/loop/scanners/review_nag.py
@@ -188,15 +188,23 @@ class ReviewNagScanner:
             f":information_source: *long-stale MR* — no reviewer for {post.mr_url} "
             "after 5 days of fibonacci nags. Manual escalation recommended."
         )
+        dm_delivered = False
         try:
             dm_channel = messaging.open_dm(self.user_slack_id)
             messaging.post_message(channel=dm_channel, text=text, thread_ts="")
+            dm_delivered = True
         except Exception as exc:  # noqa: BLE001 — DM transport must never crash a tick.
             logger.warning(
                 "review_nag: stale-DM failed for %s to %s: %s",
                 post.mr_url,
                 self.user_slack_id,
                 exc,
+            )
+        if not dm_delivered:
+            return ScanSignal(
+                kind="review_nag.stale_no_dm",
+                summary=f"Stale-DM failed for {post.mr_url} — nag train left open for retry",
+                payload={"mr_url": post.mr_url, "post_id": post.pk},
             )
         post.done_at = right_now
         post.save(update_fields=["done_at"])

--- a/src/teatree/loop/scanners/slack_mentions.py
+++ b/src/teatree/loop/scanners/slack_mentions.py
@@ -113,13 +113,17 @@ class SlackMentionsScanner:
             )
             if ts:
                 cursors["dms"] = max(cursors.get("dms", ""), ts)
-        if signals:
+        if signals or drained_any:
+            # Persist the cursor advance before discarding the backing file.
+            # Decoupled from ``signals``: drained events that match no
+            # signal-producing type still advance the cursor so those events
+            # are not re-fetched on the next tick.
             _write_cursors(self.cursor_path, cursors)
         if drained_any:
-            # Discard the backing file only after the durable persist
-            # (cursor advance + review-intent rows) above. A crash before
-            # this point leaves the ``.draining`` file for the next drain to
-            # recover, so no mention is lost (Slack never retries them).
+            # Discard the backing file only after the durable cursor persist
+            # above. A crash before this point leaves the ``.draining`` file
+            # for the next drain to recover, so no mention is lost (Slack
+            # never retries them).
             from teatree.backends.slack_receiver import commit_drain  # noqa: PLC0415
 
             commit_drain()

--- a/src/teatree/messaging/notify_with_fallback.py
+++ b/src/teatree/messaging/notify_with_fallback.py
@@ -25,7 +25,7 @@ import enum
 import logging
 from dataclasses import dataclass
 
-from django.db import IntegrityError, transaction
+from django.db import DatabaseError, IntegrityError, transaction
 
 from teatree.backends.protocols import MessagingBackend
 from teatree.core.backend_factory import messaging_from_overlay
@@ -316,6 +316,8 @@ def _upsert_botping(  # noqa: PLR0913 — one typed write site for the BotPing a
             )
     except IntegrityError:
         logger.debug("notify_with_fallback: BotPing upsert race on key=%s", idempotency_key)
+    except DatabaseError:
+        logger.warning("notify_with_fallback: BotPing upsert db error on key=%s", idempotency_key)
 
 
 def _stamp_transport(idempotency_key: str, transport: NotifyTransport) -> None:
@@ -325,6 +327,8 @@ def _stamp_transport(idempotency_key: str, transport: NotifyTransport) -> None:
             BotPing.objects.filter(idempotency_key=idempotency_key).update(transport=transport.value)
     except IntegrityError:
         logger.debug("notify_with_fallback: transport stamp race on key=%s", idempotency_key)
+    except DatabaseError:
+        logger.warning("notify_with_fallback: transport stamp db error on key=%s", idempotency_key)
 
 
 __all__ = ["NotifyResult", "NotifyTransport", "notify_with_fallback"]

--- a/tests/teatree_loop/test_gitlab_approvals_scanner.py
+++ b/tests/teatree_loop/test_gitlab_approvals_scanner.py
@@ -216,8 +216,14 @@ class TestGitLabApprovalsScanner(TestCase):
         assert signal.payload["target_ref"] == "main"
 
     def test_idempotent_emission_same_sha(self) -> None:
-        """A second tick at the same head SHA emits nothing — recorded in ``Ticket.extra``."""
+        """A second tick at the same head SHA emits nothing — recorded in ``Ticket.extra``.
+
+        ``_record_emission`` only updates *existing* Ticket rows; a real ticket
+        must exist for idempotency to function.  The scanner never creates
+        phantom blank-overlay rows (F4 fix).
+        """
         url = "https://gitlab.com/acme/backend/-/merge_requests/46"
+        Ticket.objects.create(issue_url=url, overlay="acme-backend")
         host = FakeCodeHost(
             my_prs=[_gitlab_mr(iid=46, sha="ccc333")],
             approvals={

--- a/tests/teatree_loop/test_gitlab_approvals_scanner.py
+++ b/tests/teatree_loop/test_gitlab_approvals_scanner.py
@@ -246,7 +246,15 @@ class TestGitLabApprovalsScanner(TestCase):
         assert ticket.extra["last_approval_sha"] == "ccc333"
 
     def test_new_sha_re_emits(self) -> None:
-        """A push (new head SHA) resets the idempotency window — re-emit."""
+        """A push (new head SHA) resets the idempotency window — re-emit.
+
+        A real ``Ticket`` row must exist so ``_record_emission`` can store
+        the first SHA and ``_already_emitted_at`` can gate the second scan
+        correctly.  Without a pre-existing row both scans always emit
+        (no-ticket → early-return → no SHA stored), making the test vacuous.
+        """
+        url = "https://gitlab.com/acme/backend/-/merge_requests/47"
+        Ticket.objects.create(issue_url=url, overlay="acme-backend")
         host = FakeCodeHost(
             my_prs=[_gitlab_mr(iid=47, sha="sha-1")],
             approvals={
@@ -266,6 +274,8 @@ class TestGitLabApprovalsScanner(TestCase):
         assert len(first) == 1
         assert len(second) == 1
         assert second[0].kind == "incoming_event.merge_needed"
+        ticket = Ticket.objects.get(issue_url=url)
+        assert ticket.extra["last_approval_sha"] == "sha-2"
 
     def test_github_backend_silently_skipped(self) -> None:
         """``get_mr_approvals`` raising NotImplementedError → scanner skips the PR."""

--- a/tests/teatree_loop/test_review_nag_scanner.py
+++ b/tests/teatree_loop/test_review_nag_scanner.py
@@ -286,15 +286,19 @@ class TestReviewNagScanner(_EnableReviewNagMixin, TestCase):
         signals = ReviewNagScanner(messaging=None, user_slack_id="U_ME").scan()
         assert signals == []
 
-    def test_dm_transport_failure_still_marks_done(self) -> None:
-        """A raised ``open_dm`` or ``post_message`` on the DM must NOT crash the tick."""
+    def test_dm_transport_failure_leaves_train_open_for_retry(self) -> None:
+        """DM failure leaves the nag train open so a future tick can retry.
+
+        A raised ``open_dm`` or ``post_message`` must NOT crash the tick
+        and must NOT close the nag train.
+        """
         post = self._seed_post(days_old=6.0, last_nag_step=4)
         slack = FakeSlack(raise_on_open_dm=RuntimeError("slack down"))
         signals = ReviewNagScanner(messaging=slack, user_slack_id="U_ME").scan()
         post.refresh_from_db()
-        # Still marks the row done — we don't keep retrying a broken DM.
-        assert post.done_at is not None
-        assert [s.kind for s in signals] == ["review_nag.stale_dm"]
+        # Train stays open so a future tick can retry the DM.
+        assert post.done_at is None
+        assert [s.kind for s in signals] == ["review_nag.stale_no_dm"]
 
     def test_no_user_slack_id_skips_stale_dm_but_still_marks_done(self) -> None:
         """At +5d with no user_slack_id, mark the row done without the DM.

--- a/tests/test_loop_resilience_fixes.py
+++ b/tests/test_loop_resilience_fixes.py
@@ -1,0 +1,366 @@
+"""RED-first tests for loop/messaging resilience fixes.
+
+Five confirmed bugs reproduced here before any fix is applied. Each test
+class is self-contained and targets a single finding. Run these against
+the unfixed code to see them go RED, then apply the fix and confirm GREEN.
+"""
+
+import datetime as dt
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.db import OperationalError
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.config import TeaTreeConfig, UserSettings
+from teatree.core.models import ReviewRequestPost
+from teatree.messaging.notify_with_fallback import notify_with_fallback
+
+# ---------------------------------------------------------------------------
+# Helpers shared across findings
+# ---------------------------------------------------------------------------
+
+_PRIMARY_TARGET = "teatree.messaging.notify_with_fallback.notify_user"
+_FALLBACK_TARGET = "teatree.messaging.notify_with_fallback.messaging_from_overlay"
+
+
+def _delivering_backend() -> Any:
+    from unittest.mock import MagicMock  # noqa: PLC0415
+
+    b = MagicMock()
+    b.open_dm.return_value = "D-USER"
+    b.post_message.return_value = {"ok": True, "ts": "1700000000.000100"}
+    b.get_permalink.return_value = "https://acme.slack.com/archives/D-USER/p1700000000000100"
+    b.fetch_message.return_value = {"ts": "1700000000.000100", "text": "the body"}
+    return b
+
+
+# ---------------------------------------------------------------------------
+# F1: notify_with_fallback must not raise on OperationalError
+# ---------------------------------------------------------------------------
+
+
+class TestF1NeverRaiseDatabaseError(TestCase):
+    """F1 — _stamp_transport / _upsert_botping catch only IntegrityError.
+
+    Any other django.db.DatabaseError (OperationalError, etc.) propagates
+    and violates the module contract 'Never raises into the calling turn'.
+    """
+
+    def test_stamp_transport_operational_error_does_not_raise(self) -> None:
+        """BotPing.objects.filter().update() raises OperationalError in _stamp_transport.
+
+        _stamp_transport must catch DatabaseError subclasses; notify_with_fallback
+        must not see the exception (never-raise contract).
+        """
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        # Patch the queryset that _stamp_transport calls to raise OperationalError.
+        mock_qs = MagicMock()
+        mock_qs.update.side_effect = OperationalError("disk full")
+
+        with (
+            patch(_PRIMARY_TARGET, return_value=True),
+            patch(
+                "teatree.messaging.notify_with_fallback.BotPing.objects.filter",
+                return_value=mock_qs,
+            ),
+        ):
+            # Must not raise — contract is "never raises into the calling turn"
+            result = notify_with_fallback(
+                "hello",
+                kind="info",
+                idempotency_key="f1-stamp-opererr",
+                user_id="U_ME",
+            )
+        # Primary DID deliver; the key is no exception was raised.
+        assert result is not None
+
+    def test_upsert_botping_operational_error_returns_not_delivered(self) -> None:
+        """OperationalError in _upsert_botping must not escape notify_with_fallback."""
+        # Make the fallback path trigger an OperationalError when it tries to
+        # write to BotPing. We patch the underlying queryset so the OperationalError
+        # surfaces inside _upsert_botping's transaction.atomic() block.
+        with (
+            patch(_PRIMARY_TARGET, return_value=False),
+            patch(_FALLBACK_TARGET, return_value=None),
+            patch(
+                "teatree.messaging.notify_with_fallback.BotPing.objects.update_or_create",
+                side_effect=OperationalError("database locked"),
+            ),
+        ):
+            # Must not raise
+            result = notify_with_fallback(
+                "hello",
+                kind="info",
+                idempotency_key="f1-upsert-opererr",
+                user_id="U_ME",
+            )
+        assert result.delivered is False
+
+
+# ---------------------------------------------------------------------------
+# F2: review_nag DM failure must NOT silently close the train
+# ---------------------------------------------------------------------------
+
+
+class _EnableReviewNagMixin:
+    def setUp(self) -> None:
+        super().setUp()
+        enabled = TeaTreeConfig(user=UserSettings(review_nag_enabled=True))
+        patcher = patch("teatree.config.load_config", return_value=enabled)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+
+@dataclass
+class _FakeSlack:
+    posts: list[dict[str, Any]] = field(default_factory=list)
+    raise_on_post: Exception | None = None
+    raise_on_open_dm: Exception | None = None
+    usergroup_id: str = ""
+    dm_channel: str = "D-USER"
+
+    def fetch_mentions(self, *, since: str = "") -> list[Any]:
+        return []
+
+    def fetch_dms(self, *, since: str = "") -> list[Any]:
+        return []
+
+    def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> dict[str, Any]:
+        if self.raise_on_post is not None:
+            raise self.raise_on_post
+        self.posts.append({"channel": channel, "text": text, "thread_ts": thread_ts})
+        return {"ok": True, "ts": f"reply.{len(self.posts)}"}
+
+    def open_dm(self, user_id: str) -> str:
+        if self.raise_on_open_dm is not None:
+            raise self.raise_on_open_dm
+        return self.dm_channel
+
+    def get_permalink(self, *, channel: str, ts: str) -> str:
+        return f"https://slack.example/archives/{channel}/p{ts}"
+
+    def react(self, *, channel: str, ts: str, emoji: str) -> dict[str, Any]:
+        return {}
+
+    def resolve_user_id(self, handle: str) -> str:
+        if handle == "engineers":
+            return self.usergroup_id
+        return ""
+
+
+class TestF2ReviewNagDmFailureDoesNotCloseTrain(_EnableReviewNagMixin, TestCase):
+    """F2 — _dm_user_and_close sets done_at OUTSIDE the try block.
+
+    A DM send failure permanently closes the nag train and the returned
+    ScanSignal kind ('review_nag.stale_dm') falsely claims delivery.
+
+    Fix: only set done_at/save on the SUCCESS path; on the except path
+    emit 'review_nag.stale_no_dm' and do NOT close the train.
+    """
+
+    def _seed_stale_post(self) -> ReviewRequestPost:
+        return ReviewRequestPost.objects.create(
+            mr_url="https://gitlab.example/x/-/merge_requests/99",
+            slack_channel_id="C0STALE",
+            slack_thread_ts="ts.stale",
+            created_at=timezone.now() - dt.timedelta(days=6),
+            last_nag_step=4,
+        )
+
+    def test_dm_failure_does_not_close_train(self) -> None:
+        """post_message raises → done_at must stay None and train must stay open."""
+        from teatree.loop.scanners.review_nag import ReviewNagScanner  # noqa: PLC0415
+
+        post = self._seed_stale_post()
+        slack = _FakeSlack(raise_on_post=RuntimeError("slack channel not found"))
+        ReviewNagScanner(messaging=slack, user_slack_id="U_ME").scan()
+
+        post.refresh_from_db()
+        # Bug: done_at is set even though the DM failed.
+        # Fix: done_at must stay None.
+        assert post.done_at is None, (
+            "done_at was set even though the DM send raised — the nag train was permanently closed on a failed delivery"
+        )
+
+    def test_dm_failure_emits_no_dm_kind_not_stale_dm(self) -> None:
+        """Signal kind must reflect no-delivery, not false 'stale_dm'."""
+        from teatree.loop.scanners.review_nag import ReviewNagScanner  # noqa: PLC0415
+
+        self._seed_stale_post()
+        slack = _FakeSlack(raise_on_post=RuntimeError("channel_not_found"))
+        signals = ReviewNagScanner(messaging=slack, user_slack_id="U_ME").scan()
+
+        kinds = [s.kind for s in signals]
+        assert "review_nag.stale_dm" not in kinds, (
+            "Signal claimed 'stale_dm' (delivery) even though post_message raised"
+        )
+        # The fix should emit review_nag.stale_no_dm on failure
+        assert any("stale_no_dm" in k or "no_dm" in k for k in kinds), f"Expected a no-dm kind in signals, got: {kinds}"
+
+
+# ---------------------------------------------------------------------------
+# F3: slack_mentions cursor not written when drained events produce no signals
+# ---------------------------------------------------------------------------
+
+
+class TestF3SlackMentionsCursorPersistedWhenDrainedNoSignals(TestCase):
+    """F3 — cursor ordering: _write_cursors must run before commit_drain.
+
+    _write_cursors was guarded by 'if signals:' while commit_drain was
+    guarded by 'if drained_any:'. If drained events produce no signals
+    (unhandled event types), commit_drain deletes the .draining file but the
+    cursor is never persisted — events are re-fetched on the next tick.
+
+    Fix: _write_cursors must run whenever drained_any, independent of signals.
+    """
+
+    def test_drained_unknown_events_do_not_lose_cursor(self) -> None:
+        """Events of unknown type are drained but produce no signals.
+
+        After draining, commit_drain MUST NOT be called if the cursor was
+        not persisted (or equivalently, _write_cursors MUST be called before
+        commit_drain).
+        """
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        from teatree.loop.scanners.slack_mentions import SlackMentionsScanner  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cursor_path = Path(tmpdir) / "slack_cursor.json"
+
+            # Backend that returns no regular mentions/dms from the API
+            backend = MagicMock()
+            backend.fetch_mentions.return_value = []
+            backend.fetch_dms.return_value = []
+
+            # The queue contains one event of an unhandled type — it gets drained
+            # (drained_any=True) but produces no signals.
+            unknown_event = {"event": {"type": "reaction_added", "ts": "1700000099.000001"}}
+
+            commit_drain_called = []
+            write_cursors_called = []
+
+            import teatree.loop.scanners.slack_mentions as sm_mod  # noqa: PLC0415
+
+            original_write_cursors = sm_mod._write_cursors
+
+            def _track_write_cursors(path: Path, data: dict) -> None:
+                write_cursors_called.append(True)
+                original_write_cursors(path, data)
+
+            with (
+                patch(
+                    "teatree.backends.slack_receiver.drain_event_queue",
+                    return_value=[unknown_event],
+                ),
+                patch(
+                    "teatree.backends.slack_receiver.commit_drain",
+                    side_effect=lambda: commit_drain_called.append(True),
+                ),
+                patch.object(sm_mod, "_write_cursors", side_effect=_track_write_cursors),
+            ):
+                scanner = SlackMentionsScanner(
+                    backend=backend,
+                    cursor_path=cursor_path,
+                )
+                scanner.scan()
+
+            # No signals (reaction_added is handled elsewhere, not here)
+            # The key assertion: commit_drain must NOT be called if
+            # _write_cursors was not called (cursor lost).
+            # OR: _write_cursors must be called whenever drained_any.
+            if commit_drain_called:
+                assert write_cursors_called, (
+                    "commit_drain was called but _write_cursors was NOT called — "
+                    "the cursor was not persisted before the backing file was deleted. "
+                    "Events would be re-fetched / lost."
+                )
+
+
+# ---------------------------------------------------------------------------
+# F4: gitlab_approvals _record_emission must not create phantom blank-overlay Ticket
+# ---------------------------------------------------------------------------
+
+
+class TestF4GitlabApprovalsNoPhantomBlankOverlayTicket(TestCase):
+    """F4 — _record_emission does get_or_create with overlay='' as default.
+
+    When the URL maps to no existing Ticket, a phantom Ticket(overlay='')
+    is created. Fix: use filter().first() and skip if no ticket exists,
+    or pass the scanner's real overlay.
+    """
+
+    pytestmark = pytest.mark.django_db
+
+    def test_no_phantom_blank_overlay_ticket_created(self) -> None:
+        """No phantom blank-overlay Ticket created for an unmapped URL.
+
+        _record_emission with a URL that has no existing Ticket row must not
+        create a new Ticket(overlay='').
+        """
+        from teatree.core.models import Ticket  # noqa: PLC0415
+        from teatree.loop.scanners.gitlab_approvals import _record_emission  # noqa: PLC0415
+
+        url = "https://gitlab.example/no-overlay/-/merge_requests/9999"
+        assert not Ticket.objects.filter(issue_url=url).exists()
+
+        _record_emission(url, "abc123")
+
+        # Bug: a phantom Ticket(overlay='') is created.
+        # Fix: no Ticket should be created if none existed.
+        phantoms = Ticket.objects.filter(issue_url=url, overlay="")
+        assert not phantoms.exists(), f"phantom blank-overlay Ticket was created: {list(phantoms.values())}"
+
+
+# ---------------------------------------------------------------------------
+# F7: pr_sweep merge_pr_squash returns misleading empty SHA on rc != 0
+# ---------------------------------------------------------------------------
+
+
+class TestF7PrSweepShaFetchFailureSurfaced(TestCase):
+    """F7 — merge_pr_squash returns (True, '') when the follow-up gh pr view rc != 0.
+
+    This yields a misleading 'SHA: ?' DM. Fix: surface a non-empty marker
+    (e.g. 'sha-unavailable') or retry once so the caller knows the SHA is
+    absent rather than empty.
+    """
+
+    def test_sha_fetch_rc_nonzero_does_not_return_empty_sha(self) -> None:
+        """SHA-fetch failure returns a non-empty marker, not silent empty string.
+
+        After a successful merge, if the SHA-fetch subprocess fails (rc!=0),
+        the returned SHA must not be silently empty string.
+        """
+        from teatree.loop.scanners.pr_sweep import GhPrApiClient  # noqa: PLC0415
+
+        # GhPrApiClient uses slots=True so patch.object won't work on an instance.
+        # Subclass to override _run_gh instead.
+        class _FakeClient(GhPrApiClient):
+            __slots__ = ()
+
+            def _run_gh(self, argv: list[str]) -> tuple[int, str, str]:
+                if "merge" in argv:
+                    return 0, "", ""
+                if "view" in argv and "mergeCommit" in argv:
+                    # SHA fetch fails
+                    return 1, "", "not found"
+                return 0, "", ""
+
+        client = _FakeClient(token="")
+        ok, sha = client.merge_pr_squash(slug="owner/repo", pr_id=42)
+
+        assert ok is True
+        # Bug: sha is "" when the fetch rc != 0.
+        # Fix: sha must carry a non-empty marker (not silently "").
+        assert sha != "", (
+            "merge_pr_squash returned empty string SHA when the gh pr view "
+            "follow-up failed — caller has no way to distinguish 'SHA unknown' "
+            "from 'merged but SHA empty'. Expected a non-empty marker."
+        )


### PR DESCRIPTION
Five loop/messaging resilience bugs confirmed via RED-first tests. Each finding is a separate commit.

## Fixes

- **F1** `notify_with_fallback`: `_stamp_transport` and `_upsert_botping` only caught `IntegrityError`; broadened to `DatabaseError` so `OperationalError` and other DB failures don't escape the never-raise contract.

- **F2** `ReviewNagScanner`: `done_at` was set outside the `try` block, permanently closing the nag train on DM transport failure. Moved to the success path only; failure emits `review_nag.stale_no_dm` so the next tick can retry.

- **F3** `SlackMentionsScanner`: `_write_cursors` was guarded by `if signals:` while `commit_drain` used `if drained_any:`. Events of unhandled types drained the backing file without advancing the cursor, causing re-fetch. Both now use `if signals or drained_any:` for `_write_cursors`.

- **F4** `GitLabApprovalsScanner._record_emission`: used `get_or_create(overlay='')` which created phantom `Ticket` rows for MR URLs with no real ticket. Switched to `filter().first()` with an early return.

- **F7** `GhPrApiClient.merge_pr_squash`: after a successful merge the follow-up SHA fetch could silently return `(True, "")` on `rc != 0`. Now returns `(True, "sha-unavailable")` so the caller can distinguish an unavailable SHA from an empty one.

Closes [#1613](https://github.com/souliane/teatree/issues/1613)