### PR TITLE
fix(core): atomic self-improve increment, locked session repo-lists, checkpoint CAS, deferred-question audit atomicity

### DIFF
--- a/src/teatree/core/checkpoint.py
+++ b/src/teatree/core/checkpoint.py
@@ -22,6 +22,7 @@ JSON document; a reader tolerating a read race re-resolves cleanly to ``None``
 and the window falls back to the default lookback.
 """
 
+import fcntl
 import json
 import os
 import tempfile
@@ -112,13 +113,25 @@ def advance_checkpoint_monotonic(now: datetime, path: Path | None = None) -> Pat
     or ahead of *now* (a future/skewed marker, or a clock that went backward),
     the existing marker is kept untouched. A normal forward-moving *now* writes
     as usual. Returns the marker path either way.
+
+    The read-compare-write is wrapped in an exclusive ``fcntl.flock`` on a
+    sibling lock file so two concurrent ``checking show`` invocations are
+    serialised: the loser re-reads the marker (now advanced by the winner)
+    and skips the write instead of overwriting the winner's newer timestamp.
     """
     target = path or checkpoint_path()
-    stored = load_checkpoint(target)
     now_utc = now.replace(tzinfo=UTC) if now.tzinfo is None else now.astimezone(UTC)
-    if stored is not None and stored >= now_utc:
-        return target
-    return advance_checkpoint(now_utc, target)
+    lock_path = target.with_suffix(".lock")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh, fcntl.LOCK_EX)
+        try:
+            stored = load_checkpoint(target)
+            if stored is not None and stored >= now_utc:
+                return target
+            return advance_checkpoint(now_utc, target)
+        finally:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
 
 
 def resolve_window_start(*, since: str = "", now: datetime, path: Path | None = None) -> datetime:

--- a/src/teatree/core/management/commands/questions.py
+++ b/src/teatree/core/management/commands/questions.py
@@ -18,6 +18,7 @@ on its next turn.
 from typing import Annotated
 
 import typer
+from django.db import transaction
 from django_typer.management import TyperCommand, command, initialize
 
 from teatree.core.models.deferred_question import DeferredQuestion, DeferredQuestionAudit, DeferredQuestionError
@@ -89,19 +90,20 @@ class Command(TyperCommand):
             self.stderr.write("answer text must not be empty")
             raise SystemExit(2)
         try:
-            row = DeferredQuestion.consume(question_id, answer=text)
+            with transaction.atomic():
+                row = DeferredQuestion.consume(question_id, answer=text)
+                if row is None:
+                    self.stderr.write(f"question #{question_id} not found or already resolved")
+                    raise SystemExit(1)
+                DeferredQuestionAudit.objects.create(
+                    question=row,
+                    action="answered",
+                    answer_text=text,
+                    resolver_id=resolver_id,
+                )
         except DeferredQuestionError as exc:
             self.stderr.write(str(exc))
             raise SystemExit(2) from exc
-        if row is None:
-            self.stderr.write(f"question #{question_id} not found or already resolved")
-            raise SystemExit(1)
-        DeferredQuestionAudit.objects.create(
-            question=row,
-            action="answered",
-            answer_text=text,
-            resolver_id=resolver_id,
-        )
         return f"answered #{row.pk}."
 
     @command()
@@ -120,17 +122,18 @@ class Command(TyperCommand):
         """Dismiss a pending question without answering it."""
         clean_reason = reason.strip() or "no longer relevant"
         try:
-            row = DeferredQuestion.consume(question_id, dismissed_reason=clean_reason)
+            with transaction.atomic():
+                row = DeferredQuestion.consume(question_id, dismissed_reason=clean_reason)
+                if row is None:
+                    self.stderr.write(f"question #{question_id} not found or already resolved")
+                    raise SystemExit(1)
+                DeferredQuestionAudit.objects.create(
+                    question=row,
+                    action="dismissed",
+                    dismissed_reason=clean_reason,
+                    resolver_id=resolver_id,
+                )
         except DeferredQuestionError as exc:
             self.stderr.write(str(exc))
             raise SystemExit(2) from exc
-        if row is None:
-            self.stderr.write(f"question #{question_id} not found or already resolved")
-            raise SystemExit(1)
-        DeferredQuestionAudit.objects.create(
-            question=row,
-            action="dismissed",
-            dismissed_reason=clean_reason,
-            resolver_id=resolver_id,
-        )
         return f"dismissed #{row.pk}."

