### PR TITLE
feat(hooks): refuse claude.ai Slack MCP self-DM writes via personal token (#1464 partial)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -2720,7 +2720,14 @@ def _run_quote_scanner_pretool(data: dict) -> bool:
 
 # ── PreToolUse: refuse self-DM via the user-token MCP tools (#1464) ──
 
-_SELF_DM_MCP_WRITE_TOOLS: frozenset[str] = frozenset({"slack_send_message", "slack_add_reaction"})
+_SELF_DM_MCP_WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "slack_send_message",
+        "slack_add_reaction",
+        "slack_schedule_message",
+        "slack_send_message_draft",
+    }
+)
 _SELF_DM_CHANNEL_FIELDS: tuple[str, ...] = ("channel", "channel_id")
 
 
@@ -2728,11 +2735,33 @@ def _slack_tool_suffix(tool_name: str) -> str:
     return tool_name.rsplit("__", 1)[-1]
 
 
-@dataclasses.dataclass(frozen=True)
-class _SelfDmChannels:
-    """Resolved set of configured bot↔user DM channel ids, with a read-success flag.
+def _self_dm_gate_enabled() -> bool:
+    import tomllib  # noqa: PLC0415
 
-    ``resolved`` distinguishes a genuinely-empty configuration (no DM channels
+    config_path = Path.home() / ".teatree.toml"
+    if not config_path.is_file():
+        return True
+    try:
+        with config_path.open("rb") as f:
+            config = tomllib.load(f)
+    except Exception:  # noqa: BLE001
+        return True
+    teatree = config.get("teatree") if isinstance(config, dict) else None
+    if not isinstance(teatree, dict):
+        return True
+    return teatree.get("self_dm_gate_enabled") is not False
+
+
+@dataclasses.dataclass(frozen=True)
+class _SelfDmDestinations:
+    """Resolved set of self-DM destination ids, with a read-success flag.
+
+    The set mirrors the canonical ``SlackBotBackend._is_self_dm``: each
+    overlay's ``slack_dm_channel_id`` (the ``D…`` self-IM id) AND each
+    ``slack_user_id`` plus the global ``[teatree] slack_user_id`` (the
+    ``U…`` id Slack accepts as a target that opens the self-IM).
+
+    ``resolved`` distinguishes a genuinely-empty configuration (nothing
     declared → ALLOW silently) from an unreadable/unparsable one (→ ALLOW+warn).
     """
 
@@ -2740,26 +2769,31 @@ class _SelfDmChannels:
     resolved: bool
 
 
-def _self_dm_channel_ids() -> _SelfDmChannels:
+def _self_dm_destination_ids() -> _SelfDmDestinations:
     import tomllib  # noqa: PLC0415
 
     config_path = Path.home() / ".teatree.toml"
     if not config_path.is_file():
-        return _SelfDmChannels(frozenset(), resolved=False)
+        return _SelfDmDestinations(frozenset(), resolved=False)
     try:
         with config_path.open("rb") as f:
             config = tomllib.load(f)
     except Exception:  # noqa: BLE001
-        return _SelfDmChannels(frozenset(), resolved=False)
-    overlays = config.get("overlays") if isinstance(config, dict) else None
-    if not isinstance(overlays, dict):
-        return _SelfDmChannels(frozenset(), resolved=True)
-    ids = frozenset(
-        cfg["slack_dm_channel_id"]
-        for cfg in overlays.values()
-        if isinstance(cfg, dict) and isinstance(cfg.get("slack_dm_channel_id"), str)
-    )
-    return _SelfDmChannels(ids, resolved=True)
+        return _SelfDmDestinations(frozenset(), resolved=False)
+    ids: set[str] = set()
+    overlays = config.get("overlays")
+    if isinstance(overlays, dict):
+        for cfg in overlays.values():
+            if not isinstance(cfg, dict):
+                continue
+            for key in ("slack_dm_channel_id", "slack_user_id"):
+                value = cfg.get(key)
+                if isinstance(value, str) and value:
+                    ids.add(value)
+    teatree = config.get("teatree")
+    if isinstance(teatree, dict) and isinstance(teatree.get("slack_user_id"), str) and teatree["slack_user_id"]:
+        ids.add(teatree["slack_user_id"])
+    return _SelfDmDestinations(frozenset(ids), resolved=True)
 
 
 def _self_dm_destination(tool_input: dict, dm_ids: frozenset[str]) -> str:
@@ -2771,27 +2805,34 @@ def _self_dm_destination(tool_input: dict, dm_ids: frozenset[str]) -> str:
 
 
 def handle_block_self_dm_via_mcp(data: dict) -> bool:
-    """Refuse a claude.ai Slack MCP write to the operator's own bot↔user DM channel.
+    """Refuse a claude.ai Slack MCP write to the operator's own bot↔user DM.
 
     The ``mcp__claude_ai_Slack__slack_*`` write tools publish under the USER's
-    OAuth token, so a post/react to the operator's own DM channel renders as
+    OAuth token, so a post/react to the operator's own self-IM renders as
     user-authored and the loop's scanners then react to the agent's own message.
     teatree's egress chokepoints (the slack_voice_classifier, the on-behalf
     egress class) never see an MCP tool call, so this PreToolUse deny is the only
     place the write can be stopped.
 
-    DENY scope: the two MCP write tools whose destination resolves to one of the
-    configured ``[overlays.*].slack_dm_channel_id`` values. The reason points the
-    caller at the bot-token path (``t3 teatree notify send -``). Posts to any
-    other channel (colleague surfaces, governed by the on-behalf gate) pass
-    through untouched.
+    DENY scope: the MCP write tools (``slack_send_message``,
+    ``slack_add_reaction``, ``slack_schedule_message``,
+    ``slack_send_message_draft``) whose destination resolves to a self-DM id.
+    Mirroring the canonical ``SlackBotBackend._is_self_dm``, a self-DM id is
+    either a configured ``[overlays.*].slack_dm_channel_id`` (``D…``) OR a
+    configured ``slack_user_id`` / global ``[teatree] slack_user_id`` (``U…``,
+    which Slack opens as the self-IM). The reason points the caller at the
+    bot-token path (``t3 teatree notify send -``). Posts to any other channel
+    (colleague surfaces, governed by the on-behalf gate) pass through untouched.
 
-    Fail direction: ALLOW+warn when the DM channel ids cannot be resolved
+    Fail direction: ALLOW+warn when the destination ids cannot be resolved
     (missing/unreadable config) — this is a UX-correctness gate, not a security
     gate, and a config hiccup must not lock the operator out of Slack. A
-    genuinely-empty configuration (config readable, no DM channels declared)
-    allows silently.
+    genuinely-empty configuration (config readable, nothing declared) allows
+    silently. The ``[teatree] self_dm_gate_enabled`` setting (default ``True``)
+    is the one-line kill-switch.
     """
