### PR TITLE
fix(install): GitHub-origin install + valid APM package + t3 setup self-DB migrate

### DIFF
--- a/.apm/contexts/teatree.context.md
+++ b/.apm/contexts/teatree.context.md
@@ -1,0 +1,16 @@
+# TeaTree
+
+TeaTree provides the `t3` CLI and a Claude plugin (skills, agents, hooks).
+
+The skills, agents, and hooks are delivered through the Claude plugin, which
+`t3 setup` registers into `~/.claude/plugins/`. This APM package exists to
+declare TeaTree's companion dependencies (superpowers and the `ac-*` skills
+listed in `apm.yml`) so `apm install -g souliane/teatree` pulls them in.
+
+Install:
+
+```sh
+uv tool install git+https://github.com/souliane/teatree
+apm install -g souliane/teatree
+t3 setup
+```

--- a/README.md
+++ b/README.md
@@ -354,9 +354,12 @@ skills carry the rest.
 
 ### For users
 
+Teatree is not on PyPI. Install the `t3` CLI straight from the repo:
+
 ```bash
-uv tool install teatree           # installs `t3` globally (pipx install teatree also works)
-apm install -g souliane/teatree   # installs skills + companion dependencies
+uv tool install git+https://github.com/souliane/teatree   # installs `t3` globally
+apm install -g souliane/teatree                            # installs skills + companion dependencies
+t3 setup                                                   # links plugin, syncs skills, migrates self-DB
 t3 startoverlay my-overlay ~/workspace/my-overlay
 ```
 
@@ -382,9 +385,10 @@ find where something lives.
 the user flow — edits in this clone take effect on the next invocation, no
 `uv run` prefix. `t3 setup` runs [APM](https://github.com/microsoft/apm) to
 install companion dependencies (superpowers, ac-django, etc.), symlinks teatree
-skills to `~/.claude/skills/`, links the Claude plugin
-(`~/.claude/plugins/t3 → <clone>`) so hooks and agents always read from the
-live checkout, and — if `t3` is not on `PATH` — re-runs
+skills to `~/.claude/skills/`, registers the Claude plugin in
+`~/.claude/plugins/installed_plugins.json` with `installPath` pointing at the
+clone so hooks and agents always read from the live checkout, applies any
+pending self-DB migrations, and — if `t3` is not on `PATH` — re-runs
 `uv tool install --editable .` to self-install. Must be run from the main
 clone, not a worktree.
 

--- a/README.md
+++ b/README.md
@@ -357,9 +357,9 @@ skills carry the rest.
 Teatree is not on PyPI. Install the `t3` CLI straight from the repo:
 
 ```bash
-uv tool install git+https://github.com/souliane/teatree   # installs `t3` globally
-apm install -g souliane/teatree                            # installs skills + companion dependencies
-t3 setup                                                   # links plugin, syncs skills, migrates self-DB
+uv tool install --from git+https://github.com/souliane/teatree.git teatree   # installs `t3` globally
+apm install -g souliane/teatree   # installs skills + companion dependencies
+t3 setup                          # links plugin, syncs skills, migrates self-DB
 t3 startoverlay my-overlay ~/workspace/my-overlay
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,9 +14,9 @@ Teatree is not on PyPI. Install the `t3` CLI straight from the repo — no clone
 needed:
 
 ```sh
-uv tool install git+https://github.com/souliane/teatree   # global `t3` binary
-apm install -g souliane/teatree                            # skills + companion deps
-t3 setup                                                   # links plugin, syncs skills, migrates self-DB
+uv tool install --from git+https://github.com/souliane/teatree.git teatree   # global `t3` binary
+apm install -g souliane/teatree   # skills + companion deps
+t3 setup                          # links plugin, syncs skills, migrates self-DB
 ```
 
 ### Work locally on an overlay

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,12 +10,13 @@
 
 ### Use only (no source code)
 
-Install teatree, or an overlay (which pulls teatree as a dependency):
+Teatree is not on PyPI. Install the `t3` CLI straight from the repo — no clone
+needed:
 
 ```sh
-git clone https://github.com/souliane/teatree && cd teatree
-uv tool install --editable .     # global `t3` binary
-t3 setup                         # links plugin, syncs skills
+uv tool install git+https://github.com/souliane/teatree   # global `t3` binary
+apm install -g souliane/teatree                            # skills + companion deps
+t3 setup                                                   # links plugin, syncs skills, migrates self-DB
 ```
 
 ### Work locally on an overlay

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -200,7 +200,8 @@ _QUOTE_STRIPPED_BLOCKED: list[tuple[re.Pattern[str], str]] = [
         re.compile(r"\buv\s+run\s+(?:\S+\s+)*?t3(?:\s|$)"),
         (
             "BLOCKED: `uv run t3` — teatree is installed globally; call `t3` directly. "
-            "If `t3` is missing on this machine, install teatree (`uv tool install teatree` "
+            "If `t3` is missing on this machine, install teatree "
+            "(`uv tool install --from git+https://github.com/souliane/teatree.git teatree` "
             "or `uv tool install --editable <teatree-repo>`)."
         ),
     ),

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -155,9 +155,9 @@ every runtime dir teatree detected along with the count of managed symlinks.
 
 ## Step 4: Claude Code Plugin Hooks
 
