### PR TITLE
fix(db): reference-DB migrate must honor a Pipfile-based main clone (uv run built a bare venv)

### DIFF
--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -42,6 +42,40 @@ def _pg_args() -> tuple[str, str, dict[str, str]]:
     return pg_host(), pg_user(), pg_env()
 
 
+def _is_pipenv_repo(repo: Path) -> bool:
+    """True iff *repo* is managed by pipenv rather than uv.
+
+    A repo is pipenv-managed when it carries a ``Pipfile`` and has no usable
+    ``uv.lock`` — either no lock at all, or a stub lock with no resolved
+    packages (only ``version``/``revision``/``requires-python``). Running
+    ``uv --directory <repo> run`` against such a stub builds a bare venv with
+    none of the repo's deps, so ``import django`` fails (souliane/teatree#1973).
+    """
+    if not (repo / "Pipfile").is_file():
+        return False
+    lock = repo / "uv.lock"
+    if not lock.is_file():
+        return True
+    try:
+        return "[[package]]" not in lock.read_text(encoding="utf-8")
+    except OSError:
+        return True
+
+
+def _migrate_runner_prefix(repo: Path) -> list[str]:
+    """Build the interpreter prefix that runs ``python`` from *repo*'s environment.
+
+    Pipenv repos (see :func:`_is_pipenv_repo`) resolve through ``pipenv run``
+    with ``PIPENV_PIPFILE`` pinned to *repo*'s ``Pipfile``, so pipenv resolves
+    *repo*'s populated venv regardless of the subprocess cwd. Everything else
+    keeps the uv path: ``uv --directory <repo> run`` auto-isolates the repo's
+    locked environment.
+    """
+    if _is_pipenv_repo(repo):
+        return ["env", f"PIPENV_PIPFILE={repo / 'Pipfile'}", "pipenv", "run", "python"]
+    return ["uv", "--directory", str(repo), "run", "python"]
+
+
 def _local_db_url(db_name: str) -> str:
     from urllib.parse import quote  # noqa: PLC0415
 
@@ -219,7 +253,8 @@ class DjangoDbImporter:
         run_env = {**inherited_env, "DATABASE_URL": ref_db_url, "DISABLE_DATABASE_SSL": "True", **cfg.migrate_env_extra}
 
         self.stdout.write(f"  Migrating reference DB ({cfg.ref_db_name}) using main repo...\n")
-        migrate_cmd = ["uv", "--directory", cfg.main_repo_path, "run", "python", "manage.py", "migrate", "--no-input"]
+        runner = _migrate_runner_prefix(Path(cfg.main_repo_path))
+        migrate_cmd = [*runner, "manage.py", "migrate", "--no-input"]
         for _attempt in range(_MAX_MIGRATE_RETRIES):
             result = run_allowed_to_fail(migrate_cmd, cwd=cfg.main_repo_path, env=run_env, expected_codes=None)
             if result.returncode == 0:
@@ -262,19 +297,9 @@ class DjangoDbImporter:
         app_label, migration_name = failing.split(".", 1)
         reason = "schema already exists" if "already exists" in combined else "table absent from dump"
         self.stdout.write(f"  Faking {failing} on reference DB ({reason})...\n")
