### PR TITLE
fix(loop): resolve durable session pid from env so an env-restricted tick never anchors the lease on the transient shell

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -5208,14 +5208,20 @@ def _loop_self_pump(data: dict) -> bool | None:
         return None
 
     marker.write_text("1", encoding="utf-8")
-    # Tag the tick with the owner session id so its re-claim heartbeat
-    # always lands under the real session (and records its pid) instead of
-    # resolving to "" in the Bash-tool subprocess (#1107). The id IS the
-    # owner session here (the self-pump only fires for the owner), so the
-    # pid-anchored claim keeps the lease anchored to this session (#1073).
+    # Tag the tick with the owner session id AND the durable session pid so
+    # its re-claim heartbeat always lands under the real session and anchors
+    # the lease on the long-lived session process — instead of resolving the
+    # id to "" and the pid to os.getppid() of the torn-down Bash-tool shell
+    # (#1107/#1722). The session id IS the owner here (the self-pump only
+    # fires for the owner), and os.getppid() in this Stop hook IS that
+    # durable session process (the same value SessionStart records in the
+    # loop registry), so the pid-anchored claim keeps the lease anchored
+    # even when the tick subprocess cannot read the registry (#1073).
+    session_pid = os.getppid()
     reason = (
         "TEATREE LOOP SELF-PUMP — consolidated work remains; continue the loop "
         f"without waiting for an external prompt. Run `T3_LOOP_SESSION_ID={session_id} "
+        f"T3_LOOP_SESSION_PID={session_pid} "
         "t3 loop tick`, then "
         "repeatedly `t3 loop claim-next` and spawn ONE fresh, bounded sub-agent "
         "(Agent tool) for each claimed unit until it returns nothing — the "

--- a/src/teatree/core/session_identity.py
+++ b/src/teatree/core/session_identity.py
@@ -26,6 +26,13 @@ dead (131 user DMs reacted/answered never). The precedence is now:
 
     ``CLAUDE_SESSION_ID`` → ``T3_LOOP_SESSION_ID`` → loop-registry → ``""``
 
+The durable session *pid* (the loop-owner lease anchor) resolves with a
+parallel precedence so an env-restricted subprocess that cannot read the
+registry still gets the long-lived session pid rather than the transient
+tick-shell pid (#1722):
+
+    ``T3_LOOP_SESSION_PID`` → loop-registry → ``None``
+
 The registry fallback is correct-not-hack: ``loop-registry.json``'s
 ``t3-loop-tick-owner`` record IS the durable owner-identity source that
 ``_session_owns_loop`` (the gate consumers) already trust; making the
@@ -95,6 +102,22 @@ def _session_id_from_loop_registry() -> str:
     return (owner or {}).get("session_id") or ""
 
 
+def _coerce_pid(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        pid = value
+    elif isinstance(value, str) and value.strip().isdigit():
+        pid = int(value)
+    else:
+        return None
+    return pid if pid > 0 else None
+
+
+def _pid_from_loop_registry() -> int | None:
+    return _coerce_pid((_owner_record_from_loop_registry() or {}).get("pid"))
+
+
 def current_session_pid() -> int | None:
     """The owning *session* process pid, or ``None`` when not resolvable (#1073).
 
@@ -110,19 +133,23 @@ def current_session_pid() -> int | None:
     the 30-min TTL lapses for a busy/idle owner, a fresh SessionStart
     finds "no live owner" and STEALS the loop.
 
-    The ``SessionStart`` hook already records the durable session pid in
-    the same ``loop-registry.json`` record this module reads for the
-    session id (``hook_router._tick_owner_record`` stores ``os.getppid()``
-    of the SessionStart hook, whose parent IS the persistent session
-    process). Reading the pid from that record anchors the lease on the
-    long-lived session, so a busy owner past TTL stays protected and only
-    a genuinely-dead session (or ``--take-over``) releases the loop.
+    Precedence mirrors :func:`current_session_id`:
+
+        ``T3_LOOP_SESSION_PID`` env → loop-registry owner record → ``None``
+
+    The Stop self-pump exports ``T3_LOOP_SESSION_PID`` (the durable session
+    pid, the same value ``SessionStart`` records in the registry) into the
+    tick command, so the env path resolves the durable pid even in an
+    env-restricted subprocess where the loop registry is unreadable. The
+    registry path is the lower-precedence fallback: the ``SessionStart``
+    hook records the durable session pid alongside the session id
+    (``hook_router._tick_owner_record`` stores ``os.getppid()`` of the
+    SessionStart hook, whose parent IS the persistent session process).
+    Without either source the resolver returns ``None`` so the caller
+    decides its own no-fallback outcome rather than silently anchoring on
+    the transient tick-shell pid.
     """
-    owner = _owner_record_from_loop_registry()
-    if owner is None:
-        return None
-    pid = owner.get("pid")
-    return int(pid) if isinstance(pid, int) or (isinstance(pid, str) and pid.isdigit()) else None
+    return _coerce_pid(os.environ.get("T3_LOOP_SESSION_PID")) or _pid_from_loop_registry()
 
 
 def current_session_id() -> str:

--- a/tests/teatree_core/test_session_identity.py
+++ b/tests/teatree_core/test_session_identity.py
@@ -13,11 +13,13 @@ branches.
 
 import io
 import json
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
+from django.utils import timezone
 
 from teatree.core.models import LoopLease
 from teatree.core.session_identity import current_session_id, current_session_pid
@@ -142,6 +144,52 @@ class TestCurrentSessionPid:
             assert current_session_pid() is None
 
 
+class TestCurrentSessionPidEnvFallback:
+    """The env-var precedence the registry-only resolver lacked (#1722).
+
+    A self-pumped tick runs in an env-restricted Bash-tool subprocess: the
+    loop registry can be unreadable (``T3_LOOP_REGISTRY_DIR`` points
+    nowhere), but the Stop self-pump exports ``T3_LOOP_SESSION_PID``. With
+    only the registry source the resolver returned ``None`` and the tick
+    silently anchored the lease on ``os.getppid()`` of the transient shell,
+    collapsing pid-liveness to TTL-only. The env path must resolve the
+    durable pid even with the registry invisible.
+    """
+
+    def _no_registry_env(self, tmp_path: Path) -> dict[str, str]:
+        return {**_no_session_env(), "T3_LOOP_REGISTRY_DIR": str(tmp_path / "does-not-exist")}
+
+    def test_env_pid_resolves_when_registry_unreadable(self, tmp_path: Path) -> None:
+        with patch.dict("os.environ", {**self._no_registry_env(tmp_path), "T3_LOOP_SESSION_PID": "4242"}, clear=True):
+            assert current_session_pid() == 4242
+
+    def test_env_pid_takes_precedence_over_registry(self, tmp_path: Path) -> None:
+        (tmp_path / "loop-registry.json").write_text(
+            json.dumps({"t3-loop-tick-owner": {"session_id": "s", "pid": 111}}), encoding="utf-8"
+        )
+        with patch.dict(
+            "os.environ",
+            {**_no_session_env(), "T3_LOOP_REGISTRY_DIR": str(tmp_path), "T3_LOOP_SESSION_PID": "4242"},
+            clear=True,
+        ):
+            assert current_session_pid() == 4242
+
+    def test_no_env_and_no_registry_is_none(self, tmp_path: Path) -> None:
+        with patch.dict("os.environ", self._no_registry_env(tmp_path), clear=True):
+            assert current_session_pid() is None
+
+    def test_non_numeric_env_pid_falls_back_to_registry(self, tmp_path: Path) -> None:
+        (tmp_path / "loop-registry.json").write_text(
+            json.dumps({"t3-loop-tick-owner": {"session_id": "s", "pid": 111}}), encoding="utf-8"
+        )
+        with patch.dict(
+            "os.environ",
+            {**_no_session_env(), "T3_LOOP_REGISTRY_DIR": str(tmp_path), "T3_LOOP_SESSION_PID": "not-a-pid"},
+            clear=True,
+        ):
+            assert current_session_pid() == 111
+
+
 class TestLoopClaimSucceedsViaRegistrySessionId:
     """The literal #1107 incident reproduction (Prong A2)."""
 
@@ -185,3 +233,64 @@ class TestLoopClaimSucceedsViaRegistrySessionId:
         assert row.owner_pid == durable_session_pid, (
             "take-over must anchor on the durable session pid, not os.getppid() of the transient shell"
         )
+
+
+class TestEnvInvisibleRegistryAnchorsDurablePid:
+    """The #1722 gap: env-restricted subprocess with the registry unreadable.
+
+    The Stop self-pump exports both ``T3_LOOP_SESSION_ID`` and
+    ``T3_LOOP_SESSION_PID`` into the tick command. When that tick runs in a
+    subprocess that cannot read the loop registry, the env-propagated pid is
+    the ONLY durable source. Before the fix ``current_session_pid()``
+    returned ``None`` there and the claim fell back to ``os.getppid()`` of
+    the torn-down shell — collapsing pid-liveness to TTL-only. These tests
+    fail on that pre-fix behaviour (lease anchors on the transient pid; a
+    fresh session steals a past-TTL owner) and pass once the env pid is
+    resolved.
+    """
+
+    def _unreadable_registry_env(self, tmp_path: Path, durable_session_pid: int) -> dict[str, str]:
+        return {
+            **_no_session_env(),
+            "T3_LOOP_REGISTRY_DIR": str(tmp_path / "does-not-exist"),
+            "T3_LOOP_SESSION_ID": "owner-sess",
+            "T3_LOOP_SESSION_PID": str(durable_session_pid),
+        }
+
+    def test_claim_anchors_on_env_pid_when_registry_unreadable(self, tmp_path: Path) -> None:
+        import os  # noqa: PLC0415
+
+        durable_session_pid = os.getpid()
+        env = self._unreadable_registry_env(tmp_path, durable_session_pid)
+        out = io.StringIO()
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("os.getppid", return_value=999999),
+        ):
+            call_command("loop_owner", "claim", "--take-over", stdout=out)
+
+        row = LoopLease.objects.get(name="loop-owner")
+        assert row.owner_pid == durable_session_pid, (
+            "with the registry unreadable, the lease must anchor on the env-propagated durable "
+            "session pid, never os.getppid() of the transient tick shell"
+        )
+
+    def test_alive_owner_past_ttl_is_not_stealable(self, tmp_path: Path) -> None:
+        import os  # noqa: PLC0415
+
+        durable_session_pid = os.getpid()
+        env = self._unreadable_registry_env(tmp_path, durable_session_pid)
+        out = io.StringIO()
+        with (
+            patch.dict("os.environ", env, clear=True),
+            patch("os.getppid", return_value=999999),
+        ):
+            call_command("loop_owner", "claim", "--take-over", stdout=out)
+
+        row = LoopLease.objects.get(name="loop-owner")
+        row.lease_expires_at = timezone.now() - timedelta(seconds=5)
+        row.save(update_fields=["lease_expires_at"])
+
+        won, owner = LoopLease.objects.claim_ownership("loop-owner", session_id="fresh-session")
+        assert won is False, "an alive owner past its TTL must NOT be stealable by a fresh session"
+        assert owner == "owner-sess"

--- a/tests/test_loop_self_pump_hook.py
+++ b/tests/test_loop_self_pump_hook.py
@@ -90,21 +90,23 @@ class TestLoopSelfPump:
     def test_pump_directive_tags_tick_with_owner_session_id(
         self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The self-pump tick command carries the owner session id (#1073 follow-up).
+        """The self-pump tick command carries the owner session id and pid (#1073/#1722).
 
-        The owner's tick must claim under its real session id (and record
-        its pid) instead of resolving to ``""`` in a Bash subprocess
-        (#1107). Prefixing the emitted ``t3 loop tick`` with
-        ``T3_LOOP_SESSION_ID=<session>`` guarantees the re-claim heartbeat
-        keeps the lease anchored to the owner.
+        The owner's tick must claim under its real session id AND its
+        durable session pid instead of resolving the id to ``""`` and the
+        pid to ``os.getppid()`` of the torn-down Bash subprocess (#1107/
+        #1722). Exporting both ``T3_LOOP_SESSION_ID`` and
+        ``T3_LOOP_SESSION_PID`` keeps the re-claim heartbeat anchored to the
+        owner even when the tick subprocess cannot read the loop registry.
         """
         _own_loop("owner-1")
         _fake_pending(monkeypatch, [{"task_id": 7, "subagent": "x", "phase": "coding", "issue_url": "u"}])
 
+        monkeypatch.setattr(os, "getppid", lambda: 4242)
         handle_loop_self_pump({"session_id": "owner-1"})
 
         reason = _decision(capsys)["reason"]
-        assert "T3_LOOP_SESSION_ID=owner-1 t3 loop tick" in reason
+        assert "T3_LOOP_SESSION_ID=owner-1 T3_LOOP_SESSION_PID=4242 t3 loop tick" in reason
 
     def test_owner_with_no_pending_work_does_not_block(
         self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Problem

Follow-up hardening for the loop-owner hijack fix. The session-PID resolution lacked the env-var fallback that the session-ID resolution already has: in an env-restricted subprocess where the loop registry is unreadable, `current_session_pid()` returned `None` and the tick fell back to `os.getppid()` — the transient Bash-tool shell that dies seconds later. The lease then silently degraded to TTL-only liveness, so a fresh `SessionStart` could steal a busy owner's loop once the TTL lapsed.

## Fix

Mirror the `T3_LOOP_SESSION_ID` propagation:

- The Stop self-pump now also exports `T3_LOOP_SESSION_PID` (the durable session pid — the same value `SessionStart` records in the loop registry) into the emitted `t3 loop tick` command.
- `current_session_pid()` now resolves with a precedence parallel to `current_session_id()`: `T3_LOOP_SESSION_PID` env -> loop-registry owner record -> `None`.

The tick callers keep their bare in-session `os.getppid()` fallback for a genuinely-in-session direct call, but the env-propagated path means the env-restricted subprocess no longer anchors on the transient tick-shell pid: in the env-invisible-registry case the lease pid is the durable session pid.

## Tests

- New `TestCurrentSessionPidEnvFallback` and `TestEnvInvisibleRegistryAnchorsDurablePid` (incl. the keystone "alive-owner-past-TTL is not stealable") fail against current main and pass after the fix — verified both directions.
- Existing self-pump directive test updated for the new `T3_LOOP_SESSION_ID=... T3_LOOP_SESSION_PID=... t3 loop tick` shape.
- Full core + loop + hook suites green (4899 passed, 12 skipped); ruff, ty-check clean; `makemigrations --check --dry-run` is a no-op (no models touched).

Part of [#1722](https://github.com/souliane/teatree/issues/1722).
