### PR TITLE
fix(speak): POST audio bytes to Slack upload URL, not PUT

### DIFF
--- a/src/teatree/backends/slack_bot.py
+++ b/src/teatree/backends/slack_bot.py
@@ -724,7 +724,7 @@ class SlackBotBackend:
 
         The three-step modern Slack upload flow (``files.upload`` is
         deprecated): ``files.getUploadURLExternal`` reserves an off-Slack
-        one-shot ``upload_url`` + file ``id``; the bytes are PUT there;
+        one-shot ``upload_url`` + file ``id``; the bytes are POSTed there;
         ``files.completeUploadExternal`` finalises the file and shares it
         into ``channel_id``. Slack renders an inline audio player for an
         ``.m4a`` / ``.mp3``, which is what surfaces the spoken reply on the
@@ -765,7 +765,7 @@ class SlackBotBackend:
         file_id = reserve.get("file_id")
         if not isinstance(upload_url, str) or not isinstance(file_id, str):
             return reserve
-        self._http.put_external(upload_url, content=content)
+        self._http.post_external(upload_url, content=content)
         file_entry: RawAPIDict = {"id": file_id}
         if title:
             file_entry["title"] = title

--- a/src/teatree/backends/slack_http.py
+++ b/src/teatree/backends/slack_http.py
@@ -182,20 +182,21 @@ class SlackHttpClient:
 
         return cast("RawAPIDict", self._run(attempt, idempotent=True).json())
 
-    def put_external(self, url: str, *, content: bytes) -> int:
-        """PUT raw ``content`` to an off-Slack upload URL, returning the status code.
+    def post_external(self, url: str, *, content: bytes) -> int:
+        """POST raw ``content`` to an off-Slack upload URL, returning the status code.
 
         The Slack ``files.getUploadURLExternal`` step returns a one-shot
         ``upload_url`` on Slack's file storage host (not ``slack.com/api``)
-        that the caller PUTs the file bytes to before
-        ``files.completeUploadExternal``. The PUT carries no token (the URL
-        is itself the capability) and the upload is idempotent — the same
-        bytes to the same one-shot URL — so it is retried under the standard
-        bounded-backoff like any read.
+        that the caller POSTs the file bytes to before
+        ``files.completeUploadExternal``. The host accepts the bytes only on
+        POST and 302-redirects any other verb to ``slack.com``. The POST
+        carries no token (the URL is itself the capability) and the upload is
+        idempotent — the same bytes to the same one-shot URL — so it is
+        retried under the standard bounded-backoff like any read.
         """
 
         def attempt() -> httpx.Response:
-            return httpx.put(url, content=content, timeout=self._timeout)
+            return httpx.post(url, content=content, timeout=self._timeout)
 
         return self._run(attempt, idempotent=True).status_code
 

--- a/tests/teatree_backends/test_slack_upload_audio.py
+++ b/tests/teatree_backends/test_slack_upload_audio.py
@@ -1,11 +1,15 @@
 """``SlackBotBackend.upload_audio_to_dm`` — the #1791 ``slack-audio`` egress.
 
 The modern three-step Slack upload (``files.getUploadURLExternal`` →
-binary PUT to the off-Slack upload URL → ``files.completeUploadExternal``
+binary POST to the off-Slack upload URL → ``files.completeUploadExternal``
 sharing into the DM channel). Only the Slack HTTP boundary