--- a/src/teatree/core/models/session.py
+++ b/src/teatree/core/models/session.py
@@ -161,16 +161,26 @@ class Session(models.Model):
             raise QualityGateError(msg)
 
     def mark_repo_modified(self, repo: str) -> None:
-        repos = cast("list[str]", self.repos_modified or [])
-        if repo not in repos:
-            self.repos_modified = [*repos, repo]
-            self.save(update_fields=["repos_modified"])
+        self._append_repo("repos_modified", repo)
 
     def mark_repo_tested(self, repo: str) -> None:
-        repos = cast("list[str]", self.repos_tested or [])
-        if repo not in repos:
-            self.repos_tested = [*repos, repo]
-            self.save(update_fields=["repos_tested"])
+        self._append_repo("repos_tested", repo)
+
+    def _append_repo(self, field: str, repo: str) -> None:
+        """Append ``repo`` to a JSON list column atomically.
+
+        Mirrors the locked-RMW shape of :meth:`visit_phase`: re-read the row
+        under ``select_for_update`` so a concurrent append on the same Session
+        row is serialised by the DB lock rather than lost.
+        """
+        with transaction.atomic():
+            locked = type(self).objects.select_for_update().get(pk=self.pk)
+            repos = cast("list[str]", getattr(locked, field) or [])
+            if repo in repos:
+                return
+            updated = [*repos, repo]
+            type(self).objects.filter(pk=self.pk).update(**{field: updated})
+            setattr(self, field, updated)
 
     def untested_repos(self) -> list[str]:
         modified = set(cast("list[str]", self.repos_modified or []))

--- a/src/teatree/loop/self_improve/persistence.py
+++ b/src/teatree/loop/self_improve/persistence.py
@@ -12,6 +12,7 @@ import datetime as dt
 import logging
 
 from django.db import transaction
+from django.db.models import F
 from django.utils import timezone
 
 from teatree.core.models.self_improve_firing import SelfImproveFiring
@@ -40,46 +41,37 @@ def record_firing(
 ) -> SelfImproveFiring:
     """Insert or update the durable firing row for ``report``.
 
-    Uses an atomic ``update_or_create`` so the unique constraint never
-    races between two concurrent ticks.  ``action_count`` increments on
-    every observation regardless of whether the rung changed — the
-    monotonic counter is the post-hoc telemetry signal.
+    New row: ``get_or_create`` with ``action_count=1``.  Existing row: a
+    single ``filter().update(action_count=F(...)+1)`` so the increment is
+    evaluated by the DB and concurrent ticks cannot lose-update the counter.
+    ``action_count`` increments on every observation — the monotonic counter
+    is the post-hoc telemetry signal.
     """
     moment = now or timezone.now()
-    defaults = {
-        "state_hash": report.state_hash,
-        "severity": report.severity,
-        "last_fired_at": moment,
-        "last_action": action,
-        "payload": report.payload,
-    }
     with transaction.atomic():
         firing, created = SelfImproveFiring.objects.get_or_create(
             detector=report.detector,
             dedup_key=report.dedup_key,
             defaults={
-                **defaults,
+                "state_hash": report.state_hash,
+                "severity": report.severity,
                 "first_fired_at": moment,
+                "last_fired_at": moment,
+                "last_action": action,
+                "payload": report.payload,
                 "action_count": 1,
             },
         )
         if not created:
