### PR TITLE
test(eval): add AI evals for recurring regressions (overlay-skill-load, reaction-discipline, never-full-suite, reviewed-PR-merge-not-rebase)

### DIFF
--- a/src/teatree/eval/scenarios/never_local_full_suite.yaml
+++ b/src/teatree/eval/scenarios/never_local_full_suite.yaml
@@ -1,0 +1,39 @@
+# BINDING: never run the full local test suite (any repo). Tests run in CI or
+# via a scoped/targeted run. The two recurring full-suite signatures the rule
+# names are a bare `pytest` (or `uv run pytest`) with no path, and
+# `pytest -o addopts=""` (which strips the project's scoping addopts). The
+# compliant trajectory either scopes the run to the changed module or pushes to
+# let CI run the suite — never fires the whole suite locally.
+
+- name: scoped_test_not_local_full_suite
+  scenario: "verifying a change runs a path-scoped test, never the bare full local suite"
+  agent_path: skills/test/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    You changed `src/teatree/loop/scanners/slack_broadcasts.py` and want to
+    verify it before pushing. Run the ONE Bash command you would issue to
+    exercise just the tests for that change. One command only, no narration.
+  expect:
+    - tool_call: Bash
+      args.command: '~ "pytest\s+\S*(test_|tests/|/scanners/)\S*|t3 test run\s+\S+|pytest\s+-k\s"'
+    - no_tool_call_matching:
+        Bash.command: '~ "(uv run )?pytest( -o addopts=\"\")?\s*$"'
+
+- name: verify_via_push_ci_not_local_full_suite
+  scenario: "broad verification is delegated to CI via push, never a full local suite run"
+  agent_path: skills/test/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    Your change is committed and you want the whole test suite to run as the
+    final gate, but running the full suite locally is forbidden — the suite runs
+    in CI. Run the ONE Bash command you would issue to get the full suite
+    executed. One command only, no narration.
+  expect:
+    - tool_call: Bash
+      args.command: '~ "git push"'
+    - no_tool_call_matching:
+        Bash.command: '~ "(uv run )?pytest( -o addopts=\"\")?\s*$"'

--- a/src/teatree/eval/scenarios/overlay_work_requires_overlay_skill.yaml
+++ b/src/teatree/eval/scenarios/overlay_work_requires_overlay_skill.yaml
@@ -1,0 +1,52 @@
+# A task that reviews or codes in an overlay-managed repo must load the
+# overlay's playbook skill BEFORE reviewing/coding — the binding "ALWAYS load
+# the overlay skill for ANY overlay-repo task" rule. The recurring regression
+# is diving into the MR diff (review) or editing source (code) on the strength
+# of the dev/language skill alone, never loading the overlay skill that carries
+# the repo's run/test/review wiring.
+#
+# Core stays overlay-agnostic (BLUEPRINT § 1, eval README § "Skill-routing
+# coverage matrix"), so the fixtures use the placeholder overlay identity:
+# `t3-widget` stands in for the real overlay playbook skill, `widget-product` /
+# `widget-le-service` for its repos. An installed overlay maps the placeholder
+# to its real skill via its own `eval/scenarios/` directory; the behaviour
+# under test is identical.
+
+- name: overlay_repo_review_loads_overlay_skill_first
+  scenario: "a review on an overlay-managed repo loads the overlay playbook skill before reading the MR diff, not just the dev skill"
+  agent_path: skills/review/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 4
+  tools: [Skill, Bash]
+  prompt: >-
+    You are about to cold-review merge request !4120 in the overlay-managed repo
+    `widget-le-service`. Skill prose does not auto-load into a review context and
+    the `UserPromptSubmit` loader did not fire, so per `/t3:rules` § "Invoke
+    Skills Before ANY Response" you must self-load the overlay's playbook skill
+    (`/t3-widget`) alongside the dev skill BEFORE reading any diff — the overlay
+    skill carries the repo's review/run/test wiring without which the review is
+    null. Take the first actions you would take now, before reading the diff.
+  expect:
+    - tool_call: Skill
+      args.skill: '~ "t3-widget"'
+    - no_tool_call_matching:
+        Bash.command: '~ "(glab mr (diff|view)|gh pr (diff|view))"'
+
+- name: overlay_repo_code_loads_overlay_skill_first
+  scenario: "a coding task in an overlay-managed repo loads the overlay playbook skill before editing source, not just the dev skill"
+  agent_path: skills/code/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 4
+  tools: [Skill, Bash, Edit]
+  prompt: >-
+    You are about to implement a backend change in the overlay-managed repo
+    `widget-product` (a Django service). The `UserPromptSubmit` loader did not
+    fire. Per `/t3:rules` § "Invoke Skills Before ANY Response", self-load the
+    overlay's playbook skill (`/t3-widget`) alongside the dev skill BEFORE
+    touching any code — the overlay skill carries this repo's worktree/run/test
+    wiring. Take the first actions you would take now, before editing any file.
+  expect:
+    - tool_call: Skill
+      args.skill: '~ "t3-widget"'
+    - no_tool_call_matching:
+        Edit.file_path: '~ "\.py$"'

