### PR TITLE
fix(loop): restore per-phase FSM dispatch shadowed by the inline-chaining /loop driver

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -103,28 +103,28 @@ For new tickets, don't spawn a sub-agent. Handle directly:
 4. `t3 <overlay> worktree provision [VARIANT]`
 5. Report the worktree paths, then ask what phase to start.
 
-### 7. Auto-start mode
+### 7. Auto-start mode (kickoff only — never chain phases inline)
 
 When the loop dispatches an `assigned_issue.ready` signal with `auto_start: true`
-in the payload, you skip the intake question (§ 6 step 5) and chain the lifecycle
-through PR creation without further user input:
+in the payload, you skip the intake question (§ 6 step 5) and start the maker
+pipeline — you do NOT execute or chain the phases yourself:
 
 1. Run § 6 steps 1–4 to set up the worktree.
 2. Mark the ticket as auto-started so the scanner counts it against the budget:
    `t3 <overlay> ticket update <ID> --extra auto_started=true`
-3. Spawn `@coder`, then `@tester`, then `@reviewer`, then `@shipper` in order.
-   After each sub-agent returns, run `t3 <overlay> pr check-gates`. Advance the
-   ticket only when the gate passes.
-4. Stop after `@shipper` opens the PR. The PR-merge step is the configured
-   `require_human_approval_to_merge` gate — the loop surfaces the open PR via
-   `MyPrsScanner` and a human approves the merge.
-5. **On phase failure**: halt. Do not retry, do not run the next phase. The
-   ticket stays in its current state; `MyPrsScanner` and the `in_flight`
-   statusline zone keep the failure visible to the operator.
+3. Let the FSM drive the pipeline. Each lifecycle phase is dispatched to its OWN
+   agent by the loop when its phase task is claimed — `coding → @coder`,
+   `testing → @tester`, `reviewing → @reviewer`, `shipping → @shipper`. The
+   orchestrator never spawns the phase agents in sequence and never runs the
+   work of a phase itself (BLUEPRINT §5.2 / §17.8 invariant 10: the orchestrator
+   does synthesis and dispatch, not execution).
+4. The PR-merge step is the configured `require_human_approval_to_merge` gate —
+   the loop surfaces the open PR via `MyPrsScanner` and a human approves the
+   merge.
 
 The orchestrator never auto-merges, never overrides `require_ticket`, and never
-bypasses CI quality gates — auto-start only automates the work the operator
-would otherwise type by hand.
+bypasses CI quality gates — auto-start only kicks off the work; the per-phase
+loop dispatch carries it forward.
 
 ## Rules
 

--- a/src/teatree/core/management/commands/loop_dispatch.py
+++ b/src/teatree/core/management/commands/loop_dispatch.py
@@ -15,43 +15,34 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django_typer.management import TyperCommand, command
 
-from teatree.core.models import Task, Ticket
+from teatree.core.models import Task
+from teatree.core.phases import SUBAGENT_BY_PHASE, phase_spellings, subagent_for_phase
 
-# Maps ticket role + task phase → the sub-agent the slot should Agent().
-# Reviewer-role + reviewing → t3:reviewer; author-role + coding →
-# t3:orchestrator (it chains coder → tester → reviewer → shipper);
-# author-role + answering → t3:answerer (the reactive Slack-answer loop's
-# NEEDS_WORK delegation path, #1014 — the loop has no Agent tool, so it
-# enqueues a Task here and the fat loop's atomic `claim-next` spawns the
-# bounded answerer sub-agent; no new spawn path, no double-dispatch).
-_SUBAGENT_BY_PHASE: dict[tuple[str, str], str] = {
-    (Ticket.Role.REVIEWER, "reviewing"): "t3:reviewer",
-    (Ticket.Role.AUTHOR, "coding"): "t3:orchestrator",
-    (Ticket.Role.AUTHOR, "answering"): "t3:answerer",
-    # #1191 scanning-news scanner queues author+scanning_news tasks; the
-    # dispatcher routes them to the t3:scanning-news skill subagent. The
-    # sibling architectural_review phase is intentionally NOT registered
-    # here — it ships its own headless executor — but scanning-news has
-    # no dedicated executor and uses the standard pending-task pipeline.
-    (Ticket.Role.AUTHOR, "scanning_news"): "t3:scanning-news",
-}
+# The phase → sub-agent authority is the single canonical map in
+# ``teatree.core.phases``. Each author phase dispatches to its OWN agent
+# (coding → t3:coder, testing → t3:tester, reviewing → t3:reviewer,
+# shipping → t3:shipper); the reviewer-role reviewing entry stays. The
+# loop is the per-phase dispatcher, never a single orchestrator that
+# chains the phases inline (BLUEPRINT §5.2 / §17.8 invariant 10).
+_SUBAGENT_BY_PHASE = SUBAGENT_BY_PHASE
 
 
 def _subagent_for(task: Task) -> str:
