### PR TITLE
fix(messaging): idempotent slack-webhook fallback key, mrkdwn label escaping, daily-digest empty-channel guard

### DIFF
--- a/src/teatree/core/daily_digest.py
+++ b/src/teatree/core/daily_digest.py
@@ -109,12 +109,18 @@ class DailyDigest:
         # loop process; same accepted at-least-once shape as
         # reply_transport._send.
         channel = self._backend.open_dm(self._user_id)
+        if not channel:
+            msg = f"open_dm returned empty channel for user {self._user_id!r} — will retry next tick"
+            raise RuntimeError(msg)
         opener = self._backend.post_message(
             channel=channel,
             text=f"🌳 teatree daily digest — {today:%Y-%m-%d}",
             thread_ts="",
         )
         root_ts = str(opener.get("ts", "")) if isinstance(opener, dict) else ""
+        if not root_ts:
+            msg = f"post_message did not return a ts for digest root on {today} — will retry next tick"
+            raise RuntimeError(msg)
         try:
             with transaction.atomic():
                 return DailyDigestThread.objects.create(

--- a/src/teatree/core/views/slack_webhook.py
+++ b/src/teatree/core/views/slack_webhook.py
@@ -45,7 +45,7 @@ class SlackWebhookView(View):
             logger.warning("Slack webhook throttled — per-source rate limit exceeded")
             return HttpResponse(status=429)
 
-        self._persist(payload)
+        self._persist(payload, body=request.body)
         return HttpResponse(status=200)
 
     def _authenticated(self, request: HttpRequest, *, secret: str) -> bool:
@@ -63,10 +63,10 @@ class SlackWebhookView(View):
         digest = hmac.new(secret.encode(), basestring, hashlib.sha256).hexdigest()
         return hmac.compare_digest(f"v0={digest}", signature)
 
-    def _persist(self, payload: dict) -> None:
+    def _persist(self, payload: dict, *, body: bytes) -> None:
         event = payload.get("event") or {}
         event_id = payload.get("event_id") or ""
-        idempotency_key = f"slack:{event_id}" if event_id else f"slack:{int(time.time() * 1000)}"
+        idempotency_key = f"slack:{event_id}" if event_id else f"slack:{hashlib.sha256(body).hexdigest()[:16]}"
         persist_incoming_event(
             IngestionRecord(
                 source=IncomingEvent.Source.SLACK,

--- a/src/teatree/slack_mrkdwn.py
+++ b/src/teatree/slack_mrkdwn.py
@@ -295,7 +295,7 @@ def _split_glued_prose(text: str) -> str:
 
 
 def _rewrite_md_link(match: re.Match[str]) -> str:
-    label = match.group(1).replace("|", "❘")
+    label = match.group(1).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("|", "❘")
     url = match.group(2)
     return f"<{url}|{label}>"
 

--- a/tests/teatree_core/test_daily_digest.py
+++ b/tests/teatree_core/test_daily_digest.py
@@ -3,6 +3,7 @@
 import datetime as dt
 from unittest.mock import MagicMock
 
+import pytest
 from django.test import TestCase, override_settings
 
 from teatree.core.daily_digest import DailyDigest
@@ -108,6 +109,28 @@ class TestDailyDigest(TestCase):
         assert thread.closed_at is not None
         # 1 work message + exactly 1 recap reply
         assert backend.post_reply.call_count == 2
+
+    def test_open_dm_failure_does_not_persist_thread_row(self) -> None:
+        backend = _backend()
+        backend.open_dm.return_value = ""  # open_dm failure
+        clock = _at(2026, 5, 15)
+        digest = DailyDigest(backend=backend, user_id="U_ME", now=lambda: clock)
+
+        with pytest.raises(RuntimeError):
+            digest.post("hello", idempotency_key="k1")
+
+        assert DailyDigestThread.objects.count() == 0
+
+    def test_post_message_failure_does_not_persist_thread_row(self) -> None:
+        backend = _backend()
+        backend.post_message.return_value = {"ok": False}
+        clock = _at(2026, 5, 15)
+        digest = DailyDigest(backend=backend, user_id="U_ME", now=lambda: clock)
+
+        with pytest.raises(RuntimeError):
+            digest.post("hello", idempotency_key="k1")
+
+        assert DailyDigestThread.objects.count() == 0
 
     def test_post_after_close_still_threads_but_does_not_reopen(self) -> None:
         backend = _backend()

--- a/tests/teatree_core/test_slack_webhook_view.py
+++ b/tests/teatree_core/test_slack_webhook_view.py
@@ -109,6 +109,26 @@ class TestSlackWebhookView(TestCase):
         assert response.status_code == 401
         assert IncomingEvent.objects.count() == 0
 
+    def test_missing_event_id_fallback_key_is_content_hash(self) -> None:
+        payload = {"type": "event_callback", "event": {"type": "message", "text": "hello"}}
+        body = json.dumps(payload).encode()
+
+        response = _post(self.client, body)
+
+        assert response.status_code == 200
+        event = IncomingEvent.objects.get()
+        expected_hash = hashlib.sha256(body).hexdigest()[:16]
+        assert event.idempotency_key == f"slack:{expected_hash}"
+
+    def test_missing_event_id_retries_collapse_to_one_row(self) -> None:
+        payload = {"type": "event_callback", "event": {"type": "message", "text": "hello"}}
+        body = json.dumps(payload).encode()
+
+        _post(self.client, body)
+        _post(self.client, body)
+
+        assert IncomingEvent.objects.count() == 1
+
 
 @override_settings(TEATREE_SLACK_SIGNING_SECRET="")
 class TestSlackWebhookViewWithoutSecret(TestCase):

--- a/tests/test_slack_mrkdwn.py
+++ b/tests/test_slack_mrkdwn.py
@@ -99,6 +99,25 @@ class TestSlackLinkifyMarkdownLinks:
             "fixes <https://github.com/souliane/teatree/issues/1011|#1011> in <https://example.com/pr/1|the PR>"
         )
 
+    def test_label_with_gt_inside_is_entity_escaped(self) -> None:
+        # A '>' in the label would terminate the mrkdwn token early.
+        out = slack_linkify("[before > after](https://x.com)")
+        # The token must be a single valid <url|label> — exactly one unescaped
+        # '>' (the terminator) and the label '>' must be entity-escaped.
+        assert out.count("<") == 1
+        assert out.count(">") == 1  # only the terminator
+        assert "&gt;" in out
+
+    def test_label_with_lt_inside_is_entity_escaped(self) -> None:
+        out = slack_linkify("[a < b](https://x.com)")
+        assert out.count("<") == 1
+        assert out.count(">") == 1
+        assert "&lt;" in out
+
+    def test_label_with_amp_inside_is_entity_escaped(self) -> None:
+        out = slack_linkify("[a & b](https://x.com)")
+        assert "&amp;" in out
+
     def test_label_with_pipe_inside_is_escaped(self) -> None:
         # Slack mrkdwn doesn't support pipes in labels; the helper substitutes
         # them with a unicode bar so the label stays readable rather than the


### PR DESCRIPTION
## Summary

Three messaging logic bugs, one consolidated PR. Blast class: **logic**.

- **Bug 1 (MEDIUM) — `SlackWebhookView._persist` non-idempotent fallback key:** when `event_id` is absent the fallback was a wall-clock millisecond timestamp, unique per delivery, so Slack retries of the same payload each created a new `IncomingEvent` row. Fixed to `sha256(body)[:16]` content hash, matching the GitHub/GitLab webhook siblings.
- **Bug 2 (LOW) — `_rewrite_md_link` label not fully escaped:** only `|` was substituted; `>` and `<` in the label would terminate the `<url|label>` mrkdwn token early. Fixed by entity-escaping `&`, `<`, `>` (in order) before the `|` substitution, per Slack mrkdwn rules.
- **Bug 3 (LOW, latent) — `DailyDigest._ensure_thread` unchecked `open_dm`:** when `open_dm` returns `""` or `post_message` returns no `ts`, the code previously persisted a `DailyDigestThread` row with empty `channel_ref`/`root_ts`, making every subsequent post a silent no-op. Fixed to hard-fail (raise) on non-delivery before the DB write, mirroring `_deliver_dm`'s contract (same class as [#1173](https://github.com/souliane/teatree/issues/1173)).

## Test plan

- RED→GREEN per bug confirmed before applying fixes:
  - Bug 1: `test_missing_event_id_fallback_key_is_content_hash` (key shape), `test_missing_event_id_retries_collapse_to_one_row` (idempotency)
  - Bug 2: `test_label_with_gt_inside_is_entity_escaped`, `test_label_with_lt_inside_is_entity_escaped`, `test_label_with_amp_inside_is_entity_escaped`
  - Bug 3: `test_open_dm_failure_does_not_persist_thread_row`, `test_post_message_failure_does_not_persist_thread_row`
- Full targeted suites (75 tests across all three modules): all pass
- Pre-push Docker matrix gate: passed