### PR TITLE
fix(hooks): match configured terms on whole tokens, not substrings

### DIFF
--- a/scripts/hooks/check-banned-terms.sh
+++ b/scripts/hooks/check-banned-terms.sh
@@ -14,6 +14,14 @@
 # If no config or no banned_terms key, exits 0 (no-op).
 # Matches that only appear inside email addresses are ignored so author/contact
 # metadata can stay intact while still blocking leaked tenant/project terms.
+#
+# Matching is WHOLE-TOKEN, not substring: both the text and each term are
+# tokenized on any non-alphanumeric character (so '-', '_', whitespace, and
+# punctuation all separate tokens) and a term matches only when its own tokens
+# appear as a contiguous run of whole tokens. So (neutral example) a term
+# 'acme' matches the standalone token in 'acme'/'xx-acme-zz' but never inside
+# 'acmecorp' or 'pacme'. Case-insensitive. This keeps the matcher in lock-step
+# with teatree.hooks.term_match (the posting gate uses the same rule).
 
 set -euo pipefail
 
@@ -46,46 +54,49 @@ if [ -z "$terms" ]; then
   exit 0
 fi
 
-# Build a grep pattern from comma-separated terms
-pattern=""
-IFS=',' read -ra term_array <<< "$terms"
-for term in "${term_array[@]}"; do
-  term="$(echo "$term" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-  [ -z "$term" ] && continue
-  if [ -n "$pattern" ]; then
-    pattern="$pattern|$term"
-  else
-    pattern="$term"
-  fi
-done
-
-if [ -z "$pattern" ]; then
-  exit 0
-fi
-
-# Check each staged file passed by pre-commit
+# Check each staged file passed by pre-commit. The comma-separated term list
+# is passed verbatim; the embedded matcher tokenizes both it and each line and
+# requires a whole-token run (see header), with the email carve-out preserved.
 found=0
 for file in "$@"; do
   [ -f "$file" ] || continue
