### PR TITLE
chore(tach): maximize graph-wide enforcement (layers, no-cycles, no-undeclared-modules, external)

### DIFF
--- a/tach.toml
+++ b/tach.toml
@@ -7,69 +7,93 @@ exclude = [
   "**/venv"
 ]
 source_roots = ["tests", "src", "e2e"]
+layers = [
+  "interface",
+  "orchestration",
+  "integration",
+  "domain",
+  "platform",
+  "foundation"
+]
 
 [[modules]]
 path = "teatree.paths"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.types"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.config"
+layer = "platform"
 depends_on = ["teatree.paths", "teatree.types", "teatree.utils", "teatree.update_check"]
 
 [[modules]]
 path = "teatree.update_check"
+layer = "platform"
 depends_on = ["teatree.paths", "teatree.utils"]
 
 [[modules]]
 path = "teatree.templates"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.claude_sessions"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.overlay_init"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.utils"
+layer = "foundation"
 depends_on = ["teatree.paths"]
 
 [[modules]]
 path = "teatree.self_update"
+layer = "platform"
 depends_on = ["teatree.utils"]
 
 [[modules]]
 path = "teatree.hooks"
+layer = "platform"
 depends_on = ["teatree.utils"]
 
 [[modules]]
 path = "teatree.timeouts"
+layer = "platform"
 depends_on = ["teatree.config"]
 
 [[modules]]
 path = "teatree.repo_mode"
+layer = "platform"
 depends_on = ["teatree.paths", "teatree.utils", "teatree.config"]
 
 [[modules]]
 path = "teatree.skill_loading"
+layer = "platform"
 depends_on = ["teatree.types", "teatree.utils", "teatree.skill_deps"]
 
 [[modules]]
 path = "teatree.skill_schema"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.skill_ref_validator"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.core"