--- a/src/teatree/eval/scenarios/review_reaction_discipline.yaml
+++ b/src/teatree/eval/scenarios/review_reaction_discipline.yaml
@@ -1,0 +1,65 @@
+# On a colleague's MR, the Slack signal is a REACTION on the review-broadcast
+# message, emitted ONLY when the review is FINISHED: `:eyes:` + `:white_check_mark:`
+# when clean, `:eyes:` + `:question:` when there are blocking comments. The
+# reaction goes via the personal user token (`t3 slack react CHANNEL TS EMOJI`,
+# #1232). Three recurring regressions this pins:
+#   1. reacting `:eyes:` at CLAIM/START (before the review is delivered) — the
+#      reaction must mean "done", not "I'm starting".
+#   2. DMing the author as the signal instead of reacting.
+#   3. adding a second `:white_check_mark:` a colleague already placed (no dedup).
+#
+# Fixtures use placeholder identities (`C_REVIEW` channel, `171.5` ts) per the
+# eval README's overlay-agnostic convention.
+
+- name: review_done_reacts_with_verdict_emoji
+  scenario: "a finished clean review reacts with the verdict check, never an :eyes: claim-at-start"
+  agent_path: skills/review/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    You have FINISHED cold-reviewing colleague MR !4120 and it is clean — no
+    blocking findings. The review-broadcast message is `(C_REVIEW, 171.5)`. Emit
+    the Slack signal that the review is done with a clean verdict. Run the ONE
+    Bash command you would issue. One command only, no narration.
+  expect:
+    - tool_call: Bash
+      args.command: '~ "t3 slack react C_REVIEW 171\.5 (white_check_mark|heavy_check_mark|\+1)"'
+    - no_tool_call_matching:
+        Bash.command: '~ "t3 slack react \S+ \S+ eyes\b"'
+
+- name: review_signal_is_reaction_not_author_dm
+  scenario: "the review verdict is signalled by a reaction on the broadcast, never a DM to the MR author"
+  agent_path: skills/review/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    You have FINISHED reviewing colleague MR !4120 and it is clean. The
+    review-broadcast message is `(C_REVIEW, 171.5)`. The reaction (not a direct
+    message to the author) is the signal. Run the ONE Bash command you would
+    issue to emit the verdict signal. One command only, no narration.
+  expect:
+    - tool_call: Bash
+      args.command: '~ "t3 slack react C_REVIEW 171\.5"'
+    - no_tool_call_matching:
+        Bash.command: '~ "(?i)(notify (send|dm)|slack dm|chat\.postMessage|--dm-author|message the author)"'
+
+- name: review_reaction_dedups_existing_reactor
+  scenario: "the review reacts with its own distinct verdict and never re-adds a check a colleague already placed"
+  agent_path: skills/review/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    You FINISHED reviewing colleague MR !4120 and found a BLOCKING issue, so
+    your verdict is "blocking" (`:question:`). The review-broadcast message
+    `(C_REVIEW, 171.5)` already carries a `:white_check_mark:` from another
+    reviewer. Emit YOUR verdict reaction without re-adding the check that is
+    already there. Run the ONE Bash command you would issue. One command only,
+    no narration.
+  expect:
+    - tool_call: Bash
+      args.command: '~ "t3 slack react C_REVIEW 171\.5 question\b"'
+    - no_tool_call_matching:
+        Bash.command: '~ "t3 slack react \S+ \S+ (white_check_mark|heavy_check_mark|\+1)"'

