### PR TITLE
fix(slack): drop SlackBotBackend below PLR0904 via _SlackInbound extraction

### DIFF
--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -119,7 +119,44 @@ class _TickFanoutQueue:
             return list(self._events)
 
 
-class SlackBotBackend:  # noqa: PLR0904 — Slack API facade; method count reflects the API surface (one method per call), not poor encapsulation.
+class _SlackInbound:
+    """Socket Mode inbound ingestion for one backend.
+
+    The Phase 3.6 Socket Mode receiver pushes ``app_mention`` /
+    ``message.im`` / ``reaction_added`` events through :meth:`enqueue_mention`
+    / :meth:`enqueue_dm` / :meth:`enqueue_reaction`; the loop scanners read
+    each per-tick batch through :meth:`snapshot_mentions` / :meth:`snapshot_dms`
+    / :meth:`snapshot_reactions`. Reads are non-destructive within a tick so
+    the scanners that share one backend each observe the same batch (#1655).
+    Bundling the three queues and their ingestion behind one collaborator
+    keeps the inbound concern out of the outbound messaging surface.
+    """
+
+    def __init__(self) -> None:
+        self._mentions = _TickFanoutQueue()
+        self._dms = _TickFanoutQueue()
+        self._reactions = _TickFanoutQueue()
+
+    def enqueue_mention(self, event: RawAPIDict) -> None:
+        self._mentions.enqueue(event)
+
+    def enqueue_dm(self, event: RawAPIDict) -> None:
+        self._dms.enqueue(event)
+
+    def enqueue_reaction(self, event: RawAPIDict) -> None:
+        self._reactions.enqueue(event)
+
+    def snapshot_mentions(self) -> list[RawAPIDict]:
+        return self._mentions.snapshot()
+
+    def snapshot_dms(self) -> list[RawAPIDict]:
+        return self._dms.snapshot()
+
+    def snapshot_reactions(self) -> list[RawAPIDict]:
+        return self._reactions.snapshot()
+
+
+class SlackBotBackend:
     """MessagingBackend backed by a Slack bot token, optionally with a user token.
 
     ``bot_token`` (``xoxb-…``) authorises Web API calls for DMs, posts, and
@@ -176,12 +213,11 @@ class SlackBotBackend:  # noqa: PLR0904 — Slack API facade; method count refle
         # Inbound queues populated by the Phase 3.6 Socket Mode receiver. Each
         # tick the loop scanners read them via ``fetch_mentions`` /
         # ``fetch_dms`` / ``fetch_reactions``; the receiver calls
-        # ``enqueue_mention`` / ``enqueue_dm`` / ``enqueue_reaction``.
-        # Reads are non-destructive within a tick so the three scanners that
-        # share one backend each see the same batch (#1655).
-        self._mentions = _TickFanoutQueue()
-        self._dms = _TickFanoutQueue()
-        self._reactions = _TickFanoutQueue()
+        # ``inbound.enqueue_mention`` / ``inbound.enqueue_dm`` /
+        # ``inbound.enqueue_reaction``. Reads are non-destructive within a
+        # tick so the three scanners that share one backend each see the same
+        # batch (#1655).
+        self._inbound = _SlackInbound()
 
     @property
     def app_token(self) -> str:
@@ -220,17 +256,15 @@ class SlackBotBackend:  # noqa: PLR0904 — Slack API facade; method count refle
         """
         return self._channel_token(channel, op=SlackOp.WRITE)
 
-    def enqueue_mention(self, event: RawAPIDict) -> None:
-        """Push a Socket Mode ``app_mention`` event into the inbound queue."""
-        self._mentions.enqueue(event)
+    @property
+    def inbound(self) -> _SlackInbound:
+        """Socket Mode ingestion surface (#1655).
 
-    def enqueue_dm(self, event: RawAPIDict) -> None:
-        """Push a Socket Mode ``message.im`` event into the inbound queue."""
-        self._dms.enqueue(event)
-
-    def enqueue_reaction(self, event: RawAPIDict) -> None:
-        """Push a Socket Mode ``reaction_added`` event into the inbound queue."""
-        self._reactions.enqueue(event)
+        The receiver pushes events via ``inbound.enqueue_mention`` /
+        ``enqueue_dm`` / ``enqueue_reaction``; ``fetch_mentions`` /
+        ``fetch_dms`` / ``fetch_reactions`` read the per-tick batches back.
+        """
+        return self._inbound
 
     def _post(self, method: str, payload: SlackPayload, *, token: str = "") -> RawAPIDict:
         auth = token or self._bot_token
