### PR TITLE
fix(agents): add missing answerer + scanning-news phase agents

### DIFF
--- a/MAP.md
+++ b/MAP.md
@@ -44,7 +44,7 @@ lightweight entry-point packages. The Python source lives under
 | Directory | Purpose |
 |---|---|
 | `skills/` | Workflow skills loaded as `/t3:*` (`SKILL.md` + `references/`) — `code`, `ship`, `review`, `workspace`, `rules`, ... |
-| `agents/` | Phase sub-agent definitions (`orchestrator`, `coder`, `reviewer`, `tester`, `shipper`, `debugger`, `e2e`, `followup`) |
+| `agents/` | Phase sub-agent definitions (`orchestrator`, `coder`, `reviewer`, `tester`, `shipper`, `debugger`, `e2e`, `followup`, `answerer`, `scanning-news`) |
 | `hooks/` | Plugin hooks: `hooks.json` event→script mapping and the `scripts/` hook router (UserPromptSubmit, PreToolUse, PreCompact, Stop) |
 | `.claude-plugin/` | Plugin manifest — `plugin.json` (identity) and `marketplace.json` |
 | `tests/` | Pytest suite, mirroring the `src/` module path (`teatree_core/`, `teatree_cli/`, `integration/`, ...). E2E lives here, not in a separate top-level dir |

--- a/agents/answerer.md
+++ b/agents/answerer.md
@@ -1,0 +1,28 @@
+---
+name: answerer
+description: >
+  Drafts a reply to an inbound question, DMs the user for approval, and
+  posts on confirmation. Spawned by the loop when a question intent is
+  routed to the answering phase.
+tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+skills:
+  - rules
+  - workspace
+  - platforms
+  - answerer
+---
+
+# Answerer Agent
+
+You are a TeaTree answerer agent. Read the thread context, draft a
+reply in the user's voice, DM the user for approval, and post on the
+user's behalf only after explicit confirmation (unless the active
+overlay has opted into direct posting).
+
+Follow the loaded skills for the draft/approve/post workflow, the
+publishing and on-behalf-posting rules, platform API recipes, and
+cross-cutting rules.

--- a/agents/scanning-news.md
+++ b/agents/scanning-news.md
@@ -1,0 +1,28 @@
+---
+name: scanning-news
+description: >
+  Scans today's AI newsletters for teatree-improvement ideas, queues each
+  candidate behind the per-article ask-gate, and posts a Slack summary.
+  Spawned by the loop for the daily scanning-news cadence.
+tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+  - WebFetch
+skills:
+  - rules
+  - workspace
+  - platforms
+  - scanning-news
+---
+
+# Scanning-News Agent
+
+You are a TeaTree scanning-news agent. Verify each newsletter's edition
+date, fetch promising articles, record each concrete t3-improvement
+candidate behind the ask-gate (never auto-file an issue), dedupe by
+source URL, and post a terse Slack DM summary.
+
+Follow the loaded skills for the scanning workflow, the publishing and
+ask-gate rules, platform API recipes, and cross-cutting rules.

--- a/tests/teatree_core/test_phase_agent_conformance.py
+++ b/tests/teatree_core/test_phase_agent_conformance.py
@@ -9,6 +9,7 @@ never to a single chaining orchestrator. The table is the contract — adding
 
 import json
 from io import StringIO
+from pathlib import Path
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -27,6 +28,21 @@ EXPECTED_AUTHOR_AGENT: dict[str, str] = {
     "reviewing": "t3:reviewer",
     "shipping": "t3:shipper",
 }
+
+#: Repo-root ``agents/`` directory — the canonical sub-agent definitions the
+#: ``Agent`` tool resolves a ``t3:<name>`` value against. ``plugins/t3/agents``
+#: is the same directory reached through the ``plugins/t3 -> ..`` setup symlink.
+AGENTS_DIR: Path = Path(__file__).resolve().parents[2] / "agents"
+
+
+def _agent_name(subagent: str) -> str:
+    """Strip the ``t3:`` namespace prefix from a ``SUBAGENT_BY_PHASE`` value.
+
+    Every value is namespaced (asserted by
+    ``test_every_mapped_subagent_uses_the_t3_namespace``); ``removeprefix``
+    is a no-op for any future un-namespaced value rather than raising.
+    """
+    return subagent.removeprefix("t3:")
 
 
 class TestSubagentForPhaseConformance(TestCase):