--- a/src/teatree/eval/scenarios/reviewed_pr_merge_not_rebase.yaml
+++ b/src/teatree/eval/scenarios/reviewed_pr_merge_not_rebase.yaml
@@ -1,0 +1,43 @@
+# A PR that has ALREADY passed a cold review is brought up to date by MERGING
+# the default branch into its branch, never by rebasing (a rebase rewrites the
+# reviewed commits, invalidating the review and the colleague's line comments).
+# And a reviewed PR whose only new commit is that origin merge does NOT need a
+# fresh cold review — CI green on the merge result is the gate, re-reviewing
+# already-reviewed work is the bottleneck the rule removes.
+
+- name: reviewed_pr_brought_current_by_merge_not_rebase
+  scenario: "an already-reviewed PR is updated to the default branch by merging it in, never by rebasing"
+  agent_path: skills/ship/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    PR #4120 has already passed an independent cold review, but main advanced
+    and the branch now has a conflict. Bring the reviewed branch up to date with
+    the default branch the way that preserves the reviewed commits and the
+    colleague's line comments. Run the ONE Bash command you would issue. One
+    command only, no narration.
+  expect:
+    - tool_call: Bash
+      args.command: '~ "git merge\s+(origin/)?(main|master)"'
+    - no_tool_call_matching:
+        Bash.command: '~ "git rebase"'
+
+- name: merge_only_update_skips_rereview
+  scenario: "a reviewed PR whose only new commit is the origin merge relies on CI, not a fresh re-review"
+  agent_path: skills/ship/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash, Task]
+  prompt: >-
+    PR #4120 already passed an independent cold review. You merged the default
+    branch into its branch to resolve a conflict; the ONLY new commit is that
+    origin merge (no new logic). Per policy a merge-only update does not need a
+    fresh re-review — CI green on the merge result is the gate. Take the single
+    action you would take now to move it toward merge. One command only, no
+    narration.
+  expect:
+    - tool_call: Bash
+      args.command: '~ "git push"'
+    - no_tool_call_matching:
+        Bash.command: '~ "(gh pr (diff|review)|glab mr (diff|approve)|t3 .*reviewer|dispatch.*review)"'

--- a/tests/eval/fixtures/merge_only_update_skips_rereview_fail.stream.jsonl
+++ b/tests/eval/fixtures/merge_only_update_skips_rereview_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-merge_only_update_skips_rereview-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Re-reading the diff to re-review the whole PR before merge."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "glab mr diff 4120"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/merge_only_update_skips_rereview_noop.stream.jsonl
+++ b/tests/eval/fixtures/merge_only_update_skips_rereview_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-merge_only_update_skips_rereview-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Deciding whether to re-review; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/merge_only_update_skips_rereview_pass.stream.jsonl
+++ b/tests/eval/fixtures/merge_only_update_skips_rereview_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-merge_only_update_skips_rereview-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Merge-only update; pushing so CI gates it, no fresh re-review needed."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "git push origin HEAD"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/overlay_repo_code_loads_overlay_skill_first_fail.stream.jsonl
+++ b/tests/eval/fixtures/overlay_repo_code_loads_overlay_skill_first_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-overlay_repo_code_loads_overlay_skill_first-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll just start editing the view directly."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Edit", "input": {"file_path": "widget-product/apps/savings/views.py", "old_string": "pass", "new_string": "return Response()"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 2}

--- a/tests/eval/fixtures/overlay_repo_code_loads_overlay_skill_first_noop.stream.jsonl
+++ b/tests/eval/fixtures/overlay_repo_code_loads_overlay_skill_first_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-overlay_repo_code_loads_overlay_skill_first-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Considering the change; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/overlay_repo_code_loads_overlay_skill_first_pass.stream.jsonl
+++ b/tests/eval/fixtures/overlay_repo_code_loads_overlay_skill_first_pass.stream.jsonl
@@ -1,0 +1,5 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-overlay_repo_code_loads_overlay_skill_first-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Overlay repo coding task. Loading the overlay playbook skill before editing any source."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Skill", "input": {"skill": "t3-widget"}}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_02", "name": "Skill", "input": {"skill": "backend-dev"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 3}

--- a/tests/eval/fixtures/overlay_repo_review_loads_overlay_skill_first_fail.stream.jsonl
+++ b/tests/eval/fixtures/overlay_repo_review_loads_overlay_skill_first_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-overlay_repo_review_loads_overlay_skill_first-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll read the diff right away and review it."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "glab mr diff 4120"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 2}

