### PR TITLE
fix(hooks): loop-registration gate must never hard-lock — exempt sub-agents, kill-switch, fail-open, circuit-breaker UX

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -382,7 +382,7 @@ _DENY_CIRCUIT_BREAKER_DEFAULT_THRESHOLD = 3
 # when looped. Conservative allow-list: a deny whose reason does not start with
 # one of these is treated as a SAFETY gate and NEVER auto-opens. The
 # skill-loading gate is the documented minimum.
-_DENY_CIRCUIT_UX_GATE_PREFIXES: tuple[str, ...] = ("SKILL LOADING ENFORCEMENT",)
+_DENY_CIRCUIT_UX_GATE_PREFIXES: tuple[str, ...] = ("SKILL LOADING ENFORCEMENT", "LOOP REGISTRATION")
 
 # Volatile substrings stripped from a deny reason before fingerprinting so "the
 # same denial" matches across retries even when the reason embeds a changing
@@ -959,14 +959,77 @@ def handle_enforce_loop_on_prompt(data: dict) -> None:
     )
 
 
+def _loop_registration_gate_enabled() -> bool:
+    """Whether the loop-registration PreToolUse gate is enabled (default True).
+
+    Best-effort read of ``[teatree] loop_registration_gate_enabled`` from
+    ``~/.teatree.toml`` (mirrors :func:`_deny_circuit_breaker_enabled`'s shape).
+    Fails OPEN to enabled on a missing/broken config; an explicit ``false`` is
+    the one-line durable kill-switch — never a code edit (NEVER-LOCKOUT).
+    """
+    import tomllib  # noqa: PLC0415
+
+    config_path = Path.home() / ".teatree.toml"
+    if not config_path.is_file():
+        return True
+    try:
+        with config_path.open("rb") as f:
+            config = tomllib.load(f)
+    except Exception:  # noqa: BLE001
+        return True
+    teatree = config.get("teatree") if isinstance(config, dict) else None
+    if not isinstance(teatree, dict):
+        return True
+    return teatree.get("loop_registration_gate_enabled") is not False
+
+
+_LOOP_REGISTRATION_EXEMPT_TOOLS = frozenset(
+    {"CronCreate", "CronDelete", "CronList", "ScheduleWakeup", "Skill", "ToolSearch"}
+)
+
+
+def _loop_registration_exempt(data: dict) -> bool:
+    """True when this call must NOT be nudge-blocked for loop registration.
+
+    Groups the side-effect-free NEVER-LOCKOUT exemptions so the handler stays a
+    single decision. A call is exempt when any of these holds:
+
+    - the tool is a cron-management / skill tool the agent uses to register the
+        loop (no point blocking the very tools that satisfy the gate);
+    - the call comes from a sub-agent (non-empty ``agent_id``) — a sub-agent has
+        no ``CronCreate`` tool, so a deny is an *unrecoverable* lockout that
+        killed every spawned coder/reviewer in the incident;
+    - the durable kill-switch ``[teatree] loop_registration_gate_enabled =
+        false`` is set (disable without a code edit);
+    - there is no ``session_id`` (no per-session marker to key on).
+    """
+    if data.get("tool_name", "") in _LOOP_REGISTRATION_EXEMPT_TOOLS:
+        return True
+    if _call_is_from_subagent(data):
+        return True
+    if not _loop_registration_gate_enabled():
+        return True
+    return not data.get("session_id")
+
+
 def handle_enforce_loop_registration(data: dict) -> bool:
-    """Block Bash/Edit/Write until the background loop cron is registered."""
-    tool_name = data.get("tool_name", "")
-    if tool_name in {"CronCreate", "CronDelete", "CronList", "ScheduleWakeup", "Skill", "ToolSearch"}:
+    """Nudge-block Bash/Edit/Write until the background loop cron is registered.
+
+    NEVER-LOCKOUT: this is the loop-bootstrap NUDGE, not a safety gate, so it
+    must never be able to wedge a session (it hard-locked the factory several
+    times — the worst recurring incident). The exemptions in
+    :func:`_loop_registration_exempt` (cron tools, sub-agents, kill-switch,
+    no-session) cover the first two layers; the deny itself adds two more:
+
+    - it routes through :func:`_fail_open_or_deny`, so the always-allowed
+        self-rescue commands and the master ``gate_fail_open`` switch relax it;
+    - the reason carries the ``LOOP REGISTRATION`` UX-gate prefix, so the
+        repeated-denial circuit breaker auto-relaxes it after K consecutive
+        denials instead of blocking forever.
+    """
+    if _loop_registration_exempt(data):
         return False