-Teatree ships a `hooks.json` that Claude Code loads automatically via the plugin symlink at `~/.claude/plugins/t3`. All hooks route through `hook_router.py`, a unified Python router that handles event dispatch.
+Teatree ships a `hooks.json` that Claude Code loads automatically. `t3 setup` registers the plugin in `~/.claude/plugins/installed_plugins.json` with `installPath` pointing at the main clone (no symlink, always live). All hooks route through `hook_router.py`, a unified Python router that handles event dispatch.
 
-Verify the symlink exists: `ls -la ~/.claude/plugins/t3`.
+Verify the registration: `t3 doctor check` (it reports the registered plugin and its `installPath`).
 
 The hooks cover these events:
 

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -339,8 +339,9 @@ class DoctorService:
         if not contribute and teatree_is_editable:
             problems.append(
                 "teatree is editable but contribute=false in ~/.teatree.toml. "
-                "You risk accidentally modifying framework code. "
-                "Fix: set contribute=true or run `uv pip install teatree`.",
+                "If you are contributing to teatree, set contribute=true. "
+                "If not, run `uv tool install git+https://github.com/souliane/teatree` "
+                "to drop the editable install.",
             )
 
         return problems

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -340,7 +340,8 @@ class DoctorService:
             problems.append(
                 "teatree is editable but contribute=false in ~/.teatree.toml. "
                 "If you are contributing to teatree, set contribute=true. "
-                "If not, run `uv tool install git+https://github.com/souliane/teatree` "
+                "If not, run "
+                "`uv tool install --from git+https://github.com/souliane/teatree.git teatree` "
                 "to drop the editable install.",
             )
 

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -16,7 +16,7 @@ from teatree.cli.slack_dm_provisioning import provision_all_overlay_dm_channels
 from teatree.cli.slack_provision import slack_provision
 from teatree.cli.slack_setup import slack_bot_setup
 from teatree.cli.slack_user_token_setup import slack_user_token_setup
-from teatree.self_update import current_editable_source
+from teatree.self_update import current_editable_source, ensure_self_db_migrated
 from teatree.utils.run import CompletedProcess, run_allowed_to_fail
 
 # Re-exported here so external callers and tests see a single import path for
@@ -599,6 +599,8 @@ def run(
         config_path=Path.home() / ".teatree.toml",
         echo=typer.echo,
     )
+
+    ensure_self_db_migrated(quiet=True)
 
     # Suggest (never apply) the recommended per-user auto-mode authorizations.
     # Teatree ships no classifier whitelist of its own — see

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -273,6 +273,23 @@ def _ensure_t3_installed(repo: Path) -> bool:
     return True
 
 
