### PR TITLE
fix(lint): SlackBotBackend trips PLR0904 (too many public methods)

### DIFF
--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -119,7 +119,7 @@ class _TickFanoutQueue:
             return list(self._events)
 
 
-class SlackBotBackend:
+class SlackBotBackend:  # noqa: PLR0904 — Slack API facade; method count reflects the API surface (one method per call), not poor encapsulation.
     """MessagingBackend backed by a Slack bot token, optionally with a user token.
 
     ``bot_token`` (``xoxb-…``) authorises Web API calls for DMs, posts, and


### PR DESCRIPTION
## What

Add an inline `# noqa: PLR0904` with rationale on `SlackBotBackend`, matching the established pattern on `OverlayBase` and `Ticket`.

## Why

The slack-provision merge ([#1759](https://github.com/souliane/teatree/pull/1759)) pushed `SlackBotBackend`'s public-method count from 25 to 26, tripping ruff `PLR0904` (max 25) and reddening the `lint` job on `main` HEAD — blocking every open PR.

`main` HEAD CI ([run 26816446251](https://github.com/souliane/teatree/actions/runs/26816446251)) is green on `test (3.13)` and every other job; only `lint` fails on this single rule.

The class is a Slack API facade where each public method wraps one distinct Slack API call, so the count reflects API surface, not poor encapsulation. An inline noqa with rationale is the idiomatic suppression already used for the equivalent `OverlayBase` (overlay extension API) and `Ticket` (FSM transition surface) classes.

## Result

`ruff check src/teatree/backends/slack_bot.py` clean; the local pre-push Docker test matrix passes.