### PR TITLE
fix(loop): never react :merge: on a review-request the user authored

### DIFF
--- a/src/teatree/backends/github.py
+++ b/src/teatree/backends/github.py
@@ -64,6 +64,7 @@ class _GitHubPullRequestSummary(TypedDict, total=False):
     requested_reviewers: list[_GitHubUser]
     state: str
     merged: bool
+    user: _GitHubUser
 
 
 def _run_gh(*args: str, token: str = "") -> CompletedProcess[str]:
@@ -547,3 +548,32 @@ class GitHubCodeHost:
         except Exception:  # noqa: BLE001 — fail open: any failure must NOT reap a live review.
             return PrOpenState.UNKNOWN
         return _pr_open_state_from_payload(pr)
+
+    def get_pr_author(self, *, pr_url: str) -> str:
+        """Return the PR author's GitHub login, or ``""`` when it can't be resolved.
+
+        Fetches the PR payload and reads ``user.login``. Any exception
+        (``gh api`` failure, auth error), unparsable URL, or non-dict /
+        author-less payload returns ``""`` — the reaction scanners treat an
+        unresolved author as "not provably self" and skip the reaction, so a
+        transient lookup failure can never cause a reaction on the user's
+        own MR.
+        """
+        match = _PR_URL_RE.match(urlparse(pr_url).path)
+        if match is None:
+            return ""
+        try:
+            pr = _gh_api_get(
+                f"repos/{match['owner']}/{match['repo']}/pulls/{match['number']}",
+                token=self._token,
+            )
+        except Exception:  # noqa: BLE001 — fail safe: an unresolved author must skip the reaction.
+            return ""
+        if not isinstance(pr, dict):
+            return ""
+        user = cast("_GitHubPullRequestSummary", pr).get("user")
+        if isinstance(user, dict):
+            login = cast("_GitHubUser", user).get("login")
+            if isinstance(login, str):
+                return login
+        return ""

--- a/src/teatree/backends/gitlab.py
+++ b/src/teatree/backends/gitlab.py
@@ -102,6 +102,7 @@ class _GitLabMergeRequestSummary(TypedDict, total=False):
 
     reviewers: list[_GitLabUser]
     state: str
+    author: _GitLabUser
 
 
 def get_client(*, token: str = "", base_url: str = "") -> GitLabAPI:
@@ -386,6 +387,34 @@ class GitLabCodeHost:
         if not isinstance(state, str):
             return PrOpenState.UNKNOWN
         return _GITLAB_MR_STATE_MAP.get(state, PrOpenState.UNKNOWN)
+
+    def get_pr_author(self, *, pr_url: str) -> str:
+        """Return the MR author's GitLab username, or ``""`` when it can't be resolved.
+
+        Fetches the MR payload and reads ``author.username``. Any exception,
+        unresolvable project, unparsable URL, or non-dict / author-less
+        payload returns ``""`` — the reaction scanners treat an unresolved
+        author as "not provably self" and skip the reaction, so a transient
+        lookup failure can never cause a reaction on the user's own MR.
+        """
+        match = _MR_URL_RE.match(urlparse(pr_url).path)
+        if match is None:
+            return ""
+        try:
+            project = self._client.resolve_project(match["path"])
+            if project is None:
+                return ""
+            mr = self._client.get_json(f"projects/{project.project_id}/merge_requests/{match['iid']}")
+        except Exception:  # noqa: BLE001 — fail safe: an unresolved author must skip the reaction.
+            return ""
+        if not isinstance(mr, dict):
+            return ""
+        author = cast("_GitLabMergeRequestSummary", mr).get("author")
+        if isinstance(author, dict):
+            username = cast("_GitLabUser", author).get("username")
+            if isinstance(username, str):
+                return username
+        return ""
 
     def assign_reviewer(self, *, pr_url: str, username: str) -> bool:
         """Append *username* as a reviewer on the MR at *pr_url* (#1295 cap B).

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -123,6 +123,8 @@ class CodeHostBackend(Protocol):
 
     def get_pr_open_state(self, *, pr_url: str) -> PrOpenState: ...  # pragma: no branch
 
+    def get_pr_author(self, *, pr_url: str) -> str: ...  # pragma: no branch
+
     def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict: ...  # pragma: no branch
 
     def update_pr_comment(

--- a/src/teatree/core/review_candidate.py
+++ b/src/teatree/core/review_candidate.py
@@ -50,6 +50,24 @@ def _author_username(mr: RawAPIDict) -> str:
     return ""
 
 
+def author_is_self(author: str, *, current_user: str, self_identities: Iterable[str] = ()) -> bool:
+    """Return True iff *author* is one of the user's own forge identities (#1321).
+
+    The single notion of "the user authored this" reused by every path that
+    must treat the user's own MR differently from a colleague's — the
+    review-candidate skip-conditions (``author_is_self`` reason) and the
+    Slack reaction scanners, which must never react on the user's own
+    review-request post. ``author`` is the MR/PR author username already
+    extracted from the forge payload (GitLab ``author.username`` / GitHub
+    ``user.login``). An empty *author* never matches: an unknown author is
+    not provably self, so a fail-closed reaction caller treats the non-match
+    as "skip the reaction" rather than "react".
+    """
+    if not author:
+        return False
+    return author in _self_identity_set(current_user, self_identities)
+
+
 def _approver_usernames(mr: RawAPIDict) -> list[str]:
     raw = mr.get("approvers")
     if not isinstance(raw, list):
@@ -138,7 +156,7 @@ def should_review_candidate_reasons(
     """
     identities = _self_identity_set(current_user, self_identities)
     reasons: list[str] = []