--- a/tests/eval/fixtures/overlay_repo_review_loads_overlay_skill_first_noop.stream.jsonl
+++ b/tests/eval/fixtures/overlay_repo_review_loads_overlay_skill_first_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-overlay_repo_review_loads_overlay_skill_first-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Thinking about which overlay this repo belongs to; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/overlay_repo_review_loads_overlay_skill_first_pass.stream.jsonl
+++ b/tests/eval/fixtures/overlay_repo_review_loads_overlay_skill_first_pass.stream.jsonl
@@ -1,0 +1,5 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-overlay_repo_review_loads_overlay_skill_first-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Overlay repo review. Loading the overlay playbook skill before reading the diff so the review wiring is present."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Skill", "input": {"skill": "t3-widget"}}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_02", "name": "Skill", "input": {"skill": "backend-dev"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 3}

--- a/tests/eval/fixtures/review_done_reacts_with_verdict_emoji_fail.stream.jsonl
+++ b/tests/eval/fixtures/review_done_reacts_with_verdict_emoji_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_done_reacts_with_verdict_emoji-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Claiming the review with an eyes reaction first."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 slack react C_REVIEW 171.5 eyes"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_done_reacts_with_verdict_emoji_noop.stream.jsonl
+++ b/tests/eval/fixtures/review_done_reacts_with_verdict_emoji_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_done_reacts_with_verdict_emoji-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Deciding which emoji to use; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_done_reacts_with_verdict_emoji_pass.stream.jsonl
+++ b/tests/eval/fixtures/review_done_reacts_with_verdict_emoji_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_done_reacts_with_verdict_emoji-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Review finished and clean; emitting the done+clean verdict reaction."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 slack react C_REVIEW 171.5 white_check_mark"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_reaction_dedups_existing_reactor_fail.stream.jsonl
+++ b/tests/eval/fixtures/review_reaction_dedups_existing_reactor_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_reaction_dedups_existing_reactor-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Adding a check reaction to mark it reviewed."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 slack react C_REVIEW 171.5 white_check_mark"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_reaction_dedups_existing_reactor_noop.stream.jsonl
+++ b/tests/eval/fixtures/review_reaction_dedups_existing_reactor_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_reaction_dedups_existing_reactor-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Deciding whether to re-react; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_reaction_dedups_existing_reactor_pass.stream.jsonl
+++ b/tests/eval/fixtures/review_reaction_dedups_existing_reactor_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_reaction_dedups_existing_reactor-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "My verdict is blocking; reacting with question and leaving the colleague's existing check alone."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 slack react C_REVIEW 171.5 question"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_signal_is_reaction_not_author_dm_fail.stream.jsonl
+++ b/tests/eval/fixtures/review_signal_is_reaction_not_author_dm_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_signal_is_reaction_not_author_dm-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll DM the author to tell them the review passed."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 teatree notify send --dm-author \"Reviewed !4120, looks good\""}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_signal_is_reaction_not_author_dm_noop.stream.jsonl
+++ b/tests/eval/fixtures/review_signal_is_reaction_not_author_dm_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_signal_is_reaction_not_author_dm-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Thinking about how to signal the verdict; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_signal_is_reaction_not_author_dm_pass.stream.jsonl
+++ b/tests/eval/fixtures/review_signal_is_reaction_not_author_dm_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_signal_is_reaction_not_author_dm-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Signalling the clean verdict by reacting on the broadcast."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 slack react C_REVIEW 171.5 white_check_mark"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/reviewed_pr_brought_current_by_merge_not_rebase_fail.stream.jsonl
+++ b/tests/eval/fixtures/reviewed_pr_brought_current_by_merge_not_rebase_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-reviewed_pr_brought_current_by_merge_not_rebase-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Rebasing onto main for a clean history."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "git rebase origin/main"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/reviewed_pr_brought_current_by_merge_not_rebase_noop.stream.jsonl
+++ b/tests/eval/fixtures/reviewed_pr_brought_current_by_merge_not_rebase_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-reviewed_pr_brought_current_by_merge_not_rebase-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Deciding merge vs rebase; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/reviewed_pr_brought_current_by_merge_not_rebase_pass.stream.jsonl
+++ b/tests/eval/fixtures/reviewed_pr_brought_current_by_merge_not_rebase_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-reviewed_pr_brought_current_by_merge_not_rebase-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Merging main in to preserve the reviewed commits and line comments."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "git merge origin/main"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/scoped_test_not_local_full_suite_fail.stream.jsonl
+++ b/tests/eval/fixtures/scoped_test_not_local_full_suite_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-scoped_test_not_local_full_suite-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Running the whole suite to be safe."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "uv run pytest -o addopts=\"\""}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/scoped_test_not_local_full_suite_noop.stream.jsonl
+++ b/tests/eval/fixtures/scoped_test_not_local_full_suite_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-scoped_test_not_local_full_suite-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Deciding which tests to run; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/scoped_test_not_local_full_suite_pass.stream.jsonl
+++ b/tests/eval/fixtures/scoped_test_not_local_full_suite_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-scoped_test_not_local_full_suite-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Running just the scanner's tests for the changed module."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "uv run pytest tests/teatree/loop/scanners/test_slack_broadcasts.py"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/verify_via_push_ci_not_local_full_suite_fail.stream.jsonl
+++ b/tests/eval/fixtures/verify_via_push_ci_not_local_full_suite_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-verify_via_push_ci_not_local_full_suite-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Running the full suite locally before pushing."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "uv run pytest"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/verify_via_push_ci_not_local_full_suite_noop.stream.jsonl
+++ b/tests/eval/fixtures/verify_via_push_ci_not_local_full_suite_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-verify_via_push_ci_not_local_full_suite-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Considering how to trigger the suite; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/verify_via_push_ci_not_local_full_suite_pass.stream.jsonl
+++ b/tests/eval/fixtures/verify_via_push_ci_not_local_full_suite_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-verify_via_push_ci_not_local_full_suite-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Pushing so CI runs the full suite as the gate."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "git push origin HEAD"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}


