### PR TITLE
fix(review): paginate identity_has_reviewed + record claim on non-DiffNote post

### DIFF
--- a/src/teatree/cli/review_approval.py
+++ b/src/teatree/cli/review_approval.py
@@ -27,9 +27,7 @@ def identity_has_reviewed(api: "GitLabAPI", encoded_repo: str, mr: int) -> tuple
     username = api.current_username()
     if not username:
         return False, "Could not resolve the approving GitLab identity (check token / `glab auth status`)."
-    discussions = api.get_json(f"projects/{encoded_repo}/merge_requests/{mr}/discussions?per_page=100")
-    if not isinstance(discussions, list):
-        return False, ""
+    discussions = api.get_json_paginated(f"projects/{encoded_repo}/merge_requests/{mr}/discussions?per_page=100")
     for discussion in discussions:
         if not isinstance(discussion, dict):
             continue

--- a/src/teatree/cli/review_post_impl.py
+++ b/src/teatree/cli/review_post_impl.py
@@ -125,8 +125,7 @@ def post_comment_impl(  # noqa: PLR0913 — every kwarg maps 1:1 to a public CLI
     notes = result_dict.get("notes")
     first_note = notes[0] if isinstance(notes, list) and notes else {}
     note_type = first_note.get("type") if isinstance(first_note, dict) else None
-    if note_type != "DiffNote":
-        return f"Comment posted but not anchored inline (type={note_type!r}). discussion_id={discussion_id}", 1
+    note_web_url = str(first_note.get("web_url", "")) if isinstance(first_note, dict) else ""
     record_note_claim(service._resolve_base_url, repo, mr, discussion_id, endpoint="discussions", file=file, line=line)
     notify_review_after_receipt(
         service._resolve_base_url,
@@ -135,7 +134,12 @@ def post_comment_impl(  # noqa: PLR0913 — every kwarg maps 1:1 to a public CLI
         review_action=ReviewAfterReceipt(
             action="post_comment",
             summary=f"posted inline comment discussion_id={discussion_id} on {repo}!{mr}",
-            note_web_url=str(first_note.get("web_url", "")) if isinstance(first_note, dict) else "",
+            note_web_url=note_web_url,
         ),
     )
+    if note_type != "DiffNote":
+        return (
+            f"OK discussion_id={discussion_id} (posted but not anchored inline, type={note_type!r}; "
+            "the MR diff may have shifted since position was resolved)"
+        ), 0
     return f"OK discussion_id={discussion_id} (inline DiffNote)", 0

--- a/tests/teatree_cli/test_review_approval.py
+++ b/tests/teatree_cli/test_review_approval.py
@@ -16,7 +16,10 @@ from teatree.cli.review_approval import identity_has_reviewed, identity_in_appro
 def _api(*, username: str = "souliane", discussions: Any = None) -> MagicMock:
     api = MagicMock()
     api.current_username.return_value = username
-    api.get_json.return_value = discussions if discussions is not None else []
+    # identity_has_reviewed uses get_json_paginated; identity_in_approved_by uses get_json.
+    resolved = discussions if discussions is not None else []
+    api.get_json_paginated.return_value = resolved if isinstance(resolved, list) else []
+    api.get_json.return_value = resolved
     return api
 
 
@@ -32,6 +35,7 @@ class TestIdentityHasReviewed:
         assert error  # non-empty diagnostic
         assert "identity" in error.lower() or "token" in error.lower()
         api.get_json.assert_not_called()
+        api.get_json_paginated.assert_not_called()
 
     def test_returns_true_when_identity_authored_a_note(self) -> None:
         discussions = [

--- a/tests/teatree_cli/test_review_approval_pagination.py
+++ b/tests/teatree_cli/test_review_approval_pagination.py
@@ -1,0 +1,65 @@
+"""M5 regression: ``identity_has_reviewed`` must paginate discussions.
+
+``get_json`` silently truncates to a single page (at most 100 threads).
+A reviewer whose note lands on page 2+ would read as "not reviewed",
+causing ``approve`` to refuse with the review-before-approve error even
+though the reviewer already left a note.
+
+This test reproduces the bug: stub ``get_json_paginated`` to return two
+pages where the reviewer's note is only on page 2, then assert the
+function returns ``(True, "")``.
+
+Severity analysis (single caller): ``ReviewService.approve``
+(``teatree/cli/review.py`` ~line 516). The wrong ``(False, "")`` hits
+the ``if not reviewed`` branch and returns ``rc=1`` with "Refusing to
+approve" — the approve is BLOCKED, not silently granted. Fail-CLOSED
+(over-blocks); no maker≠checker hole. The fix lets a legitimate
+reviewer approve.
+"""
+
+from unittest.mock import MagicMock
+
+from teatree.cli.review_approval import identity_has_reviewed
+
+
+def _api_with_paginated(*, username: str, page1: list, page2: list) -> MagicMock:
+    """Return a mock that has both ``get_json_paginated`` and ``get_json``."""
+    api = MagicMock()
+    api.current_username.return_value = username
+    # get_json_paginated must return the full flattened list across pages.
+    # Here we simulate the fixed code calling get_json_paginated with all items.
+    api.get_json_paginated.return_value = page1 + page2
+    # get_json returns only page1 (the old broken behaviour).
+    api.get_json.return_value = page1
+    return api
+
+
+class TestIdentityHasReviewedPagination:
+    """Reviewer on page 2 is found only when all pages are fetched."""
+
+    def test_finds_reviewer_note_on_page_two(self) -> None:
+        page1 = [
+            {"notes": [{"author": {"username": "other-reviewer"}}]},
+        ] * 100  # fill page 1 with someone else's notes
+        page2 = [
+            {"notes": [{"author": {"username": "souliane"}}]},
+        ]
+        api = _api_with_paginated(username="souliane", page1=page1, page2=page2)
+
+        reviewed, error = identity_has_reviewed(api, "org%2Frepo", 1)
+
+        assert reviewed is True, "reviewer's note is on page 2 — must be found when all pages are fetched"
+        assert error == ""
+        # The paginated method must be used (not the single-page get_json).
+        api.get_json_paginated.assert_called_once()
+        api.get_json.assert_not_called()
+
+    def test_returns_false_when_reviewer_absent_across_all_pages(self) -> None:
+        page1 = [{"notes": [{"author": {"username": "other"}}]}] * 100
+        page2 = [{"notes": [{"author": {"username": "also-other"}}]}]
+        api = _api_with_paginated(username="souliane", page1=page1, page2=page2)
+
+        reviewed, error = identity_has_reviewed(api, "org%2Frepo", 1)
+
+        assert reviewed is False
+        assert error == ""

--- a/tests/teatree_cli/test_review_approve_already_approved.py
+++ b/tests/teatree_cli/test_review_approve_already_approved.py
@@ -44,6 +44,10 @@ class _AlreadyApprovedAPI:
         self.calls.append(("get_json", endpoint))
         if endpoint.endswith("/approvals"):
             return {"approved_by": [{"user": {"username": "souliane"}}]}
+        return []
+
+    def get_json_paginated(self, endpoint: str) -> list:
+        self.calls.append(("get_json_paginated", endpoint))
         # discussions probe for the review-before-approve precondition
         return [{"notes": [{"author": {"username": "souliane"}}]}]
 
@@ -65,6 +69,10 @@ class _GenuineAuthFailureAPI:
         self.calls.append(("get_json", endpoint))
         if endpoint.endswith("/approvals"):
             return {"approved_by": [{"user": {"username": "someone-else"}}]}
+        return []
+
+    def get_json_paginated(self, endpoint: str) -> list:
+        self.calls.append(("get_json_paginated", endpoint))
         return [{"notes": [{"author": {"username": "souliane"}}]}]
 
     def post_status(self, endpoint: str) -> int:

--- a/tests/teatree_cli/test_review_approve_gate.py
+++ b/tests/teatree_cli/test_review_approve_gate.py
@@ -51,6 +51,10 @@ class _ApproveStubAPI:
 
     def get_json(self, endpoint: str) -> object:
         self.calls.append(("get_json", endpoint, None))
+        return []
+
+    def get_json_paginated(self, endpoint: str) -> list:
+        self.calls.append(("get_json_paginated", endpoint, None))
         return [{"notes": [{"author": {"username": "souliane"}}]}]
 
     def post_status(self, endpoint: str) -> int:

--- a/tests/teatree_cli/test_review_outbound_claim.py
+++ b/tests/teatree_cli/test_review_outbound_claim.py
@@ -44,6 +44,10 @@ class _StubAPI:
 
     def get_json(self, endpoint: str) -> object:
         self.calls.append(("get_json", endpoint, None))
+        return []
+
+    def get_json_paginated(self, endpoint: str) -> list:
+        self.calls.append(("get_json_paginated", endpoint, None))
         if "discussions" in endpoint:
             return [{"notes": [{"author": {"username": "souliane"}}]}]
         return []
@@ -151,7 +155,7 @@ class TestFailurePathsDoNotRecordClaims:
 
     def test_review_first_precondition_blocks_approve_and_records_no_claim(self) -> None:
         service, stub = _service()
-        stub.get_json = lambda _endpoint: []  # type: ignore[method-assign]
+        stub.get_json_paginated = lambda _endpoint: []  # type: ignore[method-assign]
         _msg, code = service.approve("org/repo", 8)
         assert code == 1
         assert not OutboundClaim.objects.filter(kind=OutboundClaim.Kind.GITLAB_APPROVE).exists()

--- a/tests/teatree_cli/test_review_post_impl_non_diffnote.py
+++ b/tests/teatree_cli/test_review_post_impl_non_diffnote.py
@@ -1,0 +1,102 @@
+"""M3 regression: non-DiffNote inline post must record the claim and not signal retry.
+
+When GitLab downgrades a DiffNote to a TextDiffNote/Note (because the MR
+head/base moved), the comment IS live on GitLab but the old code returned
+``rc=1`` without calling ``record_note_claim`` or
+``notify_review_after_receipt``.  The caller would then retry, double-posting.
+
+Safe-direction fix: on a non-DiffNote SUCCESS, still call
+``record_note_claim`` and ``notify_review_after_receipt``, return rc=0 with
+a warning that it wasn't anchored inline.  rc=1 stays reserved for genuine
+post FAILURES (``post_json`` returning None/falsy).
+
+These tests call ``post_comment_impl`` directly to avoid the live-post
+authorization chain which is irrelevant to this code path.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from teatree.cli.review_post_impl import post_comment_impl
+from teatree.core.models import OutboundClaim
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_service(*, resolve_base_url: str = "https://gitlab.example/api/v4") -> MagicMock:
+    """Minimal ReviewService stand-in for post_comment_impl."""
+    service = MagicMock()
+    service._resolve_base_url = lambda: resolve_base_url
+    return service
+
+
+def _make_api(*, note_type: str) -> MagicMock:
+    """GitLabAPI stub whose inline post returns a discussion with note_type."""
+    api = MagicMock()
+    api.post_json.return_value = {
+        "id": "disc-99",
+        "notes": [
+            {
+                "type": note_type,
+                "id": 77,
+                "web_url": "https://gitlab.example/org/repo/-/mr/7#note_77",
+            },
+        ],
+    }
+    return api
+
+
+def _patch_position(*, file: str = "src/foo.py", line: int = 42):
+    """Patch resolve_inline_position to return a valid position without network."""
+    return patch(
+        "teatree.cli.review_post_impl.resolve_inline_position",
+        return_value=({"base_sha": "abc", "head_sha": "def", "start_sha": "ghi"}, None),
+    )
+
+
+class TestPostCommentImplNonDiffNote:
+    """Inline post downgraded to non-DiffNote must record claim and return rc=0."""
+
+    def test_non_diffnote_post_records_claim(self, tmp_path: Path) -> None:
+        service = _make_service()
+        api = _make_api(note_type="TextDiffNote")
+        service._get_api.return_value = api
+
+        with _patch_position():
+            msg, code = post_comment_impl(service, "org/repo", 7, "nit", file="src/foo.py", line=42)
+
+        assert code == 0, f"expected rc=0 for non-DiffNote success (post is live), got rc={code!r}, msg={msg!r}"
+        assert OutboundClaim.objects.filter(
+            idempotency_key__startswith="gitlab_note:org/repo!7:",
+        ).exists(), "record_note_claim must be called even when GitLab downgrades to non-DiffNote"
+
+    def test_non_diffnote_post_message_warns_not_anchored(self) -> None:
+        service = _make_service()
+        api = _make_api(note_type="Note")
+        service._get_api.return_value = api
+
+        with _patch_position():
+            msg, code = post_comment_impl(service, "org/repo", 7, "nit", file="src/foo.py", line=42)
+
+        assert code == 0
+        # The message must signal the downgrade so the caller knows it wasn't anchored inline.
+        assert "not anchored" in msg.lower() or "type=" in msg, (
+            f"message should warn about non-DiffNote downgrade, got: {msg!r}"
+        )
+
+    def test_genuine_failure_still_returns_rc1(self) -> None:
+        """``post_json`` returning None is a real failure — rc must stay 1."""
+        service = _make_service()
+        api = MagicMock()
+        api.post_json.return_value = None
+        service._get_api.return_value = api
+
+        with _patch_position():
+            _msg, code = post_comment_impl(service, "org/repo", 7, "nit", file="src/foo.py", line=42)
+
+        assert code == 1
+        assert not OutboundClaim.objects.filter(
+            idempotency_key__startswith="gitlab_note:org/repo!7:",
+        ).exists()

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -290,7 +290,13 @@ class TestPostComment:
             assert "approve-live-post" in result.output
 
     def test_inline_anchor_falls_back_to_discussion_note(self, monkeypatch):
-        """If GitLab posts a non-DiffNote on the ``--live`` path, the command reports failure."""
+        """If GitLab downgrades to a non-DiffNote, the command succeeds (rc=0) with a warning.
+
+        The comment is live on GitLab; returning rc=1 would cause callers to retry
+        and double-post.  The fix: record the claim and return rc=0 with a message
+        that names the downgraded type so the caller knows the note was not anchored
+        inline.
+        """
         from teatree.core.models import LivePostApproval  # noqa: PLC0415
 
         LivePostApproval.record(mr_url="org/repo!1", slack_ts="1700000000.0001", slack_user_id="U-OP")
@@ -305,7 +311,7 @@ class TestPostComment:
                 app,
                 ["review", "post-comment", "org/repo", "1", "msg", "--file", "a.py", "--line", "5", "--live"],
             )
-            assert result.exit_code == 1
+            assert result.exit_code == 0
             assert "not anchored inline" in result.output
 
     def test_inline_context_line_rejected(self, monkeypatch):
@@ -687,8 +693,9 @@ class TestApprove:
         monkeypatch.setenv("GITLAB_TOKEN", "test-token")
         mock_api = MagicMock()
         mock_api.current_username.return_value = "reviewer-bot"
-        mock_api.get_json.side_effect = lambda endpoint: (
-            _discussions_with_author("reviewer-bot") if "/discussions" in endpoint else {"id": 1}
+        mock_api.get_json.side_effect = lambda endpoint: {"id": 1}
+        mock_api.get_json_paginated.side_effect = lambda endpoint: (
+            _discussions_with_author("reviewer-bot") if "/discussions" in endpoint else []
         )
         mock_api.post_status.return_value = 201
         with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
@@ -703,8 +710,9 @@ class TestApprove:
         monkeypatch.setenv("GITLAB_TOKEN", "test-token")
         mock_api = MagicMock()
         mock_api.current_username.return_value = "reviewer-bot"
-        mock_api.get_json.side_effect = lambda endpoint: (
-            _discussions_with_author("someone-else") if "/discussions" in endpoint else {"id": 1}
+        mock_api.get_json.side_effect = lambda endpoint: {"id": 1}
+        mock_api.get_json_paginated.side_effect = lambda endpoint: (
+            _discussions_with_author("someone-else") if "/discussions" in endpoint else []
         )
         with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
             result = runner.invoke(app, ["review", "approve", "org/repo", "7"])
@@ -717,19 +725,23 @@ class TestApprove:
         monkeypatch.setenv("GITLAB_TOKEN", "test-token")
         mock_api = MagicMock()
         mock_api.current_username.return_value = "reviewer-bot"
-        mock_api.get_json.side_effect = lambda endpoint: [] if "/discussions" in endpoint else {"id": 1}
+        mock_api.get_json.side_effect = lambda endpoint: {"id": 1}
+        mock_api.get_json_paginated.side_effect = lambda endpoint: []
         with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
             result = runner.invoke(app, ["review", "approve", "org/repo", "7"])
             assert result.exit_code == 1
             assert "review before approve" in result.output
             mock_api.post_status.assert_not_called()
 
-    def test_approve_refused_when_discussions_not_a_list(self, monkeypatch):
-        """A non-list discussions payload is treated as 'no review yet'."""
+    def test_approve_refused_when_discussions_only_have_other_authors(self, monkeypatch):
+        """Approve refuses when discussions exist but none authored by the approving identity."""
         monkeypatch.setenv("GITLAB_TOKEN", "test-token")
         mock_api = MagicMock()
         mock_api.current_username.return_value = "reviewer-bot"
-        mock_api.get_json.side_effect = lambda endpoint: "unexpected" if "/discussions" in endpoint else {"id": 1}
+        mock_api.get_json.side_effect = lambda endpoint: {"id": 1}
+        mock_api.get_json_paginated.side_effect = lambda endpoint: (
+            _discussions_with_author("unrelated-user") if "/discussions" in endpoint else []
+        )
         with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
             result = runner.invoke(app, ["review", "approve", "org/repo", "7"])
             assert result.exit_code == 1
@@ -747,7 +759,8 @@ class TestApprove:
             {"id": "d3", "notes": ["not-a-dict-note"]},
             {"id": "d4", "notes": [{"id": 9, "author": {"username": "reviewer-bot"}}]},
         ]
-        mock_api.get_json.side_effect = lambda endpoint: discussions if "/discussions" in endpoint else {"id": 1}
+        mock_api.get_json.side_effect = lambda endpoint: {"id": 1}
+        mock_api.get_json_paginated.side_effect = lambda endpoint: discussions if "/discussions" in endpoint else []
         mock_api.post_status.return_value = 201
         with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
             result = runner.invoke(app, ["review", "approve", "org/repo", "7"])
@@ -773,8 +786,9 @@ class TestApprove:
         monkeypatch.setenv("GITLAB_TOKEN", "test-token")
         mock_api = MagicMock()
         mock_api.current_username.return_value = "reviewer-bot"
-        mock_api.get_json.side_effect = lambda endpoint: (
-            _discussions_with_author("reviewer-bot") if "/discussions" in endpoint else {"id": 1}
+        mock_api.get_json.side_effect = lambda endpoint: {"id": 1}
+        mock_api.get_json_paginated.side_effect = lambda endpoint: (
+            _discussions_with_author("reviewer-bot") if "/discussions" in endpoint else []
         )
         mock_api.post_status.return_value = 403
         with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
@@ -791,8 +805,9 @@ class TestApprove:
         monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
         mock_api = MagicMock()
         mock_api.current_username.return_value = "reviewer-bot"
-        mock_api.get_json.side_effect = lambda endpoint: (
-            _discussions_with_author("reviewer-bot") if "/discussions" in endpoint else {"id": 1}
+        mock_api.get_json.side_effect = lambda endpoint: {"id": 1}
+        mock_api.get_json_paginated.side_effect = lambda endpoint: (
+            _discussions_with_author("reviewer-bot") if "/discussions" in endpoint else []
         )
         with patch.object(gitlab_api_mod, "GitLabAPI", return_value=mock_api):
             result = runner.invoke(app, ["review", "approve", "org/repo", "7"])


### PR DESCRIPTION
## Summary

Two correctness bugs in the review/approve gate, fixed via TDD (RED-first per finding).

### M5 — `identity_has_reviewed` silently truncated to page 1

`review_approval.py` called `api.get_json(…?per_page=100)` with no pagination loop. Any reviewer whose discussion thread landed past position 100 read as "not reviewed", so `approve` refused with the review-before-approve error even though the reviewer had already left a note.

Fix: replaced `api.get_json` with `api.get_json_paginated` (accumulates all pages via `X-Next-Page`; capped at `_MAX_PAGES=100` by the client).

Per-callsite severity: the single caller is `ReviewService.approve` (~line 516 of `review.py`). Wrong `(False, "")` hits the `if not reviewed` branch → `rc=1` "Refusing to approve". Fail-CLOSED (over-blocks a legitimate reviewer); no maker≠checker hole opened.

### M3 — non-DiffNote downgrade returned `rc=1`, skipping `record_note_claim`

`review_post_impl.py`'s inline-diff branch posted the discussion to GitLab via `api.post_json`, then checked the returned note type. If GitLab downgraded from `DiffNote` to `TextDiffNote`/`Note` (happens when the MR diff shifts after the position was resolved), the old code returned `rc=1` and skipped both `record_note_claim` and `notify_review_after_receipt`. Since the comment was already live, a retry would double-post.

Fix: move `record_note_claim` + `notify_review_after_receipt` before the type check; on a non-DiffNote success return `rc=0` with a warning. `rc=1` is now reserved for genuine post failures (`post_json` returning falsy).

### Test coverage added

- `tests/teatree_cli/test_review_approval_pagination.py` — M5 regression (2 cases)
- `tests/teatree_cli/test_review_post_impl_non_diffnote.py` — M3 regression (3 cases)
- Updated 7 tests in `tests/test_cli_review.py::TestApprove` to route discussions through `get_json_paginated`
- Updated stubs in `test_review_approval.py`, `test_review_approve_already_approved.py`, `test_review_approve_gate.py`, `test_review_outbound_claim.py`

Full suite: 9426 passed, 0 failures. Ruff clean.

Closes [souliane/teatree issue 1615](https://github.com/souliane/teatree/issues/1615)