@@ -339,7 +373,7 @@ class SlackBotBackend:  # noqa: PLR0904 — Slack API facade; method count refle
         (#1655).
         """
         _ = since
-        return self._mentions.snapshot()
+        return self._inbound.snapshot_mentions()
 
     def fetch_dms(self, *, since: str = "") -> list[RawAPIDict]:
         """Return new DMs from the user, including thread replies.
@@ -365,7 +399,7 @@ class SlackBotBackend:  # noqa: PLR0904 — Slack API facade; method count refle
         Only messages FROM the user are returned (bot's own messages are
         filtered out).
         """
-        queued = self._dms.snapshot()
+        queued = self._inbound.snapshot_dms()
         if queued:
             return queued
         if not self._user_id or not self._bot_token:
@@ -437,7 +471,7 @@ class SlackBotBackend:  # noqa: PLR0904 — Slack API facade; method count refle
         draining it (#1655); the buffer rolls on the next enqueue.
         """
         _ = since
-        return self._reactions.snapshot()
+        return self._inbound.snapshot_reactions()
 
     def fetch_message(self, *, channel: str, ts: str) -> RawAPIDict:
         """Fetch a single message by ``(channel, ts)``.

--- a/tests/integration/slack_bridge_e2e/test_backend_error_paths.py
+++ b/tests/integration/slack_bridge_e2e/test_backend_error_paths.py
@@ -50,7 +50,7 @@ class TestSlackBotBackendErrorPathsE2E:
         polling — the queue contract is broken.
         """
         backend = SlackBotBackend(bot_token="xoxb-bot", user_id="U_HUMAN")
-        backend.enqueue_dm({"ts": "1.0", "user": "U_HUMAN", "text": "queued"})
+        backend.inbound.enqueue_dm({"ts": "1.0", "user": "U_HUMAN", "text": "queued"})
 
         events = backend.fetch_dms()
 
@@ -296,7 +296,7 @@ class TestSlackBotBackendErrorPathsE2E:
         """
         _ = transport  # ensure no HTTP call happens
         backend = SlackBotBackend(bot_token="xoxb-bot")
-        backend.enqueue_mention({"ts": "1.0", "user": "U", "text": "@bot hi"})
+        backend.inbound.enqueue_mention({"ts": "1.0", "user": "U", "text": "@bot hi"})
 
         events = backend.fetch_mentions()
         again = backend.fetch_mentions()

--- a/tests/teatree_backends/test_messaging.py
+++ b/tests/teatree_backends/test_messaging.py
@@ -240,8 +240,8 @@ def test_slack_inbound_methods_return_empty_until_socket_mode_enqueues() -> None
 
 def test_slack_fetch_mentions_drains_enqueued_events() -> None:
     backend = SlackBotBackend(bot_token="xoxb-test")
-    backend.enqueue_mention({"text": "hi", "ts": "1.0"})
-    backend.enqueue_mention({"text": "hello", "ts": "2.0"})
+    backend.inbound.enqueue_mention({"text": "hi", "ts": "1.0"})
+    backend.inbound.enqueue_mention({"text": "hello", "ts": "2.0"})
 
     first = backend.fetch_mentions()
     second = backend.fetch_mentions()
@@ -252,7 +252,7 @@ def test_slack_fetch_mentions_drains_enqueued_events() -> None:
 
 def test_slack_fetch_dms_drains_enqueued_events() -> None:
     backend = SlackBotBackend(bot_token="xoxb-test")
-    backend.enqueue_dm({"text": "dm", "ts": "3.0"})
+    backend.inbound.enqueue_dm({"text": "dm", "ts": "3.0"})
 
     drained = backend.fetch_dms()
 
@@ -262,7 +262,7 @@ def test_slack_fetch_dms_drains_enqueued_events() -> None:
 
 def test_slack_fetch_dms_non_destructive_across_scanners_in_tick() -> None:
     backend = SlackBotBackend(bot_token="")
-    backend.enqueue_dm({"text": "red card", "ts": "9.0", "channel": "D1"})
+    backend.inbound.enqueue_dm({"text": "red card", "ts": "9.0", "channel": "D1"})
 
     slack_dm_inbound = backend.fetch_dms()
     slack_mentions = backend.fetch_dms()
@@ -275,7 +275,7 @@ def test_slack_fetch_dms_non_destructive_across_scanners_in_tick() -> None:
 
 def test_slack_fetch_reactions_non_destructive_across_scanners_in_tick() -> None:
     backend = SlackBotBackend(bot_token="")
-    backend.enqueue_reaction({"reaction": "no_entry_sign", "event_ts": "9.1"})
+    backend.inbound.enqueue_reaction({"reaction": "no_entry_sign", "event_ts": "9.1"})
 
     review_intent = backend.fetch_reactions()
     red_card = backend.fetch_reactions()
@@ -286,7 +286,7 @@ def test_slack_fetch_reactions_non_destructive_across_scanners_in_tick() -> None
 
 def test_slack_fetch_mentions_non_destructive_across_scanners_in_tick() -> None:
     backend = SlackBotBackend(bot_token="")
-    backend.enqueue_mention({"text": "@bot", "ts": "9.2"})
+    backend.inbound.enqueue_mention({"text": "@bot", "ts": "9.2"})
 
     mentions_scanner = backend.fetch_mentions()
     review_intent = backend.fetch_mentions()
@@ -297,7 +297,7 @@ def test_slack_fetch_mentions_non_destructive_across_scanners_in_tick() -> None:
 
 def test_slack_fetch_dms_concurrent_consumers_each_see_event() -> None:
     backend = SlackBotBackend(bot_token="")
-    backend.enqueue_dm({"text": "dm", "ts": "9.3"})
+    backend.inbound.enqueue_dm({"text": "dm", "ts": "9.3"})
 
     barrier = threading.Barrier(3)
 
@@ -313,11 +313,11 @@ def test_slack_fetch_dms_concurrent_consumers_each_see_event() -> None:
 
 def test_slack_fetch_dms_new_enqueue_rolls_batch() -> None:
     backend = SlackBotBackend(bot_token="")
-    backend.enqueue_dm({"text": "first tick", "ts": "10.0"})
+    backend.inbound.enqueue_dm({"text": "first tick", "ts": "10.0"})
 
     assert [e["ts"] for e in backend.fetch_dms()] == ["10.0"]
 
-    backend.enqueue_dm({"text": "second tick", "ts": "11.0"})
+    backend.inbound.enqueue_dm({"text": "second tick", "ts": "11.0"})
 
     assert [e["ts"] for e in backend.fetch_dms()] == ["11.0"]
     assert [e["ts"] for e in backend.fetch_dms()] == ["11.0"]

--- a/tests/teatree_backends/test_slack_connect_channel_routing.py
+++ b/tests/teatree_backends/test_slack_connect_channel_routing.py
@@ -1,7 +1,7 @@
 """Tests for the systematic Slack-Connect token-selection policy.
 
-Slack-Connect externally-shared channels (``#the-review-crew``,
-``#ext_project_mbh_api``) reject the bot token with
+Slack-Connect externally-shared channels (e.g. a shared partner channel)
+reject the bot token with
 ``mcp_externally_shared_channel_restricted``. The user's personal
 ``xoxp-…`` token *is* a member of those partner channels and can post
 there. The deterministic policy: ``chat.postMessage`` (and reactions) to
@@ -23,7 +23,7 @@ import pytest
 from teatree.backends import slack_bot
 from teatree.backends.slack_bot import SlackBotBackend
 
-_EXT_SHARED = "C0AM3TENTLK"  # #the-review-crew (Slack-Connect)
+_EXT_SHARED = "C0AM3TENTLK"  # an externally-shared partner channel (Slack-Connect)
 _INTERNAL = "C09INTERNAL0"  # an ordinary workspace channel
 _DM = "D0000000001"
 


### PR DESCRIPTION
Replaces the inline `PLR0904` suppression on `SlackBotBackend` (added in [#1769](https://github.com/souliane/teatree/pull/1769)) with a cohesive refactor, and scrubs a partner-channel literal from a Connect-routing test.

## What

- Extract the three Socket Mode ingestion methods (`enqueue_mention` / `enqueue_dm` / `enqueue_reaction`) onto a new private `_SlackInbound` collaborator that owns the per-tick fan-out queues, exposed through a single `inbound` property. `fetch_mentions` / `fetch_dms` / `fetch_reactions` now read the collaborator's snapshots.
- This drops `SlackBotBackend` from 26 to 24 public methods (max 25), so the inline `# noqa: PLR0904` is removed rather than carried.
- Scrub a real partner-channel name from the `test_slack_connect_channel_routing.py` docstring/constant, leaving a neutral placeholder so the public repo carries no channel literal.

## Why

[#1769](https://github.com/souliane/teatree/pull/1769) green-lit `lint` by suppressing the rule inline. The project guideline prefers a genuine refactor over a complexity-rule suppression when one is feasible; the inbound ingestion is a self-contained concern with a clean boundary, so extracting it both fixes the rule and keeps the inbound queues off the outbound messaging surface. The partner-channel literal is a separate public-repo hygiene fix that [#1769](https://github.com/souliane/teatree/pull/1769) did not touch.

## Verification

- `uv run ruff check .` clean (repo-wide).
- `prek run --all-files` passes fully in a CI-equivalent environment (no `~/.teatree.toml`): all 36 hooks green.
- `uv run pytest tests/ -k slack -q --no-cov`: 962 passed, 1 skipped.
- `uv run ty check` clean; pre-push Docker test matrix passed.