### PR TITLE
docs(platforms): add X/Twitter post-reading recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ graph LR
 | `handover` | Use when the user wants to hand all current work from one Claude session to another (or to a not-yet-existing session) with a single command, or to transfer an in-flight TeaTree task from Claude to another runtime, or asks whether it is time to switch because Claude usage is getting high. |
 | `loops` | Show t3 loop status — which loops are running vs stalled, the cadence and next tick of each loop, and loop ownership |
 | `next` | Wrap up the current session — retro, structured result, pipeline handoff. |
-| `platforms` | Platform-specific API recipes for GitLab, GitHub, and Slack. Auto-loaded as a dependency by skills that interact with these platforms. |
+| `platforms` | Platform-specific API recipes for GitLab, GitHub, Slack, and X (Twitter). Auto-loaded as a dependency by skills that interact with these platforms. |
 | `retro` | Conversation retrospective and skill improvement |
 | `review` | Code review — self-review before finalization, giving review, receiving review feedback |
 | `review-request` | Batch review requests — discover open PRs, validate metadata, check for duplicates, post to review channels |

--- a/docs/generated/skills-catalogue.json
+++ b/docs/generated/skills-catalogue.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "platforms",
-      "summary": "Platform-specific API recipes for GitLab, GitHub, and Slack. Auto-loaded as a dependency by skills that interact with these platforms"
+      "summary": "Platform-specific API recipes for GitLab, GitHub, Slack, and X (Twitter). Auto-loaded as a dependency by skills that interact with these platforms"
     },
     {
       "name": "retro",

--- a/docs/generated/skills-catalogue.md
+++ b/docs/generated/skills-catalogue.md
@@ -16,7 +16,7 @@ Source: `skills/*/SKILL.md` frontmatter
 | `handover` | Use when the user wants to hand all current work from one Claude session to another (or to a not-yet-existing session) with a single command, or to transfer an in-flight TeaTree task from Claude to another runtime, or asks whether it is time to switch because Claude usage is getting high |
 | `loops` | Show t3 loop status — which loops are running vs stalled, the cadence and next tick of each loop, and loop ownership |
 | `next` | Wrap up the current session — retro, structured result, pipeline handoff |
-| `platforms` | Platform-specific API recipes for GitLab, GitHub, and Slack. Auto-loaded as a dependency by skills that interact with these platforms |
+| `platforms` | Platform-specific API recipes for GitLab, GitHub, Slack, and X (Twitter). Auto-loaded as a dependency by skills that interact with these platforms |
 | `retro` | Conversation retrospective and skill improvement |
 | `review` | Code review — self-review before finalization, giving review, receiving review feedback |
 | `review-request` | Batch review requests — discover open PRs, validate metadata, check for duplicates, post to review channels |

--- a/skills/platforms/SKILL.md
+++ b/skills/platforms/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platforms
-description: Platform-specific API recipes for GitLab, GitHub, and Slack. Auto-loaded as a dependency by skills that interact with these platforms.
+description: Platform-specific API recipes for GitLab, GitHub, Slack, and X (Twitter). Auto-loaded as a dependency by skills that interact with these platforms.
 compatibility: any
 metadata:
   version: 0.0.1
@@ -18,5 +18,6 @@ API recipes for issue trackers, CI systems, and chat platforms. Each platform ha
 | [`references/gitlab.md`](references/gitlab.md) | GitLab API, PR validation, pipeline control |
 | [`references/github.md`](references/github.md) | GitHub API, PR workflows |
 | [`references/slack.md`](references/slack.md) | Slack messaging, channel discovery |
+| [`references/x-twitter.md`](references/x-twitter.md) | X (Twitter) post reading via JSON mirror |
 
 Skills reference these via `See platforms/references/gitlab.md § <section>`.

--- a/skills/platforms/references/x-twitter.md
+++ b/skills/platforms/references/x-twitter.md
@@ -1,0 +1,42 @@
+# X / Twitter Platform Reference
+
+> Recipes for reading X (Twitter) posts. Skills reference this file via `See platforms/x-twitter.md § <section>`.
+
+---
+
+## Access Method
+
+X has no read API on the free tier and gates direct fetches behind JS + auth. To read a post's content, route the URL through a mirror that returns plain JSON.
+
+## Reading a Post
+
+Rewrite the post URL to the mirror host and fetch it — no auth needed:
+
+```text
+https://x.com/<user>/status/<id>  →  https://api.fxtwitter.com/<user>/status/<id>
+```
+
+The JSON response carries the full text, author, date, attached media, and the resolved target of any `t.co` shortlink. For a link-tweet (the post is just a headline + link), follow the embedded article URL next and fetch that.
+
+## Media
+
+The JSON also returns media objects with direct URLs:
+
+- **Photos / article-card covers** — direct `pbs.twimg.com` image URLs. Download the URL, then validate with `file` before reading it as an image (raster only).
+- **Videos** — direct `mp4` variants.
+
+## Why Not Fetch x.com Directly
+
+A direct `x.com` / `twitter.com` fetch returns **402**. User-agent spoofing does not help — the gating is JS + auth, not UA-based — so don't bother retrying with a fake UA.
+
+## Alternate Mirror
+
+`api.vxtwitter.com`, same path shape:
+
+```text
+https://api.vxtwitter.com/<user>/status/<id>
+```
+
+## Last Resort
+
+If both mirrors fail, use browser automation through the user's authenticated session (main-agent only).


### PR DESCRIPTION
Adds an X/Twitter reading recipe to the t3:platforms skill: new `references/x-twitter.md` (rewrite `x.com/<user>/status/<id>` to the `api.fxtwitter.com` JSON mirror; direct fetch returns 402; `api.vxtwitter.com` alternate; media URLs; authenticated-browser last resort) plus a References-table row in the platforms SKILL.md.

No existing skill documented an X/link-fetch fallback (grepped scanning-news, rules, e2e) — this is the single canonical home, not a duplicate.