### PR TITLE
fix(core): resolve worktree env-cache overlay from the worktree, not bare get_overlay() (#1975)

### DIFF
--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -51,6 +51,21 @@ def get_overlay(name: str | None = None) -> "OverlayBase":
     raise ImproperlyConfigured(msg)
 
 
+def _canonical_overlay_name(name: str) -> str | None:
+    """Fold a stored overlay name onto its canonical registered name, or ``None``.
+
+    A blank name is the ambient single-overlay default (``None`` → the
+    caller lets ``get_overlay(None)`` resolve it). A non-blank name is
+    canonicalized through the same :func:`resolve_overlay_name` rule the
+    config loader uses, so a stored legacy alias (``teatree`` → ``t3-teatree``)
+    resolves instead of raising ``Overlay not found``. An unresolvable name
+    is returned unchanged so ``get_overlay`` raises a precise ``not found``.
+    """
+    if not name:
+        return None
+    return resolve_overlay_name(name) or name
+
+
 def get_overlay_for_ticket(ticket: "Ticket") -> "OverlayBase":
     """Resolve the overlay a ticket belongs to.
 
@@ -59,9 +74,10 @@ def get_overlay_for_ticket(ticket: "Ticket") -> "OverlayBase":
     ``Multiple overlays found`` (souliane/teatree#1814). The ticket records
     its own overlay, so resolution is unambiguous regardless of how many
     overlays are installed; an empty value falls through to the ambient
-    single-overlay default.
+    single-overlay default. A stored legacy alias is folded onto its
+    canonical registered name (souliane/teatree#1975).
     """
-    return get_overlay(ticket.overlay or None)
+    return get_overlay(_canonical_overlay_name(ticket.overlay))
 
 
 def get_overlay_for_worktree(worktree: "Worktree") -> "OverlayBase":
@@ -72,7 +88,7 @@ def get_overlay_for_worktree(worktree: "Worktree") -> "OverlayBase":
     before the field was populated (souliane/teatree#1814).
     """
     if worktree.overlay:
-        return get_overlay(worktree.overlay)
+        return get_overlay(_canonical_overlay_name(worktree.overlay))
     return get_overlay_for_ticket(worktree.ticket)
 
 

--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -76,7 +76,7 @@ class WorktreeProvisionRunner(RunnerBase):
         worktree = self.worktree
         overlay = self.overlay
 
-        spec = write_env_cache(worktree)
+        spec = write_env_cache(worktree, overlay=overlay)
         if spec:
             logger.info("Wrote env cache: %s", spec.path)
 

--- a/src/teatree/core/runners/worktree_start.py
+++ b/src/teatree/core/runners/worktree_start.py
@@ -87,7 +87,7 @@ class WorktreeStartRunner(RunnerBase):
         commands = overlay.get_run_commands(worktree)
         ServiceLauncher.prepare_all(worktree, list(commands), overlay=overlay)
 
-        write_env_cache(worktree)
+        write_env_cache(worktree, overlay=overlay)
 
         compose_file = overlay.get_compose_file(worktree)
         if not compose_file:

--- a/src/teatree/core/worktree_env.py
+++ b/src/teatree/core/worktree_env.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, cast
 
 from teatree.core.models import Ticket, Worktree, WorktreeEnvOverride
 from teatree.core.models.types import WorktreeExtra, validated_worktree_extra
-from teatree.core.overlay_loader import get_overlay
+from teatree.core.overlay_loader import get_overlay_for_worktree
 from teatree.utils.postgres_secret import PASS_KEY_ENV, postgres_pass_key
 
 if TYPE_CHECKING:
@@ -108,11 +108,18 @@ def _check_overlay_does_not_collide_with_core(overlay: "OverlayBase") -> None:
         raise RuntimeError(msg)
 
 
-def render_env_cache(worktree: Worktree) -> EnvCacheSpec | None:
+def render_env_cache(worktree: Worktree, *, overlay: "OverlayBase | None" = None) -> EnvCacheSpec | None:
     """Render the env cache content for *worktree* without touching disk.
 
     Returns ``None`` when the worktree has no ``worktree_path`` yet (not
     provisioned).  Used by drift detection and ``t3 env show``.
+
+    The overlay is resolved from the worktree's own ``overlay`` field
+    (``get_overlay_for_worktree``) so this works on a multi-overlay host
+    where a bare ``get_overlay()`` would raise ``Multiple overlays found``
+    (souliane/teatree#1975). Callers that already hold the resolved
+    instance — the provision/start runners — pass it via *overlay* to skip
+    re-resolution.
     """
     extra: WorktreeExtra = validated_worktree_extra(worktree.extra)
     wt_path_str = extra.get("worktree_path")
@@ -120,7 +127,8 @@ def render_env_cache(worktree: Worktree) -> EnvCacheSpec | None:
         return None
     ticket_dir = Path(wt_path_str).parent
 
-    overlay = get_overlay()
+    if overlay is None:
+        overlay = get_overlay_for_worktree(worktree)
     pairs = dict(_core_env_pairs(worktree))
 
     db_strategy = overlay.get_db_import_strategy(worktree)
@@ -146,7 +154,7 @@ def render_env_cache(worktree: Worktree) -> EnvCacheSpec | None:
     return EnvCacheSpec(path=cache_path, keys=ordered_keys, content=_HEADER + body)
 
 
-def write_env_cache(worktree: Worktree) -> EnvCacheSpec | None:
+def write_env_cache(worktree: Worktree, *, overlay: "OverlayBase | None" = None) -> EnvCacheSpec | None:
     """Write the env cache and copy it into the repo worktree.
 
     Idempotent.  Writes the file ``chmod 444``.  Callers that modify the
@@ -160,7 +168,7 @@ def write_env_cache(worktree: Worktree) -> EnvCacheSpec | None:
     canonical file under ``.t3-cache/`` against a fresh DB render, so
     the worktree-local copy is just a consumer-facing convenience.
     """
-    spec = render_env_cache(worktree)
+    spec = render_env_cache(worktree, overlay=overlay)
     if spec is None:
         return None
 
@@ -182,13 +190,13 @@ def write_env_cache(worktree: Worktree) -> EnvCacheSpec | None:
     return spec
 
 
-def detect_drift(worktree: Worktree) -> tuple[bool, Path | None]:
+def detect_drift(worktree: Worktree, *, overlay: "OverlayBase | None" = None) -> tuple[bool, Path | None]:
     """Return ``(is_drifted, cache_path)``.
 
     Drift = file on disk differs from a fresh DB render, OR file is
     missing.  Returns ``(False, None)`` for unprovisioned worktrees.
     """
-    spec = render_env_cache(worktree)
+    spec = render_env_cache(worktree, overlay=overlay)
     if spec is None:
         return False, None
     if not spec.path.is_file():

--- a/src/teatree/core/worktree_tasks.py
+++ b/src/teatree/core/worktree_tasks.py
@@ -50,9 +50,19 @@ def execute_worktree_provision(worktree_id: int) -> WorktreeTransitionResult:
     At-least-once delivery is safe: every step is idempotent (env cache
     rewrites cleanly, ``db_import`` no-ops when the DB exists, overlay
     steps are expected to be re-runnable).
+
+    Poison-pill guard (souliane/teatree#1975, mirroring #1959/#1969): a
+    worktree whose effective overlay (its own field, falling back to the
+    ticket's) names a non-empty overlay that no longer resolves can never
+    provision — ``get_overlay_for_worktree`` raises ``Overlay not found``
+    every re-fire. Fail it permanently with a recorded result instead of
+    raising forever. A blank overlay is the ambient single-overlay default
+    and stays dispatchable.
     """
+    from teatree.core.overlay_loader import resolve_overlay_name  # noqa: PLC0415
+
     with transaction.atomic():
-        worktree = Worktree.objects.select_for_update().get(pk=worktree_id)
+        worktree = Worktree.objects.select_for_update().select_related("ticket").get(pk=worktree_id)
         if worktree.state != Worktree.State.PROVISIONED:
             logger.info(
                 "execute_worktree_provision skipped for worktree %s: state=%s (not PROVISIONED)",
@@ -60,6 +70,12 @@ def execute_worktree_provision(worktree_id: int) -> WorktreeTransitionResult:
                 worktree.state,
             )
             return {"worktree_id": worktree_id, "skipped": True, "state": str(worktree.state)}
+
+        effective_overlay = worktree.overlay or worktree.ticket.overlay
+        if effective_overlay and resolve_overlay_name(effective_overlay) is None:
+            reason = f"unknown overlay {effective_overlay!r}: worktree {worktree_id} cannot be provisioned"
+            logger.warning("execute_worktree_provision: %s", reason)
+            return {"worktree_id": worktree_id, "ok": False, "detail": reason}
 
         result = WorktreeProvisionRunner(worktree).run()
         if not result.ok:

--- a/tests/teatree_core/management_commands/_overlays.py
+++ b/tests/teatree_core/management_commands/_overlays.py
@@ -4,7 +4,7 @@ Extracted verbatim from the former monolithic ``test_new_management_commands`` m
 """
 
 import shutil
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.utils.module_loading import import_string
@@ -48,6 +48,25 @@ def _patch_overlays(overlay_class_path: str):
     _fake_discover.cache_clear = lambda: None
 
     return patch.object(overlay_loader_mod, "_discover_overlays", new=_fake_discover)
+
+
+def env_safe_mock_overlay() -> MagicMock:
+    """A ``MagicMock`` overlay safe to feed through the env-cache renderer.
+
+    The provision/start runners now thread their resolved overlay straight
+    into ``write_env_cache`` (souliane/teatree#1975), so a bare ``MagicMock``
+    whose ``declared_env_keys`` / ``get_base_images`` return un-iterable
+    mocks crashes the renderer. This double pins those to empty collections
+    so the env-cache path no-ops cleanly while the test keeps full control
+    over the behaviour it actually asserts.
+    """
+    overlay = MagicMock()
+    overlay.get_env_extra.return_value = {}
+    overlay.declared_env_keys.return_value = set()
+    overlay.declared_secret_env_keys.return_value = set()
+    overlay.get_base_images.return_value = []
+    overlay.get_db_import_strategy.return_value = None
+    return overlay
 
 
 class FullMetadata(OverlayMetadata):

--- a/tests/teatree_core/management_commands/test_lifecycle.py
+++ b/tests/teatree_core/management_commands/test_lifecycle.py
@@ -27,6 +27,7 @@ from tests.teatree_core.management_commands._overlays import (
     PRE_RUN_OVERLAY,
     SETTINGS,
     _patch_overlays,
+    env_safe_mock_overlay,
 )
 
 pytestmark = pytest.mark.filterwarnings(
@@ -343,13 +344,11 @@ class TestLifecycleSetup(TestCase):
                 extra={"worktree_path": str(wt_path)},
             )
 
-            mock_overlay = MagicMock()
+            mock_overlay = env_safe_mock_overlay()
             mock_overlay.get_envrc_lines.return_value = ["export USE_UV=1"]
-            mock_overlay.get_db_import_strategy.return_value = None
             mock_overlay.get_provision_steps.return_value = []
             mock_overlay.get_post_db_steps.return_value = []
             mock_overlay.get_reset_passwords_command.return_value = ""
-            mock_overlay.get_env_extra.return_value = {}
             mock_overlay.metadata.get_skill_metadata.return_value = {}
 
             with (
@@ -391,13 +390,11 @@ class TestLifecycleSetup(TestCase):
                 extra={"worktree_path": str(wt_path)},
             )
 
-            mock_overlay = MagicMock()
+            mock_overlay = env_safe_mock_overlay()
             mock_overlay.get_envrc_lines.return_value = []
-            mock_overlay.get_db_import_strategy.return_value = None
             mock_overlay.get_provision_steps.return_value = []
             mock_overlay.get_post_db_steps.return_value = []
             mock_overlay.get_reset_passwords_command.return_value = ""
-            mock_overlay.get_env_extra.return_value = {}
             mock_overlay.metadata.get_skill_metadata.return_value = {}
 
             with (
@@ -429,12 +426,10 @@ class TestLifecycleSetup(TestCase):
                 extra={"worktree_path": str(wt_path)},
             )
 
-            mock_overlay = MagicMock()
-            mock_overlay.get_db_import_strategy.return_value = None
+            mock_overlay = env_safe_mock_overlay()
             mock_overlay.get_provision_steps.return_value = []
             mock_overlay.get_post_db_steps.return_value = []
             mock_overlay.get_reset_passwords_command.return_value = ""
-            mock_overlay.get_env_extra.return_value = {}
             mock_overlay.get_envrc_lines.return_value = []
             mock_overlay.metadata.get_skill_metadata.return_value = {}
 
@@ -547,12 +542,10 @@ class TestLifecycleStart(TestCase):
                 state=Worktree.State.PROVISIONED,
             )
 
-            mock_overlay = MagicMock()
+            mock_overlay = env_safe_mock_overlay()
             mock_overlay.get_run_commands.return_value = {"backend": "run-backend", "frontend": "run-frontend"}
             mock_overlay.get_pre_run_steps.return_value = []
-            mock_overlay.get_env_extra.return_value = {}
             mock_overlay.get_envrc_lines.return_value = []
-            mock_overlay.get_db_import_strategy.return_value = None
             mock_overlay.get_provision_steps.return_value = []
             mock_overlay.get_post_db_steps.return_value = []
             mock_overlay.get_health_checks.return_value = []
@@ -597,12 +590,10 @@ class TestLifecycleStart(TestCase):
                 state=Worktree.State.PROVISIONED,
             )
 
-            mock_overlay = MagicMock()
+            mock_overlay = env_safe_mock_overlay()
             mock_overlay.get_run_commands.return_value = {}
             mock_overlay.get_pre_run_steps.return_value = []
-            mock_overlay.get_env_extra.return_value = {}
             mock_overlay.get_envrc_lines.return_value = []
-            mock_overlay.get_db_import_strategy.return_value = None
             mock_overlay.get_provision_steps.return_value = []
             mock_overlay.get_post_db_steps.return_value = []
             mock_overlay.get_health_checks.return_value = []
@@ -643,12 +634,10 @@ class TestLifecycleStart(TestCase):
                 state=Worktree.State.PROVISIONED,
             )
 
-            mock_overlay = MagicMock()
+            mock_overlay = env_safe_mock_overlay()
             mock_overlay.get_run_commands.return_value = {"backend": "run-backend"}
             mock_overlay.get_pre_run_steps.return_value = []
-            mock_overlay.get_env_extra.return_value = {}
             mock_overlay.get_envrc_lines.return_value = []
-            mock_overlay.get_db_import_strategy.return_value = None
             mock_overlay.get_provision_steps.return_value = []
             mock_overlay.get_post_db_steps.return_value = []
             mock_overlay.get_health_checks.return_value = []
@@ -711,12 +700,10 @@ class TestImagePreflight(TestCase):
             state=Worktree.State.PROVISIONED,
         )
 
-        mock_overlay = MagicMock()
+        mock_overlay = env_safe_mock_overlay()
         mock_overlay.get_run_commands.return_value = {"backend": "run-backend"}
         mock_overlay.get_pre_run_steps.return_value = []
-        mock_overlay.get_env_extra.return_value = {}
         mock_overlay.get_envrc_lines.return_value = []
-        mock_overlay.get_db_import_strategy.return_value = None
         mock_overlay.get_provision_steps.return_value = []
         mock_overlay.get_post_db_steps.return_value = []
         mock_overlay.get_health_checks.return_value = []

--- a/tests/teatree_core/test_provisioning_contract.py
+++ b/tests/teatree_core/test_provisioning_contract.py
@@ -250,8 +250,9 @@ class WorktreeProvisionRunnerContractTests(TestCase):
         self._tmp.cleanup()
 
     def _run(self, overlay: FullStackOverlay) -> object:
-        with patch("teatree.core.worktree_env.get_overlay", return_value=overlay):
-            return WorktreeProvisionRunner(self.worktree, overlay=overlay).run()
+        # The runner threads its resolved overlay straight into the env-cache
+        # writer (souliane/teatree#1975), so no overlay-loader patch is needed.
+        return WorktreeProvisionRunner(self.worktree, overlay=overlay).run()
 
     # Provision steps run before per-service pre-run steps, in declared
     # order — the env cache and overlay schema must exist before anything
@@ -298,10 +299,7 @@ class WorktreeStartRunnerContractTests(TestCase):
 
     def test_prepare_all_runs_before_compose_phase(self) -> None:
         overlay = FullStackOverlay(self.order_file)
-        with (
-            patch("teatree.core.runners.worktree_start.docker_compose_down") as down,
-            patch("teatree.core.worktree_env.get_overlay", return_value=overlay),
-        ):
+        with patch("teatree.core.runners.worktree_start.docker_compose_down") as down:
             result = WorktreeStartRunner(self.worktree, overlay=overlay).run()
         down.assert_called_once()
         ran = sorted(self.order_file.read_text().splitlines())

--- a/tests/teatree_core/test_worktree_env_multi_overlay.py
+++ b/tests/teatree_core/test_worktree_env_multi_overlay.py
@@ -1,0 +1,163 @@
+"""Env-cache rendering must resolve the overlay from the worktree, not bare get_overlay().
+
+Regression for souliane/teatree#1975: ``render_env_cache`` (and the
+``write_env_cache`` / ``detect_drift`` paths that funnel through it) called a
+bare ``get_overlay()``. On a multi-overlay host that raises
+``ImproperlyConfigured: Multiple overlays found``, so every queued
+``execute_worktree_provision`` job crashed at env-cache rendering even though
+the worktree row records its own overlay. The fix resolves the overlay the
+worktree itself names; an explicit ``overlay=`` short-circuits re-resolution
+for callers (the provision/start runners) that already hold the instance.
+"""
+
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay import OverlayBase, ProvisionStep
+from teatree.core.runners.worktree_provision import WorktreeProvisionRunner
+from teatree.core.worktree_env import detect_drift, render_env_cache, write_env_cache
+from teatree.core.worktree_tasks import execute_worktree_provision
+
+OVERLAY_A = "overlay-alpha"
+OVERLAY_B = "overlay-beta"
+
+
+class _MarkedOverlay(OverlayBase):
+    def __init__(self, marker: str) -> None:
+        super().__init__()
+        self.marker = marker
+
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        return []
+
+    def get_env_extra(self, worktree: Worktree) -> dict[str, str]:
+        return {"MARKER": self.marker}
+
+    def declared_env_keys(self) -> set[str]:
+        return {"MARKER"}
+
+
+class _MultiOverlayEnvTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def _register_both_overlays(self) -> Iterator[None]:
+        self.overlay_a = _MarkedOverlay(OVERLAY_A)
+        self.overlay_b = _MarkedOverlay(OVERLAY_B)
+        registry = {OVERLAY_A: self.overlay_a, OVERLAY_B: self.overlay_b}
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=registry):
+            yield
+
+    def _worktree(self, tmp: str, *, overlay: str, ticket_overlay: str | None = None) -> Worktree:
+        ticket_dir = Path(tmp) / "ticket"
+        ticket_dir.mkdir(exist_ok=True)
+        wt_path = ticket_dir / "backend"
+        wt_path.mkdir(exist_ok=True)
+        ticket = Ticket.objects.create(
+            overlay=ticket_overlay if ticket_overlay is not None else overlay,
+            issue_url="https://example.com/1975",
+        )
+        return Worktree.objects.create(
+            ticket=ticket,
+            overlay=overlay,
+            repo_path="backend",
+            branch="feat-x",
+            db_name="wt_1975",
+            state=Worktree.State.PROVISIONED,
+            extra={"worktree_path": str(wt_path)},
+        )
+
+
+class TestRenderEnvCacheResolvesWorktreeOverlay(_MultiOverlayEnvTest):
+    def test_render_resolves_worktree_overlay_on_multi_overlay_host(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = self._worktree(tmp, overlay=OVERLAY_A)
+            spec = render_env_cache(wt)
+        assert spec is not None
+        assert f"MARKER={OVERLAY_A}" in spec.content
+
+    def test_render_picks_the_other_overlay(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = self._worktree(tmp, overlay=OVERLAY_B)
+            spec = render_env_cache(wt)
+        assert spec is not None
+        assert f"MARKER={OVERLAY_B}" in spec.content
+
+    def test_render_falls_back_to_ticket_overlay_when_field_blank(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = self._worktree(tmp, overlay="", ticket_overlay=OVERLAY_A)
+            spec = render_env_cache(wt)
+        assert spec is not None
+        assert f"MARKER={OVERLAY_A}" in spec.content
+
+    def test_explicit_overlay_argument_short_circuits_resolution(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = self._worktree(tmp, overlay=OVERLAY_A)
+            spec = render_env_cache(wt, overlay=self.overlay_b)
+        assert spec is not None
+        assert f"MARKER={OVERLAY_B}" in spec.content
+
+
+class TestWriteAndDriftResolveWorktreeOverlay(_MultiOverlayEnvTest):
+    def test_write_env_cache_succeeds_on_multi_overlay_host(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = self._worktree(tmp, overlay=OVERLAY_B)
+            spec = write_env_cache(wt)
+            assert spec is not None
+            assert f"MARKER={OVERLAY_B}" in spec.path.read_text(encoding="utf-8")
+
+    def test_detect_drift_succeeds_on_multi_overlay_host(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = self._worktree(tmp, overlay=OVERLAY_A)
+            write_env_cache(wt)
+            drifted, _ = detect_drift(wt)
+        assert drifted is False
+
+
+class TestProvisionRunnerEnvCacheOnMultiOverlayHost(_MultiOverlayEnvTest):
+    def test_runner_writes_env_cache_without_ambiguity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = self._worktree(tmp, overlay=OVERLAY_B)
+            result = WorktreeProvisionRunner(wt).run()
+            assert result.ok, result.detail
+            spec_path = Path(wt.worktree_path).parent / ".t3-cache" / ".t3-env.cache"
+            assert spec_path.is_file()
+            assert f"MARKER={OVERLAY_B}" in spec_path.read_text(encoding="utf-8")
+
+    def test_queued_provision_job_completes_on_multi_overlay_host(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt = self._worktree(tmp, overlay=OVERLAY_A)
+            result = execute_worktree_provision.call(wt.pk)
+        assert result == {"worktree_id": wt.pk, "ok": True, "detail": result["detail"]}
+        assert result["ok"] is True
+
+
+class TestProvisionPoisonPillGuard(TestCase):
+    """An unresolvable overlay must fail permanently, not raise every re-fire (#1975/#1969)."""
+
+    @pytest.fixture(autouse=True)
+    def _register_one_overlay(self) -> Iterator[None]:
+        registry = {OVERLAY_A: _MarkedOverlay(OVERLAY_A)}
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=registry):
+            yield
+
+    def test_unknown_overlay_worktree_fails_permanently(self) -> None:
+        ticket = Ticket.objects.create(overlay="gone-overlay", issue_url="https://example.com/poison")
+        wt = Worktree.objects.create(
+            ticket=ticket,
+            overlay="gone-overlay",
+            repo_path="backend",
+            branch="feat-x",
+            state=Worktree.State.PROVISIONED,
+            extra={"worktree_path": "/tmp/wt"},
+        )
+        result = execute_worktree_provision.call(wt.pk)
+        assert result["ok"] is False
+        assert "gone-overlay" in result["detail"]

--- a/tests/teatree_core/test_worktree_tasks.py
+++ b/tests/teatree_core/test_worktree_tasks.py
@@ -1,5 +1,6 @@
 """Per-worktree FSM task workers — state guard, runner dispatch, result shape."""
 
+from collections.abc import Iterator
 from unittest.mock import patch
 
 import pytest
@@ -13,6 +14,7 @@ from teatree.core.worktree_tasks import (
     execute_worktree_teardown,
     execute_worktree_verify,
 )
+from tests.teatree_core.conftest import CommandOverlay
 
 
 @pytest.fixture(autouse=True)
@@ -22,6 +24,14 @@ def _no_op_signals() -> None:
 
 
 class _WorktreeTaskTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def _register_test_overlay(self) -> Iterator[None]:
+        # The provision worker poison-guards on overlay resolvability
+        # (souliane/teatree#1975); register ``test`` so the dispatch path
+        # is exercised rather than short-circuited as an unknown overlay.
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value={"test": CommandOverlay()}):
+            yield
+
     def _ticket(self) -> Ticket:
         return Ticket.objects.create(overlay="test", issue_url="https://example.com/1")
 


### PR DESCRIPTION
Closes #1975.

## Problem

render_env_cache (src/teatree/core/worktree_env.py) called a bare get_overlay(), which raises ImproperlyConfigured: Multiple overlays found on any host with more than one overlay registered. Every queued execute_worktree_provision job crashed at env-cache rendering even though the worktree row records its own overlay so the call was always resolvable. The reconcile drift scan (reconcile.py -> render_env_cache / detect_drift, run in the loop tick) crashed on the same call path.

Live evidence on a multi-overlay host: 46 FAILED execute_worktree_provision rows, all ImproperlyConfigured: Multiple overlays found, across worktrees that re-fired provision() over days.

## Fix

- render_env_cache / write_env_cache / detect_drift resolve the overlay via get_overlay_for_worktree(worktree). An explicit overlay= kwarg short-circuits re-resolution for the provision/start runners that already hold the resolved instance.
- get_overlay_for_ticket / get_overlay_for_worktree fold a stored legacy alias onto its canonical registered name (same resolve_overlay_name rule the config loader uses), so a stored legacy short name resolves to its entry-point name instead of raising not-found. get_overlay's own ambiguity behavior is unchanged (raising on a truly context-free call is correct).
- Sweep: worktree_env.py and the provision-queue path (execute_worktree_provision -> WorktreeProvisionRunner.run -> write_env_cache / _setup_worktree_dir / db import / steps / health) now contain no bare get_overlay() calls. The remaining bare calls in the repo run in the per-overlay CLI subprocess (T3_OVERLAY_NAME set) or pre-existing loop-scanner paths, out of scope for this fix.

## Fault isolation (issue Q2)

The #1969-style fault isolation did NOT cover this queue path. A crashing execute_worktree_provision raised, so the queue marked it FAILED (terminal), but provision() re-fired each cycle and enqueued a fresh job, producing the observed stream of FAILED rows. For a resolvable overlay (the live symptom) the env-cache fix makes provision succeed, ending the cycle. For a truly-unresolvable overlay, execute_worktree_provision now carries a permanent-failure guard mirroring the #1959 pattern: it returns a recorded failed result instead of raising on every re-fire.

## Tests (TDD)

New tests/teatree_core/test_worktree_env_multi_overlay.py registers two overlays and proves the env-cache render / write_env_cache / detect_drift / provision-runner / queued-job paths resolve the worktree's overlay; all RED against the bare call before the fix. Plus a permanent-failure-guard test for an unknown overlay. Existing tests that patched the now-removed worktree_env.get_overlay or fed bare MagicMock overlays into the now-threaded env cache were updated.

Scoped pytest green; ruff / ruff format / ty-check clean.