### PR TITLE
ci(eval): auto-retry the weekly behavioral-eval job on transient flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,14 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - run: uv sync
+      # Bounded retry: transient registry/network ReadTimeout, not a manual rerun.
+      - name: Sync dependencies (retry on transient network failure)
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: uv sync
       - name: Decide whether this is the first PR of the ISO week
         id: gate
         env:
@@ -318,6 +325,12 @@ jobs:
       - name: Regression corpus (deterministic, free; also gated every PR via pytest)
         if: steps.gate.outputs.run_eval == 'true'
         run: uv run t3 eval regression
+      # Bounded retry on a transient model/network flake; a real miss repeats and still fails fast.
       - name: Behavioral eval suite (pass@k; SKIPs cleanly without the claude CLI)
         if: steps.gate.outputs.run_eval == 'true'
-        run: uv run t3 eval run --trials 3 --require any
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: uv run t3 eval run --trials 3 --require any

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,14 @@ eval-weekly:
   before_script:
     - pip install --no-cache-dir uv
     - uv sync
+  # Bounded retry on transient infra classes (script_failure = a model/network ReadTimeout); a real miss still fails fast.
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - api_failure
+      - script_failure
   script:
     # Trigger-QA is deterministic and free; the scenario suite SKIPs cleanly
     # when `claude` is not on PATH (the runner emits SKIP and exits 0), so the

--- a/tests/test_eval_ci_retries_transient_failures.py
+++ b/tests/test_eval_ci_retries_transient_failures.py
@@ -1,0 +1,81 @@
+"""The weekly behavioral-eval CI job retries transient/flaky failures.
+
+AI/trajectory evals are non-deterministic and reach the network/model API, so a
+transient infra flake used to red-fail the pipeline and force a manual rerun.
+GitHub Actions now wraps the eval and ``uv sync`` steps in ``nick-fields/retry``
+and GitLab gives ``eval-weekly`` a bounded ``retry:``. These tests pin both, and
+assert the attempt cap so an unbounded retry can never mask a real regression.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_GH_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_GITLAB_CI = _REPO_ROOT / ".gitlab-ci.yml"
+
+_RETRY_ACTION = "nick-fields/retry"
+_MAX_RETRY_ATTEMPTS = 5
+
+
+def _gh_eval_steps() -> list[dict[str, Any]]:
+    jobs = cast("dict[str, Any]", yaml.safe_load(_GH_WORKFLOW.read_text(encoding="utf-8"))["jobs"])
+    assert "eval-weekly" in jobs, "GitHub CI must define the weekly behavioral-eval job."
+    return cast("list[dict[str, Any]]", jobs["eval-weekly"]["steps"])
+
+
+def _gitlab_eval_job() -> dict[str, Any]:
+    config = cast("dict[str, Any]", yaml.safe_load(_GITLAB_CI.read_text(encoding="utf-8")))
+    assert "eval-weekly" in config, "GitLab CI must define the weekly behavioral-eval job."
+    return cast("dict[str, Any]", config["eval-weekly"])
+
+
+def _step_using_retry_for(command_fragment: str) -> dict[str, Any]:
+    for step in _gh_eval_steps():
+        if step.get("uses", "").startswith(_RETRY_ACTION) and command_fragment in step.get("with", {}).get(
+            "command", ""
+        ):
+            return step
+    msg = f"No {_RETRY_ACTION} step wrapping a command containing {command_fragment!r} in eval-weekly."
+    raise AssertionError(msg)
+
+
+class TestGitHubEvalRetry:
+    def test_behavioral_eval_step_is_retried(self) -> None:
+        step = _step_using_retry_for("t3 eval run")
+        attempts = int(step["with"]["max_attempts"])
+        assert 2 <= attempts <= _MAX_RETRY_ATTEMPTS, (
+            "Behavioral eval retry must be bounded (2-5 attempts) so a deterministic "
+            f"eval miss still fails fast; got {attempts}."
+        )
+
+    def test_dependency_sync_is_retried(self) -> None:
+        # `uv sync` is where Docker Hub/registry/PyPI ReadTimeouts hit.
+        step = _step_using_retry_for("uv sync")
+        assert 2 <= int(step["with"]["max_attempts"]) <= _MAX_RETRY_ATTEMPTS
+
+    def test_retry_uses_backoff(self) -> None:
+        step = _step_using_retry_for("t3 eval run")
+        assert int(step["with"].get("retry_wait_seconds", 0)) > 0, (
+            "Retry must wait between attempts so a transient outage has time to clear."
+        )
+
+
+class TestGitLabEvalRetry:
+    def test_eval_job_defines_bounded_retry(self) -> None:
+        retry = _gitlab_eval_job().get("retry")
+        assert retry is not None, "GitLab eval-weekly must declare a retry policy for transient flakes."
+        assert isinstance(retry, dict), "retry must specify max + when (not a bare integer that retries on anything)."
+        assert 1 <= int(retry["max"]) <= _MAX_RETRY_ATTEMPTS, (
+            "GitLab eval retry must be bounded so a deterministic miss fails fast."
+        )
+
+    def test_retry_targets_transient_failure_classes(self) -> None:
+        when = set(_gitlab_eval_job()["retry"]["when"])
+        # Retrying on transient signals, not a blanket `always` that masks bugs.
+        assert "always" not in when, "retry must not be 'always' — that masks deterministic eval regressions."
+        assert {"runner_system_failure", "stuck_or_timeout_failure"} <= when, (
+            "retry must cover the runner/system + timeout transient classes."
+        )


### PR DESCRIPTION
## Problem

The weekly behavioral-eval job (`eval-weekly`) is non-deterministic: it shells out to `claude -p` and reaches the network/model API. A transient infra flake — a registry/CDN ReadTimeout during dependency sync, a model 5xx, a stuck runner — red-fails the whole pipeline and forces a manual rerun, even though nothing about the change is actually broken.

## Change

Bound an auto-retry around the flaky work on both CI surfaces so a transient/flaky failure retries instead of red-failing:

- **GitHub Actions** ([`.github/workflows/ci.yml`](https://github.com/souliane/teatree/blob/eval-ci-retry/.github/workflows/ci.yml)): wrap the behavioral-eval step and the network-bound `uv sync` in [`nick-fields/retry@v3`](https://github.com/nick-fields/retry) with capped attempts (3) and backoff.
- **GitLab CI** ([`.gitlab-ci.yml`](https://github.com/souliane/teatree/blob/eval-ci-retry/.gitlab-ci.yml)): give `eval-weekly` a bounded `retry: { max: 2, when: [runner_system_failure, stuck_or_timeout_failure, api_failure, script_failure] }`.

## Why this does not mask real failures

`t3 eval run --trials 3 --require any` already aggregates pass@k across model variance for an eval-logic miss. The retry only adds bounded coverage for an *infra* flake on top of that. The attempt cap is the safeguard: a deterministic eval miss repeats on every attempt and still fails fast — the retry never turns a real regression green. `when:` targets the transient classes only (no blanket `always`).

## Tests

New [`tests/test_eval_ci_retries_transient_failures.py`](https://github.com/souliane/teatree/blob/eval-ci-retry/tests/test_eval_ci_retries_transient_failures.py) parses both workflow files and pins the retry mechanism + the attempt bound, so a future edit cannot silently drop the retry or make it unbounded. Mirrors the existing `tests/test_ci_audit_uses_pip_audit.py` convention.

All pre-push hooks pass (Docker pytest matrix, near-zero-comments gate, public-repo privacy gate).