### PR TITLE
fix(resolve): attribute manual worktrees to their branch ticket + add provision --ticket

### DIFF
--- a/src/teatree/core/management/commands/worktree.py
+++ b/src/teatree/core/management/commands/worktree.py
@@ -22,7 +22,7 @@ from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.readiness import run_and_report_probes
-from teatree.core.resolve import resolve_worktree
+from teatree.core.resolve import _ticket_by_number, resolve_worktree
 from teatree.core.runners import (
     WorktreeProvisionRunner,
     WorktreeStartRunner,
@@ -127,6 +127,10 @@ class Command(TyperCommand):
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
         variant: str = typer.Option("", help="Tenant variant. Updates ticket if provided."),
         overlay: str = typer.Option("", help="Overlay name (auto-detects if empty)."),
+        ticket: str = typer.Option(
+            "",
+            help="Pin attribution to this ticket number (overrides auto-register for a manual worktree).",
+        ),
         slow_import: bool = typer.Option(  # noqa: FBT001
             default=False,
             help="Allow slow DB fallbacks (pg_restore, remote dump). DSLR-only by default.",
@@ -138,14 +142,20 @@ class Command(TyperCommand):
         CREATED → PROVISIONED and enqueues ``execute_worktree_provision``;
         the runner also runs synchronously here so the operator sees
         immediate output. Idempotent — re-running is safe.
+
+        ``--ticket`` pins attribution: a manually-added worktree
+        (``git worktree add``) has no DB row, so resolution would auto-register
+        and could cross-attach to an unrelated workspace sibling. The flag
+        binds it to the named ticket instead.
         """
         variant, overlay_name = _resolve_typer_defaults(variant, overlay)
         if overlay_name:
             os.environ["T3_OVERLAY_NAME"] = overlay_name
-        worktree = resolve_worktree(path)
-        ticket = Ticket.objects.get(pk=worktree.ticket.pk)
+        ticket_hint = self._resolve_ticket_hint(ticket)
+        worktree = resolve_worktree(path, ticket_hint=ticket_hint)
+        ticket_obj = Ticket.objects.get(pk=worktree.ticket.pk)
 
-        _update_ticket_variant(ticket, variant)
+        _update_ticket_variant(ticket_obj, variant)
         # _update_ticket_variant mutated the ticket + worktree rows through
         # separate instances; reload so this worktree's cached ticket FK and
         # db_name reflect the new variant before provision() and the env render
@@ -155,7 +165,7 @@ class Command(TyperCommand):
         resolved_overlay = get_overlay()
         if resolved_overlay.uses_redis():
             redis_container.ensure_running(db_count=load_config().user.redis_db_count)
-            Ticket.objects.allocate_redis_slot(ticket)
+            Ticket.objects.allocate_redis_slot(ticket_obj)
         validate_docker_service_contract(resolved_overlay, worktree)
         _build_base_images(resolved_overlay, worktree, writer=self.stdout.write)
 
@@ -171,6 +181,16 @@ class Command(TyperCommand):
             self.stderr.write(f"  Provision failed for {worktree.repo_path}")
             raise SystemExit(1)
         return int(worktree.pk)
+
+    def _resolve_ticket_hint(self, ticket: str) -> Ticket | None:
+        """Resolve the ``--ticket`` number to a Ticket, or raise if it is unknown."""
+        if not ticket:
+            return None
+        hint = _ticket_by_number(ticket)
+        if hint is None:
+            self.stderr.write(f"  No ticket found for --ticket {ticket}")
+            raise SystemExit(1)
+        return hint
 
     def _check_readiness_probes(self, worktree: Worktree, overlay: OverlayBase) -> None:
         """Run overlay readiness probes; raise SystemExit(1) on any failure.

--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -13,6 +13,7 @@ across the ``uv --directory`` subprocess chain.
 
 import logging
 import os
+import re
 from pathlib import Path
 
 from teatree.core.models import Ticket, Worktree
@@ -20,6 +21,10 @@ from teatree.core.worktree_env import CACHE_FILENAME
 from teatree.utils import git
 
 logger = logging.getLogger(__name__)
+
+# Leading ``<number>`` of a ``<number>-<slug>`` branch (after an optional
+# ``<scope>/``); digits buried later in the slug never match (see the parser).
+_LEADING_TICKET_NUMBER = re.compile(r"^(?:[^/]*/)?(\d+)(?:-|$)")
 
 
 class WorktreeNotFoundError(RuntimeError):
@@ -112,7 +117,45 @@ def _match_worktree_by_path(path: str) -> Worktree | None:
     return None
 
 
-def _auto_register_from_git(cwd: str) -> Worktree | None:
+def _ticket_number_from_branch(branch: str) -> str | None:
+    """Return the ticket number a ``<number>-<slug>`` branch encodes, or None.
+
+    Mirrors ``workspace._build_branch_name``: the number is the leading
+    segment (optionally after a ``<scope>/`` prefix). Digits that appear
+    later in the slug are not a ticket number and must not match.
+    """
+    match = _LEADING_TICKET_NUMBER.match(branch)
+    return match.group(1) if match else None
+
+
+def _ticket_by_number(number: str) -> Ticket | None:
+    """Return the non-synthetic ticket whose ``ticket_number`` is *number*.
+
+    ``ticket_number`` is a derived property (trailing digits of ``issue_url``,
+    else the pk), so the match is done in Python over real tickets — synthetic
+    ``auto:`` rows are excluded so a hint never resolves back to a placeholder.
+    """
+    for ticket in Ticket.objects.exclude(issue_url="").exclude(issue_url__startswith="auto:"):
+        if ticket.ticket_number == number:
+            return ticket
+    return None
+
+
+def _ticket_owning_branch(branch: str) -> Ticket | None:
+    """Return the ticket whose ``ticket_number`` the branch encodes, or None.
+
+    A manually-added worktree (``git worktree add`` without ``workspace
+    ticket``) has no Worktree row yet, but its branch already names the
+    ticket. Matching on that number attaches the worktree to the correct
+    ticket instead of the most-recent workspace sibling.
+    """
+    number = _ticket_number_from_branch(branch)
+    if number is None:
+        return None
+    return _ticket_by_number(number)
+
+
+def _auto_register_from_git(cwd: str, ticket_hint: Ticket | None = None) -> Worktree | None:
     """Detect a git worktree from the filesystem and auto-register it in the DB.
 
     Reuses an existing Worktree row keyed by branch + repo before falling
@@ -120,6 +163,13 @@ def _auto_register_from_git(cwd: str) -> Worktree | None:
     ticket rows when a real-ticket worktree exists but its
     ``extra["worktree_path"]`` is missing or stale (which would make
     ``_match_worktree_by_path`` miss it).
+
+    Ticket attribution for a manually-added worktree resolves in order:
+    an explicit *ticket_hint* (the ``--ticket`` flag), the branch-encoded
+    ticket number (``_ticket_owning_branch``), the workspace-dir owner
+    (``_workspace_owner_ticket``), then a fresh ``auto:<branch>`` ticket. The
+    hint and branch number win first so a manual worktree never cross-attaches
+    to an unrelated sibling under the same workspace dir.
     """
     cwd_path = Path(cwd).resolve()
     git_file = cwd_path / ".git"
@@ -141,7 +191,9 @@ def _auto_register_from_git(cwd: str) -> Worktree | None:
         return existing
 
     ticket = (
-        _workspace_owner_ticket(cwd_path)
+        ticket_hint
+        or _ticket_owning_branch(branch)
+        or _workspace_owner_ticket(cwd_path)
         or Ticket.objects.get_or_create(
             issue_url=f"auto:{branch}",
             defaults={"variant": "", "repos": [repo_name]},
@@ -236,7 +288,33 @@ def _warn_cwd_mismatch(worktree: Worktree, cwd: str) -> None:
         )
 
 
-def resolve_worktree(path: str = "") -> Worktree:
+def _rebind_ticket_if_synthetic(worktree: Worktree, ticket_hint: Ticket) -> None:
+    """Re-attach *worktree* to *ticket_hint* when its current ticket is synthetic.
+
+    An explicit ``--ticket`` correction only overrides auto-registration: a
+    worktree already bound to a real ticket is left alone (the caller's hint
+    cannot silently steal a correctly-attributed worktree), but one stuck on
+    a placeholder ``auto:`` ticket is rebound to the named ticket.
+    """
+    current = worktree.ticket
+    if current.pk == ticket_hint.pk:
+        return
+    if not current.issue_url.startswith("auto:"):
+        return
+    worktree.ticket = ticket_hint
+    worktree.save(update_fields=["ticket"])
+
+
+def _finalize_matched(worktree: Worktree, cwd: str, ticket_hint: Ticket | None) -> Worktree:
+    """Apply the guards + optional ticket rebind shared by every DB-matched path."""
+    _reject_main_clone(worktree)
+    _warn_cwd_mismatch(worktree, cwd)
+    if ticket_hint is not None:
+        _rebind_ticket_if_synthetic(worktree, ticket_hint)
+    return worktree
+
+
+def resolve_worktree(path: str = "", ticket_hint: Ticket | None = None) -> Worktree:
     """Resolve a worktree from *path* or the user's CWD.
 
     Raises ``WorktreeNotFoundError`` if no worktree can be found or if
@@ -244,6 +322,10 @@ def resolve_worktree(path: str = "") -> Worktree:
 
     Logs a warning when the resolved worktree path doesn't contain the
     user's CWD, which may indicate the wrong worktree was matched.
+
+    *ticket_hint* (the ``worktree provision --ticket`` flag) pins the ticket
+    a newly-auto-registered worktree attaches to, and rebinds an already-
+    resolved worktree that is stuck on a synthetic ``auto:`` ticket.
     """
     cwd = str(Path(path).resolve()) if path else _get_user_cwd()
 
@@ -256,19 +338,15 @@ def resolve_worktree(path: str = "") -> Worktree:
         if ticket_dir:
             wt = _match_worktree_by_path(ticket_dir)
             if wt is not None:  # pragma: no branch
-                _reject_main_clone(wt)
-                _warn_cwd_mismatch(wt, cwd)
-                return wt
+                return _finalize_matched(wt, cwd, ticket_hint)
 
     # 2. Match CWD directly against stored worktree paths
     wt = _match_worktree_by_path(cwd)
     if wt is not None:
-        _reject_main_clone(wt)
-        _warn_cwd_mismatch(wt, cwd)
-        return wt
+        return _finalize_matched(wt, cwd, ticket_hint)
 
     # 3. Detect git worktree from filesystem and auto-register
-    wt = _auto_register_from_git(cwd)
+    wt = _auto_register_from_git(cwd, ticket_hint=ticket_hint)
     if wt is not None:
         return wt
 

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -184,6 +184,78 @@ class TestLifecycleCommands(TestCase):
             assert not Worktree.objects.filter(pk=worktree_id).exists()
 
 
+class TestProvisionTicketFlag(TestCase):
+    """``worktree provision --ticket`` pins attribution to a named ticket.
+
+    A manually-added git worktree (``git worktree add``, no ``workspace
+    ticket``) has no Worktree row. Resolution would auto-register and could
+    cross-attach to an unrelated workspace sibling. ``--ticket <number>``
+    overrides the heuristic and binds the worktree to the named ticket.
+    """
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_ticket_flag_pins_attribution_for_manual_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            # A sibling worktree for an unrelated ticket under the same parent.
+            sibling_ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/999")
+            sibling_path = tmp_path / "sibling-backend"
+            sibling_path.mkdir()
+            (sibling_path / ".git").write_text("gitdir: /some/.git/worktrees/sibling-backend\n")
+            Worktree.objects.create(
+                ticket=sibling_ticket,
+                overlay="test",
+                repo_path="sibling-backend",
+                branch="999-unrelated",
+                extra={"worktree_path": str(sibling_path)},
+            )
+
+            target_ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/321")
+
+            # The manual worktree: a git worktree marker, no Worktree row, on a
+            # branch whose number does not name the target ticket — so only the
+            # explicit --ticket flag can attribute it correctly.
+            manual_path = tmp_path / "manual-backend"
+            manual_path.mkdir()
+            (manual_path / ".git").write_text("gitdir: /some/.git/worktrees/manual-backend\n")
+
+            mock_config = MagicMock()
+            mock_config.user.workspace_dir = tmp_path
+
+            with (
+                patch.dict("os.environ", {"T3_ORIG_CWD": str(manual_path)}),
+                patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
+                patch.object(utils_run_mod, "subprocess") as mock_sp,
+                patch("teatree.core.resolve.git.current_branch", return_value="no-number-branch"),
+                patch("teatree.utils.redis_container.ensure_running"),
+                patch("teatree.config.load_config", return_value=mock_config),
+            ):
+                mock_sp.run.return_value = MagicMock(returncode=0)
+                worktree_id = cast("int", call_command("worktree", "provision", "--ticket", "321"))
+
+            wt = Worktree.objects.get(pk=worktree_id)
+            assert wt.ticket_id == target_ticket.pk
+            assert wt.ticket_id != sibling_ticket.pk
+            assert not Ticket.objects.filter(issue_url__startswith="auto:").exists()
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_ticket_flag_for_unknown_number_aborts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manual_path = Path(tmp) / "manual-backend"
+            manual_path.mkdir()
+            (manual_path / ".git").write_text("gitdir: /some/.git/worktrees/manual-backend\n")
+
+            with (
+                patch.dict("os.environ", {"T3_ORIG_CWD": str(manual_path)}),
+                patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
+                pytest.raises(SystemExit),
+            ):
+                call_command("worktree", "provision", "--ticket", "404")
+
+            assert not Worktree.objects.exists()
+
+
 class TestTaskCommands(TestCase):
     @override_settings(**COMMAND_SETTINGS)
     def test_claim_and_complete_work(self) -> None:

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -14,6 +14,8 @@ from teatree.core.resolve import (
     _find_env_cache,
     _match_worktree_by_path,
     _parse_env_file,
+    _ticket_number_from_branch,
+    _ticket_owning_branch,
     _warn_cwd_mismatch,
     _workspace_owner_ticket,
     resolve_worktree,
@@ -566,6 +568,174 @@ class TestAutoRegisterReusesExistingWorktree(TestCase):
 
         assert result is not None
         assert result.ticket.issue_url == "auto:feat/solo"
+
+
+class TestTicketNumberFromBranch:
+    """Parse the ticket number that ``_build_branch_name`` encodes in a branch.
+
+    ``workspace ticket`` names branches ``<number>-<slug>`` (see
+    ``workspace._build_branch_name``). Older/manual branches also use a
+    ``<scope>/<number>-<slug>`` shape. The parser must recover ``<number>``
+    from both so a manually-added worktree attaches to the right ticket.
+    """
+
+    def test_flat_number_slug(self) -> None:
+        assert _ticket_number_from_branch("1180-fix-the-thing") == "1180"
+
+    def test_scoped_number_slug(self) -> None:
+        assert _ticket_number_from_branch("ac/1180-fix-the-thing") == "1180"
+
+    def test_bare_number(self) -> None:
+        assert _ticket_number_from_branch("1180") == "1180"
+
+    def test_no_leading_number_returns_none(self) -> None:
+        assert _ticket_number_from_branch("feat/some-feature") is None
+
+    def test_no_number_at_all_returns_none(self) -> None:
+        assert _ticket_number_from_branch("main") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert _ticket_number_from_branch("") is None
+
+    def test_does_not_match_number_buried_after_words(self) -> None:
+        """The number must be the leading segment, not any digits in the slug."""
+        assert _ticket_number_from_branch("feature-1180-thing") is None
+
+
+class TestTicketOwningBranch(TestCase):
+    """Match a branch to the ticket whose ``ticket_number`` it encodes."""
+
+    def test_matches_ticket_by_trailing_issue_number(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/org/repo/issues/1180")
+
+        assert _ticket_owning_branch("1180-fix-the-thing") == ticket
+
+    def test_returns_none_when_no_ticket_has_that_number(self) -> None:
+        Ticket.objects.create(issue_url="https://github.com/org/repo/issues/42")
+
+        assert _ticket_owning_branch("1180-fix-the-thing") is None
+
+    def test_returns_none_when_branch_has_no_number(self) -> None:
+        Ticket.objects.create(issue_url="https://github.com/org/repo/issues/1180")
+
+        assert _ticket_owning_branch("feat/no-number") is None
+
+
+class TestAutoRegisterAttributesManualWorktreeToBranchTicket(TestCase):
+    """A manually-added worktree must attach to the ticket its branch encodes.
+
+    Bug: ``git worktree add`` (no ``workspace ticket``) drops through
+    ``_auto_register_from_git``. With no matching Worktree row, it used to
+    call ``_workspace_owner_ticket``, which keys on the parent directory and
+    grabs the most-recent *sibling* ticket — misattributing the worktree to
+    an unrelated ticket. The branch name already carries the ticket number
+    (``<number>-<slug>``), so resolution must prefer the ticket that number
+    identifies.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+
+    def _make_git_worktree(self, name: str) -> Path:
+        wt_dir = self._tmp_path / name
+        wt_dir.mkdir()
+        (wt_dir / ".git").write_text(f"gitdir: /some/.git/worktrees/{name}\n")
+        return wt_dir
+
+    def test_branch_ticket_wins_over_sibling_workspace_owner(self) -> None:
+        # A sibling worktree for an unrelated ticket already lives under the
+        # same parent dir — the misattribution trap.
+        sibling_ticket = Ticket.objects.create(issue_url="https://github.com/org/repo/issues/999")
+        sibling = self._make_git_worktree("sibling-repo")
+        Worktree.objects.create(
+            ticket=sibling_ticket,
+            repo_path="sibling-repo",
+            branch="999-unrelated",
+            extra={"worktree_path": str(sibling)},
+        )
+        # The real ticket the manual worktree belongs to.
+        real_ticket = Ticket.objects.create(issue_url="https://github.com/org/repo/issues/1180")
+        manual = self._make_git_worktree("manual-repo")
+
+        with patch("teatree.core.resolve.git.current_branch", return_value="1180-fix-the-thing"):
+            result = _auto_register_from_git(str(manual))
+
+        assert result is not None
+        assert result.ticket_id == real_ticket.pk
+        assert result.ticket_id != sibling_ticket.pk
+        assert not Ticket.objects.filter(issue_url__startswith="auto:").exists()
+
+    def test_falls_back_to_auto_ticket_when_no_branch_ticket_and_no_owner(self) -> None:
+        manual = self._make_git_worktree("manual-repo")
+
+        with patch("teatree.core.resolve.git.current_branch", return_value="1180-fix-the-thing"):
+            result = _auto_register_from_git(str(manual))
+
+        assert result is not None
+        assert result.ticket.issue_url == "auto:1180-fix-the-thing"
+
+
+class TestResolveWorktreeTicketHint(TestCase):
+    """``ticket_hint`` rebinds a synthetic-ticket worktree but never steals a real one."""
+
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        self._monkeypatch = monkeypatch
+        self._tmp_path = tmp_path
+
+    def test_rebinds_worktree_stuck_on_auto_ticket(self) -> None:
+        auto_ticket = Ticket.objects.create(issue_url="auto:some-branch")
+        wt_path = str(self._tmp_path / "backend")
+        wt = Worktree.objects.create(
+            ticket=auto_ticket,
+            repo_path="backend",
+            branch="some-branch",
+            extra={"worktree_path": wt_path},
+        )
+        real_ticket = Ticket.objects.create(issue_url="https://github.com/org/repo/issues/321")
+        self._monkeypatch.setenv("T3_ORIG_CWD", wt_path)
+
+        result = resolve_worktree(ticket_hint=real_ticket)
+
+        assert result.pk == wt.pk
+        result.refresh_from_db()
+        assert result.ticket_id == real_ticket.pk
+
+    def test_noop_when_hint_already_the_current_ticket(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/org/repo/issues/77")
+        wt_path = str(self._tmp_path / "backend")
+        wt = Worktree.objects.create(
+            ticket=ticket,
+            repo_path="backend",
+            branch="77-x",
+            extra={"worktree_path": wt_path},
+        )
+        self._monkeypatch.setenv("T3_ORIG_CWD", wt_path)
+
+        result = resolve_worktree(ticket_hint=ticket)
+
+        assert result.pk == wt.pk
+        result.refresh_from_db()
+        assert result.ticket_id == ticket.pk
+
+    def test_leaves_worktree_on_real_ticket_untouched(self) -> None:
+        real_ticket = Ticket.objects.create(issue_url="https://github.com/org/repo/issues/55")
+        wt_path = str(self._tmp_path / "backend")
+        wt = Worktree.objects.create(
+            ticket=real_ticket,
+            repo_path="backend",
+            branch="55-real",
+            extra={"worktree_path": wt_path},
+        )
+        other_ticket = Ticket.objects.create(issue_url="https://github.com/org/repo/issues/999")
+        self._monkeypatch.setenv("T3_ORIG_CWD", wt_path)
+
+        result = resolve_worktree(ticket_hint=other_ticket)
+
+        assert result.pk == wt.pk
+        result.refresh_from_db()
+        assert result.ticket_id == real_ticket.pk
 
 
 class TestWorkspaceOwnerTicketIsDeterministic(TestCase):


### PR DESCRIPTION
## Problem

A worktree created with a bare `git worktree add` (instead of `workspace ticket`) has no `Worktree` row, so resolution falls through to `_auto_register_from_git`. When no row matched by branch+repo, it called `_workspace_owner_ticket`, which keys on the **parent directory** and grabs the most-recent *sibling* ticket under that workspace dir — cross-attaching the worktree to an unrelated ticket and misnaming its `.t3-env.cache`. There was no branch-name → ticket parsing, and `worktree provision` had no `--ticket` flag to pin attribution explicitly.

## Fix

Ticket attribution for a manually-added worktree now resolves in priority order:

1. an explicit `--ticket` hint (the new `worktree provision --ticket <number>` flag),
2. the ticket the **branch name** encodes — `_build_branch_name` produces `<number>-<slug>` (optionally `<scope>/`-prefixed), parsed by `_ticket_number_from_branch` / `_ticket_owning_branch`,
3. the workspace-dir owner (existing behaviour),
4. a fresh `auto:<branch>` ticket (existing fallback).

`--ticket` also rebinds a worktree that is currently stuck on a synthetic `auto:` ticket, but never steals one already bound to a real ticket.

## Tests (TDD — red before green)

- `_ticket_number_from_branch` parser: flat `1180-slug`, scoped `ac/1180-slug`, bare number, and the negative cases (no leading number, digits buried in the slug).
- `_ticket_owning_branch` matching against existing tickets.
- Integration: a manual worktree with an unrelated sibling under the same workspace dir now attaches to the branch's ticket, not the sibling.
- `provision --ticket` honoring + unknown-ticket abort.
- `ticket_hint` rebind-vs-leave-alone behaviour.

Full `teatree_core` suite: 3405 passed, 12 skipped. New code fully covered (resolve.py 98.1%).