### PR TITLE
test(hooks): never-lockout behavioral corpus for the loop-registration gate + UX-gate breaker relax (#1693)

### DIFF
--- a/tests/test_lockout_regression_corpus.py
+++ b/tests/test_lockout_regression_corpus.py
@@ -8,9 +8,18 @@ a regression here is a bypass.
 Each corpus entry calls the same real gate function the PreToolUse hook uses:
 ``_deny_match`` (F3/F6/F8/--no-verify/blocked-tools),
 ``_extract_bash_ai_sig_payload`` (F1 double-space, F2 REST-API write routing),
-``handle_block_out_of_band_merge`` (raw merge on managed repos), and
-``handle_enforce_skill_loading`` (skill-loading lockout vs bypass dimension).
-No matchers are re-implemented in this test.
+``handle_block_out_of_band_merge`` (raw merge on managed repos),
+``handle_enforce_skill_loading`` (skill-loading lockout vs bypass dimension),
+``handle_enforce_loop_registration`` (the #1677 incident gate's four
+never-lockout escapes), and ``_apply_deny_circuit_breaker`` (the UX-gate
+auto-relax that breaks a token-burning deny loop). No matchers are
+re-implemented in this test.
+
+The loop-registration and circuit-breaker rows are the behavioral pin
+complementing the static AST never-lockout contract
+(``test_gate_never_lockout_contract.py``): the contract proves a deny gate
+*routes through* the escapes structurally; this corpus proves each escape
+*actually relaxes the deny* at runtime.
 """
 
 import json
@@ -22,10 +31,12 @@ import pytest
 
 import hooks.scripts.hook_router as router
 from hooks.scripts.hook_router import (
+    _apply_deny_circuit_breaker,
     _deny_match,
     _extract_bash_ai_sig_payload,
     handle_block_out_of_band_merge,
     handle_dispatch_prompt_quote_scanner_on_task_create,
+    handle_enforce_loop_registration,
     handle_enforce_orchestrator_boundary,
     handle_enforce_skill_loading,
     handle_quote_scanner_pretool,
@@ -662,3 +673,117 @@ class TestValidateMrMetadataMcpArm:
         verdict = handle_validate_mr_metadata(data)
         assert verdict is True, "BYPASS regression — malformed glab-MR MCP metadata was allowed."
         assert capsys.readouterr().out.strip(), "a deny must emit a hookSpecificOutput payload"
+
+
+class TestLoopRegistrationGateNeverLockout:
+    """The #1677 incident gate's four never-lockout escapes, pinned behaviorally.
+
+    ``handle_enforce_loop_registration`` hard-locked the whole factory several
+    times — the worst recurring incident. It denied every Bash/Edit/Write until
+    the loop cron was registered, with no escape for the agents that could not
+    register one. The fix layered four NEVER-LOCKOUT escapes; the static AST
+    contract (``test_gate_never_lockout_contract.py``) proves the gate *routes
+    through* them structurally. This corpus proves each escape *actually relaxes
+    the deny at runtime*:
+
+    1. sub-agent exemption — a sub-agent has no ``CronCreate``, so a deny is an
+        unrecoverable lockout that killed every spawned coder/reviewer;
+    2. the durable ``loop_registration_gate_enabled = false`` kill-switch;
+    3. ``_fail_open_or_deny`` routing — a self-rescue command is never denied;
+    4. ``_fail_open_or_deny`` routing — the master ``gate_fail_open`` switch
+        relaxes the deny.
+
+    The must-DENY anchor (main session, gate on, no escape → blocked) is the
+    proof the must-ALLOW rows are escapes, not a gate that never fires.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _state(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        state = tmp_path / "state"
+        state.mkdir()
+        monkeypatch.setattr(router, "STATE_DIR", state)
+        monkeypatch.setattr(router, "_teatree_active", lambda _session_id: True)
+        monkeypatch.setattr(router, "_session_drives_loop", lambda _session_id: True)
+
+    def _pending(self, session_id: str) -> None:
+        (router.STATE_DIR / f"{session_id}.loop-pending").write_text("1", encoding="utf-8")
+
+    def _event(self, session_id: str, *, command: str = "", agent_id: str = "") -> dict:
+        data: dict = {"session_id": session_id, "tool_name": "Bash", "tool_input": {"command": command}}
+        if agent_id:
+            data["agent_id"] = agent_id
+        return data
+
+    def test_must_deny_main_session_with_pending_marker(self, capsys: pytest.CaptureFixture[str]) -> None:
+        self._pending("anchor")
+        assert handle_enforce_loop_registration(self._event("anchor")) is True, (
+            "ANCHOR regression — the loop-registration nudge no longer fires for a main session "
+            "with a pending marker; the must-ALLOW rows below would then be vacuous."
+        )
+        assert "LOOP REGISTRATION" in capsys.readouterr().out
+
+    def test_must_allow_subagent_dispatch(self) -> None:
+        self._pending("sub")
+        assert handle_enforce_loop_registration(self._event("sub", agent_id="sub-1")) is False, (
+            "LOCKOUT regression (escape 1) — a sub-agent (no CronCreate tool) was nudge-blocked; "
+            "this is the unrecoverable lockout that killed every spawned coder/reviewer."
+        )
+
+    def test_must_allow_when_kill_switch_disables_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        (Path.home() / ".teatree.toml").write_text(
+            "[teatree]\nloop_registration_gate_enabled = false\n", encoding="utf-8"
+        )
+        self._pending("off")
+        assert handle_enforce_loop_registration(self._event("off")) is False, (
+            "LOCKOUT regression (escape 2) — the durable loop_registration_gate_enabled=false "
+            "kill-switch no longer disables the nudge."
+        )
+
+    def test_must_allow_self_rescue_command(self) -> None:
+        self._pending("rescue")
+        assert handle_enforce_loop_registration(self._event("rescue", command="t3 teatree gate disable")) is False, (
+            "LOCKOUT regression (escape 3) — a self-rescue command was nudge-blocked; the gate must "
+            "never block the very commands that rescue a lockout."
+        )
+
+    def test_must_allow_when_master_fail_open_enabled(self) -> None:
+        (Path.home() / ".teatree.toml").write_text("[teatree]\ngate_fail_open = true\n", encoding="utf-8")
+        self._pending("failopen")
+        assert handle_enforce_loop_registration(self._event("failopen")) is False, (
+            "LOCKOUT regression (escape 4) — the master gate_fail_open switch no longer relaxes the "
+            "loop-registration deny via _fail_open_or_deny."
+        )
+
+
+class TestCircuitBreakerRelaxesUxGate:
+    """Symmetric must-ALLOW for the repeated-denial circuit breaker (escape 4 of #1677).
+
+    ``TestCircuitBreakerNeverOpensSafetyGate`` pins the must-DENY direction (a
+    safety gate never auto-relaxes). This is the missing must-ALLOW direction:
+    the breaker MUST fail a looped UX gate (``LOOP REGISTRATION`` /
+    ``SKILL LOADING ENFORCEMENT`` prefix) OPEN at the threshold, so a UX-gate
+    deny that the agent cannot satisfy can never wedge a session forever. The
+    threshold-minus-one calls still deny — proving the relax is the breaker
+    acting at K, not the gate silently never firing.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _breaker_context(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(router, "STATE_DIR", tmp_path / "state")
+        router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(router, "_CURRENT_EVENT", "PreToolUse")
+        monkeypatch.setattr(router, "_CURRENT_DATA", {"session_id": "corpus-ux-breaker", "tool_name": "Bash"})
+
+    def test_ux_gate_relaxes_at_threshold_after_denying_below_it(self) -> None:
+        reason = "LOOP REGISTRATION: the teatree background loop is not registered yet. Register it with CronCreate."
+        threshold = router._deny_circuit_breaker_threshold()
+        below = [_apply_deny_circuit_breaker(reason) for _ in range(threshold - 1)]
+        assert all(d.allow is False for d in below), (
+            "BYPASS regression — the UX gate relaxed before the threshold; it must keep denying "
+            "until the loop is actually detected."
+        )
+        at_threshold = _apply_deny_circuit_breaker(reason)
+        assert at_threshold.allow is True, (
+            "LOCKOUT regression — the circuit breaker did not auto-relax a looped UX gate at the "
+            "threshold; a UX-gate deny the agent cannot satisfy would wedge the session forever."
+        )


### PR DESCRIPTION
Closes #1693.

Complements the static AST never-lockout contract (`tests/test_gate_never_lockout_contract.py`, from [#1677](https://github.com/souliane/teatree/pull/1677)) with the behavioral over-block pin it was missing. The AST contract proves a `PreToolUse` deny gate routes through the never-lockout escapes structurally; this corpus proves each escape actually relaxes the deny at runtime.

## What was already there vs. what this adds

The behavioral corpus (`tests/test_lockout_regression_corpus.py`) already landed ([#1624](https://github.com/souliane/teatree/issues/1624)) and grew to 664 lines covering the skill-loading, merge, privacy, orchestrator-boundary, and MR-metadata gates, plus the circuit breaker's must-DENY (safety-never-relaxes) direction. It was missing the two cases that are exactly the never-lockout class the AST contract exists to guard:

- `handle_enforce_loop_registration` — the [#1677](https://github.com/souliane/teatree/pull/1677) incident gate, the worst recurring lockout (denied every Bash/Edit/Write until the loop cron was registered). Its four layered escapes were tested in scattered files but had no presence in the consolidated behavioral pin.
- the circuit breaker's must-ALLOW direction (a looped UX gate auto-relaxes at the threshold) — the corpus only had the must-DENY safety direction.

## Coverage map

| # | Behavior guarded (the escape) | Direction | Test | Proven RED by |
|---|---|---|---|---|
| 1 | loop-reg nudge fires for a main session with a pending marker (anchor that makes the must-ALLOW rows non-vacuous) | must-DENY | `TestLoopRegistrationGateNeverLockout::test_must_deny_main_session_with_pending_marker` | anchor — fires by construction; observed green |
| 2 | sub-agent exemption (sub-agent has no `CronCreate`; denying it is an unrecoverable lockout) | must-ALLOW | `…::test_must_allow_subagent_dispatch` | removing the `_call_is_from_subagent` branch |
| 3 | durable `loop_registration_gate_enabled = false` kill-switch | must-ALLOW | `…::test_must_allow_when_kill_switch_disables_gate` | forcing the reader to ignore `false` |
| 4 | `_fail_open_or_deny` routing — self-rescue command never denied | must-ALLOW | `…::test_must_allow_self_rescue_command` | forcing `_is_self_rescue` off |
| 5 | `_fail_open_or_deny` routing — master `gate_fail_open` switch relaxes the deny | must-ALLOW | `…::test_must_allow_when_master_fail_open_enabled` | forcing `_gate_fail_open_enabled` off |
| 6 | circuit breaker relaxes a looped UX gate at K (deny below K, relax at K) | must-ALLOW | `TestCircuitBreakerRelaxesUxGate::test_ux_gate_relaxes_at_threshold_after_denying_below_it` | stubbing `_deny_is_ux_gate` to `False` |

Every row calls the same real gate function the `PreToolUse` hook uses (no matcher re-implemented). Each must-ALLOW row was observed RED with its escape disabled in `hook_router.py` and GREEN restored — the anti-vacuous bar. The must-DENY anchor proves the must-ALLOW rows are escapes, not a gate that never fires.

## Scope

Test-only — no `src/` change. 86 tests in the corpus file pass; the contract test, cadence-hook, over-deny-fail-open, and circuit-breaker test files all stay green (117 passed across the set). `ruff`, `ruff format`, `ty`, `tach` clean on the touched file.

## Architecture pre-check — #1693

Tactical scope: a single test file, no `src/` change, no FSM/Protocol/OverlayBase/scanner/BLUEPRINT surface touched — the nine-check gate does not fire. Notes: #4 component boundaries — `tests/` mirrors the gate it pins (`hooks/scripts/hook_router.py`); #5 dependency direction — `tach check` green; #6 test surface — the coverage map above is the observable contract, each row proven RED.

## Open questions & assumptions

- The issue referenced landing the ~332-line `test-lockout-regression-corpus` branch and verifying it against current main. That original corpus ([#1624](https://github.com/souliane/teatree/issues/1624)) already landed on main and was extended since to 664 lines ([#1633](https://github.com/souliane/teatree/issues/1633)/[#1635](https://github.com/souliane/teatree/issues/1635)/[#1645](https://github.com/souliane/teatree/issues/1645)/[#1647](https://github.com/souliane/teatree/issues/1647)/[#1853](https://github.com/souliane/teatree/issues/1853)), so the literal ask is stale/superseded — the 332-line branch is a strict subset of what is already on main. This PR delivers the issue's core ask (the over-block dimension gets a behavioral pin complementing the AST contract) by adding the one never-lockout gate the consolidated corpus was missing — the actual #1677 incident gate — plus the breaker's missing relax direction. Assumed this is the highest-value honest close vs. resurrecting a 179-commit-stale branch.
- The stale remote branch `1693-lockout-golden-corpus` is diverged ~1018 files from main (based on a very old point) and is not usable; left untouched.
- Did not pursue the other [#1681](https://github.com/souliane/teatree/issues/1681) fast-follows (BLUEPRINT §17.6.4 invariant-10 enumeration, the settings-table row, the plan-gate / orchestrator-boundary migration off the allowlist, the `_teatree_bool_setting` DRY). They are separate hardening tasks, out of scope for the behavioral-corpus item this issue tracks.
