### PR TITLE
Skip review dispatch for MR/PR already eyes-claimed by a colleague

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -166,6 +166,8 @@ Run gates → Any failure? → Fix → Re-run gates → Repeat until clean
 
 Do NOT skip these steps to "save time" when reviewing multiple PRs. Each step exists because skipping it caused missed findings in real reviews.
 
+**BINDING — never review an MR/PR already :eyes:-claimed by a colleague.** Do NOT dispatch or perform a review of any MR/PR whose review-broadcast / review-request message already carries a `:eyes:` (👀) reaction from someone other than the user — that reaction is the colleague's claim on the review, and a second pass duplicates their in-flight work. The only override is the user explicitly naming that MR (an `<@user_slack_id>` mention on the broadcast, or a direct instruction). This is enforced structurally in `SlackBroadcastsScanner` (`src/teatree/loop/scanners/slack_broadcasts.py`) via `eyes_reacted_by_other` (`src/teatree/core/review_candidate.py`), which excludes the user's own `:eyes:` so the gate only fires on a colleague's claim. When reviewing manually, check the broadcast's reactions first and skip a colleague-claimed MR unless the user named it.
+
 #### Colleague-MR Autonomy — Act on the Verdict, Don't Ask (config-driven)
 
 What the agent does *after* an independent cold-review verdict exists on a **colleague-authored** MR (the MR's author is not your identity) is governed by **one config knob**, the per-overlay `autonomy` switch in `~/.teatree.toml` (`src/teatree/config.py`; tiers `full > notify > babysit`, see [`docs/blueprint/configuration.md`](../../docs/blueprint/configuration.md) § 10.1). It is *not* a per-MR judgement call and *not* a personal memory rule — read the resolved tier and follow it.

--- a/src/teatree/core/review_candidate.py
+++ b/src/teatree/core/review_candidate.py
@@ -87,6 +87,24 @@ def _self_has_non_system_note(mr: RawAPIDict, identities: set[str]) -> bool:
     return False
 
 
+def eyes_reacted_by_other(message: RawAPIDict, *, user_id: str) -> bool:
+    reactions = message.get("reactions")
+    if not isinstance(reactions, list):
+        return False
+    for reaction in reactions:
+        if not isinstance(reaction, dict):
+            continue
+        reaction_dict = cast("RawAPIDict", reaction)
+        if reaction_dict.get("name") != "eyes":
+            continue
+        users = reaction_dict.get("users")
+        if not isinstance(users, list):
+            continue
+        if any(isinstance(user, str) and user and user != user_id for user in users):
+            return True
+    return False
+
+
 def _broadcast_reacted_by_other(broadcast: RawAPIDict, current_user: str) -> bool:
     reactions = broadcast.get("reactions")
     if not isinstance(reactions, list):

--- a/src/teatree/loop/scanners/slack_broadcasts.py
+++ b/src/teatree/loop/scanners/slack_broadcasts.py
@@ -59,6 +59,7 @@ from django.db import OperationalError, ProgrammingError
 
 from teatree.backends.protocols import MessagingBackend
 from teatree.core.models import BroadcastObservation, ScannedBroadcast
+from teatree.core.review_candidate import eyes_reacted_by_other
 from teatree.loop.scanners.base import ScanSignal
 from teatree.types import RawAPIDict
 
@@ -305,12 +306,18 @@ class SlackBroadcastsScanner:
         # review channel were previously invisible to the nag train because
         # only the bot's review-request flow wrote ReviewRequestPost rows.
         _seed_review_request_posts(channel=row.channel, ts=row.slack_ts, states=states)
-        signals = self._apply_classification(row, states)
+        signals = self._apply_classification(row, states, message, user_named=self._user_named(text))
         # #1295 cap B: detect ``<@user_slack_id>`` mentions so the
         # mechanical assigner picks up the MR without waiting for a
         # forge-side assignment to land.
         signals.extend(self._pickup_signals(text, row, states))
         return signals
+
+    def _user_named(self, text: str) -> bool:
+        user_id = self._user_id()
+        if not user_id:
+            return False
+        return user_id in {match.group(1) for match in _SLACK_MENTION_RE.finditer(text)}
 
     def _pickup_signals(
         self,
@@ -344,6 +351,9 @@ class SlackBroadcastsScanner:
         self,
         row: ScannedBroadcast,
         states: Sequence[MrState],
+        message: RawAPIDict,
+        *,
+        user_named: bool,
     ) -> list[ScanSignal]:
         if row.classification == ScannedBroadcast.Classification.ALL_MERGED:
             self._react(row.channel, row.slack_ts, "white_check_mark")
@@ -361,8 +371,16 @@ class SlackBroadcastsScanner:
             # meaningless noise on one's own MR, and there is nothing to
             # dispatch a reviewer for. Skip both. Sibling of #1321.
             return []
+        if not user_named and eyes_reacted_by_other(message, user_id=self._user_id()):
+            # A colleague has already :eyes:-claimed this review. Dispatching
+            # ``t3:reviewer`` anyway duplicates their in-flight work. An
+            # explicit ``<@user_slack_id>`` mention re-opens dispatch.
+            return []
         self._react(row.channel, row.slack_ts, "eyes")
         return [_signal_for_pending_mr(state.url, row, overlay=self.overlay) for state in open_states]
+
+    def _user_id(self) -> str:
+        return getattr(self.backend, "user_id", "") or self.user_slack_id
 
     def _all_authored_by_me(self, open_states: Sequence[MrState]) -> bool:
         """True when every open MR in the broadcast is authored by the current user (#1384).

--- a/tests/teatree_core/test_review_candidate.py
+++ b/tests/teatree_core/test_review_candidate.py
@@ -4,7 +4,11 @@ The auto-sweep / discover surfaces previously relied on agent-side BINDING
 memory to apply these rules; this module is the canonical structural fix.
 """
 
-from teatree.core.review_candidate import should_review_candidate, should_review_candidate_reasons
+from teatree.core.review_candidate import (
+    eyes_reacted_by_other,
+    should_review_candidate,
+    should_review_candidate_reasons,
+)
 
 
 class TestSkipSelfAuthor:
@@ -274,3 +278,37 @@ class TestReasonsAccumulate:
     def test_clean_candidate_returns_empty_reasons(self) -> None:
         mr = {"author": {"username": "bob"}, "state": "opened", "notes": []}
         assert should_review_candidate_reasons(mr, current_user="alice") == []
+
+
+class TestEyesReactedByOther:
+    def test_eyes_from_colleague_is_a_claim(self) -> None:
+        message = {"reactions": [{"name": "eyes", "users": ["UC0LLEAGUE"], "count": 1}]}
+        assert eyes_reacted_by_other(message, user_id="UME") is True
+
+    def test_eyes_only_from_user_is_not_a_claim(self) -> None:
+        message = {"reactions": [{"name": "eyes", "users": ["UME"], "count": 1}]}
+        assert eyes_reacted_by_other(message, user_id="UME") is False
+
+    def test_non_eyes_colleague_reaction_is_not_a_claim(self) -> None:
+        message = {"reactions": [{"name": "thumbsup", "users": ["UC0LLEAGUE"], "count": 1}]}
+        assert eyes_reacted_by_other(message, user_id="UME") is False
+
+    def test_no_reactions_is_not_a_claim(self) -> None:
+        assert eyes_reacted_by_other({}, user_id="UME") is False
+
+    def test_malformed_reactions_block_is_not_a_claim(self) -> None:
+        assert eyes_reacted_by_other({"reactions": "nope"}, user_id="UME") is False
+
+    def test_malformed_reaction_entry_and_users_are_skipped(self) -> None:
+        message = {
+            "reactions": [
+                "not-a-dict",
+                {"name": "eyes", "users": "not-a-list"},
+                {"name": "eyes", "users": [42, "", "UME", "UC0LLEAGUE"], "count": 1},
+            ],
+        }
+        assert eyes_reacted_by_other(message, user_id="UME") is True
+
+    def test_empty_user_id_treats_every_eyes_as_other(self) -> None:
+        message = {"reactions": [{"name": "eyes", "users": ["UC0LLEAGUE"], "count": 1}]}
+        assert eyes_reacted_by_other(message, user_id="") is True

--- a/tests/teatree_loop/test_slack_broadcasts_scanner.py
+++ b/tests/teatree_loop/test_slack_broadcasts_scanner.py
@@ -111,6 +111,16 @@ def _message(text: str, ts: str) -> RawAPIDict:
     return {"text": text, "ts": ts, "user": "USRG", "type": "message"}
 
 
+def _message_with_reactions(text: str, ts: str, reactions: list[RawAPIDict]) -> RawAPIDict:
+    message = _message(text, ts)
+    message["reactions"] = reactions
+    return message
+
+
+USER_SLACK_ID = "U0A72P7CK0A"
+COLLEAGUE_SLACK_ID = "UC0LLEAGUE"
+
+
 class TestClassificationBehaviour(TestCase):
     def test_all_merged_broadcast_reacts_green_check_and_skips_dispatch(self) -> None:
         backend = FakeMessaging()
@@ -248,6 +258,104 @@ class TestSkipsEyesOnOwnMrBroadcasts(TestCase):
 
         assert {s.payload["mr_url"] for s in signals} == {MR_OPEN, MR_OPEN_2}
         assert backend.react_calls == [(CHANNEL, TS_A, "eyes")]
+
+
+class TestSkipsBroadcastsAlreadyEyesReactedByColleague(TestCase):
+    """A broadcast already :eyes:-reacted by a colleague must not be dispatched.
+
+    Standing user rule: never dispatch a review of an MR/PR carrying a
+    :eyes: reaction from someone other than the user — that reaction is the
+    colleague's claim on the review. The override is an explicit
+    ``<@user_slack_id>`` mention: the user naming the MR re-opens dispatch.
+    """
+
+    def _scanner(self, history: dict[str, list[RawAPIDict]]) -> SlackBroadcastsScanner:
+        return SlackBroadcastsScanner(
+            backend=FakeMessaging(user_id=USER_SLACK_ID),
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher(history),
+            classify_mrs=_classifier({MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False)}),
+        )
+
+    def test_colleague_eyes_reaction_skips_react_and_dispatch(self) -> None:
+        message = _message_with_reactions(
+            f"please review {MR_OPEN}",
+            TS_A,
+            [{"name": "eyes", "users": [COLLEAGUE_SLACK_ID], "count": 1}],
+        )
+        scanner = self._scanner({CHANNEL: [message]})
+
+        signals = scanner.scan()
+
+        assert signals == []
+        assert scanner.backend.react_calls == []
+        row = ScannedBroadcast.objects.get(channel=CHANNEL, slack_ts=TS_A)
+        assert row.classification == ScannedBroadcast.Classification.PENDING
+
+    def test_own_eyes_reaction_does_not_count_as_a_colleague_claim(self) -> None:
+        message = _message_with_reactions(
+            f"please review {MR_OPEN}",
+            TS_A,
+            [{"name": "eyes", "users": [USER_SLACK_ID], "count": 1}],
+        )
+        scanner = self._scanner({CHANNEL: [message]})
+
+        signals = scanner.scan()
+
+        assert [s.payload["mr_url"] for s in signals] == [MR_OPEN]
+        assert scanner.backend.react_calls == [(CHANNEL, TS_A, "eyes")]
+
+    def test_non_eyes_colleague_reaction_still_dispatches(self) -> None:
+        message = _message_with_reactions(
+            f"please review {MR_OPEN}",
+            TS_A,
+            [{"name": "thumbsup", "users": [COLLEAGUE_SLACK_ID], "count": 1}],
+        )
+        scanner = self._scanner({CHANNEL: [message]})
+
+        signals = scanner.scan()
+
+        assert [s.payload["mr_url"] for s in signals] == [MR_OPEN]
+        assert scanner.backend.react_calls == [(CHANNEL, TS_A, "eyes")]
+
+    def test_no_user_id_configured_cannot_be_overridden_by_mention(self) -> None:
+        message = _message_with_reactions(
+            f"<@{USER_SLACK_ID}> please review {MR_OPEN}",
+            TS_A,
+            [{"name": "eyes", "users": [COLLEAGUE_SLACK_ID], "count": 1}],
+        )
+        scanner = SlackBroadcastsScanner(
+            backend=FakeMessaging(user_id=""),
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher({CHANNEL: [message]}),
+            classify_mrs=_classifier({MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False)}),
+        )
+
+        signals = scanner.scan()
+
+        assert signals == []
+        assert scanner.backend.react_calls == []
+
+    def test_user_mention_overrides_colleague_eyes_reaction(self) -> None:
+        message = _message_with_reactions(
+            f"<@{USER_SLACK_ID}> please review {MR_OPEN}",
+            TS_A,
+            [{"name": "eyes", "users": [COLLEAGUE_SLACK_ID], "count": 1}],
+        )
+        scanner = SlackBroadcastsScanner(
+            backend=FakeMessaging(user_id=USER_SLACK_ID),
+            channels=[CHANNEL],
+            fetch_channel_history=_fetcher({CHANNEL: [message]}),
+            classify_mrs=_classifier({MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False)}),
+            user_slack_id=USER_SLACK_ID,
+            reviewer_username="me",
+        )
+
+        signals = scanner.scan()
+
+        assert {s.kind for s in signals} == {"slack.review_intent", "review_request_in_slack"}
+        assert {s.payload["mr_url"] for s in signals} == {MR_OPEN}
+        assert scanner.backend.react_calls == [(CHANNEL, TS_A, "eyes")]
 
 
 class TestIdempotency(TestCase):


