### PR TITLE
fix(loop): isolate unknown-overlay tasks so one poison job can't crash every tick (#1959)

### DIFF
--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -1358,14 +1358,41 @@ def discover_active_overlay() -> OverlayEntry | None:
 
 
 def _discover_from_manage_py() -> OverlayEntry | None:
-    """Walk up from cwd to find a manage.py and extract its settings module."""
+    """Walk up from cwd to find a manage.py and extract its settings module.
+
+    The directory basename names the overlay, but a clone dir can differ from
+    the registered entry-point name (``teatree`` on disk vs the registered
+    ``t3-teatree``). ``_canonical_active_overlay_name`` folds the basename onto
+    the registered entry point so every consumer — most importantly the scanners
+    that stamp ``ticket.overlay`` — writes the dispatchable name, never a stale
+    alias that the queue then can't resolve (souliane/teatree#1959).
+    """
     for directory in [Path.cwd(), *Path.cwd().parents]:
         manage_py = directory / "manage.py"
         if manage_py.is_file():
             settings_module = _extract_settings_module(manage_py)
             if settings_module:
-                return OverlayEntry(name=directory.name, overlay_class="", project_path=directory)
+                name = _canonical_active_overlay_name(directory.name)
+                return OverlayEntry(name=name, overlay_class="", project_path=directory)
     return None
+
+
+def _canonical_active_overlay_name(directory_name: str) -> str:
+    """Fold a clone-directory basename onto its registered entry-point name, if one exists.
+
+    Stays inside the ``platform`` layer (``config``): reads the entry-point
+    names directly and reuses the local ``_match_canonical_ep`` alias rule
+    rather than calling into the ``core`` overlay loader.
+    """
+    from importlib.metadata import entry_points  # noqa: PLC0415
+
+    try:
+        ep_names = {ep.name for ep in entry_points(group="teatree.overlays")}
+    except Exception:  # noqa: BLE001 — discovery must not crash before django.setup()
+        return directory_name
+    if directory_name in ep_names:
+        return directory_name
+    return _match_canonical_ep(directory_name, ep_names) or directory_name
 
 
 def _resolve_ep_project_path(overlay_class: str) -> Path | None:

--- a/src/teatree/core/migrations/0054_canonicalize_legacy_overlay_names.py
+++ b/src/teatree/core/migrations/0054_canonicalize_legacy_overlay_names.py
@@ -1,0 +1,78 @@
+"""Canonicalize every legacy overlay value that folds onto a registered overlay.
+
+souliane/teatree#1959: rows can carry a stale overlay value that no longer
+resolves — a legacy short alias written before #1108 (``teatree`` instead of
+``t3-teatree``), or any short alias of an installed entry point (``acme`` →
+``t3-acme``). At dispatch time ``get_overlay_for_ticket`` raises
+``ImproperlyConfigured`` for such a value and the queued task re-crashes on
+every drain (the poison pill).
+
+0027 fixed the single ``teatree`` → ``t3-teatree`` case. This migration
+generalizes it: for every distinct overlay value across the overlay-carrying
+models, ``resolve_overlay_name`` decides the canonical registered name; a value
+that folds onto a *different* canonical is renamed (collision twins deleted
+first, as in 0027). A value that resolves to itself, or to nothing (a removed
+overlay, a synthetic scanner tag), is left untouched — the unresolvable rows
+are surfaced and permanently failed by the runtime poison-pill guard rather
+than silently rewritten to a wrong overlay.
+
+No ``AlterField`` is emitted: the ``overlay`` field type is unchanged, so
+``makemigrations --check`` stays "No changes".
+"""
+
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import Model, Q, UniqueConstraint
+
+_OVERLAY_MODELS = (
+    "Ticket",
+    "Worktree",
+    "Session",
+    "PullRequest",
+    "ReviewAssignment",
+    "PendingChatInjection",
+)
+
+
+def _delete_legacy_rows_with_canonical_twin(model: type[Model], *, legacy: str, canonical: str) -> None:
+    """Drop ``overlay=legacy`` rows whose other-field tuple already has a ``canonical`` twin."""
+    overlay_keyed_constraints = [
+        c
+        for c in model._meta.constraints  # noqa: SLF001
+        if isinstance(c, UniqueConstraint) and "overlay" in c.fields and len(c.fields) > 1
+    ]
+    if not overlay_keyed_constraints:
+        return
+    for constraint in overlay_keyed_constraints:
+        other_fields = [f for f in constraint.fields if f != "overlay"]
+        canonical_tuples = set(model.objects.filter(overlay=canonical).values_list(*other_fields))
+        if not canonical_tuples:
+            continue
+        collision_q = Q()
+        for tup in canonical_tuples:
+            collision_q |= Q(**dict(zip(other_fields, tup, strict=True)))
+        model.objects.filter(overlay=legacy).filter(collision_q).delete()
+
+
+def _canonicalize_legacy_overlay_names(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+    from teatree.core.overlay_loader import resolve_overlay_name  # noqa: PLC0415
+
+    for model_name in _OVERLAY_MODELS:
+        model = apps.get_model("core", model_name)
+        for legacy in model.objects.exclude(overlay="").values_list("overlay", flat=True).distinct():
+            canonical = resolve_overlay_name(legacy)
+            if canonical is None or canonical == legacy:
+                continue
+            _delete_legacy_rows_with_canonical_twin(model, legacy=legacy, canonical=canonical)
+            model.objects.filter(overlay=legacy).update(overlay=canonical)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0053_planartifact"),
+    ]
+
+    operations = [
+        migrations.RunPython(_canonicalize_legacy_overlay_names, migrations.RunPython.noop),
+    ]

