### PR TITLE
fix(speak): surface slack-audio upload failures to the user instead of dropping them silently

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -156,8 +156,9 @@ speak_target = "both"       # local (default, say → speakers) | slack-audio (u
 Stop-hook handler spawning a detached `t3 speak`. `slack-audio`/`both`
 upload an `.m4a` to the user's DM via `SlackBotBackend.upload_audio_to_dm`,
 which needs the token's **`files:write`** scope (else `ok:false` /
-`missing_scope`, logged — local leg still plays; add the scope and re-run
-`t3 setup slack-bot`).
+`missing_scope` — the local leg still plays, and the failure is surfaced
+once per error class to the user's DM with the scope-fix hint instead of
+being silently dropped; add the scope and re-run `t3 setup slack-bot`).
 
 Callers use `get_effective_settings()` (returns a `UserSettings` with the
 active overlay's overrides applied) instead of reaching into

--- a/src/teatree/core/speak.py
+++ b/src/teatree/core/speak.py
@@ -26,7 +26,10 @@ Delivery is governed by :class:`~teatree.types.SpeakTarget`:
 
 Every leg is non-blocking (spawned in a daemon thread / detached process)
 and never raises into the caller's egress / Stop path — a failure to
-synthesise or play is logged at debug and dropped.
+synthesise or play locally is logged at debug and dropped. A failed
+``slack-audio`` upload is additionally surfaced to the user once per error
+class via a text DM (:func:`_surface_upload_failure`), so a missing
+``files:write`` scope can't silently masquerade as working delivery.
 """
 
 import logging
@@ -201,8 +204,9 @@ def _upload_to_slack(audio_path: Path) -> None:
     Reuses the same backend + ``slack_user_id`` resolution the bot→user
     DM path uses (:func:`teatree.core.notify.notify_user`'s helpers), so
     a single config drives both. A non-ok upload body (e.g. ``files:write``
-    scope missing) is logged at debug and dropped — the spoken reply just
-    doesn't reach the phone this time.
+    scope missing) is logged at debug AND surfaced once to the user via a
+    text DM through :func:`_surface_upload_failure`, so a silent audio drop
+    can't masquerade as working ``slack-audio`` delivery.
     """
     from teatree.core.backend_factory import messaging_from_overlay  # noqa: PLC0415
     from teatree.core.notify import _resolve_user_id  # noqa: PLC0415
@@ -218,5 +222,41 @@ def _upload_to_slack(audio_path: Path) -> None:
         return
     body = backend.upload_audio_to_dm(channel=channel, filepath=str(audio_path), title="Agent reply")
     if not body.get("ok"):
-        error = body.get("error", "no response")
+        error = str(body.get("error", "no response"))
         logger.debug("speak slack upload not ok: %s", error)
+        _surface_upload_failure(error)
+
+
+_MISSING_SCOPE_HINT = (
+    "Add the `files:write` scope to the bot's OAuth scopes and re-run "
+    "`t3 setup slack-bot`, then the audio will reach your phone."
+)
+
+
+def _surface_upload_failure(error: str) -> None:
+    """DM the user once per error class when ``slack-audio`` delivery fails.
+
+    A failed upload is otherwise invisible: the user enables
+    ``speak_target = both`` / ``slack-audio``, hears nothing on his phone,
+    and gets no signal why. The text DM path (``chat:write``) is healthy
+    even when ``files:write`` is not, so this reaches the user reliably.
+
+    Idempotent per error class — the ``BotPing`` ledger dedupes the
+    ``speak-upload-failed-<error>`` key, so a recurring ``missing_scope``
+    surfaces once, not on every spoken reply. Never raises into the speak
+    seam (the daemon-thread delivery path must stay crash-proof).
+    """
+    from teatree.core.notify import NotifyKind, notify_user  # noqa: PLC0415
+
+    hint = _MISSING_SCOPE_HINT if error == "missing_scope" else ""
+    message = f"Couldn't deliver the spoken reply as Slack audio (Slack error: {error})."
+    if hint:
+        message = f"{message} {hint}"
+    try:
+        notify_user(
+            message,
+            kind=NotifyKind.INFO,
+            idempotency_key=f"speak-upload-failed-{error}",
+        )
+    except Exception as exc:  # noqa: BLE001 — surfacing must never break the speak seam
+        logger.debug("speak upload-failure surface failed: %s", exc)

--- a/tests/teatree_core/test_speak.py
+++ b/tests/teatree_core/test_speak.py
@@ -316,13 +316,61 @@ class TestUploadToSlack:
             speak_mod._upload_to_slack(audio)
         backend.upload_audio_to_dm.assert_not_called()
 
-    def test_missing_scope_body_is_logged_not_raised(self, tmp_path: Path) -> None:
+    def test_ok_body_does_not_surface_failure(self, tmp_path: Path) -> None:
+        audio = tmp_path / "speech.m4a"
+        audio.write_bytes(b"x")
+        backend = self._backend(ok=True)
+        with (
+            patch("teatree.core.backend_factory.messaging_from_overlay", return_value=backend),
+            patch("teatree.core.notify._resolve_user_id", return_value="U_ME"),
+            patch.object(speak_mod, "_surface_upload_failure") as surface,
+        ):
+            speak_mod._upload_to_slack(audio)
+        surface.assert_not_called()
+
+    def test_missing_scope_surfaces_failure_to_user(self, tmp_path: Path) -> None:
         audio = tmp_path / "speech.m4a"
         audio.write_bytes(b"x")
         backend = self._backend(ok=False, error="missing_scope")
         with (
             patch("teatree.core.backend_factory.messaging_from_overlay", return_value=backend),
             patch("teatree.core.notify._resolve_user_id", return_value="U_ME"),
+            patch.object(speak_mod, "_surface_upload_failure") as surface,
         ):
-            speak_mod._upload_to_slack(audio)  # must not raise
-        backend.upload_audio_to_dm.assert_called_once()
+            speak_mod._upload_to_slack(audio)
+        surface.assert_called_once_with("missing_scope")
+
+    def test_no_response_body_surfaces_default_error(self, tmp_path: Path) -> None:
+        audio = tmp_path / "speech.m4a"
+        audio.write_bytes(b"x")
+        backend = self._backend(ok=False)
+        with (
+            patch("teatree.core.backend_factory.messaging_from_overlay", return_value=backend),
+            patch("teatree.core.notify._resolve_user_id", return_value="U_ME"),
+            patch.object(speak_mod, "_surface_upload_failure") as surface,
+        ):
+            speak_mod._upload_to_slack(audio)
+        surface.assert_called_once_with("no response")
+
+
+class TestSurfaceUploadFailure:
+    def test_missing_scope_dm_carries_files_write_hint(self) -> None:
+        with patch("teatree.core.notify.notify_user") as notify:
+            speak_mod._surface_upload_failure("missing_scope")
+        notify.assert_called_once()
+        message = notify.call_args.args[0]
+        assert "files:write" in message
+        assert "t3 setup slack-bot" in message
+        assert notify.call_args.kwargs["idempotency_key"] == "speak-upload-failed-missing_scope"
+
+    def test_other_error_dm_has_no_hint_and_per_error_key(self) -> None:
+        with patch("teatree.core.notify.notify_user") as notify:
+            speak_mod._surface_upload_failure("channel_not_found")
+        message = notify.call_args.args[0]
+        assert "channel_not_found" in message
+        assert "files:write" not in message
+        assert notify.call_args.kwargs["idempotency_key"] == "speak-upload-failed-channel_not_found"
+
+    def test_notify_failure_is_swallowed(self) -> None:
+        with patch("teatree.core.notify.notify_user", side_effect=RuntimeError("boom")):
+            speak_mod._surface_upload_failure("missing_scope")  # must not raise


### PR DESCRIPTION
## What

A failed slack-audio upload (e.g. the bot token missing the files:write scope) was logged at debug and dropped. A user enabling speak_target = both / slack-audio would hear nothing on their phone and get no signal why; the failure was indistinguishable from working delivery. _upload_to_slack now surfaces a non-ok upload body to the user once per error class via the healthy text-DM path (chat:write works even when files:write does not). A missing_scope error carries the exact fix hint (add files:write, re-run t3 setup slack-bot).

## Why

Found while exercising the slack-audio leg end to end: synthesis (say -o plus afconvert) produced a valid .m4a, but files.getUploadURLExternal returned missing_scope and the failure vanished silently. That is exactly the silent-drop this surfaces, so a user can trust speak_target = both before enabling it.

## Architecture pre-check

1. BLUEPRINT alignment: section 10.1.1 (Local text-to-speech); the appendix line describing the missing_scope failure as logged is updated to logged AND surfaced once per error class. No new section.
2. FSM phase boundaries: n/a.
3. Extension-point contracts: n/a (reuses the existing notify_user chokepoint and upload_audio_to_dm backend method unchanged).
4. Component boundaries: stays in src/teatree/core/speak.py; surfacing delegates to the existing teatree.core.notify.notify_user helper (same package, no new module).
5. Dependency direction: no new cross-package import; speak already imports notify (both in teatree.core). tach and import-linter green.
6. Test surface: tests/teatree_core/test_speak.py covers surface-on-non-ok (missing_scope and default-error), no-surface-on-ok, the files:write hint only for missing_scope, the per-error idempotency key, and notify-failure swallow. Anti-vacuity confirmed: RED with the call removed, GREEN restored.
7. Resilience invariants: external write (bot to user DM). Idempotency via the BotPing ledger per-error key, so a recurring failure surfaces once. never-raise: wrapped so it can never break the daemon-thread speak seam.
8. Identity and key normalization: n/a.
9. Behavior preservation: only removed behavior is the silent drop (the debug log is kept). No matcher narrowed, no must-block test inverted. Purely additive.

## Open questions and assumptions

- Surfacing keys on the raw Slack error string; a never-before-seen error still surfaces (default message, no hint), the safe direction.
- Idempotency is per error class, not per utterance: the user is told once per distinct failure, since repeated identical failures carry no new info until the config is fixed.

## Test evidence

72 speak-related tests pass; t3 tool verify-gates all green. RED/GREEN anti-vacuity verified by reverting the _surface_upload_failure call.