### PR TITLE
ci(eval): manual on-demand trigger for the weekly eval gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,19 @@ on:
     # cannot see a brand name already committed; this catches a pre-existing
     # leak even when no new diff touches it.
     - cron: "17 6 * * *"
+  workflow_dispatch:
+    # On-demand manual run of the weekly behavioral-eval gate. The weekly
+    # cadence (first PR of the ISO week or the Sunday cron) means a maintainer
+    # who wants the suite at an arbitrary time has no CI path otherwise. A
+    # dispatch forces the eval to run unconditionally (see the eval-weekly gate
+    # step). The backend input picks the AI-lane runner: sdk (metered claude -p,
+    # the CI default) requires ANTHROPIC_API_KEY.
+    inputs:
+      backend:
+        description: "AI-lane backend for the manual run (sdk = metered claude -p)."
+        required: false
+        default: sdk
+        type: string
 
 jobs:
   preflight:
@@ -482,11 +495,15 @@ jobs:
     # last-resort backstop; the zero-run direction (PR-less week → no eval at
     # all) is the bug this closes and is fully eliminated.
     #
-    # Manual on-demand runs bypass CI: the user runs `t3 eval run` /
-    # `t3 eval trigger-qa` locally (also wired as the periodic local-eval
-    # loop job — `EvalLocalScanner`). The GitLab mirror carries the PR-path
-    # rule in `.gitlab-ci.yml` (no scheduled-pipeline equivalent there).
-    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
+    # On-demand: a `workflow_dispatch` event runs the suite unconditionally
+    # (the gate step below forces run_eval=true for it). Local runs still work
+    # via `t3 eval run` / `t3 eval trigger-qa` (also the periodic local-eval
+    # loop job — `EvalLocalScanner`). The GitLab mirror carries the PR-path rule
+    # and a `when: manual` eval job in `.gitlab-ci.yml`.
+    if: >
+      github.event_name == 'pull_request' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -516,7 +533,10 @@ jobs:
           # newest window as a second line of defence regardless of ordering.
           gh api "repos/${{ github.repository }}/pulls?state=all&sort=created&direction=desc&per_page=100" \
             --jq '[.[] | {number: .number, created_at: .created_at}]' > prs.json || echo "[]" > prs.json
-          if [ "$EVENT_NAME" = "schedule" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # Manual on-demand run: always run, no first-of-week gating.
+            echo "run_eval=true" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "schedule" ]; then
             # Cron path: last-resort backstop for a PR-less ISO week. Pinned to
             # the week's LAST day (Sunday, %u == 7) so it cannot preempt the
             # PR path mid-week (which would let a later first-PR run double-fire)
@@ -562,10 +582,10 @@ jobs:
             echo "require_executed=" >> "$GITHUB_OUTPUT"
           fi
       # Bounded retry on a transient model/network flake; a real miss repeats and still fails fast.
-      # `--backend sdk` keeps CI on the metered claude -p / ANTHROPIC_API_KEY path
-      # explicitly. LOCAL `t3 eval run` defaults to the subscription backend (no API
-      # spend); CI is the budgeted exception. (`--trials` already forces the sdk
-      # runner, so the flag is the explicit, debuggable statement of that intent.)
+      # `--backend` keeps CI on the metered claude -p / ANTHROPIC_API_KEY path explicitly
+      # (sdk default). A workflow_dispatch run may override it via the backend input; the
+      # empty PR/schedule input falls back to sdk. LOCAL `t3 eval run` defaults to the
+      # subscription backend (no API spend); CI is the budgeted exception.
       # `--require-executed` (armed only when a key is configured) fails the job
       # if the suite collected scenarios but executed none — no silent decorative pass.
       - name: Behavioral eval suite (pass@k; --require-executed armed when a key is set)
@@ -573,8 +593,9 @@ jobs:
         uses: nick-fields/retry@v4
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          EVAL_BACKEND: ${{ inputs.backend || 'sdk' }}
         with:
           timeout_minutes: 30
           max_attempts: 3
           retry_wait_seconds: 60
