### PR TITLE
fix(worktree): reconcile stack-gate vs docker + connect db_exists with worktree pg role

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -24,6 +24,7 @@ from teatree.config import load_config
 from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_overlay
+from teatree.core.worktree_env import worktree_pg_connection
 from teatree.core.worktree_recovery import _has_unpushed_commits, capture_recovery_artifact
 from teatree.utils import git
 from teatree.utils.db import drop_db
@@ -31,16 +32,6 @@ from teatree.utils.postgres_secret import remove_postgres_pass_entry
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
-
-
-def _read_env_cache_value(worktree_path: Path, key: str) -> str:
-    cache_file = worktree_path / ".t3-cache" / ".t3-env.cache"
-    if not cache_file.is_file():
-        return ""
-    for line in cache_file.read_text(encoding="utf-8").splitlines():
-        if line.startswith(f"{key}="):
-            return line.split("=", maxsplit=1)[1]
-    return ""
 
 
 _PR_SUFFIX_RE = re.compile(r"(?:\s*\(#\d+\))+$")
@@ -562,7 +553,7 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene:
     step_errors.extend(_remove_git_worktree(repo_main, wt_path, worktree, force=force, strict_hygiene=strict_hygiene))
 
     if worktree.db_name:
-        db_user = _read_env_cache_value(Path(wt_path), "POSTGRES_USER")
+        db_user, _, _ = worktree_pg_connection(worktree, overlay=overlay)
         try:
             drop_db(worktree.db_name, user=db_user)
         except Exception as exc:

--- a/src/teatree/core/local_stack_gate.py
+++ b/src/teatree/core/local_stack_gate.py
@@ -16,12 +16,24 @@ knows which ``t3 <overlay> worktree teardown`` to run.
 The candidate worktree's own row is excluded from the count so an
 idempotent re-fire of ``start`` against an already-running worktree
 does not refuse against itself.
