### PR TITLE
fix(core): resolve overlay from worktree/ticket in queued workers (#1814)

### DIFF
--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -19,6 +19,7 @@ from django.core.exceptions import ImproperlyConfigured
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from teatree.core.models import Ticket, Worktree
     from teatree.core.overlay import OverlayBase
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,31 @@ def get_overlay(name: str | None = None) -> "OverlayBase":
 
     msg = f"Multiple overlays found ({', '.join(sorted(overlays))}). Pass an explicit name to get_overlay()."
     raise ImproperlyConfigured(msg)
+
+
+def get_overlay_for_ticket(ticket: "Ticket") -> "OverlayBase":
+    """Resolve the overlay a ticket belongs to.
+
+    The queued FSM workers run a ticket's runners in a process where every
+    installed overlay is registered, so a bare :func:`get_overlay` raises
+    ``Multiple overlays found`` (souliane/teatree#1814). The ticket records
+    its own overlay, so resolution is unambiguous regardless of how many
+    overlays are installed; an empty value falls through to the ambient
+    single-overlay default.
+    """
+    return get_overlay(ticket.overlay or None)
+
+
+def get_overlay_for_worktree(worktree: "Worktree") -> "OverlayBase":
+    """Resolve the overlay a worktree belongs to.
+
+    Like :func:`get_overlay_for_ticket` but keyed on the worktree's own
+    ``overlay`` field, falling back to the owning ticket for rows created
+    before the field was populated (souliane/teatree#1814).
+    """
+    if worktree.overlay:
+        return get_overlay(worktree.overlay)
+    return get_overlay_for_ticket(worktree.ticket)
 
 
 def get_overlay_for_repo(repo: str = ".") -> "OverlayBase | None":

--- a/src/teatree/core/runners/service_launch.py
+++ b/src/teatree/core/runners/service_launch.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from teatree.core.overlay_loader import get_overlay
+from teatree.core.overlay_loader import get_overlay_for_worktree
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.core.step_runner import run_provision_steps
 from teatree.types import RunCommand
@@ -25,7 +25,7 @@ class ServiceLauncher(RunnerBase):
     def __init__(self, worktree: "Worktree", service: str, *, overlay: "OverlayBase | None" = None) -> None:
         self.worktree = worktree
         self.service = service
-        self.overlay = overlay or get_overlay()
+        self.overlay = overlay or get_overlay_for_worktree(worktree)
 
     @staticmethod
     def _collect_steps(overlay: "OverlayBase", worktree: "Worktree", services: list[str]) -> "list[ProvisionStep]":
@@ -41,7 +41,7 @@ class ServiceLauncher(RunnerBase):
 
     @classmethod
     def prepare_all(cls, worktree: "Worktree", services: list[str], *, overlay: "OverlayBase | None" = None) -> None:
-        overlay = overlay or get_overlay()
+        overlay = overlay or get_overlay_for_worktree(worktree)
         run_provision_steps(cls._collect_steps(overlay, worktree, services), stop_on_required_failure=False)
 
     def prepare(self) -> None:

--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from teatree.core.models import Worktree
 from teatree.core.overlay import OverlayBase
-from teatree.core.overlay_loader import get_overlay
+from teatree.core.overlay_loader import get_overlay_for_worktree
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.core.step_runner import ProvisionReport, run_provision_steps, run_step
 from teatree.core.worktree_env import CACHE_FILENAME, write_env_cache
@@ -69,7 +69,7 @@ class WorktreeProvisionRunner(RunnerBase):
         slow_import: bool = False,
     ) -> None:
         self.worktree = worktree
-        self.overlay = overlay or get_overlay()
+        self.overlay = overlay or get_overlay_for_worktree(worktree)
         self.slow_import = slow_import
 
     def run(self) -> RunnerResult:

--- a/src/teatree/core/runners/worktree_start.py
+++ b/src/teatree/core/runners/worktree_start.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from teatree.core.models import Worktree
 from teatree.core.overlay import OverlayBase
