### PR TITLE
fix(loop): isolate per-ticket transition errors in recovery sweep (ValueError family)

### DIFF
--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -11,6 +12,9 @@ from teatree.core.models.errors import RedisSlotsExhaustedError
 if TYPE_CHECKING:
     from teatree.core.models.task import Task
     from teatree.core.models.ticket import Ticket
+
+
+logger = logging.getLogger(__name__)
 
 
 class _OverlayFilterMixin:
@@ -285,20 +289,26 @@ class TaskQuerySet(models.QuerySet):
         because ``_apply_phase_transition`` itself no-ops for a held task.
         Returns the number of tickets a transition actually fired for.
         """
-        from teatree.core.models.task import Task  # noqa: PLC0415
-
         # Latest COMPLETED task per ticket: iterate newest-first and keep
         # the first one seen for each ticket. ``distinct("ticket_id")`` is
         # Postgres-only; teatree's production DB is SQLite (the #786 B1
         # backend-agnostic lesson), so this stays a plain ordered scan.
+        from django_fsm import TransitionNotAllowed  # noqa: PLC0415
+
+        from teatree.core.models.task import Task  # noqa: PLC0415
+
         replayed = 0
         seen: set[int] = set()
         for task in self.filter(status=Task.Status.COMPLETED).select_related("ticket").order_by("-pk"):
             if task.ticket_id in seen:
                 continue
             seen.add(task.ticket_id)
-            if task._apply_phase_transition():  # noqa: SLF001  # the shared single transition path (#883)
-                replayed += 1
+            try:
+                if task._apply_phase_transition():  # noqa: SLF001  # the shared single transition path (#883)
+                    replayed += 1
+            except (TransitionNotAllowed, ValueError) as exc:
+                # Per-ticket isolation: one un-gated ticket must not abort the sweep.
+                logger.warning("replay skip task=%s ticket=%s %s: %s", task.pk, task.ticket_id, type(exc).__name__, exc)
         return replayed
 
     def reap_stale_claims(self) -> int:

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -815,6 +815,89 @@ class TestTickReplaysOrphanedTransitions(django.test.TestCase):
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.CODED
 
+    def test_valueerror_in_one_ticket_does_not_abort_sweep_or_tick(self) -> None:
+        """A ValueError-family error from _apply_phase_transition must not crash the whole tick.
+
+        Regression for the factory-wedge class: a shipping task on a REVIEWED ticket
+        whose session has no testing/reviewing attestations raises QualityGateError
+        (a ValueError subclass) during replay. The old suppress(RuntimeError) does not
+        catch it, so the entire _reap_stale_task_claims call — and with it
+        reclaim_orphaned_claims + reap_stale_claims — never runs, wedging the loop on
+        every tick for as long as the stuck row exists.
+
+        After the fix:
+        - the offending ticket's transition error is logged and skipped
+        - the healthy ticket's transition still fires (sweep continues)
+        - the stale claim sweep still runs (reap_stale_claims executes)
+        - run_tick completes without raising
+        """
+        import tempfile  # noqa: PLC0415
+        from datetime import timedelta  # noqa: PLC0415
+
+        from django.utils import timezone  # noqa: PLC0415
+
+        from teatree.core.models import Session, Task, Ticket  # noqa: PLC0415
+
+        # Stuck ticket: REVIEWED + shipping task COMPLETED but session has no
+        # testing/reviewing attestations → _apply_phase_transition raises QualityGateError.
+        stuck_ticket = Ticket.objects.create(state=Ticket.State.REVIEWED)
+        stuck_session = Session.objects.create(ticket=stuck_ticket, agent_id="ship-agent")
+        Task.objects.create(
+            ticket=stuck_ticket,
+            session=stuck_session,
+            phase="shipping",
+            status=Task.Status.COMPLETED,
+        )
+
+        # Healthy ticket: half-advanced coding task that replay should recover.
+        healthy_ticket = Ticket.objects.create(state=Ticket.State.STARTED)
+        healthy_session = Session.objects.create(ticket=healthy_ticket, agent_id="code-agent")
+        Task.objects.create(
+            ticket=healthy_ticket,
+            session=healthy_session,
+            phase="coding",
+            status=Task.Status.COMPLETED,
+        )
+
+        # Orphaned claim that reclaim_orphaned_claims must reclaim — verifies the
+        # sibling claim sweeps still run even when replay hit an error on the first
+        # ticket. reclaim_orphaned_claims runs before reap_stale_claims in the same
+        # _reap_stale_task_claims call, so returning this task to PENDING confirms
+        # that the claim sweeps were not skipped by the replay error.
+        orphan_ticket = Ticket.objects.create(state=Ticket.State.STARTED)
+        orphan_session = Session.objects.create(ticket=orphan_ticket, agent_id="stale-agent")
+        orphan_task = Task.objects.create(
+            ticket=orphan_ticket,
+            session=orphan_session,
+            status=Task.Status.CLAIMED,
+            claimed_by="dead-worker",
+            lease_expires_at=timezone.now() - timedelta(minutes=10),
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # Must not raise — the stuck ticket's QualityGateError is isolated.
+            run_tick(TickRequest(scanners=[]), statusline_path=Path(tmp) / "statusline.txt")
+
+        # The healthy ticket was advanced by replay despite the error on the stuck one.
+        healthy_ticket.refresh_from_db()
+        assert healthy_ticket.state == Ticket.State.CODED, (
+            f"healthy ticket not advanced — replay aborted early (state={healthy_ticket.state!r})"
+        )
+
+        # The stuck ticket stays at REVIEWED — the error was non-fatal and no bad advance happened.
+        stuck_ticket.refresh_from_db()
+        assert stuck_ticket.state == Ticket.State.REVIEWED, (
+            f"stuck ticket unexpectedly advanced to {stuck_ticket.state!r}"
+        )
+
+        # The orphaned claim was reclaimed to PENDING — reclaim_orphaned_claims ran
+        # after the replay error, confirming the sibling sweeps were not skipped.
+        orphan_task.refresh_from_db()
+        assert orphan_task.status == Task.Status.PENDING, (
+            f"orphaned claim was not reclaimed — sibling sweeps did not run (status={orphan_task.status!r})"
+        )
+        assert orphan_task.claimed_by == ""
+
 
 def test_tick_captures_mechanical_handler_exception(
     tmp_path: Path,


### PR DESCRIPTION
## Bug

`_reap_stale_task_claims` in `src/teatree/loop/tick_recovery.py` wraps the recovery sweep in `contextlib.suppress(RuntimeError)`. That sweep calls `TaskQuerySet.replay_orphaned_transitions()`, which re-fires real FSM transition bodies through `Task._apply_phase_transition()`. Those bodies can raise `QualityGateError`, `DirtyWorktreeError`, and `DodLocalE2EError` — all of which are `ValueError` subclasses (`QualityGateError(ValueError)`, `InvalidTransitionError(ValueError)`, `DirtyWorktreeError(InvalidTransitionError)`, `DodLocalE2EError(InvalidTransitionError)`), not `RuntimeError`.

So `suppress(RuntimeError)` does not catch them. `run_tick` calls `_reap_stale_task_claims()` before any scanner runs, with no catch-all above it. The result: a single stuck ticket — e.g. a COMPLETED shipping task on a `REVIEWED` ticket whose session is missing testing/reviewing attestations — raises a `ValueError`-family error during replay and crashes the entire loop tick. It crashes on every tick for as long as the stuck row exists, wedging the whole loop. This is the same silent-stall class the recovery sweep was meant to prevent.

It also means the two sibling recoveries that run in the same call (`reclaim_orphaned_claims`, `reap_stale_claims`) never execute when replay aborts early.

## Fix

Per-ticket isolation inside `replay_orphaned_transitions()`: wrap the per-ticket `_apply_phase_transition()` call in `try/except (TransitionNotAllowed, ValueError)`, log-and-continue per ticket. `ValueError` covers the `QualityGateError` / `InvalidTransitionError` / `DirtyWorktreeError` / `DodLocalE2EError` family; `TransitionNotAllowed` (from `django_fsm`) covers the FSM-guard case.

This isolates one un-gated ticket so it cannot abort the sweep, and the other recoveries still run. The existing documented `suppress(RuntimeError)` at the call site is left intact — it is there for the pytest-django DB-blocked case. Broadening that suppress to `Exception` was deliberately avoided, since it would also swallow real errors from the two claim sweeps.

## Test (RED-first)

`tests/teatree_loop/test_tick.py::TestTickReplaysOrphanedTransitions::test_valueerror_in_one_ticket_does_not_abort_sweep_or_tick`

Constructs three tickets:
- a stuck ticket (REVIEWED + COMPLETED shipping task, no attestations) whose replay raises `QualityGateError`,
- a healthy ticket whose replay should advance it,
- an orphaned CLAIMED task with an expired lease that `reclaim_orphaned_claims` must return to PENDING.

Asserts that `run_tick` does not raise, the healthy ticket still advances (sweep continued past the error), the stuck ticket stays put, and the orphaned claim is reclaimed (the sibling sweeps still ran). Observed RED on the unpatched code (the tick raised `QualityGateError`), GREEN after the fix.