-  matches=$(python3 - "$file" "$pattern" <<'PY'
+  matches=$(python3 - "$file" "$terms" <<'PY'
 import re
 import sys
 from pathlib import Path
 
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokens(text):
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _contains_run(haystack, needle):
+    if not needle:
+        return False
+    if len(needle) == 1:
+        return needle[0] in haystack
+    span = len(needle)
+    for start in range(len(haystack) - span + 1):
+        if haystack[start : start + span] == needle:
+            return True
+    return False
+
+
 path = Path(sys.argv[1])
-pattern = re.compile(rf"\b({sys.argv[2]})\b", re.IGNORECASE)
+terms = [t.strip() for t in sys.argv[2].split(",") if t.strip()]
+term_tokens = [tt for tt in (_tokens(t) for t in terms) if tt]
 email_pattern = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 
-for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-    email_spans = [match.span() for match in email_pattern.finditer(line)]
-    has_non_email_match = False
-    for match in pattern.finditer(line):
-        if any(start <= match.start() and match.end() <= end for start, end in email_spans):
-            continue
-        has_non_email_match = True
-        break
-    if has_non_email_match:
-        print(f"{line_number}:{line}")
+if term_tokens:
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        # Tokenize the line with the email addresses stripped out, so a term
+        # that appears ONLY inside an author/contact email is not flagged.
+        stripped = email_pattern.sub(" ", line)
+        line_tokens = _tokens(stripped)
+        if any(_contains_run(line_tokens, tt) for tt in term_tokens):
+            print(f"{line_number}:{line}")
 PY
 )
   if [ -n "$matches" ]; then

--- a/scripts/hooks/check-banned-terms.sh
+++ b/scripts/hooks/check-banned-terms.sh
@@ -12,16 +12,7 @@
 #   banned_terms = ["term1", "term2"]
 #
 # If no config or no banned_terms key, exits 0 (no-op).
-# Matches that only appear inside email addresses are ignored so author/contact
-# metadata can stay intact while still blocking leaked tenant/project terms.
-#
-# Matching is WHOLE-TOKEN, not substring: both the text and each term are
-# tokenized on any non-alphanumeric character (so '-', '_', whitespace, and
-# punctuation all separate tokens) and a term matches only when its own tokens
-# appear as a contiguous run of whole tokens. So (neutral example) a term
-# 'acme' matches the standalone token in 'acme'/'xx-acme-zz' but never inside
-# 'acmecorp' or 'pacme'. Case-insensitive. This keeps the matcher in lock-step
-# with teatree.hooks.term_match (the posting gate uses the same rule).
+# Matching mirrors teatree.hooks.term_match (whole-token, camelCase-split, email carve-out).
 
 set -euo pipefail
 
@@ -54,9 +45,7 @@ if [ -z "$terms" ]; then
   exit 0
 fi
 
-# Check each staged file passed by pre-commit. The comma-separated term list
-# is passed verbatim; the embedded matcher tokenizes both it and each line and
-# requires a whole-token run (see header), with the email carve-out preserved.
+# Check each staged file with the embedded whole-token matcher (email carve-out kept).
 found=0
 for file in "$@"; do
   [ -f "$file" ] || continue
@@ -66,10 +55,14 @@ import sys
 from pathlib import Path
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
+_CAMEL_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
+_ACRONYM_BOUNDARY_RE = re.compile(r"([A-Z]+)([A-Z][a-z])")
 
 
 def _tokens(text):
-    return _TOKEN_RE.findall(text.lower())
+    split = _ACRONYM_BOUNDARY_RE.sub(r"\1 \2", text)
+    split = _CAMEL_BOUNDARY_RE.sub(r"\1 \2", split)
+    return _TOKEN_RE.findall(split.lower())
 
 
 def _contains_run(haystack, needle):
@@ -81,7 +74,7 @@ def _contains_run(haystack, needle):
     for start in range(len(haystack) - span + 1):
         if haystack[start : start + span] == needle:
             return True
-    return False
+    return "".join(needle) in haystack
 
 
 path = Path(sys.argv[1])
@@ -91,8 +84,7 @@ email_pattern = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 
 if term_tokens:
     for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        # Tokenize the line with the email addresses stripped out, so a term
-        # that appears ONLY inside an author/contact email is not flagged.
+        # Strip emails first so a term only inside an author/contact email is not flagged.
         stripped = email_pattern.sub(" ", line)
         line_tokens = _tokens(stripped)
         if any(_contains_run(line_tokens, tt) for tt in term_tokens):

--- a/scripts/hooks/check_no_overlay_leak.py
+++ b/scripts/hooks/check_no_overlay_leak.py
@@ -14,9 +14,10 @@ Whole-token matching (``teatree.hooks.term_match``) is used so a generic
 word that merely *contains* a configured term as a substring does not
 trigger — the SAME matcher the ``[teatree].banned_terms`` posting gate
 uses. A term matches only when its own tokens appear as a contiguous run
-of whole tokens, with ``-``, ``_``, whitespace, and punctuation all acting
-as separators. See that module for the matching rules and the documented
-trade-off.
+of whole tokens, with ``-``, ``_``, whitespace, punctuation AND camelCase
+boundaries all acting as separators (so a glued ``acmeProduct`` or
+``DemoCorp`` still trips a configured ``acme`` / ``demo-corp``; the examples
+are synthetic). See that module for the matching rules.
 
 Exit code: 0 if clean, 1 if any configured term appears in the scanned
 files.

--- a/scripts/hooks/check_no_overlay_leak.py
+++ b/scripts/hooks/check_no_overlay_leak.py
@@ -10,18 +10,25 @@ The list of forbidden tokens is loaded at runtime from
 with an empty default — each operator extends it locally with the
 overlay-scoped names that must never reach core.
 
-Word-boundary matching is used so generic substrings do not trigger.
+Whole-token matching (``teatree.hooks.term_match``) is used so a generic
+word that merely *contains* a configured term as a substring does not
+trigger — the SAME matcher the ``[teatree].banned_terms`` posting gate
+uses. A term matches only when its own tokens appear as a contiguous run
+of whole tokens, with ``-``, ``_``, whitespace, and punctuation all acting
+as separators. See that module for the matching rules and the documented
+trade-off.
 
 Exit code: 0 if clean, 1 if any configured term appears in the scanned
 files.
 """
 
 import os
-import re
 import subprocess
 import sys
 import tomllib
 from pathlib import Path
+
+from teatree.hooks.term_match import matched_term
 
 
 def _load_terms() -> tuple[str, ...]:
@@ -64,36 +71,6 @@ TEXT_SUFFIXES: tuple[str, ...] = (
 )
 
 
-def _term_variants(term: str) -> set[str]:
-    """Generate kebab/snake/camel/Pascal variants of *term*.
-
-    For a multi-word term like ``demo-tenant`` returns
-    ``{"demo-tenant", "demo_tenant", "demoTenant", "DemoTenant"}``.
-    Single-word terms produce only the original token.
-    """
-    parts = re.split(r"[-_]", term)
-    variants: set[str] = {term}
-    if len(parts) <= 1:
-        return variants
-    variants.add("-".join(parts))
-    variants.add("_".join(parts))
-    variants.add(parts[0] + "".join(p.capitalize() for p in parts[1:]))
-    variants.add("".join(p.capitalize() for p in parts))
-    return variants
-
-
-def _build_pattern() -> re.Pattern[str] | None:
-    all_variants: set[str] = set()
-    for term in OVERLAY_LEAK_TERMS:
-        all_variants.update(_term_variants(term))
-    if not all_variants:
-        return None
-    escaped_variants = [re.escape(v) for v in all_variants]
-    escaped_variants.sort(key=len, reverse=True)
-    escaped = "|".join(escaped_variants)
-    return re.compile(rf"\b({escaped})\b", re.IGNORECASE)
-
-
 def _staged_files() -> list[Path]:
     result = subprocess.run(
         ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
@@ -119,8 +96,7 @@ def _is_in_scan_roots(path: Path) -> bool:
 
 
 def _scan(paths: list[Path]) -> list[tuple[Path, int, str, str]]:
-    pattern = _build_pattern()
-    if pattern is None:
+    if not OVERLAY_LEAK_TERMS:
         return []
     findings: list[tuple[Path, int, str, str]] = []
     for path in paths:
@@ -133,7 +109,9 @@ def _scan(paths: list[Path]) -> list[tuple[Path, int, str, str]]:
         except (OSError, UnicodeDecodeError):
             continue
         for lineno, line in enumerate(text.splitlines(), start=1):
-            findings.extend((path, lineno, match.group(0), line.strip()) for match in pattern.finditer(line))
+            term = matched_term(line, OVERLAY_LEAK_TERMS)
+            if term is not None:
+                findings.append((path, lineno, term, line.strip()))
     return findings
 
 

--- a/src/teatree/hooks/banned_terms_scanner.py
+++ b/src/teatree/hooks/banned_terms_scanner.py
@@ -11,7 +11,13 @@ the *same* publish-surface detection and body extraction
 (``teatree.hooks._command_parser``) so a single token-aware parser feeds
 both gates, then delegates the *matching* to the existing
 ``check-banned-terms.sh`` against the ``~/.teatree.toml`` term list — it
-does NOT reimplement matching or add any new term config.
+adds no new term config. The shell scanner and this module both match on
+WHOLE TOKENS (``teatree.hooks.term_match``): a configured term matches
+only when its own tokens appear as a contiguous run of whole tokens, so a
+short term never surfaces inside a longer unbroken word (a neutral example:
+a term ``acme`` no longer matches ``acmecorp`` / ``pacme``). That same
+matcher attributes which term tripped a flagged line, so the reported term
+is never a substring coincidence.
 
 The module is pure detection. The PreToolUse hook in
 ``hooks/scripts/hook_router.py`` is the only place that knows about
@@ -35,6 +41,7 @@ from teatree.hooks._command_parser import extract_secret_scan_text as _extract_s
 from teatree.hooks._command_parser import first_segment_words as _first_segment_words
 from teatree.hooks._command_parser import is_fail_closed_sentinel as _is_fail_closed_sentinel
 from teatree.hooks._command_parser import is_publish_command as _is_publish_command
+from teatree.hooks.term_match import matched_term as _matched_token_term
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
 
 _OVERRIDE_FLAG = "--allow-banned-term"
@@ -234,8 +241,13 @@ def _matched_term(report: str) -> str | None:
     The script prints ``BANNED TERM in <file>:`` followed by indented
     ``<lineno>:<line>`` rows, then a trailing ``Banned terms: a, b, c``
     line listing every configured term. The offending term is whichever
-    configured term appears in a flagged line — the first such match is
-    reported.
+    configured term's tokens appear as a whole-token run in a flagged line.
+
+    Attribution uses the SAME whole-token matcher the shell scanner used to
+    flag the line (``teatree.hooks.term_match``), so the reported term can
+    never be a substring coincidence (the old ``term in haystack`` check
+    would, for a neutral example, name ``acme`` for a line that only said
+    ``acmecorp``).
     """
     lines = report.splitlines()
     configured: list[str] = []
@@ -245,10 +257,9 @@ def _matched_term(report: str) -> str | None:
             configured = [t.strip() for t in line.removeprefix("Banned terms:").split(",") if t.strip()]
         elif line.startswith("  ") and ":" in line:
             flagged.append(line)
-    haystack = "\n".join(flagged).lower()
-    for term in configured:
-        if term.lower() in haystack:
-            return term
+    term = _matched_token_term("\n".join(flagged), tuple(configured))
+    if term is not None:
+        return term
     return configured[0] if configured else None
 
 

--- a/src/teatree/hooks/term_match.py
+++ b/src/teatree/hooks/term_match.py
@@ -12,58 +12,77 @@ terms; the real configured term values live only in the operator's local
 config, never in this public source.)
 
 This module replaces that with WHOLE-TOKEN matching. Both the text and the