--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -138,6 +138,32 @@ def get_all_overlay_names() -> list[str]:
     return sorted(names)
 
 
+def resolve_overlay_name(name: str) -> str | None:
+    """Return the canonical registered overlay name for *name*, or ``None``.
+
+    The single source of truth for "is this overlay name dispatchable, and
+    under what canonical name". A name that is already a registered overlay
+    returns unchanged; a legacy short alias folds onto its registered
+    entry-point via the same ``_match_canonical_ep`` rule the config loader
+    uses (``teatree`` → ``t3-teatree``). A name that matches nothing — a
+    removed overlay, a synthetic scanner tag, a typo — returns ``None`` so
+    callers can fail it permanently instead of crashing on every retry
+    (souliane/teatree#1959 poison-pill).
+
+    Callers asking only "is this dispatchable?" test ``resolve_overlay_name(x)
+    is not None``; an empty/blank ``name`` is the ambient single-overlay default
+    and is the caller's responsibility to special-case (it returns ``None``).
+    """
+    from teatree.config import _match_canonical_ep  # noqa: PLC0415
+
+    if not name:
+        return None
+    known = set(get_all_overlay_names())
+    if name in known:
+        return name
+    return _match_canonical_ep(name, known)
+
+
 def infer_overlay_for_url(url: str) -> str:
     """Return the overlay whose workspace repos own ``url``, or ``""``.
 

--- a/src/teatree/core/recover.py
+++ b/src/teatree/core/recover.py
@@ -230,8 +230,15 @@ def _collect_stranded_snapshots(report: RecoverReport) -> None:
 
 
 def _collect_requeue_candidates(report: RecoverReport) -> None:
+    from teatree.core.overlay_loader import resolve_overlay_name  # noqa: PLC0415
+
     for task in Task.objects.filter(status=Task.Status.FAILED).select_related("ticket").order_by("pk"):
         if task.ticket.is_terminal:
+            continue
+        # An unknown-overlay task can never be dispatched — reopening it would
+        # re-crash on every drain (souliane/teatree#1959 poison pill). A blank
+        # overlay is the ambient single-overlay default and stays eligible.
+        if task.ticket.overlay and resolve_overlay_name(task.ticket.overlay) is None:
             continue
         last = task.attempts.order_by("-pk").first()
         error = last.error if last else ""

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -168,12 +168,22 @@ def _auto_enqueue_headless_task(
     ``_is_loop_dispatched`` stays as a belt-and-braces skip for any HEADLESS
     row of such a pair, so a ``db_worker`` draining the queue never
     double-runs (or meters) loop phase work.
+
+    A task whose ticket names a non-empty unknown overlay is never enqueued
+    (souliane/teatree#1959): dispatching it would crash ``execute_headless_task``
+    — the drain safety-net fails such rows permanently instead. A blank overlay
+    is the ambient single-overlay default and stays dispatchable.
     """
     if instance.execution_target != Task.ExecutionTarget.HEADLESS:
         return
     if instance.status != Task.Status.PENDING:
         return
     if _is_loop_dispatched(instance):
