### PR TITLE
fix(statusline): render SDK cost chip next to the weekly usage segment

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -171,6 +171,22 @@ if [ -n "$seven_day_pct" ] && [ "$seven_day_pct" != "empty" ]; then
     g_usage="${g_usage}${_LBL}7d=${_RST}$(color_pct "$seven_day_pct")"
 fi
 
+# SDK-equivalent month-to-date spend, rendered immediately after the weekly
+# (7d) rate-limit segment so the two usage windows read together. The dollar
+# figure is computed Python-side and handed over via tick-meta.json's
+# ``cost_chip`` (e.g. ``SDK mtd ≈$48/$200``); this hook only places it. Empty
+# when no headless cost is captured this cycle or the sidecar is unreadable.
+_cost_chip=""
+_cost_meta="${target%.txt}-meta.json"
+[ ! -r "$_cost_meta" ] && _cost_meta="$(dirname "$target")/tick-meta.json"
+if [ -r "$_cost_meta" ] && command -v jq >/dev/null 2>&1; then
+    _cost_chip=$(jq -r '.cost_chip // empty' "$_cost_meta" 2>/dev/null)
+fi
+if [ -n "$_cost_chip" ]; then
+    [ -n "$g_usage" ] && g_usage="${g_usage}${isep}"
+    g_usage="${g_usage}${_BLU}${_cost_chip}${_RST}"
+fi
+
 # Skills are kept aside and tacked on last (or on their own line — see below)
 # so they never push critical info off a narrow terminal. Skills sharing a
 # ``<ns>:`` prefix collapse into one ``ns:{a,b,c}`` token so a long t3:* set

--- a/src/teatree/core/cost.py
+++ b/src/teatree/core/cost.py
@@ -246,12 +246,18 @@ class CostReport:
         )
 
     def chip(self) -> str:
