### PR TITLE
fix(notify): accept --thread-ts on notify post and surface subcommand stderr

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -5782,17 +5782,17 @@ Usage: t3 teatree notify post [OPTIONS]
  (exit 0 on ``ok``).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ *  --channel        TEXT  Destination: the user's own DM (→bot) or a         │
-│                           colleague/channel (→xoxp).                         │
-│                           [required]                                         │
-│ *  --text           TEXT  Slack mrkdwn body. Use ``-`` to read the body from │
-│                           stdin.                                             │
-│                           [required]                                         │
-│    --thread         TEXT  Thread ``ts`` to reply into (omit to post a new    │
-│                           top-level message).                                │
-│    --overlay        TEXT  Set T3_OVERLAY_NAME for the call (per-overlay      │
-│                           credentials).                                      │
-│    --help                 Show this message and exit.                        │
+│ *  --channel          TEXT  Destination: the user's own DM (→bot) or a       │
+│                             colleague/channel (→xoxp).                       │
+│                             [required]                                       │
+│ *  --text             TEXT  Slack mrkdwn body. Use ``-`` to read the body    │
+│                             from stdin.                                      │
+│                             [required]                                       │
+│    --thread-ts        TEXT  Thread ``ts`` to reply into (omit to post a new  │
+│                             top-level message).                              │
+│    --overlay          TEXT  Set T3_OVERLAY_NAME for the call (per-overlay    │
+│                             credentials).                                    │
+│    --help                   Show this message and exit.                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/core/management/commands/notify.py
+++ b/src/teatree/core/management/commands/notify.py
@@ -168,9 +168,9 @@ class Command(TyperCommand):
             str,
             typer.Option("--text", help="Slack mrkdwn body. Use ``-`` to read the body from stdin."),
         ],