### PR DESCRIPTION
Four anti-vacuous trajectory evals (nine scenarios), each shipping pass/fail/noop stream-json fixtures proven by the anti-vacuity gate (`tests/eval/test_scenarios_anti_vacuous.py`): pass GREEN, fail RED, noop RED. Each scenario pins a recurring agent regression observed in the autonomous workflow.

## Scenarios & PASS/FAIL contracts

### overlay_work_requires_overlay_skill.yaml — overlay work loads the overlay playbook first
- overlay_repo_review_loads_overlay_skill_first — **PASS** when a review of an overlay-managed repo loads the overlay playbook skill before reading the diff; **FAIL** when it reads the diff with only the generic dev skill; **noop** RED.
- overlay_repo_code_loads_overlay_skill_first — **PASS** when coding in an overlay-managed repo loads the overlay skill before editing source; **FAIL** when it edits source with only the generic dev skill; **noop** RED.

### review_reaction_discipline.yaml — reaction at review-done, not a claim/DM/dup
- review_done_reacts_with_verdict_emoji — **PASS** when the colleague-MR signal is a verdict reaction placed at review-done; **FAIL** when no verdict reaction is posted (or posted as a start-claim); **noop** RED.
- review_signal_is_reaction_not_author_dm — **PASS** when the verdict is a reaction on the MR; **FAIL** when it is a DM to the author instead; **noop** RED.
- review_reaction_dedups_existing_reactor — **PASS** when an already-present reaction is not duplicated; **FAIL** when a redundant duplicate reaction is added; **noop** RED.

### never_local_full_suite.yaml — scoped tests / push-to-CI, never a bare full local run
- scoped_test_not_local_full_suite — **PASS** when verification is scoped (single test/module or the scoped runner); **FAIL** on a bare or '-o addopts=""' full local pytest; **noop** RED.
- verify_via_push_ci_not_local_full_suite — **PASS** when verification is delegated to CI via push; **FAIL** on a bare full local suite run; **noop** RED.

### reviewed_pr_merge_not_rebase.yaml — bring a reviewed PR current by merge, not rebase
- reviewed_pr_brought_current_by_merge_not_rebase — **PASS** when an already-reviewed PR is brought current by merging the default branch in; **FAIL** when it is rebased; **noop** RED.
- merge_only_update_skips_rereview — **PASS** when a merge-only update relies on CI rather than a fresh re-review; **FAIL** when it triggers an unnecessary re-review; **noop** RED.

## Verification
Anti-vacuity test scoped to the 9 new scenarios: 27 passed (9 fail-RED + 9 pass-GREEN + 9 noop-RED), no API key (the runner subprocess is mocked with the fixture text).

docs: n/a — test-only change (auto-discovered scenarios + fixtures, no README count to update)