-        """Compact statusline chip, e.g. ``SDK ≈$48/$200``.
+        """Compact statusline chip, e.g. ``SDK mtd ≈$48/$200``.
+
+        ``mtd`` (month-to-date) names the accumulation window explicitly so the
+        figure is unambiguous next to the weekly rate-limit segment: it is the
+        spend since :attr:`cycle_start_date` (the monthly Agent-SDK billing
+        cycle, anchored to ``billing_cycle_anchor_day`` or the calendar month),
+        not a 5-hour or 7-day window. The ``/$<credit>`` is the monthly credit.
 
         Stays tiny at any spend: whole dollars, no decimals, no thousands
         separators that would balloon the width.
         """
-        return f"SDK ≈${round(self.breakdown.total_usd)}/${round(self.credit_usd)}"
+        return f"SDK mtd ≈${round(self.breakdown.total_usd)}/${round(self.credit_usd)}"
 
     def render_lines(self) -> list[str]:
         """Human-readable multi-line report body."""

--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -63,7 +63,6 @@ def zones_for(
     # The dedicated ``loop running · …`` line must stay line 1 (#130/#1400);
     # the live availability segment rides on that line (#1678).
     _populate_live_loops_anchor(zones)
-    _populate_cost_chip(zones)
     c = _classify_actions(actions, identity_aliases)
     ticket_index = build_ticket_index(actions)
     enrich_pr_refs_with_permalinks(c, build_review_post_permalinks(actions))
@@ -112,20 +111,16 @@ def _populate_live_loops_anchor(zones: StatuslineZones) -> None:
     zones.anchors.extend(live_loops_anchor())
 
 
-def _populate_cost_chip(zones: StatuslineZones) -> None:
-    """Append the compact ``SDK ≈$48/$200`` cost chip anchor (#cost).
+def cost_chip_lines() -> list[str]:
+    """Return the SDK-equivalent cost chip as a one-line list, or ``[]``.
 
     Cycle-to-date SDK-equivalent spend of the loop's headless ``claude -p``
-    usage against the monthly Agent-SDK credit, tiny at any spend. Silenced
-    (no line) when no headless cost is captured this cycle. Fails open to a
-    no-op on any DB / import error so a broken cost read never blanks the
-    statusline.
+    usage against the monthly Agent-SDK credit, tiny at any spend. Empty when
+    no headless cost is captured this cycle. The statusline header reads it
+    from the ``tick-meta.json`` sidecar and renders it next to the weekly
+    (``7d=``) rate-limit segment. Fails open to ``[]`` on any DB / import
+    error so a broken cost read never blanks the statusline.
     """
-    zones.anchors.extend(cost_chip_lines())
-
-
-def cost_chip_lines() -> list[str]:
-    """Return the cost chip as a one-line anchor list, or ``[]``. Fail-open."""
     try:
         from teatree.config import get_effective_settings  # noqa: PLC0415
         from teatree.core.cost import CostReport, cycle_start, cycle_start_datetime  # noqa: PLC0415

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -173,7 +173,6 @@ def run_tick(
     if not jobs:
         empty_zones = StatuslineZones()
         _populate_live_loops_in_anchors(empty_zones)
-        _populate_cost_chip_in_anchors(empty_zones)
         _populate_loop_owner_anchor(empty_zones)
         report.statusline_path = render(
             empty_zones,
@@ -234,21 +233,6 @@ def _populate_live_loops_in_anchors(zones: StatuslineZones) -> None:
         return
     try:
         zones.anchors.extend(live_loops_anchor())
-    except Exception:  # noqa: BLE001
-        return
-
-
-def _populate_cost_chip_in_anchors(zones: StatuslineZones) -> None:
-    """Append the SDK-equivalent cost chip on the empty-jobs path.
-
-    Mirrors :func:`_populate_live_loops_in_anchors`: the non-empty path goes
-    through :func:`teatree.loop.rendering._populate_cost_chip`. Fails open:
-    any import/query error degrades to a no-op.
-    """
-    try:
-        from teatree.loop.rendering import cost_chip_lines  # noqa: PLC0415
-
-        zones.anchors.extend(cost_chip_lines())
     except Exception:  # noqa: BLE001
         return
 

--- a/src/teatree/loop/tick_freshness.py
+++ b/src/teatree/loop/tick_freshness.py
@@ -116,6 +116,21 @@ def _collect_repo_freshness() -> dict[str, dict[str, int | str]]:
     }
 
 
+def _cost_chip() -> str:
+    """The SDK-equivalent cost chip for the sidecar, or ``""`` when silent.
+
+    The statusline header (``hooks/scripts/statusline.sh``) reads this from
+    ``tick-meta.json`` and renders it in the usage group right after the
+    weekly (``7d=``) rate-limit segment. Computing it here (Python) and
+    handing the rendered string to the shell keeps the dollar figure in one
+    place. Fails open to ``""`` so a broken cost read never blanks the line.
+    """
+    from teatree.loop.rendering import cost_chip_lines  # noqa: PLC0415
+
+    lines = cost_chip_lines()
+    return lines[0] if lines else ""
+
+
 def _write_tick_meta(started_at: dt.datetime, *, target: Path | None = None) -> None:
     from teatree.config import cadence_seconds  # noqa: PLC0415
     from teatree.loop.statusline import default_path  # noqa: PLC0415
@@ -132,6 +147,7 @@ def _write_tick_meta(started_at: dt.datetime, *, target: Path | None = None) -> 
     next_epoch = int(started_at.timestamp()) + cadence
     freshness = _collect_repo_freshness()
     meta_path.write_text(
-        json.dumps({"next_epoch": next_epoch, "cadence": cadence, "freshness": freshness}) + "\n",
+        json.dumps({"next_epoch": next_epoch, "cadence": cadence, "freshness": freshness, "cost_chip": _cost_chip()})
+        + "\n",
         encoding="utf-8",
     )

--- a/tests/teatree_core/management_commands/test_cost.py
+++ b/tests/teatree_core/management_commands/test_cost.py
@@ -49,7 +49,7 @@ class TestCostCommand:
         assert payload["cycle_to_date_usd"] == pytest.approx(4.4)
         assert payload["attempts"] == 2
         assert payload["credit_usd"] == pytest.approx(200.0)
-        assert payload["chip"] == "SDK ≈$4/$200"
+        assert payload["chip"] == "SDK mtd ≈$4/$200"
 
     def test_excludes_interactive_attempts(self) -> None:
         now = timezone.now()

--- a/tests/teatree_core/test_cost.py
+++ b/tests/teatree_core/test_cost.py
@@ -144,11 +144,11 @@ class TestCostReport:
             today=date(2026, 6, 10),
         )
 
-    def test_chip_is_compact_whole_dollars(self) -> None:
-        assert self._report(48.4).chip() == "SDK ≈$48/$200"
+    def test_chip_is_compact_whole_dollars_with_period_label(self) -> None:
+        assert self._report(48.4).chip() == "SDK mtd ≈$48/$200"
 
     def test_chip_stays_tiny_at_high_spend(self) -> None:
-        assert self._report(1234.0).chip() == "SDK ≈$1234/$200"
+        assert self._report(1234.0).chip() == "SDK mtd ≈$1234/$200"
 
     def test_render_lines_show_credit_and_projection(self) -> None:
         lines = "\n".join(self._report(50.0).render_lines())

--- a/tests/teatree_loop/test_statusline_cost_chip.py
+++ b/tests/teatree_loop/test_statusline_cost_chip.py
@@ -1,10 +1,21 @@
-"""The compact SDK-equivalent cost chip anchor on the statusline."""
+"""The compact SDK-equivalent cost chip on the statusline (#1714).
+
+The chip carries an explicit ``mtd`` (month-to-date) period label and is
+handed to the statusline header via ``tick-meta.json``'s ``cost_chip`` field,
+which ``hooks/scripts/statusline.sh`` renders next to the weekly (``7d=``)
+rate-limit segment.
+"""
+
+import datetime as dt
+import json
+from pathlib import Path
 
 import pytest
 from django.utils import timezone
 
 from teatree.core.models import Session, Task, TaskAttempt
 from teatree.loop.rendering import cost_chip_lines
+from teatree.loop.tick_freshness import _write_tick_meta
 from tests.factories import TicketFactory
 
 pytestmark = pytest.mark.django_db
@@ -31,11 +42,11 @@ class TestCostChipLines:
     def test_renders_compact_chip(self) -> None:
         _headless_attempt(self.task, cost=30.0)
         _headless_attempt(self.task, cost=18.0)
-        assert cost_chip_lines() == ["SDK ≈$48/$200"]
+        assert cost_chip_lines() == ["SDK mtd ≈$48/$200"]
 
     def test_chip_stays_tiny_at_high_spend(self) -> None:
         _headless_attempt(self.task, cost=1234.0)
-        assert cost_chip_lines() == ["SDK ≈$1234/$200"]
+        assert cost_chip_lines() == ["SDK mtd ≈$1234/$200"]
 
     def test_excludes_interactive_attempts(self) -> None:
         TaskAttempt.objects.create(
@@ -45,3 +56,22 @@ class TestCostChipLines:
             started_at=timezone.now(),
         )
         assert cost_chip_lines() == []
+
+
+class TestCostChipInTickMeta:
+    def setup_method(self) -> None:
+        self.ticket = TicketFactory()
+        self.session = Session.objects.create(ticket=self.ticket)
+        self.task = Task.objects.create(ticket=self.ticket, session=self.session)
+
+    def _meta(self, tmp_path: Path) -> dict:
+        statusline = tmp_path / "statusline.txt"
+        _write_tick_meta(dt.datetime(2026, 6, 10, tzinfo=dt.UTC), target=statusline)
+        return json.loads((tmp_path / "tick-meta.json").read_text(encoding="utf-8"))
+
+    def test_meta_carries_period_labelled_chip(self, tmp_path: Path) -> None:
+        _headless_attempt(self.task, cost=48.0)
+        assert self._meta(tmp_path)["cost_chip"] == "SDK mtd ≈$48/$200"
+
+    def test_meta_chip_empty_when_no_headless_cost(self, tmp_path: Path) -> None:
+        assert self._meta(tmp_path)["cost_chip"] == ""

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -102,6 +102,44 @@ class TestStatuslineHook:
         assert "5h=42%" in plain
         assert "7d=85%" in plain
 
+    def test_renders_sdk_cost_chip_next_to_weekly_segment(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        statusline_file = tmp_path / "statusline.txt"
+        statusline_file.write_text("loop running · tick 5m\n", encoding="utf-8")
+        (tmp_path / "tick-meta.json").write_text(
+            json.dumps({"cost_chip": "SDK mtd ≈$48/$200"}),
+            encoding="utf-8",
+        )
+
+        result = _run(
+            {
+                "session_id": "s-cost",
+                "model": {"display_name": "Claude Opus"},
+                "rate_limits": {"seven_day": {"used_percentage": 85}},
+            },
+            state_dir=state_dir,
+            statusline_file=statusline_file,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "SDK mtd ≈$48/$200" in plain, plain
+        # The cost chip sits immediately after the weekly (7d) usage segment.
+        assert plain.index("7d=85%") < plain.index("SDK mtd"), plain
+
+    def test_omits_sdk_cost_chip_when_meta_absent(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        result = _run(
+            {"session_id": "s-no-cost", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "SDK mtd" not in _strip_ansi(result.stdout)
+
     def test_renders_model_and_context_window_from_stdin(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"
         state_dir.mkdir()


### PR DESCRIPTION
Renders the SDK-equivalent cost estimation in the statusline usage group right after the weekly (7d) rate-limit segment, with an explicit month-to-date (mtd) period label, instead of on its own anchor line. cost.py aggregates spend from the billing-cycle start to today (a month-long window anchored to billing_cycle_anchor_day, or the calendar month when unset), so mtd names that window truthfully beside the 5h and 7d windows; the credit denominator already shows it is the monthly Agent-SDK credit. The chip flows to the header hook via the tick-meta.json cost_chip field; the shell only positions it, and the prior separate Python anchor line is removed so the chip has one home. Tests cover the label, the sidecar field, and the shell placement after the weekly segment.