### PR TITLE
fix(db): reference-DB migrate must not trust an unverified host venv (dockerized fallback)

### DIFF
--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -18,9 +18,11 @@ import enum
 import logging
 import os
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from subprocess import CompletedProcess
 from typing import TextIO
 
 from teatree.utils import bad_artifacts
@@ -29,6 +31,13 @@ from teatree.utils.django_db_dslr import prune_dslr_snapshots
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
+
+#: Overlay-supplied dockerized migrate runner. Given the ``manage.py`` args and
+#: the resolved subprocess env, it runs the migrate inside the repo-canonical
+#: docker image (every dependency baked in) and returns the result. Core calls
+#: it only as a fallback when the host runner fails with an import/config error
+#: — the signature of an unverified, dep-incomplete host venv (#1977).
+DockerizedMigrate = Callable[[list[str], dict[str, str]], CompletedProcess[str]]
 
 
 # ---------------------------------------------------------------------------
@@ -60,6 +69,19 @@ def _is_pipenv_repo(repo: Path) -> bool:
         return "[[package]]" not in lock.read_text(encoding="utf-8")
     except OSError:
         return True
+
+
+_CONFIG_ERROR_MARKERS = ("ModuleNotFoundError", "ImproperlyConfigured", "DJANGO_SETTINGS_MODULE", "No module named")
+
+
+def _is_config_error(combined: str) -> bool:
+    """True iff *combined* migrate output looks like an import/config failure.
+
+    These markers signal the interpreter could not import the app's
+    dependencies or settings — the unverified-venv signature that gates the
+    dockerized fallback and the unfakeable-migration skip.
+    """
+    return any(m in combined for m in _CONFIG_ERROR_MARKERS)
 
 
 def _migrate_runner_prefix(repo: Path) -> list[str]:
@@ -142,6 +164,7 @@ class DjangoDbImportConfig:
     dump_timeout: int = 1800
     dslr_snapshot: str = ""
     dump_path: str = ""
+    dockerized_migrate: DockerizedMigrate | None = None
 
 
 _MAX_MIGRATE_RETRIES = 20
@@ -190,6 +213,7 @@ class DjangoDbImporter:
         self.pg_user = pg_user
         self.pg_env = pg_env
         self._remote_dump_failed = False
+        self._migrate_via_docker = False
 
     # ------- low-level template copy / migration --------------------------
 
@@ -253,10 +277,8 @@ class DjangoDbImporter:
         run_env = {**inherited_env, "DATABASE_URL": ref_db_url, "DISABLE_DATABASE_SSL": "True", **cfg.migrate_env_extra}
 
         self.stdout.write(f"  Migrating reference DB ({cfg.ref_db_name}) using main repo...\n")
-        runner = _migrate_runner_prefix(Path(cfg.main_repo_path))
-        migrate_cmd = [*runner, "manage.py", "migrate", "--no-input"]
         for _attempt in range(_MAX_MIGRATE_RETRIES):
-            result = run_allowed_to_fail(migrate_cmd, cwd=cfg.main_repo_path, env=run_env, expected_codes=None)
+            result = self._run_migrate(["manage.py", "migrate", "--no-input"], run_env)
             if result.returncode == 0:
                 if "No migrations to apply" in result.stdout:
                     self.stdout.write("  Reference DB already up to date (no migrations applied).\n")
@@ -265,6 +287,18 @@ class DjangoDbImporter:
                 return _MigrateResult.APPLIED
 
             combined = f"{result.stdout}\n{result.stderr}"
+            # souliane/teatree#1977: a host config/import error means the
+            # selected interpreter's venv is unverified and dep-incomplete (a
+            # stale uv-built in-project ``.venv`` django may leak through but
+            # celery does not). Don't trust it — retry the whole migrate inside
+            # the repo-canonical docker image, where every dependency is baked
+            # in, then re-classify. This switch happens once; the --fake step
+            # then runs in docker too.
+            if _is_config_error(combined) and not self._migrate_via_docker and cfg.dockerized_migrate is not None:
+                self.stdout.write("  Host migrate failed to import deps; retrying inside the docker image...\n")
+                self._migrate_via_docker = True
+                continue
+
             failure_reason = self._try_fake_failing_migration(combined, result.stdout, run_env)
             if failure_reason:
                 # souliane/teatree#959: surface the real subprocess output on
@@ -281,10 +315,23 @@ class DjangoDbImporter:
         self.stdout.write("  WARNING: Reference DB migration exhausted retries, skipping.\n")
         return _MigrateResult.FAILED
 
