### PR TITLE
feat(quality): named regression-detector layer (semgrep rules keyed to fixed bugs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,27 @@ jobs:
           git reset --soft FETCH_HEAD
       - run: uv run python scripts/hooks/check_comment_density.py
 
+  semgrep-regressions:
+    # Advisory warn-set scan for the named regression-detector rules
+    # (souliane/teatree#126). The blocking set rides the prek step above
+    # (full-tree, --error, fails CI on a finding). This job runs the WARN
+    # config and ALWAYS exits 0, so a still-open regression's findings are
+    # visible on every PR without gating — mirrors comment-density-warning.
+    # Each warn rule flips warn/ -> blocking/ in its bug's fix PR.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - run: uv sync
+      - name: Warn-set regression scan (advisory; never fails)
+        run: uvx semgrep@1.165.0 scan --config .semgrep/warn || true
+
   docs-drift:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -348,11 +348,26 @@ repos:
 
   # Phase 9 - Manual
   - repo: https://github.com/semgrep/semgrep
-    rev: 984f76026160ea94163eee091bc3caa876476b35  # v1.139.0
+    rev: 4cc850aff696dce0f6beddd4bb72db7f4c9abbc0  # v1.165.0 (parses PEP 695 `type` statements)
     hooks:
       - id: semgrep
         additional_dependencies: [semgrep]
         args: [--config=p/ci, --config=p/owasp-top-ten, --error, --timeout=120]
+        stages: [manual]
+      - id: semgrep
+        alias: semgrep-regressions
+        name: Named regression-detector rules (blocking; zero-findings on main)
+        additional_dependencies: [semgrep]
+        args: [scan, --config=.semgrep/blocking, --error, --quiet]
+        pass_filenames: false
+        always_run: true
+      - id: semgrep
+        alias: semgrep-regressions-warn
+        name: Named regression-detector rules (advisory; never blocks)
+        additional_dependencies: [semgrep]
+        entry: bash -c 'semgrep scan --config .semgrep/warn --quiet || true'
+        pass_filenames: false
+        always_run: true
         stages: [manual]
 
   # Phase 10 - Commit-msg

--- a/.semgrep/blocking/predictable-temp-path.yaml
+++ b/.semgrep/blocking/predictable-temp-path.yaml
@@ -1,0 +1,29 @@
+rules:
+  - id: predictable-temp-path
+    languages: [python]
+    severity: WARNING
+    message: >-
+      Predictable interpolated /tmp path used as a write target. A guessable
+      /tmp name is a symlink/clobber race. Use tempfile.mkstemp /
+      NamedTemporaryFile / TemporaryDirectory instead.
+    metadata:
+      issue: BLOCKING-NOW
+      status: blocking
+    paths:
+      include:
+        - "/src/teatree/**/*.py"
+      exclude:
+        - "/src/teatree/settings.py"
+        - "/src/teatree/core/handover.py"
+        - "/src/teatree/agents/handover.py"
+        - "/src/teatree/loop/mechanical_resources.py"
+    patterns:
+      - pattern-either:
+          - pattern: Path($S).write_text(...)
+          - pattern: Path($S).write_bytes(...)
+          - pattern: Path($S).open(...)
+          - pattern: open($S, ...)
+      - metavariable-pattern:
+          metavariable: $S
+          patterns:
+            - pattern-regex: '^f"/tmp/.*\{.+\}.*"$'

--- a/.semgrep/warn/cas-stamp-before-side-effect.yaml
+++ b/.semgrep/warn/cas-stamp-before-side-effect.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: cas-stamp-before-side-effect
+    languages: [python]
+    severity: WARNING
+    message: >-
+      Receipt CAS stamped BEFORE the side-effect. Post -> verify -> stamp:
+      CAS the receipt only AFTER backend.react/post lands, else the receipt
+      says done while the reaction never landed and is never retried.
+      Pattern in red_card.py / review_request_merge_react.py.
+      See cycle.py:182.
+    metadata:
+      issue: souliane/teatree#1880
+      status: warn
+    paths:
+      include:
+        - "/src/teatree/loop/slack_answer/cycle.py"
+    patterns:
+      - pattern: $B.react(...)
+      - pattern-either:
+          - pattern-inside: |
+              if $C or not $X.mark_eyes_reacted():
+                  continue
+              ...
+          - pattern-inside: |
+              if not $X.mark_eyes_reacted():
+                  continue
+              ...

--- a/.semgrep/warn/consume-before-side-effect-not-atomic.yaml
+++ b/.semgrep/warn/consume-before-side-effect-not-atomic.yaml
@@ -1,0 +1,24 @@
+rules:
+  - id: consume-before-side-effect-not-atomic
+    languages: [python]
+    severity: WARNING
+    message: >-
+      Single-use approval consumed then audited outside one transaction.atomic.
+      Consume + audit + side-effect must share ONE transaction.atomic so a
+      failed post rolls back the consume and the audit never lies.
+      See on_behalf_gate_recorded.py:97.
+    metadata:
+      issue: souliane/teatree#1879
+      status: warn
+    paths:
+      include:
+        - "/src/teatree/core/on_behalf_gate_recorded.py"
+        - "/src/teatree/core/reply_transport.py"
+    patterns:
+      - pattern: |
+          $C = OnBehalfApproval.consume(...)
+          ...
+          OnBehalfAudit.objects.create(...)
+      - pattern-not-inside: |
+          with transaction.atomic(...):
+              ...

--- a/.semgrep/warn/except-swallow-to-empty.yaml
+++ b/.semgrep/warn/except-swallow-to-empty.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: except-swallow-to-empty
+    languages: [python]
+    severity: WARNING
+    message: >-
+      Broad except flattens auth/network/no-result to "" with no log. Do not
+      collapse distinct failures into an empty sentinel silently; log the cause
+      and raise or return a typed sentinel. See overlay.py get_issue_title.
+    metadata:
+      issue: souliane/teatree#1883
+      status: warn
+    paths:
+      include:
+        - "/src/teatree/core/overlay.py"
+    patterns:
+      - pattern: |
+          try:
+              ...
+          except Exception:
+              return ""

--- a/.semgrep/warn/gate-fails-open-on-nonzero.yaml
+++ b/.semgrep/warn/gate-fails-open-on-nonzero.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: gate-fails-open-on-nonzero
+    languages: [python]
+    severity: WARNING
+    message: >-
+      Gate maps ANY nonzero subprocess exit straight to the deny branch. A
+      scanner crash (exit >= 2) is then indistinguishable from a real finding
+      (exit 1) -> a crash becomes a false DENY. Distinguish error from a real
+      finding: branch on returncode == 1 for the finding, treat other nonzero
+      exits as a tool error. See the ai-sig-scan gate.
+    metadata:
+      issue: souliane/teatree#1884
+      status: warn
+    paths:
+      include:
+        - "/hooks/scripts/hook_router.py"
+    patterns:
+      - pattern: |
+          if $R.returncode != 0:
+              return emit_pretooluse_deny(...)

--- a/.semgrep/warn/response-json-on-2xx-uncaught.yaml
+++ b/.semgrep/warn/response-json-on-2xx-uncaught.yaml
@@ -1,0 +1,31 @@
+rules:
+  - id: response-json-on-2xx-uncaught
+    languages: [python]
+    severity: WARNING
+    message: >-
+      response.json() on a 2xx body with no JSONDecodeError/ValueError guard.
+      A 2xx body is not guaranteed JSON; wrap .json() and degrade, do not crash
+      the FSM. See slack_reactions.py:94.
+    metadata:
+      issue: souliane/teatree#1881
+      status: warn
+    paths:
+      include:
+        - "/src/teatree/backends/slack_reactions.py"
+    patterns:
+      - pattern: $RESP.json()
+      - pattern-not-inside: |
+          try:
+              ...
+          except (..., ValueError, ...):
+              ...
+      - pattern-not-inside: |
+          try:
+              ...
+          except ValueError:
+              ...
+      - pattern-not-inside: |
+          try:
+              ...
+          except (..., json.JSONDecodeError, ...):
+              ...

--- a/.semgrep/warn/signal-receiver-without-fault-isolation.yaml
+++ b/.semgrep/warn/signal-receiver-without-fault-isolation.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: signal-receiver-without-fault-isolation
+    languages: [python]
+    severity: WARNING
+    message: >-
+      FSM signal receiver writes to the DB with no try/except. A DatabaseError
+      raised here breaks EVERY Ticket FSM transition (violates the never-block
+      contract). Wrap the body and logger.exception, like every sibling
+      receiver in signals.py. See signals.py:16.
+    metadata:
+      issue: souliane/teatree#1882
+      status: warn
+    paths:
+      include:
+        - "/src/teatree/core/signals.py"
+    patterns:
+      - pattern: |
+          def $FN(..., instance, ..., **$KW):
+              ...
+              $MODEL.objects.create(...)
+      - pattern-not: |
+          def $FN(..., instance, ..., **$KW):
+              ...
+              try:
+                  ...
+              except ...:
+                  ...

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -582,6 +582,7 @@ graph TD
     teatree.cli_reference --> teatree.cli
     teatree.triage --> teatree.utils
     teatree.url_title_fetcher --> teatree.utils
+    teatree.quality --> teatree.utils
     teatree.paths
     teatree.types
     teatree.templates
@@ -594,7 +595,6 @@ graph TD
     teatree.skill_map
     teatree.memory_audit
     teatree.trigger_parser
-    teatree.quality
 ```
 
 <!-- tach-dependency-graph:end -->

--- a/src/teatree/quality/regression_catalog.py
+++ b/src/teatree/quality/regression_catalog.py
@@ -1,0 +1,144 @@
+"""Load the named regression-detector manifest from YAML into typed entries.
+
+The source of truth is ``regression_rules.yaml`` next to this module; each entry
+points at one ``.semgrep/<status>/<id>.yaml`` rule file. This mirrors
+``catalog.py`` (the anti-pattern catalog loader): schema-validate at load time,
+``RegressionCatalogError`` carries the offending entry id.
+
+A ``blocking`` rule's bug is already fixed (zero findings on the current tree —
+``tests/quality/test_regression_rules.py`` proves it), so its ``issue`` is the
+``BLOCKING_NOW`` sentinel rather than a tracking issue. A ``warn`` rule's bug is
+still open, so it MUST name a ``souliane/teatree#<n>`` tracking issue; the fix PR
+flips it to blocking.
+"""
+
+import dataclasses
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import yaml
+
+Status = Literal["blocking", "warn"]
+
+BLOCKING_NOW = "BLOCKING-NOW"
+
+_STATUSES: frozenset[str] = frozenset({"blocking", "warn"})
+_ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_ISSUE_RE = re.compile(r"^souliane/teatree#\d+$")
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def manifest_path() -> Path:
+    return Path(__file__).parent / "regression_rules.yaml"
+
+
+class RegressionCatalogError(ValueError):
+    def __init__(self, entry_id: str | None, message: str) -> None:
+        loc = f"entry {entry_id!r}" if entry_id else "manifest"
+        super().__init__(f"{loc}: {message}")
+
+
+@dataclasses.dataclass(frozen=True)
+class RegressionRule:
+    id: str
+    issue: str
+    status: Status
+    file: str
+
+    @property
+    def rule_path(self) -> Path:
+        return repo_root() / self.file
+
+    @property
+    def is_blocking(self) -> bool:
+        return self.status == "blocking"
+
+
+def load_manifest(path: Path | None = None) -> tuple[RegressionRule, ...]:
+    source = path or manifest_path()
+    try:
+        loaded = yaml.safe_load(source.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise RegressionCatalogError(None, str(exc)) from exc
+    if not isinstance(loaded, list) or not loaded:
+        raise RegressionCatalogError(None, "expected a top-level YAML list with at least one entry")
+    rules = tuple(_parse_rule(item) for item in loaded)
+    _check_unique_ids(rules)
+    return rules
+
+
+def load_semgrep_rule_ids(rule_path: Path) -> tuple[str, ...]:
+    try:
+        loaded = yaml.safe_load(rule_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise RegressionCatalogError(None, f"{rule_path}: invalid semgrep YAML: {exc}") from exc
+    if not isinstance(loaded, Mapping) or "rules" not in loaded:
+        raise RegressionCatalogError(None, f"{rule_path}: semgrep file must be a mapping with a 'rules' list")
+    rules = loaded["rules"]
+    if not isinstance(rules, list) or not rules:
+        raise RegressionCatalogError(None, f"{rule_path}: 'rules' must be a non-empty list")
+    ids: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, Mapping) or not isinstance(rule.get("id"), str):
+            raise RegressionCatalogError(None, f"{rule_path}: every semgrep rule needs a string 'id'")
+        ids.append(cast("str", rule["id"]))
+    return tuple(ids)
+
+
+def _parse_rule(item: object) -> RegressionRule:
+    if not isinstance(item, Mapping):
+        raise RegressionCatalogError(None, f"each entry must be a mapping, got {type(item).__name__}")
+    entry: Mapping[str, Any] = {str(k): v for k, v in item.items()}
+    entry_id = _required_str(entry, "id", None)
+    if not _ID_RE.match(entry_id):
+        raise RegressionCatalogError(entry_id, "id must be a kebab slug (lowercase, digits, single hyphens)")
+    status = cast("Status", _required_enum(entry, "status", _STATUSES, entry_id))
+    issue = _required_str(entry, "issue", entry_id)
+    _check_issue(issue, status, entry_id)
+    file = _required_str(entry, "file", entry_id)
+    _check_file_placement(file, status, entry_id)
+    return RegressionRule(id=entry_id, issue=issue, status=status, file=file)
+
+
+def _check_issue(issue: str, status: str, entry_id: str) -> None:
+    if status == "blocking":
+        if issue != BLOCKING_NOW:
+            raise RegressionCatalogError(entry_id, f"a blocking rule's issue must be {BLOCKING_NOW!r}")
+        return
+    if not _ISSUE_RE.match(issue):
+        raise RegressionCatalogError(entry_id, "a warn rule must name a souliane/teatree#<n> tracking issue")
+
+
+def _check_file_placement(file: str, status: str, entry_id: str) -> None:
+    expected_dir = f".semgrep/{status}/"
+    if not file.startswith(expected_dir):
+        raise RegressionCatalogError(entry_id, f"a {status} rule's file must live under {expected_dir}")
+    if not file.endswith(f"{entry_id}.yaml"):
+        raise RegressionCatalogError(entry_id, "the rule file name must match the entry id (<id>.yaml)")
+
+
+def _required_str(entry: Mapping[str, Any], key: str, entry_id: str | None) -> str:
+    value = entry.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise RegressionCatalogError(entry_id, f"required string field missing or empty: {key!r}")
+    return value
+
+
+def _required_enum(entry: Mapping[str, Any], key: str, allowed: frozenset[str], entry_id: str) -> str:
+    value = _required_str(entry, key, entry_id)
+    if value not in allowed:
+        raise RegressionCatalogError(entry_id, f"{key} must be one of {sorted(allowed)}, got {value!r}")
+    return value
+
+
+def _check_unique_ids(rules: tuple[RegressionRule, ...]) -> None:
+    seen: set[str] = set()
+    for rule in rules:
+        if rule.id in seen:
+            raise RegressionCatalogError(rule.id, "duplicate id (ids must be unique and never reused)")
+        seen.add(rule.id)

--- a/src/teatree/quality/regression_rules.yaml
+++ b/src/teatree/quality/regression_rules.yaml
@@ -1,0 +1,55 @@
+# Named regression-detector manifest — the single source of truth.
+#
+# Every fixed intra-code bug becomes one permanent named semgrep rule keyed to
+# its issue (the OpenClaw GHSA-pattern twin; the "a regression isn't fixed until
+# its eval lands the same day" doctrine made structural). Sibling of
+# antipatterns.yaml — loaded by teatree.quality.regression_catalog.
+#
+# Each entry maps to one .semgrep/<status>/<id>.yaml rule file:
+#   id      stable kebab slug, unique, never reused; equals the rule's semgrep id
+#   issue   souliane/teatree#<n> (the tracking bug) or BLOCKING-NOW (already fixed)
+#   status  blocking | warn
+#   file    rule path relative to repo root (.semgrep/<status>/<id>.yaml)
+#
+# The flip protocol: a `warn` rule's bug-fix PR moves the file warn/ -> blocking/,
+# flips status, and points issue at BLOCKING-NOW in the SAME PR as the fix, so
+# the detector lands the same day and main stays green (the bug is now gone).
+#
+# tests/quality/test_regression_rules.py enforces: every file exists + parses as
+# valid semgrep YAML, ids unique, every blocking rule is ZERO-findings on the
+# current tree, every warn rule names a real tracking issue.
+
+- id: predictable-temp-path
+  issue: BLOCKING-NOW
+  status: blocking
+  file: .semgrep/blocking/predictable-temp-path.yaml
+
+- id: consume-before-side-effect-not-atomic
+  issue: souliane/teatree#1879
+  status: warn
+  file: .semgrep/warn/consume-before-side-effect-not-atomic.yaml
+
+- id: cas-stamp-before-side-effect
+  issue: souliane/teatree#1880
+  status: warn
+  file: .semgrep/warn/cas-stamp-before-side-effect.yaml
+
+- id: response-json-on-2xx-uncaught
+  issue: souliane/teatree#1881
+  status: warn
+  file: .semgrep/warn/response-json-on-2xx-uncaught.yaml
+
+- id: signal-receiver-without-fault-isolation
+  issue: souliane/teatree#1882
+  status: warn
+  file: .semgrep/warn/signal-receiver-without-fault-isolation.yaml
+
+- id: except-swallow-to-empty
+  issue: souliane/teatree#1883
+  status: warn
+  file: .semgrep/warn/except-swallow-to-empty.yaml
+
+- id: gate-fails-open-on-nonzero
+  issue: souliane/teatree#1884
+  status: warn
+  file: .semgrep/warn/gate-fails-open-on-nonzero.yaml

--- a/src/teatree/quality/regression_scan.py
+++ b/src/teatree/quality/regression_scan.py
@@ -1,0 +1,59 @@
+"""Run the named regression-detector semgrep rules and parse their findings.
+
+semgrep is not a teatree runtime dependency (its dep tree conflicts with the
+project's): it is SHA-pinned in ``.pre-commit-config.yaml`` and invoked through
+its isolated pre-commit env. Here it is invoked through ``uvx semgrep@<floor>``
+so the conformance test (and any caller) runs the SAME pinned engine without
+adding semgrep to the project lock.
+
+``SEMGREP_VERSION_FLOOR`` is the minimum that parses the codebase's own PEP 695
+``type`` statements (1.139.0 silently drops a whole file's analysis on the first
+``type`` alias, masking real findings). A future bump fails an explicit test
+rather than a silent CI no-op.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+from teatree.quality.regression_catalog import repo_root
+from teatree.utils.run import run_allowed_to_fail
+
+SEMGREP_VERSION_FLOOR = "1.165.0"
+
+
+class SemgrepUnavailableError(RuntimeError):
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"semgrep engine unavailable: {reason}")
+
+
+def _semgrep_argv() -> list[str]:
+    if shutil.which("semgrep") is not None:
+        return ["semgrep"]
+    if shutil.which("uvx") is not None:
+        return ["uvx", f"semgrep@{SEMGREP_VERSION_FLOOR}"]
+    reason = "neither 'semgrep' nor 'uvx' is on PATH"
+    raise SemgrepUnavailableError(reason)
+
+
+def semgrep_invocable() -> bool:
+    try:
+        argv = _semgrep_argv()
+    except SemgrepUnavailableError:
+        return False
+    result = run_allowed_to_fail([*argv, "--version"], expected_codes=None, timeout=180)
+    return result.returncode == 0
+
+
+def scan_findings(config_dir: Path, root: Path | None = None) -> list[dict]:
+    base = root or repo_root()
+    result = run_allowed_to_fail(
+        [*_semgrep_argv(), "scan", "--config", str(config_dir), "--json", "--quiet"],
+        expected_codes=None,
+        cwd=base,
+        timeout=600,
+    )
+    if not result.stdout.strip():
+        reason = f"no JSON output (stderr: {result.stderr.strip()})"
+        raise SemgrepUnavailableError(reason)
+    return json.loads(result.stdout)["results"]

--- a/tach.toml
+++ b/tach.toml
@@ -255,4 +255,4 @@ depends_on = []
 
 [[modules]]
 path = "teatree.quality"
-depends_on = []
+depends_on = ["teatree.utils"]

--- a/tests/quality/test_regression_rules.py
+++ b/tests/quality/test_regression_rules.py
@@ -1,0 +1,258 @@
+"""Conformance ledger for the named regression-detector layer (#126).
+
+Sibling of ``test_catalog.py``. The blocking-set zero-findings assertion is what
+lets the blocking gate be trusted and keeps main green: a blocking rule whose bug
+re-appears on the tree turns this test red. Warn rules are advisory and must each
+name a tracking issue (the flip protocol's forward guarantee).
+
+The semgrep-invoking tests need the pinned engine on PATH (``uvx`` in CI, a local
+``semgrep``/``uvx`` otherwise); they skip when neither is available so a
+network-less inner loop is not blocked, while CI always runs them.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from teatree.quality import regression_scan
+from teatree.quality.regression_catalog import (
+    BLOCKING_NOW,
+    RegressionCatalogError,
+    RegressionRule,
+    load_manifest,
+    load_semgrep_rule_ids,
+    manifest_path,
+    repo_root,
+)
+from teatree.quality.regression_scan import SemgrepUnavailableError, scan_findings, semgrep_invocable
+
+
+def _fake_completed(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _patch_which(*present: str):
+    return patch.object(
+        regression_scan.shutil, "which", side_effect=lambda name: f"/bin/{name}" if name in present else None
+    )
+
+
+requires_semgrep = pytest.mark.skipif(not semgrep_invocable(), reason="semgrep/uvx not on PATH")
+
+
+@pytest.fixture(scope="module")
+def manifest() -> tuple[RegressionRule, ...]:
+    return load_manifest()
+
+
+@pytest.fixture(scope="module")
+def blocking_dir() -> Path:
+    return repo_root() / ".semgrep" / "blocking"
+
+
+@pytest.fixture(scope="module")
+def warn_dir() -> Path:
+    return repo_root() / ".semgrep" / "warn"
+
+
+class TestManifestSchema:
+    def test_manifest_is_non_empty(self, manifest: tuple[RegressionRule, ...]) -> None:
+        assert manifest
+
+    def test_ids_are_unique(self, manifest: tuple[RegressionRule, ...]) -> None:
+        ids = [rule.id for rule in manifest]
+        assert len(ids) == len(set(ids))
+
+    def test_every_rule_file_exists(self, manifest: tuple[RegressionRule, ...]) -> None:
+        for rule in manifest:
+            assert rule.rule_path.is_file(), f"{rule.id}: rule file {rule.file} does not exist"
+
+    def test_every_rule_file_parses_as_semgrep_yaml(self, manifest: tuple[RegressionRule, ...]) -> None:
+        for rule in manifest:
+            ids = load_semgrep_rule_ids(rule.rule_path)
+            assert ids, f"{rule.id}: rule file has no semgrep rules"
+
+    def test_manifest_id_matches_the_semgrep_rule_id(self, manifest: tuple[RegressionRule, ...]) -> None:
+        for rule in manifest:
+            ids = load_semgrep_rule_ids(rule.rule_path)
+            assert ids == (rule.id,), f"{rule.id}: rule file declares semgrep ids {ids}, expected ({rule.id!r},)"
+
+    def test_blocking_rules_use_the_blocking_now_sentinel(self, manifest: tuple[RegressionRule, ...]) -> None:
+        for rule in manifest:
+            if rule.is_blocking:
+                assert rule.issue == BLOCKING_NOW
+
+    def test_every_warn_rule_names_a_tracking_issue(self, manifest: tuple[RegressionRule, ...]) -> None:
+        for rule in manifest:
+            if not rule.is_blocking:
+                assert rule.issue.startswith("souliane/teatree#"), (
+                    f"{rule.id}: a warn rule must name a souliane/teatree#<n> tracking issue, got {rule.issue!r}"
+                )
+
+
+class TestManifestMatchesTree:
+    def test_every_semgrep_file_is_in_the_manifest(self, manifest: tuple[RegressionRule, ...]) -> None:
+        on_disk = {p.relative_to(repo_root()).as_posix() for p in (repo_root() / ".semgrep").rglob("*.yaml")}
+        declared = {rule.file for rule in manifest}
+        assert on_disk == declared, (
+            f"manifest/disk drift: only-disk={on_disk - declared} only-manifest={declared - on_disk}"
+        )
+
+
+class TestBlockingSetIsGreen:
+    @requires_semgrep
+    def test_blocking_rules_have_zero_findings_on_the_current_tree(self, blocking_dir: Path) -> None:
+        findings = scan_findings(blocking_dir)
+        assert findings == [], (
+            "blocking regression rules must be zero-findings on the current tree (main stays green); "
+            f"got: {[(f['check_id'], f['path'], f['start']['line']) for f in findings]}"
+        )
+
+
+class TestWarnSetGuardsItsBugs:
+    @requires_semgrep
+    def test_each_warn_rule_fires_on_its_bug(self, manifest: tuple[RegressionRule, ...], warn_dir: Path) -> None:
+        findings = scan_findings(warn_dir)
+        fired = {f["check_id"].rsplit(".", 1)[-1] for f in findings}
+        warn_ids = {rule.id for rule in manifest if not rule.is_blocking}
+        assert warn_ids <= fired, (
+            "every warn rule must still fire on its (open) bug, else it guards nothing; "
+            f"silent rules: {sorted(warn_ids - fired)}"
+        )
+
+
+class TestSemgrepEngine:
+    def test_semgrep_is_invocable(self) -> None:
+        assert semgrep_invocable(), (
+            "the pinned semgrep engine is not invocable; a future bump or a broken pin must fail HERE, "
+            "not silently no-op the CI scan"
+        )
+
+
+class TestSemgrepEngineBranches:
+    def test_prefers_a_local_semgrep_binary(self) -> None:
+        with _patch_which("semgrep", "uvx"):
+            assert regression_scan._semgrep_argv() == ["semgrep"]
+
+    def test_falls_back_to_uvx(self) -> None:
+        with _patch_which("uvx"):
+            assert regression_scan._semgrep_argv()[0] == "uvx"
+
+    def test_raises_when_neither_engine_present(self) -> None:
+        with _patch_which(), pytest.raises(SemgrepUnavailableError, match="neither"):
+            regression_scan._semgrep_argv()
+
+    def test_not_invocable_when_no_engine(self) -> None:
+        with _patch_which():
+            assert semgrep_invocable() is False
+
+    def test_invocable_reads_version_exit_code(self) -> None:
+        with (
+            _patch_which("semgrep"),
+            patch.object(regression_scan, "run_allowed_to_fail", return_value=_fake_completed(0)),
+        ):
+            assert semgrep_invocable() is True
+
+    def test_scan_findings_parses_results(self, tmp_path: Path) -> None:
+        payload = '{"results": [{"check_id": "x"}]}'
+        with (
+            _patch_which("semgrep"),
+            patch.object(regression_scan, "run_allowed_to_fail", return_value=_fake_completed(1, stdout=payload)),
+        ):
+            assert scan_findings(tmp_path) == [{"check_id": "x"}]
+
+    def test_scan_findings_raises_on_empty_output(self, tmp_path: Path) -> None:
+        with (
+            _patch_which("semgrep"),
+            patch.object(regression_scan, "run_allowed_to_fail", return_value=_fake_completed(2, stderr="boom")),
+            pytest.raises(SemgrepUnavailableError, match="no JSON output"),
+        ):
+            scan_findings(tmp_path)
+
+
+class TestLoaderValidation:
+    def _load(self, tmp_path: Path, body: str) -> tuple[RegressionRule, ...]:
+        path = tmp_path / "regression_rules.yaml"
+        path.write_text(body, encoding="utf-8")
+        return load_manifest(path)
+
+    def test_real_manifest_loads(self) -> None:
+        assert manifest_path().is_file()
+        assert load_manifest()
+
+    def test_non_kebab_id_rejected(self, tmp_path: Path) -> None:
+        body = "- id: Not_Kebab\n  issue: BLOCKING-NOW\n  status: blocking\n  file: .semgrep/blocking/Not_Kebab.yaml\n"
+        with pytest.raises(RegressionCatalogError, match="kebab slug"):
+            self._load(tmp_path, body)
+
+    def test_bad_status_rejected(self, tmp_path: Path) -> None:
+        body = "- id: x\n  issue: BLOCKING-NOW\n  status: nope\n  file: .semgrep/nope/x.yaml\n"
+        with pytest.raises(RegressionCatalogError, match="status must be one of"):
+            self._load(tmp_path, body)
+
+    def test_blocking_with_tracking_issue_rejected(self, tmp_path: Path) -> None:
+        body = "- id: x\n  issue: souliane/teatree#1\n  status: blocking\n  file: .semgrep/blocking/x.yaml\n"
+        with pytest.raises(RegressionCatalogError, match="blocking rule's issue must be"):
+            self._load(tmp_path, body)
+
+    def test_warn_without_tracking_issue_rejected(self, tmp_path: Path) -> None:
+        body = "- id: x\n  issue: BLOCKING-NOW\n  status: warn\n  file: .semgrep/warn/x.yaml\n"
+        with pytest.raises(RegressionCatalogError, match="must name a souliane/teatree"):
+            self._load(tmp_path, body)
+
+    def test_file_in_wrong_dir_rejected(self, tmp_path: Path) -> None:
+        body = "- id: x\n  issue: BLOCKING-NOW\n  status: blocking\n  file: .semgrep/warn/x.yaml\n"
+        with pytest.raises(RegressionCatalogError, match=r"must live under \.semgrep/blocking/"):
+            self._load(tmp_path, body)
+
+    def test_file_name_id_mismatch_rejected(self, tmp_path: Path) -> None:
+        body = "- id: x\n  issue: BLOCKING-NOW\n  status: blocking\n  file: .semgrep/blocking/y.yaml\n"
+        with pytest.raises(RegressionCatalogError, match="must match the entry id"):
+            self._load(tmp_path, body)
+
+    def test_duplicate_id_rejected(self, tmp_path: Path) -> None:
+        one = "- id: dup\n  issue: BLOCKING-NOW\n  status: blocking\n  file: .semgrep/blocking/dup.yaml\n"
+        with pytest.raises(RegressionCatalogError, match="duplicate id"):
+            self._load(tmp_path, one + one)
+
+    def test_invalid_semgrep_file_rejected(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("not_rules: []\n", encoding="utf-8")
+        with pytest.raises(RegressionCatalogError, match="must be a mapping with a 'rules' list"):
+            load_semgrep_rule_ids(bad)
+
+    def test_malformed_manifest_yaml_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(RegressionCatalogError):
+            self._load(tmp_path, "- id: x\n   bad: : indent\n")
+
+    def test_non_list_manifest_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(RegressionCatalogError, match="top-level YAML list"):
+            self._load(tmp_path, "id: x\n")
+
+    def test_non_mapping_entry_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(RegressionCatalogError, match="each entry must be a mapping"):
+            self._load(tmp_path, "- just-a-string\n")
+
+    def test_missing_required_field_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(RegressionCatalogError, match="required string field"):
+            self._load(tmp_path, "- id: x\n  status: blocking\n  file: .semgrep/blocking/x.yaml\n")
+
+    def test_malformed_semgrep_yaml_rejected(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("rules: : :\n", encoding="utf-8")
+        with pytest.raises(RegressionCatalogError, match="invalid semgrep YAML"):
+            load_semgrep_rule_ids(bad)
+
+    def test_empty_rules_list_rejected(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("rules: []\n", encoding="utf-8")
+        with pytest.raises(RegressionCatalogError, match="non-empty list"):
+            load_semgrep_rule_ids(bad)
+
+    def test_semgrep_rule_without_string_id_rejected(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("rules:\n  - message: m\n", encoding="utf-8")
+        with pytest.raises(RegressionCatalogError, match="needs a string 'id'"):
+            load_semgrep_rule_ids(bad)


### PR DESCRIPTION
Named regression-detector layer: every fixed intra-code bug becomes a permanent named semgrep rule keyed to its tracking issue (the OpenClaw GHSA-pattern twin; the same-day anti-vacuous-eval doctrine made structural). Sibling of the anti-pattern catalog, not a new framework: regression_rules.yaml is source of truth, regression_catalog.py the loader (mirrors catalog.py), test_regression_rules.py the conformance ledger (mirrors test_catalog.py), .semgrep/blocking and .semgrep/warn hold one rule YAML per bug. Blocking set is zero-findings on main (the test proves it; the prek/CI gate trusts it): predictable-temp-path. Warn rules are advisory only and flip warn-to-blocking in each bug fix PR: consume-before-side-effect-not-atomic (#1879), cas-stamp-before-side-effect (#1880), response-json-on-2xx-uncaught (#1881), signal-receiver-without-fault-isolation (#1882), except-swallow-to-empty (#1883), gate-fails-open-on-nonzero (#1884). Boundary: semgrep owns intra-function code-shape regressions; import direction to tach (#127), who-may-call-X to the chokepoint registry (#128), agent behaviour to the eval corpus. Wiring: a blocking prek hook (runs in CI) plus an advisory manual hook and an advisory CI job that always exits 0; semgrep pinned to v1.165.0 (1.139.0 cannot parse the codebase PEP 695 type statements); a test asserts the engine is invocable. Filed tracking issues: #1879 #1880 #1881 #1882 #1883 #1884.