+_APM_FAILURE_MARKERS = ("installation failed", "package failed", "package(s) failed")
+
+
+def _apm_reported_failure(result: CompletedProcess[str]) -> bool:
+    """Whether an apm-install run failed, accounting for apm's exit-0-on-error.
+
+    apm writes its per-package diagnostics to *stdout* and (in some versions)
+    exits 0 even when a package fails validation, so a bare returncode check
+    misses the failure entirely.  Treat a non-zero exit OR a failure marker in
+    either stream as failure.
+    """
+    if result.returncode != 0:
+        return True
+    combined = f"{result.stdout}\n{result.stderr}".lower()
+    return any(marker in combined for marker in _APM_FAILURE_MARKERS)
+
+
 def _run_apm_install(repo: Path) -> bool:
     """Run apm install -g --target claude from the teatree repo."""
     apm_path = shutil.which("apm")
@@ -282,8 +299,9 @@ def _run_apm_install(repo: Path) -> bool:
         return False
 
     result = _run_captured([apm_path, "install", "-g", "--target", "claude"], cwd=repo)
-    if result.returncode != 0:
-        typer.echo(f"WARN  apm install failed: {result.stderr.strip()}")
+    if _apm_reported_failure(result):
+        detail = result.stdout.strip() or result.stderr.strip() or "(no output)"
+        typer.echo(f"WARN  apm install failed: {detail}")
         return False
     typer.echo("OK    APM dependencies installed globally.")
     return True

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -600,7 +600,7 @@ def run(
         echo=typer.echo,
     )
 
-    ensure_self_db_migrated(quiet=True)
+    self_db_unmigrated = ensure_self_db_migrated(quiet=True)
 
     # Suggest (never apply) the recommended per-user auto-mode authorizations.
     # Teatree ships no classifier whitelist of its own — see
