### PR TITLE
fix(slack): bounded-retry transport + validate/back-up token writes

### DIFF
--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -108,7 +108,23 @@ EOF
 ### Slack integration (per-overlay)
 
 Messaging is configured per overlay in `~/.teatree.toml`, not via `T3_CHAT_PLATFORM`.
-Run `t3 setup slack-bot --overlay <name>` to register a Slack app and store tokens.
+Three commands cover distinct phases of the Slack lifecycle — they are not
+interchangeable:
+
+- `t3 setup slack-bot --overlay <name>` — first-time bootstrap: registers the
+  app and **captures** the bot (`xoxb-`) + app-level (`xapp-`) tokens into
+  `pass`, recording the overlay's Slack settings.
+- `t3 setup slack-provision [--overlay <name>]` — the idempotent one-shot
+  lifecycle pass: pushes the manifest (all bot + user scopes), prints the OAuth
+  reinstall URL, joins review channels, provisions the bot IM, and **verifies**
+  the shared personal token's scopes. It reads tokens; it does not capture them.
+- `t3 setup slack-user-token` — (re)captures the personal user (`xoxp-`) token
+  after a manual OAuth reinstall and verifies its scopes.
+
+Token writes are prefix-validated (`xoxb-`/`xapp-`/`xoxp-`) and back up any
+prior value to a timestamped `pass` key before overwriting, so a mis-pasted
+token can never clobber a good secret.
+
 Then start `t3 slack listen` for real-time event delivery via Socket Mode.
 
 ```toml

--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -44,9 +44,8 @@ resolves correctly.
 import threading
 from typing import cast
 
-import httpx
-
 from teatree.backends.slack_bot_errors import GLOBAL_TOKEN_FAILURES as _GLOBAL_TOKEN_FAILURES
+from teatree.backends.slack_http import SlackHttpClient
 from teatree.backends.slack_react_errors import SingleEmojiBodyRefusedError, is_single_emoji_body
 from teatree.backends.slack_scopes import OAUTH_SCOPES_HEADER, attach_granted_scopes
 from teatree.backends.slack_token_policy import SlackOp, channel_token
@@ -204,6 +203,7 @@ class SlackBotBackend:
         # fallback through whichever bot already had an IM with the user —
         # the per-overlay attribution leak the issue reports).
         self._dm_channel_id = dm_channel_id
+        self._http = SlackHttpClient()
         # #1395 voice/token gate; factory overrides via set_voice_classifier_mode.
         self._voice_gate = VoiceTokenGate(mode=VoiceClassifierMode.WARN, dm_channel_id=dm_channel_id)
         self._cached_bot_id: str | None = None
@@ -261,34 +261,26 @@ class SlackBotBackend:
         """
         return self._inbound
 
-    def _post(self, method: str, payload: SlackPayload, *, token: str = "") -> RawAPIDict:
+    def _post(self, method: str, payload: SlackPayload, *, token: str = "", idempotent: bool = True) -> RawAPIDict:
+        """POST *method* through the bounded-retry transport.
+
+        ``idempotent`` gates the response-phase retry. A non-idempotent
+        ``chat.postMessage`` (``idempotent=False``) is never replayed on a
+        response-phase failure — a ``ReadTimeout`` after the request reached
+        Slack may mean it already posted. Replayable calls (``reactions.add``'s
+        ``already_reacted`` no-op, ``auth.test``, ``conversations.*`` lookups)
+        keep the ``True`` default.
+        """
         auth = token or self._bot_token
         if not auth:
             return {}
-        response = httpx.post(
-            f"https://slack.com/api/{method}",
-            headers={
-                "Authorization": f"Bearer {auth}",
-                "Content-Type": "application/json; charset=utf-8",
-            },
-            json=payload,
-            timeout=10.0,
-        )
-        response.raise_for_status()
-        return cast("RawAPIDict", response.json())
+        return self._http.post(method, token=auth, json=payload, idempotent=idempotent)
 
     def _get(self, method: str, params: dict[str, str | int], *, token: str = "") -> RawAPIDict:
         auth = token or self._bot_token
         if not auth:
             return {}
-        response = httpx.get(
-            f"https://slack.com/api/{method}",
-            headers={"Authorization": f"Bearer {auth}"},
-            params=params,
-            timeout=10.0,
-        )
-        response.raise_for_status()
-        return cast("RawAPIDict", response.json())
+        return self._http.get(method, token=auth, params=params)
 
     def _is_ext_shared(self, channel: str) -> bool | None:
         """Whether *channel* is a Slack-Connect externally-shared channel.
@@ -564,11 +556,13 @@ class SlackBotBackend:
         """
         if not self._bot_token:
             return {}
-        headers = {"Authorization": f"Bearer {self._bot_token}", "Content-Type": "application/json; charset=utf-8"}
-        response = httpx.post("https://slack.com/api/auth.test", headers=headers, json={}, timeout=10.0)
-        response.raise_for_status()
-        body = cast("RawAPIDict", response.json())
-        return attach_granted_scopes(body, response.headers.get(OAUTH_SCOPES_HEADER, ""))
+        body, scopes_header = self._http.post_with_header(
+            "auth.test",
+            token=self._bot_token,
+            json={},
+            header=OAUTH_SCOPES_HEADER,
+        )
+        return attach_granted_scopes(body, scopes_header)
 
     def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:
         if is_single_emoji_body(text):
@@ -578,7 +572,7 @@ class SlackBotBackend:
         payload: SlackPayload = {"channel": channel, "text": text}
         if thread_ts:
             payload["thread_ts"] = thread_ts
-        return self._post("chat.postMessage", payload, token=token)
+        return self._post("chat.postMessage", payload, token=token, idempotent=False)
 
     def post_reply(self, *, channel: str, ts: str, text: str) -> RawAPIDict:
         if is_single_emoji_body(text):
@@ -589,6 +583,7 @@ class SlackBotBackend:
             "chat.postMessage",
             {"channel": channel, "thread_ts": ts, "text": text},
             token=token,
+            idempotent=False,
         )
 
     def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
@@ -638,6 +633,17 @@ class SlackBotBackend:
             return self._bot_token or self._user_token
         return self._user_token or self._bot_token
 
+    def route_token(self, channel: str) -> str:
+        """Public accessor over the #1750 destination router (self-DM→bot, else→xoxp).
+
+        The deterministic classifier ``post_routed`` / ``react_routed`` and
+        ``t3 <overlay> notify post`` / ``react`` consult to choose the
+        outbound token by destination. Distinct from
+        :meth:`resolve_channel_token`, which is the Connect-membership policy
+        that cannot tell the user's own DM from a colleague's.
+        """
+        return self._route_token(channel)
+
     def post_routed(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict:
         """Post to *channel*, token chosen by destination (#1750).
 
@@ -652,7 +658,7 @@ class SlackBotBackend:
         payload: SlackPayload = {"channel": channel, "text": text}
         if thread_ts:
             payload["thread_ts"] = thread_ts
-        return self._post("chat.postMessage", payload, token=token)
+        return self._post("chat.postMessage", payload, token=token, idempotent=False)
 
     def react_routed(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
         """Add a reaction to *channel*'s message, token chosen by destination (#1750).

--- a/src/teatree/backends/slack_http.py
+++ b/src/teatree/backends/slack_http.py
@@ -1,0 +1,264 @@
+"""Bounded-retry HTTP transport for the Slack Web API (#1110, reliability).
+
+``SlackBotBackend`` previously issued every ``httpx.post`` / ``httpx.get``
+with a hard ``timeout=10.0`` and no retry. A single transient
+``ReadTimeout`` / ``ConnectTimeout`` / ``5xx`` / Slack ``ratelimited``
+then broke a loop tick — a missed ``reactions.add``, a dropped
+merge-notify ``chat.postMessage`` during the PR sweep — even though the
+very next attempt would have succeeded. :class:`SlackHttpClient`
+centralises the transport so every call gets a configurable timeout and
+a bounded exponential backoff on *transient* failures only.
+
+Idempotency is the load-bearing safety constraint. A
+``chat.postMessage`` is **not** idempotent: a ``ReadTimeout`` after the
+request reached Slack may mean the message *was* posted and only the
+response was lost — a blind retry would double-post. So retries are
+gated by *both* the failure class and the call's idempotency:
+
+*   :class:`RetryClass.CONNECT` — the request never reached Slack
+    (``ConnectTimeout`` / ``ConnectError`` / ``PoolTimeout``). Safe to
+    retry for *every* call, idempotent or not, because nothing was sent.
+*   :class:`RetryClass.RESPONSE` — the request reached Slack but the
+    response failed or signalled "try again" (``ReadTimeout``,
+    ``5xx``, Slack ``ratelimited``). Retried only for an *idempotent*
+    call (a ``GET`` read, ``reactions.add`` — adding the same reaction
+    twice is the no-op ``already_reacted``). A non-idempotent
+    ``chat.postMessage`` is **not** retried on a response-phase failure;
+    its body surfaces to the caller, which already tolerates a bare
+    ``ok:false`` / transport error without double-posting.
+
+``ratelimited`` is honoured by sleeping the ``Retry-After`` header (Slack
+sends it in seconds) when present, else the standard backoff. The
+backoff and timeout are read once from the environment so a slow link
+can widen them without a code change.
+"""
+
+import os
+import time
+from collections.abc import Callable
+from enum import Enum
+from typing import cast
+
+import httpx
+
+from teatree.types import RawAPIDict
+
+type SleepFn = Callable[[float], None]
+type AttemptFn = Callable[[], httpx.Response]
+
+__all__ = [
+    "DEFAULT_BACKOFF_BASE_SECONDS",
+    "DEFAULT_MAX_RETRIES",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "RetryClass",
+    "SlackHttpClient",
+]
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_BACKOFF_BASE_SECONDS = 0.5
+_MAX_BACKOFF_SECONDS = 30.0
+_RATELIMITED = "ratelimited"
+_CONNECT_ERRORS = (httpx.ConnectTimeout, httpx.ConnectError, httpx.PoolTimeout)
+
+
+class RetryClass(Enum):
+    """How a transient failure may be retried.
+
+    ``CONNECT`` — the request never reached Slack, so a retry cannot
+    duplicate a side effect; safe even for a non-idempotent post.
+    ``RESPONSE`` — the request reached Slack; retry only when the call
+    itself is idempotent (a read, or ``reactions.add``).
+    """
+
+    CONNECT = "connect"
+    RESPONSE = "response"
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+class SlackHttpClient:
+    """Transport for the Slack Web API with a bounded retry on transient errors.
+
+    ``timeout`` and ``max_retries`` default from
+    ``T3_SLACK_HTTP_TIMEOUT`` / ``T3_SLACK_HTTP_MAX_RETRIES`` /
+    ``T3_SLACK_HTTP_BACKOFF`` so a slow workspace can widen them without a
+    code change. ``max_retries`` is the number of *additional* attempts
+    after the first, so the default ``3`` means up to four total tries.
+    ``sleep`` is injectable purely so tests assert the backoff schedule
+    without real delay — production uses ``time.sleep``.
+    """
+
+    _BASE_URL = "https://slack.com/api"
+
+    def __init__(
+        self,
+        *,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        backoff_base: float | None = None,
+        sleep: SleepFn = time.sleep,
+    ) -> None:
+        self._timeout = timeout if timeout is not None else _env_float("T3_SLACK_HTTP_TIMEOUT", DEFAULT_TIMEOUT_SECONDS)
+        self._max_retries = (
+            max_retries if max_retries is not None else _env_int("T3_SLACK_HTTP_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+        )
+        self._backoff_base = (
+            backoff_base
+            if backoff_base is not None
+            else _env_float("T3_SLACK_HTTP_BACKOFF", DEFAULT_BACKOFF_BASE_SECONDS)
+        )
+        self._sleep = sleep
+
+    def post(
+        self,
+        method: str,
+        *,
+        token: str,
+        json: RawAPIDict,
+        idempotent: bool,
+    ) -> RawAPIDict:
+        return cast("RawAPIDict", self._post_response(method, token=token, json=json, idempotent=idempotent).json())
+
+    def post_with_header(
+        self,
+        method: str,
+        *,
+        token: str,
+        json: RawAPIDict,
+        header: str,
+    ) -> tuple[RawAPIDict, str]:
+        """Idempotent POST returning ``(body, header_value)`` for header-carried data.
+
+        ``auth.test`` reports the granted OAuth scopes in a response
+        *header*, not the JSON body, so the backend needs the header back.
+        Always idempotent — ``auth.test`` has no side effect.
+        """
+        response = self._post_response(method, token=token, json=json, idempotent=True)
+        return cast("RawAPIDict", response.json()), response.headers.get(header, "")
+
+    def _post_response(self, method: str, *, token: str, json: RawAPIDict, idempotent: bool) -> httpx.Response:
+        def attempt() -> httpx.Response:
+            return httpx.post(
+                f"{self._BASE_URL}/{method}",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json; charset=utf-8",
+                },
+                json=json,
+                timeout=self._timeout,
+            )
+
+        return self._run(attempt, idempotent=idempotent)
+
+    def get(self, method: str, *, token: str, params: dict[str, str | int]) -> RawAPIDict:
+        def attempt() -> httpx.Response:
+            return httpx.get(
+                f"{self._BASE_URL}/{method}",
+                headers={"Authorization": f"Bearer {token}"},
+                params=params,
+                timeout=self._timeout,
+            )
+
+        return cast("RawAPIDict", self._run(attempt, idempotent=True).json())
+
+    def _run(self, attempt: AttemptFn, *, idempotent: bool) -> httpx.Response:
+        # The final iteration (retries_left == 0) always returns or re-raises,
+        # so the loop is exhaustive — no unreachable fall-through.
+        for retries_left in range(self._max_retries, -1, -1):
+            last = retries_left == 0
+            try:
+                response = attempt()
+            except _CONNECT_ERRORS:
+                if last:
+                    raise
+                self._backoff(self._max_retries - retries_left)
+                continue
+            except httpx.TimeoutException:
+                if last or not self._may_retry(RetryClass.RESPONSE, idempotent=idempotent):
+                    raise
+                self._backoff(self._max_retries - retries_left)
+                continue
+            retry_after = self._transient_response_wait(response, idempotent=idempotent)
+            if retry_after is None or last:
+                response.raise_for_status()
+                return response
+            self._sleep_for(retry_after if retry_after > 0 else self._backoff_seconds(self._max_retries - retries_left))
+        unreachable = "retry loop is exhaustive: the final iteration always returns or raises"
+        raise AssertionError(unreachable)  # pragma: no cover
+
+    def _transient_response_wait(self, response: httpx.Response, *, idempotent: bool) -> float | None:
+        """Seconds to wait before a response-phase retry, or ``None`` when not retryable.
+
+        ``0.0`` means "retry on the standard backoff"; a positive value is
+        an explicit ``Retry-After`` to honour. ``None`` means surface the
+        response to the caller (success, a non-transient ``ok:false``, or a
+        non-idempotent post that must not be replayed on a response-phase
+        failure).
+        """
+        if not self._is_transient_response(response):
+            return None
+        if not self._may_retry(RetryClass.RESPONSE, idempotent=idempotent):
+            return None
+        return self._retry_after_seconds(response)
+
+    def _is_transient_response(self, response: httpx.Response) -> bool:
+        if response.status_code >= httpx.codes.INTERNAL_SERVER_ERROR:
+            return True
+        if response.status_code == httpx.codes.TOO_MANY_REQUESTS:
+            return True
+        return self._is_slack_ratelimited(response)
+
+    @staticmethod
+    def _is_slack_ratelimited(response: httpx.Response) -> bool:
+        if response.status_code != httpx.codes.OK:
+            return False
+        try:
+            body = response.json()
+        except ValueError:
+            return False
+        return isinstance(body, dict) and body.get("error") == _RATELIMITED
+
+    @staticmethod
+    def _retry_after_seconds(response: httpx.Response) -> float:
+        header = response.headers.get("Retry-After", "").strip()
+        if not header:
+            return 0.0
+        try:
+            return max(0.0, float(header))
+        except ValueError:
+            return 0.0
+
+    @staticmethod
+    def _may_retry(failure: RetryClass, *, idempotent: bool) -> bool:
+        return failure is RetryClass.CONNECT or idempotent
+
+    def _backoff(self, attempt_index: int) -> None:
+        self._sleep_for(self._backoff_seconds(attempt_index))
+
+    def _backoff_seconds(self, attempt_index: int) -> float:
+        return min(_MAX_BACKOFF_SECONDS, self._backoff_base * (2**attempt_index))
+
+    def _sleep_for(self, seconds: float) -> None:
+        if seconds > 0:
+            self._sleep(min(_MAX_BACKOFF_SECONDS, seconds))

--- a/src/teatree/cli/slack_provision.py
+++ b/src/teatree/cli/slack_provision.py
@@ -86,9 +86,14 @@ def _resolve_app_id(*, config_path: Path, overlay: str, echo: Callable[[str], No
 def _push_manifest(*, overlay: str, app_id: str, echo: Callable[[str], None]) -> str:
     """Push the desired manifest; return the action taken ("updated"/"current"/"degraded")."""
     if not read_pass(_CONFIG_TOKEN_REF):
-        echo("WARN  No Slack app-config token in `pass` — cannot auto-update the manifest.")
-        echo(f"      Edit it manually: {app_manifest_editor_url(app_id)}")
-        echo("      To automate next time, store a config token:")
+        echo("!! DEGRADED — manifest NOT pushed; user scopes are NOT set on the app.")
+        echo("!! Until you add them, the app has ZERO user scopes — the personal xoxp")
+        echo("!! token cannot post or react in Slack-Connect channels.")
+        echo(f"   No Slack app-config token in `pass {_CONFIG_TOKEN_REF}` — cannot auto-update the manifest.")
+        echo(f"   FIX NOW (manual): open {app_manifest_editor_url(app_id)}")
+        echo("   and add these user scopes under oauth_config.scopes.user, then reinstall:")
+        echo(f"        {', '.join(REQUIRED_USER_SCOPES)}")
+        echo("   To automate next time, store a config token:")
         echo(f"        pass insert {_CONFIG_TOKEN_REF}")
         return "degraded"
     desired = build_manifest(overlay_name=overlay)

--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -35,6 +35,7 @@ import httpx
 import typer
 
 from teatree.backends.slack_bot import SlackBotBackend
+from teatree.cli.slack_token_store import SlackTokenWriteError, app_token_slot, bot_token_slot, store_slack_token
 from teatree.config import CONFIG_PATH, discover_overlays
 from teatree.utils.secrets import read_pass, write_pass
 
@@ -300,12 +301,12 @@ def _prompt_user_id() -> str:
 
 
 def _store_tokens(token_ref: str, *, bot_token: str, app_token: str) -> None:
-    if not write_pass(f"{token_ref}-bot", bot_token):
-        typer.echo("ERROR Failed to store bot token via `pass`.")
-        raise typer.Exit(code=1)
-    if not write_pass(f"{token_ref}-app", app_token):
-        typer.echo("ERROR Failed to store app token via `pass`.")
-        raise typer.Exit(code=1)
+    for slot, value in ((bot_token_slot(token_ref), bot_token), (app_token_slot(token_ref), app_token)):
+        try:
+            store_slack_token(slot, value, echo=typer.echo)
+        except SlackTokenWriteError as exc:
+            typer.echo(f"ERROR {exc}")
+            raise typer.Exit(code=1) from exc
     typer.echo(f"OK    Stored bot + app tokens under `{token_ref}-bot` and `{token_ref}-app`.")
 
 

--- a/src/teatree/cli/slack_token_store.py
+++ b/src/teatree/cli/slack_token_store.py
@@ -1,0 +1,118 @@
+"""Safe ``pass`` writes for Slack token slots — validate-before-write, back-up-before-overwrite.
+
+The ``pass`` store is not version-controlled, so an overwrite is
+irreversible and a wrong-slot write (a ``xoxb-`` value in the ``xoxp-``
+slot) is silent until the slot-based routing policy mis-sends or drops a
+call. The prefix validators in
+:mod:`teatree.backends.slack_token_validation` run at *read* time
+(backend construction), where a mismatch aborts a loop tick rather than
+refusing the bad write up front.
+
+:class:`SlackTokenSlot` pairs each ``pass`` key with the validator its
+value must pass, and :func:`store_slack_token` enforces two invariants
+before any ``pass insert``:
+
+1.  **Validate before write.** A value whose prefix does not match the
+    slot is refused — no write happens — so a bot token cannot reach the
+    user slot.
+2.  **Back up before overwrite.** An existing value is copied to a
+    timestamped ``<key>.bak-<UTC stamp>`` sibling key before the
+    overwrite, keeping the prior token recoverable on a non-git store.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from teatree.backends.slack_token_validation import (
+    TokenSlotMismatchError,
+    assert_app_token,
+    assert_bot_token,
+    assert_user_token,
+)
+from teatree.utils.secrets import read_pass, write_pass
+
+type Validator = Callable[[str], None]
+type Echo = Callable[[str], None]
+
+
+class SlackTokenWriteError(RuntimeError):
+    """A Slack token write was refused or the backup/insert failed."""
+
+
+@dataclass(frozen=True, slots=True)
+class SlackTokenSlot:
+    """A ``pass`` key paired with the prefix validator its value must pass."""
+
+    pass_key: str
+    validator: Validator
+    slot_name: str
+
+
+USER_TOKEN_SLOT = SlackTokenSlot("slack/user-oauth-token", assert_user_token, "user (xoxp-)")
+BOT_TOKEN_SLOT = SlackTokenSlot("slack/bot-token", assert_bot_token, "bot (xoxb-)")
+
+
+def bot_token_slot(token_ref: str) -> SlackTokenSlot:
+    """The per-overlay bot-token slot (``<token_ref>-bot``)."""
+    return SlackTokenSlot(f"{token_ref}-bot", assert_bot_token, "bot (xoxb-)")
+
+
+def app_token_slot(token_ref: str) -> SlackTokenSlot:
+    """The per-overlay app-token slot (``<token_ref>-app``)."""
+    return SlackTokenSlot(f"{token_ref}-app", assert_app_token, "app (xapp-)")
+
+
+def _backup_key(pass_key: str) -> str:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"{pass_key}.bak-{stamp}"
+
+
+def store_slack_token(slot: SlackTokenSlot, value: str, *, echo: Echo) -> str:
+    """Validate *value* for *slot*, back up any prior value, then write it.
+
+    Returns the backup key when an existing value was preserved, else
+    ``""``. Raises :class:`SlackTokenWriteError` when the value fails its
+    prefix validator (no write happens) or when the backup / insert
+    itself fails (no clobber happens).
+    """
+    if not value.strip():
+        empty_message = f"refusing to write an empty value to the {slot.slot_name} slot."
+        raise SlackTokenWriteError(empty_message)
+    try:
+        slot.validator(value)
+    except TokenSlotMismatchError as exc:
+        echo(f"ERROR Refusing to write to the {slot.slot_name} slot ({slot.pass_key}): {exc}")
+        raise SlackTokenWriteError(str(exc)) from exc
+
+    backup_key = _back_up_existing(slot, echo=echo)
+
+    if not write_pass(slot.pass_key, value):
+        insert_message = f"`pass insert {slot.pass_key}` failed — token not stored."
+        raise SlackTokenWriteError(insert_message)
+    return backup_key
+
+
+def _back_up_existing(slot: SlackTokenSlot, *, echo: Echo) -> str:
+    existing = read_pass(slot.pass_key)
+    if not existing:
+        return ""
+    backup_key = _backup_key(slot.pass_key)
+    if not write_pass(backup_key, existing):
+        backup_message = (
+            f"could not back up the existing {slot.slot_name} token to `{backup_key}` — refusing to overwrite."
+        )
+        raise SlackTokenWriteError(backup_message)
+    echo(f"OK    Backed up the existing {slot.slot_name} token to `pass {backup_key}` before overwriting.")
+    return backup_key
+
+
+__all__ = [
+    "BOT_TOKEN_SLOT",
+    "USER_TOKEN_SLOT",
+    "SlackTokenSlot",
+    "SlackTokenWriteError",
+    "app_token_slot",
+    "bot_token_slot",
+    "store_slack_token",
+]

--- a/src/teatree/cli/slack_user_token_setup.py
+++ b/src/teatree/cli/slack_user_token_setup.py
@@ -35,8 +35,9 @@ import typer
 from teatree.backends.slack_token_validation import USER_TOKEN_RE as _USER_TOKEN_RE
 from teatree.cli.slack_app_resolve import derive_app_id_from_token
 from teatree.cli.slack_setup import _USER_SCOPES
+from teatree.cli.slack_token_store import BOT_TOKEN_SLOT, USER_TOKEN_SLOT, SlackTokenWriteError, store_slack_token
 from teatree.config import CONFIG_PATH
-from teatree.utils.secrets import read_pass, write_pass
+from teatree.utils.secrets import read_pass
 
 USER_TOKEN_PASS_KEY = "slack/user-oauth-token"  # noqa: S105 — pass key name, not a secret
 BOT_TOKEN_PASS_KEY = "slack/bot-token"  # noqa: S105 — pass key name, not a secret
@@ -138,7 +139,12 @@ def _print_reauthorize_instructions(overlay_app_id: str) -> None:
     typer.echo("      app's 'OAuth & Permissions' page and paste it below.")
 
 
-def _store_and_verify(token: str, previous_scopes: list[str]) -> tuple[list[str], list[str]]:
+def _store_and_verify(
+    token: str,
+    previous_scopes: list[str],
+    *,
+    echo: Callable[[str], None],
+) -> tuple[list[str], list[str]]:
     granted = fetch_token_scopes(token)
     missing = missing_scopes(granted, REQUIRED_USER_SCOPES)
     if missing:
@@ -148,9 +154,10 @@ def _store_and_verify(token: str, previous_scopes: list[str]) -> tuple[list[str]
             f"Re-run after updating the Slack app manifest and reinstalling."
         )
         raise TokenScopeError(message)
-    if not write_pass(USER_TOKEN_PASS_KEY, token):
-        message = f"Failed to store token via `pass insert {USER_TOKEN_PASS_KEY}`."
-        raise TokenScopeError(message)
+    try:
+        store_slack_token(USER_TOKEN_SLOT, token, echo=echo)
+    except SlackTokenWriteError as exc:
+        raise TokenScopeError(str(exc)) from exc
     added = added_scopes(granted, previous_scopes)
     return granted, added
 
@@ -186,14 +193,16 @@ def _detect_and_backup_xoxb_mis_install(*, echo: Callable[[str], None]) -> None:
     current = read_pass(USER_TOKEN_PASS_KEY)
     if not current.startswith("xoxb-"):
         return
-    existing_bot = read_pass(BOT_TOKEN_PASS_KEY)
+    if read_pass(BOT_TOKEN_PASS_KEY) == current:
+        return
     echo(
         "      bot token mis-install detected at pass "
         f"{USER_TOKEN_PASS_KEY} — backing up to {BOT_TOKEN_PASS_KEY} before reinstall."
     )
-    if existing_bot == current:
-        return
-    write_pass(BOT_TOKEN_PASS_KEY, current)
+    try:
+        store_slack_token(BOT_TOKEN_SLOT, current, echo=echo)
+    except SlackTokenWriteError as exc:
+        echo(f"WARN  Could not preserve the mis-installed bot token: {exc}")
 
 
 # Source of truth for the derive-from-token chain is
@@ -229,7 +238,7 @@ def slack_user_token_setup(
 
     typer.echo("Step 3/3 — Verify scopes via auth.test and store via pass.")
     try:
-        granted, added = _store_and_verify(token, previous_scopes)
+        granted, added = _store_and_verify(token, previous_scopes, echo=typer.echo)
     except TokenScopeError as exc:
         typer.echo(f"ERROR {exc}")
         raise typer.Exit(code=1) from exc

--- a/tests/cli_setup/test_slack_provision.py
+++ b/tests/cli_setup/test_slack_provision.py
@@ -238,6 +238,18 @@ class TestPushManifest:
             assert _push_manifest(overlay="t3", app_id="A1", echo=lines.append) == "degraded"
         assert any("app-config token" in line for line in lines)
 
+    def test_degraded_warns_loudly_that_user_scopes_are_not_set(self) -> None:
+        lines: list[str] = []
+        with patch("teatree.cli.slack_provision.read_pass", return_value=""):
+            _push_manifest(overlay="t3", app_id="A1", echo=lines.append)
+        joined = "\n".join(lines)
+        # The degraded path must NOT read as a success: it states the manifest
+        # was not pushed, that user scopes are unset, and lists the scopes to
+        # add manually so the user can fix the zero-user-scope app.
+        assert "DEGRADED" in joined
+        assert "manifest NOT pushed" in joined
+        assert "reactions:write" in joined
+
     def test_current_when_equivalent(self) -> None:
         with (
             patch("teatree.cli.slack_provision.read_pass", return_value="cfg-tok"),

--- a/tests/cli_setup/test_slack_token_store.py
+++ b/tests/cli_setup/test_slack_token_store.py
@@ -1,0 +1,80 @@
+"""Tests for ``slack_token_store`` — validate-before-write + back-up-before-overwrite.
+
+The clobber that destroyed a live xoxp token had two roots: the value was
+written without a prefix check, and the prior value was overwritten with no
+backup on a non-git store. These tests pin both guards.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from teatree.cli.slack_token_store import BOT_TOKEN_SLOT, USER_TOKEN_SLOT, SlackTokenWriteError, store_slack_token
+
+
+class TestValidateBeforeWrite:
+    def test_refuses_bot_token_into_user_slot_without_writing(self) -> None:
+        with (
+            patch("teatree.cli.slack_token_store.read_pass", return_value="xoxp-prioruser"),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True) as write,
+            pytest.raises(SlackTokenWriteError, match="must start with 'xoxp-'"),
+        ):
+            store_slack_token(USER_TOKEN_SLOT, "xoxb-WRONG", echo=lambda _m: None)
+        write.assert_not_called()
+
+    def test_refuses_user_token_into_bot_slot_without_writing(self) -> None:
+        with (
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True) as write,
+            pytest.raises(SlackTokenWriteError, match="must start with 'xoxb-'"),
+        ):
+            store_slack_token(BOT_TOKEN_SLOT, "xoxp-WRONG", echo=lambda _m: None)
+        write.assert_not_called()
+
+    def test_refuses_empty_value(self) -> None:
+        with (
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True) as write,
+            pytest.raises(SlackTokenWriteError, match="empty"),
+        ):
+            store_slack_token(USER_TOKEN_SLOT, "   ", echo=lambda _m: None)
+        write.assert_not_called()
+
+    def test_writes_a_valid_token_when_slot_empty(self) -> None:
+        with (
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True) as write,
+        ):
+            backup_key = store_slack_token(USER_TOKEN_SLOT, "xoxp-freshuser", echo=lambda _m: None)
+        assert backup_key == ""
+        write.assert_called_once_with(USER_TOKEN_SLOT.pass_key, "xoxp-freshuser")
+
+
+class TestBackupBeforeOverwrite:
+    def test_existing_value_backed_up_before_overwrite(self) -> None:
+        writes: list[tuple[str, str]] = []
+        messages: list[str] = []
+        with (
+            patch("teatree.cli.slack_token_store.read_pass", return_value="xoxp-prioruser"),
+            patch(
+                "teatree.cli.slack_token_store.write_pass",
+                side_effect=lambda key, value: writes.append((key, value)) or True,
+            ),
+        ):
+            backup_key = store_slack_token(USER_TOKEN_SLOT, "xoxp-freshuser", echo=messages.append)
+
+        assert backup_key.startswith(f"{USER_TOKEN_SLOT.pass_key}.bak-")
+        assert (backup_key, "xoxp-prioruser") in writes
+        assert (USER_TOKEN_SLOT.pass_key, "xoxp-freshuser") in writes
+        assert writes.index((backup_key, "xoxp-prioruser")) < writes.index((USER_TOKEN_SLOT.pass_key, "xoxp-freshuser"))
+        assert any("Backed up" in m for m in messages)
+
+    def test_refuses_overwrite_when_backup_write_fails(self) -> None:
+        def fake_write(key: str, _value: str) -> bool:
+            return not key.startswith(f"{USER_TOKEN_SLOT.pass_key}.bak-")
+
+        with (
+            patch("teatree.cli.slack_token_store.read_pass", return_value="xoxp-prioruser"),
+            patch("teatree.cli.slack_token_store.write_pass", side_effect=fake_write),
+            pytest.raises(SlackTokenWriteError, match="could not back up"),
+        ):
+            store_slack_token(USER_TOKEN_SLOT, "xoxp-freshuser", echo=lambda _m: None)

--- a/tests/cli_setup/test_slack_user_token.py
+++ b/tests/cli_setup/test_slack_user_token.py
@@ -107,26 +107,55 @@ class TestStoreAndVerify:
         granted = list(REQUIRED_USER_SCOPES)
         with (
             self._patch_fetch(granted),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True) as write,
         ):
-            actual, added = _store_and_verify("xoxp-good", previous_scopes=["chat:write"])
+            actual, added = _store_and_verify("xoxp-good", previous_scopes=["chat:write"], echo=lambda _m: None)
         assert actual == granted
         assert "reactions:write" in added
         write.assert_called_once_with(USER_TOKEN_PASS_KEY, "xoxp-good")
 
+    def test_refuses_to_write_a_bot_token_into_the_user_slot(self) -> None:
+        granted = list(REQUIRED_USER_SCOPES)
+        with (
+            self._patch_fetch(granted),
+            patch("teatree.cli.slack_token_store.read_pass", return_value="xoxp-prioruser"),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True) as write,
+            pytest.raises(TokenScopeError, match="must start with 'xoxp-'"),
+        ):
+            _store_and_verify("xoxb-WRONG", previous_scopes=[], echo=lambda _m: None)
+        write.assert_not_called()
+
+    def test_backs_up_prior_token_before_overwrite(self) -> None:
+        granted = list(REQUIRED_USER_SCOPES)
+        writes: list[tuple[str, str]] = []
+        with (
+            self._patch_fetch(granted),
+            patch("teatree.cli.slack_token_store.read_pass", return_value="xoxp-prioruser"),
+            patch(
+                "teatree.cli.slack_token_store.write_pass",
+                side_effect=lambda key, value: writes.append((key, value)) or True,
+            ),
+        ):
+            _store_and_verify("xoxp-new", previous_scopes=[], echo=lambda _m: None)
+        backup_writes = [w for w in writes if w[0].startswith(f"{USER_TOKEN_PASS_KEY}.bak-")]
+        assert backup_writes == [(backup_writes[0][0], "xoxp-prioruser")]
+        assert (USER_TOKEN_PASS_KEY, "xoxp-new") in writes
+
     def test_raises_when_a_scope_is_missing(self) -> None:
         granted = [s for s in REQUIRED_USER_SCOPES if s != "reactions:write"]
         with self._patch_fetch(granted), pytest.raises(TokenScopeError, match="reactions:write"):
-            _store_and_verify("xoxp-bad", previous_scopes=[])
+            _store_and_verify("xoxp-bad", previous_scopes=[], echo=lambda _m: None)
 
     def test_raises_when_pass_write_fails(self) -> None:
         granted = list(REQUIRED_USER_SCOPES)
         with (
             self._patch_fetch(granted),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=False),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=False),
             pytest.raises(TokenScopeError, match="pass insert"),
         ):
-            _store_and_verify("xoxp-good", previous_scopes=[])
+            _store_and_verify("xoxp-good", previous_scopes=[], echo=lambda _m: None)
 
 
 class TestCliWalkthrough:
@@ -140,7 +169,8 @@ class TestCliWalkthrough:
         granted = list(REQUIRED_USER_SCOPES)
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", return_value=""),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
         ):
@@ -153,7 +183,8 @@ class TestCliWalkthrough:
         granted = [s for s in REQUIRED_USER_SCOPES if s != "chat:write.public"]
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", return_value=""),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
         ):
@@ -199,7 +230,8 @@ class TestCliWalkthrough:
         granted = list(REQUIRED_USER_SCOPES)
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", return_value="xoxp-old"),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value="xoxp-old"),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
             patch("teatree.cli.slack_user_token_setup._derive_app_id_from_bot", return_value=""),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
@@ -216,7 +248,8 @@ class TestDetectAndBackupXoxbMisInstall:
 
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", side_effect=fake_read),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+            patch("teatree.cli.slack_token_store.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True) as write,
         ):
             messages: list[str] = []
             _detect_and_backup_xoxb_mis_install(echo=messages.append)
@@ -229,7 +262,7 @@ class TestDetectAndBackupXoxbMisInstall:
 
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", side_effect=fake_read),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True) as write,
         ):
             _detect_and_backup_xoxb_mis_install(echo=lambda _msg: None)
         write.assert_not_called()
@@ -240,22 +273,31 @@ class TestDetectAndBackupXoxbMisInstall:
 
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", side_effect=fake_read),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True) as write,
         ):
             _detect_and_backup_xoxb_mis_install(echo=lambda _msg: None)
         write.assert_not_called()
 
-    def test_xoxb_backup_overwrites_when_bot_slot_holds_different_value(self) -> None:
+    def test_xoxb_backup_preserves_stale_bot_slot_before_overwrite(self) -> None:
         def fake_read(key: str) -> str:
             return {USER_TOKEN_PASS_KEY: "xoxb-1-new", BOT_TOKEN_PASS_KEY: "xoxb-1-stale"}.get(key, "")
 
+        writes: list[tuple[str, str]] = []
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", side_effect=fake_read),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+            patch("teatree.cli.slack_token_store.read_pass", side_effect=fake_read),
+            patch(
+                "teatree.cli.slack_token_store.write_pass",
+                side_effect=lambda key, value: writes.append((key, value)) or True,
+            ),
         ):
             messages: list[str] = []
             _detect_and_backup_xoxb_mis_install(echo=messages.append)
-        write.assert_called_once_with(BOT_TOKEN_PASS_KEY, "xoxb-1-new")
+        # The stale bot-slot value is preserved to a timestamped backup before
+        # the new value overwrites it, so a clobber stays recoverable.
+        backup_writes = [w for w in writes if w[0].startswith(f"{BOT_TOKEN_PASS_KEY}.bak-")]
+        assert backup_writes == [(backup_writes[0][0], "xoxb-1-stale")]
+        assert (BOT_TOKEN_PASS_KEY, "xoxb-1-new") in writes
         assert any("bot token mis-install detected" in m for m in messages)
 
 
@@ -330,7 +372,8 @@ class TestNewIntegrationsInWalkthrough:
 
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", side_effect=fake_read),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True) as write,
+            patch("teatree.cli.slack_token_store.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True) as write,
             patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open"),
         ):
@@ -345,7 +388,8 @@ class TestNewIntegrationsInWalkthrough:
         opens: list[str] = []
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", return_value="xoxp-existing"),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value="xoxp-existing"),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
             patch("teatree.cli.slack_user_token_setup._derive_app_id_from_bot", return_value="AABCDEF"),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open", side_effect=opens.append),
@@ -360,7 +404,8 @@ class TestNewIntegrationsInWalkthrough:
         opens: list[str] = []
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", return_value="xoxp-existing"),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value="xoxp-existing"),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
             patch("teatree.cli.slack_user_token_setup._derive_app_id_from_bot", return_value=""),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open", side_effect=opens.append),
@@ -377,7 +422,8 @@ class TestNewIntegrationsInWalkthrough:
         opens: list[str] = []
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", return_value=""),
-            patch("teatree.cli.slack_user_token_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_user_token_setup.fetch_token_scopes", return_value=granted),
             patch("teatree.cli.slack_user_token_setup.webbrowser.open", side_effect=opens.append),
         ):

--- a/tests/integration/slack_bridge_e2e/conftest.py
+++ b/tests/integration/slack_bridge_e2e/conftest.py
@@ -42,7 +42,7 @@ from typing import Any
 import httpx
 import pytest
 
-from teatree.backends import slack_bot
+from teatree.backends import slack_http
 from teatree.types import SlackVoiceClassifierMode as _VoiceClassifierMode
 
 # ── Fake Slack transport ──────────────────────────────────────────────
@@ -171,8 +171,8 @@ def _isolate_bundled_overlay_module() -> Iterator[None]:
 def transport(monkeypatch: pytest.MonkeyPatch) -> FakeSlackTransport:
     """Install :class:`FakeSlackTransport` as the ``httpx`` boundary for slack_bot."""
     fake = FakeSlackTransport()
-    monkeypatch.setattr(slack_bot.httpx, "post", fake.post)
-    monkeypatch.setattr(slack_bot.httpx, "get", fake.get)
+    monkeypatch.setattr(slack_http.httpx, "post", fake.post)
+    monkeypatch.setattr(slack_http.httpx, "get", fake.get)
     return fake
 
 

--- a/tests/integration/slack_bridge_e2e/test_outbound.py
+++ b/tests/integration/slack_bridge_e2e/test_outbound.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 from inline_snapshot import snapshot
 
-from teatree.backends import slack_bot
+from teatree.backends import slack_http
 from teatree.backends.slack_bot import SlackBotBackend
 from teatree.core import backend_factory
 from teatree.core import notify as core_notify
@@ -98,8 +98,8 @@ class TestOutboundBridgeEndToEnd:
         assert alpha is not beta
 
         recording = FakeSlackTransport()
-        monkeypatch.setattr(slack_bot.httpx, "post", recording.post)
-        monkeypatch.setattr(slack_bot.httpx, "get", recording.get)
+        monkeypatch.setattr(slack_http.httpx, "post", recording.post)
+        monkeypatch.setattr(slack_http.httpx, "get", recording.get)
 
         alpha.post_message(channel="D-alpha", text="for alpha only")
         beta.post_message(channel="D-beta", text="for beta only")

--- a/tests/teatree_backends/test_messaging.py
+++ b/tests/teatree_backends/test_messaging.py
@@ -7,7 +7,7 @@ from typing import cast
 import httpx
 import pytest
 
-from teatree.backends import slack_bot, slack_scopes
+from teatree.backends import slack_http, slack_scopes
 from teatree.backends.messaging_noop import NoopMessagingBackend
 from teatree.backends.protocols import MessagingBackend
 from teatree.backends.slack_bot import SlackBotBackend
@@ -46,7 +46,7 @@ def test_slack_post_message_omits_thread_ts_by_default(monkeypatch: pytest.Monke
         captured["json"] = json
         return httpx.Response(200, json={"ok": True, "ts": "1.2"}, request=httpx.Request("POST", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     result = backend.post_message(channel="C42", text="hello")
@@ -64,7 +64,7 @@ def test_slack_post_message_includes_thread_ts_when_set(monkeypatch: pytest.Monk
         payloads.append(cast("dict[str, object]", kwargs["json"]))
         return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     backend.post_message(channel="C42", text="hello", thread_ts="123.456")
@@ -80,7 +80,7 @@ def test_slack_react_calls_reactions_add(monkeypatch: pytest.MonkeyPatch) -> Non
         captured["json"] = kwargs["json"]
         return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     backend.react(channel="C", ts="1.2", emoji="white_check_mark")
@@ -100,7 +100,7 @@ def test_slack_auth_test_returns_raw_response(monkeypatch: pytest.MonkeyPatch) -
             request=httpx.Request("POST", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     result = backend.auth_test()
@@ -119,7 +119,7 @@ def test_slack_auth_test_surfaces_ok_false(monkeypatch: pytest.MonkeyPatch) -> N
             request=httpx.Request("POST", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     result = backend.auth_test()
@@ -148,7 +148,7 @@ def test_slack_auth_test_surfaces_granted_scopes_from_header(monkeypatch: pytest
             request=httpx.Request("POST", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     result = backend.auth_test()
@@ -166,7 +166,7 @@ def test_slack_auth_test_surfaces_empty_scopes_when_header_absent(monkeypatch: p
             request=httpx.Request("POST", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.auth_test()[slack_scopes.GRANTED_SCOPES_KEY] == []
@@ -189,7 +189,7 @@ def test_slack_resolve_user_id_via_lookup_by_email(monkeypatch: pytest.MonkeyPat
             )
         return httpx.Response(200, json={"ok": False}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.resolve_user_id("alice@example.com") == "U999"
@@ -211,7 +211,7 @@ def test_slack_resolve_user_id_falls_back_to_user_list(monkeypatch: pytest.Monke
             )
         return httpx.Response(200, json={"ok": False}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.resolve_user_id("@alice") == "U2"
@@ -221,7 +221,7 @@ def test_slack_resolve_user_id_returns_empty_on_no_match(monkeypatch: pytest.Mon
     def fake_get(url: str, **kwargs: object) -> httpx.Response:
         return httpx.Response(200, json={"ok": True, "members": []}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.resolve_user_id("ghost") == ""
@@ -337,7 +337,7 @@ def test_slack_open_dm_returns_channel_id(monkeypatch: pytest.MonkeyPatch) -> No
             request=httpx.Request("POST", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.open_dm("U01ABCD1234") == "D9XYZ"
@@ -347,7 +347,7 @@ def test_slack_open_dm_returns_empty_on_failure(monkeypatch: pytest.MonkeyPatch)
     def fake_post(url: str, **kwargs: object) -> httpx.Response:
         return httpx.Response(200, json={"ok": False}, request=httpx.Request("POST", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.open_dm("U01ABCD1234") == ""
@@ -369,7 +369,7 @@ def test_slack_get_reactions_returns_emoji_names(monkeypatch: pytest.MonkeyPatch
             request=httpx.Request("GET", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.get_reactions(channel="C1", ts="123.456") == ["white_check_mark", "eyes"]
@@ -383,7 +383,7 @@ def test_slack_get_reactions_returns_empty_when_no_reactions(monkeypatch: pytest
             request=httpx.Request("GET", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.get_reactions(channel="C1", ts="123.456") == []
@@ -411,7 +411,7 @@ def test_slack_get_reactions_skips_non_dict_entries(monkeypatch: pytest.MonkeyPa
             request=httpx.Request("GET", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.get_reactions(channel="C1", ts="123") == ["eyes"]
@@ -425,7 +425,7 @@ def test_slack_get_reactions_returns_empty_when_reactions_not_list(monkeypatch: 
             request=httpx.Request("GET", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.get_reactions(channel="C1", ts="123") == []
@@ -435,7 +435,7 @@ def test_slack_get_reactions_returns_empty_when_get_fails(monkeypatch: pytest.Mo
     def fake_get(url: str, **kwargs: object) -> httpx.Response:
         return httpx.Response(200, json={"ok": False}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.get_reactions(channel="C1", ts="123") == []
@@ -466,8 +466,8 @@ def test_slack_fetch_dms_polls_conversations_history(monkeypatch: pytest.MonkeyP
             request=httpx.Request("GET", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test", user_id="UHUMAN")
 
     dms = backend.fetch_dms(since="0.5")
@@ -485,7 +485,7 @@ def test_slack_fetch_dms_returns_empty_when_dm_channel_fails(monkeypatch: pytest
     def fake_post(url: str, **kwargs: object) -> httpx.Response:
         return httpx.Response(200, json={"ok": False}, request=httpx.Request("POST", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test", user_id="U1")
 
     assert backend.fetch_dms() == []
@@ -506,8 +506,8 @@ def test_slack_fetch_dms_filters_non_dict_messages(monkeypatch: pytest.MonkeyPat
             request=httpx.Request("GET", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test", user_id="UHUMAN")
 
     dms = backend.fetch_dms()
@@ -523,8 +523,8 @@ def test_slack_fetch_dms_returns_empty_when_messages_not_list(monkeypatch: pytes
     def fake_get(url: str, **kwargs: object) -> httpx.Response:
         return httpx.Response(200, json={"ok": True, "messages": "not-a-list"}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test", user_id="U1")
 
     assert backend.fetch_dms() == []
@@ -539,8 +539,8 @@ def test_slack_fetch_dms_returns_empty_when_api_fails(monkeypatch: pytest.Monkey
     def fake_get(url: str, **kwargs: object) -> httpx.Response:
         return httpx.Response(200, json={"ok": False}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test", user_id="U1")
 
     assert backend.fetch_dms() == []
@@ -561,8 +561,8 @@ def test_slack_resolve_bot_id_caches_result(monkeypatch: pytest.MonkeyPatch) -> 
     def fake_get(url: str, **kwargs: object) -> httpx.Response:
         return httpx.Response(200, json={"ok": True, "messages": []}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test", user_id="U1")
 
     backend.fetch_dms()
@@ -585,8 +585,8 @@ def test_slack_resolve_bot_id_returns_empty_on_api_failure(monkeypatch: pytest.M
             request=httpx.Request("GET", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test", user_id="U1")
 
     dms = backend.fetch_dms()
@@ -600,7 +600,7 @@ def test_slack_post_reply_includes_thread_ts(monkeypatch: pytest.MonkeyPatch) ->
         captured["json"] = kwargs["json"]
         return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     backend.post_reply(channel="C", ts="1.0", text="reply")
@@ -612,7 +612,7 @@ def test_slack_resolve_user_id_returns_empty_when_members_not_list(monkeypatch: 
     def fake_get(url: str, **kwargs: object) -> httpx.Response:
         return httpx.Response(200, json={"ok": True, "members": "not-a-list"}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.resolve_user_id("alice") == ""
@@ -642,8 +642,8 @@ def test_slack_fetch_dms_stamps_channel_on_each_event(monkeypatch: pytest.Monkey
             )
         return httpx.Response(200, json={"ok": True, "messages": []}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test", user_id="UHUMAN")
 
     dms = backend.fetch_dms()
@@ -672,8 +672,8 @@ def test_slack_fetch_dms_preserves_existing_channel(monkeypatch: pytest.MonkeyPa
             request=httpx.Request("GET", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test", user_id="UHUMAN")
 
     dms = backend.fetch_dms()
@@ -718,8 +718,8 @@ def test_slack_fetch_dms_includes_thread_replies(monkeypatch: pytest.MonkeyPatch
             )
         return httpx.Response(200, json={"ok": True}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test", user_id="UHUMAN")
 
     dms = backend.fetch_dms()
@@ -756,7 +756,7 @@ def test_slack_fetch_channel_history_returns_messages_with_channel_stamped(
             request=httpx.Request("GET", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     messages = backend.fetch_channel_history(channel="C0AM3TENT", limit=10)
@@ -770,7 +770,7 @@ def test_slack_fetch_channel_history_returns_empty_on_non_ok(monkeypatch: pytest
     def fake_get(url: str, **kwargs: object) -> httpx.Response:
         return httpx.Response(200, json={"ok": False, "error": "channel_not_found"}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.fetch_channel_history(channel="C404") == []
@@ -796,7 +796,7 @@ def test_slack_resolve_user_id_skips_non_dict_members(monkeypatch: pytest.Monkey
             request=httpx.Request("GET", url),
         )
 
-    monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+    monkeypatch.setattr(slack_http.httpx, "get", fake_get)
     backend = SlackBotBackend(bot_token="xoxb-test")
 
     assert backend.resolve_user_id("alice") == "U99"

--- a/tests/teatree_backends/test_slack_connect_channel_routing.py
+++ b/tests/teatree_backends/test_slack_connect_channel_routing.py
@@ -20,7 +20,7 @@ from typing import cast
 import httpx
 import pytest
 
-from teatree.backends import slack_bot
+from teatree.backends import slack_bot, slack_http
 from teatree.backends.slack_bot import SlackBotBackend
 
 _EXT_SHARED = "C0AM3TENTLK"  # an externally-shared partner channel (Slack-Connect)
@@ -92,8 +92,8 @@ class TestPostMessageRoutesConnectChannelsThroughUserToken:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         result = backend.post_message(channel=_EXT_SHARED, text="review please")
@@ -110,8 +110,8 @@ class TestPostMessageRoutesConnectChannelsThroughUserToken:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_reply(channel=_EXT_SHARED, ts="1.0", text="ping")
@@ -128,8 +128,8 @@ class TestPostMessageKeepsInternalChannelsOnBotToken:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels=set())
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_message(channel=_INTERNAL, text="status")
@@ -142,8 +142,8 @@ class TestPostMessageKeepsInternalChannelsOnBotToken:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels=set())
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_message(channel=_DM, text="dm")
@@ -158,8 +158,8 @@ class TestPostMessageKeepsInternalChannelsOnBotToken:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot")
         backend.post_message(channel=_EXT_SHARED, text="hi")
@@ -178,8 +178,8 @@ class TestConnectMembershipIsCachedPerChannel:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_message(channel=_EXT_SHARED, text="one")
@@ -209,8 +209,8 @@ class TestReactionsRoutedByTheSamePolicy:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels=set())
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.react(channel=_INTERNAL, ts="1.0", emoji="eyes")
@@ -223,8 +223,8 @@ class TestReactionsRoutedByTheSamePolicy:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.react(channel=_EXT_SHARED, ts="1.0", emoji="eyes")
@@ -237,8 +237,8 @@ class TestReactionsRoutedByTheSamePolicy:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.get_reactions(channel=_EXT_SHARED, ts="1.0")
@@ -255,8 +255,8 @@ class TestChannelTokenIsTheSingleSelectionPoint:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         assert backend._channel_token(_EXT_SHARED, op=slack_bot.SlackOp.WRITE) == "xoxp-user"
@@ -293,8 +293,8 @@ class TestChannelTokenIsTheSingleSelectionPoint:
         def fake_post(url: str, **kwargs: object) -> httpx.Response:
             return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         assert backend._channel_token(_EXT_SHARED, op=slack_bot.SlackOp.WRITE) == "xoxp-user"
@@ -323,8 +323,8 @@ class TestChannelTokenIsTheSingleSelectionPoint:
         def fake_post(url: str, **kwargs: object) -> httpx.Response:
             return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         assert backend._channel_token(_EXT_SHARED, op=slack_bot.SlackOp.READ) == "xoxb-bot"
@@ -354,8 +354,8 @@ class TestChannelTokenIsTheSingleSelectionPoint:
             captured.append({"method": "POST", "url": url, **kwargs})
             return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.react(channel=_EXT_SHARED, ts="1.0", emoji="eyes")
@@ -374,8 +374,8 @@ class TestChannelTokenIsTheSingleSelectionPoint:
         """
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels=set())
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_message(channel=_INTERNAL, text="status")
@@ -395,8 +395,8 @@ class TestChannelTokenIsTheSingleSelectionPoint:
         """
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels=set())
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_message(channel=_DM, text="dm drain")
@@ -435,8 +435,8 @@ class TestChannelTokenIsTheSingleSelectionPoint:
             captured.append({"method": "POST", "url": url, **kwargs})
             return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_message(channel=_EXT_SHARED, text="one")  # info fails -> WRITE -> xoxp
@@ -468,8 +468,8 @@ class TestFetchChannelHistoryRoutedAsTheBroadcastPost:
     ) -> None:
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels={_EXT_SHARED})
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.fetch_channel_history(channel=_EXT_SHARED, limit=10)
@@ -503,8 +503,8 @@ class TestFetchChannelHistoryRoutedAsTheBroadcastPost:
         def fake_post(url: str, **kwargs: object) -> httpx.Response:
             return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.fetch_channel_history(channel=_EXT_SHARED, limit=10)
@@ -523,8 +523,8 @@ class TestFetchChannelHistoryRoutedAsTheBroadcastPost:
         """
         captured: list[dict[str, object]] = []
         fake_post, fake_get = _router(captured, ext_shared_channels=set())
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.fetch_channel_history(channel=_INTERNAL, limit=10)

--- a/tests/teatree_backends/test_slack_http.py
+++ b/tests/teatree_backends/test_slack_http.py
@@ -1,0 +1,250 @@
+"""Tests for ``SlackHttpClient`` — bounded retry on transient Slack failures.
+
+Only the httpx boundary and the clock are mocked. The retry contract:
+a transient connect/response failure is retried with backoff, a
+non-idempotent post is NOT replayed on a response-phase failure (it may
+have already posted), and a ``Retry-After`` is honoured.
+"""
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+
+from teatree.backends import slack_http
+from teatree.backends.slack_http import SlackHttpClient
+
+
+def _ok(body: dict[str, object] | None = None) -> httpx.Response:
+    return httpx.Response(200, json=body or {"ok": True}, request=httpx.Request("POST", "https://slack.com/api/x"))
+
+
+def _client(sleeps: list[float]) -> SlackHttpClient:
+    return SlackHttpClient(timeout=1.0, max_retries=3, backoff_base=0.5, sleep=sleeps.append)
+
+
+class TestRetryOnTransientThenSuccess:
+    def test_read_timeout_then_success_on_get(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        calls = iter([httpx.ReadTimeout("slow"), _ok({"ok": True, "n": 1})])
+        monkeypatch.setattr(slack_http.httpx, "get", lambda *a, **k: _raise_or_return(calls))
+
+        body = _client(sleeps).get("conversations.info", token="xoxb-x", params={"channel": "C1"})
+
+        assert body == {"ok": True, "n": 1}
+        assert sleeps == [0.5]
+
+    def test_connect_error_then_success_on_post(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        calls = iter([httpx.ConnectError("down"), _ok({"ok": True, "ts": "1.2"})])
+        monkeypatch.setattr(slack_http.httpx, "post", lambda *a, **k: _raise_or_return(calls))
+
+        body = _client(sleeps).post("chat.postMessage", token="xoxb-x", json={"channel": "C1"}, idempotent=False)
+
+        assert body == {"ok": True, "ts": "1.2"}
+        assert sleeps == [0.5]
+
+    def test_server_error_then_success_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        responses = iter(
+            [
+                httpx.Response(503, request=httpx.Request("POST", "https://slack.com/api/x")),
+                _ok({"ok": True}),
+            ]
+        )
+        monkeypatch.setattr(slack_http.httpx, "post", lambda *a, **k: next(responses))
+
+        body = _client(sleeps).post("reactions.add", token="xoxb-x", json={}, idempotent=True)
+
+        assert body == {"ok": True}
+        assert sleeps == [0.5]
+
+    def test_slack_ratelimited_honours_retry_after(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        limited = httpx.Response(
+            200,
+            json={"ok": False, "error": "ratelimited"},
+            headers={"Retry-After": "7"},
+            request=httpx.Request("POST", "https://slack.com/api/x"),
+        )
+        responses = iter([limited, _ok({"ok": True})])
+        monkeypatch.setattr(slack_http.httpx, "get", lambda *a, **k: next(responses))
+
+        body = _client(sleeps).get("conversations.history", token="xoxb-x", params={"channel": "C1"})
+
+        assert body == {"ok": True}
+        assert sleeps == [7.0]
+
+
+class TestNonIdempotentPostNotReplayedOnResponseFailure:
+    def test_read_timeout_on_non_idempotent_post_does_not_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        attempts: list[int] = []
+
+        timeout = httpx.ReadTimeout("response lost")
+
+        def fake_post(*_args: object, **_kwargs: object) -> httpx.Response:
+            attempts.append(1)
+            raise timeout
+
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+
+        with pytest.raises(httpx.ReadTimeout):
+            _client(sleeps).post("chat.postMessage", token="xoxb-x", json={"channel": "C1"}, idempotent=False)
+
+        assert attempts == [1]
+        assert sleeps == []
+
+    def test_idempotent_post_does_retry_on_read_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        calls = iter([httpx.ReadTimeout("slow"), _ok({"ok": True})])
+        monkeypatch.setattr(slack_http.httpx, "post", lambda *a, **k: _raise_or_return(calls))
+
+        body = _client(sleeps).post("reactions.add", token="xoxb-x", json={}, idempotent=True)
+
+        assert body == {"ok": True}
+        assert sleeps == [0.5]
+
+
+class TestExhaustionRaisesLastError:
+    def test_persistent_connect_error_raises_after_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        down = httpx.ConnectError("always down")
+
+        def always_fail(*_args: object, **_kwargs: object) -> httpx.Response:
+            raise down
+
+        monkeypatch.setattr(slack_http.httpx, "post", always_fail)
+
+        with pytest.raises(httpx.ConnectError):
+            _client(sleeps).post("reactions.add", token="xoxb-x", json={}, idempotent=True)
+
+        assert sleeps == [0.5, 1.0, 2.0]
+
+
+class TestAuthTestHeaderPassThrough:
+    def test_post_with_header_returns_body_and_named_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        response = httpx.Response(
+            200,
+            json={"ok": True, "user_id": "U1"},
+            headers={"X-OAuth-Scopes": "chat:write,reactions:write"},
+            request=httpx.Request("POST", "https://slack.com/api/auth.test"),
+        )
+        monkeypatch.setattr(slack_http.httpx, "post", lambda *a, **k: response)
+
+        body, header = SlackHttpClient(sleep=lambda _s: None).post_with_header(
+            "auth.test", token="xoxb-x", json={}, header="X-OAuth-Scopes"
+        )
+
+        assert body == {"ok": True, "user_id": "U1"}
+        assert header == "chat:write,reactions:write"
+
+
+class TestResponseEdgeCases:
+    def test_429_status_retries_for_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        too_many = httpx.Response(429, request=httpx.Request("GET", "https://slack.com/api/x"))
+        responses = iter([too_many, _ok({"ok": True})])
+        monkeypatch.setattr(slack_http.httpx, "get", lambda *a, **k: next(responses))
+
+        body = _client(sleeps).get("conversations.info", token="xoxb-x", params={})
+
+        assert body == {"ok": True}
+        assert sleeps == [0.5]
+
+    def test_non_idempotent_post_surfaces_5xx_without_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        attempts: list[int] = []
+
+        def fake_post(*_args: object, **_kwargs: object) -> httpx.Response:
+            attempts.append(1)
+            return httpx.Response(503, request=httpx.Request("POST", "https://slack.com/api/x"))
+
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            _client(sleeps).post("chat.postMessage", token="xoxb-x", json={}, idempotent=False)
+
+        assert attempts == [1]
+        assert sleeps == []
+
+    def test_ratelimited_without_retry_after_uses_backoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        limited = httpx.Response(
+            200,
+            json={"ok": False, "error": "ratelimited"},
+            request=httpx.Request("GET", "https://slack.com/api/x"),
+        )
+        responses = iter([limited, _ok({"ok": True})])
+        monkeypatch.setattr(slack_http.httpx, "get", lambda *a, **k: next(responses))
+
+        body = _client(sleeps).get("conversations.history", token="xoxb-x", params={})
+
+        assert body == {"ok": True}
+        assert sleeps == [0.5]
+
+    def test_invalid_retry_after_header_falls_back_to_backoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        limited = httpx.Response(
+            200,
+            json={"ok": False, "error": "ratelimited"},
+            headers={"Retry-After": "soon"},
+            request=httpx.Request("GET", "https://slack.com/api/x"),
+        )
+        responses = iter([limited, _ok({"ok": True})])
+        monkeypatch.setattr(slack_http.httpx, "get", lambda *a, **k: next(responses))
+
+        body = _client(sleeps).get("conversations.history", token="xoxb-x", params={})
+
+        assert body == {"ok": True}
+        assert sleeps == [0.5]
+
+    def test_plain_ok_false_is_not_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        attempts: list[int] = []
+
+        def fake_get(*_args: object, **_kwargs: object) -> httpx.Response:
+            attempts.append(1)
+            return _ok({"ok": False, "error": "channel_not_found"})
+
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
+
+        body = _client(sleeps).get("conversations.info", token="xoxb-x", params={})
+
+        assert body == {"ok": False, "error": "channel_not_found"}
+        assert attempts == [1]
+        assert sleeps == []
+
+
+class TestEnvConfiguration:
+    def test_env_overrides_timeout_and_retries_and_backoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_SLACK_HTTP_TIMEOUT", "42")
+        monkeypatch.setenv("T3_SLACK_HTTP_MAX_RETRIES", "0")
+        monkeypatch.setenv("T3_SLACK_HTTP_BACKOFF", "2.5")
+        client = SlackHttpClient()
+        assert client._timeout == pytest.approx(42.0)
+        assert client._max_retries == 0
+        assert client._backoff_base == pytest.approx(2.5)
+
+    @pytest.mark.parametrize("raw", ["", "not-a-number", "-1", "0"])
+    def test_invalid_or_nonpositive_timeout_falls_back_to_default(
+        self, raw: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("T3_SLACK_HTTP_TIMEOUT", raw)
+        assert SlackHttpClient()._timeout == slack_http.DEFAULT_TIMEOUT_SECONDS
+
+    @pytest.mark.parametrize("raw", ["", "not-a-number", "-1"])
+    def test_invalid_or_negative_retries_falls_back_to_default(self, raw: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_SLACK_HTTP_MAX_RETRIES", raw)
+        assert SlackHttpClient()._max_retries == slack_http.DEFAULT_MAX_RETRIES
+
+    def test_zero_retries_is_honoured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_SLACK_HTTP_MAX_RETRIES", "0")
+        assert SlackHttpClient()._max_retries == 0
+
+
+def _raise_or_return(calls: Iterator[httpx.Response | BaseException]) -> httpx.Response:
+    item = next(calls)
+    if isinstance(item, BaseException):
+        raise item
+    return item

--- a/tests/teatree_backends/test_slack_join_conversation.py
+++ b/tests/teatree_backends/test_slack_join_conversation.py
@@ -5,7 +5,7 @@ from typing import cast
 import httpx
 import pytest
 
-from teatree.backends import slack_bot
+from teatree.backends import slack_http
 from teatree.backends.slack_bot import SlackBotBackend
 
 
@@ -20,7 +20,7 @@ def _post_returning(body: dict, captured: list[dict[str, object]]) -> object:
 class TestJoinConversation:
     def test_posts_to_conversations_join_with_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _post_returning({"ok": True}, captured))
+        monkeypatch.setattr(slack_http.httpx, "post", _post_returning({"ok": True}, captured))
         backend = SlackBotBackend(bot_token="xoxb-bot")
         body = backend.join_conversation("C123")
         assert body["ok"] is True
@@ -31,12 +31,13 @@ class TestJoinConversation:
 
     def test_empty_channel_short_circuits(self, monkeypatch: pytest.MonkeyPatch) -> None:
         called: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _post_returning({"ok": True}, called))
+        monkeypatch.setattr(slack_http.httpx, "post", _post_returning({"ok": True}, called))
         assert SlackBotBackend(bot_token="xoxb-bot").join_conversation("") == {}
         assert called == []
 
     def test_returns_error_body_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _post_returning({"ok": False, "error": "missing_scope"}, captured))
+        failing_post = _post_returning({"ok": False, "error": "missing_scope"}, captured)
+        monkeypatch.setattr(slack_http.httpx, "post", failing_post)
         body = SlackBotBackend(bot_token="xoxb-bot").join_conversation("C1")
         assert body["error"] == "missing_scope"

--- a/tests/teatree_backends/test_slack_post_react_routing.py
+++ b/tests/teatree_backends/test_slack_post_react_routing.py
@@ -18,7 +18,7 @@ from typing import cast
 import httpx
 import pytest
 
-from teatree.backends import slack_bot
+from teatree.backends import slack_http
 from teatree.backends.slack_bot import SlackBotBackend
 
 _SELF_DM = "D_SELF"
@@ -47,6 +47,11 @@ def _backend() -> SlackBotBackend:
 
 
 class TestRouteToken:
+    def test_public_route_token_matches_private(self) -> None:
+        backend = _backend()
+        assert backend.route_token(_SELF_DM) == "xoxb-bot"
+        assert backend.route_token("C_TEAM") == "xoxp-user"
+
     def test_self_dm_channel_id_routes_to_bot(self) -> None:
         assert _backend()._route_token(_SELF_DM) == "xoxb-bot"
 
@@ -74,7 +79,7 @@ class TestRouteToken:
 class TestPostRouted:
     def test_self_dm_posts_under_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[_Call] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured, {"ok": True, "ts": "1.2"}))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured, {"ok": True, "ts": "1.2"}))
 
         _backend().post_routed(channel=_SELF_DM, text="status update")
 
@@ -83,7 +88,7 @@ class TestPostRouted:
 
     def test_colleague_posts_under_user_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[_Call] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured, {"ok": True, "ts": "1.2"}))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured, {"ok": True, "ts": "1.2"}))
 
         result = _backend().post_routed(channel="D_COLLEAGUE", text="ping")
 
@@ -92,7 +97,7 @@ class TestPostRouted:
 
     def test_channel_posts_under_user_token_threaded(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[_Call] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured, {"ok": True, "ts": "1.2"}))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured, {"ok": True, "ts": "1.2"}))
 
         _backend().post_routed(channel="C_TEAM", text="hi team", thread_ts="1700.0001")
 
@@ -102,7 +107,7 @@ class TestPostRouted:
     def test_returns_error_body_on_not_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[_Call] = []
         monkeypatch.setattr(
-            slack_bot.httpx,
+            slack_http.httpx,
             "post",
             _capturing_post(captured, {"ok": False, "error": "channel_not_found"}),
         )
@@ -116,7 +121,7 @@ class TestPostRouted:
             called.append(url)
             return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-        monkeypatch.setattr(slack_bot.httpx, "post", fail_post)
+        monkeypatch.setattr(slack_http.httpx, "post", fail_post)
 
         assert SlackBotBackend().post_routed(channel="C_TEAM", text="x") == {}
         assert called == []
@@ -125,7 +130,7 @@ class TestPostRouted:
 class TestReactRouted:
     def test_react_self_dm_under_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[_Call] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured, {"ok": True}))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured, {"ok": True}))
 
         _backend().react_routed(channel=_SELF_DM, ts="1.2", emoji="eyes")
 
@@ -134,7 +139,7 @@ class TestReactRouted:
 
     def test_react_colleague_under_user_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[_Call] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured, {"ok": True}))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured, {"ok": True}))
 
         _backend().react_routed(channel="D_COLLEAGUE", ts="1.2", emoji="eyes")
 
@@ -142,7 +147,7 @@ class TestReactRouted:
 
     def test_react_channel_under_user_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[_Call] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured, {"ok": True}))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured, {"ok": True}))
 
         _backend().react_routed(channel="C_TEAM", ts="1.2", emoji="eyes")
 
@@ -152,7 +157,7 @@ class TestReactRouted:
     def test_returns_error_body_on_missing_scope(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[_Call] = []
         monkeypatch.setattr(
-            slack_bot.httpx,
+            slack_http.httpx,
             "post",
             _capturing_post(captured, {"ok": False, "error": "missing_scope", "needed": "reactions:write"}),
         )
@@ -168,7 +173,7 @@ class TestReactRouted:
             called.append(url)
             return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-        monkeypatch.setattr(slack_bot.httpx, "post", fail_post)
+        monkeypatch.setattr(slack_http.httpx, "post", fail_post)
 
         assert SlackBotBackend().react_routed(channel="C_TEAM", ts="1.2", emoji="eyes") == {}
         assert called == []

--- a/tests/teatree_backends/test_slack_user_token_routing.py
+++ b/tests/teatree_backends/test_slack_user_token_routing.py
@@ -19,7 +19,7 @@ from typing import cast
 import httpx
 import pytest
 
-from teatree.backends import slack_bot
+from teatree.backends import slack_http
 from teatree.backends.slack_bot import SlackBotBackend
 
 
@@ -74,8 +74,8 @@ class TestReactRoutesThroughUserToken:
 
     def test_react_uses_user_token_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
-        monkeypatch.setattr(slack_bot.httpx, "get", _capturing_get(captured))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured))
+        monkeypatch.setattr(slack_http.httpx, "get", _capturing_get(captured))
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.react(channel="C0AM3TENTLK", ts="1779168774.186559", emoji="eyes")
@@ -86,7 +86,7 @@ class TestReactRoutesThroughUserToken:
 
     def test_react_falls_back_to_bot_token_when_user_token_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured))
 
         backend = SlackBotBackend(bot_token="xoxb-bot")
         backend.react(channel="C1", ts="1.0", emoji="eyes")
@@ -104,7 +104,7 @@ class TestGetReactionsRoutesThroughUserToken:
 
     def test_get_reactions_uses_user_token_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "get", _capturing_get(captured))
+        monkeypatch.setattr(slack_http.httpx, "get", _capturing_get(captured))
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.get_reactions(channel="C0AM3TENTLK", ts="1779168774.186559")
@@ -115,7 +115,7 @@ class TestGetReactionsRoutesThroughUserToken:
 
     def test_get_reactions_falls_back_to_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "get", _capturing_get(captured))
+        monkeypatch.setattr(slack_http.httpx, "get", _capturing_get(captured))
 
         backend = SlackBotBackend(bot_token="xoxb-bot")
         backend.get_reactions(channel="C1", ts="1.0")
@@ -136,9 +136,9 @@ class TestBotTokenStillAuthorisesNonReactionCalls:
 
     def test_post_message_uses_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured))
 
-        monkeypatch.setattr(slack_bot.httpx, "get", _internal_channel_get)
+        monkeypatch.setattr(slack_http.httpx, "get", _internal_channel_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_message(channel="C", text="hi")
@@ -149,9 +149,9 @@ class TestBotTokenStillAuthorisesNonReactionCalls:
 
     def test_post_reply_uses_bot_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured))
 
-        monkeypatch.setattr(slack_bot.httpx, "get", _internal_channel_get)
+        monkeypatch.setattr(slack_http.httpx, "get", _internal_channel_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.post_reply(channel="C", ts="1.0", text="hi")
@@ -170,7 +170,7 @@ class TestBotTokenStillAuthorisesNonReactionCalls:
                 request=httpx.Request("POST", url),
             )
 
-        monkeypatch.setattr(slack_bot.httpx, "post", fake_post)
+        monkeypatch.setattr(slack_http.httpx, "post", fake_post)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.open_dm("U123")
@@ -190,7 +190,7 @@ class TestBotTokenStillAuthorisesNonReactionCalls:
                 request=httpx.Request("GET", url),
             )
 
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         backend.resolve_user_id("alice")
@@ -204,7 +204,7 @@ class TestUserTokenOnly:
 
     def test_react_works_with_only_user_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured))
 
         backend = SlackBotBackend(user_token="xoxp-user")
         result = backend.react(channel="C", ts="1.0", emoji="eyes")
@@ -225,7 +225,7 @@ class TestUserTokenOnly:
         ``chat.postMessage`` through ``xoxp`` (#1072).
         """
         captured: list[dict[str, object]] = []
-        monkeypatch.setattr(slack_bot.httpx, "post", _capturing_post(captured))
+        monkeypatch.setattr(slack_http.httpx, "post", _capturing_post(captured))
 
         backend = SlackBotBackend(user_token="xoxp-user")
         result = backend.post_message(channel="C", text="hi")

--- a/tests/teatree_core/test_connector_preflight.py
+++ b/tests/teatree_core/test_connector_preflight.py
@@ -12,7 +12,7 @@ import httpx
 import pytest
 from django.test import TestCase
 
-from teatree.backends import slack_bot
+from teatree.backends import slack_http
 from teatree.backends.slack_bot import SlackBotBackend
 from teatree.core.connector_preflight import assert_slack_scope, run_connector_preflight
 from teatree.core.models import Worktree
@@ -42,12 +42,12 @@ def _fake_auth_test_post(header_value: str | None):
 
 class TestAssertSlackScope(TestCase):
     def test_passes_when_scope_present_in_header(self) -> None:
-        with patch.object(slack_bot.httpx, "post", _fake_auth_test_post("chat:write,reactions:write,users:read")):
+        with patch.object(slack_http.httpx, "post", _fake_auth_test_post("chat:write,reactions:write,users:read")):
             assert_slack_scope(SlackBotBackend(bot_token="xoxb-test"), "reactions:write")
 
     def test_fires_when_scope_missing_from_header(self) -> None:
         with (
-            patch.object(slack_bot.httpx, "post", _fake_auth_test_post("chat:write,users:read")),
+            patch.object(slack_http.httpx, "post", _fake_auth_test_post("chat:write,users:read")),
             pytest.raises(RuntimeError) as excinfo,
         ):
             assert_slack_scope(SlackBotBackend(bot_token="xoxb-test"), "reactions:write")
@@ -55,7 +55,7 @@ class TestAssertSlackScope(TestCase):
 
     def test_fires_when_header_absent_entirely(self) -> None:
         with (
-            patch.object(slack_bot.httpx, "post", _fake_auth_test_post(None)),
+            patch.object(slack_http.httpx, "post", _fake_auth_test_post(None)),
             pytest.raises(RuntimeError),
         ):
             assert_slack_scope(SlackBotBackend(bot_token="xoxb-test"), "reactions:write")

--- a/tests/teatree_core/test_review_request_guard.py
+++ b/tests/teatree_core/test_review_request_guard.py
@@ -431,7 +431,7 @@ class TestResolveGuardTarget(TestCase):
         The real ``resolve_channel_token`` / ``_channel_token`` run; only
         the ``httpx`` boundary is faked so ``conversations.info`` fails.
         """
-        from teatree.backends import slack_bot  # noqa: PLC0415
+        from teatree.backends import slack_http  # noqa: PLC0415
 
         overlay = _overlay_with_channel()
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
@@ -446,7 +446,7 @@ class TestResolveGuardTarget(TestCase):
         with (
             patch("teatree.core.overlay_loader._discover_overlays", return_value={"test": overlay}),
             patch("teatree.core.backend_factory.messaging_from_overlay", return_value=backend),
-            patch.object(slack_bot.httpx, "get", fake_get),
+            patch.object(slack_http.httpx, "get", fake_get),
         ):
             target = resolve_guard_target()
 

--- a/tests/teatree_loop/test_scanner_error_signals.py
+++ b/tests/teatree_loop/test_scanner_error_signals.py
@@ -24,7 +24,7 @@ import httpx
 import pytest
 from django.test import TestCase
 
-from teatree.backends import slack_bot
+from teatree.backends import slack_http
 from teatree.backends.protocols import ApprovalState, ReviewState
 from teatree.backends.slack_bot import SlackBotBackend
 from teatree.loop.scanners.base import ScannerError, ScannerErrorClass, ScanSignal
@@ -269,9 +269,9 @@ class TestSlackFetchChannelHistoryAuthFailure:
             return _slack_response({"ok": False, "error": "missing_scope"})
 
         # _channel_token consults conversations.info via _post; stub it too.
-        monkeypatch.setattr(slack_bot.httpx, "get", fake_get)
+        monkeypatch.setattr(slack_http.httpx, "get", fake_get)
         monkeypatch.setattr(
-            slack_bot.httpx,
+            slack_http.httpx,
             "post",
             lambda url, **kwargs: _slack_response({"ok": False, "error": "missing_scope"}),
         )
@@ -283,12 +283,12 @@ class TestSlackFetchChannelHistoryAuthFailure:
 
     def test_invalid_auth_raises_scanner_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
-            slack_bot.httpx,
+            slack_http.httpx,
             "get",
             lambda url, **kwargs: _slack_response({"ok": False, "error": "invalid_auth"}),
         )
         monkeypatch.setattr(
-            slack_bot.httpx,
+            slack_http.httpx,
             "post",
             lambda url, **kwargs: _slack_response({"ok": False, "error": "invalid_auth"}),
         )
@@ -300,12 +300,12 @@ class TestSlackFetchChannelHistoryAuthFailure:
 
     def test_rate_limited_raises_scanner_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
-            slack_bot.httpx,
+            slack_http.httpx,
             "get",
             lambda url, **kwargs: _slack_response({"ok": False, "error": "ratelimited"}),
         )
         monkeypatch.setattr(
-            slack_bot.httpx,
+            slack_http.httpx,
             "post",
             lambda url, **kwargs: _slack_response({"ok": False, "error": "ratelimited"}),
         )
@@ -323,12 +323,12 @@ class TestSlackFetchChannelHistoryAuthFailure:
         (auth/scope/ratelimit) raise.
         """
         monkeypatch.setattr(
-            slack_bot.httpx,
+            slack_http.httpx,
             "get",
             lambda url, **kwargs: _slack_response({"ok": False, "error": "channel_not_found"}),
         )
         monkeypatch.setattr(
-            slack_bot.httpx,
+            slack_http.httpx,
             "post",
             lambda url, **kwargs: _slack_response({"ok": False, "error": "channel_not_found"}),
         )

--- a/tests/test_slack_setup.py
+++ b/tests/test_slack_setup.py
@@ -268,7 +268,8 @@ class TestSlackBotCommand:
         inputs = "xoxb-1-test\nxapp-1-test\nU01ABCD1234\nA123456\n"
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
-            patch("teatree.cli.slack_setup.write_pass", side_effect=fake_write_pass),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", side_effect=fake_write_pass),
             patch("teatree.cli.slack_setup.webbrowser.open"),
         ):
             result = self._invoke(
@@ -290,6 +291,8 @@ class TestSlackBotCommand:
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup.webbrowser.open", side_effect=opened.append),
         ):
             result = self._invoke(
@@ -315,6 +318,8 @@ class TestSlackBotCommand:
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup.webbrowser.open"),
         ):
             result = self._invoke(
@@ -333,6 +338,8 @@ class TestSlackBotCommand:
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup.webbrowser.open"),
         ):
             result = self._invoke(
@@ -349,7 +356,8 @@ class TestSlackBotCommand:
         inputs = "xoxb-1-test\nxapp-1-test\nU01ABCD1234\n"
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
-            patch("teatree.cli.slack_setup.write_pass", return_value=False),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=False),
             patch("teatree.cli.slack_setup.webbrowser.open"),
         ):
             result = self._invoke(
@@ -359,17 +367,18 @@ class TestSlackBotCommand:
             )
 
         assert result.exit_code == 1
-        assert "Failed to store bot token" in result.stdout
+        assert "`pass insert teatree/acme/slack-bot` failed" in result.stdout
 
     def test_app_token_pass_failure_exits_with_error(self, tmp_path: Path) -> None:
         inputs = "xoxb-1-test\nxapp-1-test\nU01ABCD1234\n"
 
         def fake_write_pass(key: str, value: str) -> bool:
-            return "bot" in key  # bot succeeds, app fails
+            return key.endswith("-bot")  # bot succeeds, app fails
 
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
-            patch("teatree.cli.slack_setup.write_pass", side_effect=fake_write_pass),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", side_effect=fake_write_pass),
             patch("teatree.cli.slack_setup.webbrowser.open"),
         ):
             result = self._invoke(
@@ -379,13 +388,15 @@ class TestSlackBotCommand:
             )
 
         assert result.exit_code == 1
-        assert "Failed to store app token" in result.stdout
+        assert "`pass insert teatree/acme/slack-app` failed" in result.stdout
 
     def test_invalid_token_format_reprompts(self, tmp_path: Path) -> None:
         inputs = "garbage\nxoxb-1-test\nxapp-1-test\nU01ABCD1234\nA123456\n"
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup.webbrowser.open"),
         ):
             result = self._invoke(
@@ -402,6 +413,8 @@ class TestSlackBotCommand:
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup.webbrowser.open"),
         ):
             result = self._invoke(
@@ -476,6 +489,8 @@ class TestSmokeTestInvocation:
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup.webbrowser.open"),
             patch("teatree.cli.slack_setup._smoke_test", return_value=False),
         ):
@@ -671,6 +686,8 @@ class TestUpdatePathModeResolution:
             patch("teatree.cli.slack_setup.webbrowser.open"),
             patch("teatree.cli.slack_setup.read_pass", return_value="xoxe.xoxp-token"),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
             patch(
                 "teatree.cli.slack_setup._slack_app_api",
@@ -691,6 +708,8 @@ class TestUpdatePathModeResolution:
             patch("teatree.cli.slack_setup.read_pass", return_value="xoxe.xoxp-token"),
             patch("teatree.cli.slack_app_resolve.read_pass", return_value=""),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
             patch(
                 "teatree.cli.slack_setup._slack_app_api",
@@ -708,6 +727,8 @@ class TestUpdatePathModeResolution:
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup.webbrowser.open"),
         ):
             result = _invoke_setup(
@@ -728,6 +749,8 @@ class TestUpdatePathModeResolution:
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup.webbrowser.open", side_effect=opened.append),
         ):
             result = _invoke_setup(
@@ -761,6 +784,8 @@ class TestUpdatePathBehavior:
             patch("teatree.cli.slack_setup.webbrowser.open"),
             patch("teatree.cli.slack_setup.read_pass", return_value="xoxe.xoxp-token"),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True) as smoke,
             patch("teatree.cli.slack_setup._slack_app_api", side_effect=fake_api),
         ):
@@ -787,6 +812,8 @@ class TestUpdatePathBehavior:
             patch("teatree.cli.slack_setup.webbrowser.open", side_effect=opened.append),
             patch("teatree.cli.slack_setup.read_pass", return_value="xoxe.xoxp-token"),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
             patch("teatree.cli.slack_setup._slack_app_api", side_effect=fake_api),
         ):
@@ -850,6 +877,8 @@ class TestUpdatePathBehavior:
             patch("teatree.cli.slack_setup.webbrowser.open"),
             patch("teatree.cli.slack_setup.read_pass", side_effect=fake_read),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
             patch(
                 "teatree.cli.slack_setup._slack_app_api",
@@ -878,6 +907,8 @@ class TestDegradedPath:
             patch("teatree.cli.slack_setup.webbrowser.open", side_effect=opened.append),
             patch("teatree.cli.slack_setup.read_pass", side_effect=fake_read),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True) as smoke,
         ):
             result = _invoke_setup(tmp_path, inputs="", args=["--overlay", "acme"], config=config)
@@ -929,6 +960,8 @@ class TestUpdatePathSmokeFailure:
             patch("teatree.cli.slack_setup.webbrowser.open"),
             patch("teatree.cli.slack_setup.read_pass", return_value="xoxe.xoxp-token"),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=False),
             patch(
                 "teatree.cli.slack_setup._slack_app_api",
@@ -947,6 +980,8 @@ class TestUpdatePathSmokeFailure:
             patch("teatree.cli.slack_setup.webbrowser.open"),
             patch("teatree.cli.slack_setup.read_pass", return_value=""),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test") as smoke,
         ):
             result = _invoke_setup(tmp_path, inputs="", args=["--overlay", "acme", "--skip-smoke-test"], config=config)
@@ -960,6 +995,8 @@ class TestUpdatePathSmokeFailure:
         with (
             patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup.webbrowser.open"),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
         ):
@@ -975,6 +1012,8 @@ class TestUpdatePathSmokeFailure:
             patch("teatree.cli.slack_setup.webbrowser.open"),
             patch("teatree.cli.slack_setup.read_pass", return_value="xoxe.xoxp-token"),
             patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_token_store.read_pass", return_value=""),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
             patch(
                 "teatree.cli.slack_setup._slack_app_api",


### PR DESCRIPTION
## Plan

The Slack integration had three reliability/safety gaps. This PR fixes them, plus a token-write clobber risk found while tracing the write paths:

1. **Reliability** — every Web API call used a hard `timeout=10.0` with no retry, so one transient `ReadTimeout`/`ConnectTimeout`/`5xx`/`ratelimited` broke a loop tick (a missed `reactions.add`, a dropped merge-notify post). Add a bounded-retry transport.
2. **Routing** — verify the destination router (DM-to-user → bot; colleague/channel message or reaction → personal OAuth token). It was already correct; the only gap was a missing public accessor the notify edge documented.
3. **Provisioning** — the user scopes (`reactions:write`/`read`, `chat:write.public`/`customize`) were already in the manifest; the degraded path (no app-config token) read like a success. Make it loud.
4. **Token-write safety** — pass writes had no prefix check and no backup, so a mis-pasted token could silently land in the wrong slot and overwrite a good secret on the non-version-controlled `pass` store.

## What changed

| Area | Files | Change |
|---|---|---|
| Reliability | `backends/slack_http.py` (new), `backends/slack_bot.py` | `SlackHttpClient` — configurable timeout (`T3_SLACK_HTTP_TIMEOUT` / `_MAX_RETRIES` / `_BACKOFF`), bounded exponential backoff. Connect-phase failures retry always (nothing was sent); response-phase (`ReadTimeout`/`5xx`/`429`/`ratelimited`) retries only for idempotent calls. A non-idempotent `chat.postMessage` is never replayed on a response-phase failure. `Retry-After` honoured. `_post`/`_get`/`auth_test` routed through it; `httpx` import dropped from the backend. |
| Routing | `backends/slack_bot.py`, `core/management/commands/notify.py` | Routing logic unchanged (already correct). Added the public `route_token` accessor the `notify post`/`react` docstring referenced. |
| Provisioning | `cli/slack_provision.py` | `slack-provision` degraded path now states the manifest was **not** pushed, that user scopes are unset, and lists the scopes to add manually. |
| Token safety | `cli/slack_token_store.py` (new), `cli/slack_setup.py`, `cli/slack_user_token_setup.py` | `store_slack_token` validates the prefix before writing (wrong-slot value refused) and backs up any prior value to a timestamped key before overwriting. Wired into the bot/app and user token capture paths. |
| Docs | `skills/setup/SKILL.md` | Clarify that `slack-bot` (bootstrap capture), `slack-provision` (idempotent lifecycle, read-only on tokens), and `slack-user-token` (xoxp re-capture) are distinct phases — none is redundant. |

## Consolidation verdict

The three setup commands are **not** duplicates: `slack-provision` orchestrates the lifecycle but only *reads/verifies* tokens, while `slack-bot` captures the bot/app tokens and `slack-user-token` captures the personal token. All three are kept first-class; the relationship is now documented.

## Tests

Mock only the httpx boundary and the clock. New: `test_slack_http.py` (retry-then-success, non-idempotent-no-replay, `Retry-After`, env config), `test_slack_token_store.py` (validate-before-write, back-up-before-overwrite), plus degraded-warning, `route_token`-accessor, and scope-list-drift assertions. Existing transport mocks migrated to the new boundary. Full suite green (11480 passed), coverage 94.25% (gate 93%).