-    session_id = data.get("session_id", "")
-    if not session_id:
-        return False
+    session_id = data["session_id"]
     pending = _state_file(session_id, "loop-pending")
     if not pending.is_file():
         return False
@@ -976,11 +1039,12 @@ def handle_enforce_loop_registration(data: dict) -> bool:
     cadence = _loop_cadence_seconds()
     minutes = max(1, cadence // 60)
     reason = (
-        f"The teatree background loop is not registered yet. "
-        f"Please call CronCreate with "
-        f'cron="*/{minutes} * * * *", prompt="{_LOOP_PROMPT}", recurring=true.'
+        f"LOOP REGISTRATION: the teatree background loop is not registered yet. "
+        f"Register it with CronCreate "
+        f'(cron="*/{minutes} * * * *", prompt="{_LOOP_PROMPT}", recurring=true). '
+        f"To run without the loop, set [teatree] loop_registration_gate_enabled = false."
     )
-    return emit_pretooluse_deny(reason)
+    return _fail_open_or_deny(data, reason)
 
 
 # ── UserPromptSubmit: todo-freshness nudge ──────────────────────────

--- a/tests/test_gate_never_lockout_contract.py
+++ b/tests/test_gate_never_lockout_contract.py
@@ -1,0 +1,207 @@
+"""Class guard: no PreToolUse deny gate may hard-lock the factory.
+
+The loop-registration gate hard-locked the whole factory several times — it
+denied *every* Bash/Edit/Write (including sub-agents, who have no ``CronCreate``
+tool and so no way out) with no kill-switch and no self-rescue. Fixing that one
+gate is necessary but not sufficient: any *future* PreToolUse deny gate added on
+the broad ``Bash|Edit|Write`` matcher path could reintroduce the same lockout
+class. This meta-test is the once-and-for-all structural guard.
+
+The invariant (static, no runtime dependency): every PreToolUse handler that can
+emit a deny — i.e. that reaches :func:`hook_router.emit_pretooluse_deny`
+transitively through the module's own call graph — must EITHER route its deny
+through :func:`hook_router._fail_open_or_deny` (which gives it the always-allowed
+self-rescue commands like ``t3 <overlay> gate disable`` and the master
+``[teatree] gate_fail_open`` kill-switch for free) OR be named in the explicit,
+documented :data:`_NEVER_LOCKOUT_EXEMPT_DENY_HANDLERS` allowlist, each entry
+carrying a one-line rationale.
+
+A new broad-deny handler that does neither FAILS this test, forcing the author to
+either route it through ``_fail_open_or_deny`` or make a deliberate, reviewable
+allowlist entry — never a silent bare ``emit_pretooluse_deny`` lockout.
+
+The allowlist is closed and explicit (the enumerate-once discipline, not a
+per-recurrence patch): the public-egress leak path is the canonical hard-safety
+exemption that intentionally stays fail-closed (relaxing a public quote/banned
+leak is a privacy regression, not a lockout rescue — see the HARD INVARIANT note
+in ``hook_router``), and the narrow gates that deny only a single targeted
+command (not arbitrary Bash) are not lockout-prone. Handlers that carry their own
+never-lockout escapes (kill-switch + per-call opt-out + sub-agent exemption) but
+do not yet route through ``_fail_open_or_deny`` are allowlisted with a
+``# TODO(never-lockout)`` marker so they are tracked, not forgotten.
+"""
+
+import ast
+from pathlib import Path
+from typing import Final
+
+import hooks.scripts.hook_router as router
+
+_HOOK_ROUTER_SRC: Final[Path] = Path(router.__file__)
+
+_DENY_EMITTER: Final[str] = "emit_pretooluse_deny"
+_FAIL_OPEN_ROUTER: Final[str] = "_fail_open_or_deny"
+
+# Handlers that legitimately reach ``emit_pretooluse_deny`` without routing
+# through ``_fail_open_or_deny``. Each MUST carry a one-line rationale. Two
+# documented classes are exempt from the never-lockout routing requirement:
+#
+#   1. PUBLIC-EGRESS LEAK PATH (hard safety, intentionally fail-closed) — the
+#      quote / banned-terms / bare-reference scanners. Relaxing a public leak is
+#      a privacy regression, NOT a lockout rescue; they MUST NEVER read
+#      ``gate_fail_open`` (the HARD INVARIANT in hook_router). They carry their
+#      own per-call ``[quote-ok:]`` / ``[banned-ok:]`` / ``--quote-ok`` escapes.
+#   2. NARROW TARGETED-COMMAND gates — deny only a specific dangerous command
+#      (a bypass of the t3 CLI, a raw merge, a raw review-post), never arbitrary
+#      Bash, so they cannot wedge a session doing unrelated work.
+#
+# A handler with its own never-lockout escapes (kill-switch + per-call opt-out +
+# sub-agent exemption) that has not YET been migrated to ``_fail_open_or_deny``
+# is tracked here with a TODO rather than silently bare-denying.
+_NEVER_LOCKOUT_EXEMPT_DENY_HANDLERS: Final[dict[str, str]] = {
+    # Public-egress leak path — fail-closed by design (privacy, not lockout).
+    "handle_quote_scanner_pretool": "public-egress quote leak; fail-closed by design, [quote-ok:] escape",
+    "handle_banned_terms_pretool": "public-egress banned-term leak; fail-closed by design, [banned-ok:] escape",
+    "handle_bare_reference_pretool": "public-egress bare-reference leak; fail-closed by design",
+    "handle_block_ai_signature": "public-egress AI-signature leak on commit/publish; fail-closed by design",
+    "handle_dispatch_prompt_quote_scanner": (
+        "public-egress verbatim-quote leak in an Agent/Task dispatch prompt; fail-closed by design, [quote-ok:] escape"
+    ),
+    # Narrow targeted-command gates — deny one specific command, never arbitrary Bash.
+    "handle_block_direct_commands": "denies only specific t3-CLI-bypass commands (_deny_match denylist)",
+    "handle_block_out_of_band_merge": "denies only raw `gh pr merge` / `glab mr merge` on managed repos",
+    "handle_block_raw_review_post": "denies only raw review-post commands that bypass the FSM",
+    "handle_validate_mr_metadata": "denies only `glab mr create/update` with missing metadata; broken-env escape",
+    # Routing conversion, not a content/enforcement deny.
+    "handle_route_away_mode_question": "converts AskUserQuestion to DeferredQuestion (away-mode); not a Bash deny",
+    # Broad-deny gates carrying their OWN never-lockout escapes, pending migration.
+    "handle_enforce_plan_gate": (
+        "broad Edit/Write deny; opt-in per overlay (plan_gate=true), cleared by /plan or a source-read. "
+        "TODO(never-lockout): route through _fail_open_or_deny"
+    ),
+    "handle_enforce_orchestrator_boundary": (
+        "broad heavy-Bash deny; kill-switch orchestrator_bash_gate_enabled=false + [fg-ok:] + sub-agent exempt. "
+        "TODO(never-lockout): route through _fail_open_or_deny"
+    ),
+}
+
+
+def _module_tree() -> ast.Module:
+    return ast.parse(_HOOK_ROUTER_SRC.read_text(encoding="utf-8"))
+
+
+def _pretooluse_handler_names(tree: ast.Module) -> list[str]:
+    """The PreToolUse handler names, read from the live ``_HANDLERS`` registry literal."""
+    for node in ast.walk(tree):
+        target = None
+        value: ast.expr | None = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target, value = node.target.id, node.value
+        elif isinstance(node, ast.Assign):
+            names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            target, value = (names[0] if names else None), node.value
+        if target != "_HANDLERS" or not isinstance(value, ast.Dict):
+            continue
+        for key, val in zip(value.keys, value.values, strict=False):
+            if isinstance(key, ast.Constant) and key.value == "PreToolUse" and isinstance(val, ast.List):
+                return [e.id for e in val.elts if isinstance(e, ast.Name)]
+    msg = "_HANDLERS['PreToolUse'] not found in hook_router source"
+    raise AssertionError(msg)
+
+
+def _callee_names(func: ast.FunctionDef) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call):
+            callee = node.func
+            if isinstance(callee, ast.Name):
+                names.add(callee.id)
+            elif isinstance(callee, ast.Attribute):
+                names.add(callee.attr)
+    return names
+
+
+def _reachable_callees(start: str, funcs: dict[str, ast.FunctionDef]) -> set[str]:
+    """Transitive set of function names called from ``start`` within this module."""
+    seen: set[str] = set()
+    stack = [start]
+    while stack:
+        current = stack.pop()
+        if current in seen or current not in funcs:
+            continue
+        seen.add(current)
+        stack.extend(_callee_names(funcs[current]))
+    return seen
+
+
+def _module_functions(tree: ast.Module) -> dict[str, ast.FunctionDef]:
+    return {n.name: n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)}
+
+
+def test_every_pretooluse_deny_handler_is_never_lockout() -> None:
+    """A PreToolUse deny gate must fail-open-route OR be a documented exemption."""
+    tree = _module_tree()
+    funcs = _module_functions(tree)
+    handlers = _pretooluse_handler_names(tree)
+    assert handlers, "no PreToolUse handlers discovered — registry parse regression"
+
+    offenders: list[str] = []
+    for handler in handlers:
+        reachable = _reachable_callees(handler, funcs)
+        if _DENY_EMITTER not in reachable:
+            continue  # never emits a deny — not a deny gate
+        if _FAIL_OPEN_ROUTER in reachable:
+            continue  # routes through the fail-open / self-rescue chokepoint
+        if handler in _NEVER_LOCKOUT_EXEMPT_DENY_HANDLERS:
+            continue  # documented hard-safety / narrow exemption
+        offenders.append(handler)
+
+    assert not offenders, (
+        "PreToolUse deny handler(s) can hard-lock the factory: they reach "
+        f"emit_pretooluse_deny without routing through {_FAIL_OPEN_ROUTER} and "
+        "are not on the documented never-lockout allowlist.\n"
+        f"  offenders: {sorted(offenders)}\n"
+        f"Fix: route the deny through {_FAIL_OPEN_ROUTER}(data, reason) (gets the "
+        "self-rescue commands + gate_fail_open kill-switch), OR add a deliberate "
+        "entry to _NEVER_LOCKOUT_EXEMPT_DENY_HANDLERS with a one-line rationale."
+    )
+
+
+def test_loop_registration_gate_routes_through_fail_open() -> None:
+    """The incident gate itself must now fail-open-route (regression pin)."""
+    tree = _module_tree()
+    funcs = _module_functions(tree)
+    reachable = _reachable_callees("handle_enforce_loop_registration", funcs)
+    assert _DENY_EMITTER in reachable, "loop-registration gate must still be able to deny"
+    assert _FAIL_OPEN_ROUTER in reachable, (
+        "handle_enforce_loop_registration must route its deny through "
+        f"{_FAIL_OPEN_ROUTER} so the self-rescue + gate_fail_open escapes apply"
+    )
+    assert "handle_enforce_loop_registration" not in _NEVER_LOCKOUT_EXEMPT_DENY_HANDLERS, (
+        "the loop-registration gate is FIXED (fail-open-routed); it must not be on the exemption allowlist"
+    )
+
+
+def test_exemption_allowlist_has_no_stale_entries() -> None:
+    """Every allowlisted handler must still be a live PreToolUse deny gate.
+
+    Prevents the allowlist from collecting dead exemptions: an entry that is no
+    longer a PreToolUse deny handler (renamed, removed, or migrated to
+    fail-open-routing) must be pruned, not left as a silent broadening.
+    """
+    tree = _module_tree()
+    funcs = _module_functions(tree)
+    handlers = set(_pretooluse_handler_names(tree))
+
+    stale: list[str] = []
+    for handler in _NEVER_LOCKOUT_EXEMPT_DENY_HANDLERS:
+        if handler not in handlers:
+            stale.append(f"{handler} (not a registered PreToolUse handler)")
+            continue
+        reachable = _reachable_callees(handler, funcs)
+        if _DENY_EMITTER not in reachable:
+            stale.append(f"{handler} (no longer reaches {_DENY_EMITTER})")
+
+    assert not stale, (
+        f"stale never-lockout exemption(s) — prune them from _NEVER_LOCKOUT_EXEMPT_DENY_HANDLERS: {sorted(stale)}"
+    )

