### PR TITLE
refactor(core): break the core↔backends and core↔agents import cycles + enable forbid_circular_dependencies

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -336,7 +336,7 @@ On every `t3 setup` run, `dep_drift` checks `[project].dependencies` against the
 | `pytest` + `pytest-cov` | >90% branch coverage |
 | `ruff` | All rules enabled, specific ignores justified (`# noqa` requires approval) |
 | `ty` | Static type checker with `error-on-warning = true` |
-| `import-linter` | Transitive/laundered dependency boundaries tach's direct-edge model misses (`core → messaging` even via an intermediate module, substrate → `contrib`, mini-loop independence); config in `pyproject.toml [tool.importlinter]` |
+| `import-linter` | Wildcard sibling-independence tach cannot express (substrate → `contrib`; mini-loops independent). Acyclicity + backend/agent-independence are tach-enforced (`forbid_circular_dependencies`, #1922). Config: `pyproject.toml` |
 | `codespell` | Spell check |
 | `prek` | Runs all above on commit |
 

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -27,8 +27,6 @@ graph TD
     teatree.core --> teatree.skill_deps
     teatree.core --> teatree.skill_map
     teatree.core --> teatree.trigger_parser
-    teatree.core --> teatree.agents
-    teatree.core --> teatree.backends
     teatree.core --> teatree.hooks
     teatree.core --> teatree.on_behalf_gate
     teatree.core --> teatree.slack_mrkdwn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,13 +276,14 @@ omit = [ "src/teatree/core/migrations/*.py" ]
 # small file dropping to 30% would still leave the project >= 93%.
 
 # --- import-linter ---
-# Complements tach: tach's depends_on is a direct-edge allow-list; these
-# contracts catch the transitive/laundered chains and the wildcard
-# sibling-independence invariants tach's per-module model cannot express
-# (BLUEPRINT §17.6.2, #724/#725). Only contracts that are GREEN on the current
-# tree are kept; the transitive-layers, acyclic, backend-independence and
-# domain-forbids-typer/httpx contracts are deferred until the core↔backends
-# cycles are broken (#179/#180) — see the PR body.
+# Complements tach: tach's depends_on is a direct-edge allow-list. The one
+# invariant tach's per-module model cannot express is wildcard
+# sibling-independence (the mini-loops must not import each other) — that is the
+# "Mini-loops are mutually independent" contract below. The acyclic and
+# backend/agent-independence guarantees are now enforced by tach itself
+# (forbid_circular_dependencies = true; teatree.core.depends_on no longer lists
+# backends/agents), so import-linter does not duplicate them.
+# (BLUEPRINT §17.6.2, #724/#725, #1922.)
 
 [tool.importlinter]
 root_package = "teatree"
@@ -318,18 +319,6 @@ modules = [
   "teatree.loops.ship",
   "teatree.loops.tickets",
 ]
-
-[[tool.importlinter.contracts]]
-name = "Domain core must not import the messaging layer"
-type = "forbidden"
-source_modules = [ "teatree.core" ]
-forbidden_modules = [ "teatree.messaging", "teatree.notify" ]
-# teatree.core.management is the interface (CLI-command) layer per tach, not the
-# domain layer this contract guards; its commands legitimately drive the loop
-# (which reaches messaging). Excluding the interface subtree leaves the contract
-# biting every domain module under teatree.core — none of which reaches
-# messaging today.
-ignore_imports = [ "teatree.core.management.** -> **" ]
 
 [tool.teatree.coverage]
 per_module_floors = [

--- a/src/teatree/agents/apps.py
+++ b/src/teatree/agents/apps.py
@@ -5,3 +5,9 @@ class AgentsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "teatree.agents"
     verbose_name = "TeaTree Agents"
+
+    def ready(self) -> None:  # noqa: PLR6301
+        from teatree.agents.headless import run_headless  # noqa: PLC0415
+        from teatree.core.headless_dispatch import register_headless_runner  # noqa: PLC0415
+
+        register_headless_runner(run_headless)

--- a/src/teatree/backends/apps.py
+++ b/src/teatree/backends/apps.py
@@ -1,0 +1,13 @@
+from django.apps import AppConfig
+
+
+class BackendsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "teatree.backends"
+    verbose_name = "TeaTree Backends"
+
+    def ready(self) -> None:  # noqa: PLR6301
+        from teatree.backends.slack_reactions import SlackReactionPublisher  # noqa: PLC0415
+        from teatree.core.reaction_dispatch import register_reaction_publisher  # noqa: PLC0415
+
+        register_reaction_publisher(SlackReactionPublisher())

--- a/src/teatree/backends/apps.py
+++ b/src/teatree/backends/apps.py
@@ -7,7 +7,9 @@ class BackendsConfig(AppConfig):
     verbose_name = "TeaTree Backends"
 
     def ready(self) -> None:  # noqa: PLR6301
+        from teatree.backends.backend_provider import install_backend_provider  # noqa: PLC0415
         from teatree.backends.slack_reactions import SlackReactionPublisher  # noqa: PLC0415
         from teatree.core.reaction_dispatch import register_reaction_publisher  # noqa: PLC0415
 
         register_reaction_publisher(SlackReactionPublisher())
+        install_backend_provider()

--- a/src/teatree/backends/backend_provider.py
+++ b/src/teatree/backends/backend_provider.py
@@ -1,0 +1,83 @@
+"""Concrete backend provider registered into ``core.backend_registry`` (#1922).
+
+Owns every concrete-class construction ``core`` used to import directly: the
+loader functions, the GitHub/GitLab/Slack clients, the sync backends, and the
+Slack review-history read. ``BackendsConfig.ready()`` registers one instance so
+``core`` reaches these capabilities through the registry, never an import.
+"""
+
+from typing import TYPE_CHECKING
+
+from teatree.backends import github_sync, gitlab_sync, loader
+from teatree.backends.github import GitHubCodeHost
+from teatree.backends.gitlab import GitLabCodeHost
+from teatree.backends.slack import SlackReviewSearchRequest, read_recent_review_matches
+from teatree.backends.slack_bot import SlackBotBackend
+from teatree.core.backend_registry import register_backend_provider
+
+if TYPE_CHECKING:
+    from teatree.core.backend_protocols import CIService, CodeHostBackend, MessagingBackend
+    from teatree.core.backend_registry import ReviewHistoryReadLike, ReviewSearchSpec
+    from teatree.core.overlay import OverlayBase
+    from teatree.types import SyncBackend
+
+
+class SlackBackendProvider:
+    def get_code_host(self, overlay: "OverlayBase") -> "CodeHostBackend | None":  # noqa: PLR6301
+        return loader.get_code_host(overlay)
+
+    def get_code_hosts(self, overlay: "OverlayBase") -> "list[CodeHostBackend]":  # noqa: PLR6301
+        return loader.get_code_hosts(overlay)
+
+    def get_messaging(self, overlay: "OverlayBase") -> "MessagingBackend | None":  # noqa: PLR6301
+        return loader.get_messaging(overlay)
+
+    def get_ci_service(self, *, gitlab_token: str, gitlab_url: str) -> "CIService | None":  # noqa: PLR6301
+        return loader.get_ci_service(gitlab_token=gitlab_token, gitlab_url=gitlab_url)
+
+    def reset_caches(self) -> None:  # noqa: PLR6301
+        loader.reset_backend_caches()
+
+    def build_github_host(self, *, token: str) -> "CodeHostBackend":  # noqa: PLR6301
+        return GitHubCodeHost(token=token)
+
+    def build_gitlab_host(self, *, token: str, base_url: str) -> "CodeHostBackend":  # noqa: PLR6301
+        return GitLabCodeHost(token=token, base_url=base_url)
+
+    def build_slack_messaging(  # noqa: PLR6301
+        self,
+        *,
+        bot_token: str,
+        app_token: str,
+        user_token: str,
+        user_id: str,
+        dm_channel_id: str,
+    ) -> "MessagingBackend":
+        return SlackBotBackend(
+            bot_token=bot_token,
+            app_token=app_token,
+            user_token=user_token,
+            user_id=user_id,
+            dm_channel_id=dm_channel_id,
+            degrade_bad_user_token=True,
+        )
+
+    def build_sync_backends(self) -> "list[SyncBackend]":  # noqa: PLR6301
+        return [github_sync.GitHubSyncBackend(), gitlab_sync.GitLabSyncBackend()]
+
+    def read_recent_review_matches(self, spec: "ReviewSearchSpec") -> "ReviewHistoryReadLike":  # noqa: PLR6301
+        return read_recent_review_matches(
+            SlackReviewSearchRequest(
+                token=spec.token,
+                channel_id=spec.channel_id,
+                channel_name=spec.channel_name,
+                pr_urls=spec.pr_urls,
+                max_pages=spec.max_pages,
+                oldest_ts=spec.oldest_ts,
+                timeout=spec.timeout,
+            ),
+        )
+
+
+def install_backend_provider() -> None:
+    register_backend_provider(SlackBackendProvider())

--- a/src/teatree/backends/protocols.py
+++ b/src/teatree/backends/protocols.py
@@ -1,247 +1,29 @@
-"""Concern-based backend protocols.
+"""Re-export of the backend protocols, now owned by :mod:`teatree.core.backend_protocols`.
 
-Each protocol defines a capability that teatree needs from external services.
-Overlays declare which implementation to load via ``OverlayConfig`` fields
-(``code_host``, ``messaging_backend``); ``backends.loader`` resolves the choice.
-
-A single class can satisfy multiple protocols when the platform provides
-multiple concerns (e.g. GitLab provides code hosting and CI in one client).
+The Protocol surface moved into ``teatree.core`` so the domain layer owns the
+abstractions it consumes and ``core`` no longer imports ``backends`` (#1922).
+Existing ``from teatree.backends.protocols import X`` consumers keep working
+through this re-export — ``backends → core`` is the allowed direction.
 """
 
-from dataclasses import dataclass, field
-from enum import StrEnum
-from typing import Protocol, TypedDict, runtime_checkable
-
-from teatree.types import RawAPIDict
-
-
-class ApprovalState(TypedDict):
-    """Backend-resolved approval snapshot for a single PR/MR (#936).
-
-    ``approvals_left`` is the remaining count of required approvals — 0 when the
-    forge-side approval threshold is satisfied. ``approved_by`` is the list of
-    approver usernames in approval order. ``unresolved_resolvable`` counts open
-    discussion threads whose ``resolvable`` flag is true (i.e. would block a
-    merge under the upstream's "must resolve" policy) — distinct from system
-    note threads or non-resolvable comments.
-    """
-
-    approvals_left: int
-    approved_by: list[str]
-    unresolved_resolvable: int
-
-
-class ReviewState(StrEnum):
-    """A reviewer's current state on a single pull/merge request.
-
-    Used by ``CodeHostBackend.get_review_state`` and by
-    ``ReviewerPrsScanner`` to detect approval dismissals — e.g. when a
-    forge invalidates a prior approval on force-push, or when a reviewer
-    is re-requested after being dismissed.
-    """
-
-    NONE = "none"
-    PENDING = "pending"
-    APPROVED = "approved"
-    CHANGES_REQUESTED = "changes_requested"
-    DISMISSED = "dismissed"
-    # The reviewer concluded an external review with no postable/approvable
-    # action (e.g. a bot MR there is nothing to comment on or approve).
-    # Distinct from APPROVED so the dedup never hides a future genuine
-    # review, yet terminal so the reviewing task stops re-queueing (#1077).
-    REVIEWED_NO_ACTION = "reviewed_no_action"
-
-
-class PrOpenState(StrEnum):
-    """Whether a pull/merge request is genuinely still open on the forge.
-
-    Used by ``CodeHostBackend.get_pr_open_state`` so the orphan-task sweep
-    (``ReviewerPrsScanner._orphaned_task_signals``) can confirm a reviewing
-    task's PR is really MERGED/CLOSED before reaping it — absence from a
-    reviewer-assignment scan is NOT proof the PR closed (#1074). ``UNKNOWN``
-    is the fail-open value: any auth error, network failure, unparsable URL,
-    or unrecognised payload maps here, and the sweep never reaps on UNKNOWN.
-    """
-
-    OPEN = "open"
-    MERGED = "merged"
-    CLOSED = "closed"
-    UNKNOWN = "unknown"
-
-
-@dataclass(frozen=True, slots=True)
-class PullRequestSpec:
-    """Fields needed to open a pull/merge request on a CodeHostBackend."""
-
-    repo: str
-    branch: str
-    title: str
-    description: str
-    target_branch: str = ""
-    labels: list[str] = field(default_factory=list)
-    assignee: str = ""
-    draft: bool = False
-
-
-@dataclass(frozen=True, slots=True)
-class MessageSpec:
-    """Fields for an outgoing chat message."""
-
-    channel: str
-    text: str
-    thread_ts: str = ""
-
-
-@runtime_checkable
-class CodeHostBackend(Protocol):
-    """Pull/merge requests + issue fetch — the canonical code-host concern.
-
-    PR is the canonical term in core; GitLab implementations translate
-    MR ↔ PR at the API edge. ``repo`` + ``pr_iid`` is the natural unit on
-    both APIs (GitLab ``merge_requests/<iid>``, GitHub ``pulls/<number>``).
-    """
-
-    def create_pr(self, spec: PullRequestSpec) -> RawAPIDict: ...  # pragma: no branch
-
-    def current_user(self) -> str: ...  # pragma: no branch
-
-    def list_my_prs(
-        self,
-        *,
-        author: str,
-        updated_after: str | None = None,
-    ) -> list[RawAPIDict]: ...  # pragma: no branch
-
-    def list_review_requested_prs(
-        self,
-        *,
-        reviewer: str,
-        updated_after: str | None = None,
-    ) -> list[RawAPIDict]: ...  # pragma: no branch
-
-    def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState: ...  # pragma: no branch
-
-    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState: ...  # pragma: no branch
-
-    def get_pr_author(self, *, pr_url: str) -> str: ...  # pragma: no branch
-
-    def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict: ...  # pragma: no branch
-
-    def update_pr_comment(
-        self,
-        *,
-        repo: str,
-        pr_iid: int,
-        comment_id: int,
-        body: str,
-    ) -> RawAPIDict: ...  # pragma: no branch
-
-    def list_pr_comments(self, *, repo: str, pr_iid: int) -> list[RawAPIDict]: ...  # pragma: no branch
-
-    def upload_file(self, *, repo: str, filepath: str) -> RawAPIDict: ...  # pragma: no branch
-
-    def get_issue(self, issue_url: str) -> RawAPIDict: ...  # pragma: no branch
-
-    def post_issue_comment(self, *, issue_url: str, body: str) -> RawAPIDict: ...  # pragma: no branch
-
-    def list_issue_comments(self, *, issue_url: str) -> list[RawAPIDict]: ...  # pragma: no branch
-
-    def update_issue_comment(
-        self,
-        *,
-        issue_url: str,
-        comment_id: int,
-        body: str,
-    ) -> RawAPIDict: ...  # pragma: no branch
-
-    def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]: ...  # pragma: no branch
-
-    def create_issue(
-        self,
-        *,
-        repo: str,
-        title: str,
-        body: str,
-        labels: list[str] | None = None,
-    ) -> RawAPIDict: ...  # pragma: no branch
-
-    def create_sub_issue(
-        self,
-        *,
-        parent_url: str,
-        title: str,
-        body: str,
-        labels: list[str] | None = None,
-        child_type: str = "Task",
-    ) -> RawAPIDict: ...  # pragma: no branch
-
-    def search_open_issues(self, *, repo: str, query: str) -> list[RawAPIDict]: ...  # pragma: no branch
-
-    def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState: ...  # pragma: no branch
-
-
-@runtime_checkable
-class CIService(Protocol):
-    """Interact with CI/CD pipelines — cancel, fetch logs/tests, trigger."""
-
-    def cancel_pipelines(self, *, project: str, ref: str) -> list[int]: ...  # pragma: no branch
-
-    def fetch_pipeline_errors(self, *, project: str, ref: str) -> list[str]: ...  # pragma: no branch
-
-    def fetch_failed_tests(self, *, project: str, ref: str) -> list[str]: ...  # pragma: no branch
-
-    def trigger_pipeline(
-        self,
-        *,
-        project: str,
-        ref: str,
-        variables: dict[str, str] | None = None,
-    ) -> RawAPIDict: ...  # pragma: no branch
-
-    def quality_check(self, *, project: str, ref: str) -> RawAPIDict: ...  # pragma: no branch
-
-
-@runtime_checkable
-class MessagingBackend(Protocol):
-    """Messaging — mentions, DMs, posts, reactions, user lookup.
-
-    The single Protocol covers both inbound (fetch_mentions, fetch_dms) and
-    outbound (post_message, post_reply, react) concerns plus user-id
-    resolution for routing.
-    """
-
-    def fetch_mentions(self, *, since: str = "") -> list[RawAPIDict]: ...  # pragma: no branch
-
-    def fetch_dms(self, *, since: str = "") -> list[RawAPIDict]: ...  # pragma: no branch
-
-    def fetch_reactions(self, *, since: str = "") -> list[RawAPIDict]: ...  # pragma: no branch
-
-    def fetch_message(self, *, channel: str, ts: str) -> RawAPIDict: ...  # pragma: no branch
-
-    def fetch_channel_history(self, *, channel: str, limit: int = 50) -> list[RawAPIDict]: ...  # pragma: no branch
-
-    def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict: ...  # pragma: no branch
-
-    def post_reply(self, *, channel: str, ts: str, text: str) -> RawAPIDict: ...  # pragma: no branch
-
-    def open_dm(self, user_id: str) -> str: ...  # pragma: no branch
-
-    def get_permalink(self, *, channel: str, ts: str) -> str: ...  # pragma: no branch
-
-    def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict: ...  # pragma: no branch
-
-    def post_routed(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict: ...  # pragma: no branch
-
-    def react_routed(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict: ...  # pragma: no branch
-
-    def resolve_user_id(self, handle: str) -> str: ...  # pragma: no branch
-
-    def auth_test(self) -> RawAPIDict: ...  # pragma: no branch
-
-    def upload_audio_to_dm(
-        self,
-        *,
-        channel: str,
-        filepath: str,
-        title: str = "",
-    ) -> RawAPIDict: ...  # pragma: no branch
+from teatree.core.backend_protocols import (
+    ApprovalState,
+    CIService,
+    CodeHostBackend,
+    MessageSpec,
+    MessagingBackend,
+    PrOpenState,
+    PullRequestSpec,
+    ReviewState,
+)
+
+__all__ = [
+    "ApprovalState",
+    "CIService",
+    "CodeHostBackend",
+    "MessageSpec",
+    "MessagingBackend",
+    "PrOpenState",
+    "PullRequestSpec",
+    "ReviewState",
+]

--- a/src/teatree/backends/slack_reactions.py
+++ b/src/teatree/backends/slack_reactions.py
@@ -227,3 +227,18 @@ def add_approval_reaction(pull_request: "PullRequest") -> int:
         )
         return 0
     return 1 if success else 0
+
+
+class SlackReactionPublisher:
+    """Adapts the module reaction functions to ``core.reaction_dispatch.ReactionPublisher``.
+
+    Registered into the core registry by ``BackendsConfig.ready()`` so
+    ``core.signals`` reaches the Slack reaction publisher without importing
+    ``backends`` (#1922).
+    """
+
+    def add_reactions_for_transition(self, ticket: "Ticket", transition_name: str) -> int:  # noqa: PLR6301
+        return add_reactions_for_transition(ticket, transition_name)
+
+    def add_approval_reaction(self, pull_request: "PullRequest") -> int:  # noqa: PLR6301
+        return add_approval_reaction(pull_request)

--- a/src/teatree/backends/slack_scopes.py
+++ b/src/teatree/backends/slack_scopes.py
@@ -8,9 +8,9 @@ guard can read it without re-issuing the request. Keeping the parsing here
 connector-preflight guard share one source of truth.
 """
 
+from teatree.core.connector_keys import GRANTED_SCOPES_KEY
 from teatree.types import RawAPIDict
 
-GRANTED_SCOPES_KEY = "_granted_scopes"
 OAUTH_SCOPES_HEADER = "X-OAuth-Scopes"
 
 

--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -13,7 +13,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from teatree.backends.loader import get_ci_service, get_code_host, get_code_hosts, get_messaging
 from teatree.backends.loader import reset_backend_caches as _reset_loader_caches
-from teatree.backends.protocols import CIService, CodeHostBackend, MessagingBackend
+from teatree.core.backend_protocols import CIService, CodeHostBackend, MessagingBackend
 from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_all_overlays, get_overlay
 from teatree.paths import find_overlay_db

--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -11,9 +11,8 @@ from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
 
-from teatree.backends.loader import get_ci_service, get_code_host, get_code_hosts, get_messaging
-from teatree.backends.loader import reset_backend_caches as _reset_loader_caches
 from teatree.core.backend_protocols import CIService, CodeHostBackend, MessagingBackend
+from teatree.core.backend_registry import get_backend_provider
 from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_all_overlays, get_overlay
 from teatree.paths import find_overlay_db
@@ -99,7 +98,7 @@ def _build_code_host(overlay_name: str) -> CodeHostBackend | None:
         overlay = get_overlay(overlay_name or None)
     except ImproperlyConfigured:
         return _code_host_from_toml_overlay(overlay_name)
-    return get_code_host(overlay)
+    return get_backend_provider().get_code_host(overlay)
 
 
 def messaging_from_overlay(overlay_name: str | None = None) -> MessagingBackend | None:
@@ -127,7 +126,7 @@ def _build_messaging(overlay_name: str) -> MessagingBackend | None:
         overlay = get_overlay(overlay_name or None)
     except ImproperlyConfigured:
         return _messaging_from_toml_overlay(overlay_name)
-    backend = get_messaging(overlay)
+    backend = get_backend_provider().get_messaging(overlay)
     _apply_voice_classifier_mode(backend)
     return backend
 
@@ -140,7 +139,7 @@ def ci_service_from_overlay(overlay_name: str | None = None) -> CIService | None
     except ImproperlyConfigured:
         return None
 
-    return get_ci_service(
+    return get_backend_provider().get_ci_service(
         gitlab_token=overlay.config.get_gitlab_token(),
         gitlab_url=overlay.config.gitlab_url,
     )
@@ -190,15 +189,16 @@ def iter_overlay_backends() -> list[OverlayBackends]:
     out: list[OverlayBackends] = []
     found_names: set[str] = set()
     identities = _resolved_identities()
+    provider = get_backend_provider()
 
     for name, overlay in get_all_overlays().items():
         found_names.add(name)
         try:
-            hosts = tuple(get_code_hosts(overlay))
+            hosts = tuple(provider.get_code_hosts(overlay))
         except (ImproperlyConfigured, ValueError):
             hosts = ()
         try:
-            messaging = get_messaging(overlay)
+            messaging = provider.get_messaging(overlay)
         except (ImproperlyConfigured, ValueError):
             messaging = None
         out.append(
@@ -287,23 +287,20 @@ def _hosts_from_toml(cfg: dict) -> list[CodeHostBackend]:
     """
     from teatree.utils.secrets import read_pass  # noqa: PLC0415
 
+    provider = get_backend_provider()
     hosts: list[CodeHostBackend] = []
     github_token_ref = cfg.get("github_token_ref", "")
     if github_token_ref:
         token = read_pass(github_token_ref)
         if token:
-            from teatree.backends.github import GitHubCodeHost  # noqa: PLC0415
-
-            hosts.append(GitHubCodeHost(token=token))
+            hosts.append(provider.build_github_host(token=token))
 
     gitlab_token_ref = cfg.get("gitlab_token_ref", "")
     gitlab_url = cfg.get("gitlab_url", "https://gitlab.com")
     if gitlab_token_ref:
         token = read_pass(gitlab_token_ref)
         if token:
-            from teatree.backends.gitlab import GitLabCodeHost  # noqa: PLC0415
-
-            hosts.append(GitLabCodeHost(token=token, base_url=gitlab_url))
+            hosts.append(provider.build_gitlab_host(token=token, base_url=gitlab_url))
     return hosts
 
 
@@ -321,7 +318,6 @@ def _host_from_toml(cfg: dict) -> CodeHostBackend | None:
 def _messaging_from_toml(cfg: dict) -> MessagingBackend | None:
     if cfg.get("messaging_backend") != "slack":
         return None
-    from teatree.backends.slack_bot import SlackBotBackend  # noqa: PLC0415
     from teatree.utils.secrets import read_pass  # noqa: PLC0415
 
     token_ref = cfg.get("slack_token_ref", "")
@@ -333,20 +329,19 @@ def _messaging_from_toml(cfg: dict) -> MessagingBackend | None:
     user_token = read_pass(user_token_ref) if user_token_ref else ""
     user_id = cfg.get("slack_user_id", "")
     # Setup-time provisioned IM channel id (#1342). When set, threads into
-    # ``SlackBotBackend`` so the per-overlay bot's ``open_dm`` short-circuits
-    # the live ``conversations.open`` for the configured user, routing DMs
-    # through this bot's IM instead of failing ``channel_not_found``.
+    # the Slack bot so its ``open_dm`` short-circuits the live
+    # ``conversations.open`` for the configured user, routing DMs through this
+    # bot's IM instead of failing ``channel_not_found``.
     dm_channel_id = cfg.get("slack_dm_channel_id", "")
     if bot_token:
         # Loop construction path — a malformed user token degrades to
         # bot-only instead of crashing the tick (see ``get_messaging``).
-        backend = SlackBotBackend(
+        backend = get_backend_provider().build_slack_messaging(
             bot_token=bot_token,
             app_token=app_token or "",
             user_token=user_token,
             user_id=user_id,
             dm_channel_id=dm_channel_id,
-            degrade_bad_user_token=True,
         )
         _apply_voice_classifier_mode(backend)
         return backend
@@ -382,16 +377,13 @@ def reset_backend_caches() -> None:
     """
     _code_host_cache.clear()
     _messaging_cache.clear()
-    _reset_loader_caches()
+    get_backend_provider().reset_caches()
 
 
 __all__ = [
     "OverlayBackends",
     "ci_service_from_overlay",
     "code_host_from_overlay",
-    "get_ci_service",
-    "get_code_host",
-    "get_messaging",
     "iter_overlay_backends",
     "messaging_from_overlay",
     "reset_backend_caches",

--- a/src/teatree/core/backend_protocols.py
+++ b/src/teatree/core/backend_protocols.py
@@ -1,0 +1,247 @@
+"""Concern-based backend protocols.
+
+Each protocol defines a capability that teatree needs from external services.
+Overlays declare which implementation to load via ``OverlayConfig`` fields
+(``code_host``, ``messaging_backend``); ``backends.loader`` resolves the choice.
+
+A single class can satisfy multiple protocols when the platform provides
+multiple concerns (e.g. GitLab provides code hosting and CI in one client).
+"""
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Protocol, TypedDict, runtime_checkable
+
+from teatree.types import RawAPIDict
+
+
+class ApprovalState(TypedDict):
+    """Backend-resolved approval snapshot for a single PR/MR (#936).
+
+    ``approvals_left`` is the remaining count of required approvals — 0 when the
+    forge-side approval threshold is satisfied. ``approved_by`` is the list of
+    approver usernames in approval order. ``unresolved_resolvable`` counts open
+    discussion threads whose ``resolvable`` flag is true (i.e. would block a
+    merge under the upstream's "must resolve" policy) — distinct from system
+    note threads or non-resolvable comments.
+    """
+
+    approvals_left: int
+    approved_by: list[str]
+    unresolved_resolvable: int
+
+
+class ReviewState(StrEnum):
+    """A reviewer's current state on a single pull/merge request.
+
+    Used by ``CodeHostBackend.get_review_state`` and by
+    ``ReviewerPrsScanner`` to detect approval dismissals — e.g. when a
+    forge invalidates a prior approval on force-push, or when a reviewer
+    is re-requested after being dismissed.
+    """
+
+    NONE = "none"
+    PENDING = "pending"
+    APPROVED = "approved"
+    CHANGES_REQUESTED = "changes_requested"
+    DISMISSED = "dismissed"
+    # The reviewer concluded an external review with no postable/approvable
+    # action (e.g. a bot MR there is nothing to comment on or approve).
+    # Distinct from APPROVED so the dedup never hides a future genuine
+    # review, yet terminal so the reviewing task stops re-queueing (#1077).
+    REVIEWED_NO_ACTION = "reviewed_no_action"
+
+
+class PrOpenState(StrEnum):
+    """Whether a pull/merge request is genuinely still open on the forge.
+
+    Used by ``CodeHostBackend.get_pr_open_state`` so the orphan-task sweep
+    (``ReviewerPrsScanner._orphaned_task_signals``) can confirm a reviewing
+    task's PR is really MERGED/CLOSED before reaping it — absence from a
+    reviewer-assignment scan is NOT proof the PR closed (#1074). ``UNKNOWN``
+    is the fail-open value: any auth error, network failure, unparsable URL,
+    or unrecognised payload maps here, and the sweep never reaps on UNKNOWN.
+    """
+
+    OPEN = "open"
+    MERGED = "merged"
+    CLOSED = "closed"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class PullRequestSpec:
+    """Fields needed to open a pull/merge request on a CodeHostBackend."""
+
+    repo: str
+    branch: str
+    title: str
+    description: str
+    target_branch: str = ""
+    labels: list[str] = field(default_factory=list)
+    assignee: str = ""
+    draft: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class MessageSpec:
+    """Fields for an outgoing chat message."""
+
+    channel: str
+    text: str
+    thread_ts: str = ""
+
+
+@runtime_checkable
+class CodeHostBackend(Protocol):
+    """Pull/merge requests + issue fetch — the canonical code-host concern.
+
+    PR is the canonical term in core; GitLab implementations translate
+    MR ↔ PR at the API edge. ``repo`` + ``pr_iid`` is the natural unit on
+    both APIs (GitLab ``merge_requests/<iid>``, GitHub ``pulls/<number>``).
+    """
+
+    def create_pr(self, spec: PullRequestSpec) -> RawAPIDict: ...  # pragma: no branch
+
+    def current_user(self) -> str: ...  # pragma: no branch
+
+    def list_my_prs(
+        self,
+        *,
+        author: str,
+        updated_after: str | None = None,
+    ) -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def list_review_requested_prs(
+        self,
+        *,
+        reviewer: str,
+        updated_after: str | None = None,
+    ) -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState: ...  # pragma: no branch
+
+    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState: ...  # pragma: no branch
+
+    def get_pr_author(self, *, pr_url: str) -> str: ...  # pragma: no branch
+
+    def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict: ...  # pragma: no branch
+
+    def update_pr_comment(
+        self,
+        *,
+        repo: str,
+        pr_iid: int,
+        comment_id: int,
+        body: str,
+    ) -> RawAPIDict: ...  # pragma: no branch
+
+    def list_pr_comments(self, *, repo: str, pr_iid: int) -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def upload_file(self, *, repo: str, filepath: str) -> RawAPIDict: ...  # pragma: no branch
+
+    def get_issue(self, issue_url: str) -> RawAPIDict: ...  # pragma: no branch
+
+    def post_issue_comment(self, *, issue_url: str, body: str) -> RawAPIDict: ...  # pragma: no branch
+
+    def list_issue_comments(self, *, issue_url: str) -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def update_issue_comment(
+        self,
+        *,
+        issue_url: str,
+        comment_id: int,
+        body: str,
+    ) -> RawAPIDict: ...  # pragma: no branch
+
+    def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def create_issue(
+        self,
+        *,
+        repo: str,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+    ) -> RawAPIDict: ...  # pragma: no branch
+
+    def create_sub_issue(
+        self,
+        *,
+        parent_url: str,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+        child_type: str = "Task",
+    ) -> RawAPIDict: ...  # pragma: no branch
+
+    def search_open_issues(self, *, repo: str, query: str) -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState: ...  # pragma: no branch
+
+
+@runtime_checkable
+class CIService(Protocol):
+    """Interact with CI/CD pipelines — cancel, fetch logs/tests, trigger."""
+
+    def cancel_pipelines(self, *, project: str, ref: str) -> list[int]: ...  # pragma: no branch
+
+    def fetch_pipeline_errors(self, *, project: str, ref: str) -> list[str]: ...  # pragma: no branch
+
+    def fetch_failed_tests(self, *, project: str, ref: str) -> list[str]: ...  # pragma: no branch
+
+    def trigger_pipeline(
+        self,
+        *,
+        project: str,
+        ref: str,
+        variables: dict[str, str] | None = None,
+    ) -> RawAPIDict: ...  # pragma: no branch
+
+    def quality_check(self, *, project: str, ref: str) -> RawAPIDict: ...  # pragma: no branch
+
+
+@runtime_checkable
+class MessagingBackend(Protocol):
+    """Messaging — mentions, DMs, posts, reactions, user lookup.
+
+    The single Protocol covers both inbound (fetch_mentions, fetch_dms) and
+    outbound (post_message, post_reply, react) concerns plus user-id
+    resolution for routing.
+    """
+
+    def fetch_mentions(self, *, since: str = "") -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def fetch_dms(self, *, since: str = "") -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def fetch_reactions(self, *, since: str = "") -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def fetch_message(self, *, channel: str, ts: str) -> RawAPIDict: ...  # pragma: no branch
+
+    def fetch_channel_history(self, *, channel: str, limit: int = 50) -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def post_message(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict: ...  # pragma: no branch
+
+    def post_reply(self, *, channel: str, ts: str, text: str) -> RawAPIDict: ...  # pragma: no branch
+
+    def open_dm(self, user_id: str) -> str: ...  # pragma: no branch
+
+    def get_permalink(self, *, channel: str, ts: str) -> str: ...  # pragma: no branch
+
+    def react(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict: ...  # pragma: no branch
+
+    def post_routed(self, *, channel: str, text: str, thread_ts: str = "") -> RawAPIDict: ...  # pragma: no branch
+
+    def react_routed(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict: ...  # pragma: no branch
+
+    def resolve_user_id(self, handle: str) -> str: ...  # pragma: no branch
+
+    def auth_test(self) -> RawAPIDict: ...  # pragma: no branch
+
+    def upload_audio_to_dm(
+        self,
+        *,
+        channel: str,
+        filepath: str,
+        title: str = "",
+    ) -> RawAPIDict: ...  # pragma: no branch

--- a/src/teatree/core/backend_registry.py
+++ b/src/teatree/core/backend_registry.py
@@ -1,0 +1,142 @@
+"""Registry for the backend builder/loader seam — the last core → backends cut (#1922).
+
+``core.backend_factory`` (the #195 overlay-aware factory), ``core.sync``,
+``core.overlay`` and ``core.review_request_guard`` all need to *build* concrete
+backends or run a backend capability, but the builders live in
+``teatree.backends`` (the loader + concrete clients). Rather than ``core``
+importing ``backends``, ``backends`` registers one :class:`BackendProvider` here
+at app-ready time and ``core`` resolves it.
+
+Fail-SAFE: an unregistered provider returns ``None`` / empty for every build (the
+same shape as "no credentials configured"), so a bare ``django.setup()`` without
+the backends app never crashes — it simply builds no backends.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from teatree.core.backend_protocols import CIService, CodeHostBackend, MessagingBackend
+    from teatree.core.overlay import OverlayBase
+    from teatree.types import SyncBackend
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewSearchSpec:
+    """Recency-bounded Slack channel-history read request (core-owned shape)."""
+
+    token: str
+    channel_id: str
+    channel_name: str
+    pr_urls: list[str]
+    max_pages: int
+    oldest_ts: str
+    timeout: float
+
+
+class ReviewHistoryReadLike(Protocol):
+    @property
+    def ok(self) -> bool: ...  # pragma: no branch
+
+    @property
+    def matches(self) -> "list[ReviewMatchLike]": ...  # pragma: no branch
+
+
+class ReviewMatchLike(Protocol):
+    pr_url: str
+    ts: str
+    author: str
+    permalink: str
+
+
+class BackendProvider(Protocol):
+    def get_code_host(self, overlay: "OverlayBase") -> "CodeHostBackend | None": ...  # pragma: no branch
+
+    def get_code_hosts(self, overlay: "OverlayBase") -> "list[CodeHostBackend]": ...  # pragma: no branch
+
+    def get_messaging(self, overlay: "OverlayBase") -> "MessagingBackend | None": ...  # pragma: no branch
+
+    def get_ci_service(self, *, gitlab_token: str, gitlab_url: str) -> "CIService | None": ...  # pragma: no branch
+
+    def reset_caches(self) -> None: ...  # pragma: no branch
+
+    def build_github_host(self, *, token: str) -> "CodeHostBackend": ...  # pragma: no branch
+
+    def build_gitlab_host(self, *, token: str, base_url: str) -> "CodeHostBackend": ...  # pragma: no branch
+
+    def build_slack_messaging(
+        self,
+        *,
+        bot_token: str,
+        app_token: str,
+        user_token: str,
+        user_id: str,
+        dm_channel_id: str,
+    ) -> "MessagingBackend": ...  # pragma: no branch
+
+    def build_sync_backends(self) -> "list[SyncBackend]": ...  # pragma: no branch
+
+    def read_recent_review_matches(self, spec: ReviewSearchSpec) -> ReviewHistoryReadLike: ...  # pragma: no branch
+
+
+class _UnconfiguredProvider:
+    """Fail-safe provider used before the backends app registers the real one."""
+
+    def get_code_host(self, overlay: "OverlayBase") -> "CodeHostBackend | None":  # noqa: ARG002, PLR6301
+        return None
+
+    def get_code_hosts(self, overlay: "OverlayBase") -> "list[CodeHostBackend]":  # noqa: ARG002, PLR6301
+        return []
+
+    def get_messaging(self, overlay: "OverlayBase") -> "MessagingBackend | None":  # noqa: ARG002, PLR6301
+        return None
+
+    def get_ci_service(self, *, gitlab_token: str, gitlab_url: str) -> "CIService | None":  # noqa: ARG002, PLR6301
+        return None
+
+    def reset_caches(self) -> None:  # noqa: PLR6301
+        return
+
+    def build_github_host(self, *, token: str) -> "CodeHostBackend":  # noqa: ARG002, PLR6301
+        msg = "no backend provider registered — teatree.backends app is not installed"
+        raise RuntimeError(msg)
+
+    def build_gitlab_host(self, *, token: str, base_url: str) -> "CodeHostBackend":  # noqa: ARG002, PLR6301
+        msg = "no backend provider registered — teatree.backends app is not installed"
+        raise RuntimeError(msg)
+
+    def build_slack_messaging(  # noqa: PLR6301
+        self,
+        *,
+        bot_token: str,  # noqa: ARG002
+        app_token: str,  # noqa: ARG002
+        user_token: str,  # noqa: ARG002
+        user_id: str,  # noqa: ARG002
+        dm_channel_id: str,  # noqa: ARG002
+    ) -> "MessagingBackend":
+        msg = "no backend provider registered — teatree.backends app is not installed"
+        raise RuntimeError(msg)
+
+    def build_sync_backends(self) -> "list[SyncBackend]":  # noqa: PLR6301
+        return []
+
+    def read_recent_review_matches(self, spec: ReviewSearchSpec) -> ReviewHistoryReadLike:  # noqa: ARG002, PLR6301
+        return _EmptyReviewHistoryRead()
+
+
+class _EmptyReviewHistoryRead:
+    ok = False
+    matches: list[ReviewMatchLike] = []  # noqa: RUF012
+
+
+_UNCONFIGURED: BackendProvider = _UnconfiguredProvider()
+_provider: BackendProvider | None = None
+
+
+def register_backend_provider(provider: BackendProvider) -> None:
+    global _provider  # noqa: PLW0603 — single process-wide provider registered at app-ready
+    _provider = provider
+
+
+def get_backend_provider() -> BackendProvider:
+    return _provider if _provider is not None else _UNCONFIGURED

--- a/src/teatree/core/connector_keys.py
+++ b/src/teatree/core/connector_keys.py
@@ -1,0 +1,11 @@
+"""Cross-layer connector keys owned by the domain.
+
+``GRANTED_SCOPES_KEY`` is the dict key under which a Slack ``auth.test``
+response carries its parsed granted OAuth scopes. Both the backend transport
+(``backends.slack_scopes``, which writes it) and the domain preflight guard
+(``core.connector_preflight``, which reads it) need the same key. It lives in
+``core`` so the guard never imports ``backends`` (#1922); ``slack_scopes``
+re-imports it as the allowed ``backends → core`` direction.
+"""
+
+GRANTED_SCOPES_KEY = "_granted_scopes"

--- a/src/teatree/core/connector_preflight.py
+++ b/src/teatree/core/connector_preflight.py
@@ -16,8 +16,8 @@ convention (``raise SystemExit``, never ``typer.Exit``).
 
 import logging
 
-from teatree.backends.protocols import MessagingBackend
-from teatree.backends.slack_scopes import GRANTED_SCOPES_KEY
+from teatree.core.backend_protocols import MessagingBackend
+from teatree.core.connector_keys import GRANTED_SCOPES_KEY
 from teatree.core.overlay_loader import get_all_overlays
 
 logger = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ def assert_slack_scope(backend: MessagingBackend, scope: str) -> None:
 
     Reads the granted OAuth scopes that ``auth.test`` surfaces from the
     ``X-OAuth-Scopes`` response header (under
-    :data:`~teatree.backends.slack_bot.GRANTED_SCOPES_KEY`). An overlay's
+    :data:`~teatree.core.connector_keys.GRANTED_SCOPES_KEY`). An overlay's
     connector-preflight callable wires this so the loop refuses to continue
     when a required scope (e.g. ``reactions:write``) is missing — rather than
     discovering ``missing_scope`` mid-tick via a phantom write success.

--- a/src/teatree/core/daily_digest.py
+++ b/src/teatree/core/daily_digest.py
@@ -33,7 +33,7 @@ from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 
-from teatree.backends.protocols import MessagingBackend
+from teatree.core.backend_protocols import MessagingBackend
 from teatree.core.models import DailyDigestMessage, DailyDigestThread
 
 logger = logging.getLogger(__name__)

--- a/src/teatree/core/headless_dispatch.py
+++ b/src/teatree/core/headless_dispatch.py
@@ -1,0 +1,46 @@
+"""Registry for the headless task runner — the core → agents inversion seam (#1922).
+
+``core.tasks.execute_headless_task`` (a django-tasks worker) must run a task in a
+headless ``claude -p`` subprocess, but that runner lives in ``teatree.agents``
+(the higher layer). Rather than ``core`` importing ``agents``, ``agents``
+registers its runner here at app-ready time and ``core`` resolves it through this
+registry.
+
+Fail-LOUD: a missing runner is fatal (a dispatched headless task that silently
+does nothing is worse than a clear error), so :func:`get_headless_runner` raises
+when nothing is registered.
+"""
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from teatree.core.models import Task, TaskAttempt
+    from teatree.types import SkillMetadata
+
+
+class HeadlessRunner(Protocol):
+    def __call__(
+        self,
+        task: "Task",
+        *,
+        phase: str,
+        overlay_skill_metadata: "SkillMetadata",
+    ) -> "TaskAttempt": ...  # pragma: no branch
+
+
+_runner: HeadlessRunner | None = None
+
+
+def register_headless_runner(runner: HeadlessRunner) -> None:
+    global _runner  # noqa: PLW0603 — single process-wide runner registered at app-ready
+    _runner = runner
+
+
+def get_headless_runner() -> HeadlessRunner:
+    if _runner is None:
+        msg = (
+            "no headless runner registered — teatree.agents.apps.AgentsConfig.ready() "
+            "must run before a headless task is dispatched"
+        )
+        raise RuntimeError(msg)
+    return _runner

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -550,7 +550,7 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         won't re-spawn the reviewer agent for the same PR until either the
         SHA moves or the forge dismisses the approval.
         """
-        from teatree.backends.protocols import ReviewState  # noqa: PLC0415
+        from teatree.core.backend_protocols import ReviewState  # noqa: PLC0415
 
         sha = str(self._extra().get("reviewed_sha", ""))
         if self.issue_url and sha:
@@ -597,7 +597,7 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         drops ``last_review_state`` (the existing #959 reset) so a new
         revision is still reviewed — no lost obligation.
         """
-        from teatree.backends.protocols import ReviewState  # noqa: PLC0415
+        from teatree.core.backend_protocols import ReviewState  # noqa: PLC0415
 
         sha = str(self._extra().get("reviewed_sha", ""))
         if self.issue_url and sha:

--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -25,9 +25,9 @@ import re
 
 from django.db import DatabaseError, IntegrityError, transaction
 
-from teatree.backends.protocols import MessagingBackend
 from teatree.config import get_effective_settings, load_config
 from teatree.core.backend_factory import messaging_from_overlay
+from teatree.core.backend_protocols import MessagingBackend
 from teatree.core.models import BotPing, DeferredQuestion, DeliveryClaim, OutboundClaim
 from teatree.core.session_identity import current_session_id
 from teatree.slack_mrkdwn import normalize_slack_message, slack_linkify

--- a/src/teatree/core/on_behalf_egress.py
+++ b/src/teatree/core/on_behalf_egress.py
@@ -2,7 +2,7 @@
 
 Every Slack post or reaction made *under the user's identity on a
 colleague surface* goes through :class:`OnBehalfSlackEgress`. One instance
-wraps one :class:`~teatree.backends.protocols.MessagingBackend`; each
+wraps one :class:`~teatree.core.backend_protocols.MessagingBackend`; each
 public method runs the identical fixed sequence in one place:
 
 1.  classify the destination self-vs-colleague via the backend's #1750
@@ -40,12 +40,11 @@ sinks (``notify_user``, ``reply_transport.post_dm``, the daily digest,
 approve/comment paths (already gated via ``check_on_behalf``).
 
 Home is :mod:`teatree.core`: both the gate and the audit already live
-here, and ``MessagingBackend``/``RawAPIDict`` are in
-``teatree.backends``/``teatree.types`` which ``teatree.core`` already
-depends on — no new tach edge.
+here, and ``MessagingBackend``/``RawAPIDict`` are owned by ``teatree.core``
+/``teatree.types`` — no edge into ``teatree.backends``.
 """
 
-from teatree.backends.protocols import MessagingBackend
+from teatree.core.backend_protocols import MessagingBackend
 from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError, require_on_behalf_approval
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 from teatree.types import RawAPIDict

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -402,9 +402,9 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
     # ── Issue title resolution ────────────────────────────────────────
 
     def get_issue_title(self, url: str) -> str:
-        from teatree.backends.loader import get_code_host  # noqa: PLC0415
+        from teatree.core.backend_registry import get_backend_provider  # noqa: PLC0415
 
-        host = get_code_host(self)
+        host = get_backend_provider().get_code_host(self)
         if host is None:
             return ""
         try:

--- a/src/teatree/core/reaction_dispatch.py
+++ b/src/teatree/core/reaction_dispatch.py
@@ -1,0 +1,45 @@
+"""Registry for the Slack transition/approval reaction publisher (#1922).
+
+``core.signals`` posts a Slack emoji reaction as the side effect of an FSM
+transition, but the reaction publisher lives in ``teatree.backends`` (the higher
+layer). Rather than ``core`` importing ``backends``, ``backends`` registers its
+publisher here at app-ready time and ``signals`` resolves it when a transition
+fires.
+
+Fail-SAFE: a reaction is a non-fatal side effect (the on-behalf gate already
+governs whether it posts), so the registry returns a no-op publisher when nothing
+is registered — the FSM transition must always commit even with no publisher.
+"""
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from teatree.core.models.pull_request import PullRequest
+    from teatree.core.models.ticket import Ticket
+
+
+class ReactionPublisher(Protocol):
+    def add_reactions_for_transition(self, ticket: "Ticket", transition_name: str) -> int: ...  # pragma: no branch
+
+    def add_approval_reaction(self, pull_request: "PullRequest") -> int: ...  # pragma: no branch
+
+
+class _NoopReactionPublisher:
+    def add_reactions_for_transition(self, ticket: "Ticket", transition_name: str) -> int:  # noqa: ARG002, PLR6301
+        return 0
+
+    def add_approval_reaction(self, pull_request: "PullRequest") -> int:  # noqa: ARG002, PLR6301
+        return 0
+
+
+_NOOP: ReactionPublisher = _NoopReactionPublisher()
+_publisher: ReactionPublisher | None = None
+
+
+def register_reaction_publisher(publisher: ReactionPublisher) -> None:
+    global _publisher  # noqa: PLW0603 — single process-wide publisher registered at app-ready
+    _publisher = publisher
+
+
+def get_reaction_publisher() -> ReactionPublisher:
+    return _publisher if _publisher is not None else _NOOP

--- a/src/teatree/core/reply_transport.py
+++ b/src/teatree/core/reply_transport.py
@@ -30,12 +30,30 @@ from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 from teatree.slack_mrkdwn import normalize_slack_message, slack_linkify
 
 if TYPE_CHECKING:
-    from teatree.backends.github import GitHubCodeHost
-    from teatree.backends.gitlab_api import GitLabAPI
-    from teatree.backends.slack_bot import SlackBotBackend
+    from teatree.core.backend_protocols import CodeHostBackend, MessagingBackend
     from teatree.types import RawAPIDict
 
 logger = logging.getLogger(__name__)
+
+
+class _ProjectInfoLike(Protocol):
+    project_id: int
+
+
+class GitLabNoteClient(Protocol):
+    """The GitLab REST surface :class:`GitLabReplier` needs to post an MR note.
+
+    Structural so ``core`` types the replier against a capability rather than
+    importing the concrete ``backends.gitlab_api.GitLabAPI`` (#1922).
+    """
+
+    def resolve_project(self, repo_path: str) -> _ProjectInfoLike | None: ...  # pragma: no branch
+
+    def post_json(
+        self,
+        endpoint: str,
+        payload: "RawAPIDict | None" = None,
+    ) -> "RawAPIDict | None": ...  # pragma: no branch
 
 
 @dataclass(slots=True)
@@ -329,7 +347,7 @@ def _linkify_for_slack(body: str) -> str:
 class SlackReplier(_BaseReplier):
     """Posts via the Slack Web API (``SlackBotBackend``)."""
 
-    def __init__(self, *, bot: "SlackBotBackend") -> None:
+    def __init__(self, *, bot: "MessagingBackend") -> None:
         self._bot = bot
 
     def _deliver(self, spec: ReplySpec) -> str:
@@ -373,7 +391,7 @@ class SlackReplier(_BaseReplier):
 class GitLabReplier(_BaseReplier):
     """Posts an MR note via the GitLab REST API."""
 
-    def __init__(self, *, client: "GitLabAPI") -> None:
+    def __init__(self, *, client: "GitLabNoteClient") -> None:
         self._client = client
 
     def _deliver(self, spec: ReplySpec) -> str:
@@ -401,7 +419,7 @@ class GitLabReplier(_BaseReplier):
 class GitHubReplier(_BaseReplier):
     """Posts a PR comment via the GitHub API (``GitHubCodeHost``)."""
 
-    def __init__(self, *, host: "GitHubCodeHost") -> None:
+    def __init__(self, *, host: "CodeHostBackend") -> None:
         self._host = host
 
     def _deliver(self, spec: ReplySpec) -> str:
@@ -423,9 +441,9 @@ class GitHubReplier(_BaseReplier):
 def replier_for(
     source: str,
     *,
-    bot: "SlackBotBackend | None" = None,
-    gitlab: "GitLabAPI | None" = None,
-    github: "GitHubCodeHost | None" = None,
+    bot: "MessagingBackend | None" = None,
+    gitlab: "GitLabNoteClient | None" = None,
+    github: "CodeHostBackend | None" = None,
 ) -> Replier:
     """Pick the production replier for *source*, or ``NoopReplier``.
 

--- a/src/teatree/core/review_findings.py
+++ b/src/teatree/core/review_findings.py
@@ -7,7 +7,7 @@ with no enforcement). That classification was prose-only — nothing recorded
 the verdicts or filed the tracking issue, so class-C findings kept recurring.
 
 This module is the reliable, deterministic half: it fetches a PR's review
-comments through the existing :class:`~teatree.backends.protocols.CodeHostBackend`,
+comments through the existing :class:`~teatree.core.backend_protocols.CodeHostBackend`,
 computes a stable fingerprint per finding for dedup, records each finding +
 its supplied classification to a durable per-PR JSON store, and — for
 class-C findings only — files a scoped enforcement issue via the same backend
@@ -35,7 +35,7 @@ from teatree.paths import get_data_dir
 from teatree.types import RawAPIDict
 
 if TYPE_CHECKING:
-    from teatree.backends.protocols import CodeHostBackend
+    from teatree.core.backend_protocols import CodeHostBackend
 
 _FINGERPRINT_MARKER = "retro-finding-fingerprint:"
 """Prefix of the hidden marker line embedded in every filed enforcement issue.

--- a/src/teatree/core/review_request_guard.py
+++ b/src/teatree/core/review_request_guard.py
@@ -46,13 +46,17 @@ independent review).
 import datetime as dt
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import httpx
 from django.db import transaction
 from django.utils import timezone
 
-from teatree.backends.slack import SlackReviewSearchRequest, read_recent_review_matches
 from teatree.core.models import PullRequest, ReviewRequestPost
+
+if TYPE_CHECKING:
+    from teatree.core.backend_protocols import MessagingBackend
+    from teatree.core.overlay import OverlayBase
 
 logger = logging.getLogger(__name__)
 
@@ -143,9 +147,11 @@ def _live_matches(
     ``ok`` is False on any failed/timed-out/not-ok read so the caller
     fails safe to suppression.
     """
+    from teatree.core.backend_registry import ReviewSearchSpec, get_backend_provider  # noqa: PLC0415
+
     right_now = opts.now or timezone.now()
     oldest = right_now - opts.recency_window
-    request = SlackReviewSearchRequest(
+    spec = ReviewSearchSpec(
         token=target.token,
         channel_id=target.channel_id,
         channel_name=target.channel_name,
@@ -155,7 +161,7 @@ def _live_matches(
         timeout=opts.read_timeout,
     )
     try:
-        read = read_recent_review_matches(request)
+        read = get_backend_provider().read_recent_review_matches(spec)
     except (httpx.HTTPError, httpx.TimeoutException) as exc:
         logger.warning("review_request_guard: live read failed for %s: %s", canonical, exc)
         return False, []
@@ -319,7 +325,6 @@ def resolve_guard_target(channel_id: str = "", channel_name: str = "") -> GuardT
     """
     from django.core.exceptions import ImproperlyConfigured  # noqa: PLC0415
 
-    from teatree.backends.slack_bot import SlackBotBackend  # noqa: PLC0415
     from teatree.core.backend_factory import messaging_from_overlay  # noqa: PLC0415
     from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
 
@@ -332,11 +337,7 @@ def resolve_guard_target(channel_id: str = "", channel_name: str = "") -> GuardT
     if not channel_id:
         return None
 
-    messaging = messaging_from_overlay()
-    if isinstance(messaging, SlackBotBackend):
-        token = messaging.resolve_channel_token(channel_id)
-    else:
-        token = overlay.config.get_slack_token()
+    token = _channel_token(messaging_from_overlay(), channel_id, overlay)
     if not token:
         return None
     return GuardTarget(channel_id=channel_id, channel_name=channel_name, token=token)
@@ -353,7 +354,6 @@ def resolve_guard_targets() -> list[GuardTarget]:
     """
     from django.core.exceptions import ImproperlyConfigured  # noqa: PLC0415
 
-    from teatree.backends.slack_bot import SlackBotBackend  # noqa: PLC0415
     from teatree.core.backend_factory import messaging_from_overlay  # noqa: PLC0415
     from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
 
@@ -369,11 +369,22 @@ def resolve_guard_targets() -> list[GuardTarget]:
     for channel_name, channel_id in channels:
         if not channel_id:
             continue
-        if isinstance(messaging, SlackBotBackend):
-            token = messaging.resolve_channel_token(channel_id)
-        else:
-            token = overlay.config.get_slack_token()
+        token = _channel_token(messaging, channel_id, overlay)
         if not token:
             continue
         targets.append(GuardTarget(channel_id=channel_id, channel_name=channel_name, token=token))
     return targets
+
+
+def _channel_token(messaging: "MessagingBackend | None", channel_id: str, overlay: "OverlayBase") -> str:
+    """Resolve the post token for *channel_id*.
+
+    A Slack bot backend (the one exposing ``resolve_channel_token``) yields a
+    per-channel token (the Slack-Connect ``xoxp`` case); any other backend falls
+    back to the overlay's configured sync token. Duck-typed on the capability so
+    ``core`` does not import the concrete ``SlackBotBackend`` (#1922).
+    """
+    resolver = getattr(messaging, "resolve_channel_token", None)
+    if callable(resolver):
+        return resolver(channel_id)
+    return overlay.config.get_slack_token()

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -3,9 +3,9 @@ import re
 from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, cast
 
-from teatree.backends.protocols import PullRequestSpec
 from teatree.config import load_config
 from teatree.core.backend_factory import code_host_from_overlay
+from teatree.core.backend_protocols import PullRequestSpec
 from teatree.core.branch_currency import sha_conflicts_with_target
 from teatree.core.close_trailer_scanner import apply_publish_gate
 from teatree.core.open_questions_gate import warn_if_open_questions_missing
@@ -14,7 +14,7 @@ from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.utils import git
 
 if TYPE_CHECKING:
-    from teatree.backends.protocols import CodeHostBackend
+    from teatree.core.backend_protocols import CodeHostBackend
     from teatree.core.models.ticket import Ticket
     from teatree.core.models.types import TicketExtra
     from teatree.core.models.worktree import Worktree

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -3,12 +3,12 @@ import logging
 from django.db.models.signals import post_save
 from django_fsm.signals import post_transition
 
-from teatree.backends.slack_reactions import add_approval_reaction, add_reactions_for_transition
 from teatree.core.models.pull_request import PullRequest
 from teatree.core.models.task import Task
 from teatree.core.models.ticket import Ticket
 from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError, require_on_behalf_approval
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
+from teatree.core.reaction_dispatch import get_reaction_publisher
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ def _add_slack_reactions_on_transition(
         reacted = require_on_behalf_approval(
             target=target,
             action=f"transition_reaction:{name}",
-            publish=lambda: add_reactions_for_transition(instance, name),
+            publish=lambda: get_reaction_publisher().add_reactions_for_transition(instance, name),
         )
     except OnBehalfPostBlockedError as blocked:
         logger.info("Transition reaction for ticket %s (%s) gated: %s", instance.pk, name, blocked)
@@ -109,7 +109,7 @@ def _add_approval_reaction_on_transition(
         reacted = require_on_behalf_approval(
             target=target,
             action="approval_reaction",
-            publish=lambda: add_approval_reaction(instance),
+            publish=lambda: get_reaction_publisher().add_approval_reaction(instance),
         )
     except OnBehalfPostBlockedError as blocked:
         logger.info("Approval reaction for PR %s gated: %s", instance.pk, blocked)

--- a/src/teatree/core/sync.py
+++ b/src/teatree/core/sync.py
@@ -45,12 +45,11 @@ def sync_followup() -> SyncResult:
     which credentials are configured in the active overlay.  When both
     tokens are present, both syncs run and results are merged.
     """
-    from teatree.backends.github_sync import GitHubSyncBackend  # noqa: PLC0415
-    from teatree.backends.gitlab_sync import GitLabSyncBackend  # noqa: PLC0415
+    from teatree.core.backend_registry import get_backend_provider  # noqa: PLC0415
     from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
 
     overlay = get_overlay()
-    backends: list[SyncBackend] = [GitHubSyncBackend(), GitLabSyncBackend()]
+    backends: list[SyncBackend] = get_backend_provider().build_sync_backends()
     result = SyncResult()
     ran_any = False
 

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -68,10 +68,10 @@ def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
     if task_obj.status == Task.Status.PENDING:
         task_obj.claim(claimed_by="headless-worker")
     try:
-        from teatree.agents.headless import run_headless  # noqa: PLC0415
+        from teatree.core.headless_dispatch import get_headless_runner  # noqa: PLC0415
 
         overlay = get_overlay_for_ticket(task_obj.ticket)
-        attempt = run_headless(
+        attempt = get_headless_runner()(
             task_obj,
             phase=phase,
             overlay_skill_metadata=overlay.metadata.get_skill_metadata(),

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     "django_tasks_db",
     "teatree.core",
     "teatree.agents",
+    "teatree.backends",
     *_discover_overlay_apps(),
 ]
 

--- a/tach.toml
+++ b/tach.toml
@@ -1,4 +1,5 @@
 interfaces = []
+forbid_circular_dependencies = true
 exclude = [
   "**/*__pycache__",
   "**/*egg-info",
@@ -104,8 +105,6 @@ depends_on = [
   "teatree.skill_deps",
   "teatree.skill_map",
   "teatree.trigger_parser",
-  "teatree.agents",
-  "teatree.backends",
   "teatree.hooks",
   "teatree.on_behalf_gate",
   "teatree.slack_mrkdwn"

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -20,6 +20,7 @@ INSTALLED_APPS = [
     "django_tasks_db",
     "teatree.core",
     "teatree.agents",
+    "teatree.backends",
     "teatree.contrib.t3_teatree",
 ]
 

--- a/tests/integration/slack_bridge_e2e/test_routing.py
+++ b/tests/integration/slack_bridge_e2e/test_routing.py
@@ -94,14 +94,23 @@ class TestPerOverlayBotRouting:
         }
         pass_lookup = {"ref-bot": "xoxb-toml", "ref-app": "xapp-toml"}
 
+        from teatree.backends.backend_provider import SlackBackendProvider  # noqa: PLC0415
+
+        # A real provider keeps ``build_slack_messaging`` live (so the TOML
+        # overlay builds a real ``SlackBotBackend``); only the entry-point
+        # credential resolution is neutralised — the synthetic ``py-overlay``
+        # has no live backends.
+        provider = SlackBackendProvider()
+
         # Justified scaffolding (#1066 nit 2): synthetic entry-point + TOML
         # overlays injected via patched ``get_all_overlays`` /
         # ``load_config`` + a ``read_pass`` stub. See the conftest module
         # docstring; the network (``httpx``) stays real.
         with (
             patch.object(backend_factory, "get_all_overlays", return_value={"py-overlay": py_overlay}),
-            patch.object(backend_factory, "get_code_hosts", return_value=[]),
-            patch.object(backend_factory, "get_messaging", return_value=None),
+            patch.object(backend_factory, "get_backend_provider", return_value=provider),
+            patch.object(provider, "get_code_hosts", return_value=[]),
+            patch.object(provider, "get_messaging", return_value=None),
             patch("teatree.config.load_config", return_value=_FakeConfig(raw={"overlays": cfg_overlays})),
             patch("teatree.utils.secrets.read_pass", side_effect=lambda k: pass_lookup.get(k, "")),
         ):

--- a/tests/quality/test_import_contracts.py
+++ b/tests/quality/test_import_contracts.py
@@ -23,7 +23,6 @@ _CONFIG = str(_REPO_ROOT / "pyproject.toml")
 _EXPECTED_CONTRACTS = {
     "Substrate must not import a concrete overlay",
     "Mini-loops are mutually independent",
-    "Domain core must not import the messaging layer",
 }
 
 
@@ -53,14 +52,6 @@ class TestConfig:
     def test_shipped_contract_set(self, contracts: tuple[dict[str, object], ...]) -> None:
         names = {contract["name"] for contract in contracts}
         assert names == _EXPECTED_CONTRACTS
-
-    def test_core_messaging_scopes_out_only_the_interface_subtree(
-        self, contracts: tuple[dict[str, object], ...]
-    ) -> None:
-        contract = next(c for c in contracts if c["name"] == "Domain core must not import the messaging layer")
-        ignored = contract["ignore_imports"]
-        assert isinstance(ignored, list)
-        assert all(str(expr).startswith("teatree.core.management.") for expr in ignored), ignored
 
 
 class TestGreenOnTree:

--- a/tests/teatree_core/test_backend_factory.py
+++ b/tests/teatree_core/test_backend_factory.py
@@ -111,7 +111,7 @@ def test_messaging_from_overlay_returns_none_when_overlay_not_configured() -> No
 def test_messaging_from_overlay_delegates_to_loader() -> None:
     with (
         _patch_overlay(_NoTokenOverlay),
-        patch("teatree.core.backend_factory.get_messaging", return_value="sentinel") as get_messaging_mock,
+        patch("teatree.backends.loader.get_messaging", return_value="sentinel") as get_messaging_mock,
     ):
         result = messaging_from_overlay()
 

--- a/tests/teatree_core/test_backend_factory_toml.py
+++ b/tests/teatree_core/test_backend_factory_toml.py
@@ -38,6 +38,29 @@ class _Overlay:
     config: _Cfg
 
 
+class _StubProvider:
+    """Backend provider double — drives ``iter_overlay_backends``' collaborator.
+
+    ``hosts`` / ``messaging`` are either a value to return or an exception
+    instance to raise, so a single stub covers the credentials-resolve and
+    per-backend-error branches.
+    """
+
+    def __init__(self, *, hosts: object = (), messaging: object = None):
+        self._hosts = hosts
+        self._messaging = messaging
+
+    def get_code_hosts(self, overlay: object) -> object:
+        if isinstance(self._hosts, Exception):
+            raise self._hosts
+        return self._hosts
+
+    def get_messaging(self, overlay: object) -> object:
+        if isinstance(self._messaging, Exception):
+            raise self._messaging
+        return self._messaging
+
+
 def _config_with(overlays: dict[str, Any]) -> object:
     return type("Cfg", (), {"raw": {"overlays": overlays}})()
 
@@ -54,8 +77,11 @@ class TestIterOverlayBackendsEntryPoints:
         overlay = _Overlay("foo", _Cfg(ready_labels=("ready",), exclude_labels=("wip",)))
         with (
             patch.object(backend_factory, "get_all_overlays", return_value={"foo": overlay}),
-            patch.object(backend_factory, "get_code_hosts", return_value=["HOST"]),
-            patch.object(backend_factory, "get_messaging", return_value="MSG"),
+            patch.object(
+                backend_factory,
+                "get_backend_provider",
+                return_value=_StubProvider(hosts=["HOST"], messaging="MSG"),
+            ),
             patch.object(backend_factory, "_backends_from_toml", return_value=[]),
         ):
             out = backend_factory.iter_overlay_backends()
@@ -74,8 +100,11 @@ class TestIterOverlayBackendsEntryPoints:
         overlay = _Overlay("foo", _Cfg())
         with (
             patch.object(backend_factory, "get_all_overlays", return_value={"foo": overlay}),
-            patch.object(backend_factory, "get_code_hosts", side_effect=ImproperlyConfigured),
-            patch.object(backend_factory, "get_messaging", side_effect=ValueError),
+            patch.object(
+                backend_factory,
+                "get_backend_provider",
+                return_value=_StubProvider(hosts=ImproperlyConfigured(), messaging=ValueError()),
+            ),
             patch.object(backend_factory, "_backends_from_toml", return_value=[]),
         ):
             out = backend_factory.iter_overlay_backends()
@@ -88,8 +117,11 @@ class TestIterOverlayBackendsEntryPoints:
         toml_backend = backend_factory.OverlayBackends(name="toml-only", hosts=(), messaging=None, ready_labels=())
         with (
             patch.object(backend_factory, "get_all_overlays", return_value={"py": py_overlay}),
-            patch.object(backend_factory, "get_code_hosts", return_value=[]),
-            patch.object(backend_factory, "get_messaging", return_value=None),
+            patch.object(
+                backend_factory,
+                "get_backend_provider",
+                return_value=_StubProvider(hosts=[], messaging=None),
+            ),
             patch.object(backend_factory, "_backends_from_toml", return_value=[toml_backend]) as mock_toml,
         ):
             out = backend_factory.iter_overlay_backends()

--- a/tests/teatree_core/test_backend_registry.py
+++ b/tests/teatree_core/test_backend_registry.py
@@ -1,0 +1,59 @@
+"""The core → backends builder/loader inversion registry (#1922)."""
+
+import pytest
+
+from teatree.core import backend_registry
+
+
+class TestBackendProviderRegistry:
+    def test_backends_ready_registers_the_real_provider(self) -> None:
+        """``BackendsConfig.ready()`` ran at django.setup() — the real provider resolves."""
+        from teatree.backends.backend_provider import SlackBackendProvider  # noqa: PLC0415
+
+        assert isinstance(backend_registry.get_backend_provider(), SlackBackendProvider)
+
+    def test_unconfigured_provider_builds_nothing(self) -> None:
+        """Fail-SAFE: with no provider registered, builds degrade to None/empty (no crash)."""
+        original = backend_registry._provider
+        backend_registry._provider = None
+        try:
+            provider = backend_registry.get_backend_provider()
+            assert provider.get_code_host(object()) is None
+            assert provider.get_code_hosts(object()) == []
+            assert provider.get_messaging(object()) is None
+            assert provider.get_ci_service(gitlab_token="t", gitlab_url="u") is None
+            assert provider.build_sync_backends() == []
+            provider.reset_caches()
+        finally:
+            backend_registry.register_backend_provider(original)
+
+    def test_unconfigured_provider_raises_on_concrete_build(self) -> None:
+        """A concrete build with no backends app is a misconfiguration, not a silent no-op."""
+        original = backend_registry._provider
+        backend_registry._provider = None
+        try:
+            provider = backend_registry.get_backend_provider()
+            with pytest.raises(RuntimeError, match="no backend provider registered"):
+                provider.build_github_host(token="t")
+        finally:
+            backend_registry.register_backend_provider(original)
+
+    def test_unconfigured_review_read_is_not_ok(self) -> None:
+        """Fail-SAFE: an unconfigured review-history read reports not-ok with no matches."""
+        original = backend_registry._provider
+        backend_registry._provider = None
+        try:
+            spec = backend_registry.ReviewSearchSpec(
+                token="t",
+                channel_id="C1",
+                channel_name="rev",
+                pr_urls=["https://example/1"],
+                max_pages=1,
+                oldest_ts="0",
+                timeout=1.0,
+            )
+            read = backend_registry.get_backend_provider().read_recent_review_matches(spec)
+            assert read.ok is False
+            assert read.matches == []
+        finally:
+            backend_registry.register_backend_provider(original)

--- a/tests/teatree_core/test_headless_dispatch.py
+++ b/tests/teatree_core/test_headless_dispatch.py
@@ -1,0 +1,35 @@
+"""The core → agents headless-runner inversion registry (#1922)."""
+
+import pytest
+
+from teatree.core import headless_dispatch
+
+
+class TestHeadlessRunnerRegistry:
+    def test_agents_ready_registers_the_real_runner(self) -> None:
+        """``AgentsConfig.ready()`` ran at django.setup() — the runner resolves."""
+        from teatree.agents.headless import run_headless  # noqa: PLC0415
+
+        assert headless_dispatch.get_headless_runner() is run_headless
+
+    def test_register_then_get_round_trips(self) -> None:
+        def _fake_runner(task: object, *, phase: str, overlay_skill_metadata: object) -> object:
+            return "attempt"
+
+        original = headless_dispatch._runner
+        try:
+            headless_dispatch.register_headless_runner(_fake_runner)
+            resolved = headless_dispatch.get_headless_runner()
+            assert resolved(object(), phase="coding", overlay_skill_metadata={}) == "attempt"
+        finally:
+            headless_dispatch.register_headless_runner(original)
+
+    def test_get_raises_when_unregistered(self) -> None:
+        """Fail-LOUD: a dispatched headless task with no runner is fatal, never silent."""
+        original = headless_dispatch._runner
+        headless_dispatch._runner = None
+        try:
+            with pytest.raises(RuntimeError, match="no headless runner registered"):
+                headless_dispatch.get_headless_runner()
+        finally:
+            headless_dispatch.register_headless_runner(original)

--- a/tests/teatree_core/test_interactive_dispatch.py
+++ b/tests/teatree_core/test_interactive_dispatch.py
@@ -219,7 +219,7 @@ class TestHeadlessDispatchGuard(TestCase):
         sentinel = TaskAttempt(exit_code=0, result={"summary": "ran"})
 
         with (
-            patch("teatree.agents.headless.run_headless", return_value=sentinel) as run,
+            patch("teatree.core.headless_dispatch._runner", return_value=sentinel) as run,
             patch("teatree.core.overlay_loader.get_overlay") as overlay,
         ):
             overlay.return_value.metadata.get_skill_metadata.return_value = {}
@@ -244,7 +244,7 @@ class TestHeadlessDispatchGuard(TestCase):
         sentinel = TaskAttempt(exit_code=0, result={"summary": "ran"})
 
         with (
-            patch("teatree.agents.headless.run_headless", return_value=sentinel) as run,
+            patch("teatree.core.headless_dispatch._runner", return_value=sentinel) as run,
             patch("teatree.core.overlay_loader.get_overlay") as overlay,
         ):
             overlay.return_value.metadata.get_skill_metadata.return_value = {}

--- a/tests/teatree_core/test_reaction_dispatch.py
+++ b/tests/teatree_core/test_reaction_dispatch.py
@@ -1,0 +1,43 @@
+"""The core → backends reaction-publisher inversion registry (#1922).
+
+Fail-SAFE contract: an empty registry returns a no-op publisher so an FSM
+transition's reaction side effect never crashes the transition.
+"""
+
+from teatree.core import reaction_dispatch
+
+
+class TestReactionPublisherRegistry:
+    def test_backends_ready_registers_the_slack_publisher(self) -> None:
+        """``BackendsConfig.ready()`` ran at django.setup() — a real publisher resolves."""
+        from teatree.backends.slack_reactions import SlackReactionPublisher  # noqa: PLC0415
+
+        assert isinstance(reaction_dispatch.get_reaction_publisher(), SlackReactionPublisher)
+
+    def test_register_then_get_round_trips(self) -> None:
+        class _Fake:
+            def add_reactions_for_transition(self, ticket: object, transition_name: str) -> int:
+                return 7
+
+            def add_approval_reaction(self, pull_request: object) -> int:
+                return 9
+
+        original = reaction_dispatch._publisher
+        try:
+            reaction_dispatch.register_reaction_publisher(_Fake())
+            pub = reaction_dispatch.get_reaction_publisher()
+            assert pub.add_reactions_for_transition(object(), "merge") == 7
+            assert pub.add_approval_reaction(object()) == 9
+        finally:
+            reaction_dispatch.register_reaction_publisher(original)
+
+    def test_empty_registry_returns_noop(self) -> None:
+        """No publisher registered → both methods are silent no-ops (return 0), never raise."""
+        original = reaction_dispatch._publisher
+        reaction_dispatch._publisher = None
+        try:
+            pub = reaction_dispatch.get_reaction_publisher()
+            assert pub.add_reactions_for_transition(object(), "merge") == 0
+            assert pub.add_approval_reaction(object()) == 0
+        finally:
+            reaction_dispatch.register_reaction_publisher(original)

--- a/tests/teatree_core/test_signals.py
+++ b/tests/teatree_core/test_signals.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from unittest.mock import patch
 
 from django.db import DatabaseError
@@ -9,6 +11,29 @@ from teatree.core.models import PullRequest, Session, Task, Ticket
 from teatree.core.models.transition import TicketTransition
 from tests.teatree_core._on_behalf_gate_helpers import on_behalf_gate_off
 from tests.teatree_core.conftest import CommandOverlay
+
+
+class _FakeReactionPublisher:
+    """Test double for the reaction-publisher registry — routes one method to *fn*."""
+
+    def __init__(self, *, transition: Callable[..., int] | None = None, approval: Callable[..., int] | None = None):
+        self._transition = transition or (lambda *_a, **_k: 0)
+        self._approval = approval or (lambda *_a, **_k: 0)
+
+    def add_reactions_for_transition(self, ticket: object, transition_name: str) -> int:
+        return self._transition(ticket, transition_name)
+
+    def add_approval_reaction(self, pull_request: object) -> int:
+        return self._approval(pull_request)
+
+
+def _patch_transition_publisher(fn: Callable[..., int]) -> AbstractContextManager[object]:
+    return patch.object(signals_mod, "get_reaction_publisher", lambda: _FakeReactionPublisher(transition=fn))
+
+
+def _patch_approval_publisher(fn: Callable[..., int]) -> AbstractContextManager[object]:
+    return patch.object(signals_mod, "get_reaction_publisher", lambda: _FakeReactionPublisher(approval=fn))
+
 
 IMMEDIATE_BACKEND = {
     "TASKS": {
@@ -181,7 +206,7 @@ class TestSlackReactionsOnTransition(TestCase):
             called.append((t, name))
             return 1
 
-        with on_behalf_gate_off(), patch.object(signals_mod, "add_reactions_for_transition", _fake):
+        with on_behalf_gate_off(), _patch_transition_publisher(_fake):
             ticket.mark_merged()
             ticket.save()
 
@@ -195,7 +220,7 @@ class TestSlackReactionsOnTransition(TestCase):
             msg = "slack down"
             raise RuntimeError(msg)
 
-        with on_behalf_gate_off(), patch.object(signals_mod, "add_reactions_for_transition", _boom):
+        with on_behalf_gate_off(), _patch_transition_publisher(_boom):
             ticket.mark_merged()
             ticket.save()
 
@@ -210,11 +235,28 @@ class TestSlackReactionsOnTransition(TestCase):
             names.append(name)
             return 0
 
-        with on_behalf_gate_off(), patch.object(signals_mod, "add_reactions_for_transition", _record):
+        with on_behalf_gate_off(), _patch_transition_publisher(_record):
             ticket.rework()
             ticket.save()
 
         assert names == ["rework"]
+
+    def test_transition_commits_when_no_publisher_registered(self) -> None:
+        """Fail-SAFE: an empty reaction registry → no-op reaction, transition still commits."""
+        from teatree.core import reaction_dispatch  # noqa: PLC0415
+
+        ticket = self._ticket_with_mr()
+        original = reaction_dispatch._publisher
+        reaction_dispatch._publisher = None
+        try:
+            with on_behalf_gate_off():
+                ticket.mark_merged()
+                ticket.save()
+        finally:
+            reaction_dispatch.register_reaction_publisher(original)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED
 
 
 class TestApprovalReactionOnTransition(TestCase):
@@ -248,7 +290,7 @@ class TestApprovalReactionOnTransition(TestCase):
             calls.append((pull_request,))
             return 1
 
-        with on_behalf_gate_off(), patch.object(signals_mod, "add_approval_reaction", _fake):
+        with on_behalf_gate_off(), _patch_approval_publisher(_fake):
             pr.approve()
             pr.save()
 
@@ -266,7 +308,7 @@ class TestApprovalReactionOnTransition(TestCase):
         # Gate ON (default) — no recorded approval → reaction is skipped
         # (NOT pure suppression: a recorded approval would let it
         # publish, exercised by the next test).
-        with patch.object(signals_mod, "add_approval_reaction", _fake):
+        with _patch_approval_publisher(_fake):
             pr.approve()
             pr.save()
 
@@ -292,7 +334,7 @@ class TestApprovalReactionOnTransition(TestCase):
             return 1
 
         # Gate ON by default — but the recorded approval satisfies it.
-        with patch.object(signals_mod, "add_approval_reaction", _fake):
+        with _patch_approval_publisher(_fake):
             pr.approve()
             pr.save()
 
@@ -305,7 +347,7 @@ class TestApprovalReactionOnTransition(TestCase):
             msg = "slack down"
             raise RuntimeError(msg)
 
-        with on_behalf_gate_off(), patch.object(signals_mod, "add_approval_reaction", _boom):
+        with on_behalf_gate_off(), _patch_approval_publisher(_boom):
             pr.approve()
             pr.save()
 
@@ -318,7 +360,7 @@ class TestApprovalReactionOnTransition(TestCase):
 
         with (
             on_behalf_gate_off(),
-            patch.object(signals_mod, "add_approval_reaction", lambda p: calls.append(p) or 0),
+            _patch_approval_publisher(lambda p: calls.append(p) or 0),
         ):
             pr.mark_merged()
             pr.save()
@@ -386,7 +428,7 @@ class TestApprovalReactionOnTransition(TestCase):
         )
         assert row is not None
 
-        with on_behalf_gate_off(), patch.object(signals_mod, "add_approval_reaction", lambda _pr: 1):
+        with on_behalf_gate_off(), _patch_approval_publisher(lambda _pr: 1):
             pr.approve()
             pr.save()
 
@@ -421,7 +463,7 @@ class TestTransitionReactionGated(TestCase):
             return 1
 
         # Gate ON by default — no recorded approval → reaction is skipped.
-        with patch.object(signals_mod, "add_reactions_for_transition", _fake):
+        with _patch_transition_publisher(_fake):
             ticket.mark_merged()
             ticket.save()
 
@@ -448,7 +490,7 @@ class TestTransitionReactionGated(TestCase):
             return 1
 
         # Gate ON by default — recorded approval satisfies it.
-        with patch.object(signals_mod, "add_reactions_for_transition", _fake):
+        with _patch_transition_publisher(_fake):
             ticket.mark_merged()
             ticket.save()
 

--- a/tests/teatree_core/test_signals_on_behalf_reactions_notify.py
+++ b/tests/teatree_core/test_signals_on_behalf_reactions_notify.py
@@ -17,6 +17,8 @@ the BotPing ledger run for real. The on-behalf pre-gate is set to
 *after*-receipt behaviour.
 """
 
+from collections.abc import Callable
+from contextlib import AbstractContextManager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -25,6 +27,31 @@ from django.test import TestCase
 
 import teatree.core.signals as signals_mod
 from teatree.core.models import BotPing, PullRequest, Ticket
+
+
+class _FakeReactionPublisher:
+    def __init__(
+        self,
+        *,
+        transition: Callable[..., int] | None = None,
+        approval: Callable[..., int] | None = None,
+    ):
+        self._transition = transition or (lambda *_a, **_k: 0)
+        self._approval = approval or (lambda *_a, **_k: 0)
+
+    def add_reactions_for_transition(self, ticket: object, transition_name: str) -> int:
+        return self._transition(ticket, transition_name)
+
+    def add_approval_reaction(self, pull_request: object) -> int:
+        return self._approval(pull_request)
+
+
+def _patch_transition_publisher(fn: Callable[..., int]) -> AbstractContextManager[object]:
+    return patch.object(signals_mod, "get_reaction_publisher", lambda: _FakeReactionPublisher(transition=fn))
+
+
+def _patch_approval_publisher(fn: Callable[..., int]) -> AbstractContextManager[object]:
+    return patch.object(signals_mod, "get_reaction_publisher", lambda: _FakeReactionPublisher(approval=fn))
 
 
 def _notify_backend() -> MagicMock:
@@ -67,7 +94,7 @@ class TestSignalsAfterReceiptDm(TestCase):
 
     def test_approval_reaction_emits_after_receipt_dm(self) -> None:
         pr = self._pr()
-        with patch.object(signals_mod, "add_approval_reaction", lambda _p: 1):
+        with _patch_approval_publisher(lambda _p: 1):
             pr.approve()
             pr.save()
 
@@ -78,7 +105,7 @@ class TestSignalsAfterReceiptDm(TestCase):
     def test_approval_reaction_no_dm_when_nothing_reacted(self) -> None:
         """No DM when the helper reacted nothing (no review message to react on)."""
         pr = self._pr()
-        with patch.object(signals_mod, "add_approval_reaction", lambda _p: 0):
+        with _patch_approval_publisher(lambda _p: 0):
             pr.approve()
             pr.save()
 
@@ -93,7 +120,7 @@ class TestSignalsAfterReceiptDm(TestCase):
         react on (helper returns 0) no ``on_behalf_post:`` DM is sent.
         """
         ticket = Ticket.objects.create(overlay="test", state=Ticket.State.IN_REVIEW, extra={"mrs": {}})
-        with patch.object(signals_mod, "add_reactions_for_transition", lambda _t, _n: 0):
+        with _patch_transition_publisher(lambda _t, _n: 0):
             ticket.mark_merged()
             ticket.save()
 
@@ -107,7 +134,7 @@ class TestSignalsAfterReceiptDm(TestCase):
             state=Ticket.State.IN_REVIEW,
             extra={"mrs": {"https://x/1": {"review_permalink": "https://t.slack.com/archives/C1/p1700000000000100"}}},
         )
-        with patch.object(signals_mod, "add_reactions_for_transition", lambda _t, _n: 1):
+        with _patch_transition_publisher(lambda _t, _n: 1):
             ticket.mark_merged()
             ticket.save()
 

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -501,7 +501,7 @@ class TestExecuteHeadlessTask(TestCase):
             msg = "headless runtime crashed"
             raise RuntimeError(msg)
 
-        self.monkeypatch.setattr("teatree.agents.headless.run_headless", _raise)
+        self.monkeypatch.setattr("teatree.core.headless_dispatch._runner", _raise)
 
         # ``architectural_review`` has no registered phase agent, so it is NOT
         # loop-dispatched — it rides the auto-enqueue path the executor owns.
@@ -533,7 +533,7 @@ class TestExecuteHeadlessTask(TestCase):
             captured["metadata"] = overlay_skill_metadata
             return MagicMock(pk=1, exit_code=0, result={})
 
-        self.monkeypatch.setattr("teatree.agents.headless.run_headless", _capture)
+        self.monkeypatch.setattr("teatree.core.headless_dispatch._runner", _capture)
 
         beta_overlay = CommandOverlay()
         beta_metadata = beta_overlay.metadata.get_skill_metadata()

--- a/tests/test_dev_settings.py
+++ b/tests/test_dev_settings.py
@@ -17,6 +17,7 @@ def test_settings_importable():
     assert mod.DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3"
     assert "teatree.core" in mod.INSTALLED_APPS
     assert "teatree.agents" in mod.INSTALLED_APPS
+    assert "teatree.backends" in mod.INSTALLED_APPS
     assert isinstance(mod.LOGGING, dict)
     assert mod.LOGGING["version"] == 1
     assert mod.STATIC_URL == "static/"

--- a/tests/test_tach_cycle_ratchet.py
+++ b/tests/test_tach_cycle_ratchet.py
@@ -1,0 +1,60 @@
+"""Only-shrinks ratchet for declared import cycles + core fan-in freeze (#1922).
+
+Pins the PR-3 acyclic invariant at the *declaration* level so a regression
+redeclaring a cross-module cycle, re-adding a back-edge into ``teatree.core``,
+or flipping the gate off fails here instead of silently rotting (the #195 → #315
+creep-back is exactly what this prevents).
+
+Dual role with ``uv run tach check``: tach parses the actual import graph and is
+the runtime cycle gate; this test guards the ``tach.toml`` declaration so a
+maintainer cannot re-open the door (drop the flag, re-add the dead edge, grow
+core fan-in) without a red test, even with no code edge. Both run in CI.
+"""
+
+import tomllib
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_TACH = _REPO / "tach.toml"
+
+# Frozen baseline: number of modules that may depend on teatree.core.
+# Re-baseline ONLY by lowering (more inversion) — never raising.
+_CORE_FANIN_BASELINE = 12
+_MAX_DECLARED_TWO_CYCLES = 0
+
+
+def _config() -> dict:
+    return tomllib.loads(_TACH.read_text(encoding="utf-8"))
+
+
+def _modules() -> list[dict]:
+    return _config()["modules"]
+
+
+def _depends(mods: list[dict], path: str) -> list[str]:
+    return next(m for m in mods if m["path"] == path).get("depends_on", [])
+
+
+class TestForbidCircularStaysOn:
+    def test_flag_is_true(self) -> None:
+        assert _config().get("forbid_circular_dependencies") is True
+
+
+class TestNoDeclaredTwoCycles:
+    def test_no_mutual_edge_between_any_pair(self) -> None:
+        mods = _modules()
+        dep = {m["path"]: set(m.get("depends_on", [])) for m in mods}
+        cycles = {tuple(sorted((a, b))) for a in dep for b in dep[a] if b in dep and a in dep[b]}
+        assert len(cycles) <= _MAX_DECLARED_TWO_CYCLES, sorted(cycles)
+
+    def test_core_does_not_depend_on_agents_or_backends(self) -> None:
+        deps = set(_depends(_modules(), "teatree.core"))
+        assert "teatree.agents" not in deps
+        assert "teatree.backends" not in deps
+
+
+class TestCoreFanInFrozen:
+    def test_core_fanin_not_grown(self) -> None:
+        mods = _modules()
+        fanin = [m["path"] for m in mods if "teatree.core" in m.get("depends_on", []) and m["path"] != "teatree.core"]
+        assert len(fanin) <= _CORE_FANIN_BASELINE, sorted(fanin)


### PR DESCRIPTION
## What

Break the two core import cycles (`teatree.core ↔ teatree.backends` and `teatree.core ↔ teatree.agents`) and turn on `forbid_circular_dependencies = true` in tach.

The final direction matches [#724](https://github.com/souliane/teatree/issues/724): `core` owns the Protocols/abstractions it consumes; `agents`/`backends` implement and register them (`agents → core`, `backends → core` stay; `core → agents`, `core → backends` go). This is the reverse of the [#195](https://github.com/souliane/teatree/issues/195) edge-removal but the same mechanism (move the contract to the layer that should own it; the other layer registers).

A key finding while implementing: **tach counts function-local (lazy `# noqa: PLC0415`) imports too** (verified via `tach report`), so lazy-demotion alone does not break a tach edge — every `core → agents`/`core → backends` site (top-level *and* lazy) had to be inverted.

## Inversion summary

| Edge | Site | How it was inverted |
|---|---|---|
| `core → agents` | `core/tasks.py` headless runner | `core/headless_dispatch.py` registry (`HeadlessRunner` Protocol); `agents.apps.AgentsConfig.ready()` registers `run_headless`. Fail-LOUD if unregistered. |
| `core → backends` | `core/signals.py` Slack reactions | `core/reaction_dispatch.py` registry (`ReactionPublisher` Protocol); the new `backends.apps.BackendsConfig.ready()` registers a `SlackReactionPublisher`; `signals` resolves at fire time. Fail-SAFE no-op when empty (transition still commits). |
| `core → backends` | `backends/protocols.py` Protocol surface | Moved to `core/backend_protocols.py`; `backends/protocols.py` is now a re-export shim (all existing `from teatree.backends.protocols import X` consumers keep working). |
| `core → backends` | `GRANTED_SCOPES_KEY` constant | Moved to `core/connector_keys.py`; `backends/slack_scopes.py` re-imports it. |
| `core → backends` | `backend_factory` loader, `sync.py`, `overlay.get_issue_title`, `review_request_guard` search | `core/backend_registry.py` `BackendProvider` (loader funcs + concrete builders + sync backends + recency-bounded review read), registered by `BackendsConfig.ready()`. `review_request_guard` also swaps `isinstance(messaging, SlackBotBackend)` for a duck-typed `resolve_channel_token` check. |
| `core → backends` | `reply_transport.py` TYPE_CHECKING hints | Concrete-class hints → core Protocols; `GitLabAPI` → a local structural `GitLabNoteClient` Protocol (tach counts TYPE_CHECKING imports). |

`teatree.backends` becomes a Django app (ready()-only, no models/migrations — same shape as `teatree.agents`) so its `ready()` runs the registrations.

`core/management/` imports of `agents`/`backends` are untouched — it is the interface layer (a separate tach module that legitimately declares both).

## Gates

- `tach check` is GREEN with `forbid_circular_dependencies = true` and the dead `teatree.agents`/`teatree.backends` entries removed from `teatree.core.depends_on`.
- New `tests/test_tach_cycle_ratchet.py` — an only-shrinks declaration ratchet (flag stays true, zero declared 2-cycles, `core` not → agents/backends, core fan-in frozen at 12) that guards the `tach.toml` declaration so the #195 → [#315](https://github.com/souliane/teatree/issues/315) creep-back cannot reopen the door without a red test.
- Redundant import-linter Contract 3 ("Domain core must not import the messaging layer") deleted (tach's `core.depends_on` already omits messaging/notify); section comment + BLUEPRINT row rewritten to claim only wildcard sibling-independence as tach-inexpressible. `lint-imports` green (2 contracts kept).

### Ratchet anti-vacuity proofs (observed RED → reverted → GREEN)

1. Re-add `teatree.backends` to `core.depends_on` → the ratchet's `test_no_mutual_edge_between_any_pair` asserts `assert 1 <= 0` with `{('teatree.backends', 'teatree.core')}` (RED); the live tach plugin additionally panics `CircularDependency(["teatree.core", "teatree.backends"])`. Reverted → GREEN.
2. Flip `forbid_circular_dependencies = false` → `test_flag_is_true` RED (`assert False is True`). Reverted → GREEN.
3. Add a fake module declaring `teatree.core` in `depends_on` → `test_core_fanin_not_grown` RED (fan-in 13 > 12). Reverted → GREEN.

## Commit sequencing

Five commits, each leaving the suite green; `tach check` goes green at the flag-flip commit (4):
1. move Protocol surface + connector key into `core` (+ re-export shim)
2. invert headless + reaction call seams via `core` registries
3. route the last `core → backends` builds through the backend provider
4. flip the gate + drop dead tach entries + ratchet test
5. retire import-linter Contract 3 + align prose

## Architecture pre-check

**1. BLUEPRINT § alignment:** § Module Dependency Graph + import-linter quality-gate row. `teatree.core` is the domain layer; depends only on Protocols it owns; graph acyclic, tach-enforced.
**2. FSM phase boundaries:** n/a. B1 touches the *reaction side effect* of an existing transition, not the transition — pinned by a must-not-crash-with-empty-registry test.
**3. Extension-point contracts:** three new `core`-owned registries (`headless_dispatch`, `reaction_dispatch`, `backend_registry`) registered by `agents`/`backends` app-ready. Protocol surface moved home; surface unchanged, all implementers still satisfy structurally.
**4. Component boundaries:** Protocols belong in the consuming layer = `core`; implementations stay in `backends`. Registries live in `core` (consumer owns the seam, producer registers).
**5. Dependency direction:** removes `core → agents`/`core → backends`; keeps `agents → core`, `backends → core`. core fan-in stays 12.
**6. Test surface:** ratchet, `tach check`, `lint-imports`, `test_import_contracts`, `test_backend_factory`, reaction must-fire/must-not-crash, headless registry round-trip + fail-loud, backend-registry fail-safe.
**7. Resilience invariants:** reaction publisher empty-registry fail-safe (no-op, transition commits); headless fail-LOUD; backend provider fail-safe (None/empty) on bare `django.setup()`.
**8. Identity/key normalization:** n/a.
**9. Behavior preservation / capability deletion:** Contract 3 deleted — fully subsumed by tach (verified via lint-imports/tach cross-check, no must-block test inverted). `isinstance → hasattr(resolve_channel_token)` is equivalent (the method is unique to the Slack bot backend). Re-export shim preserves all `backends.protocols` consumers. No privacy/security matcher narrowed.

## Open questions & assumptions

- **Re-export shim lifetime.** `backends/protocols.py` stays a re-export of `core/backend_protocols.py` to avoid churning ~40 consumers in this PR. Assumption: a later campaign PR migrates those consumers to the `core` path and deletes the shim. Flagged, not orphaned.
- **`teatree.backends` as a Django app.** Added to `INSTALLED_APPS` (and the test settings) purely for the `ready()` registration hook — no models, no migrations, mirroring `teatree.agents`. Assumes overlays' own `INSTALLED_APPS` are unaffected (they append to the list).
- **B5 chose the registry over lazy-demotion.** The plan offered lazy-demotion as the lower-churn option, but `tach report` showed tach counts function-local imports, so lazy-demotion would not have cut the edge. The registry is the only option that makes the `core.depends_on` entry genuinely dead.
- **Layering unchanged.** `core`/`agents`/`backends` remain `layer = "domain"`; the acyclic guarantee comes from `forbid_circular_dependencies`, not a re-layer (the layer cleanup is a later PR per the campaign plan).

Closes #1922
Relates to #724
