### PR TITLE
fix(hooks): resolve commit carve-out from the effective worktree, not the ambient cwd

### DIFF
--- a/src/teatree/hooks/publish_surface.py
+++ b/src/teatree/hooks/publish_surface.py
@@ -24,12 +24,17 @@ first, then CWD fallback). Unknown or public targets stay hard-blocked.
 ``commit_targets_private_repo`` decides the commit's repo is known-private,
 via an offline allowlist (``[teatree] private_repos`` slug substrings in
 ``~/.teatree.toml``) first, then a cached ``gh``/``glab`` visibility probe.
-The dir it resolves is the command's EFFECTIVE worktree (``-C`` /
-``--work-tree`` / ``--git-dir``, via :func:`effective_worktree`) when one
-is present, falling back to the harness ``cwd`` for a plain ``git commit``.
-A sub-agent's ``git -C <worktree> commit`` runs from an ambient hook cwd
-that has reset away from the worktree, so resolving from the command's own
-flag is what keeps the carve-out from over-blocking that commit.
+The dir it resolves is the one whose repo the commit LANDS in (via
+:func:`effective_repo_dir`): the ``--git-dir`` repo if specified, else the
+repo discovered from the ``-C``-adjusted working directory, falling back to
+the harness ``cwd`` for a plain ``git commit``. ``--work-tree`` only sets
+the working tree and NEVER selects the repo, so it is excluded -- a
+``--git-dir <PUBLIC> --work-tree <PRIVATE>`` commit lands in the PUBLIC
+repo, and resolving the private work-tree would leak banned content to
+public history. A sub-agent's ``git -C <worktree> commit`` runs from an
+ambient hook cwd that has reset away from the worktree, so resolving from
+the command's own flag is what keeps the carve-out from over-blocking that
+commit.
 
 ``posting_command_targets_private_repo`` applies the same privacy
 decision to a ``gh``/``glab`` posting command: the target repo slug is