+
+The DB FSM state alone is not trusted: a ``SERVICES_UP`` / ``READY``
+row whose docker stack is gone (a docker restart, a manual
+``compose down``, an OOM kill) is a phantom that would otherwise refuse
+every legitimate start forever. Before counting, each blocker is
+reconciled against live ``docker ps`` — a counted row with zero running
+containers is demoted to ``PROVISIONED`` (with a log line) and excluded.
+A docker binary that cannot be queried fails safe: the row stays counted.
 """
 
+import logging
 from collections.abc import Callable
 
 from teatree.config import get_effective_settings
 from teatree.core.models import Worktree
+from teatree.utils.run import run_allowed_to_fail
+
+logger = logging.getLogger(__name__)
 
 
 class LocalStackLimitExceededError(RuntimeError):
@@ -29,6 +41,60 @@ class LocalStackLimitExceededError(RuntimeError):
 
 
 _BLOCKING_STATES: tuple[str, ...] = (Worktree.State.SERVICES_UP, Worktree.State.READY)
+
+
+def _running_container_count(compose_project: str) -> int:
+    """Count *running* docker containers belonging to *compose_project*.
+
+    ``docker ps`` (no ``-a``) lists only running containers, so a stack
+    whose containers were stopped or removed (a docker restart, a manual
+    ``compose down``, an OOM kill) reports zero — the signal that a
+    ``SERVICES_UP`` / ``READY`` row is a phantom holding no real stack.
+    A docker binary that is missing or erroring yields ``-1`` so the
+    caller can distinguish "verified empty" from "could not verify" and
+    fail safe (keep the row counted) on the latter.
+    """
+    if not compose_project:
+        return -1
+    result = run_allowed_to_fail(
+        [
+            "docker",
+            "ps",
+            "--filter",
+            f"label=com.docker.compose.project={compose_project}",
+            "--format",
+            "{{.Names}}",
+        ],
+        expected_codes=None,
+    )
+    if result.returncode != 0:
+        return -1
+    return sum(1 for name in result.stdout.splitlines() if name.strip())
+
+
+def _reconcile_phantom_blocker(worktree: Worktree) -> bool:
+    """Demote *worktree* to ``PROVISIONED`` when its compose stack is gone.
+
+    Returns ``True`` when the row is a verified phantom (state says a
+    stack is up but docker reports zero running containers) and was
+    demoted, so the gate must not count it. Returns ``False`` when the
+    stack is genuinely live or its liveness could not be verified — both
+    keep the row counted (fail safe).
+    """
+    ticket = worktree.ticket
+    compose_project = f"{worktree.repo_path}-wt{ticket.ticket_number}" if ticket else worktree.repo_path
+    if _running_container_count(compose_project) != 0:
+        return False
+    logger.warning(
+        "Demoting phantom worktree %s (%s): state=%s but compose project %r has zero live containers",
+        worktree.repo_path,
+        worktree.branch,
+        worktree.state,
+        compose_project,
+    )
+    worktree.state = Worktree.State.PROVISIONED
+    worktree.save(update_fields=["state"])
+    return True
 
 
 def _blocker_label(worktree: Worktree) -> str:
@@ -74,7 +140,7 @@ def check_local_stack_limit(candidate: Worktree, *, limit: int | None = None) ->
         return
 
     candidate_ticket_pk = candidate.ticket.pk
-    blockers = list(
+    counted_blockers = list(
         Worktree.objects.filter(
             overlay=candidate.overlay,
             state__in=_BLOCKING_STATES,
@@ -82,6 +148,7 @@ def check_local_stack_limit(candidate: Worktree, *, limit: int | None = None) ->
         .exclude(ticket__pk=candidate_ticket_pk)
         .order_by("ticket__pk", "pk"),
     )
+    blockers = [b for b in counted_blockers if not _reconcile_phantom_blocker(b)]
     blocking_tickets = {b.ticket.pk for b in blockers}
     if len(blocking_tickets) < effective_limit:
         return

--- a/src/teatree/core/reconcile.py
+++ b/src/teatree/core/reconcile.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from teatree.config import load_config
 from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Ticket, Worktree
-from teatree.core.worktree_env import detect_drift, render_env_cache
+from teatree.core.worktree_env import detect_drift, render_env_cache, worktree_pg_connection
 from teatree.utils import git
 from teatree.utils.db import db_exists
 from teatree.utils.run import run_allowed_to_fail
@@ -178,8 +178,10 @@ def _reconcile_worktree_row(drift: Drift, wt: Worktree, ticket_number: str) -> N
             else:
                 drift.missing_env_caches.append(MissingEnvCache(worktree_pk=wt.pk, cache_path=cache_path))
 
-    if wt.db_name and wt.state != Worktree.State.CREATED and not db_exists(wt.db_name):
-        drift.missing_dbs.append(MissingDB(worktree_pk=wt.pk, db_name=wt.db_name))
+    if wt.db_name and wt.state != Worktree.State.CREATED:
+        user, host, env = worktree_pg_connection(wt)
+        if not db_exists(wt.db_name, user=user, host=host, env=env or None):
+            drift.missing_dbs.append(MissingDB(worktree_pk=wt.pk, db_name=wt.db_name))
 
     if wt.state == Worktree.State.CREATED:
         compose_project = f"{wt.repo_path}-wt{ticket_number}"

--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -103,14 +103,16 @@ class WorktreeProvisionRunner(RunnerBase):
         return RunnerResult(ok=True, detail=f"{len(report.steps)} step(s) ok")
 
     def _run_db_import(self) -> None:
+        from teatree.core.worktree_env import worktree_pg_connection  # noqa: PLC0415
         from teatree.utils.db import db_exists  # noqa: PLC0415
 
         worktree = self.worktree
         overlay = self.overlay
 
         if worktree.db_name:
+            user, host, env = worktree_pg_connection(worktree, overlay=overlay)
             try:
-                if db_exists(worktree.db_name):
+                if db_exists(worktree.db_name, user=user, host=host, env=env or None):
                     logger.info("DB exists: %s — skipping import", worktree.db_name)
                     return
             except FileNotFoundError:

--- a/src/teatree/core/worktree_env.py
+++ b/src/teatree/core/worktree_env.py
@@ -11,6 +11,7 @@ this module makes the file actively inhospitable to being treated as
 truth.
 """
 
+import os
 import platform
 import shutil
 import stat
