### PR TITLE
fix(ship): validate MR description first line client-side (#1367)

### DIFF
--- a/docs/overlay-api.md
+++ b/docs/overlay-api.md
@@ -70,7 +70,7 @@ Project metadata, CI integration, MR validation, and skill registration live on 
 
 | Method | Default | Purpose |
 |--------|---------|---------|
-| `validate_pr(title, description)` | reject title not matching the effective `mr_title_regex` (Conventional Commits plus the release-notes types `improvement\|config\|techdebt` some overlays narrow to) or a description missing a What/Why header (#1540) | Validate PR title and description against project conventions; override to assemble a different grammar, but the default is a real gate enforced at `pr create` |
+| `validate_pr(title, description)` | reject a title or a description **first line** not matching the effective `mr_title_regex` (Conventional Commits plus the release-notes types `improvement\|config\|techdebt` some overlays narrow to), or a description missing a What/Why header (#1540, #1367); the first-line check mirrors the GitLab `validate_mr_title_and_description` CI gate, which parses the literal first line and never falls back to the title | Validate PR title and description against project conventions; override to assemble a different grammar, but the default is a real gate enforced at `pr create` |
 | `build_pr_title(branch, subject, body, issue_url)` | the commit `subject` | Produce the PR title from structured ticket data so the ship path generates a compliant title instead of copying a raw subject |
 | `get_followup_repos()` | `[]` | Repos to check during follow-up sync |
 | `get_skill_metadata()` | `{}` | Skill path, remote patterns, trigger index for the overlay's companion skills |

--- a/src/teatree/core/mr_metadata.py
+++ b/src/teatree/core/mr_metadata.py
@@ -1,17 +1,29 @@
-"""Deterministic MR title/description convention checks (#1540).
+"""Deterministic MR title/description convention checks (#1540, #1367).
 
 Pure, overlay-agnostic helpers used by ``OverlayMetadata.validate_pr`` to
-reject a non-conforming MR before the ``pr create`` network call. The title
-must match the overlay's effective ``mr_title_regex`` and the description must
-be non-empty with at least one What/Why header. Both error strings name the
-EXACT expected format so the caller can fix the metadata without guessing.
+reject a non-conforming MR before the ``pr create`` network call. Three checks,
+each naming the EXACT expected format so the caller can fix the metadata
+without guessing: the title matches the overlay's effective ``mr_title_regex``;
+the description's FIRST LINE matches that same regex; and the description
+carries at least one What/Why header.
+
+The first-line check mirrors the GitLab ``validate_mr_title_and_description``
+CI gate, which parses the literal first line of the description and does NOT
+fall back to the title (#1367) — so a description opening with ``## Summary``
+reds the pipeline while the title is fine. Encoding the gate's own rule here
+rejects the bad first line client-side, eliminating the validator round-trip.
 """
 
 import re
 
 from teatree.types import DEFAULT_MR_TITLE_REGEX
 
-__all__ = ["DEFAULT_MR_TITLE_REGEX", "expected_title_format", "validate_mr_metadata"]
+__all__ = [
+    "DEFAULT_MR_TITLE_REGEX",
+    "expected_first_line_format",
+    "expected_title_format",
+    "validate_mr_metadata",
+]
 
 _WHAT_WHY_RE = re.compile(r"^\s*(?:#{1,6}\s*)?(what|why)\b\s*:?", re.IGNORECASE | re.MULTILINE)
 
@@ -20,22 +32,40 @@ def expected_title_format(title_regex: str) -> str:
     return f"MR title must match the overlay convention: {title_regex}"
 
 
+def expected_first_line_format(title_regex: str) -> str:
+    return (
+        "MR description first line will fail the GitLab "
+        "validate_mr_title_and_description CI gate — it must be the "
+        f"conventional-commit form {title_regex} (prepend the MR title as line "
+        "1, blank line, then the body)."
+    )
+
+
 def _has_what_why_header(description: str) -> bool:
     return _WHAT_WHY_RE.search(description) is not None
+
+
+def _first_line(description: str) -> str:
+    return description.split("\n", 1)[0]
 
 
 def validate_mr_metadata(title: str, description: str, title_regex: str) -> list[str]:
     """Return convention violations for ``title``/``description`` (empty == valid).
 
-    The title is matched against ``title_regex`` (the overlay's effective
-    ``mr_title_regex``). The description must be non-empty and carry a What or
-    Why header (``## What`` / ``Why:`` and case/level variants).
+    The title and the description's first line are each matched against
+    ``title_regex`` (the overlay's effective ``mr_title_regex``); the
+    description must be non-empty and carry a What or Why header (``## What`` /
+    ``Why:`` and case/level variants).
     """
     errors: list[str] = []
     if not re.search(title_regex, title):
         errors.append(f"{expected_title_format(title_regex)} (got: {title!r})")
     if not description.strip():
         errors.append("MR description is empty — add a What/Why body (e.g. '## What' / '## Why').")
-    elif not _has_what_why_header(description):
+        return errors
+    first = _first_line(description)
+    if not re.search(title_regex, first):
+        errors.append(f"{expected_first_line_format(title_regex)} (got: {first!r})")
+    if not _has_what_why_header(description):
         errors.append("MR description must contain at least one What or Why header (e.g. '## What' / '## Why').")
     return errors

--- a/tests/teatree_core/test_mr_metadata.py
+++ b/tests/teatree_core/test_mr_metadata.py
@@ -1,16 +1,18 @@
-"""Tests for the deterministic MR title/description convention gate (#1540).
+"""Tests for the deterministic MR title/description convention gate (#1540, #1367).
 
 Pure-logic unit coverage of ``validate_mr_metadata`` — the helper that
 ``OverlayMetadata.validate_pr`` delegates to. It rejects a title that does not
-match the overlay's ``mr_title_regex`` and a description that is empty or
-carries no What/Why header, returning the EXACT expected format in each error.
+match the overlay's ``mr_title_regex``, a description whose first line is not
+conventional-commit (the GitLab CI gate's own rule, #1367), and a description
+that is empty or carries no What/Why header, returning the EXACT expected
+format in each error.
 """
 
 import pytest
 
 from teatree.core.mr_metadata import DEFAULT_MR_TITLE_REGEX, expected_title_format, validate_mr_metadata
 
-_GOOD_DESC = "## What\nAdds the gate.\n\n## Why\nThe convention is missed often."
+_GOOD_DESC = "feat(ship): add the gate (#1540)\n\n## What\nAdds the gate.\n\n## Why\nThe convention is missed often."
 
 
 class TestTitleRegex:
@@ -54,8 +56,9 @@ class TestTitleRegex:
 
     def test_per_overlay_regex_is_honoured(self) -> None:
         custom = r"^(feat|fix): .+"
-        assert validate_mr_metadata("feat: ok", _GOOD_DESC, custom) == []
-        rejected = validate_mr_metadata("chore: not allowed here", _GOOD_DESC, custom)
+        good = "feat: add the gate\n\n## What\nbody\n\n## Why\nreason"
+        assert validate_mr_metadata("feat: ok", good, custom) == []
+        rejected = validate_mr_metadata("chore: not allowed here", good, custom)
         assert rejected
         assert any(custom in err for err in rejected)
 
@@ -72,10 +75,10 @@ class TestDescriptionWhatWhy:
     @pytest.mark.parametrize(
         "description",
         [
-            "## What\nthe change",
-            "## Why\nthe reason",
-            "What: the change\nWhy: the reason",
-            "Some preamble.\n\n## What\nbody",
+            "feat(ship): ok\n\n## What\nthe change",
+            "feat(ship): ok\n\n## Why\nthe reason",
+            "feat(ship): ok\n\nWhat: the change\nWhy: the reason",
+            "feat(ship): ok\n\nSome preamble.\n\n## What\nbody",
         ],
     )
     def test_description_with_what_or_why_header_passes(self, description: str) -> None:
@@ -83,11 +86,55 @@ class TestDescriptionWhatWhy:
 
     def test_description_without_what_why_rejected(self) -> None:
         errors = validate_mr_metadata(
-            "feat(ship): ok", "Just a plain paragraph with no headers.", DEFAULT_MR_TITLE_REGEX
+            "feat(ship): ok", "feat(ship): ok\n\nJust a plain paragraph with no headers.", DEFAULT_MR_TITLE_REGEX
         )
         assert any("What" in err and "Why" in err for err in errors)
 
 
-def test_both_failures_surface_together() -> None:
+class TestDescriptionFirstLineConventionalCommit:
+    """The description's FIRST LINE must be conventional-commit (#1367).
+
+    The GitLab ``validate_mr_title_and_description`` CI gate parses the
+    LITERAL first line of the description and rejects anything not in
+    conventional-commit form — it does NOT fall back to the MR title. A
+    description starting with ``## Summary`` / ``## What`` passes the title
+    and What/Why checks yet still reds the pipeline. The client-side gate
+    must encode the SAME first-line rule so the validator round-trip is
+    eliminated.
+    """
+
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "## Summary\nAdds the gate.\n\n## Why\nThe convention is missed often.",
+            "## What\nthe change\n\n## Why\nthe reason",
+            "What: the change\nWhy: the reason",
+            "Some preamble.\n\n## What\nbody",
+        ],
+    )
+    def test_non_conventional_first_line_rejected(self, description: str) -> None:
+        errors = validate_mr_metadata("feat(ship): ok", description, DEFAULT_MR_TITLE_REGEX)
+        assert any("first line" in err.lower() for err in errors)
+
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "feat(ship): add the gate (#1367)\n\n## What\nthe change\n\n## Why\nthe reason",
+            "fix: correct the off-by-one\n\n## What\nbody",
+        ],
+    )
+    def test_conventional_first_line_passes(self, description: str) -> None:
+        assert validate_mr_metadata("feat(ship): ok", description, DEFAULT_MR_TITLE_REGEX) == []
+
+    def test_first_line_must_match_overlay_regex(self) -> None:
+        custom = r"^(feat|fix): .+"
+        rejected = validate_mr_metadata("feat: ok", "chore: nope\n\n## What\nbody", custom)
+        assert any("first line" in err.lower() for err in rejected)
+
+
+def test_all_failures_surface_together() -> None:
     errors = validate_mr_metadata("bad title", "no headers here", DEFAULT_MR_TITLE_REGEX)
-    assert len(errors) == 2
+    assert len(errors) == 3
+    assert any("title" in err.lower() and "first line" not in err.lower() for err in errors)
+    assert any("first line" in err.lower() for err in errors)
+    assert any("What" in err and "Why" in err for err in errors)

--- a/tests/teatree_core/test_overlay.py
+++ b/tests/teatree_core/test_overlay.py
@@ -129,11 +129,12 @@ class TestOverlayBase(TestCase):
             assert overlay.get_symlinks(worktree) == []
             assert overlay.get_services_config(worktree) == {}
             assert overlay.uses_redis() is False
-            # #1540: the default gate accepts a conforming title + What/Why body.
-            assert overlay.metadata.validate_pr("feat(ship): add the gate (#1540)", "## What\nx\n\n## Why\ny") == {
-                "errors": [],
-                "warnings": [],
-            }
+            # #1540/#1367: default gate accepts a conforming title, a
+            # conventional-commit description first line, and a What/Why body.
+            assert overlay.metadata.validate_pr(
+                "feat(ship): add the gate (#1540)",
+                "feat(ship): add the gate (#1540)\n\n## What\nx\n\n## Why\ny",
+            ) == {"errors": [], "warnings": []}
             assert overlay.metadata.get_skill_metadata() == {}
 
     def test_abstract_fallthroughs_raise_not_implemented(self) -> None:

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -385,7 +385,7 @@ class TestValidateMrCommand:
             "import sys\n"
             "from teatree.cli import main\n"
             "sys.argv = ['t3', 'tool', 'validate-mr', '--title', 'feat: x (#1)', "
-            "'--description', '## What\\nx\\n\\n## Why\\ny']\n"
+            "'--description', 'feat: x (#1)\\n\\n## What\\nx\\n\\n## Why\\ny']\n"
             "main()\n"
         )
         env = {k: v for k, v in os.environ.items() if k != "DJANGO_SETTINGS_MODULE"}

--- a/tests/test_contrib_overlay.py
+++ b/tests/test_contrib_overlay.py
@@ -532,12 +532,13 @@ class TestOverlayDefaults(TestCase):
         assert overlay.get_post_db_steps(worktree) == []
         assert overlay.get_symlinks(worktree) == []
         assert overlay.get_services_config(worktree) == {}
-        # #1540: the default gate is inherited by the teatree overlay — a
-        # conforming title + What/Why body passes with no errors.
-        assert overlay.metadata.validate_pr("feat(ship): add the gate (#1540)", "## What\nx\n\n## Why\ny") == {
-            "errors": [],
-            "warnings": [],
-        }
+        # #1540/#1367: the default gate is inherited by the teatree overlay —
+        # a conforming title, a conventional-commit description first line, and
+        # a What/Why body passes with no errors.
+        assert overlay.metadata.validate_pr(
+            "feat(ship): add the gate (#1540)",
+            "feat(ship): add the gate (#1540)\n\n## What\nx\n\n## Why\ny",
+        ) == {"errors": [], "warnings": []}
         assert overlay.metadata.get_ci_project_path() == ""
         assert overlay.metadata.get_e2e_config() == {}
         assert overlay.metadata.detect_variant() == ""

--- a/tests/test_overlay_base.py
+++ b/tests/test_overlay_base.py
@@ -151,16 +151,16 @@ def test_validate_pr_passes_conforming_title_and_what_why_description():
     overlay = _MinimalOverlay()
     result = overlay.metadata.validate_pr(
         "feat(ship): add the gate (#1540)",
-        "## What\nAdds the gate.\n\n## Why\nThe convention is missed.",
+        "feat(ship): add the gate (#1540)\n\n## What\nAdds the gate.\n\n## Why\nThe convention is missed.",
     )
     assert result == {"errors": [], "warnings": []}
 
 
-def test_validate_pr_rejects_non_conforming_title_and_missing_what_why():
+def test_validate_pr_rejects_non_conforming_title_first_line_and_missing_what_why():
     overlay = _MinimalOverlay()
     result = overlay.metadata.validate_pr("Add the gate", "no headers here")
     assert result["warnings"] == []
-    assert len(result["errors"]) == 2
+    assert len(result["errors"]) == 3
 
 
 def test_get_followup_repos_returns_empty_list():


### PR DESCRIPTION
fix(ship): validate MR description first line client-side (#1367)

## What

`validate_mr_metadata` (the single deterministic chokepoint behind `OverlayMetadata.validate_pr`, the `t3 tool validate-mr` CLI, and the PreToolUse `glab mr create/update` hook) now also rejects a description whose FIRST LINE is not conventional-commit. Previously it only checked the title against `mr_title_regex` and that the description carried a What/Why header somewhere — the first line was never validated.

## Why

The GitLab `validate_mr_title_and_description` CI gate parses the literal first line of the MR description and never falls back to the title. A description opening with `## Summary` (or `## What`) passed teatree's client-side gate yet red the pipeline — the !394/!395/!7485 occurrences described in #1367. Encoding the gate's own rule at the existing chokepoint rejects the bad first line client-side, eliminating the validator-CI round-trip.

## How

- `src/teatree/core/mr_metadata.py`: add the first-line check against the same `title_regex`, plus `expected_first_line_format` naming the canonical fix (prepend the title as line 1). Empty-description still short-circuits.
- The fix lands at the one chokepoint, so it propagates automatically to `pr create`, `mr update`, REST-API MR/PR writes, and the retroactive `t3 tool validate-mr` lint — no new per-call-site command (maintainability / chokepoint bar).
- The auto-generated ship path is unaffected: `ship_preview` already builds the description as `<title>\n\n<body>`, so its first line is the conventional title by construction.
- Docs (`docs/overlay-api.md`) and existing fixtures updated to the canonical `<conventional first line>\n\n<What/Why body>` shape.

## Test

- `tests/teatree_core/test_mr_metadata.py::TestDescriptionFirstLineConventionalCommit` — new RED-first coverage: `## Summary` / `## What` / `What:` first lines rejected, conventional first lines pass, honours the per-overlay regex.
- Reconciled the existing overlay/CLI/pr-command suites to canonical descriptions.

Closes #1367