+layer = "domain"
 depends_on = [
   "teatree.types",
   "teatree.paths",
@@ -89,6 +113,7 @@ depends_on = [
 
 [[modules]]
 path = "teatree.agents"
+layer = "domain"
 depends_on = [
   "teatree.types",
   "teatree.core",
@@ -99,6 +124,7 @@ depends_on = [
 
 [[modules]]
 path = "teatree.backends"
+layer = "domain"
 depends_on = [
   "teatree.types",
   "teatree.utils",
@@ -108,10 +134,12 @@ depends_on = [
 
 [[modules]]
 path = "teatree.contrib"
+layer = "integration"
 depends_on = ["teatree.types", "teatree.core", "teatree.config", "teatree.docker", "teatree.utils", "teatree.visual_qa"]
 
 [[modules]]
 path = "teatree.cli"
+layer = "interface"
 depends_on = [
   "teatree.paths",
   "teatree.config",
@@ -140,10 +168,12 @@ depends_on = [
 
 [[modules]]
 path = "teatree.eval"
+layer = "integration"
 depends_on = ["teatree.core", "teatree.hooks", "teatree.utils", "teatree.trigger_parser"]
 
 [[modules]]
 path = "teatree.core.management"
+layer = "interface"
 depends_on = [
   "teatree.core",
   "teatree.agents",
@@ -161,10 +191,12 @@ depends_on = [
 
 [[modules]]
 path = "teatree.loop_enabled"
+layer = "platform"
 depends_on = ["teatree.config"]
 
 [[modules]]
 path = "teatree.loop"
+layer = "orchestration"
 depends_on = [
   "teatree.types",
   "teatree.paths",
@@ -180,6 +212,7 @@ depends_on = [
 
 [[modules]]
 path = "teatree.loops"
+layer = "orchestration"
 depends_on = [
   "teatree.config",
   "teatree.core",
@@ -191,68 +224,85 @@ depends_on = [
 
 [[modules]]
 path = "teatree.docker"
+layer = "platform"
 depends_on = ["teatree.types", "teatree.utils"]
 
 [[modules]]
 path = "teatree.visual_qa"
+layer = "integration"
 depends_on = ["teatree.core", "teatree.utils"]
 
 [[modules]]
 path = "teatree.identity"
+layer = "platform"
 depends_on = ["teatree.config"]
 
 [[modules]]
 path = "teatree.on_behalf_gate"
+layer = "platform"
 depends_on = ["teatree.config"]
 
 [[modules]]
 path = "teatree.notify"
+layer = "integration"
 depends_on = ["teatree.core"]
 
 [[modules]]
 path = "teatree.messaging"
+layer = "integration"
 depends_on = ["teatree.core", "teatree.notify", "teatree.backends"]
 
 [[modules]]
 path = "teatree.outbound_claim"
+layer = "integration"
 depends_on = ["teatree.core"]
 
 [[modules]]
 path = "teatree.slack_mrkdwn"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.settings"
+layer = "platform"
 depends_on = ["teatree.config", "teatree.paths"]
 
 [[modules]]
 path = "teatree.cli_reference"
+layer = "interface"
 depends_on = ["teatree.cli"]
 
 [[modules]]
 path = "teatree.triage"
+layer = "platform"
 depends_on = ["teatree.utils"]
 
 [[modules]]
 path = "teatree.url_title_fetcher"
+layer = "platform"
 depends_on = ["teatree.utils"]
 
 [[modules]]
 path = "teatree.skill_deps"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.skill_map"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.memory_audit"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.trigger_parser"
+layer = "foundation"
 depends_on = []
 
 [[modules]]
 path = "teatree.quality"
+layer = "foundation"
 depends_on = []

--- a/tests/test_architecture_contract.py
+++ b/tests/test_architecture_contract.py
@@ -15,29 +15,61 @@ every environment (local venv, the Docker test matrix), whereas a bare
 the Docker matrix.
 """
 
+import shutil
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+_TACH_TOML = _REPO_ROOT / "tach.toml"
+
+
+def _run_tach_check(cwd: Path) -> subprocess.CompletedProcess[str]:
+    # S603: trusted fixed argv — sys.executable plus literal flags, no user
+    # input. sys.executable is portable across every test env.
+    return subprocess.run(
+        [sys.executable, "-m", "tach", "check"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
 
 class TestArchitectureContract:
     def test_tach_check_module_graph_is_clean(self) -> None:
-        # S603: trusted fixed argv — sys.executable plus literal flags, no
-        # user input. sys.executable is portable across every test env.
-        result = subprocess.run(
-            [sys.executable, "-m", "tach", "check"],
-            cwd=_REPO_ROOT,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        result = _run_tach_check(_REPO_ROOT)
         if result.returncode != 0:
             pytest.fail(
                 "tach check found a module-boundary violation — a package "
                 "imports something not in its tach.toml `depends_on`:\n"
                 f"{result.stdout}\n{result.stderr}",
             )
+
+    def test_every_module_carries_a_layer(self) -> None:
+        config = tomllib.loads(_TACH_TOML.read_text(encoding="utf-8"))
+        declared_layers = set(config["layers"])
+        unlayered = [m["path"] for m in config["modules"] if m.get("layer") not in declared_layers]
+        assert not unlayered, f"modules missing a valid layer tag: {unlayered}"
+
+    def test_layers_reject_a_backwards_cross_layer_import(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        shutil.copytree(_REPO_ROOT / "src", repo / "src", ignore=shutil.ignore_patterns("__pycache__"))
+        shutil.copy2(_TACH_TOML, repo / "tach.toml")
+        config = tomllib.loads((repo / "tach.toml").read_text(encoding="utf-8"))
+        layer_of = {m["path"]: m.get("layer") for m in config["modules"]}
+        assert layer_of["teatree.types"] == "foundation"
+        assert layer_of["teatree.core"] == "domain"
+
+        types_init = repo / "src" / "teatree" / "types.py"
+        types_init.write_text(
+            types_init.read_text(encoding="utf-8") + "\nfrom teatree.core.models import Ticket as _Probe\n",
+            encoding="utf-8",
+        )
+
+        result = _run_tach_check(repo)
+        assert result.returncode != 0, "layers config did not reject a foundation->domain import"
+        assert "Layer 'foundation'" in result.stdout + result.stderr


### PR DESCRIPTION
Turn on tach's dormant layer power so cross-boundary internal access fails CI for current and future code. Foundation PR of the anti-drift initiative; no behavior change, lowest risk.

## Enabled

`layers` (6-tier stack, highest to lowest: interface, orchestration, integration, domain, platform, foundation) plus a `layer` tag on all 44 `[[modules]]` entries. The stack is derived from the actual dependency DAG (each module at the layer matching its real dependency depth; validated with zero layer violations against the live graph), not imposed. A lower layer importing a higher one, or any backwards cross-layer edge in future code, now fails `tach check`.

## Anti-vacuous guard

`tests/test_architecture_contract.py` gains: (1) `test_layers_reject_a_backwards_cross_layer_import` (a deliberate foundation-to-domain import is rejected with a layer-rank error; observed red before green: without the layers config the same edge reports as a depends_on violation, not a layer-rank one, so the layer-specific assertion genuinely guards the new capability), and (2) `test_every_module_carries_a_layer`. The existing `test_tach_check_module_graph_is_clean` already runs `tach check` in CI.

## Deferred (real debt, follow-ups; kept out so this PR stays green and behavior-neutral)

- `forbid_circular_dependencies`: teatree.core and teatree.agents/backends form a real import cycle (40+ edges, many deferred PLC0415 imports). Breaking it is an architectural refactor, not a config flip.
- `root_module = forbid`: legitimate package-dunder access (`import teatree` for `__version__`/`__file__`, the latter underpinning the #1507 currency gate), plus the t3_bootstrap entrypoint package and the project/_overlay_api/urls leaf modules, reference the package root. The existing check_tach_modules_declared.py hook already guarantees no undeclared top-level module for future code.
- `[external] unused_external_dependencies`: not a real key in tach 0.34.1 (parsed but silently ignored). check-external is advisory (exit 1 on 116 pre-existing undeclared third-party imports, not wired into any hook or CI job). Pre-existing debt unrelated to this change.

## Verification

- `uv run tach check` green (exit 0).
- `tests/test_architecture_contract.py` 3 passed; `test_check_blueprint_size_budget.py` 14 passed (headroom 4544 bytes, >= 4000); `test_tach_modules_declared_hook.py` 8 passed.
- BLUEPRINT mermaid regenerated, no change (layers add tags, not edges).