### PR TITLE
fix(workspace): clean-all reaps squash-merged worktrees + per-worktree docker (#1940)

### DIFF
--- a/skills/workspace/SKILL.md
+++ b/skills/workspace/SKILL.md
@@ -128,7 +128,9 @@ All workspace operations go through the `t3` CLI. Run `t3 <overlay> --help` for 
 
 ## Cleanup Patterns
 
-`t3 <overlay> workspace clean-all` is the entry point for all cleanup. It prunes merged worktrees, drops orphaned databases, classifies and removes stale local branches (gone-remote, fully-merged, **squash-merged via subject match**), drops orphaned stashes, removes empty workspace dirs, and prunes old DSLR snapshots. The squash-merge classifier handles `(#NNN)` suffixes and `relax:` → `feat(scope):` prefix rewrites, so squash-merged branches don't appear as "unsynced".
+`t3 <overlay> workspace clean-all` is the entry point for all cleanup. It tears down **Worktree rows whose branch is squash-merged** (any FSM state, via the forge merged-PR signal — not just `CREATED` rows), prunes merged worktrees, drops orphaned databases, reaps per-worktree docker images/containers for compose projects with no live worktree, classifies and removes stale local branches (gone-remote, fully-merged, **squash-merged via subject match**), drops orphaned stashes, recursively removes empty workspace/ticket dirs (including multi-repo ticket dirs left holding only empty repo subdirs), and prunes old DSLR snapshots. The squash-merge classifier handles `(#NNN)` suffixes and `relax:` → `feat(scope):` prefix rewrites, so squash-merged branches don't appear as "unsynced".
+
+Branch names matching a `clean_ignore` glob in `~/.teatree.toml` (`[teatree] clean_ignore = ["spike/*", "dev-override"]`, per-overlay overridable) are never reaped — for never-merge dev overrides and long-lived spikes. When the squash signal is uncertain (no merged PR, non-empty diff, forge CLI absent) the worktree is **kept with a warning**, never deleted — the data-loss guards (#706/#835/#1506) are never bypassed.
 
 ### Single-repo cleanup
 

--- a/src/teatree/config.py
+++ b/src/teatree/config.py
@@ -366,6 +366,7 @@ OVERLAY_OVERRIDABLE_SETTINGS: dict[str, Callable[[Any], Any]] = {
     "todo_sweep_disabled": bool,
     "todo_sweep_recheck_interval_hours": int,
     "max_concurrent_local_stacks": int,
+    "clean_ignore": _parse_excluded_skills,
     "slack_voice_classifier_mode": SlackVoiceClassifierMode.parse,
     "speak_mode": SpeakMode.parse,
     "speak_target": SpeakTarget.parse,
@@ -690,6 +691,11 @@ class UserSettings:
     # Per-overlay overridable: a heavy overlay can cap to ``1`` while a
     # cheap dogfood overlay stays unbounded.
     max_concurrent_local_stacks: int = 0
+    # fnmatch globs of branch names ``clean-all`` must NEVER reap even when the
+    # squash-merge classifier says shipped — never-merge dev overrides, long-lived
+    # spikes. Matched against the full branch name. Default empty: nothing
+    # protected beyond the data-loss guards. Per-overlay overridable.
+    clean_ignore: list[str] = field(default_factory=list)
     # #1395 Slack voice/token mismatch classifier. The pre-publish gate
     # between ``chat.postMessage`` and the Slack API refuses (or warns)
     # when the body's voice ("PR merged" / "evidence" → agent vs "please
@@ -903,6 +909,7 @@ def load_config(path: Path | None = None) -> TeaTreeConfig:
         todo_sweep_disabled=bool(teatree.get("todo_sweep_disabled", False)),
         todo_sweep_recheck_interval_hours=int(teatree.get("todo_sweep_recheck_interval_hours", 1)),
         max_concurrent_local_stacks=int(teatree.get("max_concurrent_local_stacks", 0)),
+        clean_ignore=_parse_excluded_skills(teatree.get("clean_ignore", [])),
         slack_voice_classifier_mode=_resolve_slack_voice_classifier_mode(teatree),
         speak_mode=_resolve_speak_mode(teatree),
         speak_target=_resolve_speak_target(teatree),

--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -6,10 +6,14 @@ prefix) because the only public surface is the ``clean-all`` subcommand.
 """
 
 import re
+from contextlib import suppress
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from teatree.config import load_config
 from teatree.core.cleanup import _branch_tree_matches_squash, cleanup_worktree
+from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Worktree
 from teatree.core.worktree_env import CACHE_DIRNAME, CACHE_FILENAME, write_env_cache
 from teatree.utils import git
@@ -155,6 +159,82 @@ def prune_squash_merged(repo: str, name: str, wt_map: dict[str, str]) -> str:
         git.run(repo=repo, args=["worktree", "prune"])
     git.branch_delete(repo, name)
     return f"Pruned squash-merged branch: {name}"
+
+
+def _branch_is_clean_ignored(branch: str, patterns: list[str]) -> bool:
+    return any(fnmatch(branch, pattern) for pattern in patterns)
+
+
+class WorktreeReaper:
+    """Workspace-scoped clean-all reaping: squash-merged rows + empty dirs.
+
+    Groups the two passes that operate on the whole ``workspace`` (rather than a
+    single repo like the branch/stash helpers): tear down Worktree rows whose
+    branch shipped, then prune the now-empty ticket dirs they leave behind.
+    """
+
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+
+    def reap_squash_merged_worktrees(self, *, interactive: bool) -> list[str]:
+        """Tear down Worktree rows whose branch is squash-merged.
+
+        ``clean-all`` only reaped ``CREATED``-state rows; a PROVISIONED/READY row
+        whose branch shipped under a retitled squash subject survived forever (its
+        dir, compose project, and ticket dir all leaking). This pass reaps those.
+
+        The squash signal reuses :func:`is_squash_merged` — the same forge-primary,
+        empty-diff-fallback classifier the branch-prune pass uses (no duplicated
+        subject-match logic). It is fail-safe to *not merged*: a missing forge CLI,
+        a non-empty diff, or any uncertain outcome reads as keep, so an uncertain
+        row is reported with a SKIPPED warning and never deleted (warn-not-fail).
+
+        The teardown goes through :func:`cleanup_worktree` with the default
+        ``strict_hygiene=True`` / ``force=False``, so the #706/#835/#1506 data-loss
+        guards still refuse a branch with commits on no remote — a positive squash
+        signal narrows the candidate set, it never bypasses the guards. Branches
+        matching ``clean_ignore`` are skipped before any classification.
+        """
+        clean_ignore = load_config().user.clean_ignore
+        cleaned: list[str] = []
+        for worktree in Worktree.objects.exclude(state=Worktree.State.CREATED).select_related("ticket"):
+            if _branch_is_clean_ignored(worktree.branch, clean_ignore):
+                cleaned.append(f"SKIPPED '{worktree.branch}': matches clean_ignore — keeping")
+                continue
+            repo = resolve_clone_path(self.workspace, worktree)
+            if repo is None or not repo.is_dir():
+                continue
+            default = git.default_branch(str(repo))
+            if not is_squash_merged(str(repo), worktree.branch, default):
+                continue
+            try:
+                cleaned.append(str(cleanup_worktree(worktree)))
+            except RuntimeError as exc:
+                cleaned.append(resolve_unsynced_worktree(worktree, exc, interactive=interactive))
+        return cleaned
+
+    def remove_empty_ticket_dirs(self) -> list[str]:
+        """Remove ticket dirs that are empty or hold only empty repo subdirs.
+
+        A multi-repo ticket dir (``ac/1234/`` with empty ``backend/`` +
+        ``frontend/`` left behind after the worktrees are reaped) is not empty
+        itself, so the single-level ``not any(iterdir())`` check kept it. This
+        prunes empty leaf subdirs first, then the ticket dir if it is now empty.
+        A subdir holding any real file or nested content is left untouched.
+        """
+        removed: list[str] = []
+        for entry in self.workspace.iterdir():
+            if not entry.is_dir():
+                continue
+            for child in list(entry.iterdir()):
+                if child.is_dir() and not any(child.iterdir()):
+                    with suppress(OSError):
+                        child.rmdir()
+            if not any(entry.iterdir()):
+                with suppress(OSError):
+                    entry.rmdir()
+                    removed.append(f"Removed empty dir: {entry.name}")
+        return removed
 
 
 def _origin_ref_exists(repo: str, branch: str) -> bool:

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -19,6 +19,7 @@ from teatree.core.dev_repo import resolve_repo_names
 from teatree.core.local_stack_gate import refuse_if_limit_exceeded
 from teatree.core.management.commands import _workspace_helpers as _wh
 from teatree.core.management.commands._workspace_cleanup import (
+    WorktreeReaper,
     _die,
     _fix_drift,
     _raise_on_cleanup_failures,
@@ -564,17 +565,15 @@ class Command(TyperCommand):
         cleaned: list[str] = []
         interactive = sys.stdin.isatty() and sys.stdout.isatty()
         in_use = _wh.dslr_tenants_in_use()  # before cleanup loop reaps CREATED worktrees (#1306)
+        reaper = WorktreeReaper(workspace)
+        cleaned.extend(reaper.reap_squash_merged_worktrees(interactive=interactive))
         for wt in Worktree.objects.filter(state=Worktree.State.CREATED):
             try:
                 cleaned.append(str(cleanup_worktree(wt)))
             except RuntimeError as exc:
                 cleaned.append(resolve_unsynced_worktree(wt, exc, interactive=interactive))
 
-        for entry in workspace.iterdir():
-            if entry.is_dir() and not any(entry.iterdir()):
-                with suppress(OSError):
-                    entry.rmdir()
-                    cleaned.append(f"Removed empty dir: {entry.name}")
+        cleaned.extend(reaper.remove_empty_ticket_dirs())
 
         cleaned.extend(drop_orphan_databases())
         cleaned.extend(reap_orphan_worktree_docker())

--- a/tests/config/test_load_config.py
+++ b/tests/config/test_load_config.py
@@ -211,6 +211,18 @@ def test_user_identity_aliases_ignores_non_list(tmp_path: Path) -> None:
     assert load_config(config_path).user.user_identity_aliases == []
 
 
+def test_clean_ignore_defaults_empty(tmp_path: Path) -> None:
+    config_path = tmp_path / ".teatree.toml"
+    _write_toml(config_path, "[teatree]\n")
+    assert load_config(config_path).user.clean_ignore == []
+
+
+def test_clean_ignore_reads_toml(tmp_path: Path) -> None:
+    config_path = tmp_path / ".teatree.toml"
+    _write_toml(config_path, '[teatree]\nclean_ignore = ["spike/*", "dev-override"]\n')
+    assert load_config(config_path).user.clean_ignore == ["spike/*", "dev-override"]
+
+
 def test_loop_cadence_seconds_override(tmp_path: Path) -> None:
     config_path = tmp_path / ".teatree.toml"
     _write_toml(config_path, "[teatree]\nloop_cadence_seconds = 300\n")

--- a/tests/config/test_overlay_overrides.py
+++ b/tests/config/test_overlay_overrides.py
@@ -195,6 +195,32 @@ user_identity_aliases = ["adrien.work", "souliane", "adrien.cossa"]
 
         assert get_effective_settings().user_identity_aliases == ["adrien.work", "souliane", "adrien.cossa"]
 
+    def test_overlay_can_override_clean_ignore(
+        self,
+        config_file: Path,
+        elsewhere: Path,
+        no_installed_overlays: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A per-overlay clean_ignore glob list wins over the global default (#1940)."""
+        del elsewhere, no_installed_overlays
+        monkeypatch.delenv("T3_MODE", raising=False)
+        monkeypatch.setenv("T3_OVERLAY_NAME", "scoped")
+
+        _write_toml(
+            config_file,
+            """
+[teatree]
+clean_ignore = ["global-*"]
+
+[overlays.scoped]
+class = "x.y:Z"
+clean_ignore = ["spike/*", "dev-override"]
+""",
+        )
+
+        assert get_effective_settings().clean_ignore == ["spike/*", "dev-override"]
+
     def test_overlay_can_override_require_human_approval_to_answer(
         self,
         config_file: Path,

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -4,6 +4,8 @@ import os
 import re
 import subprocess
 import tempfile
+from contextlib import AbstractContextManager
+from dataclasses import replace
 from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -22,6 +24,7 @@ import teatree.core.runners.provision as provision_mod
 import teatree.utils.db as db_mod
 import teatree.utils.git as git_mod
 import teatree.utils.run as utils_run_mod
+from teatree.config import load_config
 from teatree.core.management.commands.workspace import _branch_prefix, _build_branch_name, _workspace_dir
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase, ProvisionStep
@@ -2598,3 +2601,234 @@ class TestPruneGoneRemoteWorktree(TestCase):
             # Removal failed → the working tree and branch ref both survive.
             assert Path(wt_path).is_dir()
             assert "feature" in _git(work, "branch", "--format=%(refname:short)").split()
+
+
+def _squash_merge_into_main(tmp: Path, *, subject: str) -> tuple[Path, str]:
+    """Build a repo whose ``feature`` branch is squash-merged into main under ``subject``.
+
+    The feature branch is pushed to its own remote ref (the PR existed, so the
+    #706 data-loss guard sees the work on a remote), then squash-merged into a
+    pushed ``main`` under a *different* subject. ``git diff origin/main...feature
+    --stat`` is therefore empty — the ``is_squash_merged`` empty-diff fallback
+    fires even though no subject matches. Returns ``(work_repo, feature_tip)``.
+    """
+    _remote, work = _init_repo_with_remote(tmp)
+    _git(work, "checkout", "-q", "-b", "feature")
+    (work / "f.py").write_text("shipped work\n", encoding="utf-8")
+    _git(work, "add", "f.py")
+    _git(work, "commit", "-q", "-m", "wip: scratch subject that will not match")
+    _git(work, "push", "-q", "origin", "feature")
+    tip = _git(work, "rev-parse", "feature")
+    _git(work, "checkout", "-q", "main")
+    _git(work, "merge", "-q", "--squash", "feature")
+    _git(work, "commit", "-q", "-m", subject)
+    _git(work, "push", "-q", "origin", "main")
+    _git(work, "fetch", "-q", "origin")
+    return work, tip
+
+
+class TestReapSquashMergedWorktreeRows(TestCase):
+    """#1940 gap (a): a Worktree *row* whose branch is squash-merged is reaped.
+
+    ``clean-all`` only reaped ``CREATED``-state rows. A PROVISIONED/READY row
+    whose branch shipped (squash-merged under a retitled subject) survived
+    forever — its dir, compose project, and ticket dir all leaked. The new
+    ``reap_squash_merged_worktrees`` pass closes that, reusing the existing
+    ``is_squash_merged`` classifier (no duplicated subject-match logic).
+    """
+
+    def _make_row(self, work: Path, wt_dir: Path, *, branch: str = "feature") -> Worktree:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/1940")
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="work",
+            branch=branch,
+            state=Worktree.State.PROVISIONED,
+            extra={"worktree_path": str(wt_dir), "clone_path": str(work)},
+        )
+
+    def _reap(self, workspace: Path) -> list[str]:
+        return ws_cleanup_mod.WorktreeReaper(workspace).reap_squash_merged_worktrees(interactive=False)
+
+    def test_squash_merged_row_with_different_subject_is_reaped(self) -> None:
+        """A squash-merged row (retitled subject) is reaped via the forge signal.
+
+        A squash-merge into a pushed main does NOT yield an empty
+        ``origin/main...feature`` diff (the squash is a new commit, not an
+        ancestor of feature) — the empty-diff fallback never fires. The forge
+        merged-PR lookup is the real-world primary signal: both the selection
+        classifier (``is_squash_merged``) and ``cleanup_worktree``'s strict
+        data-loss guards probe the forge, so the unstoppable ``gh``/``glab``
+        CLI is the legitimate mock boundary for both.
+        """
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            workspace = tmp / "workspace"
+            workspace.mkdir()
+            work, _tip = _squash_merge_into_main(workspace, subject="feat: shipped work (#1940)")
+            wt_dir = workspace / "feature" / "work"
+            _git(work, "worktree", "add", "-q", str(wt_dir), "feature")
+            row = self._make_row(work, wt_dir)
+
+            ws_merged = subprocess.CompletedProcess([], 0, '[{"number": 1940}]', "")
+            with (
+                patch.object(ws_cleanup_mod, "_run_host_cli", return_value=ws_merged),
+                patch.object(cleanup_mod, "_branch_pr_is_merged", return_value=True),
+                patch.object(cleanup_mod, "capture_recovery_artifact", return_value=None),
+            ):
+                cleaned = self._reap(workspace)
+
+            assert not Worktree.objects.filter(pk=row.pk).exists(), (
+                f"squash-merged row should be reaped; got: {cleaned!r}"
+            )
+            assert not wt_dir.exists(), "squash-merged worktree dir should be removed"
+            assert any("Cleaned" in c or "feature" in c for c in cleaned)
+
+    def test_clean_ignore_branch_is_skipped_with_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            workspace = tmp / "workspace"
+            workspace.mkdir()
+            work, _tip = _squash_merge_into_main(workspace, subject="feat: shipped work (#1940)")
+            wt_dir = workspace / "keepme" / "work"
+            _git(work, "branch", "-m", "feature", "keepme")
+            _git(work, "worktree", "add", "-q", str(wt_dir), "keepme")
+            row = self._make_row(work, wt_dir, branch="keepme")
+
+            with self._patch_clean_ignore(["keep*"]):
+                cleaned = self._reap(workspace)
+
+            assert Worktree.objects.filter(pk=row.pk).exists(), "clean_ignore branch must be kept"
+            assert wt_dir.is_dir(), "clean_ignore worktree dir must survive"
+            assert any("SKIP" in c and "keepme" in c for c in cleaned)
+
+    def _patch_clean_ignore(self, patterns: list[str]) -> AbstractContextManager[object]:
+        base = load_config()
+        patched = replace(base, user=replace(base.user, clean_ignore=patterns))
+        return patch.object(ws_cleanup_mod, "load_config", return_value=patched)
+
+    def test_uncertain_classification_is_skipped_not_deleted(self) -> None:
+        """A row whose branch is genuinely ahead (not merged) is kept, warn-not-fail."""
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            workspace = tmp / "workspace"
+            workspace.mkdir()
+            _remote, work = _init_repo_with_remote(workspace)
+            _git(work, "checkout", "-q", "-b", "feature")
+            (work / "ahead.py").write_text("unmerged work\n", encoding="utf-8")
+            _git(work, "add", "ahead.py")
+            _git(work, "commit", "-q", "-m", "feat: not merged yet")
+            _git(work, "push", "-q", "origin", "feature")
+            _git(work, "checkout", "-q", "main")
+            wt_dir = workspace / "feature" / "work"
+            _git(work, "worktree", "add", "-q", str(wt_dir), "feature")
+            row = self._make_row(work, wt_dir)
+
+            cleaned = self._reap(workspace)
+
+            assert Worktree.objects.filter(pk=row.pk).exists(), (
+                f"genuinely-ahead row must NOT be deleted; got: {cleaned!r}"
+            )
+            assert wt_dir.is_dir()
+
+    def test_row_without_a_resolvable_clone_is_skipped(self) -> None:
+        """A row whose source clone is gone is silently skipped, not crashed."""
+        with tempfile.TemporaryDirectory() as tmp_s:
+            workspace = Path(tmp_s) / "workspace"
+            workspace.mkdir()
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/1940")
+            row = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="ghost",
+                branch="feature",
+                state=Worktree.State.PROVISIONED,
+                extra={"worktree_path": str(workspace / "feature" / "ghost")},
+            )
+
+            cleaned = self._reap(workspace)
+
+            assert Worktree.objects.filter(pk=row.pk).exists()
+            assert cleaned == []
+
+    def test_data_loss_guard_refusal_is_surfaced_not_deleted(self) -> None:
+        """is_squash_merged says shipped, but cleanup_worktree's #706 guard refuses → kept.
+
+        A positive squash signal narrows the candidate set; it never bypasses the
+        data-loss guards. A branch with commits on no remote is surfaced as a
+        Skipped warning, the row preserved.
+        """
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            workspace = tmp / "workspace"
+            workspace.mkdir()
+            _remote, work = _init_repo_with_remote(workspace)
+            _git(work, "checkout", "-q", "-b", "feature")
+            (work / "unpushed.py").write_text("never pushed\n", encoding="utf-8")
+            _git(work, "add", "unpushed.py")
+            _git(work, "commit", "-q", "-m", "feat: unpushed work")
+            _git(work, "checkout", "-q", "main")
+            wt_dir = workspace / "feature" / "work"
+            _git(work, "worktree", "add", "-q", str(wt_dir), "feature")
+            row = self._make_row(work, wt_dir)
+
+            ws_merged = subprocess.CompletedProcess([], 0, '[{"number": 1940}]', "")
+            with (
+                patch.object(ws_cleanup_mod, "_run_host_cli", return_value=ws_merged),
+                patch.object(cleanup_mod, "_branch_pr_is_merged", return_value=False),
+            ):
+                cleaned = self._reap(workspace)
+
+            assert Worktree.objects.filter(pk=row.pk).exists(), f"data-loss row must be kept; got: {cleaned!r}"
+            assert wt_dir.is_dir()
+            assert any("Skipped" in c for c in cleaned)
+
+
+class TestRemoveEmptyTicketDirs(TestCase):
+    """#1940 gap (b): a ticket dir holding only empty repo subdirs is removed.
+
+    A multi-repo ticket dir (``ac/1234/`` with empty ``backend/`` + ``frontend/``)
+    has children, so the old single-level ``not any(iterdir())`` check left it
+    behind. The recursive remover prunes the empty leaves then the now-empty
+    ticket dir.
+    """
+
+    def _remove(self, workspace: Path) -> list[str]:
+        return ws_cleanup_mod.WorktreeReaper(workspace).remove_empty_ticket_dirs()
+
+    def test_ticket_dir_with_only_empty_repo_subdirs_is_removed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            workspace = Path(tmp_s)
+            ticket_dir = workspace / "ac-1234"
+            (ticket_dir / "backend").mkdir(parents=True)
+            (ticket_dir / "frontend").mkdir(parents=True)
+
+            removed = self._remove(workspace)
+
+            assert not ticket_dir.exists(), f"empty multi-repo ticket dir should be removed; got: {removed!r}"
+            assert any("ac-1234" in r for r in removed)
+
+    def test_ticket_dir_with_real_files_is_kept(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_s:
+            workspace = Path(tmp_s)
+            ticket_dir = workspace / "ac-5678"
+            (ticket_dir / "backend").mkdir(parents=True)
+            (ticket_dir / "backend" / "real.py").write_text("x\n", encoding="utf-8")
+
+            removed = self._remove(workspace)
+
+            assert ticket_dir.exists(), "ticket dir with real content must be kept"
+            assert not any("ac-5678" in r for r in removed)
+
+    def test_top_level_file_is_left_untouched(self) -> None:
+        """A loose file at the workspace root is not a ticket dir — skip it."""
+        with tempfile.TemporaryDirectory() as tmp_s:
+            workspace = Path(tmp_s)
+            loose = workspace / "notes.txt"
+            loose.write_text("x\n", encoding="utf-8")
+
+            removed = self._remove(workspace)
+
+            assert loose.exists()
+            assert removed == []


### PR DESCRIPTION
Closes #1940.

clean-all only tore down CREATED-state Worktree rows, so a PROVISIONED/READY row whose branch was squash-merged under a retitled subject survived forever — its dir, compose project (and its docker images), and ticket dir all leaking.

## What changed
- WorktreeReaper.reap_squash_merged_worktrees tears down any non-CREATED Worktree row whose branch is squash-merged, reusing the existing is_squash_merged classifier (forge merged-PR primary signal + empty-diff fallback, no duplicated subject-match logic). Teardown goes through cleanup_worktree with the default strict_hygiene/force, so the data-loss guards still refuse an unpushed branch; a positive squash signal narrows the candidate set, it never bypasses a guard. Once the row + dir are gone, the existing reap_orphan_worktree_docker pass removes the now-dead compose project images/containers (scoped by the com.docker.compose.project label, so base images and running projects are never touched).
- clean_ignore: fnmatch globs of branch names clean-all must never reap (never-merge dev overrides, long-lived spikes). New UserSettings field, per-overlay overridable. Uncertain classification keeps the worktree with a warning.
- WorktreeReaper.remove_empty_ticket_dirs recursively prunes empty repo subdirs then the ticket dir, so multi-repo ticket dirs left holding only empty subdirs are removed.

## Tests
RED-first; the squash-reap test is proven anti-vacuous. Real tmp_path git repos; only the forge CLI and the empty-diff edge are mocked. 100% coverage on new code; ruff / ty / tach / module-health green.

## Architecture pre-check (#1940)
1. BLUEPRINT: workspace lifecycle / cleanup chokepoint; clean-all reaps a Worktree row in any FSM state whose branch is squash-merged.
2. FSM: no new transition; reuses cleanup_worktree; selection widens beyond state=CREATED.
3. Extension points: none changed; reuses reap_worktree_external_resources + reap_orphan_compose_projects.
4. Components: WorktreeReaper in _workspace_cleanup.py; clean_ignore in config.py; wiring in workspace.py.
5. Deps: new imports load_config, resolve_clone_path, stdlib fnmatch/contextlib; no backwards edge; tach green.
6. Tests: TestReapSquashMergedWorktreeRows + TestRemoveEmptyTicketDirs + config load/override tests.
7. Resilience: fails safe to SKIP+WARN; idempotent; docker writes scoped by compose-project label.
8. Identity: compose key is fully-qualified repo-wt<number>; clean_ignore matches full branch name; no stripping.
9. Behavior: purely additive; CREATED-state loop + data-loss guards preserved, never bypassed; no must-block test inverted.