### PR TITLE
fix(hooks): exempt line-anchored close trailers from bare-ref gate (#1619)

### DIFF
--- a/src/teatree/hooks/bare_reference_scanner.py
+++ b/src/teatree/hooks/bare_reference_scanner.py
@@ -22,12 +22,24 @@ deliberately conservative to stay clear of the lockout direction: only
 numbers (``5 PRs``, ``100GB``, ``line 42``, ``v1.2.3``) and hex shas are
 never flagged.
 
-The one exemption is the conventional trailing ``(#NNNN)`` / ``(!NNNN)``
-parenthetical at the END of a PR/MR title or a git-commit subject (#1544):
-the forge auto-links the ref there, it is the universal conventional-commit
-and MR-title convention, and it is required by the MR-title-convention gate.
-The exemption is narrow — a bare ref anywhere else (description bodies,
-slack-send, t3-notify, mid-title text) stays flagged.
+Two exemptions apply:
+
+Exemption 1 — trailing title suffix: the conventional trailing
+``(#NNNN)`` / ``(!NNNN)`` parenthetical at the END of a PR/MR title or
+a git-commit subject (#1544). The forge auto-links the ref there; it is
+the universal conventional-commit and MR-title convention and is required
+by the MR-title-convention gate. The exemption is narrow — a bare ref
+anywhere else (description bodies, slack-send, t3-notify, mid-title
+text) stays flagged.
+
+Exemption 2 — body close trailers: a line that STARTS with a recognised
+close/relates keyword (``Closes``, ``Fixes``, ``Resolves``, ``Refs``,
+``Relates-to``, and their variants) followed by ``#N`` or ``!N`` is the
+canonical AGENTS.md convention for auto-closing issues on merge (#1619).
+The platform auto-links these keywords natively; requiring a markdown
+link defeats the auto-close mechanism. The exemption is anchored to
+``^`` (MULTILINE) + the keyword so a mid-sentence bare ref cannot be
+smuggled past the gate by prefixing prose with a close keyword.
 
 Fail-closed on an unparsable body via the shared
 ``FAIL_CLOSED_SENTINEL`` (same contract as the quote-scanner).
@@ -78,14 +90,43 @@ _SLACK_MCP_WRITE_FIELDS: Final[tuple[str, ...]] = ("text", "message", "document_
 _TRAILING_CONVENTIONAL_REF_RE: Final[re.Pattern[str]] = re.compile(r"(\s*\([#!]\d+\)\s*)+$")
 
 
+# Leading auto-close / relates trailers in body content (#1619). A line
+# that starts with a recognised close/relates keyword followed by ``#N``
+# or ``!N`` is the AGENTS.md canonical auto-close convention; the platform
+# natively auto-links these trailers and requiring a markdown link defeats
+# the mechanism. The match is anchored to ``^`` (MULTILINE) so only a
+# genuine line-start trailer is exempt — a mid-sentence bare ref cannot
+# be smuggled past the gate by prefixing prose with a close keyword.
+#
+# Keyword set extends ``teatree.core.close_trailer_scanner.CLOSE_TRAILER_RE``
+# with ``refs?`` and ``relates?(?:\s*-\s*to|\s+to)?`` and adds ``!N``
+# (MR reference) beside the existing ``#N`` / URL forms.
+_BODY_CLOSE_TRAILER_RE: Final[re.Pattern[str]] = re.compile(
+    r"^(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|relates?(?:\s*-\s*to|\s+to)?)(?:\s+part\s+of)?"
+    r"(?::\s*|\s+)"
+    r"(?:(?:[\w./-]+)?[#!]\d+|https?://\S+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
 def _strip_linked_spans(text: str) -> str:
     return _ANGLE_LINK_RE.sub(" ", _MARKDOWN_LINK_RE.sub(" ", text))
+
+
+def _strip_body_close_trailers(text: str) -> str:
+    """Excise leading auto-close / relates trailer lines before bare-ref matching.
+
+    Replaces each matching line with a space so character offsets stay
+    stable and adjacent tokens cannot accidentally merge into a new pattern.
+    """
+    return _BODY_CLOSE_TRAILER_RE.sub(" ", text)
 
 
 def find_bare_references(text: str) -> list[str]:
     if not text:
         return []
     unlinked = _strip_linked_spans(text)
+    unlinked = _strip_body_close_trailers(unlinked)
     refs: list[str] = []
     seen: set[str] = set()
     for pattern in (_BARE_URL_RE, _BARE_ISSUE_RE, _BARE_SLACK_TS_RE):

--- a/tests/test_bare_reference_scanner.py
+++ b/tests/test_bare_reference_scanner.py
@@ -51,7 +51,10 @@ class TestFindBareReferencesPositives:
     @pytest.mark.parametrize(
         ("text", "expected"),
         [
-            ("fixed #1500", "#1500"),
+            # ``fixed`` is a valid GitHub/GitLab close keyword but the line
+            # ``I fixed #1500 last week`` has prose before the keyword so the
+            # line-start anchor does not exempt it.
+            ("I fixed #1500 last week", "#1500"),
             ("merged !6301", "!6301"),
             ("see issue #42 for details", "#42"),
             ("MR !7 is green", "!7"),
@@ -65,6 +68,8 @@ class TestFindBareReferencesPositives:
         assert expected in find_bare_references(text)
 
     def test_multiple_bare_refs_all_returned(self) -> None:
+        # ``closes #1500`` is NOT at end-of-line here (`` and #1501`` follows),
+        # so the trailer exemption does not apply; all three refs are flagged.
         refs = find_bare_references("closes #1500 and #1501, supersedes !42")
         assert "#1500" in refs
         assert "#1501" in refs
@@ -316,6 +321,128 @@ class TestConventionalTitleSuffixExemption:
         assert payload is not None
         assert "ref: feat(x): desc (#123) and more" in payload
         assert "feat(x): desc\n" in payload or payload.endswith("feat(x): desc")
+
+
+class TestBodyCloseTrailerExemption:
+    """Leading auto-close / relates trailers in body content are exempt (#1619).
+
+    A line that STARTS with a recognised close/relates keyword (``Closes``,
+    ``Fixes``, ``Resolves``, ``Refs``, ``Relates-to``, and their variants)
+    followed by a single ``#N`` or ``!N`` ref at end-of-line is the canonical
+    AGENTS.md convention for auto-closing issues on merge. The platform
+    auto-links these trailer keywords natively; requiring a markdown link would
+    defeat the auto-close mechanism.
+
+    The exemption is anchored to ``^`` (MULTILINE) + keyword + end-of-line so
+    a mid-sentence bare ref cannot be smuggled past the gate by prefixing prose
+    with a close keyword.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Closes #1613",
+            "closes #1613",
+            "CLOSES #1613",
+            "Fixes #1613",
+            "Fixed #1613",
+            "Resolves #1613",
+            "Resolved #1613",
+            "Refs #10",
+            "Ref #10",
+            "Relates-to #10",
+            "Relates to #10",
+            "relate to #10",
+            "Closes !42",
+            "Fixes !42",
+            "Refs !10",
+            "Closes: #1613",
+            "Fixes: #1613",
+            "Some commit body.\n\nCloses #1613",
+            "Summary.\n\nFixes #10\n",
+        ],
+    )
+    def test_close_trailer_line_is_not_flagged(self, text: str) -> None:
+        assert find_bare_references(text) == []
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            # Prose before the keyword → NOT a trailer, must flag.
+            ("see #1613 for context", "#1613"),
+            ("I fixed #1500 last week", "#1500"),
+            ("this supersedes !42", "!42"),
+            # Trailing prose after the ref → NOT a clean trailer, must flag.
+            ("fixes #123 in the parser", "#123"),
+            ("closes #1500 and then #1501", "#1500"),
+            # Mid-sentence keyword + ref where the ref is not the last token.
+            ("relates to #10 as discussed", "#10"),
+        ],
+    )
+    def test_mid_sentence_or_trailing_prose_is_still_flagged(self, text: str, expected: str) -> None:
+        assert expected in find_bare_references(text)
+
+    def test_closes_ref_in_pr_body_is_allowed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd = 'gh pr create --title "feat: some feature" --body "Closes #1613"'
+        blocked = handle_bare_reference_pretool(_bash(cmd))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_fixes_ref_in_pr_body_is_allowed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd = 'gh pr create --title "fix: something" --body "Fixes #1613"'
+        blocked = handle_bare_reference_pretool(_bash(cmd))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_resolves_ref_in_glab_mr_is_allowed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd = 'glab mr create --title "fix: bug" --description "Resolves #1613"'
+        blocked = handle_bare_reference_pretool(_bash(cmd))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_refs_in_glab_mr_is_allowed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd = 'glab mr create --title "chore: update" --description "Refs #10"'
+        blocked = handle_bare_reference_pretool(_bash(cmd))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_relates_to_in_commit_body_is_allowed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd = "git commit -m 'chore: maintenance' -m 'Relates-to #10'"
+        blocked = handle_bare_reference_pretool(_bash(cmd))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_closes_mr_ref_in_body_is_allowed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd = 'gh pr create --title "fix: something" --body "Closes !42"'
+        blocked = handle_bare_reference_pretool(_bash(cmd))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_close_trailer_with_prose_body_is_still_allowed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        body = "This implements the feature described in the ticket.\n\nCloses #1613"
+        cmd = f'gh pr create --title "feat: feature" --body "{body}"'
+        blocked = handle_bare_reference_pretool(_bash(cmd))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_mid_sentence_close_ref_is_still_denied(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd = 'gh pr create --title "feat: something" --body "see #1613 for context"'
+        blocked = handle_bare_reference_pretool(_bash(cmd))
+        assert blocked is True
+        assert "#1613" in _out(capsys)["permissionDecisionReason"]
+
+    def test_trailing_prose_after_ref_is_still_denied(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd = 'gh pr create --title "fix: parser" --body "fixes #123 in the parser"'
+        blocked = handle_bare_reference_pretool(_bash(cmd))
+        assert blocked is True
+        assert "#123" in _out(capsys)["permissionDecisionReason"]
+
+    def test_bare_slack_ref_mid_sentence_is_still_denied(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_bare_reference_pretool(
+            {"tool_name": "mcp__claude_ai_Slack__slack_send_message", "tool_input": {"text": "see #1613 for context"}}
+        )
+        assert blocked is True
+        assert "#1613" in _out(capsys)["permissionDecisionReason"]
 
 
 class TestStopSoftWarn:


### PR DESCRIPTION
## What

The bare-reference gate ([#1530](https://github.com/souliane/teatree/issues/1530) / `handle_bare_reference_pretool`) blocked any body line with a bare `#N` token — including the documented `Closes #N` / `Fixes #N` / `Refs #N` auto-close trailer convention. The forge's auto-close mechanism requires the literal `#N` form; a markdown link defeats it.

Add a `_BODY_CLOSE_TRAILER_RE` regex (MULTILINE, `^`-anchored) covering the close/relates keyword set, and a `_strip_body_close_trailers` pre-pass in `find_bare_references`. The `^…\s*$` anchors enforce that only a genuine line-start trailer is exempt — a mid-sentence bare ref prefixed with a close keyword still fires.

## Why

The gate was locking out its own repo's documented convention. This is an over-block: the gate is meant to catch bare refs in prose/Slack/Notion, not the auto-close trailer that requires the bare `#N` form to work at all.

## Keyword coverage

Extends `teatree.core.close_trailer_scanner.CLOSE_TRAILER_RE` with `refs?` and `relates?` (with `-to` / `to` suffix variants) and adds `!N` (MR ref) beside the existing `#N` / URL forms. All are anchored to `^` (line-start, MULTILINE) and `\s*$` (end-of-line, no trailing prose).

## RED→GREEN evidence

Trailer forms now **exempt** (were BLOCKED before this PR): `Closes #N`, `Fixes #N`, `Resolves #N`, `Refs #N`, `Relates-to #N`, `Relates to #N`, `Fixes: #N`, `closes org/repo#N`, `Fixes !N`

Still **flagged** (must-flag cases confirmed passing): `see #N for context` (mid-prose), `fixes #N in the parser` (trailing prose after ref), `closes #N and #M` (trailing content after first ref)

## Test changes

- New `TestBodyCloseTrailerExemption` class: 18 exempt forms + 6 must-flag forms parametrized, plus 10 individual PreToolUse handler tests covering gh/glab/git commit surfaces.
- `test_bare_reference_is_flagged`: changed `"fixed #NNN"` → `"I fixed #NNN last week"` — `fixed` is a valid close keyword so a line-start `fixed #NNN` is now correctly exempt; the test needs prose before the keyword to exercise the must-flag path.
- Full suite: 9463 passed, 14 skipped, 5 xfailed, 0 failures. ruff: clean.

Closes [#1619](https://github.com/souliane/teatree/issues/1619)
