### PR TITLE
docs(skills): arch-design checklist — normalize identities to the qualified canonical, never strip

### DIFF
--- a/skills/architecture-design/SKILL.md
+++ b/skills/architecture-design/SKILL.md
@@ -19,7 +19,7 @@ Generic planning methodology is delegated to `obra/superpowers/writing-plans`. T
 
 ## When the gate fires
 
-The seven checks apply when the work meets any of:
+The eight checks apply when the work meets any of:
 
 - touches `src/teatree/cli/`, `src/teatree/core/`, `src/teatree/loop/scanners/`, `src/teatree/agents/`, `OverlayBase`, scanner registration, or any `*Backend` Protocol
 - crosses an FSM phase boundary (introduces or moves a `Ticket.State` transition)
@@ -29,7 +29,7 @@ The seven checks apply when the work meets any of:
 
 Tactical fixes (typo, narrow string change, single-call-site bug) skip the gate — the implementer notes that in the PR body.
 
-## The seven checks
+## The eight checks
 
 ### 1. BLUEPRINT § alignment
 
@@ -92,6 +92,16 @@ For any external write (Slack post, GitHub PR mutation, GitLab MR update, DB row
 
 If even one is missing, the design is incomplete — adding it later is a tech-debt commitment, not a follow-up.
 
+### 8. Identity and key normalization
+
+When a logical identity has both a bare and a qualified form (namespace:name, scope/path, prefix+id, fully-qualified name), the **fully-qualified form is the canonical key**.
+
+- **One source-of-truth function** normalizes every reference UP to the fully-qualified form at every boundary — read, write, compare, dedup, cache lookup, registry lookup.
+- Stripping a qualifier to make two things match discards qualifying information and conflates genuinely distinct entities (e.g. `t3:review` vs `overlay-a:review`), creating silent collisions that produce wrong results with no error.
+- **Normalization smell to challenge at review:** any `split(":")[-1]`, `rsplit("/", 1)[-1]`, `removeprefix(...)`, or `lstrip(prefix)` whose sole purpose is to make a comparison succeed. The under-qualified side should be canonicalized UP instead. A transformation that can only ever lose information is almost always the wrong seam.
+
+_Example: skill name lookups in the registry. The registered key is `namespace:skill-name`. A lookup arriving as bare `skill-name` should be qualified to `namespace:skill-name` at the boundary, not matched by stripping the namespace off the registered key._
+
 ## ARCHITECTURE.md template
 
 The implementer drops a file at `ARCHITECTURE.md` in the worktree root BEFORE touching `src/`. The PR template references it; an empty or missing file is a review gap.
@@ -119,6 +129,9 @@ The implementer drops a file at `ARCHITECTURE.md` in the worktree root BEFORE to
 
 ## 7. Resilience invariants
 <per external write: verify-by-re-read, fallback-transport, idempotency, heartbeat, sub-agent return contract>
+
+## 8. Identity and key normalization
+<identities with bare vs qualified forms; canonical form chosen; one normalization function at every boundary; any strip/split whose purpose is to make a comparison succeed — justify or remove>
 ```
 
 ## Workflow
@@ -136,6 +149,6 @@ The implementer drops a file at `ARCHITECTURE.md` in the worktree root BEFORE to
 
 ## Scope discipline
 
-This skill ships v1 with the seven checks above. If a check is missing from the in-worktree `ARCHITECTURE.md`, the reviewer surfaces it as a discussion thread on the PR — no merge until the gap is closed.
+This skill ships v1 with the eight checks above. If a check is missing from the in-worktree `ARCHITECTURE.md`, the reviewer surfaces it as a discussion thread on the PR — no merge until the gap is closed.
 
 The companion does not block implementation skills from loading — it loads alongside them. The discipline is that the implementer reads it first; the PR review enforces that the artifact (`ARCHITECTURE.md`) was produced.

--- a/skills/architecture-design/SKILL.md
+++ b/skills/architecture-design/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 This is a companion gate. Implementation skills (`t3:code`, `t3:ticket` for new features, `t3:retro` when a retro touches skills) declare `requires: [architecture-design]` so it loads BEFORE coding starts. The flywheel (BLUEPRINT § 17.1 invariant 2) is enforcement encoded as structure, not prose vigilance — this companion is the structure for the "design first, then code" step.
 
-Generic planning methodology is delegated to `obra/superpowers/writing-plans`. The teatree-specific value-add is the seven-check architecture pass below, plus the `ARCHITECTURE.md` template the implementer fills in before touching `src/`.
+Generic planning methodology is delegated to `obra/superpowers/writing-plans`. The teatree-specific value-add is the eight-check architecture pass below, plus the `ARCHITECTURE.md` template the implementer fills in before touching `src/`.
 
 ## When the gate fires
 
@@ -137,7 +137,7 @@ The implementer drops a file at `ARCHITECTURE.md` in the worktree root BEFORE to
 ## Workflow
 
 1. Read `BLUEPRINT.md` and the appendix for the touched section.
-2. Run the seven checks against the proposed change.
+2. Run the eight checks against the proposed change.
 3. Write `ARCHITECTURE.md` in the worktree root.
 4. Hand off to the implementation skill (`t3:code`) — it picks up from here with TDD.
 


### PR DESCRIPTION
## Summary

- Adds check [#8](https://github.com/souliane/teatree/issues/8) (identity and key normalization) to the architecture-design companion skill
- Principle: fully-qualified form is the canonical key; normalize UP at every boundary through one source-of-truth function; stripping a qualifier to make a comparison succeed is a design smell to challenge at review
- Updates the `ARCHITECTURE.md` template and all "seven checks" references to "eight checks"

## Test plan

- [ ] Skill frontmatter validates (pre-commit `Validate SKILL.md frontmatter` hook)
- [ ] No banned terms, no imperative prose violations (pre-commit hooks passed)
- [ ] README skills catalogue updated (hook ran clean)