+        return
+    from teatree.core.overlay_loader import resolve_overlay_name  # noqa: PLC0415
+
+    if instance.ticket.overlay and resolve_overlay_name(instance.ticket.overlay) is None:
+        logger.warning("Skipping auto-enqueue of task %s: unknown overlay %r", instance.pk, instance.ticket.overlay)
         return
     from teatree.core.tasks import execute_headless_task  # noqa: PLC0415
 

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -23,9 +23,23 @@ class TransitionResult(TypedDict, total=False):
 def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
     import traceback  # noqa: PLC0415
 
-    from teatree.core.overlay_loader import get_overlay_for_ticket  # noqa: PLC0415
+    from teatree.core.overlay_loader import get_overlay_for_ticket, resolve_overlay_name  # noqa: PLC0415
 
     task_obj = Task.objects.get(pk=task_id)
+
+    # Poison-pill guard (souliane/teatree#1959): a task whose ticket names a
+    # non-empty overlay that no longer resolves crashes ``get_overlay_for_ticket``
+    # on every drain. Fail it permanently here — a recorded FAILED attempt the
+    # operator can inspect — instead of raising an exception that re-fires next
+    # tick. A blank overlay is the ambient single-overlay default and stays
+    # dispatchable (``get_overlay(None)`` resolves it).
+    if task_obj.ticket.overlay and resolve_overlay_name(task_obj.ticket.overlay) is None:
+        reason = f"unknown overlay {task_obj.ticket.overlay!r}: ticket {task_obj.ticket_id} cannot be dispatched"
+        logger.warning("Task %s: %s", task_obj.pk, reason)
+        if task_obj.status == Task.Status.PENDING:
+            task_obj.claim(claimed_by="unknown-overlay-guard")
+        task_obj.complete_with_attempt(exit_code=1, error=reason, result={"unknown_overlay": reason})
+        return {"exit_code": 1, "unknown_overlay": reason}
 
     # Fail-closed billing guard: a loop-dispatched phase task (one whose
     # (role, phase) has a registered phase agent) must run INTERACTIVE in the
@@ -72,14 +86,21 @@ def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
 
 @task()
 def drain_headless_queue() -> dict[str, list[int]]:
-    """Auto-enqueue pending headless tasks for execution (safety net).
+    """Auto-enqueue pending headless tasks for execution (safety net), failing poison rows.
 
     Loop-dispatched phase tasks (those whose ``(ticket.role, phase)`` has a
     registered phase agent) are skipped — the loop is their sole dispatcher,
     so draining them here would double-run them (the same guard the
     ``_auto_enqueue_headless_task`` post_save applies). Only genuinely
     headless tasks with no registered phase agent are drained.
