### PR TITLE
fix(hooks): resolve printf/echo write-then-post body files in the publish gate

### DIFF
--- a/src/teatree/hooks/_body_file_resolution.py
+++ b/src/teatree/hooks/_body_file_resolution.py
@@ -37,8 +37,10 @@ class BodyFileContext:
     """Resolution context for ``-F``/``--file``/``--body-file`` body files.
 
     Groups the three settings that flow together through the body-file
-    walkers: the in-command ``heredoc_files`` map, the ``base`` dir a relative
-    body file is retried against (the commit's repo dir), and
+    walkers: the in-command ``heredoc_files`` map (a body written earlier in
+    the SAME command — a ``> path <<EOF`` heredoc or a ``printf``/``echo >
+    path`` redirect — keyed by the redirect-target token), the ``base`` dir a
+    relative body file is retried against (the commit's repo dir), and
     ``fail_closed_body_file`` (what an UNREADABLE ``gh``/``glab`` body file
     does — the git ``-F`` commit-message path always fails closed regardless).
     """
@@ -111,15 +113,18 @@ def _append_file_payload(path: str, payloads: list[str], ctx: BodyFileContext, *
     """Append the body referenced by a ``-F``/``--file``/``--body-file`` path.
 
     Resolution order: the on-disk file (as-is, then relative to ``ctx.base`` --
-    the commit's repo dir), then an in-command heredoc that writes to that
-    path (``cat > path <<EOF … EOF``), then the ``fail_closed`` branch. The
-    heredoc fallback closes the #126 false positive where a body written to a
-    temp file and committed via ``-F`` in the same command was unreadable at
-    PreToolUse scan time (the hook runs BEFORE the file is created). The
-    ``ctx.base`` fallback closes the cold-hook false positive where the harness
-    cwd has reset away from the worktree, so a ``git -C <worktree> commit -F
-    <relpath>`` body file is unreadable from the cwd yet readable from the
-    commit's own repo dir.
+    the commit's repo dir), then an in-command body written to that path — a
+    ``cat > path <<EOF … EOF`` heredoc or a ``printf``/``echo > path`` redirect
+    — then the ``fail_closed`` branch. The in-command fallback closes the #126
+    false positive where a body written to a temp file and posted via
+    ``--body-file``/``-F`` in the same command was unreadable at PreToolUse
+    scan time (the hook runs BEFORE the file is created); the lookup key is the
+    raw ``--body-file`` argument token, so a ``$f`` / ``$(mktemp)`` path matches
+    the textually-identical redirect target even though neither is expanded.
+    The ``ctx.base`` fallback closes the cold-hook false positive where the
+    harness cwd has reset away from the worktree, so a ``git -C <worktree>
+    commit -F <relpath>`` body file is unreadable from the cwd yet readable from
+    the commit's own repo dir.
 
     ``fail_closed`` selects what an unresolvable path does. ``True`` appends
     the fail-closed sentinel: the ``git commit -F <path>`` commit-message path

--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -207,6 +207,84 @@ def _heredoc_file_bodies(command: str) -> dict[str, str]:
     return bodies
 
 
+# Commands whose operands ARE the body content when redirected to a file
+# (an agent's two idioms for materialising a body temp file before a post).
+_REDIRECT_WRITER_COMMANDS: Final[frozenset[str]] = frozenset({"printf", "echo"})
+# Output-redirect operator prefixes, longest-first so ``>>`` precedes ``>``;
+# matched as a prefix to also catch the unspaced glued ``>$f`` lexer token.
+_REDIRECT_OPERATOR_PREFIXES: Final[tuple[str, ...]] = (">>", ">|", ">")
+
+
+def _split_redirect_token(word: str) -> str | None:
+    """Return the redirect target if ``word`` is/begins a write redirect, else None.
+
+    A bare operator (``>``/``>>``/``>|``) returns ``""`` — the target is the
+    NEXT word. An unspaced glued form (``>$f``, ``>/tmp/x``) returns the target
+    suffix. A word that does not start with a redirect operator returns ``None``.
+    """
+    for prefix in _REDIRECT_OPERATOR_PREFIXES:
+        if word.startswith(prefix):
+            return word[len(prefix) :]
+    return None
+
+
+def _redirect_written_bodies(tokens: list[Token]) -> dict[str, str]:
+    r"""Map each ``printf``/``echo`` ``> path`` redirect target token to its body.
+
+    Resolves the body-via-indirection idiom the heredoc map misses: an agent
+    materialises a body into a temp file with ``printf``/``echo`` and then
+    posts it with ``--body-file <path>``/``-F <path>`` in the SAME command
+    (``f=$(mktemp); printf '%s' 'text' > "$f"; gh ... --body-file "$f"``). At
+    PreToolUse scan time the file does NOT exist yet (the hook runs BEFORE the
+    write), so the only place the body lives is the writer's own operands.
+
+    The map is keyed by the **lexer token value** of the redirect target so a
+    shell-variable / command-substitution path (``$f``, ``$(mktemp)``) pairs
+    with the textually-identical ``--body-file`` argument token even though
+    neither is expanded at scan time — the resolver compares the two
+    unexpanded tokens, not a resolved filesystem path. A literal path
+    (``/tmp/x.txt``) likewise keys by its own value, matching how the body-file
+    walker looks the path up. Both the spaced (``> "$f"``) and unspaced
+    (``>"$f"``) redirect spellings are handled.
+
+    Conservative by construction: the writer's operands (every WORD between the
+    command name and the ``>``/``>>`` redirect) are joined verbatim. Over-
+    including a ``%s`` format token only ADDS text to what the gate scans; it
+    never hides the real body. A redirect with no preceding writer operands
+    contributes no entry, so a genuinely-unresolvable target still fails closed.
+    """
+    bodies: dict[str, str] = {}
+    for segment in split_commands(tokens):
+        words = [tok.value for tok in segment if tok.kind is TokenKind.WORD]
+        if not words or words[0] not in _REDIRECT_WRITER_COMMANDS:
+            continue
+        target, operands = _redirect_target_and_operands(words)
+        if target and operands:
+            bodies[target] = " ".join(operands)
+    return bodies
+
+
+def _redirect_target_and_operands(words: list[str]) -> tuple[str, list[str]]:
+    """Return the write-redirect target token and the writer operands preceding it.
+
+    Returns ``("", [])`` when the segment carries no output redirect. The target
+    is the glued suffix of an unspaced ``>$f`` token, or the next word after a
+    bare ``>`` operator. Operands are every WORD between the command name and
+    the redirect (the body content the writer emits).
+    """
+    for i in range(1, len(words)):
+        suffix = _split_redirect_token(words[i])
+        if suffix is None:
+            continue
+        operands = words[1:i]
+        if suffix:  # glued form ``>path`` — target is the suffix of this token
+            return suffix, operands
+        if i + 1 < len(words):  # bare ``>`` operator — target is the next word
+            return words[i + 1], operands
+        return "", operands
+    return "", []
+
+
 # Per-command argument-walker dispatch tables --------------------------
 
 # Body-bearing long options (value follows the flag as next token or
@@ -485,9 +563,12 @@ def extract_bash_payload(command: str, *, fail_closed_body_file: bool = False, c
     right per-command argument walker.
 
     Indirect body sources (``gh api --input -``, missing files, opaque
-    ``-d @file`` references) fail closed via the sentinel. A ``-F <path>``
-    reference whose file is written by a ``> path <<EOF … EOF`` redirect
-    in the same command resolves to that heredoc body instead (#126).
+    ``-d @file`` references) fail closed via the sentinel. A
+    ``--body-file``/``-F <path>`` reference whose body is written earlier in
+    the same command — by a ``> path <<EOF … EOF`` heredoc (#126) or by a
+    ``printf``/``echo > path`` redirect, including when the path is the same
+    unexpanded ``$f`` / ``$(mktemp)`` token in both the write and the
+    reference — resolves to that in-command body instead of failing closed.
 
     ``fail_closed_body_file`` controls an UNREADABLE ``gh``/``glab`` body
     file: ``False`` (default, the quote scanner) keeps the #126 behaviour
@@ -506,12 +587,12 @@ def extract_bash_payload(command: str, *, fail_closed_body_file: bool = False, c
     from teatree.hooks._body_file_resolution import BodyFileContext, commit_body_file_base  # noqa: PLC0415
 
     parts: list[str] = []
+    tokens = tokenize(command)
     ctx = BodyFileContext(
-        heredoc_files=_heredoc_file_bodies(command),
+        heredoc_files={**_heredoc_file_bodies(command), **_redirect_written_bodies(tokens)},
         fail_closed_body_file=fail_closed_body_file,
         base=commit_body_file_base(command) or cwd,
     )
-    tokens = tokenize(command)
     for segment in split_commands(tokens):
         _walk_command_segment(segment, parts, ctx)
     # Heredocs still need to be parsed against the raw command — the

--- a/tests/test_banned_terms_scanner.py
+++ b/tests/test_banned_terms_scanner.py
@@ -305,6 +305,83 @@ class TestExtractPublishPayload:
         assert "acmecorp" in payload
 
 
+class TestBodyFileWriteThenPostResolution:
+    """An in-command write paired with a later ``--body-file <path>`` resolves.
+
+    A ``printf``/``echo > path`` write paired with a later ``--body-file
+    <path>`` in the SAME command resolves to the written body — the file does
+    NOT exist on disk at PreToolUse scan time, so the gate must read the body
+    from the writer's operands rather than fail closed on every body (the
+    indirection-body bug). Safety is preserved: a ``--body-file`` whose body is
+    NOT written in-command (a bare shell variable, a missing literal file)
+    still fails closed.
+    """
+
+    def test_printf_redirect_to_var_path_resolves_clean_body(self) -> None:
+        # ``f=$(mktemp); printf '%s' '<clean>' > "$f"; gh ... --body-file "$f"``.
+        # The $f token is identical in the write and the reference, so the
+        # resolver pairs them even though neither is expanded at scan time.
+        cmd = 'f=$(mktemp); printf "%s" "ship next week" > "$f"; gh pr comment 5 --repo o/r --body-file "$f"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "ship next week" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_echo_redirect_to_var_path_resolves_clean_body(self) -> None:
+        cmd = 'f=$(mktemp); echo "ship next week" > "$f"; glab mr note create 7 --repo o/r --body-file "$f"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "ship next week" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_attached_redirect_no_space_resolves_clean_body(self) -> None:
+        # ``printf '%s' 'x' >"$f"`` — the unspaced redirect lexes as a single
+        # glued ``>$f`` token; the target must still pair with --body-file "$f".
+        cmd = 'f=$(mktemp); printf "%s" "ship next week" >"$f"; gh pr comment 5 --repo o/r --body-file "$f"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "ship next week" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_append_redirect_resolves_clean_body(self) -> None:
+        cmd = 'f=$(mktemp); printf "%s" "ship next week" >> "$f"; gh pr comment 5 --repo o/r --body-file "$f"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "ship next week" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_printf_redirect_to_literal_path_resolves_clean_body(self, tmp_path: Path) -> None:
+        body_file = tmp_path / "post-body.txt"
+        cmd = f'printf "%s" "ship next week" > {body_file}; gh pr comment 5 --repo o/r --body-file {body_file}'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "ship next week" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_write_then_post_with_banned_term_resolves_and_carries_term(self) -> None:
+        # The gate checks the RESOLVED content, so a banned term written via
+        # printf and posted via --body-file is surfaced for the matcher.
+        cmd = 'f=$(mktemp); printf "%s" "ship to acmecorp" > "$f"; gh pr comment 5 --repo o/r --body-file "$f"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "acmecorp" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_body_file_var_without_in_command_write_fails_closed(self) -> None:
+        # No in-command write to $BODY and no on-disk file — genuinely
+        # unresolvable, so the gate must STILL fail closed.
+        cmd = 'gh pr comment 5 --repo o/r --body-file "$BODY"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert FAIL_CLOSED_SENTINEL in payload
+
+    def test_body_file_missing_literal_path_fails_closed(self) -> None:
+        cmd = "gh pr comment 5 --repo o/r --body-file /no/such/body-file-xyz.txt"
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert FAIL_CLOSED_SENTINEL in payload
+
+
 class TestOverride:
     def test_flag_in_first_segment_bypasses(self) -> None:
         cmd = 'gh issue create --title t --body "acmecorp" --allow-banned-term'
@@ -388,6 +465,33 @@ class TestHookHandlerEndToEnd:
         decision = json.loads(capsys.readouterr().out)
         assert decision["permissionDecision"] == "deny"
         assert "acmecorp" in decision["permissionDecisionReason"]
+
+    def test_write_then_post_clean_body_via_body_file_passes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # The indirection-body bug: a clean body materialised with printf into a
+        # mktemp file and posted via --body-file used to fail closed on EVERY
+        # body. It must now resolve and pass the gate.
+        cmd = 'f=$(mktemp); printf "%s" "ship next week" > "$f"; gh pr comment 5 --repo o/r --body-file "$f"'
+        blocked = handle_banned_terms_pretool(_bash(cmd))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_write_then_post_banned_body_via_body_file_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # The gate checks the RESOLVED body content, not a placeholder, so a
+        # banned term written via printf and posted via --body-file is blocked.
+        cmd = 'f=$(mktemp); printf "%s" "ship to acmecorp" > "$f"; gh pr comment 5 --repo o/r --body-file "$f"'
+        blocked = handle_banned_terms_pretool(_bash(cmd))
+        assert blocked is True
+        decision = json.loads(capsys.readouterr().out)
+        assert decision["permissionDecision"] == "deny"
+        assert "acmecorp" in decision["permissionDecisionReason"]
+
+    def test_unresolvable_body_file_still_fails_closed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # A --body-file whose body is NOT written in-command and is not on disk
+        # is genuinely unresolvable — the gate must STILL block (fail closed),
+        # never pass an unscanned public body.
+        blocked = handle_banned_terms_pretool(_bash('gh pr comment 5 --repo o/r --body-file "$BODY"'))
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
     def test_gh_pr_comment_with_banned_term_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
         blocked = handle_banned_terms_pretool(_bash('gh pr comment 5 --body "acmecorp asked for this"'))


### PR DESCRIPTION
## Problem

The pre-publish posting gate (banned-terms / overlay-leak / bare-reference / quote scanners) fail-closed on **every** outgoing body — even a trivial clean plain-ASCII probe — whenever the body was passed by indirection rather than inline. The block surfaced as the placeholder term `<unresolved publish body>` (the fail-closed sentinel).

Root cause: the gate resolves a `--body-file`/`-F <path>` reference by (1) reading the file off disk, then (2) falling back to an in-command heredoc write (`cat > path <<EOF … EOF`). It had **no** fallback for the common agent idiom of materialising a body with `printf`/`echo` into a temp file and posting it via `--body-file` in the **same** command:

```
f=$(mktemp); printf '%s' 'body' > "$f"; gh pr comment N --body-file "$f"
```

At PreToolUse scan time the file does not exist yet (the hook runs *before* the write) and the path token is an unexpanded shell variable or command substitution, so the on-disk read fails, the heredoc map misses, and the gate substitutes the fail-closed sentinel — hard-blocking the body unread. The only workaround was writing the body to a fixed literal path in a separate prior command.

## Fix

Resolve the body for these standard passing paths by pairing a `printf`/`echo` `> path` redirect with a later `--body-file`/`-F` reference on the **textually identical** target token. Because the redirect target and the `--body-file` argument both come through the lexer the same way, an unexpanded `$f` / `$(mktemp)` in both the write and the reference resolves to the written operands. Covers the spaced (`> "$f"`), unspaced glued (`>"$f"`), and append (`>>`) redirect spellings.

The new in-command-written-body map is merged into the existing heredoc map and consulted **only after** the on-disk read, so a real readable file still wins.

Fail-closed safety is unchanged: a `--body-file` whose body is neither on disk nor written in-command (a bare variable, a missing literal file) still blocks. The fix correctly *resolves* resolvable bodies; it does not weaken the gate.

## Tests

New cases in `tests/test_banned_terms_scanner.py` (synthetic terms only — `acmecorp`, no real values, no absolute user paths):

- `TestBodyFileWriteThenPostResolution` — clean body via `printf`/`echo` → `--body-file` (var, literal, attached `>"$f"`, append `>>`) now **resolves**; a body with a synthetic banned term **carries the term** for the matcher; an unresolvable `$BODY` / missing literal file still carries the **fail-closed sentinel**.
- `TestHookHandlerEndToEnd` — end-to-end gate decisions: clean write-then-post **passes**; banned write-then-post **blocks**; unresolvable `--body-file` **still fails closed**.

## Verification

- `prek run --all-files` and `prek run --all-files --hook-stage pre-push` both green on the changed files (the only `--all-files` failures are `banned-terms` false positives on four pre-existing, unchanged files matching the local term list on innocuous English — identical to the base branch, not introduced here).
- Full scanner + parser suites pass.