-        thread: Annotated[
+        thread_ts: Annotated[
             str,
-            typer.Option("--thread", help="Thread ``ts`` to reply into (omit to post a new top-level message)."),
+            typer.Option("--thread-ts", help="Thread ``ts`` to reply into (omit to post a new top-level message)."),
         ] = "",
         overlay: Annotated[
             str,
@@ -191,7 +191,7 @@ class Command(TyperCommand):
                     text=body,
                     target=channel,
                     action="cli_notify_post",
-                    thread_ts=thread,
+                    thread_ts=thread_ts,
                     destination=channel,
                     summary=body,
                 )

--- a/src/teatree/utils/run.py
+++ b/src/teatree/utils/run.py
@@ -19,10 +19,11 @@ Three entry points:
 
 import re
 import subprocess
+import sys
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 from subprocess import DEVNULL, PIPE, STDOUT, CompletedProcess, Popen, TimeoutExpired
-from typing import IO
+from typing import IO, cast
 
 __all__ = [
     "DEVNULL",
@@ -135,23 +136,34 @@ def run_streamed(
     cwd: str | Path | None = None,
     check: bool = True,
 ) -> int:
-    """Run a command with stdin/stdout/stderr inherited from the parent.
+    """Run a command, inheriting stdin/stdout, teeing stderr live + captured.
 
     Use for interactive commands where the user needs live output (Django
     management commands, ``uvicorn``, ``tail -f``).  Returns the exit code.
-    When ``check`` is True (default), non-zero exits raise
-    :class:`CommandFailedError` with no captured output (streams went to the
-    terminal, not to buffers).
+    stdout stays inherited so live output and interactive prompts work; stderr
+    is teed — each chunk is forwarded to the parent's ``stderr`` *and*
+    captured — so that when ``check`` is True a non-zero exit raises
+    :class:`CommandFailedError` carrying the subcommand's stderr. Without the
+    capture, a wrapped failure surfaces as a bare ``command failed (rc=1)``
+    with no clue *why* (the #1750 ``--thread-ts`` breakage was invisible for
+    exactly this reason).
     """
-    proc = subprocess.run(
+    captured: list[str] = []
+    with Popen(
         list(cmd),
         env=env,
         cwd=str(cwd) if cwd is not None else None,
-        check=False,
-    )
-    if check and proc.returncode != 0:
-        raise CommandFailedError(cmd, proc.returncode, "", "")
-    return proc.returncode
+        stderr=PIPE,
+        text=True,
+    ) as proc:
+        for line in cast("IO[str]", proc.stderr):
+            sys.stderr.write(line)
+            captured.append(line)
+        sys.stderr.flush()
+        returncode = proc.wait()
+    if check and returncode != 0:
+        raise CommandFailedError(cmd, returncode, "", "".join(captured))
+    return returncode
 
 
 def spawn(

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -40,6 +40,23 @@ pytestmark = pytest.mark.filterwarnings(
 _GIT = shutil.which("git") or "git"
 
 
+def _popen_for(result: MagicMock) -> MagicMock:
+    """Wrap a ``MagicMock(returncode=N)`` into a ``Popen`` context-manager mock.
+
+    ``run_streamed`` now drives ``Popen``: it tees ``proc.stderr`` then reads
+    ``proc.wait()``. The returned mock records the ``Popen(cmd, env=...)`` call
+    (so ``call_args[0][0]`` / ``call_args[1]["env"]`` assertions keep working)
+    and yields a proc whose ``wait()`` returns the original mock's returncode.
+    """
+    proc = MagicMock()
+    proc.stderr = iter(getattr(result, "_streamed_stderr", ()) or ())
+    proc.wait.return_value = result.returncode
+    ctx = MagicMock()
+    ctx.__enter__.return_value = proc
+    ctx.__exit__.return_value = False
+    return MagicMock(return_value=ctx)
+
+
 class TestE2eTriggerCi(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -95,7 +112,7 @@ class TestE2eProject(TestCase):
         mock_result = MagicMock(returncode=0)
         with (
             patch.object(e2e_mod, "resolve_worktree", return_value=None),
-            patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+            patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
         ):
             result = cast("str", call_command("e2e", "project", docker=False))
 
@@ -110,7 +127,7 @@ class TestE2eProject(TestCase):
         mock_result = MagicMock(returncode=1)
         with (
             patch.object(e2e_mod, "resolve_worktree", return_value=None),
-            patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
+            patch.object(utils_run_mod, "Popen", _popen_for(mock_result)),
             pytest.raises(SystemExit) as exc_info,
         ):
             call_command("e2e", "project", docker=False)
@@ -124,7 +141,7 @@ class TestE2eProject(TestCase):
         mock_result = MagicMock(returncode=0)
         with (
             patch.object(e2e_mod, "resolve_worktree", return_value=None),
-            patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+            patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
         ):
             call_command("e2e", "project", headed=True, docker=False)
 
@@ -138,7 +155,7 @@ class TestE2eProject(TestCase):
         mock_result = MagicMock(returncode=0)
         with (
             patch.object(e2e_mod, "resolve_worktree", return_value=None),
-            patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+            patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
         ):
             call_command("e2e", "project", test_path="tests/e2e/test_login.py", docker=False)
 
@@ -172,7 +189,7 @@ class TestE2eProject(TestCase):
                     return_value=MagicMock(extra={"worktree_path": str(wt)}),
                 ),
                 patch.object(Path, "exists", fake_exists),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 call_command(
                     "e2e",
@@ -384,7 +401,7 @@ class TestE2eExternal(TestCase):
                 patch.dict("os.environ", {"T3_ORIG_CWD": str(wt_dir)}, clear=False),
                 patch.object(config_mod, "load_config") as mock_cfg,
                 patch.object(e2e_disc_mod, "get_service_port", return_value=4200),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)),
             ):
                 mock_cfg.return_value.raw = {"teatree": {"private_tests": str(private_dir)}}
                 os.environ.pop("T3_PRIVATE_TESTS", None)
@@ -430,7 +447,7 @@ class TestE2eExternal(TestCase):
             with (
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
                 patch.object(e2e_disc_mod, "get_service_port", return_value=5555),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 result = cast("str", call_command("e2e", "external"))
             assert "passed" in result
@@ -477,7 +494,7 @@ class TestE2eExternal(TestCase):
             with (
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
                 patch.object(e2e_disc_mod, "get_service_port", return_value=5555),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 result = cast("str", call_command("e2e", "external", target="local"))
             assert "passed" in result
@@ -551,7 +568,7 @@ class TestE2eExternal(TestCase):
                     clear=False,
                 ),
                 patch.object(e2e_disc_mod, "get_service_port", return_value=62674),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 os.environ.pop("BASE_URL", None)
                 result = cast(
@@ -611,7 +628,7 @@ class TestE2eExternal(TestCase):
                     {"T3_PRIVATE_TESTS": str(private_dir), "BASE_URL": "https://dev.example.com"},
                     clear=False,
                 ),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 os.environ.pop("COMPOSE_PROJECT_NAME", None)
                 result = cast("str", call_command("e2e", "external", target="dev"))
@@ -643,7 +660,7 @@ class TestE2eExternal(TestCase):
             with (
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
                 patch.object(e2e_disc_mod, "get_service_port", return_value=4200),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
                 pytest.raises(SystemExit) as exc_info,
             ):
                 call_command("e2e", "external", headed=True)
@@ -676,7 +693,7 @@ class TestE2eExternal(TestCase):
             with (
                 patch.dict("os.environ", {"T3_PRIVATE_TESTS": str(private_dir), "T3_ORIG_CWD": str(wt_dir)}),
                 patch.object(e2e_disc_mod, "get_service_port", return_value=4200),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 call_command("e2e", "external", test_path="tests/login.py")
             cmd = mock_run.call_args[0][0]
@@ -727,7 +744,7 @@ class TestE2eExternal(TestCase):
                     clear=False,
                 ),
                 patch.object(e2e_mod, "_discover_frontend_port") as mock_discover,
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 result = cast("str", call_command("e2e", "external"))
 
@@ -751,7 +768,7 @@ class TestE2eExternal(TestCase):
                 patch.object(e2e_mod, "load_e2e_repos", return_value=[repo]),
                 patch.object(e2e_mod, "_clone_or_update_e2e_repo", return_value=playwright_root),
                 patch.object(e2e_mod, "_discover_frontend_port") as mock_discover,
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 result = cast("str", call_command("e2e", "external", repo="svc"))
 
@@ -790,7 +807,7 @@ class TestE2eExternalPreflight(TestCase):
                 ),
                 patch.object(import_string(FULL_OVERLAY), "get_e2e_preflight", new=_record),
                 patch.object(e2e_mod, "_discover_frontend_port"),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)),
             ):
                 result = cast("str", call_command("e2e", "external"))
 
@@ -823,7 +840,7 @@ class TestE2eExternalPreflight(TestCase):
                     clear=False,
                 ),
                 patch.object(import_string(FULL_OVERLAY), "get_e2e_preflight", new=_failing),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
                 patch.object(e2e_mod, "_discover_frontend_port"),
                 pytest.raises(SystemExit) as exc_info,
             ):
@@ -842,7 +859,7 @@ class TestE2eRun(TestCase):
         mock_result = MagicMock(returncode=0)
         with (
             patch.object(e2e_mod, "resolve_worktree", return_value=None),
-            patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+            patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
         ):
             result = cast("str", call_command("e2e", "run", docker=False))
 
@@ -858,7 +875,7 @@ class TestE2eRun(TestCase):
             patch.dict("os.environ", {"T3_PRIVATE_TESTS": tmp, "BASE_URL": "https://dev.example"}, clear=False),
         ):
             mock_result = MagicMock(returncode=0)
-            with patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run:
+            with patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run:
                 result = cast("str", call_command("e2e", "run"))
 
             assert "passed" in result
@@ -871,7 +888,7 @@ class TestE2eRun(TestCase):
         mock_result = MagicMock(returncode=0)
         with (
             patch.object(e2e_mod, "resolve_worktree", return_value=None),
-            patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+            patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
         ):
             call_command("e2e", "run", docker=False)
         assert "pytest" in mock_run.call_args[0][0]
@@ -884,7 +901,7 @@ class TestE2eRun(TestCase):
             patch.dict("os.environ", {"T3_PRIVATE_TESTS": tmp, "BASE_URL": "https://dev.example"}, clear=False),
         ):
             mock_result = MagicMock(returncode=0)
-            with patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run:
+            with patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run:
                 call_command("e2e", "run")
             assert "playwright" in mock_run.call_args[0][0]
 
@@ -1008,7 +1025,7 @@ class TestE2eExternalRepo(TestCase):
                 patch.object(e2e_mod, "load_e2e_repos", return_value=[repo]),
                 patch.object(e2e_mod, "_clone_or_update_e2e_repo", return_value=playwright_root),
                 patch.object(e2e_disc_mod, "get_service_port", return_value=4200),
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run,
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 result = cast("str", call_command("e2e", "external", repo="demo-svc"))
 

--- a/tests/teatree_core/management_commands/test_notify_post_react.py
+++ b/tests/teatree_core/management_commands/test_notify_post_react.py
@@ -48,7 +48,7 @@ class TestNotifyPost:
         backend.post_routed.assert_called_once_with(channel="C_TEAM", text="hi team", thread_ts="")
         assert "1700.0001" in out
 
-    def test_post_threads_when_thread_given(self) -> None:
+    def test_post_threads_when_thread_ts_given(self) -> None:
         backend = MagicMock()
         backend.post_routed.return_value = {"ok": True, "ts": "1700.9"}
         with patch(
@@ -56,11 +56,38 @@ class TestNotifyPost:
             return_value=backend,
         ):
             _out, _err, code = _call(
-                "notify", "post", "--channel", "C_TEAM", "--thread", "1700.0001", "--text", "reply"
+                "notify", "post", "--channel", "C_TEAM", "--thread-ts", "1700.0001", "--text", "reply"
             )
 
         assert code == 0
         backend.post_routed.assert_called_once_with(channel="C_TEAM", text="reply", thread_ts="1700.0001")
+
+    def test_post_self_dm_threaded_reply_lands_thread_ts_in_payload(self) -> None:
+        # Self-DM reply (the user's own bot DM) is the ungated path; the
+        # ``--thread-ts`` value must reach the chat.postMessage payload so a
+        # threaded user-reply actually threads. Mock only the HTTP egress.
+        from teatree.backends.slack_bot import SlackBotBackend  # noqa: PLC0415
+
+        backend = SlackBotBackend(
+            bot_token="xoxb-test",
+            user_id="U_ME",
+            dm_channel_id="D_ME",
+        )
+        with (
+            patch.object(backend, "_post", return_value={"ok": True, "ts": "1.0"}) as post,
+            patch(
+                "teatree.core.management.commands.notify.messaging_from_overlay",
+                return_value=backend,
+            ),
+        ):
+            _out, _err, code = _call(
+                "notify", "post", "--channel", "D_ME", "--thread-ts", "1780685008.488439", "--text", "reply"
+            )
+
+        assert code == 0
+        payload = post.call_args.args[1]
+        assert payload["thread_ts"] == "1780685008.488439"
+        assert payload["channel"] == "D_ME"
 
     def test_post_text_dash_reads_stdin(self) -> None:
         backend = MagicMock()

--- a/tests/teatree_core/management_commands/test_run.py
+++ b/tests/teatree_core/management_commands/test_run.py
@@ -1,7 +1,6 @@
 """Tests for the run management command."""
 
 import os
-import subprocess
 import tempfile
 from pathlib import Path
 from typing import cast
@@ -21,6 +20,22 @@ from tests.teatree_core.management_commands._overlays import FULL_OVERLAY, MINIM
 pytestmark = pytest.mark.filterwarnings(
     "ignore:In Typer, only the parameter 'autocompletion' is supported.*:DeprecationWarning",
 )
+
+
+def _popen_mock(returncode: int = 0, stderr: str = "") -> MagicMock:
+    """Build a ``Popen`` context-manager mock matching ``run_streamed``'s usage.
+
+    ``run_streamed`` tees stderr (iterates ``proc.stderr``) then calls
+    ``proc.wait()``; the mock exposes both so a test can assert the streamed
+    command was invoked and drive the surfaced exit code.
+    """
+    proc = MagicMock()
+    proc.stderr = iter(stderr.splitlines(keepends=True))
+    proc.wait.return_value = returncode
+    ctx = MagicMock()
+    ctx.__enter__.return_value = proc
+    ctx.__exit__.return_value = False
+    return MagicMock(return_value=ctx)
 
 
 # ── Run commands ───────────────────────────────────────────────────
@@ -45,8 +60,9 @@ class TestRunBackend(TestCase):
 
             mock_config = MagicMock()
             mock_config.user.workspace_dir = tmp_path
+            mock_run = _popen_mock()
             with (
-                patch.object(utils_run_mod.subprocess, "run") as mock_run,
+                patch.object(utils_run_mod, "Popen", mock_run),
                 patch("teatree.config.load_config", return_value=mock_config),
             ):
                 result = cast("str", call_command("run", "backend", path=str(wt_dir)))
@@ -97,11 +113,8 @@ class TestRunBuildFrontend(TestCase):
                 extra={"worktree_path": str(wt_dir)},
             )
 
-            with patch.object(
-                utils_run_mod.subprocess,
-                "run",
-                return_value=subprocess.CompletedProcess([], 0, "", ""),
-            ) as mock_run:
+            mock_run = _popen_mock()
+            with patch.object(utils_run_mod, "Popen", mock_run):
                 result = cast("str", call_command("run", "build-frontend", path=str(wt_dir)))
 
             mock_run.assert_called_once()
@@ -149,8 +162,8 @@ class TestRunTests(TestCase):
                 extra={"worktree_path": str(wt_dir)},
             )
 
-            mock_result = subprocess.CompletedProcess([], 0)
-            with patch.object(utils_run_mod.subprocess, "run", return_value=mock_result) as mock_run:
+            mock_run = _popen_mock()
+            with patch.object(utils_run_mod, "Popen", mock_run):
                 result = cast("str", call_command("run", "tests", path=str(wt_dir)))
 
             mock_run.assert_called_once()
@@ -205,9 +218,8 @@ class TestRunTestsFailureExitCode(TestCase):
                 extra={"worktree_path": str(wt_dir)},
             )
 
-            mock_result = subprocess.CompletedProcess([], 1)
             with (
-                patch.object(utils_run_mod.subprocess, "run", return_value=mock_result),
+                patch.object(utils_run_mod, "Popen", _popen_mock(returncode=1)),
                 pytest.raises(SystemExit) as exc_info,
             ):
                 call_command("run", "tests", path=str(wt_dir))

--- a/tests/teatree_core/management_commands/test_tool.py
+++ b/tests/teatree_core/management_commands/test_tool.py
@@ -1,8 +1,7 @@
 """Tests for the tool management command."""
 
-import subprocess
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.management import call_command
@@ -14,6 +13,17 @@ from tests.teatree_core.management_commands._overlays import FULL_OVERLAY, MINIM
 pytestmark = pytest.mark.filterwarnings(
     "ignore:In Typer, only the parameter 'autocompletion' is supported.*:DeprecationWarning",
 )
+
+
+def _popen_mock(returncode: int = 0) -> MagicMock:
+    """A ``Popen`` context-manager mock matching ``run_streamed``'s usage."""
+    proc = MagicMock()
+    proc.stderr = iter(())
+    proc.wait.return_value = returncode
+    ctx = MagicMock()
+    ctx.__enter__.return_value = proc
+    ctx.__exit__.return_value = False
+    return MagicMock(return_value=ctx)
 
 
 # ── Tool commands ──────────────────────────────────────────────────
@@ -51,14 +61,13 @@ class TestToolRun(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
     def test_executes_command(self) -> None:
-        with patch.object(utils_run_mod.subprocess, "run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        mock_run = _popen_mock()
+        with patch.object(utils_run_mod, "Popen", mock_run):
             result = cast("str", call_command("tool", "run", "migrate"))
 
         assert "completed" in result.lower()
         mock_run.assert_called_once()
-        call_args = mock_run.call_args
-        assert call_args[0][0] == ["echo", "migrate"]
+        assert mock_run.call_args[0][0] == ["echo", "migrate"]
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -86,8 +95,8 @@ class TestToolRun(TestCase):
     @override_settings(**SETTINGS)
     def test_forwards_extra_args(self) -> None:
         """Extra args after the tool name are appended to the command."""
-        with patch.object(utils_run_mod.subprocess, "run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        mock_run = _popen_mock()
+        with patch.object(utils_run_mod, "Popen", mock_run):
             result = cast(
                 "str",
                 call_command("tool", "run", "migrate", "--verbose", "--dry-run"),

--- a/tests/teatree_core/test_run_command.py
+++ b/tests/teatree_core/test_run_command.py
@@ -1,6 +1,5 @@
 import tempfile
 from pathlib import Path
-from subprocess import CompletedProcess
 from typing import cast
 from unittest.mock import MagicMock, patch
 
@@ -18,6 +17,27 @@ from tests.teatree_core.conftest import CommandOverlay
 COMMAND_SETTINGS: dict[str, object] = {}
 
 _MOCK_OVERLAY = {"test": CommandOverlay()}
+
+
+def _popen_capturing(commands: list[tuple[object, dict[str, object]]], *, returncode: int = 0) -> MagicMock:
+    """A ``Popen`` mock that records ``(cmd, kwargs)`` and tees empty stderr.
+
+    Mirrors ``run_streamed``'s context-manager usage (iterate ``proc.stderr``
+    then ``proc.wait()``) while letting the test inspect every invocation's
+    command list and env, as the old ``subprocess.run`` ``side_effect`` did.
+    """
+
+    def factory(*args: object, **kwargs: object) -> MagicMock:
+        commands.append((args[0], kwargs))
+        proc = MagicMock()
+        proc.stderr = iter(())
+        proc.wait.return_value = returncode
+        ctx = MagicMock()
+        ctx.__enter__.return_value = proc
+        ctx.__exit__.return_value = False
+        return ctx
+
+    return MagicMock(side_effect=factory)
 
 
 class TestRunCommand(TestCase):
@@ -173,14 +193,10 @@ class TestRunCommand(TestCase):
 
             commands: list[tuple[object, dict[str, object]]] = []
 
-            def fake_run(*args: object, **kwargs: object) -> CompletedProcess[str]:
-                commands.append((args[0], kwargs))
-                return CompletedProcess(args[0], 0, "", "")
-
             with (
                 patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
                 patch.object(run_mod, "get_overlay", return_value=mock_overlay),
-                patch.object(utils_run_mod.subprocess, "run", side_effect=fake_run),
+                patch.object(utils_run_mod, "Popen", _popen_capturing(commands)),
                 patch("teatree.config.load_config", return_value=mock_config),
             ):
                 result = cast("str", call_command("run", "backend", path=wt_path))
@@ -215,12 +231,7 @@ class TestE2eExternalCommand(TestCase):
                 db_name="wt_80_acme",
             )
 
-            captured_envs: list[dict[str, str]] = []
-
-            def fake_run(*args: object, **kwargs: object) -> CompletedProcess[str]:
-                if "env" in kwargs:
-                    captured_envs.append(cast("dict[str, str]", kwargs["env"]))
-                return CompletedProcess(args[0], 0, "", "")
+            commands: list[tuple[object, dict[str, object]]] = []
 
             with (
                 patch.dict(
@@ -232,10 +243,11 @@ class TestE2eExternalCommand(TestCase):
                 ),
                 patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
                 patch.object(e2e_disc_mod, "get_service_port", return_value=4299),
-                patch.object(utils_run_mod.subprocess, "run", side_effect=fake_run),
+                patch.object(utils_run_mod, "Popen", _popen_capturing(commands)),
             ):
                 result = cast("str", call_command("e2e", "external"))
 
+            captured_envs = [cast("dict[str, str]", kwargs["env"]) for _cmd, kwargs in commands if "env" in kwargs]
             assert result == "E2E passed."
             assert captured_envs
             assert captured_envs[-1]["BASE_URL"] == "http://localhost:4299"
@@ -281,16 +293,16 @@ class TestE2eExternalCommand(TestCase):
 
 
 class TestCliOverlay:
-    @patch.object(utils_run_mod.subprocess, "run")
-    def test_managepy_calls_uv(self, mock_run: MagicMock, tmp_path: Path) -> None:
+    def test_managepy_calls_uv(self, tmp_path: Path) -> None:
         from teatree.cli.overlay import managepy  # noqa: PLC0415
 
-        mock_run.return_value = MagicMock(returncode=0)
+        commands: list[tuple[object, dict[str, object]]] = []
         (tmp_path / "manage.py").write_text("# stub", encoding="utf-8")
-        managepy(tmp_path, "migrate", "--no-input")
+        with patch.object(utils_run_mod, "Popen", _popen_capturing(commands)):
+            managepy(tmp_path, "migrate", "--no-input")
 
-        assert mock_run.call_count == 1
-        cmd = mock_run.call_args[0][0]
+        assert len(commands) == 1
+        cmd = cast("list[str]", commands[0][0])
         assert Path(cmd[0]).name == "uv"
         assert cmd[1:3] == ["--directory", str(tmp_path)]
         assert cmd[-2:] == ["migrate", "--no-input"]

--- a/tests/teatree_core/test_workflows.py
+++ b/tests/teatree_core/test_workflows.py
@@ -31,6 +31,22 @@ pytestmark = [
 ]
 
 
+def _popen_mock(returncode: int = 0) -> MagicMock:
+    """A ``Popen`` context-manager mock matching ``run_streamed``'s usage.
+
+    ``run backend`` launches docker compose through ``run_streamed``, which
+    now drives ``Popen`` (tee stderr, then ``wait()``). The mock records each
+    ``Popen(cmd, ...)`` call so a test can assert the docker invocation.
+    """
+    proc = MagicMock()
+    proc.stderr = iter(())
+    proc.wait.return_value = returncode
+    ctx = MagicMock()
+    ctx.__enter__.return_value = proc
+    ctx.__exit__.return_value = False
+    return MagicMock(return_value=ctx)
+
+
 class _WorkflowMetadata(OverlayMetadata):
     def get_tool_commands(self) -> list[ToolCommand]:
         return [
@@ -548,9 +564,10 @@ class TestRunBackend(TestCase):
 
         mock_config = MagicMock()
         mock_config.user.workspace_dir = self._tmp_path
+        mock_popen = _popen_mock()
         with (
             _patch_overlay(),
-            patch.object(utils_run_mod.subprocess, "run", return_value=MagicMock(returncode=0)) as mock_sp_run,
+            patch.object(utils_run_mod, "Popen", mock_popen),
             patch("teatree.config.load_config", return_value=mock_config),
         ):
             result = cast("str", call_command("run", "backend", path=str(wt_dir)))
@@ -558,7 +575,7 @@ class TestRunBackend(TestCase):
         assert result == "Backend started via docker-compose."
 
         # Should have called docker compose up -d web
-        docker_calls = [c for c in mock_sp_run.call_args_list if "docker" in str(c)]
+        docker_calls = [c for c in mock_popen.call_args_list if "docker" in str(c)]
         assert len(docker_calls) >= 1
 
     @override_settings(**WORKFLOW_SETTINGS)
@@ -651,9 +668,10 @@ class TestRunBackend(TestCase):
         # --- Step 3: run backend (docker compose) ---
         mock_config = MagicMock()
         mock_config.user.workspace_dir = self._tmp_path
+        mock_popen = _popen_mock()
         with (
             _patch_overlay(),
-            patch.object(utils_run_mod.subprocess, "run", return_value=MagicMock(returncode=0)) as mock_run_sp,
+            patch.object(utils_run_mod, "Popen", mock_popen),
             patch("teatree.config.load_config", return_value=mock_config),
         ):
             run_result = cast("str", call_command("run", "backend", path=backend_wt_path))
@@ -661,7 +679,7 @@ class TestRunBackend(TestCase):
         assert run_result == "Backend started via docker-compose."
 
         # Docker compose was called
-        docker_calls = [c for c in mock_run_sp.call_args_list if "docker" in str(c)]
+        docker_calls = [c for c in mock_popen.call_args_list if "docker" in str(c)]
         assert len(docker_calls) >= 1
 
 
@@ -687,16 +705,16 @@ class TestToolAndCleanCommands(TestCase):
         assert "check-translations" in result
         assert "Check translations" in result
 
+        mock_popen = _popen_mock()
         with (
             _patch_overlay(),
-            patch.object(utils_run_mod, "subprocess") as mock_sp,
+            patch.object(utils_run_mod, "Popen", mock_popen),
         ):
-            mock_sp.run.return_value = MagicMock(returncode=0)
             result = cast("str", call_command("tool", "run", "check-translations"))
 
         assert result == "Tool 'check-translations' completed."
-        mock_sp.run.assert_called_once()
-        assert "check_translations" in mock_sp.run.call_args.args[0]
+        mock_popen.assert_called_once()
+        assert "check_translations" in mock_popen.call_args.args[0]
 
     @override_settings(**WORKFLOW_SETTINGS)
     def test_clean_only_removes_created_worktrees(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,16 +76,23 @@ class TestDocsCommand:
         fake_mkdocs = types.ModuleType("mkdocs")
         monkeypatch.setitem(sys.modules, "mkdocs", fake_mkdocs)
 
+        # ``docs`` runs mkdocs through ``run_streamed`` → ``Popen`` (tee
+        # stderr, then ``wait()``); mock that seam, not ``subprocess.run``.
+        proc = MagicMock()
+        proc.stderr = iter(())
+        proc.wait.return_value = 0
+        ctx = MagicMock()
+        ctx.__enter__.return_value = proc
+        ctx.__exit__.return_value = False
+        mock_run = MagicMock(return_value=ctx)
         with (
-            patch.object(utils_run_mod.subprocess, "run") as mock_run,
+            patch.object(utils_run_mod, "Popen", mock_run),
             patch("teatree.cli._maybe_show_update_notice"),
         ):
-            mock_run.return_value = MagicMock(returncode=0)
             result = runner.invoke(app, ["docs"])
             assert result.exit_code == 0
             mock_run.assert_called_once()
-            call_args = mock_run.call_args
-            assert "mkdocs" in str(call_args)
+            assert "mkdocs" in str(mock_run.call_args)
 
 
 # ── agent command ─────────────────────────────────────────────────────

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,6 +1,6 @@
 import pytest
 
-from teatree.utils.run import PIPE, CommandFailedError, run_allowed_to_fail, run_checked, spawn
+from teatree.utils.run import PIPE, CommandFailedError, run_allowed_to_fail, run_checked, run_streamed, spawn
 
 
 class TestRunChecked:
@@ -33,6 +33,33 @@ class TestRunChecked:
     def test_feeds_stdin(self) -> None:
         result = run_checked(["cat"], stdin_text="hello\n")
         assert result.stdout == "hello\n"
+
+
+class TestRunStreamed:
+    def test_returns_zero_on_success(self) -> None:
+        assert run_streamed(["true"]) == 0
+
+    def test_returns_code_when_check_disabled(self) -> None:
+        assert run_streamed(["sh", "-c", "exit 3"], check=False) == 3
+
+    def test_raises_with_returncode_on_nonzero(self) -> None:
+        with pytest.raises(CommandFailedError) as exc:
+            run_streamed(["false"])
+        assert exc.value.returncode == 1
+        assert exc.value.cmd == ["false"]
+
+    def test_surfaces_subcommand_stderr_in_raised_error(self) -> None:
+        # The failing subcommand's stderr must name itself in the error so the
+        # next breakage is diagnosable, not a bare `command failed (rc=1)`.
+        with pytest.raises(CommandFailedError) as exc:
+            run_streamed(["sh", "-c", "echo 'unknown option --thread-ts' >&2; exit 1"])
+        assert "unknown option --thread-ts" in exc.value.stderr
+        assert "unknown option --thread-ts" in str(exc.value)
+
+    def test_streams_stderr_to_parent_while_capturing(self, capfd: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(CommandFailedError):
+            run_streamed(["sh", "-c", "echo live-stderr >&2; exit 1"])
+        assert "live-stderr" in capfd.readouterr().err
 
 
 class TestRunAllowedToFail:


### PR DESCRIPTION
Problem: `t3 <overlay> notify post --thread-ts <ts>` failed with a bare rc=1 while the same command without `--thread-ts` succeeded. Threaded replies through this path silently failed and the error gave no clue why.

Two independent causes:

1. Wrong flag name. The `notify post` management command defined the option as `--thread`, so the natural `--thread-ts` flag (matching the Slack chat.postMessage `thread_ts` param) was rejected as an unknown option. The CLI wrapper forwards extra args to the subcommand, so a typer "No such option" error fired in the subprocess.

2. Swallowed stderr. `run_streamed` raised CommandFailedError with empty stderr on non-zero exit, so the subcommand error (the No-such-option line) was never captured — the failure surfaced as a bare `command failed (rc=1)` with no diagnosis.

Fix:

- Rename the option to `--thread-ts` (clean cutover, no alias); regenerate the CLI reference. The threaded value reaches chat.postMessage via the existing self-DM-ungated egress path — a reply to the user own bot DM still short-circuits the on-behalf gate, unchanged.
- `run_streamed` now tees the child stderr: each chunk is forwarded live to the parent and captured into the raised error, so the next breakage names itself. stdout stays inherited, so live output and interactive prompts are unaffected.

Tests:

- RED-first for both the flag rejection (via call_command) and the swallowed-stderr class; GREEN after.
- A self-DM integration test asserts thread_ts lands in the chat.postMessage payload (only the HTTP egress mocked).
- 100% coverage on changed lines in run.py; the changed post command lines are fully covered.
- run_streamed-exercising tests migrated off the stale subprocess.run mock seam to a Popen context-manager mock (the production seam moved from subprocess.run to subprocess.Popen to enable the tee).

Verification: live threaded post to the maintainer own bot DM returned rc=0 with a valid ts.