### PR TITLE
fix(core): fault-isolate _log_ticket_transition so a DB error cannot break the FSM transition

### DIFF
--- a/.semgrep/blocking/signal-receiver-without-fault-isolation.yaml
+++ b/.semgrep/blocking/signal-receiver-without-fault-isolation.yaml
@@ -8,8 +8,8 @@ rules:
       contract). Wrap the body and logger.exception, like every sibling
       receiver in signals.py. See signals.py:16.
     metadata:
-      issue: souliane/teatree#1882
-      status: warn
+      issue: BLOCKING-NOW
+      status: blocking
     paths:
       include:
         - "/src/teatree/core/signals.py"

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -23,14 +23,17 @@ def _log_ticket_transition(
 ) -> None:
     from teatree.core.models.transition import TicketTransition  # noqa: PLC0415
 
-    session = instance.sessions.order_by("-started_at").first()  # ty: ignore[unresolved-attribute]
-    TicketTransition.objects.create(
-        ticket=instance,
-        session=session,
-        from_state=source,
-        to_state=target,
-        triggered_by=name,
-    )
+    try:
+        session = instance.sessions.order_by("-started_at").first()  # ty: ignore[unresolved-attribute]
+        TicketTransition.objects.create(
+            ticket=instance,
+            session=session,
+            from_state=source,
+            to_state=target,
+            triggered_by=name,
+        )
+    except Exception:
+        logger.exception("Failed to record TicketTransition audit for ticket %s transition %s", instance.pk, name)
 
 
 def _add_slack_reactions_on_transition(

--- a/src/teatree/quality/regression_rules.yaml
+++ b/src/teatree/quality/regression_rules.yaml
@@ -40,9 +40,9 @@
   file: .semgrep/warn/response-json-on-2xx-uncaught.yaml
 
 - id: signal-receiver-without-fault-isolation
-  issue: souliane/teatree#1882
-  status: warn
-  file: .semgrep/warn/signal-receiver-without-fault-isolation.yaml
+  issue: BLOCKING-NOW
+  status: blocking
+  file: .semgrep/blocking/signal-receiver-without-fault-isolation.yaml
 
 - id: except-swallow-to-empty
   issue: souliane/teatree#1883

--- a/tests/teatree_core/test_signals.py
+++ b/tests/teatree_core/test_signals.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
+from django.db import DatabaseError
 from django.test import TestCase, override_settings
 
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.core.signals as signals_mod
 from teatree.core.models import PullRequest, Session, Task, Ticket
+from teatree.core.models.transition import TicketTransition
 from tests.teatree_core._on_behalf_gate_helpers import on_behalf_gate_off
 from tests.teatree_core.conftest import CommandOverlay
 
@@ -452,3 +454,38 @@ class TestTransitionReactionGated(TestCase):
 
         assert len(calls) == 1
         assert calls[0][1] == "mark_merged"
+
+
+class TestLogTicketTransitionFaultIsolation(TestCase):
+    """The transition-audit receiver must never break the FSM transition (#1882).
+
+    ``_log_ticket_transition`` writes a ``TicketTransition`` audit row. A
+    ``DatabaseError`` raised there must be swallowed and logged like every
+    sibling receiver — the Ticket FSM transition itself completes and
+    persists regardless.
+    """
+
+    def test_transition_survives_audit_db_error(self) -> None:
+        ticket = Ticket.objects.create(overlay="test")
+
+        with (
+            patch.object(TicketTransition.objects, "create", side_effect=DatabaseError("audit table gone")),
+            self.assertLogs(signals_mod.logger, level="ERROR"),
+        ):
+            ticket.scope()
+            ticket.save()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SCOPED
+
+    def test_audit_db_error_is_logged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test")
+
+        with (
+            patch.object(TicketTransition.objects, "create", side_effect=DatabaseError("audit table gone")),
+            self.assertLogs(signals_mod.logger, level="ERROR") as captured,
+        ):
+            ticket.scope()
+            ticket.save()
+
+        assert any("audit table gone" in line for line in captured.output)


### PR DESCRIPTION
`_log_ticket_transition` was the only `post_transition` receiver in `signals.py` lacking try/except. A `DatabaseError` raised while writing the `TicketTransition` audit row propagated through `post_transition.send` and broke every Ticket FSM transition (violates the never-block-the-FSM contract every sibling receiver already honors).

Wrapped the body in try/except + `logger.exception`, mirroring the siblings exactly — the audit write is best-effort, a failure is logged and swallowed, the transition completes regardless.

Flipped the regression rule `signal-receiver-without-fault-isolation` warn to blocking now that the only offender is gone: moved the rule file to `.semgrep/blocking/`, set `metadata.status` to blocking, updated the manifest entry. The blocking set is now green-on-tree (`semgrep scan --config .semgrep/blocking --error` exits 0; the rule scans only `signals.py` and finds nothing after the wrap).

Regression test reproduces the break (RED on the unwrapped receiver — the `DatabaseError` escaped `change_state`) and confirms the wrap (GREEN).

Closes #1882
