### PR TITLE
fix(workspace): reconcile renamed branch before pre-push ship gates (#1587)

### DIFF
--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -57,7 +57,7 @@ from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.phases import normalize_phase
 from teatree.core.public_identity import MergeResult
-from teatree.core.runners.ship import resolve_ship_worktree
+from teatree.core.runners.ship import resolve_and_reconcile_branch, resolve_ship_worktree
 from teatree.types import RawAPIDict
 from teatree.utils import git
 
@@ -252,22 +252,26 @@ class Command(TyperCommand):
             # pr_urls / visual_qa).
             ticket.merge_extra(set_keys={"ship_invoking_branch": invoking_branch})
 
+        # #1587: reconcile the recorded branch to the worktree's ACTUAL git
+        # branch BEFORE any gate reads `worktree.branch` — the single chokepoint
+        # shared with `ShipExecutor` so a renamed branch can no longer reach a
+        # gate range query that fails fail-soft.
+        ship_worktree = resolve_ship_worktree(ticket, cast("TicketExtra", ticket.extra or {})) or worktree
+        repo_path = (ship_worktree.extra or {}).get("worktree_path", "") or ship_worktree.repo_path
+        if repo_path:
+            resolve_and_reconcile_branch(ticket, ship_worktree, repo_path)
+
         # #788: refuse a hollow ship — the branch ShipExecutor will
         # actually push (the #776/#800 canonical resolver, so the check
         # matches what is shipped) must have ≥1 commit ahead of base.
         # Placed before BOTH the gate and the --skip-validation
         # reconcile so no path can advance the FSM to a hollow SHIPPED.
-        # `resolve_ship_worktree` cannot be None here — the
-        # WorktreeMissingError check above guarantees a worktree (it
-        # falls back to that same `worktrees.first()`).
-        no_commits = _assert_commits_ahead_of_base(
-            resolve_ship_worktree(ticket, cast("TicketExtra", ticket.extra or {})) or worktree
-        )
+        no_commits = _assert_commits_ahead_of_base(ship_worktree)
         if no_commits is not None:
             return no_commits
 
         if not skip_validation:
-            gate_failure = _run_ship_gates(ticket, worktree, skip_visual_qa=skip_visual_qa)
+            gate_failure = _run_ship_gates(ticket, ship_worktree, skip_visual_qa=skip_visual_qa)
             if gate_failure is not None:
                 return gate_failure
         else:
@@ -282,11 +286,11 @@ class Command(TyperCommand):
             # not slip onto GitLab via the bypass; only the explicit
             # --skip-mr-format-check opt-in disables the format check too.
             if not skip_mr_format_check:
-                format_error = validate_pr_metadata(ticket, worktree)
+                format_error = validate_pr_metadata(ticket, ship_worktree)
                 if format_error is not None:
                     return format_error
 
-        return _dispatch_ship(ticket, worktree, title=title, dry_run=dry_run, sync=sync)
+        return _dispatch_ship(ticket, ship_worktree, title=title, dry_run=dry_run, sync=sync)
 
     @command(name="ensure-pr")
     def ensure_pr(

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -107,6 +107,57 @@ def resolve_ship_worktree(ticket: "Ticket", extra: "TicketExtra") -> "Worktree |
     return ticket.worktrees.first()  # ty: ignore[unresolved-attribute]
 
 
+def resolve_and_reconcile_branch(ticket: "Ticket", worktree: "Worktree", repo_path: str) -> str:
+    """Return the worktree's actual git branch, reconciling the DB to it.
+
+    #1519: ``Worktree.branch`` is minted as ``<N>-ticket`` and the agent
+    renames the real git branch to ``<N>-<type>-<desc>``. Every branch-range
+    consumer must read what exists, so read ``git rev-parse --abbrev-ref HEAD``
+    in the worktree dir and adopt it — but only when it is a real branch that
+    belongs to this ticket. A detached ``HEAD`` or an unrelated branch (not
+    prefixed ``<ticket_id>-``) falls back to the recorded branch and logs a
+    WARNING, never silently adopting an unrelated ref.
+
+    On a genuine drift the recorded ``Worktree.branch`` (and the ticket-level
+    ``extra['branch']`` when it matched the old name) are updated to the current
+    branch so every later reader — the pre-push gates (#1587), the ship
+    executor, the merge path, ``_recorded_url_for_branch``, the provisioner —
+    sees the same branch. This is the single reconcile chokepoint: callers run
+    it BEFORE reading ``worktree.branch`` so the stale ``<N>-ticket`` ref can no
+    longer reach a ``git`` range query that fails fail-soft (#1587). Idempotent:
+    once reconciled, a second call resolves the same current branch with no
+    further write.
+    """
+    recorded = worktree.branch
+    current = git.current_branch(repo=repo_path)
+    prefix = f"{ticket.ticket_number}-"
+    if not current or current == "HEAD" or not current.startswith(prefix):
+        if current and current != recorded:
+            logger.warning(
+                "Ship branch resolution for ticket %s: worktree at %s is on %r "
+                "(detached or not prefixed %r) — falling back to recorded branch %r",
+                ticket.ticket_number,
+                repo_path,
+                current,
+                prefix,
+                recorded,
+            )
+        return recorded
+    if current != recorded:
+        logger.info(
+            "Ship reconciling ticket %s worktree branch %r → %r (renamed in the worktree)",
+            ticket.ticket_number,
+            recorded,
+            current,
+        )
+        worktree.branch = current
+        worktree.save(update_fields=["branch"])
+        extra = ticket.extra or {}
+        if extra.get("branch") == recorded:
+            ticket.merge_extra(set_keys={"branch": current})
+    return current
+
+
 class ShipExecutor(RunnerBase):
     """Push the worktree branch and open the pull request.
 
@@ -138,7 +189,7 @@ class ShipExecutor(RunnerBase):
         # stale DB rows so the worktree↔branch mapping stops desyncing.
         # (Minting the convention name upfront — option 1 — is a separate
         # design decision deliberately left out of this fix.)
-        branch = self._resolve_and_reconcile_branch(ticket, worktree, repo_path)
+        branch = resolve_and_reconcile_branch(ticket, worktree, repo_path)
 
         # #1263: short-circuit only when THIS branch already has a PR.
         # The legacy truthiness check fired on any prior ``pr_urls`` entry,
@@ -192,55 +243,6 @@ class ShipExecutor(RunnerBase):
         if host is None:
             return RunnerResult(ok=False, detail="no code host configured")
         return host
-
-    @staticmethod
-    def _resolve_and_reconcile_branch(ticket: "Ticket", worktree: "Worktree", repo_path: str) -> str:
-        """Return the worktree's actual git branch, reconciling the DB to it.
-
-        #1519: ``Worktree.branch`` is minted as ``<N>-ticket`` and the agent
-        renames the real git branch to ``<N>-<type>-<desc>``. Ship must push
-        what exists, so read ``git rev-parse --abbrev-ref HEAD`` in the
-        worktree dir and adopt it — but only when it is a real branch that
-        belongs to this ticket. A detached ``HEAD`` or an unrelated branch
-        (not prefixed ``<ticket_id>-``) falls back to the recorded branch
-        and logs a WARNING, never silently pushing an unrelated ref.
-
-        On a genuine drift the recorded ``Worktree.branch`` (and the
-        ticket-level ``extra['branch']`` when it matched the old name) are
-        updated to the current branch so every later reader — the merge
-        path, ``_recorded_url_for_branch``, the provisioner — sees the same
-        branch. Reconciling BEFORE the recorded-url lookup keeps the #1522
-        idempotency intact: a redelivered job resolves the same current
-        branch and finds the url recorded under it.
-        """
-        recorded = worktree.branch
-        current = git.current_branch(repo=repo_path)
-        prefix = f"{ticket.ticket_number}-"
-        if not current or current == "HEAD" or not current.startswith(prefix):
-            if current and current != recorded:
-                logger.warning(
-                    "Ship branch resolution for ticket %s: worktree at %s is on %r "
-                    "(detached or not prefixed %r) — falling back to recorded branch %r",
-                    ticket.ticket_number,
-                    repo_path,
-                    current,
-                    prefix,
-                    recorded,
-                )
-            return recorded
-        if current != recorded:
-            logger.info(
-                "Ship reconciling ticket %s worktree branch %r → %r (renamed in the worktree)",
-                ticket.ticket_number,
-                recorded,
-                current,
-            )
-            worktree.branch = current
-            worktree.save(update_fields=["branch"])
-            extra = ticket.extra or {}
-            if extra.get("branch") == recorded:
-                ticket.merge_extra(set_keys={"branch": current})
-        return current
 
     def _open_pr_and_record(
         self,

--- a/tests/teatree_core/pr_command/test_create_branch_currency.py
+++ b/tests/teatree_core/pr_command/test_create_branch_currency.py
@@ -212,3 +212,66 @@ class TestPrCreateBranchCurrency(TestCase):
         assert _git(clone, "rev-parse", "HEAD") == pre_sha
         ticket.refresh_from_db()
         assert "branch_currency_post_merge_sha" not in (ticket.extra or {})
+
+
+class TestPrCreateGatesReconcileRenamedBranch(TestCase):
+    """#1587: gates evaluate against the branch that actually exists.
+
+    `workspace ticket <N>` mints `Worktree.branch` as `<N>-ticket`; the agent
+    renames the git branch to the `<N>-fix-...` convention. The pre-push gates
+    read the stale recorded ref, so each gate's `origin/main..<stale>` range
+    query failed and was caught fail-soft — silently skipping its check rather
+    than evaluating the real branch. `pr create` now reconciles the recorded
+    branch to the worktree's actual git branch BEFORE the gates run, so the
+    currency gate evaluates (and its auto-merge lands) instead of skipping.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _inject_tmp(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+
+    def _ticket_with_renamed_branch(self) -> tuple[Ticket, Path, str]:
+        clone, _bare, real_branch = _make_stale_feature_worktree(self.tmp_path)
+        # The agent renamed the convention-compliant branch; the DB still
+        # records the `<N>-ticket` ref minted at `workspace ticket` time.
+        renamed = "4242-fix-foo"
+        _git(clone, "branch", "-m", real_branch, renamed)
+        ticket = Ticket.objects.create(
+            overlay="test",
+            state=Ticket.State.REVIEWED,
+            issue_url="https://github.com/souliane/teatree/issues/4242",
+        )
+        session = Session.objects.create(ticket=ticket, overlay="test")
+        session.visit_phase("testing")
+        session.visit_phase("reviewing")
+        session.visit_phase("retro")
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path=str(clone),
+            branch="4242-ticket",
+            extra={"worktree_path": str(clone)},
+        )
+        return ticket, clone, renamed
+
+    def test_currency_gate_evaluates_on_renamed_branch(self) -> None:
+        ticket, clone, renamed = self._ticket_with_renamed_branch()
+        pre_sha = _git(clone, "rev-parse", "HEAD")
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command, "_run_visual_qa_gate", return_value=None),
+            patch.object(pr_command, "validate_pr_metadata", return_value=None),
+        ):
+            call_command("pr", "create", str(ticket.id))
+
+        # The currency gate evaluated against the real branch: the auto-merge
+        # landed (HEAD advanced, c.txt reachable, post-merge SHA recorded) —
+        # it did not silently skip on the stale `4242-ticket` ref.
+        post_sha = _git(clone, "rev-parse", "HEAD")
+        assert post_sha != pre_sha
+        assert (clone / "c.txt").exists()
+        ticket.refresh_from_db()
+        assert ticket.extra.get("branch_currency_post_merge_sha") == post_sha
+        # The DB was reconciled to the branch that exists in the worktree.
+        assert ticket.worktrees.get().branch == renamed


