### PR TITLE
fix(hooks): classify forge api calls by effective HTTP method

### DIFF
--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -74,14 +74,14 @@ _BASH_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
     "git commit -F",
     "git commit --file",
     "git tag --message",
-    # ``gh api`` / ``glab api`` POST/PATCH calls land on REST endpoints
-    # that publish issue/PR/MR comments. The payload is carried via
-    # ``-f``/``-F``/``--raw-field``/``--field``/``--input`` and parsed
-    # by :func:`extract_bash_payload`.
-    "gh api ",
-    "glab api ",
     "chat.postMessage",
 )
+# ``gh api`` / ``glab api`` is NOT a contiguous-substring publish: a bare
+# substring match flagged read-only GET calls (``gh api user``, ``gh api
+# repos/o/r/commits/main``) as publishes, so the destination-aware gates
+# over-blocked them (#1530). Raw-REST publishes are classified WRITE-only and
+# flag-order-robust by the token-aware :func:`_publish_detection.segment_is_api_write`
+# (effective method ≠ GET), reached via :func:`is_publish_command`.
 
 # t3 sub-commands that publish on the user's behalf. The overlay segment
 # between ``t3`` and the verb is arbitrary (one of the registered
@@ -153,10 +153,10 @@ def is_publish_command(command: str) -> bool:
     The contiguous substring catalogue (:data:`_BASH_PUBLISH_SUBSTRINGS`)
     catches the common spellings; the token-aware per-segment checks
     (:func:`_publish_detection.command_has_token_aware_publish_surface`) catch
