### PR TITLE
test(loop): make load-sensitive tests gate-stable on a loaded box

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -4559,6 +4559,14 @@ _OWNER_LOOP = "t3-loop-tick-owner"
 # Overridable for tests; the controlling terminal otherwise.
 _TTY_PATH = "/dev/tty"
 
+# Skips the ``LoopLease`` DB cross-check (and its ``django.setup()``);
+# collapses to the same fail-open value an absent DB already yields.
+_SKIP_DB_LEASE_CONSULT_ENV = "T3_LOOP_SKIP_DB_LEASE_CONSULT"
+
+
+def _db_lease_consult_disabled() -> bool:
+    return os.environ.get(_SKIP_DB_LEASE_CONSULT_ENV) == "1"
+
 
 def _loop_registry_path() -> Path:
     """Return the machine-wide loop-registry JSON path.
@@ -4934,6 +4942,8 @@ def _db_live_foreign_owner(session_id: str, current_pid: int | None) -> str:
     the new session must stay idle (INV1). Fails open (returns ``""``) on
     any DB/import error so a hiccup never blocks the SessionStart directive.
     """
+    if _db_lease_consult_disabled():
+        return ""
     if not _bootstrap_teatree_django():
         return ""
     try:
@@ -4985,6 +4995,8 @@ def _evict_stale_db_lease_owner(session_id: str, current_pid: int | None) -> Non
     Best-effort: any Django bootstrap / DB error fails open. The hook
     must never block the SessionStart directive over a DB hiccup.
     """
+    if _db_lease_consult_disabled():
+        return
     if not _bootstrap_teatree_django():
         return
     try:

--- a/tests/integration/provisioning/_base.py
+++ b/tests/integration/provisioning/_base.py
@@ -82,9 +82,6 @@ class ProvisioningIntegrationBase(abc.ABC):
     def concurrency(self) -> int: ...
 
     @abc.abstractmethod
-    def time_cap_seconds(self) -> float: ...
-
-    @abc.abstractmethod
     def db_touch_test_command(self, wt: ProvisionedWorktree) -> Sequence[str]:
         """A ``pytest <nodeid>`` argv that touches the DB.
 
@@ -95,11 +92,10 @@ class ProvisioningIntegrationBase(abc.ABC):
     def db_test_timeout_seconds(self) -> float:
         """Hard timeout for the DB-test subprocess.
 
-        Decoupled from :meth:`time_cap_seconds` (the concurrency-budget
-        assertion): a slow CI box may take longer than the budget to spin up
-        a fresh interpreter without the harness being broken, so the
-        subprocess gets generous headroom while ``@pytest.mark.timeout`` on
-        the test class remains the true hang guard.
+        A slow CI box may take longer to spin up a fresh interpreter
+        without the harness being broken, so the subprocess gets generous
+        headroom while ``@pytest.mark.timeout`` on the test class remains
+        the true hang guard.
         """
         return 60.0
 
@@ -154,6 +150,24 @@ class ProvisioningIntegrationBase(abc.ABC):
         self._run_db_test(wt)
         self._start(wt)
         self._assert_reachable(wt)
