### PR TITLE
fix(hooks): distinguish unresolvable publish body from a real banned term (#182)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -3237,6 +3237,33 @@ _BANNED_TERMS_CREDENTIAL_DENY = (
 )
 
 
+def _emit_banned_term_deny(
+    tool_name: str,
+    command: str,
+    payload: str,
+    term: str,
+    cwd_repo: "Path | None",
+) -> bool:
+    from teatree.hooks import publish_surface  # noqa: PLC0415
+
+    if publish_surface.carve_out_applies(tool_name, command, payload, cwd_repo):
+        sys.stderr.write(
+            f"WARNING: banned-terms gate (#1415) — term '{term}' on a private-repo commit; "
+            "downgraded to warn (#126). The repo's own domain words are expected on its commits.\n"
+        )
+        return False
+    unknown_slug = publish_surface.visibility_unknown_for_block(command, cwd_repo)
+    if unknown_slug:
+        sys.stderr.write(
+            f"NOTE: banned-terms gate (#1415/#1657) — target '{unknown_slug}' visibility unknown in-hook "
+            "(probe unavailable). If private, add it to [teatree] private_repos in ~/.teatree.toml "
+            "for a reliable offline carve-out.\n"
+        )
+    from teatree.hooks import banned_terms_scanner  # noqa: PLC0415
+
+    return emit_pretooluse_deny(banned_terms_scanner.format_block_message(term))
+
+
 def _run_banned_terms_pretool(data: dict) -> bool:
     """Banned-terms inner body — assumes ``teatree`` is already importable."""
     from typing import cast  # noqa: PLC0415
@@ -3271,23 +3298,9 @@ def _run_banned_terms_pretool(data: dict) -> bool:
     term = None if skipped else banned_terms_scanner.scan_text(payload)
     if term is None:
         return False
-
-    if publish_surface.carve_out_applies(tool_name, command, payload, cwd_repo):
-        sys.stderr.write(
-            f"WARNING: banned-terms gate (#1415) — term '{term}' on a private-repo commit; "
-            "downgraded to warn (#126). The repo's own domain words are expected on its commits.\n"
-        )
-        return False
-
-    unknown_slug = publish_surface.visibility_unknown_for_block(command, cwd_repo)
-    if unknown_slug:
-        sys.stderr.write(
-            f"NOTE: banned-terms gate (#1415/#1657) — target '{unknown_slug}' visibility unknown in-hook "
-            "(probe unavailable). If private, add it to [teatree] private_repos in ~/.teatree.toml "
-            "for a reliable offline carve-out.\n"
-        )
-
-    return emit_pretooluse_deny(banned_terms_scanner.format_block_message(term))
+    if term == banned_terms_scanner.UNRESOLVABLE_BODY_MARKER:
+        return emit_pretooluse_deny(banned_terms_scanner.format_unresolvable_body_message())
+    return _emit_banned_term_deny(tool_name, command, payload, term, cwd_repo)
 
 
 # ── PreToolUse: block-uncovered-diff (#937 §17.6 gate 12) ───────────

--- a/src/teatree/hooks/banned_terms_scanner.py
+++ b/src/teatree/hooks/banned_terms_scanner.py
@@ -47,12 +47,12 @@ from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to
 _OVERRIDE_FLAG = "--allow-banned-term"
 _OVERRIDE_ENV = "ALLOW_BANNED_TERM"
 
-# What a fail-closed sentinel surfaces as in the block message: an unresolvable
-# body source (a relative-path / chmod-000 / absent ``--body-file`` to a PUBLIC
-# repo) cannot be scanned, so it BLOCKS rather than slips through unread --
-# mirroring ``quote_scanner``, which treats the same sentinel as a fail-closed
-# finding.
-_UNRESOLVED_BODY_TERM = "<unresolved publish body>"
+# Marker returned by ``scan_text`` when the body source cannot be resolved
+# (a missing ``--body-file``, an unreadable path). The gate blocks on this
+# sentinel rather than slipping an unscanned body through. Callers that need
+# to emit a message MUST check for this marker explicitly and use
+# ``format_unresolvable_body_message`` — it is NOT a configured banned term.
+UNRESOLVABLE_BODY_MARKER: str = "<unresolvable-publish-body>"
 
 # How long to wait for the shell scanner before failing open. A hook that
 # hangs blocks the user, so the budget is deliberately tight.
@@ -201,7 +201,7 @@ def scan_text(text: str, *, config_path: Path | None = None) -> str | None:
     if not text:
         return None
     if _is_fail_closed_sentinel(text):
-        return _UNRESOLVED_BODY_TERM
+        return UNRESOLVABLE_BODY_MARKER
     return _run_shell_scanner(text, config_path)
 
 
@@ -275,4 +275,18 @@ def format_block_message(term: str) -> str:
         f"'{term}'. Remove the overlay/customer term before posting to the public surface. "
         f"If the match is a false positive, re-issue the command with {_OVERRIDE_FLAG} "
         f"(or set {_OVERRIDE_ENV}=1 in the tool env)."
