### PR TITLE
feat(clean-all): reap per-worktree docker artifacts for removed worktrees

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -494,6 +494,7 @@ graph TD
     teatree.contrib --> teatree.types
     teatree.contrib --> teatree.core
     teatree.contrib --> teatree.config
+    teatree.contrib --> teatree.docker
     teatree.contrib --> teatree.utils
     teatree.contrib --> teatree.visual_qa
     teatree.cli --> teatree.paths

--- a/docs/generated/overlay-extension-points.json
+++ b/docs/generated/overlay-extension-points.json
@@ -78,6 +78,12 @@
       "signature": "(worktree: 'Worktree') -> set[str]"
     },
     {
+      "description": "Reap a reaped worktree's out-of-band resources (e.g. its docker compose containers + images).",
+      "name": "reap_worktree_external_resources",
+      "required": false,
+      "signature": "(worktree: 'Worktree') -> list[str]"
+    },
+    {
       "description": "Return extra 'needs you' source identifiers for the `t3 <overlay> checking show` report.",
       "name": "get_checking_sources",
       "required": false,

--- a/docs/generated/overlay-extension-points.md
+++ b/docs/generated/overlay-extension-points.md
@@ -17,6 +17,7 @@ Base class: `teatree.core.overlay.OverlayBase`
 | `get_services_config` | No | `(worktree: 'Worktree') -> dict[str, teatree.types.ServiceSpec]` | Return additional service metadata for worktree-lifecycle orchestration. |
 | `get_base_images` | No | `(worktree: 'Worktree') -> list[teatree.types.BaseImageConfig]` | Declare Docker base images teatree builds once and shares across worktrees. |
 | `get_docker_services` | No | `(worktree: 'Worktree') -> set[str]` | Declare service names that MUST run in Docker — enforced at `worktree provision`. |
+| `reap_worktree_external_resources` | No | `(worktree: 'Worktree') -> list[str]` | Reap a reaped worktree's out-of-band resources (e.g. its docker compose containers + images). |
 | `get_checking_sources` | No | `() -> list[str]` | Return extra 'needs you' source identifiers for the `t3 <overlay> checking show` report. |
 | `metadata.validate_pr` | No | `(title: str, description: str) -> teatree.types.ValidationResult` | Return PR validation problems for this overlay. |
 | `metadata.build_pr_title` | No | `(*, branch: str, subject: str, body: str, issue_url: str) -> str` | Produce the PR title from structured ticket data (default: the commit subject). |

--- a/src/teatree/contrib/t3_teatree/overlay.py
+++ b/src/teatree/contrib/t3_teatree/overlay.py
@@ -10,6 +10,8 @@ from typing import override
 from teatree.config import discover_overlays, load_config
 from teatree.core.models import Worktree
 from teatree.core.overlay import OverlayBase, OverlayConfig, OverlayMetadata
+from teatree.core.runners.worktree_start import compose_project
+from teatree.docker.reap import reap_compose_project
 from teatree.types import ProvisionStep, RunCommands, SkillMetadata
 from teatree.utils.run import run_checked
 from teatree.visual_qa import matches_triggers
@@ -163,6 +165,11 @@ class TeatreeOverlay(OverlayBase):
             "src/teatree/core/urls.py",
         )
         return ["/"] if matches_triggers(changed_files, teatree_globs) else []
+
+    @override
+    def reap_worktree_external_resources(self, worktree: Worktree) -> list[str]:
+        result = reap_compose_project(compose_project(worktree))
+        return [] if result.is_noop else [str(result)]
 
     @override
     def get_eval_scenarios_dir(self) -> Path | None:

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -15,7 +15,10 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from teatree.core.overlay import OverlayBase
 
 from teatree.config import load_config
 from teatree.core.clone_paths import resolve_clone_path