@@ -608,6 +608,9 @@ def run(
     from teatree.cli.recommended_authorizations import report_missing_authorizations  # noqa: PLC0415
 
     report_missing_authorizations(typer.echo)
+
+    if self_db_unmigrated:
+        raise typer.Exit(code=1)
 
     typer.echo("Done.")
 

--- a/src/teatree/self_update.py
+++ b/src/teatree/self_update.py
@@ -183,7 +183,7 @@ def _migrate_self_db() -> None:
     typer.echo("OK    self-DB migrations applied.")
 
 
-def ensure_self_db_migrated() -> bool:
+def ensure_self_db_migrated(*, quiet: bool = False) -> bool:
     """Migrate the runtime teatree self-DB iff migrations are actually pending.
 
     Probe-gated and fully decoupled from whether a repo advanced *this
@@ -193,12 +193,17 @@ def ensure_self_db_migrated() -> bool:
     unmigrated (caller exits non-zero — fail-closed, #870); ``False``
     when nothing was pending or the migration succeeded.
 
+    With *quiet* the no-op case (nothing pending) emits nothing, so a
+    caller like ``t3 setup`` stays silent on a current DB; the migrate and
+    fail-closed paths always report regardless of *quiet*.
+
     Both probe and migrate run in the runtime interpreter (``python -m
     teatree``), so they always target the DB the runtime resolves — there
     is no clone to resolve and no ``uv`` dependency for this path (#126).
     """
     if not _self_db_has_pending_migrations():
-        typer.echo("OK    self-DB already migrated.")
+        if not quiet:
+            typer.echo("OK    self-DB already migrated.")
         return False
     try:
         _migrate_self_db()

--- a/tests/cli_doctor/test_editable_sanity.py
+++ b/tests/cli_doctor/test_editable_sanity.py
@@ -75,6 +75,17 @@ class TestCheckEditableSanity:
 
         assert any("contribute=false" in p for p in problems)
 
+    def test_teatree_editable_warning_does_not_scold_contributor_setup(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        _write_teatree_toml(tmp_path / ".teatree.toml", "[teatree]\ncontribute = false\n")
+
+        with patch.object(IntrospectionHelpers, "editable_info", return_value=(True, "file:///src")):
+            problems = DoctorService.check_editable_sanity()
+
+        msg = next(p for p in problems if "contribute=false" in p)
+        assert "risk accidentally modifying" not in msg
+        assert "contribute=true" in msg
+
     def test_auto_fixes_overlay_when_contribute_true(self, tmp_path, monkeypatch):
         _stage_home(tmp_path, monkeypatch)
         _write_teatree_toml(

--- a/tests/cli_setup/test_plugin_install.py
+++ b/tests/cli_setup/test_plugin_install.py
@@ -31,6 +31,7 @@ class TestRunApmInstall:
             patch("subprocess.run") as mock_run,
         ):
             mock_run.return_value.returncode = 1
+            mock_run.return_value.stdout = ""
             mock_run.return_value.stderr = "some error"
             assert _run_apm_install(tmp_path) is False
 
@@ -40,10 +41,47 @@ class TestRunApmInstall:
             patch("subprocess.run") as mock_run,
         ):
             mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "[*] All packages installed."
+            mock_run.return_value.stderr = ""
             assert _run_apm_install(tmp_path) is True
             mock_run.assert_called_once()
             args = mock_run.call_args
             assert args[0][0] == ["/usr/bin/apm", "install", "-g", "--target", "claude"]
+
+    def test_failure_warning_surfaces_stdout_when_stderr_empty(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        apm_diagnostics = (
+            "-- Diagnostics --\n  [x] 1 package failed:\n    +- souliane/teatree -- Missing required directory: .apm/\n"
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/apm"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 1
+            mock_run.return_value.stdout = apm_diagnostics
+            mock_run.return_value.stderr = ""
+            assert _run_apm_install(tmp_path) is False
+        out = capsys.readouterr().out
+        assert "Missing required directory: .apm/" in out
+
+    def test_detects_failure_when_apm_exits_zero(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        apm_diagnostics = (
+            "-- Diagnostics --\n"
+            "  [x] 1 package failed:\n"
+            "    +- souliane/teatree -- Missing required directory: .apm/\n"
+            "[x] Installation failed with 1 error(s).\n"
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/apm"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = apm_diagnostics
+            mock_run.return_value.stderr = ""
+            assert _run_apm_install(tmp_path) is False
+        out = capsys.readouterr().out
+        assert "Installation failed" in out
 
 
 class TestEnablePlugin:

--- a/tests/cli_setup/test_self_db_migrate.py
+++ b/tests/cli_setup/test_self_db_migrate.py
@@ -13,7 +13,9 @@ from unittest.mock import patch
 import pytest
 
 
-def _run_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def _run_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, migrate_returns: bool = False):
+    import typer  # noqa: PLC0415
+
     from teatree.cli import setup as setup_module  # noqa: PLC0415
 
     skills_src = tmp_path / "core_skills"
@@ -30,23 +32,34 @@ def _run_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     (repo / "apm.yml").touch()
     (repo / ".git").mkdir()
 
+    raised: list[int] = []
     with (
         patch("teatree.agents.skill_bundle.DEFAULT_SKILLS_DIR", skills_src),
         patch.object(setup_module, "_find_main_clone", return_value=repo),
         patch.object(setup_module, "_run_apm_install", return_value=True),
         patch.object(setup_module, "_install_claude_plugin", return_value=True),
-        patch.object(setup_module, "ensure_self_db_migrated", return_value=False) as mock_migrate,
+        patch.object(setup_module, "ensure_self_db_migrated", return_value=migrate_returns) as mock_migrate,
         patch("teatree.config.load_config") as mock_load,
     ):
         mock_load.return_value.user.contribute = False
         mock_load.return_value.user.excluded_skills = []
         mock_load.return_value.user.workspace_dir = str(tmp_path / "workspace")
-        setup_module.run(SimpleNamespace(invoked_subcommand=None), skip_plugin=True)
+        try:
+            setup_module.run(SimpleNamespace(invoked_subcommand=None), skip_plugin=True)
+        except typer.Exit as exc:
+            raised.append(exc.exit_code)
 
-    return mock_migrate
+    return mock_migrate, raised
 
 
 class TestSetupRunsSelfDbMigrations:
     def test_setup_invokes_self_db_migrate_quietly(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        mock_migrate = _run_setup(tmp_path, monkeypatch)
+        mock_migrate, raised = _run_setup(tmp_path, monkeypatch)
         mock_migrate.assert_called_once_with(quiet=True)
+        assert raised == []
+
+    def test_setup_exits_nonzero_when_self_db_left_unmigrated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _mock_migrate, raised = _run_setup(tmp_path, monkeypatch, migrate_returns=True)
+        assert raised == [1]

--- a/tests/cli_setup/test_self_db_migrate.py
+++ b/tests/cli_setup/test_self_db_migrate.py
@@ -1,0 +1,52 @@
+"""``t3 setup`` applies pending teatree self-DB migrations.
+
+A fresh GitHub-origin install has an empty self-DB; ``t3 doctor check`` then
+FAILs on the unapplied-migrations gate until they are applied. ``t3 setup`` is
+the one command a new user always runs, so it must converge the self-DB to
+current — idempotently and quietly when there is nothing to do.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _run_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from teatree.cli import setup as setup_module  # noqa: PLC0415
+
+    skills_src = tmp_path / "core_skills"
+    skills_src.mkdir()
+    (skills_src / "code").mkdir()
+    (skills_src / "code" / "SKILL.md").touch()
+
+    home = tmp_path / "home"
+    (home / ".claude" / "skills").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: home))
+
+    repo = tmp_path / "teatree"
+    repo.mkdir()
+    (repo / "apm.yml").touch()
+    (repo / ".git").mkdir()
+
+    with (
+        patch("teatree.agents.skill_bundle.DEFAULT_SKILLS_DIR", skills_src),
+        patch.object(setup_module, "_find_main_clone", return_value=repo),
+        patch.object(setup_module, "_run_apm_install", return_value=True),
+        patch.object(setup_module, "_install_claude_plugin", return_value=True),
+        patch.object(setup_module, "ensure_self_db_migrated", return_value=False) as mock_migrate,
+        patch("teatree.config.load_config") as mock_load,
+    ):
+        mock_load.return_value.user.contribute = False
+        mock_load.return_value.user.excluded_skills = []
+        mock_load.return_value.user.workspace_dir = str(tmp_path / "workspace")
+        setup_module.run(SimpleNamespace(invoked_subcommand=None), skip_plugin=True)
+
+    return mock_migrate
+
+
+class TestSetupRunsSelfDbMigrations:
+    def test_setup_invokes_self_db_migrate_quietly(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_migrate = _run_setup(tmp_path, monkeypatch)
+        mock_migrate.assert_called_once_with(quiet=True)

--- a/tests/cli_setup/test_skill_symlinks.py
+++ b/tests/cli_setup/test_skill_symlinks.py
@@ -295,6 +295,7 @@ class TestSetupSyncsCodexWhenDirExists:
             patch.object(setup_module, "_find_main_clone", return_value=repo),
             patch.object(setup_module, "_run_apm_install", return_value=True),
             patch.object(setup_module, "_install_claude_plugin", return_value=True),
+            patch.object(setup_module, "ensure_self_db_migrated", return_value=False),
             patch.object(setup_module, "DoctorService") as mock_svc,
             patch("teatree.config.load_config") as mock_load,
         ):
@@ -338,6 +339,7 @@ class TestSetupSyncsCodexWhenDirExists:
             patch.object(setup_module, "_find_main_clone", return_value=repo),
             patch.object(setup_module, "_run_apm_install", return_value=True),
             patch.object(setup_module, "_install_claude_plugin", return_value=True),
+            patch.object(setup_module, "ensure_self_db_migrated", return_value=False),
             patch.object(setup_module, "DoctorService") as mock_svc,
             patch("teatree.config.load_config") as mock_load,
         ):
@@ -374,6 +376,7 @@ class TestSetupSyncsCodexWhenDirExists:
             patch.object(setup_module, "_find_main_clone", return_value=repo),
             patch.object(setup_module, "_run_apm_install", return_value=True),
             patch.object(setup_module, "_install_claude_plugin", return_value=True),
+            patch.object(setup_module, "ensure_self_db_migrated", return_value=False),
             patch.object(setup_module, "DoctorService") as mock_svc,
             patch("teatree.config.load_config") as mock_load,
         ):

--- a/tests/test_apm_package_structure.py
+++ b/tests/test_apm_package_structure.py
@@ -1,0 +1,58 @@
+"""The teatree repo must be a valid APM package.
+
+``README``'s "For users" flow runs ``apm install -g souliane/teatree``.  APM's
+detection cascade classifies any directory that carries ``apm.yml`` as an
+``APM_PACKAGE`` and then *requires* a ``.apm/`` directory holding at least one
+primitive — otherwise the install aborts with
+``Missing required directory: .apm/``.
+
+These assertions mirror APM's canonical validator
+(``apm_cli.models.validation._validate_apm_package_with_yml``) so the package
+structure can never silently regress out of conformance without APM installed
+as a test dependency.
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Mirrors apm_cli.models.validation: primitive markdown lives in one of these
+# subdirectories of ``.apm/`` (hooks JSON is the alternative primitive form).
+_PRIMITIVE_DIRS = ("instructions", "chatmodes", "contexts", "prompts")
+
+
+def _has_primitive(apm_dir: Path) -> bool:
+    for primitive_type in _PRIMITIVE_DIRS:
+        if list((apm_dir / primitive_type).glob("*.md")):
+            return True
+    for hooks_dir in (apm_dir / "hooks", apm_dir.parent / "hooks"):
+        if hooks_dir.is_dir() and list(hooks_dir.glob("*.json")):
+            return True
+    return False
+
+
+class TestApmPackageStructure:
+    def test_apm_yml_present_and_parseable(self) -> None:
+        apm_yml = REPO_ROOT / "apm.yml"
+        assert apm_yml.is_file()
+        data = yaml.safe_load(apm_yml.read_text(encoding="utf-8"))
+        assert data.get("name")
+        assert data.get("version")
+
+    def test_apm_directory_exists(self) -> None:
+        apm_dir = REPO_ROOT / ".apm"
+        assert apm_dir.is_dir(), (
+            "APM classifies a repo with apm.yml as an APM_PACKAGE and requires a "
+            ".apm/ directory; without it `apm install -g souliane/teatree` aborts "
+            "with 'Missing required directory: .apm/'."
+        )
+
+    def test_apm_directory_has_a_primitive(self) -> None:
+        apm_dir = REPO_ROOT / ".apm"
+        assert _has_primitive(apm_dir), (
+            ".apm/ must hold at least one primitive (instructions/chatmodes/"
+            "contexts/prompts *.md, or hooks/*.json) or APM warns the package is "
+            "empty."
+        )

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -296,6 +296,31 @@ class TestSelfDbMigrate:
         assert not [c for c in calls if c[-2:] == ["migrate", "--no-input"]]
         assert "already migrated" in capsys.readouterr().out
 
+    def test_ensure_quiet_emits_nothing_when_clean(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(self_update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(0, "", ""))
+
+        failed = ensure_self_db_migrated(quiet=True)
+
+        assert failed is False
+        assert capsys.readouterr().out == ""
+
+    def test_ensure_quiet_still_reports_when_migrating(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        def _run(cmd: list[str], **_kw: object) -> _Proc:
+            if "--check" in cmd:
+                return _Proc(1, "", "")  # pending
+            return _Proc(0, "Applying ...", "")
+
+        monkeypatch.setattr(self_update_mod, "run_allowed_to_fail", _run)
+
+        failed = ensure_self_db_migrated(quiet=True)
+
+        assert failed is False
+        assert "migrations applied" in capsys.readouterr().out
+
     def test_ensure_returns_failed_when_migration_fails_closed(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/test_setup_skill_plugin_registration.py
+++ b/tests/test_setup_skill_plugin_registration.py
@@ -1,0 +1,23 @@
+"""setup/SKILL.md must describe the current plugin-registration model.
+
+Registration moved from a ``~/.claude/plugins/t3`` symlink to a record in
+``installed_plugins.json`` (``installPath`` → main clone); ``t3 setup``
+actively removes the legacy symlink (``_cleanup_legacy_plugin``). A skill
+that still tells users to verify that symlink documents a path that no longer
+exists.
+"""
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SETUP_SKILL = _REPO_ROOT / "skills" / "setup" / "SKILL.md"
+
+
+def test_setup_skill_does_not_tell_user_to_verify_legacy_symlink() -> None:
+    text = _SETUP_SKILL.read_text(encoding="utf-8")
+    assert "ls -la ~/.claude/plugins/t3" not in text
+
+
+def test_setup_skill_names_the_registration_record() -> None:
+    text = _SETUP_SKILL.read_text(encoding="utf-8")
+    assert "installed_plugins.json" in text


### PR DESCRIPTION
## Summary

Fixes so a fresh GitHub-origin install works end to end. teatree is not on PyPI (it is not stable); the documented user install now comes from GitHub origin/main.

### What a fresh-machine user hit before this

- The first install command was `uv tool install teatree` (PyPI) -- teatree is not published there, so it failed immediately.
- `apm install -g souliane/teatree` aborted: the repo carries `apm.yml` so APM classifies it as a package and requires a `.apm/` directory, which was absent.
- `_run_apm_install` could report APM dependencies installed on a failed run -- apm writes diagnostics to stdout and exits 0 even on validation failure.
- After installing, `t3 doctor check` FAILed on the unapplied-migrations gate: a fresh install has an empty self-DB and nothing converged it.

### After this change

1. **GitHub-origin install everywhere.** README, docs/install.md, the `t3` self-install hint in hook_router.py, and the doctor editable-install hint all use the tested-good form `uv tool install --from git+https://github.com/souliane/teatree.git teatree` (the form exercised by tests/test_t3_bootstrap.py). The repo-wide sweep `rg -i 'pip install teatree|pipx install teatree|uv tool install teatree'` returns zero hits.

2. **APM package validity + non-silent failure.** Added `.apm/contexts/teatree.context.md` so the repo is a valid APM package (verified against APM's own `validate_apm_package`). `_run_apm_install` now treats a non-zero exit OR a failure marker in either stream as failure, and surfaces stdout in the WARN.

3. **`t3 setup` migrates the self-DB.** Applies pending migrations via the existing `ensure_self_db_migrated` chokepoint (runtime interpreter, fail-closed). Idempotent (probe-gated) and quiet when nothing is pending (new `quiet` flag). When a migrate fails and leaves the self-DB unmigrated, `t3 setup` now exits non-zero (parity with `t3 update`) instead of printing Done. and exiting 0.

4. **Two prose corrections.** The editable-contributor doctor WARN no longer scolds the documented contributor setup; the setup skill drops the stale verify-the-symlink line (plugin registration is via installed_plugins.json now).

## Verification

- Affected tests pass (TDD: RED observed before each fix).
- `uv tool install --from git+...teatree.git teatree` then `t3 --help` confirmed in an isolated sandbox (temp HOME + UV_TOOL_DIR + UV_TOOL_BIN_DIR).
- `validate_apm_package` confirms the package is valid (no errors/warnings).
- `t3 teatree db migrate` then `t3 doctor check` confirmed the migration FAIL clears.
- `t3 tool verify-gates`: all gate stages green (commit + push).

## Architecture pre-check

Tactical fixes (docs, a CLI failure-detection helper, reuse of an existing migrate chokepoint, a non-zero-exit propagation, prose corrections). No FSM transitions, no new module, no Protocol/extension-point change. `.apm/contexts/` lives outside src/ and skills/, so no scanner/invariant owns it. tach check passes.

## Open questions and assumptions

- decided-by-user: install comes from GitHub origin/main, not PyPI.
- Used the `--from <url> teatree` install form everywhere (over a bare `git+` URL) for consistency with the only form a test exercises; both resolve.
- Assumed a single context primitive is the minimal valid `.apm/` content -- teatree skills/agents/hooks reach Claude via plugin registration, not via APM primitives.
- Assumed `t3 setup` is the right home for the self-DB converge step (the universal post-install command; `t3 update` already runs the same chokepoint).
- skills/workspace/references/troubleshooting.md keeps one passing mention of PyPI libs describing the bootstrap entry-point fallback; it is not an install instruction, so it was left as-is.
