### PR TITLE
fix(notify): preserve attempts through claim_delivery recreate on failed-delivery path

### DIFF
--- a/src/teatree/core/models/bot_ping.py
+++ b/src/teatree/core/models/bot_ping.py
@@ -198,10 +198,14 @@ class BotPing(models.Model):
         not deliver (the backend did not resolve, or a configured send failed).
         Keyed by ``idempotency_key`` rather than pk because a failed delivery
         through :meth:`claim_delivery` deletes the recoverable row and recreates
-        a fresh one under the same key — the count must survive that swap.
-        Drives the :attr:`MAX_REDELIVERY_ATTEMPTS` bound so a row that can never
-        deliver is EXPIRED rather than retried forever. An ``F`` expression so
-        concurrent drains never lose a count.
+        a fresh one under the same key — the pk changes but the key does not.
+        :meth:`claim_delivery` carries the prior ``attempts`` onto the recreated
+        row so this bump lands on the accumulated count, not a reset-to-zero row;
+        without that the failed-delivery path would re-record at ``attempts=1``
+        every tick and the :attr:`MAX_REDELIVERY_ATTEMPTS` bound would never trip
+        (#2068). Drives that bound so a row that can never deliver is EXPIRED
+        rather than retried forever. An ``F`` expression so concurrent drains
+        never lose a count.
         """
         cls.objects.filter(idempotency_key=idempotency_key).update(attempts=models.F("attempts") + 1)
 
@@ -233,23 +237,28 @@ class BotPing(models.Model):
         :meth:`finalize_sent` / :meth:`finalize_failed`. A recoverable row
         (FAILED/NOOP — #1306, or a STALE SENDING whose owner crashed before
         finalizing — see :meth:`is_stale_sending`) is replaced by the fresh
-        SENDING claim so a retry still re-delivers.
+        SENDING claim so a retry still re-delivers; its ``attempts`` count is
+        carried onto the fresh row so the :attr:`MAX_REDELIVERY_ATTEMPTS` bound
+        accumulates across delete-recreate cycles rather than resetting (#2068).
         """
         manager = cls.objects.using(using) if using else cls.objects
         with transaction.atomic(using=using):
             row = manager.select_for_update().filter(idempotency_key=idempotency_key).first()
+            prior_attempts = 0
             if row is not None:
                 if row.status == cls.Status.SENT:
                     return DeliveryClaim.ALREADY_SENT
                 recoverable = row.status in cls._RECOVERABLE or cls.is_stale_sending(row.status, row.posted_at)
                 if not recoverable:
                     return DeliveryClaim.IN_FLIGHT
+                prior_attempts = row.attempts
                 row.delete()
             manager.create(
                 idempotency_key=idempotency_key,
                 kind=kind,
                 status=cls.Status.SENDING,
                 text=text,
+                attempts=prior_attempts,
             )
         return DeliveryClaim.CLAIMED
 

--- a/tests/teatree_core/test_notify_undelivered_drain.py
+++ b/tests/teatree_core/test_notify_undelivered_drain.py
@@ -248,3 +248,38 @@ class TestDrainUndeliveredNotifies(TestCase):
 
         assert total == 2
         assert delivered == 1
+
+    def test_failed_delivery_preserves_prior_attempt_count(self) -> None:
+        BotPing.objects.create(
+            idempotency_key="backend-up-send-fails",
+            kind=BotPing.Kind.INFO,
+            status=BotPing.Status.NOOP,
+            text="backend resolves but the send breaks",
+            attempts=3,
+        )
+        backend = _backend()
+        backend.post_message.return_value = {"ok": False, "error": "channel_not_found"}
+        with patch("teatree.core.notify.messaging_from_overlay", return_value=backend):
+            delivered, total = drain_undelivered_notifies(user_id="U_ME")
+
+        assert (delivered, total) == (0, 1)
+        row = BotPing.objects.get(idempotency_key="backend-up-send-fails")
+        assert row.status == BotPing.Status.FAILED
+        assert row.attempts == 4
+
+    def test_failed_delivery_path_eventually_expires_at_the_cap(self) -> None:
+        BotPing.objects.create(
+            idempotency_key="backend-up-always-fails",
+            kind=BotPing.Kind.INFO,
+            status=BotPing.Status.NOOP,
+            text="send keeps breaking",
+        )
+        backend = _backend()
+        backend.post_message.return_value = {"ok": False, "error": "channel_not_found"}
+        with patch("teatree.core.notify.messaging_from_overlay", return_value=backend):
+            for _ in range(BotPing.MAX_REDELIVERY_ATTEMPTS + 1):
+                drain_undelivered_notifies(user_id="U_ME")
+
+        row = BotPing.objects.get(idempotency_key="backend-up-always-fails")
+        assert row.status == BotPing.Status.EXPIRED
+        assert list(BotPing.recoverable_info()) == []


### PR DESCRIPTION
## Problem

On the backend-resolves-but-send-FAILS re-delivery path, `BotPing.claim_delivery` deleted the recoverable row (at `attempts=N`) and created a fresh `SENDING` row with `attempts=0`. `finalize_failed` then stamped it `FAILED` (still `attempts=0`), and the drain's `bump_attempt` set it to `1`. So a row at `attempts=3` ended a failed-delivery tick at `attempts=1` — the `MAX_REDELIVERY_ATTEMPTS=5` bound never tripped on that path, and the row could re-deliver-and-fail indefinitely (bounded only by the 72h `REDELIVERY_AGE_CUTOFF`).

The `bump_attempt` docstring claimed the count survived the delete-recreate swap; it did not.

## Fix (root cause)

Carry the prior `attempts` count onto the recreated `SENDING` row inside `claim_delivery` — the single chokepoint where the delete-recreate swap happens. The counter now survives every recovery path (failed-delivery, NOOP, stale-SENDING), so `bump_attempt`'s documented contract is actually true. Fixed the `bot_ping.py` docstrings that misattributed survival to keying on `idempotency_key`.

No schema change (`attempts` field already existed; `makemigrations --check` clean).

## Tests (TDD — observed RED before the fix)

- `test_failed_delivery_preserves_prior_attempt_count` — a NOOP row at `attempts=3`, backend resolves but the send fails: row ends `FAILED` at `attempts=4` (was `1` on buggy code).
- `test_failed_delivery_path_eventually_expires_at_the_cap` — repeated failing sends through the recreate path now converge on the cap and EXPIRE.

Full `tests/teatree_core/test_notify_undelivered_drain.py` (20) plus `test_notify`, `test_notify_concurrent_dedup`, `test_notify_stale_sending`, `test_botping_backlog_migration` (38) all green. `ruff`, `tach`, `ty`, and the prek gates pass.

Relates to #2064 / #2066.

Closes #2068