-from teatree.core.overlay_loader import get_overlay
+from teatree.core.overlay_loader import get_overlay_for_worktree
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.core.runners.service_launch import ServiceLauncher
 from teatree.core.worktree_env import write_env_cache
@@ -74,7 +74,7 @@ class WorktreeStartRunner(RunnerBase):
         timeouts: TimeoutConfig | None = None,
     ) -> None:
         self.worktree = worktree
-        self.overlay = overlay or get_overlay()
+        self.overlay = overlay or get_overlay_for_worktree(worktree)
         self.timeouts = timeouts or load_timeouts(self.overlay)
 
     def run(self) -> RunnerResult:

--- a/src/teatree/core/runners/worktree_verify.py
+++ b/src/teatree/core/runners/worktree_verify.py
@@ -2,7 +2,7 @@ import logging
 
 from teatree.core.models import Worktree
 from teatree.core.overlay import OverlayBase
-from teatree.core.overlay_loader import get_overlay
+from teatree.core.overlay_loader import get_overlay_for_worktree
 from teatree.core.runners.base import RunnerBase, RunnerResult
 
 logger = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ class WorktreeVerifyRunner(RunnerBase):
 
     def __init__(self, worktree: Worktree, *, overlay: OverlayBase | None = None) -> None:
         self.worktree = worktree
-        self.overlay = overlay or get_overlay()
+        self.overlay = overlay or get_overlay_for_worktree(worktree)
 
     def run(self) -> RunnerResult:
         checks = self.overlay.get_health_checks(self.worktree)

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -23,7 +23,7 @@ class TransitionResult(TypedDict, total=False):
 def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
     import traceback  # noqa: PLC0415
 
-    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+    from teatree.core.overlay_loader import get_overlay_for_ticket  # noqa: PLC0415
 
     task_obj = Task.objects.get(pk=task_id)
 
@@ -57,7 +57,7 @@ def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
     try:
         from teatree.agents.headless import run_headless  # noqa: PLC0415
 