-    if identities and _author_username(mr) in identities:
+    if identities and author_is_self(_author_username(mr), current_user=current_user, self_identities=self_identities):
         reasons.append("author_is_self")
     approvers = _approver_usernames(mr)
     if identities and identities.intersection(approvers):

--- a/src/teatree/loop/scanners/review_nag.py
+++ b/src/teatree/loop/scanners/review_nag.py
@@ -42,7 +42,7 @@ failure, unparsable URL) fails open and the nag proceeds as before.
 
 import datetime as dt
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from django.utils import timezone
 
@@ -88,6 +88,7 @@ class ReviewNagScanner:
     messaging: MessagingBackend | None
     user_slack_id: str
     host: CodeHostBackend | None = None
+    identities: tuple[str, ...] = field(default_factory=tuple)
     now: dt.datetime | None = None
     name: str = "review_nag"
 
@@ -168,7 +169,7 @@ class ReviewNagScanner:
             logger.warning("review_nag: open-state lookup failed for %s: %s", post.mr_url, exc)
             return None
         if open_state is PrOpenState.MERGED:
-            return react_merge_on_post(post, messaging)
+            return react_merge_on_post(post, messaging, host=self.host, identities=self.identities)
         if open_state is not PrOpenState.CLOSED:
             return None
         post.done_at = right_now

--- a/src/teatree/loop/scanners/review_request_merge_react.py
+++ b/src/teatree/loop/scanners/review_request_merge_react.py
@@ -28,15 +28,26 @@ cannot both react — the tick that loses the claim matches zero rows and
 skips. A transient Slack failure (``not_in_channel``, a raised transport
 error) releases the claim so a future tick retries; a definitive
 ``missing_scope`` keeps the row closed.
