### PR TITLE
fix(cli): graceful failure for transitions/config/since/transcript + e2e short-SHA dedup

### DIFF
--- a/src/teatree/cli/eval.py
+++ b/src/teatree/cli/eval.py
@@ -134,7 +134,7 @@ def transcript_replay(
     if transcript is None:
         typer.echo("SKIP transcript-replay: no session transcript found in scope", err=True)
         return
-    events = parse_session_jsonl(transcript.read_text(encoding="utf-8"))
+    events = parse_session_jsonl(transcript.read_text(encoding="utf-8", errors="replace"))
     results = replay(events)
     rendered = render_report_json(results) if output_format == "json" else render_report(results)
     typer.echo(rendered)

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -600,14 +600,30 @@ class TeaTreeConfig:
     raw: dict = field(default_factory=dict)
 
 
+def _load_toml(path: Path) -> dict:
+    """Parse ``path`` as TOML, re-raising a syntax error as a named config error.
+
+    A raw ``tomllib.TOMLDecodeError`` would propagate a parser traceback
+    through ``main()`` on every ``t3`` command (even ``--help``); instead it
+    becomes a typed, message-bearing ``ValueError`` naming the file and the
+    parser's position — the same error shape the intentional invalid-``mode``
+    path raises.
+    """
+    with path.open("rb") as f:
+        try:
+            return tomllib.load(f)
+        except tomllib.TOMLDecodeError as exc:
+            msg = f"Malformed TOML in config file {path}: {exc}"
+            raise ValueError(msg) from exc
+
+
 def load_config(path: Path | None = None) -> TeaTreeConfig:
     if path is None:
         path = CONFIG_PATH
     if not path.is_file():
         return TeaTreeConfig()
 
-    with path.open("rb") as f:
-        raw = tomllib.load(f)
+    raw = _load_toml(path)
 
     teatree = raw.get("teatree", {})
     workspace_dir = Path(teatree.get("workspace_dir", "~/workspace")).expanduser()

--- a/src/teatree/core/checkpoint.py
+++ b/src/teatree/core/checkpoint.py
@@ -157,7 +157,11 @@ def resolve_window_start(*, since: str = "", now: datetime, path: Path | None = 
     """
     explicit = since.strip()
     if explicit:
-        parsed = datetime.fromisoformat(explicit)
+        try:
+            parsed = datetime.fromisoformat(explicit)
+        except ValueError as exc:
+            msg = f"--since must be an ISO-8601 timestamp (e.g. 2026-05-19T18:00:00+02:00), got {since!r}: {exc}"
+            raise ValueError(msg) from exc
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=UTC)
         return _clamp_future_start(parsed, now=now)

--- a/src/teatree/core/management/commands/_e2e_evidence.py
+++ b/src/teatree/core/management/commands/_e2e_evidence.py
@@ -159,9 +159,17 @@ def resolve_and_validate_commit(*, commit: str, repo: str) -> str:
         if not resolved:
             msg = f"Could not resolve a commit SHA (no --commit and git HEAD unavailable in {repo!r})."
             raise EvidenceValidationError(msg)
-    elif not git.check(repo=repo, args=["rev-parse", "--verify", f"{resolved}^{{commit}}"]):
-        msg = f"--commit {commit!r} is not a known commit in {repo!r}."
-        raise EvidenceValidationError(msg)
+    else:
+        # Expand the supplied SHA (often a short prefix) to the canonical
+        # full 40-char form so the stored marker matches the auto-detect
+        # path's ``git.head_sha`` — without this, a short-then-default
+        # round trip would post a duplicate evidence comment because
+        # ``find_matching_comment`` does raw string equality on the SHA.
+        try:
+            resolved = git.run_strict(repo=repo, args=["rev-parse", "--verify", f"{resolved}^{{commit}}"])
+        except CommandFailedError:
+            msg = f"--commit {commit!r} is not a known commit in {repo!r}."
+            raise EvidenceValidationError(msg) from None
 
     if git.status_porcelain(repo=repo).strip():
         msg = f"Working tree in {repo!r} is dirty; commit or stash changes so the evidence is reproducible."

--- a/src/teatree/core/management/commands/checking.py
+++ b/src/teatree/core/management/commands/checking.py
@@ -64,6 +64,8 @@ class Command(TyperCommand):
         overlay_name = os.environ.get("T3_OVERLAY_NAME", "")
         now = timezone.now()
 
+        _validate_since(since)
+
         if this_overlay:
             return self._show_single_overlay(
                 overlay_name=overlay_name,
@@ -174,6 +176,22 @@ class Command(TyperCommand):
             return [repo for repo in repos if isinstance(repo, str) and repo]
         except Exception:  # noqa: BLE001 — config read must never wedge a read-only report
             return []
+
+
+def _validate_since(since: str) -> None:
+    """Reject a malformed ``--since`` at the command boundary (#1652).
+
+    ``resolve_window_start`` raises ``ValueError`` on an unparsable
+    timestamp; surface it as a ``typer.BadParameter`` so the user sees a
+    clean "expected ISO-8601" message and a non-zero exit rather than a raw
+    traceback (mirrors ``availability._parse_until``).
+    """
+    if not since.strip():
+        return
+    try:
+        resolve_window_start(since=since, now=timezone.now())
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _overlay_code_host(overlay: object) -> str:

--- a/src/teatree/core/management/commands/lifecycle.py
+++ b/src/teatree/core/management/commands/lifecycle.py
@@ -10,6 +10,7 @@ from django_typer.management import TyperCommand, command, initialize
 
 from teatree.core.db_anchor import assert_lifecycle_db_is_canonical
 from teatree.core.models import Ticket
+from teatree.core.models.errors import InvalidTransitionError
 from teatree.core.models.merge_clear import is_non_reviewer_role
 from teatree.core.phases import normalize_phase, phase_transition
 from teatree.core.review_skill_gate import ReviewSkillEvidenceError, check_review_skill_evidence
@@ -189,15 +190,20 @@ def _try_advance(ticket: Ticket, transition_name: str) -> None:
         with transaction.atomic():
             method()
             ticket.save()
-    except TransitionNotAllowed:
+    except (TransitionNotAllowed, InvalidTransitionError) as exc:
         # Loud, not swallowed (#694): an out-of-order / skipped transition
         # used to vanish at DEBUG and only resurface as a raw
         # TransitionNotAllowed at `pr create`. The phase visit is still
         # recorded; the shipping gate reconciles the FSM from it later.
+        # InvalidTransitionError (dirty-worktree / missing-E2E DoD refusals)
+        # is handled identically: the FSM stays put, so the gate keeps
+        # blocking, but the operator sees the refusal reason instead of a
+        # raw traceback.
         logger.warning(
             "Transition '%s' not valid from state '%s' for ticket %s — "
-            "FSM unchanged; phase visit recorded, gate will reconcile",
+            "FSM unchanged; phase visit recorded, gate will reconcile (%s)",
             transition_name,
             ticket.state,
             ticket.pk,
+            exc,
         )

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -12,6 +12,7 @@ from django_typer.management import TyperCommand, command, group
 from teatree.core.management.commands._clear_branch_currency import check_clear_branch_currency
 from teatree.core.merge_execution import MergePreconditionError, merge_ticket_pr
 from teatree.core.models import ClearIssuanceError, ClearRequest, MergeClear, Ticket
+from teatree.core.models.errors import InvalidTransitionError
 from teatree.core.schema_guard import SelfDbMigrationError, require_current_schema
 
 
@@ -125,6 +126,13 @@ class Command(TyperCommand):
         except TransitionNotAllowed:
             return {
                 "error": f"Transition '{transition_name}' not allowed from state '{ticket.state}'",
+            }
+        except InvalidTransitionError as exc:
+            # Dirty-worktree / missing-E2E DoD refusals: the FSM stays put
+            # (the gate keeps blocking) and the refusal reason is surfaced
+            # to the caller instead of a raw traceback.
+            return {
+                "error": f"Transition '{transition_name}' refused from state '{ticket.state}': {exc}",
             }
 
         return {"ticket_id": int(ticket.pk), "state": ticket.state}

--- a/tests/config/test_load_config.py
+++ b/tests/config/test_load_config.py
@@ -10,6 +10,7 @@ Integration-first per the Test-Writing Doctrine: real TOML fixtures
 under ``tmp_path`` with ``teatree.config.CONFIG_PATH`` monkeypatched.
 """
 
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -342,6 +343,17 @@ class TestMode:
 
         with pytest.raises(ValueError, match="Invalid t3 mode"):
             load_config(config_path)
+
+    def test_load_config_malformed_toml_raises_named_error(self, tmp_path: Path) -> None:
+        # #1652: a TOML syntax error surfaces as a typed, message-bearing
+        # config error naming the file, never a raw TOMLDecodeError traceback.
+        config_path = tmp_path / ".teatree.toml"
+        _write_toml(config_path, "[teatree]\nworkspace_dir = \n")
+
+        with pytest.raises(ValueError, match="Malformed TOML") as exc_info:
+            load_config(config_path)
+        assert str(config_path) in str(exc_info.value)
+        assert not isinstance(exc_info.value, tomllib.TOMLDecodeError)
 
     def test_get_mode_reflects_loaded_config(
         self,

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -117,6 +117,21 @@ class TestEvalRun:
         assert result.exit_code == 2
         assert "available scenarios: (none)" in result.output
 
+
+class TestTranscriptReplay:
+    def test_non_utf8_transcript_does_not_crash(self, tmp_path: Path) -> None:
+        # #1652: a session JSONL carrying non-UTF-8 bytes must replay what it
+        # can (errors="replace") instead of raising UnicodeDecodeError. The
+        # valid lines from the all_pass fixture still parse green.
+        fixture = Path(__file__).parents[1] / "fixtures" / "transcripts" / "all_pass.session.jsonl"
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_bytes(fixture.read_bytes() + b'\n{"type":"user","message":"\xff\xfe bad bytes"}\n')
+
+        result = CliRunner().invoke(app, ["eval", "transcript-replay", "--file", str(transcript)])
+
+        assert "UnicodeDecodeError" not in result.output
+        assert result.exit_code == 0, result.output
+
     def test_unknown_format_exits_with_code_2(self) -> None:
         specs = [_spec("alpha")]
 

--- a/tests/teatree_core/e2e_command/test_post_evidence.py
+++ b/tests/teatree_core/e2e_command/test_post_evidence.py
@@ -175,7 +175,11 @@ class TestHardFail(_EvidenceTestBase):
 
     def test_unknown_commit(self) -> None:
         self._monkeypatch.setattr(_evidence.git, "status_porcelain", lambda repo=".": "")
-        self._monkeypatch.setattr(_evidence.git, "check", lambda *, repo=".", args: False)
+
+        def _reject(*, repo: str = ".", args: list[str]) -> str:
+            raise _evidence.CommandFailedError(["git", *args], 128, "", "bad object")
+
+        self._monkeypatch.setattr(_evidence.git, "run_strict", _reject)
         before, after = self._before_after()
         host = MagicMock()
         self._run_expecting_exit(
@@ -253,6 +257,44 @@ class TestIdempotency(_EvidenceTestBase):
 
         assert result["action"] == "updated"
         assert result["comment_id"] == 33
+        host.update_issue_comment.assert_called_once()
+        host.post_issue_comment.assert_not_called()
+
+    def test_short_commit_dedups_against_full_sha_marker(self) -> None:
+        # #1652: a supplied short `--commit` is expanded to the canonical
+        # full SHA, so it matches a prior comment whose marker carries the
+        # full 40-char SHA (the no-`--commit` auto-detect form) instead of
+        # posting a duplicate.
+        self._ticket()
+        before, after = self._before_after()
+        full = "a" * 40
+        host = MagicMock()
+        host.list_issue_comments.return_value = [
+            self._existing_comment(env="dev", commit=full, comment_id=55),
+        ]
+        host.update_issue_comment.return_value = {"id": 55, "web_url": "u"}
+
+        self._patch_host(host)
+        self._monkeypatch.setattr(_evidence.git, "status_porcelain", lambda repo=".": "")
+        self._monkeypatch.setattr(_evidence.git, "run_strict", lambda *, repo=".", args: full)
+        host.upload_file.return_value = {"markdown": "![x](u)"}
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast(
+                "dict[str, object]",
+                call_command(
+                    "e2e",
+                    "post-evidence",
+                    ticket=_ISSUE_URL,
+                    env="dev",
+                    commit="aaaaaaa",
+                    before=before,
+                    after=after,
+                    assertion="works",
+                ),
+            )
+
+        assert result["action"] == "updated"
+        assert result["commit"] == full
         host.update_issue_comment.assert_called_once()
         host.post_issue_comment.assert_not_called()
 
@@ -339,6 +381,15 @@ class TestPureValidators:
         ]
         assert _evidence.find_matching_comment(comments, env=EvidenceEnv.DEV, commit="zzz") == 1
         assert _evidence.find_matching_comment(comments, env=EvidenceEnv.DEV, commit="nope") is None
+
+    def test_resolve_commit_expands_short_to_full(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # #1652: the supplied short SHA is captured from rev-parse output as
+        # the canonical full SHA, not echoed verbatim.
+        full = "b" * 40
+        monkeypatch.setattr(_evidence.git, "run_strict", lambda *, repo=".", args: full)
+        monkeypatch.setattr(_evidence.git, "status_porcelain", lambda repo=".": "")
+        resolved = _evidence.resolve_and_validate_commit(commit="bbbbbbb", repo=".")
+        assert resolved == full
 
     def test_build_body_includes_video_row_only_when_given(self) -> None:
         without = _evidence.build_evidence_body(

--- a/tests/teatree_core/management_commands/test_checking.py
+++ b/tests/teatree_core/management_commands/test_checking.py
@@ -152,6 +152,18 @@ class TestCheckingShow:
         _call("checking", "show", "--this-overlay", "--no-advance")
         assert not checkpoint_file.is_file()
 
+    def test_unparseable_since_exits_nonzero_not_traceback(self, checkpoint_file: Path) -> None:
+        # #1652: --since yesterday is rejected with a clean non-zero exit
+        # (typer.BadParameter), never a raw datetime ValueError traceback,
+        # and the marker is left untouched.
+        from typer.testing import CliRunner  # noqa: PLC0415
+
+        from teatree.core.management.commands.checking import Command  # noqa: PLC0415
+
+        result = CliRunner().invoke(Command().typer_app, ["show", "--this-overlay", "--since", "yesterday"])
+        assert result.exit_code != 0
+        assert not checkpoint_file.is_file()
+
     def test_json_is_parseable(self, checkpoint_file: Path) -> None:
         _merged_ticket()
         out = _call("checking", "show", "--this-overlay", "--json")

--- a/tests/teatree_core/test_checkpoint.py
+++ b/tests/teatree_core/test_checkpoint.py
@@ -13,6 +13,8 @@ the tests stay hermetic — no real DATA_DIR, no network, no git.
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
 from teatree.core.checkpoint import (
     DEFAULT_LOOKBACK,
     advance_checkpoint,
@@ -102,6 +104,16 @@ class TestResolveWindowStart:
         now = datetime(2026, 5, 30, 18, 0, tzinfo=UTC)
         start = resolve_window_start(since="2026-05-29T08:00:00", now=now, path=tmp_path / "cp.json")
         assert start == datetime(2026, 5, 29, 8, 0, tzinfo=UTC)
+
+    def test_unparseable_since_raises_friendly_value_error(self, tmp_path: Path) -> None:
+        # #1652: a non-ISO --since (e.g. "yesterday") raises a typed,
+        # message-bearing ValueError naming the expected format — not a raw
+        # datetime.fromisoformat ValueError the command would dump as a
+        # traceback.
+        now = datetime(2026, 5, 30, 18, 0, tzinfo=UTC)
+        with pytest.raises(ValueError, match="ISO-8601") as exc_info:
+            resolve_window_start(since="yesterday", now=now, path=tmp_path / "cp.json")
+        assert "yesterday" in str(exc_info.value)
 
     def test_checkpoint_used_when_no_since(self, tmp_path: Path) -> None:
         path = tmp_path / "cp.json"

--- a/tests/teatree_core/test_lifecycle_fsm_enforcement.py
+++ b/tests/teatree_core/test_lifecycle_fsm_enforcement.py
@@ -103,6 +103,48 @@ class TestVisitPhaseLoudFailure(TestCase):
         assert "not_started" in result
 
 
+class TestVisitPhaseDodRefusalIsGraceful(TestCase):
+    """A transition body that raises ``InvalidTransitionError`` (#1652).
+
+    The dirty-worktree / missing-local-E2E DoD refusals are
+    ``InvalidTransitionError`` subclasses — a disjoint hierarchy from
+    ``TransitionNotAllowed``. The ``visit-phase`` wrapper must handle them
+    exactly like ``TransitionNotAllowed``: log the refusal (with its reason),
+    leave the FSM put (the gate keeps blocking), and never dump a traceback.
+    """
+
+    def _assert_graceful(self, exc: Exception) -> None:
+        from teatree.core.models import Ticket as TicketModel  # noqa: PLC0415
+
+        ticket = _ticket(state=Ticket.State.REVIEWED)
+        with (
+            patch.object(TicketModel, "ship", side_effect=exc),
+            self.assertLogs("teatree.core.management.commands.lifecycle", level="WARNING") as cm,
+        ):
+            result = cast("str", call_command("lifecycle", "visit-phase", str(ticket.pk), "ship"))
+
+        ticket.refresh_from_db()
+        # FSM did NOT advance — the DoD gate keeps blocking.
+        assert ticket.state == Ticket.State.REVIEWED
+        # The phase is still recorded (single source of truth).
+        session = ticket.sessions.first()
+        assert "shipping" in session.visited_phases
+        # The refusal reason is surfaced in the warning, not a raw traceback.
+        joined = "\n".join(cm.output)
+        assert str(exc) in joined
+        assert "reviewed" in result
+
+    def test_dirty_worktree_refusal_is_logged_no_op(self) -> None:
+        from teatree.core.models.errors import DirtyWorktreeError  # noqa: PLC0415
+
+        self._assert_graceful(DirtyWorktreeError("worktree has uncommitted changes"))
+
+    def test_missing_local_e2e_refusal_is_logged_no_op(self) -> None:
+        from teatree.core.dod_gate import DodLocalE2EError  # noqa: PLC0415
+
+        self._assert_graceful(DodLocalE2EError("UI-visible ticket has no local-stack E2E"))
+
+
 class TestShippingGateReconciliation(TestCase):
     def test_gate_auto_walks_fsm_to_reviewed_when_phases_present(self) -> None:
         # The loop path advanced phases but the FSM is still STARTED

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -465,6 +465,24 @@ class TestTicketCommand(TestCase):
         )
         assert "not allowed" in str(result["error"])
 
+    def test_transition_dod_refusal_returns_error_not_traceback(self) -> None:
+        # #1652: a ship transition whose body raises DodLocalE2EError
+        # (an InvalidTransitionError, disjoint from TransitionNotAllowed)
+        # returns a refusal error carrying the reason; the FSM stays put.
+        from teatree.core.dod_gate import DodLocalE2EError  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.REVIEWED)
+        reason = "UI-visible ticket has no local-stack E2E"
+        with patch.object(Ticket, "ship", side_effect=DodLocalE2EError(reason)):
+            result = cast(
+                "dict[str, object]",
+                call_command("ticket", "transition", ticket.pk, "ship"),
+            )
+        assert "refused" in str(result["error"])
+        assert reason in str(result["error"])
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.REVIEWED
+
     def test_transition_mark_review_no_action_delivers_reviewer_ticket(self) -> None:
         """#1077: the no-action disposition is reachable via the CLI transition."""
         from teatree.core.models.ticket import schedule_external_review  # noqa: PLC0415


### PR DESCRIPTION
Closes #1652

Five command-layer defects from the round-2 read-only bug-hunt sweep. Each fix mirrors a sibling in the same module that already handles the case; changes are minimal and the existing gate semantics are preserved.

## Fixes

1. **(high) Transition wrappers caught too narrow an exception.** `lifecycle._try_advance` and `ticket.transition` caught only `django_fsm.TransitionNotAllowed`, but the code/test/review/ship transition bodies raise `DirtyWorktreeError` / `DodLocalE2EError`, which subclass `InvalidTransitionError(ValueError)` — a disjoint hierarchy. Both `except` clauses now also catch `InvalidTransitionError`, so a dirty-worktree or missing-local-E2E DoD refusal fails gracefully (FSM unchanged, the gate keeps blocking) with the refusal reason logged / returned, instead of a raw traceback.

2. **(medium) e2e post-evidence short-`--commit` dedup miss.** A supplied short `--commit` was validated but stored verbatim, so a later default run (full `head_sha`) never matched it and posted a duplicate. The supplied SHA is now expanded to the canonical full form by capturing `git rev-parse --verify <sha>^{commit}` output, matching the no-`--commit` path.

3. **(medium) Malformed `~/.teatree.toml` crashed every `t3` command.** `load_config` now catches `tomllib.TOMLDecodeError` and re-raises a typed `ValueError` naming the file + parser position (same error shape the intentional invalid-`mode` path uses), so a syntax error gives a clear message + non-zero exit, not a parser traceback through `main()`. The intentional invalid-`mode` behavior is unchanged.

4. **(quick-win) `checking show --since <bad>` crashed.** `resolve_window_start` guards `datetime.fromisoformat` and raises a friendly "expected ISO-8601" `ValueError`; `checking show` converts it to a `typer.BadParameter` clean non-zero exit (mirrors `availability._parse_until`).

5. **(quick-win) `eval transcript-replay` crashed on a non-UTF-8 session log.** `read_text(encoding="utf-8", errors="replace")`, matching the eval runner's `_coerce_stream`; the JSONL parser already skips malformed lines.

## Tests

One focused, non-vacuous test per fix; fixes 1, 2, 3 were mutation-checked (reverted the fix → the new test failed for the right reason → re-applied → green). Full requested selection: `1579 passed, 10 skipped`.