### PR TITLE
fix(slack): resolve shared message ts on the audio-attach DM path (#2054)

### DIFF
--- a/src/teatree/backends/slack/bot.py
+++ b/src/teatree/backends/slack/bot.py
@@ -59,6 +59,7 @@ from teatree.backends.slack.token_validation import (
     assert_user_token,
     resolve_user_token_or_degrade,
 )
+from teatree.backends.slack.upload_response import shared_message_ts
 from teatree.backends.slack.voice_classifier import ClassifierMode as VoiceClassifierMode
 from teatree.backends.slack.voice_classifier import SlackVoiceMismatchError, VoiceTokenGate
 from teatree.types import RawAPIDict, ScannerError
@@ -743,12 +744,10 @@ class SlackBotBackend:
         payload: RawAPIDict = {"files": [file_entry], "channel_id": channel, "initial_comment": text}
         if thread_ts:
             payload["thread_ts"] = thread_ts
-        return self._post(
-            "files.completeUploadExternal",
-            payload,
-            token=token,
-            idempotent=False,
-        )
+        body = self._post("files.completeUploadExternal", payload, token=token, idempotent=False)
+        if shared_ts := shared_message_ts(body, channel=channel):
+            body["ts"] = shared_ts
+        return body
 
     def get_reactions(self, *, channel: str, ts: str) -> list[str]:
         """Return the emoji names currently set on a message."""

--- a/src/teatree/backends/slack/upload_response.py
+++ b/src/teatree/backends/slack/upload_response.py
@@ -1,0 +1,47 @@
+"""Parse the ``files.completeUploadExternal`` response (#2054).
+
+``files.completeUploadExternal`` returns file objects, not the chat
+message ``ts`` a ``chat.postMessage`` does. The shared message's ``ts``
+lives under the first file's ``shares.private`` / ``shares.public`` entry
+for the target channel. Resolving it here lets
+:meth:`~teatree.backends.slack.bot.SlackBotBackend.post_audio_dm` keep the
+same ``{"ok": ..., "ts": ...}`` evidence-pointer convention every text
+post returns, so no caller has to special-case the audio-attach path.
+
+Kept separate from the backend transport (mirrors ``scopes.py`` /
+``token_policy.py``) so the response-shape knowledge has one home.
+"""
+
+from typing import cast
+
+from teatree.types import RawAPIDict
+
+_SHARE_VISIBILITIES = ("private", "public")
+
+
+def shared_message_ts(body: RawAPIDict, *, channel: str) -> str:
+    """The ``ts`` of the message ``completeUploadExternal`` shared into *channel*.
+
+    Empty string when no ``shares`` entry for *channel* carries a ``ts``.
+    """
+    files = body.get("files")
+    if not isinstance(files, list):
+        return ""
+    for raw_file in files:
+        if not isinstance(raw_file, dict):
+            continue
+        shares = cast("RawAPIDict", raw_file).get("shares")
+        if not isinstance(shares, dict):
+            continue
+        for visibility in _SHARE_VISIBILITIES:
+            scope = cast("RawAPIDict", shares).get(visibility)
+            if not isinstance(scope, dict):
+                continue
+            entries = cast("RawAPIDict", scope).get(channel)
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                ts = cast("RawAPIDict", entry).get("ts") if isinstance(entry, dict) else None
+                if isinstance(ts, str):
+                    return ts
+    return ""

--- a/tests/teatree_backends/test_slack_upload_audio.py
+++ b/tests/teatree_backends/test_slack_upload_audio.py
@@ -173,6 +173,63 @@ class TestPostAudioDm:
         _backend().post_audio_dm(channel=_SELF_DM, filepath=str(audio_file), text="hi")
         assert complete_payloads[0]["files"] == [{"id": "F1"}]
 
+    @pytest.mark.parametrize("visibility", ["private", "public"])
+    def test_resolves_shared_message_ts_from_file_shares(
+        self,
+        audio_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        visibility: str,
+    ) -> None:
+        complete_body = {
+            "ok": True,
+            "files": [
+                {
+                    "id": "F123",
+                    "shares": {visibility: {_SELF_DM: [{"ts": "1717689600.001900"}]}},
+                }
+            ],
+        }
+
+        def fake_get(url: str, **kwargs: object) -> httpx.Response:
+            body = {"ok": True, "upload_url": "https://files.slack/u", "file_id": "F123"}
+            return httpx.Response(200, json=body, request=httpx.Request("GET", url))
+
+        def fake_post(url: str, **kwargs: object) -> httpx.Response:
+            if _API_HOST not in url:
+                return httpx.Response(200, request=httpx.Request("POST", url))
+            return httpx.Response(200, json=complete_body, request=httpx.Request("POST", url))
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+        monkeypatch.setattr(httpx, "post", fake_post)
+
+        result = _backend().post_audio_dm(channel=_SELF_DM, filepath=str(audio_file), text="hi")
+        assert result["ts"] == "1717689600.001900"
+
+    def test_no_ts_when_shares_missing_the_channel(
+        self,
+        audio_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        complete_body = {
+            "ok": True,
+            "files": [{"id": "F123", "shares": {"private": {"D_OTHER": [{"ts": "1.0"}]}}}],
+        }
+
+        def fake_get(url: str, **kwargs: object) -> httpx.Response:
+            body = {"ok": True, "upload_url": "https://files.slack/u", "file_id": "F123"}
+            return httpx.Response(200, json=body, request=httpx.Request("GET", url))
+
+        def fake_post(url: str, **kwargs: object) -> httpx.Response:
+            if _API_HOST not in url:
+                return httpx.Response(200, request=httpx.Request("POST", url))
+            return httpx.Response(200, json=complete_body, request=httpx.Request("POST", url))
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+        monkeypatch.setattr(httpx, "post", fake_post)
+
+        result = _backend().post_audio_dm(channel=_SELF_DM, filepath=str(audio_file), text="hi")
+        assert result.get("ts", "") == ""
+
 
 class TestPostExternal:
     def test_posts_bytes_untokened_and_returns_status(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/teatree_backends/test_upload_response.py
+++ b/tests/teatree_backends/test_upload_response.py
@@ -1,0 +1,56 @@
+"""``shared_message_ts`` — parsing the ``completeUploadExternal`` body (#2054).
+
+The resolve-from-``shares`` happy paths (private/public, missing channel)
+are covered end-to-end through the real backend in
+``test_slack_upload_audio.py``; these cover the malformed-shape edges the
+parser must tolerate without raising.
+"""
+
+import pytest
+
+from teatree.backends.slack.upload_response import shared_message_ts
+
+_CHANNEL = "D_SELF"
+
+
+class TestSharedMessageTs:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},
+            {"ok": True},
+            {"files": "not-a-list"},
+            {"files": ["not-a-dict"]},
+            {"files": [{"id": "F1"}]},
+            {"files": [{"id": "F1", "shares": "not-a-dict"}]},
+            {"files": [{"id": "F1", "shares": {"private": "not-a-dict"}}]},
+            {"files": [{"id": "F1", "shares": {"private": {_CHANNEL: "not-a-list"}}}]},
+            {"files": [{"id": "F1", "shares": {"private": {_CHANNEL: ["not-a-dict"]}}}]},
+            {"files": [{"id": "F1", "shares": {"private": {_CHANNEL: [{"no_ts": "x"}]}}}]},
+            {"files": [{"id": "F1", "shares": {"private": {_CHANNEL: [{"ts": 123}]}}}]},
+        ],
+    )
+    def test_empty_on_missing_or_malformed_shape(self, body: dict[str, object]) -> None:
+        assert shared_message_ts(body, channel=_CHANNEL) == ""
+
+    def test_first_matching_entry_wins(self) -> None:
+        body = {
+            "files": [
+                {"id": "F1", "shares": {"private": {_CHANNEL: [{"ts": "1.0"}, {"ts": "2.0"}]}}},
+            ]
+        }
+        assert shared_message_ts(body, channel=_CHANNEL) == "1.0"
+
+    def test_private_preferred_over_public(self) -> None:
+        body = {
+            "files": [
+                {
+                    "id": "F1",
+                    "shares": {
+                        "public": {_CHANNEL: [{"ts": "9.0"}]},
+                        "private": {_CHANNEL: [{"ts": "1.0"}]},
+                    },
+                }
+            ]
+        }
+        assert shared_message_ts(body, channel=_CHANNEL) == "1.0"

