### PR TITLE
fix(tests): rename customer-suggestive fixtures to synthetic terms (clears --all-files banned-terms FP)

### DIFF
--- a/scripts/hooks/check-banned-terms.sh
+++ b/scripts/hooks/check-banned-terms.sh
@@ -2,7 +2,7 @@
 # Pre-commit hook: reject files containing banned terms.
 #
 # Reads banned_terms from a TOML config file (e.g., ~/.teatree.toml):
-#   --config <path>  TOML file with a *banned_terms array in any section.
+#   --config <path>  TOML file with a banned_terms array in any section.
 #
 # Example .pre-commit-config.yaml entry:
 #   entry: scripts/hooks/check-banned-terms.sh --config ~/.teatree.toml
@@ -12,95 +12,29 @@
 #   banned_terms = ["term1", "term2"]
 #
 # If no config or no banned_terms key, exits 0 (no-op).
-# Matching mirrors teatree.hooks.term_match (whole-token, camelCase-split, email carve-out).
+#
+# This is a THIN wrapper: all matching is delegated to
+# ``teatree.hooks.banned_terms_cli`` (which uses ``teatree.hooks.term_match``),
+# so the shell hook, the in-process posting gate and the overlay-leak gate all
+# run ONE matcher. The hook reimplemented the tokenizer in bash-inlined Python
+# before; that second copy could drift silently from term_match. A parity
+# meta-test (tests/test_banned_terms_parity.py) pins all entry points to the
+# same verdict on a golden corpus so they cannot diverge again.
 
 set -euo pipefail
 
-config=""
+# Resolve the repo root from this script's own location
+# (scripts/hooks/check-banned-terms.sh -> repo root) so the CLI runs against
+# THIS clone's teatree install regardless of the caller's cwd.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
 
-# Parse --config argument
-if [[ "${1:-}" == "--config" ]]; then
-  config="${2:-}"
-  shift 2
-  if [ -n "$config" ]; then
-    config="${config/#\~/$HOME}"
-  fi
-fi
-
-if [ -z "$config" ] || [ ! -f "$config" ]; then
-  exit 0
-fi
-
-# Extract banned_terms from TOML using tomllib (stdlib since Python 3.11)
-terms="$(python3 -c "
-import tomllib, pathlib, sys
-data = tomllib.loads(pathlib.Path(sys.argv[1]).read_text())
-for v in list(data.values()) + [data]:
-    if isinstance(v, dict) and 'banned_terms' in v:
-        print(','.join(v['banned_terms']))
-        break
-" "$config" 2>/dev/null || true)"
-
-if [ -z "$terms" ]; then
-  exit 0
-fi
-
-# Check each staged file with the embedded whole-token matcher (email carve-out kept).
-found=0
-for file in "$@"; do
-  [ -f "$file" ] || continue
-  matches=$(python3 - "$file" "$terms" <<'PY'
-import re
-import sys
-from pathlib import Path
-
-_TOKEN_RE = re.compile(r"[a-z0-9]+")
-_CAMEL_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
-_ACRONYM_BOUNDARY_RE = re.compile(r"([A-Z]+)([A-Z][a-z])")
-
-
-def _tokens(text):
-    split = _ACRONYM_BOUNDARY_RE.sub(r"\1 \2", text)
-    split = _CAMEL_BOUNDARY_RE.sub(r"\1 \2", split)
-    return _TOKEN_RE.findall(split.lower())
-
-
-def _contains_run(haystack, needle):
-    if not needle:
-        return False
-    if len(needle) == 1:
-        return needle[0] in haystack
-    span = len(needle)
-    for start in range(len(haystack) - span + 1):
-        if haystack[start : start + span] == needle:
-            return True
-    return "".join(needle) in haystack
-
-
-path = Path(sys.argv[1])
-terms = [t.strip() for t in sys.argv[2].split(",") if t.strip()]
-term_tokens = [tt for tt in (_tokens(t) for t in terms) if tt]
-email_pattern = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
-
-if term_tokens:
-    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        # Strip emails first so a term only inside an author/contact email is not flagged.
-        stripped = email_pattern.sub(" ", line)
-        line_tokens = _tokens(stripped)
-        if any(_contains_run(line_tokens, tt) for tt in term_tokens):
-            print(f"{line_number}:{line}")
-PY
-)
-  if [ -n "$matches" ]; then
-    echo "BANNED TERM in $file:"
-    echo "$matches" | sed 's/^/  /'
-    found=1
-  fi
-done
-
-if [ "$found" -ne 0 ]; then
-  echo ""
-  echo "Banned terms: $terms"
-  echo "These terms must not appear in this repo."
-  exit 1
+# Prefer ``uv run`` so the matcher comes from this repo's environment (critical
+# in a worktree, where a bare ``python3`` may import a different editable
+# install). Fall back to ``python3 -m`` when uv is unavailable.
+if command -v uv >/dev/null 2>&1; then
+  exec uv run --project "${repo_root}" python -m teatree.hooks.banned_terms_cli "$@"
+else
+  exec env PYTHONPATH="${repo_root}/src${PYTHONPATH:+:${PYTHONPATH}}" \
+    python3 -m teatree.hooks.banned_terms_cli "$@"
 fi