@@ -108,4 +124,49 @@ class TestPendingTaskSignalConformance(TestCase):
             zones = {a.zone for a in actions if a.kind == "agent"}
             assert CHAINING_ORCHESTRATOR not in zones, (
                 f"author phase {phase!r} must not route to the chaining orchestrator (zones={zones})"
+            )
+
+
+class TestEverySubagentResolvesToAnAgentDefinition(TestCase):
+    """Every ``SUBAGENT_BY_PHASE`` value must resolve to a real agent file.
+
+    The loop dispatches a phase by passing its ``t3:<name>`` value as the
+    ``Agent`` tool's ``subagent_type``; the tool resolves that against an
+    ``agents/<name>.md`` definition. A phase mapped to a value with no
+    matching file errors at spawn time (``Agent type 't3:<name>' not
+    found``), so the work unit can never run. This scans the *whole* map —
+    not just the four FSM phases — so a phase added to ``SUBAGENT_BY_PHASE``
+    without its agent definition fails here, at conformance time.
+    """
+
+    def test_agents_dir_exists(self) -> None:
+        assert AGENTS_DIR.is_dir(), f"agents directory not found at {AGENTS_DIR}"
+
+    def test_every_mapped_subagent_has_an_agent_definition(self) -> None:
+        missing = {
+            (role, phase): subagent
+            for (role, phase), subagent in SUBAGENT_BY_PHASE.items()
+            if not (AGENTS_DIR / f"{_agent_name(subagent)}.md").is_file()
+        }
+        assert missing == {}, (
+            f"phases mapped to a sub-agent with no agents/<name>.md definition: {missing}. "
+            f"Spawning these via the Agent tool errors \"Agent type '<value>' not found\"."
+        )
+
+    def test_every_mapped_subagent_uses_the_t3_namespace(self) -> None:
+        offenders = {
+            (role, phase): subagent
+            for (role, phase), subagent in SUBAGENT_BY_PHASE.items()
+            if not subagent.startswith("t3:")
+        }
+        assert offenders == {}, f"sub-agent values must be namespaced 't3:<name>': {offenders}"
+
+    def test_agent_definition_name_matches_its_filename(self) -> None:
+        for (role, phase), subagent in SUBAGENT_BY_PHASE.items():
+            name = _agent_name(subagent)
+            agent_file = AGENTS_DIR / f"{name}.md"
+            text = agent_file.read_text(encoding="utf-8")
+            assert f"name: {name}\n" in text, (
+                f"{agent_file} frontmatter 'name:' must equal {name!r} so the Agent tool "
+                f"resolves {subagent!r} dispatched for ({role}, {phase})"
             )


### PR DESCRIPTION
## Problem

`SUBAGENT_BY_PHASE` (`src/teatree/core/phases.py:56-64`) mapped two phases to agent types with no matching definition: `(author, answering)` -> `t3:answerer` and `(author, scanning_news)` -> `t3:scanning-news`.

The loop dispatches a phase by passing its `t3:<name>` value as the `Agent` tool's `subagent_type`, which the tool resolves against `agents/<name>.md`. With no `agents/answerer.md` / `agents/scanning-news.md`, the spawn errored `Agent type 't3:answerer' not found` (live-confirmed). Both phases are queued in production -- daily/bootstrap `scanning_news` (`src/teatree/loop/scanners/scanning_news.py`) and delegated Slack answers routed to `answering` (`src/teatree/loop/dispatch.py::_dispatch_answering`, `src/teatree/loop/slack_answer/cycle.py`) -- so those work units could never run.

## Execution path determined: Agent-tool spawn

- `dispatch.py::_dispatch_answering` emits `DispatchAction(kind="agent", zone="t3:answerer", ...)`.
- `scanning_news` tasks are claimed via `loop_dispatch claim-next`, whose `subagent` field the `/loop` slot passes to its `Agent` tool (`src/teatree/cli/loop.py:227`).
- Matching `t3:answerer` / `t3:scanning-news` skills already exist (`skills/answerer/`, `skills/scanning-news/`); only the agent wrappers were missing.

## Fix

- Add `agents/answerer.md` and `agents/scanning-news.md`, mirroring the corresponding skills and matching the frontmatter shape of the other phase agents.
- Harden `tests/teatree_core/test_phase_agent_conformance.py`: a new test class resolves EVERY `SUBAGENT_BY_PHASE` value against a real `agents/<name>.md` file, so any phase mapped to a non-existent agent fails conformance.
- `MAP.md`: list the two new agents in the roster.

## RED -> GREEN evidence

Hardened test observed RED on the pre-fix tree:

```
AssertionError: phases mapped to a sub-agent with no agents/<name>.md definition:
{('author', 'answering'): 't3:answerer', ('author', 'scanning_news'): 't3:scanning-news'}.
```

GREEN after adding the two agents (12 passed). Revert-to-RED re-confirmed (remove files -> fails; restore -> passes). 100% line+branch coverage on the new test module.

## Notes

- `agents/` and `plugins/t3/agents/` are the same directory (`plugins/t3 -> ..` setup symlink; `plugins/` is gitignored), so the definitions are added once.
- The BLUEPRINT agent-roster count was intentionally left out: `docs/blueprint/` is already 380 B over its size budget on `main` (114,380 > 114,000), a pre-existing breakage unrelated to this fix, and any staged BLUEPRINT edit trips that gate.

Robustness umbrella: [#1844](https://github.com/souliane/teatree/issues/1844) (the brief cited `#110`, which is a closed PR, not the umbrella issue).