@@ -73,13 +78,13 @@ _ENV_ASSIGNMENT_RE: Final[re.Pattern[str]] = re.compile(r"[A-Za-z_][A-Za-z0-9_]*
 # ``git commit`` is the first command name + verb (after any env prefix).
 _COMMIT_WORD_COUNT: Final[int] = 2
 
-# Global ``git`` flags that select an alternate working tree / git dir and
-# take a value: ``-C <dir>``, ``--git-dir <dir>``, ``--work-tree <dir>``.
-# They sit BEFORE the sub-command verb, so the verb-finding walk skips
-# them as flag(+value) pairs to still recognise ``git -C <dir> commit``.
-# The same flags name the EFFECTIVE worktree the command operates on,
-# which the carve-out resolves instead of trusting the ambient hook cwd.
-_GIT_WORKTREE_FLAGS: Final[frozenset[str]] = frozenset({"-C", "--git-dir", "--work-tree"})
+# Value-taking global ``git`` flags that sit BEFORE the sub-command verb:
+# ``-C <dir>``, ``--git-dir <dir>``, ``--work-tree <dir>``. The verb-finding
+# walk skips them as flag(+value) pairs so ``git --work-tree=x commit`` and
+# ``git --git-dir=x commit`` are still recognised as commits. These three
+# are recognised for VERB SKIPPING only -- repo identity is resolved
+# separately (git-dir/-C only, never --work-tree) by ``effective_repo_dir``.
+_GIT_GLOBAL_DIR_FLAGS: Final[frozenset[str]] = frozenset({"-C", "--git-dir", "--work-tree"})
 
 # A slug must have at least ``owner/repo`` (host-prefixed slugs add more).
 _MIN_SLUG_PARTS: Final[int] = 2
@@ -135,10 +140,10 @@ def _strip_git_global_prefix(words: list[str]) -> list[str]:
     i = 0
     while i < len(rest):
         w = rest[i]
-        if w in _GIT_WORKTREE_FLAGS:
+        if w in _GIT_GLOBAL_DIR_FLAGS:
             i += 2
             continue
-        if any(w.startswith(flag + "=") for flag in _GIT_WORKTREE_FLAGS):
+        if any(w.startswith(flag + "=") for flag in _GIT_GLOBAL_DIR_FLAGS):
             i += 1
             continue
         break
@@ -157,34 +162,52 @@ def is_git_commit_command(command: str) -> bool:
     return len(words) >= _COMMIT_WORD_COUNT and words[0] == "git" and words[1] == "commit"
 
 
-def effective_worktree(command: str) -> str | None:
-    """Return the EFFECTIVE worktree dir of a ``git`` command, or ``None``.
+def _last_flag_value(words: list[str], flag: str) -> str | None:
+    """Return the LAST ``flag <value>`` / ``flag=<value>`` value, or ``None``.
 
-    A sub-agent's ``git -C <worktree> commit`` runs from an ambient hook
-    ``cwd`` that has reset away from the worktree, so the dir the command
-    actually targets lives in its own ``-C``/``--work-tree``/``--git-dir``
-    flags. ``git`` resolves repeated worktree-selecting flags LAST-WINS
-    (the same effective-resolution rule as ``_extract_repo_flag``'s
-    ``--repo``/``-R``), so this scans the WHOLE word list and keeps the
-    LAST value across all three flag forms (and their ``=`` spellings).
-    ``None`` when no worktree-selecting flag is present, so the caller
-    falls back to the ambient cwd for a plain ``git commit``.
+    ``git`` resolves a repeated global flag LAST-WINS, so this scans the
+    whole word list and keeps the final occurrence across both the
+    space-separated and ``=`` spellings.
     """
-    words = first_segment_words(command)
     found: str | None = None
     i = 0
+    prefix = flag + "="
     while i < len(words):
         w = words[i]
-        if w in _GIT_WORKTREE_FLAGS and i + 1 < len(words):
+        if w == flag and i + 1 < len(words):
             found = words[i + 1]
             i += 2
             continue
-        for flag in _GIT_WORKTREE_FLAGS:
-            if w.startswith(flag + "="):
-                found = w[len(flag) + 1 :]
-                break
+        if w.startswith(prefix):
+            found = w[len(prefix) :]
         i += 1
     return found
+
+
+def effective_repo_dir(command: str) -> str | None:
+    """Return the dir whose repo a ``git`` command's commit LANDS in, or ``None``.
+
+    ``git`` selects a commit's repo as: the ``--git-dir``/``$GIT_DIR`` repo
+    if specified, otherwise the repo discovered from the effective working
+    directory, which ``-C <dir>`` changes. ``--work-tree`` only sets the
+    working tree and NEVER selects the repo, so it is excluded here -- a
+    ``--git-dir <PUBLIC> --work-tree <PRIVATE>`` commit lands in the PUBLIC
+    repo, and resolving the private work-tree would leak banned content to
+    public history. Repeated ``-C``/``--git-dir`` flags are LAST-WINS.
+
+    Resolution: ``--git-dir`` (last-wins) if present, resolved relative to
+    the ``-C``-adjusted cwd when relative; else the ``-C``-adjusted path
+    (last-wins ``-C``). ``None`` when neither flag is present, so the caller
+    falls back to the ambient cwd for a plain ``git commit``.
+    """
+    words = first_segment_words(command)
+    dash_c = _last_flag_value(words, "-C")
+    git_dir = _last_flag_value(words, "--git-dir")
+    if git_dir is not None:
+        if dash_c is not None and not Path(git_dir).is_absolute():
+            return str(Path(dash_c) / git_dir)
+        return git_dir
+    return dash_c
 
 
 def is_gh_glab_posting_command(command: str) -> bool:
@@ -560,10 +583,11 @@ def carve_out_applies(
     - The payload was actually resolved (fail-closed sentinel => hard-block).
     - The payload carries no high-confidence secret (credentials always leak).
     - The command is a ``git commit`` to a known-private repo (resolved
-        from the command's EFFECTIVE worktree -- ``-C`` / ``--work-tree`` /
-        ``--git-dir`` -- when present, else the CWD), OR a structured
-        ``gh``/``glab`` create-or-comment command whose RESOLVED TARGET is
-        positively known-private (--repo/-R first, CWD fallback).
+        from the dir whose repo the commit LANDS in -- ``--git-dir`` else the
+        ``-C``-adjusted cwd, never ``--work-tree`` -- when present, else the
+        CWD), OR a structured ``gh``/``glab`` create-or-comment command whose
+        RESOLVED TARGET is positively known-private (--repo/-R first, CWD
+        fallback).
 
     Ineligible regardless: ``gh api`` / ``glab api`` raw REST, ``curl``,
     Slack, and any non-structured verb. Public/unknown targets stay blocked.
@@ -578,8 +602,8 @@ def carve_out_applies(
         return False
 
     if is_git_commit_command(command):
-        worktree = effective_worktree(command)
-        target = Path(worktree) if worktree else cwd
+        repo_dir = effective_repo_dir(command)
+        target = Path(repo_dir) if repo_dir else cwd
         return commit_targets_private_repo(target, config_path=config_path)
 
     if is_gh_glab_posting_command(command):

--- a/src/teatree/hooks/publish_surface.py
+++ b/src/teatree/hooks/publish_surface.py
@@ -21,10 +21,15 @@ repo target. These are eligible for the carve-out ONLY when the target
 repo is POSITIVELY known-private (resolved from ``--repo``/``-R`` flag
 first, then CWD fallback). Unknown or public targets stay hard-blocked.
 
-``commit_targets_private_repo`` decides the commit's repo (resolved from
-the harness ``cwd``) is known-private, via an offline allowlist
-(``[teatree] private_repos`` slug substrings in ``~/.teatree.toml``)
-first, then a cached ``gh``/``glab`` visibility probe.
+``commit_targets_private_repo`` decides the commit's repo is known-private,
+via an offline allowlist (``[teatree] private_repos`` slug substrings in
+``~/.teatree.toml``) first, then a cached ``gh``/``glab`` visibility probe.
+The dir it resolves is the command's EFFECTIVE worktree (``-C`` /
+``--work-tree`` / ``--git-dir``, via :func:`effective_worktree`) when one
+is present, falling back to the harness ``cwd`` for a plain ``git commit``.
+A sub-agent's ``git -C <worktree> commit`` runs from an ambient hook cwd
+that has reset away from the worktree, so resolving from the command's own
+flag is what keeps the carve-out from over-blocking that commit.
 
 ``posting_command_targets_private_repo`` applies the same privacy
 decision to a ``gh``/``glab`` posting command: the target repo slug is
@@ -68,6 +73,14 @@ _ENV_ASSIGNMENT_RE: Final[re.Pattern[str]] = re.compile(r"[A-Za-z_][A-Za-z0-9_]*
 # ``git commit`` is the first command name + verb (after any env prefix).
 _COMMIT_WORD_COUNT: Final[int] = 2
 
+# Global ``git`` flags that select an alternate working tree / git dir and
+# take a value: ``-C <dir>``, ``--git-dir <dir>``, ``--work-tree <dir>``.
+# They sit BEFORE the sub-command verb, so the verb-finding walk skips
+# them as flag(+value) pairs to still recognise ``git -C <dir> commit``.
+# The same flags name the EFFECTIVE worktree the command operates on,
+# which the carve-out resolves instead of trusting the ambient hook cwd.
+_GIT_WORKTREE_FLAGS: Final[frozenset[str]] = frozenset({"-C", "--git-dir", "--work-tree"})
+
 # A slug must have at least ``owner/repo`` (host-prefixed slugs add more).
 _MIN_SLUG_PARTS: Final[int] = 2
 
@@ -104,16 +117,74 @@ _GLAB_ELIGIBLE_VERBS: Final[frozenset[tuple[str, str]]] = frozenset(
 )
 
 
+def _strip_git_global_prefix(words: list[str]) -> list[str]:
+    """Drop a leading env assignment and ``git`` global worktree flags.
+
+    Leaves ``words`` positioned so ``words[0]`` is the sub-command verb of
+    a ``git`` invocation. A leading inline env assignment (``FOO=1 git``)
+    and the value-taking global flags (``-C <dir>``, ``--git-dir <dir>``,
+    ``--work-tree <dir>``, plus their ``=`` forms) are skipped so
+    ``git -C <dir> commit`` resolves to the ``commit`` verb. ``words[0]``
+    must already be ``git`` for the global-flag skip to run.
+    """
+    while words and _ENV_ASSIGNMENT_RE.fullmatch(words[0]):
+        words = words[1:]
+    if not words or words[0] != "git":
+        return words
+    rest = words[1:]
+    i = 0
+    while i < len(rest):
+        w = rest[i]
+        if w in _GIT_WORKTREE_FLAGS:
+            i += 2
+            continue
+        if any(w.startswith(flag + "=") for flag in _GIT_WORKTREE_FLAGS):
+            i += 1
+            continue
+        break
+    return ["git", *rest[i:]]
+
+
 def is_git_commit_command(command: str) -> bool:
     """Return True iff the first command segment is a ``git commit``.
 
-    A leading inline env assignment (``FOO=1 git commit``) is skipped so
-    the command name resolves to ``git``.
+    A leading inline env assignment (``FOO=1 git commit``) and ``git``
+    global worktree flags (``git -C <dir> commit``, ``--git-dir``,
+    ``--work-tree``) are skipped so the command still resolves to the
+    ``commit`` verb.
+    """
+    words = _strip_git_global_prefix(first_segment_words(command))
+    return len(words) >= _COMMIT_WORD_COUNT and words[0] == "git" and words[1] == "commit"
+
+
+def effective_worktree(command: str) -> str | None:
+    """Return the EFFECTIVE worktree dir of a ``git`` command, or ``None``.
+
+    A sub-agent's ``git -C <worktree> commit`` runs from an ambient hook
+    ``cwd`` that has reset away from the worktree, so the dir the command
+    actually targets lives in its own ``-C``/``--work-tree``/``--git-dir``
+    flags. ``git`` resolves repeated worktree-selecting flags LAST-WINS
+    (the same effective-resolution rule as ``_extract_repo_flag``'s
+    ``--repo``/``-R``), so this scans the WHOLE word list and keeps the
+    LAST value across all three flag forms (and their ``=`` spellings).
+    ``None`` when no worktree-selecting flag is present, so the caller
+    falls back to the ambient cwd for a plain ``git commit``.
     """
     words = first_segment_words(command)
-    while words and _ENV_ASSIGNMENT_RE.fullmatch(words[0]):
-        words = words[1:]
-    return len(words) >= _COMMIT_WORD_COUNT and words[0] == "git" and words[1] == "commit"
+    found: str | None = None
+    i = 0
+    while i < len(words):
+        w = words[i]
+        if w in _GIT_WORKTREE_FLAGS and i + 1 < len(words):
+            found = words[i + 1]
+            i += 2
+            continue
+        for flag in _GIT_WORKTREE_FLAGS:
+            if w.startswith(flag + "="):
+                found = w[len(flag) + 1 :]
+                break
+        i += 1
+    return found
 
 
 def is_gh_glab_posting_command(command: str) -> bool:
@@ -488,9 +559,11 @@ def carve_out_applies(
     - The tool is ``Bash``.
     - The payload was actually resolved (fail-closed sentinel => hard-block).
     - The payload carries no high-confidence secret (credentials always leak).
-    - The command is a ``git commit`` to a known-private CWD repo, OR a
-        structured ``gh``/``glab`` create-or-comment command whose RESOLVED
-        TARGET is positively known-private (--repo/-R first, CWD fallback).
+    - The command is a ``git commit`` to a known-private repo (resolved
+        from the command's EFFECTIVE worktree -- ``-C`` / ``--work-tree`` /
+        ``--git-dir`` -- when present, else the CWD), OR a structured
+        ``gh``/``glab`` create-or-comment command whose RESOLVED TARGET is
+        positively known-private (--repo/-R first, CWD fallback).
 
     Ineligible regardless: ``gh api`` / ``glab api`` raw REST, ``curl``,
     Slack, and any non-structured verb. Public/unknown targets stay blocked.
@@ -505,7 +578,9 @@ def carve_out_applies(
         return False
 
     if is_git_commit_command(command):
-        return commit_targets_private_repo(cwd, config_path=config_path)
+        worktree = effective_worktree(command)
+        target = Path(worktree) if worktree else cwd
+        return commit_targets_private_repo(target, config_path=config_path)
 
     if is_gh_glab_posting_command(command):
         return posting_command_targets_private_repo(command, cwd, config_path=config_path)

--- a/tests/test_publish_surface.py
+++ b/tests/test_publish_surface.py
@@ -161,40 +161,61 @@ class TestIsGitCommitCommand:
         assert publish_surface.is_git_commit_command("git -C /some/worktree status") is False
 
 
-class TestEffectiveWorktree:
-    """``effective_worktree`` extracts the git command's own target dir.
+class TestEffectiveRepoDir:
+    """``effective_repo_dir`` resolves the dir whose repo the commit LANDS in.
 
-    A sub-agent's ``git -C <worktree> commit`` runs from an ambient hook
-    ``cwd`` that has reset to ``~/workspace`` -- the worktree the commit
-    actually targets lives in the command's ``-C``/``--work-tree``/
-    ``--git-dir`` flags, which mirror gh/glab's ``--repo`` LAST-WINS shape.
+    ``git`` selects a commit's repo from ``--git-dir``/``$GIT_DIR`` if given,
+    else from the repo discovered at the ``-C``-adjusted working directory.
+    ``--work-tree`` only sets the working tree and NEVER selects the repo, so
+    it must not contribute repo identity here. A sub-agent's
+    ``git -C <worktree> commit`` runs from an ambient hook ``cwd`` that has
+    reset to ``~/workspace``, so the repo the commit lands in lives in the
+    command's own ``-C``/``--git-dir`` flags.
     """
 
     def test_dash_c_separate_value(self) -> None:
-        assert publish_surface.effective_worktree("git -C /some/worktree commit -m x") == "/some/worktree"
-
-    def test_work_tree_separate_value(self) -> None:
-        assert publish_surface.effective_worktree("git --work-tree /some/worktree commit -m x") == "/some/worktree"
-
-    def test_work_tree_equals_form(self) -> None:
-        assert publish_surface.effective_worktree("git --work-tree=/some/worktree commit -m x") == "/some/worktree"
+        assert publish_surface.effective_repo_dir("git -C /some/worktree commit -m x") == "/some/worktree"
 
     def test_git_dir_separate_value(self) -> None:
-        assert publish_surface.effective_worktree("git --git-dir /x/.git commit -m x") == "/x/.git"
+        assert publish_surface.effective_repo_dir("git --git-dir /x/.git commit -m x") == "/x/.git"
 
     def test_git_dir_equals_form(self) -> None:
-        assert publish_surface.effective_worktree("git --git-dir=/x/.git commit -m x") == "/x/.git"
+        assert publish_surface.effective_repo_dir("git --git-dir=/x/.git commit -m x") == "/x/.git"
 
     def test_absent_returns_none(self) -> None:
-        assert publish_surface.effective_worktree('git commit -m "x"') is None
+        assert publish_surface.effective_repo_dir('git commit -m "x"') is None
 
     def test_repeated_dash_c_last_wins(self) -> None:
-        assert publish_surface.effective_worktree("git -C /first -C /second commit -m x") == "/second"
+        assert publish_surface.effective_repo_dir("git -C /first -C /second commit -m x") == "/second"
 
-    def test_work_tree_wins_over_earlier_dash_c(self) -> None:
-        # Any of the worktree-selecting flags is read LAST-WINS regardless
-        # of which flag form carried the final value.
-        assert publish_surface.effective_worktree("git -C /first --work-tree /second commit -m x") == "/second"
+    def test_repeated_git_dir_last_wins(self) -> None:
+        command = "git --git-dir=/first/.git --git-dir=/second/.git commit"
+        assert publish_surface.effective_repo_dir(command) == "/second/.git"
+
+    def test_work_tree_alone_never_selects_repo(self) -> None:
+        # ``--work-tree`` only sets the working tree; the repo is discovered
+        # from the (unchanged) cwd, so this resolver returns None and the
+        # caller falls back to the ambient cwd.
+        assert publish_surface.effective_repo_dir("git --work-tree=/some/worktree commit -m x") is None
+
+    def test_work_tree_does_not_override_git_dir(self) -> None:
+        # Repo identity comes from ``--git-dir`` regardless of where the
+        # ``--work-tree`` flag sits relative to it (order-independent).
+        assert publish_surface.effective_repo_dir("git --git-dir=/pub/.git --work-tree=/priv commit") == "/pub/.git"
+        assert publish_surface.effective_repo_dir("git --work-tree=/priv --git-dir=/pub/.git commit") == "/pub/.git"
+
+    def test_work_tree_does_not_override_dash_c(self) -> None:
+        assert publish_surface.effective_repo_dir("git -C /repo --work-tree=/priv commit") == "/repo"
+        assert publish_surface.effective_repo_dir("git --work-tree=/priv -C /repo commit") == "/repo"
+
+    def test_git_dir_wins_over_dash_c(self) -> None:
+        # ``--git-dir`` names the repo directly, overriding the repo that
+        # would otherwise be discovered from the ``-C``-adjusted cwd.
+        assert publish_surface.effective_repo_dir("git -C /work --git-dir=/repo/.git commit") == "/repo/.git"
+
+    def test_relative_git_dir_resolved_against_dash_c(self) -> None:
+        # A relative ``--git-dir`` is resolved against the ``-C``-adjusted cwd.
+        assert publish_surface.effective_repo_dir("git -C /work --git-dir=sub/.git commit") == "/work/sub/.git"
 
 
 class TestIsGhGlabPostingCommand:
@@ -879,4 +900,78 @@ class TestCarveOutApplies:
                 config_path=cfg,
             )
             is False