+    if not _self_dm_gate_enabled():
+        return False
     tool_name = data.get("tool_name", "")
     if _slack_tool_suffix(tool_name) not in _SELF_DM_MCP_WRITE_TOOLS:
         return False
@@ -2799,21 +2840,21 @@ def handle_block_self_dm_via_mcp(data: dict) -> bool:
     if not isinstance(tool_input, dict):
         return False
 
-    dm_channels = _self_dm_channel_ids()
-    if not dm_channels.resolved:
+    destinations = _self_dm_destination_ids()
+    if not destinations.resolved:
         sys.stderr.write(
             "WARNING: self-DM gate (#1464) — could not resolve the bot↔user DM "
-            "channel ids from ~/.teatree.toml; allowing the Slack MCP write.\n"
+            "destination ids from ~/.teatree.toml; allowing the Slack MCP write.\n"
         )
         return False
 
-    destination = _self_dm_destination(tool_input, dm_channels.ids)
+    destination = _self_dm_destination(tool_input, destinations.ids)
     if not destination:
         return False
 
     return emit_pretooluse_deny(
         f"SELF-DM REFUSED: this claude.ai Slack MCP write targets the operator's own "
-        f"bot↔user DM channel ({destination}) under the USER's OAuth token, so it renders "
+        f"bot↔user DM ({destination}) under the USER's OAuth token, so it renders "
         f"as user-authored and the loop's scanners will react to the agent's own message. "
         f"Use the bot-token path instead: `t3 teatree notify send -` (reads the body from "
         f"stdin). Posts to colleague channels are unaffected by this gate."

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -2762,7 +2762,9 @@ class _SelfDmDestinations:
     ``U…`` id Slack accepts as a target that opens the self-IM).
 
     ``resolved`` distinguishes a genuinely-empty configuration (nothing
-    declared → ALLOW silently) from an unreadable/unparsable one (→ ALLOW+warn).
+    declared → ALLOW silently) from an unreadable/unparsable one
+    (→ DENY fail-closed: the hook cannot self-identify the author without the
+    config, so a can't-read config must not let a self-DM through).
     """
 
     ids: frozenset[str]
@@ -2824,12 +2826,14 @@ def handle_block_self_dm_via_mcp(data: dict) -> bool:
     bot-token path (``t3 teatree notify send -``). Posts to any other channel
     (colleague surfaces, governed by the on-behalf gate) pass through untouched.
 
-    Fail direction: ALLOW+warn when the destination ids cannot be resolved
-    (missing/unreadable config) — this is a UX-correctness gate, not a security
-    gate, and a config hiccup must not lock the operator out of Slack. A
-    genuinely-empty configuration (config readable, nothing declared) allows
-    silently. The ``[teatree] self_dm_gate_enabled`` setting (default ``True``)
-    is the one-line kill-switch.
+    Fail direction (user decision): FAIL-CLOSED. The hook cannot self-identify
+    the author without the config (no MCP token or network in the hook
+    subprocess, and the tool-schema text is not part of the hook input), so a
+    missing/unreadable/unparsable config DENIES with an error naming the toml
+    problem and the fix. A genuinely-empty configuration (config readable,
+    nothing declared) is a real state, not an error, so it allows silently. The
+    ``[teatree] self_dm_gate_enabled = false`` setting is the sanctioned
+    explicit escape hatch (never a silent one).
     """
     if not _self_dm_gate_enabled():
         return False
@@ -2842,11 +2846,15 @@ def handle_block_self_dm_via_mcp(data: dict) -> bool:
 
     destinations = _self_dm_destination_ids()
     if not destinations.resolved:
-        sys.stderr.write(
-            "WARNING: self-DM gate (#1464) — could not resolve the bot↔user DM "
-            "destination ids from ~/.teatree.toml; allowing the Slack MCP write.\n"
+        return emit_pretooluse_deny(
+            "SELF-DM REFUSED (fail-closed): could not read the bot↔user DM destination ids "
+            "from ~/.teatree.toml (the file is missing or not valid TOML), so this gate "
+            "cannot confirm the Slack MCP write is not a self-DM under the USER's OAuth "
+            "token. Fix the ~/.teatree.toml so it parses (with the per-overlay "
+            "slack_dm_channel_id / slack_user_id keys), or set [teatree] "
+            "self_dm_gate_enabled = false to disable this gate explicitly. To DM the user "
+            "now, use the bot-token path: `t3 teatree notify send -` (reads the body from stdin)."
         )
-        return False
 
     destination = _self_dm_destination(tool_input, destinations.ids)
     if not destination:

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -2718,6 +2718,108 @@ def _run_quote_scanner_pretool(data: dict) -> bool:
     return False
 
 
+# ── PreToolUse: refuse self-DM via the user-token MCP tools (#1464) ──
+
+_SELF_DM_MCP_WRITE_TOOLS: frozenset[str] = frozenset({"slack_send_message", "slack_add_reaction"})
+_SELF_DM_CHANNEL_FIELDS: tuple[str, ...] = ("channel", "channel_id")
+
+
+def _slack_tool_suffix(tool_name: str) -> str:
+    return tool_name.rsplit("__", 1)[-1]
+
+
+@dataclasses.dataclass(frozen=True)
+class _SelfDmChannels:
+    """Resolved set of configured bot↔user DM channel ids, with a read-success flag.
+
+    ``resolved`` distinguishes a genuinely-empty configuration (no DM channels
+    declared → ALLOW silently) from an unreadable/unparsable one (→ ALLOW+warn).
+    """
+
+    ids: frozenset[str]
+    resolved: bool
+
+
+def _self_dm_channel_ids() -> _SelfDmChannels:
+    import tomllib  # noqa: PLC0415
+
+    config_path = Path.home() / ".teatree.toml"
+    if not config_path.is_file():
+        return _SelfDmChannels(frozenset(), resolved=False)
+    try:
+        with config_path.open("rb") as f:
+            config = tomllib.load(f)
+    except Exception:  # noqa: BLE001
+        return _SelfDmChannels(frozenset(), resolved=False)
+    overlays = config.get("overlays") if isinstance(config, dict) else None
+    if not isinstance(overlays, dict):
+        return _SelfDmChannels(frozenset(), resolved=True)
+    ids = frozenset(
+        cfg["slack_dm_channel_id"]
+        for cfg in overlays.values()
+        if isinstance(cfg, dict) and isinstance(cfg.get("slack_dm_channel_id"), str)
+    )
+    return _SelfDmChannels(ids, resolved=True)
+
+
+def _self_dm_destination(tool_input: dict, dm_ids: frozenset[str]) -> str:
+    for field in _SELF_DM_CHANNEL_FIELDS:
+        value = tool_input.get(field)
+        if isinstance(value, str) and value in dm_ids:
+            return value
+    return ""
+
+
+def handle_block_self_dm_via_mcp(data: dict) -> bool:
+    """Refuse a claude.ai Slack MCP write to the operator's own bot↔user DM channel.
+
+    The ``mcp__claude_ai_Slack__slack_*`` write tools publish under the USER's
+    OAuth token, so a post/react to the operator's own DM channel renders as
+    user-authored and the loop's scanners then react to the agent's own message.
+    teatree's egress chokepoints (the slack_voice_classifier, the on-behalf
+    egress class) never see an MCP tool call, so this PreToolUse deny is the only
+    place the write can be stopped.
+
+    DENY scope: the two MCP write tools whose destination resolves to one of the
+    configured ``[overlays.*].slack_dm_channel_id`` values. The reason points the
+    caller at the bot-token path (``t3 teatree notify send -``). Posts to any
+    other channel (colleague surfaces, governed by the on-behalf gate) pass
+    through untouched.
+
+    Fail direction: ALLOW+warn when the DM channel ids cannot be resolved
+    (missing/unreadable config) — this is a UX-correctness gate, not a security
+    gate, and a config hiccup must not lock the operator out of Slack. A
+    genuinely-empty configuration (config readable, no DM channels declared)
+    allows silently.
+    """
+    tool_name = data.get("tool_name", "")
+    if _slack_tool_suffix(tool_name) not in _SELF_DM_MCP_WRITE_TOOLS:
+        return False
+    tool_input = data.get("tool_input", {}) or {}
+    if not isinstance(tool_input, dict):
+        return False
+
+    dm_channels = _self_dm_channel_ids()
+    if not dm_channels.resolved:
+        sys.stderr.write(
+            "WARNING: self-DM gate (#1464) — could not resolve the bot↔user DM "
+            "channel ids from ~/.teatree.toml; allowing the Slack MCP write.\n"
+        )
+        return False
+
+    destination = _self_dm_destination(tool_input, dm_channels.ids)
+    if not destination:
+        return False
+
+    return emit_pretooluse_deny(
+        f"SELF-DM REFUSED: this claude.ai Slack MCP write targets the operator's own "
+        f"bot↔user DM channel ({destination}) under the USER's OAuth token, so it renders "
+        f"as user-authored and the loop's scanners will react to the agent's own message. "
+        f"Use the bot-token path instead: `t3 teatree notify send -` (reads the body from "
+        f"stdin). Posts to colleague channels are unaffected by this gate."
+    )
+
+
 # ── PreToolUse: pre-dispatch quote-scanner gate (#1401) ─────────────
 
 
@@ -7674,6 +7776,7 @@ _HANDLERS: dict[str, list] = {
         handle_enforce_loop_registration,
         handle_block_edit_before_planned,
         handle_protect_default_branch,
+        handle_block_self_dm_via_mcp,
         handle_quote_scanner_pretool,
         handle_dispatch_prompt_quote_scanner,
         handle_banned_terms_pretool,

--- a/tests/test_gate_liveness_corpus.py
+++ b/tests/test_gate_liveness_corpus.py
@@ -389,6 +389,34 @@ def _quote_slack_allow(ctx: GateContext) -> dict:
     return _slack_send("mcp__claude_ai_Slack__slack_send_message", "Routine status update.")
 
 
+# self-DM gate (mcp__*slack* send/react): a write to a configured bot↔user DM
+# channel denies (renders as user-authored under the personal token); a write to
+# a colleague channel allows. The arrange step declares the DM channel id under
+# an overlay table so the gate can resolve it.
+
+_SELF_DM_CHANNEL = "D0BLIVEDM001"
+
+
+def _arrange_self_dm_gate(ctx: GateContext) -> None:
+    ctx.write_teatree_toml(f'[overlays.t3-acme]\nslack_dm_channel_id = "{_SELF_DM_CHANNEL}"\n')
+
+
+def _self_dm_deny(ctx: GateContext) -> dict:
+    return {
+        "session_id": "sess-liveness",
+        "tool_name": "mcp__claude_ai_Slack__slack_send_message",
+        "tool_input": {"channel": _SELF_DM_CHANNEL, "text": "Full-day review report"},
+    }
+
+
+def _self_dm_allow(ctx: GateContext) -> dict:
+    return {
+        "session_id": "sess-liveness",
+        "tool_name": "mcp__claude_ai_Slack__slack_send_message",
+        "tool_input": {"channel": "C0COLLEAGUE9", "text": "review note"},
+    }
+
+
 # dispatch-prompt quote-scanner (Agent/Task): a dispatch prompt carrying a
 # verbatim user quote denies; a clean prompt allows. Phantom because no Agent
 # matcher is wired in hooks.json (the Agent tool itself DOES reach PreToolUse —
@@ -664,6 +692,15 @@ GATE_REGISTRY: Final[tuple[GateRow, ...]] = (
         deny_input=_quote_slack_deny,
         allow_input=_quote_slack_allow,
         arrange=_arrange_mcp_privacy_gate,
+    ),
+    GateRow(
+        gate_id="block-self-dm-via-mcp",
+        handler=router.handle_block_self_dm_via_mcp,
+        event="PreToolUse",
+        matched="mcp__claude_ai_Slack__slack_send_message",
+        deny_input=_self_dm_deny,
+        allow_input=_self_dm_allow,
+        arrange=_arrange_self_dm_gate,
     ),
     GateRow(
         gate_id="dispatch-prompt-quote-scanner",

--- a/tests/test_gate_never_lockout_contract.py
+++ b/tests/test_gate_never_lockout_contract.py
@@ -86,6 +86,10 @@ _NEVER_LOCKOUT_EXEMPT_DENY_HANDLERS: Final[dict[str, str]] = {
     "handle_block_direct_commands": "denies only specific t3-CLI-bypass commands (_deny_match denylist)",
     "handle_block_out_of_band_merge": "denies only raw `gh pr merge` / `glab mr merge` on managed repos",
     "handle_block_raw_review_post": "denies only raw review-post commands that bypass the FSM",
+    "handle_block_self_dm_via_mcp": (
+        "denies only the 4 Slack MCP write tools to a self-DM id, never arbitrary Bash; "
+        "own self_dm_gate_enabled kill-switch"
+    ),
     "handle_validate_mr_metadata": "denies only `glab mr create/update` with missing metadata; broken-env escape",
     # Routing conversion, not a content/enforcement deny.
     "handle_route_away_mode_question": "converts AskUserQuestion to DeferredQuestion (away-mode); not a Bash deny",

--- a/tests/test_hook_router_self_dm_mcp.py
+++ b/tests/test_hook_router_self_dm_mcp.py
@@ -16,9 +16,14 @@ slack_user_id``) — never hardcoded.
 
 This gate denies an MCP write whose destination is one of those ids and points
 the caller at the bot-token path (``t3 teatree notify send -``). Posts to any
-other channel pass through untouched. The fail direction is ALLOW+warn: an
-unreadable/unresolvable config must not lock the user out of Slack. The
-``[teatree] self_dm_gate_enabled`` kill-switch disables the gate without a code edit.
+other channel pass through untouched.
+
+Fail direction (user decision): FAIL-CLOSED. The hook cannot self-identify the
+author config-free (no token/network, schema text not in the input), so an
+unreadable/missing/malformed config DENIES with an error naming the toml
+problem and the fix. A readable config with no ids stays ALLOW (genuinely-empty
+is a real state, not an error). The ``[teatree] self_dm_gate_enabled`` kill-switch
+is the sanctioned explicit disable.
 """
 
 import json
@@ -184,18 +189,23 @@ class TestPassesThroughColleagueAndUnrelated:
         assert capsys.readouterr().out.strip() == ""
 
 
-class TestFailsOpenOnUnresolvableConfig:
-    def test_missing_config_allows_and_warns(
+class TestFailsClosedOnUnresolvableConfig:
+    # User decision: config-free self-identification isn't reliably available
+    # inside the PreToolUse hook (no token/network, schema text not in the input),
+    # so an unreadable/missing/malformed config DENIES — the kill-switch
+    # [teatree] self_dm_gate_enabled=false is the sanctioned escape hatch.
+
+    def test_missing_config_is_denied(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         _patch_home(tmp_path / "home", None, monkeypatch)
         verdict = router.handle_block_self_dm_via_mcp(
             _event(_SEND, {"channel": "D0BFIRSTDM01", "text": "report"}, session_id="s4")
         )
-        assert verdict is False
-        captured = capsys.readouterr()
-        assert captured.out.strip() == ""
-        assert "self-DM" in captured.err
+        assert verdict is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert "self_dm_gate_enabled" in deny["permissionDecisionReason"]
 
     @pytest.mark.parametrize(
         "body",
@@ -206,12 +216,12 @@ class TestFailsOpenOnUnresolvableConfig:
             '[teatree]\nmode = "auto"\n[overlays]\nbroken = "not-a-table"\n',
         ],
     )
-    def test_config_without_dm_channels_allows_silently(
+    def test_readable_config_without_ids_allows_silently(
         self, body: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        # Readable config but no DM channel ids to match (an overlay without the
-        # key, no overlays table, OR a malformed non-table overlay) → ALLOW, no
-        # warn (genuinely-empty, not the can't-read case).
+        # Readable config but no self-DM ids to match (an overlay without the
+        # keys, no overlays table, OR a malformed non-table overlay) → ALLOW, no
+        # warn. Genuinely-empty is a real state, NOT an error → not fail-closed.
         _patch_home(tmp_path / "home", body, monkeypatch)
         verdict = router.handle_block_self_dm_via_mcp(
             _event(_SEND, {"channel": "D0BFIRSTDM01", "text": "report"}, session_id="s5")
@@ -219,7 +229,7 @@ class TestFailsOpenOnUnresolvableConfig:
         assert verdict is False
         assert capsys.readouterr().out.strip() == ""
 
-    def test_unreadable_config_allows_and_warns(
+    def test_unreadable_config_is_denied(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         home = tmp_path / "home"
@@ -229,10 +239,10 @@ class TestFailsOpenOnUnresolvableConfig:
         verdict = router.handle_block_self_dm_via_mcp(
             _event(_SEND, {"channel": "D0BFIRSTDM01", "text": "report"}, session_id="s6")
         )
-        assert verdict is False
-        captured = capsys.readouterr()
-        assert captured.out.strip() == ""
-        assert "self-DM" in captured.err
+        assert verdict is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert "self_dm_gate_enabled" in deny["permissionDecisionReason"]
 
 
 class TestMalformedToolInputPassesThrough:

--- a/tests/test_hook_router_self_dm_mcp.py
+++ b/tests/test_hook_router_self_dm_mcp.py
@@ -1,0 +1,201 @@
+"""Self-DM-token gate: refuse claude.ai Slack MCP writes to a bot↔user DM channel.
+
+The claude.ai Slack MCP write tools (``mcp__claude_ai_Slack__slack_send_message``,
+``mcp__claude_ai_Slack__slack_add_reaction``) publish under the USER's OAuth token.
+A post/react to the operator's own bot↔user DM channel renders as user-authored
+and lets the loop's scanners react to the agent's own message. The on-behalf
+egress class governs colleague surfaces but never sees an MCP tool call.
+
+This gate denies an MCP write whose destination is a configured DM channel id
+and points the caller at the bot-token path (``t3 teatree notify send -``).
+Posts to any other channel pass through untouched. The fail direction is
+ALLOW+warn: an unreadable/unresolvable config must not lock the user out of Slack.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+
+
+class _FakeHomePath:
+    def __init__(self, home: Path) -> None:
+        self._home = home
+
+    def __call__(self, *args: object, **kwargs: object) -> Path:
+        return Path(*args, **kwargs)
+
+    def home(self) -> Path:
+        return self._home
+
+
+_CONFIG_WITH_DM_CHANNELS = """
+[teatree]
+mode = "auto"
+
+[overlays.t3-acme]
+messaging_backend = "slack"
+slack_user_id = "U0AAAAAAAAA"
+slack_dm_channel_id = "D0BFIRSTDM01"
+
+[overlays.t3-widget]
+messaging_backend = "slack"
+slack_user_id = "U0AAAAAAAAA"
+slack_dm_channel_id = "D0BSECONDDM2"
+"""
+
+_CONFIG_NO_DM_CHANNELS = """
+[teatree]
+mode = "auto"
+
+[overlays.t3-acme]
+messaging_backend = "slack"
+slack_user_id = "U0AAAAAAAAA"
+"""
+
+_SEND = "mcp__claude_ai_Slack__slack_send_message"
+_REACT = "mcp__claude_ai_Slack__slack_add_reaction"
+
+
+def _patch_home(home: Path, body: str | None, monkeypatch: pytest.MonkeyPatch) -> None:
+    home.mkdir(exist_ok=True)
+    if body is not None:
+        (home / ".teatree.toml").write_text(body, encoding="utf-8")
+    monkeypatch.setattr(router, "Path", _FakeHomePath(home))
+
+
+def _event(tool_name: str, tool_input: dict, *, session_id: str) -> dict:
+    return {"session_id": session_id, "tool_name": tool_name, "tool_input": tool_input}
+
+
+def _parse_deny(capsys: pytest.CaptureFixture[str]) -> dict | None:
+    output = capsys.readouterr().out.strip()
+    return json.loads(output) if output else None
+
+
+class TestDeniesSelfDmWrites:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_home(tmp_path / "home", _CONFIG_WITH_DM_CHANNELS, monkeypatch)
+
+    @pytest.mark.parametrize(
+        ("tool_name", "tool_input"),
+        [
+            (_SEND, {"channel": "D0BFIRSTDM01", "text": "Full-day review report"}),
+            (_SEND, {"channel": "D0BSECONDDM2", "text": "status"}),
+            (_REACT, {"channel": "D0BFIRSTDM01", "name": "eyes", "timestamp": "1.2"}),
+            # Defensive: some MCP shapes use ``channel_id`` for the destination.
+            (_SEND, {"channel_id": "D0BSECONDDM2", "text": "status"}),
+        ],
+    )
+    def test_self_dm_write_is_denied(
+        self, tool_name: str, tool_input: dict, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        verdict = router.handle_block_self_dm_via_mcp(_event(tool_name, tool_input, session_id="s1"))
+        assert verdict is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert deny["permissionDecision"] == "deny"
+        assert "notify send" in deny["permissionDecisionReason"]
+
+
+class TestPassesThroughColleagueAndUnrelated:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_home(tmp_path / "home", _CONFIG_WITH_DM_CHANNELS, monkeypatch)
+
+    @pytest.mark.parametrize(
+        ("tool_name", "tool_input"),
+        [
+            # Colleague channel — governed by the on-behalf gate, not this one.
+            (_SEND, {"channel": "C0COLLEAGUE1", "text": "review note"}),
+            (_REACT, {"channel": "C0COLLEAGUE1", "name": "white_check_mark", "timestamp": "1.2"}),
+            # A different DM-shaped id that is NOT configured stays untouched.
+            (_SEND, {"channel": "D0BUNKNOWN99", "text": "hi"}),
+        ],
+    )
+    def test_non_dm_channel_passes_through(
+        self, tool_name: str, tool_input: dict, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        verdict = router.handle_block_self_dm_via_mcp(_event(tool_name, tool_input, session_id="s2"))
+        assert verdict is False
+        assert capsys.readouterr().out.strip() == ""
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "Bash",
+            "Edit",
+            "mcp__claude_ai_Slack__slack_read_channel",
+        ],
+    )
+    def test_non_target_tool_passes_through(self, tool_name: str, capsys: pytest.CaptureFixture[str]) -> None:
+        verdict = router.handle_block_self_dm_via_mcp(
+            _event(tool_name, {"channel": "D0BFIRSTDM01", "text": "x"}, session_id="s3")
+        )
+        assert verdict is False
+        assert capsys.readouterr().out.strip() == ""
+
+
+class TestFailsOpenOnUnresolvableConfig:
+    def test_missing_config_allows_and_warns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _patch_home(tmp_path / "home", None, monkeypatch)
+        verdict = router.handle_block_self_dm_via_mcp(
+            _event(_SEND, {"channel": "D0BFIRSTDM01", "text": "report"}, session_id="s4")
+        )
+        assert verdict is False
+        captured = capsys.readouterr()
+        assert captured.out.strip() == ""
+        assert "self-DM" in captured.err
+
+    @pytest.mark.parametrize("body", [_CONFIG_NO_DM_CHANNELS, '[teatree]\nmode = "auto"\n'])
+    def test_config_without_dm_channels_allows_silently(
+        self, body: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Readable config but no DM channel ids to match (an overlay without the
+        # key, OR no overlays table at all) → ALLOW, no warn (genuinely-empty,
+        # not the can't-read case).
+        _patch_home(tmp_path / "home", body, monkeypatch)
+        verdict = router.handle_block_self_dm_via_mcp(
+            _event(_SEND, {"channel": "D0BFIRSTDM01", "text": "report"}, session_id="s5")
+        )
+        assert verdict is False
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_unreadable_config_allows_and_warns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        home = tmp_path / "home"
+        home.mkdir(exist_ok=True)
+        (home / ".teatree.toml").write_text("this is = not valid toml [[[", encoding="utf-8")
+        monkeypatch.setattr(router, "Path", _FakeHomePath(home))
+        verdict = router.handle_block_self_dm_via_mcp(
+            _event(_SEND, {"channel": "D0BFIRSTDM01", "text": "report"}, session_id="s6")
+        )
+        assert verdict is False
+        captured = capsys.readouterr()
+        assert captured.out.strip() == ""
+        assert "self-DM" in captured.err
+
+
+class TestMalformedToolInputPassesThrough:
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_home(tmp_path / "home", _CONFIG_WITH_DM_CHANNELS, monkeypatch)
+
+    @pytest.mark.parametrize("tool_input", ["not-a-dict", None, ["channel", "D0BFIRSTDM01"]])
+    def test_non_dict_tool_input_passes_through(self, tool_input: object, capsys: pytest.CaptureFixture[str]) -> None:
+        verdict = router.handle_block_self_dm_via_mcp(
+            {"session_id": "s7", "tool_name": _SEND, "tool_input": tool_input}
+        )
+        assert verdict is False
+        assert capsys.readouterr().out.strip() == ""
+
+
+class TestRegisteredInPreToolUseChain:
+    def test_handler_is_registered(self) -> None:
+        assert router.handle_block_self_dm_via_mcp in router._HANDLERS["PreToolUse"]

--- a/tests/test_hook_router_self_dm_mcp.py
+++ b/tests/test_hook_router_self_dm_mcp.py
@@ -1,15 +1,24 @@
 """Self-DM-token gate: refuse claude.ai Slack MCP writes to a bot↔user DM channel.
 
-The claude.ai Slack MCP write tools (``mcp__claude_ai_Slack__slack_send_message``,
-``mcp__claude_ai_Slack__slack_add_reaction``) publish under the USER's OAuth token.
-A post/react to the operator's own bot↔user DM channel renders as user-authored
-and lets the loop's scanners react to the agent's own message. The on-behalf
-egress class governs colleague surfaces but never sees an MCP tool call.
+The claude.ai Slack MCP write tools (``slack_send_message``,
+``slack_add_reaction``, ``slack_schedule_message``, ``slack_send_message_draft``)
+publish under the USER's OAuth token. A post/react to the operator's own bot↔user
+DM renders as user-authored and lets the loop's scanners react to the agent's own
+message. The on-behalf egress class governs colleague surfaces but never sees an
+MCP tool call.
 
-This gate denies an MCP write whose destination is a configured DM channel id
-and points the caller at the bot-token path (``t3 teatree notify send -``).
-Posts to any other channel pass through untouched. The fail direction is
-ALLOW+warn: an unreadable/unresolvable config must not lock the user out of Slack.
+The self-DM destination has two forms, mirroring the canonical
+``SlackBotBackend._is_self_dm``: the configured ``D…`` DM channel id AND the
+``U…`` user id (Slack accepts a user id as a ``chat.postMessage`` target that
+opens the self-IM). Both are collected from config (per-overlay
+``slack_dm_channel_id`` + ``slack_user_id``, and the global ``[teatree]
+slack_user_id``) — never hardcoded.
+
+This gate denies an MCP write whose destination is one of those ids and points
+the caller at the bot-token path (``t3 teatree notify send -``). Posts to any
+other channel pass through untouched. The fail direction is ALLOW+warn: an
+unreadable/unresolvable config must not lock the user out of Slack. The
+``[teatree] self_dm_gate_enabled`` kill-switch disables the gate without a code edit.
 """
 
 import json
@@ -52,11 +61,23 @@ mode = "auto"
 
 [overlays.t3-acme]
 messaging_backend = "slack"
-slack_user_id = "U0AAAAAAAAA"
 """
+
+# No overlay table at all — only the global [teatree] slack_user_id. The U-form
+# must still deny via the global fallback (mirrors notify._resolve_user_id).
+_CONFIG_GLOBAL_USER_ONLY = """
+[teatree]
+mode = "auto"
+slack_user_id = "U0GLOBALUSER"
+"""
+
+_USER_ID = "U0AAAAAAAAA"
+_DM_CHANNEL = "D0BFIRSTDM01"
 
 _SEND = "mcp__claude_ai_Slack__slack_send_message"
 _REACT = "mcp__claude_ai_Slack__slack_add_reaction"
+_SCHEDULE = "mcp__claude_ai_Slack__slack_schedule_message"
+_DRAFT = "mcp__claude_ai_Slack__slack_send_message_draft"
 
 
 def _patch_home(home: Path, body: str | None, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -83,11 +104,21 @@ class TestDeniesSelfDmWrites:
     @pytest.mark.parametrize(
         ("tool_name", "tool_input"),
         [
+            # ── D… DM channel id form ──
             (_SEND, {"channel": "D0BFIRSTDM01", "text": "Full-day review report"}),
             (_SEND, {"channel": "D0BSECONDDM2", "text": "status"}),
             (_REACT, {"channel": "D0BFIRSTDM01", "name": "eyes", "timestamp": "1.2"}),
             # Defensive: some MCP shapes use ``channel_id`` for the destination.
             (_SEND, {"channel_id": "D0BSECONDDM2", "text": "status"}),
+            # SCOPE ADD: scheduled + draft writes reproduce the incident too.
+            (_SCHEDULE, {"channel": "D0BFIRSTDM01", "text": "delayed report", "post_at": "1"}),
+            (_DRAFT, {"channel": "D0BSECONDDM2", "text": "draft body"}),
+            # ── U… user id form (Slack opens the self-IM) — the BLOCKER ──
+            (_SEND, {"channel": _USER_ID, "text": "Full-day review report"}),
+            (_SEND, {"channel_id": _USER_ID, "text": "status"}),
+            (_REACT, {"channel": _USER_ID, "name": "eyes", "timestamp": "1.2"}),
+            (_SCHEDULE, {"channel": _USER_ID, "text": "delayed report", "post_at": "1"}),
+            (_DRAFT, {"channel": _USER_ID, "text": "draft body"}),
         ],
     )
     def test_self_dm_write_is_denied(
@@ -98,6 +129,20 @@ class TestDeniesSelfDmWrites:
         deny = _parse_deny(capsys)
         assert deny is not None
         assert deny["permissionDecision"] == "deny"
+        assert "notify send" in deny["permissionDecisionReason"]
+
+    def test_global_user_id_fallback_denies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # No overlay table — only the global [teatree] slack_user_id. The U-form
+        # must still deny (mirrors notify._resolve_user_id overlay→global order).
+        _patch_home(tmp_path / "home2", _CONFIG_GLOBAL_USER_ONLY, monkeypatch)
+        verdict = router.handle_block_self_dm_via_mcp(
+            _event(_SEND, {"channel": "U0GLOBALUSER", "text": "report"}, session_id="s1g")
+        )
+        assert verdict is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
         assert "notify send" in deny["permissionDecisionReason"]
 
 
@@ -152,13 +197,21 @@ class TestFailsOpenOnUnresolvableConfig:
         assert captured.out.strip() == ""
         assert "self-DM" in captured.err
 
-    @pytest.mark.parametrize("body", [_CONFIG_NO_DM_CHANNELS, '[teatree]\nmode = "auto"\n'])
+    @pytest.mark.parametrize(
+        "body",
+        [
+            _CONFIG_NO_DM_CHANNELS,
+            '[teatree]\nmode = "auto"\n',
+            # A non-table overlay value (overlays.name = "string") is skipped, not crashed.
+            '[teatree]\nmode = "auto"\n[overlays]\nbroken = "not-a-table"\n',
+        ],
+    )
     def test_config_without_dm_channels_allows_silently(
         self, body: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         # Readable config but no DM channel ids to match (an overlay without the
-        # key, OR no overlays table at all) → ALLOW, no warn (genuinely-empty,
-        # not the can't-read case).
+        # key, no overlays table, OR a malformed non-table overlay) → ALLOW, no
+        # warn (genuinely-empty, not the can't-read case).
         _patch_home(tmp_path / "home", body, monkeypatch)
         verdict = router.handle_block_self_dm_via_mcp(
             _event(_SEND, {"channel": "D0BFIRSTDM01", "text": "report"}, session_id="s5")
@@ -194,6 +247,30 @@ class TestMalformedToolInputPassesThrough:
         )
         assert verdict is False
         assert capsys.readouterr().out.strip() == ""
+
+
+class TestKillSwitch:
+    def test_disabled_setting_allows_a_self_dm_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body = _CONFIG_WITH_DM_CHANNELS.replace('mode = "auto"', 'mode = "auto"\nself_dm_gate_enabled = false')
+        _patch_home(tmp_path / "home", body, monkeypatch)
+        verdict = router.handle_block_self_dm_via_mcp(
+            _event(_SEND, {"channel": _DM_CHANNEL, "text": "report"}, session_id="sk1")
+        )
+        assert verdict is False
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_enabled_default_still_denies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # No explicit flag → default ON → still denies (kill-switch is opt-out).
+        _patch_home(tmp_path / "home", _CONFIG_WITH_DM_CHANNELS, monkeypatch)
+        verdict = router.handle_block_self_dm_via_mcp(
+            _event(_SEND, {"channel": _DM_CHANNEL, "text": "report"}, session_id="sk2")
+        )
+        assert verdict is True
+        assert _parse_deny(capsys) is not None
 
 
 class TestRegisteredInPreToolUseChain:


### PR DESCRIPTION
## Summary

Partial implementation of #1464 — the **self-DM-token slice** (gate 2), built at the layer the live incident actually traveled through.

**Incident (2026-06-05):** an agent posted a "Full-day review" report to the operator's own bot to user DM through the claude.ai Slack MCP tool (`mcp__claude_ai_Slack__slack_send_message`), which publishes with the USER's OAuth token. The message rendered as user-authored; the loop's scanners then reacted to it and queued answer-tasks against the agent's own post. The existing voice classifier / on-behalf egress class guard teatree's own egress + Bash curl — **MCP tool calls bypass them entirely**, because they are an external tool, not a teatree code path.

## What this does

A new PreToolUse hook handler `handle_block_self_dm_via_mcp` in `hooks/scripts/hook_router.py`:

- Intercepts the claude.ai Slack MCP write tools: `slack_send_message`, `slack_add_reaction`, `slack_schedule_message`, `slack_send_message_draft`.
- **Denies** when the destination resolves to the operator's own self-DM. Mirroring the canonical `SlackBotBackend._is_self_dm`, a self-DM id is either a configured `[overlays.*].slack_dm_channel_id` (`D…`) OR a configured `slack_user_id` / global `[teatree] slack_user_id` (`U…`, which Slack opens as the self-IM). The reason points the caller at `t3 teatree notify send -` (bot token).
- All ids are resolved from config — **never hardcoded**.
- Posts to other channels (colleague surfaces, governed by the on-behalf gate) pass through untouched.
- **Fail direction `[decided-by-user]`: FAIL-CLOSED.** The hook cannot self-identify the author config-free (no MCP token or network in the hook subprocess, and the tool-schema text is not part of the hook input), so a missing/unreadable/malformed config DENIES with an error naming the toml problem and the fix. A readable config with no ids declared is a real state (genuinely-empty), not an error, so it allows silently.
- **Kill-switch:** `[teatree] self_dm_gate_enabled = false` is the sanctioned explicit disable (never a silent one), mirroring the sibling `mcp_privacy_gate_enabled`.
- Registered in the PreToolUse chain and carries a liveness `GateRow` so the deny-coverage guard sees it.

## RED to GREEN evidence

- **BLOCKER (U-form) RED:** with the U-arm removed (only `slack_dm_channel_id` collected), the 5 U-form deny cases + the global-user-id fallback test go RED (`6 failed`); D-form stays green. Restored → GREEN.
- **Fail-closed RED (both directions):** the missing-config and unreadable-config tests go RED against the old ALLOW+warn behavior and GREEN against the new DENY behavior; readable-config-without-ids stays ALLOW in both. Kill-switch test also anti-vacuous (RED when the check is removed).
- **GREEN:** all 29 tests in `tests/test_hook_router_self_dm_mcp.py` pass; gate-liveness + lockout corpora stay green (`169 passed, 2 xfailed`); 100% coverage on the new lines; ruff + format + ty clean.

## Architecture pre-check — #1464 (self-DM slice)

**1. BLUEPRINT alignment** — Hook-layer enforcement. Closes a class the on-behalf egress class cannot see because the MCP write is an external tool, not a teatree code path. A PreToolUse deny is the only chokepoint that sees the MCP call.

**2. FSM phase boundaries** — n/a, no Ticket/Worktree transition.

**3. Extension-point contracts** — PreToolUse handler in `_HANDLERS["PreToolUse"]`. No OverlayBase / scanner / Protocol change. Follows the sibling deny-handler contract (`True` to deny via `emit_pretooluse_deny`, `False` to pass through).

**4. Component boundaries** — `hooks/scripts/hook_router.py`, same module as every other gate. Self-DM ids read directly from config via stdlib `tomllib` (no django bootstrap — the fast hook subprocess), mirroring the sibling config readers in this module.

**5. Dependency direction** — no new src import; `tach check` unaffected (hooks/ is not in the src tach graph).

**6. Test surface** — `tests/test_hook_router_self_dm_mcp.py`: deny fires for send/react/schedule/draft on both the D-channel-id and U-user-id forms; global-user-id fallback denies; pass-through for colleague + unconfigured-DM-shaped channels; non-target tools pass; missing/unreadable config DENIES (fail-closed), readable-but-empty config allows silently; malformed tool_input passes; kill-switch disables; registration guard. Plus a `GateRow` in the liveness corpus.

**7. Resilience invariants** — the handler gates an external write rather than making one. Crash-proof (router wraps handlers in try/except). Config read **fail-closed** (DENY on can't-read; the explicit kill-switch is the escape hatch). Idempotent (pure read+verdict, no state mutation).

**8. Identity and key normalization** — the destination id is the canonical key, exact-matched against the configured self-DM id set (D channel ids + U user ids), mirroring `_is_self_dm`; no qualifier stripping. Tool name matched by exact suffix after the `mcp__<server>__` prefix, reusing the established `rsplit("__", 1)[-1]` convention.

**9. Behavior preservation** — purely additive, a new gate. No existing behavior removed. No privacy/security matcher narrowed; no must-block test inverted.

## Open questions & assumptions

- **Fail-direction `[decided-by-user]`: FAIL-CLOSED.** Config-free self-identification isn't reliably available inside the PreToolUse hook, so an unreadable/missing/malformed config DENIES; the `[teatree] self_dm_gate_enabled = false` kill-switch is the sanctioned escape hatch. Readable-config-with-no-ids stays ALLOW.
- The U-form match is exact-id, mirroring `_is_self_dm`. A colleague's `D…` id is a different id and correctly stays a colleague surface (the on-behalf gate's job).
- The `slack_schedule_message` / `slack_send_message_draft` / `slack_add_reaction` suffixes are assumed from the quote-scanner write-tool allowlist; extend the set if the server renames them.
- Destination field is read from `channel` (observed in fixtures) and `channel_id` (defensive). If a future MCP shape names it otherwise, extend the field tuple.
- Implemented as a PreToolUse hook (the incident vector) rather than #1464 gate 2's `notify_user` helper preflight — the helper path is teatree's own egress and is already covered by the on-behalf chain; the MCP path was the actual bypass. The `notify_user` / `auth.test` / `xoxp` preflight described in the issue and the gate-1 / gate-3 slices remain separate.
- `hooks/scripts/hook_router.py` is concurrently edited on another branch (banned-terms sections); this diff is confined to a new handler + registration to keep the merge trivial.