+
+    A task whose ticket names a non-empty unknown overlay is failed permanently
+    rather than re-enqueued (souliane/teatree#1959): re-enqueuing it would crash
+    ``execute_headless_task`` on every tick forever — the poison pill this drain
+    must not keep feeding. A blank overlay is the ambient single-overlay default
+    and stays dispatchable.
     """
+    from teatree.core.overlay_loader import resolve_overlay_name  # noqa: PLC0415
     from teatree.core.phases import subagent_for_phase  # noqa: PLC0415
 
     pending = (
@@ -88,15 +109,23 @@ def drain_headless_queue() -> dict[str, list[int]]:
             status=Task.Status.PENDING,
         )
         .select_related("ticket")
-        .only("pk", "phase", "ticket__role")
+        .only("pk", "phase", "ticket__role", "ticket__overlay")
     )
     enqueued: list[int] = []
+    failed_unknown_overlay: list[int] = []
     for task_obj in pending:
         if subagent_for_phase(task_obj.ticket.role, task_obj.phase):
             continue
+        if task_obj.ticket.overlay and resolve_overlay_name(task_obj.ticket.overlay) is None:
+            reason = f"unknown overlay {task_obj.ticket.overlay!r}: ticket {task_obj.ticket_id} cannot be dispatched"
+            logger.warning("Drain: failing task %s permanently — %s", task_obj.pk, reason)
+            task_obj.claim(claimed_by="unknown-overlay-guard")
+            task_obj.complete_with_attempt(exit_code=1, error=reason, result={"unknown_overlay": reason})
+            failed_unknown_overlay.append(task_obj.pk)
+            continue
         execute_headless_task.enqueue(task_obj.pk, task_obj.phase)
         enqueued.append(task_obj.pk)
-    return {"enqueued": enqueued}
+    return {"enqueued": enqueued, "failed_unknown_overlay": failed_unknown_overlay}
 
 
 @task()

--- a/tests/config/test_overlay_discovery.py
+++ b/tests/config/test_overlay_discovery.py
@@ -155,6 +155,24 @@ def test_discover_active_overlay_from_manage_py(tmp_path: Path, monkeypatch: pyt
     assert result.project_path == tmp_path
 
 
+def test_discover_active_overlay_canonicalizes_clone_dir_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A clone dir named ``teatree`` resolves to the registered ``t3-teatree`` (#1959)."""
+    project = tmp_path / "teatree"
+    _write_manage_py(project, "active.settings")
+    monkeypatch.chdir(project)
+
+    ep = MagicMock()
+    ep.name = "t3-teatree"
+    ep.value = "t3_teatree.overlay:TeatreeOverlay"
+
+    with patch("importlib.metadata.entry_points", return_value=[ep]):
+        result = discover_active_overlay()
+
+    assert result is not None
+    assert result.name == "t3-teatree"
+    assert result.project_path == project
+
+
 def test_discover_active_overlay_single_installed(
     config_file: Path,
     elsewhere: Path,

--- a/tests/teatree_core/test_recover.py
+++ b/tests/teatree_core/test_recover.py
@@ -83,6 +83,21 @@ class TestGatherRecoverReport(TestCase):
 
         assert report.requeue_candidates == []
 
+    def test_unknown_overlay_failed_task_is_not_a_candidate(self) -> None:
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED, overlay="ghost-overlay", issue_url="https://x/i/8"
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="coding")
+        task = Task.objects.create(ticket=ticket, session=session, phase="coding")
+        task.claim(claimed_by="loop")
+        TaskAttempt.objects.create(task=task, execution_target=task.execution_target, error="boom")
+        task.fail()
+
+        with _mocked_probes():
+            report = gather_recover_report()
+
+        assert report.requeue_candidates == []
+
     def test_empty_report_has_no_findings(self) -> None:
         with _mocked_probes():
             report = gather_recover_report()

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -106,14 +106,94 @@ class TestDrainHeadlessQueue(TestCase):
         with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
             result = drain_headless_queue.enqueue()
 
-        assert result.return_value == {"enqueued": [pending.pk]}
+        assert result.return_value == {"enqueued": [pending.pk], "failed_unknown_overlay": []}
 
     @override_settings(**IMMEDIATE_BACKEND)
     def test_skips_when_no_pending_tasks(self) -> None:
         with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
             result = drain_headless_queue.enqueue()
 
-        assert result.return_value == {"enqueued": []}
+        assert result.return_value == {"enqueued": [], "failed_unknown_overlay": []}
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_unknown_overlay_task_is_failed_not_enqueued(self) -> None:
+        ticket = Ticket.objects.create(overlay="ghost-overlay")
+        session = Session.objects.create(ticket=ticket, overlay="ghost-overlay")
+        poison = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            status=Task.Status.PENDING,
+            phase="architectural_review",
+        )
+
+        with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
+            result = drain_headless_queue.enqueue()
+
+        assert result.return_value == {"enqueued": [], "failed_unknown_overlay": [poison.pk]}
+        poison.refresh_from_db()
+        assert poison.status == Task.Status.FAILED
+
+
+class TestExecuteHeadlessUnknownOverlay(TestCase):
+    """A task on an unknown overlay fails permanently — never an eternal re-crash (#1959)."""
+
+    def setUp(self) -> None:
+        from django.db.models.signals import post_save  # noqa: PLC0415
+
+        from teatree.core.signals import _auto_enqueue_headless_task  # noqa: PLC0415
+
+        post_save.disconnect(_auto_enqueue_headless_task, sender=Task, dispatch_uid="auto_enqueue_headless")
+        self.addCleanup(
+            post_save.connect,
+            _auto_enqueue_headless_task,
+            sender=Task,
+            dispatch_uid="auto_enqueue_headless",
+        )
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_unknown_overlay_marks_task_failed_with_attempt(self) -> None:
+        from teatree.core.tasks import execute_headless_task  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="ghost-overlay")
+        session = Session.objects.create(ticket=ticket, overlay="ghost-overlay")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            status=Task.Status.PENDING,
+            phase="architectural_review",
+        )
+
+        with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
+            result = execute_headless_task.func(task.pk, task.phase)
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert result["exit_code"] == 1
+        attempt = TaskAttempt.objects.get(task=task)
+        assert attempt.exit_code == 1
+        assert "ghost-overlay" in attempt.error
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_failed_unknown_overlay_task_is_not_re_enqueued_next_drain(self) -> None:
+        from teatree.core.tasks import execute_headless_task  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="ghost-overlay")
+        session = Session.objects.create(ticket=ticket, overlay="ghost-overlay")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            status=Task.Status.PENDING,
+            phase="architectural_review",
+        )
+
+        with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
+            execute_headless_task.func(task.pk, task.phase)
+            result = drain_headless_queue.enqueue()
+
+        assert task.pk not in result.return_value["enqueued"]
 
 
 class TestExecuteRetrospect(TestCase):

