### PR TITLE
fix(timeouts): docker_compose_build defaults to 600s, not the 120s fallback

### DIFF
--- a/src/teatree/core/runners/worktree_start.py
+++ b/src/teatree/core/runners/worktree_start.py
@@ -9,14 +9,11 @@ from teatree.core.overlay_loader import get_overlay_for_worktree
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.core.runners.service_launch import ServiceLauncher
 from teatree.core.worktree_env import write_env_cache
-from teatree.timeouts import TimeoutConfig, load_timeouts
+from teatree.timeouts import DOCKER_COMPOSE_BUILD, DOCKER_COMPOSE_DOWN, DOCKER_COMPOSE_UP, TimeoutConfig, load_timeouts
 from teatree.utils.ports import get_worktree_ports
 from teatree.utils.run import TimeoutExpired, run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
-
-# Build can take minutes on first start — much longer than the 60s default for `up`.
-DOCKER_COMPOSE_BUILD_TIMEOUT = 600
 
 
 def compose_project(worktree: Worktree) -> str:
@@ -82,7 +79,7 @@ class WorktreeStartRunner(RunnerBase):
         overlay = self.overlay
         project = compose_project(worktree)
 
-        docker_compose_down(project, timeout=self.timeouts.get("docker_compose_down"))
+        docker_compose_down(project, timeout=self.timeouts.get(DOCKER_COMPOSE_DOWN))
 
         commands = overlay.get_run_commands(worktree)
         ServiceLauncher.prepare_all(worktree, list(commands), overlay=overlay)
@@ -131,7 +128,7 @@ class WorktreeStartRunner(RunnerBase):
             "--no-build",
             "--pull=never",
         ]
-        timeout = self.timeouts.get("docker_compose_up")
+        timeout = self.timeouts.get(DOCKER_COMPOSE_UP)
         try:
             result = run_allowed_to_fail(cmd, env=env, expected_codes=None, timeout=timeout)
         except TimeoutExpired:
@@ -175,7 +172,7 @@ class WorktreeStartRunner(RunnerBase):
             "build",
             *missing,
         ]
-        timeout = self.timeouts.get("docker_compose_build") or DOCKER_COMPOSE_BUILD_TIMEOUT
+        timeout = self.timeouts.get(DOCKER_COMPOSE_BUILD)
         try:
             result = run_allowed_to_fail(cmd, env=env, expected_codes=None, timeout=timeout)
         except TimeoutExpired:

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -140,6 +140,7 @@ TEATREE_TIMEOUTS = {
     "start": 60,
     "db_import": 180,
     "docker_compose_up": 60,
+    "docker_compose_build": 600,
     "docker_compose_down": 30,
     "provision_step": 120,
     "pre_run_step": 60,

--- a/src/teatree/timeouts.py
+++ b/src/teatree/timeouts.py
@@ -20,6 +20,7 @@ SETUP = "setup"
 START = "start"
 DB_IMPORT = "db_import"
 DOCKER_COMPOSE_UP = "docker_compose_up"
+DOCKER_COMPOSE_BUILD = "docker_compose_build"
 DOCKER_COMPOSE_DOWN = "docker_compose_down"
 PROVISION_STEP = "provision_step"
 PRE_RUN_STEP = "pre_run_step"
@@ -30,6 +31,8 @@ CORE_DEFAULTS: dict[str, int] = {
     START: 60,
     DB_IMPORT: 180,
     DOCKER_COMPOSE_UP: 60,
+    # First-time image builds (Gradle/Java sidecars) routinely exceed 120s.
+    DOCKER_COMPOSE_BUILD: 600,
     DOCKER_COMPOSE_DOWN: 30,
     PROVISION_STEP: 120,
     PRE_RUN_STEP: 60,

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -8,6 +8,7 @@ from django.test import TestCase, override_settings
 from teatree.timeouts import (
     CORE_DEFAULTS,
     DB_IMPORT,
+    DOCKER_COMPOSE_BUILD,
     DOCKER_COMPOSE_DOWN,
     DOCKER_COMPOSE_UP,
     PRE_RUN_STEP,
@@ -42,6 +43,17 @@ class TestTimeoutConfig:
     def test_completely_unknown_operation_returns_120(self) -> None:
         cfg = TimeoutConfig(values={})
         assert cfg.get("nonexistent_operation") == 120
+
+    def test_docker_compose_build_uses_600s_default(self) -> None:
+        """First-time image builds need a long default, not the 120s fallback.
+
+        Regression: ``docker_compose_build`` was missing from CORE_DEFAULTS,
+        so ``get`` fell through to the hardcoded 120 for unknown operations —
+        timing out first-time Gradle/Java sidecar builds at 120s.
+        """
+        cfg = TimeoutConfig()
+        assert cfg.get(DOCKER_COMPOSE_BUILD) == 600
+        assert CORE_DEFAULTS[DOCKER_COMPOSE_BUILD] == 600
 
     def test_frozen(self) -> None:
         cfg = TimeoutConfig()
@@ -114,7 +126,16 @@ class TestLoadTimeouts(TestCase):
 
     def test_all_operations_have_defaults(self) -> None:
         cfg = load_timeouts()
-        for op in (SETUP, START, DB_IMPORT, DOCKER_COMPOSE_UP, DOCKER_COMPOSE_DOWN, PROVISION_STEP, PRE_RUN_STEP):
+        for op in (
+            SETUP,
+            START,
+            DB_IMPORT,
+            DOCKER_COMPOSE_UP,
+            DOCKER_COMPOSE_BUILD,
+            DOCKER_COMPOSE_DOWN,
+            PROVISION_STEP,
+            PRE_RUN_STEP,
+        ):
             val = cfg.get(op)
             assert val is not None, f"{op} should not be None"
             assert val > 0, f"{op} should have a positive default"


### PR DESCRIPTION
## Problem

`docker_compose_build` was never registered in `CORE_DEFAULTS`, so
`TimeoutConfig.get("docker_compose_build")` fell through to the hardcoded
120s "unknown operation" fallback (`timeouts.py:47`). The
`or DOCKER_COMPOSE_BUILD_TIMEOUT` guard in `worktree_start._ensure_images_built`
could never fire because 120 is truthy, leaving the 600s constant dead code.
First-time image builds for services that build from a Dockerfile (slow
toolchain-heavy sidecars) timed out at 120s instead of 600s.

## Fix

- Register `docker_compose_build` at 600s in the single source of truth:
  `timeouts.CORE_DEFAULTS` + `settings.TEATREE_TIMEOUTS` (parity with the
  other compose keys, so it is overridable at every tier).
- Drop the dead `DOCKER_COMPOSE_BUILD_TIMEOUT` constant and the `or` fallback.
- Resolve all three compose timeouts (`up` / `build` / `down`) via the named
  `timeouts` constants in `worktree_start` for one uniform pattern.

## Test

`test_docker_compose_build_uses_600s_default` asserts the key resolves to 600.
Verified RED on the pre-fix code (`assert 120 == 600`), GREEN after. The
`test_all_operations_have_defaults` invariant now also covers the new key.