+
+Self-authored skip (#1838): the bot must never react on a review-request
+the *user themselves* posted for their *own* MR. Before claiming the row
+the merge author is fetched from the code host and matched against the
+user's forge identities via :func:`teatree.core.review_candidate.author_is_self`
+— the same notion of "self" the review-candidate skip-conditions use.
+A self-authored merged MR closes the row (so the nag train stops too)
+without reacting; an unresolved author is not provably self, so it is
+left for a later tick rather than risk reacting on the user's own MR.
 """
 
 import logging
-from dataclasses import dataclass
+from collections.abc import Iterable
+from dataclasses import dataclass, field
 
 from django.utils import timezone
 
 from teatree.backends.protocols import CodeHostBackend, MessagingBackend, PrOpenState
 from teatree.core.models import ReviewRequestPost
+from teatree.core.review_candidate import author_is_self
 from teatree.loop.scanners.base import ScanSignal
 from teatree.types import RawAPIDict
 
@@ -51,6 +62,50 @@ _REACTION_PRESENT_ERRORS = frozenset({"already_reacted"})
 def _claim_post(post: ReviewRequestPost) -> bool:
     updated = ReviewRequestPost.objects.filter(pk=post.pk, done_at__isnull=True).update(done_at=timezone.now())
     return updated == 1
+
+
+def _resolve_self_identities(host: CodeHostBackend | None, identities: Iterable[str]) -> set[str]:
+    """Union of configured identity aliases and the host's current user.
+
+    Configured ``identities`` come from ``user_identity_aliases``; the
+    host's ``current_user`` is folded in so the self-author skip still
+    works when no aliases are configured (legacy single-identity setups).
+    A failed ``current_user`` lookup is non-fatal — the configured aliases
+    still apply.
+    """
+    resolved = {name for name in identities if name}
+    if host is not None:
+        try:
+            current = host.current_user()
+        except Exception as exc:  # noqa: BLE001 — a current-user lookup must never crash a tick.
+            logger.warning("review_request_merge_react: current_user lookup failed: %s", exc)
+            current = ""
+        if current:
+            resolved.add(current)
+    return resolved
+
+
+def _is_self_authored(post: ReviewRequestPost, host: CodeHostBackend | None, identities: Iterable[str]) -> bool:
+    """Return True iff the MR for *post* was authored by the user themselves.
+
+    Fail-closed on a *resolved* self-identity set but no author: when we
+    know who the user is and the author lookup returns ``""`` (transient
+    failure / unparsable URL), the author is not provably *not* self, so we
+    report ``True`` to suppress the reaction rather than risk reacting on
+    the user's own MR. With no resolvable self-identity at all there is
+    nothing to protect, so the colleague path proceeds.
+    """
+    self_identities = _resolve_self_identities(host, identities)
+    if not self_identities or host is None:
+        return False
+    try:
+        author = host.get_pr_author(pr_url=post.mr_url)
+    except Exception as exc:  # noqa: BLE001 — author lookup must never crash a tick.
+        logger.warning("review_request_merge_react: author lookup failed for %s: %s", post.mr_url, exc)
+        author = ""
+    if not author:
+        return True
+    return author_is_self(author, current_user="", self_identities=self_identities)
 
 
 def _release_post(post: ReviewRequestPost) -> None:
@@ -83,7 +138,23 @@ def _signal_for_react_response(post: ReviewRequestPost, response: RawAPIDict) ->
     )
 
 
-def react_merge_on_post(post: ReviewRequestPost, messaging: MessagingBackend) -> ScanSignal | None:
+def _close_self_authored(post: ReviewRequestPost) -> ScanSignal:
+    """Close *post* without reacting — the user authored their own MR (#1838)."""
+    ReviewRequestPost.objects.filter(pk=post.pk, done_at__isnull=True).update(done_at=timezone.now())
+    return ScanSignal(
+        kind="review_request_merge_react.self_authored",
+        summary=f":merge: reaction skipped for {post.mr_url} — the user authored this MR",
+        payload={"mr_url": post.mr_url, "post_id": post.pk},
+    )
+
+
+def react_merge_on_post(
+    post: ReviewRequestPost,
+    messaging: MessagingBackend,
+    *,
+    host: CodeHostBackend | None = None,
+    identities: Iterable[str] = (),
+) -> ScanSignal | None:
     """Atomically claim *post* and react ``:merge:`` on its tracked Slack message.
 
     The single entry point shared by the merge-react scanner and the nag
@@ -94,9 +165,16 @@ def react_merge_on_post(post: ReviewRequestPost, messaging: MessagingBackend) ->
     failure releases the claim for a later retry; ``missing_scope`` keeps
     the row closed. Returns ``None`` when there is no thread to react on or
     the claim is lost.
+
+    Self-authored skip (#1838): when the MR was authored by the user
+    themselves (matched against ``identities`` plus ``host.current_user()``),
+    the row is closed and a ``self_authored`` signal returned WITHOUT
+    reacting — the bot must never react on the user's own review-request.
     """
     if not post.slack_thread_ts:
         return None
+    if _is_self_authored(post, host, identities):
+        return _close_self_authored(post)
     if not _claim_post(post):
         return None
     try:
@@ -134,6 +212,7 @@ class ReviewRequestMergeReactScanner:
 
     messaging: MessagingBackend | None
     host: CodeHostBackend | None = None
+    identities: tuple[str, ...] = field(default_factory=tuple)
     name: str = "review_request_merge_react"
 
     def scan(self) -> list[ScanSignal]:
@@ -158,7 +237,7 @@ class ReviewRequestMergeReactScanner:
             return None
         if self._open_state(host, post.mr_url) is not PrOpenState.MERGED:
             return None
-        return react_merge_on_post(post, messaging)
+        return react_merge_on_post(post, messaging, host=host, identities=self.identities)
 
     @staticmethod
     def _open_state(host: CodeHostBackend, mr_url: str) -> PrOpenState:

--- a/src/teatree/loop/tick_jobs.py
+++ b/src/teatree/loop/tick_jobs.py
@@ -1032,6 +1032,7 @@ def _followup_jobs_for_overlay(backend: OverlayBackends) -> list[_ScannerJob]:
                         messaging=backend.messaging,
                         user_slack_id=_user_slack_id_for_overlay(tag),
                         host=backend.host,
+                        identities=backend.identities,
                     ),
                     overlay=tag,
                 ),