@@ -477,6 +480,23 @@ def _worktree_has_work_to_lose(repo_main: Path, wt_path: str, worktree: Worktree
         return True
 
 
+def _reap_external_resources(overlay: "OverlayBase", worktree: Worktree, step_errors: list[str]) -> str:
+    """Run the overlay's external-resource reaper, returning a label suffix.
+
+    Appends a descriptive string to *step_errors* on failure (collect-and-
+    surface, never crash mid-teardown) and returns the joined outcomes as a
+    ``" — …"`` suffix for the cleanup label, or ``""`` when nothing was removed
+    or the reaper failed.
+    """
+    try:
+        reaped = overlay.reap_worktree_external_resources(worktree)
+    except Exception as exc:
+        logger.exception("external-resource reap failed for %s (%s)", worktree.repo_path, worktree.branch)
+        step_errors.append(f"external-resource reap failed for {worktree.branch}: {exc}")
+        return ""
+    return " — " + "; ".join(reaped) if reaped else ""
+
+
 def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> CleanupResult:
     """Remove a single worktree: git worktree, branch, DB, overlay cleanup.
 
@@ -559,6 +579,8 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene:
                 step_errors.append(f"pass-entry removal failed for {ticket.ticket_number}: {exc}")
 
     label = f"Cleaned: {worktree.repo_path} ({worktree.branch})"
+    label += _reap_external_resources(overlay, worktree, step_errors)
+
     ticket_id = worktree.ticket.pk
     worktree.delete()
     if not Worktree.objects.filter(ticket_id=ticket_id).exists():

--- a/src/teatree/core/doc_render.py
+++ b/src/teatree/core/doc_render.py
@@ -20,6 +20,7 @@ _OVERLAY_HOOK_ORDER = (
     "get_services_config",
     "get_base_images",
     "get_docker_services",
+    "reap_worktree_external_resources",
     "get_checking_sources",
 )
 
@@ -46,6 +47,9 @@ _OVERLAY_HOOK_DESCRIPTIONS = {
     "get_services_config": "Return additional service metadata for worktree-lifecycle orchestration.",
     "get_base_images": "Declare Docker base images teatree builds once and shares across worktrees.",
     "get_docker_services": "Declare service names that MUST run in Docker — enforced at `worktree provision`.",
+    "reap_worktree_external_resources": (
+        "Reap a reaped worktree's out-of-band resources (e.g. its docker compose containers + images)."
+    ),
     "get_checking_sources": "Return extra 'needs you' source identifiers for the `t3 <overlay> checking show` report.",
 }
 

--- a/src/teatree/core/management/commands/_workspace_docker.py
+++ b/src/teatree/core/management/commands/_workspace_docker.py
@@ -1,0 +1,38 @@
+"""Orphan per-worktree docker reaping used by ``t3 workspace clean-all``.
+
+Its own module so :mod:`teatree.core.management.commands._workspace_cleanup`
+stays under the module-health function cap. The per-worktree (on-teardown)
+half lives on the overlay hook ``reap_worktree_external_resources``; this is
+the orphan half — compose projects whose worktree directory is already gone.
+"""
+
+from pathlib import Path
+
+from teatree.core.models import Worktree
+from teatree.core.runners.worktree_start import compose_project
+from teatree.docker.reap import reap_orphan_compose_projects
+
+
+def _live_compose_projects() -> set[str]:
+    """Compose projects whose worktree row still exists on disk — the keep set.
+
+    A project is live only when a ``Worktree`` row claims it AND that row's
+    directory is present; a row whose directory is gone is not live, so its
+    docker artifacts fall to :func:`reap_orphan_worktree_docker`.
+    """
+    live: set[str] = set()
+    for wt in Worktree.objects.select_related("ticket"):
+        wt_path = (wt.extra or {}).get("worktree_path", "")
+        if wt_path and Path(wt_path).is_dir():
+            live.add(compose_project(wt))
+    return live
+
+
+def reap_orphan_worktree_docker() -> list[str]:
+    """Reap docker containers + images for compose projects with no live worktree.
+
+    Scoped by the ``com.docker.compose.project`` label, so base/official images
+    and the main-clone deps image — none of which carry a worktree project label
+    — are never touched.
+    """
+    return [str(result) for result in reap_orphan_compose_projects(_live_compose_projects())]

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -27,6 +27,7 @@ from teatree.core.management.commands._workspace_cleanup import (
     prune_branches,
     resolve_unsynced_worktree,
 )
+from teatree.core.management.commands._workspace_docker import reap_orphan_worktree_docker
 from teatree.core.models import Ticket, Worktree
 from teatree.core.models.ticket import format_intake_summary
 from teatree.core.orphan_guard import find_orphans_in_workspace
@@ -558,7 +559,7 @@ class Command(TyperCommand):
         self,
         keep_dslr: int = typer.Option(1, help="Number of DSLR snapshots to keep per tenant."),
     ) -> list[str]:
-        """Prune merged worktrees, stale branches, orphaned stashes, orphan databases, and old DSLR snapshots."""
+        """Prune merged worktrees, stale branches, stashes, orphan databases + docker, and old DSLR snapshots."""
         workspace = _workspace_dir()
         cleaned: list[str] = []
         interactive = sys.stdin.isatty() and sys.stdout.isatty()
@@ -576,6 +577,7 @@ class Command(TyperCommand):
                     cleaned.append(f"Removed empty dir: {entry.name}")
 
         cleaned.extend(drop_orphan_databases())
+        cleaned.extend(reap_orphan_worktree_docker())
 
         repo_root = Path.cwd()
         if (repo_root / ".git").exists():

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -534,6 +534,23 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
     def get_cleanup_steps(self, worktree: "Worktree") -> list[ProvisionStep]:
         return []
 
+    def reap_worktree_external_resources(self, worktree: "Worktree") -> list[str]:
+        """Remove out-of-band resources a reaped worktree leaves behind.
+
+        Called by ``cleanup_worktree`` for every worktree it tears down. The
+        docker case: a worktree's compose stack leaves per-worktree containers
+        and a multi-GB application image that the git/DB teardown never touches.
+        Docker is an overlay concern — core stays overlay-agnostic, so the
+        reaping engine (:mod:`teatree.docker.reap`) is a configurable core
+        utility the docker-using overlay reaches through this hook.
+
+        Returns human-readable one-line outcomes (empty when nothing was
+        removed). The default is ``[]`` — an overlay with no external resources
+        opts out without action.
+        """
+        _ = worktree
+        return []
+
     def get_health_checks(self, worktree: "Worktree") -> list["HealthCheck"]:
         return _default_health_checks(self, worktree)
 

--- a/src/teatree/docker/__init__.py
+++ b/src/teatree/docker/__init__.py
@@ -1,5 +1,12 @@
 """Docker helpers — base-image sharing, compose orchestration."""
 
 from teatree.docker.build import ensure_base_image
+from teatree.docker.reap import ReapResult, list_compose_projects, reap_compose_project, reap_orphan_compose_projects
 
-__all__ = ["ensure_base_image"]
+__all__ = [
+    "ReapResult",
+    "ensure_base_image",
+    "list_compose_projects",
+    "reap_compose_project",
+    "reap_orphan_compose_projects",
+]

--- a/src/teatree/docker/reap.py
+++ b/src/teatree/docker/reap.py
@@ -1,0 +1,114 @@
+"""Reap a worktree's per-compose-project docker containers and images.
+
+Docker Compose stamps every container *and* every image it builds for a
+project with the ``com.docker.compose.project=<project>`` label. That single
+label is the safety boundary: filtering by it reaps exactly the artifacts a
+worktree's stack created and nothing else. Base / official images
+(``postgres``, ``python``, ``node``, ``redis``, ``nginx``) and the main-clone's
+shared ``{image_name}:deps-<hash>`` image are built via ``docker build`` (see
+:mod:`teatree.docker.build`), not compose, so they carry no compose-project
+label and are never enumerated under a removed worktree's project.
+
+This is a core utility — the generic engine (BLUEPRINT §6.0) — that the
+docker-using overlay reaches through
+``OverlayBase.reap_worktree_external_resources``. Tolerant of an unavailable
+docker binary (CI sandboxes, hermetic tests) so cleanup paths funnelling
+through it never break when there is no daemon to talk to.
+"""
+
+import logging
+from dataclasses import dataclass
+
+from teatree.utils.run import TimeoutExpired, run_allowed_to_fail
+
+logger = logging.getLogger(__name__)
+
+_PROJECT_LABEL = "com.docker.compose.project"
+_LIST_TIMEOUT = 30
+_REMOVE_TIMEOUT = 60
+
+
+@dataclass(frozen=True, slots=True)
+class ReapResult:
+    project: str
+    containers_removed: int = 0
+    images_removed: int = 0
+
+    @property
+    def is_noop(self) -> bool:
+        return self.containers_removed == 0 and self.images_removed == 0
+
+    def __str__(self) -> str:
+        return (
+            f"Reaped docker project {self.project}: "
+            f"{self.containers_removed} container(s), {self.images_removed} image(s)"
+        )
+
+
+def _docker_lines(cmd: list[str], *, timeout: int) -> list[str]:
+    try:
+        result = run_allowed_to_fail(cmd, expected_codes=None, timeout=timeout)
+    except (FileNotFoundError, PermissionError) as exc:
+        logger.debug("docker unavailable, skipping %s: %s", cmd[:3], exc)
+        return []
+    except TimeoutExpired:
+        logger.warning("docker command timed out: %s", cmd[:3])
+        return []
+    if result.returncode != 0:
+        logger.warning("docker %s failed: %s", cmd[:3], result.stderr.strip()[:300])
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _project_filter(project: str) -> list[str]:
+    return ["--filter", f"label={_PROJECT_LABEL}={project}"]
+
+
+def _list_project_containers(project: str) -> list[str]:
+    return _docker_lines(
+        ["docker", "ps", "-a", *_project_filter(project), "--format", "{{.ID}}"],
+        timeout=_LIST_TIMEOUT,
+    )
+
+
+def _list_project_images(project: str) -> list[str]:
+    return _docker_lines(
+        ["docker", "images", *_project_filter(project), "--format", "{{.ID}}"],
+        timeout=_LIST_TIMEOUT,
+    )
+
+
+def _remove(kind: str, ids: list[str]) -> int:
+    if not ids:
+        return 0
+    flag = "rm" if kind == "container" else "rmi"
+    removed = _docker_lines(["docker", flag, "-f", *ids], timeout=_REMOVE_TIMEOUT)
+    return len(removed) or len(ids)
+
+
+def reap_compose_project(project: str) -> ReapResult:
+    if not project:
+        return ReapResult(project=project)
+    containers = _remove("container", _list_project_containers(project))
+    images = _remove("image", _list_project_images(project))
+    if containers or images:
+        logger.info("reaped docker project %s: %s containers, %s images", project, containers, images)
+    return ReapResult(project=project, containers_removed=containers, images_removed=images)
+
+
+def list_compose_projects() -> set[str]:
+    label_filter = ["--filter", f"label={_PROJECT_LABEL}"]
+    label_format = ["--format", f'{{{{.Label "{_PROJECT_LABEL}"}}}}']
+    containers = _docker_lines(["docker", "ps", "-a", *label_filter, *label_format], timeout=_LIST_TIMEOUT)
+    images = _docker_lines(["docker", "images", *label_filter, *label_format], timeout=_LIST_TIMEOUT)
+    return {name for name in (*containers, *images) if name}
+
+
+def reap_orphan_compose_projects(live_projects: set[str]) -> list[ReapResult]:
+    orphans = sorted(list_compose_projects() - live_projects)
+    results: list[ReapResult] = []
+    for project in orphans:
+        result = reap_compose_project(project)
+        if not result.is_noop:
+            results.append(result)
+    return results

--- a/tach.toml
+++ b/tach.toml
@@ -104,7 +104,7 @@ depends_on = [
 
 [[modules]]
 path = "teatree.contrib"
-depends_on = ["teatree.types", "teatree.core", "teatree.config", "teatree.utils", "teatree.visual_qa"]
+depends_on = ["teatree.types", "teatree.core", "teatree.config", "teatree.docker", "teatree.utils", "teatree.visual_qa"]
 
 [[modules]]
 path = "teatree.cli"

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -114,6 +114,58 @@ class TestCleanupWorktree(TestCase):
     @_patch_overlay
     @_patch_git
     @_patch_config
+    def test_invokes_overlay_external_resource_reaper(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """#1523: cleanup hands each reaped worktree to the overlay's reaper.
+
+        ``docker_compose_down`` removes containers but never images, so the
+        per-worktree application image (~9GB) lingered for every removed
+        worktree. ``cleanup_worktree`` now calls
+        ``reap_worktree_external_resources`` for the docker-using overlay to
+        remove that worktree's compose images + containers in the same pass.
+        """
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_overlay.return_value.reap_worktree_external_resources.return_value = ["reaped 1 image"]
+        mock_git.status_porcelain.return_value = ""
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        result = cleanup_worktree(wt)
+
+        mock_overlay.return_value.reap_worktree_external_resources.assert_called_once_with(wt)
+        assert "reaped 1 image" in result.label
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
+    def test_overlay_reaper_failure_is_surfaced_not_crashed(
+        self,
+        mock_config: MagicMock,
+        mock_git: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        _mock_workspace(mock_config)
+        _no_unpushed(mock_git)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_overlay.return_value.reap_worktree_external_resources.side_effect = RuntimeError("docker exploded")
+        mock_git.status_porcelain.return_value = ""
+
+        wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
+        wt_id = wt.pk
+        result = cleanup_worktree(wt)
+
+        assert not result.clean
+        assert any("docker exploded" in e for e in result.errors)
+        assert not Worktree.objects.filter(pk=wt_id).exists()
+
+    @_patch_overlay
+    @_patch_git
+    @_patch_config
     def test_drops_database_when_db_name_set(
         self,
         mock_config: MagicMock,

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -15,6 +15,7 @@ from django.utils.module_loading import import_string
 
 import teatree.core.cleanup as cleanup_mod
 import teatree.core.management.commands._workspace_cleanup as ws_cleanup_mod
+import teatree.core.management.commands._workspace_docker as ws_docker_mod
 import teatree.core.management.commands.workspace as workspace_mod
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.core.runners.provision as provision_mod
@@ -640,6 +641,9 @@ _no_stash = patch.object(workspace_mod, "drop_orphaned_stashes", new=lambda _rep
 _no_orphan_dbs = patch.object(workspace_mod, "drop_orphan_databases", new=list)
 
 
+_no_orphan_docker = patch.object(workspace_mod, "reap_orphan_worktree_docker", new=list)
+
+
 _no_dslr_prune = patch("teatree.utils.django_db.prune_dslr_snapshots", new=lambda **kw: [])
 
 
@@ -1011,6 +1015,7 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_no_orphan_docker
     @_no_dslr_prune
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1026,6 +1031,7 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_no_orphan_docker
     @_no_dslr_prune
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1077,6 +1083,7 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_no_orphan_docker
     @_no_dslr_prune
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1124,6 +1131,7 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_no_orphan_docker
     @_no_dslr_prune
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1165,6 +1173,7 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_no_orphan_docker
     @_no_dslr_prune
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1211,6 +1220,7 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_no_orphan_docker
     @_no_dslr_prune
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1246,6 +1256,7 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_no_orphan_docker
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
     def test_includes_dslr_snapshot_pruning(self) -> None:
@@ -1263,6 +1274,7 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_no_orphan_docker
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
     def test_passes_in_use_tenants_from_active_worktrees(self) -> None:
@@ -1308,6 +1320,7 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_no_orphan_docker
     @_no_dslr_prune
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1381,6 +1394,7 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_prune
     @_no_stash
     @_no_orphan_dbs
+    @_no_orphan_docker
     @_no_dslr_prune
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1416,6 +1430,63 @@ class TestWorkspaceCleanAll(TestCase):
             call_command("workspace", "clean-all")
 
         assert exc_info.value.code == 1
+
+    @_no_prune
+    @_no_stash
+    @_no_orphan_dbs
+    @_no_dslr_prune
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_reaps_orphan_worktree_docker(self) -> None:
+        """#1523: clean-all reaps docker for compose projects whose worktree dir is gone."""
+        with patch.object(workspace_mod, "reap_orphan_worktree_docker") as mock_reap:
+            mock_reap.return_value = ["Reaped docker project teatree-wt99: 1 container(s), 1 image(s)"]
+            cleaned = cast("list[str]", call_command("workspace", "clean-all"))
+
+        mock_reap.assert_called_once_with()
+        assert any("Reaped docker project teatree-wt99" in c for c in cleaned)
+
+
+class TestReapOrphanWorktreeDocker(TestCase):
+    """#1523 orphan reaper: a worktree whose dir is gone is not live, so its docker is reaped.
+
+    The docker subprocess is mocked at the engine boundary
+    (``reap_orphan_compose_projects``); this asserts the live/keep set is
+    computed correctly from the rows-on-disk and handed to the engine.
+    """
+
+    def _worktree(self, *, repo: str, number: str, wt_path: str | None) -> Worktree:
+        ticket = Ticket.objects.create(overlay="test", issue_url=f"https://example.com/issues/{number}")
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path=repo,
+            branch=f"{number}-x",
+            extra={"worktree_path": wt_path} if wt_path else {},
+        )
+
+    def test_live_set_excludes_worktrees_whose_dir_is_gone(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            live_dir = Path(tmp) / "live"
+            live_dir.mkdir()
+            self._worktree(repo="backend", number="1", wt_path=str(live_dir))
+            self._worktree(repo="backend", number="9", wt_path=str(Path(tmp) / "gone"))
+
+            with patch.object(ws_docker_mod, "reap_orphan_compose_projects", return_value=[]) as mock_engine:
+                ws_docker_mod.reap_orphan_worktree_docker()
+
+        (live_projects,) = mock_engine.call_args.args
+        assert live_projects == {"backend-wt1"}
+
+    def test_renders_engine_results_as_lines(self) -> None:
+        from teatree.docker.reap import ReapResult  # noqa: PLC0415
+
+        result = ReapResult(project="backend-wt9", containers_removed=2, images_removed=1)
+        with patch.object(ws_docker_mod, "reap_orphan_compose_projects", return_value=[result]):
+            lines = ws_docker_mod.reap_orphan_worktree_docker()
+
+        assert lines == [str(result)]
+        assert "backend-wt9" in lines[0]
 
 
 class TestResolveUnsyncedWorktree(TestCase):

--- a/tests/test_contrib_overlay.py
+++ b/tests/test_contrib_overlay.py
@@ -386,6 +386,40 @@ class TestGetTestCommand(TestCase):
         assert overlay.get_test_command(worktree) == ["uv", "run", "pytest"]
 
 
+class TestReapWorktreeExternalResources(TestCase):
+    """#1523: the docker overlay reaps a removed worktree's compose containers + images."""
+
+    def _worktree(self) -> Worktree:
+        ticket = Ticket.objects.create(overlay="t3-teatree", issue_url="https://example.com/issues/1523")
+        return Worktree.objects.create(ticket=ticket, overlay="t3-teatree", repo_path="teatree", branch="1523-x")
+
+    def test_reaps_the_worktree_compose_project(self) -> None:
+        from teatree.docker.reap import ReapResult  # noqa: PLC0415
+
+        worktree = self._worktree()
+        with patch.object(
+            overlay_mod,
+            "reap_compose_project",
+            return_value=ReapResult(project="teatree-wt1523", containers_removed=2, images_removed=1),
+        ) as mock_reap:
+            outcomes = TeatreeOverlay().reap_worktree_external_resources(worktree)
+
+        mock_reap.assert_called_once_with("teatree-wt1523")
+        assert len(outcomes) == 1
+        assert "teatree-wt1523" in outcomes[0]
+
+    def test_returns_empty_when_nothing_to_reap(self) -> None:
+        from teatree.docker.reap import ReapResult  # noqa: PLC0415
+
+        worktree = self._worktree()
+        with patch.object(
+            overlay_mod,
+            "reap_compose_project",
+            return_value=ReapResult(project="teatree-wt1523"),
+        ):
+            assert TeatreeOverlay().reap_worktree_external_resources(worktree) == []
+
+
 class TestRepoRoot:
     def test_finds_repo_root(self) -> None:
         root = _repo_root()

--- a/tests/test_docker_reap.py
+++ b/tests/test_docker_reap.py
@@ -1,0 +1,229 @@
+"""Tests for teatree.docker.reap — compose-project container + image reaping.
+
+The docker subprocess is the only mocked boundary: a fake ``run_allowed_to_fail``
+records the commands and serves canned ``docker ps`` / ``docker images`` output.
+The label scoping (``com.docker.compose.project=<project>``) is what keeps base
+images and the main-clone deps image safe — compose only labels artifacts it
+built for that project, so they never appear under a removed worktree's project.
+"""
+
+from subprocess import CompletedProcess
+
+import pytest
+
+from teatree.docker.reap import ReapResult, list_compose_projects, reap_compose_project, reap_orphan_compose_projects
+from teatree.utils.run import TimeoutExpired
+
+_LABEL = "com.docker.compose.project"
+_MISSING_DOCKER = "docker"
+
+
+def _scoped_project(cmd: list[str]) -> str:
+    for arg in cmd:
+        if arg.startswith(f"label={_LABEL}="):
+            return arg.removeprefix(f"label={_LABEL}=")
+    return ""
+
+
+def _is_enumeration(cmd: list[str]) -> bool:
+    return f"label={_LABEL}" in cmd and not _scoped_project(cmd)
+
+
+class _FakeDocker:
+    """Canned docker daemon: serves per-project containers/images and records removals.
+
+    ``containers`` / ``images`` map a scoped project to the ids its filter
+    returns; ``enumerated`` is the project-label list returned by the unscoped
+    enumeration calls (``list_compose_projects``). Removal commands are recorded
+    rather than executed.
+    """
+
+    def __init__(
+        self,
+        *,
+        containers: dict[str, list[str]] | None = None,
+        images: dict[str, list[str]] | None = None,
+        enumerated: list[str] | None = None,
+    ) -> None:
+        self.containers = containers or {}
+        self.images = images or {}
+        self.enumerated = enumerated or []
+        self.removed_containers: list[str] = []
+        self.removed_images: list[str] = []
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, *, expected_codes=None, timeout=None, **_kwargs) -> CompletedProcess:
+        del expected_codes, timeout
+        cmd = list(cmd)
+        self.calls.append(cmd)
+        return CompletedProcess(cmd, 0, self._stdout(cmd), "")
+
+    def _stdout(self, cmd: list[str]) -> str:
+        if cmd[:3] == ["docker", "rm", "-f"]:
+            self.removed_containers.extend(cmd[3:])
+            return "\n".join(cmd[3:]) + "\n"
+        if cmd[:3] == ["docker", "rmi", "-f"]:
+            self.removed_images.extend(cmd[3:])
+            return "\n".join(cmd[3:]) + "\n"
+        if _is_enumeration(cmd):
+            return "\n".join(self.enumerated) + "\n"
+        if cmd[:2] == ["docker", "ps"]:
+            return "\n".join(self.containers.get(_scoped_project(cmd), [])) + "\n"
+        if cmd[:2] == ["docker", "images"]:
+            return "\n".join(self.images.get(_scoped_project(cmd), [])) + "\n"
+        return ""
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, fake: object) -> None:
+    monkeypatch.setattr("teatree.docker.reap.run_allowed_to_fail", fake)
+
+
+class TestReapResult:
+    def test_is_noop_only_when_nothing_removed(self) -> None:
+        assert ReapResult(project="p").is_noop
+        assert not ReapResult(project="p", images_removed=1).is_noop
+
+    def test_str_names_the_project_and_counts(self) -> None:
+        text = str(ReapResult(project="backend-wt9", containers_removed=2, images_removed=1))
+        assert "backend-wt9" in text
+        assert "2 container(s)" in text
+        assert "1 image(s)" in text
+
+
+class TestReapComposeProject:
+    def test_removes_containers_and_images_for_the_project(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _FakeDocker(
+            containers={"backend-wt99": ["backend-wt99-web-1", "backend-wt99-db-1"]},
+            images={"backend-wt99": ["sha256:img1", "sha256:img2"]},
+        )
+        _patch(monkeypatch, fake)
+
+        result = reap_compose_project("backend-wt99")
+
+        assert fake.removed_containers == ["backend-wt99-web-1", "backend-wt99-db-1"]
+        assert fake.removed_images == ["sha256:img1", "sha256:img2"]
+        assert result.containers_removed == 2
+        assert result.images_removed == 2
+        assert result.project == "backend-wt99"
+
+    def test_no_artifacts_is_a_clean_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _FakeDocker()
+        _patch(monkeypatch, fake)
+
+        result = reap_compose_project("gone-wt7")
+
+        assert result.is_noop
+        assert fake.removed_containers == []
+        assert fake.removed_images == []
+
+    def test_empty_project_name_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _FakeDocker()
+        _patch(monkeypatch, fake)
+
+        result = reap_compose_project("")
+
+        assert result.is_noop
+        assert fake.calls == []
+
+    def test_filters_by_compose_project_label(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _FakeDocker()
+        _patch(monkeypatch, fake)
+
+        reap_compose_project("backend-wt99")
+
+        list_calls = [c for c in fake.calls if c[:2] in (["docker", "ps"], ["docker", "images"])]
+        assert list_calls, "expected a ps + images listing"
+        for call in list_calls:
+            assert f"label={_LABEL}=backend-wt99" in call
+
+    def test_missing_docker_binary_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_missing(cmd, **_kwargs):
+            raise FileNotFoundError(_MISSING_DOCKER)
+
+        _patch(monkeypatch, raise_missing)
+
+        assert reap_compose_project("backend-wt99").is_noop
+
+    def test_timeout_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_timeout(cmd, **_kwargs):
+            raise TimeoutExpired(cmd, 30)
+
+        _patch(monkeypatch, raise_timeout)
+
+        assert reap_compose_project("backend-wt99").is_noop
+
+    def test_denied_docker_is_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A sandbox that denies the docker binary (PermissionError) is a clean skip."""
+
+        def raise_denied(cmd, **_kwargs):
+            raise PermissionError(_MISSING_DOCKER)
+
+        _patch(monkeypatch, raise_denied)
+
+        assert reap_compose_project("backend-wt99").is_noop
+
+
+class TestListComposeProjects:
+    def test_aggregates_project_labels_across_containers_and_images(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake(cmd, *, expected_codes=None, timeout=None, **_kwargs):
+            del expected_codes, timeout
+            cmd = list(cmd)
+            if cmd[:2] == ["docker", "ps"]:
+                return CompletedProcess(cmd, 0, "backend-wt1\nbackend-wt2\n\n", "")
+            return CompletedProcess(cmd, 0, "backend-wt2\nfrontend-wt3\n", "")
+
+        _patch(monkeypatch, fake)
+
+        assert list_compose_projects() == {"backend-wt1", "backend-wt2", "frontend-wt3"}
+
+    def test_ignores_blank_lines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake(cmd, *, expected_codes=None, timeout=None, **_kwargs):
+            del expected_codes, timeout
+            return CompletedProcess(list(cmd), 0, "backend-wt1\n\n   \n", "")
+
+        _patch(monkeypatch, fake)
+
+        assert list_compose_projects() == {"backend-wt1"}
+
+    def test_missing_docker_returns_empty_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_missing(cmd, **_kwargs):
+            raise FileNotFoundError(_MISSING_DOCKER)
+
+        _patch(monkeypatch, raise_missing)
+
+        assert list_compose_projects() == set()
+
+    def test_daemon_error_returncode_yields_empty_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake(cmd, *, expected_codes=None, timeout=None, **_kwargs):
+            del expected_codes, timeout
+            return CompletedProcess(list(cmd), 1, "", "Cannot connect to the Docker daemon")
+
+        _patch(monkeypatch, fake)
+
+        assert list_compose_projects() == set()
+
+
+class TestReapOrphanComposeProjects:
+    def test_reaps_only_projects_absent_from_live_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _FakeDocker(
+            containers={"orphan-wt9": ["orphan-wt9-web-1"]},
+            images={"orphan-wt9": ["sha256:orphanimg"]},
+            enumerated=["live-wt1", "orphan-wt9"],
+        )
+        _patch(monkeypatch, fake)
+
+        results = reap_orphan_compose_projects(live_projects={"live-wt1"})
+
+        assert fake.removed_containers == ["orphan-wt9-web-1"]
+        assert fake.removed_images == ["sha256:orphanimg"]
+        assert [r.project for r in results] == ["orphan-wt9"]
+
+    def test_no_orphans_when_every_project_is_live(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _FakeDocker(enumerated=["live-wt1"])
+        _patch(monkeypatch, fake)
+
+        results = reap_orphan_compose_projects(live_projects={"live-wt1"})
+
+        assert results == []
+        assert fake.removed_containers == []
+        assert fake.removed_images == []

--- a/tests/test_overlay_base.py
+++ b/tests/test_overlay_base.py
@@ -129,6 +129,12 @@ def test_get_docker_services_returns_empty_set():
     assert overlay.get_docker_services(_make_worktree()) == set()
 
 
+def test_reap_worktree_external_resources_returns_empty_list_by_default():
+    """#1523: an overlay with no out-of-band resources opts out via the default."""
+    overlay = _MinimalOverlay()
+    assert overlay.reap_worktree_external_resources(_make_worktree()) == []
+
+
 def test_validate_pr_passes_conforming_title_and_what_why_description():
     overlay = _MinimalOverlay()
     result = overlay.metadata.validate_pr(


### PR DESCRIPTION
## What

`t3 <overlay> workspace clean-all` now reaps an overlay's per-worktree docker artifacts (containers + images) for removed worktrees, in the same pass that prunes worktrees, DBs, branches and stashes.

Two halves, both scoped by the `com.docker.compose.project` label:

- **Per-worktree reap (on teardown):** a new core extension point `OverlayBase.reap_worktree_external_resources(worktree)` that `cleanup_worktree` calls for every worktree it tears down. Docker stays an overlay concern — the reusable engine lives in `teatree.docker.reap`, and the teatree overlay opts in by reaping its compose project's containers + images. Default is `[]`.
- **Orphan reaper:** `clean-all` removes docker for compose projects whose worktree directory no longer exists — the clearly-safe buildup case. The live/keep set is computed from `Worktree` rows whose directory is still present on disk.

## Why

`clean-all` pruned worktrees, DBs, branches and stashes but never touched docker, so per-worktree compose images (multi-GB each) and stale stopped containers accumulated unbounded across merged-and-removed worktrees — the single biggest local-disk consumer.

## Must-NOT-remove (held)

The `com.docker.compose.project` label is the safety boundary. Base/official images (postgres, python, node, redis, nginx) and the main-clone's shared `{image_name}:deps-<hash>` image are built via `docker build` (not compose), so they carry no compose-project label and are never enumerated under a removed worktree's project. Live-worktree and in-flight projects stay in the keep set. The engine tolerates an unavailable/denied docker binary and a non-zero daemon, returning a clean no-op.

## Tests

- `tests/test_docker_reap.py` — the reaping engine (mock only the docker subprocess boundary).
- `tests/teatree_core/management_commands/test_workspace.py` — `clean-all` calls the orphan reaper; the keep set excludes worktrees whose dir is gone (the overlay-level orphan test the acceptance criteria asks for).
- `tests/teatree_core/cleanup/test_cleanup_worktree.py` — `cleanup_worktree` invokes the overlay reaper per worktree and surfaces (not crashes on) its failures.
- `tests/test_contrib_overlay.py` / `tests/test_overlay_base.py` — the teatree overlay reaps its compose project; the default hook returns `[]`.

Closes [#1523](https://github.com/souliane/teatree/issues/1523)
