### PR TITLE
feat(loop): `t3 loop list` live loop-status command + /t3:loops skill

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -526,6 +526,7 @@ graph TD
     teatree.loops --> teatree.loop
     teatree.loops --> teatree.messaging
     teatree.loops --> teatree.notify
+    teatree.loops --> teatree.utils
     teatree.docker --> teatree.types
     teatree.docker --> teatree.utils
     teatree.visual_qa --> teatree.core

--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ graph LR
 | `followup` | Daily follow-up — batch process new tickets, check/advance ticket statuses, remind about PRs waiting for review |
 | `full-speed` | Deprecated alias for `/t3:speed boost`. Parallel backlog blast — classify the actionable backlog, fan out autonomous-safe work across isolated worktrees, surface the rest |
 | `handover` | Use when the user wants to hand all current work from one Claude session to another (or to a not-yet-existing session) with a single command, or to transfer an in-flight TeaTree task from Claude to another runtime, or asks whether it is time to switch because Claude usage is getting high. |
+| `loops` | Show t3 loop status — which loops are running vs stalled, the cadence and next tick of each loop, and loop ownership |
 | `next` | Wrap up the current session — retro, structured result, pipeline handoff. |
 | `platforms` | Platform-specific API recipes for GitLab, GitHub, and Slack. Auto-loaded as a dependency by skills that interact with these platforms. |
 | `retro` | Conversation retrospective and skill improvement |

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -2094,6 +2094,8 @@ Usage: t3 loop [OPTIONS] COMMAND [ARGS]...
 │                     session alive.                                           │
 │ uninstall-watchdog  Remove the macOS LaunchAgent installed by                │
 │                     ``install-watchdog``.                                    │
+│ list                Print LIVE loop status: each loop's enabled state,       │
+│                     cadence, last fire, and next tick.                       │
 │ self-improve        Self-improving monitor — scheduled smell detection with  │
 │                     a tiered action ladder. Runs in the same loop-owner      │
 │                     session as `t3 loop tick` on a separate LoopLease so a   │
@@ -2372,6 +2374,24 @@ Usage: t3 loop uninstall-watchdog [OPTIONS]
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --label        TEXT  LaunchAgent label (default: com.$USER.teatree-loop).    │
 │ --help               Show this message and exit.                             │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 loop list`
+
+```
+Usage: t3 loop list [OPTIONS]
+
+ Print LIVE loop status: each loop's enabled state, cadence, last fire, and
+ next tick.
+
+ Read-only: it computes the report from the DB and prints it — never ticks,
+ claims, or mutates anything. Unlike ``t3 loop status`` (the cached
+ statusline view), every countdown here is recomputed at call time.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json          Emit the live loop status as JSON.                           │
+│ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/generated/skills-catalogue.json
+++ b/docs/generated/skills-catalogue.json
@@ -45,6 +45,10 @@
       "summary": "Use when the user wants to hand all current work from one Claude session to another (or to a not-yet-existing session) with a single command, or to transfer an in-flight TeaTree task from Claude to another runtime, or asks whether it is time to switch because Claude usage is getting high"
     },
     {
+      "name": "loops",
+      "summary": "Show t3 loop status \u2014 which loops are running vs stalled, the cadence and next tick of each loop, and loop ownership"
+    },
+    {
       "name": "next",
       "summary": "Wrap up the current session \u2014 retro, structured result, pipeline handoff"
     },

--- a/docs/generated/skills-catalogue.md
+++ b/docs/generated/skills-catalogue.md
@@ -15,6 +15,7 @@ Source: `skills/*/SKILL.md` frontmatter
 | `followup` | Daily follow-up — batch process new tickets, check/advance ticket statuses, remind about PRs waiting for review |
 | `full-speed` | Deprecated alias for `/t3:speed boost`. Parallel backlog blast — classify the actionable backlog, fan out autonomous-safe work across isolated worktrees, surface the rest |
 | `handover` | Use when the user wants to hand all current work from one Claude session to another (or to a not-yet-existing session) with a single command, or to transfer an in-flight TeaTree task from Claude to another runtime, or asks whether it is time to switch because Claude usage is getting high |
+| `loops` | Show t3 loop status — which loops are running vs stalled, the cadence and next tick of each loop, and loop ownership |
 | `next` | Wrap up the current session — retro, structured result, pipeline handoff |
 | `platforms` | Platform-specific API recipes for GitLab, GitHub, and Slack. Auto-loaded as a dependency by skills that interact with these platforms |
 | `retro` | Conversation retrospective and skill improvement |

--- a/skills/loops/SKILL.md
+++ b/skills/loops/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: loops
+description: 'Show t3 loop status — which loops are running vs stalled, the cadence and next tick of each loop, and loop ownership. Use when the user says "which loops are running", "loop status", "loops", "loop health", "is the loop ticking".'
+compatibility: any
+triggers:
+  priority: 50
+  keywords:
+    - '\b(which loops are running|loop status|loops|loop health|is the loop ticking)\b'
+requires:
+  - rules
+metadata:
+  version: 0.0.1
+  subagent_safe: false
+---
+
+# Loops — Live Loop Status
+
+A SHORT, read-only view of every loop's live state. `/t3:loops` never ticks, claims, or starts work — it computes the status from the DB, prints it, and stops.
+
+It exists because `t3 loop status` prints the *cached* statusline written at the last tick, so its countdowns go stale — it can read "loop running" while the loop has actually been dead for hours. `t3 loop list` recomputes the state live on every call.
+
+## When to load
+
+Load `/t3:loops` when the user wants to know the live loop state — phrasings like "which loops are running", "loop status", "loop health", "is the loop ticking".
+
+Do NOT use it to start, claim, or advance a loop — that is `t3 loop claim` / `t3 loop tick` (see `t3:teatree`). This is a read-only glance.
+
+## The single command
+
+```bash
+t3 loop list           # live loop status, computed from the DB
+t3 loop list --json     # the same status as a machine-readable payload
+```
+
+## Output contract
+
+- Two labeled sections in fixed order — **`infra slots:`** first, then **`mini-loops:`** — never merged.
+- Each loop line is `<name>  <enabled|disabled>  cadence <dur>  last <age>  next <when>`; infra-slot lines append `held` or `idle`.
+- `next` reads `overdue` when the next fire is in the past and `—` when the loop has never fired (`last` is also `—`).
+- One **loop-owner** line: the owning session id, its `owner_pid`, whether that pid is `alive` or `dead/unknown`, and whether the claim is `live` or `stale`; `unclaimed` when no session holds it.
+- A **STALL** line appears only when the most recent tick is older than twice the tick cadence: `STALLED — last tick <age> ago`, followed by a one-line remediation hint (register the `t3 loop tick` cron, or `t3 loop claim` to take ownership).
+- No preamble, no "Here is the loop status."
+
+For ownership hand-off, claiming, or how the loop is driven, see `t3:teatree`.