@@ -188,6 +189,36 @@ def write_env_cache(worktree: Worktree, *, overlay: "OverlayBase | None" = None)
     shutil.copy2(spec.path, repo_copy)
 
     return spec
+
+
+def worktree_pg_connection(
+    worktree: Worktree, *, overlay: "OverlayBase | None" = None
+) -> tuple[str, str, dict[str, str]]:
+    """Resolve ``(user, host, env)`` for connecting to *worktree*'s postgres.
+
+    The worktree's overlay decides the connecting role, host and port
+    via ``get_env_extra`` (an overlay may connect as a non-default
+    superuser role on ``localhost``). The bare process-env defaults in
+    ``utils.db`` fall back to ``postgres`` / ``localhost`` — a role that
+    need not exist on the host — so a per-worktree existence check must
+    connect with the overlay's resolved params, not the defaults.
+
+    Returns ``("", "", {})`` for an unprovisioned worktree so callers fall
+    back to the plain ``db_exists`` defaults.
+    """
+    from teatree.utils.db import pg_env  # noqa: PLC0415
+
+    extra: WorktreeExtra = validated_worktree_extra(worktree.extra)
+    if not extra.get("worktree_path"):
+        return "", "", {}
+
+    if overlay is None:
+        overlay = get_overlay_for_worktree(worktree)
+    resolved = dict(overlay.get_env_extra(worktree))
+
+    env = {**os.environ, **resolved}
+    env.pop("VIRTUAL_ENV", None)
+    return resolved.get("POSTGRES_USER", ""), resolved.get("POSTGRES_HOST", ""), pg_env(env)
 
 
 def detect_drift(worktree: Worktree, *, overlay: "OverlayBase | None" = None) -> tuple[bool, Path | None]:

--- a/src/teatree/utils/db.py
+++ b/src/teatree/utils/db.py
@@ -4,11 +4,11 @@ from teatree.utils.postgres_secret import resolve_postgres_password
 from teatree.utils.run import CommandFailedError, run_allowed_to_fail, run_checked
 
 
-def pg_env() -> dict[str, str]:
-    env = os.environ.copy()
+def pg_env(base: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(base) if base is not None else os.environ.copy()
     if password := resolve_postgres_password(env):
         env["PGPASSWORD"] = password
-    if port := os.environ.get("POSTGRES_PORT", ""):
+    if port := env.get("POSTGRES_PORT", ""):
         env["PGPORT"] = port
     return env
 
@@ -88,10 +88,10 @@ def db_restore(db_name: str, dump_path: str) -> None:
     _check_truncation(restore.stderr, db_name, dump_path)
 
 
-def db_exists(db_name: str) -> bool:
+def db_exists(db_name: str, *, user: str = "", host: str = "", env: dict[str, str] | None = None) -> bool:
     result = run_allowed_to_fail(
-        ["psql", "-h", pg_host(), "-U", pg_user(), "-lqt"],
-        env=pg_env(),
+        ["psql", "-h", host or pg_host(), "-U", user or pg_user(), "-lqt"],
+        env=env if env is not None else pg_env(),
         expected_codes=None,
     )
     return any(line.split("|")[0].strip() == db_name for line in result.stdout.splitlines() if line)

--- a/tests/teatree_core/test_reconcile.py
+++ b/tests/teatree_core/test_reconcile.py
@@ -3,17 +3,26 @@
 import shutil
 import tempfile
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import patch
 
 from django.test import TestCase
 
 import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay import OverlayBase
 from teatree.core.reconcile import Drift, EnvCacheDrift, MissingEnvCache, MissingWorktreeDir, reconcile_ticket
 from teatree.core.worktree_env import write_env_cache
 from tests.teatree_core.conftest import CommandOverlay
 
 _COMMAND = {"test": CommandOverlay()}
+
+
+class _PgUserOverlay(CommandOverlay):
+    """Overlay that connects to postgres as a non-default superuser role."""
+
+    def get_env_extra(self, worktree: Worktree) -> dict[str, str]:
+        return {"POSTGRES_USER": "db_superuser", "POSTGRES_HOST": "localhost"}
 
 
 def _make(tmp: str, *, db_name: str = "wt_99") -> tuple[Ticket, Worktree, Path]:
@@ -124,3 +133,48 @@ class TestReconcileTicket(TestCase):
             write_env_cache(wt)
             drift = reconcile_ticket(ticket)
         assert not drift.has_drift
+
+
+class TestReconcileMissingDbUsesWorktreePgUser(TestCase):
+    """An existing DB reachable only as the overlay's role must not read as missing.
+
+    The bug: ``db_exists`` connected with the bare process-env default
+    ``POSTGRES_USER`` (``postgres`` — a role that need not exist), so a
+    DB owned by a non-default superuser role reported missing for many
+    tickets. ``doctor --fix`` then nudges a re-provision that drops the
+    good DB. The reconciler must connect with the worktree's resolved role.
+    """
+
+    _OVERLAYS: ClassVar[dict[str, OverlayBase]] = {"test": _PgUserOverlay()}
+
+    def _existing_only_as_superuser(self, db_name: str, *, user: str = "", **_: object) -> bool:
+        # Mirrors the host: the DB exists, but only the overlay's role can see it.
+        # The default ``postgres`` connection fails and yields no rows -> False.
+        return user == "db_superuser" and db_name == "wt_99"
+
+    def test_existing_db_not_reported_missing_when_owned_by_overlay_role(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=self._OVERLAYS),
+            patch("teatree.core.reconcile._find_docker_containers", return_value=[]),
+            patch("teatree.core.reconcile._find_worktree_paths_on_disk", return_value=set()),
+            patch("teatree.core.reconcile.db_exists", side_effect=self._existing_only_as_superuser),
+        ):
+            ticket, wt, _ = _make(tmp)
+            write_env_cache(wt)
+            drift = reconcile_ticket(ticket)
+        assert drift.missing_dbs == []
+
+    def test_genuinely_absent_db_still_reported_missing(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=self._OVERLAYS),
+            patch("teatree.core.reconcile._find_docker_containers", return_value=[]),
+            patch("teatree.core.reconcile._find_worktree_paths_on_disk", return_value=set()),
+            patch("teatree.core.reconcile.db_exists", return_value=False),
+        ):
+            ticket, wt, _ = _make(tmp)
+            write_env_cache(wt)
+            drift = reconcile_ticket(ticket)
+        assert len(drift.missing_dbs) == 1
+        assert drift.missing_dbs[0].db_name == "wt_99"

