### PR TITLE
feat(statusline): show CPU load/usage indicator

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -246,7 +246,38 @@ if [ -n "$_df_out" ]; then
     fi
 fi
 
+# CPU load (macOS/Linux). A single non-delayed read of the 1-minute load
+# average — never a multi-second sampler like `top -l 2`, so the hook stays
+# fast. The load is normalized by core count and rendered as a percent so it
+# reads alongside the RAM/disk indicators under the same color thresholds;
+# above 100% means more runnable work than cores, which color_pct paints red.
+_cpu_segment=""
+_loadavg_raw=""
+if [ -n "${TEATREE_STATUSLINE_LOADAVG_FILE:-}" ]; then
+    [ -r "$TEATREE_STATUSLINE_LOADAVG_FILE" ] && _loadavg_raw=$(awk 'NR==1{print $1}' "$TEATREE_STATUSLINE_LOADAVG_FILE" 2>/dev/null)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    _loadavg_raw=$(sysctl -n vm.loadavg 2>/dev/null | awk '{gsub(/[{}]/,""); print $1}')
+elif [ -r /proc/loadavg ]; then
+    _loadavg_raw=$(awk 'NR==1{print $1}' /proc/loadavg 2>/dev/null)
+fi
+_ncpu="${TEATREE_STATUSLINE_NCPU:-}"
+if [ -z "$_ncpu" ]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        _ncpu=$(sysctl -n hw.ncpu 2>/dev/null)
+    else
+        _ncpu=$(nproc 2>/dev/null)
+    fi
+fi
+if [[ "$_loadavg_raw" =~ ^[0-9]+\.?[0-9]*$ ]] && [[ "$_ncpu" =~ ^[0-9]+$ ]] && [ "$_ncpu" -gt 0 ]; then
+    _cpu_pct=$(awk "BEGIN{printf \"%.0f\", $_loadavg_raw * 100 / $_ncpu}")
+    _cpu_segment="${_LBL}cpu=${_RST}$(color_pct "$_cpu_pct")"
+fi
+
 g_resource="$_ram_segment"
+if [ -n "$_cpu_segment" ]; then
+    [ -n "$g_resource" ] && g_resource="${g_resource}${isep}"
+    g_resource="${g_resource}${_cpu_segment}"
+fi
 if [ -n "$_disk_segment" ]; then
     [ -n "$g_resource" ] && g_resource="${g_resource}${isep}"
     g_resource="${g_resource}${_disk_segment}"

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -31,6 +31,7 @@ def _run(
     state_dir: Path,
     statusline_file: Path | None = None,
     registry_dir: Path | None = None,
+    cpu: tuple[Path, int] | None = None,
 ) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env["TEATREE_CLAUDE_STATUSLINE_STATE_DIR"] = str(state_dir)
@@ -38,6 +39,10 @@ def _run(
         env["TEATREE_STATUSLINE_FILE"] = str(statusline_file)
     if registry_dir is not None:
         env["T3_LOOP_REGISTRY_DIR"] = str(registry_dir)
+    if cpu is not None:
+        loadavg_file, ncpu = cpu
+        env["TEATREE_STATUSLINE_LOADAVG_FILE"] = str(loadavg_file)
+        env["TEATREE_STATUSLINE_NCPU"] = str(ncpu)
     return subprocess.run(
         [str(SCRIPT)],
         input=json.dumps(payload),
@@ -386,6 +391,86 @@ class TestFreshnessInlineRefresh:
         result = _run({"model": {"display_name": "Claude Opus"}}, state_dir=state_dir, statusline_file=sl)
         plain = _strip_ansi(result.stdout)
         assert "old=5" in plain
+
+
+class TestCpuSegment:
+    """CPU load indicator in the resource group, normalized by core count.
+
+    The 1-minute load average is read cheaply (a single non-delayed read) and
+    divided by the core count so it reads as a percentage comparable to the RAM
+    and disk indicators, colored by the same green/yellow/red thresholds.
+    """
+
+    def test_renders_cpu_segment_in_resource_group(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        loadavg = tmp_path / "loadavg"
+        loadavg.write_text("4.00 3.10 2.50 1/420 99\n", encoding="utf-8")
+
+        result = _run(
+            {"session_id": "s-cpu", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            cpu=(loadavg, 8),
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        # 4.00 / 8 cores = 50%.
+        assert "cpu=50%" in plain, plain
+        # The CPU indicator sits in the resource group alongside ram/disk.
+        assert plain.index("cpu=") > plain.index("ram="), plain
+
+    def test_cpu_segment_colors_red_when_overloaded(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        loadavg = tmp_path / "loadavg"
+        loadavg.write_text("16.00 12.00 9.00\n", encoding="utf-8")
+
+        result = _run(
+            {"session_id": "s-cpu-hot", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            cpu=(loadavg, 8),
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        # 16.00 / 8 = 200% → over the red threshold.
+        assert "cpu=200%" in plain, plain
+        assert "\033[1;31m" in result.stdout, "expected red SGR for an overloaded CPU"
+
+    def test_cpu_segment_omitted_when_source_unavailable(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        missing = tmp_path / "no-such-loadavg"
+
+        result = _run(
+            {"session_id": "s-no-cpu", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            cpu=(missing, 8),
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "cpu=" not in plain, plain
+        # The rest of the statusline still renders.
+        assert "model=Claude Opus" in plain, plain
+
+    def test_cpu_segment_omitted_when_loadavg_empty(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        loadavg = tmp_path / "loadavg"
+        loadavg.write_text("\n", encoding="utf-8")
+
+        result = _run(
+            {"session_id": "s-empty-cpu", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+            cpu=(loadavg, 8),
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "cpu=" not in plain, plain
+        assert "model=Claude Opus" in plain, plain
 
 
 class TestLoopOwnerBadge:


### PR DESCRIPTION
Adds a CPU indicator to the Claude Code statusline, alongside the existing RAM and disk indicators in the resource group.

## What

- New `cpu=` segment rendered in the resource group between `ram=` and `disk=`, sharing the same `color_pct` green/yellow/red thresholds so it reads consistently with the other resource indicators.
- The value is the 1-minute load average normalized by core count (`load / ncpu * 100`), expressed as a percent so it is directly comparable to the RAM/disk percentages. Above 100% means more runnable work than cores and paints red.

## Method (cheap, non-blocking)

The statusline renders on every prompt, so the read must be fast. The 1-minute load average is a single non-delayed read — never a multi-second sampler like `top -l 2`:

- macOS: `sysctl -n vm.loadavg` (first load field), cores via `sysctl -n hw.ncpu`
- Linux: `/proc/loadavg` (first field), cores via `nproc`

## Fail-safe

If the load source is unreadable, empty, or non-numeric, or the core count is invalid, the `cpu=` chip is omitted and the rest of the statusline still renders — matching the existing RAM/disk fail-safe behaviour.

## Tests

`tests/test_claude_statusline.py::TestCpuSegment` covers a stubbed load source (placement next to `ram=`, the 50% normalization, red coloring on overload) and the two omission paths (source missing, source empty). The stub is wired via `TEATREE_STATUSLINE_LOADAVG_FILE` / `TEATREE_STATUSLINE_NCPU` test-only env overrides; the production path uses the native reads above. Verified RED before the implementation and GREEN after.