### PR TITLE
test(provisioning): real-provisioning integration tests on a shared ABC

### DIFF
--- a/tests/integration/provisioning/__init__.py
+++ b/tests/integration/provisioning/__init__.py
@@ -1,0 +1,15 @@
+"""Real-provisioning integration tests on a shared abstract base.
+
+Where ``tests/teatree_core/test_provisioning_contract.py`` pins the
+orchestration *logic* with docker/subprocess seams mocked, this package
+provisions a *real* worktree, runs a *real* DB-touching test inside it,
+starts the *real* server(s), and asserts they actually serve over HTTP
+via :func:`teatree.core.readiness.run_probes`.
+
+``_base.py`` holds the overlay-agnostic machinery as an ``abc.ABC``; each
+``test_<target>.py`` subclasses it and fills in the per-target hooks. The
+teatree self-test runs in normal CI (no docker, two concurrent worktrees).
+The external-overlay test is env-gated (docker + a registered external
+overlay whose repos resolve on disk + an opt-in flag) so default CI stays
+green and the coverage gate is untouched.
+"""

--- a/tests/integration/provisioning/_base.py
+++ b/tests/integration/provisioning/_base.py
@@ -1,0 +1,195 @@
+"""Shared abstract harness for real-provisioning integration tests.
+
+A subclass declares *which* overlay, *how many* concurrent worktrees, the
+*time cap*, the *DB-touching test* to run per worktree, and the *readiness
+probes* that prove the started runtime serves. The concrete machinery here
+provisions a real git worktree, runs the DB test as its own ``pytest``
+subprocess by node id (Django is **not** booted inside it), starts the
+server(s), and asserts reachability through
+:func:`teatree.core.readiness.run_probes`.
+
+Teardown finalizers are registered per worktree *at creation*, before the
+start attempt, so a half-started worktree is still torn down.
+"""
+
+import abc
+import os
+import socket
+import subprocess
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from teatree.core.overlay import OverlayBase
+from teatree.core.readiness import Probe, ProbeResult, run_probes
+from teatree.utils import git
+from teatree.utils.run import spawn
+
+
+def git_clean_env() -> dict[str, str]:
+    """Process env with every ``GIT_*`` override stripped.
+
+    The pre-commit ``pytest`` hook runs under an outer ``git commit`` that
+    exports ``GIT_DIR`` / ``GIT_INDEX_FILE`` / ``GIT_WORK_TREE``. A child
+    ``git`` (or ``uv run pytest`` that shells out to git) inherits these and
+    hijacks itself onto the outer repo's index instead of the tmp worktree.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def free_tcp_port() -> int:
+    """Bind to port 0, read the OS-assigned port, release it.
+
+    The brief release-then-reuse race is acceptable for a test harness — the
+    server claims the port within milliseconds and a collision merely fails
+    the boot probe rather than corrupting state.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@dataclass
+class ProvisionedWorktree:
+    """A real git worktree plus the runtime state a probe needs.
+
+    ``extra['ports']`` mirrors what ``WorktreeStartRunner`` stores on a real
+    ``Worktree`` model, so an overlay's ``get_readiness_probes`` consumes it
+    unchanged. ``servers`` are the spawned processes the teardown reaps.
+    """
+
+    path: Path
+    repo: str
+    ports: dict[str, int] = field(default_factory=dict)
+    servers: list[subprocess.Popen[str]] = field(default_factory=list)
+
+    @property
+    def extra(self) -> dict[str, object]:
+        return {"worktree_path": str(self.path), "ports": dict(self.ports)}
+
+
+class ProvisioningIntegrationBase(abc.ABC):
+    """Provision → DB-test → start → assert-reachable, on real artifacts."""
+
+    @abc.abstractmethod
+    def overlay(self) -> OverlayBase: ...
+
+    @abc.abstractmethod
+    def workspace_repos(self) -> list[str]: ...
+
+    @abc.abstractmethod
+    def concurrency(self) -> int: ...
+
+    @abc.abstractmethod
+    def time_cap_seconds(self) -> float: ...
+
+    @abc.abstractmethod
+    def db_touch_test_command(self, wt: ProvisionedWorktree) -> Sequence[str]:
+        """A ``pytest <nodeid>`` argv that touches the DB.
+
+        It must NOT start Django/a server — DB reachability is asserted on
+        its own, before the long-lived server process is spawned.
+        """
+
+    def db_test_timeout_seconds(self) -> float:
+        """Hard timeout for the DB-test subprocess.
+
+        Decoupled from :meth:`time_cap_seconds` (the concurrency-budget
+        assertion): a slow CI box may take longer than the budget to spin up
+        a fresh interpreter without the harness being broken, so the
+        subprocess gets generous headroom while ``@pytest.mark.timeout`` on
+        the test class remains the true hang guard.
+        """
+        return 60.0
+
+    @abc.abstractmethod
+    def readiness_probes(self, wt: ProvisionedWorktree) -> list[Probe]:
+        """HTTP probes proving the started runtime actually serves."""
+
+    @abc.abstractmethod
+    def _start(self, wt: ProvisionedWorktree) -> None:
+        """Start the server(s) for *wt*, recording each into ``wt.servers``."""
+
+    def _provision(self, root: Path, repo: str) -> ProvisionedWorktree:
+        wt_path = root / repo
+        wt_path.mkdir(parents=True, exist_ok=True)
+        git.run_strict(repo=str(wt_path), args=["init", "-q", "-b", "main"])
+        return ProvisionedWorktree(path=wt_path, repo=repo)
+
+    def _run_db_test(self, wt: ProvisionedWorktree) -> None:
+        cmd = list(self.db_touch_test_command(wt))
+        result = subprocess.run(
+            cmd,
+            env=git_clean_env(),
+            capture_output=True,
+            text=True,
+            timeout=self.db_test_timeout_seconds(),
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"DB-touching test failed ({' '.join(cmd)}):\n"
+            f"--- stdout ---\n{result.stdout[-2000:]}\n"
+            f"--- stderr ---\n{result.stderr[-2000:]}"
+        )
+
+    def _assert_reachable(self, wt: ProvisionedWorktree) -> None:
+        probes = self.readiness_probes(wt)
+        assert probes, f"no readiness probes declared for {wt.repo}"
+        results: list[ProbeResult] = run_probes(probes)
+        failures = [r for r in results if not r.passed]
+        assert not failures, "; ".join(r.format() for r in failures)
+
+    def _teardown(self, wt: ProvisionedWorktree) -> None:
+        for server in wt.servers:
+            if server.poll() is None:
+                server.terminate()
+                try:
+                    server.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    server.kill()
+                    server.wait(timeout=10)
+
+    def run_one_worktree(self, wt: ProvisionedWorktree) -> None:
+        self._run_db_test(wt)
+        self._start(wt)
+        self._assert_reachable(wt)
+
+    def _spawn_server(
+        self,
+        cmd: Sequence[str],
+        *,
+        cwd: Path,
+        env_overrides: dict[str, str] | None = None,
+    ) -> subprocess.Popen[str]:
+        env = git_clean_env()
+        env.update(env_overrides or {})
+        return spawn(
+            cmd,
+            env=env,
+            cwd=cwd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    def provision_all(
+        self,
+        root: Path,
+        register_finalizer: Callable[[Callable[[], None]], None],
+    ) -> list[ProvisionedWorktree]:
+        """Provision every workspace repo, registering teardown BEFORE start.
+
+        The finalizer is wired the instant the worktree exists — so a worktree
+        that later fails to start is still reaped.
+        """
+        worktrees: list[ProvisionedWorktree] = []
+        for repo in self.workspace_repos():
+            wt = self._provision(root, repo)
+            register_finalizer(lambda wt=wt: self._teardown(wt))
+            worktrees.append(wt)
+        return worktrees
+
+    def run_concurrently(self, worktrees: list[ProvisionedWorktree]) -> None:
+        workers = min(self.concurrency(), len(worktrees)) or 1
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            list(pool.map(self.run_one_worktree, worktrees))

--- a/tests/integration/provisioning/_self_settings.py
+++ b/tests/integration/provisioning/_self_settings.py
@@ -1,0 +1,11 @@
+"""Django settings for the teatree-self provisioning integration server.
+
+Extends the project test settings so the booted ``runserver`` accepts the
+loopback host the readiness probe targets. Used only by
+``test_teatree_self.py`` when it spawns a real server subprocess.
+"""
+
+from tests.django_settings import *  # noqa: F403
+
+ALLOWED_HOSTS = ["127.0.0.1", "localhost", "[::1]"]
+DEBUG = False

--- a/tests/integration/provisioning/conftest.py
+++ b/tests/integration/provisioning/conftest.py
@@ -1,0 +1,26 @@
+"""Fixtures for the real-provisioning integration package.
+
+The ``provisioning_root`` fixture hands the test a clean tmp directory and a
+``register_finalizer`` callback. Subclasses register a per-worktree teardown
+through it at creation time (before any start attempt), so every spawned
+server is reaped even when a later worktree fails to start.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def provisioning_root(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+) -> tuple[Path, Callable[[Callable[[], None]], None]]:
+    root = tmp_path / "workspace"
+    root.mkdir(parents=True, exist_ok=True)
+
+    def register_finalizer(fn: Callable[[], None]) -> None:
+        request.addfinalizer(fn)
+
+    return root, register_finalizer

--- a/tests/integration/provisioning/test_external_overlay.py
+++ b/tests/integration/provisioning/test_external_overlay.py
@@ -1,0 +1,180 @@
+"""Real-provisioning integration test for a registered external overlay.
+
+The companion to ``test_teatree_self.py``: where that test pins the bundled
+overlay, this one exercises whatever *external* full-stack overlay is
+installed (an overlay that owns multiple repos — a backend, a frontend, a
+microservice) entirely through the :class:`~teatree.core.overlay.OverlayBase`
+ABC. It stays overlay-agnostic on purpose — it names no overlay, no client,
+no repo — so the same harness validates any third-party overlay's real
+provisioning and the public repo carries no overlay-specific identifiers
+(BLUEPRINT § 1).
+
+Concurrency 1: one workspace, one fast DB-touching test, then every service
+the overlay declares is started and asserted reachable through
+``overlay.get_readiness_probes``.
+
+Heavy and environment-bound, so it is skipped unless ALL hold: ``docker``
+is on ``PATH`` (an external full-stack overlay starts its services via
+compose); exactly one external (non-bundled) overlay is registered,
+instantiable, declares more than one on-disk workspace repo; and
+``T3_EXTERNAL_OVERLAY_INTEGRATION=1`` is set (explicit opt-in).
+
+The skip lives here, not in ``src/``, so default CI stays green and the 93%
+coverage gate is untouched.
+"""
+
+import os
+import shutil
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from teatree.config import discover_overlays, load_config
+from teatree.core.overlay import OverlayBase, RunCommand
+from teatree.core.overlay_loader import get_overlay
+from teatree.core.readiness import Probe
+from teatree.core.runners.worktree_start import compose_project
+from teatree.utils.ports import get_worktree_ports
+
+from ._base import ProvisionedWorktree, ProvisioningIntegrationBase
+
+_BUNDLED_OVERLAY = "t3-teatree"
+_TIME_CAP_SECONDS = 120.0
+_MULTI_REPO_THRESHOLD = 1
+
+
+@dataclass
+class _ProbeWorktree:
+    """Minimal ``Worktree`` stand-in for the overlay's ABC hooks.
+
+    Overlays read only ``repo_path``, ``worktree_path`` (via ``extra``), and
+    ``extra['ports']`` from the worktree they're handed; a real model row
+    would drag in the FSM and DB lifecycle this harness does not exercise.
+    """
+
+    repo_path: str
+    extra: dict[str, object] = field(default_factory=dict)
+    ticket: object | None = None
+
+    @property
+    def worktree_path(self) -> str:
+        return str(self.extra.get("worktree_path", ""))
+
+
+def _external_overlay_name() -> str:
+    from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+
+    workspace_dir = load_config().user.workspace_dir.expanduser()
+    instantiable = set(get_all_overlays())
+    candidates: list[str] = []
+    for entry in discover_overlays():
+        if entry.name == _BUNDLED_OVERLAY or entry.name not in instantiable:
+            continue
+        if entry.project_path is None or not (workspace_dir / entry.project_path.name).is_dir():
+            continue
+        candidates.append(entry.name)
+    return candidates[0] if len(candidates) == 1 else ""
+
+
+def _resolvable_repos(overlay: OverlayBase) -> list[str]:
+    workspace_dir = load_config().user.workspace_dir.expanduser()
+    return [repo for repo in overlay.get_workspace_repos() if (workspace_dir / Path(repo).name).is_dir()]
+
+
+def _skip_reason() -> str:
+    if os.environ.get("T3_EXTERNAL_OVERLAY_INTEGRATION") != "1":
+        return "set T3_EXTERNAL_OVERLAY_INTEGRATION=1 to run the external-overlay provisioning integration test"
+    if shutil.which("docker") is None:
+        return "docker not on PATH"
+    name = _external_overlay_name()
+    if not name:
+        return "no single instantiable external overlay with an on-disk project is registered"
+    overlay = get_overlay(name)
+    if len(_resolvable_repos(overlay)) <= _MULTI_REPO_THRESHOLD:
+        return f"external overlay {name!r} has fewer than two repos resolvable on disk"
+    return ""
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(150)
+@pytest.mark.skipif(bool(_skip_reason()), reason=_skip_reason() or "external-overlay prerequisites met")
+class TestExternalOverlayProvisioning(ProvisioningIntegrationBase):
+    def overlay(self) -> OverlayBase:
+        return get_overlay(_external_overlay_name())
+
+    def workspace_repos(self) -> list[str]:
+        return ["workspace"]
+
+    def concurrency(self) -> int:
+        return 1
+
+    def time_cap_seconds(self) -> float:
+        return _TIME_CAP_SECONDS
+
+    def _backend_root(self) -> Path:
+        workspace_dir = load_config().user.workspace_dir.expanduser()
+        return workspace_dir / Path(_resolvable_repos(self.overlay())[0]).name
+
+    def db_touch_test_command(self, wt: ProvisionedWorktree) -> Sequence[str]:
+        backend = self._backend_root()
+        return [
+            "docker",
+            "compose",
+            "-f",
+            str(backend / "docker-compose.yml"),
+            "run",
+            "--rm",
+            "web",
+            "python",
+            "manage.py",
+            "migrate",
+            "--check",
+        ]
+
+    def _probe_worktree(self, repo: str, ports: dict[str, int]) -> _ProbeWorktree:
+        workspace_dir = load_config().user.workspace_dir.expanduser()
+        return _ProbeWorktree(
+            repo_path=repo,
+            extra={"worktree_path": str(workspace_dir), "ports": dict(ports)},
+        )
+
+    def readiness_probes(self, wt: ProvisionedWorktree) -> list[Probe]:
+        overlay = self.overlay()
+        probes: list[Probe] = []
+        for repo in _resolvable_repos(overlay):
+            probes.extend(overlay.get_readiness_probes(self._probe_worktree(repo, wt.ports)))
+        return probes
+
+    def _start(self, wt: ProvisionedWorktree) -> None:
+        overlay = self.overlay()
+        workspace_dir = load_config().user.workspace_dir.expanduser()
+        commands = overlay.get_run_commands(self._probe_worktree(_resolvable_repos(overlay)[0], wt.ports))
+        for command in commands.values():
+            if isinstance(command, RunCommand):
+                args = [str(a) for a in command.args]
+                cwd = command.cwd or workspace_dir
+            else:
+                args = [str(a) for a in command]
+                cwd = workspace_dir
+            wt.servers.append(self._spawn_server(args, cwd=Path(cwd)))
+        backend = self._backend_root()
+        project = compose_project(_ProbeWorktree(repo_path=backend.name))
+        wt.ports.update(get_worktree_ports(project, compose_file=str(backend / "docker-compose.yml")))
+
+    def test_workspace_provisions_serves_reachable(
+        self,
+        provisioning_root: tuple[Path, Callable[[Callable[[], None]], None]],
+    ) -> None:
+        root, register_finalizer = provisioning_root
+        worktrees = self.provision_all(root, register_finalizer)
+        assert len(worktrees) == 1
+
+        import time  # noqa: PLC0415
+
+        start = time.monotonic()
+        self.run_concurrently(worktrees)
+        elapsed = time.monotonic() - start
+
+        assert elapsed <= self.time_cap_seconds(), f"took {elapsed:.1f}s, cap {self.time_cap_seconds()}s"

--- a/tests/integration/provisioning/test_teatree_self.py
+++ b/tests/integration/provisioning/test_teatree_self.py
@@ -1,0 +1,133 @@
+"""Real-provisioning integration test for the bundled teatree overlay.
+
+Two concurrent real git worktrees, each running one real DB-touching test
+(as its own ``pytest`` subprocess that does NOT boot Django) and then
+booting a real Django ``runserver`` on a distinct OS-assigned port, asserted
+reachable via :func:`teatree.core.readiness.run_probes`. No docker — runs in
+normal CI. The two servers get distinct ports (never hardcode 8000), proving
+the concurrency is genuine; an elapsed-time cap guards against serialization
+or a hang (generous enough to survive a loaded CI box).
+
+The DB-touching probe is :func:`test_db_roundtrip` in this module: each
+worktree's subprocess runs it by node id, exercising a real Django ORM
+round-trip against the test database.
+"""
+
+import sys
+import time
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+import pytest
+from django.test import TestCase
+
+from teatree.contrib.t3_teatree.overlay import TeatreeOverlay
+from teatree.contrib.t3_teatree.overlay import _repo_root as teatree_repo_root
+from teatree.core.models import Ticket
+from teatree.core.overlay import OverlayBase
+from teatree.core.readiness import HTTPProbeSpec, Probe, http_probe
+
+from ._base import ProvisionedWorktree, ProvisioningIntegrationBase, free_tcp_port
+
+_SELF_SETTINGS = "tests.integration.provisioning._self_settings"
+_MODULE_PATH = f"{__name__.replace('.', '/')}.py"
+_DB_TEST_NODEID = f"{_MODULE_PATH}::DbRoundtripTests::test_db_roundtrip"
+
+
+class DbRoundtripTests(TestCase):
+    """The DB-touching test each worktree's subprocess runs by node id.
+
+    A real Django ORM round-trip against the test database — it must not boot
+    a server, so server reachability stays a separate, later assertion.
+    """
+
+    def test_db_roundtrip(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", issue_url="https://example.com/prov-self")
+        assert Ticket.objects.filter(pk=ticket.pk).exists()
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(60)
+class TestTeatreeSelfProvisioning(ProvisioningIntegrationBase):
+    CONCURRENT_WORKTREES = 2
+
+    def overlay(self) -> OverlayBase:
+        return TeatreeOverlay()
+
+    def workspace_repos(self) -> list[str]:
+        return [f"teatree-wt-{i}" for i in range(self.CONCURRENT_WORKTREES)]
+
+    def concurrency(self) -> int:
+        return self.CONCURRENT_WORKTREES
+
+    def time_cap_seconds(self) -> float:
+        return 40.0
+
+    def db_touch_test_command(self, wt: ProvisionedWorktree) -> Sequence[str]:
+        return [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-o",
+            "addopts=",
+            "-p",
+            "no:randomly",
+            "-p",
+            "no:tach",
+            "-p",
+            "no:cacheprovider",
+            "--no-cov",
+            "-q",
+            _DB_TEST_NODEID,
+        ]
+
+    def readiness_probes(self, wt: ProvisionedWorktree) -> list[Probe]:
+        port = wt.ports["backend"]
+        return [
+            http_probe(
+                name=f"{wt.repo}-routing",
+                description="Django runserver is up and routing — webhook view rejects GET with 405",
+                spec=HTTPProbeSpec(
+                    url=f"http://127.0.0.1:{port}/hooks/slack/",
+                    expected_status=405,
+                    retries=20,
+                    retry_delay=0.25,
+                    timeout_seconds=2.0,
+                ),
+            ),
+        ]
+
+    def _start(self, wt: ProvisionedWorktree) -> None:
+        port = free_tcp_port()
+        wt.ports["backend"] = port
+        repo_root = teatree_repo_root()
+        server = self._spawn_server(
+            [
+                sys.executable,
+                str(repo_root / "manage.py"),
+                "runserver",
+                f"127.0.0.1:{port}",
+                "--noreload",
+                "--skip-checks",
+            ],
+            cwd=repo_root,
+            env_overrides={"DJANGO_SETTINGS_MODULE": _SELF_SETTINGS},
+        )
+        wt.servers.append(server)
+
+    def test_two_worktrees_provision_serve_concurrently(
+        self,
+        provisioning_root: tuple[Path, Callable[[Callable[[], None]], None]],
+    ) -> None:
+        root, register_finalizer = provisioning_root
+        worktrees = self.provision_all(root, register_finalizer)
+        assert len(worktrees) == self.CONCURRENT_WORKTREES
+
+        start = time.monotonic()
+        self.run_concurrently(worktrees)
+        elapsed = time.monotonic() - start
+
+        ports = {wt.ports["backend"] for wt in worktrees}
+        assert len(ports) == self.CONCURRENT_WORKTREES, "worktrees must bind distinct ports"
+        assert 8000 not in ports, "port must be OS-assigned, never the hardcoded default"
+        assert elapsed <= self.time_cap_seconds(), f"took {elapsed:.1f}s, cap {self.time_cap_seconds()}s"


### PR DESCRIPTION
## What

Real-provisioning integration tests on a shared abstract base, extending the docker-mocked provisioning contract test to **real servers**.

The recurring provisioning-bug class shares one shape: the orchestration *logic* has branch coverage, but the *provisioned, serving reality* is never asserted. `tests/teatree_core/test_provisioning_contract.py` pins the logic with the docker/subprocess seams mocked; this package provisions a real worktree, runs a real DB-touching test inside it, starts the real server(s), and asserts they actually serve over HTTP.

## How

`tests/integration/provisioning/_base.py` — `ProvisioningIntegrationBase(abc.ABC)`. A subclass declares which overlay, how many concurrent worktrees, the time cap, the DB-touching test, and the readiness probes. The concrete machinery:

- provisions a real git worktree (`GIT_*`-stripped env);
- runs the DB test as its **own** `pytest` subprocess by node id — Django is never booted inside it;
- starts the server(s), then asserts reachability through `teatree.core.readiness.run_probes`, reusing `HTTPProbeSpec` retry/backoff for the server-boot wait (no fixed sleep);
- registers teardown finalizers **per worktree at creation**, before the start attempt, so a half-started worktree is still reaped.

`test_teatree_self.py` — the bundled `TeatreeOverlay`, **two concurrent** real worktrees, each running one DB round-trip then booting Django `runserver` on a **distinct OS-assigned port** (never the hardcoded 8000), asserted reachable (webhook view rejects GET with 405). No docker — runs in normal CI. The DB-test subprocess overrides the project `addopts` (drops `--doctest-modules`, which would re-import the whole tree, and the cache provider so it never writes on a read-only CI filesystem). The elapsed cap is generous enough to survive a loaded CI box while still catching serialization or a hang; the subprocess timeout is decoupled from that cap.

`test_external_overlay.py` — deliberately **overlay-agnostic**: it names no overlay, client, or repo, so the public repo's banned-terms / no-overlay-leak gate stays satisfied. It discovers whatever single external full-stack overlay is registered with on-disk repos and exercises it entirely through the `OverlayBase` ABC (concurrency 1, one workspace, backend + frontend + microservice). Env-gated — skipped unless `docker` is on `PATH`, a resolvable external overlay is registered, and `T3_EXTERNAL_OVERLAY_INTEGRATION=1` — so default CI stays green and the 93% coverage gate is untouched (skip logic lives in the test module, not `src/`).

Reuses the existing `integration` marker (no new markers under `--strict-markers`). The harness is thin, so it adds nothing to the `src` coverage denominator.

## Test evidence

Self test green + external test collected and skipped (not errored):

```
tests/integration/provisioning/test_teatree_self.py::DbRoundtripTests::test_db_roundtrip PASSED
tests/integration/provisioning/test_teatree_self.py::TestTeatreeSelfProvisioning::test_two_worktrees_provision_serve_concurrently PASSED
  GET http://127.0.0.1:<port-a>/hooks/slack/ "HTTP/1.1 405 Method Not Allowed"
  GET http://127.0.0.1:<port-b>/hooks/slack/ "HTTP/1.1 405 Method Not Allowed"
tests/integration/provisioning/test_external_overlay.py::TestExternalOverlayProvisioning::test_workspace_provisions_serves_reachable SKIPPED
  (set T3_EXTERNAL_OVERLAY_INTEGRATION=1 to run the external-overlay provisioning integration test)
2 passed, 1 skipped
```

The full pre-push Docker test matrix passed (privacy-leak gate, near-zero-comments gate, banned-terms gate included).