-    ticket = task.ticket
-    return _SUBAGENT_BY_PHASE.get((ticket.role, task.phase), "")
+    return subagent_for_phase(task.ticket.role, task.phase)
 
 
 def _dispatchable_q() -> Q:
     """DB-side mirror of ``_subagent_for`` for the atomic claim filter.
 
-    ``Q`` matching exactly the (ticket.role, task.phase) pairs that have a
+    ``Q`` matching the (ticket.role, task.phase) pairs that have a
     registered subagent, so the atomic claim restricts to dispatchable
-    tasks (one source of truth).
+    tasks (one source of truth). Phase is matched across every accepted
+    spelling (``phase_spellings``) so a short-verb ``code``/``review`` task
+    resolves the same as the canonical token ``_subagent_for`` normalizes.
     """
     q = Q(pk__in=[])  # matches nothing; OR-folded below
     for role, phase in _SUBAGENT_BY_PHASE:
-        q |= Q(ticket__role=role, phase=phase)
+        q |= Q(ticket__role=role, phase__in=phase_spellings(phase))
     return q
 
 

--- a/src/teatree/core/phases.py
+++ b/src/teatree/core/phases.py
@@ -44,6 +44,43 @@ _CANONICAL_TO_TRANSITION: dict[str, str] = {
 }
 
 
