### PR TITLE
fix(statusline): show every active loop/cron with its own next-tick countdown

### DIFF
--- a/src/teatree/core/management/commands/loop_tick.py
+++ b/src/teatree/core/management/commands/loop_tick.py
@@ -209,6 +209,16 @@ class Command(TyperCommand):
                 suffix=" — loop-tick lease held.",
             )
             return
+        from teatree.loop.statusline import set_mini_loop_schedules_reader  # noqa: PLC0415
+        from teatree.loops.schedule import mini_loop_schedules  # noqa: PLC0415
+
+        # Bridge the up-stack mini-loop next-fire reader into the statusline
+        # for the duration of this tick's render so the ``loop running · …``
+        # line shows every enabled cron with its own countdown (#1400). This
+        # command is the only place allowed to import :mod:`teatree.loops`
+        # into the statusline (tach graph); the reader is reset afterwards so
+        # the process-global seam never leaks past the tick.
+        set_mini_loop_schedules_reader(mini_loop_schedules)
         try:
             if overlay:
                 request = TickRequest(host=code_host_from_overlay(), messaging=messaging_from_overlay())
@@ -216,6 +226,7 @@ class Command(TyperCommand):
                 request = TickRequest(backends=iter_overlay_backends())
             report = run_tick(request, statusline_path=statusline_file, jobs_builder=_registry_jobs_builder)
         finally:
+            set_mini_loop_schedules_reader(None)
             LoopLease.objects.release("loop-tick", owner=owner)
 
         # #1107 Prong B — defense-in-depth safety net. We are PAST the

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -1,6 +1,7 @@
 import os
 import re
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from itertools import starmap
@@ -216,6 +217,51 @@ def _live_loop_leases() -> list[tuple[str, datetime | None]]:
     return [(row.name, row.acquired_at) for row in rows]
 
 
+# The per-mini-loop next-fire reader lives up-stack in
+# :func:`teatree.loops.schedule.mini_loop_schedules` because resolving it
+# needs the mini-loop registry and ``[loops]`` config, both of which live in
+# :mod:`teatree.loops` — and the tach module graph forbids
+# :mod:`teatree.loop` from importing :mod:`teatree.loops` (the dependency
+# points the other way). Mirroring the ``jobs_builder`` seam in
+# :func:`teatree.loop.tick.run_tick`, the live entry point (the ``loop_tick``
+# management command) injects the real reader via
+# :func:`set_mini_loop_schedules_reader`; absent injection (a quiet machine,
+# a unit test) the default reader returns ``[]`` and the mini-loop chunks are
+# simply omitted — never an import-direction violation, never a crash.
+type MiniLoopSchedulesReader = Callable[[], list[tuple[str, datetime | None]]]
+
+
+def _empty_mini_loop_schedules() -> list[tuple[str, datetime | None]]:
+    return []
+
+
+_mini_loop_schedules_reader: MiniLoopSchedulesReader = _empty_mini_loop_schedules
+
+
+def set_mini_loop_schedules_reader(reader: MiniLoopSchedulesReader | None) -> None:
+    """Install the up-stack mini-loop next-fire reader (``None`` resets to empty).
+
+    Called once by the ``loop_tick`` management command — the only place
+    allowed to bridge :mod:`teatree.loops` into the statusline without
+    violating the tach module graph.
+    """
+    global _mini_loop_schedules_reader  # noqa: PLW0603
+    _mini_loop_schedules_reader = reader or _empty_mini_loop_schedules
+
+
+def _mini_loop_schedules() -> list[tuple[str, datetime | None]]:
+    """Return ``(loop_name, next_fire_at)`` for every enabled mini-loop.
+
+    Delegates to the injected reader (:func:`set_mini_loop_schedules_reader`).
+    Each domain mini-loop (``dispatch``, ``tickets``, ``review``, ``ship``,
+    ``inbox``, ``resource_pressure``, …) is a cron with its own cadence: its
+    ``next_fire_at`` is the cadence-ledger ``last_fired_at`` plus the loop's
+    resolved cadence, or ``None`` when the loop has never fired (the renderer
+    surfaces that as ``due``).
+    """
+    return _mini_loop_schedules_reader()
+
+
 # Per-loop cadence resolution (#1400). Each named loop ticks on its own
 # schedule, so the next-tick countdown is ``acquired_at + cadence`` with the
 # loop's own cadence — not a single shared value. Unknown / future loops fall
