### PR TITLE
fix(checking): match pr_id as path segment, not bare substring

### DIFF
--- a/src/teatree/core/_checking_gather.py
+++ b/src/teatree/core/_checking_gather.py
@@ -30,13 +30,19 @@ class _MergedScope:
     overlay_repos: list[str]
 
 
+def _url_matches_pr_id(url: str, pr_id: int) -> bool:
+    """True when *url*'s last path segment equals *pr_id* (not just a substring)."""
+    segment = url.rstrip("/").rsplit("/", 1)[-1]
+    return segment == str(pr_id)
+
+
 def pr_url_for(ticket: Ticket | None, *, repo_slug: str, pr_id: int, code_host: str) -> str:
     """Prefer an exact stored PR URL, else a host-aware built URL, else issue URL."""
     if ticket is not None:
         stored = (ticket.extra or {}).get("pr_urls") or []
         if isinstance(stored, list):
             for url in stored:
-                if isinstance(url, str) and url and str(pr_id) in url:
+                if isinstance(url, str) and url and _url_matches_pr_id(url, pr_id):
                     return url
     from teatree.core.checking import build_pr_url  # noqa: PLC0415
 

--- a/tests/teatree_core/test_checking.py
+++ b/tests/teatree_core/test_checking.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 from django.test import TestCase
 from django.utils import timezone
 
+from teatree.core._checking_gather import pr_url_for
 from teatree.core.checking import (
     AllOverlaysReport,
     CheckGroup,
@@ -410,6 +411,54 @@ class TestPureRenderers:
             needs_you=CheckGroup(title="Needs you"),
         )
         assert report.to_terse().startswith("Nothing since ")
+
+
+class TestPrUrlForPathSegmentMatch(TestCase):
+    """``pr_url_for`` must match pr_id as a path segment, not a bare substring (#1621).
+
+    When ``pr_urls`` contains both ``/pull/123`` and ``/pull/12``, resolving
+    pr_id=12 must return the ``/pull/12`` URL, not ``/pull/123``.
+    """
+
+    def _ticket_with_urls(self, *urls: str) -> Ticket:
+        t = Ticket.objects.create(
+            overlay="acme",
+            issue_url="https://github.com/synthetic-owner/synthetic-repo/issues/1",
+            state=Ticket.State.IN_REVIEW,
+        )
+        t.extra = {"pr_urls": list(urls)}
+        t.save(update_fields=["extra"])
+        return t
+
+    def test_github_shorter_id_not_confused_with_longer(self) -> None:
+        ticket = self._ticket_with_urls(
+            "https://github.com/synthetic-owner/synthetic-repo/pull/123",
+            "https://github.com/synthetic-owner/synthetic-repo/pull/12",
+        )
+        result = pr_url_for(ticket, repo_slug="synthetic-owner/synthetic-repo", pr_id=12, code_host="github")
+        assert result == "https://github.com/synthetic-owner/synthetic-repo/pull/12"
+
+    def test_gitlab_shorter_id_not_confused_with_longer(self) -> None:
+        ticket = self._ticket_with_urls(
+            "https://gitlab.com/synthetic-owner/synthetic-repo/-/merge_requests/123",
+            "https://gitlab.com/synthetic-owner/synthetic-repo/-/merge_requests/12",
+        )
+        result = pr_url_for(ticket, repo_slug="synthetic-owner/synthetic-repo", pr_id=12, code_host="gitlab")
+        assert result == "https://gitlab.com/synthetic-owner/synthetic-repo/-/merge_requests/12"
+
+    def test_no_match_falls_through_to_builder(self) -> None:
+        ticket = self._ticket_with_urls(
+            "https://github.com/synthetic-owner/synthetic-repo/pull/99",
+        )
+        result = pr_url_for(ticket, repo_slug="synthetic-owner/synthetic-repo", pr_id=7, code_host="github")
+        assert result == "https://github.com/synthetic-owner/synthetic-repo/pull/7"
+
+    def test_single_entry_exact_match_still_works(self) -> None:
+        ticket = self._ticket_with_urls(
+            "https://github.com/synthetic-owner/synthetic-repo/pull/7",
+        )
+        result = pr_url_for(ticket, repo_slug="synthetic-owner/synthetic-repo", pr_id=7, code_host="github")
+        assert result == "https://github.com/synthetic-owner/synthetic-repo/pull/7"
 
 
 class TestAllOverlaysAggregation(CheckingTestBase):


### PR DESCRIPTION
## Summary

- `pr_url_for` in `_checking_gather.py` matched pr_id as a bare substring of the stored URL, so resolving a short id against a list containing a longer id with the same prefix returned the wrong URL.
- Fixed by comparing only the last path segment of each stored URL against the string pr_id, covering both GitHub `/pull/{id}` and GitLab `/-/merge_requests/{id}` shapes.
- Fallthrough to the `build_pr_url` builder when no stored URL's last segment matches is preserved.

## Test plan

- [x] RED test observed before fix: `test_github_shorter_id_not_confused_with_longer` returned the longer-id URL for the shorter id
- [x] GREEN after fix: all 4 new tests in `TestPrUrlForPathSegmentMatch` pass (GitHub multi-entry, GitLab multi-entry, no-match builder fallthrough, single-entry still works)
- [x] Full `test_checking.py` module: 40/40 passed
- [x] Docker pre-push matrix: passed