--- a/tests/teatree_core/test_worktree_env.py
+++ b/tests/teatree_core/test_worktree_env.py
@@ -19,6 +19,7 @@ from teatree.core.worktree_env import (
     load_overrides,
     render_env_cache,
     set_override,
+    worktree_pg_connection,
     write_env_cache,
 )
 from teatree.types import BaseImageConfig, DbImportStrategy
@@ -448,3 +449,38 @@ class TestOverrides(TestCase):
             assert spec is not None
             assert "SECRET_PASSWORD" not in spec.content
             assert "leak" not in spec.content
+
+
+class _PgUserOverlay(OverlayBase):
+    """Overlay that connects to postgres as a non-default role + custom port."""
+
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        return []
+
+    def get_env_extra(self, worktree: Worktree) -> dict[str, str]:
+        return {"POSTGRES_USER": "db_superuser", "POSTGRES_HOST": "db.internal", "POSTGRES_PORT": "5544"}
+
+
+_PG_USER = {"test": _PgUserOverlay()}
+
+
+class TestWorktreePgConnection(TestCase):
+    def test_resolves_overlay_role_host_and_port(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt, _ = _make_worktree(tmp, ticket_name="pgc", ticket_url="https://ex.com/pgc", db_name="wt_pgc")
+            with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_PG_USER):
+                user, host, env = worktree_pg_connection(wt)
+        assert user == "db_superuser"
+        assert host == "db.internal"
+        assert env["PGPORT"] == "5544"
+
+    def test_unprovisioned_worktree_returns_blank_defaults(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://ex.com/np")
+        wt = Worktree.objects.create(
+            overlay="test", ticket=ticket, repo_path="backend", branch="feature", db_name="wt_np", extra={}
+        )
+        user, host, env = worktree_pg_connection(wt)
+        assert (user, host, env) == ("", "", {})

--- a/tests/test_max_concurrent_local_stacks.py
+++ b/tests/test_max_concurrent_local_stacks.py
@@ -22,8 +22,22 @@ from django.core.management import call_command
 from django.test import TestCase
 
 from teatree.config import load_config
+from teatree.core import local_stack_gate as gate_mod
 from teatree.core.local_stack_gate import LocalStackLimitExceededError, check_local_stack_limit
 from teatree.core.models import Ticket, Worktree
+
+
+@pytest.fixture(autouse=True)
+def _stacks_appear_live() -> "object":
+    """Default every blocker to a live docker stack for the existing gate tests.
+
+    The gate now reconciles blocker rows against ``docker ps`` and demotes
+    phantoms (zero running containers). The pre-existing tests model rows
+    that are genuinely up, so default the docker probe to "live"; the
+    reconciliation tests override this with their own ``patch.object``.
+    """
+    with patch.object(gate_mod, "_running_container_count", return_value=1):
+        yield
 
 
 def _write_toml(config_path: Path, content: str) -> None:
@@ -279,6 +293,112 @@ class TestWorktreeStartCliRefusesWhenLimitExceeded(TestCase):
             ):
                 call_command("worktree", "start", path=str(wt_dir))
             assert exc_info.value.code == 1
