### PR TITLE
fix: render env-set overrides + pr_sweep --limit 100 + outbound_audit drift-alert ordering

### DIFF
--- a/src/teatree/core/worktree_env.py
+++ b/src/teatree/core/worktree_env.py
@@ -133,6 +133,8 @@ def render_env_cache(worktree: Worktree) -> EnvCacheSpec | None:
     for cfg in overlay.get_base_images(worktree):
         pairs[cfg.env_var] = cfg.image_tag()
 
+    pairs.update(load_overrides(worktree))
+
     # Drop secret keys from the on-disk cache — they remain in ``get_env_extra``
     # so subprocess callers (run backend, worktree_start) still receive them
     # via ``env=``, but the file at chmod 444 must not contain credentials.

--- a/src/teatree/loop/scanners/outbound_audit.py
+++ b/src/teatree/loop/scanners/outbound_audit.py
@@ -216,8 +216,7 @@ class OutboundAuditScanner:
 
         claim.drift_detected = True
         claim.drift_reason = result.drift_reason
-        claim.drift_alerted_at = now
-        claim.save(update_fields=["drift_detected", "drift_reason", "drift_alerted_at"])
+        claim.save(update_fields=["drift_detected", "drift_reason"])
         alert_text = self.DEFAULT_DRIFT_TEMPLATE.format(
             kind=claim.kind,
             url=claim.target_url or "(no url)",
@@ -226,7 +225,10 @@ class OutboundAuditScanner:
         try:
             self.notifier(alert_text, f"outbound_drift:{claim.idempotency_key}")
         except Exception as exc:  # noqa: BLE001 — never break a tick on a notifier raise
-            logger.warning("Drift notifier raised: %s — drift recorded but DM skipped", exc)
+            logger.warning("Drift notifier raised: %s — drift recorded, alert retried next tick", exc)
+        else:
+            claim.drift_alerted_at = now
+            claim.save(update_fields=["drift_alerted_at"])
         return ScanSignal(
             kind="outbound.drift",
             summary=f"Drift on {claim.kind}: {result.drift_reason[:80]}",

--- a/src/teatree/loop/scanners/pr_sweep.py
+++ b/src/teatree/loop/scanners/pr_sweep.py
@@ -448,6 +448,8 @@ class GhPrApiClient:
             slug,
             "--state",
             "open",
+            "--limit",
+            "100",
             "--json",
             "number,headRefOid,isDraft,url,title,reviews,statusCheckRollup",
         ]

--- a/tests/teatree_core/test_worktree_env.py
+++ b/tests/teatree_core/test_worktree_env.py
@@ -418,3 +418,33 @@ class TestOverrides(TestCase):
             wt, _ = _make_worktree(tmp, ticket_name="t", ticket_url="https://ex.com/1", db_name="wt_1")
             with pytest.raises(ValueError, match="owned by core"):
                 set_override(wt, "WT_DB_NAME", "hack")
+
+    def test_render_includes_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt, _ = _make_worktree(tmp, ticket_name="t", ticket_url="https://ex.com/1", db_name="wt_1")
+            with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_COMMAND):
+                set_override(wt, "MY_KEY", "my_value")
+                spec = render_env_cache(wt)
+            assert spec is not None
+            assert "MY_KEY" in spec.keys
+            assert "MY_KEY=my_value" in spec.content
+
+    def test_override_wins_over_overlay_extra(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt, _ = _make_worktree(tmp, ticket_name="t", ticket_url="https://ex.com/1", db_name="wt_1")
+            with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_EXTRA_ONLY):
+                WorktreeEnvOverride.objects.create(worktree=wt, key="EXTRA_KEY", value="overridden")
+                spec = render_env_cache(wt)
+            assert spec is not None
+            assert "EXTRA_KEY=overridden" in spec.content
+            assert "EXTRA_KEY=extra_value" not in spec.content
+
+    def test_override_of_secret_key_still_dropped_from_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt, _ = _make_worktree(tmp, ticket_name="ts", ticket_url="https://ex.com/1", variant="acme")
+            with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_SECRET):
+                WorktreeEnvOverride.objects.create(worktree=wt, key="SECRET_PASSWORD", value="leak")
+                spec = render_env_cache(wt)
+            assert spec is not None
+            assert "SECRET_PASSWORD" not in spec.content
+            assert "leak" not in spec.content

--- a/tests/teatree_loop/test_outbound_audit.py
+++ b/tests/teatree_loop/test_outbound_audit.py
@@ -207,11 +207,19 @@ class OutboundAuditScannerTests(TestCase):
         kwargs = notify_mock.call_args.kwargs
         assert kwargs["idempotency_key"] == "outbound_drift:key-1"
 