### PR DESCRIPTION
## Problem

The pre-push CLI gates in `_ship_gates.py` (branch-currency #940, commits-ahead #788) plus the close-keyword (#1012) and closes-issue (#83) gates read the stale `Worktree.branch`. `workspace ticket <N>` mints that as `<N>-ticket`; the agent then renames the git branch to the `<N>-<type>-<desc>` convention. On a renamed branch the stale ref no longer exists, so each gate's `git` range query (`origin/main..<stale>`) fails and is caught fail-soft — the gate silently skips its range validation instead of evaluating the branch that actually exists.

PR #1586 fixed only the actual `git push` (`ShipExecutor` resolves the real current branch); the pre-push validation coverage stayed silently degraded on a renamed branch.

## Root cause

There was no single reconcile chokepoint — each consumer read `Worktree.branch` independently, and only `ShipExecutor` reconciled it (and only inside its own `run`, after the pre-push gates had already read the stale value).

## Fix (issue option 1)

- Extract `ShipExecutor._resolve_and_reconcile_branch` to a module-level `resolve_and_reconcile_branch` in `runners/ship.py` — single source of truth, idempotent, same belongs-to-this-ticket guard (detached HEAD / unrelated branch fall back to the recorded ref).
- `pr create` calls it **once, before any gate runs**, on the resolved ship worktree, so the currency / commits-ahead / close-keyword / closes-issue gates and the ship path all read the same reconciled branch.
- Unifies the previously-inconsistent worktree resolution between `_assert_commits_ahead_of_base` and `_run_ship_gates` onto one `ship_worktree`.

## Test

`tests/teatree_core/pr_command/test_create_branch_currency.py::TestPrCreateGatesReconcileRenamedBranch::test_currency_gate_evaluates_on_renamed_branch`

Real `git` under `tmp_path`: a branch renamed away from the recorded `<N>-ticket` ref, with `origin/main` advanced. Asserts the currency gate now evaluates (auto-merge lands, HEAD advances, post-merge SHA recorded, DB reconciled) instead of skipping on the stale ref. Verified RED before the fix (HEAD unchanged, ship hollow-passes).

## Verification

- Affected tests green: `tests/teatree_core/pr_command/` + `tests/teatree_core/test_runners_ship.py` + close-keyword / closes-issue gate tests (126 + 31).
- `ruff check`, `ruff format --check`, `tach check`, `ty check`, and full prek gate suite pass (no `--no-verify`).

Closes #1587
