### PR TITLE
fix(core): make on-behalf consume+audit+post atomic so a failed post cannot burn the approval or write a lying audit (#1879)

### DIFF
--- a/.semgrep/blocking/consume-before-side-effect-not-atomic.yaml
+++ b/.semgrep/blocking/consume-before-side-effect-not-atomic.yaml
@@ -5,11 +5,13 @@ rules:
     message: >-
       Single-use approval consumed then audited outside one transaction.atomic.
       Consume + audit + side-effect must share ONE transaction.atomic so a
-      failed post rolls back the consume and the audit never lies.
-      See on_behalf_gate_recorded.py:97.
+      failed post rolls back the consume and the audit never lies. The gate
+      takes the publish action as a callback and runs consume + publish +
+      OnBehalfAudit.create in one atomic block — see
+      require_on_behalf_approval in on_behalf_gate_recorded.py.
     metadata:
-      issue: souliane/teatree#1879
-      status: warn
+      issue: BLOCKING-NOW
+      status: blocking
     paths:
       include:
         - "/src/teatree/core/on_behalf_gate_recorded.py"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,160 +1,98 @@
-# Architecture pre-check — souliane/teatree#128 (generic chokepoint registry)
+# Architecture pre-check — souliane/teatree#1879
+
+Make on-behalf consume+audit+post atomic so a failed post cannot burn the
+approval or write a lying audit.
 
 ## 1. BLUEPRINT § alignment
 
-Extends the §17.1-invariant-2 flywheel (enforcement-as-structure) and the
-quality-catalog machinery (`antipatterns.yaml`/`regression_rules.yaml`): one
-declarative registry {protected symbol -> sole allowed module} + one generic
-AST checker for call-site authorization. Distinct from tach (import graph) and
-semgrep (intra-body shapes).
+§17.4 (recorded-approval / clear+audit family) and `/t3:rules` § "Ask Before
+Posting on the User's Behalf". The on-behalf gate consumes a single-use
+`OnBehalfApproval`, writes an `OnBehalfAudit`, and the caller posts — these
+three must be all-or-nothing. No BLUEPRINT prose change: the documented
+outcome table is unchanged; only the consume+post+audit ordering becomes
+atomic.
 
 ## 2. FSM phase boundaries
 
-n/a — no `Ticket.State`/`Worktree.State` transition touched.
+n/a — no `Ticket.State` / `Worktree.State` transition. The PR-approval and
+ticket-transition signal receivers call the gate, but the FSM transition
+itself is unchanged and never blocked.
 
 ## 3. Extension-point contracts
 
-n/a — no `OverlayBase`/scanner/hook-router/`*Backend` Protocol surface changed.
-The registry references existing symbols (`subprocess.*`, `post_routed`,
-`react_routed`, `react`, `post_message`) but adds no new contract.
+No `OverlayBase` / scanner-registration / `*Backend` Protocol change. The
+chokepoint registry entry #1 (`on-behalf-routed-egress`: post_routed /
+react_routed) protects backend symbols, not `require_on_behalf_approval`'s
+signature — unaffected; `tests/quality/test_chokepoints.py` stays green (37
+passing). Consumers of the gate, updated in lockstep to the callback form:
+
+- `teatree.core.on_behalf_egress` (post / react)
+- `teatree.core.reply_transport` (_send / redeliver)
+- `teatree.core.signals` (transition / approval reaction)
+- `teatree.core.management.commands.review_request_post`
+- `teatree.core.management.commands.pr` (post_evidence)
+- `teatree.core.management.commands._e2e_evidence`
+- `teatree.cli.review_on_behalf` (peek `check_on_behalf` +
+  consuming `publish_on_behalf`) and `teatree.cli.review.ReviewService`
+  (8 post sites wrapped in `_publish_or_blocked`).
 
 ## 4. Component boundaries
 
