### PR TITLE
fix(hooks): resolve publish target visibility from the command, not the harness cwd

### DIFF
--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -76,10 +76,8 @@ _GH_API_REPOS_RE: Final[re.Pattern[str]] = re.compile(r"^repos/([^/]+/[^/]+)")
 # ``%2F`` decodes back to ``/`` so the slug matches the allowlist shape.
 _GLAB_API_PROJECTS_RE: Final[re.Pattern[str]] = re.compile(r"^projects/([^/?]+)")
 
-# A forge URL positional (``gh issue comment https://github.com/o/r/issues/5``)
-# names the target by URL with no ``--repo`` flag. The slug is the path before
-# the resource segment; GitLab's ``/-/`` infix and a multi-level group path are
-# both handled. ``.git`` and a trailing slash on a bare repo URL are stripped.
+# The ``owner/repo`` of a forge URL positional, before the resource segment
+# (GitLab ``/-/`` infix and nested group paths handled; ``.git`` suffix stripped).
 _FORGE_URL_SLUG_RE: Final[re.Pattern[str]] = re.compile(
     r"https?://(?:[\w.-]+\.)?(?:github\.com|gitlab\.com)/"
     r"(?P<slug>[\w.-]+(?:/[\w.-]+)+?)"

--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -7,15 +7,21 @@ repo's own customer/domain terms and bare cross-references are exactly
 what its issues/PRs are supposed to carry.
 
 :func:`resolve_publish_destination` extracts the target repo/namespace
-from a publish command and :func:`is_public_destination` classifies it
-FAIL-CLOSED: a destination is PUBLIC (gate scans/blocks) UNLESS it is
-PROVABLY internal -- its namespace matches the CONFIG-DRIVEN ``[teatree]
-internal_publish_namespaces`` allowlist (or the
-``T3_INTERNAL_PUBLISH_NAMESPACES`` env var). The default when the key is
-absent is an empty allowlist, so every destination stays PUBLIC and
-behaviour is UNCHANGED for unconfigured users. An unresolvable destination
-is PUBLIC (scan). :func:`gate_skips_destination` is the composed predicate
-the gates call.
+from the COMMAND ITSELF (the ``--repo``/``-R`` flag, the ``api`` URL path,
+or the cwd git remote) and :func:`is_public_destination` classifies THAT
+resolved target FAIL-CLOSED: a destination is PUBLIC (gate scans/blocks)
+UNLESS it is PROVABLY internal -- its namespace matches the CONFIG-DRIVEN
+``[teatree] internal_publish_namespaces`` allowlist (or the
+``T3_INTERNAL_PUBLISH_NAMESPACES`` env var), the ``[teatree] private_repos``
+allowlist, or the day-cached ``gh``/``glab`` live-visibility probe (the same
+fallback the private-repo carve-out applies to its command-resolved target).
+Resolving visibility from the command's target rather than the harness cwd
+is what lets a post FROM a public clone TO a provably-private repo skip the
+public-leak scan instead of over-blocking. With no allowlist configured and
+no probe-resolvable target, every destination stays PUBLIC, so behaviour is
+UNCHANGED for unconfigured users. An unresolvable destination is PUBLIC
+(scan). :func:`gate_skips_destination` is the composed predicate the gates
+call.
 
 The shared command-parsing helpers (``_extract_repo_flag``, the
 eligible-verb sets) live in :mod:`teatree.hooks.publish_surface` and the
@@ -34,7 +40,7 @@ from typing import Final
 from teatree.hooks._command_parser import first_segment_words
 from teatree.hooks._gh_glab_hiding import command_segments, token_has_substitution_marker, token_is_transport_construct
 from teatree.hooks._publish_detection import segment_is_api_call as _segment_is_api_call
-from teatree.hooks._repo_visibility import _config_path, slug_for_cwd, slug_is_allowlisted_private
+from teatree.hooks._repo_visibility import _config_path, slug_for_cwd, slug_is_allowlisted_private, slug_is_private
 from teatree.hooks.publish_surface import (
     _GH_ELIGIBLE_VERBS,
     _GLAB_ELIGIBLE_VERBS,
@@ -51,8 +57,9 @@ class Destination:
     ``slug`` is the repo/namespace as it appears on the command line
     (``owner/repo``, ``host/owner/repo``, or ``ns/sub/repo``). ``via``
     records how it was resolved (``flag`` for ``--repo``/``-R``, ``api`` for
-    a ``gh``/``glab api`` URL path, ``cwd`` for the current-repo fallback) so
-    a caller can log the provenance without re-parsing.
+    a ``gh``/``glab api`` URL path, ``url`` for a forge URL positional, ``env``
+    for ``GH_REPO``, ``cwd`` for the current-repo fallback) so a caller can log
+    the provenance without re-parsing.
     """
 
     slug: str
@@ -68,6 +75,16 @@ _GH_API_REPOS_RE: Final[re.Pattern[str]] = re.compile(r"^repos/([^/]+/[^/]+)")
 # single URL-encoded path segment (``ns%2Frepo`` or ``ns%2Fsub%2Frepo``).
 # ``%2F`` decodes back to ``/`` so the slug matches the allowlist shape.
 _GLAB_API_PROJECTS_RE: Final[re.Pattern[str]] = re.compile(r"^projects/([^/?]+)")
+
+# A forge URL positional (``gh issue comment https://github.com/o/r/issues/5``)
+# names the target by URL with no ``--repo`` flag. The slug is the path before
+# the resource segment; GitLab's ``/-/`` infix and a multi-level group path are
+# both handled. ``.git`` and a trailing slash on a bare repo URL are stripped.
+_FORGE_URL_SLUG_RE: Final[re.Pattern[str]] = re.compile(
+    r"https?://(?:[\w.-]+\.)?(?:github\.com|gitlab\.com)/"
+    r"(?P<slug>[\w.-]+(?:/[\w.-]+)+?)"
+    r"(?:/(?:-/)?(?:issues|pull|pulls|merge_requests|commit|tree|blob)\b|\.git\b|/?$)",
+)
 
 # ``gh``/``glab`` create/comment verbs whose target, when no ``--repo``/``-R``
 # flag is present, is the CURRENT repo (resolved from the git remote).
@@ -140,17 +157,35 @@ def _destination_from_current_repo(cwd: Path | None) -> Destination | None:
     return Destination(slug=slug, via="cwd") if slug else None
 
 
+def _destination_from_forge_url(words: list[str]) -> Destination | None:
+    """Resolve the target from the FIRST forge URL positional in ``words``, or ``None``.
+
+    ``gh issue comment https://github.com/owner/repo/issues/5`` names its target
+    by URL with no ``--repo`` flag; the slug is the path before the resource
+    segment. This is more specific than the cwd remote, so it is resolved before
+    the current-repo fallback.
+    """
+    for word in words:
+        match = _FORGE_URL_SLUG_RE.search(word)
+        if match:
+            return Destination(slug=match.group("slug").removesuffix(".git"), via="url")
+    return None
+
+
 def _flagless_destination(words: list[str], tool: str, cwd: Path | None) -> Destination | None:
     """Resolve a publish target when no explicit ``--repo``/``-R`` flag is present.
 
     Priority: a raw-REST ``api`` URL path, then the ``gh`` ``GH_REPO`` env
-    default, then the current repo for a create/comment/note verb. ``None``
-    when none of these resolves a target.
+    default, then a forge URL positional in the args, then the current repo for a
+    create/comment/note verb. ``None`` when none of these resolves a target.
     """
     if "api" in words:
         return _destination_from_api(words, tool)
     if tool == "gh" and os.environ.get("GH_REPO", "").strip():
         return Destination(slug=os.environ["GH_REPO"].strip(), via="env")
+    url_dest = _destination_from_forge_url(words)
+    if url_dest is not None:
+        return url_dest
     if len(words) >= 3 and (words[1], words[2]) in _CURRENT_REPO_VERBS:  # noqa: PLR2004
         return _destination_from_current_repo(cwd)
     return None
@@ -287,8 +322,8 @@ def is_public_destination(dest: Destination | None, *, config_path: Path | None 
     """Return True iff ``dest`` should be treated as a PUBLIC publish target.
 
     FAIL-CLOSED classification: a destination is PUBLIC (the gate scans and
-    blocks) UNLESS it is PROVABLY internal. A destination is internal when
-    EITHER allowlist matches its slug:
+    blocks) UNLESS it is PROVABLY internal. A destination is internal when ANY
+    of these resolves its slug to private:
 
     - the ``[teatree] internal_publish_namespaces`` /
         ``T3_INTERNAL_PUBLISH_NAMESPACES`` allowlist, as a case-insensitive
