### PR TITLE
test(eval): pin security regressions — private-repo path-segment + banned-terms fail-closed

### DIFF
--- a/src/teatree/eval/README.md
+++ b/src/teatree/eval/README.md
@@ -338,6 +338,8 @@ class, where it is pinned, and the originating fix:
 | blocked sub-agent surfaces a structured block, never silently works around; orchestrator escalates, never swallows | `scenarios/blocked_subagent_escalation.yaml` | [#1915](https://github.com/souliane/teatree/issues/1915) |
 | near-zero-comments — agent does not write a code-restating comment first-try (the worked example of the gate-failure feedback loop) | `skills/code/evals.yaml` (`comment_density_writes_sparse_code`, co-located) | [#2024](https://github.com/souliane/teatree/issues/2024) |
 | skip the bot's OWN TTS audio attachment on Slack read (transcribe the user's voice note, never the bot's own speech.m4a) | `scenarios/skip_own_tts_audio.yaml` | [#2089](https://github.com/souliane/teatree/issues/2089) |
+| private-repo allowlist path-segment match (security — a public slug containing the org as a substring never downgrades) | `regression_corpus` (allowlist resolver) | [#2084](https://github.com/souliane/teatree/pull/2084) |
+| banned-terms scanner fail-closed on a crashing scanner (security — a dead/timed-out scanner blocks, never ALLOW) | `regression_corpus` (`scan_text` crash path) | [#2079](https://github.com/souliane/teatree/pull/2079) |
 
 The on-behalf / answerer-draft, sweep-merge-never-rebase, review-branch-current,
 skill-ref-resolve, and per-phase scenarios (answerer, sweeping-prs, review,

--- a/src/teatree/eval/regression_corpus.py
+++ b/src/teatree/eval/regression_corpus.py
@@ -406,6 +406,58 @@ def _check_account_switch_detect_and_recover() -> bool:
     return unreachable.switched and unreachable.all_reachable is False
 
 
+def _check_private_repo_allowlist_path_segment_match() -> bool:
+    """#1953: the private-repo allowlist matches PATH SEGMENTS, never a substring.
+
+    Pre-fix the allowlist used case-insensitive substring containment, so an
+    allowlisted org name appearing ANYWHERE in a PUBLIC slug (an alias-glued
+    ``<org>-mirror/x`` owner) falsely downgraded it to private — relaxing the
+    public-leak gate on a public surface. The fixed
+    :func:`slug_is_allowlisted_private` (via :func:`slug_namespace_matches`) must:
+    * match the allowlisted ``org/secret`` slug, its path-segment child
+        ``org/secret/sub``, and the bare org ``secretorg`` for its repo, but
+    * NOT match a PUBLIC slug that merely contains the org as a substring of a
+        longer owner segment (``secretorg-mirror/x``).
+    """
+    from teatree.hooks._repo_visibility import slug_is_allowlisted_private  # noqa: PLC0415
+
+    with tempfile.TemporaryDirectory() as raw:
+        cfg = Path(raw) / ".teatree.toml"
+        cfg.write_text('[teatree]\nprivate_repos = ["org/secret", "secretorg"]\n', encoding="utf-8")
+        matches_exact = slug_is_allowlisted_private("org/secret", cfg)
+        matches_path_segment_child = slug_is_allowlisted_private("org/secret/sub", cfg)
+        matches_org_repo = slug_is_allowlisted_private("secretorg/repo", cfg)
+        matches_substring_alias = slug_is_allowlisted_private("secretorg-mirror/x", cfg)
+    return matches_exact and matches_path_segment_child and matches_org_repo and not matches_substring_alias
+
+
+def _check_banned_terms_scanner_fails_closed_on_crash() -> bool:
+    """#1954: the banned-terms scanner FAILS CLOSED when the shell scanner dies.
+
+    Pre-fix a crashing/timed-out scanner read as ``None`` (ALLOW) — a security
+    gate failing open on a crash. The fixed :func:`scan_text` must:
+    * return :data:`SCANNER_UNAVAILABLE_MARKER` (gate BLOCKS) when the shell
+        scanner raises, never ``None``, and
+    * return ``None`` on a genuine no-op (no config / no script to run).
+    """
+    from unittest.mock import patch  # noqa: PLC0415
+
+    from teatree.hooks import banned_terms_scanner  # noqa: PLC0415
+    from teatree.hooks.banned_terms_scanner import SCANNER_UNAVAILABLE_MARKER, scan_text  # noqa: PLC0415
+    from teatree.utils.run import CommandFailedError  # noqa: PLC0415
+
+    def _crashing_scanner(*_args: object, **_kwargs: object) -> object:
+        raise CommandFailedError(cmd=["check-banned-terms.sh"], returncode=2, stdout="", stderr="boom")
+
+    with tempfile.TemporaryDirectory() as raw:
+        cfg = Path(raw) / ".teatree.toml"
+        cfg.write_text('[teatree]\nbanned_terms = ["acmecorp"]\n', encoding="utf-8")
+        with patch.object(banned_terms_scanner, "run_allowed_to_fail", _crashing_scanner):
+            on_crash = scan_text("we ship to acmecorp", config_path=cfg)
+        on_no_config = scan_text("we ship to acmecorp", config_path=Path(raw) / "absent.toml")
+    return on_crash == SCANNER_UNAVAILABLE_MARKER and on_no_config is None
+
+
 _CHECKS: tuple[RegressionCheck, ...] = (
     RegressionCheck(
         failure_class="branch-currency §940 (conflict-only, never behind-only)",
@@ -453,6 +505,18 @@ _CHECKS: tuple[RegressionCheck, ...] = (
         origin="https://github.com/souliane/teatree/issues/1916",
         invariant="a /login switch invalidates the backend cache and re-probes; same account is a no-op",
         predicate=_check_account_switch_detect_and_recover,
+    ),
+    RegressionCheck(
+        failure_class="private-repo allowlist path-segment match (security, #1953)",
+        origin="https://github.com/souliane/teatree/pull/2084",
+        invariant="private_repos matches path segments, not substring; an alias-glued public slug never downgrades",
+        predicate=_check_private_repo_allowlist_path_segment_match,
+    ),
+    RegressionCheck(
+        failure_class="banned-terms scanner fail-closed on crash (security, #1954)",
+        origin="https://github.com/souliane/teatree/pull/2079",
+        invariant="a crashing scanner returns SCANNER_UNAVAILABLE_MARKER (gate blocks), never None; a no-op is None",
+        predicate=_check_banned_terms_scanner_fails_closed_on_crash,
     ),
 )
 

--- a/tests/eval/test_regression_corpus.py
+++ b/tests/eval/test_regression_corpus.py
@@ -23,6 +23,7 @@ from teatree.core import merge as merge_execution
 from teatree.core.models import LoopLease
 from teatree.eval import regression_corpus
 from teatree.eval.regression_corpus import RegressionCheck, _count_core_leaves, run_regression_corpus
+from teatree.hooks import _repo_visibility, banned_terms_scanner
 
 
 def _linear_core_graph() -> MigrationGraph:
@@ -127,6 +128,24 @@ class TestRegressionCorpusAntiVacuous(TestCase):
             report = run_regression_corpus()
         assert not report.ok
         assert any("account-switch" in r.check.failure_class for r in report.failures)
+
+    def test_private_repo_allowlist_check_fails_under_substring_match(self) -> None:
+        def _substring_match(entry: str, slug: str) -> bool:
+            return entry.strip().lower() in slug.strip().lower()
+
+        with patch.object(_repo_visibility, "slug_namespace_matches", _substring_match):
+            report = run_regression_corpus()
+        assert not report.ok
+        assert any("private-repo allowlist" in r.check.failure_class for r in report.failures)
+
+    def test_banned_terms_scanner_check_fails_when_crash_returns_none(self) -> None:
+        def _fail_open(text: str, *, config_path=None) -> None:
+            return None
+
+        with patch.object(banned_terms_scanner, "scan_text", _fail_open):
+            report = run_regression_corpus()
+        assert not report.ok
+        assert any("banned-terms scanner fail-closed" in r.check.failure_class for r in report.failures)
 
     def test_skips_db_checks_when_django_not_configured(self) -> None:
         with patch.object(regression_corpus, "_django_ready", return_value=False):


### PR DESCRIPTION
Pins the two SECURITY bugs fixed this session as deterministic pinned-regression
checks in the corpus (`t3 eval pinned-regressions`), each calling the REAL fixed
function on a must-block + must-allow input, with a matching anti-vacuity test
that drives the corpus RED under the pre-fix behavior. Part of the session
eval-coverage sweep that lands a pinned regression for every bug fixed this
session ("a regression isn't fixed until an anti-vacuous eval lands in the eval
suite").

## Checks added

### 1. private-repo allowlist path-segment match — [#1953](https://github.com/souliane/teatree/issues/1953) ([#2084](https://github.com/souliane/teatree/pull/2084))

Calls the real `slug_is_allowlisted_private` (via `slug_namespace_matches`):

- must-ALLOW: allowlist `["org/secret", "secretorg"]` matches `org/secret`, its
  path-segment child `org/secret/sub`, and the bare-org repo `secretorg/repo`.
- must-BLOCK: a PUBLIC slug that merely contains the org as a substring of a
  longer owner segment (`secretorg-mirror/x`) must NOT downgrade to private —
  the substring false-positive that would relax the public-leak gate.
- Anti-vacuity: `test_private_repo_allowlist_check_fails_under_substring_match`
  monkeypatches `slug_namespace_matches` back to `in`-substring semantics → corpus RED.

### 2. banned-terms scanner fail-closed on crash — [#1954](https://github.com/souliane/teatree/issues/1954) ([#2079](https://github.com/souliane/teatree/pull/2079))

Calls the real `scan_text`:

- must-BLOCK: when the shell scanner crashes / times out / exits non-zero
  (the subprocess runner is patched to raise), `scan_text` returns
  `SCANNER_UNAVAILABLE_MARKER` (gate BLOCKS) — never `None`.
- must-ALLOW: a genuine no-op (no config / no script present) returns `None`.
- Anti-vacuity: `test_banned_terms_scanner_check_fails_when_crash_returns_none`
  stubs `scan_text` to the pre-fix fail-OPEN behavior (`None` on crash) → corpus RED.

Both checks are pure functions (`needs_db=False`). README § "Failure-class
coverage" gains a row per check.

## Verification

- `t3 eval pinned-regressions` → 9 passed, 0 failed, 0 skipped (both new checks GREEN)
- `tests/eval/test_regression_corpus.py` → 14 passed (incl. both new anti-vacuity tests)
- `uv run ruff check`, `uv run ruff format --check`, `uv run tach check`, `uv run ty check` all clean
- prek pre-commit + pre-push (`eval-pinned-regressions`) green (no `--no-verify`)

## Architecture pre-check — eval coverage sweep (#1953 + #1954)

**1. BLUEPRINT § alignment** — Additive to the existing pinned-regressions corpus; README § "Pinned-regressions corpus" / "Failure-class coverage" already specify the add-a-check contract. No BLUEPRINT section change.

**2. FSM phase boundaries** — n/a (no state transition).

**3. Extension-point contracts** — n/a (calls existing public functions; no OverlayBase / scanner-registration / Protocol surface touched).

**4. Component boundaries** — `src/teatree/eval/regression_corpus.py` + sibling test + README row, the same module the six existing checks live in.

**5. Dependency direction** — `teatree.eval` → `teatree.hooks` is a forward edge; `uv run tach check` clean.

**6. Test surface** — one anti-vacuity test per check (substring stand-in; fail-open stub) asserting the corpus reds.

**7. Resilience invariants** — n/a (no external write; crash path exercised by patching the subprocess runner, no network).

**8. Identity and key normalization** — Check 1 itself pins the canonical-key concern: the allowlist must canonicalize on `/`-segment boundaries, not substring.

**9. Behavior preservation / capability deletion** — n/a, purely additive; no existing check/behavior/test removed or inverted; both new checks pin SECURITY invariants.
