### PR TITLE
fix(backends): paginate issue-comment, open-issue-search and pipeline-job listings

### DIFF
--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -448,8 +448,7 @@ class GitHubCodeHost:
             return []
 
         repo = f"{match['owner']}/{match['repo']}"
-        data = _gh_api_get(f"repos/{repo}/issues/{match['number']}/comments?per_page=100", token=self._token)
-        return cast("list[RawAPIDict]", data) if isinstance(data, list) else []
+        return _gh_api_get_paginated(f"repos/{repo}/issues/{match['number']}/comments?per_page=100", token=self._token)
 
     def update_issue_comment(self, *, issue_url: str, comment_id: int, body: str) -> RawAPIDict:
         """Edit an existing GitHub issue comment in place.

--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -189,8 +189,7 @@ class GitLabCodeHost:
         if project is None:
             return []
         endpoint = f"projects/{project.project_id}/issues?state=opened&search={quote_plus(query)}&per_page=100"
-        data = self._client.get_json(endpoint)
-        return data if isinstance(data, list) else []
+        return self._client.get_json_paginated(endpoint)
 
     def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict:
         project = self._resolve_project(repo)
@@ -376,10 +375,9 @@ class GitLabCodeHost:
         if project is None:
             return []
 
-        data = self._client.get_json(
+        return self._client.get_json_paginated(
             f"projects/{project.project_id}/issues/{int(match['iid'])}/notes?per_page=100",
         )
-        return cast("list[RawAPIDict]", data) if isinstance(data, list) else []
 
     def update_issue_comment(self, *, issue_url: str, comment_id: int, body: str) -> RawAPIDict:
         """Edit an existing note on a GitLab issue or work item in place.

--- a/src/teatree/backends/gitlab_ci.py
+++ b/src/teatree/backends/gitlab_ci.py
@@ -21,9 +21,9 @@ class GitLabCIService:
             return [f"No pipeline found for ref: {ref}"]
 
         pipeline_id = int(cast("int | str", pipeline["id"]))
-        jobs = self._client.get_json(f"projects/{project_info.project_id}/pipelines/{pipeline_id}/jobs?per_page=100")
-        if not isinstance(jobs, list):
-            return []
+        jobs = self._client.get_json_paginated(
+            f"projects/{project_info.project_id}/pipelines/{pipeline_id}/jobs?per_page=100"
+        )
 
         errors: list[str] = []
         for job in jobs:

--- a/tests/teatree_backends/test_gitlab_ci.py
+++ b/tests/teatree_backends/test_gitlab_ci.py
@@ -77,12 +77,10 @@ def test_fetch_failed_tests_returns_empty_for_no_pipeline() -> None:
 
 def test_fetch_pipeline_errors_extracts_from_failed_jobs() -> None:
     client, mock = _make_client(project=_project())