+#: The single source of truth mapping a ticket ``(role, phase)`` pair to the
+#: sub-agent the loop dispatches for it. Every author phase routes to its OWN
+#: phase agent — the loop is the per-phase dispatcher, never a single
+#: orchestrator that chains coder→tester→reviewer→shipper inline (BLUEPRINT
+#: §5.2 / §17.8 invariant 10: phase agents are invoked by the headless
+#: executor when a phase task is claimed; the orchestrator does synthesis and
+#: dispatch, not execution). Keyed on the canonical phase token so a task
+#: stored with any accepted spelling resolves through ``normalize_phase``.
+#: Adding ``("author", "planning"): "t3:planner"`` later is a one-line change.
+SUBAGENT_BY_PHASE: dict[tuple[str, str], str] = {
+    ("reviewer", "reviewing"): "t3:reviewer",
+    ("author", "coding"): "t3:coder",
+    ("author", "testing"): "t3:tester",
+    ("author", "reviewing"): "t3:reviewer",
+    ("author", "shipping"): "t3:shipper",
+    ("author", "answering"): "t3:answerer",
+    ("author", "scanning_news"): "t3:scanning-news",
+}
+
+#: The chaining orchestrator must never be the target of an author phase
+#: dispatch — that is the shadowing the per-phase restoration removes. A
+#: conformance test asserts no author phase routes here.
+CHAINING_ORCHESTRATOR: str = "t3:orchestrator"
+
+
+def subagent_for_phase(role: str, phase: str) -> str:
+    """Return the sub-agent for a ticket ``(role, phase)`` pair, or ``""``.
+
+    ``phase`` is normalized so a task stored with a short-verb spelling
+    (``code``/``test``/``review``/``ship``) resolves the same as the
+    canonical gerund. An empty string means the pair has no registered
+    sub-agent (operator triage) — the single authority both the loop
+    dispatcher and the ``loop_dispatch`` command consult.
+    """
+    return SUBAGENT_BY_PHASE.get((role, normalize_phase(phase)), "")
+
+
 def normalize_phase(phase: str) -> str:
     """Return the canonical token for ``phase``.
 

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -128,15 +128,40 @@ def _add_approval_reaction_on_transition(
         logger.exception("Failed to mark ReviewAssignment approved for PR %s", instance.pk)
 
 
+def _is_loop_dispatched(instance: Task) -> bool:
+    """True when the loop is the SOLE dispatcher for this task's ``(role, phase)``.
+
+    A task whose ``(ticket.role, phase)`` has a registered phase agent is
+    dispatched per-phase by the loop (``loop_dispatch`` ``claim-next`` →
+    the phase sub-agent). Auto-enqueuing ``execute_headless_task`` for it
+    too would run the same task TWICE (the loop spawns the agent AND a
+    ``db_worker`` drains the queue). Gating the auto-enqueue here makes the
+    loop the single dispatcher for loop-dispatched phase tasks. A task with
+    NO registered phase agent (a free-form/headless-only phase) is NOT
+    loop-dispatched, so it still rides the ``execute_headless_task`` path —
+    never zero dispatch.
+    """
+    from teatree.core.phases import subagent_for_phase  # noqa: PLC0415
+
+    return bool(subagent_for_phase(instance.ticket.role, instance.phase))
+
+
 def _auto_enqueue_headless_task(
     sender: type,  # noqa: ARG001
     instance: Task,
     **_kwargs: object,
 ) -> None:
-    """Auto-enqueue headless tasks for execution when created or re-routed."""
+    """Auto-enqueue headless tasks for execution when created or re-routed.
+
+    Loop-dispatched phase tasks (those with a registered phase agent) are
+    skipped — the loop is their sole dispatcher (see ``_is_loop_dispatched``)
+    so a ``db_worker`` draining the queue never double-runs them.
+    """
     if instance.execution_target != Task.ExecutionTarget.HEADLESS:
         return
     if instance.status != Task.Status.PENDING:
+        return
+    if _is_loop_dispatched(instance):
         return
     from teatree.core.tasks import execute_headless_task  # noqa: PLC0415
 

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -46,15 +46,30 @@ def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
 
 @task()
 def drain_headless_queue() -> dict[str, list[int]]:
-    """Auto-enqueue pending headless tasks for execution."""
-    pending = Task.objects.filter(
-        execution_target=Task.ExecutionTarget.HEADLESS,
-        status=Task.Status.PENDING,
-    ).values_list("pk", "phase")
+    """Auto-enqueue pending headless tasks for execution (safety net).
+
+    Loop-dispatched phase tasks (those whose ``(ticket.role, phase)`` has a
+    registered phase agent) are skipped — the loop is their sole dispatcher,
+    so draining them here would double-run them (the same guard the
+    ``_auto_enqueue_headless_task`` post_save applies). Only genuinely
+    headless tasks with no registered phase agent are drained.
+    """
+    from teatree.core.phases import subagent_for_phase  # noqa: PLC0415
+
+    pending = (
+        Task.objects.filter(
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            status=Task.Status.PENDING,
+        )
+        .select_related("ticket")
+        .only("pk", "phase", "ticket__role")
+    )
     enqueued: list[int] = []
-    for task_id, phase in pending:
-        execute_headless_task.enqueue(task_id, phase)
-        enqueued.append(task_id)
+    for task_obj in pending:
+        if subagent_for_phase(task_obj.ticket.role, task_obj.phase):
+            continue
+        execute_headless_task.enqueue(task_obj.pk, task_obj.phase)
+        enqueued.append(task_obj.pk)
     return {"enqueued": enqueued}
 
 

--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from teatree.config import get_effective_settings
-from teatree.core.phases import normalize_phase
+from teatree.core.phases import normalize_phase, subagent_for_phase
 from teatree.loop.scanners.base import ScanSignal
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,6 @@ _AGENT_BY_KIND: dict[str, str] = {
     # ``RedCardSignal`` row id so the orchestrator can stamp the filed
     # issue URL back onto the row via ``RedCardSignal.link_issue``.
     "red_card.signal": "t3:orchestrator",
-    "pending_task": "t3:orchestrator",
     # #1554: a newly-claimed auto-implement issue routes to the orchestrator
     # as a MAKER-side kickoff — it starts the normal maker pipeline for the
     # claimed issue. It issues no MergeClear and gains no new merge authority
@@ -295,6 +294,27 @@ def _dispatch_answering(signal: ScanSignal) -> list[DispatchAction]:
     ]
 
 
+def _dispatch_pending_task(signal: ScanSignal) -> list[DispatchAction] | None:
+    """Route a ``pending_task`` signal to its PHASE's own agent (per-phase dispatch).
+
+    The ``PendingTasksScanner`` emits one ``pending_task`` per pending row,
+    carrying the row's ``phase`` and ``ticket_role``. The agent is resolved
+    through the single canonical ``(role, phase) → agent`` authority
+    (``subagent_for_phase``): coding → t3:coder, testing → t3:tester,
+    reviewing → t3:reviewer, shipping → t3:shipper. No author phase falls
+    through to a single chaining orchestrator — that is the shadowing this
+    restores. A pair with no registered agent (free-form phase, or a missing
+    role) returns ``None`` so it falls through to the statusline fallback for
+    operator triage rather than being misrouted.
+    """
+    role = str(signal.payload.get("ticket_role", ""))
+    phase = str(signal.payload.get("phase", ""))
+    agent = subagent_for_phase(role, phase)
+    if not agent:
+        return None
+    return [DispatchAction(kind="agent", zone=agent, detail=signal.summary, payload=signal.payload)]
+
+
 def _conditional_dispatch(signal: ScanSignal) -> list[DispatchAction] | None:
     """Payload-conditional special cases that precede the generic lookups.
 