--- a/tests/test_migration_0054_canonicalize_legacy_overlay.py
+++ b/tests/test_migration_0054_canonicalize_legacy_overlay.py
@@ -1,0 +1,108 @@
+"""Regression tests for ``core.0054_canonicalize_legacy_overlay_names`` (#1959).
+
+0054 generalizes 0027: every distinct overlay value that ``resolve_overlay_name``
+folds onto a *different* registered canonical is renamed (collision twins deleted
+first); a value that resolves to itself or to nothing is left untouched. The
+poison-pill guard then permanently fails the genuinely-unresolvable rows.
+"""
+
+import importlib
+from unittest.mock import patch
+
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+_migration_module = importlib.import_module("teatree.core.migrations.0054_canonicalize_legacy_overlay_names")
+
+# Deterministic resolver: legacy aliases fold onto canonical entry points;
+# a genuinely-unknown value resolves to None and must be left untouched.
+_RESOLUTIONS = {
+    "teatree": "t3-teatree",
+    "beta": "t3-beta",
+    "t3-teatree": "t3-teatree",
+    "t3-beta": "t3-beta",
+}
+
+
+def _fake_resolve(name: str) -> str | None:
+    return _RESOLUTIONS.get(name)
+
+
+class CanonicalizeLegacyOverlayMigrationTest(TransactionTestCase):
+    _BEFORE = ("core", "0053_planartifact")
+    _AFTER = ("core", "0054_canonicalize_legacy_overlay_names")
+
+    def _migrate(self, target: tuple[str, str]) -> "object":
+        executor = MigrationExecutor(connection)
+        executor.migrate([target])
+        executor.loader.build_graph()
+        return executor.loader.project_state([target]).apps
+
+    def _restore_head(self) -> None:
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()
+        core_leaves = [node for node in executor.loader.graph.leaf_nodes() if node[0] == "core"]
+        executor.migrate(core_leaves)
+
+    def test_legacy_alias_is_renamed_to_registered_canonical(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        ticket = apps.get_model("core", "Ticket")
+        legacy = ticket.objects.create(overlay="teatree", issue_url="scanning-news://teatree")
+
+        with patch("teatree.core.overlay_loader.resolve_overlay_name", _fake_resolve):
+            _migration_module._canonicalize_legacy_overlay_names(apps, connection.schema_editor())
+
+        legacy.refresh_from_db()
+        assert legacy.overlay == "t3-teatree"
+
+        self._restore_head()
+
+    def test_unresolvable_overlay_is_left_untouched(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        ticket = apps.get_model("core", "Ticket")
+        synthetic = ticket.objects.create(overlay="removed-overlay", issue_url="architectural-review://removed-overlay")
+
+        with patch("teatree.core.overlay_loader.resolve_overlay_name", _fake_resolve):
+            _migration_module._canonicalize_legacy_overlay_names(apps, connection.schema_editor())
+
+        synthetic.refresh_from_db()
+        assert synthetic.overlay == "removed-overlay"
+
+        self._restore_head()
+
+    def test_colliding_legacy_row_is_merged_into_canonical_twin(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        pending = apps.get_model("core", "PendingChatInjection")
+        now = timezone.now()
+        canonical = pending.objects.create(
+            overlay="t3-teatree", channel="C1", slack_ts="1700000000.000100", text="canonical", received_at=now
+        )
+        legacy = pending.objects.create(
+            overlay="teatree", channel="C1", slack_ts="1700000000.000100", text="legacy", received_at=now
+        )
+
+        with patch("teatree.core.overlay_loader.resolve_overlay_name", _fake_resolve):
+            _migration_module._canonicalize_legacy_overlay_names(apps, connection.schema_editor())
+
+        survivors = list(pending.objects.filter(slack_ts="1700000000.000100"))
+        assert len(survivors) == 1
+        assert survivors[0].pk == canonical.pk
+        assert survivors[0].overlay == "t3-teatree"
+        assert not pending.objects.filter(pk=legacy.pk).exists()
+
+        self._restore_head()
+
+    def test_non_colliding_alias_is_canonicalized(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        ticket = apps.get_model("core", "Ticket")
+        legacy = ticket.objects.create(overlay="beta", issue_url="scanning-news://beta")
+
+        with patch("teatree.core.overlay_loader.resolve_overlay_name", _fake_resolve):
+            _migration_module._canonicalize_legacy_overlay_names(apps, connection.schema_editor())
+
+        legacy.refresh_from_db()
+        assert legacy.overlay == "t3-beta"
+
+        self._restore_head()

--- a/tests/test_overlay_loader.py
+++ b/tests/test_overlay_loader.py
@@ -9,7 +9,12 @@ from unittest.mock import patch
 import teatree.config as config_mod
 from teatree.config import TeaTreeConfig
 from teatree.core.overlay import OverlayBase
-from teatree.core.overlay_loader import _discover_toml_overlays, get_overlay_for_repo, infer_overlay_for_url
+from teatree.core.overlay_loader import (
+    _discover_toml_overlays,
+    get_overlay_for_repo,
+    infer_overlay_for_url,
+    resolve_overlay_name,
+)
 
 _GIT = shutil.which("git") or "git"
 
@@ -243,6 +248,45 @@ class TestGetOverlayForRepo:
         with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
             assert get_overlay_for_repo(str(repo)) is overlays["a"]
         assert "failed during repo resolution" in caplog.text
+
+
+class TestResolveOverlayName:
+    """``resolve_overlay_name`` folds a name onto its registered canonical form (#1959)."""
+
+    def test_registered_name_resolves_to_itself(self):
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlay_names",
+            return_value=["t3-teatree", "t3-beta"],
+        ):
+            assert resolve_overlay_name("t3-teatree") == "t3-teatree"
+
+    def test_legacy_short_alias_folds_onto_entry_point(self):
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlay_names",
+            return_value=["t3-teatree", "t3-beta"],
+        ):
+            assert resolve_overlay_name("teatree") == "t3-teatree"
+            assert resolve_overlay_name("beta") == "t3-beta"
+
+    def test_unknown_name_resolves_to_none(self):
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlay_names",
+            return_value=["t3-teatree", "t3-beta"],
+        ):
+            assert resolve_overlay_name("removed-overlay") is None
+            assert resolve_overlay_name("synthetic-tag") is None
+            assert resolve_overlay_name("a-multi-segment-stale-name") is None
+
+    def test_empty_name_resolves_to_none(self):
+        assert resolve_overlay_name("") is None
+
+    def test_dispatchable_check_via_resolution(self):
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlay_names",
+            return_value=["t3-teatree", "t3-beta"],
+        ):
+            assert resolve_overlay_name("teatree") is not None
+            assert resolve_overlay_name("removed-overlay") is None
 
 
 # ── Test helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Every `t3 loop tick` drained a queued headless job that crashed with an `ImproperlyConfigured` overlay-not-found error (`get_overlay` at `overlay_loader.py`). The crash was a poison pill: the job re-fired on every tick forever.