--- a/src/teatree/cli/loop.py
+++ b/src/teatree/cli/loop.py
@@ -38,6 +38,7 @@ from pathlib import Path
 import typer
 
 from teatree.cli.loop_claim_next import claim_next_command
+from teatree.cli.loop_list import list_command
 from teatree.cli.loop_owner import register as register_loop_owner
 from teatree.cli.loop_slack_answer import slack_answer_app
 from teatree.cli.loop_watchdog import register as register_watchdog
@@ -386,3 +387,7 @@ loop_app.command("claim-next")(claim_next_command)
 # `uninstall-watchdog`. Split off so this file stays under the module-health
 # public-function cap.
 register_watchdog(loop_app)
+
+# #1744 — the read-only live loop-status view. Split off (same module-health
+# reason) and registered as a flat ``t3 loop list``.
+loop_app.command("list")(list_command)

--- a/src/teatree/cli/loop_list.py
+++ b/src/teatree/cli/loop_list.py
@@ -1,0 +1,39 @@
+"""``t3 loop list`` — print LIVE loop status from the DB (read-only; #1744).
+
+Split out of ``cli.loop`` (module-health: that file owns the tick / start /
+dashboard / self-improve concerns). ``t3 loop status`` prints the cached
+statusline file written at the last tick, so its countdowns go stale —
+``t3 loop list`` recomputes the state live on every call. Delegates to the
+``loop_list`` Django management command (anything touching the ORM is a
+management command, not a plain typer command).
+"""
+
+import os
+
+import typer
+
+
+def list_command(
+    *,
+    json_output: bool = typer.Option(False, "--json", help="Emit the live loop status as JSON."),
+) -> None:
+    """Print LIVE loop status: each loop's enabled state, cadence, last fire, and next tick.
+
+    Read-only: it computes the report from the DB and prints it — never ticks,
+    claims, or mutates anything. Unlike ``t3 loop status`` (the cached
+    statusline view), every countdown here is recomputed at call time.
+    """
+    import django  # noqa: PLC0415
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+    django.setup()
+
+    from django.core.management import call_command  # noqa: PLC0415
+
+    kwargs: dict[str, bool] = {}
+    if json_output:
+        kwargs["json_output"] = True
+    call_command("loop_list", **kwargs)
+
+
+__all__ = ["list_command"]

--- a/src/teatree/core/management/commands/loop_list.py
+++ b/src/teatree/core/management/commands/loop_list.py
@@ -1,0 +1,137 @@
+"""``manage.py loop_list`` — print LIVE loop status from the DB (#1744).
+
+Backs the read-only ``t3 loop list``. Unlike ``t3 loop status`` (which prints
+the statusline file written at the *last* tick, so its countdowns are stale),
+this rebuilds the state on every call from the cadence ledger, the mini-loop
+registry + ``[loops]`` config, and the infra-slot leases — including the
+PID-anchored loop-owner liveness. ORM access lives here (a management command,
+not a plain typer command) per the project's "anything touching the ORM is a
+management command" rule.
+
+Strictly read-only: it issues ORM reads only via
+:func:`teatree.loops.live.build_report` and never ticks, claims, acquires,
+marks fired, or mutates a row.
+"""
+
+import datetime as dt
+import json
+from typing import Annotated, Any
+
+import typer
+from django_typer.management import TyperCommand
+
+from teatree.loops.live import LoopOwnerStatus, LoopStatusEntry, LoopStatusReport, build_report
+
+_NEVER = "—"
+_REMEDIATION = "register the `t3 loop tick` cron, or run `t3 loop claim` in a Claude Code session to take ownership"
+_SECONDS_PER_MINUTE = 60
+_SECONDS_PER_HOUR = 3600
+
+
+def _human_age(seconds: float | None) -> str:
+    if seconds is None:
+        return _NEVER
+    total = int(seconds)
+    if total < _SECONDS_PER_MINUTE:
+        return f"{total}s"
+    if total < _SECONDS_PER_HOUR:
+        return f"{total // _SECONDS_PER_MINUTE}m{total % _SECONDS_PER_MINUTE:02d}s"
+    hours, remainder = divmod(total, _SECONDS_PER_HOUR)
+    return f"{hours}h{remainder // _SECONDS_PER_MINUTE:02d}m"
+
+
+def _next_tick_label(entry: LoopStatusEntry, now: dt.datetime) -> str:
+    if entry.next_fire_at is None:
+        return _NEVER
+    if entry.overdue(now):
+        return "overdue"
+    return f"in {_human_age(entry.due_seconds(now))}"
+
+
+def _entry_line(entry: LoopStatusEntry, now: dt.datetime) -> str:
+    enabled = "enabled" if entry.enabled else "disabled"
+    cadence = _human_age(entry.cadence_seconds)
+    age = _human_age(entry.age_seconds(now))
+    next_tick = _next_tick_label(entry, now)
+    line = f"  {entry.name:<22} {enabled:<8} cadence {cadence:<7} last {age:<10} next {next_tick}"
+    if entry.kind.value == "infra-slot":
+        line += "  held" if entry.held else "  idle"
+    return line
+
+
+def _owner_line(owner: LoopOwnerStatus) -> str:
+    if not owner.is_claimed:
+        return "loop-owner: unclaimed (no live owner)"
+    pid = owner.owner_pid if owner.owner_pid is not None else _NEVER
+    liveness = "alive" if owner.pid_is_alive else "dead/unknown"
+    state = "live" if owner.is_live else "stale"
+    return f"loop-owner: session {owner.session_id} (pid {pid} {liveness}) — {state}"
+
+
+def _stall_lines(report: LoopStatusReport) -> list[str]:
+    if not report.stalled:
+        return []
+    age = _human_age(report.last_tick_age_seconds)
+    return [f"STALLED — last tick {age} ago", f"  hint: {_REMEDIATION}"]
+
+
+def _render_text(report: LoopStatusReport) -> list[str]:
+    now = report.generated_at
+    lines = ["infra slots:"]
+    lines.extend(_entry_line(entry, now) for entry in report.infra_slots)
+    lines.append("mini-loops:")
+    lines.extend(_entry_line(entry, now) for entry in report.mini_loops)
+    lines.append(_owner_line(report.owner))
+    lines.extend(_stall_lines(report))
+    return lines
+
+
+def _entry_payload(entry: LoopStatusEntry, now: dt.datetime) -> dict[str, Any]:
+    return {
+        "name": entry.name,
+        "kind": entry.kind.value,
+        "enabled": entry.enabled,
+        "cadence_seconds": entry.cadence_seconds,
+        "last_fired_at": entry.last_fired_at.isoformat() if entry.last_fired_at else "",
+        "age_seconds": entry.age_seconds(now),
+        "next_fire_at": entry.next_fire_at.isoformat() if entry.next_fire_at else "",
+        "never_fired": entry.never_fired,
+        "overdue": entry.overdue(now),
+        "held": entry.held,
+    }
+
+
+def _render_json(report: LoopStatusReport) -> str:
+    now = report.generated_at
+    payload = {
+        "generated_at": report.generated_at.isoformat(),
+        "tick_cadence_seconds": report.tick_cadence_seconds,
+        "last_tick_at": report.last_tick_at.isoformat() if report.last_tick_at else "",
+        "last_tick_age_seconds": report.last_tick_age_seconds,
+        "stalled": report.stalled,
+        "infra_slots": [_entry_payload(entry, now) for entry in report.infra_slots],
+        "mini_loops": [_entry_payload(entry, now) for entry in report.mini_loops],
+        "owner": {
+            "session_id": report.owner.session_id,
+            "owner_pid": report.owner.owner_pid,
+            "pid_is_alive": report.owner.pid_is_alive,
+            "is_live": report.owner.is_live,
+        },
+    }
+    return json.dumps(payload, indent=2)
+
+
+class Command(TyperCommand):
+    help = "Print LIVE loop status computed from the DB (read-only; #1744)."
+
+    def handle(
+        self,
+        *,
+        json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
+    ) -> None:
+        report = build_report()
+        if json_output:
+            self.stdout.write(_render_json(report))
+            return
+        for line in _render_text(report):
+            self.stdout.write(line)

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -282,6 +282,10 @@ def _cadence_for_loop(name: str) -> int:
         from teatree.loop.tick_piggyback import _loop_owner_ttl_seconds  # noqa: PLC0415
 
         return _loop_owner_ttl_seconds()