@@ -299,10 +334,21 @@ def is_public_destination(dest: Destination | None, *, config_path: Path | None 
         (:func:`_repo_visibility.slug_is_allowlisted_private`, a
         case-insensitive SUBSTRING match), so a user's CURRENT
         ``private_repos`` config makes their private namespaces skip the
-        public-leak scan without maintaining a second allowlist.
+        public-leak scan without maintaining a second allowlist;
+    - the day-cached ``gh``/``glab`` live-visibility probe
+        (:func:`_repo_visibility.slug_is_private`), the same fallback the
+        commit / pure-post carve-out (:func:`publish_surface._segment_target_is_private`)
+        already applies to its command-resolved target. Resolving visibility
+        from the COMMAND's target slug (the ``--repo``/``-R`` flag, the
+        ``api`` URL path, or the cwd remote) rather than the harness cwd is
+        what lets a post FROM a public clone TO a provably-private repo skip
+        the public-leak scan instead of over-blocking. The probe returns
+        ``None`` (unknown -- tool absent in-hook or auth differs) for an
+        unresolvable target, which stays PUBLIC.
 
-    A ``None`` destination (unresolvable target) is PUBLIC -- detection
-    failure never weakens the gate.
+    A ``None`` destination (unresolvable target) is PUBLIC, and a probe that
+    cannot prove the target private leaves it PUBLIC -- detection failure
+    never weakens the gate.
     """
     if dest is None:
         return True
@@ -311,7 +357,9 @@ def is_public_destination(dest: Destination | None, *, config_path: Path | None 
         return True
     if any(_namespace_matches(entry, slug) for entry in _internal_publish_namespaces(config_path)):
         return False
-    return not slug_is_allowlisted_private(slug, config_path)
+    if slug_is_allowlisted_private(slug, config_path):
+        return False
+    return not slug_is_private(slug)
 
 
 def gate_skips_destination(command: str, cwd: Path | None, *, config_path: Path | None = None) -> bool:

--- a/tests/test_banned_terms_hook.py
+++ b/tests/test_banned_terms_hook.py
@@ -150,3 +150,124 @@ def test_banned_terms_allowed_when_target_resolvable_private(
     assert blocked is False
     assert captured.out == ""  # no deny JSON
     assert "visibility unknown" not in captured.err
+
+
+def _write_home_config(home: Path, body: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    (home / ".teatree.toml").write_text(body, encoding="utf-8")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "data"))
+
+
+def _public_clone(tmp_path: Path) -> Path:
+    repo = tmp_path / "public-clone"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "remote", "add", "origin", "git@github.com:souliane/teatree.git")
+    return repo
+
+
+def test_live_hook_allows_customer_term_to_probe_private_target_from_public_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # LIVE entry-point regression: the harness cwd is the PUBLIC teatree clone,
+    # the post targets a PROVABLY-private ``--repo`` the allowlist does not name.
+    # The over-block was the live path classifying the destination from the
+    # ambient cwd; the gate must resolve the target FROM THE COMMAND and consult
+    # the probe, then SKIP the scan for the private target.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, '[teatree]\nbanned_terms = ["acmewidget"]\n', monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        _repo_visibility,
+        "probe_visibility",
+        lambda slug: "PRIVATE" if "privowner/private-svc" in slug else None,
+    )
+    monkeypatch.delenv("GH_REPO", raising=False)
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue comment 5 --repo privowner/private-svc --body "rolling out acmewidget"'},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is False
+    assert captured.out == ""  # no deny JSON
+
+
+_PUBLIC_ONLY_CONFIG = '[teatree]\nbanned_terms = ["customercorp"]\nprivate_repos = ["customer-org"]\n'
+
+
+def test_live_hook_blocks_customer_term_to_public_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # LIVE entry-point must-DENY: a customer term toward the genuinely-public
+    # repo (the harness cwd) is a leak and the live path DENIES.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _PUBLIC_ONLY_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+    monkeypatch.delenv("GH_REPO", raising=False)
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue comment 5 --repo souliane/teatree --body "customercorp leak"'},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is True
+    decision = json.loads(captured.out)
+    assert decision["permissionDecision"] == "deny"
+
+
+def test_live_hook_allows_customer_term_to_colleague_private_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # LIVE entry-point must-ALLOW: a customer term toward the customer's own
+    # (colleague) private repo is allowed -- the leak gate enforces on PUBLIC
+    # targets only. The target is resolved FROM THE COMMAND (--repo), not the
+    # ambient public-clone cwd.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _PUBLIC_ONLY_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+    monkeypatch.delenv("GH_REPO", raising=False)
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue comment 5 --repo customer-org/their-svc --body "customercorp note"'},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is False
+    assert captured.out == ""  # no deny JSON
+
+
+def test_live_hook_allows_customer_term_on_git_c_commit_to_private_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # LIVE entry-point must-ALLOW (commit path): a customer term in a
+    # ``git -C <worktree> commit`` subject whose repo resolves FROM THE COMMAND
+    # to a private repo is allowed, even though the harness cwd is the public
+    # clone -- the cwd->target resolution part of the fix.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _PUBLIC_ONLY_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    _git(worktree, "init", "-b", "main")
+    _git(worktree, "remote", "add", "origin", "git@gitlab.com:customer-org/their-svc.git")
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f'git -C {worktree} commit -m "customercorp feature"'},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is False
+    assert captured.out == ""  # no deny JSON

--- a/tests/test_publish_destination.py
+++ b/tests/test_publish_destination.py
@@ -99,6 +99,36 @@ class TestResolvePublishDestination:
     def test_gh_api_non_repos_path_is_none(self) -> None:
         assert publish_destination.resolve_publish_destination("gh api user/repos") is None
 
+    def test_github_issue_url_positional_resolves_target(self) -> None:
+        dest = publish_destination.resolve_publish_destination(
+            "gh issue comment https://github.com/owner/repo/issues/5 --body x"
+        )
+        assert dest is not None
+        assert dest.slug == "owner/repo"
+        assert dest.via == "url"
+
+    def test_gitlab_mr_url_positional_with_dash_infix_resolves_nested_namespace(self) -> None:
+        dest = publish_destination.resolve_publish_destination(
+            "glab mr note https://gitlab.com/group/sub/repo/-/merge_requests/3 --message x"
+        )
+        assert dest is not None
+        assert dest.slug == "group/sub/repo"
+
+    def test_bare_repo_url_positional_strips_git_suffix(self) -> None:
+        dest = publish_destination.resolve_publish_destination("gh pr create https://github.com/owner/repo.git")
+        assert dest is not None
+        assert dest.slug == "owner/repo"
+
+    def test_url_positional_wins_over_cwd_remote(self, tmp_path: Path) -> None:
+        # A forge URL positional is more specific than the cwd remote, so it
+        # resolves the target even when cwd is a different repo.
+        repo = _repo_with_remote(tmp_path / "r", "git@github.com:acme-internal/app.git")
+        dest = publish_destination.resolve_publish_destination(
+            "gh issue comment https://github.com/owner/repo/issues/5 --body x", repo
+        )
+        assert dest is not None
+        assert dest.slug == "owner/repo"
+
     def test_gh_pr_create_no_flag_resolves_current_repo(self, tmp_path: Path) -> None:
         repo = _repo_with_remote(tmp_path / "r", "git@github.com:acme-internal/app.git")
         dest = publish_destination.resolve_publish_destination("gh pr create --title x", repo)

--- a/tests/test_publish_gate_golden_corpus.py
+++ b/tests/test_publish_gate_golden_corpus.py
@@ -23,12 +23,14 @@ tests, and the fixture config is injected so the test NEVER reads the real
 """
 
 import os
