### PR TITLE
fix(slack): drop bot-only scopes from _USER_SCOPES (user-token mint)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3506,7 +3506,7 @@ Usage: t3 teatree workspace clean-merged [OPTIONS]
 ```
 Usage: t3 teatree workspace clean-all [OPTIONS]
 
- Prune merged worktrees, stale branches, orphaned stashes, orphan databases,
+ Prune merged worktrees, stale branches, stashes, orphan databases + docker,
  and old DSLR snapshots.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮

--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -66,6 +66,12 @@ _BOT_SCOPES = [
     "users:read",
     "users:read.email",
 ]
+_BOT_ONLY_SCOPES = frozenset(
+    {
+        "chat:write.customize",
+        "chat:write.public",
+    }
+)
 # Scopes for the human user's OAuth token (``xoxp-…``). ``SlackBotBackend``
 # routes every outbound call (``chat.postMessage``, ``reactions.add`` /
 # ``reactions.get``) through this token for Slack-Connect externally-shared
@@ -89,8 +95,6 @@ _USER_SCOPES = [
     "canvases:write",
     "channels:history",
     "chat:write",
-    "chat:write.customize",
-    "chat:write.public",
     "files:read",
     "groups:history",
     "im:history",
@@ -106,6 +110,17 @@ _USER_SCOPES = [
     "users:read",
     "users:read.email",
 ]
+
+
+def _user_scopes_carry_no_bot_only_scope() -> None:
+    leaked = _BOT_ONLY_SCOPES.intersection(_USER_SCOPES)
+    if leaked:
+        joined = ", ".join(sorted(leaked))
+        message = f"_USER_SCOPES contains bot-only scope(s) Slack rejects on a user token: {joined}"
+        raise AssertionError(message)
+
+
+_user_scopes_carry_no_bot_only_scope()
 _BOT_EVENTS = ["app_mention", "message.im"]
 
 _SMOKE_TEST_TIMEOUT_SECONDS = 120

--- a/src/teatree/cli/slack_user_token_setup.py
+++ b/src/teatree/cli/slack_user_token_setup.py
@@ -4,9 +4,11 @@ The personal token at ``pass slack/user-oauth-token`` is the credential that
 ``SlackBotBackend`` uses to post and react in Slack-Connect externally-shared
 channels (where the bot token is rejected with
 ``mcp_externally_shared_channel_restricted``). Several scopes that recent
-backend work depends on — notably ``reactions:write``, ``chat:write.public``
-and ``chat:write.customize`` — are missing from existing installations because
-they were not yet in the manifest when the user last consented.
+backend work depends on — notably ``reactions:write`` and ``chat:write`` —
+are missing from existing installations because they were not yet in the
+manifest when the user last consented. (``chat:write.public`` and
+``chat:write.customize`` are bot-only and are intentionally absent from the
+user-scope set; see ``slack_setup._BOT_ONLY_SCOPES``.)
 
 This command walks the user through reinstalling the Slack app to re-prompt
 OAuth consent for an updated user-scope set, then captures the new ``xoxp-…``

--- a/tests/cli_setup/test_slack_user_token.py
+++ b/tests/cli_setup/test_slack_user_token.py
@@ -35,9 +35,14 @@ class TestUserTokenPattern:
 
 
 class TestRequiredUserScopes:
-    def test_includes_new_connect_write_scopes(self) -> None:
-        for scope in ("reactions:write", "chat:write.public", "chat:write.customize"):
+    def test_includes_connect_write_and_reaction_scopes(self) -> None:
+        for scope in ("reactions:write", "reactions:read", "chat:write"):
             assert scope in REQUIRED_USER_SCOPES
+
+    def test_excludes_bot_only_scopes(self) -> None:
+        from teatree.cli.slack_setup import _BOT_ONLY_SCOPES  # noqa: PLC0415
+
+        assert _BOT_ONLY_SCOPES.isdisjoint(REQUIRED_USER_SCOPES)
 
     def test_preserves_existing_user_capabilities(self) -> None:
         for scope in ("chat:write", "users:read", "users:read.email", "canvases:write"):
@@ -180,7 +185,7 @@ class TestCliWalkthrough:
 
     def test_missing_scope_fails_loudly(self, tmp_path: Path) -> None:
         config = tmp_path / "teatree.toml"
-        granted = [s for s in REQUIRED_USER_SCOPES if s != "chat:write.public"]
+        granted = [s for s in REQUIRED_USER_SCOPES if s != "reactions:write"]
         with (
             patch("teatree.cli.slack_user_token_setup.read_pass", return_value=""),
             patch("teatree.cli.slack_token_store.read_pass", return_value=""),
@@ -190,7 +195,7 @@ class TestCliWalkthrough:
         ):
             result = self._run(["--config", str(config)], inputs="xoxp-new-token\n")
         assert result.exit_code == 1
-        assert "chat:write.public" in result.output
+        assert "reactions:write" in result.output
 
     def test_default_mode_prompts_before_overwriting_existing(self, tmp_path: Path) -> None:
         config = tmp_path / "teatree.toml"

--- a/tests/test_slack_setup.py
+++ b/tests/test_slack_setup.py
@@ -1,6 +1,7 @@
 """Tests for ``t3 setup slack-bot`` — interactive Slack-bot walkthrough."""
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -14,9 +15,12 @@ from typer.testing import CliRunner
 from teatree.cli.setup import setup_app
 from teatree.cli.slack_setup import (
     _APP_ID_RE,
+    _BOT_ONLY_SCOPES,
     _BOT_TOKEN_RE,
     _USER_ID_RE,
+    _USER_SCOPES,
     SlackManifestError,
+    _user_scopes_carry_no_bot_only_scope,
     app_install_url,
     app_manifest_editor_url,
     build_manifest,
@@ -142,6 +146,35 @@ class TestBuildManifest:
         assert "bot" in scopes
         assert "user" in scopes
         assert "chat:write" in scopes["bot"]
+
+
+class TestUserScopesExcludeBotOnly:
+    """``_USER_SCOPES`` must list only scopes Slack grants on a *user* token.
+
+    A user token (``xoxp-…``) minted via ``apps.manifest.update`` is rejected
+    with ``illegal_user_scopes`` if the manifest's ``oauth_config.scopes.user``
+    contains a bot-only scope. The data-driven ``_BOT_ONLY_SCOPES`` set is the
+    guard: any future bot-only scope added to it is automatically enforced
+    against both the manifest and the verifier without touching this test.
+    """
+
+    def test_known_bot_only_scopes_enumerated(self) -> None:
+        assert {"chat:write.customize", "chat:write.public"} <= _BOT_ONLY_SCOPES
+
+    def test_user_scopes_contain_no_bot_only_scope(self) -> None:
+        assert _BOT_ONLY_SCOPES.isdisjoint(_USER_SCOPES)
+
+    def test_built_manifest_user_section_has_no_bot_only_scope(self) -> None:
+        user_scopes = build_manifest(overlay_name="acme")["oauth_config"]["scopes"]["user"]
+        assert _BOT_ONLY_SCOPES.isdisjoint(user_scopes)
+
+    def test_guard_raises_when_a_bot_only_scope_leaks_in(self) -> None:
+        leaked = min(_BOT_ONLY_SCOPES)
+        with (
+            patch("teatree.cli.slack_setup._USER_SCOPES", [*_USER_SCOPES, leaked]),
+            pytest.raises(AssertionError, match=re.escape(leaked)),
+        ):
+            _user_scopes_carry_no_bot_only_scope()
 
 
 class TestManifestInstallUrl:


### PR DESCRIPTION
## Problem

Minting a Slack user (`xoxp-…`) token via `apps.manifest.update` failed with `illegal_user_scopes`. The manifest's `oauth_config.scopes.user` set (`_USER_SCOPES` in `src/teatree/cli/slack_setup.py`) listed two scopes Slack only grants on a **bot** token:

- `chat:write.customize`
- `chat:write.public`

Slack accepts both only under `oauth_config.scopes.bot`, never `.user`, so the whole user-scope manifest update was rejected.

## Fix

- Remove `chat:write.customize` and `chat:write.public` from `_USER_SCOPES`. The remaining entries are all legitimately user-grantable.
- Add a data-driven `_BOT_ONLY_SCOPES` frozenset as the single source of truth for the invariant, plus an import-time guard (`_user_scopes_carry_no_bot_only_scope`) that raises if any bot-only scope leaks into `_USER_SCOPES` — caught at import time, not at xoxp-mint time.
- `slack_user_token_setup.py` derives `REQUIRED_USER_SCOPES` from `_USER_SCOPES`, so its docstring (which claimed the two bot-only scopes were required) is corrected.

## Tests

- New `TestUserScopesExcludeBotOnly` in `tests/test_slack_setup.py`: enumerates the known bot-only scopes, asserts `_USER_SCOPES` and the built manifest's user section contain none of them, and exercises the guard's raise path.
- Inverted `tests/cli_setup/test_slack_user_token.py::TestRequiredUserScopes` — the old test asserted the two bot-only scopes **belonged** in the user set; it now asserts they are excluded (`_BOT_ONLY_SCOPES.isdisjoint(...)`) and keeps the real user-grantable scopes covered.
- Updated the missing-scope CLI walkthrough test to use a real user scope (`reactions:write`) as its example instead of the now-removed `chat:write.public`.

Verified RED on the buggy code (re-adding a bot-only scope fails both the import-time guard and the regression tests), GREEN after the fix. Full `slack_setup` + `cli_setup` + backend slack-scope suites pass (279 tests); `slack_setup.py` at 100% coverage.

`docs/generated/cli-reference.md` carries a one-line pre-existing drift correction auto-produced by the docs-regeneration pre-commit hook (unrelated `workspace clean-all` help text).

docs: n/a — no skill, BLUEPRINT, or prose doc references these scopes; the only doc touched is the auto-generated CLI reference.
