### PR TITLE
fix(hooks): Stop self-pump reads loop kill-switch from ~/.teatree when env-absent

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -5377,6 +5377,77 @@ def handle_loop_self_pump(data: dict) -> bool | None:
 _DISOWN_FALSEY: frozenset[str] = frozenset({"", "0", "false", "False"})
 
 
+def _bash_env_file() -> Path:
+    """Path to the shell-sourceable teatree env file (``~/.teatree``).
+
+    The harness spawns the Stop hook as a bare ``python3`` that does NOT
+    source the user's shell profile, so ``export VAR=value`` lines in this
+    file never reach ``os.environ`` (the ``ensure-skills-loaded.sh``
+    bootstrap calls it out: "hooks don't source .zshrc/.teatree").
+    ``TEATREE_BASH_ENV_FILE`` overrides the location (tests / non-default
+    HOME).
+    """
+    override = os.environ.get("TEATREE_BASH_ENV_FILE", "").strip()
+    if override:
+        return Path(override)
+    return Path(os.environ.get("HOME", str(Path.home()))) / ".teatree"
+
+
+def _read_bash_env_var(name: str) -> str:
+    """Last ``export <name>=<value>`` value in :func:`_bash_env_file`.
+
+    Pure-stdlib parse — no ``teatree`` import (the hook interpreter may
+    lack it, #810) and no shell invocation. Tolerant of a leading
+    ``export``/whitespace, spaces around ``=``, single/double quotes, and
+    trailing ``# comments``. Crash-proof: a missing or unreadable file
+    yields ``""``. Last assignment wins, mirroring shell sourcing.
+    """
+    try:
+        path = _bash_env_file()
+        if not path.is_file():
+            return ""
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    value = ""
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        key, sep, rest = line.partition("=")
+        if not sep or key.strip() != name:
+            continue
+        value = _strip_bash_value(rest)
+    return value
+
+
+def _strip_bash_value(rest: str) -> str:
+    """Strip surrounding quotes and a trailing ``# comment``."""
+    rest = rest.strip()
+    quote = rest[0] if rest[:1] in {"'", '"'} else ""
+    if quote:
+        end = rest.find(quote, 1)
+        if end != -1:
+            return rest[1:end]
+        return rest[1:]
+    return rest.split("#", 1)[0].strip()
+
+
+def _resolve_loop_env(name: str) -> str:
+    """Resolve a loop control var: process env first, bash env file second.
+
+    The process env is authoritative — an explicit value (even empty)
+    there is never overridden by the file. The file is consulted only when
+    the var is wholly absent from ``os.environ``, recovering the
+    kill-switch the unsourced Stop hook would otherwise miss.
+    """
+    if name in os.environ:
+        return os.environ[name]
+    return _read_bash_env_var(name)
+
+
 def _all_loops_disabled() -> bool:
     """Does ``T3_LOOPS_DISABLED`` fully prune the loop for this session?
 
@@ -5391,8 +5462,12 @@ def _all_loops_disabled() -> bool:
     pending Tasks that drive ``pending-spawn`` keep the pump re-arming every
     interval. That is the busy-loop the prune is meant to silence, so a fully
     pruned session never pumps.
+
+    The value is resolved via :func:`_resolve_loop_env` so the kill-switch
+    set in ``~/.teatree`` (never sourced into the bare-``python3`` Stop
+    hook) is still honoured.
     """
-    raw = os.environ.get("T3_LOOPS_DISABLED", "").strip()
+    raw = _resolve_loop_env("T3_LOOPS_DISABLED").strip()
     if not raw:
         return False
     return any(part.strip().lower() == "all" for part in raw.split(","))
@@ -5416,16 +5491,20 @@ def _self_pump_suppressed(session_id: str) -> bool:
     ``T3_LOOPS_DISABLED=all`` fully prunes the loop (the same kill-switch
     the orchestrator honours per tick job): the owner's Stop hook becomes
     a clean no-op so a pruned environment cannot busy-loop on stale