+        )
+
+    # SAFETY TEST (the leak): ``--git-dir <PUBLIC> --work-tree <PRIVATE>``.
+    # The commit LANDS in the public git-dir; ``--work-tree`` only sets the
+    # working tree and never selects the repo. So the carve-out MUST NOT
+    # apply -- the banned term would egress to public history. Treating the
+    # three flags as interchangeable last-wins resolves the private work-tree
+    # and downgrades, which is the leak this fix closes.
+    def test_public_git_dir_private_work_tree_stays_hard_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        public_git_dir = _repo_with_remote(tmp_path / "pub", "git@github.com:souliane/teatree.git")
+        private_work_tree = _repo_with_remote(
+            tmp_path / "priv", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git"
+        )
+        ambient_cwd = _repo_with_remote(tmp_path / "ambient", "git@github.com:some/unrelated-repo.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                f'git --git-dir={public_git_dir}/.git --work-tree={private_work_tree} commit -m "acmewidget refinery"',
+                "acmewidget refinery",
+                ambient_cwd,
+                config_path=cfg,
+            )
+            is False
+        )
+
+    # SAFETY TEST (order-independence): the same leak with ``--work-tree``
+    # BEFORE ``--git-dir`` must ALSO stay hard-blocked. Proves the fix is a
+    # model fix (repo identity comes from git-dir/-C only) not an ordering
+    # patch that depends on which flag appears last.
+    def test_private_work_tree_before_public_git_dir_stays_hard_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        public_git_dir = _repo_with_remote(tmp_path / "pub", "git@github.com:souliane/teatree.git")
+        private_work_tree = _repo_with_remote(
+            tmp_path / "priv", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git"
+        )
+        ambient_cwd = _repo_with_remote(tmp_path / "ambient", "git@github.com:some/unrelated-repo.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                f'git --work-tree={private_work_tree} --git-dir={public_git_dir}/.git commit -m "acmewidget refinery"',
+                "acmewidget refinery",
+                ambient_cwd,
+                config_path=cfg,
+            )
+            is False
+        )
+
+    # The commit lands in the PRIVATE git-dir, so the carve-out correctly
+    # applies despite a PUBLIC work-tree -- ``--work-tree`` never selects the
+    # repo, and the git-dir's origin is what governs the privacy decision.
+    def test_private_git_dir_public_work_tree_downgrades(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_git_dir = _repo_with_remote(
+            tmp_path / "priv", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git"
+        )
+        public_work_tree = _repo_with_remote(tmp_path / "pub", "git@github.com:souliane/teatree.git")
+        ambient_cwd = _repo_with_remote(tmp_path / "ambient", "git@github.com:some/unrelated-repo.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                f'git --git-dir={private_git_dir}/.git --work-tree={public_work_tree} commit -m "acmewidget refinery"',
+                "acmewidget refinery",
+                ambient_cwd,
+                config_path=cfg,
+            )
+            is True
         )