-        overlay = get_overlay()
+        overlay = get_overlay_for_ticket(task_obj.ticket)
         attempt = run_headless(
             task_obj,
             phase=phase,

--- a/tests/teatree_core/test_runner_multi_overlay_resolution.py
+++ b/tests/teatree_core/test_runner_multi_overlay_resolution.py
@@ -1,0 +1,130 @@
+"""Worktree-scoped runners must resolve the overlay from the worktree.
+
+Regression for souliane/teatree#1814: with two overlays installed, the
+queued FSM workers built ``WorktreeProvisionRunner(worktree)`` (and the
+start/verify/service-launch siblings) with a bare ``get_overlay()`` that
+cannot disambiguate, so every loop-driven worktree provision crashed with
+``ImproperlyConfigured: Multiple overlays found``. Each runner now resolves
+the overlay the worktree itself records.
+"""
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay import OverlayBase, ProvisionStep, RunCommands
+from teatree.core.overlay_loader import get_overlay, get_overlay_for_ticket, get_overlay_for_worktree
+from teatree.core.runners.service_launch import ServiceLauncher
+from teatree.core.runners.worktree_provision import WorktreeProvisionRunner
+from teatree.core.runners.worktree_start import WorktreeStartRunner
+from teatree.core.runners.worktree_verify import WorktreeVerifyRunner
+
+
+class _NamedOverlay(OverlayBase):
+    def __init__(self, marker: str) -> None:
+        super().__init__()
+        self.marker = marker
+
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        return []
+
+    def get_run_commands(self, worktree: Worktree) -> RunCommands:
+        return {}
+
+
+OVERLAY_A = "overlay-alpha"
+OVERLAY_B = "overlay-beta"
+
+
+class _MultiOverlayTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def _register_both_overlays(self) -> Iterator[None]:
+        self.overlay_a = _NamedOverlay(OVERLAY_A)
+        self.overlay_b = _NamedOverlay(OVERLAY_B)
+        registry = {OVERLAY_A: self.overlay_a, OVERLAY_B: self.overlay_b}
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=registry):
+            yield
+
+    def _worktree(self, *, overlay: str) -> Worktree:
+        ticket = Ticket.objects.create(overlay=overlay, issue_url=f"https://example.com/{overlay}")
+        return Worktree.objects.create(
+            ticket=ticket,
+            overlay=overlay,
+            repo_path="repo",
+            branch="feat-x",
+            extra={"worktree_path": "/tmp/wt"},
+        )
+
+
+class TestMultiOverlayCrash(_MultiOverlayTest):
+    def test_bare_get_overlay_is_ambiguous(self) -> None:
+        with pytest.raises(ImproperlyConfigured, match="Multiple overlays found"):
+            get_overlay()
+
+
+class TestGetOverlayForTicket(_MultiOverlayTest):
+    def test_resolves_ticket_overlay_field(self) -> None:
+        ticket = Ticket.objects.create(overlay=OVERLAY_A, issue_url="https://example.com/t")
+        assert get_overlay_for_ticket(ticket) is self.overlay_a
+
+    def test_blank_overlay_is_still_ambiguous(self) -> None:
+        ticket = Ticket.objects.create(overlay="", issue_url="https://example.com/blank-t")
+        with pytest.raises(ImproperlyConfigured, match="Multiple overlays found"):
+            get_overlay_for_ticket(ticket)
+
+
+class TestGetOverlayForWorktree(_MultiOverlayTest):
+    def test_resolves_worktree_overlay_field(self) -> None:
+        worktree = self._worktree(overlay=OVERLAY_B)
+        assert get_overlay_for_worktree(worktree) is self.overlay_b
+
+    def test_falls_back_to_ticket_overlay_when_field_blank(self) -> None:
+        ticket = Ticket.objects.create(overlay=OVERLAY_A, issue_url="https://example.com/blank")
+        worktree = Worktree.objects.create(
+            ticket=ticket,
+            overlay="",
+            repo_path="repo",
+            branch="feat-x",
+            extra={"worktree_path": "/tmp/wt"},
+        )
+        assert get_overlay_for_worktree(worktree) is self.overlay_a
+
+
+class TestRunnersResolveWorktreeOverlay(_MultiOverlayTest):
+    def test_provision_runner_resolves_worktree_overlay(self) -> None:
+        worktree = self._worktree(overlay=OVERLAY_A)
+        runner = WorktreeProvisionRunner(worktree)
+        assert runner.overlay is self.overlay_a
+
+    def test_provision_runner_resolves_other_overlay(self) -> None:
+        worktree = self._worktree(overlay=OVERLAY_B)
+        runner = WorktreeProvisionRunner(worktree)
+        assert runner.overlay is self.overlay_b
+
+    def test_start_runner_resolves_worktree_overlay(self) -> None:
+        worktree = self._worktree(overlay=OVERLAY_B)
+        runner = WorktreeStartRunner(worktree)
+        assert runner.overlay is self.overlay_b
+
+    def test_verify_runner_resolves_worktree_overlay(self) -> None:
+        worktree = self._worktree(overlay=OVERLAY_A)
+        runner = WorktreeVerifyRunner(worktree)
+        assert runner.overlay is self.overlay_a
+
+    def test_service_launcher_resolves_worktree_overlay(self) -> None:
+        worktree = self._worktree(overlay=OVERLAY_B)
+        launcher = ServiceLauncher(worktree, "backend")
+        assert launcher.overlay is self.overlay_b
+
+    def test_service_launcher_prepare_all_resolves_without_explicit_overlay(self) -> None:
+        worktree = self._worktree(overlay=OVERLAY_A)
+        with patch.object(ServiceLauncher, "_collect_steps", return_value=[]) as collect:
+            ServiceLauncher.prepare_all(worktree, ["backend"])
+        assert collect.call_args.args[0] is self.overlay_a

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -435,6 +435,33 @@ class TestExecuteHeadlessTask(TestCase):
         assert attempt.exit_code == 1
         assert "headless runtime crashed" in attempt.error
 
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_resolves_ticket_overlay_with_multiple_installed(self) -> None:
+        """The headless worker resolves the ticket's overlay, not the ambient default.
+
+        Regression for souliane/teatree#1814: with two overlays registered a
+        bare ``get_overlay()`` crashes the worker. ``execute_headless_task``
+        must key off ``task.ticket.overlay`` instead.
+        """
+        ticket = Ticket.objects.create(overlay="beta")
+        session = Session.objects.create(ticket=ticket, overlay="beta", agent_id="agent-2")
+
+        captured: dict[str, object] = {}
+
+        def _capture(task_obj: object, *, phase: str, overlay_skill_metadata: object) -> MagicMock:
+            captured["metadata"] = overlay_skill_metadata
+            return MagicMock(pk=1, exit_code=0, result={})
+
+        self.monkeypatch.setattr("teatree.agents.headless.run_headless", _capture)
+
+        beta_overlay = CommandOverlay()
+        beta_metadata = beta_overlay.metadata.get_skill_metadata()
+        registry = {"alpha": CommandOverlay(), "beta": beta_overlay}
+        with patch.object(overlay_loader_mod, "_discover_overlays", return_value=registry):
+            Task.objects.create(ticket=ticket, session=session, phase="architectural_review")
+
+        assert captured["metadata"] == beta_metadata
+
 
 class TestAdvanceTicketNormalizesPhase(TestCase):
     """``Task._advance_ticket`` normalizes phase before the FSM compare (#750).


### PR DESCRIPTION
## Problem

With two or more overlays installed, every loop-driven worktree provision job crashed. The queued job `execute_worktree_provision` (`src/teatree/core/worktree_tasks.py`) builds `WorktreeProvisionRunner(worktree)`, whose `__init__` did `self.overlay = overlay or get_overlay()` with no name. A bare `get_overlay()` cannot disambiguate a multi-overlay install and raises:

```
ImproperlyConfigured: Multiple overlays found (overlay-a, overlay-b). Pass an explicit name to get_overlay().
```

The same `overlay or get_overlay()` pattern (queued-worker runner paths with a worktree or ticket in scope) appeared in the sibling runners and the headless task worker, so each would hit the identical crash.

## Fix

Two small resolvers in `overlay_loader.py` that key off the entity's own overlay:

- `get_overlay_for_ticket(ticket)` — resolves `ticket.overlay`, falling through to the ambient default only when blank.
- `get_overlay_for_worktree(worktree)` — resolves the worktree's `overlay` field, falling back to its ticket for rows created before the field was populated.

Routed through them:

- `WorktreeProvisionRunner`, `WorktreeStartRunner`, `WorktreeVerifyRunner`
- `ServiceLauncher.__init__` and `ServiceLauncher.prepare_all`
- `execute_headless_task` (queued worker, keyed on `task.ticket.overlay`)

`ShipExecutor` / `code_host_from_overlay` were left out deliberately: that path already has its own `ImproperlyConfigured`-to-TOML fallback and a resolution chain shared with CLI call sites, so it warrants a separate change rather than being folded into this fix.

## Tests

`tests/teatree_core/test_runner_multi_overlay_resolution.py` registers BOTH overlays and asserts each runner resolves the worktree's own overlay instead of raising. A multi-overlay case was added to `TestExecuteHeadlessTask`.

- RED before the fix: the worktree path raised `ImproperlyConfigured: Multiple overlays found`, and the headless worker crashed the same way (observed by reverting the `tasks.py` change).
- GREEN after: full `tests/teatree_core` suite passes (3434 passed, 12 skipped). 100% line coverage on the new/changed lines.

Closes #1814