-(``httpx.get`` / ``httpx.put`` / ``httpx.post``) is mocked; the routing,
-the file read, the ``files:write`` scope-failure surfacing, and the
-missing-file / empty-token guards are exercised against the real backend.
+(``httpx.get`` / ``httpx.post``) is mocked; the routing, the file read,
+the ``files:write`` scope-failure surfacing, and the missing-file /
+empty-token guards are exercised against the real backend.
+
+The file transfer is a POST per ``files.getUploadURLExternal``: Slack's
+file storage host accepts the bytes only on POST and 302-redirects any
+other verb to ``slack.com``, so a PUT here silently dropped the audio.
 """
 
 from pathlib import Path
@@ -17,6 +21,7 @@ import pytest
 from teatree.backends.slack_bot import SlackBotBackend
 
 _SELF_DM = "D_SELF"
+_API_HOST = "slack.com/api"
 
 
 def _backend() -> SlackBotBackend:
@@ -31,14 +36,14 @@ def audio_file(tmp_path: Path) -> Path:
 
 
 class TestUploadAudioToDm:
-    def test_full_flow_reserves_puts_and_completes(
+    def test_full_flow_reserves_posts_and_completes(
         self,
         audio_file: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         get_calls: list[tuple[str, dict[str, object]]] = []
-        put_calls: list[tuple[str, bytes]] = []
-        post_calls: list[tuple[str, dict[str, object], str]] = []
+        upload_calls: list[tuple[str, bytes, str | None]] = []
+        complete_calls: list[tuple[str, dict[str, object], str]] = []
 
         def fake_get(url: str, **kwargs: object) -> httpx.Response:
             params = cast("dict[str, object]", kwargs.get("params") or {})
@@ -46,18 +51,16 @@ class TestUploadAudioToDm:
             body = {"ok": True, "upload_url": "https://files.slack/upload/abc", "file_id": "F123"}
             return httpx.Response(200, json=body, request=httpx.Request("GET", url))
 
-        def fake_put(url: str, **kwargs: object) -> httpx.Response:
-            put_calls.append((url, cast("bytes", kwargs.get("content", b""))))
-            return httpx.Response(200, request=httpx.Request("PUT", url))
-
         def fake_post(url: str, **kwargs: object) -> httpx.Response:
-            headers = cast("dict[str, str]", kwargs["headers"])
+            headers = cast("dict[str, str]", kwargs.get("headers") or {})
+            if _API_HOST not in url:
+                upload_calls.append((url, cast("bytes", kwargs.get("content", b"")), headers.get("Authorization")))
+                return httpx.Response(200, request=httpx.Request("POST", url))
             payload = cast("dict[str, object]", kwargs.get("json") or {})
-            post_calls.append((url, payload, headers["Authorization"]))
+            complete_calls.append((url, payload, headers["Authorization"]))
             return httpx.Response(200, json={"ok": True, "files": [{"id": "F123"}]}, request=httpx.Request("POST", url))
 
         monkeypatch.setattr(httpx, "get", fake_get)
-        monkeypatch.setattr(httpx, "put", fake_put)
         monkeypatch.setattr(httpx, "post", fake_post)
 
         result = _backend().upload_audio_to_dm(channel=_SELF_DM, filepath=str(audio_file), title="Agent reply")
@@ -67,13 +70,13 @@ class TestUploadAudioToDm:
         assert get_calls[0][0].endswith("files.getUploadURLExternal")
         assert get_calls[0][1]["filename"] == "speech.m4a"
         assert get_calls[0][1]["length"] == len(b"fake-audio-bytes")
-        # Step 2: PUT the exact bytes to the reserved URL.
-        assert put_calls == [("https://files.slack/upload/abc", b"fake-audio-bytes")]
+        # Step 2: POST the exact bytes to the reserved URL, untokened (the URL is the capability).
+        assert upload_calls == [("https://files.slack/upload/abc", b"fake-audio-bytes", None)]
         # Step 3: complete + share into the channel, on the bot token.
-        assert post_calls[0][0].endswith("files.completeUploadExternal")
-        assert post_calls[0][1]["channel_id"] == _SELF_DM
-        assert post_calls[0][1]["files"] == [{"id": "F123", "title": "Agent reply"}]
-        assert post_calls[0][2] == "Bearer xoxb-bot"
+        assert complete_calls[0][0].endswith("files.completeUploadExternal")
+        assert complete_calls[0][1]["channel_id"] == _SELF_DM
+        assert complete_calls[0][1]["files"] == [{"id": "F123", "title": "Agent reply"}]
+        assert complete_calls[0][2] == "Bearer xoxb-bot"
 
     def test_empty_when_no_token_configured(self, audio_file: Path) -> None:
         backend = SlackBotBackend(bot_token="", user_token="", user_id="U_ME")
@@ -121,34 +124,37 @@ class TestUploadAudioToDm:
         audio_file: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        post_payloads: list[dict[str, object]] = []
+        complete_payloads: list[dict[str, object]] = []
 
         def fake_get(url: str, **kwargs: object) -> httpx.Response:
             body = {"ok": True, "upload_url": "https://files.slack/u", "file_id": "F1"}
             return httpx.Response(200, json=body, request=httpx.Request("GET", url))
 
-        def fake_put(url: str, **kwargs: object) -> httpx.Response:
-            return httpx.Response(200, request=httpx.Request("PUT", url))
-
         def fake_post(url: str, **kwargs: object) -> httpx.Response:
-            post_payloads.append(cast("dict[str, object]", kwargs.get("json") or {}))
+            if _API_HOST not in url:
+                return httpx.Response(200, request=httpx.Request("POST", url))
+            complete_payloads.append(cast("dict[str, object]", kwargs.get("json") or {}))
             return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
         monkeypatch.setattr(httpx, "get", fake_get)
-        monkeypatch.setattr(httpx, "put", fake_put)
         monkeypatch.setattr(httpx, "post", fake_post)
 
         _backend().upload_audio_to_dm(channel=_SELF_DM, filepath=str(audio_file))
-        assert post_payloads[0]["files"] == [{"id": "F1"}]
+        assert complete_payloads[0]["files"] == [{"id": "F1"}]
 
 
-class TestPutExternal:
-    def test_returns_status_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
+class TestPostExternal:
+    def test_posts_bytes_untokened_and_returns_status(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from teatree.backends.slack_http import SlackHttpClient  # noqa: PLC0415
 
-        def fake_put(url: str, **kwargs: object) -> httpx.Response:
-            return httpx.Response(200, request=httpx.Request("PUT", url))
+        seen: list[tuple[str, bytes, str | None]] = []
 
-        monkeypatch.setattr(httpx, "put", fake_put)
+        def fake_post(url: str, **kwargs: object) -> httpx.Response:
+            headers = cast("dict[str, str]", kwargs.get("headers") or {})
+            seen.append((url, cast("bytes", kwargs.get("content", b"")), headers.get("Authorization")))
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+        monkeypatch.setattr(httpx, "post", fake_post)
         client = SlackHttpClient(sleep=lambda _: None)
-        assert client.put_external("https://files.slack/u", content=b"x") == 200
+        assert client.post_external("https://files.slack/u", content=b"x") == 200
+        assert seen == [("https://files.slack/u", b"x", None)]


### PR DESCRIPTION
## Bug

`t3 speak --overlay <overlay> "<text>"` with `speak_target=slack-audio` synthesises the m4a and reserves an upload URL via `files.getUploadURLExternal` (200 OK), but the file transfer to the returned upload URL fails:

```
PUT https://files.slack.com/upload/v1/... "HTTP/1.1 302 Found"  -> Redirect location: 'https://slack.com'
speak delivery failed: Redirect response '302 Found'
```

Previously masked by a missing `files:write` scope; once the token gained the scope the upload leg ran for the first time and the wrong HTTP verb surfaced.

## Root cause

Slack's external-upload flow requires the file body to be POSTed to the one-shot `upload_url` (per `files.getUploadURLExternal`). The code issued a PUT; `files.slack.com` accepts the bytes only on POST and 302-redirects any other verb to the marketing page. httpx does not follow redirects, so the bytes were silently dropped. Authority: `slack_sdk`'s `_upload_file_via_v2_url` uses `Request(method="POST", url=upload_url, data=data, headers={})` -- POST, raw body, untokened (the URL is the capability).

## Fix

`SlackHttpClient.put_external` -> `post_external` (`httpx.put` -> `httpx.post`), same untokened raw-body + bounded-retry semantics. `SlackBotBackend.upload_audio_to_dm` calls `post_external`; docstring verb corrected. The reserve and `files.completeUploadExternal` (finalise + share into `channel_id`) legs were already correct; the whole sequence is now pinned by the test.

## RED -> GREEN proof

Pre-existing tests asserted the PUT (`monkeypatch httpx.put`, `assert put_calls == [...]`) -- they passed on buggy code and guarded nothing. Rewrote them to mock only the network boundary and pin the contract: POST of the audio bytes to `upload_url` (untokened) + `completeUploadExternal` with channel + file id.

- RED (current code): `test_full_flow_reserves_posts_and_completes` -> `httpx.ConnectError` (code still calls `httpx.put`, not intercepted by the POST-only mock -> real connection attempt); `test_posts_bytes_untokened_and_returns_status` -> `AttributeError: 'SlackHttpClient' object has no attribute 'post_external'`.
- GREEN (after fix): all 8 tests in the file pass; 67 pass across the touched area (`test_slack_http.py`, `test_slack_upload_audio.py`, `test_speak.py`).

docs: n/a -- bug fix preserving the existing contract. No BLUEPRINT/configuration doc states the upload verb.