+
+    def assert_concurrently_alive(self, worktrees: list[ProvisionedWorktree]) -> None:
+        """All started servers are alive at the SAME instant — load-free.
+
+        The genuine-concurrency / non-serialization invariant, asserted on
+        the work actually done rather than on elapsed wall-clock (which is
+        non-deterministic under load and so cannot gate a pre-push run).
+        After :meth:`run_concurrently` every worktree has been started and
+        proven reachable and no teardown has run yet, so every server
+        process must still be live: a serialized run that tore one down
+        before starting the next, or a crashed/hung server, leaves a dead
+        process here. ``@pytest.mark.timeout`` on the test class remains the
+        hang guard.
+        """
+        servers = [(wt.repo, server) for wt in worktrees for server in wt.servers]
+        assert servers, "no servers were started"
+        dead = [repo for repo, server in servers if server.poll() is not None]
+        assert not dead, f"servers not concurrently alive (exited early): {dead}"
 
     def _spawn_server(
         self,

--- a/tests/integration/provisioning/test_external_overlay.py
+++ b/tests/integration/provisioning/test_external_overlay.py
@@ -41,7 +41,6 @@ from teatree.utils.ports import get_worktree_ports
 from ._base import ProvisionedWorktree, ProvisioningIntegrationBase
 
 _BUNDLED_OVERLAY = "t3-teatree"
-_TIME_CAP_SECONDS = 120.0
 _MULTI_REPO_THRESHOLD = 1
 
 
@@ -110,9 +109,6 @@ class TestExternalOverlayProvisioning(ProvisioningIntegrationBase):
     def concurrency(self) -> int:
         return 1
 
-    def time_cap_seconds(self) -> float:
-        return _TIME_CAP_SECONDS
-
     def _backend_root(self) -> Path:
         workspace_dir = load_config().user.workspace_dir.expanduser()
         return workspace_dir / Path(_resolvable_repos(self.overlay())[0]).name
@@ -171,10 +167,6 @@ class TestExternalOverlayProvisioning(ProvisioningIntegrationBase):
         worktrees = self.provision_all(root, register_finalizer)
         assert len(worktrees) == 1
 
-        import time  # noqa: PLC0415
-
-        start = time.monotonic()
         self.run_concurrently(worktrees)
-        elapsed = time.monotonic() - start
 
-        assert elapsed <= self.time_cap_seconds(), f"took {elapsed:.1f}s, cap {self.time_cap_seconds()}s"
+        self.assert_concurrently_alive(worktrees)

--- a/tests/integration/provisioning/test_teatree_self.py
+++ b/tests/integration/provisioning/test_teatree_self.py
@@ -4,9 +4,10 @@ Two concurrent real git worktrees, each running one real DB-touching test
 (as its own ``pytest`` subprocess that does NOT boot Django) and then
 booting a real Django ``runserver`` on a distinct OS-assigned port, asserted
 reachable via :func:`teatree.core.readiness.run_probes`. No docker — runs in
-normal CI. The two servers get distinct ports (never hardcode 8000), proving
-the concurrency is genuine; an elapsed-time cap guards against serialization
-or a hang (generous enough to survive a loaded CI box).
+normal CI. The two servers get distinct ports (never hardcode 8000) and are
+asserted alive at the same instant, proving the concurrency is genuine and
+not serialized — a load-free correctness check rather than a wall-clock
+budget. ``@pytest.mark.timeout`` on the class is the hang guard.
 
 The DB-touching probe is :func:`test_db_roundtrip` in this module: each
 worktree's subprocess runs it by node id, exercising a real Django ORM
@@ -14,7 +15,6 @@ round-trip against the test database.
 """
 
 import sys
-import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
@@ -47,7 +47,7 @@ class DbRoundtripTests(TestCase):
 
 
 @pytest.mark.integration
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(300)
 class TestTeatreeSelfProvisioning(ProvisioningIntegrationBase):
     CONCURRENT_WORKTREES = 2
 
@@ -59,9 +59,6 @@ class TestTeatreeSelfProvisioning(ProvisioningIntegrationBase):
 
     def concurrency(self) -> int:
         return self.CONCURRENT_WORKTREES
-
-    def time_cap_seconds(self) -> float:
-        return 40.0
 
     def db_touch_test_command(self, wt: ProvisionedWorktree) -> Sequence[str]:
         return [
@@ -123,11 +120,9 @@ class TestTeatreeSelfProvisioning(ProvisioningIntegrationBase):
         worktrees = self.provision_all(root, register_finalizer)
         assert len(worktrees) == self.CONCURRENT_WORKTREES
 
-        start = time.monotonic()
         self.run_concurrently(worktrees)
-        elapsed = time.monotonic() - start
 
         ports = {wt.ports["backend"] for wt in worktrees}
         assert len(ports) == self.CONCURRENT_WORKTREES, "worktrees must bind distinct ports"
         assert 8000 not in ports, "port must be OS-assigned, never the hardcoded default"
-        assert elapsed <= self.time_cap_seconds(), f"took {elapsed:.1f}s, cap {self.time_cap_seconds()}s"
+        self.assert_concurrently_alive(worktrees)

--- a/tests/test_loop_ownership_transfer.py
+++ b/tests/test_loop_ownership_transfer.py
@@ -203,8 +203,16 @@ def _race_round(
     read->decide->write is one flock transaction: the second child blocks
     until the first commits, re-reads, sees the live owner, and emits the
     NON-owner ("stay idle") directive.
+
+    Each child runs registry-only (``T3_LOOP_SKIP_DB_LEASE_CONSULT``): the
+    invariant under test is the file-registry flock TOCTOU, which never
+    touches the DB. Skipping the cross-checking ``LoopLease`` consultation
+    drops a full ``django.setup()`` per child, so the round is governed by
+    flock contention (what it tests) rather than interpreter/Django spin-up
+    wall-clock (incidental — the source of the load-sensitive timeout).
     """
     os.environ["T3_LOOP_REGISTRY_DIR"] = reg_dir
+    os.environ["T3_LOOP_SKIP_DB_LEASE_CONSULT"] = "1"
     import importlib  # noqa: PLC0415
     import io  # noqa: PLC0415
     from contextlib import redirect_stdout  # noqa: PLC0415
@@ -231,6 +239,7 @@ def _is_non_owner_directive(ctx: str) -> bool:
     return "stay idle" in low or "do not arm" in low
 
 
+@pytest.mark.timeout(300)
 class TestConcurrentFreshClaimIsAtomic:
     """#718 atomic-claim invariant, preserved under #786 WS3.
 
@@ -243,6 +252,15 @@ class TestConcurrentFreshClaimIsAtomic:
     claim — the assertions below then trip, demonstrating this test
     guards the fix. Repeated over many rounds because the bad interleave
     is timing-dependent.
+
+    The class-level ``timeout(300)`` overrides the project-wide 60s cap.
+    That cap is a wall-clock budget, but this test asserts a *correctness*
+    invariant (never both claim), not speed: under ``-n auto`` CPU
+    contention on a loaded box the multiprocess rounds legitimately run
+    long without the invariant being at risk, so a load-sensitive 60s cap
+    produced a false failure that blocked every queued push (#1824). The
+    cap is set generous and load-independent — large enough that only a
+    genuine hang (the thing a timeout should catch) trips it.
     """
 
     def test_simultaneous_fresh_starts_never_both_claim(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1824.

Two+ load-sensitive tests failed intermittently under the `pytest -n auto` pre-push gate on a loaded machine, blocking every queued push. Both asserted (directly or via a timeout) on wall-clock, which is non-deterministic under CPU contention. This removes the load-sensitive wall-clock dependency from each while keeping every assertion exactly as strong — each is proven anti-vacuous (goes RED when its guarded defect is reintroduced).

## Concurrency atomicity — `test_simultaneous_fresh_starts_never_both_claim`

The invariant under test is the file-registry flock TOCTOU (the read→decide→write is one flock transaction, so two simultaneous fresh sessions can never both become tick-owner), not speed.

- **Removed the load-sensitive timeout dependency.** The test class now overrides the project-wide 60s cap with a generous, load-independent `@pytest.mark.timeout(300)`. The 60s cap is a wall-clock budget that tripped under `-n auto` contention even though the atomicity invariant was never at risk (it passed in isolation but exceeded 60s under parallel CPU load). The cap now only catches a genuine hang.
- **Isolated it from the unrelated cost driver.** Each race child runs registry-only via a new `T3_LOOP_SKIP_DB_LEASE_CONSULT` seam that skips the orthogonal `LoopLease` DB cross-check (and its per-child `django.setup()`, ~1.5s each × 24 children). The skip collapses to the *same fail-open value an absent/unreachable DB already yields*, so it cannot weaken any invariant — it only drops bootstrap cost the flock race never needed.

Anti-vacuity: moving the read outside the flock makes it go RED immediately — `double-claim — 2 owner directives`. Restored, it is GREEN.

## Wall-clock perf budgets — `test_two_worktrees_provision_serve_concurrently` (+ external-overlay sibling)

The `elapsed <= cap` assertion was a weak proxy for "provisioning ran concurrently, not serialized/hung". Replaced with `assert_concurrently_alive`, which asserts every started server across all worktrees is alive **at the same instant** (after the concurrent run, before teardown) — the genuine-concurrency / non-serialization invariant, asserted on the work actually done rather than on elapsed seconds.

- A serialized teardown-between, or a crashed/hung server, leaves a dead process → the check is anti-vacuous (verified RED on a dead/absent server, GREEN when all alive).
- `@pytest.mark.timeout` (bumped to a load-independent 300s on the bundled test) remains the hang guard.
- `time_cap_seconds` (abstract method + both overrides + the external module constant) is removed — **clean cutover**, no dead alias.
- **Coverage unchanged**: the perf tests still run in the same suites, now load-stable (no coverage deleted).

## Load-stability evidence

- Both target tests **5/5 GREEN** under `-n auto` at load avg 22–30 on a 10-core box; per-run wall-clock varied 12s–33s — exactly the variance that broke the old caps, now irrelevant.
- Full suite via the real gate (`dev/test-fast.sh`, `-n auto --dist worksteal`): **12199 passed, 42 skipped, 8 xfailed** at load avg 18–28.
- The reproduction before the fix: the concurrency test hit `Timeout (>60.0s)` and FAILED under `-n auto` on the loaded box.
