### PR TITLE
fix(todos/banned-terms): read live harness store, generalise scan-tree summary ([#1736](https://github.com/souliane/teatree/issues/1736))

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -288,8 +288,7 @@ Usage: t3 banned-terms [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ scan-tree  Scan every git-tracked file for committed high-confidence brand   │
-│            names.                                                            │
+│ scan-tree  Scan every git-tracked file for committed banned terms.           │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -298,7 +297,7 @@ Usage: t3 banned-terms [OPTIONS] COMMAND [ARGS]...
 ```
 Usage: t3 banned-terms scan-tree [OPTIONS]
 
- Scan every git-tracked file for committed high-confidence brand names.
+ Scan every git-tracked file for committed banned terms.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --repo-root        PATH  Repository root to scan (defaults to the current    │

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -4039,44 +4039,37 @@ def handle_read_dedup(data: dict) -> None:
     )
 
 
-# ── PostToolUse: capture TodoWrite into durable per-session state ──
+# ── PostToolUse: refresh the harness TODO statusline view ──────────
 #
-# Issue #970: the recovery snapshot was missing the active TODO list.
-# When ``TodoWrite`` fires, persist the latest todos to
-# ``<session>.todos`` so the PreCompact snapshot can quote them back.
-# Anthropic's newer ``TaskCreate``/``TaskUpdate`` tools currently bypass
-# PostToolUse (documented regression in ``docs/claude-code-internals.md``);
-# whenever they start firing hooks again, register them here too.
+# Issue #970 captured the active TODO list for the recovery snapshot via
+# the ``TodoWrite`` PostToolUse. Issue #1734 retired that path: the
+# harness migrated to the ``TaskCreate`` / ``TaskUpdate`` store, which
+# bypasses PostToolUse entirely, so the ``TodoWrite`` capture stopped
+# firing and ``<session>.todos`` went stale. The canonical live source is
+# now the harness task store, read by ``read_harness_todos``. This handler
+# materialises that store into ``<session>.todos`` on every PostToolUse so
+# the fast statusline keeps reading a fresh file rather than a dead one.
 
 
 def handle_track_todos(data: dict) -> None:
-    """Persist the current ``TodoWrite`` todo list to ``<session>.todos``.
+    """Refresh ``<session>.todos`` from the live harness task store.
 
-    Stores one ``- [status] content`` line per todo so the snapshot
-    renderer can include it verbatim. Overwrites on each TodoWrite so
-    completed/removed items don't linger — TodoWrite is the source of
-    truth for the active list. No-op for any other tool name.
+    Reads the current harness TODO list via ``read_harness_todos`` (#1734)
+    and overwrites ``<session>.todos`` with one ``- [status] content`` line
+    per item, so the statusline summary and the PreCompact snapshot read
+    the live store rather than the retired ``TodoWrite`` capture file.
+    No-op without a session id; never raises — capture must not block.
     """
-    if data.get("tool_name") != "TodoWrite":
-        return
     session_id = data.get("session_id", "")
     if not session_id:
         return
-    todos = data.get("tool_input", {}).get("todos", [])
-    if not isinstance(todos, list):
-        return
 
+    from teatree.core.management.commands.tasks_session_view import read_harness_todos  # noqa: PLC0415
+
+    todos = read_harness_todos(session_id)
     _ensure_state_dir()
     todos_file = _state_file(session_id, "todos")
-    lines: list[str] = []
-    for todo in todos:
-        if not isinstance(todo, dict):
-            continue
-        content = str(todo.get("content", "")).strip()
-        if not content:
-            continue
-        status = str(todo.get("status", "pending")).strip() or "pending"
-        lines.append(f"- [{status}] {content}")
+    lines = [f"- [{status}] {content}" for status, content in todos]
     todos_file.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
 
 
@@ -4336,9 +4329,8 @@ def _durable_session_snapshot(session_id: str, data: dict | None = None) -> str:
     additionally pins, when ``data`` carries the harness ``cwd``: the
     current worktree, branch, HEAD short SHA, uncommitted/unpushed
     counts, and the live open PRs for that repo (best-effort, never
-    blocking). Captured TODOs (via :func:`handle_track_todos`) round out
-    "what was I about to do next" from the durable side, since the Tasks
-    API doesn't fire ``PostToolUse``.
+    blocking). The live harness TODO list (via :func:`read_harness_todos`,
+    #1734) rounds out "what was I about to do next" from the durable side.
     """
     data = data or {}
     lines = [
@@ -4395,9 +4387,11 @@ def _durable_session_snapshot(session_id: str, data: dict | None = None) -> str:
 
     lines += _render_no_commit_section(session_id)
 
-    todos = _read_lines(_state_file(session_id, "todos"))
+    from teatree.core.management.commands.tasks_session_view import read_harness_todos  # noqa: PLC0415
+
+    todos = read_harness_todos(session_id)
     if todos:
-        lines += ["", "## Pending TODOs", *todos]
+        lines += ["", "## Pending TODOs", *(f"- [{status}] {content}" for status, content in todos)]
 
     active = _read_lines(_state_file(session_id, "active"))
     if active:

--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -11,10 +11,11 @@
 #     exactly one home, the loop line.
 #  2. Live per-session info from Claude's stdin JSON: model, context-window %,
 #     5-hour and 7-day rate-limit usage, skills loaded this session, a compact
-#     summary of this session's harness TODO list (TodoWrite), and a
+#     summary of this session's harness TODO list, and a
 #     per-session loop-owner badge — the skills and TODO summaries are
 #     populated by hook_router.py into ${state_dir}/<session_id>.skills and
-#     ${state_dir}/<session_id>.todos, the badge from loop-registry.json. The loop-owner badge shows "you ✓" (green) when this
+#     ${state_dir}/<session_id>.todos (the TODO file is materialised from the
+#     live harness task store), the badge from loop-registry.json. The loop-owner badge shows "you ✓" (green) when this
 #     session owns the loop, "owner·pid<PID>" (yellow, neutral) when a
 #     different session owns it, or "unclaimed" (dim) when the registry has
 #     no live owner. Unlike the shared loop line, this badge is resolved
@@ -57,11 +58,12 @@ if [ -n "$session_id" ]; then
     if [ -r "$skills_file" ]; then
         skills=$(paste -sd ' ' "$skills_file")
     fi
-    # This session's harness TODO list (TodoWrite), persisted by hook_router.py
-    # as one ``- [status] content`` line per todo. Rendered as a fixed-width
-    # ``TODO done/total ✓ · Nwip`` summary — never item content, so width is
-    # bounded no matter how many todos exist. Distinct from the loop work
-    # queue (rendered Python-side); this is the current session's checklist.
+    # This session's harness TODO list, materialised by hook_router.py from
+    # the live harness task store as one ``- [status] content`` line per
+    # todo. Rendered as a fixed-width ``TODO done/total ✓ · Nwip`` summary —
+    # never item content, so width is bounded no matter how many todos exist.
+    # Distinct from the loop work queue (rendered Python-side); this is the
+    # current session's checklist.
     todos_file="$state_dir/${session_id}.todos"
     if [ -r "$todos_file" ]; then
         _total=$(grep -c '^- \[' "$todos_file" 2>/dev/null || true)

--- a/src/teatree/cli/banned_terms.py
+++ b/src/teatree/cli/banned_terms.py
@@ -1,10 +1,11 @@
 """Banned-terms CLI — the full-tree backstop scan (#1570).
 
 ``t3 banned-terms scan-tree`` enumerates every git-tracked file and scans
-its committed CONTENT for the high-confidence brand list, exiting non-zero
-with the offending ``file:line`` list. It is the backstop the diff-only
-posting gate cannot provide: a brand name already committed never appears
-in a post-landing diff. CI runs this on push-to-main and on a schedule.
+its committed CONTENT for the operator brand list AND the built-in
+conflated-terminology gate, exiting non-zero with the offending
+``file:line`` list. It is the backstop the diff-only posting gate cannot
+provide: a committed banned term never appears in a post-landing diff. CI
+runs this on push-to-main and on a schedule.
 """
 
 from pathlib import Path
@@ -43,18 +44,18 @@ def scan_tree(
         help="Override the ~/.teatree.toml term-list config (else resolved as the gate does).",
     ),
 ) -> None:
-    """Scan every git-tracked file for committed high-confidence brand names."""
+    """Scan every git-tracked file for committed banned terms."""
     root = repo_root if repo_root is not None else Path.cwd()
     findings = scan_committed_tree(root, config_path=config)
     if not findings:
         _console.print("[green]banned-terms scan-tree: clean (0 findings).[/]")
         return
 
-    _console.print(f"[red]banned-terms scan-tree: {len(findings)} committed brand-name finding(s).[/]")
+    _console.print(f"[red]banned-terms scan-tree: {len(findings)} committed banned-term finding(s).[/]")
     for finding in findings:
         _console.print(f"  {finding.render()}")
     _console.print(
-        "\nA high-confidence brand name is committed to the tree. Scrub it "
+        "\nA banned term is committed to the tree. Scrub it "
         "(the diff-only gate cannot see it — it is not in any new diff)."
     )
     raise typer.Exit(_FINDINGS_EXIT_CODE)

--- a/tests/test_banned_terms_tree_scan.py
+++ b/tests/test_banned_terms_tree_scan.py
@@ -282,6 +282,40 @@ class TestScanTreeCli:
         assert "clean" in result.stdout
 
 
+class TestScanTreeCliSummaryIsBrandAgnostic:
+    """The summary describes findings generically, not as brand-only (#1736).
+
+    ``scan-tree`` returns brand AND terminology findings; the summary line
+    and remediation must not call a terminology finding a "brand" one.
+    """
+
+    def test_terminology_only_summary_does_not_say_brand(self, tmp_path: Path) -> None:
+        # A conflated-terminology hit with NO brand configured: the only
+        # finding is a terminology violation, never a brand. The conflated
+        # phrase is assembled at runtime so this (non-exempt) test file's
+        # own committed source never trips the terminology backstop.
+        conflated = "claude-" + "code " + "todos"
+        repo = _repo_with(tmp_path, "docs/note.md", f"tracking {conflated} here\n")
+        result = CliRunner().invoke(
+            banned_terms_app,
+            ["scan-tree", "--repo-root", str(repo), "--config", str(tmp_path / "absent.toml")],
+        )
+        assert result.exit_code == 1
+        assert "docs/note.md" in result.stdout
+        assert "brand" not in result.stdout.lower()
+
+    def test_summary_counts_findings_generically(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path, brands=[SYNTH_BRAND])
+        repo = _repo_with(tmp_path, "src/app.py", f"WORKTREE = 'wt_777_{SYNTH_BRAND}'\n")
+        result = CliRunner().invoke(
+            banned_terms_app,
+            ["scan-tree", "--repo-root", str(repo), "--config", str(cfg)],
+        )
+        assert result.exit_code == 1
+        assert "banned-term finding(s)" in result.stdout
+        assert "brand-name finding" not in result.stdout
+
+
 @pytest.mark.parametrize("joined", ["wt_777_{b}", "{b}_777", "a_{b}_z"])
 def test_all_underscore_shapes_are_caught(joined: str) -> None:
     pattern = banned_terms_tree_scan.build_brand_pattern((SYNTH_BRAND,))

--- a/tests/test_pre_compact_snapshot_enriched.py
+++ b/tests/test_pre_compact_snapshot_enriched.py
@@ -10,6 +10,7 @@ was I doing" after compaction. These tests pin the enriched capture so
 the snapshot reliably contains that recovery-relevant state.
 """
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -194,50 +195,66 @@ class TestSnapshotIncludesOpenPRs:
         assert "Open PRs" not in body
 
 
-class TestTodoCaptureAndSnapshot:
-    """The TODO list is durable-state we have to populate ourselves.
+def _seed_harness_store(tmp_path: Path, session_id: str, todos: list[tuple[str, str]]) -> None:
+    """Write one ``<n>.json`` per harness TODO under ``CLAUDE_TASKS_DIR/<session>``."""
+    session_dir = tmp_path / "harness-tasks" / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    for index, (status, subject) in enumerate(todos, start=1):
+        (session_dir / f"{index}.json").write_text(json.dumps({"subject": subject, "status": status}), encoding="utf-8")
 
-    Anthropic's current Tasks API doesn't fire PostToolUse, but the legacy
-    ``TodoWrite`` tool does (and any tool the agent uses to maintain a
-    visible task list can plug in here). The hook captures the latest
-    snapshot of the todos to ``<session>.todos`` so PreCompact can quote
-    them back into the snapshot.
+
+class TestTodoCaptureFromHarnessStore:
+    """The ``.todos`` statusline state file is a materialised view of the live store (#1736).
+
+    ``TodoWrite`` PostToolUse no longer fires (the harness migrated to the
+    ``TaskCreate`` / ``TaskUpdate`` store, #1734), so the only live source
+    is the harness task store. ``handle_track_todos`` refreshes
+    ``<session>.todos`` from ``read_harness_todos`` on each PostToolUse so
+    the fast statusline keeps reading a fresh file rather than a dead one.
     """
 
-    def test_todowrite_is_captured_to_session_todos_file(self) -> None:
-        session_id = "sess-todo-capture"
-        handle_track_todos(
-            {
-                "session_id": session_id,
-                "tool_name": "TodoWrite",
-                "tool_input": {
-                    "todos": [
-                        {"content": "fix snapshot", "status": "in_progress"},
-                        {"content": "push and open PR", "status": "pending"},
-                    ]
-                },
-            }
+    def test_refreshes_todos_file_from_harness_store(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_id = "sess-todo-store"
+        _seed_harness_store(
+            tmp_path,
+            session_id,
+            [("in_progress", "fix snapshot"), ("pending", "push and open PR")],
         )
+        monkeypatch.setenv("CLAUDE_TASKS_DIR", str(tmp_path / "harness-tasks"))
+
+        handle_track_todos({"session_id": session_id, "tool_name": "Read", "tool_input": {"file_path": "x"}})
+
         todos_file = router.STATE_DIR / f"{session_id}.todos"
         assert todos_file.is_file()
         text = todos_file.read_text(encoding="utf-8")
-        assert "fix snapshot" in text
-        assert "push and open PR" in text
+        assert "- [in_progress] fix snapshot" in text
+        assert "- [pending] push and open PR" in text
 
-    def test_non_todowrite_tool_does_not_clobber_todos(self) -> None:
-        session_id = "sess-todo-noclobber"
-        todos_file = router.STATE_DIR / f"{session_id}.todos"
-        router.STATE_DIR.mkdir(parents=True, exist_ok=True)
-        todos_file.write_text("- existing\n", encoding="utf-8")
+    def test_empty_store_writes_empty_todos_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_id = "sess-todo-empty"
+        monkeypatch.setenv("CLAUDE_TASKS_DIR", str(tmp_path / "harness-tasks"))
+
         handle_track_todos({"session_id": session_id, "tool_name": "Read", "tool_input": {"file_path": "x"}})
-        assert todos_file.read_text(encoding="utf-8") == "- existing\n"
 
-    def test_snapshot_renders_captured_todos(self) -> None:
+        todos_file = router.STATE_DIR / f"{session_id}.todos"
+        assert todos_file.read_text(encoding="utf-8") == ""
+
+    def test_missing_session_id_is_a_noop(self, tmp_path: Path) -> None:
+        handle_track_todos({"tool_name": "Read", "tool_input": {"file_path": "x"}})
+        assert not any(router.STATE_DIR.glob("*.todos"))
+
+
+class TestSnapshotTodosFromHarnessStore:
+    """The PreCompact snapshot quotes the live harness store, not the dead file (#1736)."""
+
+    def test_snapshot_renders_harness_store_todos(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         session_id = "sess-todo-render"
-        router.STATE_DIR.mkdir(parents=True, exist_ok=True)
-        (router.STATE_DIR / f"{session_id}.todos").write_text(
-            "- [in_progress] fix snapshot\n- [pending] push PR\n", encoding="utf-8"
+        _seed_harness_store(
+            tmp_path,
+            session_id,
+            [("in_progress", "fix snapshot"), ("pending", "push PR")],
         )
+        monkeypatch.setenv("CLAUDE_TASKS_DIR", str(tmp_path / "harness-tasks"))
 
         handle_pre_compact({"session_id": session_id})
 


### PR DESCRIPTION
## What

Closes [#1736](https://github.com/souliane/teatree/issues/1736).

- **statusline + PreCompact no longer read the dead `.todos` capture path.** `handle_track_todos` now materialises `<session>.todos` from the live harness task store (`read_harness_todos`, [#1734](https://github.com/souliane/teatree/pull/1734)) on every PostToolUse, so the fast statusline keeps reading a fresh file. The PreCompact recovery snapshot renders the TODO list directly from `read_harness_todos`. The retired `TodoWrite` PostToolUse capture path and its "TodoWrite" statusline comment are gone.
- **`scan-tree` summary is brand-agnostic.** `t3 banned-terms scan-tree` returns brand AND terminology findings; the summary now counts them generically ("banned-term finding(s)") and the remediation no longer says "brand", so a terminology-only finding is not misreported as a brand violation.

## Why

[#1734](https://github.com/souliane/teatree/pull/1734) made `read_harness_todos()` the canonical harness-TODO path and retired the `<session>.todos` `TodoWrite` capture (the harness migrated to `TaskCreate`/`TaskUpdate`, which bypass PostToolUse). Two call sites still read the dead file and silently returned stale/empty data, and the `scan-tree` summary text was hardcoded to brand findings.

## Tests (RED → GREEN)

- `tests/test_pre_compact_snapshot_enriched.py`: new `TestTodoCaptureFromHarnessStore` + `TestSnapshotTodosFromHarnessStore` seed only the harness task store (no `.todos` file). RED on pre-fix code (handler gated on `TodoWrite`; snapshot read `_state_file(..., "todos")` → no output); GREEN after the rewire. These fail if either call site reverts to the old `.todos` path.
- `tests/test_banned_terms_tree_scan.py`: new `TestScanTreeCliSummaryIsBrandAgnostic` proves a terminology-only finding's summary says no "brand". RED on pre-fix ("committed brand-name finding(s)"), GREEN after.

Targeted suites green (statusline, hooks, banned-terms, terminology, management commands), ruff clean, 100% coverage on new lines, `t3 tool privacy-scan` clean, `t3 banned-terms scan-tree` clean. Full pre-push Docker test matrix passed.