### PR TITLE
test(slack-answer): pin the thread-reply :eyes: receipt end-to-end (#1366)

### DIFF
--- a/tests/integration/slack_bridge_e2e/test_thread_reply_eyes_reaction.py
+++ b/tests/integration/slack_bridge_e2e/test_thread_reply_eyes_reaction.py
@@ -1,0 +1,76 @@
+"""Thread-reply :eyes: receipt end-to-end (#1366).
+
+The inbound-to-reactive chain for a user message that arrives as a Slack
+*thread reply* (not a top-level DM): the bot posts a top-level message,
+the user replies in-thread, and the reactive Slack-answer loop must stamp
+the same :eyes: receipt it stamps on a top-level DM. The whole chain runs
+unmodified — real ``SlackBotBackend.fetch_dms`` (with the
+``conversations.replies`` fan-out), real ``SlackDmInboundScanner``, real
+``PendingChatInjection`` rows, real ``run_slack_answer_cycle`` — with only
+the ``httpx`` network faked. The load-bearing assertion is that
+``reactions.add`` is called on the *thread reply's* ``ts``, not the thread
+root's.
+"""
+
+import pytest
+
+from teatree.backends.slack.bot import SlackBotBackend
+from teatree.core.models import PendingChatInjection
+from teatree.loop.scanners.slack_dm_inbound import SlackDmInboundScanner
+from teatree.loop.slack_answer.cycle import run_slack_answer_cycle
+from tests.integration.slack_bridge_e2e.conftest import FakeSlackTransport
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+_ROOT_TS = "1700000000.0001"
+_REPLY_TS = "1700000000.0002"
+
+
+class TestThreadReplyEyesReaction:
+    """User replies in-thread to a bot DM → loop reacts :eyes: on the reply.
+
+    The thread root is the bot's own top-level message; the user's reply
+    carries its own ``ts``. The reactive cycle must react on the reply's
+    ``ts`` exactly as it does for a top-level DM — the gap reported in
+    #1366 was the :eyes: receipt never landing on thread replies.
+    """
+
+    def _seed_thread_reply(self, transport: FakeSlackTransport) -> SlackBotBackend:
+        transport.default_responses["conversations.history"] = {
+            "ok": True,
+            "messages": [
+                {
+                    "ts": _ROOT_TS,
+                    "thread_ts": _ROOT_TS,
+                    "user": "B_BOT",
+                    "text": "bot top-level notify",
+                },
+            ],
+        }
+        transport.default_responses["conversations.replies"] = {
+            "ok": True,
+            "messages": [
+                {"ts": _ROOT_TS, "user": "B_BOT", "text": "bot top-level notify"},
+                {"ts": _REPLY_TS, "thread_ts": _ROOT_TS, "user": "U_HUMAN", "text": "thanks"},
+            ],
+        }
+        return SlackBotBackend(bot_token="xoxb-bot", user_id="U_HUMAN")
+
+    def test_reactions_add_called_on_thread_reply_ts(self, transport: FakeSlackTransport) -> None:
+        backend = self._seed_thread_reply(transport)
+        SlackDmInboundScanner(backend=backend, overlay="demo").scan()
+
+        run_slack_answer_cycle(messaging_resolver=lambda _overlay: backend)
+
+        eyes_calls = [c for c in transport.calls_to("reactions.add") if c.payload.get("name") == "eyes"]
+        reacted_ts = [c.payload.get("timestamp") for c in eyes_calls]
+        assert reacted_ts == [_REPLY_TS]
+
+    def test_thread_reply_row_marked_eyes_reacted(self, transport: FakeSlackTransport) -> None:
+        backend = self._seed_thread_reply(transport)
+        SlackDmInboundScanner(backend=backend, overlay="demo").scan()
+
+        run_slack_answer_cycle(messaging_resolver=lambda _overlay: backend)
+
+        reply_row = PendingChatInjection.objects.get(slack_ts=_REPLY_TS)
+        assert reply_row.eyes_reacted_at is not None


### PR DESCRIPTION
## Summary

Issue #1366 reported two gaps from 2026-05-27:
- (a) the :eyes: receipt not firing on user *thread replies* in bot DM channels, and
- (b) no `t3 <overlay> react` CLI (forcing raw `curl` against `reactions.add`).

On reading current `main`, both are already implemented:

- **(a)** The reactive Slack-answer loop (#1014 / #1075) reacts :eyes: on **every** `PendingChatInjection` row, with no top-level-vs-thread distinction (`run_slack_answer_cycle._react_eyes_once` iterates `unit.rows` and reacts on each `row.slack_ts`). The backend's `conversations.replies` fan-out (#1044 / #1046) is what surfaces thread replies to the scanner in the first place, so a thread reply becomes a row and the loop reacts on it.
- **(b)** `t3 <overlay> notify react --channel … --ts … --emoji …` exists (#1750), routing the reaction by destination through `SlackBotBackend.react_routed` (self-DM → bot, colleague/channel → xoxp). Smoke coverage lives in `tests/teatree_core/management_commands/test_notify_post_react.py::TestNotifyReact` (exit 0, colon stripping, missing-scope remediation, no-backend, empty-emoji).

## The actual gap this PR closes

The two halves of the chain were covered **separately** — the scanner records a thread reply (`test_inbound::test_thread_reply_lands_as_pending_chat_injection_row`) and the cycle reacts on a row (`test_cycle::TestEyesReaction`) — but **no test joined the seam**: a user replying in-thread → scanner row → `run_slack_answer_cycle` → `reactions.add` on the *reply's own* ts. That is exactly the regression #1366 describes (part c: "scanner fixture with thread reply → tick → assert reactions.add called").

This PR adds that end-to-end regression in `tests/integration/slack_bridge_e2e/test_thread_reply_eyes_reaction.py`. It runs the real `SlackBotBackend.fetch_dms` (with the replies fan-out), the real `SlackDmInboundScanner`, real `PendingChatInjection` rows, and the real `run_slack_answer_cycle`, faking only the `httpx` Slack boundary, and asserts `reactions.add` is called with `name=eyes` on the **thread reply's** ts (`1700000000.0002`), not the thread root's.

## Anti-vacuous evidence (RED-on-regression)

Stubbing out the `backend.react(...)` call in `_react_eyes_once` turns the new test RED:

```
AssertionError: assert [] == ['1700000000.0002']
```

Restoring it returns the test to green. The production code is unchanged; the diff is the test only.

## Gates

- `uv run pytest --no-cov` over the affected suites (`slack_bridge_e2e`, `slack_answer`, `test_slack_dm_inbound`, `test_notify_post_react`): 201 passed.
- `uv run ruff check`, `uv run tach check`, `uv run ty check`: all green.
- `prek run` over the staged file: all hooks pass.

Sibling-safe: does not touch the #1321 own-MR-broadcast scanner filter or the #1361 silent-tick path.

Closes #1366