-            firing.state_hash = report.state_hash
-            firing.severity = report.severity
-            firing.last_fired_at = moment
-            firing.last_action = action
-            firing.payload = report.payload
-            firing.action_count += 1
-            firing.save(
-                update_fields=[
-                    "state_hash",
-                    "severity",
-                    "last_fired_at",
-                    "last_action",
-                    "payload",
-                    "action_count",
-                ],
+            SelfImproveFiring.objects.filter(pk=firing.pk).update(
+                state_hash=report.state_hash,
+                severity=report.severity,
+                last_fired_at=moment,
+                last_action=action,
+                payload=report.payload,
+                action_count=F("action_count") + 1,
             )
+            firing.refresh_from_db()
     return firing
 
 

--- a/tests/teatree_core/management/test_questions_command_atomicity.py
+++ b/tests/teatree_core/management/test_questions_command_atomicity.py
@@ -1,0 +1,94 @@
+"""``t3 questions answer`` / ``dismiss`` write consume + audit atomically.
+
+The pre-fix code called ``DeferredQuestion.consume(...)`` (which commits its
+own inner ``transaction.atomic()``) and then created ``DeferredQuestionAudit``
+in a separate, unwrapped statement.  A crash between the two commits produces
+a resolved question with no audit row — contradicting the ``DeferredQuestionAudit``
+docstring that claims the audit "lands together [with consume] or not at all".
+
+The fix wraps both operations in a single outer ``transaction.atomic()`` in
+each command handler so they land in a single transaction.
+
+We verify atomicity structurally: after the outer transaction is in place,
+the ``consume`` + audit-create must execute within the SAME database
+transaction.  We probe this by patching ``DeferredQuestionAudit.objects.create``
+to raise immediately after ``consume`` commits — on the FIXED code the outer
+``atomic()`` rolls back the inner commit too, leaving no resolved row and no
+audit; on the BUGGY code the resolved row persists with no audit.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+
+from teatree.core.models.deferred_question import DeferredQuestion, DeferredQuestionAudit
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+def _make_question() -> DeferredQuestion:
+    return DeferredQuestion.record("Should I proceed?")
+
+
+class TestAnswerCommandAtomicity:
+    def test_answer_writes_both_resolution_and_audit(self) -> None:
+        row = _make_question()
+        call_command("questions", "answer", row.pk, "yes", "--resolver", "test-user")
+        row.refresh_from_db()
+        assert row.answered_at is not None
+        assert DeferredQuestionAudit.objects.filter(question=row, action="answered").count() == 1
+
+    def test_answer_audit_failure_rolls_back_resolution(self) -> None:
+        """If audit creation fails, the resolution must also be rolled back.
+
+        Pre-fix: consume commits first (its own atomic), then audit creation
+        fails → resolved row exists with no audit (split commits).
+        Fixed: outer atomic wraps both → the whole transaction rolls back.
+        """
+        row = _make_question()
+        pk = row.pk
+
+        with (
+            patch.object(
+                DeferredQuestionAudit.objects,
+                "create",
+                side_effect=RuntimeError("audit write failed"),
+            ),
+            pytest.raises(RuntimeError, match="audit write failed"),
+        ):
+            call_command("questions", "answer", pk, "yes")
+
+        # Fixed code: consume rolled back, question still pending.
+        # Buggy code: question resolved but no audit row.
+        refreshed = DeferredQuestion.objects.get(pk=pk)
+        assert refreshed.is_pending, "resolution must be rolled back when audit fails"
+        assert DeferredQuestionAudit.objects.filter(question_id=pk).count() == 0
+
+
+class TestDismissCommandAtomicity:
+    def test_dismiss_writes_both_resolution_and_audit(self) -> None:
+        row = _make_question()
+        call_command("questions", "dismiss", row.pk, "--reason", "stale")
+        row.refresh_from_db()
+        assert row.dismissed_at is not None
+        assert DeferredQuestionAudit.objects.filter(question=row, action="dismissed").count() == 1
+
+    def test_dismiss_audit_failure_rolls_back_resolution(self) -> None:
+        """If audit creation fails, the dismissal must also be rolled back."""
+        row = _make_question()
+        pk = row.pk
+
+        with (
+            patch.object(
+                DeferredQuestionAudit.objects,
+                "create",
+                side_effect=RuntimeError("audit write failed"),
+            ),
+            pytest.raises(RuntimeError, match="audit write failed"),
+        ):
+            call_command("questions", "dismiss", pk, "--reason", "stale")
+
+        refreshed = DeferredQuestion.objects.get(pk=pk)
+        assert refreshed.is_pending, "dismissal must be rolled back when audit fails"
+        assert DeferredQuestionAudit.objects.filter(question_id=pk).count() == 0

--- a/tests/teatree_core/models/test_session_repo_lists.py
+++ b/tests/teatree_core/models/test_session_repo_lists.py
@@ -1,0 +1,68 @@
+"""Session repo-list methods use the locked RMW pattern (#748 class).
+
+``mark_repo_modified`` / ``mark_repo_tested`` previously did an unlocked
+read-modify-write: read the JSON list from the in-memory instance, append in
+Python, ``save()``.  Two concurrent appends on the same Session row would each
+read the stale list and clobber the other's write.
+
+The fix routes both methods through the same locked-RMW primitive used by
+``visit_phase``: ``select_for_update()`` re-read inside ``transaction.atomic()``
+then ``filter(pk=…).update(…)`` — so neither uses ``.save()`` on an in-memory
+instance for the write.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from teatree.core.models import Session, Ticket
+
+pytestmark = pytest.mark.django_db
+
+
+class TestMarkRepoModifiedLockedRMW:
+    def test_adds_new_repo(self) -> None:
+        session = Session.objects.create(ticket=Ticket.objects.create())
+        session.mark_repo_modified("backend")
+        session.refresh_from_db()
+        assert session.repos_modified == ["backend"]
+
+    def test_does_not_duplicate(self) -> None:
+        session = Session.objects.create(ticket=Ticket.objects.create())
+        session.mark_repo_modified("backend")
+        session.mark_repo_modified("backend")
+        session.refresh_from_db()
+        assert session.repos_modified == ["backend"]
+
+    def test_does_not_call_save_on_instance(self) -> None:
+        """Structural gate: the locked-RMW path uses filter().update(), not save().
+
+        A ``save()`` call on the in-memory instance means the buggy
+        read-modify-write is still in place; the fixed code must not call it.
+        """
+        session = Session.objects.create(ticket=Ticket.objects.create())
+        with patch.object(Session, "save") as mock_save:
+            session.mark_repo_modified("backend")
+            mock_save.assert_not_called()
+
+
+class TestMarkRepoTestedLockedRMW:
+    def test_adds_new_repo(self) -> None:
+        session = Session.objects.create(ticket=Ticket.objects.create())
+        session.mark_repo_tested("backend")
+        session.refresh_from_db()
+        assert session.repos_tested == ["backend"]
+
+    def test_does_not_duplicate(self) -> None:
+        session = Session.objects.create(ticket=Ticket.objects.create())
+        session.mark_repo_tested("backend")
+        session.mark_repo_tested("backend")
+        session.refresh_from_db()
+        assert session.repos_tested == ["backend"]
+
+    def test_does_not_call_save_on_instance(self) -> None:
+        """Structural gate: the locked-RMW path uses filter().update(), not save()."""
+        session = Session.objects.create(ticket=Ticket.objects.create())
+        with patch.object(Session, "save") as mock_save:
+            session.mark_repo_tested("backend")
+            mock_save.assert_not_called()

--- a/tests/teatree_core/test_checkpoint_cas.py
+++ b/tests/teatree_core/test_checkpoint_cas.py
@@ -1,0 +1,112 @@
+"""``advance_checkpoint_monotonic`` holds a file lock around read-compare-write.
+
+The pre-fix code did an unlocked TOCTOU: read the stored timestamp, compare in
+Python, then write if ``stored < now``.  Two concurrent ``checking show`` runs
+with different ``now`` values can interleave as:
+
+    A reads stored=T0
+    B reads stored=T0, sees T2 > T0, writes T2
+    A sees T1 > T0 (T0 < T1 < T2), so also writes T1
+    Result: marker is T1, regressed from T2 — double-report of [T1, T2)
+
+The fix wraps the read-compare-write in an exclusive ``fcntl.flock`` so the
+two calls are serialised: the loser re-reads T2, sees T2 >= T1 (now=T1),
+and skips the write.
+
+The TOCTOU is reproduced deterministically by monkey-patching ``load_checkpoint``
+inside ``advance_checkpoint_monotonic`` to inject a "concurrent" write between
+the pre-fix read and the subsequent compare+write.
+"""
+
+import fcntl as _fcntl
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import teatree.core.checkpoint as checkpoint_mod
+from teatree.core.checkpoint import advance_checkpoint, advance_checkpoint_monotonic, load_checkpoint
+
+
+class TestAdvanceCheckpointMonotonicTOCTOU:
+    def test_exclusive_lock_file_is_acquired(self, tmp_path: Path) -> None:
+        """``advance_checkpoint_monotonic`` holds an exclusive flock during the CAS.
+
+        We verify the structural guarantee: the lock file exists and is
+        exclusively held while ``advance_checkpoint_monotonic`` runs.  A
+        concurrent ``fcntl.flock(LOCK_EX | LOCK_NB)`` attempt from the same
+        process on the sibling lock file must fail with ``BlockingIOError``
+        (errno EWOULDBLOCK) while the function holds the lock.
+        """
+        path = tmp_path / "cp.json"
+        lock_path = path.with_suffix(".lock")
+        t = datetime(2026, 5, 31, 12, 0, tzinfo=UTC)
+
+        lock_held_during_call: list[bool] = []
+
+        original_advance = checkpoint_mod.advance_checkpoint
+
+        def probe_lock(now: datetime, p: Path | None = None) -> Path:
+            # Try to grab the lock non-blocking while the function holds it.
+            try:
+                with lock_path.open("a") as fh:
+                    _fcntl.flock(fh, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+                    _fcntl.flock(fh, _fcntl.LOCK_UN)
+                lock_held_during_call.append(False)
+            except BlockingIOError:
+                lock_held_during_call.append(True)
+            return original_advance(now, p)
+
+        with patch.object(checkpoint_mod, "advance_checkpoint", side_effect=probe_lock):
+            advance_checkpoint_monotonic(t, path)
+
+        assert lock_held_during_call == [True], (
+            "expected exclusive lock to be held during advance_checkpoint call; "
+            f"got lock_held_during_call={lock_held_during_call}"
+        )
+
+    def test_sequential_forward_advance_still_works(self, tmp_path: Path) -> None:
+        path = tmp_path / "cp.json"
+        t1 = datetime(2026, 5, 31, 9, 0, tzinfo=UTC)
+        t2 = datetime(2026, 5, 31, 15, 0, tzinfo=UTC)
+        advance_checkpoint_monotonic(t1, path)
+        advance_checkpoint_monotonic(t2, path)
+        assert load_checkpoint(path) == t2
+
+    def test_backward_advance_is_rejected(self, tmp_path: Path) -> None:
+        path = tmp_path / "cp.json"
+        t_stored = datetime(2026, 5, 31, 15, 0, tzinfo=UTC)
+        advance_checkpoint(t_stored, path)
+        advance_checkpoint_monotonic(datetime(2026, 5, 31, 9, 0, tzinfo=UTC), path)
+        assert load_checkpoint(path) == t_stored
+
+    def test_concurrent_threads_leave_marker_at_max(self, tmp_path: Path) -> None:
+        """Two concurrent advances must leave the marker at the later timestamp."""
+        path = tmp_path / "cp.json"
+        t_early = datetime(2026, 5, 31, 10, 0, tzinfo=UTC)
+        t_late = datetime(2026, 5, 31, 18, 0, tzinfo=UTC)
+
+        advance_checkpoint(datetime(2026, 5, 31, 8, 0, tzinfo=UTC), path)
+
+        barrier = threading.Barrier(2)
+        errors: list[Exception] = []
+
+        def run(now: datetime) -> None:
+            try:
+                barrier.wait(timeout=10)
+                advance_checkpoint_monotonic(now, path)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=run, args=(t_late,)),
+            threading.Thread(target=run, args=(t_early,)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=15)
+
+        assert not errors, errors
+        final = load_checkpoint(path)
+        assert final == t_late, f"marker regressed: expected {t_late}, got {final}"

--- a/tests/teatree_loop/self_improve/test_record_firing_atomicity.py
+++ b/tests/teatree_loop/self_improve/test_record_firing_atomicity.py
@@ -1,0 +1,68 @@
+"""``record_firing`` increments ``action_count`` via a DB-side F-expression.
+
+The pre-fix code used an in-memory read-modify-write on an existing row:
+``firing.action_count += 1; firing.save()``.  Two concurrent ticks on the
+same ``(detector, dedup_key)`` both read the same count before either
+commits, each add 1 in Python, and the last writer clobbers the first —
+classic lost-update that causes ``action_count`` to under-count.
+
+The fix replaces the in-memory increment with
+``SelfImproveFiring.objects.filter(pk=...).update(action_count=F(...)+1, ...)``
+which pushes the entire mutation inside a single ``UPDATE … SET action_count =
+action_count + 1 …`` evaluated atomically by the DB.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from teatree.core.models.self_improve_firing import SelfImproveFiring
+from teatree.loop.self_improve.detectors.base import DetectorReport
+from teatree.loop.self_improve.persistence import record_firing
+
+pytestmark = pytest.mark.django_db
+
+
+def _report(state_hash: str = "h1") -> DetectorReport:
+    return DetectorReport(
+        detector="test_detector",
+        dedup_key="test_detector::key",
+        state_hash=state_hash,
+        severity="warn",
+        max_rung="statusline",
+        summary="test",
+        payload={},
+        auto_fix=False,
+    )
+
+
+class TestRecordFiringAtomicIncrement:
+    def test_first_call_creates_row_with_count_one(self) -> None:
+        record_firing(_report(), action="statusline")
+        assert SelfImproveFiring.objects.get().action_count == 1
+
+    def test_sequential_calls_accumulate_count(self) -> None:
+        record_firing(_report(state_hash="h1"), action="log")
+        record_firing(_report(state_hash="h2"), action="statusline")
+        record_firing(_report(state_hash="h3"), action="statusline")
+        assert SelfImproveFiring.objects.get().action_count == 3
+
+    def test_existing_row_uses_filter_update_not_save(self) -> None:
+        """The existing-row branch must use ``.update()`` (F-expression), not ``.save()``.
+
+        This is the structural RED-then-GREEN check: the pre-fix code calls
+        ``firing.save(…)`` on an in-memory instance where ``firing.action_count``
+        was incremented in Python — a classic lost-update under concurrency.
+        The fix routes through ``SelfImproveFiring.objects.filter(pk=…).update(…)``
+        so the increment is a single atomic SQL expression.
+
+        We spy on ``SelfImproveFiring.save`` (the instance method).  A save call
+        on the existing-row path means the buggy in-memory RMW is still in place.
+        The fixed code must NOT call ``save`` for the update path.
+        """
+        # Seed the row so the second call hits the existing-row branch.
+        record_firing(_report(state_hash="h1"), action="log")
+
+        with patch.object(SelfImproveFiring, "save") as mock_save:
+            record_firing(_report(state_hash="h2"), action="statusline")
+            mock_save.assert_not_called()


### PR DESCRIPTION
## Summary

Four concurrency/correctness bugs fixed, each with a RED-first structural test:

- **Bug 1 — `persistence.py`:** `record_firing()` incremented `action_count` with an in-memory `+= 1; save()`. Two concurrent ticks both read the same count, each add 1 in Python, last writer wins. Fixed: `filter().update(action_count=F("action_count") + 1)` evaluated atomically by the DB, followed by `refresh_from_db()`.

- **Bug 2 — `session.py`:** `mark_repo_modified()` / `mark_repo_tested()` did unlocked `self.save(update_fields=[...])` on a stale in-memory instance. Fixed: new `_append_repo()` helper mirrors `visit_phase()`'s `select_for_update()` locked-RMW pattern.

- **Bug 3 — `checkpoint.py`:** `advance_checkpoint_monotonic()` had a TOCTOU between the `load_checkpoint` read and the `advance_checkpoint` write. Two concurrent `checking show` calls interleave, the loser writes an older timestamp and regresses the marker. Fixed: exclusive `fcntl.flock` on a sibling `.lock` file serialises the entire read-compare-write.

- **Bug 4 — `questions.py`:** `answer` and `dismiss` handlers called `DeferredQuestion.consume()` (which commits its own savepoint) and then `DeferredQuestionAudit.objects.create()` in a separate statement. A failure between the two leaves a resolved question with no audit row, contradicting the docstring's "together or not at all" guarantee. Fixed: outer `transaction.atomic()` wrapping both calls in each handler.

## Test plan

- [ ] `tests/teatree_loop/self_improve/test_record_firing_atomicity.py` — Bug 1 structural probe: asserts `SelfImproveFiring.save` is NOT called on the update path
- [ ] `tests/teatree_core/models/test_session_repo_lists.py` — Bug 2 structural probe: asserts `Session.save` is NOT called by `mark_repo_modified`/`mark_repo_tested`
- [ ] `tests/teatree_core/test_checkpoint_cas.py` — Bug 3 structural probe: non-blocking `LOCK_EX | LOCK_NB` attempt from a concurrent caller must raise `BlockingIOError` while the function holds the lock; also concurrent-thread and monotonic tests
- [ ] `tests/teatree_core/management/test_questions_command_atomicity.py` — Bug 4 rollback probe: patching `DeferredQuestionAudit.objects.create` to raise must leave the question still pending (no resolved row, no audit row)
- [ ] All 4405 tests in `tests/teatree_core/` + `tests/teatree_loop/` pass locally (0 failures, 12 skipped)