+
+
+class TestLocalStackGateDockerReconciliation(TestCase):
+    """A ``SERVICES_UP`` row with no live docker stack is a phantom — it must not block.
+
+    The DB FSM state can lie after a docker restart / OOM / manual
+    ``compose down``: the row still reads ``SERVICES_UP`` but holds no
+    real stack. Counting it refuses every legitimate start forever
+    (the 8568 Kletterrate blocker). The gate reconciles against
+    ``docker ps`` and demotes such phantoms before counting.
+    """
+
+    def test_phantom_blocker_with_zero_live_containers_does_not_count(self) -> None:
+        phantom = _make_worktree(
+            overlay="t3-heavy",
+            ticket_number="7010",
+            state=Worktree.State.SERVICES_UP,
+            worktree_path="/ws/7010-feat/backend",
+        )
+        candidate = _make_worktree(
+            overlay="t3-heavy",
+            ticket_number="7011",
+            state=Worktree.State.PROVISIONED,
+        )
+        with patch.object(gate_mod, "_running_container_count", return_value=0):
+            check_local_stack_limit(candidate, limit=1)
+        phantom.refresh_from_db()
+        assert phantom.state == Worktree.State.PROVISIONED
+
+    def test_running_stack_still_counts_and_refuses(self) -> None:
+        live = _make_worktree(
+            overlay="t3-heavy",
+            ticket_number="7020",
+            state=Worktree.State.SERVICES_UP,
+            worktree_path="/ws/7020-feat/backend",
+        )
+        candidate = _make_worktree(
+            overlay="t3-heavy",
+            ticket_number="7021",
+            state=Worktree.State.PROVISIONED,
+        )
+        with (
+            patch.object(gate_mod, "_running_container_count", return_value=2),
+            pytest.raises(LocalStackLimitExceededError),
+        ):
+            check_local_stack_limit(candidate, limit=1)
+        live.refresh_from_db()
+        assert live.state == Worktree.State.SERVICES_UP
+
+    def test_unverifiable_docker_fails_safe_and_keeps_counting(self) -> None:
+        """When docker liveness can't be verified (-1) the row stays counted."""
+        blocker = _make_worktree(
+            overlay="t3-heavy",
+            ticket_number="7030",
+            state=Worktree.State.SERVICES_UP,
+            worktree_path="/ws/7030-feat/backend",
+        )
+        candidate = _make_worktree(
+            overlay="t3-heavy",
+            ticket_number="7031",
+            state=Worktree.State.PROVISIONED,
+        )
+        with (
+            patch.object(gate_mod, "_running_container_count", return_value=-1),
+            pytest.raises(LocalStackLimitExceededError),
+        ):
+            check_local_stack_limit(candidate, limit=1)
+        blocker.refresh_from_db()
+        assert blocker.state == Worktree.State.SERVICES_UP
+
+    def test_phantom_among_real_blockers_drops_only_the_phantom(self) -> None:
+        """With limit=1, demoting one phantom while another stack is live still refuses."""
+        phantom = _make_worktree(
+            overlay="t3-heavy",
+            ticket_number="7040",
+            state=Worktree.State.SERVICES_UP,
+            worktree_path="/ws/7040-feat/backend",
+        )
+        live = _make_worktree(
+            overlay="t3-heavy",
+            ticket_number="7041",
+            state=Worktree.State.READY,
+            worktree_path="/ws/7041-feat/backend",
+        )
+        candidate = _make_worktree(
+            overlay="t3-heavy",
+            ticket_number="7042",
+            state=Worktree.State.PROVISIONED,
+        )
+
+        def counts(project: str) -> int:
+            return 0 if "wt7040" in project else 1
+
+        with (
+            patch.object(gate_mod, "_running_container_count", side_effect=counts),
+            pytest.raises(LocalStackLimitExceededError) as exc,
+        ):
+            check_local_stack_limit(candidate, limit=1)
+        phantom.refresh_from_db()
+        live.refresh_from_db()
+        assert phantom.state == Worktree.State.PROVISIONED
+        assert live.state == Worktree.State.READY
+        # The phantom must not appear in the refusal message; the live one must.
+        message = str(exc.value)
+        assert "/ws/7040-feat/backend" not in message
+        assert "/ws/7041-feat/backend" in message
 
 
 class TestLocalStackGateMultipleBlockers(TestCase):


