### PR TITLE
fix(ci): make the weekly eval gate fetch the current ISO week

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh api "repos/${{ github.repository }}/pulls?state=all&sort=created&direction=asc&per_page=100" \
+          # Most-recent-first so the current ISO week is on the first page even
+          # for a repo with thousands of PRs. first_pr_of_week.py also keeps the
+          # newest window as a second line of defence regardless of ordering.
+          gh api "repos/${{ github.repository }}/pulls?state=all&sort=created&direction=desc&per_page=100" \
             --jq '[.[] | {number: .number, created_at: .created_at}]' > prs.json || echo "[]" > prs.json
           if uv run python scripts/eval/first_pr_of_week.py --mrs-file prs.json --current-iid "$PR_NUMBER" --skip-code 1; then
             echo "run_eval=true" >> "$GITHUB_OUTPUT"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,9 +28,12 @@ eval-gate:
   before_script:
     - apk add --no-cache python3 glab curl jq
   script:
-    # Pull the project's MRs (iid + created_at) for the ISO-week decision.
+    # Pull the project's MRs (iid + created_at) for the ISO-week decision,
+    # most-recent-first so the current ISO week is on the first page even for a
+    # project with thousands of MRs. first_pr_of_week.py also keeps the newest
+    # window as a second line of defence regardless of platform ordering.
     - >-
-      glab api "projects/$CI_PROJECT_ID/merge_requests?state=all&order_by=created_at&sort=asc&per_page=100"
+      glab api "projects/$CI_PROJECT_ID/merge_requests?state=all&order_by=created_at&sort=desc&per_page=100"
       > mrs.json || echo "[]" > mrs.json
     - >-
       if python3 scripts/eval/first_pr_of_week.py

--- a/scripts/eval/first_pr_of_week.py
+++ b/scripts/eval/first_pr_of_week.py
@@ -18,6 +18,13 @@ The MR list is read from a JSON file (``--mrs-file``) so the platform query
 (``glab api`` / ``gh api``) stays in the CI YAML and this script stays a pure,
 unit-testable decision function. Each MR entry needs ``iid``/``number`` and
 ``created_at`` (ISO-8601). The current MR is identified by ``--current-iid``.