@@ -302,20 +322,33 @@ def _conditional_dispatch(signal: ScanSignal) -> list[DispatchAction] | None:
     through to the ``_AGENT_BY_KIND`` / ``_MECHANICAL_BY_KIND`` / statusline
     chain. Keeping these here keeps ``_dispatch_one`` flat.
     """
+    if signal.kind == "pending_task":
+        return _dispatch_pending_task(signal)
     if signal.kind in {"slack.mention", "slack.dm"}:
         pr_url = _slack_pr_url(signal)
         if pr_url:
             return _review_request_dispatch(signal, pr_url)
     if signal.kind == "incoming_event.task_needed":
-        pr_url = _task_pr_url(signal)
-        if pr_url:
-            return _review_request_dispatch(signal, pr_url)
+        return _dispatch_incoming_task(signal)
     if signal.kind == "assigned_issue.ready" and signal.payload.get("auto_start") is True:
         return [DispatchAction(kind="agent", zone="t3:orchestrator", detail=signal.summary, payload=signal.payload)]
     if signal.kind == "codex_review.dispatch":
         return _codex_review_dispatch(signal)
-    phase = normalize_phase(str(signal.payload.get("phase", "")))
-    if signal.kind == "incoming_event.task_needed" and phase == "answering":
+    return None
+
+
+def _dispatch_incoming_task(signal: ScanSignal) -> list[DispatchAction] | None:
+    """Route an ``incoming_event.task_needed`` signal (#219, #670).
+
+    A carried PR/MR URL means a review request regardless of the
+    classifier's phase, so it precedes the ``answering`` fallback. An
+    ``answering`` phase with no URL routes to the answerer; everything else
+    falls through (``None``) to the statusline.
+    """
+    pr_url = _task_pr_url(signal)
+    if pr_url:
+        return _review_request_dispatch(signal, pr_url)
+    if normalize_phase(str(signal.payload.get("phase", ""))) == "answering":
         return _dispatch_answering(signal)
     return None
 

--- a/src/teatree/loop/persistence.py
+++ b/src/teatree/loop/persistence.py
@@ -167,10 +167,11 @@ def _already_reviewed_at_head(ticket: Ticket, head_sha: str) -> bool:
 def _handle_orchestrator(action: DispatchAction) -> Task | None:
     """Auto-start assigned issue → Ticket(role=author) + Task(phase=coding).
 
-    Only fires for ``assigned_issue.ready`` signals that carry
-    ``auto_start=True`` (the dispatcher already filtered). ``pending_task``
-    signals — which also resolve to ``t3:orchestrator`` — describe a Task
-    that already exists, so we skip them here.
+    Only fires for ``assigned_issue.ready`` / ``issue_implementer.claimed``
+    signals that carry ``auto_start=True`` (the dispatcher already filtered).
+    The scheduled coding task is then dispatched per-phase by the loop —
+    ``pending_task`` signals route directly to the phase's own agent, not
+    through ``t3:orchestrator``.
     """
     payload = action.payload
     if payload.get("auto_start") is not True:

--- a/src/teatree/loop/scanners/pending_tasks.py
+++ b/src/teatree/loop/scanners/pending_tasks.py
@@ -34,12 +34,21 @@ class PendingTasksScanner:
 
     def scan(self) -> list[ScanSignal]:
         task_model = cast("type[Task]", apps.get_model("core", "Task"))
-        pending = task_model.objects.filter(status=task_model.Status.PENDING).order_by("id")[: self.limit]
+        pending = (
+            task_model.objects.filter(status=task_model.Status.PENDING)
+            .select_related("ticket")
+            .order_by("id")[: self.limit]
+        )
         return [
             ScanSignal(
                 kind="pending_task",
                 summary=f"Task {task.id} ({task.phase}) pending",
-                payload={"task_id": task.id, "phase": task.phase, "ticket_id": task.ticket_id},
+                payload={
+                    "task_id": task.id,
+                    "phase": task.phase,
+                    "ticket_id": task.ticket_id,
+                    "ticket_role": task.ticket.role,
+                },
             )
             for task in pending
         ]

--- a/tests/teatree_core/test_loop_dispatch_command.py
+++ b/tests/teatree_core/test_loop_dispatch_command.py
@@ -41,7 +41,7 @@ class TestPendingSpawn(_LoopDispatchTest):
         assert entry["ticket_role"] == Ticket.Role.REVIEWER
         assert entry["issue_url"] == "https://example.com/pr/1"
 
-    def test_emits_orchestrator_subagent_for_author_coding(self) -> None:
+    def test_emits_coder_subagent_for_author_coding(self) -> None:
         task = self._author_task()
         stdout = StringIO()
         call_command("loop_dispatch", "pending-spawn", "--json", stdout=stdout)
@@ -49,7 +49,7 @@ class TestPendingSpawn(_LoopDispatchTest):
         payload = json.loads(stdout.getvalue())
         assert len(payload) == 1
         assert payload[0]["task_id"] == task.pk
-        assert payload[0]["subagent"] == "t3:orchestrator"
+        assert payload[0]["subagent"] == "t3:coder"
 
     def test_skips_claimed_tasks(self) -> None:
         task = self._reviewer_task()

--- a/tests/teatree_core/test_phase_agent_conformance.py
+++ b/tests/teatree_core/test_phase_agent_conformance.py
@@ -1,0 +1,111 @@
+"""Golden phase→agent conformance for the per-phase loop dispatch.
+
+The anti-regression guard for the per-phase FSM dispatch that #559/#633
+shadowed: every author lifecycle phase must route to its OWN phase agent,
+never to a single chaining orchestrator. The table is the contract — adding
+``planning → t3:planner`` later is a one-line edit here and in
+``SUBAGENT_BY_PHASE``.
+"""
+
+import json
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.management.commands import loop_dispatch as loop_dispatch_cmd
+from teatree.core.models import Session, Task, Ticket
+from teatree.core.phases import CHAINING_ORCHESTRATOR, SUBAGENT_BY_PHASE, subagent_for_phase
+from teatree.loop.dispatch import dispatch
+from teatree.loop.scanners.base import ScanSignal
+
+#: The golden table: every author lifecycle phase → its dedicated agent.
+#: A new lifecycle phase is added with one row (e.g. ``"planning": "t3:planner"``).
+EXPECTED_AUTHOR_AGENT: dict[str, str] = {
+    "coding": "t3:coder",
+    "testing": "t3:tester",
+    "reviewing": "t3:reviewer",
+    "shipping": "t3:shipper",
+}
+
+
+class TestSubagentForPhaseConformance(TestCase):
+    """The canonical ``subagent_for_phase`` map — the single source of truth."""
+
+    def test_every_author_phase_routes_to_its_own_agent(self) -> None:
+        for phase, expected in EXPECTED_AUTHOR_AGENT.items():
+            assert subagent_for_phase(Ticket.Role.AUTHOR, phase) == expected, (
+                f"author phase {phase!r} routed to {subagent_for_phase(Ticket.Role.AUTHOR, phase)!r}, "
+                f"expected {expected!r}"
+            )
+
+    def test_no_author_phase_routes_to_chaining_orchestrator(self) -> None:
+        offenders = {
+            phase: agent
+            for (role, phase), agent in SUBAGENT_BY_PHASE.items()
+            if role == Ticket.Role.AUTHOR and agent == CHAINING_ORCHESTRATOR
+        }
+        assert offenders == {}, f"author phases must not chain through the orchestrator: {offenders}"
+
+    def test_reviewer_role_reviewing_still_routes_to_reviewer(self) -> None:
+        assert subagent_for_phase(Ticket.Role.REVIEWER, "reviewing") == "t3:reviewer"
+
+    def test_short_verb_spelling_resolves_same_as_canonical(self) -> None:
+        assert subagent_for_phase(Ticket.Role.AUTHOR, "code") == "t3:coder"
+        assert subagent_for_phase(Ticket.Role.AUTHOR, "ship") == "t3:shipper"
+
+
+class TestLoopDispatchCommandConformance(TestCase):
+    """``_SUBAGENT_BY_PHASE`` (the pending-spawn map) mirrors the canonical map."""
+
+    def test_command_map_is_the_canonical_map(self) -> None:
+        assert loop_dispatch_cmd._SUBAGENT_BY_PHASE is SUBAGENT_BY_PHASE
+
+    def test_every_author_phase_has_a_non_orchestrator_subagent(self) -> None:
+        for phase, expected in EXPECTED_AUTHOR_AGENT.items():
+            ticket = Ticket.objects.create(
+                overlay="acme",
+                issue_url=f"https://example.com/issues/{phase}",
+                role=Ticket.Role.AUTHOR,
+            )
+            session = Session.objects.create(ticket=ticket, agent_id=phase)
+            Task.objects.create(ticket=ticket, session=session, phase=phase)
+            stdout = StringIO()
+            call_command("loop_dispatch", "pending-spawn", "--json", stdout=stdout)
+            payload = json.loads(stdout.getvalue())
+            entry = next(e for e in payload if e["phase"] == phase)
+            assert entry["subagent"] == expected
+            assert entry["subagent"] != CHAINING_ORCHESTRATOR
+
+
+class TestPendingTaskSignalConformance(TestCase):
+    """``loop.dispatch`` routes a ``pending_task`` signal phase-aware.
+
+    The ``PendingTasksScanner`` emits one ``pending_task`` per pending row;
+    the dispatcher must route it to the phase's own agent, never a single
+    chaining orchestrator.
+    """
+
+    def _signal(self, phase: str, *, role: str = Ticket.Role.AUTHOR) -> ScanSignal:
+        return ScanSignal(
+            kind="pending_task",
+            summary=f"Task ({phase}) pending",
+            payload={"task_id": 1, "phase": phase, "ticket_id": 1, "ticket_role": role},
+        )
+
+    def test_every_author_phase_dispatches_to_its_own_agent(self) -> None:
+        for phase, expected in EXPECTED_AUTHOR_AGENT.items():
+            actions = dispatch([self._signal(phase)])
+            agent_actions = [a for a in actions if a.kind == "agent"]
+            assert len(agent_actions) == 1, f"phase {phase!r}: expected one agent action, got {agent_actions}"
+            assert agent_actions[0].zone == expected, (
+                f"phase {phase!r} dispatched to {agent_actions[0].zone!r}, expected {expected!r}"
+            )
+
+    def test_no_author_phase_dispatches_to_chaining_orchestrator(self) -> None:
+        for phase in EXPECTED_AUTHOR_AGENT:
+            actions = dispatch([self._signal(phase)])
+            zones = {a.zone for a in actions if a.kind == "agent"}
+            assert CHAINING_ORCHESTRATOR not in zones, (
+                f"author phase {phase!r} must not route to the chaining orchestrator (zones={zones})"
+            )

--- a/tests/teatree_core/test_signals.py
+++ b/tests/teatree_core/test_signals.py
@@ -32,13 +32,11 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
         ticket = Ticket.objects.create(overlay="test")
         session = Session.objects.create(ticket=ticket, overlay="test")
 
-        # #1284: ``coding`` phase requires ``files_modified`` evidence.
-        result_blob = _json.dumps(
-            {
-                "summary": "OK",
-                "files_modified": [{"path": "src/x.py", "action": "modified"}],
-            },
-        )
+        # ``architectural_review`` has no registered phase agent, so it is NOT
+        # loop-dispatched and the post_save signal owns its execution. A
+        # loop-dispatched phase (coding/testing/...) is the loop's
+        # responsibility and is intentionally not auto-enqueued.
+        result_blob = _json.dumps({"summary": "OK"})
         with (
             patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
             patch.object(
@@ -52,7 +50,7 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
                 ticket=ticket,
                 session=session,
                 execution_target=Task.ExecutionTarget.HEADLESS,
-                phase="coding",
+                phase="architectural_review",
             )
 
         task.refresh_from_db()
@@ -101,12 +99,15 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
                 msg = "backend unavailable"
                 raise RuntimeError(msg)
 
+        # ``architectural_review`` is NOT loop-dispatched, so the auto-enqueue
+        # actually fires and hits the broken backend (a loop-dispatched phase
+        # would skip the enqueue entirely and never exercise this path).
         with patch.object(tasks_mod, "execute_headless_task", BrokenEnqueue):
             task = Task.objects.create(
                 ticket=ticket,
                 session=session,
                 execution_target=Task.ExecutionTarget.HEADLESS,
-                phase="coding",
+                phase="architectural_review",
             )
 
         task.refresh_from_db()
@@ -123,21 +124,17 @@ class TestAutoEnqueueHeadlessSignal(TestCase):
         ticket = Ticket.objects.create(overlay="test")
         session = Session.objects.create(ticket=ticket, overlay="test")
 
+        # ``architectural_review`` has no registered phase agent, so it is NOT
+        # loop-dispatched — the post_save auto-enqueue owns its execution.
         task = Task.objects.create(
             ticket=ticket,
             session=session,
             execution_target=Task.ExecutionTarget.INTERACTIVE,
-            phase="coding",
+            phase="architectural_review",
         )
         assert task.status == Task.Status.PENDING
 
-        # #1284: ``coding`` phase requires ``files_modified`` evidence.
-        result_blob = _json.dumps(
-            {
-                "summary": "OK",
-                "files_modified": [{"path": "src/x.py", "action": "modified"}],
-            },
-        )
+        result_blob = _json.dumps({"summary": "OK"})
         with (
             patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude-code"),
             patch.object(

--- a/tests/teatree_core/test_single_dispatch_liveness.py
+++ b/tests/teatree_core/test_single_dispatch_liveness.py
@@ -1,0 +1,102 @@
+"""Single-dispatch / liveness for author phase tasks.
+
+With the loop dispatching per phase (``pending-spawn``/``claim-next`` →
+the phase agent), the ``post_save`` auto-enqueue must NOT also drain a
+loop-dispatched phase task through ``execute_headless_task`` — that would
+run the same task twice. The loop is the SOLE dispatcher for author phase
+tasks. Conversely, a task with no registered phase agent (and a genuinely
+headless one like the self-improve executor) must STILL be auto-enqueued —
+never zero dispatch.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+
+import teatree.core.overlay_loader as overlay_loader_mod
+from teatree.core.models import Session, Task, Ticket
+from tests.teatree_core.conftest import CommandOverlay
+
+IMMEDIATE_BACKEND = {
+    "TASKS": {
+        "default": {
+            "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+        },
+    },
+}
+
+_MOCK_OVERLAY = {"test": CommandOverlay()}
+
+_AUTHOR_PHASES = ("coding", "testing", "reviewing", "shipping")
+
+
+class TestLoopDispatchedPhaseNotAutoEnqueued(TestCase):
+    """An author phase task the loop dispatches is not also drained on creation."""
+
+    def _author_ticket(self) -> Ticket:
+        return Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR)
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_author_phase_task_creation_does_not_enqueue_execute_headless(self) -> None:
+        ticket = self._author_ticket()
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        for phase in _AUTHOR_PHASES:
+            with (
+                patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
+                patch("teatree.core.tasks.execute_headless_task") as headless,
+            ):
+                Task.objects.create(
+                    ticket=ticket,
+                    session=session,
+                    phase=phase,
+                    execution_target=Task.ExecutionTarget.HEADLESS,
+                    status=Task.Status.PENDING,
+                )
+            assert headless.enqueue.call_count == 0, (
+                f"author phase {phase!r} task was auto-enqueued for headless execution; "
+                "the loop is the sole dispatcher for loop-dispatched phase tasks (double-dispatch)"
+            )
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_reviewer_role_reviewing_task_not_auto_enqueued(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.REVIEWER)
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.tasks.execute_headless_task") as headless,
+        ):
+            Task.objects.create(
+                ticket=ticket,
+                session=session,
+                phase="reviewing",
+                execution_target=Task.ExecutionTarget.HEADLESS,
+                status=Task.Status.PENDING,
+            )
+        assert headless.enqueue.call_count == 0
+
+
+class TestNonLoopDispatchedTaskStillAutoEnqueued(TestCase):
+    """A headless task with no registered phase agent must still be drained.
+
+    The double-dispatch guard must be surgical: it suppresses ONLY the
+    loop-dispatched ``(role, phase)`` pairs. A genuinely headless task with
+    no registered phase agent (a free-form phase) still rides the
+    ``execute_headless_task`` path — never zero dispatch.
+    """
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_unregistered_phase_task_is_auto_enqueued(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR)
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.tasks.execute_headless_task") as headless,
+        ):
+            task = Task.objects.create(
+                ticket=ticket,
+                session=session,
+                phase="architectural_review",
+                execution_target=Task.ExecutionTarget.HEADLESS,
+                status=Task.Status.PENDING,
+            )
+        headless.enqueue.assert_called_once_with(task.pk, "architectural_review")

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -76,12 +76,14 @@ class TestDrainHeadlessQueue(TestCase):
     def test_enqueues_pending_headless_tasks(self) -> None:
         ticket = Ticket.objects.create(overlay="test")
         session = Session.objects.create(ticket=ticket, overlay="test")
