### PR TITLE
chore(deps): django 6.0.6 — clear PYSEC-2026-197..201

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -473,16 +473,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.5"
+version = "6.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f1/bf85f0d29ef76abf901f193fe8fef4769d3da7794197832bc30151c071d8/django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269", size = 10924131, upload-time = "2026-05-05T13:54:39.329Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/29/ac41e16097af67066d97a7d5775c5d8e7efc5d0284f6b0a159e07b9adb92/django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713", size = 10905525, upload-time = "2026-06-03T13:02:46.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/5b/1328f8b84fce040c404f76822bf8c57d254e368e8cbd8bd67ec2b26d75f5/django-6.0.5-py3-none-any.whl", hash = "sha256:9d58a7cb49244e74c8e161d5e403a46d6209f1009ba40f5a66d6aa0d0786a8f0", size = 8368680, upload-time = "2026-05-05T13:54:33.532Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/50/23f9dc45483419a3cc2085b498b25adfbf10642b2941c73e6d2dfaffc9ab/django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2", size = 8373354, upload-time = "2026-06-03T13:02:41.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Refresh `uv.lock` so `django` resolves to **6.0.6**, clearing the 5 freshly-disclosed CVEs (`PYSEC-2026-197` through `PYSEC-2026-201`) flagged by the `uv-audit` job (`pip-audit --strict --vulnerability-service osv`).

## Root cause

django 6.0.5 carries PYSEC-2026-197..201 (all fixed in 6.0.6). The lock pinned 6.0.5, so `pip-audit` exits 1.

## Fix

`uv lock --upgrade-package django`. The constraint already allows it (`django>=5.2,<6.1`), so **no `pyproject.toml` change** — single-package lock delta (6.0.5 -> 6.0.6).

## Local verification

- before: `pip-audit ... -r requirements.audit.txt` -> `Found 5 known vulnerabilities in 1 package` (django 6.0.5, PYSEC-2026-197..201, Fixed in 6.0.6), exit 1.
- after: `No known vulnerabilities found`, exit 0.

prek scoped to the lock change passes (tach, import-linter, ty-check, banned-terms).

## Architecture pre-check

Tactical dependency-pin fix (lockfile only, no `src/` change) — the nine-check gate does not apply.