### PR DESCRIPTION
## What

Enforces a standing user rule: never dispatch or perform a review of an MR/PR whose review-broadcast / review-request message already carries an eyes (👀) reaction from someone other than the user. That reaction is the colleague's claim on the review — a second pass duplicates their in-flight work. The only override is the user explicitly naming the MR.

## The miss this guards

An MR was dispatched for review despite a colleague's eyes reaction on the review-broadcast message (and an open colleague discussion on the MR). The miss travelled the channel-poll path: `SlackBroadcastsScanner` reacted eyes and emitted a `slack.review_intent` signal for every open colleague MR, checking only own-authorship — never a colleague's prior eyes claim.

## Where the gate lives

- Signal source: the Slack broadcast message's native `reactions` field, which `fetch_channel_history` (`conversations.history`) passes through verbatim as `[{"name": "eyes", "users": ["U…"], "count": N}]`.
- Predicate: `eyes_reacted_by_other(message, user_id=...)` in `src/teatree/core/review_candidate.py` — emoji-specific to `eyes`, excluding the user's own reaction (the sibling `_broadcast_reacted_by_other` treats any reaction as a claim).
- Gate: `SlackBroadcastsScanner._apply_classification` (`src/teatree/loop/scanners/slack_broadcasts.py`) skips the eyes react + review-intent emission when `eyes_reacted_by_other` fires and the broadcast is not user-named. "The user" is `backend.user_id` (falling back to `user_slack_id`).
- Override: an at-mention of the user's own Slack id on the broadcast re-opens dispatch. Persisting the `ScannedBroadcast` row and seeding nag posts are unchanged.
- Rule encoded under the Giving-review section of `skills/review/SKILL.md`.

## Tests (proved RED before the gate)

- colleague-eyes broadcast is SKIPPED (no react, no dispatch)
- non-eyes colleague reaction still dispatches
- user-mention override still dispatches an eyes-reacted broadcast
- the user's own eyes does not count as a colleague claim
- predicate unit tests cover the Slack reactions shape + malformed inputs

100% coverage on new code. ruff / ty / targeted pytest green.

Closes https://github.com/souliane/teatree/issues/1746