### PR TITLE
fix(overlay): derive teatree followup repos from workspace repos

### DIFF
--- a/src/teatree/contrib/t3_teatree/overlay.py
+++ b/src/teatree/contrib/t3_teatree/overlay.py
@@ -17,6 +17,12 @@ from teatree.utils.run import run_checked
 from teatree.visual_qa import matches_triggers
 
 _SETTINGS_MODULE = "teatree.contrib.t3_teatree.overlay_settings"
+_DEFAULT_FOLLOWUP_REPOS = ["souliane/teatree"]
+
+
+def _is_github_slug(value: str) -> bool:
+    owner, sep, name = value.partition("/")
+    return bool(sep) and bool(owner) and bool(name) and "/" not in name
 
 
 def _repo_root() -> Path:
@@ -57,9 +63,13 @@ def _discover_workspace_repos() -> list[str]:
 class TeatreeMetadata(OverlayMetadata):
     """Metadata for the bundled teatree overlay."""
 
+    def __init__(self, config: OverlayConfig) -> None:
+        self._config = config
+
     @override
     def get_followup_repos(self) -> list[str]:
-        return ["souliane/teatree"]
+        slugs = [repo for repo in self._config.workspace_repos if _is_github_slug(repo)]
+        return slugs or list(_DEFAULT_FOLLOWUP_REPOS)
 
     @override
     def get_skill_metadata(self) -> SkillMetadata:
@@ -75,7 +85,7 @@ class TeatreeOverlay(OverlayBase):
 
     django_app: str | None = "teatree.contrib.t3_teatree"
     config = OverlayConfig(settings_module=_SETTINGS_MODULE, overlay_name="t3-teatree")
-    metadata = TeatreeMetadata()
+    metadata = TeatreeMetadata(config)
 
     @override
     def get_repos(self) -> list[str]:

--- a/tests/test_contrib_overlay.py
+++ b/tests/test_contrib_overlay.py
@@ -150,8 +150,37 @@ class TestGetWorkspaceRepos:
 
 
 class TestGetFollowupRepos:
-    def test_returns_github_project(self) -> None:
+    def test_falls_back_to_default_when_no_slug_workspace_repos(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        isolated_config: Path,
+    ) -> None:
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        isolated_config.write_text(f'[teatree]\nworkspace_dir = "{workspace}"\n', encoding="utf-8")
+        monkeypatch.setattr(overlay_mod, "_repo_root", lambda: tmp_path / "elsewhere")
+
         overlay = TeatreeOverlay()
+        overlay.config.workspace_repos = []
+        assert overlay.metadata.get_followup_repos() == ["souliane/teatree"]
+
+    def test_governs_every_configured_workspace_repo(self) -> None:
+        overlay = TeatreeOverlay()
+        overlay.config.workspace_repos = [
+            "souliane/teatree",
+            "acme/sibling-overlay",
+            "acme/sibling-overlay-e2e",
+        ]
+        assert overlay.metadata.get_followup_repos() == [
+            "souliane/teatree",
+            "acme/sibling-overlay",
+            "acme/sibling-overlay-e2e",
+        ]
+
+    def test_excludes_non_slug_workspace_entries(self) -> None:
+        overlay = TeatreeOverlay()
+        overlay.config.workspace_repos = ["teatree", "souliane/teatree", "owner/name/extra"]
         assert overlay.metadata.get_followup_repos() == ["souliane/teatree"]
 
 


### PR DESCRIPTION
Governance settings (merge policy, on-behalf mode, etc.) must resolve by **which overlay governs a repo** (the overlay whose `workspace_repos` contains it), not by which overlay a repo implements. The ownership resolver `infer_overlay_for_url` already does this correctly via `get_workspace_repos()`. The gap was the auto-merge path.

The PR-sweep and codex scanners poll `overlay.metadata.get_followup_repos()` to decide which repos a governing overlay merges under its own settings. The bundled teatree overlay hardcoded that to the single teatree repo, so the *other* repos in its `workspace_repos` were never swept for auto-merge — a repo the overlay governs sat outside its merge loop entirely. The ownership resolver and the sweep set disagreed.

This derives `get_followup_repos()` from the configured `workspace_repos` (filtered to `owner/repo` GitHub slugs, with a default fallback), making `workspace_repos` the single source of truth for both governance-ownership resolution and the auto-merge sweep set.

## Architecture pre-check

**1. BLUEPRINT alignment** — Section 6 (Overlay System: the `OverlayBase`/`OverlayMetadata` extension contract) and Section 17.4 (orchestrator-decides / loop-executes auto-merge keystone). No contract surface change; the bundled overlay hook is made consistent with the governance-ownership relation core already uses.

**2. FSM phase boundaries** — n/a, no state transition touched.

**3. Extension-point contracts** — `OverlayMetadata.get_followup_repos()` consumers: `_pr_sweep_scanner_for`, `_codex_review_scanner_for`, and the checking repo-scoping. Base default `[]` unchanged; only the bundled overlay override changes. Other overlays unaffected.

**4. Component boundaries** — confined to `src/teatree/contrib/t3_teatree/overlay.py`. Core stays overlay-agnostic.

**5. Dependency direction** — no new imports, no backwards edge, `tach check` green.

**6. Test surface** — `tests/test_contrib_overlay.py::TestGetFollowupRepos`: configured slugs flow through; non-`owner/repo` entries excluded; default fallback when none. Verified RED on the pre-fix hardcoded implementation, GREEN after.

**7. Resilience invariants** — n/a, pure in-process config derivation, no external write.

**8. Identity and key normalization** — canonical form is the `owner/repo` GitHub slug; `_is_github_slug` admits exactly that shape, no qualifier stripped to force a match.

**9. Behavior preservation** — old hardcoded default preserved as the fallback. No must-block test inverted, no matcher narrowed.