-    pending work.
+    pending work. Both this and ``T3_LOOP_DISOWN`` resolve through
+    :func:`_resolve_loop_env`, which falls back to the ``~/.teatree`` bash
+    env file when the var is absent from the process env — the bare
+    ``python3`` Stop hook never sources that file, so a kill-switch set
+    only there would otherwise be invisible to the self-pump.
 
-    Immediate mitigation knob: ``T3_LOOP_DISOWN`` truthy in the
-    session's env makes even the owner's Stop hook a clean no-op, so a
-    session can stop driving the loop in-process without touching the
-    registry or ending the session.
+    Immediate mitigation knob: ``T3_LOOP_DISOWN`` truthy (in the session's
+    env or the bash env file) makes even the owner's Stop hook a clean
+    no-op, so a session can stop driving the loop in-process without
+    touching the registry or ending the session.
     """
     if _all_loops_disabled():
         return True
-    if os.environ.get("T3_LOOP_DISOWN", "").strip() not in _DISOWN_FALSEY:
+    if _resolve_loop_env("T3_LOOP_DISOWN").strip() not in _DISOWN_FALSEY:
         return True
     return not _session_owns_loop(session_id)
 

--- a/tests/test_loop_self_pump_hook.py
+++ b/tests/test_loop_self_pump_hook.py
@@ -46,6 +46,11 @@ def _isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(router, "STATE_DIR", state)
     monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", str(tmp_path / "data"))
     (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+    # Point the bash-env-file fallback at a path that does not exist so a
+    # developer's real ``~/.teatree`` (which may set ``T3_LOOPS_DISABLED``)
+    # never leaks into a test that does not opt in. Cases that exercise the
+    # file override it explicitly.
+    monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(tmp_path / "no-bash-env"))
 
 
 def _own_loop(session_id: str) -> None:
@@ -254,6 +259,115 @@ class TestLoopSelfPump:
         assert _decision(capsys).get("decision") == "block"
         assert result is True
 
+    def test_loops_disabled_from_bash_env_file_makes_owner_a_noop(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The harness spawns the Stop hook as a bare ``python3`` that never
+        # sources ``~/.teatree``, so ``T3_LOOPS_DISABLED=all`` set there is
+        # absent from ``os.environ``. The kill-switch must still be honoured
+        # by reading the canonical bash env file when the env var is unset.
+        env_file = tmp_path / ".teatree"
+        env_file.write_text("export T3_LOOP_CADENCE=60\nexport T3_LOOPS_DISABLED=all\n", encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert _decision(capsys) == {}
+        assert result is not True
+
+    def test_disown_from_bash_env_file_makes_owner_a_noop(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``T3_LOOP_DISOWN`` set only in the bash env file is likewise honoured
+        # by the bare-``python3`` Stop hook.
+        env_file = tmp_path / ".teatree"
+        env_file.write_text('export T3_LOOP_DISOWN="1"\n', encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOP_DISOWN", raising=False)
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 2, "subagent": "x", "phase": "c", "issue_url": "u"}])
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert _decision(capsys) == {}
+        assert result is not True
+
+    def test_process_env_wins_over_bash_env_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The process env is authoritative: a value present in ``os.environ``
+        # is never overridden by a stale value in the bash env file. An
+        # explicit empty ``T3_LOOPS_DISABLED`` in the env means "not disabled"
+        # even when the file says ``all``, so the owner still pumps.
+        env_file = tmp_path / ".teatree"
+        env_file.write_text("export T3_LOOPS_DISABLED=all\n", encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.setenv("T3_LOOPS_DISABLED", "")
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 9, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert _decision(capsys).get("decision") == "block"
+        assert result is True
+
+    def test_named_loop_in_bash_env_file_does_not_suppress_self_pump(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Only the ``all`` sentinel prunes — a named-loop disable read from
+        # the bash env file leaves the owner pumping its genuine work.
+        env_file = tmp_path / ".teatree"
+        env_file.write_text("export T3_LOOPS_DISABLED=review,self-improve\n", encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 9, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert _decision(capsys).get("decision") == "block"
+        assert result is True
+
+    def test_bash_env_file_parse_is_quote_and_comment_tolerant(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The pure-stdlib parse tolerates surrounding quotes, inline comments,
+        # leading ``export``/whitespace, and unrelated lines.
+        env_file = tmp_path / ".teatree"
+        env_file.write_text(
+            "# a comment\n\n  export   T3_LOOP_CADENCE=60   # cadence\nexport T3_LOOPS_DISABLED='all'  # kill switch\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert _decision(capsys) == {}
+        assert result is not True
+
+    def test_missing_bash_env_file_is_a_clean_pump(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No env var, no file => not disabled; the owner pumps as before. The
+        # crash-proof parse must degrade to "not disabled" on a missing file.
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(tmp_path / "nonexistent"))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+        monkeypatch.delenv("T3_LOOP_DISOWN", raising=False)
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 9, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert _decision(capsys).get("decision") == "block"
+        assert result is True
+
     def test_anti_spin_suppresses_immediate_repeat(
         self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -291,6 +405,90 @@ class TestLoopSelfPump:
         result = handle_loop_self_pump({"session_id": ""})
         assert _decision(capsys) == {}
         assert result is not True
+
+
+class TestBashEnvFileResolver:
+    """Pure-stdlib parse of the ``export VAR=value`` bash env file (#810).
+
+    The Stop hook process never sources ``~/.teatree``, so the loop
+    kill-switch set there must be recovered by parsing the file directly —
+    crash-proof, with the process env taking precedence.
+    """
+
+    def test_env_var_present_short_circuits_file_read(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        env_file = tmp_path / ".teatree"
+        env_file.write_text("export T3_LOOPS_DISABLED=all\n", encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.setenv("T3_LOOPS_DISABLED", "review")
+
+        assert router._resolve_loop_env("T3_LOOPS_DISABLED") == "review"
+
+    def test_falls_back_to_file_when_env_absent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        env_file = tmp_path / ".teatree"
+        env_file.write_text("export T3_LOOPS_DISABLED=all\n", encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+
+        assert router._resolve_loop_env("T3_LOOPS_DISABLED") == "all"
+
+    def test_strips_quotes_inline_comment_and_export(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        env_file = tmp_path / ".teatree"
+        env_file.write_text("  export T3_LOOPS_DISABLED = 'all'  # kill switch\n", encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+
+        assert router._resolve_loop_env("T3_LOOPS_DISABLED") == "all"
+
+    def test_last_assignment_wins(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        env_file = tmp_path / ".teatree"
+        env_file.write_text("export T3_LOOPS_DISABLED=review\nexport T3_LOOPS_DISABLED=all\n", encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+
+        assert router._resolve_loop_env("T3_LOOPS_DISABLED") == "all"
+
+    def test_missing_file_returns_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(tmp_path / "nope"))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+
+        assert router._resolve_loop_env("T3_LOOPS_DISABLED") == ""
+
+    def test_unreadable_file_degrades_to_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        env_file = tmp_path / ".teatree"
+        env_file.write_text("export T3_LOOPS_DISABLED=all\n", encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+
+        def _boom(*_args: object, **_kwargs: object) -> str:
+            msg = "unreadable"
+            raise OSError(msg)
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        assert router._resolve_loop_env("T3_LOOPS_DISABLED") == ""
+
+    def test_double_quoted_value(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        env_file = tmp_path / ".teatree"
+        env_file.write_text('export T3_LOOP_DISOWN="1"\n', encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOP_DISOWN", raising=False)
+
+        assert router._resolve_loop_env("T3_LOOP_DISOWN") == "1"
+
+    def test_assignment_without_export_keyword(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        env_file = tmp_path / ".teatree"
+        env_file.write_text("T3_LOOPS_DISABLED=all\n", encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+
+        assert router._resolve_loop_env("T3_LOOPS_DISABLED") == "all"
+
+    def test_unterminated_quote_keeps_remainder(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        env_file = tmp_path / ".teatree"
+        env_file.write_text("export T3_LOOPS_DISABLED='all\n", encoding="utf-8")
+        monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(env_file))
+        monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)
+
+        assert router._resolve_loop_env("T3_LOOPS_DISABLED") == "all"
 
 
 class TestSessionEndClearsPumpMarker:

--- a/tests/test_per_agent_consolidation_loop.py
+++ b/tests/test_per_agent_consolidation_loop.py
@@ -54,6 +54,10 @@ def _isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(router, "STATE_DIR", state)
     monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", str(tmp_path / "data"))
     (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+    # Isolate from a developer's real ``~/.teatree`` loop kill-switch — the
+    # self-pump now falls back to that bash env file when the var is absent
+    # from the process env.
+    monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(tmp_path / "no-bash-env"))
 
 
 def _fake_pending(monkeypatch: pytest.MonkeyPatch, entries: list[dict]) -> None:


### PR DESCRIPTION
## Root cause

The Stop self-pump kept emitting a `block` decision on the live loop-owner
session turn after turn, even though the loop was disabled via
`T3_LOOPS_DISABLED=all`.

[#1735](https://github.com/souliane/teatree/pull/1735) added the gating
(`_all_loops_disabled()` -> `_self_pump_suppressed()`) but resolved the value
only from `os.environ`. `T3_LOOPS_DISABLED=all` lives in `~/.teatree`, a
shell-sourceable env file. The harness spawns the Stop hook as a bare
`python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook_router.py --event Stop`
process that never sources the user's shell profile — `ensure-skills-loaded.sh`
already calls this out: "hooks don't source .zshrc/.teatree". So inside the
Stop handler the var was absent, `_all_loops_disabled()` returned `False`, the
gate fell through to the owner check, and a still-pending Task re-armed the
pump every interval — the busy-loop the prune was meant to silence.

Confirmed empirically: the running session process carries no
`T3_LOOPS_DISABLED`, and a bare `python3` resolves it to `None`, while
`~/.teatree` sets it to `all`. The env-propagation gap was the cause.

## Fix

Resolve both `T3_LOOPS_DISABLED` and `T3_LOOP_DISOWN` through a new
`_resolve_loop_env()`:

- process env first (authoritative — an explicit value, even empty, is never
  overridden by the file);
- when the var is wholly absent from `os.environ`, fall back to a crash-proof,
  pure-stdlib parse of the `~/.teatree` `export VAR=value` lines.

The parser imports no `teatree` (the hook interpreter may lack it — the
crash-proof contract in
[#810](https://github.com/souliane/teatree/issues/810)), invokes no shell, and
tolerates a leading `export`/whitespace, spaces around `=`, single/double
quotes, and trailing `# comments`. A missing or unreadable file degrades to
empty (no busy-loop change). The `all` sentinel and the
named-loop-still-pumps semantics are unchanged. `TEATREE_BASH_ENV_FILE`
overrides the file location for tests / non-default HOME.

## Tests

RED before, GREEN after — added to `tests/test_loop_self_pump_hook.py`:

- `test_loops_disabled_from_bash_env_file_makes_owner_a_noop` — the live
  failure: env var absent, `~/.teatree` sets `all`, owner + pending work ->
  suppressed (no block).
- `test_disown_from_bash_env_file_makes_owner_a_noop`
- `test_process_env_wins_over_bash_env_file` — empty env value beats a stale
  `all` in the file (owner still pumps).
- `test_named_loop_in_bash_env_file_does_not_suppress_self_pump`
- `test_bash_env_file_parse_is_quote_and_comment_tolerant`
- `test_missing_bash_env_file_is_a_clean_pump`
- `TestBashEnvFileResolver` — pure-logic parser unit tests (env precedence,
  file fallback, quote/comment/export stripping, last-assignment-wins, missing
  file, unreadable file, double-quoted, no-export, unterminated quote).

The autouse isolation fixtures in `test_loop_self_pump_hook.py` and
`test_per_agent_consolidation_loop.py` now point `TEATREE_BASH_ENV_FILE` at a
nonexistent path so a developer's real `~/.teatree` kill-switch can never
leak into a test that does not opt in.

All prior-PR tests stay green (env-present path, named-loop, whitespace/case
tolerance, crash-proof). ruff / ty / tach / makemigrations-check clean; the
self-pump, consolidation, hooks, loops, and never-lockout suites pass
(1935 + 54).