--- a/tests/teatree_core/management_commands/test_notify_post_speaks.py
+++ b/tests/teatree_core/management_commands/test_notify_post_speaks.py
@@ -26,6 +26,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+import httpx
 import pytest
 from django.core.management import call_command
 
@@ -67,6 +68,15 @@ def _call(*args: str) -> int:
     except SystemExit as exc:
         return int(exc.code or 0)
     return 0
+
+
+def _call_capturing(*args: str) -> tuple[int, str]:
+    out, err = StringIO(), StringIO()
+    try:
+        call_command(*args, stdout=out, stderr=err)
+    except SystemExit as exc:
+        return int(exc.code or 0), out.getvalue()
+    return 0, out.getvalue()
 
 
 def _wait_for(marker: Path, timeout: float = 3.0) -> None:
@@ -134,6 +144,52 @@ class TestNotifyPostSpeaks:
 
         time.sleep(0.5)
         assert not marker.exists(), "a colleague-surface post must not be read aloud to the user"
+
+    def test_self_dm_audio_post_success_line_carries_resolved_ts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        say = bin_dir / "say"
+        say.write_text('#!/bin/sh\n: > "$2"\nexit 0\n')
+        afconvert = bin_dir / "afconvert"
+        afconvert.write_text('#!/bin/sh\neval "out=\\${$#}"\n: > "$out"\nexit 0\n')
+        for fake in (say, afconvert):
+            fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+
+        complete_body = {
+            "ok": True,
+            "files": [{"id": "F1", "shares": {"private": {_DM_CHANNEL: [{"ts": "1717689600.001900"}]}}}],
+        }
+
+        def fake_get(url: str, **kwargs: object) -> httpx.Response:
+            body = {"ok": True, "upload_url": "https://files.slack/u", "file_id": "F1"}
+            return httpx.Response(200, json=body, request=httpx.Request("GET", url))
+
+        def fake_post(url: str, **kwargs: object) -> httpx.Response:
+            if "slack.com/api" not in url:
+                return httpx.Response(200, request=httpx.Request("POST", url))
+            return httpx.Response(200, json=complete_body, request=httpx.Request("POST", url))
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+        monkeypatch.setattr(httpx, "post", fake_post)
+
+        backend = _backend()
+        with (
+            patch(
+                "teatree.core.management.commands.notify.messaging_from_overlay",
+                lambda *_a, **_k: backend,
+            ),
+            patch(
+                "teatree.core.speak.get_effective_settings",
+                lambda *_a, **_k: _settings(SpeakConfig(slack=True)),
+            ),
+        ):
+            code, out = _call_capturing("notify", "post", "--channel", _DM_CHANNEL, "--text", "tests are green")
+
+        assert code == 0
+        assert "ts=1717689600.001900" in out
 
     def test_self_dm_post_silent_under_speak_off(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         bin_dir = tmp_path / "bin"


### PR DESCRIPTION
## Problem

When `t3 <overlay> notify post` rides the audio-attach path
(`files.completeUploadExternal` with `initial_comment`), the success line
reported an empty message ts, while the plain-text path reports the real
message ts. `files.completeUploadExternal` returns file objects, not the
chat message ts that `chat.postMessage` returns, so the audio DM body had
no top-level ts and every caller's ts evidence pointer came back blank.

## Root cause

`SlackBotBackend.post_audio_dm` returned the raw
`files.completeUploadExternal` body verbatim. That body carries the shared
message ts only under the first file's `shares.private` / `shares.public`
entry for the channel, never as a top-level `ts`, so the
`{"ok": ..., "ts": ...}` convention the success line and delivery rows
rely on was silently broken on the audio path.

## Fix

Resolve the shared message ts from the file's `shares` entry for the
channel inside `post_audio_dm` (the one method that owns the
`completeUploadExternal` call) and set it on the returned body. All
callers keep reading `body["ts"]` exactly as for a text post, so the
empty-ts bug class on the audio path cannot recur.

The parsing lives in a new `slack/upload_response.py` (mirrors
`scopes.py` / `token_policy.py`) so the response-shape knowledge has one
home and `bot.py` stays within its module-health cap.

## Tests

- Backend integration (real `post_audio_dm`, only httpx mocked):
  resolves the shared message ts from `shares.private` and
  `shares.public`; no ts when the channel is absent from `shares`.
- CLI integration (`notify post` self-DM audio path end-to-end): the
  success line now carries the resolved ts. Observed RED on current
  behavior (empty ts) before the fix, GREEN after.
- Pure-parser edge cases for malformed `completeUploadExternal` shapes.

Closes #2054