-          command: uv run t3 eval run --trials 3 --require any --backend sdk ${{ steps.eval_exec.outputs.require_executed }}
+          command: uv run t3 eval run --trials 3 --require any --backend "$EVAL_BACKEND" ${{ steps.eval_exec.outputs.require_executed }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,3 +80,24 @@ eval-weekly:
     - REQUIRE_EXECUTED=""; if [ -n "$ANTHROPIC_API_KEY" ]; then REQUIRE_EXECUTED="--require-executed"; fi
     - uv run t3 eval run --trials 3 --require any --backend sdk $REQUIRE_EXECUTED
   allow_failure: false
+
+# On-demand manual run, the GitLab mirror of the GitHub `workflow_dispatch`
+# trigger. `when: manual` adds a play button on merge-request pipelines so a
+# maintainer can run the full suite at an arbitrary time without waiting for the
+# first-of-week gate. It is allow_failure so a manual run never blocks the MR.
+eval-manual:
+  stage: eval
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: manual
+      allow_failure: true
+  image: python:3.13-slim
+  before_script:
+    - pip install --no-cache-dir uv
+    - uv sync
+  script:
+    - uv run t3 eval trigger-qa
+    - uv run python -m teatree migrate --no-input
+    - uv run t3 eval regression
+    - REQUIRE_EXECUTED=""; if [ -n "$ANTHROPIC_API_KEY" ]; then REQUIRE_EXECUTED="--require-executed"; fi
+    - uv run t3 eval run --trials 3 --require any --backend sdk $REQUIRE_EXECUTED

--- a/tests/test_eval_ci_manual_trigger.py
+++ b/tests/test_eval_ci_manual_trigger.py
@@ -1,0 +1,86 @@
+"""The behavioral-eval CI jobs can be triggered manually on demand.
+
+The weekly eval gate fires only on the first PR of the ISO week or the Sunday
+cron backstop, so a maintainer who wants to run the suite at an arbitrary time
+has no CI path — only the local ``t3 eval run``. These tests pin a manual
+trigger on both mirrors: GitHub ``workflow_dispatch`` (with an optional backend
+input) that forces ``run_eval=true``, and a GitLab ``when: manual`` eval job.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_GH_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_GITLAB_CI = _REPO_ROOT / ".gitlab-ci.yml"
+
+
+def _gh_workflow() -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(_GH_WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _gh_on() -> dict[str, Any]:
+    # PyYAML parses the unquoted ``on:`` key as the boolean True.
+    workflow = _gh_workflow()
+    return cast("dict[str, Any]", workflow.get("on", workflow.get(True)))
+
+
+def _gh_eval_weekly() -> dict[str, Any]:
+    return cast("dict[str, Any]", _gh_workflow()["jobs"]["eval-weekly"])
+
+
+def _gh_gate_step_run() -> str:
+    for step in cast("list[dict[str, Any]]", _gh_eval_weekly()["steps"]):
+        if step.get("id") == "gate":
+            return cast("str", step["run"])
+    msg = "eval-weekly has no step with id `gate`."
+    raise AssertionError(msg)
+
+
+def _gitlab_config() -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(_GITLAB_CI.read_text(encoding="utf-8")))
+
+
+class TestGitHubManualTrigger:
+    def test_workflow_dispatch_is_a_trigger(self) -> None:
+        assert "workflow_dispatch" in _gh_on(), (
+            "The workflow must accept a manual `workflow_dispatch` trigger so the eval "
+            "suite can run on demand from the Actions UI."
+        )
+
+    def test_eval_weekly_if_covers_workflow_dispatch(self) -> None:
+        assert "workflow_dispatch" in _gh_eval_weekly()["if"], (
+            "eval-weekly's `if:` must include workflow_dispatch or the manual run never reaches the job."
+        )
+
+    def test_gate_step_forces_run_eval_on_dispatch(self) -> None:
+        run = _gh_gate_step_run()
+        assert "workflow_dispatch" in run, "The gate step must branch on the workflow_dispatch event."
+        assert "run_eval=true" in run, "The dispatch branch must set run_eval=true unconditionally."
+
+    def test_backend_input_defaults_to_sdk(self) -> None:
+        inputs = cast("dict[str, Any]", _gh_on()["workflow_dispatch"]["inputs"])
+        assert inputs["backend"]["default"] == "sdk", (
+            "The optional `backend` input should default to sdk (the metered CI path)."
+        )
+
+    def test_pr_and_schedule_paths_are_preserved(self) -> None:
+        condition = _gh_eval_weekly()["if"]
+        assert "pull_request" in condition, "The manual trigger must be additive — the PR path stays."
+        assert "schedule" in condition, "The manual trigger must be additive — the cron path stays."
+
+
+class TestGitLabManualTrigger:
+    def test_eval_manual_job_exists_with_when_manual(self) -> None:
+        config = _gitlab_config()
+        assert "eval-manual" in config, "GitLab must expose an `eval-manual` eval job variant."
+        rules = cast("list[dict[str, Any]]", config["eval-manual"]["rules"])
+        assert any(rule.get("when") == "manual" for rule in rules), (
+            "The eval-manual job must carry a `when: manual` rule for on-demand parity."
+        )
+
+    def test_eval_manual_runs_the_suite(self) -> None:
+        script = "\n".join(cast("list[str]", _gitlab_config()["eval-manual"]["script"]))
+        assert "t3 eval run" in script, "eval-manual must run the behavioral suite."


### PR DESCRIPTION
## Summary

Add a manual on-demand trigger for the weekly behavioral-eval gate. The weekly cadence (first PR of the ISO week, or the Sunday cron backstop) means a maintainer who wants the suite at an arbitrary time has no CI path — only the local `t3 eval run`.

## Changes

- **GitHub** (`.github/workflows/ci.yml`):
  - `workflow_dispatch` trigger with an optional `backend` input (default `sdk`).
  - `eval-weekly`'s `if:` now covers the dispatch event.
  - The decide-whether gate step forces `run_eval=true` unconditionally on a dispatch (skips the first-of-week decision).
  - The eval run step reads the backend input (falls back to `sdk` for the empty PR/schedule input).
  - PR and cron paths are unchanged — the trigger is additive.
- **GitLab** (`.gitlab-ci.yml`): an `eval-manual` job variant carrying a `when: manual` rule on merge-request pipelines for parity (`allow_failure` so a manual run never blocks the MR).

## Tests

`tests/test_eval_ci_manual_trigger.py` asserts the dispatch trigger, the `eval-weekly` `if:` coverage, the gate-step force, the input default, the preserved PR/schedule paths, and the GitLab manual job. Validated with actionlint (exit 0).

## Architecture pre-check

1. **BLUEPRINT § alignment** — eval CI surface; additive trigger. No new section.
2. **FSM phase boundaries** — n/a.
3. **Extension-point contracts** — n/a.
4. **Component boundaries** — CI workflow YAML only, no business logic.
5. **Dependency direction** — no imports changed.
6. **Test surface** — `tests/test_eval_ci_manual_trigger.py` (7 assertions).
7. **Resilience invariants** — additive trigger; no external write.
8. **Identity and key normalization** — n/a.
9. **Behavior preservation** — purely additive; PR/schedule/cron paths untouched, no test inverted.

## Open questions & assumptions

- The `backend` input defaults to `sdk` (the metered CI path); a dispatch run can override it, but that path needs a configured runner with credentials.
- `--docker` is intentionally out of scope (separate decision pending).