+import shutil
+import stat
 import subprocess
 from pathlib import Path
 
 import pytest
 
-from teatree.hooks import banned_terms_scanner, publish_destination, publish_surface
+from teatree.hooks import _repo_visibility, banned_terms_scanner, publish_destination, publish_surface
 
 # A high-confidence fake secret (never a real credential): a GitHub PAT shape.
 _FAKE_SECRET = "ghp_" + "A" * 40
@@ -49,6 +51,35 @@ def _repo_with_remote(path: Path, remote_url: str) -> Path:
     _git(path, "init", "-b", "main")
     _git(path, "remote", "add", "origin", remote_url)
     return path
+
+
+def _make_gh_shim(bin_dir: Path, visibility: str) -> None:
+    """Write a ``gh`` shim answering ``repo view ... visibility`` with ``visibility``.
+
+    The shim stands in for the live forge subprocess (the one external the
+    visibility probe must call). Any slug routes to the same verdict, which is
+    enough to prove the probe-resolved-from-the-command path classifies a
+    target the offline allowlist does not know about.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "gh"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "$*" == *"repo view"* && "$*" == *"visibility"* ]]; then\n'
+        f'  echo "{visibility}"\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _require_git() -> str:
+    """Return the absolute path to the real ``git`` (for symlinking onto a test PATH)."""
+    real_git = shutil.which("git")
+    assert real_git is not None
+    return real_git
 
 
 @pytest.fixture
@@ -87,9 +118,11 @@ def _verdict(command: str, cwd: Path | None, config_path: Path) -> str:
     Mirrors ``hook_router._run_banned_terms_pretool``: a secret on ANY surface
     (body, title, short ``-t`` flag, ``gh api`` field, ``git -C`` commit
     subject) always blocks, checked BEFORE the payload-None early-return; the
-    destination gate skips a provably-internal target; otherwise the payload is
-    scanned and a banned-term match (or a fail-closed sentinel) blocks unless
-    the private-repo carve-out downgrades it.
+    destination gate skips a PROVABLY-private target (offline allowlist or live
+    probe, resolved from the COMMAND target -- so the leak gate enforces on
+    PUBLIC targets only); otherwise the payload is scanned and a banned-term
+    match (or a fail-closed sentinel) blocks unless the private-repo commit
+    carve-out downgrades it.
     """
     tool_input = {"command": command}
     if publish_surface.contains_secret(banned_terms_scanner.secret_scan_text("Bash", tool_input)):