+    def _run_migrate(self, manage_args: list[str], run_env: dict[str, str]) -> CompletedProcess[str]:
+        """Run one ``manage.py`` invocation via the selected runner.
+
+        Dispatches to the overlay's dockerized runner once core has switched to
+        it (#1977); otherwise runs on the host with the dependency-manager-aware
+        prefix (#1973).
+        """
+        if self._migrate_via_docker and self.cfg.dockerized_migrate is not None:
+            return self.cfg.dockerized_migrate(manage_args, run_env)
+        runner = _migrate_runner_prefix(Path(self.cfg.main_repo_path))
+        return run_allowed_to_fail(
+            [*runner, *manage_args], cwd=self.cfg.main_repo_path, env=run_env, expected_codes=None
+        )
+
     def _try_fake_failing_migration(self, combined: str, stdout: str, run_env: dict[str, str]) -> str:
         """Try to fake a failing migration. Returns empty string on success, error message on failure."""
-        config_markers = ("ModuleNotFoundError", "ImproperlyConfigured", "DJANGO_SETTINGS_MODULE", "No module named")
-        if any(m in combined for m in config_markers):
+        if _is_config_error(combined):
             return "Cannot migrate reference DB (config error), skipping."
 
         if "already exists" not in combined and "does not exist" not in combined:
@@ -297,13 +344,7 @@ class DjangoDbImporter:
         app_label, migration_name = failing.split(".", 1)
         reason = "schema already exists" if "already exists" in combined else "table absent from dump"
         self.stdout.write(f"  Faking {failing} on reference DB ({reason})...\n")
-        runner = _migrate_runner_prefix(Path(self.cfg.main_repo_path))
-        run_allowed_to_fail(
-            [*runner, "manage.py", "migrate", app_label, migration_name, "--fake"],
-            cwd=self.cfg.main_repo_path,
-            env=run_env,
-            expected_codes=None,
-        )
+        self._run_migrate(["manage.py", "migrate", app_label, migration_name, "--fake"], run_env)
         return ""
 
     # ------- restore + clone pipeline -------------------------------------

--- a/tests/django_db/test_migration.py
+++ b/tests/django_db/test_migration.py
@@ -276,6 +276,87 @@ class TestMigrateRunnerSelection:
         assert calls[1][:4] == ["env", f"PIPENV_PIPFILE={tmp_path / 'Pipfile'}", "pipenv", "run"], calls[1]
 
 