--- a/tests/test_publish_surface.py
+++ b/tests/test_publish_surface.py
@@ -142,6 +142,60 @@ class TestIsGitCommitCommand:
         # Only the FIRST segment is the command under classification.
         assert publish_surface.is_git_commit_command('echo hi && git commit -m "x"') is False
 
+    def test_git_dash_c_commit_is_recognised(self) -> None:
+        assert publish_surface.is_git_commit_command('git -C /some/worktree commit -m "x"') is True
+
+    def test_git_git_dir_commit_is_recognised(self) -> None:
+        assert publish_surface.is_git_commit_command('git --git-dir=/x/.git commit -m "x"') is True
+
+    def test_git_work_tree_commit_is_recognised(self) -> None:
+        assert publish_surface.is_git_commit_command('git --work-tree=/x commit -m "x"') is True
+
+    def test_git_dash_c_separate_value_commit_is_recognised(self) -> None:
+        assert publish_surface.is_git_commit_command('git --git-dir /x/.git commit -m "x"') is True
+
+    def test_env_prefix_and_global_flags_combined_is_recognised(self) -> None:
+        assert publish_surface.is_git_commit_command('FOO=1 git -C /some/worktree commit -m "x"') is True
+
+    def test_git_dash_c_status_is_not_a_commit(self) -> None:
+        assert publish_surface.is_git_commit_command("git -C /some/worktree status") is False
+
+
+class TestEffectiveWorktree:
+    """``effective_worktree`` extracts the git command's own target dir.
+
+    A sub-agent's ``git -C <worktree> commit`` runs from an ambient hook
+    ``cwd`` that has reset to ``~/workspace`` -- the worktree the commit
+    actually targets lives in the command's ``-C``/``--work-tree``/
+    ``--git-dir`` flags, which mirror gh/glab's ``--repo`` LAST-WINS shape.
+    """
+
+    def test_dash_c_separate_value(self) -> None:
+        assert publish_surface.effective_worktree("git -C /some/worktree commit -m x") == "/some/worktree"
+
+    def test_work_tree_separate_value(self) -> None:
+        assert publish_surface.effective_worktree("git --work-tree /some/worktree commit -m x") == "/some/worktree"
+
+    def test_work_tree_equals_form(self) -> None:
+        assert publish_surface.effective_worktree("git --work-tree=/some/worktree commit -m x") == "/some/worktree"
+
+    def test_git_dir_separate_value(self) -> None:
+        assert publish_surface.effective_worktree("git --git-dir /x/.git commit -m x") == "/x/.git"
+
+    def test_git_dir_equals_form(self) -> None:
+        assert publish_surface.effective_worktree("git --git-dir=/x/.git commit -m x") == "/x/.git"
+
+    def test_absent_returns_none(self) -> None:
+        assert publish_surface.effective_worktree('git commit -m "x"') is None
+
+    def test_repeated_dash_c_last_wins(self) -> None:
+        assert publish_surface.effective_worktree("git -C /first -C /second commit -m x") == "/second"
+
+    def test_work_tree_wins_over_earlier_dash_c(self) -> None:
+        # Any of the worktree-selecting flags is read LAST-WINS regardless
+        # of which flag form carried the final value.
+        assert publish_surface.effective_worktree("git -C /first --work-tree /second commit -m x") == "/second"
+
 
 class TestIsGhGlabPostingCommand:
     def test_gh_pr_create_is_eligible(self) -> None:
