### PR TITLE
docs(review): add per-change file-hierarchy & module-placement dimension to /t3:review

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -117,6 +117,18 @@ After verifying repo rules, **check the full file** (not just changed lines) of 
 
 This step prevents architectural drift. Each diff looks fine in isolation — this check catches the cumulative effect by examining the full module.
 
+#### File-Hierarchy & Module-Placement Check (Non-Negotiable)
+
+The Module-Level Architectural Check above asks *what's inside* each touched file. This one asks *where the changed files live* — but **scoped strictly to the diff**, never a whole-tree audit. Examine only files the change adds, moves, or renames, plus the directories they land in:
+
+1. **New files in the wrong directory or module.** For each added file, confirm it sits in the package whose concern it shares. A scanner belongs under the scanners package, a CLI command under the CLI package, a model under the models package — flag a file dropped beside unrelated neighbors with a concrete "this new file should live at `X`" suggestion.
+2. **Should the change have created or moved into a subpackage?** When a diff adds the third or fourth sibling file all serving one new concern into an already-crowded directory, flag that the cohesive set should become its own subpackage (with the proposed path).
+3. **Files added at the repo root that belong under a directory.** A new script, config, or module dropped at the repo root is a finding unless the repo's conventions place it there — name the directory it should move under.
+4. **Diffs that worsen module cohesion or scoping.** Flag a change that widens a module's responsibility (an unrelated concern bolted onto an existing file), leaks a private helper across a package boundary, or imports across a layer the architecture keeps separate — point at the boundary the change crosses.
+5. **Obvious reorg opportunities the change reveals.** When implementing the change makes a misplacement plain (e.g. the file you just edited clearly belongs next to the collaborators it now calls), surface the concrete move — but only for files this diff touches.
+
+Each finding must name the suggested target path so the implementer can act without re-deriving it. **Full-tree reorganization audits are out of scope here** — sweeping the entire repository's layout for misplaced modules is the `ac-reviewing-codebase` skill's job (the periodic holistic review dispatched by the architectural-review loop). Keep this per-change check scoped to the diff so the two surfaces complement rather than duplicate each other.
+
 #### Read BLUEPRINT.md Before Designing (Non-Negotiable)
 
 Before proposing a design that changes how existing code is structured, read `BLUEPRINT.md` and any architectural-invariants doc FIRST, not last. Inventory existing patterns touching the same subsystem before proposing new ones. If the proposed design reverses a BLUEPRINT invariant, surface that to the user BEFORE designing around it — the user decides whether to overturn the invariant; if yes, update BLUEPRINT.md in the same change.


### PR DESCRIPTION
## What

Adds a **File-Hierarchy & Module-Placement Check** dimension to the `/t3:review` rubric (`skills/review/SKILL.md`), placed beside the existing **Module-Level Architectural Check**.

## Why

`/t3:review` is the per-change review rubric used both for self-review and for the loop's reviewer-PR (several-commits) review — the reviewing phase loads `t3:review` (`agents/prompt.py`'s `_REVIEWER_LIFECYCLE_SKILL`), so a single rubric serves both per-change surfaces. Its existing dimensions covered *what is inside* each touched file (module size, function count, god-module, complexity-rule suppressions) but nothing about *where the changed files live*. That left a gap: a new file dropped in the wrong package, a cohesive set of siblings that should have become a subpackage, an unrelated concern bolted onto an existing module, or a script added at the repo root could pass review unflagged.

## What the new dimension does

Prompts the reviewer to flag, **scoped strictly to the diff** (added / moved / renamed files only):

1. New files placed in the wrong directory or module — with a concrete "this file should live at X" suggestion.
2. A change that should have created or moved into a subpackage.
3. Files added at the repo root that belong under a directory.
4. Diffs that worsen module cohesion or scoping (widened responsibility, leaked private helper, cross-layer import).
5. Obvious reorg opportunities the change reveals — but only for files the diff touches.

Each finding must name the suggested target path.

## Scoping — no duplication with the whole-tree audit

The new check explicitly **defers full-tree reorganization audits to `ac-reviewing-codebase`** (the periodic holistic review the architectural-review loop dispatches). The per-change reviewer stays scoped to the diff; the holistic skill owns sweeping the whole repository's layout — so the two surfaces complement rather than duplicate each other.

## Surfaces checked

- **`/t3:review` (per-change + loop reviewer-PR review):** had no file-placement dimension → added here.
- **`review` mini-loop (`reviewer_prs.py`):** a pure signal-emitting scanner with no rubric of its own; its dispatched reviewing phase loads `/t3:review`, so this single edit covers it.
- **`arch_review` mini-loop (`architectural_review.py`):** already dispatches `ac-reviewing-codebase` for the whole-tree audit — unchanged, and now cross-referenced as the out-of-scope owner.

## Notes

- Purely additive; every existing review dimension is preserved.
- Pre-commit + pre-push gates green (SKILL.md frontmatter, skill-ref resolution, markdownlint, BLUEPRINT-sync gates, module-health, near-zero-comments, public-repo privacy-leak gate, fast pytest gate).