+    )
+
+
+def format_unresolvable_body_message() -> str:
+    """Render the PreToolUse deny reason when the publish body cannot be read.
+
+    A missing ``--body-file`` or an unreadable path is blocked rather than
+    passed unscanned. Use ``-m``/``--body`` with an inline value, or write
+    the body to a file the command can resolve before posting.
+    """
+    return (
+        "BLOCKED: banned-terms posting gate (#1415). The publish body could not be read "
+        "(the body file is missing or unresolvable at scan time). Use an inline body "
+        "(-m/--body/--message) or write the file content in the same command before posting."
     )

--- a/tests/test_banned_terms_scanner.py
+++ b/tests/test_banned_terms_scanner.py
@@ -74,6 +74,14 @@ def _private_repo(tmp_path: Path) -> Path:
     return repo
 
 
+def _public_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "public-repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "remote", "add", "origin", "git@github.com:souliane/teatree.git")
+    return repo
+
+
 class TestScanText:
     def test_banned_term_is_matched(self, config: Path) -> None:
         term = banned_terms_scanner.scan_text("we ship to acmecorp next week", config_path=config)
@@ -493,6 +501,17 @@ class TestHookHandlerEndToEnd:
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
+    def test_unresolvable_body_deny_message_is_not_a_banned_term(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # The false-positive: an unresolvable body used to surface the internal
+        # sentinel as the "banned term", making the deny read "the body carries
+        # the banned term '<unresolved publish body>'". The message must instead
+        # explain the body could not be read.
+        handle_banned_terms_pretool(_bash('gh pr comment 5 --repo o/r --body-file "$BODY"'))
+        reason = json.loads(capsys.readouterr().out)["permissionDecisionReason"]
+        assert "<unresolved publish body>" not in reason
+        assert "banned term" not in reason
+        assert "--allow-banned-term" not in reason
+
     def test_gh_short_body_file_flag_is_read_and_blocks(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -575,6 +594,184 @@ class TestHookHandlerEndToEnd:
         blocked = handle_banned_terms_pretool(_bash('gh issue create --body "acmecorp"'))
         assert blocked is False
         assert capsys.readouterr().out == ""
+
+
+@pytest.mark.integration
+class TestCleanPublishFormsMustNotBlock:
+    """Every common publish form with a clean body MUST pass the gate.
+
+    These are the anti-vacuous regression guards for issue #182: a clean
+    inline body or a readable body file must never be blocked by the sentinel
+    false-positive. Each form below is paired with a must-FLAG counterpart in
+    ``TestBannedTermPublishFormsMustBlock`` so the guards are two-sided.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_cache(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "data"))
+
+    def test_git_commit_inline_m_clean_body_passes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(_bash('git commit -m "feat: ship faster builds"'))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_git_commit_inline_message_clean_body_passes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(_bash('git commit --message "fix: resolve timeout in retry loop"'))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_git_commit_file_absolute_path_clean_body_passes(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body_file = tmp_path / "commit_msg.txt"
+        body_file.write_text("feat: improve throughput\n\nDetails here.\n", encoding="utf-8")
+        blocked = handle_banned_terms_pretool(_bash(f"git commit -F {body_file}"))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_git_commit_long_file_flag_absolute_path_clean_body_passes(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body_file = tmp_path / "commit_msg.txt"
+        body_file.write_text("chore: bump dependencies\n", encoding="utf-8")
+        blocked = handle_banned_terms_pretool(_bash(f"git commit --file {body_file}"))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_git_commit_c_flag_with_inline_m_clean_body_passes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(_bash('git -C /some/worktree commit -m "refactor: extract helper"'))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_gh_pr_create_inline_body_clean_passes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(_bash('gh pr create --title "feat" --body "Clean PR body"'))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_gh_pr_create_body_file_absolute_path_clean_passes(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body_file = tmp_path / "pr_body.md"
+        body_file.write_text("## Summary\n\nClean description.\n", encoding="utf-8")
+        blocked = handle_banned_terms_pretool(_bash(f"gh pr create --title t --body-file {body_file}"))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_gh_issue_create_inline_body_clean_passes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(
+            _bash('gh issue create --title "Bug report" --body "Steps to reproduce..."')
+        )
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_gh_issue_create_body_file_absolute_path_clean_passes(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body_file = tmp_path / "issue_body.md"
+        body_file.write_text("## Description\n\nReproduction steps.\n", encoding="utf-8")
+        blocked = handle_banned_terms_pretool(_bash(f"gh issue create --title t --body-file {body_file}"))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_glab_mr_create_inline_description_clean_passes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(_bash('glab mr create --title "feat" --description "Clean MR body."'))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_glab_mr_create_description_file_absolute_path_clean_passes(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body_file = tmp_path / "mr_body.md"
+        body_file.write_text("## Summary\n\nThis MR adds a feature.\n", encoding="utf-8")
+        blocked = handle_banned_terms_pretool(_bash(f"glab mr create --title t --description-file {body_file}"))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+
+@pytest.mark.integration
+class TestBannedTermPublishFormsMustBlock:
+    """The must-FLAG counterpart of ``TestCleanPublishFormsMustNotBlock``.
+
+    A real banned term in the same publish form must still be caught after
+    the fix — the fix must not weaken detection, only eliminate the sentinel
+    false-positive.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_cache(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "data"))
+
+    def test_git_commit_inline_m_banned_term_blocks(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        repo = _public_repo(tmp_path)
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'git commit -m "fix the acmecorp issue"'},
+            "cwd": str(repo),
+        }
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_git_commit_file_absolute_path_banned_term_blocks(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = _public_repo(tmp_path)
+        body_file = tmp_path / "commit_msg.txt"
+        body_file.write_text("feat: ship acmecorp feature\n", encoding="utf-8")
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": f"git commit -F {body_file}"},
+            "cwd": str(repo),
+        }
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_gh_pr_create_inline_body_banned_term_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(_bash('gh pr create --title "feat" --body "Deploy to acmecorp cluster"'))
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_gh_pr_create_body_file_absolute_path_banned_term_blocks(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body_file = tmp_path / "pr_body.md"
+        body_file.write_text("This PR fixes the acmecorp integration.\n", encoding="utf-8")
+        blocked = handle_banned_terms_pretool(_bash(f"gh pr create --title t --body-file {body_file}"))
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_gh_issue_create_inline_body_banned_term_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(
+            _bash('gh issue create --title "Bug" --body "acmecorp reports this error"')
+        )
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_gh_issue_create_body_file_absolute_path_banned_term_blocks(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body_file = tmp_path / "issue_body.md"
+        body_file.write_text("acmecorp's deployment is broken.\n", encoding="utf-8")
+        blocked = handle_banned_terms_pretool(_bash(f"gh issue create --title t --body-file {body_file}"))
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_glab_mr_create_inline_description_banned_term_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(
+            _bash('glab mr create --title "feat" --description "Update acmecorp config"')
+        )
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_glab_mr_create_description_file_absolute_path_banned_term_blocks(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body_file = tmp_path / "mr_body.md"
+        body_file.write_text("This MR updates the acmecorp adapter.\n", encoding="utf-8")
+        blocked = handle_banned_terms_pretool(_bash(f"glab mr create --title t --description-file {body_file}"))
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
 
 class TestHookChainRegistration:
@@ -667,6 +864,17 @@ class TestFormatBlockMessage:
         message = banned_terms_scanner.format_block_message("acmecorp")
         assert "acmecorp" in message
         assert "--allow-banned-term" in message
+
+    def test_unresolvable_body_message_is_distinct_from_banned_term_message(self) -> None:
+        message = banned_terms_scanner.format_unresolvable_body_message()
+        assert "acmecorp" not in message
+        assert "<unresolved publish body>" not in message
+        assert "banned term" not in message
+
+    def test_unresolvable_body_message_is_actionable(self) -> None:
+        message = banned_terms_scanner.format_unresolvable_body_message()
+        assert "body" in message.lower()
+        assert "--allow-banned-term" not in message
 
 
 @pytest.mark.integration

--- a/tests/test_banned_terms_scanner.py
+++ b/tests/test_banned_terms_scanner.py
@@ -600,9 +600,13 @@ class TestHookHandlerEndToEnd:
 class TestCleanPublishFormsMustNotBlock:
     """Every common publish form with a clean body MUST pass the gate.
 
-    These are the anti-vacuous regression guards for issue #182: a clean
-    inline body or a readable body file must never be blocked by the sentinel
-    false-positive. Each form below is paired with a must-FLAG counterpart in
+    These guard the non-sentinel pass-through path: a clean inline body or a
+    readable body file must never be routed through a blocking path. They are
+    forward-looking coverage, not the #182 regression guard — each would also
+    pass on pre-fix code (the bug only fired on an *unresolvable* body). The
+    anti-vacuous RED-before-fix guard for issue #182 is
+    ``TestHookHandlerEndToEnd.test_unresolvable_body_deny_message_is_not_a_banned_term``.
+    Each form below is paired with a must-FLAG counterpart in
     ``TestBannedTermPublishFormsMustBlock`` so the guards are two-sided.
     """
 


### PR DESCRIPTION
## What

The banned-terms gate was surfacing the internal sentinel as the banned term in deny messages.

## Why

When extract_bash_payload cannot read a body file, it returns a fail-closed sentinel. scan_text() returned the private constant which flowed into format_block_message().

## Changes

- Rename private constant to public UNRESOLVABLE_BODY_MARKER
- Add format_unresolvable_body_message() with a clear actionable message
- hook_router checks the marker before calling format_block_message
- Extract _emit_banned_term_deny to stay within the 6-return ruff cap
- Add TestCleanPublishFormsMustNotBlock (11 tests) and TestBannedTermPublishFormsMustBlock (8 tests)