-    mock.get_json.side_effect = [
-        [{"id": 600}],  # latest pipeline
-        [  # jobs
-            {"id": 1, "name": "test", "status": "failed"},
-            {"id": 2, "name": "lint", "status": "success"},
-        ],
+    mock.get_json.return_value = [{"id": 600}]  # latest pipeline
+    mock.get_json_paginated.return_value = [
+        {"id": 1, "name": "test", "status": "failed"},
+        {"id": 2, "name": "lint", "status": "success"},
     ]
 
     with patch.object(service := GitLabCIService(client=client), "_get_job_trace", return_value="FAILED in test_foo"):
@@ -192,12 +190,10 @@ def test_latest_pipeline_url_encodes_ref_with_slash() -> None:
     assert "ref=feature%2Fabc" in endpoint
 
 
-def test_fetch_pipeline_errors_returns_empty_when_jobs_not_a_list() -> None:
+def test_fetch_pipeline_errors_returns_empty_when_no_jobs() -> None:
     client, mock = _make_client(project=_project())
-    mock.get_json.side_effect = [
-        [{"id": 600}],  # latest pipeline
-        {"error": "not a list"},  # jobs response is a dict, not a list
-    ]
+    mock.get_json.return_value = [{"id": 600}]  # latest pipeline
+    mock.get_json_paginated.return_value = []  # paginated helper owns the list contract
     service = GitLabCIService(client=client)
 
     result = service.fetch_pipeline_errors(project="org/repo", ref="main")
@@ -207,10 +203,8 @@ def test_fetch_pipeline_errors_returns_empty_when_jobs_not_a_list() -> None:
 
 def test_fetch_pipeline_errors_skips_empty_trace() -> None:
     client, mock = _make_client(project=_project())
-    mock.get_json.side_effect = [
-        [{"id": 600}],  # latest pipeline
-        [{"id": 1, "name": "test", "status": "failed"}],  # jobs
-    ]
+    mock.get_json.return_value = [{"id": 600}]  # latest pipeline
+    mock.get_json_paginated.return_value = [{"id": 1, "name": "test", "status": "failed"}]
 
     with patch.object(service := GitLabCIService(client=client), "_get_job_trace", return_value=""):
         result = service.fetch_pipeline_errors(project="org/repo", ref="main")
@@ -377,3 +371,40 @@ def test_default_client_is_created_when_none_provided() -> None:
     service = GitLabCIService()
 
     assert isinstance(service._client, GitLabAPI)
+
+
+def test_fetch_pipeline_errors_paginates_jobs_beyond_first_page() -> None:
+    """A failed job past the first jobs page must still surface an error.
+
+    A non-paginated GET caps the jobs list at per_page=100; a job that failed
+    but sits on page 2 would be silently dropped from the error report.
+    """
+    page1 = [{"id": i, "name": f"job{i}", "status": "success"} for i in range(100)]
+    page2 = [{"id": 100, "name": "test", "status": "failed"}]
+
+    def _http_side_effect(url: str, **_: object) -> MagicMock:
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        if "/jobs" in url:
+            if "page=2" in url:
+                resp.json.return_value = page2
+                resp.headers = {"x-next-page": ""}
+            else:
+                resp.json.return_value = page1
+                resp.headers = {"x-next-page": "2"}
+        else:  # latest pipeline list
+            resp.json.return_value = [{"id": 600}]
+            resp.headers = {"x-next-page": ""}
+        return resp
+
+    api = GitLabAPI(token="tok", base_url="https://gitlab.example.com/api/v4")
+    with (
+        patch("httpx.get", side_effect=_http_side_effect),
+        patch.object(api, "resolve_project", return_value=_project()),
+    ):
+        service = GitLabCIService(client=api)
+        with patch.object(service, "_get_job_trace", return_value="FAILED in test_foo"):
+            result = service.fetch_pipeline_errors(project="org/repo", ref="main")
+
+    assert len(result) == 1
+    assert "test" in result[0]

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab_api import GitLabAPI, ProjectInfo
@@ -7,6 +7,27 @@ from teatree.backends.protocols import PullRequestSpec
 
 def _project() -> ProjectInfo:
     return ProjectInfo(project_id=42, path_with_namespace="org/repo", short_name="repo", default_branch="main")
+
+
+def _two_page_http_side_effect(page1: list[dict], page2: list[dict]):
+    """httpx.get side-effect: page 1 advertises x-next-page=2, page 2 ends it.
+
+    ``get_json_paginated`` appends ``&page=N``; this routes the request by that
+    marker so a real ``GitLabAPI`` walks both pages.
+    """
+
+    def _side_effect(url: str, **_: object) -> MagicMock:
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        if "page=2" in url:
+            resp.json.return_value = page2
+            resp.headers = {"x-next-page": ""}
+        else:
+            resp.json.return_value = page1
+            resp.headers = {"x-next-page": "2"}
+        return resp
+
+    return _side_effect
 
 
 def test_create_pr_uses_repo_remote_and_auto_labels(tmp_path) -> None:
@@ -117,13 +138,13 @@ def test_create_issue_returns_error_when_project_not_resolved() -> None:
 def test_search_open_issues_searches_project() -> None:
     client = MagicMock(spec=GitLabAPI)
     client.resolve_project.return_value = _project()
-    client.get_json.return_value = [{"iid": 3}]
+    client.get_json_paginated.return_value = [{"iid": 3}]
     host = GitLabCodeHost(client=client)
 
     result = host.search_open_issues(repo="org/repo", query="fingerprint:abc")
 
     assert result == [{"iid": 3}]
-    endpoint = client.get_json.call_args[0][0]
+    endpoint = client.get_json_paginated.call_args[0][0]
     assert endpoint.startswith("projects/42/issues?state=opened&search=")
 
 
@@ -485,29 +506,29 @@ def test_post_issue_comment_returns_empty_dict_when_post_returns_none() -> None:
 
 
 def test_list_issue_comments_hits_notes_endpoint() -> None:
-    """list_issue_comments GETs the issue notes endpoint with per_page=100."""
+    """list_issue_comments paginates the issue notes endpoint with per_page=100."""
     client = MagicMock(spec=GitLabAPI)
     client.resolve_project.return_value = _project()
-    client.get_json.return_value = [{"id": 1, "body": "a"}, {"id": 2, "body": "b"}]
+    client.get_json_paginated.return_value = [{"id": 1, "body": "a"}, {"id": 2, "body": "b"}]
     host = GitLabCodeHost(client=client)
 
     result = host.list_issue_comments(issue_url="https://gitlab.com/org/repo/-/issues/7")
 
     assert result == [{"id": 1, "body": "a"}, {"id": 2, "body": "b"}]
-    client.get_json.assert_called_once_with("projects/42/issues/7/notes?per_page=100")
+    client.get_json_paginated.assert_called_once_with("projects/42/issues/7/notes?per_page=100")
 
 
 def test_list_issue_comments_supports_work_items_url() -> None:
     client = MagicMock(spec=GitLabAPI)
     client.resolve_project.return_value = _project()
-    client.get_json.return_value = []
+    client.get_json_paginated.return_value = []
     host = GitLabCodeHost(client=client)
 
     result = host.list_issue_comments(issue_url="https://gitlab.com/group/sub/repo/-/work_items/469")
 
     assert result == []
     client.resolve_project.assert_called_once_with("group/sub/repo")
-    client.get_json.assert_called_once_with("projects/42/issues/469/notes?per_page=100")
+    client.get_json_paginated.assert_called_once_with("projects/42/issues/469/notes?per_page=100")
 
 
 def test_list_issue_comments_returns_empty_on_non_issue_url() -> None:
@@ -517,7 +538,7 @@ def test_list_issue_comments_returns_empty_on_non_issue_url() -> None:
     result = host.list_issue_comments(issue_url="https://gitlab.com/org/repo/-/merge_requests/12")
 
     assert result == []
-    client.get_json.assert_not_called()
+    client.get_json_paginated.assert_not_called()
 
 
 def test_list_issue_comments_returns_empty_when_project_unresolved() -> None:
@@ -528,13 +549,14 @@ def test_list_issue_comments_returns_empty_when_project_unresolved() -> None:
     result = host.list_issue_comments(issue_url="https://gitlab.com/org/repo/-/issues/7")
 
     assert result == []
-    client.get_json.assert_not_called()
+    client.get_json_paginated.assert_not_called()
 
 
-def test_list_issue_comments_returns_empty_when_get_returns_non_list() -> None:
+def test_list_issue_comments_returns_paginated_result() -> None:
+    """The paginated helper owns the list contract; the method returns it verbatim."""
     client = MagicMock(spec=GitLabAPI)
     client.resolve_project.return_value = _project()
-    client.get_json.return_value = {"error": "boom"}
+    client.get_json_paginated.return_value = []
     host = GitLabCodeHost(client=client)
 
     result = host.list_issue_comments(issue_url="https://gitlab.com/org/repo/-/issues/7")
@@ -774,6 +796,47 @@ def test_get_mr_approvals_uses_canonical_approvals_left_not_fallback() -> None:
     state = host.get_mr_approvals(repo="org/repo", pr_iid=12)
 
     assert state["approvals_left"] == 2
+
+
+def test_list_issue_comments_returns_notes_from_page_two() -> None:
+    """A note that sits exclusively on page 2 must be returned, not truncated.
+
+    A non-paginated GET caps at per_page=100, so a ``## Test Plan`` evidence
+    note older than the 100 most-recent notes goes unseen and the poster
+    duplicates it. Pagination must surface the full note history (>100).
+    """
+    page1 = [{"id": i, "body": f"c{i}"} for i in range(100)]
+    page2 = [{"id": 100, "body": "## Test Plan"}]
+    api = GitLabAPI(token="tok", base_url="https://gitlab.example.com/api/v4")
+    host = GitLabCodeHost(client=api)
+    with (
+        patch("httpx.get", side_effect=_two_page_http_side_effect(page1, page2)),
+        patch.object(api, "resolve_project", return_value=_project()),
+    ):
+        result = host.list_issue_comments(issue_url="https://gitlab.com/org/repo/-/issues/7")
+
+    assert len(result) == 101
+    assert {"id": 100, "body": "## Test Plan"} in result
+
+
+def test_search_open_issues_returns_issues_from_page_two() -> None:
+    """An open issue past the first page must be found by the dedup search.
+
+    A non-paginated GET caps the matched-issue list at per_page=100; a
+    previously-filed enforcement issue on page 2 would be missed and refiled.
+    """
+    page1 = [{"iid": i} for i in range(100)]
+    page2 = [{"iid": 100, "title": "fingerprint:abc"}]
+    api = GitLabAPI(token="tok", base_url="https://gitlab.example.com/api/v4")
+    host = GitLabCodeHost(client=api)
+    with (
+        patch("httpx.get", side_effect=_two_page_http_side_effect(page1, page2)),
+        patch.object(api, "resolve_project", return_value=_project()),
+    ):
+        result = host.search_open_issues(repo="org/repo", query="fingerprint:abc")
+
+    assert len(result) == 101
+    assert {"iid": 100, "title": "fingerprint:abc"} in result
 
 
 def test_get_mr_approvals_falls_back_when_left_absent() -> None:

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -693,7 +693,7 @@ class TestGitHubCodeHost:
 
     def test_list_issue_comments_returns_payload(self) -> None:
         notes = [{"id": 1, "body": "x"}]
-        with patch.object(github_mod, "_gh_api_get", return_value=notes) as mock_get:
+        with patch.object(github_mod, "_gh_api_get_paginated", return_value=notes) as mock_get:
             host = GitHubCodeHost()
             result = host.list_issue_comments(issue_url="https://github.com/souliane/teatree/issues/7")
         assert result == notes
@@ -703,6 +703,23 @@ class TestGitHubCodeHost:
         host = GitHubCodeHost()
         result = host.list_issue_comments(issue_url="https://github.com/souliane/teatree/pull/7")
         assert result == []
+
+    def test_list_issue_comments_paginates_beyond_the_first_page(self) -> None:
+        # A busy issue with >100 comments: a non-paginated GET silently caps at
+        # GitHub's default page size, so a ``## Test Plan`` note past the first
+        # page goes unseen and the evidence-poster duplicates it every run.
+        page_one = [{"id": i, "body": f"c{i}"} for i in range(100)]
+        page_two = [{"id": 100, "body": "## Test Plan"}]
+        slurped_pages = json.dumps([page_one, page_two])
+        with patch.object(github_mod, "_run_gh") as mock_run:
+            mock_run.return_value = MagicMock(stdout=slurped_pages)
+            host = GitHubCodeHost()
+            result = host.list_issue_comments(issue_url="https://github.com/souliane/teatree/issues/7")
+        argv = mock_run.call_args.args
+        assert "--paginate" in argv
+        assert "--slurp" in argv
+        assert result == [*page_one, *page_two]
+        assert {"id": 100, "body": "## Test Plan"} in result
 
     def test_update_issue_comment_patches_comment_endpoint(self) -> None:
         with patch.object(github_mod, "_gh_api_patch", return_value={"id": 99}) as mock_patch:


### PR DESCRIPTION
Four list calls used a single-page getter where a paginated sibling already existed, silently truncating at the forge default page size (100). Each now routes through the existing paginated helper (mirroring `list_pr_comments`); the redundant non-list guards are dropped since the paginated helpers own the list contract.

Per-fix summary:
- `src/teatree/backends/github.py` `list_issue_comments`: `_gh_api_get(...?per_page=100)` -> `_gh_api_get_paginated(...)`.
- `src/teatree/backends/gitlab.py` `list_issue_comments`: `get_json(...?per_page=100)` -> `get_json_paginated(...)`.
- `src/teatree/backends/gitlab.py` `search_open_issues`: `get_json(...?per_page=100)` -> `get_json_paginated(...)`.
- `src/teatree/backends/gitlab_ci.py` `fetch_pipeline_errors` (jobs fetch): `get_json(...?per_page=100)` -> `get_json_paginated(...)`; downstream failed-job filtering unchanged.

Added a multi-page test for each fix (first page of 100 + a second page; assert >100 total and the page-2 item is present). Mutation check held: reverting a getter to the single-page form fails the corresponding multi-page test.

Closes #1648