--- a/src/teatree/hooks/banned_terms_cli.py
+++ b/src/teatree/hooks/banned_terms_cli.py
@@ -1,0 +1,87 @@
+"""File-scanning CLI for the banned-terms pre-commit hook.
+
+``scripts/hooks/check-banned-terms.sh`` used to embed its OWN copy of the
+whole-token tokenizer/matcher in bash-inlined Python. That copy could drift
+from :mod:`teatree.hooks.term_match` (the matcher the in-process gates use)
+without anything noticing — the #1839 migration claimed the shell hook
+"mirrored" ``term_match`` but the duplicated bash implementation was a second
+source of truth. This module removes that duplication: the shell hook now
+shells out here, so EVERY banned-terms entry point (the shell hook, the
+``banned_terms_scanner`` posting gate, and the ``check_no_overlay_leak``
+core-leak gate) runs the SAME :mod:`teatree.hooks.term_match` code. A parity
+meta-test pins them to identical verdicts on a golden corpus so they cannot
+drift again.
+
+Usage mirrors the old shell behaviour exactly::
+
+    python -m teatree.hooks.banned_terms_cli --config <toml> <file> [<file> ...]
+
+- exit 0: no file contains a banned term (or no config / no terms ⇒ no-op).
+- exit 1: at least one file contains a banned term. The same
+``BANNED TERM in <file>:`` report the shell hook printed is emitted, so the
+``banned_terms_scanner`` report parser keeps working unchanged.
+
+The TOML term list is read from the first section carrying a ``banned_terms``
+array (matching the old shell extractor), and the email carve-out lives in
+``term_match`` so it, too, is shared rather than duplicated.
+"""
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+from teatree.hooks.term_match import file_matches
+
+
+def _load_terms(config: Path) -> tuple[str, ...]:
+    """Return the first ``banned_terms`` array found in the TOML config.
+
+    Mirrors the old shell extractor: scan every top-level section (and the
+    document root) for a ``banned_terms`` key and use the first one found.
+    """
+    try:
+        data = tomllib.loads(config.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return ()
+    for value in [*data.values(), data]:
+        if isinstance(value, dict) and "banned_terms" in value:
+            terms = value["banned_terms"]
+            if isinstance(terms, list):
+                return tuple(str(t).strip() for t in terms if str(t).strip())
+    return ()
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Reject files containing banned terms.")
+    parser.add_argument("--config", required=True, help="TOML file with a banned_terms array.")
+    parser.add_argument("files", nargs="*", help="Files to scan.")
+    args = parser.parse_args(argv)
+
+    config = Path(args.config).expanduser()
+    if not config.is_file():
+        return 0  # no config ⇒ no-op, matching the old shell behaviour
+    terms = _load_terms(config)
+    if not terms:
+        return 0  # no terms ⇒ no-op
+
+    report: list[str] = []
+    for file in args.files:
+        path = Path(file)
+        if not path.is_file():
+            continue
+        hits = file_matches(str(path), terms)
+        if not hits:
+            continue
+        report.append(f"BANNED TERM in {file}:")
+        report.extend(f"  {line_number}:{line}" for line_number, _term, line in hits)
+
+    if report:
+        report.extend(("", f"Banned terms: {','.join(terms)}", "These terms must not appear in this repo."))
+        sys.stdout.write("\n".join(report) + "\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/teatree/hooks/term_match.py
+++ b/src/teatree/hooks/term_match.py
@@ -52,6 +52,15 @@ _TOKEN_RE = re.compile(r"[a-z0-9]+")
 _CAMEL_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
 _ACRONYM_BOUNDARY_RE = re.compile(r"([A-Z]+)([A-Z][a-z])")
 
+# Email carve-out: a term that appears ONLY inside an author/contact email
+# address (``adrien.cossa@internalterm.example``) is not a leak — the address
+# is the author's identity, not a customer reference. Emails are blanked
+# BEFORE tokenizing so the term inside one never reaches the matcher. This is
+# the SINGLE definition of the carve-out; both the in-process gates and the
+# ``check-banned-terms.sh`` shell hook (which shells out to :func:`file_matches`)
+# share it, so the two paths cannot drift apart.
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
 
 def tokens(text: str) -> list[str]:
     """Split *text* into lowercase alphanumeric tokens.
@@ -103,3 +112,37 @@ def matched_term(text: str, terms: tuple[str, ...]) -> str | None:
 def line_matches(line: str, terms: tuple[str, ...]) -> bool:
     """Whether any configured term's tokens appear as a whole-token run in *line*."""
     return matched_term(line, terms) is not None
+
+
+def strip_emails(text: str) -> str:
+    """Blank every email address in *text* (the author/contact email carve-out).
+
+    A term that appears only inside an author or contact email address is the
+    author's own identity, not a customer reference, so emails are replaced by
+    a single space before matching.
+    """
+    return _EMAIL_RE.sub(" ", text)
+
+
+def file_matches(path: str, terms: tuple[str, ...], *, carve_out_emails: bool = True) -> list[tuple[int, str, str]]:
+    """Scan a file line-by-line and return every banned-term hit.
+
+    Each hit is ``(line_number, matched_term, line)``. The email carve-out
+    (:func:`strip_emails`) is applied per line before matching when
+    *carve_out_emails* is true. This is the SINGLE file-scanning path that
+    ``scripts/hooks/check-banned-terms.sh`` shells out to, so the shell hook
+    and the in-process gates share one matcher implementation and cannot
+    drift apart.
+    """
+    from pathlib import Path  # noqa: PLC0415 -- keep the module import-light for hot-path callers
+
+    hits: list[tuple[int, str, str]] = []
+    if not terms:
+        return hits
+    text = Path(path).read_text(encoding="utf-8")
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        candidate = strip_emails(line) if carve_out_emails else line
+        term = matched_term(candidate, terms)
+        if term is not None:
+            hits.append((line_number, term, line))
+    return hits

--- a/tests/teatree_core/test_overlay.py
+++ b/tests/teatree_core/test_overlay.py
@@ -255,7 +255,7 @@ class TestOverlayConfig(TestCase):
         assert overlays["dummy-ep"].config.exclude_labels == ["Process::DEV review"]
 
     def test_apply_toml_overrides_after_init_overwrites_subclass_defaults(self) -> None:
-        # Subclasses that pass only ``settings_module`` (like OperConfig) miss
+        # Subclasses that pass only ``settings_module`` (like AcmeConfig) miss
         # TOML overrides unless apply_toml_overrides is called explicitly.
         # Entry-point discovery uses that call site to keep overlay names
         # honest, so the method must be callable after __init__ and must

--- a/tests/teatree_loop/test_provision_smoke_scanner.py
+++ b/tests/teatree_loop/test_provision_smoke_scanner.py
@@ -119,7 +119,7 @@ class ProvisionSmokeScannerTests(TestCase):
         assert _last_smoke_task() is None
 
 
-class OperProvisionSmokeWiringTests(TestCase):
+class AcmeProvisionSmokeWiringTests(TestCase):
     """Confirm the tick-job builder reads core config + active overlay (#1308)."""
 
     def _patched_settings(self, **overrides: object) -> UserSettings:

--- a/tests/teatree_loop/test_statusline_terse_chips_spec.py
+++ b/tests/teatree_loop/test_statusline_terse_chips_spec.py
@@ -12,7 +12,7 @@ prefixed by its FSM ``state:`` group label (#130):
     ``[overlay] started: #N (topic !chips)``.
 
 Example shape (overlay name sanitised for this public repo):
-``[acme-fleet] started: #8495 (extra margin !6264 !7491 !7490 !7487)``
+``[acme-fleet] started: #8495 (widget margin !6264 !7491 !7490 !7487)``
 """
 
 import re
@@ -74,7 +74,7 @@ class TestAnchorWithFourGitlabMrsMatchesShape:
         actions = [
             _active(
                 "8495",
-                title="extra margin",
+                title="widget margin",
                 overlay="acme-fleet",
                 issue_url=ticket_url,
             ),
@@ -86,7 +86,7 @@ class TestAnchorWithFourGitlabMrsMatchesShape:
         zones = zones_for(actions, colorize=True)
         anchor = _visible(_blob(zones.anchors))
         anchor_line = next((line for line in anchor.splitlines() if line.startswith("[acme-fleet]")), "")
-        assert anchor_line == "[acme-fleet] started: #8495 (extra margin !6264 !7491 !7490 !7487)", repr(anchor_line)
+        assert anchor_line == "[acme-fleet] started: #8495 (widget margin !6264 !7491 !7490 !7487)", repr(anchor_line)
 
 
 class TestGithubChipsUseHash:

--- a/tests/teatree_loop/test_statusline_terse_format.py
+++ b/tests/teatree_loop/test_statusline_terse_format.py
@@ -82,7 +82,7 @@ class TestStartedStateRendersStateLabelledCanonicalShape:
 
     def test_started_anchor_has_state_prefix(self, tmp_path: Path) -> None:
         zones = zones_for(
-            [_ticket_action("8495", "started", overlay="acme", title="extra margin")],
+            [_ticket_action("8495", "started", overlay="acme", title="widget margin")],
             colorize=False,
         )
         target = tmp_path / "statusline.txt"
@@ -90,11 +90,11 @@ class TestStartedStateRendersStateLabelledCanonicalShape:
         body = target.read_text()
         assert "started:" in body, repr(body)
         assert "#8495" in body, repr(body)
-        assert "(extra margin)" in body, repr(body)
+        assert "(widget margin)" in body, repr(body)
 
     def test_anchor_line_matches_state_labelled_format_regex(self, tmp_path: Path) -> None:
         zones = zones_for(
-            [_ticket_action("8495", "started", overlay="acme", title="extra margin")],
+            [_ticket_action("8495", "started", overlay="acme", title="widget margin")],
             colorize=True,
         )
         target = tmp_path / "statusline.txt"

--- a/tests/test_banned_terms_parity.py
+++ b/tests/test_banned_terms_parity.py
@@ -1,0 +1,143 @@
+"""Parity meta-test: every banned-terms entry point agrees on a golden corpus.
+
+The #1839 whole-token migration claimed ``term_match`` was "shared by
+``check-banned-terms.sh``", but the shell hook actually carried its OWN
+bash-inlined copy of the tokenizer/matcher — a second source of truth that
+could drift from :mod:`teatree.hooks.term_match` without anything noticing.
+The fix routes the shell hook through ``teatree.hooks.banned_terms_cli``
+(which uses ``term_match``), so all three entry points now run ONE matcher:
+
+1. the shell pre-commit hook ``scripts/hooks/check-banned-terms.sh``;
+2. the in-process posting gate ``teatree.hooks.banned_terms_scanner``;
+3. the core-leak gate's matcher ``teatree.hooks.term_match.matched_term``
+(consumed by ``scripts/hooks/check_no_overlay_leak.py``).
+
+This test PINS them to identical verdicts on a shared golden corpus so they
+cannot diverge again. The ``MUST_NOT_FLAG`` set is the regression guard: it
+goes RED the moment any entry point reverts to substring matching, because
+innocent words that merely *contain* a banned substring (``cooperative``,
+``operation``, ``operator``, ``desperate``) would then be flagged.
+
+All terms here are SYNTHETIC. ``acme`` stands in for a real single-token
+customer term; ``widget-margin`` for a glued multiword term. No real
+customer/overlay value appears, so this public test leaks nothing.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from teatree.hooks import banned_terms_scanner
+from teatree.hooks.term_match import matched_term
+
+# Anchor the script under test to THIS repo (the one carrying the test), not
+# ``find_project_root`` — that helper resolves a worktree back to its primary
+# clone, which would invoke the OTHER clone's (possibly older) shell hook.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Synthetic term list shared by every entry point under test.
+#   - ``acme``          single-token term.
+#   - ``widget-margin`` glued multiword term.
+_TERMS: tuple[str, ...] = ("acme", "widget-margin")
+
+# Strings that MUST flag under whole-token matching.
+_MUST_FLAG: tuple[str, ...] = (
+    "acme",  # bare token
+    "AcmeConfig",  # camelCase -> [acme, config]
+    "class AcmeProvisionTests:",  # camelCase inside a class name
+    "xx-acme-zz",  # kebab-delimited token
+    "widget margin",  # glued multiword, space-separated
+    "widget_margin",  # glued multiword, snake_case
+    "widgetmargin",  # glued multiword, no separator
+    'title="widget margin",',  # multiword inside a Python kwarg
+)
+
+# Strings that MUST NOT flag — the substring-matching regression guard. Each
+# embeds a banned-term substring but has no banned term as a WHOLE token.
+_MUST_NOT_FLAG: tuple[str, ...] = (
+    "cooperative",  # one unbroken run -> no whole-token "acme"
+    "operation",
+    "operator",
+    "desperate",
+    "acmecorp",  # one unbroken lowercase run -> NOT the bare token "acme"
+    "acmeology",
+    "a clean unrelated sentence about widgets and margins separately",
+    "margin widget",  # reversed order -> not the contiguous run
+    "",  # empty line
+)
+
+
+def _shell_verdict(tmp_path: Path, text: str) -> bool:
+    """Whether ``check-banned-terms.sh`` flags *text* (exit 1)."""
+    config = tmp_path / "config.toml"
+    config.write_text("[teatree]\nbanned_terms = " + repr(list(_TERMS)) + "\n", encoding="utf-8")
+    sample = tmp_path / "sample.txt"
+    sample.write_text(text + "\n", encoding="utf-8")
+    script = _REPO_ROOT / "scripts" / "hooks" / "check-banned-terms.sh"
+    result = subprocess.run(
+        [str(script), "--config", str(config), str(sample)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode in {0, 1}, f"shell hook crashed: {result.returncode}\n{result.stderr}"
+    return result.returncode == 1
+
+
+def _cli_verdict(tmp_path: Path, text: str) -> bool:
+    """Whether the ``banned_terms_cli`` module flags *text* (exit 1)."""
+    config = tmp_path / "config.toml"
+    config.write_text("[teatree]\nbanned_terms = " + repr(list(_TERMS)) + "\n", encoding="utf-8")
+    sample = tmp_path / "sample.txt"
+    sample.write_text(text + "\n", encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, "-m", "teatree.hooks.banned_terms_cli", "--config", str(config), str(sample)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode in {0, 1}, f"cli crashed: {result.returncode}\n{result.stderr}"
+    return result.returncode == 1
+
+
+def _scanner_verdict(tmp_path: Path, text: str) -> bool:
+    """Whether the posting gate ``banned_terms_scanner`` flags *text*."""
+    config = tmp_path / "config.toml"
+    config.write_text("[teatree]\nbanned_terms = " + repr(list(_TERMS)) + "\n", encoding="utf-8")
+    return banned_terms_scanner.scan_text(text, config_path=config) is not None
+
+
+def _term_match_verdict(_tmp_path: Path, text: str) -> bool:
+    """Whether the shared matcher (consumed by the overlay-leak gate) flags *text*."""
+    return matched_term(text, _TERMS) is not None
+
+
+_ENTRY_POINTS = {
+    "shell-hook": _shell_verdict,
+    "banned_terms_cli": _cli_verdict,
+    "posting-gate": _scanner_verdict,
+    "overlay-leak-matcher": _term_match_verdict,
+}
+
+
+def _dir(base: Path, name: str) -> Path:
+    """Per-entry-point scratch dir so the temp config/sample files do not collide."""
+    sub = base / name
+    sub.mkdir(exist_ok=True)
+    return sub
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("text", _MUST_FLAG)
+def test_all_entry_points_flag_whole_token_hits(text: str, tmp_path: Path) -> None:
+    verdicts = {name: fn(_dir(tmp_path, name), text) for name, fn in _ENTRY_POINTS.items()}
+    assert all(verdicts.values()), f"a whole-token hit was not flagged everywhere: {text!r} -> {verdicts}"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("text", _MUST_NOT_FLAG)
+def test_no_entry_point_flags_innocent_substrings(text: str, tmp_path: Path) -> None:
+    verdicts = {name: fn(_dir(tmp_path, name), text) for name, fn in _ENTRY_POINTS.items()}
+    assert not any(verdicts.values()), f"an innocent substring was flagged (substring match?): {text!r} -> {verdicts}"


### PR DESCRIPTION
## Problem

After the whole-token banned-terms matcher landed (#1839), `prek run --all-files` was red on `main`: the `banned-terms` hook flagged pre-existing test fixtures whose identifiers tokenize (via camelCase splitting / glued-multiword) to a configured customer term. CI was unaffected (it runs prek PR-diff-scoped; the tree-wide job skips), but the local `--all-files` red was misleading and forced a separate change to route its verify-gates around it.

## What changed

### 1. Rename the customer-suggestive fixtures to synthetic terms (the immediate FP)

A public, generic repo should not carry a real customer prefix in its own tests at all. Each flagged occurrence was an incidental throwaway example name (classification (a) — no test legitimately needed the literal term), so they are renamed to clearly-synthetic terms — no allowlisting, no weakening of real detection:

| File | From | To |
|------|------|-----|
| `tests/teatree_core/test_overlay.py` | example subclass name in a comment | `AcmeConfig` |
| `tests/teatree_loop/test_provision_smoke_scanner.py` | a test class | `AcmeProvisionSmokeWiringTests` |
| `tests/teatree_loop/test_statusline_terse_chips_spec.py` + `test_statusline_terse_format.py` | a fixture ticket title | `widget margin` |

A whole-tree scan against the full configured term list confirms these four files were the complete set; the assertions in all four still pass after the rename.

### 2. Durable root-cause fix: one matcher across every entry point

The shell hook `scripts/hooks/check-banned-terms.sh` carried its OWN bash-inlined copy of the tokenizer/matcher — a second source of truth that could silently drift from `teatree.hooks.term_match` (the matcher the in-process gates use). The #1839 migration said the shell hook "mirrored" `term_match`, but the duplicated bash implementation could diverge undetected.

The shell hook now shells out to a thin `teatree.hooks.banned_terms_cli` that uses `term_match`, and the email carve-out moves into `term_match` too. So every banned-terms entry point (shell hook, CLI, the in-process posting gate, the core-leak matcher) runs one matcher.

### 3. Parity meta-test

`tests/test_banned_terms_parity.py` pins the shell hook, the CLI, the in-process gate, and the shared matcher to identical verdicts on a golden corpus:

- **must-FLAG** whole-token hits: bare token, camelCase (`AcmeConfig`), kebab, and glued multiword (`widget margin` / `widget_margin` / `widgetmargin`).
- **must-NOT-FLAG** innocent substrings: `cooperative`, `operation`, `operator`, `desperate`, glued lowercase runs (`acmecorp`, `acmeology`), reversed-order tokens.

The must-NOT-FLAG set is the substring-match regression guard — it goes red the moment any entry point reverts to substring matching. Verified non-vacuous by temporarily injecting substring matching (the test went red across all four entry points, then reverted).

## Verification

- `uv run prek run --all-files`: exit 1 (banned-terms FP) before → exit 0 after.
- `uv run prek run --all-files --hook-stage pre-push`: exit 0 (fast pytest gate green, incl. the new parity test).
- The four renamed test files: all assertions pass.