@@ -1039,6 +1040,7 @@ def _followup_jobs_for_overlay(backend: OverlayBackends) -> list[_ScannerJob]:
                     scanner=ReviewRequestMergeReactScanner(
                         messaging=backend.messaging,
                         host=backend.host,
+                        identities=backend.identities,
                     ),
                     overlay=tag,
                 ),
@@ -1218,6 +1220,7 @@ def _messaging_jobs_for_backend(
                     messaging=messaging,
                     user_slack_id=_user_slack_id_for_overlay(tag),
                     host=backend.host,
+                    identities=backend.identities,
                 ),
                 overlay=tag,
             ),

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -729,6 +729,61 @@ def test_get_pr_open_state_any_exception_fails_open_to_unknown() -> None:
     assert host.get_pr_open_state(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == PrOpenState.UNKNOWN
 
 
+# ── #1838 self-author skip: get_pr_author on GitLabCodeHost ─────────────
+
+
+def test_get_pr_author_returns_username() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_json.return_value = {"author": {"username": "adrien.cossa"}}
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_author(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == "adrien.cossa"
+    client.get_json.assert_called_once_with("projects/42/merge_requests/12")
+
+
+def test_get_pr_author_author_less_payload_is_empty() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_json.return_value = {"state": "opened"}
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_author(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == ""
+
+
+def test_get_pr_author_unparsable_url_is_empty() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_author(pr_url="https://github.com/o/r/pull/7") == ""
+    client.resolve_project.assert_not_called()
+
+
+def test_get_pr_author_unresolved_project_is_empty() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = None
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_author(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == ""
+
+
+def test_get_pr_author_non_dict_payload_is_empty() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.return_value = _project()
+    client.get_json.return_value = ["not", "a", "dict"]
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_author(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == ""
+
+
+def test_get_pr_author_any_exception_fails_safe_to_empty() -> None:
+    client = MagicMock(spec=GitLabAPI)
+    client.resolve_project.side_effect = RuntimeError("network down / auth error")
+    host = GitLabCodeHost(client=client)
+
+    assert host.get_pr_author(pr_url="https://gitlab.com/org/repo/-/merge_requests/12") == ""
+
+
 # ── #1295 cap B: assign_reviewer on GitLabCodeHost ──────────────────────
 
 

--- a/tests/teatree_backends/test_protocols.py
+++ b/tests/teatree_backends/test_protocols.py
@@ -64,6 +64,10 @@ class _FakeCodeHost:
         _ = pr_url
         return PrOpenState.UNKNOWN
 
+    def get_pr_author(self, *, pr_url: str) -> str:
+        _ = pr_url
+        return ""
+
     def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> dict[str, object]:
         _ = (repo, pr_iid, body)
         return {}

--- a/tests/teatree_core/test_review_candidate.py
+++ b/tests/teatree_core/test_review_candidate.py
@@ -5,10 +5,28 @@ memory to apply these rules; this module is the canonical structural fix.
 """
 
 from teatree.core.review_candidate import (
+    author_is_self,
     eyes_reacted_by_other,
     should_review_candidate,
     should_review_candidate_reasons,
 )
+
+
+class TestAuthorIsSelf:
+    def test_matches_primary_identity(self) -> None:
+        assert author_is_self("alice", current_user="alice") is True
+
+    def test_matches_secondary_alias(self) -> None:
+        assert author_is_self("alice-gh", current_user="alice", self_identities=("alice-gh",)) is True
+
+    def test_does_not_match_colleague(self) -> None:
+        assert author_is_self("bob", current_user="alice", self_identities=("alice-gh",)) is False
+
+    def test_empty_author_never_matches(self) -> None:
+        assert author_is_self("", current_user="alice", self_identities=("alice-gh",)) is False
+
+    def test_no_identities_never_matches(self) -> None:
+        assert author_is_self("alice", current_user="") is False
 
 
 class TestSkipSelfAuthor:

--- a/tests/teatree_loop/test_review_nag_scanner.py
+++ b/tests/teatree_loop/test_review_nag_scanner.py
@@ -456,12 +456,21 @@ class FakeHost:
 
     open_state: "Any"
     raise_on_lookup: Exception | None = None
+    user: str = ""
+    author: str = ""
 
     def get_pr_open_state(self, *, pr_url: str) -> "Any":
         _ = pr_url
         if self.raise_on_lookup is not None:
             raise self.raise_on_lookup
         return self.open_state
+
+    def current_user(self) -> str:
+        return self.user
+
+    def get_pr_author(self, *, pr_url: str) -> str:
+        _ = pr_url
+        return self.author
 
 
 class TestConcurrentTickPostsExactlyOnce(_EnableReviewNagMixin, TestCase):
@@ -524,8 +533,13 @@ class TestNeverNagMergedOrClosedMr(_EnableReviewNagMixin, TestCase):
 
         post = self._due_post()
         slack = FakeSlack()
-        host = FakeHost(open_state=PrOpenState.MERGED)
-        signals = ReviewNagScanner(messaging=slack, user_slack_id="U_ME", host=host).scan()
+        host = FakeHost(open_state=PrOpenState.MERGED, author="a-colleague")
+        signals = ReviewNagScanner(
+            messaging=slack,
+            user_slack_id="U_ME",
+            host=host,
+            identities=("souliane",),
+        ).scan()
 
         assert slack.posts == []
         assert slack.reactions == [{"channel": "C0AM3TENTLK", "ts": "ts.5", "emoji": "merge"}]
@@ -533,6 +547,25 @@ class TestNeverNagMergedOrClosedMr(_EnableReviewNagMixin, TestCase):
         assert post.done_at is not None
         assert post.last_nag_step == 0
         assert [s.kind for s in signals] == ["review_request_merge_react.reacted"]
+
+    def test_self_authored_merged_mr_via_nag_path_never_reacts(self) -> None:
+        from teatree.backends.protocols import PrOpenState  # noqa: PLC0415
+
+        post = self._due_post()
+        slack = FakeSlack()
+        host = FakeHost(open_state=PrOpenState.MERGED, author="souliane", user="souliane")
+        signals = ReviewNagScanner(
+            messaging=slack,
+            user_slack_id="U_ME",
+            host=host,
+            identities=("souliane",),
+        ).scan()
+
+        assert slack.posts == []
+        assert slack.reactions == []
+        post.refresh_from_db()
+        assert post.done_at is not None
+        assert [s.kind for s in signals] == ["review_request_merge_react.self_authored"]
 
     def test_closed_mr_is_not_nagged_not_reacted_and_row_closed(self) -> None:
         from teatree.backends.protocols import PrOpenState  # noqa: PLC0415

--- a/tests/teatree_loop/test_review_react_self_authored_skip_1838.py
+++ b/tests/teatree_loop/test_review_react_self_authored_skip_1838.py
@@ -1,0 +1,233 @@
+"""The merge :merge: reaction must never land on the user's OWN MR (#1838).
+
+The loop reacts ``:merge:`` on a review-request's Slack message once its
+MR merges (#1797) so reviewers see at a glance which requests landed. That
+reaction is a *colleague* signal: it must NEVER fire on a review-request
+the user posted for their *own* MR. The recurring bug was the bot reacting
+to the user's own merge-request review-request message.
+
+The fix gates :func:`react_merge_on_post` on the MR author resolved from
+the code host and matched against the user's forge identities (the same
+notion of "self" the review-candidate skip-conditions use). This module
+proves the gate across the full matrix:
+
+    author   in {user-self, colleague}
+    state    in {merged, open}
+    reacted  in {already-reacted, not-reacted}
+
+The bot reacts EXACTLY on (colleague, merged, not-reacted) - never on a
+self-authored MR, never on an open MR, never twice.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from django.utils import timezone
+
+from teatree.backends.protocols import PrOpenState
+from teatree.core.models import ReviewRequestPost
+from teatree.loop.scanners.review_request_merge_react import (
+    MERGE_REACTION_EMOJI,
+    ReviewRequestMergeReactScanner,
+    react_merge_on_post,
+)
+from teatree.types import RawAPIDict
+
+_USER_LOGIN = "souliane"
+_COLLEAGUE_LOGIN = "a-colleague"
+_MR_URL = "https://github.com/o/r/pull/7"
+_CHANNEL = "C0AM3TENTLK"
+_THREAD_TS = "1780473408.767019"
+
+_SELF = "self"
+_COLLEAGUE = "colleague"
+_AUTHOR_LOGIN = {_SELF: _USER_LOGIN, _COLLEAGUE: _COLLEAGUE_LOGIN}
+
+
+@dataclass
+class _RecordingSlack:
+    """In-memory MessagingBackend recording every ``react_routed`` call."""
+
+    reactions: list[dict[str, Any]] = field(default_factory=list)
+
+    def react_routed(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
+        self.reactions.append({"channel": channel, "ts": ts, "emoji": emoji})
+        return {"ok": True}
+
+
+@dataclass
+class _AuthoredHost:
+    """In-memory ``CodeHostBackend`` with a fixed open-state and author."""
+
+    open_state: PrOpenState
+    author: str
+    user: str = _USER_LOGIN
+    raise_on_author: Exception | None = None
+    raise_on_current_user: Exception | None = None
+
+    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState:
+        _ = pr_url
+        return self.open_state
+
+    def get_pr_author(self, *, pr_url: str) -> str:
+        _ = pr_url
+        if self.raise_on_author is not None:
+            raise self.raise_on_author
+        return self.author
+
+    def current_user(self) -> str:
+        if self.raise_on_current_user is not None:
+            raise self.raise_on_current_user
+        return self.user
+
+
+def _seed(*, reacted: bool) -> ReviewRequestPost:
+    return ReviewRequestPost.objects.create(
+        mr_url=_MR_URL,
+        slack_channel_id=_CHANNEL,
+        slack_thread_ts=_THREAD_TS,
+        created_at=timezone.now(),
+        last_nag_step=0,
+        done_at=timezone.now() if reacted else None,
+    )
+
+
+@pytest.mark.django_db
+class TestSelfAuthoredReactSkipMatrix:
+    """author x state x already-reacted: react only on (colleague, merged, not-reacted)."""
+
+    @pytest.mark.parametrize("author", [_SELF, _COLLEAGUE])
+    @pytest.mark.parametrize("state", [PrOpenState.MERGED, PrOpenState.OPEN])
+    @pytest.mark.parametrize("reacted", [False, True])
+    def test_react_only_on_colleague_merged_unreacted(
+        self,
+        author: str,
+        state: PrOpenState,
+        reacted: bool,  # noqa: FBT001 — parametrized matrix dimension, not a flag arg.
+    ) -> None:
+        _seed(reacted=reacted)
+        slack = _RecordingSlack()
+        host = _AuthoredHost(open_state=state, author=_AUTHOR_LOGIN[author])
+        scanner = ReviewRequestMergeReactScanner(
+            messaging=slack,
+            host=host,
+            identities=(_USER_LOGIN,),
+        )
+
+        scanner.scan()
+
+        should_react = author == _COLLEAGUE and state is PrOpenState.MERGED and not reacted
+        expected = [{"channel": _CHANNEL, "ts": _THREAD_TS, "emoji": MERGE_REACTION_EMOJI}] if should_react else []
+        assert slack.reactions == expected, (author, state, reacted)
+
+    def test_self_authored_merge_never_reacts_and_closes_row(self) -> None:
+        post = _seed(reacted=False)
+        slack = _RecordingSlack()
+        host = _AuthoredHost(open_state=PrOpenState.MERGED, author=_USER_LOGIN)
+        scanner = ReviewRequestMergeReactScanner(messaging=slack, host=host, identities=(_USER_LOGIN,))
+
+        signals = scanner.scan()
+
+        assert slack.reactions == []
+        post.refresh_from_db()
+        assert post.done_at is not None
+        assert [s.kind for s in signals] == ["review_request_merge_react.self_authored"]
+
+    def test_self_authored_via_alias_identity_never_reacts(self) -> None:
+        post = _seed(reacted=False)
+        slack = _RecordingSlack()
+        host = _AuthoredHost(open_state=PrOpenState.MERGED, author="adrien.cossa", user="")
+        scanner = ReviewRequestMergeReactScanner(
+            messaging=slack,
+            host=host,
+            identities=(_USER_LOGIN, "adrien.cossa"),
+        )
+
+        scanner.scan()
+
+        assert slack.reactions == []
+        post.refresh_from_db()
+        assert post.done_at is not None
+
+    def test_self_authored_via_current_user_only_never_reacts(self) -> None:
+        post = _seed(reacted=False)
+        slack = _RecordingSlack()
+        host = _AuthoredHost(open_state=PrOpenState.MERGED, author=_USER_LOGIN, user=_USER_LOGIN)
+        scanner = ReviewRequestMergeReactScanner(messaging=slack, host=host, identities=())
+
+        scanner.scan()
+
+        assert slack.reactions == []
+        post.refresh_from_db()
+        assert post.done_at is not None
+
+    def test_colleague_merge_reacts_exactly_once_across_two_scans(self) -> None:
+        _seed(reacted=False)
+        slack = _RecordingSlack()
+        host = _AuthoredHost(open_state=PrOpenState.MERGED, author=_COLLEAGUE_LOGIN)
+        scanner = ReviewRequestMergeReactScanner(messaging=slack, host=host, identities=(_USER_LOGIN,))
+
+        scanner.scan()
+        scanner.scan()
+
+        assert slack.reactions == [{"channel": _CHANNEL, "ts": _THREAD_TS, "emoji": MERGE_REACTION_EMOJI}]
+
+    def test_unresolved_author_fails_closed_when_identity_known(self) -> None:
+        post = _seed(reacted=False)
+        slack = _RecordingSlack()
+        host = _AuthoredHost(open_state=PrOpenState.MERGED, author="", user=_USER_LOGIN)
+        scanner = ReviewRequestMergeReactScanner(messaging=slack, host=host, identities=(_USER_LOGIN,))
+
+        scanner.scan()
+
+        assert slack.reactions == []
+        post.refresh_from_db()
+        assert post.done_at is not None
+
+    def test_author_lookup_raising_fails_closed_and_skips(self) -> None:
+        post = _seed(reacted=False)
+        slack = _RecordingSlack()
+        host = _AuthoredHost(
+            open_state=PrOpenState.MERGED,
+            author="",
+            user=_USER_LOGIN,
+            raise_on_author=RuntimeError("github 500"),
+        )
+        scanner = ReviewRequestMergeReactScanner(messaging=slack, host=host, identities=(_USER_LOGIN,))
+
+        scanner.scan()
+
+        assert slack.reactions == []
+        post.refresh_from_db()
+        assert post.done_at is not None
+
+    def test_current_user_raising_with_no_aliases_reacts_for_colleague(self) -> None:
+        _seed(reacted=False)
+        slack = _RecordingSlack()
+        host = _AuthoredHost(
+            open_state=PrOpenState.MERGED,
+            author=_COLLEAGUE_LOGIN,
+            raise_on_current_user=RuntimeError("auth_test failed"),
+        )
+        scanner = ReviewRequestMergeReactScanner(messaging=slack, host=host, identities=())
+
+        scanner.scan()
+
+        assert slack.reactions == [{"channel": _CHANNEL, "ts": _THREAD_TS, "emoji": MERGE_REACTION_EMOJI}]
+
+    def test_react_merge_on_post_without_thread_ts_is_a_noop(self) -> None:
+        post = ReviewRequestPost.objects.create(
+            mr_url=_MR_URL,
+            slack_channel_id=_CHANNEL,
+            slack_thread_ts="",
+            created_at=timezone.now(),
+            last_nag_step=0,
+        )
+        slack = _RecordingSlack()
+        host = _AuthoredHost(open_state=PrOpenState.MERGED, author=_COLLEAGUE_LOGIN)
+
+        result = react_merge_on_post(post, slack, host=host, identities=(_USER_LOGIN,))
+
+        assert result is None
+        assert slack.reactions == []

--- a/tests/teatree_loop/test_review_request_merge_react_scanner.py
+++ b/tests/teatree_loop/test_review_request_merge_react_scanner.py
@@ -49,6 +49,10 @@ class FakeHost:
     states_by_url: dict[str, PrOpenState] = field(default_factory=dict)
     raise_on_lookup: Exception | None = None
     lookups: list[str] = field(default_factory=list)
+    user: str = ""
+    author: str = ""
+    authors_by_url: dict[str, str] = field(default_factory=dict)
+    raise_on_author: Exception | None = None
 
     def get_pr_open_state(self, *, pr_url: str) -> PrOpenState:
         self.lookups.append(pr_url)
@@ -58,6 +62,14 @@ class FakeHost:
             return self.states_by_url[pr_url]
         assert self.open_state is not None
         return self.open_state
+
+    def current_user(self) -> str:
+        return self.user
+
+    def get_pr_author(self, *, pr_url: str) -> str:
+        if self.raise_on_author is not None:
+            raise self.raise_on_author
+        return self.authors_by_url.get(pr_url, self.author)
 
 
 class _SeedMixin:

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -925,6 +925,33 @@ class TestGitHubCodeHost:
             host = GitHubCodeHost()
             assert host.get_pr_open_state(pr_url="https://github.com/o/r/pull/7") == PrOpenState.UNKNOWN
 
+    def test_get_pr_author_returns_login(self) -> None:
+        with patch.object(github_mod, "_gh_api_get", return_value={"user": {"login": "souliane"}}) as mock_get:
+            host = GitHubCodeHost(token="tok")
+            assert host.get_pr_author(pr_url="https://github.com/o/r/pull/7") == "souliane"
+        mock_get.assert_called_once_with("repos/o/r/pulls/7", token="tok")
+
+    def test_get_pr_author_author_less_payload_is_empty(self) -> None:
+        with patch.object(github_mod, "_gh_api_get", return_value={"state": "open"}):
+            host = GitHubCodeHost()
+            assert host.get_pr_author(pr_url="https://github.com/o/r/pull/7") == ""
+
+    def test_get_pr_author_non_dict_payload_is_empty(self) -> None:
+        with patch.object(github_mod, "_gh_api_get", return_value=["not", "a", "dict"]):
+            host = GitHubCodeHost()
+            assert host.get_pr_author(pr_url="https://github.com/o/r/pull/7") == ""
+
+    def test_get_pr_author_unparsable_url_is_empty(self) -> None:
+        with patch.object(github_mod, "_gh_api_get") as mock_get:
+            host = GitHubCodeHost()
+            assert host.get_pr_author(pr_url="https://gitlab.com/o/r/-/merge_requests/7") == ""
+        mock_get.assert_not_called()
+
+    def test_get_pr_author_any_exception_fails_safe_to_empty(self) -> None:
+        with patch.object(github_mod, "_gh_api_get", side_effect=RuntimeError("gh api auth failure")):
+            host = GitHubCodeHost()
+            assert host.get_pr_author(pr_url="https://github.com/o/r/pull/7") == ""
+
 
 import pytest  # noqa: E402
 


### PR DESCRIPTION
Closes #1832.

## Problem

The merge-react scanner (#1797) reacts `:merge:` on a review-request's Slack message once the requested MR merges — a colleague-facing "this landed" signal. It fired regardless of MR author, so a review-request for the **user's own MR** got a self-reaction. Recurring, unwanted.

## Root cause

`react_merge_on_post` (the chokepoint shared by the merge-react scanner and the nag scanner's merged branch) gated only on `PrOpenState`, never on the author.

## Fix

- `author_is_self` — shared self-author predicate in `review_candidate`, reusing the same identity-set notion as the review-candidate skip-conditions; `should_review_candidate_reasons` routes through it (one definition of "self").
- `CodeHostBackend.get_pr_author(pr_url=...)` — GitHub + GitLab, fail-safe to `""`.
- `react_merge_on_post` skips the reaction and closes the row when the MR was authored by the user (matched against the overlay's `identities` plus `host.current_user()`). An unresolved author with a known self-identity **fails closed** (skip), never reacting on the user's own MR.
- `ReviewRequestMergeReactScanner` and `ReviewNagScanner` carry `identities`, wired from the backend identity set.

Colleague-MR behaviour is unchanged.

## Tests

Parametrized matrix over author `{user-self, colleague}` × state `{merged, open}` × `{already-reacted, not-reacted}` → react only on `(colleague, merged, not-reacted)`, exactly once, never on the user's own MR. Plus alias-identity / `current_user`-only / fail-closed / graceful-degradation cases, the `author_is_self` unit matrix, and `get_pr_author` backend tests on both forges.

Observed RED before the fix: reverting the self-author gate makes the self-authored cells emit a reaction (test goes red); restored → green. Full suite passes (12377 passed, coverage 94.5% ≥ 93% gate).