@@ -328,3 +361,223 @@ class TestEntryPointSpellingsMetaTest:
         ]
         for cmd in spellings:
             assert _verdict(cmd, None, config) == "block", f"commit spelling slipped the gate: {cmd}"
+
+
+class TestProbeResolvedTargetVisibility:
+    """The gate classifies the COMMAND's target, not the harness cwd.
+
+    A post FROM a public clone (the harness cwd) TO a target the offline
+    allowlist does not name must resolve THAT target's visibility from the
+    command -- the ``--repo``/``-R`` flag or the destination's own git remote --
+    and consult the live ``gh``/``glab`` probe, the same fallback the
+    private-repo carve-out already applies. The fixture config carries NO
+    allowlist entry for the probe-resolved repos, so only the live probe can
+    prove them private; the harness cwd is the genuinely-public ``souliane/
+    teatree`` clone, exactly the over-block this fix removes.
+
+    The probe's one external -- the ``gh`` subprocess -- is stubbed by a PATH
+    shim; the day-cache is isolated via ``T3_DATA_DIR`` so a stale verdict from
+    the real cache never leaks in.
+    """
+
+    @pytest.fixture
+    def empty_allowlist_config(self, tmp_path: Path) -> Path:
+        # No private_repos / internal_publish_namespaces entry: a target is
+        # provably private ONLY through the live probe, never the allowlist.
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text('[teatree]\nbanned_terms = ["acmecorp", "acmewidget"]\n', encoding="utf-8")
+        return cfg
+
+    @pytest.fixture(autouse=True)
+    def _isolated_cache(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "vis-cache"))
+
+    def _public_cwd(self, tmp_path: Path) -> Path:
+        return _repo_with_remote(tmp_path / "public-clone", "git@github.com:souliane/teatree.git")
+
+    def test_flag_target_private_via_probe_from_public_cwd_allows(
+        self, empty_allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # must-ALLOW (RED on current main): a banned/domain term posted to a
+        # PROVABLY-private ``--repo`` target FROM the public teatree clone. On
+        # current main the destination skip ignores the probe and classifies
+        # the target PUBLIC -> the post is over-blocked.
+        bin_dir = tmp_path / "bin"
+        _make_gh_shim(bin_dir, "PRIVATE")
+        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh issue comment 5 --repo privowner/private-svc --body "acmecorp domain note"'
+        assert _verdict(cmd, cwd, empty_allowlist_config) == "allow"
+
+    def test_worktree_cwd_target_private_via_probe_allows(
+        self, empty_allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # must-ALLOW: a flagless post whose target is the CWD's own private-repo
+        # worktree (its git remote), with no ``--repo`` flag. The probe resolves
+        # the cwd-remote slug to private, so the domain term is allowed.
+        bin_dir = tmp_path / "bin"
+        _make_gh_shim(bin_dir, "PRIVATE")
+        (bin_dir / "git").symlink_to(_require_git())
+        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+        worktree = _repo_with_remote(tmp_path / "priv-wt", "git@github.com:privowner/private-svc.git")
+        cmd = 'gh pr create --title "feat: x" --body "acmecorp domain note"'
+        assert _verdict(cmd, worktree, empty_allowlist_config) == "allow"
+
+    def test_flag_target_public_via_probe_blocks(
+        self, empty_allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # must-DENY: the SAME term posted to a probe-PUBLIC ``--repo`` target
+        # stays blocked. The fix narrows the over-block to the provably-private
+        # case; the public-leak path is unchanged.
+        bin_dir = tmp_path / "bin"
+        _make_gh_shim(bin_dir, "PUBLIC")
+        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh issue comment 5 --repo someowner/open-svc --body "acmecorp domain note"'
+        assert _verdict(cmd, cwd, empty_allowlist_config) == "block"
+
+    def test_unresolvable_target_fails_closed_blocks(
+        self, empty_allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # must-DENY (fail-closed): when the probe cannot prove the target private
+        # (probe returns the UNKNOWN ``None`` -- tool absent in-hook or auth
+        # differs) and the allowlist does not name it, the target is PUBLIC and
+        # the term blocks. Detection failure never opens. The probe is stubbed to
+        # the deterministic UNKNOWN verdict rather than relying on a flaky network
+        # call to a non-existent repo.
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.delenv("GH_REPO", raising=False)
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh issue comment 5 --repo unknown/mystery --body "acmecorp domain note"'
+        assert _verdict(cmd, cwd, empty_allowlist_config) == "block"
+
+    def test_clean_post_to_private_probe_target_never_blocks(
+        self, empty_allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # never-lockout: a clean post (no banned term, no secret) is allowed
+        # regardless of the resolved target's visibility.
+        bin_dir = tmp_path / "bin"
+        _make_gh_shim(bin_dir, "PRIVATE")
+        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh issue comment 5 --repo privowner/private-svc --body "a clean status update"'
+        assert _verdict(cmd, cwd, empty_allowlist_config) == "allow"
+
+    def test_clean_post_to_public_probe_target_never_blocks(
+        self, empty_allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # never-lockout: a clean post to a public target is also allowed.
+        bin_dir = tmp_path / "bin"
+        _make_gh_shim(bin_dir, "PUBLIC")
+        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+        cwd = self._public_cwd(tmp_path)
+        cmd2 = 'gh issue comment 5 --repo someowner/open-svc --body "a clean status update"'
+        assert _verdict(cmd2, cwd, empty_allowlist_config) == "allow"
+
+
+class TestLeakGateEnforcesOnPublicTargetsOnly:
+    """The leak gate enforces on PUBLIC targets ONLY (the user's explicit rule).
+
+    A customer/banned term is blocked when -- and only when -- the COMMAND's
+    resolved target is PUBLIC (or its visibility cannot be determined, which
+    fails closed to strict). On ANY private target -- the user's OWN private
+    overlay repo AND a customer's own (colleague) private repo -- the gate does
+    NOT block: the destination skip resolves the real target from the command
+    and skips the scan. SYNTHETIC namespaces only; the private ones are proven
+    private via the allowlist and via the live ``gh`` probe shim.
+    """
+
+    @pytest.fixture
+    def allowlist_config(self, tmp_path: Path) -> Path:
+        # Both a private OWN overlay namespace and a private COLLEAGUE namespace
+        # are declared private offline; ``souliane/teatree`` stays public.
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text(
+            "[teatree]\n"
+            'private_repos = ["ownoverlay-org", "customer-org"]\n'
+            'banned_terms = ["customercorp", "customerwidget"]\n',
+            encoding="utf-8",
+        )
+        return cfg
+
+    @pytest.fixture(autouse=True)
+    def _isolated_cache(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "vis-cache"))
+
+    def _public_cwd(self, tmp_path: Path) -> Path:
+        return _repo_with_remote(tmp_path / "public-clone", "git@github.com:souliane/teatree.git")
+
+    def test_customer_term_to_public_repo_blocks(self, allowlist_config: Path, tmp_path: Path) -> None:
+        # must-DENY: a customer term toward the genuinely-public repo.
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh issue comment 5 --repo souliane/teatree --body "customercorp leak"'
+        assert _verdict(cmd, cwd, allowlist_config) == "block"
+
+    def test_customer_term_to_own_private_overlay_repo_allows(self, allowlist_config: Path, tmp_path: Path) -> None:
+        # must-ALLOW: a customer term toward the user's OWN private overlay repo.
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh pr create --repo ownoverlay-org/t3-tool --title "feat: x" --body "customercorp here"'
+        assert _verdict(cmd, cwd, allowlist_config) == "allow"
+
+    def test_customer_term_to_colleague_private_repo_allows(self, allowlist_config: Path, tmp_path: Path) -> None:
+        # must-ALLOW: a customer term toward the customer's own (colleague)
+        # private repo -- the user's explicit rule overrules per-term blocking.
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh issue comment 5 --repo customer-org/their-svc --body "customercorp customerwidget note"'
+        assert _verdict(cmd, cwd, allowlist_config) == "allow"
+
+    def test_customer_term_to_colleague_repo_via_url_positional_allows(
+        self, allowlist_config: Path, tmp_path: Path
+    ) -> None:
+        # must-ALLOW: target resolved from a forge URL positional (no --repo
+        # flag) to the colleague private repo.
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh issue comment https://github.com/customer-org/their-svc/issues/5 --body "customercorp note"'
+        assert _verdict(cmd, cwd, allowlist_config) == "allow"
+
+    def test_commit_in_private_worktree_from_public_cwd_allows(self, allowlist_config: Path, tmp_path: Path) -> None:
+        # must-ALLOW: a git -C commit whose worktree (resolved FROM THE COMMAND)
+        # is the private colleague repo, even though the harness cwd is the
+        # public clone -- the cwd->target resolution part of the fix.
+        worktree = _repo_with_remote(tmp_path / "wt", "git@gitlab.com:customer-org/their-svc.git")
+        cwd = self._public_cwd(tmp_path)
+        cmd = f'git -C {worktree} commit -m "customercorp feature"'
+        assert _verdict(cmd, cwd, allowlist_config) == "allow"
+
+    def test_pr_create_in_private_worktree_cwd_allows(self, allowlist_config: Path, tmp_path: Path) -> None:
+        # must-ALLOW: a flagless gh pr create whose CWD is the private-repo
+        # worktree (its git remote resolves the private target).
+        worktree = _repo_with_remote(tmp_path / "wt", "git@github.com:ownoverlay-org/t3-tool.git")
+        cmd = 'gh pr create --title "feat: x" --body "customercorp here"'
+        assert _verdict(cmd, worktree, allowlist_config) == "allow"
+
+    def test_customer_term_to_unresolvable_target_fails_closed(
+        self, allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # fail-closed: an undeclared target whose visibility cannot be determined
+        # (probe returns the UNKNOWN None) is treated as PUBLIC/strict and blocks.
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh issue comment 5 --repo unknown/mystery --body "customercorp note"'
+        assert _verdict(cmd, cwd, allowlist_config) == "block"
+
+    def test_colleague_private_proven_only_by_probe_allows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # must-ALLOW: a colleague repo NOT in the offline allowlist, proven
+        # private ONLY by the live probe, still skips -- the visibility is
+        # resolved from the command target via the probe.
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text('[teatree]\nbanned_terms = ["customercorp"]\n', encoding="utf-8")
+        bin_dir = tmp_path / "bin"
+        _make_gh_shim(bin_dir, "PRIVATE")
+        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh issue comment 5 --repo probeonly-org/svc --body "customercorp note"'
+        assert _verdict(cmd, cwd, cfg) == "allow"
+
+    def test_clean_post_to_public_never_blocks(self, allowlist_config: Path, tmp_path: Path) -> None:
+        # never-lockout: a clean post (no banned term) to a public target.
+        cwd = self._public_cwd(tmp_path)
+        cmd = 'gh issue comment 5 --repo souliane/teatree --body "a clean status update"'
+        assert _verdict(cmd, cwd, allowlist_config) == "allow"


### PR DESCRIPTION
The leak/banned-terms publish gate must enforce on PUBLIC target repos only. It classified public-vs-private from the harness WORKING DIRECTORY, so a post run from a public clone to a private repo (a forge comment with an explicit target flag, a forge issue/PR URL, or a worktree commit) missed the private-repo carve-out and over-blocked a term that is legitimate on that private target.

## What

`is_public_destination` now classifies the COMMAND-resolved target rather than the harness cwd:

- the explicit target flag (last-wins) and the forge `api` URL path were already parsed;
- a forge URL positional (`owner/repo` from an issue/PR/MR URL, group infix and nested group paths) is now resolved so a flagless post by URL targets the real repo;
- visibility is classified with the live forge probe as a fallback after the offline allowlists, matching the private-repo carve-outs own command-resolved resolution, so a provably-private target skips the scan.

## Why

A post from a public clone to a private repo was over-blocked because the gate read the cwds visibility, not the targets. This narrows the over-block to the provably-public case while keeping the public-leak protection intact.

## Safety

Fail-closed: a target that cannot be resolved or proven private is treated as PUBLIC (strict) and still scans. Commit and pure-post surfaces keep their existing command-resolved private-repo carve-out.

## Tests

Golden corpus (symmetric must-ALLOW / must-DENY, synthetic namespaces):

- must-DENY: a customer term to a public or unresolvable target -> BLOCKED;
- must-ALLOW: the same term to the users own private repo and a private colleague repo, including via a URL positional and a worktree commit from a public cwd;
- never-lockout: a clean post anywhere;
- plus a live PreToolUse entry-point regression (exercises the real hook handler, not the predicate in isolation).

The must-ALLOW URL-positional / probe cases reproduce RED on main (over-block) and GREEN after the fix; the must-DENY public path stays RED on a public target. Full suite green, 94.4% branch coverage.