### PR TITLE
fix(loop): resolve own-MR review skip identity from backend.identities

### DIFF
--- a/src/teatree/loop/tick_jobs.py
+++ b/src/teatree/loop/tick_jobs.py
@@ -294,6 +294,28 @@ def _resolve_broadcast_channels(config: object) -> list[tuple[str, str]]:
     return pairs
 
 
+def _own_author_identity(backend: OverlayBackends) -> str:
+    """Resolve the user's forge username for the own-MR review skip (#1844 L3).
+
+    The own-author ``:eyes:``-and-dispatch skip in
+    :class:`SlackBroadcastsScanner` needs to know who "we" are. Deriving
+    this from ``overlay.config.get_gitlab_username()`` breaks for every
+    overlay that leaves the getter at the core default ``""`` — an empty
+    value disables the skip and the loop reviews the user's own MRs. The
+    self-identity source of truth is the same one
+    :class:`ReviewerPrsScanner` uses: ``backend.identities`` (the
+    multi-alias operator set) with a ``host.current_user()`` fallback, so
+    the skip works regardless of whether an overlay implements the getter.
+    """
+    if backend.identities:
+        return backend.identities[0]
+    for host in backend.hosts:
+        user = host.current_user()
+        if user:
+            return user
+    return ""
+
+
 def _slack_broadcasts_scanner_for(backend: OverlayBackends) -> SlackBroadcastsScanner | None:
     """Build a per-overlay broadcast scanner from the overlay's review channel (#1255).
 
@@ -313,12 +335,7 @@ def _slack_broadcasts_scanner_for(backend: OverlayBackends) -> SlackBroadcastsSc
         return None
     glab_token = overlay.config.get_gitlab_token() if hasattr(overlay.config, "get_gitlab_token") else ""
     github_token = overlay.config.get_github_token() if hasattr(overlay.config, "get_github_token") else ""
-    # #1384: pass the user's forge username so the scanner skips :eyes: on
-    # their own-author MR broadcasts. Empty (no getter / unconfigured) leaves
-    # the filter off, preserving react-on-every-pending for legacy overlays.
-    current_gitlab_username = (
-        overlay.config.get_gitlab_username() if hasattr(overlay.config, "get_gitlab_username") else ""
-    )
+    current_gitlab_username = _own_author_identity(backend)
     return SlackBroadcastsScanner(
         backend=backend.messaging,
         channels=channel_ids,

--- a/tests/teatree_loop/test_slack_broadcasts_own_author_identity.py
+++ b/tests/teatree_loop/test_slack_broadcasts_own_author_identity.py
@@ -1,0 +1,185 @@
+"""Own-MR review skip must resolve identity from ``backend.identities`` (#1844 L3).
+
+The own-author ``:eyes:``-and-dispatch skip in
+:class:`teatree.loop.scanners.slack_broadcasts.SlackBroadcastsScanner` keys
+off ``current_gitlab_username``. The wiring builder
+``_slack_broadcasts_scanner_for`` previously derived that value solely from
+``overlay.config.get_gitlab_username()`` — a getter many overlays leave at
+the core default ``""``. An empty value disables the skip, so the loop
+``:eyes:``-reacts and dispatches ``t3:reviewer`` on the user's OWN MRs
+(maker == checker).
+
+The durable fix reuses the self-identity path
+:class:`teatree.loop.scanners.reviewer_prs.ReviewerPrsScanner` uses:
+``backend.identities`` (the multi-alias operator set) with a
+``host.current_user()`` fallback, so the own-author skip works regardless
+of whether an overlay implements ``get_gitlab_username()``.
+"""
+
+from dataclasses import dataclass, field
+
+from django.test import TestCase
+
+from teatree.core.backend_factory import OverlayBackends
+from teatree.core.models import ScannedBroadcast
+from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.slack_broadcasts import MrState
+from teatree.loop.tick_jobs import _slack_broadcasts_scanner_for
+from teatree.types import RawAPIDict
+
+CHANNEL = "C0AM3TENTLK"
+TS_A = "1779201478.501469"
+OWN_MR = "https://gitlab.example.com/team/project/-/merge_requests/7432"
+OWN_AUTHOR = "the-user"
+
+
+@dataclass
+class _FakeMessaging:
+    user_id: str = "U0A72P7CK0A"
+    react_calls: list[tuple[str, str, str]] = field(default_factory=list)
+    history: dict[str, list[RawAPIDict]] = field(default_factory=dict)
+
+    def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
+        self.react_calls.append((channel, ts, emoji))
+        return {"ok": True}
+
+    def fetch_channel_history(self, *, channel: str, limit: int = 0) -> list[RawAPIDict]:
+        _ = limit
+        return list(self.history.get(channel, []))
+
+
+@dataclass
+class _EmptyUsernameConfig:
+    """Overlay config that leaves ``get_gitlab_username`` at the core default ``""``."""
+
+    channel_id: str
+
+    def get_review_channel(self) -> tuple[str, str]:
+        return ("the-review-crew", self.channel_id)
+
+    def get_gitlab_username(self) -> str:
+        return ""
+
+    def get_gitlab_token(self) -> str:
+        return ""
+
+    def get_github_token(self) -> str:
+        return ""
+
+
+@dataclass
+class _FakeOverlay:
+    config: _EmptyUsernameConfig
+
+
+def _own_author_broadcast(messaging: _FakeMessaging) -> None:
+    messaging.history[CHANNEL] = [
+        {"text": f"please review {OWN_MR}", "ts": TS_A, "user": "USRG", "type": "message"},
+    ]
+
+
+class OwnAuthorBroadcastIdentityTests(TestCase):
+    """The built scanner skips ``:eyes:`` + dispatch on the user's own-MR broadcast.
+
+    Identity comes from ``backend.identities``, not the empty overlay getter.
+    """
+
+    def _build_and_scan(self, backend: OverlayBackends) -> list[ScanSignal]:
+        from unittest.mock import patch  # noqa: PLC0415
+
+        from teatree.loop.scanners.slack_broadcasts import GlabGhMrStateClassifier  # noqa: PLC0415
+
+        def _classify(_self: GlabGhMrStateClassifier, urls: list[str]) -> list[MrState]:
+            return [MrState(url=url, merged=False, approved=False, author_username=OWN_AUTHOR) for url in urls]
+
+        with patch.object(GlabGhMrStateClassifier, "__call__", _classify):
+            scanner = _slack_broadcasts_scanner_for(backend)
+            assert scanner is not None
+            return scanner.scan()
+
+    def test_own_mr_broadcast_emits_no_review_intent_and_no_eyes(self) -> None:
+        messaging = _FakeMessaging()
+        _own_author_broadcast(messaging)
+        overlay = _FakeOverlay(config=_EmptyUsernameConfig(channel_id=CHANNEL))
+        backend = OverlayBackends(
+            name="acme",
+            overlay=overlay,
+            messaging=messaging,
+            identities=(OWN_AUTHOR,),
+        )
+
+        signals = self._build_and_scan(backend)
+
+        assert [s.kind for s in signals if s.kind == "slack.review_intent"] == []
+        assert (CHANNEL, TS_A, "eyes") not in messaging.react_calls
+        row = ScannedBroadcast.objects.get(channel=CHANNEL, slack_ts=TS_A)
+        assert row.classification == ScannedBroadcast.Classification.PENDING
+
+    def test_colleague_mr_broadcast_still_dispatches(self) -> None:
+        messaging = _FakeMessaging()
+        messaging.history[CHANNEL] = [
+            {"text": f"please review {OWN_MR}", "ts": TS_A, "user": "USRG", "type": "message"},
+        ]
+        overlay = _FakeOverlay(config=_EmptyUsernameConfig(channel_id=CHANNEL))
+        backend = OverlayBackends(
+            name="acme",
+            overlay=overlay,
+            messaging=messaging,
+            identities=("someone.else",),
+        )
+
+        from unittest.mock import patch  # noqa: PLC0415
+
+        from teatree.loop.scanners.slack_broadcasts import GlabGhMrStateClassifier  # noqa: PLC0415
+
+        def _classify(_self: GlabGhMrStateClassifier, urls: list[str]) -> list[MrState]:
+            return [MrState(url=url, merged=False, approved=False, author_username=OWN_AUTHOR) for url in urls]
+
+        with patch.object(GlabGhMrStateClassifier, "__call__", _classify):
+            scanner = _slack_broadcasts_scanner_for(backend)
+            assert scanner is not None
+            signals = scanner.scan()
+
+        assert [s.kind for s in signals] == ["slack.review_intent"]
+        assert (CHANNEL, TS_A, "eyes") in messaging.react_calls
+
+
+@dataclass
+class _FakeHost:
+    username: str
+
+    def current_user(self) -> str:
+        return self.username
+
+
+class OwnAuthorIdentityResolutionTests(TestCase):
+    """``_own_author_identity`` mirrors ``ReviewerPrsScanner._resolve_identities``."""
+
+    def test_identities_take_precedence(self) -> None:
+        from teatree.loop.tick_jobs import _own_author_identity  # noqa: PLC0415
+
+        backend = OverlayBackends(
+            name="acme",
+            identities=(OWN_AUTHOR, "alias-2"),
+            hosts=(_FakeHost("host-user"),),
+        )
+
+        assert _own_author_identity(backend) == OWN_AUTHOR
+
+    def test_falls_back_to_first_host_current_user(self) -> None:
+        from teatree.loop.tick_jobs import _own_author_identity  # noqa: PLC0415
+
+        backend = OverlayBackends(
+            name="acme",
+            identities=(),
+            hosts=(_FakeHost(""), _FakeHost(OWN_AUTHOR)),
+        )
+
+        assert _own_author_identity(backend) == OWN_AUTHOR
+
+    def test_empty_when_no_identity_and_no_host_user(self) -> None:
+        from teatree.loop.tick_jobs import _own_author_identity  # noqa: PLC0415
+
+        backend = OverlayBackends(name="acme", identities=(), hosts=())
+
+        assert _own_author_identity(backend) == ""


### PR DESCRIPTION
## Problem (L3, live-confirmed)

The loop reviews the user's OWN MRs (maker == checker). The own-author `:eyes:`-and-dispatch skip in `SlackBroadcastsScanner._all_authored_by_me` keys off `current_gitlab_username`. The wiring builder `_slack_broadcasts_scanner_for` derived that value **solely** from `overlay.config.get_gitlab_username()` — a getter overlays leave at the core default `""`.

An empty username disables the skip, so the scanner `:eyes:`-reacts and dispatches `t3:reviewer` on broadcasts of MRs the user authored. This is a wired-but-not-exercised gate: the scanner-level skip logic is correct and unit-tested, but the wiring never feeds it a non-empty identity for overlays that don't implement the getter.

## Fix

Derive the own-author identity from `backend.identities` (the multi-alias operator set, the same self-identity source `ReviewerPrsScanner._resolve_identities` uses) with a `host.current_user()` fallback. The skip now works regardless of whether an overlay implements `get_gitlab_username()`.

New helper `_own_author_identity(backend)` in `src/teatree/loop/tick_jobs.py`:

- `backend.identities[0]` when set (the canonical self-identity set)
- else the first host's `current_user()`
- else `""` (filter stays off — legacy react-on-every-pending preserved)

## Tests (anti-vacuous, RED -> GREEN -> revert-to-RED verified)

`tests/teatree_loop/test_slack_broadcasts_own_author_identity.py`:

- own-MR broadcast built via the wiring (empty getter + `identities` set) emits **no** `slack.review_intent` and **no** `:eyes:` — was RED on the empty-getter wiring, GREEN after; reverting the fix returns it to RED.
- colleague-MR broadcast still dispatches + `:eyes:` (control)
- direct unit coverage of `_own_author_identity`: identities precedence, host fallback, empty default (100% on the new lines)

## Review

Do not self-merge — maker != reviewer. Robustness audit finding L3: https://github.com/souliane/teatree/issues/1844