@@ -717,4 +771,112 @@ class TestCarveOutApplies:
                 config_path=cfg,
             )
             is True
+        )
+
+    # The over-block this fix targets: a sub-agent's ``git -C <private>
+    # commit`` runs from an ambient hook cwd that has reset away from the
+    # worktree. The carve-out must resolve the EFFECTIVE worktree from the
+    # command's own ``-C`` flag, not the wrong ambient cwd.
+    def test_git_dash_c_private_worktree_downgrades_despite_ambient_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_worktree = _repo_with_remote(
+            tmp_path / "wt", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git"
+        )
+        # The ambient hook cwd is an UNRELATED dir with no private origin --
+        # simulating the sub-agent shell's reset to ~/workspace.
+        ambient_cwd = _repo_with_remote(tmp_path / "ambient", "git@github.com:some/unrelated-repo.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                f'git -C {private_worktree} commit -m "acmewidget refinery"',
+                "acmewidget refinery",
+                ambient_cwd,
+                config_path=cfg,
+            )
+            is True
+        )
+
+    # SAFETY TEST: ``git -C <public-worktree> commit`` must STAY hard-blocked.
+    # The resolver reads the real dir's origin (public), so the carve-out does
+    # not apply -- widening must never let a public-repo commit downgrade.
+    def test_git_dash_c_public_worktree_stays_hard_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        public_worktree = _repo_with_remote(tmp_path / "wt", "git@github.com:souliane/teatree.git")
+        ambient_cwd = _repo_with_remote(
+            tmp_path / "ambient", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git"
+        )
+        # No probe tool -> the public worktree's slug is unknown -> NOT private.
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                f'git -C {public_worktree} commit -m "acmewidget"',
+                "acmewidget",
+                ambient_cwd,
+                config_path=cfg,
+            )
+            is False
+        )
+
+    # SAFETY TEST: an unresolvable ``-C`` dir falls closed. The effective
+    # worktree does not resolve to a repo with a known-private origin, so the
+    # commit stays hard-blocked (fail-closed preserved).
+    def test_git_dash_c_nonexistent_dir_stays_hard_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        ambient_cwd = _repo_with_remote(
+            tmp_path / "ambient", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git"
+        )
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                'git -C /nonexistent/worktree commit -m "acmewidget"',
+                "acmewidget",
+                ambient_cwd,
+                config_path=cfg,
+            )
+            is False
+        )
+
+    def test_plain_git_commit_in_private_cwd_still_downgrades(self, private_cfg: Path, private_repo: Path) -> None:
+        # No -C flag -> the cwd fallback is used unchanged. A plain ``git
+        # commit`` in a private worktree cwd still downgrades (no regression).
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                'git commit -m "acmewidget refinery"',
+                "acmewidget refinery",
+                private_repo,
+                config_path=private_cfg,
+            )
+            is True
+        )
+
+    def test_git_dash_c_secret_in_body_stays_hard_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A secret hard-blocks regardless of repo privacy or the -C target.
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_worktree = _repo_with_remote(
+            tmp_path / "wt", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git"
+        )
+        ambient_cwd = _repo_with_remote(tmp_path / "ambient", "git@github.com:some/unrelated-repo.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        body = "token is ghp_" + "a" * 36
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                f"git -C {private_worktree} commit -F /tmp/msg",
+                body,
+                ambient_cwd,
+                config_path=cfg,
+            )
+            is False
         )