-    the spellings an interspersed persistent flag breaks -- ``gh``/``glab api``
-    after a ``--hostname``/``-X`` flag, ``git [global-flags] commit`` after a
-    ``-C``/``--git-dir`` flag -- so the body reaches the scanner regardless of
-    flag ordering.
+    the ``git [global-flags] commit`` after a ``-C``/``--git-dir`` flag and the
+    raw-REST ``gh``/``glab api`` WRITE (effective method ≠ GET) regardless of
+    flag ordering, so the body reaches the scanner. A read-only ``gh``/``glab
+    api`` GET is NOT a publish and is not flagged (#1530).
     """
     joined = normalize_for_substring_match(command)
     if any(needle in joined for needle in _BASH_PUBLISH_SUBSTRINGS):

--- a/src/teatree/hooks/_publish_detection.py
+++ b/src/teatree/hooks/_publish_detection.py
@@ -60,6 +60,15 @@ _TITLE_LONG_FLAG: Final[str] = "--title"
 _TITLE_SHORT_FLAG: Final[str] = "-t"
 _GIT_COMMIT_MESSAGE_FLAGS: Final[frozenset[str]] = frozenset({"-m", "--message"})
 
+# ``gh api`` / ``glab api`` request-body flags. Their presence makes a
+# method-less call default to POST (a write); absent them it defaults to GET (a
+# read). Mirrors ``hook_router._REVIEW_POST_BODY_FLAG_RE``.
+_API_BODY_FLAGS: Final[frozenset[str]] = frozenset(
+    {"-f", "--field", "-F", "--raw-field", "--input", "-d", "--data"},
+)
+# Read-only effective HTTP methods. Every other method mutates and is a write.
+_API_READ_METHODS: Final[frozenset[str]] = frozenset({"GET", "HEAD"})
+
 
 def _attached_value(token: str, prefix: str) -> str | None:
     """Return the attached value of ``-X<value>`` / ``-X=<value>``, if any."""
@@ -98,6 +107,55 @@ def segment_is_api_call(words: list[str]) -> bool:
     token, so it does not match.
     """
     return bool(words) and words[0] in {"gh", "glab"} and "api" in words[1:]
+
+
+def _api_effective_method(words: list[str]) -> str:
+    """Return the EFFECTIVE HTTP method gh/glab would send for a ``... api`` call.
+
+    Models the gh (2.87.x) / glab (1.80.x) resolution the merge / review-post
+    gates already encode (``hook_router._is_raw_review_write``): a repeated
+    ``-X``/``--method`` flag resolves LAST-WINS, so ``-X GET -X POST`` POSTs and
+    ``-X POST -X GET`` reads. With no method flag the forge defaults to POST when
+    a request-body flag is present (``-f``/``--field``/``--input``/``-d``/…),
+    else GET. The returned method is upper-cased; ``GET``/``HEAD`` are reads,
+    every other method is a write.
+
+    Both spaced/``=`` (``-X PUT``, ``--method=POST``) and attached
+    (``-XPUT``/``-X=POST``) forms are honoured; a quoted value merely containing
+    the text ``-X`` stays a single distinct token and cannot spoof the method.
+    """
+    method: str | None = None
+    has_body_flag = False
+    i = 0
+    n = len(words)
+    while i < n:
+        word = words[i]
+        if word in {"-X", "--method"} and i + 1 < n:
+            method = words[i + 1]
+            i += 2
+            continue
+        attached = _attached_value(word, "-X") or _attached_value(word, "--method=")
+        if attached is not None:
+            method = attached
+        if word in _API_BODY_FLAGS:
+            has_body_flag = True
+        i += 1
+    if method is not None:
+        return method.strip("'\"").upper()
+    return "POST" if has_body_flag else "GET"
+
+
+def segment_is_api_write(words: list[str]) -> bool:
+    """Return True iff ``words`` is a ``gh``/``glab api`` call whose method WRITES.
+
+    A read (effective ``GET``/``HEAD``) is NOT a publish surface: ``gh api
+    user``, ``gh api repos/o/r/commits/main``, ``gh api … --method GET`` only
+    READ and must not be force-classified as a publish (#1530). A call whose
+    effective method mutates (``POST``/``PATCH``/``PUT``/``DELETE``/…) hits the
+    REST endpoints that publish issue/PR/MR comments, so it stays a publish
+    surface the body walkers must scan.
+    """
+    return segment_is_api_call(words) and _api_effective_method(words) not in _API_READ_METHODS
 
 
 def segment_is_git_commit_publish(words: list[str]) -> bool:
@@ -182,14 +240,17 @@ def segment_is_opaque_forge_transport(words: list[str]) -> bool:
 
 
 def command_has_token_aware_publish_surface(command: str) -> bool:
-    """Return True iff any segment is a token-aware ``api`` / ``git commit`` publish.
+    """Return True iff any segment is a token-aware ``api`` WRITE / ``git commit`` publish.
 
     The position-aware complement of the contiguous-substring catalogue, used by
     :func:`_command_parser.is_publish_command` to catch the interspersed-flag
-    spellings the substring matcher misses.
+    spellings the substring matcher misses. A ``gh``/``glab api`` segment is a
+    publish surface only when its EFFECTIVE method writes
+    (:func:`segment_is_api_write`); a read-only GET ``api`` call is not a publish
+    and must not be force-classified as one (#1530).
     """
     return any(
-        segment_is_api_call(words) or segment_is_git_commit_publish(words) for words in segment_word_lists(command)
+        segment_is_api_write(words) or segment_is_git_commit_publish(words) for words in segment_word_lists(command)
     )
 
 

--- a/tests/test_banned_terms_scanner.py
+++ b/tests/test_banned_terms_scanner.py
@@ -143,6 +143,73 @@ class TestIsPublishCommandTokenAware:
         assert not _command_parser.is_publish_command("git -C /some/dir status")
 
 
+class TestApiEffectiveMethodCorpus:
+    """`gh`/`glab api` is classified by EFFECTIVE HTTP method, not bare substring (#1530).
+
+    A read-only `api` call (effective GET/HEAD) is NOT a publish, so the
+    destination-aware gates no longer over-block it; an `api` WRITE (effective
+    POST/PATCH/PUT/DELETE, last-wins on repeated `-X`/`--method`) stays a publish
+    surface the body walkers must scan.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Bare reads — no method flag, no body flag → default GET.
+            "gh api user",
+            "gh api repos/o/r/commits/main",
+            "glab api projects/42/merge_requests",
+            # Explicit GET, even alongside a `-f` query param (#1568): a forced
+            # GET sends `-f` as a query param, never a body write.
+            "gh api repos/o/r/issues --method GET",
+            "gh api repos/o/r/issues -X GET -f state=open",
+            "glab api projects/42/issues --method=GET -f per_page=100",
+            # No-space explicit GET forces a read.
+            "gh api repos/o/r/issues -XGET -f state=open",
+            # Repeated method flags, GET LAST → effective GET → read.
+            "gh api repos/o/r/issues -X POST -X GET",
+            # HEAD is a read.
+            "gh api repos/o/r -X HEAD",
+        ],
+    )
+    def test_read_only_api_is_not_a_publish(self, command: str) -> None:
+        assert not _command_parser.is_publish_command(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Body flag with no method → gh/glab default to POST → write.
+            "gh api repos/o/r/issues -f title=bug -f body=x",
+            "glab api projects/42/issues --field body=x",
+            # Explicit write methods.
+            "gh api repos/o/r/issues -X POST -f body=x",
+            "gh api repos/o/r/issues/1 --method PATCH -f body=x",
+            "glab api projects/42/merge_requests/7/notes -X PUT -f body=x",
+            "gh api repos/o/r/issues/1 -X DELETE",
+            # No-space write shorthand.
+            "glab api projects/42/issues -XPOST -f body=x",
+            # Repeated method flags, write LAST → effective write.
+            "gh api repos/o/r/issues -X GET -X POST -f body=x",
+            # Interspersed persistent flag before `api` still detected as write.
+            "gh --hostname github.com api repos/o/r/issues -f body=x",
+        ],
+    )
+    def test_write_api_stays_a_publish(self, command: str) -> None:
+        assert _command_parser.is_publish_command(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh pr view 12",
+            "gh pr list --state open",
+            "gh pr diff 12",
+            "gh repo view o/r",
+        ],
+    )
+    def test_gh_pr_reads_are_not_a_publish(self, command: str) -> None:
+        assert not _command_parser.is_publish_command(command)
+
+
 class TestExtractPublishPayload:
     def test_gh_issue_create_body_is_extracted(self) -> None:
         payload = banned_terms_scanner.extract_publish_payload(

--- a/tests/test_bare_reference_scanner.py
+++ b/tests/test_bare_reference_scanner.py
@@ -209,6 +209,23 @@ class TestPreToolUseHardGate:
         assert blocked is False
         assert capsys.readouterr().out == ""
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api user",
+            "gh api repos/o/r/commits/main",
+            "gh api repos/o/r/issues --method GET",
+            "gh pr view 12",
+            "gh pr list",
+            "gh pr diff 12",
+            "gh repo view o/r",
+        ],
+    )
+    def test_read_only_api_is_not_over_blocked(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_bare_reference_pretool(_bash(command))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
 
 class TestExtractTitleFragments:
     @pytest.mark.parametrize(

--- a/tests/test_publish_detection_api_method.py
+++ b/tests/test_publish_detection_api_method.py
@@ -1,0 +1,78 @@
+"""Tests for the effective-HTTP-method `gh`/`glab api` classifier (#1530).
+
+`segment_is_api_write` and its `_api_effective_method` helper mirror the
+gh (2.87.x) / glab (1.80.x) last-wins method resolution the merge / review-post
+gates already encode (`hook_router._is_raw_review_write`): a read-only `api`
+call (effective GET/HEAD) is not a publish surface, a mutating call is.
+"""
+
+import pytest
+
+from teatree.hooks._publish_detection import (
+    _api_effective_method,
+    command_has_token_aware_publish_surface,
+    segment_is_api_call,
+    segment_is_api_write,
+)
+
+
+class TestApiEffectiveMethod:
+    @pytest.mark.parametrize(
+        ("words", "expected"),
+        [
+            (["gh", "api", "user"], "GET"),
+            (["gh", "api", "repos/o/r/issues", "-X", "GET"], "GET"),
+            (["gh", "api", "repos/o/r/issues", "--method=GET"], "GET"),
+            (["gh", "api", "repos/o/r/issues", "-XGET"], "GET"),
+            (["gh", "api", "repos/o/r/issues", "-f", "body=x"], "POST"),
+            (["gh", "api", "repos/o/r/issues", "--field", "body=x"], "POST"),
+            (["gh", "api", "repos/o/r/issues", "-X", "POST", "-f", "body=x"], "POST"),
+            (["gh", "api", "repos/o/r/issues/1", "--method", "PATCH"], "PATCH"),
+            (["gh", "api", "repos/o/r/issues/1", "-X", "DELETE"], "DELETE"),
+            (["gh", "api", "repos/o/r/issues", "-X", "GET", "-X", "POST"], "POST"),
+            (["gh", "api", "repos/o/r/issues", "-X", "POST", "-X", "GET"], "GET"),
+        ],
+    )
+    def test_effective_method(self, words: list[str], expected: str) -> None:
+        assert _api_effective_method(words) == expected
+
+
+class TestSegmentIsApiWrite:
+    @pytest.mark.parametrize(
+        "words",
+        [
+            ["gh", "api", "user"],
+            ["gh", "api", "repos/o/r/commits/main"],
+            ["gh", "api", "repos/o/r/issues", "--method", "GET"],
+            ["glab", "api", "projects/42/merge_requests"],
+        ],
+    )
+    def test_reads_are_not_writes(self, words: list[str]) -> None:
+        assert segment_is_api_call(words)
+        assert not segment_is_api_write(words)
+
+    @pytest.mark.parametrize(
+        "words",
+        [
+            ["gh", "api", "repos/o/r/issues", "-f", "body=x"],
+            ["gh", "api", "repos/o/r/issues", "-X", "POST", "-f", "body=x"],
+            ["glab", "api", "projects/42/merge_requests/7/notes", "-X", "PUT", "-f", "body=x"],
+            ["gh", "api", "repos/o/r/issues/1", "-X", "DELETE"],
+        ],
+    )
+    def test_writes_are_writes(self, words: list[str]) -> None:
+        assert segment_is_api_write(words)
+
+    def test_non_api_segment_is_not_a_write(self) -> None:
+        assert not segment_is_api_write(["git", "status"])
+
+
+class TestTokenAwarePublishSurface:
+    def test_read_only_api_is_not_a_publish_surface(self) -> None:
+        assert not command_has_token_aware_publish_surface("gh api user")
+
+    def test_write_api_after_interspersed_flag_is_a_publish_surface(self) -> None:
+        assert command_has_token_aware_publish_surface("gh --hostname github.com api repos/o/r/issues -f body=x")
+
+    def test_chained_read_then_write_api_is_a_publish_surface(self) -> None:
+        assert command_has_token_aware_publish_surface("gh api user && gh api repos/o/r/issues -f body=x")


### PR DESCRIPTION
## Problem

The bare-reference link gate ([issue #1530](https://github.com/souliane/teatree/issues/1530)) and the banned-terms gate classify **any** raw-REST forge api invocation as a publish command. Read-only GET calls therefore hit the fail-closed sentinel and get blocked: a bare forge-api read, a commits read, and an explicit `--method GET` call were all refused even though they only read.

Root cause: the forge-`api` entries in `_BASH_PUBLISH_SUBSTRINGS` (`_command_parser.py`) and the bare-`api`-word match in `segment_is_api_call` (`_publish_detection.py`) match regardless of HTTP method.

## Fix

Classify raw-REST forge api calls by their **effective HTTP method**, mirroring the last-wins `-X`/`--method` semantics the review-post and merge gates already use (`hook_router._is_raw_review_write`):

- a forge api call with no method (and no body flag), or an effective `GET`/`HEAD` (incl. `--method GET`, `-X GET`, repeated flags resolved last-wins) = **READ** → not a publish, no sentinel, allowed.
- a forge api call whose effective method is `POST`/`PATCH`/`PUT`/`DELETE` (explicit, or the default when a body flag like `-f`/`--field`/`--input`/`-d` is present) = **WRITE** → stays a publish surface.

Changes:

- Drop the forge-`api` contiguous substrings from `_BASH_PUBLISH_SUBSTRINGS`.
- Add `_api_effective_method` + `segment_is_api_write` to `_publish_detection.py`; `command_has_token_aware_publish_surface` now uses the write-aware predicate.
- `segment_is_api_call` (and its use in `publish_destination.py`'s private-post carve-out, where any api = fail-closed-scan) is intentionally unchanged — that is the safe direction.

## Golden corpus (never-lockout + never-under-block, symmetric)

must-ALLOW (no longer blocked): bare forge-api reads, a commits read, an explicit `--method GET` call, `pr view`/`pr list`/`pr diff`, `repo view`.

must-DENY (still gated as write): an api POST with a body field, an api PATCH, an api DELETE, interspersed-flag writes; `pr create` unchanged.

## Verification

- Full suite green: 10800 passed, coverage 94.22% (gate 93%).
- ruff check / ruff format / ty check clean; `makemigrations --check` clean (no model changes).
