### PR TITLE
perf(ci): align local pre-push gate with CI (3.13 only, full matrix opt-in)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -316,13 +316,13 @@ repos:
         files: ^(pyproject\.toml|uv\.lock)$
         stages: [manual]
 
-  # Phase 8b - Pre-push (Docker)
+  # Phase 8b - Pre-push
   - repo: local
     hooks:
-      - id: pytest-docker
-        name: pytest (Docker test matrix)
+      - id: pytest-fast
+        name: pytest (fast gate, Python 3.13, parallel — matches CI)
         language: script
-        entry: dev/test-matrix.sh
+        entry: dev/test-fast.sh
         pass_filenames: false
         always_run: true
         stages: [push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,10 +270,13 @@ t3 agent                            # Launch Claude Code (teatree-self developme
 ```bash
 uv run pytest                       # Test suite with coverage (>93% required)
 prek run --all-files                # Pre-commit hooks (ruff, codespell, tach, ty)
-bash dev/test-matrix.sh             # Docker matrix: Python 3.13 + 3.14 (MANDATORY before push)
+bash dev/test-fast.sh               # Fast pre-push gate: Python 3.13, host, parallel
+bash dev/test-matrix.sh             # Opt-in Docker matrix: Python 3.13 + 3.14
 ```
 
-**Always run `dev/test-matrix.sh` before claiming a fix works.** Local `uv run pytest` only tests one Python version with locally-installed tools. The Docker matrix catches missing system dependencies and Python-version-specific coverage differences. If the Dockerfile changed, remove the cached image first: `docker rmi teatree-test`.
+**The pre-push gate runs `dev/test-fast.sh`** — the full suite on Python 3.13 (the single version CI checks), host-native and parallel with `pytest-xdist`. It runs the real tests and fails the push on red; there is no bypass.
+
+**`dev/test-matrix.sh` is the opt-in superset, not the default push path.** Run it before merges that touch `dev/Dockerfile.test`, `uv.lock`, or system dependencies: it runs the suite in Docker across Python 3.13 + 3.14 and catches missing system dependencies and Python-version-specific differences the host gate can't. If the Dockerfile changed, remove the cached image first: `docker rmi teatree-test`.
 
 ### Test-Writing Doctrine (Non-Negotiable)
 

--- a/dev/test-fast.sh
+++ b/dev/test-fast.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Default pre-push gate: full suite on Python 3.13 (CI's version), host + parallel.
+# The opt-in Docker superset is dev/test-matrix.sh.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PY_VERSION="${TEATREE_TEST_PYTHON:-3.13}"
+
+echo "=== Fast pre-push: Python ${PY_VERSION} (host, parallel) ==="
+# Output is captured: streaming 11k+ lines through the git hook panics its buffer.
+# Coverage floor is CI's job (`test`); --no-cov keeps the gate fast.
+tmpout=$(mktemp)
+if uv run -p "${PY_VERSION}" pytest \
+    --no-header --no-cov -q --tb=short \
+    -p no:cacheprovider \
+    -n auto --dist worksteal \
+    -o "addopts=--color=yes --doctest-modules --strict-config --strict-markers --reuse-db" \
+    > "$tmpout" 2>&1; then
+    tail -4 "$tmpout"
+    echo "  -> Python ${PY_VERSION}: OK"
+    rm -f "$tmpout"
+    exit 0
+else
+    tail -40 "$tmpout"
+    echo "  -> Python ${PY_VERSION}: FAILED"
+    rm -f "$tmpout"
+    exit 1
+fi

--- a/dev/test-matrix.sh
+++ b/dev/test-matrix.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Run tests in Docker across all supported Python versions (mirrors CI).
-# Uses a cached image with apt packages + uv pre-installed.
-# Caches uv data (Python installs) and venvs between runs to avoid re-downloading.
+# OPT-IN Docker superset of the fast pre-push gate (dev/test-fast.sh).
+# Runs the suite in Docker across Python 3.13 + 3.14; not the default push path.
+#
+# Usage: dev/test-matrix.sh [--all | <version>...]   (no args / --all = 3.13 3.14)
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -9,7 +10,13 @@ IMAGE="teatree-test"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/teatree-test"
 mkdir -p "${CACHE_DIR}/uv"
 failed=0
-versions=(3.13)
+
+default_versions=(3.13 3.14)
+if [ "$#" -eq 0 ] || [ "${1:-}" = "--all" ]; then
+    versions=("${default_versions[@]}")
+else
+    versions=("$@")
+fi
 total=${#versions[@]}
 current=0
 

--- a/skills/workspace/references/troubleshooting.md
+++ b/skills/workspace/references/troubleshooting.md
@@ -194,7 +194,7 @@ See your [issue tracker platform reference](../../platforms/references/) § "Kno
 - **Cause:** New code introduced a `subprocess.run` call to an external tool. Local dev has the tool installed; Docker CI does not. Common culprits: `_compose_has_service` (calls `docker compose`), `_drop_orphan_databases` (calls `psql`/`dropdb`).
 - **Subtle variant — local imports:** When a function uses `from module import func` inside the function body, patching the *caller's* `subprocess` doesn't cover calls made through the *imported module's* `subprocess`. Example: patching `lifecycle_mod.subprocess` does NOT mock `_compose_has_service` which is imported from `run_mod` at call time.
 - **Fix:** Patch the function directly on the module it lives in: `patch.object(run_mod, "_compose_has_service", return_value=True)`.
-- **Prevention:** When adding any `subprocess` call to an external tool, grep all test files for tests that exercise that code path (`grep -r "lifecycle.*start\|workspace.*clean"`) and add mocks. Run the Docker test matrix locally before pushing: the pre-push hook does this automatically.
+- **Prevention:** When adding any `subprocess` call to an external tool, grep all test files for tests that exercise that code path (`grep -r "lifecycle.*start\|workspace.*clean"`) and add mocks. The default pre-push gate (`dev/test-fast.sh`) runs host-native, so it won't catch a missing-in-Docker tool; run the opt-in Docker matrix (`dev/test-matrix.sh`) before merging changes that add such a subprocess call.
 
 ## direnv Not Loading `.envrc`
 

--- a/tests/test_skill_loading_ambient_overfire_hook.py
+++ b/tests/test_skill_loading_ambient_overfire_hook.py
@@ -164,17 +164,17 @@ class TestInputLengthCap:
         assert sentinel in stripped
 
     def test_unterminated_open_tag_flood_stays_fast(self) -> None:
-        # Defense-in-depth (NOT the primary assertion): ~200 KB of
-        # unclosed open tags — the O(n²) trigger — must complete well under
-        # 2s once the cap is applied. CI timing is noisy, so this is a
-        # generous guard layered on top of the deterministic cap test.
+        # Defense-in-depth (NOT the primary assertion): ~200 KB of unclosed
+        # open tags — the O(n²) trigger — burns little CPU once the cap applies.
+        # process_time (CPU, not wall-clock) keeps the guard immune to the
+        # scheduler contention of a parallel `-n auto` run.
         import time  # noqa: PLC0415
 
         flood = "<system-reminder> blog " * 9000
         assert len(flood) > 200_000
-        start = time.monotonic()
+        start = time.process_time()
         _strip_ambient_context(flood)
-        assert time.monotonic() - start < 2.0
+        assert time.process_time() - start < 2.0
 
 
 class TestAmbientKeywordDoesNotEnterSuggestions:


### PR DESCRIPTION
## Problem

The pre-push gate's `pytest-docker` hook ran the full suite **inside Docker** via `dev/test-matrix.sh`. CI's `test` job is Python 3.13-only, yet the local gate paid Docker build + container + bind-mount overhead on every push — a ~30-min tax in its historical multi-version form, and still ~4min warm-cache for a single version. Every push paid for versions CI does not check.

## Change (root cause — align the local gate with CI, no bypass)

- **New default pre-push path: `dev/test-fast.sh`** — the full suite on Python 3.13 (CI's version), host-native and parallel with `pytest-xdist` (`-n auto`, worksteal). Each xdist worker gets its own in-memory sqlite DB, so parallelism is isolation-safe. Coverage stays CI's job (the 93% floor in the `test` job), so the gate runs `--no-cov` and stays fast. It runs the **real tests and fails the push on red** — no `--no-verify`, no bypass.
- **`dev/test-matrix.sh` is now the opt-in Docker superset** (`--all` or explicit versions, default `3.13 3.14`) for catching system-dependency / Python-version differences. Run it before merges that touch `dev/Dockerfile.test`, `uv.lock`, or system deps. It is no longer on the default push path.
- The `.pre-commit-config.yaml` `pytest-docker` hook is replaced by `pytest-fast` (clean cutover — no old hook id left behind).
- Parallel execution exposed a latent flake: a defense-in-depth timing test asserted **wall-clock** `< 2s`, which starves under `-n auto` CPU contention (the operation itself burns ~0.5s of CPU). Switched it to `time.process_time` so the guard measures CPU and is immune to scheduler contention.

## Evidence — wall-clock (11702 tests, all pass)

| Path | Wall-clock |
|------|-----------|
| Old Docker matrix (warm image cache) | 250s |
| Serial host-native pytest | 443s |
| **New fast gate (host, `-n auto`)** | **~89s quiet / ~150s loaded** |

The new `pytest-fast` hook ran on the actual `git push` for this branch and **passed**, alongside the privacy-leak, doc-update, comment-density, and ensure-PR gates.

## Docs

- `AGENTS.md` testing section: fast gate is the default; matrix is opt-in.
- `skills/workspace/references/troubleshooting.md`: the default gate is host-native, so run the opt-in matrix to catch missing-in-Docker tools.