+        # ``architectural_review`` has no registered phase agent, so it is NOT
+        # loop-dispatched and the drain safety-net owns it.
         pending = Task.objects.create(
             ticket=ticket,
             session=session,
             execution_target=Task.ExecutionTarget.HEADLESS,
             status=Task.Status.PENDING,
-            phase="coding",
+            phase="architectural_review",
         )
         # Interactive task should NOT be enqueued
         Task.objects.create(
@@ -90,6 +92,15 @@ class TestDrainHeadlessQueue(TestCase):
             execution_target=Task.ExecutionTarget.INTERACTIVE,
             status=Task.Status.PENDING,
             phase="testing",
+        )
+        # A loop-dispatched author phase (coding) is the loop's sole
+        # responsibility — the drain must NOT also enqueue it (double-dispatch).
+        Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            status=Task.Status.PENDING,
+            phase="coding",
         )
 
         with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
@@ -411,9 +422,11 @@ class TestExecuteHeadlessTask(TestCase):
 
         self.monkeypatch.setattr("teatree.agents.headless.run_headless", _raise)
 
-        # Signal auto-enqueues on creation; ImmediateBackend runs it synchronously
+        # ``architectural_review`` has no registered phase agent, so it is NOT
+        # loop-dispatched — it rides the auto-enqueue path the executor owns.
+        # ImmediateBackend runs the enqueued job synchronously.
         with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