## Root cause (three layers)

1. **Write-time (the source of new stale rows).** `config._discover_from_manage_py` returned the overlay name as the **clone-directory basename** (`teatree`) instead of the **registered entry-point name** (`t3-teatree`). Scanners (`eval_local`, `scanning_news`, `provision_smoke`, `architectural_review`) call `discover_active_overlay()` and stamp `ticket.overlay` with that basename, so they wrote a value the queue could not resolve.
2. **Exec/drain (the loop).** `execute_headless_task` resolved the overlay inside its `try`, so an unknown overlay raised. The fail handler recorded a failed attempt but **re-raised**; meanwhile `drain_headless_queue` (the tick safety-net) re-enqueued the still-`PENDING` row each pass, and `t3 recover --requeue` reopens `FAILED` rows — so the same job re-crashed indefinitely.
3. **Data.** Rows already carry stale values. Migration `0027` fixed only the single `teatree` → `t3-teatree` case; new rows accumulated since.

## Fix

- **Write-time:** `_discover_from_manage_py` now folds the clone-dir basename onto the registered entry-point name via the config-local `_match_canonical_ep` rule (stays inside the `platform` layer — no `core` import, tach-clean).
- **Runtime guard:** `execute_headless_task`, `drain_headless_queue`, `_auto_enqueue_headless_task`, and `recover._collect_requeue_candidates` treat a **non-empty unknown** overlay as a permanent failure — failed with a recorded attempt, never re-enqueued or reopened. A **blank** overlay stays the ambient single-overlay default.
- **Data migration `0054`:** generalizes `0027` — for every distinct overlay value, `resolve_overlay_name` decides the canonical name; a value folding onto a *different* registered canonical is renamed (collision twins deleted first, as in `0027`); a value resolving to itself or to nothing is left untouched for the runtime guard to surface.

`resolve_overlay_name` in `overlay_loader` is the single source of truth, reusing the existing `_match_canonical_ep` alias rule.

## Tests (TDD — red before green)

- `test_tasks.py`: unknown-overlay task fails permanently with a recorded attempt and is not re-enqueued on the next drain; blank overlay still dispatches.
- `test_queue_drain.py` / `test_signals.py` / `test_single_dispatch_liveness.py`: unchanged contracts hold.
- `test_recover.py`: unknown-overlay FAILED task is not a requeue candidate; blank overlay stays eligible.
- `test_overlay_loader.py`: `resolve_overlay_name` folds aliases, returns `None` for genuinely-unknown names.
- `test_migration_0054_canonicalize_legacy_overlay.py`: rename, collision-merge, and leave-unresolvable-untouched.
- `test_overlay_discovery.py`: clone-dir basename canonicalizes to the registered name.

`makemigrations --check` is clean (pure data migration, no `AlterField`); single migration leaf node (no fork).

## Open questions

- The maintainer DB carries a few `PENDING` headless tasks on genuinely-unresolvable overlays (synthetic dogfood/scanning/architectural-review tags that map to no current overlay). The drain guard fails them permanently on the next tick; no manual DB mutation was performed.