-    def test_notifier_exception_is_swallowed_and_does_not_break_tick(self) -> None:
-        """A failing notifier never breaks the tick — drift row still flips."""
+    def test_notifier_exception_leaves_alert_unsent_and_retries_next_tick(self) -> None:
+        """A failing notifier never breaks the tick and never marks the alert sent.
+
+        ``drift_alerted_at`` is the dedupe key, so stamping it before the DM
+        lands would permanently bury an undelivered drift alert. It must stay
+        null on failure so the next tick re-attempts the notifier.
+        """
         claim = _aged_claim(kind=OutboundClaim.Kind.GITLAB_NOTE, key="notify-boom")
 
+        calls: list[str] = []
+
         def _boom(_text: str, _key: str) -> None:
+            calls.append(_key)
             msg = "slack 500"
             raise RuntimeError(msg)
 
@@ -223,8 +231,14 @@ class OutboundAuditScannerTests(TestCase):
 
         claim.refresh_from_db()
         assert claim.drift_detected is True
-        assert claim.drift_alerted_at is not None
+        assert claim.drift_alerted_at is None
         assert len(signals) == 1
+        assert len(calls) == 1
+
+        scanner.scan()
+        claim.refresh_from_db()
+        assert claim.drift_alerted_at is None
+        assert len(calls) == 2
 
     def test_limit_caps_number_of_verifications_per_tick(self) -> None:
         for i in range(5):

--- a/tests/test_loop_resilience_fixes.py
+++ b/tests/test_loop_resilience_fixes.py
@@ -364,3 +364,27 @@ class TestF7PrSweepShaFetchFailureSurfaced(TestCase):
             "follow-up failed — caller has no way to distinguish 'SHA unknown' "
             "from 'merged but SHA empty'. Expected a non-empty marker."
         )
+
+
+class TestPrSweepListLimit(TestCase):
+    """``gh pr list`` must request more than the 30-PR default cap."""
+
+    def test_list_open_prs_passes_limit_at_least_100(self) -> None:
+        from teatree.loop.scanners.pr_sweep import GhPrApiClient  # noqa: PLC0415
+
+        captured: list[list[str]] = []
+
+        class _FakeClient(GhPrApiClient):
+            __slots__ = ()
+
+            def _run_gh(self, argv: list[str]) -> tuple[int, str, str]:
+                captured.append(argv)
+                return 0, "[]", ""
+
+        _FakeClient(token="").list_open_prs(slug="owner/repo")
+
+        assert captured, "list_open_prs never shelled out to gh"
+        argv = captured[0]
+        assert "--limit" in argv, f"no --limit in argv: {argv}"
+        limit = int(argv[argv.index("--limit") + 1])
+        assert limit >= 100, f"--limit {limit} below the 100 convention"


### PR DESCRIPTION
Three confirmed defects from bug-hunt round 3 ([#1654](https://github.com/souliane/teatree/issues/1654)).

## Fix 1 (HIGH) — `t3 env set` override never rendered
`src/teatree/core/worktree_env.py` — `render_env_cache` built env pairs from core + `overlay.get_env_extra` + base images and never read `WorktreeEnvOverride` / `load_overrides`. Confirmed dead by tracing every consumer: the `.envrc` does `dotenv .t3-env.cache` (worktree_provision.py:40) and all runtime paths (`run backend`/`run tests`/`worktree_start`/`worktree_provision`/`db`) build env as `{**os.environ, **overlay.get_env_extra(worktree)}` — none merge overrides. So a persisted `t3 env set` row reached no consumer. Fix merges `load_overrides` after the overlay layer (user override wins over overlay defaults; core keys are already rejected at `set_override` time) and before the secret-key drop (an override of a declared-secret key is still stripped from the on-disk cache).

## Fix 2 (MEDIUM) — pr_sweep `gh pr list` 30-cap
`src/teatree/loop/scanners/pr_sweep.py` — `GhPrApiClient.list_open_prs` built the argv with no `--limit`; `gh` defaults to 30, so a cleared green PR past position 30 was silently skipped every tick. Added `--limit 100`, matching the per-100 convention in `backends/github.py`.

## Fix 3 (QUICK-WIN) — outbound_audit drift-alert ordering
`src/teatree/loop/scanners/outbound_audit.py` — `_apply_result` saved `drift_alerted_at=now` before calling the notifier. Since `_candidate_claims` filters `drift_alerted_at__isnull=True`, a notifier raise permanently buried an undelivered drift DM. Now `drift_alerted_at` is stamped only after the notifier returns; on failure it stays null (keeping `drift_detected`/`drift_reason`) so the next tick re-attempts.

## Tests
- `test_render_includes_override`, `test_override_wins_over_overlay_extra`, `test_override_of_secret_key_still_dropped_from_cache` (worktree_env)
- `test_list_open_prs_passes_limit_at_least_100` (pr_sweep argv)
- `test_notifier_exception_leaves_alert_unsent_and_retries_next_tick` (outbound_audit, replaces a test that asserted the buggy behavior)

528 relevant tests pass. Mutation-checked fixes 1 and 3 (revert -> new test fails -> restore).

Closes [#1654](https://github.com/souliane/teatree/issues/1654)