+    if name == "loop-drain-queue":
+        from teatree.loop.queue_drain import drain_cadence_seconds  # noqa: PLC0415
+
+        return drain_cadence_seconds()
     return _cadence_seconds()
 
 

--- a/src/teatree/loops/live.py
+++ b/src/teatree/loops/live.py
@@ -1,0 +1,192 @@
+"""Live loop-status snapshot shared by the statusline and ``t3 loop list`` (#1744).
+
+``t3 loop status`` prints the statusline file written at the *last* tick, so
+its countdowns are stale — it can read "loop running" while the loop has been
+dead for hours. This module computes the same state LIVE from the DB on every
+call: the per-mini-loop cadence ledger (:class:`MiniLoopMarker`), the
+mini-loop registry + ``[loops]`` config, and the infra-slot leases
+(:class:`LoopLease`) with PID-anchored owner liveness.
+
+Strictly read-only: it issues ORM reads only — never ticks, claims, acquires,
+marks fired, or mutates a row. :func:`teatree.loops.schedule.mini_loop_schedules`
+derives its mini-loop next-fire numbers from :func:`build_report` so the
+statusline and ``t3 loop list`` never drift.
+"""
+
+import datetime as dt
+import operator
+from dataclasses import dataclass
+from enum import StrEnum
+
+from django.utils import timezone
+
+from teatree.core.models.loop_lease import LoopLease
+from teatree.core.models.mini_loop_marker import MiniLoopMarker
+from teatree.loop.statusline import _cadence_for_loop as cadence_for_loop
+from teatree.loops.config import LoopsConfig
+from teatree.loops.registry import iter_loops
+from teatree.utils.singleton import pid_alive
+
+INFRA_SLOTS: tuple[str, ...] = (
+    "loop-tick",
+    "loop-self-improve",
+    "loop-slack-answer",
+    "loop-drain-queue",
+)
+
+OWNER_SLOT = "loop-owner"
+TICK_SLOT = "loop-tick"
+STALL_FACTOR = 2
+
+
+class LoopKind(StrEnum):
+    INFRA = "infra-slot"
+    MINI = "mini-loop"
+
+
+@dataclass(frozen=True, slots=True)
+class LoopOwnerStatus:
+    session_id: str
+    owner_pid: int | None
+    pid_is_alive: bool
+    is_live: bool
+
+    @property
+    def is_claimed(self) -> bool:
+        return bool(self.session_id)
+
+
+@dataclass(frozen=True, slots=True)
+class LoopStatusEntry:
+    name: str
+    kind: LoopKind
+    enabled: bool
+    cadence_seconds: int
+    last_fired_at: dt.datetime | None
+    next_fire_at: dt.datetime | None
+    held: bool = False
+
+    @property
+    def never_fired(self) -> bool:
+        return self.last_fired_at is None
+
+    def age_seconds(self, now: dt.datetime) -> float | None:
+        if self.last_fired_at is None:
+            return None
+        return (now - self.last_fired_at).total_seconds()
+
+    def overdue(self, now: dt.datetime) -> bool:
+        return self.next_fire_at is not None and self.next_fire_at <= now
+
+    def due_seconds(self, now: dt.datetime) -> float | None:
+        if self.next_fire_at is None:
+            return None
+        return (self.next_fire_at - now).total_seconds()
+
+
+@dataclass(frozen=True, slots=True)
+class LoopStatusReport:
+    generated_at: dt.datetime
+    infra_slots: tuple[LoopStatusEntry, ...]
+    mini_loops: tuple[LoopStatusEntry, ...]
+    owner: LoopOwnerStatus
+    tick_cadence_seconds: int
+    last_tick_at: dt.datetime | None
+
+    @property
+    def last_tick_age_seconds(self) -> float | None:
+        if self.last_tick_at is None:
+            return None
+        return (self.generated_at - self.last_tick_at).total_seconds()
+
+    @property
+    def stalled(self) -> bool:
+        age = self.last_tick_age_seconds
+        if age is None:
+            return True
+        return age > STALL_FACTOR * self.tick_cadence_seconds
+
+
+def build_report(*, now: dt.datetime | None = None) -> LoopStatusReport:
+    moment = now if now is not None else timezone.now()
+    leases = {row.name: row for row in LoopLease.objects.all()}
+    infra = tuple(_infra_entry(slot, leases.get(slot)) for slot in INFRA_SLOTS)
+    mini = _mini_entries()
+    owner = _owner_status(leases.get(OWNER_SLOT), moment)
+    tick_cadence = cadence_for_loop(TICK_SLOT)
+    return LoopStatusReport(
+        generated_at=moment,
+        infra_slots=infra,
+        mini_loops=mini,
+        owner=owner,
+        tick_cadence_seconds=tick_cadence,
+        last_tick_at=_last_tick_at(infra, mini),
+    )
+
+
+def _infra_entry(slot: str, lease: LoopLease | None) -> LoopStatusEntry:
+    cadence = cadence_for_loop(slot)
+    acquired_at = lease.acquired_at if lease is not None else None
+    held = lease.is_held if lease is not None else False
+    next_fire_at = acquired_at + dt.timedelta(seconds=cadence) if acquired_at is not None else None
+    return LoopStatusEntry(
+        name=slot,
+        kind=LoopKind.INFRA,
+        enabled=True,
+        cadence_seconds=cadence,
+        last_fired_at=acquired_at,
+        next_fire_at=next_fire_at,
+        held=held,
+    )
+
+
+def _mini_entries() -> tuple[LoopStatusEntry, ...]:
+    config = LoopsConfig.load()
+    markers = {row.name: row.last_fired_at for row in MiniLoopMarker.objects.all()}
+    entries: list[LoopStatusEntry] = []
+    for loop in iter_loops():
+        cadence = config.cadence_for(loop)
+        last_fired_at = markers.get(loop.name)
+        next_fire_at = last_fired_at + dt.timedelta(seconds=cadence) if last_fired_at is not None else None
+        entries.append(
+            LoopStatusEntry(
+                name=loop.name,
+                kind=LoopKind.MINI,
+                enabled=config.is_enabled(loop),
+                cadence_seconds=cadence,
+                last_fired_at=last_fired_at,
+                next_fire_at=next_fire_at,
+            )
+        )
+    return tuple(sorted(entries, key=operator.attrgetter("name")))
+
+
+def _owner_status(lease: LoopLease | None, now: dt.datetime) -> LoopOwnerStatus:
+    if lease is None or not lease.session_id:
+        return LoopOwnerStatus(session_id="", owner_pid=None, pid_is_alive=False, is_live=False)
+    pid_ok = lease.owner_pid is not None and pid_alive(lease.owner_pid)
+    ttl_live = lease.lease_expires_at is not None and lease.lease_expires_at > now
+    return LoopOwnerStatus(
+        session_id=lease.session_id,
+        owner_pid=lease.owner_pid,
+        pid_is_alive=pid_ok,
+        is_live=ttl_live or pid_ok,
+    )
+
+
+def _last_tick_at(infra: tuple[LoopStatusEntry, ...], mini: tuple[LoopStatusEntry, ...]) -> dt.datetime | None:
+    fired = [entry.last_fired_at for entry in (*infra, *mini) if entry.last_fired_at is not None]
+    return max(fired) if fired else None
+
+
+__all__ = [
+    "INFRA_SLOTS",
+    "OWNER_SLOT",
+    "STALL_FACTOR",
+    "TICK_SLOT",
+    "LoopKind",
+    "LoopOwnerStatus",
+    "LoopStatusEntry",
+    "LoopStatusReport",
+    "build_report",
+]

