### PR TITLE
fix(notify): thread question mirror + deferred-question drain under the active DM

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -6646,11 +6646,14 @@ def _slack_open_dm(bot_token: str, user_id: str, *, timeout: float) -> str:
     return cid if isinstance(cid, str) else ""
 
 
-def _slack_post_message(bot_token: str, channel: str, text: str, *, timeout: float) -> bool:
+def _slack_post_message(bot_token: str, channel: str, text: str, *, timeout: float, thread_ts: str = "") -> bool:
     """Post ``text`` to ``channel``. Return True iff Slack acknowledged success."""
     import urllib.request  # noqa: PLC0415
 
-    payload = json.dumps({"channel": channel, "text": text}).encode()
+    body: dict[str, str] = {"channel": channel, "text": text}
+    if thread_ts:
+        body["thread_ts"] = thread_ts
+    payload = json.dumps(body).encode()
     req = urllib.request.Request(
         "https://slack.com/api/chat.postMessage",
         data=payload,
@@ -6663,20 +6666,42 @@ def _slack_post_message(bot_token: str, channel: str, text: str, *, timeout: flo
     return bool(isinstance(resp, dict) and resp.get("ok") is True)
 
 
+def _active_dm_thread_for_channel(channel: str) -> str:
+    """Resolve the user's active DM thread for ``channel`` from ``IncomingEvent``.
+
+    Threads the mirrored question under the conversation the user is
+    already in instead of opening a new top-level message. Fail-open:
+    any bootstrap or DB error yields ``""`` (post at root) so the hook
+    stays crash-proof.
+    """
+    if not channel or not _bootstrap_teatree_django():
+        return ""
+    try:
+        from teatree.core.models import IncomingEvent  # noqa: PLC0415
+
+        return IncomingEvent.objects.active_dm_thread(channel=channel)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def _slack_post_dm(bot_token: str, user_id: str, text: str, *, timeout: float = 2.0) -> None:
     """Post ``text`` to ``user_id``'s DM. Resolves channel via cache when possible.
 
     Cache hit → single ``chat.postMessage`` call (sub-second on a normal
     connection, fits inside the 3s hook timeout). Cache miss or
     ``channel_not_found`` → open the DM, cache the channel id, retry.
+    Threads under the user's active DM conversation when one exists.
     """
     cached = _read_dm_channel_cache(user_id)
-    if cached and _slack_post_message(bot_token, cached, text, timeout=timeout):
-        return
+    if cached:
+        thread_ts = _active_dm_thread_for_channel(cached)
+        if _slack_post_message(bot_token, cached, text, timeout=timeout, thread_ts=thread_ts):
+            return
     channel = _slack_open_dm(bot_token, user_id, timeout=timeout)
     if not channel:
         return
-    if _slack_post_message(bot_token, channel, text, timeout=timeout):
+    thread_ts = _active_dm_thread_for_channel(channel)
+    if _slack_post_message(bot_token, channel, text, timeout=timeout, thread_ts=thread_ts):
         _write_dm_channel_cache(user_id, channel)
 
 

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -126,6 +126,19 @@ class IncomingEventQuerySet(models.QuerySet):
     def unprocessed(self) -> models.QuerySet:
         return self.filter(processed_at__isnull=True)
 
+    def active_dm_thread(self, *, channel: str) -> str:
+        from teatree.core.models.incoming_event import IncomingEvent  # noqa: PLC0415
+
+        if not channel:
+            return ""
+        latest = (
+            self.filter(source=IncomingEvent.Source.SLACK, channel_ref=channel)
+            .order_by("-received_at", "-pk")
+            .values_list("thread_ref", flat=True)
+            .first()
+        )
+        return latest or ""
+
 
 class ReplyDispatchQuerySet(models.QuerySet):
     def due_for_retry(self, now: datetime | None = None) -> models.QuerySet:

--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -208,6 +208,16 @@ def _maybe_stamp_answered(*, idempotency_key: str, answering_slack_ts: str) -> N
         logger.debug("notify_user answered_at stamp failed for ts=%s: %s", ts, exc)
 
 
+def _active_dm_thread(channel: str) -> str:
+    from teatree.core.models import IncomingEvent  # noqa: PLC0415
+
+    try:
+        return IncomingEvent.objects.active_dm_thread(channel=channel)
+    except DatabaseError as exc:
+        logger.debug("active_dm_thread lookup failed for channel=%s: %s", channel, exc)
+        return ""
+
+
 def _deliver_dm(
     backend: MessagingBackend,
     *,
@@ -233,7 +243,7 @@ def _deliver_dm(
         channel = backend.open_dm(user_id)
         if not channel:
             return "", "", "open_dm returned an empty channel (Slack conversations.open ok:false)"
-        response = backend.post_message(channel=channel, text=text, thread_ts="")
+        response = backend.post_message(channel=channel, text=text, thread_ts=_active_dm_thread(channel))
     except Exception as exc:  # noqa: BLE001 — notify must never bubble up
         return "", "", str(exc)
 

--- a/tests/teatree_core/test_managers.py
+++ b/tests/teatree_core/test_managers.py
@@ -51,6 +51,48 @@ class TestWorktreeQuerySet(TestCase):
         assert list(Worktree.objects.active()) == [active, also_active]
 
 
+class TestIncomingEventQuerySet(TestCase):
+    def _slack(self, *, channel: str, thread_ref: str, key: str) -> IncomingEvent:
+        return IncomingEvent.objects.create(
+            source=IncomingEvent.Source.SLACK,
+            channel_ref=channel,
+            thread_ref=thread_ref,
+            idempotency_key=key,
+        )
+
+    def test_active_dm_thread_returns_most_recent_thread_ref_for_channel(self) -> None:
+        self._slack(channel="D1", thread_ref="1700000000.0001", key="slack:a")
+        self._slack(channel="D1", thread_ref="1700000099.0009", key="slack:b")
+
+        assert IncomingEvent.objects.active_dm_thread(channel="D1") == "1700000099.0009"
+
+    def test_active_dm_thread_scopes_to_the_requested_channel(self) -> None:
+        self._slack(channel="D-other", thread_ref="9999999999.0001", key="slack:other")
+        self._slack(channel="D1", thread_ref="1700000000.0001", key="slack:mine")
+
+        assert IncomingEvent.objects.active_dm_thread(channel="D1") == "1700000000.0001"
+
+    def test_active_dm_thread_ignores_non_slack_sources(self) -> None:
+        IncomingEvent.objects.create(
+            source=IncomingEvent.Source.GITHUB,
+            channel_ref="D1",
+            thread_ref="github-ref",
+            idempotency_key="github:1",
+        )
+
+        assert IncomingEvent.objects.active_dm_thread(channel="D1") == ""
+
+    def test_active_dm_thread_empty_when_no_event_for_channel(self) -> None:
+        self._slack(channel="D-other", thread_ref="1700000000.0001", key="slack:other")
+
+        assert IncomingEvent.objects.active_dm_thread(channel="D1") == ""
+
+    def test_active_dm_thread_empty_channel_matches_nothing(self) -> None:
+        self._slack(channel="D1", thread_ref="1700000000.0001", key="slack:a")
+
+        assert IncomingEvent.objects.active_dm_thread(channel="") == ""
+
+
 class TestSessionQuerySet(TestCase):
     def test_for_agent_filters_by_agent_identifier(self) -> None:
         wanted = Session.objects.create(ticket=Ticket.objects.create(), agent_id="agent-1")

--- a/tests/teatree_core/test_notify.py
+++ b/tests/teatree_core/test_notify.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 from django.db import OperationalError
 from django.test import TestCase
 
-from teatree.core.models import BotPing
+from teatree.core.models import BotPing, IncomingEvent
 from teatree.notify import NotifyKind, notify_user
 
 _DB_LOCKED = OperationalError("database is locked")
@@ -48,6 +48,55 @@ class TestNotifyUser(TestCase):
         assert row.posted_ts == "1700000000.000000"
         assert row.permalink.startswith("https://")
         assert row.text == "tests are green"
+
+    def test_threads_under_active_dm_thread_when_one_exists(self) -> None:
+        IncomingEvent.objects.create(
+            source=IncomingEvent.Source.SLACK,
+            channel_ref="D-USER",
+            thread_ref="1700000000.000111",
+            idempotency_key="slack:Ev-active",
+        )
+        backend = _backend()
+
+        notify_user(
+            "answering your question",
+            kind=NotifyKind.ANSWER,
+            idempotency_key="threaded-answer",
+            backend=backend,
+            user_id="U_ME",
+        )
+
+        assert backend.post_message.call_args.kwargs["thread_ts"] == "1700000000.000111"
+
+    def test_no_active_thread_posts_at_root(self) -> None:
+        backend = _backend()
+
+        notify_user(
+            "first message in the conversation",
+            kind=NotifyKind.INFO,
+            idempotency_key="rootless",
+            backend=backend,
+            user_id="U_ME",
+        )
+
+        assert backend.post_message.call_args.kwargs["thread_ts"] == ""
+
+    def test_active_thread_lookup_db_error_falls_back_to_root(self) -> None:
+        backend = _backend()
+        with patch(
+            "teatree.core.models.IncomingEvent.objects.active_dm_thread",
+            side_effect=OperationalError("database is locked"),
+        ):
+            sent = notify_user(
+                "lookup blew up but the DM still lands",
+                kind=NotifyKind.INFO,
+                idempotency_key="thread-lookup-db-error",
+                backend=backend,
+                user_id="U_ME",
+            )
+
+        assert sent is True
+        assert backend.post_message.call_args.kwargs["thread_ts"] == ""
 
     def test_kind_accepts_string_alias(self) -> None:
         backend = _backend()

--- a/tests/test_slack_mirror_hook.py
+++ b/tests/test_slack_mirror_hook.py
@@ -137,21 +137,23 @@ class TestSlackPostDm:
         router._write_dm_channel_cache("U1", "D-cached")
         with (
             patch.object(router, "_slack_open_dm") as mock_open,
+            patch.object(router, "_active_dm_thread_for_channel", return_value=""),
             patch.object(router, "_slack_post_message", return_value=True) as mock_post,
         ):
             router._slack_post_dm("xoxb-tok", "U1", "hello")
         mock_open.assert_not_called()
-        mock_post.assert_called_once_with("xoxb-tok", "D-cached", "hello", timeout=2.0)
+        mock_post.assert_called_once_with("xoxb-tok", "D-cached", "hello", timeout=2.0, thread_ts="")
 
     def test_cache_miss_opens_dm_and_caches(self, tmp_path: Path, monkeypatch) -> None:
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
         with (
             patch.object(router, "_slack_open_dm", return_value="D-new") as mock_open,
+            patch.object(router, "_active_dm_thread_for_channel", return_value=""),
             patch.object(router, "_slack_post_message", return_value=True) as mock_post,
         ):
             router._slack_post_dm("xoxb-tok", "U1", "hello")
         mock_open.assert_called_once()
-        mock_post.assert_called_once_with("xoxb-tok", "D-new", "hello", timeout=2.0)
+        mock_post.assert_called_once_with("xoxb-tok", "D-new", "hello", timeout=2.0, thread_ts="")
         assert router._read_dm_channel_cache("U1") == "D-new"
 
     def test_stale_cache_falls_back_to_open(self, tmp_path: Path, monkeypatch) -> None:
@@ -159,12 +161,53 @@ class TestSlackPostDm:
         router._write_dm_channel_cache("U1", "D-stale")
         with (
             patch.object(router, "_slack_open_dm", return_value="D-fresh") as mock_open,
+            patch.object(router, "_active_dm_thread_for_channel", return_value=""),
             patch.object(router, "_slack_post_message", side_effect=[False, True]) as mock_post,
         ):
             router._slack_post_dm("xoxb-tok", "U1", "hello")
         mock_open.assert_called_once()
         assert mock_post.call_count == 2
         assert router._read_dm_channel_cache("U1") == "D-fresh"
+
+    def test_cache_hit_threads_under_active_dm_thread(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        router._write_dm_channel_cache("U1", "D-cached")
+        with (
+            patch.object(router, "_active_dm_thread_for_channel", return_value="1700000000.0009") as mock_thread,
+            patch.object(router, "_slack_post_message", return_value=True) as mock_post,
+        ):
+            router._slack_post_dm("xoxb-tok", "U1", "hello")
+        mock_thread.assert_called_once_with("D-cached")
+        mock_post.assert_called_once_with("xoxb-tok", "D-cached", "hello", timeout=2.0, thread_ts="1700000000.0009")
+
+    def test_opened_channel_threads_under_active_dm_thread(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        with (
+            patch.object(router, "_slack_open_dm", return_value="D-new"),
+            patch.object(router, "_active_dm_thread_for_channel", return_value="1700000000.0042") as mock_thread,
+            patch.object(router, "_slack_post_message", return_value=True) as mock_post,
+        ):
+            router._slack_post_dm("xoxb-tok", "U1", "hello")
+        mock_thread.assert_called_once_with("D-new")
+        mock_post.assert_called_once_with("xoxb-tok", "D-new", "hello", timeout=2.0, thread_ts="1700000000.0042")
+
+
+class TestActiveDmThreadResolver:
+    def test_resolves_most_recent_slack_thread_ref_for_channel(self) -> None:
+        from teatree.core.models import IncomingEvent  # noqa: PLC0415
+
+        IncomingEvent.objects.create(
+            source=IncomingEvent.Source.SLACK,
+            channel_ref="D-cached",
+            thread_ref="1700000000.0009",
+            idempotency_key="slack:Ev-mirror",
+        )
+
+        assert router._active_dm_thread_for_channel("D-cached") == "1700000000.0009"
+
+    def test_empty_when_django_unavailable(self) -> None:
+        with patch.object(router, "_bootstrap_teatree_django", return_value=False):
+            assert router._active_dm_thread_for_channel("D-cached") == ""
 
 
 class TestHooksJsonWiring:


### PR DESCRIPTION
Closes [#1747](https://github.com/souliane/teatree/issues/1747).

The AskUserQuestion Slack mirror (present and away mode) and the deferred-question re-surfacing drain posted every DM as a new top-level message, so each question opened a fresh thread instead of landing under the conversation the user was already in.

Root cause: every bot-to-user posting surface emitted the message with no thread_ts — hooks/scripts/hook_router.py _slack_post_message / _slack_post_dm (both the present-mode and away-mode mirrors route through _slack_post_dm), and src/teatree/core/notify.py _deliver_dm (notify_user, used by drain_deferred_questions).

Fix: added IncomingEvent.objects.active_dm_thread(channel=...), resolving the thread_ref of the most recent Slack IncomingEvent for the channel (the webhook sets thread_ref to the inbound thread_ts or ts). Both surfaces now resolve it and pass it as thread_ts. notify.py swallows DatabaseError; the hook resolver bootstraps Django and fails open to root on any bootstrap/DB error so the PreToolUse hook stays crash-proof. When no active thread exists, the first post establishes the thread and subsequent ones reply to it — so the question, its re-surfacing, and the answer-ack all live in one thread.

Tests (each observed red on the pre-fix root-posting code before the fix): the active_dm_thread resolver (most-recent / channel-scoped / Slack-only / empty); notify._deliver_dm carries the active thread_ts when one exists, posts at root when none, falls back to root on a DB error; the hook mirror threads on both the cache-hit and opened-channel paths and returns empty when Django is unavailable.