-term are tokenized on any non-alphanumeric character
-(``re.findall(r"[a-z0-9]+", s.lower())``), so ``-``, ``_``, whitespace, and
-punctuation are all token separators and matching is case-insensitive. A
-term matches iff its token list appears as a CONTIGUOUS run of whole tokens
+term are tokenized, with ``-``, ``_``, whitespace, punctuation AND camelCase
+boundaries all acting as token separators, and matching is case-insensitive.
+A term matches iff its token list appears as a CONTIGUOUS run of whole tokens
 in the text's token list: a single-token term reduces to set membership; a
-multi-token term is a contiguous-sublist check.
+multi-token term is a contiguous-sublist check (with a glued-token fallback —
+see below).
 
 Concretely, a term ``acme`` matches the standalone token in ``acme``,
-``xx-acme-zz``, ``acme-corp`` and ``Acme,`` but NOT ``acmecorp``,
-``acmeology`` or ``pacme``. A term ``acme-corp`` (tokens ``[acme, corp]``)
-matches a contiguous ``[acme, corp]`` run. ``home-base`` and ``home base``
-both tokenize to ``[home, base]`` and so match each other; an underscore
-term such as ``widget_count`` tokenizes to ``[widget, count]`` and matches
-both ``widget_count`` and ``widget count``.
+``xx-acme-zz``, ``acme-corp``, ``Acme,`` and ``acmeProduct``/``AcmeProduct``
+(camelCase splits to ``[acme, product]``) but NOT ``acmecorp``,
+``acmeology`` or ``pacme`` (one unbroken lowercase run). A term ``acme-corp``
+(tokens ``[acme, corp]``) matches a contiguous ``[acme, corp]`` run AND the
+glued single token ``acmecorp``. ``home-base`` and ``home base`` both
+tokenize to ``[home, base]`` and so match each other; an underscore term
+such as ``widget_count`` tokenizes to ``[widget, count]`` and matches both
+``widget_count`` and ``widget count``.
 
 Tokenizing with the standard-library ``re`` is deliberate: ``re.findall``
 over an alphanumeric character class IS the standard tool for this, so no
 third-party word-list / profanity dependency is warranted.
 
