### PR TITLE
feat(todos): session-scoped task list skill + fix TaskCreated abort on unresolvable skill

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -254,7 +254,7 @@ The resolved-order config chain (`~/.teatree.toml` global → `[overlays.<name>]
 
 ## 11. Skills & Plugin Architecture
 
-Skills live in `skills/*/` — one `SKILL.md` + optional `references/` per skill. When installed as a plugin, skills are namespaced under `t3:` (e.g. `/t3:code`). The lifecycle skill set is `code`, `debug`, `test`, `review`, `review-request`, `ship`, `ticket`, `workspace`, `followup`, `handover`, `next`, `retro`, `contribute`, `setup`, `platforms`, `rules`.
+Skills live in `skills/*/` — one `SKILL.md` + optional `references/` per skill. When installed as a plugin, skills are namespaced under `t3:` (e.g. `/t3:code`). The lifecycle skill set is `code`, `debug`, `test`, `review`, `review-request`, `ship`, `ticket`, `workspace`, `followup`, `handover`, `next`, `retro`, `contribute`, `setup`, `platforms`, `rules`. Read-only auxiliary skills sit alongside it: `checking` (what-did-I-miss) and `todos` (the current session's task list, via `tasks list --session`).
 
 Skills declare dependencies via YAML frontmatter `requires:` (transitive, topo-sorted) and optional `companions:` (best-effort, warn on miss). Third-party skill frameworks (e.g. superpowers) are absorbed into the `rules` skill rather than delegated, to avoid context duplication.
 

--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ graph LR
 | `teatree-plan` | Backlog prioritization with the GitHub Projects v2 board as single source of truth. Syncs repo issues to the board, walks the user through prioritization one question at a time, and reorders/updates board columns |
 | `test` | Testing, QA, and CI — running tests, analyzing failures, quality checks, CI interaction, test plans, and posting testing evidence |
 | `ticket` | Ticket intake and kickoff — from zero to ready-to-code |
+| `todos` | List the current session's tasks/todos — terse, grouped pending / in_progress / completed, with clickable refs |
 | `update` | WHEN to bring teatree core and registered overlays up to date with their default branch, and the safety guarantees of doing so |
 | `workspace` | Environment and workspace lifecycle — worktree creation, setup, DB provisioning, dev servers, cleanup |
 <!-- END SKILLS -->

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3812,7 +3812,8 @@ Usage: t3 teatree tasks [OPTIONS] COMMAND [ARGS]...
 │ complete              Mark a claimed task COMPLETED for work finished        │
 │                       out-of-band.                                           │
 │ create                Enqueue the next-phase task for a ticket.              │
-│ list                  List tasks with optional filters.                      │
+│ list                  List tasks with optional filters; --session scopes to  │
+│                       the current Claude session's todos.                    │
 │ start                 Claim and run the next interactive task in the current │
 │                       terminal.                                              │
 │ work-next-sdk         Claim and execute an headless task.                    │
@@ -3912,9 +3913,13 @@ Usage: t3 teatree tasks create [OPTIONS] TICKET
 Usage: t3 teatree tasks list [OPTIONS]
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --status                  TEXT  Filter by status                             │
-│ --execution-target        TEXT  Filter by execution target                   │
-│ --help                          Show this message and exit.                  │
+│ --status                              TEXT  Filter by status                 │
+│ --execution-target                    TEXT  Filter by execution target       │
+│ --session             --no-session          Scope to the current Claude      │
+│                                             session and group pending /      │
+│                                             claimed / done.                  │
+│                                             [default: no-session]            │
+│ --help                                      Show this message and exit.      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/generated/skills-catalogue.json
+++ b/docs/generated/skills-catalogue.json
@@ -113,6 +113,10 @@
       "summary": "Ticket intake and kickoff \u2014 from zero to ready-to-code"
     },
     {
+      "name": "todos",
+      "summary": "List the current session's tasks/todos \u2014 terse, grouped pending / in_progress / completed, with clickable refs"
+    },
+    {
       "name": "update",
       "summary": "WHEN to bring teatree core and registered overlays up to date with their default branch, and the safety guarantees of doing so"
     },

--- a/docs/generated/skills-catalogue.md
+++ b/docs/generated/skills-catalogue.md
@@ -32,5 +32,6 @@ Source: `skills/*/SKILL.md` frontmatter
 | `teatree-plan` | Backlog prioritization with the GitHub Projects v2 board as single source of truth. Syncs repo issues to the board, walks the user through prioritization one question at a time, and reorders/updates board columns |
 | `test` | Testing, QA, and CI — running tests, analyzing failures, quality checks, CI interaction, test plans, and posting testing evidence |
 | `ticket` | Ticket intake and kickoff — from zero to ready-to-code |
+| `todos` | List the current session's tasks/todos — terse, grouped pending / in_progress / completed, with clickable refs |
 | `update` | WHEN to bring teatree core and registered overlays up to date with their default branch, and the safety guarantees of doing so |
 | `workspace` | Environment and workspace lifecycle — worktree creation, setup, DB provisioning, dev servers, cleanup |

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -1612,17 +1612,17 @@ def handle_enforce_skill_loading_on_task_create(data: dict) -> bool:
     if not demanded:
         return False
 
+    # A demanded skill that does not resolve (a stale/renamed keyword→skill
+    # mapping in ``~/.teatree-skills.yml``, e.g. one pointing at a skill name
+    # the registry no longer carries) is dropped from the demand — never
+    # blocked on. The drop is SILENT: the harness treats ANY ``TaskCreated``
+    # hook stderr as an error and aborts task creation, so a fail-open skip
+    # must emit nothing. (#1488 originally warned here, which made every task
+    # whose text mapped to an unresolvable skill fail to be created.) The
+    # ``PreToolUse`` counterpart still warns — there stderr is the documented
+    # logging channel and does not abort the tool call.
     search_dirs = _skill_search_dirs()
     enforceable = [s for s in demanded if _skill_resolves(s, search_dirs)]
-    stale = [s for s in demanded if s not in enforceable]
-
-    config_path = os.environ.get("T3_SUPPLEMENTARY_SKILLS", str(Path.home() / ".teatree-skills.yml"))
-    for name in stale:
-        sys.stderr.write(
-            f"WARNING: skill-loading-on-task gate skipped unresolvable skill '{name}' "
-            f"(not found in any skill dir; check the keyword→skill mapping in {config_path}).\n"
-        )
-
     if not enforceable:
         return False
 

--- a/skills/todos/SKILL.md
+++ b/skills/todos/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: todos
+description: List the current session's tasks/todos — terse, grouped pending / in_progress / completed, with clickable refs. Use when the user says "task list", "todos", "what's on my list", "where is the task list", or "my tasks".
+compatibility: any
+triggers:
+  priority: 50
+  keywords:
+    - '\b(task list|todos?|what''?s on my list|where is the task list|my tasks)\b'
+requires:
+  - rules
+metadata:
+  version: 0.0.1
+  subagent_safe: false
+---
+
+# Todos — The Current Session's Task List
+
+A SHORT, read-only view of everything on the current Claude session's plate. `/t3:todos` never starts work, never transitions a ticket, never posts — it prints the session's tasks grouped by status and stops.
+
+## When to load
+
+Load `/t3:todos` when the user wants to see what is on their list — phrasings like "task list", "todos", "what's on my list", "where is the task list", "my tasks".
+
+## The single command
+
+```bash
+t3 <overlay> tasks list --session
+```
+
+`--session` scopes the list to the **current Claude session** (resolved from `CLAUDE_SESSION_ID`). It sources from the teatree `Task` model — the durable, DB-backed tasks teatree persists per session — and merges the harness `TodoWrite` list captured for the same session, so one view covers both.
+
+Drop `--session` for the unscoped queue across every ticket; add `--status` / `--execution-target` to filter either view.
+
+## Output contract
+
+- Groups in fixed order — `pending`, `in_progress`, `completed`. Each group header carries its count; an empty group is omitted.
+- A task line is `task #<id> (ticket #<n> <phase>): <reason>`; a harness todo line is `todo: <text>`.
+- `claimed` tasks show under `in_progress`; `failed` tasks show under `completed` (both terminal-or-active states the user reads as "done with for now").
+- No active Claude session → one line saying so (an anonymous caller has no session-scoped list).
+- Nothing on the list → one line: `No todos for this session.`
+- No preamble, no "Here is your list."
+
+Keep references clickable when surfacing them to the user — link a ticket/PR id, never paste a bare number.

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -126,7 +126,7 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("claim", "Claim the next available task."),
             ("complete", "Mark a claimed task COMPLETED for work finished out-of-band."),
             ("create", "Enqueue the next-phase task for a ticket."),
-            ("list", "List tasks with optional filters."),
+            ("list", "List tasks with optional filters; --session scopes to the current Claude session's todos."),
             ("start", "Claim and run the next interactive task in the current terminal."),
             ("work-next-sdk", "Claim and execute an headless task."),
             ("work-next-user-input", "Claim and execute a user input task."),

--- a/src/teatree/core/management/commands/tasks.py
+++ b/src/teatree/core/management/commands/tasks.py
@@ -174,28 +174,55 @@ class Command(TyperCommand):
     @command(name="list")
     def list_tasks(
         self,
+        *,
         status: Annotated[str | None, typer.Option(help="Filter by status")] = None,
         execution_target: Annotated[str | None, typer.Option(help="Filter by execution target")] = None,
+        session: Annotated[
+            bool,
+            typer.Option(help="Scope to the current Claude session and group pending / claimed / done."),
+        ] = False,
     ) -> list[TaskRow]:
         Task.objects.reap_stale_claims()
+        if session:
+            return self._list_session_todos(status=status, execution_target=execution_target)
         qs = Task.objects.all().order_by("pk")
         if status:
             qs = qs.filter(status=status)
         if execution_target:
             qs = qs.filter(execution_target=execution_target)
-        rows: list[TaskRow] = [
-            TaskRow(
-                task_id=task.pk,
-                ticket_id=task.ticket_id,
-                status=task.status,
-                execution_target=task.execution_target,
-                phase=task.phase,
-                execution_reason=task.execution_reason,
-                claimed_by=task.claimed_by,
-            )
-            for task in qs
-        ]
+        rows = [_task_row(task) for task in qs]
         _render_tasks_table(rows, stream=cast("IO[str]", self.stdout))
+        return rows
+
+    def _list_session_todos(
+        self,
+        *,
+        status: str | None,
+        execution_target: str | None,
+    ) -> list[TaskRow]:
+        """Print the current Claude session's tasks, grouped by status (#todos).
+
+        Sources from the teatree ``Task`` model scoped to the active Claude
+        session (``Session.agent_id``), then merges the harness ``TodoWrite``
+        list persisted to ``<session>.todos`` so a single view covers both the
+        durable lifecycle tasks and the in-flight harness todos.
+        """
+        from teatree.core.session_identity import current_session_id  # noqa: PLC0415
+
+        session_id = current_session_id()
+        qs = Task.objects.for_claude_session(session_id)
+        if status:
+            qs = qs.filter(status=status)
+        if execution_target:
+            qs = qs.filter(execution_target=execution_target)
+        rows = [_task_row(task) for task in qs]
+        harness_todos = _read_harness_todos(session_id)
+        _render_session_todos(
+            rows,
+            harness_todos=harness_todos,
+            session_id=session_id,
+            stream=cast("IO[str]", self.stdout),
+        )
         return rows
 
     @command()
@@ -282,6 +309,54 @@ _STATUS_STYLES: dict[str, str] = {
     "failed": "red",
 }
 
+# Status → display group for the session-scoped ``--session`` view. ``claimed``
+# is the loop's in-flight state, surfaced as "in_progress" to match the harness
+# task-list vocabulary; ``failed`` is grouped under "completed" (terminal).
+_TODO_GROUPS: list[tuple[str, tuple[str, ...]]] = [
+    ("pending", ("pending",)),
+    ("in_progress", ("claimed",)),
+    ("completed", ("completed", "failed")),
+]
+
+
+def _task_row(task: Task) -> TaskRow:
+    return TaskRow(
+        task_id=task.pk,
+        ticket_id=task.ticket_id,  # ty: ignore[unresolved-attribute]
+        status=task.status,
+        execution_target=task.execution_target,
+        phase=task.phase,
+        execution_reason=task.execution_reason,
+        claimed_by=task.claimed_by,
+    )
+
+
+def _read_harness_todos(session_id: str) -> list[tuple[str, str]]:
+    """Read the harness ``TodoWrite`` list for *session_id* as ``(status, text)``.
+
+    The hook persists one ``- [status] content`` line per todo to
+    ``<state_dir>/<session>.todos``. Best-effort: a missing file or unreadable
+    state dir yields an empty list (the task model rows still render).
+    """
+    import re  # noqa: PLC0415
+
+    from teatree.agents.handover import get_claude_statusline_state_dir  # noqa: PLC0415
+
+    if not session_id:
+        return []
+    path = get_claude_statusline_state_dir() / f"{session_id}.todos"
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    line_re = re.compile(r"^- \[(?P<status>[^\]]*)\]\s*(?P<text>.+)$")
+    todos: list[tuple[str, str]] = []
+    for line in raw.splitlines():
+        match = line_re.match(line.strip())
+        if match:
+            todos.append((match.group("status").strip() or "pending", match.group("text").strip()))
+    return todos
+
 
 def _render_tasks_table(rows: list[TaskRow], *, stream: IO[str] | None = None) -> None:
     console = Console(file=stream) if stream is not None else Console()
@@ -312,6 +387,54 @@ def _render_tasks_table(rows: list[TaskRow], *, stream: IO[str] | None = None) -
         )
 
     console.print(table)
+
+
+def _render_session_todos(
+    rows: list[TaskRow],
+    *,
+    harness_todos: list[tuple[str, str]],
+    session_id: str,
+    stream: IO[str] | None = None,
+) -> None:
+    """Render the current session's todos grouped pending / in_progress / completed."""
+    console = Console(file=stream) if stream is not None else Console()
+    if not session_id:
+        console.print("[dim]No active Claude session — cannot scope todos to a session.[/dim]")
+        return
+    if not rows and not harness_todos:
+        console.print("[dim]No todos for this session.[/dim]")
+        return
+
+    rows_by_status: dict[str, list[TaskRow]] = {}
+    for row in rows:
+        rows_by_status.setdefault(row["status"], []).append(row)
+
+    for group, statuses in _TODO_GROUPS:
+        group_rows = [row for status in statuses for row in rows_by_status.get(status, [])]
+        group_todos = [text for status, text in harness_todos if _todo_group(status) == group]
+        if not group_rows and not group_todos:
+            continue
+        style = _STATUS_STYLES.get(statuses[0], "")
+        console.print(f"[bold {style}]{group}[/] ({len(group_rows) + len(group_todos)})" if style else group)
+        for row in group_rows:
+            phase = f" {row['phase']}" if row["phase"] else ""
+            reason = row["execution_reason"] or "-"
+            console.print(f"  task #{row['task_id']} (ticket #{row['ticket_id']}{phase}): {reason}")
+        for text in group_todos:
+            console.print(f"  [dim]todo:[/] {text}")
+
+
+def _todo_group(status: str) -> str:
+    """Map a harness todo status to a display group key.
+
+    The harness already speaks ``pending`` / ``in_progress`` / ``completed``;
+    any unknown status falls under ``pending`` so it is never silently dropped.
+    """
+    normalized = status.strip().lower()
+    for group, _statuses in _TODO_GROUPS:
+        if normalized == group:
+            return group
+    return "completed" if normalized in {"done", "complete"} else "pending"
 
 
 def _build_claude_command(task: Task) -> list[str]:

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -140,6 +140,18 @@ class ReplyDispatchQuerySet(models.QuerySet):
 
 
 class TaskQuerySet(models.QuerySet):
+    def for_claude_session(self, claude_session_id: str) -> models.QuerySet:
+        """Tasks whose session is the given Claude session, newest first.
+
+        Scopes the task list to the work persisted under one Claude session:
+        ``Session.agent_id`` holds the Claude session UUID (set by Claude Code),
+        so the join is ``task.session.agent_id == claude_session_id``. An empty
+        id matches nothing — an anonymous caller has no session-scoped list.
+        """
+        if not claude_session_id:
+            return self.none()
+        return self.filter(session__agent_id=claude_session_id).order_by("-pk")
+
     def completed_in_phase(self, phase: str) -> models.QuerySet:
         """Completed tasks whose phase normalizes to ``phase`` (#757).
 

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -229,6 +229,110 @@ class TestTaskCommands(TestCase):
         assert call_command("tasks", "work-next-sdk", claimed_by="worker-1") is None
 
 
+class TestTasksListSession(TestCase):
+    """``t3 <overlay> tasks list --session`` scopes to the current Claude session."""
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_scopes_rows_to_the_active_claude_session(self) -> None:
+        with patch.dict("os.environ", {"CLAUDE_SESSION_ID": "claude-abc", "T3_LOOP_SESSION_ID": ""}):
+            ticket = Ticket.objects.create(overlay="test")
+            mine = Session.objects.create(ticket=ticket, overlay="test", agent_id="claude-abc")
+            other = Session.objects.create(ticket=ticket, overlay="test", agent_id="claude-xyz")
+            my_task = Task.objects.create(ticket=ticket, session=mine, phase="coding")
+            Task.objects.create(ticket=ticket, session=other, phase="coding")
+
+            rows = cast("list[dict]", call_command("tasks", "list", "--session"))
+
+        assert [row["task_id"] for row in rows] == [my_task.pk]
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_anonymous_session_lists_nothing(self) -> None:
+        with patch.dict("os.environ", {"CLAUDE_SESSION_ID": "", "T3_LOOP_SESSION_ID": "", "XDG_DATA_HOME": ""}):
+            ticket = Ticket.objects.create(overlay="test")
+            session = Session.objects.create(ticket=ticket, overlay="test", agent_id="claude-abc")
+            Task.objects.create(ticket=ticket, session=session, phase="coding")
+
+            rows = cast("list[dict]", call_command("tasks", "list", "--session"))
+
+        assert rows == []
+
+
+class TestSessionTodoRendering(TestCase):
+    """The session-scoped renderer groups task rows + harness todos."""
+
+    @staticmethod
+    def _row(
+        task_id: int, *, status: str, ticket_id: int = 1, phase: str = "coding", reason: str = "do it"
+    ) -> tasks_cmd.TaskRow:
+        return tasks_cmd.TaskRow(
+            task_id=task_id,
+            ticket_id=ticket_id,
+            status=status,
+            execution_target="headless",
+            phase=phase,
+            execution_reason=reason,
+            claimed_by="",
+        )
+
+    def test_groups_tasks_and_merges_harness_todos(self) -> None:
+        out = io.StringIO()
+        rows = [
+            self._row(1, status="pending", reason="write the gate"),
+            self._row(2, status="claimed", reason="run the suite"),
+            self._row(3, status="completed", reason="read the model"),
+        ]
+        tasks_cmd._render_session_todos(
+            rows,
+            harness_todos=[("pending", "draft the helper"), ("completed", "open the PR")],
+            session_id="claude-abc",
+            stream=out,
+        )
+        printed = out.getvalue()
+        assert "pending" in printed
+        assert "in_progress" in printed
+        assert "completed" in printed
+        assert "write the gate" in printed
+        assert "run the suite" in printed
+        assert "draft the helper" in printed
+        assert "open the PR" in printed
+
+    def test_no_active_session_is_explicit(self) -> None:
+        out = io.StringIO()
+        tasks_cmd._render_session_todos([], harness_todos=[], session_id="", stream=out)
+        assert "No active Claude session" in out.getvalue()
+
+    def test_empty_session_says_no_todos(self) -> None:
+        out = io.StringIO()
+        tasks_cmd._render_session_todos([], harness_todos=[], session_id="claude-abc", stream=out)
+        assert "No todos for this session" in out.getvalue()
+
+
+class TestReadHarnessTodos(TestCase):
+    """The harness ``TodoWrite`` state file is parsed into ``(status, text)``."""
+
+    def test_parses_status_lines(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as state_dir,
+            override_settings(TEATREE_CLAUDE_STATUSLINE_STATE_DIR=state_dir),
+        ):
+            (Path(state_dir) / "claude-abc.todos").write_text(
+                "- [pending] draft the helper\n- [in_progress] wire the CLI\n",
+                encoding="utf-8",
+            )
+            todos = tasks_cmd._read_harness_todos("claude-abc")
+        assert todos == [("pending", "draft the helper"), ("in_progress", "wire the CLI")]
+
+    def test_missing_file_is_empty(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as state_dir,
+            override_settings(TEATREE_CLAUDE_STATUSLINE_STATE_DIR=state_dir),
+        ):
+            assert tasks_cmd._read_harness_todos("claude-abc") == []
+
+    def test_empty_session_id_is_empty(self) -> None:
+        assert tasks_cmd._read_harness_todos("") == []
+
+
 class DbOverlay(CommandOverlay):
     """CommandOverlay with a DB import strategy that always fails."""
 

--- a/tests/teatree_core/test_managers.py
+++ b/tests/teatree_core/test_managers.py
@@ -60,6 +60,23 @@ class TestSessionQuerySet(TestCase):
 
 
 class TestTaskQuerySet(TestCase):
+    def test_for_claude_session_scopes_to_matching_agent_id_newest_first(self) -> None:
+        ticket = Ticket.objects.create()
+        mine = Session.objects.create(ticket=ticket, agent_id="claude-abc")
+        other = Session.objects.create(ticket=ticket, agent_id="claude-xyz")
+        first = Task.objects.create(ticket=ticket, session=mine, phase="coding")
+        second = Task.objects.create(ticket=ticket, session=mine, phase="testing")
+        Task.objects.create(ticket=ticket, session=other, phase="coding")
+
+        assert list(Task.objects.for_claude_session("claude-abc")) == [second, first]
+
+    def test_for_claude_session_empty_id_matches_nothing(self) -> None:
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket, agent_id="claude-abc")
+        Task.objects.create(ticket=ticket, session=session)
+
+        assert list(Task.objects.for_claude_session("")) == []
+
     def test_claimable_queries_respect_target_status_and_leases(self) -> None:
         ticket = Ticket.objects.create()
         session = Session.objects.create(ticket=ticket, agent_id="agent-1")

--- a/tests/test_hook_router_skill_loading_on_task.py
+++ b/tests/test_hook_router_skill_loading_on_task.py
@@ -26,6 +26,7 @@ real fixture skills seeded under a temp ``T3_SKILL_SEARCH_DIRS`` whose
 companion closure resolves through the production resolver.
 """
 
+import io
 import json
 from collections.abc import Iterator
 from io import StringIO
@@ -127,6 +128,20 @@ def _run(data: dict) -> tuple[bool, dict | None]:
     if raw:
         payload = json.loads(raw)
     return blocked, payload
+
+
+def _run_capturing_stderr(data: dict) -> tuple[bool, str]:
+    """Invoke the gate, returning ``(blocked, stderr_text)``.
+
+    The harness treats any ``TaskCreated`` hook stderr as an error and aborts
+    task creation, so a fail-open skip of an unresolvable skill must stay
+    silent on stderr.
+    """
+    out = StringIO()
+    err = io.StringIO()
+    with patch("sys.stdout", out), patch("sys.stderr", err):
+        blocked = handle_enforce_skill_loading_on_task_create(data)
+    return blocked, err.getvalue()
 
 
 class TestBlocksUnloadedReviewFanout:
@@ -244,6 +259,24 @@ class TestFailOpenOnStaleName:
         blocked, payload = _run(_task(description="do some neutral work"))
         assert blocked is False
         assert payload is None
+
+    def test_stale_pending_name_is_silent_on_stderr(self, gate: Path) -> None:
+        # The harness aborts task creation on ANY TaskCreated-hook stderr, so a
+        # fail-open skip of an unresolvable skill (e.g. a keyword→skill map that
+        # points at a non-existent skill) must emit nothing on stderr — the task
+        # still gets created.
+        _write_pending("sess-task", ["ac-exporting-webhook-mapping"])
+        blocked, stderr = _run_capturing_stderr(_task(description="do some neutral work"))
+        assert blocked is False
+        assert stderr == ""
+
+    def test_unresolvable_alongside_resolvable_blocks_silently_on_the_stale_one(self, gate: Path) -> None:
+        # A resolvable demand still blocks, but the unresolvable sibling must not
+        # leak onto stderr (which would abort the very task we are blocking).
+        _write_pending("sess-task", ["review", "ac-exporting-webhook-mapping"])
+        blocked, stderr = _run_capturing_stderr(_task(description="do some neutral work"))
+        assert blocked is True
+        assert stderr == ""
 
 
 class TestKillSwitch:


### PR DESCRIPTION
## What

Adds a `/t3:todos` skill and fixes a `TaskCreated`-hook bug that aborted task creation.

### 1. `/t3:todos` skill — the current session's task list

- New skill `skills/todos/SKILL.md`, namespaced `t3:todos`. Trigger phrases: `task list`, `todos`, `what's on my list`, `where is the task list`, `my tasks`.
- Read-only: prints the current Claude session's tasks grouped pending / in_progress / completed, then stops.

### 2. CLI backing — `t3 <overlay> tasks list --session`

- Extends the existing `tasks list` with a `--session` flag (rather than a new command).
- Scopes the teatree `Task` model to the active Claude session via a new `TaskQuerySet.for_claude_session(session_id)` — matches `Session.agent_id == CLAUDE_SESSION_ID` (resolved through the existing `current_session_id()`).
- Merges the harness `TodoWrite` list persisted to `<session>.todos` (read via the existing `get_claude_statusline_state_dir`), so one view covers both durable lifecycle tasks and in-flight harness todos.

### 3. Fix: `TaskCreated` gate aborting task creation on an unresolvable skill

Root cause: `handle_enforce_skill_loading_on_task_create` already dropped an unresolvable demanded skill from the gate (fail-open), but it wrote a `WARNING:` line to **stderr** first. The harness treats any `TaskCreated`-hook stderr as an error and aborts task creation — so any task whose text mapped to a stale `~/.teatree-skills.yml` keyword→skill entry (e.g. a mapping pointing at a skill the registry no longer carries) failed to be created.

Fix: the stale-skill skip is now **silent** on the `TaskCreated` path (the `PreToolUse` counterpart still warns — there stderr is the documented logging channel and does not abort). End-to-end: a task mapping to an unresolvable skill now creates with exit 0 and empty stderr.

## Tests

- `tests/test_hook_router_skill_loading_on_task.py` — observed RED first: a stale-skill task now emits nothing on stderr (the regression test the issue asked for), plus an unresolvable-alongside-resolvable case.
- `tests/teatree_core/test_managers.py` — `for_claude_session` scoping (newest-first; empty id matches nothing).
- `tests/teatree_core/test_management_commands.py` — `--session` scoping, harness-todo merge, grouped rendering, anonymous-session and empty-session cases.
- Full prek commit gate green; `tasks list --session` and the hook fix dogfooded against the real CLI/hook.

## Notes

- The Docker pre-push matrix (`pytest-docker`) was skipped (NO DOCKER constraint). Its single failure is a pre-existing, unrelated docker-env issue (`No teatree overlays found` → DoD E2E gate fails closed on `test_phase_dispatch`); that test is untouched by this diff and passes in the real non-docker env.
- BLUEPRINT size budget was already over on `main` (82,196 B > 82,000); this adds a one-line auxiliary-skills note required by the doc-update gate (committed with the sanctioned `BLUEPRINT_SIZE_OVERRIDE`).