@@ -276,31 +322,51 @@ def loop_owner_anchor(status: "OwnershipStatus", this_session: str) -> tuple[str
     return "action_needed", f"loop-owner=session {short8} (NOT this session)"
 
 
+def _live_lease_chunks() -> list[str]:
+    """Return one ``<short-name> <next-tick>`` chunk per live infra LoopLease.
+
+    The ``loop-owner`` lease is excluded: it is a session-ownership token,
+    not a work loop, and its countdown is meaningless in the shared zones
+    file (every terminal would show the same ``owner Nm`` chunk regardless
+    of which session is actually the owner). The per-session owner badge in
+    ``statusline.sh`` replaces that signal with a context-aware you ✓ /
+    owner·pid / unclaimed display. Fails open to ``[]`` on any read error.
+    """
+    try:
+        leases = _live_loop_leases()
+    except Exception:  # noqa: BLE001
+        return []
+    return [_loop_chunk(name, acquired_at) for name, acquired_at in leases if name != "loop-owner"]
+
+
 def live_loops_anchor() -> list[str]:
     """Return the single dedicated loop line for the dashboard (#1400, #130).
 
     Single line, prepended at the top of the statusline so the user's
-    "are the loops live, when do they tick, and am I blocked?" question is
-    answered with one glance:
+    "which loops are running, when does each tick next, and am I blocked?"
+    question is answered with one glance:
 
-        ``loop running · my-prs 11m · tickets 11m · waiting: 2 questions``
+        ``loop running · tick 11m · dispatch 2m · tickets 4m · news 18m · waiting: 2 questions``
 
     Shape:
 
     *   ``loop running`` — the leading state word. The line is only ever
-        rendered when at least one loop is live; when none is, the function
-        returns ``[]`` and the line is silenced entirely (no ``idle`` line
-        is shown). The foreign-hijack case is NOT shown here — it is RED and
-        routed to the action line by :func:`loop_owner_anchor`.
-    *   one ``<short-name> <next-tick>`` chunk per live
-        :class:`~teatree.core.models.LoopLease`. ``<short-name>`` is the
-        lease name with its ``loop-`` prefix stripped (``loop-my-prs`` →
-        ``my-prs``); ``<next-tick>`` is the RELATIVE whole-minute
-        countdown to that loop's next tick (``11m``), never a clock time.
-        Each loop has its own cadence (:func:`_cadence_for_loop`), so a
-        fast reactive loop and a slow self-improve loop show different
-        countdowns. The chunk is name-only when the lease has no recorded
-        ``acquired_at`` yet; ``due`` replaces the duration when overdue.
+        rendered when at least one loop or cron is active; when none is, the
+        function returns ``[]`` and the line is silenced entirely (no
+        ``idle`` line is shown). The foreign-hijack case is NOT shown here —
+        it is RED and routed to the action line by :func:`loop_owner_anchor`.
+    *   one ``<short-name> <next-tick>`` chunk per live infra
+        :class:`~teatree.core.models.LoopLease` (``tick``,
+        ``self-improve``, ``slack-answer``) — see :func:`_live_lease_chunks`.
+    *   one ``<name> <next-tick>`` chunk per ENABLED domain mini-loop /
+        cron (``dispatch``, ``tickets``, ``review``, ``ship``, ``inbox``,
+        ``resource_pressure``, …) — see :func:`mini_loops_anchor`. Every
+        chunk's ``<next-tick>`` is the RELATIVE whole-minute countdown to
+        THAT loop's own next fire (``2m``), derived live from its own
+        cadence and last-fired instant — not one shared constant — so a
+        fast 60s cron and a slow 1h cron show different countdowns and the
+        whole line counts down across renders. ``due`` replaces the
+        duration when a loop is overdue or has never fired.
     *   ``availability: <present|away> (<source>)`` — the currently-resolved
         availability, read live at render time (:func:`_availability_segment`)
         so the user always sees the present/away value and which layer decided
@@ -310,29 +376,15 @@ def live_loops_anchor() -> list[str]:
         the dashboard surfaces "the loop is held, you owe it an answer"
         without the user hunting for it.
 
-    Returns ``[]`` when no loop is live — silences the line entirely on
-    a quiet machine. Fails open: any DB / import error degrades to ``[]``
-    (or, for an individual segment, drops just that segment) so a broken
-    read can never blank the statusline.
+    Returns ``[]`` when neither an infra lease nor an enabled mini-loop is
+    active — silences the line entirely on a quiet machine. Fails open: any
+    DB / import error degrades to ``[]`` (or, for an individual segment,
+    drops just that segment) so a broken read can never blank the statusline.
     """
-    try:
-        leases = _live_loop_leases()
-    except Exception:  # noqa: BLE001
-        return []
-    if not leases:
+    chunks = [*_live_lease_chunks(), *mini_loops_anchor()]
+    if not chunks:
         return []
 
-    # Exclude the loop-owner lease: it is a session-ownership token, not a
-    # work loop, and its countdown is meaningless in the shared zones file
-    # (every terminal would show the same "owner Nm" chunk regardless of
-    # which session is actually the owner). The per-session owner badge in
-    # statusline.sh replaces that signal with a context-aware you ✓ /
-    # owner·pid / unclaimed display.
-    leases = [(name, acquired_at) for name, acquired_at in leases if name != "loop-owner"]
-    if not leases:
-        return []
-
-    chunks = list(starmap(_loop_chunk, leases))
     parts = ["loop running", *chunks]
     availability = _availability_segment()
     if availability:
@@ -411,15 +463,57 @@ def _next_tick_minutes(name: str, acquired_at: datetime | None) -> str:
         cadence = _cadence_for_loop(name)
     except Exception:  # noqa: BLE001
         return ""
+    return _relative_minutes(acquired_at + timedelta(seconds=cadence))
+
+
+def _relative_minutes(next_fire_at: datetime) -> str:
+    """Return the relative whole-minute countdown to *next_fire_at* (``11m`` / ``due``).
+
+    ``due`` once the instant is in the past — the loop fires on the
+    orchestrator's next tick. Always derived from the live clock at render
+    time so the value counts down across successive renders rather than
+    freezing on a cached string.
+    """
     from django.utils import timezone  # noqa: PLC0415
 
-    now = timezone.now()
-    next_tick_at = acquired_at + timedelta(seconds=cadence)
-    delta_seconds = int((next_tick_at - now).total_seconds())
+    delta_seconds = int((next_fire_at - timezone.now()).total_seconds())
     if delta_seconds <= 0:
         return "due"
     minutes = max(1, round(delta_seconds / _SECONDS_PER_MINUTE))
     return f"{minutes}m"
+
+
+def _mini_loop_chunk(name: str, next_fire_at: datetime | None) -> str:
+    """Render one ``<name> <next-tick>`` chunk for an enabled mini-loop.
+
+    ``due`` when the loop has never fired (no marker → ``next_fire_at`` is
+    ``None``) or is already overdue; otherwise the relative whole-minute
+    countdown derived live from ``next_fire_at``.
+    """
+    tick = "due" if next_fire_at is None else _relative_minutes(next_fire_at)
+    return f"{name} {tick}"
+
+
+def mini_loops_anchor() -> list[str]:
+    """Return one ``<name> <next-tick>`` chunk per enabled domain mini-loop.
+
+    Companion to :func:`live_loops_anchor`: where that renders the infra
+    leases (``loop-tick`` and friends), this renders every enabled domain
+    cron from :func:`teatree.loops.registry.iter_loops` — ``dispatch``,
+    ``tickets``, ``review``, ``ship``, ``inbox``, ``resource_pressure``, … —
+    each with its own next-tick countdown derived from the cadence ledger
+    (:func:`_mini_loop_schedules`), never a shared constant. The two anchors
+    compose into the single ``loop running · …`` line in
+    :func:`combined_loops_chunks`.
+
+    Returns ``[]`` when no mini-loop is enabled, or fails open to ``[]`` on
+    any DB / config read error so a broken ledger never blanks the line.
+    """
+    try:
+        schedules = _mini_loop_schedules()
+    except Exception:  # noqa: BLE001
+        return []
+    return list(starmap(_mini_loop_chunk, schedules))
 
 
 _SECONDS_PER_MINUTE = 60
@@ -473,6 +567,8 @@ __all__ = [
     "default_path",
     "live_loops_anchor",
     "loop_owner_anchor",
+    "mini_loops_anchor",
     "render",
+    "set_mini_loop_schedules_reader",
     "statusline_for_slack",
 ]

--- a/src/teatree/loops/schedule.py
+++ b/src/teatree/loops/schedule.py
@@ -1,0 +1,56 @@
+"""Per-mini-loop next-fire reader for the statusline loop line (#1400).
+
+The statusline's ``loop running · …`` line lists every active cron with its
+own next-tick countdown. The infra ``LoopLease`` rows are read in
+:mod:`teatree.loop.statusline` directly, but the domain mini-loops
+(``dispatch``, ``tickets``, ``review``, ``ship``, ``inbox``,
+``resource_pressure``, …) need the mini-loop registry and ``[loops]`` config
+— both of which live here in :mod:`teatree.loops`. The tach module graph
+forbids :mod:`teatree.loop` from importing :mod:`teatree.loops`, so this
+module owns the read and is wired into the statusline via the
+:func:`teatree.loop.statusline.set_mini_loop_schedules_reader` injection seam
+(installed by the ``loop_tick`` management command), mirroring the
+``jobs_builder`` seam :func:`teatree.loop.tick.run_tick` already uses.
+
+The next-fire instant for a loop is the same ``last_fired_at + cadence``
+boundary :func:`teatree.loops.gating.elapsed_and_enabled` gates on, so the
+statusline countdown stays in lockstep with the orchestrator: a loop reads
+``due`` exactly when the gate would fire it.
+"""
+
+import datetime as dt
+import operator
+
+from teatree.loops.cadence_ledger import MiniLoopMarker
+from teatree.loops.config import LoopsConfig
+from teatree.loops.registry import iter_loops
+
+
+def mini_loop_schedules() -> list[tuple[str, dt.datetime | None]]:
+    """Return ``(loop_name, next_fire_at)`` for every enabled mini-loop.
+
+    ``next_fire_at`` is the cadence-ledger ``last_fired_at`` plus the loop's
+    resolved cadence (:meth:`LoopsConfig.cadence_for`); ``None`` when the loop
+    has never fired (no marker row) — the statusline renders that as ``due``.
+    Disabled loops are omitted. Sorted by name for a deterministic render.
+    """
+    config = LoopsConfig.load()
+    schedules: list[tuple[str, dt.datetime | None]] = []
+    for loop in iter_loops():
+        if not config.is_enabled(loop):
+            continue
+        last_fired_at = _last_fired_at(loop.name)
+        if last_fired_at is None:
+            schedules.append((loop.name, None))
+            continue
+        schedules.append((loop.name, last_fired_at + dt.timedelta(seconds=config.cadence_for(loop))))
+    return sorted(schedules, key=operator.itemgetter(0))
+
+
+def _last_fired_at(name: str) -> dt.datetime | None:
+    """Return the cadence-ledger ``last_fired_at`` for *name*, or ``None``."""
+    marker = MiniLoopMarker.objects.filter(name=name).only("last_fired_at").first()
+    return marker.last_fired_at if marker is not None else None
+
+
+__all__ = ["mini_loop_schedules"]

--- a/tests/teatree_core/test_loop_tick_command.py
+++ b/tests/teatree_core/test_loop_tick_command.py
@@ -64,6 +64,21 @@ class TestLoopTickCommand(TestCase):
         assert "1 signal(s)" in output
         assert "statusline" in output
 
+    def test_installs_then_resets_mini_loop_schedules_reader(self) -> None:
+        from unittest.mock import call  # noqa: PLC0415
+
+        from teatree.loops.schedule import mini_loop_schedules  # noqa: PLC0415
+
+        report = _build_report(statusline_path=Path("/tmp/sl.txt"))
+        with (
+            patch("teatree.core.backend_factory.iter_overlay_backends", return_value=[]),
+            patch("teatree.loop.tick.run_tick", return_value=report),
+            patch("teatree.loop.statusline.set_mini_loop_schedules_reader") as seam,
+        ):
+            call_command("loop_tick", stdout=StringIO())
+        # Installed for the tick, then reset so the process-global never leaks.
+        assert seam.call_args_list == [call(mini_loop_schedules), call(None)]
+
     def test_text_output_includes_scanner_errors(self) -> None:
         report = _build_report(errors={"my_prs": "RuntimeError: x"})
         stdout = StringIO()

--- a/tests/teatree_loop/test_statusline_mini_loop_schedules.py
+++ b/tests/teatree_loop/test_statusline_mini_loop_schedules.py
@@ -1,0 +1,132 @@
+"""End-to-end mini-loop cadence read for the statusline loop line (#1400).
+
+Exercises :func:`teatree.loops.schedule.mini_loop_schedules` against a real
+:class:`~teatree.core.models.MiniLoopMarker` ledger, the real mini-loop
+registry, and a real :class:`~teatree.loops.config.LoopsConfig` — no stub of
+the DB+config read — so the statusline's next-fire numbers stay in lockstep
+with the orchestrator's own cadence gate
+(:func:`teatree.loops.gating.elapsed_and_enabled`). Also covers the
+injection seam that bridges this up-stack reader into the statusline without
+violating the tach module graph.
+"""
+
+import datetime as dt
+from contextlib import AbstractContextManager
+from pathlib import Path
+from unittest.mock import patch
+
+import django.test
+from django.utils import timezone
+
+from teatree.core.models.mini_loop_marker import MiniLoopMarker
+from teatree.loop.statusline import mini_loops_anchor, set_mini_loop_schedules_reader
+from teatree.loops.base import MiniLoop
+from teatree.loops.config import LoopsConfig
+from teatree.loops.schedule import mini_loop_schedules
+
+
+def _stub_loop(name: str, cadence: int) -> MiniLoop:
+    return MiniLoop(name=name, default_cadence_seconds=cadence, build_jobs=lambda **_: [])
+
+
+def _default_config() -> AbstractContextManager[object]:
+    """Patch ``LoopsConfig.load`` so the host's ``~/.teatree.toml`` never leaks in."""
+    return patch.object(LoopsConfig, "load", classmethod(lambda cls, path=None: cls()))
+
+
+class TestMiniLoopSchedulesFromLedger(django.test.TestCase):
+    """``mini_loop_schedules`` derives each next-fire from the ledger + cadence."""
+
+    def test_next_fire_is_last_fired_plus_cadence(self) -> None:
+        loops = (_stub_loop("dispatch", 300), _stub_loop("news", 3600))
+        fired_at = timezone.now() - dt.timedelta(seconds=60)
+        MiniLoopMarker.objects.mark_fired("dispatch", fired_at)
+        MiniLoopMarker.objects.mark_fired("news", fired_at)
+        with patch("teatree.loops.schedule.iter_loops", return_value=loops), _default_config():
+            schedules = dict(mini_loop_schedules())
+        assert schedules["dispatch"] == fired_at + dt.timedelta(seconds=300)
+        assert schedules["news"] == fired_at + dt.timedelta(seconds=3600)
+
+    def test_never_fired_loop_has_no_next_fire(self) -> None:
+        loops = (_stub_loop("inbox", 60),)
+        with patch("teatree.loops.schedule.iter_loops", return_value=loops), _default_config():
+            schedules = dict(mini_loop_schedules())
+        assert schedules["inbox"] is None
+
+    def test_disabled_loop_is_excluded(self) -> None:
+        loops = (_stub_loop("dispatch", 300), _stub_loop("review", 300))
+        with (
+            patch("teatree.loops.schedule.iter_loops", return_value=loops),
+            patch(
+                "teatree.loops.config.LoopsConfig.is_enabled",
+                side_effect=lambda loop: loop.name != "review",
+            ),
+        ):
+            names = [name for name, _ in mini_loop_schedules()]
+        assert names == ["dispatch"]
+        assert "review" not in names
+
+    def test_results_sorted_by_name(self) -> None:
+        loops = (_stub_loop("ship", 300), _stub_loop("audit", 300), _stub_loop("inbox", 60))
+        with patch("teatree.loops.schedule.iter_loops", return_value=loops), _default_config():
+            names = [name for name, _ in mini_loop_schedules()]
+        assert names == ["audit", "inbox", "ship"]
+
+
+class TestSeamRendersMiniLoopsOnStatusline(django.test.TestCase):
+    """The injected reader makes every enabled cron appear with its own countdown."""
+
+    def setUp(self) -> None:
+        self.addCleanup(set_mini_loop_schedules_reader, None)
+
+    def test_installed_reader_renders_relative_countdown(self) -> None:
+        loops = (_stub_loop("tickets", 300),)
+        MiniLoopMarker.objects.mark_fired("tickets", timezone.now() - dt.timedelta(seconds=120))
+        with patch("teatree.loops.schedule.iter_loops", return_value=loops), _default_config():
+            set_mini_loop_schedules_reader(mini_loop_schedules)
+            chunks = mini_loops_anchor()
+        # 120s elapsed of a 300s cadence → next fire in 180s → 3m.
+        assert chunks == ["tickets 3m"], chunks
+
+    def test_overdue_loop_reads_due(self) -> None:
+        loops = (_stub_loop("audit", 60),)
+        MiniLoopMarker.objects.mark_fired("audit", timezone.now() - dt.timedelta(hours=1))
+        with patch("teatree.loops.schedule.iter_loops", return_value=loops), _default_config():
+            set_mini_loop_schedules_reader(mini_loop_schedules)
+            chunks = mini_loops_anchor()
+        assert chunks == ["audit due"], chunks
+
+    def test_no_reader_installed_renders_nothing(self) -> None:
+        set_mini_loop_schedules_reader(None)
+        assert mini_loops_anchor() == []
+
+
+class TestMiniLoopCadenceMatchesGate(django.test.TestCase):
+    """The statusline next-fire stays in lockstep with the orchestrator gate.
+
+    The same ``last_fired_at + cadence`` boundary the gate uses to decide
+    ``should_fire`` is the boundary the statusline counts down to: when the
+    gate would fire (boundary in the past) the statusline reads ``due``.
+    """
+
+    def setUp(self) -> None:
+        self.addCleanup(set_mini_loop_schedules_reader, None)
+
+    def test_due_when_gate_would_fire(self) -> None:
+        from teatree.loops.gating import elapsed_and_enabled  # noqa: PLC0415
+
+        loop = _stub_loop("ship", 300)
+        now = timezone.now()
+        MiniLoopMarker.objects.mark_fired("ship", now - dt.timedelta(seconds=400))
+        decision = elapsed_and_enabled(LoopsConfig(), loop, now)
+        with patch("teatree.loops.schedule.iter_loops", return_value=(loop,)), _default_config():
+            set_mini_loop_schedules_reader(mini_loop_schedules)
+            chunks = mini_loops_anchor()
+        assert decision.should_fire is True
+        assert chunks == ["ship due"], chunks
+
+
+def test_config_loader_degrades_to_defaults_on_missing_file(tmp_path: Path) -> None:
+    """Sanity guard: the config loader degrades to defaults on a missing file."""
+    cfg = LoopsConfig.load(path=tmp_path / "absent.toml")
+    assert cfg.enabled is True

--- a/tests/teatree_loop/test_statusline_next_tick.py
+++ b/tests/teatree_loop/test_statusline_next_tick.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 from teatree.loop.dispatch import DispatchAction
 from teatree.loop.rendering import zones_for
-from teatree.loop.statusline import _format_duration, live_loops_anchor, render
+from teatree.loop.statusline import _format_duration, _mini_loop_chunk, live_loops_anchor, mini_loops_anchor, render
 
 
 def _active_ticket(num: str, state: str, *, url: str = "", overlay: str = "ov") -> DispatchAction:
@@ -111,12 +111,114 @@ class TestConsolidatedLoopAnchor:
         assert "loop:self-improve" not in lines[0], lines[0]
 
     def test_empty_when_no_loops_live(self) -> None:
-        with patch("teatree.loop.statusline._live_loop_leases", return_value=[]):
+        with (
+            patch("teatree.loop.statusline._live_loop_leases", return_value=[]),
+            patch("teatree.loop.statusline._mini_loop_schedules", return_value=[]),
+        ):
             assert live_loops_anchor() == []
 
     def test_fails_open_on_db_error(self) -> None:
-        with patch("teatree.loop.statusline._live_loop_leases", side_effect=RuntimeError("db down")):
+        with (
+            patch("teatree.loop.statusline._live_loop_leases", side_effect=RuntimeError("db down")),
+            patch("teatree.loop.statusline._mini_loop_schedules", return_value=[]),
+        ):
             assert live_loops_anchor() == []
+
+
+class TestMiniLoopsAnchor:
+    """Every enabled domain mini-loop renders its own next-tick countdown.
+
+    The line must show ALL active crons, not just the infra leases, and
+    each countdown must be DERIVED from that loop's own ``next_fire_at`` so
+    it counts down across renders rather than freezing on a constant.
+    """
+
+    def test_one_chunk_per_enabled_mini_loop_with_own_countdown(self) -> None:
+        now = datetime.now(UTC)
+        schedules = [
+            ("dispatch", now + timedelta(seconds=120)),
+            ("tickets", now + timedelta(seconds=240)),
+            ("news", now + timedelta(seconds=18 * 60)),
+        ]
+        with patch("teatree.loop.statusline._mini_loop_schedules", return_value=schedules):
+            chunks = mini_loops_anchor()
+        # Each loop carries its OWN countdown, not a shared value.
+        assert chunks == ["dispatch 2m", "tickets 4m", "news 18m"], chunks
+
+    def test_never_fired_loop_reads_due(self) -> None:
+        with patch("teatree.loop.statusline._mini_loop_schedules", return_value=[("inbox", None)]):
+            assert mini_loops_anchor() == ["inbox due"]
+
+    def test_overdue_loop_reads_due(self) -> None:
+        past = datetime.now(UTC) - timedelta(minutes=5)
+        with patch("teatree.loop.statusline._mini_loop_schedules", return_value=[("review", past)]):
+            assert mini_loops_anchor() == ["review due"]
+
+    def test_empty_when_no_mini_loops_enabled(self) -> None:
+        with patch("teatree.loop.statusline._mini_loop_schedules", return_value=[]):
+            assert mini_loops_anchor() == []
+
+    def test_fails_open_on_db_error(self) -> None:
+        with patch("teatree.loop.statusline._mini_loop_schedules", side_effect=RuntimeError("db down")):
+            assert mini_loops_anchor() == []
+
+    def test_chunk_countdown_is_relative_to_now_not_static(self) -> None:
+        # A nearer next-fire instant renders a SMALLER countdown than a
+        # farther one — proving the value is derived from (next_fire - now),
+        # not a cached constant.
+        now = datetime.now(UTC)
+        with patch(
+            "teatree.loop.statusline._mini_loop_schedules", return_value=[("ship", now + timedelta(seconds=600))]
+        ):
+            far = mini_loops_anchor()
+        with patch(
+            "teatree.loop.statusline._mini_loop_schedules", return_value=[("ship", now + timedelta(seconds=120))]
+        ):
+            near = mini_loops_anchor()
+        assert far == ["ship 10m"], far
+        assert near == ["ship 2m"], near
+
+
+class TestLoopLineComposesLeasesAndMiniLoops:
+    """The single ``loop running · …`` line lists infra leases AND mini-loops."""
+
+    def test_both_sources_appear_on_one_line(self) -> None:
+        acquired_at = datetime.now(UTC) - timedelta(seconds=120)
+        with (
+            patch("teatree.loop.statusline._live_loop_leases", return_value=[("loop-tick", acquired_at)]),
+            patch("teatree.loop.statusline._cadence_for_loop", return_value=720),
+            patch(
+                "teatree.loop.statusline._mini_loop_schedules",
+                return_value=[("dispatch", datetime.now(UTC) + timedelta(seconds=120))],
+            ),
+            patch("teatree.loop.statusline._availability_segment", return_value=""),
+        ):
+            lines = live_loops_anchor()
+        assert lines == ["loop running · tick 10m · dispatch 2m"], lines
+
+    def test_line_renders_for_mini_loops_even_with_no_live_lease(self) -> None:
+        # The user's complaint: crons were invisible when no infra lease was
+        # live. A mini-loop alone now surfaces the loop line.
+        with (
+            patch("teatree.loop.statusline._live_loop_leases", return_value=[]),
+            patch(
+                "teatree.loop.statusline._mini_loop_schedules",
+                return_value=[("resource_pressure", datetime.now(UTC) + timedelta(seconds=60))],
+            ),
+            patch("teatree.loop.statusline._availability_segment", return_value=""),
+        ):
+            lines = live_loops_anchor()
+        assert lines == ["loop running · resource_pressure 1m"], lines
+
+
+class TestMiniLoopChunk:
+    """The pure ``<name> <next-tick>`` formatter."""
+
+    def test_none_next_fire_is_due(self) -> None:
+        assert _mini_loop_chunk("audit", None) == "audit due"
+
+    def test_future_next_fire_is_relative_minutes(self) -> None:
+        assert _mini_loop_chunk("audit", datetime.now(UTC) + timedelta(seconds=300)) == "audit 5m"
 
 
 class TestFormatDuration:

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -1251,9 +1251,9 @@ class TestLoopOwnerAnchorWiring(django.test.TestCase):
                 run_tick(TickRequest(scanners=[]), statusline_path=sl)
             # loop-owner is excluded from the shared consolidated loop line;
             # its badge is rendered per-session in statusline.sh instead
-            # (you ✓ / owner·pid / unclaimed). With only the owner lease live
-            # and no actual work loop, the loop line is intentionally absent
-            # from the shared zones file.
+            # (you ✓ / owner·pid / unclaimed). With only the owner lease live,
+            # no work loop, and no mini-loop reader injected on this direct
+            # ``run_tick`` path, the loop line is intentionally absent.
             body = sl.read_text(encoding="utf-8")
             assert "loops live" not in body, body
             assert "loop running · " not in body, body


### PR DESCRIPTION
## Problem

The dashboard loop line (`loop running · …`) listed only the infra
`LoopLease` rows (`loop-tick`, `loop-self-improve`, `loop-slack-answer`).
The 13 domain mini-loop crons — `dispatch`, `tickets`, `review`, `ship`,
`inbox`, `resource_pressure`, `audit`, `followup`, `arch_review`,
`housekeeping`, `issue_implementer`, `news`, `dogfood` — were invisible, so
the line looked like a single static tick even though many crons run on
their own cadences.

## Change

Render one chunk per **enabled** mini-loop, each with its **own** next-tick
countdown derived from the cadence ledger:
`MiniLoopMarker.last_fired_at + LoopsConfig.cadence_for(loop)` — the same
`last_fired_at + cadence` boundary `elapsed_and_enabled` gates on. So a fast
60s cron and a slow 1h cron show different countdowns, the line counts down
across renders (never a hardcoded constant), and a loop reads `due` exactly
when the orchestrator gate would fire it.

Example (reader installed, three loops fired at staggered times):

```
loop running · dispatch 3m · inbox 1m · news 50m · availability: present (default)
```

With a single loop it still renders that one correctly; with none enabled
the line is silenced.

### Architecture

The next-fire reader needs the mini-loop registry and `[loops]` config,
both in `teatree.loops`. The tach graph forbids `teatree.loop` from
importing `teatree.loops`, so the reader lives in a new
`teatree.loops.schedule` module and is injected into
`teatree.loop.statusline` through a `set_mini_loop_schedules_reader` seam
wired (and reset) by the `loop_tick` management command — mirroring the
existing `jobs_builder` seam in `run_tick`. The process-global seam is reset
after each tick so it never leaks.

## Tests

- `tests/teatree_loop/test_statusline_mini_loop_schedules.py` (new): DB-backed
  next-fire derivation from a real `MiniLoopMarker` ledger + registry + config,
  the injection seam, and a lockstep check that the statusline reads `due`
  exactly when `elapsed_and_enabled` would fire.
- `tests/teatree_loop/test_statusline_next_tick.py`: per-loop chunk rendering,
  relative-countdown derivation, lease+mini-loop composition on one line, and
  the "renders for mini-loops even with no live lease" case.
- `tests/teatree_core/test_loop_tick_command.py`: the command installs then
  resets the reader.

Full suite green (10296 passed), coverage 94.09% (gate 93%). `prek` clean on
the changed files (`banned-terms --all-files` fails identically on `main` —
pre-existing, unrelated).

Core teatree logic — leaving for independent cold-review, not self-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)