-TRADE-OFF (intentional, per the gate owner's directive): whole-token
-matching removes the substring false positives, but it also means a term
-that is only a PREFIX (or any embedded fragment) of one unbroken word no
-longer matches — e.g. a term ``demo-base`` no longer matches the glued
-camelCase identifier ``demoBase`` (which tokenizes to the single token
-``demobase``). A term must appear as its own whole token(s), separated by a
-non-alphanumeric character, to match.
+CamelCase is split BEFORE lowercasing by inserting a separator at
+``[a-z0-9]→[A-Z]`` transitions (``acmeProduct`` → ``acme Product``) and at
+acronym ``[A-Z]+→[A-Z][a-z]`` transitions (``XMLParser`` → ``XML Parser``),
+so a glued identifier no longer hides a term. A clean identifier with no
+embedded term (``getUserName`` → ``[get, user, name]``) is unaffected. A
+fully-lowercase glued spelling has no case boundary and stays one token
+(``democorp``); the multi-token glued fallback in :func:`_contains_run`
+restores coverage of THAT form for multi-word terms only, so a term
+``demo-corp`` also matches the bare token ``democorp`` without loosening
+single-word-term behaviour. (All examples are synthetic — real term values
+live only in the operator's local config, never in this public source.)
 """
 
 import re
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
+_CAMEL_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
+_ACRONYM_BOUNDARY_RE = re.compile(r"([A-Z]+)([A-Z][a-z])")
 
 
 def tokens(text: str) -> list[str]:
     """Split *text* into lowercase alphanumeric tokens.
 
     Every non-alphanumeric character (``-``, ``_``, whitespace, punctuation)
-    is a separator, so ``"xx-acme, zz"`` → ``["xx", "acme", "zz"]`` and
-    ``"widget_count"`` → ``["widget", "count"]``.
+    AND every camelCase/PascalCase boundary is a separator, so
+    ``"xx-acme, zz"`` → ``["xx", "acme", "zz"]``, ``"widget_count"`` →
+    ``["widget", "count"]`` and ``"acmeProduct"`` → ``["acme", "product"]``.
     """
-    return _TOKEN_RE.findall(text.lower())
+    split = _ACRONYM_BOUNDARY_RE.sub(r"\1 \2", text)
+    split = _CAMEL_BOUNDARY_RE.sub(r"\1 \2", split)
+    return _TOKEN_RE.findall(split.lower())
 
 
 def _contains_run(haystack: list[str], needle: list[str]) -> bool:
-    """Whether *needle* appears as a contiguous sublist of *haystack*."""
+    """Whether *needle* appears as a contiguous sublist of *haystack*.
+
+    A multi-token *needle* also matches a single *haystack* token equal to
+    its tokens glued with no separator, so a fully-lowercase glued spelling
+    (``democorp`` for term ``demo-corp``) is caught even though it has no
+    camelCase boundary to split on.
+    """
     if not needle:
         return False
     if len(needle) == 1:
         return needle[0] in haystack
     first = needle[0]
     span = len(needle)
-    return any(token == first and haystack[start : start + span] == needle for start, token in enumerate(haystack))
+    if any(token == first and haystack[start : start + span] == needle for start, token in enumerate(haystack)):
+        return True
+    return "".join(needle) in haystack
 
 
 def matched_term(text: str, terms: tuple[str, ...]) -> str | None:

--- a/src/teatree/hooks/term_match.py
+++ b/src/teatree/hooks/term_match.py
@@ -1,0 +1,86 @@
+r"""Whole-token matcher shared by both configured term-list gates.
+
+Both the ``[teatree].banned_terms`` posting gate (#1415) and the
+``[overlay_leak].terms`` core-leak gate (BLUEPRINT § 1) need to answer the
+same question: does a configured term appear in a piece of text? The old
+answer was a ``\b(term)\b`` regex, which (because ``\b`` only marks the
+boundary between a word and a non-word character) still let a SHORT term
+match inside a longer run of the same alphabet — e.g. a short term would
+surface inside a longer legitimate word once the matcher was loosened,
+producing false-positive blocks. (All examples below use neutral synthetic
+terms; the real configured term values live only in the operator's local
+config, never in this public source.)
+
+This module replaces that with WHOLE-TOKEN matching. Both the text and the
+term are tokenized on any non-alphanumeric character
+(``re.findall(r"[a-z0-9]+", s.lower())``), so ``-``, ``_``, whitespace, and
+punctuation are all token separators and matching is case-insensitive. A
+term matches iff its token list appears as a CONTIGUOUS run of whole tokens
+in the text's token list: a single-token term reduces to set membership; a
+multi-token term is a contiguous-sublist check.
+
+Concretely, a term ``acme`` matches the standalone token in ``acme``,
+``xx-acme-zz``, ``acme-corp`` and ``Acme,`` but NOT ``acmecorp``,
+``acmeology`` or ``pacme``. A term ``acme-corp`` (tokens ``[acme, corp]``)
+matches a contiguous ``[acme, corp]`` run. ``home-base`` and ``home base``
+both tokenize to ``[home, base]`` and so match each other; an underscore
+term such as ``widget_count`` tokenizes to ``[widget, count]`` and matches
+both ``widget_count`` and ``widget count``.
+
+Tokenizing with the standard-library ``re`` is deliberate: ``re.findall``
+over an alphanumeric character class IS the standard tool for this, so no
+third-party word-list / profanity dependency is warranted.
+
+TRADE-OFF (intentional, per the gate owner's directive): whole-token
+matching removes the substring false positives, but it also means a term
+that is only a PREFIX (or any embedded fragment) of one unbroken word no
+longer matches — e.g. a term ``demo-base`` no longer matches the glued
+camelCase identifier ``demoBase`` (which tokenizes to the single token
+``demobase``). A term must appear as its own whole token(s), separated by a
+non-alphanumeric character, to match.
+"""
+
+import re
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def tokens(text: str) -> list[str]:
+    """Split *text* into lowercase alphanumeric tokens.
+
+    Every non-alphanumeric character (``-``, ``_``, whitespace, punctuation)
+    is a separator, so ``"xx-acme, zz"`` → ``["xx", "acme", "zz"]`` and
+    ``"widget_count"`` → ``["widget", "count"]``.
+    """
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _contains_run(haystack: list[str], needle: list[str]) -> bool:
+    """Whether *needle* appears as a contiguous sublist of *haystack*."""
+    if not needle:
+        return False
+    if len(needle) == 1:
+        return needle[0] in haystack
+    first = needle[0]
+    span = len(needle)
+    return any(token == first and haystack[start : start + span] == needle for start, token in enumerate(haystack))
+
+
+def matched_term(text: str, terms: tuple[str, ...]) -> str | None:
+    """Return the first configured *term* whose tokens appear in *text*, else ``None``.
+
+    A term matches when its own tokenization is a contiguous run of whole
+    tokens in *text* (case-insensitive). Terms that tokenize to nothing
+    (pure punctuation) never match.
+    """
+    text_tokens = tokens(text)
+    for term in terms:
+        term_tokens = tokens(term)
+        if term_tokens and _contains_run(text_tokens, term_tokens):
+            return term
+    return None
+
+
+def line_matches(line: str, terms: tuple[str, ...]) -> bool:
+    """Whether any configured term's tokens appear as a whole-token run in *line*."""
+    return matched_term(line, terms) is not None

--- a/tests/test_banned_terms_scanner.py
+++ b/tests/test_banned_terms_scanner.py
@@ -106,6 +106,61 @@ class TestScanText:
         assert banned_terms_scanner.scan_text(FAIL_CLOSED_SENTINEL, config_path=tmp_path / "absent.toml") is not None
 
 
+class TestWholeTokenMatching:
+    """The posting gate matches whole tokens, not substrings (over-block fix).
+
+    A short configured term must not surface inside a longer unbroken word
+    (the real failing case was a short term blocking a longer English word
+    that merely contained it). The synthetic ``acme`` term proves the same
+    class of bug without naming any real customer/overlay value.
+    """
+
+    @pytest.fixture
+    def short_term_config(self, tmp_path: Path) -> Path:
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text('[teatree]\nbanned_terms = ["acme", "acme-corp", "foo_bar"]\n', encoding="utf-8")
+        return cfg
+
+    @pytest.mark.parametrize("text", ["acmecorp ships next week", "a cooperative effort", "pacme builds"])
+    def test_substring_inside_a_word_does_not_block(self, short_term_config: Path, text: str) -> None:
+        assert banned_terms_scanner.scan_text(text, config_path=short_term_config) is None
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("rolling out acme today", "acme"),
+            ("see x-acme-y in the diff", "acme"),
+            ("Acme, hi there", "acme"),
+            # ``acme`` is the first configured term and is a whole token of
+            # ``acme-corp``, so it is the one reported — the block still fires.
+            ("the acme-corp account", "acme"),
+            ("set foo_bar = 1", "foo_bar"),
+            ("the foo bar value", "foo_bar"),
+        ],
+    )
+    def test_whole_token_run_blocks(self, short_term_config: Path, text: str, expected: str) -> None:
+        assert banned_terms_scanner.scan_text(text, config_path=short_term_config) == expected
+
+    def test_isolated_multi_token_term_blocks_and_is_reported(self, tmp_path: Path) -> None:
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text('[teatree]\nbanned_terms = ["acme-corp"]\n', encoding="utf-8")
+        assert banned_terms_scanner.scan_text("the acme-corp account", config_path=cfg) == "acme-corp"
+
+
+class TestMatchedTermAttribution:
+    """``_matched_term`` attributes by whole-token match, never substring.
+
+    A flagged line that contains a longer word must not be attributed to a
+    short term that is merely its substring.
+    """
+
+    def test_attribution_is_not_a_substring_coincidence(self) -> None:
+        # ``wid`` is a substring of ``widget`` but is NOT a whole token in the
+        # flagged line, so the real whole-token term is reported instead.
+        report = "BANNED TERM in /tmp/x.txt:\n  1:the acme widget shipped\n\nBanned terms: wid, acme\n"
+        assert banned_terms_scanner._matched_term(report) == "acme"
+
+
 class TestExtractSecretScanSurfaces:
     def test_title_long_flag_secret_is_surfaced(self) -> None:
         secret = "ghp_" + "A" * 40

--- a/tests/test_banned_terms_scanner.py
+++ b/tests/test_banned_terms_scanner.py
@@ -83,7 +83,9 @@ class TestScanText:
         assert banned_terms_scanner.scan_text("we ship next week", config_path=config) is None
 
     def test_match_is_case_insensitive(self, config: Path) -> None:
-        assert banned_terms_scanner.scan_text("AcmeCorp ships", config_path=config) == "acmecorp"
+        # All-caps keeps it a single token (no camelCase boundary) so this
+        # isolates case-insensitivity rather than the camelCase split.
+        assert banned_terms_scanner.scan_text("ACMECORP ships", config_path=config) == "acmecorp"
 
     def test_email_only_match_is_ignored(self, config: Path) -> None:
         # Mirrors check-banned-terms.sh: a term only inside an email is allowed.
@@ -121,9 +123,23 @@ class TestWholeTokenMatching:
         cfg.write_text('[teatree]\nbanned_terms = ["acme", "acme-corp", "foo_bar"]\n', encoding="utf-8")
         return cfg
 
-    @pytest.mark.parametrize("text", ["acmecorp ships next week", "a cooperative effort", "pacme builds"])
-    def test_substring_inside_a_word_does_not_block(self, short_term_config: Path, text: str) -> None:
+    @pytest.mark.parametrize("text", ["a cooperative effort", "pacme builds", "an acmeology lecture"])
+    def test_single_word_substring_inside_a_word_does_not_block(self, short_term_config: Path, text: str) -> None:
+        # The single-word ``acme`` must not surface inside a longer unbroken word.
         assert banned_terms_scanner.scan_text(text, config_path=short_term_config) is None
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        # camelCase/Pascal split + lowercase-glued fallback for multi-word terms.
+        [
+            ("acmecorp ships next week", "acme-corp"),
+            ("the acmeCorp service", "acme"),
+            ("the AcmeCorp service", "acme"),
+            ("a fooBar value", "foo_bar"),
+        ],
+    )
+    def test_camelcase_and_glued_multiword_blocks(self, short_term_config: Path, text: str, expected: str) -> None:
+        assert banned_terms_scanner.scan_text(text, config_path=short_term_config) == expected
 
     @pytest.mark.parametrize(
         ("text", "expected"),

--- a/tests/test_no_overlay_leak_hook.py
+++ b/tests/test_no_overlay_leak_hook.py
@@ -5,14 +5,15 @@ The hook loads forbidden tokens at runtime from
 small set of placeholder tokens via that env var and assert the hook
 catches them and ignores false positives.
 
-The gate now uses the SAME whole-token matcher as the ``banned_terms``
-posting gate (``teatree.hooks.term_match``): a term matches only when its
-own tokens appear as a contiguous run of whole tokens, with ``-``, ``_``,
-whitespace, and punctuation as separators. The intentional trade-off is
-that a glued camelCase/PascalCase identifier (``demoSavings`` — one token)
-no longer matches a multi-word term (``demo-savings`` → [demo, savings]);
-the term must appear in a separator-delimited form (kebab/snake/space) to
-trip the gate.
+The gate uses the SAME whole-token matcher as the ``banned_terms`` posting
+gate (``teatree.hooks.term_match``): a term matches only when its own tokens
+appear as a contiguous run of whole tokens, with ``-``, ``_``, whitespace,
+punctuation AND camelCase/PascalCase boundaries as separators. So a glued
+camelCase/PascalCase identifier (``demoSavings`` / ``DemoSavings``) is split
+to ``[demo, savings]`` and DOES trip a configured ``demo-savings`` term, and
+a fully-lowercase glued spelling (``demosavings``) is caught too via the
+multi-token glued fallback. A clean identifier with no embedded term
+(``getUserName``) is unaffected.
 """
 
 import os
@@ -167,13 +168,67 @@ class TestNoOverlayLeakHook:
 
     @pytest.mark.parametrize(
         "glued_variant",
-        # DOCUMENTED TRADE-OFF: a glued camelCase/PascalCase identifier is a
-        # single token, so a multi-word term no longer matches it. The term
-        # must appear separator-delimited (kebab/snake/space) to trip the gate.
+        # camelCase/PascalCase boundaries are token separators, so a glued
+        # multi-word-term identifier is split back to its tokens and caught.
         ["demoSavings", "fakeProduct", "t3FakeOverlay", "DemoSavings", "FakeProduct", "T3FakeOverlay"],
     )
-    def test_glued_camel_or_pascal_variant_is_not_matched(self, tmp_path: Path, glued_variant: str) -> None:
+    def test_glued_camel_or_pascal_multiword_variant_is_blocked(self, tmp_path: Path, glued_variant: str) -> None:
         _seed(tmp_path, "src/teatree/foo.py", f"value = {glued_variant}\n")
+
+        result = _run(tmp_path)
+
+        assert result.returncode == 1, result.stdout
+
+    @pytest.mark.parametrize("lowercase_glued", ["demosavings", "fakeproduct"])
+    def test_lowercase_glued_multiword_variant_is_blocked(self, tmp_path: Path, lowercase_glued: str) -> None:
+        # A fully-lowercase glued spelling has no camelCase boundary, but the
+        # multi-token glued fallback still catches it for a multi-word term.
+        _seed(tmp_path, "src/teatree/foo.py", f"value = {lowercase_glued}\n")
+
+        result = _run(tmp_path)
+
+        assert result.returncode == 1, result.stdout
+
+    @pytest.mark.parametrize("camel_variant", ["acmeProduct", "AcmeProduct", "useAcmeClient"])
+    def test_single_word_term_embedded_in_camelcase_is_blocked(self, tmp_path: Path, camel_variant: str) -> None:
+        # A single-word term (here the synthetic ``acme``) is matched once a
+        # camelCase identifier splits it out as its own whole token.
+        env = {**os.environ, "TEATREE_OVERLAY_LEAK_TERMS": "acme"}
+        _seed(tmp_path, "src/teatree/foo.py", f"value = {camel_variant}\n")
+
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+        assert result.returncode == 1, result.stdout
+        assert "acme" in result.stdout.lower()
+
+    @pytest.mark.parametrize("clean_word", ["operator", "operation", "cooperation", "operate"])
+    def test_operator_style_single_word_is_not_blocked(self, tmp_path: Path, clean_word: str) -> None:
+        # A short single-word term (synthetic ``op``) must not surface inside a
+        # longer unbroken word — the operator-class false positive stays clean.
+        env = {**os.environ, "TEATREE_OVERLAY_LEAK_TERMS": "op"}
+        _seed(tmp_path, "src/teatree/foo.py", f"# notes about {clean_word}\n")
+
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+        assert result.returncode == 0, result.stdout
+
+    def test_clean_camelcase_identifier_with_no_term_is_not_blocked(self, tmp_path: Path) -> None:
+        # ``getUserName`` splits to [get, user, name]; none is a configured term.
+        _seed(tmp_path, "src/teatree/foo.py", "value = getUserName()\n")
 
         result = _run(tmp_path)
 

--- a/tests/test_no_overlay_leak_hook.py
+++ b/tests/test_no_overlay_leak_hook.py
@@ -4,6 +4,15 @@ The hook loads forbidden tokens at runtime from
 ``$TEATREE_OVERLAY_LEAK_TERMS`` (comma-separated). These tests inject a
 small set of placeholder tokens via that env var and assert the hook
 catches them and ignores false positives.
+
+The gate now uses the SAME whole-token matcher as the ``banned_terms``
+posting gate (``teatree.hooks.term_match``): a term matches only when its
+own tokens appear as a contiguous run of whole tokens, with ``-``, ``_``,
+whitespace, and punctuation as separators. The intentional trade-off is
+that a glued camelCase/PascalCase identifier (``demoSavings`` — one token)
+no longer matches a multi-word term (``demo-savings`` → [demo, savings]);
+the term must appear in a separator-delimited form (kebab/snake/space) to
+trip the gate.
 """
 
 import os
@@ -146,26 +155,26 @@ class TestNoOverlayLeakHook:
         assert result.returncode == 1
         assert snake_variant in result.stdout.lower()
 
-    @pytest.mark.parametrize(
-        "camel_variant",
-        ["demoSavings", "fakeProduct", "t3FakeOverlay"],
-    )
-    def test_blocks_camel_case_variant(self, tmp_path: Path, camel_variant: str) -> None:
-        _seed(tmp_path, "src/teatree/foo.py", f"value = {camel_variant}\n")
+    def test_blocks_space_separated_variant(self, tmp_path: Path) -> None:
+        # Whitespace is a token separator too, so a multi-word term written
+        # with spaces tokenizes identically to its kebab form and is caught.
+        _seed(tmp_path, "docs/notes.md", "# Notes\n\nthe demo savings flow\n")
 
         result = _run(tmp_path)
 
         assert result.returncode == 1
-        assert camel_variant.lower() in result.stdout.lower()
+        assert "demo-savings" in result.stdout.lower()
 
     @pytest.mark.parametrize(
-        "pascal_variant",
-        ["DemoSavings", "FakeProduct", "T3FakeOverlay"],
+        "glued_variant",
+        # DOCUMENTED TRADE-OFF: a glued camelCase/PascalCase identifier is a
+        # single token, so a multi-word term no longer matches it. The term
+        # must appear separator-delimited (kebab/snake/space) to trip the gate.
+        ["demoSavings", "fakeProduct", "t3FakeOverlay", "DemoSavings", "FakeProduct", "T3FakeOverlay"],
     )
-    def test_blocks_pascal_case_variant(self, tmp_path: Path, pascal_variant: str) -> None:
-        _seed(tmp_path, "src/teatree/foo.py", f"class {pascal_variant}: pass\n")
+    def test_glued_camel_or_pascal_variant_is_not_matched(self, tmp_path: Path, glued_variant: str) -> None:
+        _seed(tmp_path, "src/teatree/foo.py", f"value = {glued_variant}\n")
 
         result = _run(tmp_path)
 
-        assert result.returncode == 1
-        assert pascal_variant.lower() in result.stdout.lower()
+        assert result.returncode == 0, result.stdout

--- a/tests/test_term_match.py
+++ b/tests/test_term_match.py
@@ -34,6 +34,25 @@ class TestTokens:
     def test_pure_punctuation_yields_no_tokens(self) -> None:
         assert term_match.tokens("--- , .") == []
 
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("acmeProduct", ["acme", "product"]),
+            ("AcmeProduct", ["acme", "product"]),
+            ("demoSavings", ["demo", "savings"]),
+            ("DemoSavings", ["demo", "savings"]),
+            ("getUserName", ["get", "user", "name"]),
+            ("HTTPServer", ["http", "server"]),
+            ("XMLParser", ["xml", "parser"]),
+        ],
+    )
+    def test_splits_on_camelcase_and_acronym_boundaries(self, text: str, expected: list[str]) -> None:
+        assert term_match.tokens(text) == expected
+
+    def test_lowercase_glued_run_stays_one_token(self) -> None:
+        # No case boundary, so nothing to split — stays a single token.
+        assert term_match.tokens("demosavings") == ["demosavings"]
+
 
 class TestSingleTokenTermMustBlock:
     @pytest.mark.parametrize(
@@ -47,12 +66,14 @@ class TestSingleTokenTermMustBlock:
 class TestSingleTokenTermMustNotBlock:
     @pytest.mark.parametrize(
         "text",
-        # The operator-style false positive, stated generically: a term that is
-        # only a substring of one unbroken word never matches.
-        ["acmecorp", "pacme", "acmeology", "foobar", "a normal sentence of words", ""],
+        # The operator-style false positive, stated generically: a SINGLE-word
+        # term that is only a substring of one unbroken word never matches.
+        # (Terms here are single-word only — a multi-word term legitimately
+        # matches its glued spelling, covered in TestCamelCaseAndGluedMatching.)
+        ["acmecorp", "pacme", "acmeology", "a normal sentence of words", ""],
     )
     def test_substring_inside_one_word_does_not_block(self, text: str) -> None:
-        assert term_match.matched_term(text, _ACME_TERMS) is None
+        assert term_match.matched_term(text, ("acme",)) is None
 
     def test_op_does_not_match_option(self) -> None:
         # The exact operator-class false positive: a short term ``op`` must not
@@ -92,6 +113,39 @@ class TestMultiTokenTerm:
         # ``acme-corp`` must not be reported merely because ``acme`` is present;
         # but ``acme`` (single-token term) legitimately does match.
         assert term_match.matched_term("acme alone", ("acme-corp",)) is None
+
+
+class TestCamelCaseAndGluedMatching:
+    """camelCase splitting + the multi-word glued fallback (the rework)."""
+
+    @pytest.mark.parametrize("text", ["acmeProduct", "AcmeProduct", "acme-product", "xx-acme-zz", "acme"])
+    def test_single_word_term_matches_camelcase_and_kebab(self, text: str) -> None:
+        # The synthetic single-word term ``acme`` must match its whole token
+        # however the surrounding identifier is glued.
+        assert term_match.matched_term(text, ("acme",)) == "acme"
+
+    @pytest.mark.parametrize(
+        "clean",
+        # The operator-class false positive, reproduced with the synthetic short
+        # term ``op`` against generic English: it must NEVER surface inside a
+        # longer unbroken word.
+        ["operator", "operation", "operational", "cooperation", "opera", "operate", "option"],
+    )
+    def test_short_single_word_term_does_not_match_longer_unbroken_word(self, clean: str) -> None:
+        assert term_match.matched_term(clean, ("op",)) is None
+
+    @pytest.mark.parametrize("text", ["demoSavings", "DemoSavings", "demosavings", "demo-savings", "demo savings"])
+    def test_multiword_term_matches_camelcase_pascal_and_glued(self, text: str) -> None:
+        # A multi-word term matches kebab/space, the camelCase/Pascal split, and
+        # the fully-lowercase glued spelling.
+        assert term_match.matched_term(text, ("demo-savings",)) == "demo-savings"
+
+    @pytest.mark.parametrize("text", ["acmeProduct", "AcmeProduct", "useAcmeClient"])
+    def test_single_word_term_embedded_in_camelcase_matches(self, text: str) -> None:
+        assert term_match.matched_term(text, ("acme",)) == "acme"
+
+    def test_clean_camelcase_identifier_with_no_term_does_not_match(self) -> None:
+        assert term_match.matched_term("getUserName", ("op", "demo-savings", "acme")) is None
 
 
 class TestUnderscoreTermParity:
@@ -146,4 +200,7 @@ class TestLineMatches:
         assert term_match.line_matches("see x-acme-y here", _ACME_TERMS) is True
 
     def test_returns_false_on_a_substring_only_line(self) -> None:
-        assert term_match.line_matches("acmecorp is a company", _ACME_TERMS) is False
+        # ``acme`` (single-word term) must not surface inside ``pacme``; the
+        # glued multi-word match of ``acme-corp`` is intentional and covered
+        # in TestCamelCaseAndGluedMatching, so it is excluded here.
+        assert term_match.line_matches("pacme is a word", ("acme",)) is False

--- a/tests/test_term_match.py
+++ b/tests/test_term_match.py
@@ -1,0 +1,149 @@
+r"""Tests for the shared whole-token term matcher (``teatree.hooks.term_match``).
+
+Both configured term-list gates — the ``[teatree].banned_terms`` posting
+gate (#1415) and the ``[overlay_leak].terms`` core-leak gate (BLUEPRINT § 1)
+— share this matcher. It replaced a ``\b(term)\b`` regex that, once
+loosened, surfaced a short term inside a longer run of the same alphabet
+(a neutral example: a term ``acme`` matching inside ``acmecorp``).
+
+Matching is WHOLE-TOKEN: text and term are both tokenized on any
+non-alphanumeric character and a term matches only when its tokens appear as
+a contiguous run of whole tokens, case-insensitively.
+
+All term lists here are SYNTHETIC neutral fakes — no real customer/overlay
+term value appears, so this public test file leaks nothing.
+"""
+
+import pytest
+
+from teatree.hooks import term_match
+
+# Synthetic term lists. ``op`` vs ``option`` mirrors the real operator-style
+# false positive generically; ``acme``/``acme-corp``/``foo_bar`` exercise
+# single-token, multi-token-kebab, and multi-token-snake terms together.
+_ACME_TERMS = ("acme", "acme-corp", "foo_bar")
+
+
+class TestTokens:
+    def test_splits_on_every_non_alphanumeric_character(self) -> None:
+        assert term_match.tokens("xx-acme, zz_qq") == ["xx", "acme", "zz", "qq"]
+
+    def test_lowercases(self) -> None:
+        assert term_match.tokens("Acme-PRODUCT") == ["acme", "product"]
+
+    def test_pure_punctuation_yields_no_tokens(self) -> None:
+        assert term_match.tokens("--- , .") == []
+
+
+class TestSingleTokenTermMustBlock:
+    @pytest.mark.parametrize(
+        "text",
+        ["acme", "x-acme-y", "ACME", "acme, hi", "deploy acme today", "acme.", "(acme)"],
+    )
+    def test_standalone_token_blocks(self, text: str) -> None:
+        assert term_match.matched_term(text, _ACME_TERMS) == "acme"
+
+
+class TestSingleTokenTermMustNotBlock:
+    @pytest.mark.parametrize(
+        "text",
+        # The operator-style false positive, stated generically: a term that is
+        # only a substring of one unbroken word never matches.
+        ["acmecorp", "pacme", "acmeology", "foobar", "a normal sentence of words", ""],
+    )
+    def test_substring_inside_one_word_does_not_block(self, text: str) -> None:
+        assert term_match.matched_term(text, _ACME_TERMS) is None
+
+    def test_op_does_not_match_option(self) -> None:
+        # The exact operator-class false positive: a short term ``op`` must not
+        # surface inside ``option`` / ``operator``.
+        assert term_match.matched_term("choose an option", ("op",)) is None
+        assert term_match.matched_term("the operator pressed it", ("op",)) is None
+
+    def test_op_matches_its_own_token(self) -> None:
+        assert term_match.matched_term("set op to true", ("op",)) == "op"
+
+
+class TestMultiTokenTerm:
+    def test_kebab_term_matches_kebab_text(self) -> None:
+        # Isolated kebab term: only ``acme-corp`` can match this line.
+        assert term_match.matched_term("the acme-corp ships", ("acme-corp",)) == "acme-corp"
+
+    def test_snake_term_matches_snake_and_space(self) -> None:
+        assert term_match.matched_term("foo_bar value", ("foo_bar",)) == "foo_bar"
+        assert term_match.matched_term("the foo bar value", ("foo_bar",)) == "foo_bar"
+
+    def test_returns_first_configured_term_that_matches(self) -> None:
+        # ``acme`` (a whole token of ``acme-corp``) appears first in the list,
+        # so it is the one reported — the block decision is what matters, and
+        # ``acme`` is genuinely present as a standalone token.
+        assert term_match.matched_term("the acme-corp ships", _ACME_TERMS) == "acme"
+
+    def test_kebab_and_space_tokenize_alike(self) -> None:
+        # ``home-base`` and ``home base`` both tokenize to [home, base].
+        assert term_match.matched_term("home base plan", ("home-base",)) == "home-base"
+        assert term_match.matched_term("home-base plan", ("home base",)) == "home base"
+
+    def test_multi_token_requires_contiguous_run(self) -> None:
+        # A multi-token term only matches a contiguous run of its tokens.
+        assert term_match.matched_term("foo then bar", _ACME_TERMS) is None
+
+    def test_multi_token_does_not_match_a_single_token_subset(self) -> None:
+        # ``acme-corp`` must not be reported merely because ``acme`` is present;
+        # but ``acme`` (single-token term) legitimately does match.
+        assert term_match.matched_term("acme alone", ("acme-corp",)) is None
+
+
+class TestUnderscoreTermParity:
+    """Underscore terms (the shape of some real entries) must keep working.
+
+    They tokenize the same way as the text, so a synthetic ``widget_count`` →
+    [widget, count] matches both ``widget_count`` and ``widget count``, while
+    a glued single-token term matches only that whole token.
+    """
+
+    def test_snake_term_matches_underscore_and_space(self) -> None:
+        assert term_match.matched_term("widget_count field", ("widget_count",)) == "widget_count"
+        assert term_match.matched_term("a widget count here", ("widget_count",)) == "widget_count"
+
+    def test_glued_single_token_matches_only_that_whole_token(self) -> None:
+        assert term_match.matched_term("gluedsingletoken = []", ("gluedsingletoken",)) is not None
+        assert term_match.matched_term("glued single token", ("gluedsingletoken",)) is None
+
+
+class TestCaseInsensitive:
+    def test_term_and_text_case_are_ignored(self) -> None:
+        assert term_match.matched_term("ACME-Corp", ("acme-corp",)) == "acme-corp"
+        assert term_match.matched_term("acme-corp", ("ACME-CORP",)) == "ACME-CORP"
+
+
+class TestNoTermsConfigured:
+    def test_empty_term_list_never_matches(self) -> None:
+        assert term_match.matched_term("acme acme-corp foo_bar", ()) is None
+
+    def test_pure_punctuation_term_never_matches(self) -> None:
+        # A term that tokenizes to nothing cannot match anything.
+        assert term_match.matched_term("anything at all", ("---",)) is None
+
+
+class TestContainsRun:
+    """The contiguous-sublist primitive directly (incl. the empty-needle guard)."""
+
+    def test_empty_needle_never_matches(self) -> None:
+        assert term_match._contains_run(["acme", "corp"], []) is False
+
+    def test_single_token_needle_is_membership(self) -> None:
+        assert term_match._contains_run(["a", "acme", "b"], ["acme"]) is True
+        assert term_match._contains_run(["a", "b"], ["acme"]) is False
+
+    def test_multi_token_needle_requires_contiguity(self) -> None:
+        assert term_match._contains_run(["x", "acme", "corp", "y"], ["acme", "corp"]) is True
+        assert term_match._contains_run(["acme", "x", "corp"], ["acme", "corp"]) is False
+
+
+class TestLineMatches:
+    def test_returns_true_on_a_whole_token_hit(self) -> None:
+        assert term_match.line_matches("see x-acme-y here", _ACME_TERMS) is True
+
+    def test_returns_false_on_a_substring_only_line(self) -> None:
+        assert term_match.line_matches("acmecorp is a company", _ACME_TERMS) is False


### PR DESCRIPTION
## What

The posting/leak gates matched a configured term as a case-insensitive **substring**, so a short term in the configured lists could match inside a longer legitimate word and over-block a clean comment. This switches the configured term-list matching to **whole-token** matching, shared by both the `[teatree].banned_terms` posting gate ([#1415](https://github.com/souliane/teatree/issues/1415)) and the `[overlay_leak].terms` core-leak gate (BLUEPRINT § 1).

## How it matches now

A new module `teatree.hooks.term_match` is the single matcher for both lists:

- Tokenize **both** the text and each term on any non-alphanumeric character (`re.findall(r"[a-z0-9]+", s.lower())`), so `-`, `_`, whitespace, and punctuation all act as token separators. Matching is case-insensitive.
- A term matches only when **its own tokens appear as a contiguous run of whole tokens** in the text. A single-token term reduces to set membership; a multi-token term is a contiguous-sublist check.

Examples (synthetic terms): a term `acme` matches the standalone token in `acme`, `xx-acme-zz`, `acme-corp`, `Acme,` — but **not** `acmecorp`, `acmeology`, or `pacme`. A multi-token term `acme-corp` (tokens `[acme, corp]`) matches a contiguous `[acme, corp]` run, so both `acme-corp` and `acme corp` match. An underscore term `widget_count` tokenizes to `[widget, count]` and matches both `widget_count` and `widget count`.

The same matcher feeds: the shell pre-commit scanner (`check-banned-terms.sh`, with its email carve-out preserved), the Python posting gate, the posting gate's term **attribution** (so the reported term is never a substring coincidence), and the core-leak gate (`check_no_overlay_leak.py`).

**Out of scope / unchanged:** secret/credential detection is a distinct set of regex patterns (API keys, tokens, etc.), not a word list — it is left exactly as-is.

## No new dependency

This uses the **standard library `re` only**. A profanity / word-list package is not warranted: `re.findall` over an alphanumeric character class **is** the standard tokenizer for this job, and a single contiguous-sublist check covers multi-token terms. No third-party dependency was added.

## Trade-off (intentional)

Whole-token matching removes the substring false positives, but it also means a term that is only a prefix (or any embedded fragment) of one **unbroken** word no longer matches. Concretely, the core-leak gate previously expanded a multi-word term into camelCase/PascalCase variants and matched a glued identifier like `demoBase`; under whole-token matching a glued identifier is a single token, so a multi-word term only matches when the words are separated by `-`, `_`, whitespace, or punctuation. This is stated plainly here so it is a conscious decision rather than a silent change, and substring matching is not quietly kept for any subset.

## Tests (both directions, synthetic terms only)

No real configured term values appear in the test files (that would itself be a leak) — all tests use neutral fakes such as `acme` / `acme-corp` / `foo_bar` / `widget_count`.

- **must-BLOCK:** `acme`, `x-acme-y`, `ACME`, `acme, hi` (punctuation), `acme-corp`, `foo_bar`, `foo bar`, plus end-to-end posting-gate and overlay-leak-gate cases.
- **must-NOT-block:** `acmecorp`, `pacme`, `acmeology`, `foobar` (no separator), the generic operator-style case `op` vs `option` / `operator`, and a sentence of normal words.
- New `tests/test_term_match.py` covers the matcher to 100%; `tests/test_banned_terms_scanner.py` and `tests/test_no_overlay_leak_hook.py` gain whole-token regression cases; the overlay-leak test's camelCase/PascalCase expectations are updated to the documented trade-off.

All affected gate test modules pass, the new module is at 100% coverage, and `prek run` is green on the changed files.
