### PR TITLE
feat(ci): diff-scoped CI lanes with fail-safe-unknown routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,47 @@ on:
     - cron: "17 6 * * *"
 
 jobs:
+  preflight:
+    # Diff-scoped lane classifier with FAIL-SAFE-UNKNOWN routing
+    # (souliane/teatree#132). Classifies the PR diff into lanes and
+    # exports booleans the heavy downstream jobs gate on. The ONLY
+    # sanctioned skip is a provably pure-docs/markdown diff, which may
+    # skip the HEAVY ``test`` + ``mutation-diff`` lanes. Any unrecognised
+    # path, any python change, or any config/CI/semgrep change forces
+    # ``run_heavy_python=true`` (run everything) — uncertainty never
+    # skips. Security/quality gates (semgrep, sbom, uv-audit) and the
+    # docs gates are NOT gated here; they always run.
+    #
+    # On push-to-main and on the schedule there is no base to diff, so
+    # this job is PR-only and the downstream ``if:`` conditions run the
+    # heavy lanes unconditionally on non-PR events.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      run_heavy_python: ${{ steps.classify.outputs.run_heavy_python }}
+      all: ${{ steps.classify.outputs.all }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # fetch-depth: 0 so the PR-vs-base ``git diff`` resolves.
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Classify the PR diff into CI lanes
+        id: classify
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin "$BASE_REF"
+          # Fail-safe: if the diff command errors, feed an empty list,
+          # which the classifier maps to all=true (run everything).
+          git diff --name-only "origin/$BASE_REF...HEAD" > changed_paths.txt || true
+          uv run python scripts/ci/changed_lanes.py < changed_paths.txt
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -153,7 +194,15 @@ jobs:
     # flipping ``mode`` to "block" in pyproject.toml promotes it to a gate
     # (only-shrinks ratchet via ``baseline_surviving``) with no workflow change.
     # The 10-min cap bounds a pathological run.
-    if: github.event_name == 'pull_request'
+    #
+    # Heavy lane: PR-only AND skipped on a provably pure-docs diff
+    # (preflight ``run_heavy_python=false``). Any non-pure-docs PR runs
+    # it — fail-safe-unknown. (#132)
+    needs: preflight
+    if: >
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.preflight.outputs.run_heavy_python == 'true'
     timeout-minutes: 12
     runs-on: ubuntu-latest
     steps:
@@ -319,6 +368,15 @@ jobs:
           path: sbom.json
 
   test:
+    # Heavy lane. Skipped ONLY on a provably pure-docs/markdown PR diff
+    # (preflight ``run_heavy_python=false``). On push-to-main and on the
+    # schedule (no PR diff to classify) and on any non-pure-docs PR it
+    # runs unconditionally — fail-safe-unknown. (#132)
+    needs: preflight
+    if: >
+      always() &&
+      (github.event_name != 'pull_request' ||
+      needs.preflight.outputs.run_heavy_python == 'true')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/scripts/ci/changed_lanes.py
+++ b/scripts/ci/changed_lanes.py
@@ -1,0 +1,189 @@
+"""Diff-scoped CI lane classifier with fail-safe-unknown routing (#132).
+
+Reads the set of paths a PR changed and decides which CI lanes must run.
+A single ``preflight`` job runs this and exports the booleans; every
+downstream job gates on the matching output via ``needs:`` + ``if:``.
+
+Safety doctrine (a wrongly-skipped lane is a false green — the worst
+outcome, so skipping is conservative):
+
+-   FAIL-SAFE-UNKNOWN: any path this classifier does not positively
+    recognise as docs, python, or config forces ``all`` — run everything.
+    Uncertainty never skips.
+-   The ONLY sanctioned skip: a provably pure-docs/markdown diff (only
+    ``*.md`` / ``docs/**``, with no python, no config, no CI/semgrep) may
+    skip the HEAVY python lanes (``test``, ``mutation-diff``). It still
+    runs every docs/markdown gate and every always-on security lane.
+-   Any ``*.py`` / ``*.pyi`` change forces every python lane. A non-python
+    file under a code directory (a fixture, a binary asset) is NOT
+    recognised as python — it falls through to ``all`` (which still runs
+    every python lane), so the code lane is never wrongly skipped.
+-   Any config / CI / semgrep / lockfile / Dockerfile change forces
+    ``all`` — those can affect any job, so none may be skipped.
+-   Security / quality lanes (semgrep, banned-terms, sbom, uv-audit) and
+    the docs gates run on EVERY classification — never skipped.
+
+The classifier itself classifies the changed PATHS; the ``preflight``
+job feeds it the result of ``git diff --name-only base...HEAD``.
+"""
+
+import json
+import pathlib
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+LANE_TEST = "test"
+LANE_LINT = "lint"
+LANE_TEST_SHAPE = "test-shape"
+LANE_SEMGREP = "semgrep-regressions"
+LANE_MUTATION_DIFF = "mutation-diff"
+LANE_DOCS_DRIFT = "docs-drift"
+LANE_DOC_UPDATE = "doc-update-gate"
+LANE_BLUEPRINT_CROSS_PR = "blueprint-cross-pr"
+LANE_COMMENT_DENSITY = "comment-density-warning"
+LANE_SBOM = "sbom"
+LANE_UV_AUDIT = "uv-audit"
+
+HEAVY_PYTHON_LANES: frozenset[str] = frozenset({LANE_TEST, LANE_MUTATION_DIFF})
+PYTHON_LANES: frozenset[str] = frozenset({LANE_TEST, LANE_LINT, LANE_TEST_SHAPE, LANE_SEMGREP, LANE_MUTATION_DIFF})
+DOCS_LANES: frozenset[str] = frozenset(
+    {LANE_DOCS_DRIFT, LANE_DOC_UPDATE, LANE_BLUEPRINT_CROSS_PR, LANE_COMMENT_DENSITY}
+)
+SECURITY_LANES: frozenset[str] = frozenset({LANE_SEMGREP, LANE_SBOM, LANE_UV_AUDIT})
+
+_DOCS_SUFFIXES: tuple[str, ...] = (".md", ".markdown")
+_DOCS_PREFIXES: tuple[str, ...] = ("docs/",)
+_PYTHON_SUFFIXES: tuple[str, ...] = (".py", ".pyi")
+_CONFIG_EXACT: frozenset[str] = frozenset(
+    {
+        "pyproject.toml",
+        "uv.lock",
+        "Dockerfile",
+        ".pre-commit-config.yaml",
+        "manage.py",
+    }
+)
+_CONFIG_PREFIXES: tuple[str, ...] = (".github/", ".semgrep/", "dev/")
+_CONFIG_SUFFIXES: tuple[str, ...] = (".toml", ".lock", ".cfg", ".ini")
+
+
+@dataclass(frozen=True)
+class Lanes:
+    """Which CI lanes the changed diff requires.
+
+    ``all`` is the dominant flag: when ``True`` every lane runs and the
+    individual ``run_*`` properties all report ``True``. The individual
+    flags only narrow the run when ``all`` is ``False`` (the pure-docs
+    skip). ``run_security`` is unconditionally ``True`` — security and
+    quality gates are never skipped on any diff.
+    """
+
+    all: bool = False
+    _run_heavy_python: bool = False
+    _run_python: bool = False
+    _run_docs: bool = False
+
+    @property
+    def run_heavy_python(self) -> bool:
+        return self.all or self._run_heavy_python
+
+    @property
+    def run_python(self) -> bool:
+        return self.all or self._run_python
+
+    @property
+    def run_docs(self) -> bool:
+        return self.all or self._run_docs
+
+    @property
+    def run_security(self) -> bool:
+        return True
+
+    def as_outputs(self) -> dict[str, bool]:
+        return {
+            "all": self.all,
+            "run_heavy_python": self.run_heavy_python,
+            "run_python": self.run_python,
+            "run_docs": self.run_docs,
+            "run_security": self.run_security,
+        }
+
+
+def _is_docs(path: str) -> bool:
+    return path.endswith(_DOCS_SUFFIXES) or path.startswith(_DOCS_PREFIXES)
+
+
+def _is_python(path: str) -> bool:
+    # Extension-only by design: a non-.py file under a code dir is left
+    # unrecognised so it fails safe to all=True, never a narrow code lane.
+    return path.endswith(_PYTHON_SUFFIXES)
+
+
+def _is_config(path: str) -> bool:
+    if path in _CONFIG_EXACT or path.startswith(_CONFIG_PREFIXES):
+        return True
+    return path.endswith(_CONFIG_SUFFIXES)
+
+
+def classify(paths: Iterable[str]) -> Lanes:
+    """Classify changed ``paths`` into the lanes that must run.
+
+    Order of dominance (most conservative wins):
+
+    1.  An empty diff or any unrecognised path → ``all`` (fail-safe).
+    2.  Any config / CI / semgrep / lockfile path → ``all``.
+    3.  Any python / code path → every python lane (+ docs + security).
+    4.  A pure-docs diff → docs + security only (heavy python skipped).
+    """
+    cleaned = [p.strip() for p in paths if p.strip()]
+    if not cleaned:
+        return Lanes(all=True)
+
+    saw_python = False
+    saw_docs = False
+
+    for path in cleaned:
+        if _is_config(path):
+            return Lanes(all=True)
+        if _is_python(path):
+            saw_python = True
+            continue
+        if _is_docs(path):
+            saw_docs = True
+            continue
+        # Unrecognised path: never skip on uncertainty.
+        return Lanes(all=True)
+
+    if saw_python:
+        return Lanes(_run_heavy_python=True, _run_python=True, _run_docs=True)
+
+    if saw_docs:
+        return Lanes(_run_docs=True)
+
+    return Lanes(all=True)
+
+
+def _read_paths(argv: Sequence[str]) -> list[str]:
+    if argv:
+        return list(argv)
+    return [line.strip() for line in sys.stdin.read().splitlines() if line.strip()]
+
+
+def main(argv: Sequence[str] | None = None, output_path: str | None = None) -> int:
+    paths = _read_paths([] if argv is None else list(argv))
+    lanes = classify(paths)
+    outputs = lanes.as_outputs()
+
+    if output_path:
+        with pathlib.Path(output_path).open("a", encoding="utf-8") as handle:
+            handle.writelines(f"{key}={'true' if value else 'false'}\n" for key, value in outputs.items())
+
+    print(json.dumps(outputs))
+    return 0
+
+
+if __name__ == "__main__":
+    import os
+
+    raise SystemExit(main(sys.argv[1:], output_path=os.environ.get("GITHUB_OUTPUT")))

--- a/tests/test_changed_lanes_classifier.py
+++ b/tests/test_changed_lanes_classifier.py
@@ -1,0 +1,222 @@
+"""Tests for the diff-scoped CI lane classifier (souliane/teatree#132).
+
+The classifier reads a list of changed paths and decides which CI lanes
+must run. The headline property is FAIL-SAFE-UNKNOWN: any path the
+classifier does not recognise forces ``all`` (run everything). The only
+sanctioned skip is a provably pure-docs/markdown diff, which may skip the
+HEAVY python lanes (``test``, ``mutation-diff``) while still running every
+docs/markdown gate and every always-on security/quality lane.
+"""
+
+import io
+import json
+
+import pytest
+
+from scripts.ci.changed_lanes import DOCS_LANES, HEAVY_PYTHON_LANES, PYTHON_LANES, Lanes, classify, main
+
+_PY_PATHS = [
+    "src/teatree/core/models/ticket.py",
+    "tests/test_changed_lanes_classifier.py",
+    "scripts/ci/changed_lanes.py",
+    "src/teatree/cli/__init__.py",
+]
+
+_PURE_DOCS_PATHS = [
+    "README.md",
+    "BLUEPRINT.md",
+    "docs/blueprint/configuration.md",
+    "docs/generated/cli-reference.md",
+    "CHANGELOG.md",
+]
+
+_CONFIG_PATHS = [
+    "pyproject.toml",
+    ".github/workflows/ci.yml",
+    ".pre-commit-config.yaml",
+    ".semgrep/blocking/foo.yml",
+    "uv.lock",
+    "Dockerfile",
+    "dev/Dockerfile.test",
+]
+
+
+class TestFailSafeUnknown:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "some/unrecognized/file.xyz",
+            "weird_extensionless_file",
+            "data/blob.bin",
+            "src/teatree/assets/logo.png",
+            ".env.example",
+            "Makefile",
+        ],
+    )
+    def test_unknown_path_forces_all(self, path: str) -> None:
+        lanes = classify([path])
+        assert lanes.all is True, f"unrecognized path {path!r} must fail safe to all=True"
+
+    def test_unknown_path_runs_every_lane(self) -> None:
+        lanes = classify(["mystery.unknownext"])
+        assert lanes.run_heavy_python is True
+        assert lanes.run_python is True
+        assert lanes.run_docs is True
+        assert lanes.run_security is True
+
+    def test_one_unknown_among_known_still_forces_all(self) -> None:
+        lanes = classify(["README.md", "src/teatree/core/x.py", "mystery.qqq"])
+        assert lanes.all is True
+
+    def test_empty_diff_fails_safe_to_all(self) -> None:
+        lanes = classify([])
+        assert lanes.all is True
+
+
+class TestPureDocsSkip:
+    def test_pure_docs_skips_heavy_python(self) -> None:
+        lanes = classify(_PURE_DOCS_PATHS)
+        assert lanes.all is False
+        assert lanes.run_heavy_python is False
+        assert lanes.run_python is False
+
+    def test_pure_docs_still_runs_docs_lanes(self) -> None:
+        lanes = classify(_PURE_DOCS_PATHS)
+        assert lanes.run_docs is True
+
+    def test_pure_docs_still_runs_security_lanes(self) -> None:
+        lanes = classify(_PURE_DOCS_PATHS)
+        assert lanes.run_security is True
+
+    @pytest.mark.parametrize("path", _PURE_DOCS_PATHS)
+    def test_each_docs_path_alone_skips_heavy(self, path: str) -> None:
+        lanes = classify([path])
+        assert lanes.run_heavy_python is False
+        assert lanes.run_docs is True
+        assert lanes.run_security is True
+
+
+class TestPythonForcesAllPythonLanes:
+    @pytest.mark.parametrize("path", _PY_PATHS)
+    def test_py_change_runs_all_python_lanes(self, path: str) -> None:
+        lanes = classify([path])
+        assert lanes.run_python is True
+        assert lanes.run_heavy_python is True
+        assert lanes.run_docs is True
+        assert lanes.run_security is True
+
+    def test_py_change_is_not_all_unknown(self) -> None:
+        lanes = classify(["src/teatree/core/x.py"])
+        assert lanes.all is False
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/teatree/anything.py",
+            "tests/anything.py",
+            "scripts/anything.py",
+        ],
+    )
+    def test_any_source_or_tests_path_triggers_heavy(self, path: str) -> None:
+        # No silent code-lane skip: any code path forces the full test lane.
+        lanes = classify([path])
+        assert lanes.run_heavy_python is True, f"{path!r} must trigger the heavy test lane"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/teatree/assets/logo.png",
+            "tests/fixtures/sample.json",
+            "scripts/data/blob.bin",
+        ],
+    )
+    def test_non_py_file_under_code_dir_still_runs_heavy(self, path: str) -> None:
+        # A non-python file under a code directory is unrecognised and
+        # forces all=True — which still runs the heavy test lane. The
+        # code lane is never wrongly skipped.
+        lanes = classify([path])
+        assert lanes.all is True
+        assert lanes.run_heavy_python is True, f"{path!r} must not skip the heavy test lane"
+
+
+class TestMixedDocsAndPython:
+    def test_mixed_docs_and_py_runs_all_python(self) -> None:
+        lanes = classify(["README.md", "src/teatree/core/x.py"])
+        assert lanes.run_heavy_python is True
+        assert lanes.run_python is True
+        assert lanes.run_docs is True
+        assert lanes.run_security is True
+        assert lanes.all is False
+
+
+class TestConfigForcesAll:
+    @pytest.mark.parametrize("path", _CONFIG_PATHS)
+    def test_config_change_forces_all(self, path: str) -> None:
+        lanes = classify([path])
+        assert lanes.all is True
+
+
+class TestSecurityAlwaysRuns:
+    @pytest.mark.parametrize(
+        "paths",
+        [
+            _PURE_DOCS_PATHS,
+            _PY_PATHS,
+            _CONFIG_PATHS,
+            ["mystery.unknownext"],
+            ["README.md", "src/teatree/core/x.py"],
+        ],
+    )
+    def test_security_runs_on_every_classification(self, paths: list[str]) -> None:
+        lanes = classify(paths)
+        assert lanes.run_security is True
+
+
+class TestLaneSetsConsistency:
+    def test_heavy_lanes_are_subset_of_python_lanes(self) -> None:
+        assert HEAVY_PYTHON_LANES <= PYTHON_LANES
+
+    def test_lane_sets_disjoint_from_docs(self) -> None:
+        assert PYTHON_LANES.isdisjoint(DOCS_LANES)
+
+    def test_all_implies_every_flag(self) -> None:
+        lanes = Lanes(all=True)
+        assert lanes.run_heavy_python is True
+        assert lanes.run_python is True
+        assert lanes.run_docs is True
+        assert lanes.run_security is True
+
+
+class TestMainCli:
+    def test_main_emits_github_output(self, tmp_path, capsys) -> None:
+        out_file = tmp_path / "gh_output"
+        rc = main(["README.md"], output_path=str(out_file))
+        assert rc == 0
+        content = out_file.read_text(encoding="utf-8")
+        assert "run_heavy_python=false" in content
+        assert "run_docs=true" in content
+        assert "run_security=true" in content
+        assert "all=false" in content
+
+    def test_main_unknown_path_writes_all_true(self, tmp_path) -> None:
+        out_file = tmp_path / "gh_output"
+        main(["mystery.zzz"], output_path=str(out_file))
+        content = out_file.read_text(encoding="utf-8")
+        assert "all=true" in content
+        assert "run_heavy_python=true" in content
+
+    def test_main_reads_paths_from_stdin(self, tmp_path, monkeypatch) -> None:
+        out_file = tmp_path / "gh_output"
+        monkeypatch.setattr("sys.stdin", io.StringIO("README.md\nBLUEPRINT.md\n"))
+        rc = main([], output_path=str(out_file))
+        assert rc == 0
+        content = out_file.read_text(encoding="utf-8")
+        assert "run_heavy_python=false" in content
+
+    def test_main_prints_json_summary(self, tmp_path, capsys) -> None:
+        out_file = tmp_path / "gh_output"
+        main(["src/teatree/core/x.py"], output_path=str(out_file))
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload["run_heavy_python"] is True
+        assert payload["all"] is False

