### PR TITLE
fix(loop): suppress intra-self reassign noise + dedup statusline reassign rows by ticket

### DIFF
--- a/src/teatree/loop/rendering_classification.py
+++ b/src/teatree/loop/rendering_classification.py
@@ -380,6 +380,25 @@ def _dedup_in_order[T](items: list[T]) -> list[T]:
     return out
 
 
+def _dedup_reassign_by_ticket(refs: list[_ReassignRef]) -> list[_ReassignRef]:
+    """Collapse reassign rows for the same ticket, first-occurrence wins.
+
+    ``_dedup_in_order`` keys on full ``_ReassignRef`` equality, so the same
+    ticket reassigned from two distinct source handles survives twice. A
+    ticket is one observable thing regardless of source handle — key on its
+    identity (issue URL, else label).
+    """
+    seen: set[str] = set()
+    out: list[_ReassignRef] = []
+    for ref in refs:
+        key = ref.ref.url or ref.ref.label
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(ref)
+    return out
+
+
 def _dedup_active_tickets_across_overlays(
     by_overlay: dict[str, list[tuple[str, str, str, str]]],
 ) -> dict[str, list[tuple[str, str, str, str]]]:
@@ -457,7 +476,7 @@ def _dedup_classified(c: _ClassifiedActions) -> None:
     for overlay, refs in list(c.inflight_prs.items()):
         c.inflight_prs[overlay] = _dedup_in_order(refs)
     for overlay, reass in list(c.reassign_refs.items()):