+class TestMigrateDockerizedFallback:
+    """An unverified host venv must not be trusted; fall back to the dockerized runner.
+
+    Regression: souliane/teatree#1977 — #1976 routed a Pipfile-based main clone
+    through ``pipenv run``, but ``PIPENV_PIPFILE`` pinned to the clone's own
+    Pipfile resolves a stale, uv-built in-project ``.venv`` that is missing the
+    repo's deps (django may leak in, ``celery`` does not). The host migrate then
+    fails with an import error and the ticket DB is never created. When a
+    ``dockerized_migrate`` runner is configured, core must attempt+classify: on
+    a host config/import error it retries the migrate inside the repo-canonical
+    docker image (every dep baked in), so host venv state stops mattering.
+    """
+
+    @staticmethod
+    def _import_error_run(args, **_kw):
+        return CompletedProcess(args, 1, "", "ModuleNotFoundError: No module named 'celery'")
+
+    def test_falls_back_to_docker_on_host_import_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "manage.py").write_text("", encoding="utf-8")
+        (tmp_path / "Pipfile").write_text("[packages]\ndjango = '*'\n", encoding="utf-8")
+        monkeypatch.setattr(run_mod.subprocess, "run", self._import_error_run)
+
+        docker_calls: list[list[str]] = []
+
+        def dockerized_migrate(manage_args: list[str], _run_env: dict[str, str]) -> CompletedProcess:
+            docker_calls.append(list(manage_args))
+            return CompletedProcess(manage_args, 0, "Applying myapp.0001_initial... OK\n", "")
+
+        importer = _make_importer(tmp_path, dockerized_migrate=dockerized_migrate)
+        assert importer._migrate_reference_db() is _MigrateResult.APPLIED
+        assert docker_calls == [["manage.py", "migrate", "--no-input"]], docker_calls
+
+    def test_docker_already_migrated_when_no_migrations(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "manage.py").write_text("", encoding="utf-8")
+        monkeypatch.setattr(run_mod.subprocess, "run", self._import_error_run)
+
+        def dockerized_migrate(manage_args: list[str], _run_env: dict[str, str]) -> CompletedProcess:
+            return CompletedProcess(manage_args, 0, "No migrations to apply.\n", "")
+
+        importer = _make_importer(tmp_path, dockerized_migrate=dockerized_migrate)
+        assert importer._migrate_reference_db() is _MigrateResult.ALREADY_MIGRATED
+
+    def test_no_docker_fallback_keeps_failed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without a dockerized runner configured, #1976 behaviour is unchanged."""
+        (tmp_path / "manage.py").write_text("", encoding="utf-8")
+        (tmp_path / "Pipfile").write_text("[packages]\ndjango = '*'\n", encoding="utf-8")
+        monkeypatch.setattr(run_mod.subprocess, "run", self._import_error_run)
+        importer = _make_importer(tmp_path)
+        assert importer._migrate_reference_db() is _MigrateResult.FAILED
+
+    def test_docker_fallback_also_fails_returns_failed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "manage.py").write_text("", encoding="utf-8")
+        monkeypatch.setattr(run_mod.subprocess, "run", self._import_error_run)
+
+        def dockerized_migrate(manage_args: list[str], _run_env: dict[str, str]) -> CompletedProcess:
+            return CompletedProcess(manage_args, 1, "", "django.db.utils.OperationalError: connection refused")
+
+        importer = _make_importer(tmp_path, dockerized_migrate=dockerized_migrate)
+        assert importer._migrate_reference_db() is _MigrateResult.FAILED
+
+    def test_docker_fake_step_uses_docker(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Once switched to docker, the selective --fake step also runs in docker."""
+        (tmp_path / "manage.py").write_text("", encoding="utf-8")
+        monkeypatch.setattr(run_mod.subprocess, "run", self._import_error_run)
+        docker_calls: list[list[str]] = []
+        call_count = 0
+
+        def dockerized_migrate(manage_args: list[str], _run_env: dict[str, str]) -> CompletedProcess:
+            nonlocal call_count
+            docker_calls.append(list(manage_args))
+            call_count += 1
+            if call_count == 1:
+                return CompletedProcess(manage_args, 1, "Applying myapp.0005_add_field...\n", "already exists")
+            return CompletedProcess(manage_args, 0, "", "")
+
+        importer = _make_importer(tmp_path, dockerized_migrate=dockerized_migrate)
+        assert importer._migrate_reference_db() is _MigrateResult.APPLIED
+        assert docker_calls[0] == ["manage.py", "migrate", "--no-input"], docker_calls
+        assert "--fake" in docker_calls[1], docker_calls
+
+
 class CanonicalizeTeatreeOverlayMigrationTest(TransactionTestCase):
     """0027 collapses the legacy ``teatree`` overlay value to ``t3-teatree``.
 


### PR DESCRIPTION
## Problem (follow-up to #1976)

#1976 merged (`59b89b49`) and fired correctly, but exposed the caveat flagged in
that PR as the live blocker. With `PIPENV_PIPFILE` pinned to the main clone's own
`Pipfile`, `pipenv run` resolves a **stale, uv-built in-project `.venv`** that is
missing the repo's dependencies — `django` may leak in, but `from celery import
Celery` raises `ModuleNotFoundError`. Both the reference-DB migrate and the
provision django-migrate step fail identically; the worktree DB is never created.

Root cause: the runner selection trusted an **unverified** interpreter. A cheap
`python -c "import django"` probe is not enough — the live failure was `celery`,
and deriving the full dep set is fragile.

## Fix — attempt + classify, dockerized fallback (class-killer)

The migrate chokepoint now does attempt+classify on one seam:

1. Run the host migrate via the dependency-manager-aware prefix (#1973).
2. If it returns 0, proceed as before.
3. If it fails with an **import/config error** (the unverified-venv signature) and
   an overlay-supplied `dockerized_migrate` runner is configured, retry the whole
   migrate **inside the repo-canonical docker image** — every dependency baked in,
   so host venv state stops mattering. The switch happens once; the selective
   `--fake` step then runs in docker too.
4. Without a dockerized runner configured, #1976 behaviour is unchanged (`FAILED`).

Core stays overlay-agnostic: it cannot know an overlay's compose file or web
service, so the dockerized command is built by the overlay and passed through
`DjangoDbImportConfig.dockerized_migrate` (the documented extension seam). **One
chokepoint, no repo special-cased by name.** Config-error detection is unified in
`_is_config_error` and reused by both the fallback gate and the
unfakeable-migration skip.

The overlay side (building the `docker compose run --rm web …` command from the
existing compose machinery) ships in a paired overlay PR.

## Tests

TDD: `TestMigrateDockerizedFallback` observed RED first (the config field and the
fallback logic did not exist), then GREEN.

- `test_falls_back_to_docker_on_host_import_error`
- `test_docker_already_migrated_when_no_migrations`
- `test_no_docker_fallback_keeps_failed` (proves #1976 behaviour preserved)
- `test_docker_fallback_also_fails_returns_failed`
- `test_docker_fake_step_uses_docker`

100% coverage on the new lines; mocks only the subprocess boundary. The full
`tests/django_db/` suite stays green (98 passed). Do not merge.