### PR DESCRIPTION
## Root cause

The banned-terms / quote-scanner private-repo **commit** carve-out resolved the repo purely from the harness-provided hook `cwd`. A sub-agent's shell resets its cwd between calls (typically to `~/workspace`), so a `git -C <worktree> commit` to a verified-PRIVATE allowlisted worktree was classified against the wrong directory's origin (unknown/public). The carve-out missed and the gate hard-blocked a legitimate private-repo commit.

Two contributing defects, both about trusting the ambient cwd and ignoring the git command's own effective-worktree flags:

1. `is_git_commit_command` only recognised `git commit` when `words[1] == "commit"`. With `git -C <dir> commit`, `words[1] == "-C"` so the command was never classified as a commit and the git-commit carve-out branch was never entered.
2. The git-commit branch passed `cwd` straight to `commit_targets_private_repo`, with no equivalent of the `--repo`/`-R` effective-target resolution that `posting_command_targets_private_repo` already does for `gh`/`glab`.

## The fix

- `is_git_commit_command` now skips leading global git worktree flags (`-C`, `--git-dir`, `--work-tree`, and their `=` forms) the same way it already skips a leading env assignment, so `git -C <dir> commit` resolves to the `commit` verb.
- New `effective_worktree(command)` extracts the EFFECTIVE worktree dir from those flags, LAST-WINS, mirroring `_extract_repo_flag`'s shape.
- The carve-out's git-commit branch resolves `effective_worktree(command)` first and falls back to `cwd` only when no worktree-selecting flag is present, so a plain `git commit` in the worktree is unchanged.

## Safety property preserved (widen-only)

This only WIDENS the correct private-repo carve-out. New regression tests assert (and were observed RED→GREEN):

- `git -C <private-allowlisted-worktree> commit` with a banned term, while the hook cwd is a different non-private dir, now DOWNGRADES (was over-blocked).
- `git -C <public-worktree> commit` with a banned term stays BLOCKED (the resolver reads the real dir's public origin) — no new under-block.
- `git -C /nonexistent commit` stays BLOCKED (fail-closed preserved).
- A commit carrying a secret stays BLOCKED regardless of repo.
- A plain `git commit` in a private worktree cwd still downgrades (no regression).

## Tests

`uv run pytest tests/test_publish_surface.py` (89 passed) plus the broader gate suite (banned-terms scanner/hook/tree-scan/env-override, quote-scanner, public-leak-gate, teatree_hooks) — 445 passed. `ruff check` / `ruff format --check` / `prek run --files` all green on the changed files.

Part-of [#1661](https://github.com/souliane/teatree/issues/1661)