### PR DESCRIPTION
## Summary

Two verified bugs surfaced by the local E2E runner, both rooted in teatree trusting one state store without reconciling against another.

### Bug 1 — `max_concurrent_local_stacks` gate counts DB state, never docker

`check_local_stack_limit` counted `Worktree` rows by FSM state alone (`SERVICES_UP` / `READY`). Phantom rows left after a docker restart / OOM / manual compose-down kept the cap maxed out, refusing every legitimate `worktree start` forever (it blocked the Kletterrate E2E backend start at cap=1 with 3 container-less rows).

Fix at the chokepoint: before counting, each blocker is reconciled against live `docker ps`. A row in a blocking state whose compose project has **zero running containers** is demoted to `PROVISIONED` (with a log line) and excluded from the count. An unqueryable docker binary keeps the row counted (conservative default).

`src/teatree/core/local_stack_gate.py`

### Bug 2 — `workspace doctor` false `missing-db` (data-loss risk)

`reconcile.py` checked DB existence with `db_exists(wt.db_name)`, which connects using the bare process-env default `POSTGRES_USER` — `"postgres"`, a role that need not exist on the host. When the worktree's DB is owned by a non-default role, every existence check failed and `doctor` reported `missing-db` for existing, populated DBs (~30 tickets). A subsequent re-provision (which `doctor`/operators do in response) drops and recreates the DB — data loss.

Fix: `reconcile` and the provision skip-import check resolve the worktree's postgres `user` / `host` / `env` via a new `worktree_pg_connection()` (reads the overlay's `get_env_extra`, the authoritative source) and pass them to `db_exists()`. The same root cause is fixed in cleanup's db-drop path, which read the postgres role from the wrong cache directory and silently fell back to the default. `db_exists()` gains optional `user`/`host`/`env` params mirroring `drop_db`'s existing `user` param.

`src/teatree/core/reconcile.py`, `src/teatree/core/worktree_env.py`, `src/teatree/core/runners/worktree_provision.py`, `src/teatree/core/cleanup.py`, `src/teatree/utils/db.py`

## Tests (RED-first, verified non-vacuous)

- Stack gate: a phantom blocker (zero live containers) must not count and is demoted; a genuinely-running stack still counts and refuses; an unverifiable docker keeps the row counted; a phantom among real blockers drops only the phantom. Reverting the reconciliation hunk turns these RED.
- Reconcile: an existing DB reachable only as the overlay's non-default role is **not** reported missing; a genuinely absent DB still is. Reverting the `worktree_pg_connection` hunk turns this RED.
- Unit: `worktree_pg_connection` resolves the overlay role/host/port; returns blank defaults for an unprovisioned worktree.

252 scoped tests pass across the touched modules (gate, reconcile, worktree_env, db, provision runner, cleanup, workspace command). `ruff`, `ty-check`, and `t3 tool verify-gates` (commit + push stages) all green.