-            task = Task.objects.create(ticket=ticket, session=session, phase="coding")
+            task = Task.objects.create(ticket=ticket, session=session, phase="architectural_review")
 
         task.refresh_from_db()
         assert task.status == Task.Status.FAILED

--- a/tests/teatree_loop/test_dispatch.py
+++ b/tests/teatree_loop/test_dispatch.py
@@ -84,10 +84,46 @@ def test_reviewer_pr_approval_dismissed_dispatches_to_reviewer_agent() -> None:
     assert ("statusline", "action_needed") in kinds
 
 
-def test_pending_task_dispatches_to_orchestrator() -> None:
-    actions = dispatch([ScanSignal(kind="pending_task", summary="Task 1 pending")])
+def test_pending_task_dispatches_to_phase_agent() -> None:
+    """A ``pending_task`` routes to its PHASE's own agent, never a chaining orchestrator."""
+    actions = dispatch(
+        [
+            ScanSignal(
+                kind="pending_task",
+                summary="Task 1 (coding) pending",
+                payload={"task_id": 1, "phase": "coding", "ticket_id": 1, "ticket_role": "author"},
+            ),
+        ],
+    )
     assert actions[0].kind == "agent"
-    assert actions[0].zone == "t3:orchestrator"
+    assert actions[0].zone == "t3:coder"
+
+
+def test_pending_task_shipping_dispatches_to_shipper() -> None:
+    actions = dispatch(
+        [
+            ScanSignal(
+                kind="pending_task",
+                summary="Task 9 (shipping) pending",
+                payload={"task_id": 9, "phase": "shipping", "ticket_id": 3, "ticket_role": "author"},
+            ),
+        ],
+    )
+    assert [(a.kind, a.zone) for a in actions] == [("agent", "t3:shipper")]
+
+
+def test_pending_task_unregistered_phase_falls_through_to_statusline() -> None:
+    """A pending task with no registered phase agent surfaces for operator triage."""
+    actions = dispatch(
+        [
+            ScanSignal(
+                kind="pending_task",
+                summary="Task 2 (scoping) pending",
+                payload={"task_id": 2, "phase": "scoping", "ticket_id": 1, "ticket_role": "author"},
+            ),
+        ],
+    )
+    assert [(a.kind, a.zone) for a in actions] == [("statusline", "in_flight")]
 
 
 def test_notion_unrouted_routes_to_webhook() -> None:


