### PR TITLE
docs(e2e): Claude-in-Chrome connectivity checklist

### DIFF
--- a/skills/e2e/SKILL.md
+++ b/skills/e2e/SKILL.md
@@ -26,6 +26,34 @@ Playwright-based end-to-end testing for overlay target applications. Covers writ
 
 Always start dev servers via `t3 <overlay> worktree start` before running tests. Never start services manually. Before running E2E tests, verify that **translations are loaded** — the frontend i18n directory is gitignored and only populated at startup. If the frontend was started manually, translations will be missing. Quick check: open any page and confirm labels show human-readable text, not raw keys like `app.feature.xxx.label`.
 
+## Claude in Chrome connectivity
+
+Browser-driven E2E and visual checks run through the Claude-in-Chrome MCP server. Two failure modes are easy to misread as "the browser is broken" when the fix is mechanical.
+
+**Diagnosis one-liner: MCP server connected ≠ extension connected.** `/mcp` showing the `claude-in-chrome` server green only proves the MCP server reachable — it does NOT prove the extension is paired with the active account.
+
+**(a) Logged into claude.ai ≠ extension connected.** Being signed into claude.ai in the browser does not connect the extension — the extension popup carries its **own** connection / sign-in state. After any account switch, every browser tool can return "extension not connected" while `/mcp` shows the server reconnected.
+
+- **Verify:** call `list_connected_browsers`. An **empty array** (`[]`) means the extension is not paired with THIS account — zero instances are connected.
+- **Fix:** open the extension popup → sign out → sign in with the active account → Connect. Do a **full browser restart** if it still reports empty, then re-run `list_connected_browsers` to confirm a non-empty result before proceeding.
+
+This is the empirical fallout item (c) from the account-switch checklist in [souliane/teatree#1916](https://github.com/souliane/teatree/issues/1916).
+
+**(b) Navigation can silently block on per-origin permission prompts.** A `navigate` call can stall on a per-origin permission prompt the user has to grant. In an interactive session this surfaces as an `AskUserQuestion` fallback you answer once per origin. For an automated/unattended run, pre-authorize the browser MCP tools in `~/.claude/settings.json` so the tool itself never prompts:
+
+```jsonc
+{
+  "permissions": {
+    "allow": [
+      "mcp__claude-in-chrome__navigate",
+      "mcp__claude-in-chrome__*"
+    ]
+  }
+}
+```
+
+**Research finding — MCP allow-rules cannot constrain by domain, and wildcard subdomains are NOT supported.** Per the [Claude Code permission rule syntax](https://docs.claude.com/en/docs/claude-code/permissions#mcp), an MCP specifier matches only by server and tool name — `mcp__server`, `mcp__server__*`, or `mcp__server__tool_name`. There is **no** argument/domain form: you cannot write `mcp__claude-in-chrome__navigate(domain:*.example.com)` the way you can write `WebFetch(domain:example.com)`. So a browser-navigation allow-rule is all-or-nothing per tool — it auto-approves the `navigate` tool for **every** origin, not a wildcard-subdomain subset. (`WebFetch(domain:...)` and the bash sandbox's `allowedDomains` do support `*.example.com`, but those govern `WebFetch` and Bash, not the Claude-in-Chrome MCP tools.) The per-origin grant the browser itself enforces is upstream of permission rules; auto-approving the tool removes the Claude Code prompt, not the browser's own origin gate. Upstream feature gap: there is no per-origin allow-list for MCP browser tools today — track it against the account-switch automation in [souliane/teatree#1916](https://github.com/souliane/teatree/issues/1916).
+
 ## Running E2E Tests
 
 - Run headless with `CI=1`.

--- a/tests/test_e2e_skill_documents_chrome_connectivity.py
+++ b/tests/test_e2e_skill_documents_chrome_connectivity.py
@@ -1,0 +1,106 @@
+"""e2e/SKILL.md must document the Claude-in-Chrome connectivity checklist.
+
+A real account switch (souliane/teatree#1916) surfaced that being logged
+into claude.ai in the browser does NOT mean the Claude-in-Chrome extension
+is connected: `/mcp` shows the server reconnected while every browser tool
+returns "extension not connected". The decisive diagnostic is
+`list_connected_browsers` returning `[]`, and navigation can silently block
+on per-origin permission prompts. The e2e skill must carry this so an agent
+reading it before a browser run knows the probe, the fix, and that an MCP
+server being connected does not imply the extension is paired.
+
+Doc-invariant guard in the spirit of ``test_ship_skill_documents_skip_flags``.
+Per ``/t3:code`` § 5d the relationship assertions scan every occurrence of
+the anchor token rather than keying on the first match.
+"""
+
+from pathlib import Path
+
+_E2E_SKILL = Path(__file__).resolve().parents[1] / "skills" / "e2e" / "SKILL.md"
+
+
+def _any_window_contains(text: str, anchor: str, *, must_include: str, radius: int) -> bool:
+    start = 0
+    while (idx := text.find(anchor, start)) != -1:
+        window = text[max(0, idx - radius) : idx + len(anchor) + radius]
+        if must_include in window:
+            return True
+        start = idx + 1
+    return False
+
+
+class TestE2ESkillDocumentsChromeConnectivity:
+    def test_has_connectivity_subsection(self) -> None:
+        text = _E2E_SKILL.read_text(encoding="utf-8")
+        assert "Claude in Chrome connectivity" in text, (
+            "e2e/SKILL.md must carry a 'Claude in Chrome connectivity' subsection "
+            "covering the extension-vs-claude.ai connection split (souliane/teatree#1916)."
+        )
+
+    def test_documents_list_connected_browsers_probe(self) -> None:
+        text = _E2E_SKILL.read_text(encoding="utf-8")
+        assert "list_connected_browsers" in text, (
+            "e2e/SKILL.md must name the list_connected_browsers probe as the decisive extension-pairing diagnostic."
+        )
+
+    def test_empty_array_means_extension_not_paired(self) -> None:
+        text = _E2E_SKILL.read_text(encoding="utf-8")
+        assert _any_window_contains(
+            text,
+            "list_connected_browsers",
+            must_include="empty array",
+            radius=400,
+        ), (
+            "e2e/SKILL.md must state that an empty array from list_connected_browsers "
+            "means the extension is not paired with the active account."
+        )
+
+    def test_logged_into_claude_ai_is_not_connected(self) -> None:
+        text = _E2E_SKILL.read_text(encoding="utf-8")
+        assert _any_window_contains(
+            text,
+            "claude.ai",
+            must_include="extension",
+            radius=400,
+        ), (
+            "e2e/SKILL.md must state that being logged into claude.ai does NOT mean "
+            "the extension is connected (the popup has its own connection state)."
+        )
+
+    def test_documents_extension_popup_fix(self) -> None:
+        text = _E2E_SKILL.read_text(encoding="utf-8")
+        assert "popup" in text, "e2e/SKILL.md must give the fix path via the extension popup sign-in + Connect."
+        assert "restart" in text.lower(), (
+            "e2e/SKILL.md must mention a full browser restart when the popup fix is not enough."
+        )
+
+    def test_documents_per_origin_navigation_block(self) -> None:
+        text = _E2E_SKILL.read_text(encoding="utf-8")
+        assert "per-origin" in text, (
+            "e2e/SKILL.md must warn that navigation can silently block on per-origin permission prompts."
+        )
+
+    def test_documents_mcp_specifier_has_no_domain_argument(self) -> None:
+        """The research finding must be recorded: MCP specifiers take no argument pattern."""
+        text = _E2E_SKILL.read_text(encoding="utf-8")
+        assert _any_window_contains(
+            text,
+            "mcp__claude-in-chrome",
+            must_include="navigate",
+            radius=600,
+        ), (
+            "e2e/SKILL.md must show the MCP allow-rule form for the browser tool and "
+            "note MCP specifiers cannot constrain by domain (no wildcard subdomains)."
+        )
+        assert "AskUserQuestion" in text, (
+            "e2e/SKILL.md must note the AskUserQuestion fallback for automated runs that hit a per-origin prompt."
+        )
+
+    def test_diagnosis_one_liner(self) -> None:
+        text = _E2E_SKILL.read_text(encoding="utf-8")
+        assert _any_window_contains(
+            text,
+            "extension connected",
+            must_include="MCP server connected",
+            radius=200,
+        ), "e2e/SKILL.md must carry the one-liner: MCP server connected != extension connected."


### PR DESCRIPTION
Encodes two operational lessons from a real account switch ([#1916](https://github.com/souliane/teatree/issues/1916)) into `skills/e2e/SKILL.md`, and records a permissions research finding.

## What changed

New "Claude in Chrome connectivity" subsection in `skills/e2e/SKILL.md`:

- **Logged into claude.ai ≠ extension connected.** The extension popup carries its own connection/sign-in state; after an account switch every browser tool can return "extension not connected" while `/mcp` shows the server reconnected. Verify via `list_connected_browsers` (empty array = not paired with this account); fix via popup sign-in + Connect, full browser restart if needed, then re-probe.
- **Navigation can silently block on per-origin permission prompts.** Pre-authorize the browser MCP tools in settings for automated runs, or expect `AskUserQuestion` fallbacks.
- **Diagnosis one-liner:** MCP server connected ≠ extension connected.

A doc-invariant test (`tests/test_e2e_skill_documents_chrome_connectivity.py`) guards every claim — RED before the edit, GREEN after — scanning all anchor occurrences per `/t3:code` § 5d.

Also commented the fallout summary on [#1916](https://github.com/souliane/teatree/issues/1916).

## Research answer (wildcard subdomain support)

**No.** Per the [Claude Code permission rule syntax](https://docs.claude.com/en/docs/claude-code/permissions#mcp), an MCP permission specifier matches **only** by server and tool name:

- `mcp__server` — any tool from the server
- `mcp__server__*` — all tools from the server (wildcard over tool names)
- `mcp__server__tool_name` — one exact tool

There is **no argument/domain form** for MCP tools. You cannot write `mcp__claude-in-chrome__navigate(domain:*.example.com)` the way `WebFetch(domain:example.com)` works. Auto-approving the browser MCP tool is therefore all-or-nothing per tool (every origin), not a wildcard-subdomain subset. `WebFetch(domain:...)` and the bash sandbox `allowedDomains` do support `*.example.com`, but those govern WebFetch and Bash, not the Claude-in-Chrome MCP tools. The per-origin grant the browser itself enforces is upstream of Claude Code permission rules. Upstream feature gap: no per-origin allow-list for MCP browser tools today.

## Architecture pre-check

1. **BLUEPRINT § alignment** — n/a; docs-only skill content + a doc-invariant test. No BLUEPRINT section governs e2e skill prose.
2. **FSM phase boundaries** — n/a; no `Ticket.State`/`Worktree.State` transition.
3. **Extension-point contracts** — n/a; no `OverlayBase`/scanner/hook/Protocol surface touched.
4. **Component boundaries** — `skills/e2e/SKILL.md` (skill prose) + `tests/` (doc-invariant guard). Correct homes.
5. **Dependency direction** — n/a; no imports added beyond stdlib `pathlib` in the test.
6. **Test surface** — `tests/test_e2e_skill_documents_chrome_connectivity.py` asserts the subsection, the `list_connected_browsers` probe, the empty-array semantics, the claude.ai-vs-extension split, the popup/restart fix, the per-origin warning, the MCP allow-rule form + `AskUserQuestion` fallback, and the diagnosis one-liner.
7. **Resilience invariants** — n/a; no external write in the change.
8. **Identity/key normalization** — n/a.
9. **Behavior preservation / capability deletion** — n/a; purely additive (new subsection + new test, no removal).

## Open questions & assumptions

- Assumes the browser MCP server is named `claude-in-chrome` and exposes a `navigate` tool; the example allow-rule uses that name. If the installed server name differs, the rule name changes accordingly.
- The per-origin grant the browser itself enforces is upstream of Claude Code permission rules; auto-approving the tool removes the Claude Code prompt, not the browser own origin gate.
- The coverage threshold (93%) is a whole-repo CI metric and cannot pass on a single-file local run; the new doc-invariant test file is itself fully covered.