--- a/tests/test_ci_diff_scoped_lanes.py
+++ b/tests/test_ci_diff_scoped_lanes.py
@@ -1,0 +1,139 @@
+"""Tests that the CI workflow wires the diff-scoped lane gate safely (#132).
+
+The headline safety property is FAIL-SAFE-UNKNOWN, enforced at two
+levels: the classifier (``tests/test_changed_lanes_classifier.py``) and
+the workflow wiring (here). These tests pin the workflow so a future
+edit cannot silently:
+
+- gate a security/quality lane (semgrep, sbom, uv-audit) on the diff,
+- gate a docs/markdown gate on the diff,
+- drop the PR-only / push-and-PR trigger of any existing job,
+- gate the heavy ``test`` lane such that a push-to-main could skip it.
+
+The only sanctioned skip is the HEAVY ``test`` + ``mutation-diff``
+lanes on a provably pure-docs PR diff.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+_PREFLIGHT = "preflight"
+_HEAVY_LANES = ("test", "mutation-diff")
+# Lanes that must NEVER be gated on the diff — always run.
+_ALWAYS_RUN = (
+    "semgrep-regressions",
+    "sbom",
+    "uv-audit",
+    "docs-drift",
+    "doc-update-gate",
+    "blueprint-cross-pr",
+    "comment-density-warning",
+    "lint",
+    "test-shape",
+)
+
+
+def _load_jobs() -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))["jobs"])
+
+
+def _needs(job: dict[str, Any]) -> list[str]:
+    needs = job.get("needs", [])
+    if isinstance(needs, str):
+        return [needs]
+    return list(needs)
+
+
+class TestPreflightJob:
+    def test_preflight_job_exists(self) -> None:
+        assert _PREFLIGHT in _load_jobs(), "the diff-scoped lane classifier needs a 'preflight' job (#132)"
+
+    def test_preflight_is_pr_only(self) -> None:
+        # No base to diff on push/schedule, so preflight is PR-only and
+        # the downstream if: conditions run heavy lanes on non-PR events.
+        job = _load_jobs()[_PREFLIGHT]
+        assert "pull_request" in str(job.get("if", ""))
+
+    def test_preflight_invokes_the_classifier(self) -> None:
+        steps = _load_jobs()[_PREFLIGHT]["steps"]
+        joined = " ".join(str(step.get("run", "")) for step in steps if isinstance(step, dict))
+        assert "scripts/ci/changed_lanes.py" in joined
+
+    def test_preflight_exports_run_heavy_python(self) -> None:
+        outputs = _load_jobs()[_PREFLIGHT].get("outputs", {})
+        assert "run_heavy_python" in outputs
+
+    def test_preflight_uses_full_fetch_depth(self) -> None:
+        # The classifier needs the base..HEAD diff to resolve.
+        steps = _load_jobs()[_PREFLIGHT]["steps"]
+        checkout = next(
+            s for s in steps if isinstance(s, dict) and str(s.get("uses", "")).startswith("actions/checkout")
+        )
+        assert checkout.get("with", {}).get("fetch-depth") == 0
+
+
+class TestHeavyLanesGatedSafely:
+    def test_heavy_lanes_depend_on_preflight(self) -> None:
+        jobs = _load_jobs()
+        for lane in _HEAVY_LANES:
+            assert _PREFLIGHT in _needs(jobs[lane]), f"{lane} must need preflight to read its lane decision"
+
+    def test_heavy_lanes_gate_on_run_heavy_python(self) -> None:
+        jobs = _load_jobs()
+        for lane in _HEAVY_LANES:
+            condition = str(jobs[lane].get("if", ""))
+            assert "run_heavy_python" in condition, f"{lane} must gate on preflight.outputs.run_heavy_python"
+
+    def test_test_lane_runs_on_non_pr_events(self) -> None:
+        # push-to-main and schedule have no diff to classify; the test
+        # lane MUST still run (fail-safe). The condition allows it when
+        # the event is not a pull_request.
+        condition = str(_load_jobs()["test"].get("if", ""))
+        assert "github.event_name != 'pull_request'" in condition
+
+    def test_heavy_lane_condition_uses_always(self) -> None:
+        # needs: preflight + a skipped preflight (push/schedule) would
+        # otherwise skip the dependent job; always() lets it evaluate its
+        # own condition so a push can never silently skip the test lane.
+        for lane in _HEAVY_LANES:
+            condition = str(_load_jobs()[lane].get("if", ""))
+            assert "always()" in condition, f"{lane} must use always() so a skipped preflight cannot skip it on push"
+
+
+class TestAlwaysRunLanesNotGated:
+    def test_security_and_docs_lanes_do_not_depend_on_preflight(self) -> None:
+        jobs = _load_jobs()
+        for lane in _ALWAYS_RUN:
+            assert _PREFLIGHT not in _needs(jobs[lane]), (
+                f"{lane} is a security/quality or docs gate and must NEVER be gated on the diff (#132)"
+            )
+
+    def test_security_and_docs_lanes_do_not_gate_on_run_heavy_python(self) -> None:
+        jobs = _load_jobs()
+        for lane in _ALWAYS_RUN:
+            condition = str(jobs[lane].get("if", ""))
+            assert "run_heavy_python" not in condition, f"{lane} must not gate on the diff classification"
+
+
+class TestExistingTriggersPreserved:
+    def test_banned_terms_tree_stays_push_or_schedule(self) -> None:
+        condition = str(_load_jobs()["banned-terms-tree"].get("if", ""))
+        assert "push" in condition
+        assert "schedule" in condition
+
+    def test_pr_only_jobs_keep_pr_guard(self) -> None:
+        jobs = _load_jobs()
+        for lane in ("blueprint-cross-pr", "doc-update-gate", "comment-density-warning", "semgrep-regressions"):
+            assert "pull_request" in str(jobs[lane].get("if", "")), f"{lane} must keep its pull_request guard"
+
+    def test_lint_and_test_shape_have_no_event_gate(self) -> None:
+        # lint and test-shape run on both push and PR (no if:). Gating
+        # them on the diff would risk skipping a quality lane.
+        jobs = _load_jobs()
+        for lane in ("lint", "test-shape", "docs-drift", "sbom", "uv-audit"):
+            assert "if" not in jobs[lane] or "run_heavy_python" not in str(jobs[lane]["if"])


### PR DESCRIPTION
## Summary

Adds a `preflight` job that classifies the PR diff into CI lanes (`scripts/ci/changed_lanes.py`) and exports `run_heavy_python`. The two HEAVY lanes — `test (3.13)` and `mutation-diff` — gate on it via `needs: preflight` + `if:`. A provably pure-docs/markdown PR diff skips those heavy lanes; everything else runs everything.

This is the final piece of the general anti-drift system (teatree#132).

## Lane classification map

| Changed paths | `all` | heavy (`test`, `mutation-diff`) | docs gates | security/quality |
|---|---|---|---|---|
| pure docs/markdown (`*.md`, `docs/**` only) | false | **skipped** | run | run |
| any `*.py` / `*.pyi` | false | run | run | run |
| mixed docs + `.py` | false | run | run | run |
| config / `.github/` / `.semgrep/` / `pyproject` / lockfile / Dockerfile | **true** | run | run | run |
| unrecognised path / extension | **true** | run | run | run |
| empty diff | **true** | run | run | run |

## Fail-safe-unknown guarantee

A wrongly-skipped lane is a false green — the worst outcome — so skipping is conservative:

- ANY path the classifier does not positively recognise as docs, python, or config → `all=true` (run everything). Uncertainty never skips.
- An empty diff and a failing `git diff` in preflight both → `all=true`.
- A non-`.py` file under a code dir (a fixture, a binary asset) is left unrecognised → `all=true`; the code lane is never wrongly skipped.

Proven anti-vacuous: reverting the unknown-path guard turns the fail-safe test RED (verified locally).

## What may / may NOT be skipped

- **May be skipped (only on a provably pure-docs diff):** `test (3.13)`, `mutation-diff`.
- **NEVER gated on the diff (always run):** security/quality — `semgrep-regressions`, `sbom`, `uv-audit`, `banned-terms-tree`; docs gates — `docs-drift`, `doc-update-gate`, `blueprint-cross-pr`, `comment-density-warning`; plus `lint` and `test-shape` (cheap python lanes kept always-on, conservative). These are structurally pinned by `tests/test_ci_diff_scoped_lanes.py` so no future edit can gate them on the diff.

## Conservative-vs-aggressive judgment

Conservative. Only the two genuinely HEAVY lanes are made skippable, and only on a provably pure-docs diff. `lint` and `test-shape` are fast and kept always-on rather than gated. The classifier reports `run_python`/`run_docs`/`run_security` for future use, but only `run_heavy_python` is wired today. For teatree's size, the speed win is the `test` + `mutation` skip on docs-only PRs, with zero skip risk on anything that could touch code.

## Non-PR events

On push-to-main and on the schedule there is no base to diff, so `preflight` is PR-only and the heavy lanes use `always()` + an event guard (`github.event_name != 'pull_request'`) to run unconditionally on non-PR events. A skipped preflight can never silently skip the test lane.

## Tests

- `tests/test_changed_lanes_classifier.py` (classifier unit tests): fail-safe-unknown forces `all`; pure-docs skips heavy; `.py` → all python; mixed → all python; non-py-under-code-dir → `all`; config → `all`; security True on every classification.
- `tests/test_ci_diff_scoped_lanes.py` (workflow wiring): preflight exists/PR-only/invokes classifier/exports `run_heavy_python`/fetch-depth 0; heavy lanes need preflight + gate + `always()`; security/docs lanes never depend on preflight; existing triggers preserved.

## Architecture pre-check

- **1. BLUEPRINT § alignment:** CI workflow wiring + a `scripts/ci` utility; no BLUEPRINT § owns the Actions job graph; no domain concept added → no BLUEPRINT edit.
- **2. FSM phase boundaries:** n/a — no `Ticket.State`/`Worktree.State` transition.
- **3. Extension-point contracts:** n/a — no `OverlayBase`/scanner/hook/Protocol touched.
- **4. Component boundaries:** standalone CI utility (no `teatree` import), matching the `scripts/hooks/*` convention; logic (Python, unit-tested) separated from wiring (YAML, structurally pinned).
- **5. Dependency direction:** stdlib-only; no module-graph edge added; tach/import-linter unaffected.
- **6. Test surface:** see Tests above; fail-safe-unknown proven anti-vacuous.
- **7. Resilience invariants:** no external write; fail-safe-unknown IS the resilience invariant (failing `git diff` or unknown path → run everything); `classify()` is pure/idempotent.
- **8. Identity/key normalization:** n/a — no bare/qualified identity pair; paths compared by suffix/prefix, no strip-to-match seam.
- **9. Behavior preservation / capability deletion:** additive — no existing job removed, every trigger preserved; the only behavior change is the pure-docs heavy-lane skip; no security/quality or docs gate gated on the diff; no must-block test inverted.

docs: n/a — CI workflow wiring + a `scripts/ci` utility; no user-facing surface (no top-level `t3` command, no `SKILL.md`, no `Ticket.State`).