-- Registry data: `src/teatree/quality/chokepoints.yaml` (sibling of
-  `antipatterns.yaml`/`regression_rules.yaml`).
-- Loader: `src/teatree/quality/chokepoints.py` (mirrors `regression_catalog.py`
-  — yaml + frozen dataclass + load-time validation, stdlib only).
-- Generic checker: `scripts/hooks/check_chokepoints.py` (generalizes
-  `check_subprocess_ban.py`'s AST visitor; registry-driven).
-- Conformance test: `tests/quality/test_chokepoints.py` (mirrors
-  `test_catalog.py`).
+`teatree.core.on_behalf_gate_recorded` — unchanged home. Split into two
+purpose-typed functions: `require_on_behalf_approval(publish=…)` (the only
+consuming path: consume + callback + audit in one `transaction.atomic`) and
+`on_behalf_block_message(target, action)` (non-consuming peek for early
+refusal). `OnBehalfApproval.has_unconsumed` backs the peek.
 
 ## 5. Dependency direction
 
-`teatree.quality` is `layer=foundation`, `depends_on=["teatree.utils"]`. The
-loader imports only stdlib + `yaml` — adds no tach edge. The reachability-ledger
-assertions that touch `teatree.backends.slack_bot` live in the TEST file (tests
-are not tach-constrained). `uv run tach check` stays green.
+No new cross-module imports — the publish callback is passed in by each
+caller. `uv run tach check` → "All modules validated!".
 
 ## 6. Test surface
 
-`tests/quality/test_chokepoints.py`:
-
-- schema invariants (ids unique/kebab, `match_kind` enum, non-empty
-  `allowed_modules`/`protected_attrs`);
-- reachability ledger (every `allowed_module` resolves to a real file; every
-  `protected_attr` is a real attribute on its declaring class/module);
-- green-on-tree (zero violations on real `src/teatree/` — the blocking gate);
-- anti-vacuous (synthetic `subprocess.run` / `x.post_routed()` outside allowed
-  -> rc 1; inside -> rc 0; `def post_routed` -> rc 0; annotation/except -> rc 0);
-- loader validation (bad enum / dup id / non-kebab / empty allowed / non-mapping
-  entry / non-sequence list / malformed YAML / missing-field rejected);
-- self-maintenance Tier-2 (subprocess entry's `protected_attrs` superset of the
-  historical `{run,Popen,check_output,check_call,call}`).
+- `tests/teatree_core/test_on_behalf_gate_recorded.py`
+  `TestPublishCallbackAtomicity`: failed publish rolls back consume + writes
+  no audit (RED-observed on pre-fix non-atomic order); success runs
+  publish→consume→audit; BLOCK+no-approval never runs publish; retry reuses
+  the approval. `TestNonConsumingPeek`: peek never consumes / DMs.
+- `tests/teatree_core/test_reply_transport_on_behalf_gate.py`
+  `TestRedeliverReusesReservation`: a failed redeliver does not burn the
+  approval; N redelivers consume exactly one (RED-observed on pre-fix
+  redeliver shape).
+- `tests/teatree_core/test_review_request_post_command.py`: no-backend
+  suppress no longer consumes (improved behavior).
 
 ## 7. Resilience invariants
 
-n/a — pure static-analysis gate, no external write, no DB row, no sub-agent.
+External write = the colleague post (callback).
+
+- verify-by-re-read / idempotency: `OnBehalfApproval.consume` keeps its
+  `select_for_update` + `consumed_at` single-use claim, now inside the same
+  atomic block as the post; `reply_transport` keeps its ReplyDispatch
+  reservation.
+- fallback-transport: BLOCK + no approval still raises
+  `OnBehalfPostBlockedError`; the caller surfaces the blocked post.
+- NEW invariant **atomicity**: consume + post + audit share one
+  `transaction.atomic` — a post failure rolls back the consume (no burn) and
+  writes no audit (no lie). Enforced structurally by flipping the
+  `consume-before-side-effect-not-atomic` semgrep rule warn→blocking in the
+  same PR.
+- heartbeat / sub-agent return contract: n/a (synchronous single post).
 
 ## 8. Identity and key normalization
 
-The canonical key is the fully-qualified dotted module path
-(`teatree.utils.run`). `module_path_for(rel_path)` canonicalizes a scanned file
-UP to its dotted path; `allowed_modules` are stored as dotted paths and compared
-by identity — no `split`/`strip`-to-match seam.
+`canonical_on_behalf_target` already canonicalizes the target up to
+`<repo>!<iid>` at both record and consume; `has_unconsumed` reuses it. No new
+identity surface; no strip/split-to-match introduced.
 
 ## 9. Behavior preservation / capability deletion
 
-Deletes `check_subprocess_ban.py` (+ test + pre-commit block) and
-`tests/teatree_core/test_on_behalf_egress_import_guard.py`. The import-guard had
-TWO invariants, BOTH preserved as registry entries:
-
-- invariant 1 (`react_routed`/`post_routed` only inside `on_behalf_egress`)
-  -> entry `on-behalf-routed-egress` (method-kind, allowed=`teatree.core.on_behalf_egress`);
-- invariant 2 (`react`/`post_message` only at documented bot->user/self-ack
-  sinks, with the receiver-is-egress carve-out) -> entry
-  `on-behalf-colleague-primitives` (method-kind + `exempt_receivers:
-  [egress, OnBehalfSlackEgress]`, allowed = the documented sink modules).
-`exempt_receivers` is an optional refinement of the existing `method` kind, NOT
-a third `match_kind` — the DSL stays two-valued. No must-block test inverted to
-must-not-block. `os.system` deliberately NOT added (zero hits; the deleted ban
-excluded it — flagged in the commit body).
-DEFER (tracked follow-ups, would break green): httpx/requests (~15 modules),
-gh/glab forge argv (different matcher), secrets `read_pass` (~9 modules),
-merge-keystone (`merge_ticket_pr`/`record_merge_and_advance` are bare-name
-function calls — neither `module_attr` nor `method`; registering needs a third
-match_kind = scope creep). KEEP SEPARATE (term/diff scans, not call sites):
-`check_no_overlay_leak.py`, banned-terms, privacy-push-scan.
-
----
-
-## Architecture pre-check — fix(core): redis-slot + notify_user TOCTOU (#1886, merged into this branch)
-
-### 1. BLUEPRINT § alignment
-
-§6.6 "The DB is the arbiter for shared state" (ac-django transactions ref): read-modify-write on shared
-state must hold an atomic guard for the whole RMW, or use an atomic conditional UPDATE / caught
-IntegrityError. Both fixes mirror the existing CAS doctrine documented on `claim_next_pending` /
-`LoopLease.acquire` (managers.py / loop_lease_manager.py).
-
-### 2. FSM phase boundaries
-
-n/a — no `Ticket.State` / `Worktree.State` transition is added or moved.
-
-### 3. Extension-point contracts
-
-n/a — no `OverlayBase` hook, scanner registration, or `*Backend` Protocol surface changes.
-`allocate_redis_slot` consumers: the `worktree` provision command; `notify_user` is the single
-notification egress.
-
-### 4. Component boundaries
-
-- `allocate_redis_slot` stays on `TicketQuerySet` (`src/teatree/core/managers.py`) — collection-level
-  claim logic belongs on the manager, beside the sibling CAS claims.
-- `notify_user` idempotency claim stays in `src/teatree/core/notify.py` — same chokepoint.
-
-### 5. Dependency direction
-
-No new imports beyond `IntegrityError` (already imported in notify.py) and `transaction` (already
-imported in managers.py). No backwards edge. `uv run tach check` confirms.
-
-### 6. Test surface
-
-- `tests/teatree_core/test_redis_slots_concurrent.py` — two real threads on a file-backed SQLite
-  registered with prod `SQLITE_WRITE_SERIALIZATION_OPTIONS` race to claim the lowest free slot; assert
-  distinct slots, no `IntegrityError` escapes, the loser reselects. RED on current code (uncaught
-  IntegrityError / duplicate slot).
-- `tests/teatree_core/test_notify.py` — `TestNotifyUserConcurrentDedup`: two threads fire the same
-  idempotency_key with a recoverable prior FAILED row; assert exactly one delivery + exactly one SENT
-  BotPing row. RED on current filter→delete→deliver→create.
-
-### 7. Resilience invariants
-
-- verify-by-re-read: the slot claim does NOT re-read a single row — it re-queries the taken-set each
-  iteration and uses the unique constraint as the CAS token, catching `IntegrityError` and reselecting
-  on a collision. The notify claim (`BotPing.claim_delivery`) re-reads the dedup row under
-  `select_for_update` inside one `transaction.atomic` and commits the SENDING claim there; delivery
-  (the Slack post) happens AFTER that atomic block, outside the lock, then the row is finalized to
-  SENT/FAILED.
-- idempotency: notify_user stays idempotent on SENT; allocate_redis_slot stays idempotent on an
-  already-allocated ticket.
-- fallback-transport: a stale SENDING claim (owner crashed before finalize) is recoverable in BOTH the
-  primary claim and the fallback (`BotPing.is_stale_sending` is the shared staleness SSOT), so one crash
-  mid-delivery cannot permanently block a reused day-granular key; a fresh SENDING still blocks.
-- heartbeat / sub-agent return contract: unchanged.
-
-### 8. Identity and key normalization
-
-n/a — no bare-vs-qualified identity. `redis_db_index` is an int slot; `idempotency_key` is already the
-canonical key (unique constraint).
-
-### 9. Behavior preservation / capability deletion
-
-Both functions are tightened, not narrowed. `allocate_redis_slot` keeps: idempotent already-allocated
-return, lowest-free selection, `RedisSlotsExhaustedError` on exhaustion, configurable count.
-`notify_user` keeps: SENT no-op, FAILED/NOOP recoverable retry (#1306), never-raise on DatabaseError,
-all hard-failure paths. The SENDING claim status is NOT a new permanent block: a stale SENDING (crashed
-owner) is recoverable in both `claim_delivery` and the fallback, preserving the old code's self-healing
-property for reused day-granular keys (`loops_tick_errors:{utc_day}`). The fallback's NOOP-not-recoverable
-behavior is preserved (NOOP means no backend; fallback can't help). No must-block test inverted; no
-privacy/security matcher touched.
+Rewrites `require_on_behalf_approval`'s body to take a publish callback.
+Behaviors preserved: PROCEED (run post, no consume/audit); AUTO_DRAFT (DM +
+run post, no consume/audit); BLOCK+approval (consume+post+audit, now atomic);
+BLOCK+no-approval (raise, never post). `check_on_behalf` keeps its
+no-publish early-refusal form but is now non-consuming (the consume moved to
+the post site). No privacy/leak/security matcher narrowed; no must-block test
+inverted. The semgrep warn rule is flipped to blocking in the same PR (proven
+to bite the pre-fix code and green-on-tree after the fix).

--- a/src/teatree/cli/review.py
+++ b/src/teatree/cli/review.py
@@ -22,16 +22,16 @@ scoped to ``(<repo>!<mr>, <method_name>)`` — the next matching
 invocation publishes and consumes the row.
 """
 
+from collections.abc import Callable
 from http import HTTPStatus
 
 import typer
 
-from teatree.cli.review_approval import identity_has_reviewed, identity_in_approved_by
-from teatree.cli.review_audit import ReviewAfterReceipt, notify_review_after_receipt, record_note_claim
+from teatree.cli.review_approval import identity_has_reviewed
 from teatree.cli.review_diff import find_added_line, resolve_inline_position
 from teatree.cli.review_drafts import register as _register_drafts
 from teatree.cli.review_evidence_gate import FindingEvidence, check_finding_evidence
-from teatree.cli.review_on_behalf import check_on_behalf, on_behalf_gate_active
+from teatree.cli.review_on_behalf import check_on_behalf, on_behalf_gate_active, publish_on_behalf
 from teatree.cli.review_on_behalf import register as _register_on_behalf
 from teatree.cli.review_shape_gate import check_review_shape
 from teatree.cli.review_todo_gate import InlineAnchor, check_todo_anchor
@@ -50,7 +50,6 @@ _resolve_inline_position = resolve_inline_position
 
 review_app = typer.Typer(no_args_is_help=True, help="Code review helpers.")
 _TOKEN_PARTS_COUNT = 2
-_HTTP_OK_CODES = frozenset({HTTPStatus.OK, HTTPStatus.CREATED, HTTPStatus.NO_CONTENT})
 
 
 class ReviewService:
@@ -85,6 +84,27 @@ class ReviewService:
         from teatree.backends.gitlab_api import GitLabAPI  # noqa: PLC0415
 
         return GitLabAPI(token=self.token, base_url=self._resolve_base_url())
+
+    @staticmethod
+    def _publish_or_blocked(
+        repo: str,
+        mr: int,
+        action: str,
+        body: Callable[[], tuple[str, int]],
+    ) -> tuple[str, int]:
+        """Run *body* (the GitLab post) atomically with the on-behalf consume + audit (#1879).
+
+        ``check_on_behalf`` already peeked non-consuming; here the approval is
+        consumed in the same ``transaction.atomic`` as the post, so a failed
+        post rolls back the consume (no burn) and writes no lying audit. A
+        BLOCK racing in after the peek is surfaced as ``(message, 1)``.
+        """
+        from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError  # noqa: PLC0415
+
+        try:
+            return publish_on_behalf(repo, mr, action, body)
+        except OnBehalfPostBlockedError as blocked:
+            return str(blocked), 1
 
     @staticmethod
     def _resolve_base_url() -> str:
@@ -144,7 +164,9 @@ class ReviewService:
         )
         if refusal:
             return refusal, 1
-        return self._post_draft_note_impl(repo, mr, note, file=file, line=line)
+        return self._publish_or_blocked(
+            repo, mr, "post_draft_note", lambda: self._post_draft_note_impl(repo, mr, note, file=file, line=line)
+        )
 
     def _run_pre_publish_gates(  # noqa: PLR0913
         self,
@@ -266,7 +288,9 @@ class ReviewService:
         blocked_live = check_live_post(repo=repo, mr=mr)
         if blocked_live:
             return blocked_live, 1
-        return self._post_comment_impl(repo, mr, note, file=file, line=line)
+        return self._publish_or_blocked(
+            repo, mr, "post_comment", lambda: self._post_comment_impl(repo, mr, note, file=file, line=line)
+        )
 
     def delete_draft_note(self, repo: str, mr: int, note_id: int) -> tuple[str, int]:
         """Delete a draft note. Returns (message, exit_code)."""
@@ -288,22 +312,12 @@ class ReviewService:
         blocked = check_on_behalf(repo, mr, "publish_draft_notes")
         if blocked:
             return blocked, 1
-        api = self._get_api()
+        from teatree.cli.review_post_impl import publish_draft_notes_impl  # noqa: PLC0415
+
         encoded = repo.replace("/", "%2F")
-        status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/draft_notes/bulk_publish")
-        if status in {HTTPStatus.OK, HTTPStatus.NO_CONTENT}:
-            record_note_claim(self._resolve_base_url, repo, mr, "bulk_publish", endpoint="draft_notes/bulk_publish")
-            notify_review_after_receipt(
-                self._resolve_base_url,
-                repo,
-                mr,
-                review_action=ReviewAfterReceipt(
-                    action="publish_draft_notes",
-                    summary=f"published all draft notes on {repo}!{mr}",
-                ),
-            )
-            return "OK — all draft notes published", 0
-        return f"Failed: HTTP {status}", 1
+        return self._publish_or_blocked(
+            repo, mr, "publish_draft_notes", lambda: publish_draft_notes_impl(self, repo, mr, encoded=encoded)
+        )
 
     def reply_to_discussion(self, repo: str, mr: int, discussion_id: str, body: str) -> tuple[str, int]:
         """Reply to an existing discussion thread on an MR. Returns (message, exit_code).
@@ -315,6 +329,8 @@ class ReviewService:
         blocked = check_on_behalf(repo, mr, "reply_to_discussion")
         if blocked:
             return blocked, 1
+        from teatree.cli.review_post_impl import reply_to_discussion_impl  # noqa: PLC0415
+
         api = self._get_api()
         encoded = repo.replace("/", "%2F")
         # Reply bodies are always inline (anchored on the existing discussion's
@@ -322,28 +338,12 @@ class ReviewService:
         shape_error = check_review_shape(api=api, encoded_repo=encoded, mr=mr, body=body, inline=True)
         if shape_error:
             return shape_error, 1
-        result = api.post_json(
-            f"projects/{encoded}/merge_requests/{mr}/discussions/{discussion_id}/notes",
-            {"body": body},
-        )
-        if not result:
-            return "Failed to post reply", 1
-        result_dict = dict(result) if isinstance(result, dict) else {}
-        note_id = result_dict.get("id")
-        record_note_claim(
-            self._resolve_base_url, repo, mr, note_id, endpoint="discussions/notes", discussion_id=discussion_id
-        )
-        notify_review_after_receipt(
-            self._resolve_base_url,
+        return self._publish_or_blocked(
             repo,
             mr,
-            review_action=ReviewAfterReceipt(
-                action="reply_to_discussion",
-                summary=f"replied to discussion {discussion_id} (note_id={note_id}) on {repo}!{mr}",
-                note_web_url=str(result_dict.get("web_url", "")),
-            ),
+            "reply_to_discussion",
+            lambda: reply_to_discussion_impl(self, repo, mr, discussion_id, body, encoded=encoded),
         )
-        return f"OK reply_note_id={note_id}", 0
 
     def resolve_discussion(self, repo: str, mr: int, discussion_id: str, *, resolved: bool = True) -> tuple[str, int]:
         """Mark a discussion thread resolved or unresolved. Returns (message, exit_code).
@@ -355,30 +355,15 @@ class ReviewService:
         blocked = check_on_behalf(repo, mr, "resolve_discussion")
         if blocked:
             return blocked, 1
-        api = self._get_api()
+        from teatree.cli.review_post_impl import resolve_discussion_impl  # noqa: PLC0415
+
         encoded = repo.replace("/", "%2F")
-        flag = "true" if resolved else "false"
-        status = api.put_status(f"projects/{encoded}/merge_requests/{mr}/discussions/{discussion_id}?resolved={flag}")
-        if status in {HTTPStatus.OK, HTTPStatus.NO_CONTENT}:
-            record_note_claim(
-                self._resolve_base_url,
-                repo,
-                mr,
-                f"{discussion_id}#resolved={flag}",
-                endpoint="discussions/resolve",
-                resolved=resolved,
-            )
-            notify_review_after_receipt(
-                self._resolve_base_url,
-                repo,
-                mr,
-                review_action=ReviewAfterReceipt(
-                    action="resolve_discussion",
-                    summary=f"set discussion {discussion_id} resolved={resolved} on {repo}!{mr}",
-                ),
-            )
-            return f"OK resolved={resolved}", 0
-        return f"Failed: HTTP {status}", 1
+        return self._publish_or_blocked(
+            repo,
+            mr,
+            "resolve_discussion",
+            lambda: resolve_discussion_impl(self, repo, mr, discussion_id, resolved=resolved, encoded=encoded),
+        )
 
     def update_note(self, repo: str, mr: int, note_id: int, body: str) -> tuple[str, int]:
         """Update a note (draft or published) on an MR.
@@ -393,6 +378,8 @@ class ReviewService:
         blocked = check_on_behalf(repo, mr, "update_note")
         if blocked:
             return blocked, 1
+        from teatree.cli.review_post_impl import update_note_impl  # noqa: PLC0415
+
         api = self._get_api()
         encoded = repo.replace("/", "%2F")
         # Without diff coordinates here, treat the updated body as MR-level
@@ -401,45 +388,9 @@ class ReviewService:
         shape_error = check_review_shape(api=api, encoded_repo=encoded, mr=mr, body=body, inline=False)
         if shape_error:
             return shape_error, 1
-
-        draft_status = api.put_status(
-            f"projects/{encoded}/merge_requests/{mr}/draft_notes/{note_id}",
-            {"note": body},
+        return self._publish_or_blocked(
+            repo, mr, "update_note", lambda: update_note_impl(self, repo, mr, note_id, body, encoded=encoded)
         )
-        if draft_status == HTTPStatus.OK:
-            record_note_claim(
-                self._resolve_base_url, repo, mr, f"update:draft:{note_id}", endpoint="draft_notes/update"
-            )
-            notify_review_after_receipt(
-                self._resolve_base_url,
-                repo,
-                mr,
-                review_action=ReviewAfterReceipt(
-                    action="update_note",
-                    summary=f"updated draft_note_id={note_id} on {repo}!{mr}",
-                ),
-            )
-            return f"OK updated draft_note_id={note_id}", 0
-        if draft_status != HTTPStatus.NOT_FOUND:
-            return f"Failed (draft): HTTP {draft_status}", 1
-
-        pub_status = api.put_status(
-            f"projects/{encoded}/merge_requests/{mr}/notes/{note_id}",
-            {"body": body},
-        )
-        if pub_status == HTTPStatus.OK:
-            record_note_claim(self._resolve_base_url, repo, mr, f"update:pub:{note_id}", endpoint="notes/update")
-            notify_review_after_receipt(
-                self._resolve_base_url,
-                repo,
-                mr,
-                review_action=ReviewAfterReceipt(
-                    action="update_note",
-                    summary=f"updated published note_id={note_id} on {repo}!{mr}",
-                ),
-            )
-            return f"OK updated note_id={note_id}", 0
-        return f"Failed: HTTP {pub_status}", 1
 
     def delete_discussion(self, repo: str, mr: int, note_id: int) -> tuple[str, int]:
         """Delete a *published* note from an MR. Returns (message, exit_code).
@@ -457,21 +408,12 @@ class ReviewService:
         blocked = check_on_behalf(repo, mr, "delete_discussion")
         if blocked:
             return blocked, 1
-        api = self._get_api()
+        from teatree.cli.review_post_impl import delete_discussion_impl  # noqa: PLC0415
+
         encoded = repo.replace("/", "%2F")
-        status = api.delete(f"projects/{encoded}/merge_requests/{mr}/notes/{note_id}")
-        if status == HTTPStatus.NO_CONTENT:
-            notify_review_after_receipt(
-                self._resolve_base_url,
-                repo,
-                mr,
-                review_action=ReviewAfterReceipt(
-                    action="delete_discussion",
-                    summary=f"deleted published note_id={note_id} on {repo}!{mr}",
-                ),
-            )
-            return f"OK deleted note_id={note_id}", 0
-        return f"Failed: HTTP {status}", status
+        return self._publish_or_blocked(
+            repo, mr, "delete_discussion", lambda: delete_discussion_impl(self, repo, mr, note_id, encoded=encoded)
+        )
 
     def list_draft_notes(self, repo: str, mr: int) -> tuple[str, int]:
         """List draft notes. Returns (message, exit_code)."""
@@ -523,17 +465,9 @@ class ReviewService:
                 "`post-draft-note`) first, then approve."
             )
             return msg, 1
-        api = self._get_api()
-        status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/approve")
-        if status in _HTTP_OK_CODES:
-            record_note_claim(self._resolve_base_url, repo, mr, "approve", kind="gitlab_approve", endpoint="approve")
-            return f"OK approved !{mr}", 0
-        # GitLab returns 401 for the idempotent already-approved case as
-        # well as a genuine auth failure (#1029). Probe /approvals to
-        # distinguish: identity already in approved_by → no-op success.
-        if identity_in_approved_by(api, encoded, mr):
-            return f"Already approved by {api.current_username()} (!{mr})", 0
-        return f"Failed: HTTP {status}", 1
+        from teatree.cli.review_post_impl import approve_impl  # noqa: PLC0415
+
+        return self._publish_or_blocked(repo, mr, "approve", lambda: approve_impl(self, repo, mr, encoded=encoded))
 
     def unapprove(self, repo: str, mr: int) -> tuple[str, int]:
         """Revoke this identity's approval on an MR. Returns (message, exit_code).
@@ -550,15 +484,10 @@ class ReviewService:
         blocked = check_on_behalf(repo, mr, "unapprove")
         if blocked:
             return blocked, 1
-        api = self._get_api()
+        from teatree.cli.review_post_impl import unapprove_impl  # noqa: PLC0415
+
         encoded = repo.replace("/", "%2F")
-        status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/unapprove")
-        if status in _HTTP_OK_CODES:
-            record_note_claim(
-                self._resolve_base_url, repo, mr, "unapprove", kind="gitlab_approve", endpoint="unapprove"
-            )
-            return f"OK unapproved !{mr}", 0
-        return f"Failed: HTTP {status}", 1
+        return self._publish_or_blocked(repo, mr, "unapprove", lambda: unapprove_impl(self, repo, mr, encoded=encoded))
 
 
 # Register sibling-module typer commands. Kept out of this file so the

--- a/src/teatree/cli/review_on_behalf.py
+++ b/src/teatree/cli/review_on_behalf.py
@@ -21,6 +21,8 @@ discovery, by a privacy-scan subprocess, etc.) before
 ``django.setup()`` has run.
 """
 
+from collections.abc import Callable
+
 import typer
 
 
@@ -62,20 +64,31 @@ def gate_target(repo: str, mr: int) -> str:
 def check_on_behalf(repo: str, mr: int, action: str) -> str:
     """Return an actionable error string when the on-behalf gate refuses, else ``""``.
 
-    The caller short-circuits with ``(message, 1)`` on a non-empty
-    return, so no GitLab API call is attempted while the gate is on
-    and no recorded :class:`OnBehalfApproval` matches the call.
+    The *non-consuming* peek (#1879): the caller short-circuits with
+    ``(message, 1)`` on a non-empty return, so no GitLab API call is
+    attempted while the gate is on and no recorded :class:`OnBehalfApproval`
+    matches. It never consumes — the single-use approval is consumed
+    atomically with the actual GitLab post via :func:`publish_on_behalf`, so
+    a peek that passes here never burns the approval if a later check refuses
+    or the post fails.
     """
-    from teatree.core.on_behalf_gate_recorded import (  # noqa: PLC0415
-        OnBehalfPostBlockedError,
-        require_on_behalf_approval,
-    )
+    from teatree.core.on_behalf_gate_recorded import on_behalf_block_message  # noqa: PLC0415
 
-    try:
-        require_on_behalf_approval(target=gate_target(repo, mr), action=action)
-    except OnBehalfPostBlockedError as blocked:
-        return str(blocked)
-    return ""
+    return on_behalf_block_message(gate_target(repo, mr), action)
+
+
+def publish_on_behalf[T](repo: str, mr: int, action: str, publish: Callable[[], T]) -> T:
+    """Run *publish* atomically with the on-behalf consume + audit (#1879).
+
+    The consuming half of the split: every ``ReviewService`` GitLab post
+    goes through here so consume, the GitLab call, and the audit share one
+    ``transaction.atomic``. A post that raises rolls back the consume (the
+    approval survives a retry) and writes no audit; a BLOCK with no recorded
+    approval raises :class:`OnBehalfPostBlockedError` before *publish* runs.
+    """
+    from teatree.core.on_behalf_gate_recorded import require_on_behalf_approval  # noqa: PLC0415
+
+    return require_on_behalf_approval(target=gate_target(repo, mr), action=action, publish=publish)
 
 
 def register(review_app: typer.Typer) -> None:

--- a/src/teatree/cli/review_post_impl.py
+++ b/src/teatree/cli/review_post_impl.py
@@ -13,9 +13,13 @@ because this module IS the extracted implementation of those methods.
 """
 # ruff: noqa: SLF001 — sibling-module extraction of ReviewService method bodies (#1280).
 
+from http import HTTPStatus
 from typing import TYPE_CHECKING
 
+from teatree.cli.review_approval import identity_in_approved_by
 from teatree.cli.review_audit import ReviewAfterReceipt, notify_review_after_receipt, record_note_claim
+
+_HTTP_OK_CODES = frozenset({HTTPStatus.OK, HTTPStatus.CREATED, HTTPStatus.NO_CONTENT})
 
 
 def _resolve_inline_position(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
@@ -143,3 +147,168 @@ def post_comment_impl(  # noqa: PLR0913 — every kwarg maps 1:1 to a public CLI
             "the MR diff may have shifted since position was resolved)"
         ), 0
     return f"OK discussion_id={discussion_id} (inline DiffNote)", 0
+
+
+def publish_draft_notes_impl(service: "ReviewService", repo: str, mr: int, *, encoded: str) -> tuple[str, int]:
+    """The pre-gate-passed publish body of :meth:`ReviewService.publish_draft_notes`."""
+    api = service._get_api()
+    status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/draft_notes/bulk_publish")
+    if status in {HTTPStatus.OK, HTTPStatus.NO_CONTENT}:
+        record_note_claim(service._resolve_base_url, repo, mr, "bulk_publish", endpoint="draft_notes/bulk_publish")
+        notify_review_after_receipt(
+            service._resolve_base_url,
+            repo,
+            mr,
+            review_action=ReviewAfterReceipt(
+                action="publish_draft_notes",
+                summary=f"published all draft notes on {repo}!{mr}",
+            ),
+        )
+        return "OK — all draft notes published", 0
+    return f"Failed: HTTP {status}", 1
+
+
+def reply_to_discussion_impl(  # noqa: PLR0913 — extracted ReviewService publish body; args mirror the method (#1280).
+    service: "ReviewService", repo: str, mr: int, discussion_id: str, body: str, *, encoded: str
+) -> tuple[str, int]:
+    """The pre-gate-passed publish body of :meth:`ReviewService.reply_to_discussion`."""
+    api = service._get_api()
+    result = api.post_json(
+        f"projects/{encoded}/merge_requests/{mr}/discussions/{discussion_id}/notes",
+        {"body": body},
+    )
+    if not result:
+        return "Failed to post reply", 1
+    result_dict = dict(result) if isinstance(result, dict) else {}
+    note_id = result_dict.get("id")
+    record_note_claim(
+        service._resolve_base_url, repo, mr, note_id, endpoint="discussions/notes", discussion_id=discussion_id
+    )
+    notify_review_after_receipt(
+        service._resolve_base_url,
+        repo,
+        mr,
+        review_action=ReviewAfterReceipt(
+            action="reply_to_discussion",
+            summary=f"replied to discussion {discussion_id} (note_id={note_id}) on {repo}!{mr}",
+            note_web_url=str(result_dict.get("web_url", "")),
+        ),
+    )
+    return f"OK reply_note_id={note_id}", 0
+
+
+def resolve_discussion_impl(  # noqa: PLR0913 — extracted ReviewService publish body; args mirror the method (#1280).
+    service: "ReviewService", repo: str, mr: int, discussion_id: str, *, resolved: bool, encoded: str
+) -> tuple[str, int]:
+    """The pre-gate-passed publish body of :meth:`ReviewService.resolve_discussion`."""
+    api = service._get_api()
+    flag = "true" if resolved else "false"
+    status = api.put_status(f"projects/{encoded}/merge_requests/{mr}/discussions/{discussion_id}?resolved={flag}")
+    if status in {HTTPStatus.OK, HTTPStatus.NO_CONTENT}:
+        record_note_claim(
+            service._resolve_base_url,
+            repo,
+            mr,
+            f"{discussion_id}#resolved={flag}",
+            endpoint="discussions/resolve",
+            resolved=resolved,
+        )
+        notify_review_after_receipt(
+            service._resolve_base_url,
+            repo,
+            mr,
+            review_action=ReviewAfterReceipt(
+                action="resolve_discussion",
+                summary=f"set discussion {discussion_id} resolved={resolved} on {repo}!{mr}",
+            ),
+        )
+        return f"OK resolved={resolved}", 0
+    return f"Failed: HTTP {status}", 1
+
+
+def update_note_impl(  # noqa: PLR0913 — extracted ReviewService publish body; args mirror the method (#1280).
+    service: "ReviewService", repo: str, mr: int, note_id: int, body: str, *, encoded: str
+) -> tuple[str, int]:
+    """The pre-gate-passed publish body of :meth:`ReviewService.update_note` (draft → published fallback)."""
+    api = service._get_api()
+    draft_status = api.put_status(
+        f"projects/{encoded}/merge_requests/{mr}/draft_notes/{note_id}",
+        {"note": body},
+    )
+    if draft_status == HTTPStatus.OK:
+        record_note_claim(service._resolve_base_url, repo, mr, f"update:draft:{note_id}", endpoint="draft_notes/update")
+        notify_review_after_receipt(
+            service._resolve_base_url,
+            repo,
+            mr,
+            review_action=ReviewAfterReceipt(
+                action="update_note",
+                summary=f"updated draft_note_id={note_id} on {repo}!{mr}",
+            ),
+        )
+        return f"OK updated draft_note_id={note_id}", 0
+    if draft_status != HTTPStatus.NOT_FOUND:
+        return f"Failed (draft): HTTP {draft_status}", 1
+
+    pub_status = api.put_status(
+        f"projects/{encoded}/merge_requests/{mr}/notes/{note_id}",
+        {"body": body},
+    )
+    if pub_status == HTTPStatus.OK:
+        record_note_claim(service._resolve_base_url, repo, mr, f"update:pub:{note_id}", endpoint="notes/update")
+        notify_review_after_receipt(
+            service._resolve_base_url,
+            repo,
+            mr,
+            review_action=ReviewAfterReceipt(
+                action="update_note",
+                summary=f"updated published note_id={note_id} on {repo}!{mr}",
+            ),
+        )
+        return f"OK updated note_id={note_id}", 0
+    return f"Failed: HTTP {pub_status}", 1
+
+
+def delete_discussion_impl(
+    service: "ReviewService", repo: str, mr: int, note_id: int, *, encoded: str
+) -> tuple[str, int]:
+    """The pre-gate-passed publish body of :meth:`ReviewService.delete_discussion`."""
+    api = service._get_api()
+    status = api.delete(f"projects/{encoded}/merge_requests/{mr}/notes/{note_id}")
+    if status == HTTPStatus.NO_CONTENT:
+        notify_review_after_receipt(
+            service._resolve_base_url,
+            repo,
+            mr,
+            review_action=ReviewAfterReceipt(
+                action="delete_discussion",
+                summary=f"deleted published note_id={note_id} on {repo}!{mr}",
+            ),
+        )
+        return f"OK deleted note_id={note_id}", 0
+    return f"Failed: HTTP {status}", status
+
+
+def approve_impl(service: "ReviewService", repo: str, mr: int, *, encoded: str) -> tuple[str, int]:
+    """The pre-gate-passed publish body of :meth:`ReviewService.approve` (post-review-precondition)."""
+    api = service._get_api()
+    status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/approve")
+    if status in _HTTP_OK_CODES:
+        record_note_claim(service._resolve_base_url, repo, mr, "approve", kind="gitlab_approve", endpoint="approve")
+        return f"OK approved !{mr}", 0
+    # GitLab returns 401 for the idempotent already-approved case as well as a
+    # genuine auth failure (#1029). Probe /approvals: identity already in
+    # approved_by → no-op success.
+    if identity_in_approved_by(api, encoded, mr):
+        return f"Already approved by {api.current_username()} (!{mr})", 0
+    return f"Failed: HTTP {status}", 1
+
+
+def unapprove_impl(service: "ReviewService", repo: str, mr: int, *, encoded: str) -> tuple[str, int]:
+    """The pre-gate-passed publish body of :meth:`ReviewService.unapprove`."""
+    api = service._get_api()
+    status = api.post_status(f"projects/{encoded}/merge_requests/{mr}/unapprove")
+    if status in _HTTP_OK_CODES:
+        record_note_claim(service._resolve_base_url, repo, mr, "unapprove", kind="gitlab_approve", endpoint="unapprove")
+        return f"OK unapproved !{mr}", 0
+    return f"Failed: HTTP {status}", 1

--- a/src/teatree/core/management/commands/_e2e_evidence.py
+++ b/src/teatree/core/management/commands/_e2e_evidence.py
@@ -26,7 +26,11 @@ from typing import TypedDict
 
 from teatree.backends.protocols import CodeHostBackend
 from teatree.core.models import Ticket, Worktree
-from teatree.core.on_behalf_gate_recorded import require_on_behalf_approval
+from teatree.core.on_behalf_gate_recorded import (
+    OnBehalfPostBlockedError,
+    on_behalf_block_message,
+    require_on_behalf_approval,
+)
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import WorktreeNotFoundError, resolve_worktree
@@ -397,11 +401,16 @@ def post_evidence_comment(host: CodeHostBackend, post: EvidencePost) -> PostEvid
     Runs only after every validator passed. The on-behalf gate is the last
     check before any side effect: a BLOCK with no recorded approval raises
     :class:`OnBehalfPostBlockedError`, which the command surfaces as a
-    non-zero exit rather than publishing unattended. Idempotency is keyed on
-    the hidden ``(env, commit)`` marker: a matching prior comment is edited
-    in place (``action="updated"``); otherwise a new comment is created.
+    non-zero exit rather than publishing unattended. The non-consuming peek
+    raises *before* any artifact upload; the consume then happens atomically
+    with the comment post (#1879), so a failed post burns no approval and
+    writes no lying audit. Idempotency is keyed on the hidden ``(env, commit)``
+    marker: a matching prior comment is edited in place (``action="updated"``);
+    otherwise a new comment is created.
     """
-    require_on_behalf_approval(target=post.issue_url, action=_ON_BEHALF_ACTION)
+    blocked = on_behalf_block_message(post.issue_url, _ON_BEHALF_ACTION)
+    if blocked:
+        raise OnBehalfPostBlockedError(post.issue_url, _ON_BEHALF_ACTION)
 
     before_md = _upload_artifact(host, repo=post.repo, filepath=str(post.before_path), label="before")
     after_md = _upload_artifact(host, repo=post.repo, filepath=str(post.after_path), label="after")
@@ -424,11 +433,19 @@ def post_evidence_comment(host: CodeHostBackend, post: EvidencePost) -> PostEvid
         commit=post.commit,
     )
     if match_id is not None:
-        result = host.update_issue_comment(issue_url=post.issue_url, comment_id=match_id, body=body)
+        result = require_on_behalf_approval(
+            target=post.issue_url,
+            action=_ON_BEHALF_ACTION,
+            publish=lambda: host.update_issue_comment(issue_url=post.issue_url, comment_id=match_id, body=body),
+        )
         action = "updated"
         comment_id = match_id
     else:
-        result = host.post_issue_comment(issue_url=post.issue_url, body=body)
+        result = require_on_behalf_approval(
+            target=post.issue_url,
+            action=_ON_BEHALF_ACTION,
+            publish=lambda: host.post_issue_comment(issue_url=post.issue_url, body=body),
+        )
         action = "created"
         comment_id = _comment_id(result)
 

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -41,7 +41,11 @@ from teatree.core.management.commands._ship_gates import check_shipping_gate as 
 from teatree.core.management.commands._ship_gates import run_branch_currency_gate as _run_branch_currency_gate
 from teatree.core.management.commands._ship_gates import run_visual_qa_gate as _run_visual_qa_gate
 from teatree.core.models import Ticket, Worktree
-from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError, require_on_behalf_approval
+from teatree.core.on_behalf_gate_recorded import (
+    OnBehalfPostBlockedError,
+    on_behalf_block_message,
+    require_on_behalf_approval,
+)
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 from teatree.core.orphan_guard import BranchStatus, classify_branch
 from teatree.core.overlay_loader import get_overlay
@@ -427,17 +431,19 @@ class Command(TyperCommand):
             return {"error": "No code host configured (check overlay GitLab token)"}
 
         repo_path = repo or get_overlay().metadata.get_ci_project_path()
+        target = f"{repo_path}!{mr_iid}"
 
-        try:
-            require_on_behalf_approval(target=f"{repo_path}!{mr_iid}", action="post_evidence")
-        except OnBehalfPostBlockedError as blocked:
-            return {"error": str(blocked)}
+        # Peek (non-consuming) so an unapproved post refuses before uploading
+        # anything; the consume happens atomically with the comment post below.
+        blocked = on_behalf_block_message(target, "post_evidence")
+        if blocked:
+            return {"error": blocked}
 
         # Upload files and build markdown embeds
         embeds: list[str] = []
         for filepath in files or []:
-            result = host.upload_file(repo=repo_path, filepath=filepath)
-            md = result.get("markdown", "")
+            upload = host.upload_file(repo=repo_path, filepath=filepath)
+            md = upload.get("markdown", "")
             if md:
                 embeds.append(str(md))
                 self.stdout.write(f"  Uploaded: {filepath}")
@@ -456,18 +462,25 @@ class Command(TyperCommand):
             None,
         )
 
-        if existing_note:
-            comment_id = int(str(existing_note["id"]))
-            self.stdout.write(f"  Updating existing note {comment_id}")
-            result = host.update_pr_comment(repo=repo_path, pr_iid=mr_iid, comment_id=comment_id, body=note_body)
-        else:
-            result = host.post_pr_comment(repo=repo_path, pr_iid=mr_iid, body=note_body)
+        def _publish() -> RawAPIDict:
+            if existing_note:
+                comment_id = int(str(existing_note["id"]))
+                self.stdout.write(f"  Updating existing note {comment_id}")
+                return host.update_pr_comment(repo=repo_path, pr_iid=mr_iid, comment_id=comment_id, body=note_body)
+            return host.post_pr_comment(repo=repo_path, pr_iid=mr_iid, body=note_body)
+
+        try:
+            # consume + post + audit atomic (#1879): a failed comment post
+            # rolls back the consume and writes no audit.
+            result = require_on_behalf_approval(target=target, action="post_evidence", publish=_publish)
+        except OnBehalfPostBlockedError as blocked_now:
+            return {"error": str(blocked_now)}
 
         notify_user_on_behalf_post(
-            target=f"{repo_path}!{mr_iid}",
+            target=target,
             action="post_evidence",
-            destination=f"{repo_path}!{mr_iid}",
-            artifact_url=str(result.get("web_url") or result.get("html_url") or f"{repo_path}!{mr_iid}"),
-            summary=f"{title} on {repo_path}!{mr_iid}",
+            destination=target,
+            artifact_url=str(result.get("web_url") or result.get("html_url") or target),
+            summary=f"{title} on {target}",
         )
         return result

--- a/src/teatree/core/management/commands/review_request_post.py
+++ b/src/teatree/core/management/commands/review_request_post.py
@@ -24,7 +24,11 @@ import typer
 from django_typer.management import TyperCommand, command
 
 from teatree.core.backend_factory import messaging_from_overlay
-from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError, require_on_behalf_approval
+from teatree.core.on_behalf_gate_recorded import (
+    OnBehalfPostBlockedError,
+    on_behalf_block_message,
+    require_on_behalf_approval,
+)
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 from teatree.core.review_message_cache import persist_review_message
 from teatree.core.review_request_guard import canonical_mr_url, resolve_guard_target, should_post_review_request
@@ -84,11 +88,13 @@ class Command(TyperCommand):
                 exit_code=0,
             )
 
-        try:
-            require_on_behalf_approval(target=canonical, action=_ACTION)
-        except OnBehalfPostBlockedError as err:
+        # Peek (non-consuming) so an unapproved post refuses early — before
+        # any wire call — and the orphan guard claim is rolled back. The
+        # consume happens atomically with the post below (#1879), never here.
+        blocked = on_behalf_block_message(canonical, _ACTION)
+        if blocked:
             self._rollback_orphan_claim(canonical)
-            self.stdout.write(str(err))
+            self.stdout.write(blocked)
             self._emit(
                 {"action": "refused", "reason": "on_behalf_not_approved", "mr_url": canonical},
                 exit_code=2,
@@ -102,7 +108,22 @@ class Command(TyperCommand):
             )
 
         text = f"{title or _DEFAULT_TITLE} {canonical}"
-        resp = messaging.post_message(channel=target.channel_id, text=text, thread_ts="")
+        try:
+            # consume + post + audit atomic: a failed post rolls back the
+            # consume and writes no audit; a BLOCK racing in after the peek
+            # raises here and posts nothing.
+            resp = require_on_behalf_approval(
+                target=canonical,
+                action=_ACTION,
+                publish=lambda: messaging.post_message(channel=target.channel_id, text=text, thread_ts=""),
+            )
+        except OnBehalfPostBlockedError as err:
+            self._rollback_orphan_claim(canonical)
+            self.stdout.write(str(err))
+            self._emit(
+                {"action": "refused", "reason": "on_behalf_not_approved", "mr_url": canonical},
+                exit_code=2,
+            )
         ts = str(resp.get("ts", ""))
         permalink = messaging.get_permalink(channel=target.channel_id, ts=ts)
 

--- a/src/teatree/core/models/on_behalf_approval.py
+++ b/src/teatree/core/models/on_behalf_approval.py
@@ -146,6 +146,22 @@ class OnBehalfApproval(models.Model):
         return self.target == canonical_on_behalf_target(target) and self.action == action.strip()
 
     @classmethod
+    def has_unconsumed(cls, target: str, action: str, *, using: str | None = None) -> bool:
+        """True iff an unconsumed approval is recorded for exactly *target* + *action*.
+
+        The read-only peek behind
+        :func:`~teatree.core.on_behalf_gate_recorded.on_behalf_block_message`:
+        it reports whether a consume *would* succeed without claiming the row,
+        so a caller can refuse a blocked post early before doing expensive
+        prep. It never stamps ``consumed_at`` — the actual single-use claim
+        stays inside :meth:`consume`, run atomically with the post.
+        """
+        clean_target = canonical_on_behalf_target(target)
+        clean_action = action.strip()
+        manager = cls.objects.using(using) if using else cls.objects
+        return manager.filter(target=clean_target, action=clean_action, consumed_at__isnull=True).exists()
+
+    @classmethod
     def consume(cls, target: str, action: str, *, using: str | None = None) -> "OnBehalfApproval | None":
         """Atomically claim and consume the matching unconsumed approval, if any.
 

--- a/src/teatree/core/on_behalf_egress.py
+++ b/src/teatree/core/on_behalf_egress.py
@@ -95,8 +95,11 @@ class OnBehalfSlackEgress:
         """
         if self._is_self_dm(channel):
             return self._messaging.react_routed(channel=channel, ts=ts, emoji=emoji)
-        require_on_behalf_approval(target=target, action=action)
-        response = self._messaging.react_routed(channel=channel, ts=ts, emoji=emoji)
+        response = require_on_behalf_approval(
+            target=target,
+            action=action,
+            publish=lambda: self._messaging.react_routed(channel=channel, ts=ts, emoji=emoji),
+        )
         if response.get("ok"):
             notify_user_on_behalf_post(
                 target=target,
@@ -129,8 +132,11 @@ class OnBehalfSlackEgress:
         """
         if self._is_self_dm(channel):
             return self._messaging.post_routed(channel=channel, text=text, thread_ts=thread_ts)
-        require_on_behalf_approval(target=target, action=action)
-        response = self._messaging.post_routed(channel=channel, text=text, thread_ts=thread_ts)
+        response = require_on_behalf_approval(
+            target=target,
+            action=action,
+            publish=lambda: self._messaging.post_routed(channel=channel, text=text, thread_ts=thread_ts),
+        )
         if response.get("ok"):
             notify_user_on_behalf_post(
                 target=target,

--- a/src/teatree/core/on_behalf_gate_recorded.py
+++ b/src/teatree/core/on_behalf_gate_recorded.py
@@ -28,12 +28,35 @@ on the tri-state :class:`~teatree.config.OnBehalfPostMode`:
     (:attr:`~teatree.config.OnBehalfPostMode.ASK` or
     :attr:`~teatree.config.OnBehalfPostMode.DRAFT_OR_ASK` for non-draft
     actions) + a recorded, unconsumed, exactly-scoped
-    :class:`OnBehalfApproval` → consume it single-use, write an
-    :class:`OnBehalfAudit` row, return — the post proceeds;
-*   BLOCK + no recorded approval → raise :class:`OnBehalfPostBlockedError`.
-    The caller must NOT publish; it surfaces the blocked post to the user
-    (the user-notify path) so the user can approve it in plain text by
-    recording an approval — never a silent drop, never an unattended post.
+    :class:`OnBehalfApproval` → inside ONE ``transaction.atomic`` block:
+    consume it single-use, run the caller's ``publish`` side-effect, write
+    an :class:`OnBehalfAudit` row — all-or-nothing. The post's result is
+    returned;
+*   BLOCK + no recorded approval → raise :class:`OnBehalfPostBlockedError`
+    *before* ``publish`` runs. The caller never publishes; it surfaces the
+    blocked post to the user (the user-notify path) so the user can approve
+    it in plain text by recording an approval — never a silent drop, never
+    an unattended post.
+
+The post is supplied as a ``publish`` callback so consume, post and audit
+share one transaction (#1879). Previously the gate consumed the single-use
+approval and wrote the audit in a transaction *separate* from the caller's
+later post: a post that failed after the gate returned burned the approval
+(forcing the user to re-approve) and left an :class:`OnBehalfAudit` row
+claiming a post that never happened. A ``publish`` that raises now rolls the
+whole block back — the approval is NOT burned, no audit is written, and a
+retry can reuse the same recorded approval. This makes the
+post→succeed→consume+audit invariant structural, the same way
+:meth:`DeferredQuestion.consume` / ``MergeClear`` / ``DbApproval`` co-locate
+consume and audit in one block, and ``red_card`` / ``review_request_merge_react``
+use the post→verify→stamp order for reactions.
+
+:func:`on_behalf_block_message` is the *non-consuming* peek: it returns the
+blocked-post message (or ``""`` when the post may proceed) without consuming
+any approval or running any side-effect — for callers that surface an early
+refusal before doing expensive prep, then publish through
+:func:`require_on_behalf_approval`. The consuming path is exactly
+:func:`require_on_behalf_approval`; the peek can never burn an approval.
 
 Default DRAFT_OR_ASK: the new default mode publishes draft-form notes
 autonomously (drafts are colleague-invisible and revocable) but blocks
@@ -43,14 +66,15 @@ every other colleague-visible mutation. The user satisfies the gate
 deliberately avoided).
 
 The ORM-model imports (``OnBehalfApproval`` / ``OnBehalfAudit``) live
-inside :func:`require_on_behalf_approval` rather than at module top
-because ``teatree.cli.review_on_behalf.check_on_behalf`` imports this
-module lazily so the ``teatree.cli`` package can be loaded before
-``django.setup()`` runs (typer command discovery, ``--help`` rendering,
-the privacy-scan subprocess). An eager ORM import here would defeat
-the lazy chain and crash the CLI with ``ImproperlyConfigured`` (see
-souliane/teatree#1003).
+inside the functions rather than at module top because
+``teatree.cli.review_on_behalf`` imports this module lazily so the
+``teatree.cli`` package can be loaded before ``django.setup()`` runs (typer
+command discovery, ``--help`` rendering, the privacy-scan subprocess). An
+eager ORM import here would defeat the lazy chain and crash the CLI with
+``ImproperlyConfigured`` (see souliane/teatree#1003).
 """
+
+from collections.abc import Callable
 
 from teatree.on_behalf_gate import OnBehalfVerdict, resolve_on_behalf_verdict
 
@@ -75,34 +99,80 @@ class OnBehalfPostBlockedError(RuntimeError):
         )
 
 
-def require_on_behalf_approval(*, target: str, action: str) -> None:
-    """Gate one on-behalf post against the tri-state mode.
+def require_on_behalf_approval[PublishResult](
+    *,
+    target: str,
+    action: str,
+    publish: Callable[[], PublishResult],
+) -> PublishResult:
+    """Gate one on-behalf post against the tri-state mode and run it atomically.
 
-    See module docstring for the four-outcome table. Fail-closed: an
-    unresolved (default) setting maps to
+    See the module docstring for the four-outcome table. ``publish`` performs
+    the colleague-visible side-effect and returns its result (the posted
+    artifact ref). Fail-closed: an unresolved (default) setting maps to
     :attr:`~teatree.config.OnBehalfPostMode.DRAFT_OR_ASK`, and that mode
     BLOCKs every action that isn't in
     :data:`~teatree.on_behalf_gate._DRAFT_FORM_ACTIONS` when no recorded
     approval matches.
+
+    *   PROCEED / AUTO_DRAFT → run ``publish`` and return its result (no
+        consume, no audit; AUTO_DRAFT also emits the autodraft DM first).
+    *   BLOCK + recorded approval → inside one ``transaction.atomic`` block
+        consume the approval, run ``publish``, write the audit, return the
+        result. A ``publish`` that raises rolls back the consume and the
+        audit (#1879) — the approval survives for a retry, no audit lies.
+    *   BLOCK + no approval → raise :class:`OnBehalfPostBlockedError` before
+        ``publish`` runs.
     """
     verdict = resolve_on_behalf_verdict(action)
     if verdict is OnBehalfVerdict.PROCEED:
-        return
+        return publish()
     if verdict is OnBehalfVerdict.AUTO_DRAFT:
         _notify_on_behalf_autodraft(target=target, action=action)
-        return
-    # BLOCK path — consume a recorded approval or raise.
+        return publish()
+
+    from django.db import transaction  # noqa: PLC0415
+
     from teatree.core.models.on_behalf_approval import OnBehalfApproval, OnBehalfAudit  # noqa: PLC0415
 
-    consumed = OnBehalfApproval.consume(target, action)
-    if consumed is None:
-        raise OnBehalfPostBlockedError(target, action)
-    OnBehalfAudit.objects.create(
-        approval=consumed,
-        target=consumed.target,
-        action=consumed.action,
-        approver_id=consumed.approver_id,
-    )
+    with transaction.atomic():
+        consumed = OnBehalfApproval.consume(target, action)
+        if consumed is None:
+            raise OnBehalfPostBlockedError(target, action)
+        result = publish()
+        OnBehalfAudit.objects.create(
+            approval=consumed,
+            target=consumed.target,
+            action=consumed.action,
+            approver_id=consumed.approver_id,
+        )
+        return result
+
+
+def on_behalf_block_message(target: str, action: str) -> str:
+    """Return the blocked-post message, or ``""`` when the post may proceed.
+
+    The *non-consuming* peek: it never consumes an approval, writes an audit,
+    or runs a side-effect — it only reports whether
+    :func:`require_on_behalf_approval` would raise for this (target, action).
+    Callers that do expensive prep before publishing use it to refuse early;
+    the real publish then goes through :func:`require_on_behalf_approval`,
+    which consumes the approval atomically with the post.
+
+    PROCEED / AUTO_DRAFT → ``""`` (the post may proceed; the autodraft DM is
+    deferred to the atomic publish so a peek never DMs). BLOCK + an
+    unconsumed matching approval → ``""``. BLOCK + no approval → the
+    actionable :class:`OnBehalfPostBlockedError` message.
+    """
+    verdict = resolve_on_behalf_verdict(action)
+    if verdict is not OnBehalfVerdict.BLOCK:
+        return ""
+
+    from teatree.core.models.on_behalf_approval import OnBehalfApproval  # noqa: PLC0415
+
+    if OnBehalfApproval.has_unconsumed(target, action):
+        return ""
+    return str(OnBehalfPostBlockedError(target, action))
 
 
 def _notify_on_behalf_autodraft(*, target: str, action: str) -> None:

--- a/src/teatree/core/reply_transport.py
+++ b/src/teatree/core/reply_transport.py
@@ -176,7 +176,15 @@ class _BaseReplier:
             return dispatch
         if spec.action_name in self._ON_BEHALF_ACTIONS:
             try:
-                require_on_behalf_approval(target=spec.target_ref, action=spec.action_name)
+                # #1879: consume + deliver + audit run in one transaction.atomic
+                # inside the gate, so a delivery failure rolls back the consume
+                # (the approval is never burned) and no audit lies. A BLOCK with
+                # no recorded approval raises before any wire call.
+                posted_ref = require_on_behalf_approval(
+                    target=spec.target_ref,
+                    action=spec.action_name,
+                    publish=lambda: self._deliver(spec),
+                )
             except OnBehalfPostBlockedError as blocked:
                 # Surface, never silently drop and never post unattended: the
                 # FAILED row + actionable message is the user-notify path —
@@ -188,15 +196,19 @@ class _BaseReplier:
                     status=ReplyDispatch.Status.FAILED,
                     error_message=str(blocked),
                 )
-        try:
-            # Savepoint so a DB-level error raised inside subclass
-            # `_deliver` (e.g. a create-vs-create race) does not poison
-            # the outer transaction and the FAILED finalize can still run.
-            with transaction.atomic():
-                posted_ref = self._deliver(spec)
-        except Exception as exc:  # noqa: BLE001 — any backend failure becomes a FAILED row
-            logger.warning("Reply %s delivery failed: %s", spec.idempotency_key, exc)
-            return self._finalize(dispatch, status=ReplyDispatch.Status.FAILED, error_message=str(exc))
+            except Exception as exc:  # noqa: BLE001 — any backend failure becomes a FAILED row
+                logger.warning("Reply %s delivery failed: %s", spec.idempotency_key, exc)
+                return self._finalize(dispatch, status=ReplyDispatch.Status.FAILED, error_message=str(exc))
+        else:
+            try:
+                # Savepoint so a DB-level error raised inside subclass
+                # `_deliver` (e.g. a create-vs-create race) does not poison
+                # the outer transaction and the FAILED finalize can still run.
+                with transaction.atomic():
+                    posted_ref = self._deliver(spec)
+            except Exception as exc:  # noqa: BLE001 — any backend failure becomes a FAILED row
+                logger.warning("Reply %s delivery failed: %s", spec.idempotency_key, exc)
+                return self._finalize(dispatch, status=ReplyDispatch.Status.FAILED, error_message=str(exc))
         if spec.action_name in self._ON_BEHALF_ACTIONS:
             # #949: after-receipt visibility DM. Fires only for the same
             # colleague-visible actions the pre-gate scopes (post_dm /
@@ -235,18 +247,27 @@ class _BaseReplier:
         retry never bypasses it: if still blocked, :class:`OnBehalfPostBlockedError`
         propagates and the sweep keeps the row FAILED until the user records
         an approval.
+
+        #1879: the consume + deliver + audit run in one ``transaction.atomic``
+        inside the gate, so a redeliver that fails rolls back the consume —
+        the recorded approval is REUSED across redelivers instead of a fresh
+        approval being burned on every retry.
         """
-        if dispatch.action_name in self._ON_BEHALF_ACTIONS:
-            require_on_behalf_approval(target=dispatch.target_ref, action=dispatch.action_name)
-        posted_ref = self._deliver(
-            ReplySpec(
-                event=dispatch.event,
-                target_ref=dispatch.target_ref,
-                body=dispatch.body,
-                idempotency_key=dispatch.idempotency_key,
-                action_name=dispatch.action_name,
-            ),
+        spec = ReplySpec(
+            event=dispatch.event,
+            target_ref=dispatch.target_ref,
+            body=dispatch.body,
+            idempotency_key=dispatch.idempotency_key,
+            action_name=dispatch.action_name,
         )
+        if dispatch.action_name in self._ON_BEHALF_ACTIONS:
+            posted_ref = require_on_behalf_approval(
+                target=dispatch.target_ref,
+                action=dispatch.action_name,
+                publish=lambda: self._deliver(spec),
+            )
+        else:
+            posted_ref = self._deliver(spec)
         if dispatch.action_name in self._ON_BEHALF_ACTIONS:
             notify_user_on_behalf_post(
                 target=dispatch.target_ref,

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -52,13 +52,17 @@ def _add_slack_reactions_on_transition(
     """
     target = f"ticket:{instance.pk}"
     try:
-        require_on_behalf_approval(target=target, action=f"transition_reaction:{name}")
+        reacted = require_on_behalf_approval(
+            target=target,
+            action=f"transition_reaction:{name}",
+            publish=lambda: add_reactions_for_transition(instance, name),
+        )
     except OnBehalfPostBlockedError as blocked:
         logger.info("Transition reaction for ticket %s (%s) gated: %s", instance.pk, name, blocked)
         return
-    try:
-        reacted = add_reactions_for_transition(instance, name)
     except Exception:
+        # A failed react rolled back the consume+audit (#1879 atomicity) — the
+        # approval survives for a retry; the FSM transition must never block.
         logger.exception("Failed to add Slack reactions for ticket %s transition %s", instance.pk, name)
         return
     if reacted:
@@ -102,13 +106,18 @@ def _add_approval_reaction_on_transition(
         return
     target = _approval_reaction_target(instance)
     try:
-        require_on_behalf_approval(target=target, action="approval_reaction")
+        reacted = require_on_behalf_approval(
+            target=target,
+            action="approval_reaction",
+            publish=lambda: add_approval_reaction(instance),
+        )
     except OnBehalfPostBlockedError as blocked:
         logger.info("Approval reaction for PR %s gated: %s", instance.pk, blocked)
-        return
-    try:
-        reacted = add_approval_reaction(instance)
+        reacted = 0
     except Exception:
+        # A failed react rolled back the consume+audit (#1879 atomicity); the
+        # approval survives. Continue to the ReviewAssignment bookkeeping —
+        # the FSM transition must never block on a reaction failure.
         logger.exception("Failed to add approval reaction for PR %s", instance.pk)
         reacted = 0
     if reacted:

--- a/src/teatree/quality/regression_rules.yaml
+++ b/src/teatree/quality/regression_rules.yaml
@@ -25,9 +25,9 @@
   file: .semgrep/blocking/predictable-temp-path.yaml
 
 - id: consume-before-side-effect-not-atomic
-  issue: souliane/teatree#1879
-  status: warn
-  file: .semgrep/warn/consume-before-side-effect-not-atomic.yaml
+  issue: BLOCKING-NOW
+  status: blocking
+  file: .semgrep/blocking/consume-before-side-effect-not-atomic.yaml
 
 - id: cas-stamp-before-side-effect
   issue: souliane/teatree#1880

--- a/tests/teatree_cli/test_review_on_behalf_gate.py
+++ b/tests/teatree_cli/test_review_on_behalf_gate.py
@@ -30,6 +30,7 @@ no-TTY satisfier — its end-to-end behaviour is also exercised here so
 the gated method ↔ approval recording loop is verified in one suite.
 """
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -475,14 +476,15 @@ class TestReviewServiceGateIntegration:
 
         called: list[tuple[str, str]] = []
 
-        def _fake_require(*, target: str, action: str) -> None:
+        def _fake_require[T](*, target: str, action: str, publish: Callable[[], T]) -> T:
             called.append((target, action))
+            return publish()
 
         with patch.object(gate_mod, "require_on_behalf_approval", _fake_require):
             service, _stub = _service_with_stub()
             service.post_comment("org/repo", 7, "lgtm")
 
-        # Default path => the on-behalf action recorded is the draft-form
+        # Default path => the on-behalf action consumed is the draft-form
         # ``post_draft_note``, NOT ``post_comment``. ``post_comment`` is
         # reserved for the ``--live`` colleague-visible branch.
         assert called == [("org/repo!7", "post_draft_note")]
@@ -490,11 +492,18 @@ class TestReviewServiceGateIntegration:
     def test_post_comment_live_calls_require_with_post_comment(self) -> None:
         """The ``--live`` branch still gates on the ``post_comment`` on-behalf action."""
         from teatree.core import on_behalf_gate_recorded as gate_mod  # noqa: PLC0415
+        from teatree.core.models import LivePostApproval  # noqa: PLC0415
+
+        # The live publish reaches the atomic gate only past the LivePostApproval
+        # authorization (#1207); record one so the post site (and thus the
+        # consume) is reached.
+        LivePostApproval.record(mr_url="org/repo!7", slack_ts="1700000000.0001", slack_user_id="U-OPERATOR")
 
         called: list[tuple[str, str]] = []
 
-        def _fake_require(*, target: str, action: str) -> None:
+        def _fake_require[T](*, target: str, action: str, publish: Callable[[], T]) -> T:
             called.append((target, action))
+            return publish()
 
         with patch.object(gate_mod, "require_on_behalf_approval", _fake_require):
             service, _stub = _service_with_stub()

--- a/tests/teatree_core/test_on_behalf_autodraft_dm.py
+++ b/tests/teatree_core/test_on_behalf_autodraft_dm.py
@@ -31,6 +31,10 @@ from teatree.core.on_behalf_gate_recorded import require_on_behalf_approval
 pytestmark = pytest.mark.django_db
 
 
+def _noop() -> None:
+    return None
+
+
 def _gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, mode: OnBehalfPostMode) -> None:
     cfg = tmp_path / ".teatree.toml"
     cfg.write_text(
@@ -66,7 +70,7 @@ class TestAutoDraftDmOnePerTargetAction:
         # notify orchestration runs for real, including the BotPing ledger.
         self.monkeypatch.setattr("teatree.core.notify.messaging_from_overlay", lambda: backend)
 
-        require_on_behalf_approval(target="org/repo!7", action="post_draft_note")
+        require_on_behalf_approval(target="org/repo!7", action="post_draft_note", publish=_noop)
 
         key = "on_behalf_autodraft:org/repo!7:post_draft_note"
         ping = BotPing.objects.get(idempotency_key=key)
@@ -83,8 +87,8 @@ class TestAutoDraftDmOnePerTargetAction:
         backend = _stub_backend()
         self.monkeypatch.setattr("teatree.core.notify.messaging_from_overlay", lambda: backend)
 
-        require_on_behalf_approval(target="org/repo!7", action="post_draft_note")
-        require_on_behalf_approval(target="org/repo!7", action="post_draft_note")
+        require_on_behalf_approval(target="org/repo!7", action="post_draft_note", publish=_noop)
+        require_on_behalf_approval(target="org/repo!7", action="post_draft_note", publish=_noop)
 
         key = "on_behalf_autodraft:org/repo!7:post_draft_note"
         assert BotPing.objects.filter(idempotency_key=key).count() == 1
@@ -96,8 +100,8 @@ class TestAutoDraftDmOnePerTargetAction:
         backend = _stub_backend()
         self.monkeypatch.setattr("teatree.core.notify.messaging_from_overlay", lambda: backend)
 
-        require_on_behalf_approval(target="org/repo!7", action="post_draft_note")
-        require_on_behalf_approval(target="org/repo!42", action="post_draft_note")
+        require_on_behalf_approval(target="org/repo!7", action="post_draft_note", publish=_noop)
+        require_on_behalf_approval(target="org/repo!42", action="post_draft_note", publish=_noop)
 
         assert BotPing.objects.filter(idempotency_key__startswith="on_behalf_autodraft:").count() == 2
         assert backend.post_message.call_count == 2

--- a/tests/teatree_core/test_on_behalf_gate_recorded.py
+++ b/tests/teatree_core/test_on_behalf_gate_recorded.py
@@ -24,7 +24,11 @@ import pytest
 
 from teatree.core.models import BotPing
 from teatree.core.models.on_behalf_approval import OnBehalfApproval, OnBehalfAudit
-from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError, require_on_behalf_approval
+from teatree.core.on_behalf_gate_recorded import (
+    OnBehalfPostBlockedError,
+    on_behalf_block_message,
+    require_on_behalf_approval,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -35,10 +39,14 @@ def _write_cfg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, body: str) -> No
     monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
 
 
+def _noop() -> None:
+    return None
+
+
 class TestRecordedOnBehalfGate:
     def test_immediate_mode_proceeds_without_approval(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "immediate"\n')
-        require_on_behalf_approval(target="org/repo#42", action="post_comment")
+        require_on_behalf_approval(target="org/repo#42", action="post_comment", publish=_noop)
         assert OnBehalfAudit.objects.count() == 0
         # No DM either — IMMEDIATE is silent.
         assert BotPing.objects.count() == 0
@@ -46,7 +54,7 @@ class TestRecordedOnBehalfGate:
     def test_ask_mode_no_approval_blocks(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "ask"\n')
         with pytest.raises(OnBehalfPostBlockedError) as exc:
-            require_on_behalf_approval(target="org/repo#42", action="post_comment")
+            require_on_behalf_approval(target="org/repo#42", action="post_comment", publish=_noop)
         # The message must tell the user exactly how to satisfy the gate (no TTY).
         assert "approve-on-behalf" in str(exc.value)
         assert "org/repo#42" in str(exc.value)
@@ -56,23 +64,151 @@ class TestRecordedOnBehalfGate:
     ) -> None:
         _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "ask"\n')
         OnBehalfApproval.record(target="org/repo#42", action="post_comment", approver_id="souliane")
-        require_on_behalf_approval(target="org/repo#42", action="post_comment")
+        require_on_behalf_approval(target="org/repo#42", action="post_comment", publish=_noop)
         assert OnBehalfAudit.objects.filter(target="org/repo#42", action="post_comment").count() == 1
         # Single-use: a second post on the same target+action is blocked again.
         with pytest.raises(OnBehalfPostBlockedError):
-            require_on_behalf_approval(target="org/repo#42", action="post_comment")
+            require_on_behalf_approval(target="org/repo#42", action="post_comment", publish=_noop)
 
     def test_default_is_fail_closed_for_non_draft_action(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _write_cfg(tmp_path, monkeypatch, "[teatree]\n")  # setting unset → DRAFT_OR_ASK
         with pytest.raises(OnBehalfPostBlockedError):
-            require_on_behalf_approval(target="t#1", action="post_comment")
+            require_on_behalf_approval(target="t#1", action="post_comment", publish=_noop)
 
     def test_recorded_approval_scope_is_exact(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "ask"\n')
         OnBehalfApproval.record(target="org/repo#1", action="post_comment", approver_id="souliane")
         # Wrong action — still blocked, the recorded approval does not match.
         with pytest.raises(OnBehalfPostBlockedError):
-            require_on_behalf_approval(target="org/repo#1", action="resolve_discussion")
+            require_on_behalf_approval(target="org/repo#1", action="resolve_discussion", publish=_noop)
+
+
+class TestPublishCallbackAtomicity:
+    """consume + publish + audit are all-or-nothing (#1879).
+
+    A failed publish must roll back the consume so the single-use approval
+    is not burned and no ``OnBehalfAudit`` row claims a post that never
+    happened. On success the audit is written only after the publish ran.
+    """
+
+    def test_block_with_approval_runs_publish_consumes_and_audits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "ask"\n')
+        approval = OnBehalfApproval.record(target="org/repo#42", action="post_comment", approver_id="souliane")
+
+        calls: list[str] = []
+
+        def publish() -> str:
+            calls.append("posted")
+            return "https://example.com/org/repo/comment/1"
+
+        result = require_on_behalf_approval(target="org/repo#42", action="post_comment", publish=publish)
+
+        assert result == "https://example.com/org/repo/comment/1"
+        assert calls == ["posted"]
+        approval.refresh_from_db()
+        assert approval.consumed_at is not None
+        assert OnBehalfAudit.objects.filter(target="org/repo#42", action="post_comment").count() == 1
+
+    def test_failed_publish_rolls_back_consume_and_writes_no_audit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "ask"\n')
+        approval = OnBehalfApproval.record(target="org/repo#42", action="post_comment", approver_id="souliane")
+
+        class PostError(RuntimeError):
+            pass
+
+        def publish() -> str:
+            raise PostError
+
+        with pytest.raises(PostError):
+            require_on_behalf_approval(target="org/repo#42", action="post_comment", publish=publish)
+
+        # The approval was NOT burned — a re-attempt can still consume it.
+        approval.refresh_from_db()
+        assert approval.consumed_at is None, "approval was consumed despite a failed post"
+        # No lying audit — nothing claims a post that never happened.
+        assert OnBehalfAudit.objects.count() == 0, "audit row written for a post that failed"
+
+    def test_failed_publish_then_retry_succeeds_consuming_exactly_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "ask"\n')
+        OnBehalfApproval.record(target="org/repo#42", action="post_comment", approver_id="souliane")
+
+        attempts = {"n": 0}
+
+        def flaky_publish() -> str:
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                msg = "transient"
+                raise RuntimeError(msg)
+            return "ok"
+
+        with pytest.raises(RuntimeError, match="transient"):
+            require_on_behalf_approval(target="org/repo#42", action="post_comment", publish=flaky_publish)
+        # The first failure rolled back: the same approval still satisfies the retry.
+        result = require_on_behalf_approval(target="org/repo#42", action="post_comment", publish=flaky_publish)
+        assert result == "ok"
+        assert OnBehalfAudit.objects.filter(target="org/repo#42", action="post_comment").count() == 1
+        assert OnBehalfApproval.objects.filter(consumed_at__isnull=False).count() == 1
+
+    def test_immediate_mode_runs_publish_without_consume_or_audit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "immediate"\n')
+
+        result = require_on_behalf_approval(target="org/repo#42", action="post_comment", publish=lambda: "posted")
+        assert result == "posted"
+        assert OnBehalfAudit.objects.count() == 0
+
+    def test_block_with_no_approval_never_runs_publish(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "ask"\n')
+
+        calls: list[str] = []
+
+        def publish() -> str:
+            calls.append("posted")
+            return "posted"
+
+        with pytest.raises(OnBehalfPostBlockedError):
+            require_on_behalf_approval(target="org/repo#42", action="post_comment", publish=publish)
+        assert calls == [], "publish ran despite a BLOCK with no recorded approval"
+
+
+class TestNonConsumingPeek:
+    """``on_behalf_block_message`` reports a verdict without consuming."""
+
+    def test_block_with_no_approval_returns_message_without_consuming(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "ask"\n')
+        msg = on_behalf_block_message("org/repo#42", "post_comment")
+        assert "approve-on-behalf" in msg
+        assert OnBehalfAudit.objects.count() == 0
+
+    def test_block_with_approval_returns_empty_and_does_not_consume(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "ask"\n')
+        approval = OnBehalfApproval.record(target="org/repo#42", action="post_comment", approver_id="souliane")
+        assert on_behalf_block_message("org/repo#42", "post_comment") == ""
+        # The peek must NOT consume — the approval survives for the real post.
+        approval.refresh_from_db()
+        assert approval.consumed_at is None
+        assert OnBehalfAudit.objects.count() == 0
+
+    def test_immediate_mode_returns_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "immediate"\n')
+        assert on_behalf_block_message("org/repo#42", "post_comment") == ""
+
+    def test_auto_draft_action_returns_empty_without_dm(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "draft_or_ask"\n')
+        assert on_behalf_block_message("org/repo!7", "post_draft_note") == ""
+        # A peek never fires the autodraft DM — that is deferred to the atomic publish.
+        assert BotPing.objects.count() == 0
 
 
 class TestAutoDraftVerdict:
@@ -83,7 +219,7 @@ class TestAutoDraftVerdict:
     ) -> None:
         _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "draft_or_ask"\n')
 
-        require_on_behalf_approval(target="org/repo!7", action="post_draft_note")
+        require_on_behalf_approval(target="org/repo!7", action="post_draft_note", publish=_noop)
 
         # (i) no OnBehalfApproval was consumed (none existed, none created).
         assert OnBehalfApproval.objects.count() == 0
@@ -96,8 +232,8 @@ class TestAutoDraftVerdict:
     def test_double_call_is_idempotent_on_bot_ping(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "draft_or_ask"\n')
 
-        require_on_behalf_approval(target="org/repo!7", action="post_draft_note")
-        require_on_behalf_approval(target="org/repo!7", action="post_draft_note")
+        require_on_behalf_approval(target="org/repo!7", action="post_draft_note", publish=_noop)
+        require_on_behalf_approval(target="org/repo!7", action="post_draft_note", publish=_noop)
 
         assert BotPing.objects.filter(idempotency_key="on_behalf_autodraft:org/repo!7:post_draft_note").count() == 1
 
@@ -105,7 +241,7 @@ class TestAutoDraftVerdict:
         """``draft_or_ask`` only auto-drafts ``post_draft_note`` — other actions BLOCK."""
         _write_cfg(tmp_path, monkeypatch, '[teatree]\non_behalf_post_mode = "draft_or_ask"\n')
         with pytest.raises(OnBehalfPostBlockedError):
-            require_on_behalf_approval(target="org/repo!7", action="post_comment")
+            require_on_behalf_approval(target="org/repo!7", action="post_comment", publish=_noop)
         # No spurious BotPing for blocked actions.
         assert BotPing.objects.count() == 0
 
@@ -118,4 +254,4 @@ class TestAutoDraftDmFailureNeverRaises:
 
         with patch("teatree.notify.notify_user", return_value=False):
             # Must return cleanly even when the DM degraded to a no-op.
-            require_on_behalf_approval(target="org/repo!7", action="post_draft_note")
+            require_on_behalf_approval(target="org/repo!7", action="post_draft_note", publish=_noop)

--- a/tests/teatree_core/test_reply_transport_on_behalf_gate.py
+++ b/tests/teatree_core/test_reply_transport_on_behalf_gate.py
@@ -20,8 +20,8 @@ import pytest
 from django.test import TestCase
 
 from teatree.config import OnBehalfPostMode
-from teatree.core.models import BotPing, IncomingEvent, OnBehalfApproval, ReplyDispatch
-from teatree.core.reply_transport import NoopReplier
+from teatree.core.models import BotPing, IncomingEvent, OnBehalfApproval, OnBehalfAudit, ReplyDispatch
+from teatree.core.reply_transport import NoopReplier, ReplySpec, _BaseReplier
 
 
 def _gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, mode: OnBehalfPostMode) -> None:
@@ -202,6 +202,76 @@ class TestReplyTransportAfterReceiptDm:
         NoopReplier().redeliver(dispatch)
 
         assert not BotPing.objects.filter(idempotency_key__startswith="on_behalf_post:").exists()
+
+
+class _FlakyReplier(_BaseReplier):
+    """A replier whose ``_deliver`` fails until ``fail_first`` deliveries pass."""
+
+    def __init__(self, *, fail_count: int) -> None:
+        self._remaining_failures = fail_count
+        self.delivery_attempts = 0
+
+    def _deliver(self, spec: ReplySpec) -> str:
+        self.delivery_attempts += 1
+        if self._remaining_failures > 0:
+            self._remaining_failures -= 1
+            msg = "transient backend failure"
+            raise RuntimeError(msg)
+        return "https://example.com/posted"
+
+
+@pytest.mark.django_db
+class TestRedeliverReusesReservation:
+    """#1879: a failed redeliver rolls back the consume — the approval is reused, not burned per retry."""
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _gate(tmp_path, monkeypatch, mode=OnBehalfPostMode.ASK)
+        self.monkeypatch = monkeypatch
+
+    def _event(self, key: str) -> IncomingEvent:
+        return IncomingEvent.objects.create(source=IncomingEvent.Source.SLACK, body="x", idempotency_key=key)
+
+    def _failed_dispatch(self, event: IncomingEvent, key: str) -> ReplyDispatch:
+        return ReplyDispatch.objects.create(
+            event=event,
+            target_ref="org/repo#7",
+            action_name="post_comment",
+            status=ReplyDispatch.Status.FAILED,
+            body="retry body",
+            idempotency_key=key,
+        )
+
+    def test_failed_redeliver_does_not_burn_the_approval(self) -> None:
+        approval = OnBehalfApproval.record(target="org/repo#7", action="post_comment", approver_id="souliane")
+        event = self._event("slack:rr-1")
+        dispatch = self._failed_dispatch(event, "slack:rr-1:reply")
+
+        with pytest.raises(RuntimeError, match="transient"):
+            _FlakyReplier(fail_count=1).redeliver(dispatch)
+
+        # The failed redeliver rolled back the consume — the approval survives.
+        approval.refresh_from_db()
+        assert approval.consumed_at is None, "a failed redeliver burned the approval"
+        assert OnBehalfAudit.objects.count() == 0, "a failed redeliver wrote a lying audit"
+
+    def test_n_redelivers_consume_exactly_one_approval(self) -> None:
+        # One recorded approval must satisfy a flaky redeliver that fails twice
+        # then succeeds — N retries must NOT burn N approvals.
+        OnBehalfApproval.record(target="org/repo#7", action="post_comment", approver_id="souliane")
+        event = self._event("slack:rr-2")
+        dispatch = self._failed_dispatch(event, "slack:rr-2:reply")
+        replier = _FlakyReplier(fail_count=2)
+
+        for _ in range(2):
+            with pytest.raises(RuntimeError, match="transient"):
+                replier.redeliver(dispatch)
+        # The third redeliver succeeds against the SAME single recorded approval.
+        replier.redeliver(dispatch)
+
+        assert replier.delivery_attempts == 3
+        assert OnBehalfApproval.objects.filter(consumed_at__isnull=False).count() == 1
+        assert OnBehalfAudit.objects.filter(target="org/repo#7", action="post_comment").count() == 1
 
 
 # Standalone django_db functions must be grouped in a TestCase (#98); this

--- a/tests/teatree_core/test_review_request_post_command.py
+++ b/tests/teatree_core/test_review_request_post_command.py
@@ -333,8 +333,11 @@ class TestReviewRequestPostHappyPath(_DataDirMixin, TestCase):
         assert code == 0
         assert payload["action"] == "suppress"
         assert payload["reason"] == "no_messaging_backend"
-        # The approval was consumed before the messaging check — single-use.
-        assert OnBehalfAudit.objects.count() == 1
+        # No backend → no post → the approval is NOT consumed (#1879). The
+        # non-consuming peek lets a real post later reuse it; nothing is burned
+        # and no audit lies about a post that never happened.
+        assert OnBehalfAudit.objects.count() == 0
+        assert OnBehalfApproval.objects.filter(consumed_at__isnull=False).count() == 0
 
 
 class TestReviewRequestPostFinalizesClaim(_DataDirMixin, TestCase):


### PR DESCRIPTION
## What

Makes the on-behalf gate **consume + post + audit atomic** so a failed post can no longer burn the single-use approval or write a "lying" `OnBehalfAudit` row.

`teatree.core.on_behalf_gate_recorded.require_on_behalf_approval` used to consume the `OnBehalfApproval` and write the `OnBehalfAudit` in a transaction **separate** from the caller's later post. Failure modes:

- a post that failed *after* the gate returned burned the approval (the user had to re-approve) and left an audit claiming a post that never happened;
- `reply_transport` re-consumed a **fresh** approval on every redeliver/retry, so N retries burned N approvals.

## How

- `require_on_behalf_approval(*, target, action, publish)` takes the publish action as a **callback** and runs `OnBehalfApproval.consume` + `publish()` + `OnBehalfAudit.create` inside **one `transaction.atomic`**. A `publish` that raises rolls the whole block back: the approval survives for a retry and no audit is written (post then succeed then consume+audit, all-or-nothing). Mirrors the `DeferredQuestion.consume` / `MergeClear` / `DbApproval` same-block invariant and the `red_card` / `review_request_merge_react` post-then-stamp order.
- New non-consuming peek `on_behalf_block_message` (backed by `OnBehalfApproval.has_unconsumed`) lets callers refuse a blocked post early before expensive prep, without burning the approval. The **only** consuming path is `require_on_behalf_approval`.
- Every consumer wired to the callback form in lockstep: `on_behalf_egress`, `reply_transport` (`_send` + `redeliver`, now reusing the reservation across retries), `signals` reactions, `review_request_post`, `pr post_evidence`, `_e2e_evidence`, and `ReviewService`'s 8 post sites (`check_on_behalf` peek + `publish_on_behalf`). The seven inline `ReviewService` send bodies moved to `review_post_impl.py` to keep `review.py` under the module-health LOC cap.

## Fixed-bug to permanent-blocking-rule (same-day eval)

Flipped the `consume-before-side-effect-not-atomic` semgrep rule **warn to blocking** in this PR:

- `git mv` from `.semgrep/warn/` to `.semgrep/blocking/`, `metadata.status: blocking`, `metadata.issue: BLOCKING-NOW`, manifest `regression_rules.yaml` updated in lockstep.
- **Non-vacuous proof:** the rule flags the pre-fix code (1 finding) and is **zero-findings on the fixed tree**. `semgrep scan --config .semgrep/blocking --error --quiet` exits 0.

## Tests (RED to GREEN)

- `TestPublishCallbackAtomicity`: a failed publish rolls back the consume and writes no audit (observed RED on the pre-fix non-atomic order); success runs publish-then-consume-then-audit; BLOCK+no-approval never runs the callback; a retry reuses the approval.
- `TestRedeliverReusesReservation`: a failed redeliver does not burn the approval; N redelivers consume exactly one (observed RED on the pre-fix redeliver shape).
- `tests/quality/test_chokepoints.py` (37) and `tests/quality/test_regression_rules.py` (34, runs semgrep) stay green.

## docs

`ARCHITECTURE.md` records the nine-check pre-check and the new atomicity invariant. No BLUEPRINT prose change: the documented on-behalf outcome table is unchanged; only the consume+post+audit ordering becomes atomic.

Closes #1879