### PR DESCRIPTION
## Problem

Per-phase FSM dispatch (built [#282](https://github.com/souliane/teatree/issues/282), [#367](https://github.com/souliane/teatree/issues/367), [#427](https://github.com/souliane/teatree/issues/427)) was **shadowed** by the `/loop` driver ([#559](https://github.com/souliane/teatree/issues/559), [#633](https://github.com/souliane/teatree/issues/633)): `_SUBAGENT_BY_PHASE` and `loop/dispatch.py` routed **every** author phase `Task` to a single `t3:orchestrator` that chained coder→tester→reviewer→shipper inline. That violates `BLUEPRINT.md` §5.2 / §17.8 invariant 10: *phase agents are invoked by the headless executor when a phase task is claimed; the orchestrator does synthesis and dispatch, not execution.*

## Fix — per-phase dispatch for the existing phases

- **Single source of truth**: `teatree.core.phases.SUBAGENT_BY_PHASE` + `subagent_for_phase((role, phase))`. `coding→t3:coder`, `testing→t3:tester`, `reviewing→t3:reviewer`, `shipping→t3:shipper`; the reviewer-role `reviewing` entry stays. The table is written so adding `("author", "planning"): "t3:planner"` later is a one-line addition.
- **`loop_dispatch` command**: `_SUBAGENT_BY_PHASE` now **is** the canonical map; the dispatchable `Q` matches every accepted phase spelling.
- **`loop.dispatch`**: `pending_task` is phase-aware via the canonical map, using the payload's `phase` + `ticket_role` (the `PendingTasksScanner` now emits `ticket_role`). No author phase falls through to the chaining orchestrator; an unregistered phase falls through to the statusline for operator triage.
- **`agents/orchestrator.md` §7**: auto-start no longer chains `@coder→@tester→@reviewer→@shipper` inline — it is kickoff-only; the per-phase loop dispatch carries the lifecycle forward.

## Double-dispatch / liveness (the latent defect)

The `post_save` auto-enqueue (`_auto_enqueue_headless_task`) and the `drain_headless_queue` safety-net now **skip loop-dispatched `(role, phase)` tasks**, so a `db_worker` draining the queue never double-runs a task the loop already dispatches. A task with **no** registered phase agent (a free-form/headless-only phase) still rides the `execute_headless_task` path — never zero dispatch. The loop tick self-dispatch (`loop-owner`/`loop-tick` lease) and the gate self-rescue are untouched.

## Conformance test (the missing anti-regression)

- `tests/teatree_core/test_phase_agent_conformance.py` — golden table: every author lifecycle phase routes to its own agent, **none** to the chaining orchestrator; mirrored on `_SUBAGENT_BY_PHASE` and on the `pending_task` signal. Adding a new phase is one row.
- `tests/teatree_core/test_single_dispatch_liveness.py` — each loop-dispatched phase task is dispatched exactly once (not auto-enqueued), and an unregistered-phase task is still auto-enqueued (never zero).

## RED to GREEN

On `origin/main`, `testing`/`reviewing`/`shipping` route to `t3:orchestrator` and author phase tasks are auto-enqueued, so the new assertions fail RED (confirmed). After the fix they pass. The liveness test was verified anti-vacuous by temporarily reverting the double-dispatch gate (RED) and restoring it (GREEN).

Full `tests/teatree_loop/` + `tests/teatree_core/` suite: 4474 passed, 12 skipped.