### PR TITLE
fix(loop): isolate per-signal failures in dispatch()

### DIFF
--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -11,6 +11,7 @@ hosts the loop (a Claude Code ``/loop`` slot) reads the action list and
 spawns agents with the standard tool. This keeps unit tests deterministic.
 """
 
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -18,6 +19,8 @@ from typing import Any, Literal
 from teatree.config import get_effective_settings
 from teatree.core.phases import normalize_phase
 from teatree.loop.scanners.base import ScanSignal
+
+logger = logging.getLogger(__name__)
 
 ActionKind = Literal["statusline", "agent", "webhook", "mechanical"]
 type ActionPayload = dict[str, Any]
@@ -443,5 +446,8 @@ def dispatch(signals: list[ScanSignal]) -> list[DispatchAction]:
     """
     actions: list[DispatchAction] = []
     for signal in signals:
-        actions.extend(_dispatch_one(signal))
+        try:
+            actions.extend(_dispatch_one(signal))
+        except Exception:
+            logger.exception("Signal %s raised during dispatch", signal.kind)
     return actions

--- a/tests/teatree_loop/test_dispatch.py
+++ b/tests/teatree_loop/test_dispatch.py
@@ -1,10 +1,13 @@
 """Tests for ``teatree.loop.dispatch`` — signal → action routing."""
 
+import logging
+
 import pytest
 from django.test import TestCase
 
 from teatree.config import UserSettings
-from teatree.loop.dispatch import dispatch
+from teatree.loop import dispatch as dispatch_module
+from teatree.loop.dispatch import DispatchAction, dispatch
 from teatree.loop.scanners.base import ScanSignal
 
 
@@ -473,3 +476,34 @@ def test_codex_review_dispatch_adversarial_variant_routes_to_hardened_agent() ->
     agent_actions = [a for a in actions if a.kind == "agent"]
     assert len(agent_actions) == 1
     assert agent_actions[0].zone == "codex:adversarial-review"
+
+
+def test_one_raising_signal_does_not_abort_the_others(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A signal whose routing raises is skipped + logged; the rest still route (#1649)."""
+    real_dispatch_one = dispatch_module._dispatch_one
+
+    def _flaky(signal: ScanSignal) -> list[DispatchAction]:
+        if signal.kind == "boom":
+            msg = "routing exploded"
+            raise RuntimeError(msg)
+        return real_dispatch_one(signal)
+
+    monkeypatch.setattr(dispatch_module, "_dispatch_one", _flaky)
+
+    with caplog.at_level(logging.ERROR, logger="teatree.loop.dispatch"):
+        actions = dispatch(
+            [
+                ScanSignal(kind="my_pr.open", summary="PR #1 open"),
+                ScanSignal(kind="boom", summary="signal that blows up"),
+                ScanSignal(kind="reviewer_pr.new_sha", summary="MR x"),
+            ],
+        )
+
+    zones = [(a.kind, a.zone) for a in actions]
+    assert ("statusline", "in_flight") in zones
+    assert ("agent", "t3:reviewer") in zones
+    assert all(a.kind != "agent" or a.zone != "boom" for a in actions)
+    assert any("boom" in r.message for r in caplog.records)


### PR DESCRIPTION
## What

`dispatch()` iterated `actions.extend(_dispatch_one(signal))` with no per-item guard, so one raising signal aborted the whole tick's routing and dropped every later signal's actions.

## Why

This completes the per-item fault-isolation pattern the rest of the loop already uses (e.g. `_run_job` isolating each scanner). One bad signal should not silently lose the other signals' actions for an entire tick.

## How

Wrap the per-signal `_dispatch_one(signal)` call in a `try/except` that logs via `logger.exception("Signal %s raised during dispatch", signal.kind)` and continues to the next signal — mirroring the `logger.exception("Scanner %s raised", label)` shape in `_run_job`. The happy path and action ordering for non-raising signals are unchanged.

Added `test_one_raising_signal_does_not_abort_the_others`: patches `_dispatch_one` to raise for one signal kind and asserts dispatch does not propagate, the other signals' actions are still returned, and the failure is logged. Mutation-checked: the test fails if the `try/except` is removed.

Closes #1649

🤖 Generated with [Claude Code](https://claude.com/claude-code)