### PR TITLE
chore(ci): fail on non-linear migration graph (makemigrations --check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
       - uses: j178/prek-action@v2
         env:
           SKIP: pytest,uv-audit,cyclonedx-sbom
+      # Migration-graph linearity gate. Two PRs branching a migration off
+      # the same parent each pass locally and pass their own CI, then merge
+      # into a forked graph with multiple leaf nodes that ``migrate`` refuses
+      # to run. ``makemigrations --check`` raises ``Conflicting migrations
+      # detected`` (exit 1) on a forked graph, failing the PR before it lands.
+      - run: uv run python manage.py makemigrations --check --dry-run
 
   blueprint-cross-pr:
     # Cross-PR §17.1 invariant-numbering gate (souliane/teatree#1288).


### PR DESCRIPTION
## What

Adds a single step to the existing `lint` job in `.github/workflows/ci.yml`:

```yaml
- run: uv run python manage.py makemigrations --check --dry-run
```

## Why

Two PRs each branching a new migration off the same parent pass locally and pass their own CI in isolation, then merge into a forked migration graph with multiple leaf nodes that `migrate` refuses to run. This is exactly the 0046-style leaf collision that broke main and required the 0047 merge migration in [#1719](https://github.com/souliane/teatree/pull/1719).

`makemigrations --check` raises `Conflicting migrations detected` (exit 1) on a forked graph, so the second PR fails CI *at PR time* — before the fork ever reaches main — instead of breaking the default branch and forcing a manual merge migration after the fact.

## Notes

- Minimal, static command — no untrusted input, no injection surface.
- Lives in the `lint` job (no extra runner/job).
- This is the durable CI guard that was split out of the now-closed [#1720](https://github.com/souliane/teatree/pull/1720).