### PR TITLE
fix(hooks): Stop self-pump honours T3_LOOPS_DISABLED=all kill-switch

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -5289,6 +5289,27 @@ def handle_loop_self_pump(data: dict) -> bool | None:
 _DISOWN_FALSEY: frozenset[str] = frozenset({"", "0", "false", "False"})
 
 
+def _all_loops_disabled() -> bool:
+    """Does ``T3_LOOPS_DISABLED`` fully prune the loop for this session?
+
+    Mirrors the ``all`` sentinel of ``teatree.loops.config._env_disabled_names``
+    without importing ``teatree`` (a Stop hook runs under whatever
+    interpreter the harness invokes, where ``teatree`` may be absent —
+    #810). The orchestrator gates every ``t3 loop tick`` job through that
+    same env var; the Stop self-pump is the in-session counterpart of a
+    tick, so it must honour the kill-switch identically. ``T3_LOOPS_DISABLED=all``
+    means every non-always-on loop is off — re-pumping then only re-runs the
+    one ``always_on`` ``dispatch`` scanner, doing no useful work while the
+    pending Tasks that drive ``pending-spawn`` keep the pump re-arming every
+    interval. That is the busy-loop the prune is meant to silence, so a fully
+    pruned session never pumps.
+    """
+    raw = os.environ.get("T3_LOOPS_DISABLED", "").strip()
+    if not raw:
+        return False
+    return any(part.strip().lower() == "all" for part in raw.split(","))
+
+
 def _self_pump_suppressed(session_id: str) -> bool:
     """Is the Stop self-pump gated off for this session (#959)?
 
@@ -5304,11 +5325,18 @@ def _self_pump_suppressed(session_id: str) -> bool:
     per-agent consolidation slot stays as a secondary cross-session
     dedup, NOT a substitute for this gate.
 
+    ``T3_LOOPS_DISABLED=all`` fully prunes the loop (the same kill-switch
+    the orchestrator honours per tick job): the owner's Stop hook becomes
+    a clean no-op so a pruned environment cannot busy-loop on stale
+    pending work.
+
     Immediate mitigation knob: ``T3_LOOP_DISOWN`` truthy in the
     session's env makes even the owner's Stop hook a clean no-op, so a
     session can stop driving the loop in-process without touching the
     registry or ending the session.
     """
+    if _all_loops_disabled():
+        return True
     if os.environ.get("T3_LOOP_DISOWN", "").strip() not in _DISOWN_FALSEY:
         return True
     return not _session_owns_loop(session_id)

--- a/tests/test_loop_self_pump_hook.py
+++ b/tests/test_loop_self_pump_hook.py
@@ -189,6 +189,71 @@ class TestLoopSelfPump:
         assert _decision(capsys) == {}
         assert result is not True
 