--- a/tests/test_hook_router_cadence_hook.py
+++ b/tests/test_hook_router_cadence_hook.py
@@ -11,6 +11,7 @@ loader pointed at a tmp ``.teatree.toml``; only the clock-dependent
 tick-meta mtime is staged on disk.
 """
 
+import json
 import time
 from pathlib import Path
 
@@ -96,6 +97,70 @@ def test_enforce_loop_registration_uses_toml_cron_minutes(
     blocked = handle_enforce_loop_registration({"session_id": "s-1036", "tool_name": "Bash"})
     assert blocked is True
     assert "*/30 * * * *" in capsys.readouterr().out
+
+
+def test_loop_registration_exempts_subagents(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # NEVER-LOCKOUT: a sub-agent (non-empty agent_id) has no CronCreate tool, so
+    # a deny here is an unrecoverable lockout — every spawned coder/reviewer was
+    # killed in the incident. The same call WITHOUT agent_id must still block the
+    # main session, proving the exemption is exactly what unblocks the sub-agent.
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setattr(router, "STATE_DIR", state)
+    (state / "sub.loop-pending").write_text("1", encoding="utf-8")
+
+    subagent = {"session_id": "sub", "tool_name": "Bash", "agent_id": "sub-1"}
+    assert handle_enforce_loop_registration(subagent) is False
+
+    main_session = {"session_id": "sub", "tool_name": "Bash"}
+    assert handle_enforce_loop_registration(main_session) is True
+
+
+def test_loop_registration_kill_switch_disables_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # NEVER-LOCKOUT: the durable [teatree] loop_registration_gate_enabled = false
+    # kill-switch disables the gate with no code edit, even with a pending marker.
+    # The autouse _isolate_env fixture already routes HOME (hence Path.home()) at
+    # tmp_path/home, so the config write lands where the gate reads it.
+    home = tmp_path / "home"
+    (home / ".teatree.toml").write_text("[teatree]\nloop_registration_gate_enabled = false\n", encoding="utf-8")
+
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setattr(router, "STATE_DIR", state)
+    (state / "off.loop-pending").write_text("1", encoding="utf-8")
+
+    assert router._loop_registration_gate_enabled() is False
+    blocked = handle_enforce_loop_registration({"session_id": "off", "tool_name": "Bash"})
+    assert blocked is False
+
+
+def test_loop_registration_gate_enabled_defaults_true_without_config(tmp_path: Path) -> None:
+    # Fails OPEN to enabled on a missing/unset config so the nudge keeps working
+    # by default; only an explicit false disables it. HOME is the conftest-
+    # isolated tmp_path/home, which has no .teatree.toml.
+    assert router._loop_registration_gate_enabled() is True
+
+    (tmp_path / "home" / ".teatree.toml").write_text("[teatree]\n", encoding="utf-8")
+    assert router._loop_registration_gate_enabled() is True
+
+
+def test_loop_registration_reason_is_ux_classified(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # NEVER-LOCKOUT backstop: the deny reason starts with the LOOP REGISTRATION
+    # UX-gate prefix, so the repeated-denial circuit breaker auto-relaxes it
+    # instead of blocking forever.
+    state = tmp_path / "state"
+    state.mkdir()
+    monkeypatch.setattr(router, "STATE_DIR", state)
+    (state / "ux.loop-pending").write_text("1", encoding="utf-8")
+
+    blocked = handle_enforce_loop_registration({"session_id": "ux", "tool_name": "Bash"})
+    assert blocked is True
+    payload = capsys.readouterr().out
+    reason = json.loads(payload.strip())["permissionDecisionReason"]
+    assert reason.startswith("LOOP REGISTRATION")
+    assert router._deny_is_ux_gate(reason) is True
 
 
 def test_loop_cadence_seconds_falls_back_to_env_when_teatree_unimportable(


### PR DESCRIPTION
## Incident

The loop-registration `PreToolUse` gate (`handle_enforce_loop_registration`) hard-locked the whole factory several times — the worst recurring incident. It denied **every** `Bash`/`Edit`/`Write` until the background-loop cron was registered, with no escape for the agents that could not register one:

- **Sub-agents** have no `CronCreate` tool in their harness, so denying them was an **unrecoverable** lockout that killed every spawned coder/reviewer.
- There was **no durable kill-switch** and **no self-rescue path** — a session could not even run `t3 <overlay> gate disable` to free itself.
- The bare `emit_pretooluse_deny` bypassed the master `gate_fail_open` switch and the repeated-denial circuit breaker, so the deny could repeat forever.

## Fix — four layered NEVER-LOCKOUT escapes

The gate is now a **nudge** that can never wedge a session:

1. **Sub-agents are exempt** (non-empty `agent_id`) — they cannot register a cron, so a deny only locks them out with zero benefit.
2. **Durable kill-switch** `[teatree] loop_registration_gate_enabled = false` disables it without a code edit (fails OPEN to enabled by default).
3. The deny **routes through `_fail_open_or_deny`**, so the always-allowed self-rescue commands and the master `gate_fail_open` switch relax it.
4. The reason carries the `LOOP REGISTRATION` UX-gate prefix (added to `_DENY_CIRCUIT_UX_GATE_PREFIXES`), so the repeated-denial circuit breaker auto-relaxes it after K consecutive denials instead of blocking forever.

## Class guard (once-and-for-all)

`tests/test_gate_never_lockout_contract.py` is a static AST contract over `hook_router.py`: every `PreToolUse` handler that can emit a deny must **either** route through `_fail_open_or_deny` **or** be on an explicit, documented `_NEVER_LOCKOUT_EXEMPT_DENY_HANDLERS` allowlist (public-egress hard-safety leak paths that intentionally stay fail-closed, and narrow targeted-command gates). A future broad-deny gate that bare-denies arbitrary `Bash`/`Edit`/`Write` fails the contract — the regression guard for the whole lockout class.

Two existing broad-deny handlers (`handle_enforce_plan_gate`, `handle_enforce_orchestrator_boundary`) carry their own never-lockout escapes (kill-switch + per-call opt-out + sub-agent exemption) but do not yet route through `_fail_open_or_deny`; they are allowlisted with a `TODO(never-lockout)` marker rather than fixed here, to keep this change focused.

## Tests (RED to GREEN)

New regression tests in `tests/test_hook_router_cadence_hook.py`, all observed RED on the pre-fix code:

- `test_loop_registration_exempts_subagents` — load-bearing: a `.loop-pending` marker + no `.crons` + `agent_id` set then not blocked; the same call **without** `agent_id` still blocks the main session (proving the exemption is exactly what unblocks the sub-agent).
- `test_loop_registration_kill_switch_disables_gate` — the `false` kill-switch disables the gate even with a pending marker.
- `test_loop_registration_gate_enabled_defaults_true_without_config` — fails OPEN to enabled on a missing/unset config.
- `test_loop_registration_reason_is_ux_classified` — the deny reason starts with `LOOP REGISTRATION` and `_deny_is_ux_gate(reason)` is `True`.

The pre-existing `test_enforce_loop_registration_uses_toml_cron_minutes` stays green (main-session block still fires).

## Verification

- Full suite: 10210 passed, 14 skipped, 8 xfailed.
- Coverage: 94.07% (gate 93.0%).
- `ruff check`, `ruff format --check`, `tach check`, `ty check`: all clean.