--- a/src/teatree/loops/schedule.py
+++ b/src/teatree/loops/schedule.py
@@ -12,45 +12,28 @@ module owns the read and is wired into the statusline via the
 (installed by the ``loop_tick`` management command), mirroring the
 ``jobs_builder`` seam :func:`teatree.loop.tick.run_tick` already uses.
 
-The next-fire instant for a loop is the same ``last_fired_at + cadence``
-boundary :func:`teatree.loops.gating.elapsed_and_enabled` gates on, so the
-statusline countdown stays in lockstep with the orchestrator: a loop reads
-``due`` exactly when the gate would fire it.
+The next-fire instant comes from :func:`teatree.loops.live.build_report` — the
+same live snapshot ``t3 loop list`` renders (#1744) — so the statusline
+countdown, ``t3 loop list``, and the orchestrator's own cadence gate
+(:func:`teatree.loops.gating.elapsed_and_enabled`) all read one source of
+truth: a loop reads ``due`` exactly when the gate would fire it.
 """
 
 import datetime as dt
-import operator
 
-from teatree.loops.cadence_ledger import MiniLoopMarker
-from teatree.loops.config import LoopsConfig
-from teatree.loops.registry import iter_loops
+from teatree.loops.live import build_report
 
 
 def mini_loop_schedules() -> list[tuple[str, dt.datetime | None]]:
     """Return ``(loop_name, next_fire_at)`` for every enabled mini-loop.
 
     ``next_fire_at`` is the cadence-ledger ``last_fired_at`` plus the loop's
-    resolved cadence (:meth:`LoopsConfig.cadence_for`); ``None`` when the loop
-    has never fired (no marker row) — the statusline renders that as ``due``.
-    Disabled loops are omitted. Sorted by name for a deterministic render.
+    resolved cadence; ``None`` when the loop has never fired (no marker row) —
+    the statusline renders that as ``due``. Disabled loops are omitted, and the
+    snapshot already returns mini-loops sorted by name for a deterministic
+    render.
     """
-    config = LoopsConfig.load()
-    schedules: list[tuple[str, dt.datetime | None]] = []
-    for loop in iter_loops():
-        if not config.is_enabled(loop):
-            continue
-        last_fired_at = _last_fired_at(loop.name)
-        if last_fired_at is None:
-            schedules.append((loop.name, None))
-            continue
-        schedules.append((loop.name, last_fired_at + dt.timedelta(seconds=config.cadence_for(loop))))
-    return sorted(schedules, key=operator.itemgetter(0))
-
-
-def _last_fired_at(name: str) -> dt.datetime | None:
-    """Return the cadence-ledger ``last_fired_at`` for *name*, or ``None``."""
-    marker = MiniLoopMarker.objects.filter(name=name).only("last_fired_at").first()
-    return marker.last_fired_at if marker is not None else None
+    return [(entry.name, entry.next_fire_at) for entry in build_report().mini_loops if entry.enabled]
 
 
 __all__ = ["mini_loop_schedules"]

--- a/tach.toml
+++ b/tach.toml
@@ -173,7 +173,8 @@ depends_on = [
   "teatree.core",
   "teatree.loop",
   "teatree.messaging",
-  "teatree.notify"
+  "teatree.notify",
+  "teatree.utils"
 ]
 
 [[modules]]

--- a/tests/teatree_cli/test_cli_loop_list.py
+++ b/tests/teatree_cli/test_cli_loop_list.py
@@ -1,0 +1,25 @@
+"""``t3 loop list`` CLI wrapper delegates to the ``loop_list`` mgmt command (#1744)."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from teatree.cli.loop import loop_app
+
+runner = CliRunner()
+
+
+class TestLoopListCommand:
+    def test_delegates_to_management_command(self) -> None:
+        with patch("django.setup"), patch("django.core.management.call_command") as call:
+            result = runner.invoke(loop_app, ["list"])
+
+        assert result.exit_code == 0, result.stdout
+        call.assert_called_once_with("loop_list")
+
+    def test_passes_json_flag(self) -> None:
+        with patch("django.setup"), patch("django.core.management.call_command") as call:
+            result = runner.invoke(loop_app, ["list", "--json"])
+
+        assert result.exit_code == 0, result.stdout
+        call.assert_called_once_with("loop_list", json_output=True)

--- a/tests/teatree_core/test_loop_list_command.py
+++ b/tests/teatree_core/test_loop_list_command.py
@@ -1,0 +1,180 @@
+"""``manage.py loop_list`` — LIVE loop status from the DB (#1744).
+
+Integration-first: drives the real ``loop_list`` management command via
+``call_command`` against a DB seeded with :class:`MiniLoopMarker` and
+:class:`LoopLease` rows, asserting the rendered text and the ``--json`` shape.
+The mini-loop registry and ``[loops]`` config are patched to a small stub set
+so the assertions don't depend on the real domain loops, and the wall clock is
+pinned so countdowns are deterministic.
+"""
+
+import datetime as dt
+import io
+import json
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import django.test
+from django.core.management import call_command
+from django.utils import timezone
+
+from teatree.core.models.loop_lease import LoopLease
+from teatree.core.models.mini_loop_marker import MiniLoopMarker
+from teatree.loops.base import MiniLoop
+from teatree.loops.config import LoopsConfig
+
+_LIVE_PID = os.getpid()
+_DEAD_PID = 2_000_000_000
+
+
+def _stub_loop(name: str, cadence: int, *, always_on: bool = False) -> MiniLoop:
+    return MiniLoop(name=name, default_cadence_seconds=cadence, build_jobs=lambda **_: [], always_on=always_on)
+
+
+@contextmanager
+def _registry(*loops: MiniLoop) -> Iterator[None]:
+    with (
+        patch("teatree.loops.live.iter_loops", return_value=loops),
+        patch.object(LoopsConfig, "load", classmethod(lambda cls, path=None: cls())),
+    ):
+        yield
+
+
+def _run(*args: str) -> str:
+    out = io.StringIO()
+    call_command("loop_list", *args, stdout=out)
+    return out.getvalue()
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestLoopListText(django.test.TestCase):
+    def test_never_fired_loop_renders_em_dash_next(self) -> None:
+        with _registry(_stub_loop("dispatch", 300)):
+            output = _run()
+        line = next(ln for ln in output.splitlines() if ln.strip().startswith("dispatch"))
+        assert "next —" in line
+        assert "last —" in line
+
+    def test_overdue_loop_renders_overdue(self) -> None:
+        MiniLoopMarker.objects.mark_fired("audit", timezone.now() - dt.timedelta(hours=2))
+        with _registry(_stub_loop("audit", 60)):
+            output = _run()
+        line = next(ln for ln in output.splitlines() if ln.strip().startswith("audit"))
+        assert "next overdue" in line
+
+    def test_disabled_loop_shown_with_disabled_marker(self) -> None:
+        with (
+            _registry(_stub_loop("review", 300)),
+            patch.object(LoopsConfig, "is_enabled", lambda self, loop: False),
+        ):
+            output = _run()
+        line = next(ln for ln in output.splitlines() if ln.strip().startswith("review"))
+        assert "disabled" in line
+
+    def test_infra_slots_listed_before_mini_loops(self) -> None:
+        with _registry(_stub_loop("dispatch", 300)):
+            output = _run()
+        assert output.index("infra slots:") < output.index("mini-loops:")
+        assert "loop-tick" in output
+
+    def test_stall_warning_when_last_tick_old(self) -> None:
+        LoopLease.objects.filter(name="loop-tick").delete()
+        lease = LoopLease.objects.create(name="loop-tick", owner="t")
+        lease.acquired_at = timezone.now() - dt.timedelta(hours=10)
+        lease.save(update_fields=["acquired_at"])
+        with _registry(_stub_loop("dispatch", 300)):
+            output = _run()
+        assert "STALLED" in output
+        assert "t3 loop tick" in output
+        assert "t3 loop claim" in output
+
+    def test_no_stall_when_recent_tick(self) -> None:
+        LoopLease.objects.create(name="loop-tick", owner="t", acquired_at=timezone.now())
+        MiniLoopMarker.objects.mark_fired("dispatch", timezone.now())
+        with _registry(_stub_loop("dispatch", 300)):
+            output = _run()
+        assert "STALLED" not in output
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestLoopOwnerLine(django.test.TestCase):
+    def test_live_owner_pid_reported_alive(self) -> None:
+        LoopLease.objects.create(
+            name="loop-owner",
+            session_id="sess-live",
+            owner_pid=_LIVE_PID,
+            acquired_at=timezone.now(),
+            lease_expires_at=timezone.now() + dt.timedelta(minutes=30),
+        )
+        with _registry(_stub_loop("dispatch", 300)):
+            output = _run()
+        line = next(ln for ln in output.splitlines() if ln.startswith("loop-owner:"))
+        assert "sess-live" in line
+        assert "alive" in line
+        assert "live" in line
+
+    def test_dead_owner_pid_reported_dead_and_stale(self) -> None:
+        LoopLease.objects.create(
+            name="loop-owner",
+            session_id="sess-dead",
+            owner_pid=_DEAD_PID,
+            acquired_at=timezone.now() - dt.timedelta(hours=2),
+            lease_expires_at=timezone.now() - dt.timedelta(hours=1),
+        )
+        with _registry(_stub_loop("dispatch", 300)):
+            output = _run()
+        line = next(ln for ln in output.splitlines() if ln.startswith("loop-owner:"))
+        assert "sess-dead" in line
+        assert "dead/unknown" in line
+        assert "stale" in line
+
+    def test_unclaimed_owner_reported(self) -> None:
+        with _registry(_stub_loop("dispatch", 300)):
+            output = _run()
+        line = next(ln for ln in output.splitlines() if ln.startswith("loop-owner:"))
+        assert "unclaimed" in line
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestLoopListJson(django.test.TestCase):
+    def test_json_shape(self) -> None:
+        fired = timezone.now() - dt.timedelta(seconds=120)
+        MiniLoopMarker.objects.mark_fired("dispatch", fired)
+        LoopLease.objects.create(
+            name="loop-owner",
+            session_id="sess-json",
+            owner_pid=_LIVE_PID,
+            acquired_at=timezone.now(),
+            lease_expires_at=timezone.now() + dt.timedelta(minutes=30),
+        )
+        with _registry(_stub_loop("dispatch", 300)):
+            payload = json.loads(_run("--json"))
+        assert {"infra_slots", "mini_loops", "owner", "stalled", "tick_cadence_seconds"} <= payload.keys()
+        dispatch = next(e for e in payload["mini_loops"] if e["name"] == "dispatch")
+        assert dispatch["kind"] == "mini-loop"
+        assert dispatch["enabled"] is True
+        assert dispatch["never_fired"] is False
+        assert payload["owner"]["session_id"] == "sess-json"
+        assert payload["owner"]["pid_is_alive"] is True
+        infra_names = {e["name"] for e in payload["infra_slots"]}
+        assert "loop-tick" in infra_names
+
+    def test_json_never_fired_has_empty_timestamps(self) -> None:
+        with _registry(_stub_loop("inbox", 60)):
+            payload = json.loads(_run("--json"))
+        inbox = next(e for e in payload["mini_loops"] if e["name"] == "inbox")
+        assert inbox["last_fired_at"] == ""
+        assert inbox["next_fire_at"] == ""
+        assert inbox["age_seconds"] is None
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestLoopListIsReadOnly(django.test.TestCase):
+    def test_no_rows_created_or_mutated(self) -> None:
+        with _registry(_stub_loop("dispatch", 300)):
+            _run()
+            _run("--json")
+        assert MiniLoopMarker.objects.count() == 0
+        assert not LoopLease.objects.exclude(session_id="").exists()

--- a/tests/teatree_loop/test_statusline_cadence_for_loop.py
+++ b/tests/teatree_loop/test_statusline_cadence_for_loop.py
@@ -1,0 +1,33 @@
+"""``teatree.loop.statusline.cadence_for_loop`` — per-slot cadence resolver.
+
+The single mapping from an infra-slot name to its cadence in seconds, shared
+by the statusline next-tick countdown and ``t3 loop list`` (#1744). The drain
+slot (#1744) is the branch under test here; the env-driven cadence readers it
+delegates to are pinned so the resolved value is deterministic.
+"""
+
+import pytest
+
+from teatree.loop.statusline import _cadence_for_loop as cadence_for_loop
+
+
+class TestCadenceForLoop:
+    @pytest.mark.parametrize(
+        ("env_var", "value", "slot", "expected"),
+        [
+            ("T3_QUEUE_DRAIN_CADENCE", "30", "loop-drain-queue", 30),
+            ("T3_SLACK_ANSWER_CADENCE", "20", "loop-slack-answer", 20),
+            ("T3_SELF_IMPROVE_CHEAP_CADENCE", "1800", "loop-self-improve", 1800),
+            ("T3_LOOP_OWNER_TTL", "1800", "loop-owner", 1800),
+        ],
+    )
+    def test_named_slot_resolves_its_own_cadence(
+        self, env_var: str, value: str, slot: str, expected: int, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(env_var, value)
+        assert cadence_for_loop(slot) == expected
+
+    def test_unknown_slot_falls_back_to_tick_cadence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_LOOP_CADENCE", "600")
+        assert cadence_for_loop("loop-tick") == 600
+        assert cadence_for_loop("loop-something-new") == 600

--- a/tests/teatree_loop/test_statusline_mini_loop_schedules.py
+++ b/tests/teatree_loop/test_statusline_mini_loop_schedules.py
@@ -42,21 +42,21 @@ class TestMiniLoopSchedulesFromLedger(django.test.TestCase):
         fired_at = timezone.now() - dt.timedelta(seconds=60)
         MiniLoopMarker.objects.mark_fired("dispatch", fired_at)
         MiniLoopMarker.objects.mark_fired("news", fired_at)
-        with patch("teatree.loops.schedule.iter_loops", return_value=loops), _default_config():
+        with patch("teatree.loops.live.iter_loops", return_value=loops), _default_config():
             schedules = dict(mini_loop_schedules())
         assert schedules["dispatch"] == fired_at + dt.timedelta(seconds=300)
         assert schedules["news"] == fired_at + dt.timedelta(seconds=3600)
 
     def test_never_fired_loop_has_no_next_fire(self) -> None:
         loops = (_stub_loop("inbox", 60),)
-        with patch("teatree.loops.schedule.iter_loops", return_value=loops), _default_config():
+        with patch("teatree.loops.live.iter_loops", return_value=loops), _default_config():
             schedules = dict(mini_loop_schedules())
         assert schedules["inbox"] is None
 
     def test_disabled_loop_is_excluded(self) -> None:
         loops = (_stub_loop("dispatch", 300), _stub_loop("review", 300))
         with (
-            patch("teatree.loops.schedule.iter_loops", return_value=loops),
+            patch("teatree.loops.live.iter_loops", return_value=loops),
             patch(
                 "teatree.loops.config.LoopsConfig.is_enabled",
                 side_effect=lambda loop: loop.name != "review",
@@ -68,7 +68,7 @@ class TestMiniLoopSchedulesFromLedger(django.test.TestCase):
 
     def test_results_sorted_by_name(self) -> None:
         loops = (_stub_loop("ship", 300), _stub_loop("audit", 300), _stub_loop("inbox", 60))
-        with patch("teatree.loops.schedule.iter_loops", return_value=loops), _default_config():
+        with patch("teatree.loops.live.iter_loops", return_value=loops), _default_config():
             names = [name for name, _ in mini_loop_schedules()]
         assert names == ["audit", "inbox", "ship"]
 
@@ -82,7 +82,7 @@ class TestSeamRendersMiniLoopsOnStatusline(django.test.TestCase):
     def test_installed_reader_renders_relative_countdown(self) -> None:
         loops = (_stub_loop("tickets", 300),)
         MiniLoopMarker.objects.mark_fired("tickets", timezone.now() - dt.timedelta(seconds=120))
-        with patch("teatree.loops.schedule.iter_loops", return_value=loops), _default_config():
+        with patch("teatree.loops.live.iter_loops", return_value=loops), _default_config():
             set_mini_loop_schedules_reader(mini_loop_schedules)
             chunks = mini_loops_anchor()
         # 120s elapsed of a 300s cadence → next fire in 180s → 3m.
@@ -91,7 +91,7 @@ class TestSeamRendersMiniLoopsOnStatusline(django.test.TestCase):
     def test_overdue_loop_reads_due(self) -> None:
         loops = (_stub_loop("audit", 60),)
         MiniLoopMarker.objects.mark_fired("audit", timezone.now() - dt.timedelta(hours=1))
-        with patch("teatree.loops.schedule.iter_loops", return_value=loops), _default_config():
+        with patch("teatree.loops.live.iter_loops", return_value=loops), _default_config():
             set_mini_loop_schedules_reader(mini_loop_schedules)
             chunks = mini_loops_anchor()
         assert chunks == ["audit due"], chunks
@@ -119,7 +119,7 @@ class TestMiniLoopCadenceMatchesGate(django.test.TestCase):
         now = timezone.now()
         MiniLoopMarker.objects.mark_fired("ship", now - dt.timedelta(seconds=400))
         decision = elapsed_and_enabled(LoopsConfig(), loop, now)
-        with patch("teatree.loops.schedule.iter_loops", return_value=(loop,)), _default_config():
+        with patch("teatree.loops.live.iter_loops", return_value=(loop,)), _default_config():
             set_mini_loop_schedules_reader(mini_loop_schedules)
             chunks = mini_loops_anchor()
         assert decision.should_fire is True

--- a/tests/teatree_loops/test_live.py
+++ b/tests/teatree_loops/test_live.py
@@ -1,0 +1,182 @@
+"""``teatree.loops.live`` — the shared live loop-status snapshot (#1744).
+
+Unit coverage for the edge cases the management-command integration test does
+not exercise directly: the stall predicate when nothing has ever ticked, the
+PID-anchored owner liveness branches, and the entry-level age / overdue / due
+helpers. The clock is pinned so the derived numbers are deterministic.
+"""
+
+import datetime as dt
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import django.test
+from django.utils import timezone
+
+from teatree.core.models.loop_lease import LoopLease
+from teatree.core.models.mini_loop_marker import MiniLoopMarker
+from teatree.loops.base import MiniLoop
+from teatree.loops.config import LoopsConfig
+from teatree.loops.live import STALL_FACTOR, LoopKind, LoopStatusEntry, build_report
+
+_LIVE_PID = os.getpid()
+_DEAD_PID = 2_000_000_000
+
+
+def _stub_loop(name: str, cadence: int) -> MiniLoop:
+    return MiniLoop(name=name, default_cadence_seconds=cadence, build_jobs=lambda **_: [])
+
+
+@contextmanager
+def _registry(*loops: MiniLoop) -> Iterator[None]:
+    with (
+        patch("teatree.loops.live.iter_loops", return_value=loops),
+        patch.object(LoopsConfig, "load", classmethod(lambda cls, path=None: cls())),
+    ):
+        yield
+
+
+class TestEntryHelpers:
+    def _entry(self, *, last: dt.datetime | None, nxt: dt.datetime | None) -> LoopStatusEntry:
+        return LoopStatusEntry(
+            name="x",
+            kind=LoopKind.MINI,
+            enabled=True,
+            cadence_seconds=60,
+            last_fired_at=last,
+            next_fire_at=nxt,
+        )
+
+    def test_never_fired_entry(self) -> None:
+        now = timezone.now()
+        entry = self._entry(last=None, nxt=None)
+        assert entry.never_fired is True
+        assert entry.age_seconds(now) is None
+        assert entry.overdue(now) is False
+        assert entry.due_seconds(now) is None
+
+    def test_overdue_when_next_fire_in_past(self) -> None:
+        now = timezone.now()
+        entry = self._entry(last=now - dt.timedelta(seconds=120), nxt=now - dt.timedelta(seconds=60))
+        assert entry.overdue(now) is True
+        assert entry.due_seconds(now) == -60
+        assert entry.age_seconds(now) == 120
+
+    def test_future_next_fire_not_overdue(self) -> None:
+        now = timezone.now()
+        entry = self._entry(last=now, nxt=now + dt.timedelta(seconds=30))
+        assert entry.overdue(now) is False
+        assert entry.due_seconds(now) == 30
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestStallPredicate(django.test.TestCase):
+    def test_stalled_when_no_tick_ever(self) -> None:
+        with _registry(_stub_loop("dispatch", 300)):
+            report = build_report()
+        assert report.last_tick_at is None
+        assert report.last_tick_age_seconds is None
+        assert report.stalled is True
+
+    def test_stalled_when_oldest_beyond_factor(self) -> None:
+        now = timezone.now()
+        cadence = 720
+        MiniLoopMarker.objects.mark_fired("dispatch", now - dt.timedelta(seconds=STALL_FACTOR * cadence + 5))
+        with _registry(_stub_loop("dispatch", 300)), patch("teatree.loops.live.cadence_for_loop", return_value=cadence):
+            report = build_report(now=now)
+        assert report.stalled is True
+
+    def test_not_stalled_when_recent(self) -> None:
+        now = timezone.now()
+        MiniLoopMarker.objects.mark_fired("dispatch", now - dt.timedelta(seconds=10))
+        with _registry(_stub_loop("dispatch", 300)):
+            report = build_report(now=now)
+        assert report.stalled is False
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestOwnerLiveness(django.test.TestCase):
+    def test_alive_pid_is_live_even_past_ttl(self) -> None:
+        now = timezone.now()
+        LoopLease.objects.create(
+            name="loop-owner",
+            session_id="busy",
+            owner_pid=_LIVE_PID,
+            lease_expires_at=now - dt.timedelta(hours=1),
+        )
+        with _registry(_stub_loop("dispatch", 300)):
+            report = build_report(now=now)
+        assert report.owner.pid_is_alive is True
+        assert report.owner.is_live is True
+
+    def test_unexpired_ttl_is_live_even_with_dead_pid(self) -> None:
+        now = timezone.now()
+        LoopLease.objects.create(
+            name="loop-owner",
+            session_id="fresh",
+            owner_pid=_DEAD_PID,
+            lease_expires_at=now + dt.timedelta(minutes=30),
+        )
+        with _registry(_stub_loop("dispatch", 300)):
+            report = build_report(now=now)
+        assert report.owner.pid_is_alive is False
+        assert report.owner.is_live is True
+
+    def test_dead_pid_and_expired_ttl_is_not_live(self) -> None:
+        now = timezone.now()
+        LoopLease.objects.create(
+            name="loop-owner",
+            session_id="gone",
+            owner_pid=_DEAD_PID,
+            lease_expires_at=now - dt.timedelta(hours=1),
+        )
+        with _registry(_stub_loop("dispatch", 300)):
+            report = build_report(now=now)
+        assert report.owner.is_live is False
+        assert report.owner.is_claimed is True
+
+    def test_null_pid_owner_decided_by_ttl(self) -> None:
+        now = timezone.now()
+        LoopLease.objects.create(
+            name="loop-owner",
+            session_id="nopid",
+            owner_pid=None,
+            lease_expires_at=now - dt.timedelta(hours=1),
+        )
+        with _registry(_stub_loop("dispatch", 300)):
+            report = build_report(now=now)
+        assert report.owner.pid_is_alive is False
+        assert report.owner.is_live is False
+
+    def test_no_lease_is_unclaimed(self) -> None:
+        with _registry(_stub_loop("dispatch", 300)):
+            report = build_report()
+        assert report.owner.is_claimed is False
+        assert report.owner.is_live is False
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestInfraEntries(django.test.TestCase):
+    def test_held_lease_marked_held(self) -> None:
+        now = timezone.now()
+        LoopLease.objects.create(
+            name="loop-tick",
+            owner="holder",
+            acquired_at=now,
+            lease_expires_at=now + dt.timedelta(minutes=2),
+        )
+        with _registry(_stub_loop("dispatch", 300)):
+            report = build_report(now=now)
+        tick = next(e for e in report.infra_slots if e.name == "loop-tick")
+        assert tick.held is True
+        assert tick.kind is LoopKind.INFRA
+        assert tick.next_fire_at is not None
+
+    def test_missing_lease_row_is_idle_never_fired(self) -> None:
+        with _registry(_stub_loop("dispatch", 300)):
+            report = build_report()
+        tick = next(e for e in report.infra_slots if e.name == "loop-tick")
+        assert tick.held is False
+        assert tick.never_fired is True


### PR DESCRIPTION
Closes [#1744](https://github.com/souliane/teatree/issues/1744)

## Why

`t3 loop status` prints the cached statusline written at the *last* tick, so its countdowns go stale — it can read "loop running" while the loop has actually been dead for hours. This adds a read-only `t3 loop list` that recomputes the state live from the DB on every call.

## What

**`t3 loop list` (read-only).** A new CLI command that prints LIVE loop status:

- Infra slots first, then mini-loops. Each line: name, enabled/disabled, cadence, last-fired age, next-tick (`overdue` when in the past, `—` when never fired); infra slots also show `held`/`idle`.
- A **loop-owner** line: owning session id, `owner_pid`, whether that pid is `alive`/`dead`, and whether the claim is `live`/`stale` (PID-anchored, matching `claim_ownership`).
- A **STALL** warning when the most recent tick is older than 2x the tick cadence, with a one-line remediation hint (register the `t3 loop tick` cron / `t3 loop claim`).
- `--json` for machine output.
- Strictly read-only — ORM reads only; never ticks, claims, acquires, marks fired, or mutates a row (covered by an explicit read-only test).

**Shared source of truth.** `teatree.loops.live.build_report` computes the snapshot from the cadence ledger, the mini-loop registry + `[loops]` config, and the infra-slot leases. The statusline's `mini_loop_schedules` now derives from it so the statusline and `t3 loop list` never drift, and the per-slot cadence resolver gains the `loop-drain-queue` slot so its 30s cadence is reported accurately by both surfaces.

**`/t3:loops` skill.** `skills/loops/SKILL.md` documents the command — when to load, the single command, and the output contract.

## Tests

TDD, integration-first: `call_command("loop_list")` against a DB seeded with `MiniLoopMarker` + `LoopLease` rows — never-fired, overdue, stalled (warning fires), live-owner-pid vs dead-owner-pid, `--json` shape, read-only. Edge cases (stall-when-never-ticked, the four owner-liveness branches, entry helpers) as unit tests. 100% coverage on all new code; full pytest suite green.

## Sample output (against a live local DB)

```
infra slots:
  loop-tick              enabled  cadence 12m00s  last —          next —  idle
  loop-self-improve      enabled  cadence 30m00s  last 9m22s      next in 20m37s  held
  loop-slack-answer      enabled  cadence 20s     last 8m27s      next overdue  idle
  loop-drain-queue       enabled  cadence 30s     last 8m27s      next overdue  idle
mini-loops:
  dispatch               enabled  cadence 5m00s   last 9m30s      next overdue
  ...
loop-owner: session 363bd804 (pid 50678 alive) — live
```