### PR TITLE
fix(slack-answer): bare URL DMs no longer misfire the statusline reply

### DIFF
--- a/src/teatree/loop/slack_answer/classifier.py
+++ b/src/teatree/loop/slack_answer/classifier.py
@@ -108,6 +108,8 @@ _INVESTIGATION_RE = re.compile(
 
 _EMOJI_ONLY_RE = re.compile(r"^[\W_]+$", re.UNICODE)
 
+_URL_RE = re.compile(r"<?https?://\S+")
+
 
 class AnswerRoute(StrEnum):
     """The three cheap paths a classified Slack message can take."""
@@ -115,6 +117,10 @@ class AnswerRoute(StrEnum):
     ACK_ONLY = "ack_only"
     SIMPLE = "simple"
     NEEDS_WORK = "needs_work"
+
+
+def strip_urls(text: str) -> str:
+    return _URL_RE.sub(" ", text)
 
 
 def _normalized(text: str) -> str:
@@ -170,9 +176,9 @@ def classify(text: str) -> AnswerRoute:
         return AnswerRoute.NEEDS_WORK
     if _is_ack(text, lowered):
         return AnswerRoute.ACK_ONLY
-    if _is_simple(lowered):
+    if _is_simple(strip_urls(lowered)):
         return AnswerRoute.SIMPLE
     return AnswerRoute.NEEDS_WORK
 
 
-__all__ = ["AnswerRoute", "classify"]
+__all__ = ["AnswerRoute", "classify", "strip_urls"]

--- a/src/teatree/loop/slack_answer/simple_answer.py
+++ b/src/teatree/loop/slack_answer/simple_answer.py
@@ -22,6 +22,7 @@ import os
 from typing import TYPE_CHECKING
 
 from teatree.loop.self_improve.budget import precheck_budget
+from teatree.loop.slack_answer.classifier import strip_urls
 from teatree.loop.statusline import statusline_for_slack
 from teatree.utils.run import CommandFailedError, run_checked
 
@@ -78,7 +79,7 @@ def _stage_a(text: str) -> str | None:
     dashboard table (#1121). When the statusline file is empty/missing,
     return ``None`` so the cycle falls through to Stage B or delegation.
     """
-    lowered = text.lower()
+    lowered = strip_urls(text.lower())
     if not any(tok in lowered for tok in _DASHBOARD_TOKENS):
         return None
     rendered = statusline_for_slack().strip()

--- a/tests/teatree_loop/slack_answer/test_classifier.py
+++ b/tests/teatree_loop/slack_answer/test_classifier.py
@@ -101,3 +101,20 @@ class TestNeedsWork:
     )
     def test_ambiguous_input_fails_safe_to_needs_work(self, text: str) -> None:
         assert classify(text) is AnswerRoute.NEEDS_WORK
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "https://x.com/user/status/1780726427261379",
+            "https://twitter.com/somebody/status/555",
+            "https://x.com/i/status/9999",
+            "<https://x.com/user/status/1780726427261379>",
+            "https://example.com/today/progress/blocker-status",
+        ],
+    )
+    def test_link_only_message_is_not_a_status_request(self, text: str) -> None:
+        # A bare URL carries no status intent: its path may contain the
+        # substring "status"/"progress"/"today", but those are URL segments,
+        # not the user asking for a status. Must fail-safe to NEEDS_WORK so
+        # the real handler picks it up — never the default statusline reply.
+        assert classify(text) is AnswerRoute.NEEDS_WORK

--- a/tests/teatree_loop/slack_answer/test_cycle.py
+++ b/tests/teatree_loop/slack_answer/test_cycle.py
@@ -188,6 +188,33 @@ class TestNeedsWorkDelegation:
         assert Task.objects.filter(phase="answering").count() == 1
 
 
+class TestLinkOnlyDmDoesNotMisfireStatusline:
+    """A link-only inbound DM must NOT get the default statusline reply.
+
+    An X.com status link contains the substring "status", which used to
+    mis-classify the DM as a SIMPLE status request, so the cycle posted
+    the statusline content threaded under the unrelated link DM. A bare
+    URL has no status intent → delegate, never a threaded statusline.
+    """
+
+    def test_x_link_only_dm_posts_no_statusline_and_no_threaded_reply(self) -> None:
+        row = _row("https://x.com/user/status/1780726427261379")
+        backend = RecordingBackend()
+
+        with patch(
+            "teatree.loop.slack_answer.simple_answer.statusline_for_slack",
+            return_value="self-improve 10m · tick 11m\nstarted · coded · tested\n",
+        ):
+            report = run_slack_answer_cycle(messaging_resolver=_resolver(backend))
+
+        assert backend.replies == []  # no statusline dump, no threaded reply
+        row.refresh_from_db()
+        assert row.answer_kind != "simple"
+        assert report.answered_simple == 0
+        tasks = Task.objects.filter(phase="answering", status=Task.Status.PENDING)
+        assert tasks.count() == 1  # left for the real handler (delegated)
+
+
 class TestRowIsolation:
     def test_one_bad_row_does_not_block_others(self) -> None:
         bad = _row("thanks", ts="1.0")


### PR DESCRIPTION
## Problem

A user DM'd a bare X.com link (body was only a URL). The reactive slack-answer loop replied **in that message's thread** with the full statusline dump (the `self-improve 10m · tick 11m · …` zones text) — threaded under a completely unrelated user message.

## Root cause

The intent gate matches status/dashboard tokens as plain **substrings**:

- `classifier._SIMPLE_QUESTION_TOKENS` contains `"status"` (and `"progress"`), matched via `tok in lowered`. An x.com / twitter.com **status** link `https://x.com/.../status/...` contains the substring `status`, so `classify()` returned `SIMPLE`.
- `simple_answer._stage_a` then matched the same substring in `_DASHBOARD_TOKENS` and returned the rendered statusline.
- `cycle._handle_simple` posted it via `post_reply(ts=<inbound ts>)` — threaded under the link DM.

So a link-only DM both (a) got mis-classified as a status request and (b) had the statusline reply threaded under an arbitrary message.

## Fix (one targeted change at the intent gate)

Strip URLs from the text **before** the SIMPLE/dashboard intent match, via a single shared `strip_urls()` helper used by both `classify()` and `_stage_a()`. A link-only DM now carries no status intent and falls through to the fail-safe `NEEDS_WORK` path — delegated to the real handler — instead of the default statusline dump. No statusline reply, nothing threaded under an arbitrary user message.

This fixes the **class**: any URL whose path happens to contain a status/dashboard token no longer triggers the cheap statusline path.

## Tests (TDD)

- RED reproduction: `test_classifier.py::TestNeedsWork::test_link_only_message_is_not_a_status_request` (5 URL shapes incl. Slack-wrapped `<…>`) and `test_cycle.py::TestLinkOnlyDmDoesNotMisfireStatusline` (link-only inbound → no statusline reply, no threaded reply, delegated).
- GREEN after the fix; anti-vacuous verified — reverting the two src files turns both tests RED again.
- Full `tests/teatree_loop/slack_answer/` suite passes (120 tests), ruff clean.