+        runner = _migrate_runner_prefix(Path(self.cfg.main_repo_path))
         run_allowed_to_fail(
-            [
-                "uv",
-                "--directory",
-                self.cfg.main_repo_path,
-                "run",
-                "python",
-                "manage.py",
-                "migrate",
-                app_label,
-                migration_name,
-                "--fake",
-            ],
+            [*runner, "manage.py", "migrate", app_label, migration_name, "--fake"],
             cwd=self.cfg.main_repo_path,
             env=run_env,
             expected_codes=None,

--- a/tests/django_db/test_migration.py
+++ b/tests/django_db/test_migration.py
@@ -193,6 +193,89 @@ class TestMigrateReferenceDb:
         assert "worktree_only.settings_local" in combined_output
 
 
+class TestMigrateRunnerSelection:
+    """The reference-DB migrate must honor the main clone's dependency manager.
+
+    Regression: souliane/teatree#1973 — a Pipfile-based (pipenv) main clone may
+    carry only a stub ``uv.lock`` (no ``[[package]]`` entries).
+    ``uv --directory <clone> run python`` builds a bare venv from that stub lock,
+    so ``import django`` raises ``ModuleNotFoundError``; the migrate is then
+    misclassified as a config error, ``_MigrateResult.FAILED`` aborts the
+    restore, and the ticket DB is never cloned. The runner prefix must be
+    selected from the main clone's dependency manager.
+    """
+
+    @staticmethod
+    def _capture_migrate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+        (tmp_path / "manage.py").write_text("", encoding="utf-8")
+        calls: list[list[str]] = []
+
+        def capture_run(args, **_kw):
+            calls.append(list(args))
+            return CompletedProcess(args, 0, "", "")
+
+        monkeypatch.setattr(run_mod.subprocess, "run", capture_run)
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.APPLIED
+        return calls
+
+    def test_pipfile_with_stub_uv_lock_uses_pipenv(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "Pipfile").write_text("[packages]\ndjango = '*'\n", encoding="utf-8")
+        (tmp_path / "uv.lock").write_text('version = 1\nrevision = 3\nrequires-python = ">=3.12"\n', encoding="utf-8")
+        cmd = self._capture_migrate(tmp_path, monkeypatch)[0]
+        assert "uv" not in cmd, f"pipenv main clone must not use `uv run`: {cmd}"
+        assert cmd[:2] == ["env", f"PIPENV_PIPFILE={tmp_path / 'Pipfile'}"], cmd
+        assert cmd[2:5] == ["pipenv", "run", "python"], cmd
+        assert cmd[5:] == ["manage.py", "migrate", "--no-input"], cmd
+
+    def test_pipfile_without_uv_lock_uses_pipenv(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "Pipfile").write_text("[packages]\ndjango = '*'\n", encoding="utf-8")
+        cmd = self._capture_migrate(tmp_path, monkeypatch)[0]
+        assert cmd[:5] == ["env", f"PIPENV_PIPFILE={tmp_path / 'Pipfile'}", "pipenv", "run", "python"], cmd
+
+    def test_real_uv_lock_keeps_uv_run(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "uv.lock").write_text(
+            'version = 1\n\n[[package]]\nname = "django"\nversion = "5.0"\n', encoding="utf-8"
+        )
+        cmd = self._capture_migrate(tmp_path, monkeypatch)[0]
+        assert cmd[:5] == ["uv", "--directory", str(tmp_path), "run", "python"], cmd
+
+    def test_no_lockfile_no_pipfile_keeps_uv_run(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cmd = self._capture_migrate(tmp_path, monkeypatch)[0]
+        assert cmd[:5] == ["uv", "--directory", str(tmp_path), "run", "python"], cmd
+
+    def test_unreadable_uv_lock_treated_as_pipenv(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from teatree.utils.django_db import _is_pipenv_repo  # noqa: PLC0415
+
+        (tmp_path / "Pipfile").write_text("[packages]\ndjango = '*'\n", encoding="utf-8")
+        (tmp_path / "uv.lock").write_text("[[package]]\n", encoding="utf-8")
+
+        def boom(*_a: object, **_kw: object) -> str:
+            raise OSError
+
+        monkeypatch.setattr(Path, "read_text", boom)
+        assert _is_pipenv_repo(tmp_path) is True
+
+    def test_fake_step_reuses_pipenv_runner(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "manage.py").write_text("", encoding="utf-8")
+        (tmp_path / "Pipfile").write_text("[packages]\ndjango = '*'\n", encoding="utf-8")
+        calls: list[list[str]] = []
+        call_count = 0
+
+        def fake_run(args, **_kw):
+            nonlocal call_count
+            calls.append(list(args))
+            call_count += 1
+            if call_count == 1:
+                return CompletedProcess(args, 1, "Applying myapp.0005_add_field...\n", "already exists")
+            return CompletedProcess(args, 0, "", "")
+
+        monkeypatch.setattr(run_mod.subprocess, "run", fake_run)
+        assert _make_importer(tmp_path)._migrate_reference_db() is _MigrateResult.APPLIED
+        assert "--fake" in calls[1]
+        assert "uv" not in calls[1], f"fake step must also use pipenv: {calls[1]}"
+        assert calls[1][:4] == ["env", f"PIPENV_PIPFILE={tmp_path / 'Pipfile'}", "pipenv", "run"], calls[1]
+
+
 class CanonicalizeTeatreeOverlayMigrationTest(TransactionTestCase):
     """0027 collapses the legacy ``teatree`` overlay value to ``t3-teatree``.
 


### PR DESCRIPTION
## Problem

`teatree.utils.django_db._migrate_reference_db` unconditionally shelled out:

```
uv --directory <main-clone> run python manage.py migrate --no-input
```

When the main clone is a **Pipfile-based (pipenv) repo** that carries only a
stub `uv.lock` (no `[[package]]` entries), `uv run` builds a bare venv with none
of the repo's dependencies. `import django` then raises `ModuleNotFoundError`,
which `_try_fake_failing_migration` classifies as a config error → the migrate
returns `_MigrateResult.FAILED`. That aborts the ref-DB restore across **all**
import strategies (DSLR, local dump, remote dump, CI dump), so the ticket-DB
clone is never created and the worktree DB never exists.

This was a deterministic blocker for **all local E2E provisioning** on a
Pipfile-based backend (`worktree provision` / `db refresh`) — gating a local
E2E run.

## Fix

Detect the main clone's dependency manager and pick the correct interpreter
prefix in one helper, used by both the migrate and the selective `--fake` step:

- **Pipfile present + uv.lock absent-or-stub** → `pipenv run` with
  `PIPENV_PIPFILE` pinned to the clone's own `Pipfile` (so pipenv resolves the
  clone's populated venv regardless of subprocess cwd).
- **Otherwise** → the existing `uv --directory <repo> run` path (uv-locked
  repos unchanged).

No repo is special-cased by name; detection is purely on `Pipfile` + `uv.lock`
contents.

## Tests

TDD: the runner-selection tests were observed RED on the buggy code (the
pipenv cases came back with `uv run`), then GREEN after the fix.

- `test_pipfile_with_stub_uv_lock_uses_pipenv`
- `test_pipfile_without_uv_lock_uses_pipenv`
- `test_real_uv_lock_keeps_uv_run`
- `test_no_lockfile_no_pipfile_keeps_uv_run`
- `test_unreadable_uv_lock_treated_as_pipenv`
- `test_fake_step_reuses_pipenv_runner`

100% coverage on the new lines. Mocks only the subprocess boundary; fake repos
built under `tmp_path`.
