### PR TITLE
fix(account-switch): don't record fingerprint on failed recovery; one-parse identity

### DIFF
--- a/src/teatree/core/account_fingerprint.py
+++ b/src/teatree/core/account_fingerprint.py
@@ -8,17 +8,51 @@ its hot path without importing Django or building backends.
 
 The full detect-invalidate-reprobe recovery cycle (which needs Django and the
 network) lives in :mod:`teatree.core.account_switch`, which re-exports these
-readers; :mod:`teatree.loop.watchdog` re-exports
-:func:`current_account_fingerprint` too. No other module parses
-``~/.claude.json``'s account identity.
+readers; :mod:`teatree.loop.watchdog` builds its ``AccountState`` from
+:func:`current_account_identity`. No other module parses ``~/.claude.json``'s
+account identity.
 """
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 
 ACTIVE_ACCOUNT_FILE = ".claude.json"
 CLAUDE_HOME_DIR = ".claude"
 RECOVERED_FINGERPRINT_FILE = "teatree-account-switch.json"
+
+
+@dataclass(frozen=True, slots=True)
+class AccountIdentity:
+    """The active Claude Code account — its fingerprint and display email."""
+
+    account_uuid: str
+    email: str = ""
+
+
+def current_account_identity(*, home: Path | None = None) -> AccountIdentity | None:
+    """Parse ``~/.claude.json`` once and return the active account, ``None`` when unknown.
+
+    The single parser of the account identity. A missing or malformed file, or
+    a record with no ``accountUuid``, is "no signal" (``None``), never an error.
+    The ``email`` is the display address, defaulting to ``""`` when absent.
+    """
+    home = home if home is not None else Path.home()
+    cfg = home / ACTIVE_ACCOUNT_FILE
+    if not cfg.is_file():
+        return None
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    oauth = data.get("oauthAccount") if isinstance(data, dict) else None
+    if not isinstance(oauth, dict):
+        return None
+    uuid = oauth.get("accountUuid")
+    if not isinstance(uuid, str) or not uuid:
+        return None
+    email = oauth.get("emailAddress", "")
+    return AccountIdentity(account_uuid=uuid, email=email if isinstance(email, str) else "")
 
 
 def current_account_fingerprint(*, home: Path | None = None) -> str:
@@ -28,19 +62,8 @@ def current_account_fingerprint(*, home: Path | None = None) -> str:
     caller treats an empty fingerprint as "cannot tell" and never claims a
     switch on it.
     """
-    home = home if home is not None else Path.home()
-    cfg = home / ACTIVE_ACCOUNT_FILE
-    if not cfg.is_file():
-        return ""
-    try:
-        data = json.loads(cfg.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, ValueError):
-        return ""
-    oauth = data.get("oauthAccount") if isinstance(data, dict) else None
-    if not isinstance(oauth, dict):
-        return ""
-    uuid = oauth.get("accountUuid")
-    return uuid if isinstance(uuid, str) else ""
+    identity = current_account_identity(home=home)
+    return identity.account_uuid if identity is not None else ""
 
 
 def _recovered_path(home: Path) -> Path:
@@ -84,7 +107,9 @@ def fingerprint_switched(*, home: Path | None = None) -> bool:
 
 
 __all__ = [
+    "AccountIdentity",
     "current_account_fingerprint",
+    "current_account_identity",
     "fingerprint_switched",
     "load_recorded_fingerprint",
     "record_fingerprint",

--- a/src/teatree/core/account_switch.py
+++ b/src/teatree/core/account_switch.py
@@ -121,27 +121,32 @@ class AccountSwitchRecovery:
             self.reset_caches()
             probes = tuple(probe_connectors(self.backends()))
 
-        if current:
-            record_fingerprint(current, home=home)
-
-        return AccountSwitchOutcome(
+        outcome = AccountSwitchOutcome(
             current_fingerprint=current,
             previous_fingerprint=previous,
             switched=switched,
             probes=probes,
         )
 
+        if current and (not switched or outcome.all_reachable):
+            record_fingerprint(current, home=home)
+
+        return outcome
+
 
 def detect_and_recover_account_switch(*, home: Path | None = None) -> AccountSwitchOutcome:
     """Detect a ``/login`` switch, invalidate the cache, and re-probe connectors.
 
     Compares the active account fingerprint against the last-recorded one. On a
-    genuine switch (both non-empty and different): reset the backend cache,
-    re-probe each messaging connector's live reachability, then record the new
-    fingerprint. A first run (no recorded fingerprint) or an unchanged account
-    records the fingerprint and probes nothing — it is not a switch. An empty
-    active fingerprint ("cannot tell") never claims a switch. Thin convenience
-    wrapper around :class:`AccountSwitchRecovery` with production seams.
+    genuine switch (both non-empty and different): reset the backend cache and
+    re-probe each messaging connector's live reachability. The new fingerprint
+    is recorded only when recovery genuinely succeeded — a no-switch run (first
+    run or unchanged account) or a switch where every connector probed
+    reachable. A switch that left a connector unreachable does NOT record, so
+    the next session re-detects the switch and the heartbeat keeps surfacing
+    until the bridge is actually fixed. An empty active fingerprint ("cannot
+    tell") never claims a switch and never records. Thin convenience wrapper
+    around :class:`AccountSwitchRecovery` with production seams.
     """
     return AccountSwitchRecovery().run(home=home)
 

--- a/src/teatree/loop/watchdog.py
+++ b/src/teatree/loop/watchdog.py
@@ -33,11 +33,10 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from teatree.core.account_fingerprint import current_account_fingerprint
+from teatree.core.account_fingerprint import current_account_identity
 from teatree.utils.run import CommandFailedError, run_allowed_to_fail
 
 CLAUDE_HOME_DIR = ".claude"
-ACTIVE_ACCOUNT_FILE = ".claude.json"
 SESSIONS_SUBDIR = "sessions"
 LOOP_PIN_FILE = "teatree-loop-session.json"
 DEFAULT_LABEL = "com.teatree.loop"
@@ -72,30 +71,17 @@ class LoopSessionInfo:
 def current_active_account(*, home: Path | None = None) -> AccountState | None:
     """Return the currently-logged-in Claude Code account, or ``None`` if unknown.
 
-    The account fingerprint (``oauthAccount.accountUuid``) comes from the
-    canonical single reader :func:`teatree.core.account_switch.current_account_fingerprint`
-    so the watchdog and the in-session recovery never diverge on which value is
-    "the account". The display ``email`` is read alongside; a missing or
-    malformed file is "no signal" (``None``) so the watchdog degrades to
-    "any session is good enough".
+    Reads ``~/.claude.json`` exactly once via the canonical single parser
+    :func:`teatree.core.account_fingerprint.current_account_identity`, so the
+    watchdog and the in-session recovery never diverge on which value is "the
+    account" and the file is never parsed twice. A missing or malformed file is
+    "no signal" (``None``) so the watchdog degrades to "any session is good
+    enough".
     """
-    home = home if home is not None else Path.home()
-    uuid = current_account_fingerprint(home=home)
-    if not uuid:
+    identity = current_account_identity(home=home)
+    if identity is None:
         return None
-    email = _read_account_email(home)
-    return AccountState(account_uuid=uuid, email=email)
-
-
-def _read_account_email(home: Path) -> str:
-    cfg = home / ACTIVE_ACCOUNT_FILE
-    try:
-        data = json.loads(cfg.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, ValueError):
-        return ""
-    oauth = data.get("oauthAccount") if isinstance(data, dict) else None
-    email = oauth.get("emailAddress", "") if isinstance(oauth, dict) else ""
-    return email if isinstance(email, str) else ""
+    return AccountState(account_uuid=identity.account_uuid, email=identity.email)
 
 
 # ── session discovery ────────────────────────────────────────────────

--- a/tests/teatree_core/test_account_fingerprint.py
+++ b/tests/teatree_core/test_account_fingerprint.py
@@ -4,7 +4,9 @@ import json
 from pathlib import Path
 
 from teatree.core.account_fingerprint import (
+    AccountIdentity,
     current_account_fingerprint,
+    current_account_identity,
     fingerprint_switched,
     load_recorded_fingerprint,
     record_fingerprint,
@@ -33,6 +35,34 @@ class TestCurrentFingerprint:
     def test_no_oauth_block_is_empty(self, tmp_path: Path) -> None:
         (tmp_path / ".claude.json").write_text(json.dumps({"userID": "x"}), encoding="utf-8")
         assert current_account_fingerprint(home=tmp_path) == ""
+
+
+class TestCurrentAccountIdentity:
+    def test_reads_uuid_and_email_in_one_parse(self, tmp_path: Path) -> None:
+        _write_active_account(tmp_path, "uuid-A")
+        assert current_account_identity(home=tmp_path) == AccountIdentity(account_uuid="uuid-A", email="u@e.com")
+
+    def test_missing_file_is_none(self, tmp_path: Path) -> None:
+        assert current_account_identity(home=tmp_path) is None
+
+    def test_no_uuid_is_none(self, tmp_path: Path) -> None:
+        (tmp_path / ".claude.json").write_text(
+            json.dumps({"oauthAccount": {"emailAddress": "u@e.com"}}), encoding="utf-8"
+        )
+        assert current_account_identity(home=tmp_path) is None
+
+    def test_missing_email_defaults_empty(self, tmp_path: Path) -> None:
+        (tmp_path / ".claude.json").write_text(
+            json.dumps({"oauthAccount": {"accountUuid": "uuid-A"}}), encoding="utf-8"
+        )
+        identity = current_account_identity(home=tmp_path)
+        assert identity is not None
+        assert identity.account_uuid == "uuid-A"
+        assert identity.email == ""
+
+    def test_fingerprint_delegates_to_identity(self, tmp_path: Path) -> None:
+        _write_active_account(tmp_path, "uuid-A")
+        assert current_account_fingerprint(home=tmp_path) == "uuid-A"
 
 
 class TestRecordedFingerprint:

--- a/tests/teatree_core/test_account_switch.py
+++ b/tests/teatree_core/test_account_switch.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from teatree.core.account_fingerprint import fingerprint_switched
 from teatree.core.account_switch import (
     AccountSwitchOutcome,
     AccountSwitchRecovery,
@@ -145,6 +146,29 @@ class TestDetectAndRecover:
         assert outcome.switched is True
         assert outcome.all_reachable is False
         assert any(not p.reachable for p in outcome.probes)
+
+    def test_failed_recovery_does_not_record_new_fingerprint(self, tmp_path: Path) -> None:
+        self.backends[:] = [_FakeBackend(ok=False, name="slack")]
+        _write_active_account(tmp_path, "uuid-B")
+        record_fingerprint("uuid-A", home=tmp_path)
+        self._run(tmp_path)
+        assert load_recorded_fingerprint(home=tmp_path) == "uuid-A"
+
+    def test_failed_recovery_keeps_surfacing_next_session(self, tmp_path: Path) -> None:
+        self.backends[:] = [_FakeBackend(ok=False, name="slack")]
+        _write_active_account(tmp_path, "uuid-B")
+        record_fingerprint("uuid-A", home=tmp_path)
+        self._run(tmp_path)
+        assert fingerprint_switched(home=tmp_path) is True
+        second = self._run(tmp_path)
+        assert second.switched is True
+
+    def test_successful_recovery_records_and_clears_next_session(self, tmp_path: Path) -> None:
+        _write_active_account(tmp_path, "uuid-B")
+        record_fingerprint("uuid-A", home=tmp_path)
+        self._run(tmp_path)
+        assert load_recorded_fingerprint(home=tmp_path) == "uuid-B"
+        assert fingerprint_switched(home=tmp_path) is False
 
     def test_outcome_is_account_switch_outcome(self, tmp_path: Path) -> None:
         _write_active_account(tmp_path, "uuid-A")


### PR DESCRIPTION
Follow-up to #2072 / addresses the cold-review findings on #1916. No `Closes` keyword — #1916 is already closed.

## Findings addressed

**Finding 1 (robustness — TDD).** `AccountSwitchRecovery.run` recorded the new fingerprint *unconditionally*, even when the post-reset connector probe (`auth.test`) came back unreachable. Consequence: `fingerprint_switched()` returned `False` next session → no re-attempt → the SessionStart advisory/heartbeat went silent while the bridge was still broken. Fix: record the new fingerprint only when recovery genuinely succeeded — a no-switch run (first run / unchanged account) or a switch where every connector probed reachable. A switch that left a connector unreachable does **not** record, so the next session re-detects it and the heartbeat keeps surfacing until the bridge is actually fixed.

- RED-first: `tests/teatree_core/test_account_switch.py::TestDetectAndRecover::test_failed_recovery_does_not_record_new_fingerprint` (+ `test_failed_recovery_keeps_surfacing_next_session`, `test_successful_recovery_records_and_clears_next_session`) observed RED on the pre-fix code (`assert 'uuid-B' == 'uuid-A'`), GREEN after. Anti-vacuity re-confirmed by reverting the one-line condition back to `if current:` → RED.

**Finding 2 (trivial).** `watchdog.current_active_account` docstring referenced `teatree.core.account_switch.current_account_fingerprint`; the canonical home is `teatree.core.account_fingerprint` (where it's defined and imported from). Reference fixed.

**Finding 3 (cohesion).** `_read_account_email` opened `~/.claude.json` a second time for the display email, after the identity parse already happened once. Consolidated: `current_account_identity` parses the file once and returns `(account_uuid, email)`; `current_account_fingerprint` delegates to it, and `watchdog.current_active_account` builds its `AccountState` from it. `_read_account_email` and the now-dead `ACTIVE_ACCOUNT_FILE` constant in `watchdog` are removed. Single parser of the account identity — matching the `account_fingerprint` module's stated invariant.

## Verification

- Touched-module tests green: `tests/teatree_core/test_account_switch.py`, `tests/teatree_core/test_account_fingerprint.py`, `tests/teatree_loop/test_watchdog.py` (58 passed). Regression corpus green incl. the account-switch anti-vacuity test.
- `account_switch.py` 100% coverage, `account_fingerprint.py` 100%. `ruff check` / `ruff format` / `ty check` / `tach check` all clean. `prek` green on all changed files.

## Architecture pre-check

Tactical review-fix bundle, no new module / Protocol / FSM transition. **Behavior preservation:** Finding 1 narrows *when* the fingerprint is recorded (a genuine bug fix, not a capability removal) — no must-block test inverted; the existing switch/unreachable surfacing test is unchanged. Finding 3 removes a duplicate parse and a dead constant; `current_account_fingerprint`'s contract (uuid-or-`""`) is preserved via delegation, covered by `test_fingerprint_delegates_to_identity`. **Identity normalization:** the consolidation strengthens the single-source-of-truth invariant (one parser of `~/.claude.json`). `tach check` green — no new edges.