+
+The decision needs the current ISO week to be *present* in the supplied
+records. A single oldest-first page (``sort=asc&per_page=100``) of a repo with
+thousands of MRs never contains a current-week record, so the gate would skip
+forever. ``select_gate_records`` defends against that: it sorts the supplied
+records most-recent-first and keeps the newest window, so the latest week is
+always reachable regardless of how the platform ordered or paginated them.
 """
 
 import argparse
@@ -25,7 +32,10 @@ import datetime as dt
 import json
 import sys
 from collections.abc import Iterable
+from operator import itemgetter
 from pathlib import Path
+
+DEFAULT_PER_PAGE = 100
 
 
 def _iso_week(moment: dt.datetime) -> tuple[int, int]:
@@ -39,6 +49,34 @@ def _parse_created_at(raw: str) -> dt.datetime:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=dt.UTC)
     return parsed.astimezone(dt.UTC)
+
+
+def select_gate_records(
+    mrs: Iterable[dict],
+    *,
+    now: dt.datetime | None = None,
+    per_page: int = DEFAULT_PER_PAGE,
+) -> list[dict]:
+    now = (now or dt.datetime.now(dt.UTC)).astimezone(dt.UTC)
+    target_week = _iso_week(now)
+    dated: list[tuple[dt.datetime, dict]] = []
+    current_week: list[dict] = []
+    for mr in mrs:
+        created = mr.get("created_at")
+        if not created:
+            continue
+        try:
+            created_at = _parse_created_at(str(created))
+        except ValueError:
+            continue
+        dated.append((created_at, mr))
+        if _iso_week(created_at) == target_week:
+            current_week.append(mr)
+    newest_first = [mr for _, mr in sorted(dated, key=itemgetter(0), reverse=True)]
+    window = newest_first[:per_page]
+    seen = {id(mr) for mr in window}
+    window.extend(mr for mr in current_week if id(mr) not in seen)
+    return window
 
 
 def is_first_mr_of_week(
@@ -83,7 +121,8 @@ def main(argv: list[str] | None = None) -> int:
         print("--mrs-file must contain a JSON list", file=sys.stderr)
         return 2
     now = _parse_created_at(args.now) if args.now else None
-    if is_first_mr_of_week(mrs, current_iid=args.current_iid, now=now):
+    records = select_gate_records(mrs, now=now)
+    if is_first_mr_of_week(records, current_iid=args.current_iid, now=now):
         print(f"first MR of the ISO week → run the weekly eval (iid={args.current_iid})")
         return 0
     print(f"not the first MR of the ISO week → skip (iid={args.current_iid})")

--- a/tests/eval/test_first_pr_of_week.py
+++ b/tests/eval/test_first_pr_of_week.py
@@ -3,6 +3,7 @@
 import datetime as dt
 import importlib.util
 import json
+from operator import itemgetter
 from pathlib import Path
 
 _SPEC = importlib.util.spec_from_file_location(
@@ -15,6 +16,7 @@ _MOD = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MOD)
 
 is_first_mr_of_week = _MOD.is_first_mr_of_week
+select_gate_records = _MOD.select_gate_records
 main = _MOD.main
 
 NOW = dt.datetime(2026, 6, 3, 12, 0, tzinfo=dt.UTC)  # Wednesday, ISO week 23
@@ -65,6 +67,69 @@ class TestIsFirstMrOfWeek:
             {"iid": 12, "created_at": "2026-06-01T10:00:00Z"},
         ]
         assert is_first_mr_of_week(mrs, current_iid=12, now=NOW) is True
+
+
+class TestSelectGateRecords:
+    def test_keeps_current_week_record_buried_past_the_oldest_hundred(self) -> None:
+        old = [
+            {"number": i, "created_at": f"2025-01-{(i % 27) + 1:02d}T09:00:00Z"}
+            for i in range(1, 1700)  # ~1700 records, none in week 23 of 2026
+        ]
+        current_week = {"number": 1701, "created_at": "2026-06-01T09:00:00Z"}  # Monday, week 23
+        corpus = [*old, current_week]
+
+        selected = select_gate_records(corpus, now=NOW)
+
+        assert any(rec.get("number") == 1701 for rec in selected)
+
+    def test_drops_the_oldest_history_beyond_the_window(self) -> None:
+        corpus = [{"number": i, "created_at": f"2025-03-{(i % 27) + 1:02d}T09:00:00Z"} for i in range(1, 500)]
+
+        selected = select_gate_records(corpus, now=NOW, per_page=100)
+
+        assert len(selected) == 100
+
+    def test_always_includes_the_full_current_week_even_past_the_window(self) -> None:
+        history = [{"number": i, "created_at": f"2025-03-{(i % 27) + 1:02d}T09:00:00Z"} for i in range(1, 300)]
+        this_week = [{"number": 900 + i, "created_at": "2026-06-01T09:00:00Z"} for i in range(150)]
+        corpus = [*this_week, *history]
+
+        selected = select_gate_records(corpus, now=NOW, per_page=100)
+
+        selected_numbers = {rec["number"] for rec in selected}
+        assert all((900 + i) in selected_numbers for i in range(150))
+
+    def test_gate_runs_on_current_week_pr_from_a_full_history(self) -> None:
+        old = [{"number": i, "created_at": f"2025-03-{(i % 27) + 1:02d}T09:00:00Z"} for i in range(1, 1700)]
+        current_week = {"number": 1701, "created_at": "2026-06-02T09:00:00Z"}  # Tuesday, week 23
+        corpus = [*old, current_week]
+
+        selected = select_gate_records(corpus, now=NOW)
+
+        assert is_first_mr_of_week(selected, current_iid=1701, now=NOW) is True
+
+    def test_skips_entries_without_a_usable_created_at(self) -> None:
+        corpus = [
+            {"number": 1},  # no created_at
+            {"number": 2, "created_at": ""},  # falsy created_at
+            {"number": 3, "created_at": "not-a-date"},  # unparsable
+            {"number": 4, "created_at": "2026-06-01T09:00:00Z"},  # week 23
+        ]
+
+        selected = select_gate_records(corpus, now=NOW)
+
+        assert [rec["number"] for rec in selected] == [4]
+
+    def test_oldest_first_page_is_inert_but_selection_fixes_it(self) -> None:
+        old = [{"number": i, "created_at": f"2025-01-{(i % 27) + 1:02d}T09:00:00Z"} for i in range(1, 1700)]
+        current_week = {"number": 1701, "created_at": "2026-06-01T09:00:00Z"}  # Monday, week 23
+        corpus = [*old, current_week]
+
+        oldest_first_page = sorted(corpus, key=itemgetter("created_at"))[:100]
+        assert is_first_mr_of_week(oldest_first_page, current_iid=1701, now=NOW) is False
+
+        selected = select_gate_records(corpus, now=NOW)
+        assert is_first_mr_of_week(selected, current_iid=1701, now=NOW) is True
 
 
 class TestMain:


### PR DESCRIPTION
## What

The weekly behavioral-eval gate fetched the **oldest** 100 PRs/MRs
(`sort=asc`/`direction=asc`, `per_page=100`) to decide "is this the first
PR/MR of the current ISO week". With thousands of records the current week is
never on that page, so `is_first_mr_of_week` always returned `False` and the
`claude -p` eval suite, `t3 eval trigger-qa`, and `t3 eval regression` jobs
were gated off permanently on both GitHub and GitLab.

This change:

- Fetches most-recent-first on both platforms (`direction=desc` on GitHub,
  `sort=desc` on GitLab) so the current ISO week is on the first page.
- Adds `select_gate_records` to `scripts/eval/first_pr_of_week.py`, which sorts
  the supplied records most-recent-first and keeps the newest window while
  always retaining the full current week — a second line of defence regardless
  of how the platform ordered or paginated the page. `main` runs every record
  set through it before deciding.
- Adds regression tests that exercise a >100-record corpus where the current
  week sits past the oldest 100: the old oldest-first page is observably inert
  (`is_first_mr_of_week(... ) is False`) while the new selection makes the gate
  fire.

## Why

Without this, the flagship weekly eval suite never runs in CI. See
[#1738](https://github.com/souliane/teatree/issues/1738).

## Testing

- `tests/eval/test_first_pr_of_week.py`: 16 tests, including the >100-record
  regression and an explicit old-page-inert vs new-selection-fixes contrast.
- Full `tests/eval/` suite: 316 passed.
- `uv run ruff check`, `uv run ruff format`, `uv run ty check`: clean.
- New lines: 100% covered.

Closes [#1738](https://github.com/souliane/teatree/issues/1738).