+    def test_all_loops_disabled_makes_owner_stop_hook_a_noop(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``T3_LOOPS_DISABLED=all`` fully prunes the loop. The owner session
+        # with stale pending work must NOT pump — re-running ``t3 loop tick``
+        # then only runs the always-on dispatch scanner (no useful work)
+        # while the pending Tasks keep re-arming the pump every interval: a
+        # busy-loop the prune is meant to silence.
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+        monkeypatch.setenv("T3_LOOPS_DISABLED", "all")
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert _decision(capsys) == {}
+        assert result is not True
+
+    def test_all_loops_disabled_does_not_probe_pending_work(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The kill-switch is checked BEFORE any ``pending-spawn`` subprocess —
+        # a fully pruned owner session must not even shell out to ``t3``.
+        _own_loop("owner-1")
+        probed = {"called": False}
+
+        def _spy() -> list[dict]:
+            probed["called"] = True
+            return [{"task_id": 1, "subagent": "x", "phase": "c", "issue_url": "u"}]
+
+        monkeypatch.setattr(router, "_consolidated_pending_work", _spy)
+        monkeypatch.setenv("T3_LOOPS_DISABLED", "all")
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert probed["called"] is False
+        assert _decision(capsys) == {}
+        assert result is not True
+
+    def test_loops_disabled_all_is_whitespace_and_case_tolerant(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+        monkeypatch.setenv("T3_LOOPS_DISABLED", " tick , ALL ")
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert _decision(capsys) == {}
+        assert result is not True
+
+    def test_named_loop_disable_does_not_suppress_self_pump(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Only the ``all`` sentinel fully prunes. A named-loop disable
+        # (e.g. just the review scanner) leaves the owner pumping its
+        # genuine pending work — the prune is per-scanner, not global.
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 9, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+        monkeypatch.setenv("T3_LOOPS_DISABLED", "review,self-improve")
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert _decision(capsys).get("decision") == "block"
+        assert result is True
+
     def test_anti_spin_suppresses_immediate_repeat(
         self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Root cause

The Stop loop self-pump (`hooks/scripts/hook_router.py` `_self_pump_suppressed` / `_loop_self_pump`) re-continued the loop-owner session whenever pending Tasks existed, with **no awareness of the `T3_LOOPS_DISABLED` kill-switch** the orchestrator honours per tick job (`src/teatree/loops/config.py` `_env_disabled_names`).

With loops fully pruned (`T3_LOOPS_DISABLED=all`) but pending `Task` rows still in the DB, the owner session busy-looped:

1. Turn ends, Stop hook emits `{"decision": "block", ...}` to re-run `t3 loop tick` + `claim-next`.
2. Under a full prune, `t3 loop tick` runs only the `always_on` `dispatch` scanner, no useful work.
3. The undrained pending Tasks keep `pending-spawn` non-empty, so the pump re-arms every interval.
4. The block lands on **stdout**, so the harness logs the Stop hook as producing no stderr while the session re-fires turn after turn.

Confirmed by replaying the live owner session's Stop event through the router: pre-fix it emits a `block` decision under `T3_LOOPS_DISABLED=all` with forced pending work; post-fix it is a clean no-op.

## Fix

`_self_pump_suppressed` now treats `T3_LOOPS_DISABLED=all` as a full kill-switch, checked **before** the `pending-spawn` subprocess, making the owner's Stop hook a clean no-op when the loop is fully pruned. A new `_all_loops_disabled()` mirrors the `all` sentinel of `_env_disabled_names` **without importing teatree** (a Stop hook runs under whatever interpreter the harness invokes, where teatree may be absent, the crash-proof contract from [#810](https://github.com/souliane/teatree/issues/810)).

Invariants preserved:
- A **named-loop** disable (e.g. `T3_LOOPS_DISABLED=review`) still pumps genuine pending work, only the `all` sentinel fully prunes.
- The owner-gate (singleton loop-owner) and the `T3_LOOP_DISOWN` in-session mitigation knob are unchanged.
- Crash-proof boundary guard and pid-anchored loop-owner liveness ([#1675](https://github.com/souliane/teatree/issues/1675)) are untouched, no regression to the hijack fix.

## Tests

Added to `tests/test_loop_self_pump_hook.py` (observed RED before the fix, pre-fix the first asserts a `block` decision is emitted):
- `test_all_loops_disabled_makes_owner_stop_hook_a_noop`
- `test_all_loops_disabled_does_not_probe_pending_work`
- `test_loops_disabled_all_is_whitespace_and_case_tolerant`
- `test_named_loop_disable_does_not_suppress_self_pump`

`tests/test_loop_self_pump_hook.py` 24 passed; loop/ownership/loops-config + never-lockout + hooks suites 447 passed. ruff check / ruff format / ty / tach / makemigrations-check all green.

## Live relief

For a session already busy-looping without editing the main clone: `T3_LOOPS_DISABLED=all` (the existing prune env) is now honoured by the self-pump, and `T3_LOOP_DISOWN=1` remains the in-session per-owner kill. Both are out-of-repo env knobs; no main-clone edit needed.