### PR TITLE
fix(hooks): extend private-repo banned-terms carve-out to gh/glab edit verbs

### DIFF
--- a/src/teatree/hooks/publish_surface.py
+++ b/src/teatree/hooks/publish_surface.py
@@ -99,24 +99,33 @@ _RAW_REST_WORD_COUNT: Final[int] = 2
 _GIT_GLOBAL_DIR_FLAGS: Final[frozenset[str]] = frozenset({"-C", "--git-dir", "--work-tree"})
 
 # Eligible ``gh`` sub-command pairs: (tool, verb) where "tool" is the
-# second word (pr/issue) and "verb" is the third word (create/comment).
+# second word (pr/issue) and "verb" is the third word. ``edit`` rewrites an
+# existing PR/issue body/title on the resolved target repo -- the same
+# single-repo, structured surface as ``create``/``comment``, so it is eligible
+# for the private-repo carve-out (#1594 covered only create/comment).
 # ``gh api`` is NOT in this set -- raw REST can target arbitrary surfaces.
 _GH_ELIGIBLE_VERBS: Final[frozenset[tuple[str, str]]] = frozenset(
     {
         ("pr", "create"),
         ("pr", "comment"),
+        ("pr", "edit"),
         ("issue", "create"),
         ("issue", "comment"),
+        ("issue", "edit"),
     }
 )
 
-# Eligible ``glab`` sub-command pairs. ``glab api`` is NOT in this set.
+# Eligible ``glab`` sub-command pairs. ``update`` is the glab equivalent of
+# ``gh ... edit`` (rewrites an existing MR/issue description on the resolved
+# target). ``glab api`` is NOT in this set.
 _GLAB_ELIGIBLE_VERBS: Final[frozenset[tuple[str, str]]] = frozenset(
     {
         ("mr", "create"),
         ("mr", "note"),
+        ("mr", "update"),
         ("issue", "create"),
         ("issue", "note"),
+        ("issue", "update"),
     }
 )
 
@@ -164,9 +173,9 @@ def is_git_commit_command(command: str) -> bool:
 def _segment_is_posting_verb(words: list[str]) -> bool:
     """Return True iff ``words`` is an eligible ``gh``/``glab`` posting verb.
 
-    Eligible: ``gh pr create``, ``gh pr comment``, ``gh issue create``,
-    ``gh issue comment``, ``glab mr create``, ``glab mr note``,
-    ``glab issue create``, ``glab issue note``.
+    Eligible: the ``create``/``comment``/``edit`` ``gh`` and
+    ``create``/``note``/``update`` ``glab`` verbs on ``pr``/``mr``/``issue``
+    (see :data:`_GH_ELIGIBLE_VERBS` / :data:`_GLAB_ELIGIBLE_VERBS`).
     """
     if len(words) < _POSTING_WORD_COUNT:
         return False
@@ -191,13 +200,13 @@ def _segment_is_raw_rest(words: list[str]) -> bool:
 def is_gh_glab_posting_command(command: str) -> bool:
     """Return True iff ANY command segment is an eligible ``gh``/``glab`` posting verb.
 
-    Eligible: ``gh pr create``, ``gh pr comment``, ``gh issue create``,
-    ``gh issue comment``, ``glab mr create``, ``glab mr note``,
-    ``glab issue create``, ``glab issue note``.
+    Eligible: the ``create``/``comment``/``edit`` ``gh`` and
+    ``create``/``note``/``update`` ``glab`` verbs on ``pr``/``mr``/``issue``
+    (see :data:`_GH_ELIGIBLE_VERBS` / :data:`_GLAB_ELIGIBLE_VERBS`).
 
     NOT eligible: ``gh api`` / ``glab api`` (raw REST -- can target any
     surface), ``gh repo view``, ``glab mr list``, or anything that is not
-    a structured create-or-comment verb against a single repo target.
+    a structured create/comment/edit verb against a single repo target.
 
     Every segment is inspected (not just the first), so a posting verb
     behind a leading ``cd ... &&`` / env-assignment prefix is still seen.

--- a/tests/test_publish_surface.py
+++ b/tests/test_publish_surface.py
@@ -276,6 +276,18 @@ class TestIsGhGlabPostingCommand:
     def test_glab_mr_note_is_eligible(self) -> None:
         assert publish_surface.is_gh_glab_posting_command("glab mr note 1 --message x") is True
 
+    def test_gh_pr_edit_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("gh pr edit 1 --body x") is True
+
+    def test_gh_issue_edit_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("gh issue edit 1 --body x") is True
+
+    def test_glab_mr_update_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("glab mr update 1 --description x") is True
+
+    def test_glab_issue_update_is_eligible(self) -> None:
+        assert publish_surface.is_gh_glab_posting_command("glab issue update 1 --description x") is True
+
     def test_gh_api_is_not_eligible(self) -> None:
         assert publish_surface.is_gh_glab_posting_command("gh api repos/owner/repo/issues") is False
 


### PR DESCRIPTION
## Problem

The banned-terms / quote private-repo carve-out ([#1594](https://github.com/souliane/teatree/issues/1594), reworked to an allowlist in [#1657](https://github.com/souliane/teatree/issues/1657)) downgraded a hit from hard-block to warn only for the structured `gh`/`glab` **create** and **comment**/**note** verbs. The **edit** verbs were missing from the eligible-verb allowlists, so editing a private-repo MR/PR/issue body that legitimately carries the repo's own org/domain terms (e.g. an org URL) was hard-blocked — forcing an `--allow-banned-term` override on a private surface, exactly the friction the carve-out exists to remove.

## Fix

- `_GH_ELIGIBLE_VERBS` gains `("pr","edit")`, `("issue","edit")`
- `_GLAB_ELIGIBLE_VERBS` gains `("mr","update")`, `("issue","update")`

`gh ... edit` / `glab ... update` rewrite an existing description on the **same single-repo, structured target** as create/comment. The pure-private-post proof (`command_is_pure_private_gh_glab_post`) is untouched, so the fail-closed-on-unresolvable property, the public-target ineligibility, and the `gh api` / `glab api` raw-REST ineligibility all hold — a public edit target still hard-blocks.

## Tests

`TestIsGhGlabPostingCommand` gains four edit/update eligibility cases (verified RED against current main, GREEN after). The raw-REST / public-target / `gh repo view` / `git commit` ineligibility cases stay green — the symmetric over-block (do-not-leak) dimension is intact. Full `tests/test_publish_surface.py`, `test_public_leak_gate_stays_fail_closed.py`, `test_banned_terms_hook.py`, `test_hook_router_gate_bypass_class.py` green (352 passed). `prek run` clean. Docker test matrix passed on push.