### PR TITLE
fix(merge): resolve overlay for substrate autonomy carve-out from ticket OR slug (#1748)

### DIFF
--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -1042,9 +1042,21 @@ def _active_overlay_overrides() -> dict[str, Any]:
 
 
 def _overlay_overrides_by_name(overlay_name: str) -> dict[str, Any]:
-    """Per-overlay overrides for a NAMED overlay (no env layer — see caller)."""
+    """Per-overlay overrides for a NAMED overlay (no env layer — see caller).
+
+    The match is canonical-alias-tolerant: a request for the short alias
+    ``teatree`` resolves the ``t3-``-prefixed entry-point overlay's
+    ``[overlays.t3-teatree]`` overrides, and vice versa. ``ticket.overlay``
+    and ``infer_overlay_for_url`` return the entry-point name while older
+    rows / configs may carry the bare alias; an exact-name-only match would
+    silently drop the per-overlay values (and an autonomous overlay would
+    resolve to ``babysit``).
+    """
+    canonical = OverlayEntry.canonical_overlay_name(overlay_name)
     for entry in discover_overlays():
-        if entry.name == overlay_name and entry.overrides:
+        if not entry.overrides:
+            continue
+        if entry.name == overlay_name or OverlayEntry.canonical_overlay_name(entry.name) == canonical:
             return dict(entry.overrides)
     return {}
 

--- a/src/teatree/core/merge_execution.py
+++ b/src/teatree/core/merge_execution.py
@@ -858,21 +858,39 @@ def _assert_clear_authorized(
     return clear
 
 
+def _resolve_clear_overlay_name(clear: "MergeClear") -> str:
+    """The overlay name to resolve autonomy against for *clear*.
+
+    The CLEAR's ``ticket.overlay`` is authoritative when present, but the loop
+    routinely issues a CLEAR with no linked ticket (every substrate CLEAR in
+    the live ledger). The CLEAR always carries the ``owner/repo`` ``slug``, so
+    the overlay is recovered from it via :func:`infer_overlay_for_url` — the
+    same workspace-repos inference ``ticket.overlay`` itself is populated from.
+    Returns ``""`` when neither source resolves an overlay.
+    """
+    from teatree.core.overlay_loader import infer_overlay_for_url  # noqa: PLC0415
+
+    overlay_name = str(getattr(getattr(clear, "ticket", None), "overlay", "") or "").strip()
+    if overlay_name:
+        return overlay_name
+    return infer_overlay_for_url(str(getattr(clear, "slug", "") or "")).strip()
+
+
 def _overlay_grants_full_substrate_autonomy(clear: "MergeClear") -> bool:
     """Whether the CLEAR's overlay stands at ``autonomy = full`` (invariant 4 carve-out).
 
-    Resolves the effective autonomy for the overlay the CLEAR's ticket belongs
-    to via :func:`get_effective_settings`. ``full`` is the owner's standing,
-    recorded grant that this overlay merges end-to-end without a per-PR human
-    sign-off; it satisfies the substrate sign-off in place of a per-CLEAR
-    ``human_authorizer``. Any other tier (``notify`` / ``babysit``), or an
-    unresolvable overlay, is fail-closed: the per-CLEAR human authoriser stays
-    mandatory. The carve-out touches ONLY the per-PR sign-off — every other
-    substrate-merge floor guard runs unchanged.
+    Resolves the effective autonomy for the CLEAR's overlay
+    (:func:`_resolve_clear_overlay_name`) via :func:`get_effective_settings`.
+    ``full`` is the owner's standing, recorded grant that this overlay merges
+    end-to-end without a per-PR human sign-off; it satisfies the substrate
+    sign-off in place of a per-CLEAR ``human_authorizer``. Any other tier
+    (``notify`` / ``babysit``), or an unresolvable overlay, is fail-closed:
+    the per-CLEAR human authoriser stays mandatory. The carve-out touches ONLY
+    the per-PR sign-off — every other substrate-merge floor guard runs unchanged.
     """
     from teatree.config import Autonomy, get_effective_settings  # noqa: PLC0415
 
-    overlay_name = str(getattr(getattr(clear, "ticket", None), "overlay", "") or "").strip()
+    overlay_name = _resolve_clear_overlay_name(clear)
     if not overlay_name:
         return False
     return get_effective_settings(overlay_name=overlay_name).autonomy is Autonomy.FULL

--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -8,12 +8,17 @@ of whether the overlay was registered via ``pip install`` (entry point) or
 import importlib
 import logging
 import os
+import tempfile
+from contextlib import contextmanager
 from functools import lru_cache
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import ImproperlyConfigured
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from teatree.core.overlay import OverlayBase
 
 logger = logging.getLogger(__name__)
@@ -231,3 +236,27 @@ def reset_overlay_cache() -> None:
 
     _discover_overlays.cache_clear()
     sys.modules.pop("teatree.contrib.t3_teatree.overlay", None)
+
+
+@contextmanager
+def staged_overlay_autonomy(overlay_name: str, autonomy: str) -> "Iterator[None]":
+    """Run the block with a hermetic ``~/.teatree.toml`` pinning *overlay_name* to *autonomy*.
+
+    A test-isolation helper for assertions whose outcome depends on the
+    overlay's effective autonomy (the substrate-merge carve-out). Swaps
+    :data:`teatree.config.CONFIG_PATH` at the single seam ``get_effective_settings``
+    reads, so the resolved autonomy is deterministic regardless of the
+    developer's live config, and restores it on exit. Production code never
+    calls this.
+    """
+    from teatree import config as config_module  # noqa: PLC0415
+
+    with tempfile.TemporaryDirectory() as raw:
+        cfg = Path(raw) / ".teatree.toml"
+        cfg.write_text(f'[teatree]\n[overlays.{overlay_name}]\nautonomy = "{autonomy}"\n', encoding="utf-8")
+        original = config_module.CONFIG_PATH
+        config_module.CONFIG_PATH = cfg
+        try:
+            yield
+        finally:
+            config_module.CONFIG_PATH = original

--- a/src/teatree/eval/README.md
+++ b/src/teatree/eval/README.md
@@ -170,6 +170,7 @@ class, where it is pinned, and the originating fix:
 | branch-currency §940 (conflict-only, never behind-only) | `regression_corpus` | [#1719](https://github.com/souliane/teatree/pull/1719) |
 | bare-reference gate over-block on read-only `gh api` | `regression_corpus` | [#1535](https://github.com/souliane/teatree/pull/1535) |
 | substrate-merge human-authorize floor | `regression_corpus` (merge precondition) | [#1498](https://github.com/souliane/teatree/pull/1498) |
+| substrate-merge full-autonomy carve-out | `regression_corpus` (merge precondition) | [#1748](https://github.com/souliane/teatree/issues/1748) |
 | maker≠checker at merge time | `regression_corpus` (merge precondition) | [#1601](https://github.com/souliane/teatree/pull/1601) |
 | loop-owner hijack / pid-anchored lease | `regression_corpus` (lease claim) | [#1724](https://github.com/souliane/teatree/pull/1724) |
 | orchestrator boundary — long work + foreground edit | `scenarios/orchestrator_boundary.yaml` | [#1446](https://github.com/souliane/teatree/pull/1446) |

--- a/src/teatree/eval/regression_corpus.py
+++ b/src/teatree/eval/regression_corpus.py
@@ -178,19 +178,45 @@ _SHA_B = "b" * 40
 
 
 def _check_merge_precondition_substrate_human_authorize() -> bool:
-    """Substrate floor: a substrate CLEAR never merges without the recorded human authorizer.
+    """Substrate floor: a below-full substrate CLEAR never merges without the recorded human authorizer.
 
     Exercises the real ``_assert_clear_authorized`` guard (the network-free
     §17.4.3 identity/substrate block) against an actionable, green,
     independently-reviewed substrate ``MergeClear``:
     * presenting no ``--human-authorized`` must RAISE (the floor holds), and
     * presenting the recorded authorizer must NOT raise on that guard.
+
+    The CLEAR's overlay (resolved from its ``slug``) is pinned to ``babysit``
+    via a hermetic ``~/.teatree.toml`` so the check is deterministic regardless
+    of the developer's live config. The ``autonomy = full`` carve-out is a
+    distinct must-allow path verified by
+    :func:`_check_merge_precondition_substrate_full_autonomy`; this check is the
+    must-block direction for a below-full overlay.
     """
+    return _exercise_substrate_authorize(autonomy="babysit", expect_cleared_without_human=False)
+
+
+def _check_merge_precondition_substrate_full_autonomy() -> bool:
+    """Carve-out: a substrate CLEAR under an ``autonomy = full`` overlay clears without a per-PR sign-off.
+
+    The mirror of :func:`_check_merge_precondition_substrate_human_authorize`:
+    with the CLEAR's overlay pinned to ``full``, the standing grant satisfies
+    the substrate sign-off, so presenting no ``--human-authorized`` must NOT
+    raise. This is the must-allow direction the ticket-less / aliased
+    overlay-resolution fix restores; without it, a full-autonomy substrate
+    merge is wrongly blocked (the rest of the floor is unaffected).
+    """
+    return _exercise_substrate_authorize(autonomy="full", expect_cleared_without_human=True)
+
+
+def _exercise_substrate_authorize(*, autonomy: str, expect_cleared_without_human: bool) -> bool:
     from teatree.core.merge_execution import MergePreconditionError, _assert_clear_authorized  # noqa: PLC0415
     from teatree.core.models import MergeClear  # noqa: PLC0415
     from teatree.core.models.merge_clear import ClearRequest  # noqa: PLC0415
+    from teatree.core.overlay_loader import infer_overlay_for_url, staged_overlay_autonomy  # noqa: PLC0415
 
     slug, pr_id, reviewer, executor = "souliane/teatree", 4242, "cold-reviewer", "loop-session"
+    overlay_name = infer_overlay_for_url(slug) or "t3-teatree"
     clear = MergeClear.issue(
         ClearRequest(
             pr_id=pr_id,
@@ -204,28 +230,21 @@ def _check_merge_precondition_substrate_human_authorize() -> bool:
         )
     )
 
-    def _authorize(human_authorized: str) -> None:
-        _assert_clear_authorized(
-            clear=clear,
-            executing_loop_identity=executor,
-            slug=slug,
-            pr_id=pr_id,
-            human_authorized=human_authorized,
-        )
+    with staged_overlay_autonomy(overlay_name, autonomy):
+        try:
+            _assert_clear_authorized(
+                clear=clear,
+                executing_loop_identity=executor,
+                slug=slug,
+                pr_id=pr_id,
+                human_authorized="",
+            )
+        except MergePreconditionError:
+            cleared_without_human = False
+        else:
+            cleared_without_human = True
 
-    refused_without_human = False
-    try:
-        _authorize("")
-    except MergePreconditionError:
-        refused_without_human = True
-
-    try:
-        _authorize("the-user")
-    except MergePreconditionError:
-        cleared_with_human = False
-    else:
-        cleared_with_human = True
-    return refused_without_human and cleared_with_human
+    return cleared_without_human is expect_cleared_without_human
 
 
 def _check_merge_precondition_maker_is_not_checker() -> bool:
@@ -343,8 +362,15 @@ _CHECKS: tuple[RegressionCheck, ...] = (
     RegressionCheck(
         failure_class="substrate-merge human-authorize floor",
         origin="https://github.com/souliane/teatree/pull/1498",
-        invariant="a substrate MergeClear never merges without the recorded human authorizer",
+        invariant="a below-full substrate MergeClear never merges without the recorded human authorizer",
         predicate=_check_merge_precondition_substrate_human_authorize,
+        needs_db=True,
+    ),
+    RegressionCheck(
+        failure_class="substrate-merge full-autonomy carve-out",
+        origin="https://github.com/souliane/teatree/issues/1748",
+        invariant="an autonomy=full overlay clears a ticket-less substrate CLEAR without a per-PR human sign-off",
+        predicate=_check_merge_precondition_substrate_full_autonomy,
         needs_db=True,
     ),
     RegressionCheck(

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -749,3 +749,30 @@ class TestFullAutonomyStandingGrantSatisfiesSubstrateSignoff(TestCase):
         with _overlay_autonomy("t3-client", "babysit"):
             precheck = _assert_preconditions(clear, human_authorized="owner:adrien")
         assert precheck is not None
+
+    def test_full_autonomy_substrate_passes_for_ticketless_clear_via_slug(self) -> None:
+        """MUST-ALLOW: a ticket-less CLEAR resolves its overlay from ``slug`` (the loop's common case)."""
+        clear = _substrate_clear(None, pr_id=1740, slug="souliane/teatree")
+        with _overlay_autonomy("t3-teatree", "full"):
+            precheck = _assert_preconditions(clear)
+        assert precheck is not None
+
+    def test_full_autonomy_substrate_passes_when_ticket_overlay_is_canonical_alias(self) -> None:
+        """MUST-ALLOW: ``ticket.overlay`` short alias resolves the entry-point-keyed override."""
+        ticket = Ticket.objects.create(overlay="teatree", state=Ticket.State.IN_REVIEW)
+        clear = _substrate_clear(ticket, pr_id=1741)
+        with _overlay_autonomy("t3-teatree", "full"):
+            precheck = _assert_preconditions(clear)
+        assert precheck is not None
+
+    def test_babysit_autonomy_ticketless_clear_still_refused(self) -> None:
+        """MUST-DENY: a ticket-less CLEAR under a below-full overlay keeps the per-PR sign-off."""
+        clear = _substrate_clear(None, pr_id=1742, slug="souliane/teatree")
+        with _overlay_autonomy("t3-teatree", "babysit"), pytest.raises(MergePreconditionError, match="substrate"):
+            _assert_preconditions(clear)
+
+    def test_full_autonomy_ticketless_clear_unresolvable_slug_refused(self) -> None:
+        """MUST-DENY: a ticket-less CLEAR whose slug maps to no overlay fails closed."""
+        clear = _substrate_clear(None, pr_id=1743, slug="unknown-owner/unknown-repo")
+        with _overlay_autonomy("t3-teatree", "full"), pytest.raises(MergePreconditionError, match="substrate"):
+            _assert_preconditions(clear)


### PR DESCRIPTION
## Problem

At `autonomy = full`, substrate PR merges were still blocked by the substrate floor (invariant 4): the loop could not auto-merge them without a per-PR `--human-authorize` sign-off. In the live ledger, every recent substrate CLEAR was issued without a linked ticket and every substrate merge required a recorded `human_authorizer` to get through. The standing `autonomy = full` grant never stood in for the per-PR sign-off as intended.

## Root cause (single wrongly-wired point)

`_overlay_grants_full_substrate_autonomy(clear)` in `src/teatree/core/merge_execution.py` resolved the overlay **only** from `clear.ticket.overlay`. Two failure modes:

1. **Ticket-less CLEAR (the common loop case).** No ticket means `overlay_name` is empty, so the carve-out returns `False` and the standing `autonomy = full` grant can never satisfy the substrate sign-off. The only way through was the per-PR `--human-authorize` path.
2. **Canonical-alias mismatch.** When `ticket.overlay` is the short alias (e.g. `teatree`) but the config table is the entry-point form (e.g. `[overlays.t3-teatree]`), `_overlay_overrides_by_name` matched on exact name only and silently dropped the per-overlay override, so autonomy fell back to `babysit`.

The keystone merge path checks **only** `autonomy`, never `require_human_approval_to_merge` — so the carve-out is the single wrongly-wired point.

## Fix

- `merge_execution`: `_resolve_clear_overlay_name` prefers `clear.ticket.overlay` and falls back to `infer_overlay_for_url(clear.slug)` for ticket-less CLEARs (the CLEAR always carries `owner/repo`).
- `config`: `_overlay_overrides_by_name` now matches canonical-alias-tolerantly (short alias to entry-point name), fixing the whole class of per-overlay name resolution, not just autonomy.

The quality/safety floor is untouched — independent cold-review (reviewer != maker), reviewed-SHA bind, CI-green, not-draft, never-lockout, privacy scan all stay in force. Only the per-PR human sign-off is what `full` removes. Below-full overlays still require the sign-off (asserted in both directions).

## Tests (TDD, RED before fix)

- Four carve-out tests in `tests/teatree_core/test_clear_issuance_and_human_substrate.py`: must-allow ticket-less-via-slug and canonical-alias; must-deny babysit-ticketless and unresolvable-slug.
- The deterministic regression corpus substrate check was passing **only because of the bug** (a ticket-less CLEAR could not resolve an overlay, so the floor always held regardless of the machine's live config). Made it hermetic via a new core test-isolation helper `staged_overlay_autonomy` and split it into the below-full must-block direction plus a new full-autonomy must-allow check that goes RED on the pre-fix code.

## Config note (no code change)

An overlay table that sets `require_human_approval_to_merge = false` without `autonomy = "full"` stays gated for substrate merges, since the keystone reads `autonomy` only. Adding `autonomy = "full"` to that table is the fix for that overlay.

Closes https://github.com/souliane/teatree/issues/1748
