### PR TITLE
docs(privacy): generalize a channel literal in two core docstrings

### DIFF
--- a/src/teatree/core/models/review_request_post.py
+++ b/src/teatree/core/models/review_request_post.py
@@ -1,6 +1,6 @@
 """Audit row for bot review-request posts in the review channel (#1038).
 
-One row per MR posted to ``#the-review-crew`` so the fibonacci nag
+One row per MR posted to the review channel so the fibonacci nag
 scanner can detect "already posted" MRs and escalate the cadence
 (+1/+2/+3/+5 days) without re-discovering the original message.
 

--- a/src/teatree/loop/review_request_tracker.py
+++ b/src/teatree/loop/review_request_tracker.py
@@ -1,6 +1,6 @@
 """Recorder for bot review-request posts (#1038).
 
-When the bot posts an MR to the review channel (``#the-review-crew``),
+When the bot posts an MR to the review channel,
 it must call :func:`record_review_request_post` so the fibonacci nag
 scanner can detect "already posted" MRs and escalate the cadence.
 


### PR DESCRIPTION
## What

Two core module docstrings (`src/teatree/core/models/review_request_post.py` and `src/teatree/loop/review_request_tracker.py`) named a specific Slack channel by its literal handle. This rewords both to the generic "the review channel".

## Why

The repo is public, so core must stay free of project-specific names (BLUEPRINT § 1: core stays generic). This is the one unique scrub that [#1776](https://github.com/souliane/teatree/pull/1776) did not carry — [#1776](https://github.com/souliane/teatree/pull/1776) handled the doc-module rename and the followup-skill config-repo name, but left this channel literal in the two core docstrings. Supersedes the docstring portion of [#1774](https://github.com/souliane/teatree/pull/1774).

## Verification

- `uv run ruff check` clean on both files.
- `check_no_overlay_leak.py` passes on the scrubbed tree with the term configured (it flagged pre-scrub).
- `grep` across `src/teatree` and `docs` confirms zero remaining references.
- Docstring-only; no behavior change. `tests/teatree_core/test_review_request_post.py` + `tests/teatree_loop/test_review_request_tracker.py`: 9 passed.