-        c.reassign_refs[overlay] = _dedup_in_order(reass)
+        c.reassign_refs[overlay] = _dedup_reassign_by_ticket(_dedup_in_order(reass))
     for overlay, dms in list(c.dms.items()):
         c.dms[overlay] = _dedup_in_order(dms)
     for reason_map in c.disposition_refs.values():

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -46,6 +46,7 @@ from teatree.loop.tick_freshness import (
 from teatree.loop.tick_jobs import (
     Domain,
     _gitlab_approvals_enabled,
+    _identity_groups_for_overlay,
     _jobs_for_backend_hosts,
     _run_job,
     _ScannerJob,
@@ -207,11 +208,19 @@ def _identity_aliases_for_request(request: TickRequest) -> tuple[tuple[str, ...]
     The renderer suppresses a reassignment between two handles of the same
     human and collapses each handle to its group's canonical name. Fails
     open: any config-read error degrades to no suppression.
+
+    Routes through :func:`_identity_groups_for_overlay` (not the raw
+    resolver) so the #1113 self-group fallback applies on the render path
+    too: when no explicit ``identity_aliases`` is configured, the operator's
+    ``backend.identities`` (← ``user_identity_aliases``; the accessor #1773's
+    ``TrustedIdentity`` will sit behind) form one implicit self-group.
+    Without it the render-side group was empty and intra-self reassigns
+    leaked as ``reassigned`` churn.
     """
     groups: list[tuple[str, ...]] = []
     try:
         for backend in request.backends or []:
-            groups.extend(_identity_alias_groups_for_overlay(backend.name, backend))
+            groups.extend(_identity_groups_for_overlay(backend))
     except Exception:  # noqa: BLE001
         return ()
     return tuple(groups)

--- a/tests/teatree_loop/test_rendering.py
+++ b/tests/teatree_loop/test_rendering.py
@@ -136,22 +136,28 @@ class TestReviewerPrRefRendering:
         assert "[teatree] !123" in action_blob, repr(action_blob)
 
 
-def _disposition_action(*, reason: str, payload_extra: dict[str, object]) -> DispatchAction:
+def _disposition_action(
+    *,
+    reason: str,
+    payload_extra: dict[str, object],
+    ticket_number: str = "77",
+) -> DispatchAction:
     """Mirror what ``dispatch._dispatch_one`` builds for ``unassigned``/etc.
 
     The disposition scanner ships ``reason`` plus the ticket coordinates;
     ``payload_extra`` adds the reason-specific fields (``old_owner`` /
-    ``new_owners`` for ``unassigned``).
+    ``new_owners`` for ``unassigned``). ``ticket_number`` lets a test vary
+    the ticket so dedup-by-ticket behaviour can be exercised.
     """
     return DispatchAction(
         kind="statusline",
         zone="action_needed",
-        detail=f"Ticket 77 — {reason}",
+        detail=f"Ticket {ticket_number} — {reason}",
         payload={
             "reason": reason,
             "overlay": "teatree",
-            "ticket_number": "77",
-            "issue_url": "https://example.com/issues/77",
+            "ticket_number": ticket_number,
+            "issue_url": f"https://example.com/issues/{ticket_number}",
             **payload_extra,
         },
     )
@@ -262,6 +268,73 @@ class TestSelfReassignmentSuppression:
         blob = "".join(item if isinstance(item, str) else item.text for item in zones.action_needed)
         assert "reassigned (from souliane → to colleague):" in blob, repr(blob)
         assert "op-alt" not in blob, repr(blob)
+
+
+# The reported-noise shape: one human owning three handles (a GitHub login,
+# a GitLab username, and the canonical name). The real handles are personal
+# accounts kept out of this public repo; the structure is what matters.
+_REPORTED_ALIASES: tuple[tuple[str, ...], ...] = (("souliane", "op-gh", "op-gl"),)
+
+
+class TestReportedReassignNoise:
+    """The user-visible noise: intra-self reassigns leaking + duplicated per source handle.
+
+    Reproduces the reported statusline::
+
+        reassigned (from op-gh → to souliane): #12 ·
+        reassigned (from op-gh → to souliane): #69 ·
+        reassigned (from op-gl → to souliane): #12 ·
+        reassigned (from op-gl → to souliane): #69 · ...
+
+    All three handles are one human, so every one of those rows is a no-op
+    self-handoff and must vanish.
+    """
+
+    def test_all_intra_self_reassigns_render_zero_output(self) -> None:
+        actions = [
+            _disposition_action(
+                reason="unassigned",
+                payload_extra={"old_owner": old, "new_owners": ["souliane"]},
+                ticket_number=num,
+            )
+            for old in ("op-gh", "op-gl")
+            for num in ("12", "69")
+        ]
+        zones = zones_for(actions, colorize=False, identity_aliases=_REPORTED_ALIASES)
+        blob = "".join(item if isinstance(item, str) else item.text for item in zones.action_needed)
+        assert "reassigned" not in blob, repr(blob)
+
+    def test_mixed_feed_shows_only_boundary_crossing_deduped(self) -> None:
+        actions = [
+            # Same ticket #12 surfaced twice, each row crossing the self
+            # boundary from a DISTINCT non-self source owner — the two rows
+            # stay distinct even after canonicalization, so the equality-based
+            # dedup keeps both. A ticket is one observable thing regardless of
+            # which source handle the reassign came from: dedup to one row.
+            _disposition_action(
+                reason="unassigned",
+                payload_extra={"old_owner": "colleague-a", "new_owners": ["souliane"]},
+                ticket_number="12",
+            ),
+            _disposition_action(
+                reason="unassigned",
+                payload_extra={"old_owner": "colleague-b", "new_owners": ["souliane"]},
+                ticket_number="12",
+            ),
+            # Pure intra-self handoff — must be suppressed entirely.
+            _disposition_action(
+                reason="unassigned",
+                payload_extra={"old_owner": "op-gh", "new_owners": ["souliane"]},
+                ticket_number="69",
+            ),
+        ]
+        zones = zones_for(actions, colorize=False, identity_aliases=_REPORTED_ALIASES)
+        blob = "".join(item if isinstance(item, str) else item.text for item in zones.action_needed)
+        assert blob.count("reassigned") == 1, repr(blob)
+        assert "#12" in blob, repr(blob)
+        assert "#69" not in blob, repr(blob)
+        assert "op-gh" not in blob, repr(blob)
+        assert "op-gl" not in blob, repr(blob)
 
 
 def _stale_action(*, number: str, state: str, age: int, overlay: str = "teatree") -> DispatchAction:

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -443,6 +443,39 @@ def test_identity_aliases_for_request_unions_across_backends(
     )
 
 
+def test_identity_aliases_for_request_falls_back_to_operator_identities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No explicit ``identity_aliases`` → ``backend.identities`` is the self-group (#1113).
+
+    The deployment that surfaced the noise configures only the flat
+    ``user_identity_aliases`` (→ ``backend.identities``), never the grouped
+    ``identity_aliases``. The render path must apply the same self-group
+    fallback the scanner path already had, or every intra-self reassignment
+    between the operator's own handles renders as ``reassigned`` churn.
+    """
+    from unittest.mock import MagicMock  # noqa: PLC0415
+
+    from teatree.backends.protocols import CodeHostBackend  # noqa: PLC0415
+    from teatree.core.backend_factory import OverlayBackends  # noqa: PLC0415
+    from teatree.core.overlay import OverlayBase  # noqa: PLC0415
+    from teatree.loop.tick import TickRequest, _identity_aliases_for_request  # noqa: PLC0415
+
+    overlay = MagicMock(spec=OverlayBase)
+    overlay.config = MagicMock()
+    overlay.config.identity_aliases = []  # no grouped aliases configured
+    backend = OverlayBackends(
+        name="teatree",
+        hosts=(MagicMock(spec=CodeHostBackend),),
+        messaging=None,
+        ready_labels=(),
+        overlay=overlay,
+        identities=("souliane", "op-gh", "op-gl"),
+    )
+    monkeypatch.setattr("teatree.loop.tick_resolvers.discover_overlays", list)
+    assert _identity_aliases_for_request(TickRequest(backends=[backend])) == (("souliane", "op-gh", "op-gl"),)
+
+
 def test_identity_aliases_for_request_empty_without_backends() -> None:
     from teatree.loop.tick import TickRequest, _identity_aliases_for_request  # noqa: PLC0415
 


### PR DESCRIPTION
## Problem

The loop statusline displayed reassignment rows between the operator's own forge identities (a GitHub login, a GitLab username, and the canonical name — all one human), with each ticket duplicated once per source handle:

```
[t3-teatree] reassigned (from op-gh → to souliane): ticket-12 · reassigned (from op-gh → to souliane): ticket-69 · reassigned (from op-gl → to souliane): ticket-12 · reassigned (from op-gl → to souliane): ticket-69 · ready: ...
```

Two defects:

1. **Intra-self reassignments reported as events.** A reassignment from one of the operator's own identities to another is a no-op and must not surface.
2. **Duplication.** The same ticket renders once per source identity. A ticket is one observable thing and must be deduped.

## Root cause

Two self-handoff suppression layers exist — a scanner-side one (`TicketDispositionScanner._is_self_handoff`, fed via `_identity_groups_for_overlay`, which already had the `backend.identities` self-group fallback) and a render-side one (`_CanonicalIdentity.is_self_handoff`, fed by `_identity_aliases_for_request`).

The render path — the one the user actually sees — called the **raw** `_identity_alias_groups_for_overlay` directly, **without** that fallback. In the deployment that surfaced this, only the flat `user_identity_aliases` (→ `backend.identities`) is configured, never the grouped `identity_aliases`. So the render-side `_CanonicalIdentity` got an empty group, `is_self_handoff` always returned `False`, and every intra-self reassign rendered, once per distinct source handle.

Duplication is the symptom: `_dedup_in_order` keys on full `_ReassignRef` equality, so the same ticket from two distinct source owners survives as two rows.

## Fix

1. Route `_identity_aliases_for_request` through the fallback-aware `_identity_groups_for_overlay`, so the render path reads the same trusted-identity set the scanner path does: `backend.identities` ← `_resolved_identities` ← `user_identity_aliases`. That is the same accessor the DB-backed `TrustedIdentity` work ([#1773](https://github.com/souliane/teatree/issues/1773)) will sit behind, so this benefits automatically when it lands — no second identity source.
2. Add `_dedup_reassign_by_ticket` so the same ticket can't render twice when surfaced from two distinct source owners (key on issue URL, else label).

## Before / after

| | Before | After |
|---|---|---|
| All-intra-self feed | 4 `reassigned` rows shown | 0 rows |
| Same ticket, two source handles, crossing to a colleague | 2 duplicate rows | 1 row |
| Genuine cross-boundary reassign (self ↔ colleague) | shown | shown (unchanged) |

## Tests

- `TestReportedReassignNoise::test_all_intra_self_reassigns_render_zero_output` — the reported feed renders zero reassignment output.
- `TestReportedReassignNoise::test_mixed_feed_shows_only_boundary_crossing_deduped` — a mix renders only the boundary-crossing one, deduped to a single row.
- `test_identity_aliases_for_request_falls_back_to_operator_identities` — the render path applies the self-group fallback when no explicit `identity_aliases` is configured.

Both production-side tests were observed RED on the unfixed code before the fix. `uv run ruff check` clean; full loop suite green.

Self-group fallback origin: [#1113](https://github.com/souliane/teatree/issues/1113).

Closes [#1788](https://github.com/souliane/teatree/issues/1788)
