### PR TITLE
fix(bootstrap): pin t3 execution tree to T3_REPO, never cwd (#2055)

### DIFF
--- a/skills/workspace/references/troubleshooting.md
+++ b/skills/workspace/references/troubleshooting.md
@@ -236,11 +236,13 @@ See your [issue tracker platform reference](../../platforms/references/) § "Kno
 - **Fix:** Run `t3 setup` from the main clone. Since #434, setup parses the receipt, detects the missing source, and reinstalls via `uv tool install --force --editable <main-clone>`. Safe to run from a worktree too — setup honors `T3_REPO` and resolves worktrees to their main clone.
 - **Prevention:** Avoid running `uv tool install --editable .` directly from a worktree. Go through `t3 setup` instead — it anchors at the main clone by default, so worktree cleanup can't orphan the global install.
 
-## Global `t3` Runs Main Clone Code Even From a Worktree
+## Dogfooding a Worktree's Teatree Source via the Global `t3`
 
-- **Symptom (pre-#434):** Editing `src/teatree/...` inside a worktree never affected the global `t3` — you had to `uv run t3` from the worktree, or reinstall the tool editable-pointed at the worktree.
-- **Fix:** `t3` now auto-selects the teatree source at invocation time via the `t3_bootstrap` entry point. When cwd is inside a directory tree whose `pyproject.toml` names the project `teatree` and ships `src/teatree/__init__.py`, the bootstrap prepends that `src/` to `sys.path` before importing `teatree.cli`. Outside any teatree tree, it falls through to whatever the uv tool install resolved (main clone editable or PyPI libs).
-- **Verify:** `t3 info | grep teatree:` prints the path that was loaded — compare against cwd to confirm the worktree source was picked up.
+- **Goal:** Exercise `src/teatree/...` changes living in a worktree through the global `t3` binary, without a `uv run` prefix or a re-`install`.
+- **Mechanism:** The `t3_bootstrap` entry point pins the teatree source to the **configured** tree at invocation time. When `T3_REPO` names a teatree source tree (a `pyproject.toml` with `name = "teatree"` shipping `src/teatree/__init__.py`), the bootstrap prepends that `T3_REPO/src` to `sys.path` before importing `teatree.cli`. When `T3_REPO` is unset, it falls through to whatever the uv tool install resolved (main clone editable or PyPI libs).
+- **To dogfood a worktree:** point `T3_REPO` at the worktree for the session (`T3_REPO=$PWD t3 …`), or use `uv run t3` from the worktree root.
+- **cwd never selects the source ([#2055](https://github.com/souliane/teatree/issues/2055)).** A `t3` subprocess whose cwd lands inside a *different* teatree checkout — e.g. an autonomous `t3 loop tick` started from a feature worktree — must **not** silently import that checkout's unreviewed `src/` against the real shared DB and connectors. The execution tree is pinned to `T3_REPO`/the install, regardless of where the process started.
+- **Verify:** `t3 info | grep teatree:` prints the path that was loaded — compare against `$T3_REPO` (or the install) to confirm the configured source, not a stray cwd, was picked up.
 - **Caveat:** The tool's venv dependencies are shared between main clone and worktree source. If a worktree bumps a dep that isn't in the tool venv, imports fail — run `uv tool install --force --editable <main-clone>` to refresh the tool's deps, or fall back to `uv run t3` from the worktree.
 
 ## Workflow-Durability Bug Class (recurring failure mode)

--- a/src/t3_bootstrap/__init__.py
+++ b/src/t3_bootstrap/__init__.py
@@ -1,3 +1,3 @@
-from t3_bootstrap._main import _find_teatree_source, main
+from t3_bootstrap._main import _resolve_pinned_source, main
 
-__all__ = ["_find_teatree_source", "main"]
+__all__ = ["_resolve_pinned_source", "main"]

--- a/src/t3_bootstrap/_main.py
+++ b/src/t3_bootstrap/_main.py
@@ -1,41 +1,55 @@
 """Entry-point bootstrap for the ``t3`` console script.
 
-Selects the teatree source to run against at invocation time.  When cwd is
-inside a teatree source tree (a pyproject with ``name = "teatree"`` and a
-populated ``src/teatree`` layout), prepend that worktree's ``src`` to
-``sys.path`` so dogfooding a worktree's changes via the global ``t3`` just
-works — no ``uv run`` prefix.  Otherwise fall through to whatever the
-interpreter already has on ``sys.path``: the uv-tool editable install
-(main clone) or the PyPI package when not installed editable.
+Pins the teatree source to run against the *configured* tree, independent of
+cwd.  When ``T3_REPO`` names a teatree source tree (a pyproject with
+``name = "teatree"`` and a populated ``src/teatree`` layout), prepend that
+tree's ``src`` to ``sys.path``.  Otherwise fall through to whatever the
+interpreter already has on ``sys.path``: the uv-tool editable install (main
+clone) or the PyPI package when not installed editable.
+
+cwd is never consulted (souliane/teatree#2055): a ``t3`` subprocess whose cwd
+lands inside a sibling checkout — e.g. an autonomous ``t3 loop tick`` started
+from a feature worktree — must not silently import that checkout's unreviewed
+``src/`` against the real shared DB and connectors.  Dogfooding a worktree's
+teatree changes is the explicit ``T3_REPO`` opt-in (or a ``uv run`` prefix),
+never an accident of where the process happened to start.
 
 This module MUST NOT import anything from ``teatree`` at module scope — the
 whole point is to adjust ``sys.path`` BEFORE the ``teatree`` package is loaded.
 """
 
+import os
 import sys
 from pathlib import Path
 
 
-def _find_teatree_source(start: Path) -> Path | None:
-    """Walk up from *start* and return ``<repo>/src`` when the repo is a teatree source tree."""
-    for parent in [start, *start.parents]:
-        pyproject = parent / "pyproject.toml"
-        if not pyproject.is_file():
-            continue
-        try:
-            content = pyproject.read_text(encoding="utf-8")
-        except OSError:
-            continue
-        if 'name = "teatree"' not in content:
-            continue
-        src = parent / "src"
-        if (src / "teatree" / "__init__.py").is_file():
-            return src
-    return None
+def _is_teatree_source(repo: Path) -> bool:
+    """Return whether *repo* is a teatree source tree (pyproject + ``src/teatree``)."""
+    pyproject = repo / "pyproject.toml"
+    if not pyproject.is_file():
+        return False
+    try:
+        content = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    if 'name = "teatree"' not in content:
+        return False
+    return (repo / "src" / "teatree" / "__init__.py").is_file()
+
+
+def _resolve_pinned_source() -> Path | None:
+    """Return ``$T3_REPO/src`` when ``T3_REPO`` names a teatree source tree, else ``None``."""
+    env_path = os.environ.get("T3_REPO", "")
+    if not env_path:
+        return None
+    repo = Path(env_path).expanduser()
+    if not _is_teatree_source(repo):
+        return None
+    return repo / "src"
 
 
 def main() -> None:
-    source = _find_teatree_source(Path.cwd())
+    source = _resolve_pinned_source()
     if source is not None:
         sys.path.insert(0, str(source))
     from teatree.cli import main as _main

--- a/tests/test_t3_bootstrap.py
+++ b/tests/test_t3_bootstrap.py
@@ -23,53 +23,154 @@ def _make_teatree_tree(root: Path) -> Path:
     return root / "src"
 
 
-class TestFindTeatreeSource:
-    def test_returns_src_when_cwd_is_worktree_root(self, tmp_path: Path) -> None:
+class TestResolvePinnedSource:
+    def test_returns_t3_repo_src_when_env_set(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         expected = _make_teatree_tree(tmp_path)
-        assert t3_bootstrap._find_teatree_source(tmp_path) == expected
+        monkeypatch.setenv("T3_REPO", str(tmp_path))
+        assert t3_bootstrap._resolve_pinned_source() == expected
 
-    def test_walks_up_to_find_worktree_root(self, tmp_path: Path) -> None:
+    def test_expands_user_in_t3_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         expected = _make_teatree_tree(tmp_path)
-        nested = tmp_path / "src" / "teatree" / "cli"
-        nested.mkdir(parents=True, exist_ok=True)
-        assert t3_bootstrap._find_teatree_source(nested) == expected
+        monkeypatch.setenv("HOME", str(tmp_path.parent))
+        monkeypatch.setenv("T3_REPO", str(Path("~") / tmp_path.name))
+        assert t3_bootstrap._resolve_pinned_source() == expected
 
-    def test_returns_none_when_no_teatree_pyproject(self, tmp_path: Path) -> None:
+    def test_returns_none_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_REPO", raising=False)
+        assert t3_bootstrap._resolve_pinned_source() is None
+
+    def test_returns_none_when_t3_repo_blank(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_REPO", "")
+        assert t3_bootstrap._resolve_pinned_source() is None
+
+    def test_returns_none_when_t3_repo_not_a_teatree_tree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "other"\n')
-        assert t3_bootstrap._find_teatree_source(tmp_path) is None
+        monkeypatch.setenv("T3_REPO", str(tmp_path))
+        assert t3_bootstrap._resolve_pinned_source() is None
 
-    def test_returns_none_when_pyproject_matches_but_src_layout_missing(self, tmp_path: Path) -> None:
+    def test_returns_none_when_t3_repo_missing_src_layout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "teatree"\n')
-        assert t3_bootstrap._find_teatree_source(tmp_path) is None
+        monkeypatch.setenv("T3_REPO", str(tmp_path))
+        assert t3_bootstrap._resolve_pinned_source() is None
 
-    def test_returns_none_when_no_pyproject_in_ancestors(self, tmp_path: Path) -> None:
-        nested = tmp_path / "a" / "b"
-        nested.mkdir(parents=True)
-        assert t3_bootstrap._find_teatree_source(nested) is None
+    def test_returns_none_when_t3_repo_points_at_missing_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("T3_REPO", str(tmp_path / "does-not-exist"))
+        assert t3_bootstrap._resolve_pinned_source() is None
 
 
 class TestMain:
-    def test_inserts_worktree_source_on_sys_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        worktree_src = _make_teatree_tree(tmp_path)
-        monkeypatch.chdir(tmp_path)
+    def test_pins_to_t3_repo_when_env_set(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo_src = _make_teatree_tree(tmp_path)
+        monkeypatch.setenv("T3_REPO", str(tmp_path))
 
-        with patch.object(sys, "path", list(sys.path)) as _, patch("teatree.cli.main") as mock_main:
+        with patch.object(sys, "path", list(sys.path)), patch("teatree.cli.main") as mock_main:
             t3_bootstrap.main()
-            assert sys.path[0] == str(worktree_src)
+            assert sys.path[0] == str(repo_src)
             mock_main.assert_called_once_with()
 
-    def test_leaves_sys_path_untouched_outside_worktree(
-        self,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.chdir(tmp_path)
+    def test_ignores_cwd_worktree_when_env_unset(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """#2055: a stray cwd inside a sibling teatree worktree must not inject its ``src``."""
+        sibling_worktree = tmp_path / "ac" / "some-branch" / "teatree"
+        sibling_worktree.mkdir(parents=True)
+        worktree_src = _make_teatree_tree(sibling_worktree)
+        monkeypatch.delenv("T3_REPO", raising=False)
+        monkeypatch.chdir(sibling_worktree)
         before = list(sys.path)
 
         with patch("teatree.cli.main") as mock_main:
             t3_bootstrap.main()
+            assert str(worktree_src) not in sys.path
             assert sys.path == before
             mock_main.assert_called_once_with()
+
+    def test_pins_to_t3_repo_even_when_cwd_is_a_different_worktree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#2055: with ``T3_REPO`` set, a cwd inside an unrelated worktree never wins."""
+        configured = tmp_path / "main-clone"
+        configured.mkdir()
+        configured_src = _make_teatree_tree(configured)
+
+        sibling_worktree = tmp_path / "ac" / "branch" / "teatree"
+        sibling_worktree.mkdir(parents=True)
+        worktree_src = _make_teatree_tree(sibling_worktree)
+
+        monkeypatch.setenv("T3_REPO", str(configured))
+        monkeypatch.chdir(sibling_worktree)
+
+        with patch.object(sys, "path", list(sys.path)), patch("teatree.cli.main") as mock_main:
+            t3_bootstrap.main()
+            assert sys.path[0] == str(configured_src)
+            assert str(worktree_src) not in sys.path
+            mock_main.assert_called_once_with()
+
+
+class TestEndToEndExecTreePin:
+    """#2055 end-to-end: run the real bootstrap from a sibling teatree worktree.
+
+    The bug was that ``t3`` invoked with cwd inside a *different* teatree checkout
+    imported teatree from THAT checkout's ``src/`` (nearest pyproject wins), then
+    crashed on a module the branch had relocated.  This drives the actual
+    ``t3_bootstrap.main`` resolution in a subprocess whose cwd is a sibling
+    checkout carrying a sentinel ``teatree`` package, and asserts the resolved
+    ``teatree.__file__`` is the install/configured tree — never the cwd checkout.
+    """
+
+    def _spawn(self, cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        prog = (
+            "import t3_bootstrap, sys;"
+            "src = t3_bootstrap._resolve_pinned_source();"
+            "sys.path.insert(0, str(src)) if src is not None else None;"
+            "import teatree;"
+            "print(teatree.__file__)"
+        )
+        return subprocess.run(
+            [sys.executable, "-c", prog],
+            cwd=cwd,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_cwd_sibling_checkout_does_not_win_when_env_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sibling = tmp_path / "ac" / "moves-a-module" / "teatree"
+        sibling.mkdir(parents=True)
+        _make_teatree_tree(sibling)
+        sentinel = sibling / "src" / "teatree" / "__init__.py"
+        sentinel.write_text("SENTINEL = 'cwd-checkout'\n")
+
+        env = {k: v for k, v in __import__("os").environ.items() if k != "T3_REPO"}
+        env["PYTHONPATH"] = str(_REPO_ROOT / "src")
+
+        result = self._spawn(sibling, env)
+        resolved = Path(result.stdout.strip()).resolve()
+        assert resolved != sentinel.resolve()
+        assert sibling not in resolved.parents
+
+    def test_env_pins_install_tree_over_cwd_checkout(self, tmp_path: Path) -> None:
+        sibling = tmp_path / "ac" / "moves-a-module" / "teatree"
+        sibling.mkdir(parents=True)
+        _make_teatree_tree(sibling)
+        sentinel = sibling / "src" / "teatree" / "__init__.py"
+        sentinel.write_text("SENTINEL = 'cwd-checkout'\n")
+
+        env = dict(__import__("os").environ)
+        env["T3_REPO"] = str(_REPO_ROOT)
+        env["PYTHONPATH"] = str(_REPO_ROOT / "src")
+
+        result = self._spawn(sibling, env)
+        resolved = Path(result.stdout.strip()).resolve()
+        assert resolved == (_REPO_ROOT / "src" / "teatree" / "__init__.py").resolve()
+        assert resolved != sentinel.resolve()
 
 
 class TestWheelShipsBootstrap:


### PR DESCRIPTION
Fixes [#2055](https://github.com/souliane/teatree/issues/2055).

## Problem

The `t3` console-script shim (`t3_bootstrap._main`) selected the teatree source
from **cwd**: when invoked with cwd inside a sibling teatree checkout, it walked
up to the nearest `pyproject.toml` named `teatree` and prepended that checkout's
`src/` to `sys.path` (nearest-pyproject-wins). So a `t3 loop tick` started with
cwd inside a feature worktree imported THAT worktree's `teatree`, then crashed
with `ModuleNotFoundError` on a module the branch had relocated, while loading
overlay entry points.

Blast radius: any `t3` subprocess whose cwd landed in a sibling checkout
silently ran unreviewed branch code against the real shared DB and connectors.

## Fix

Pin the execution tree to the configured `T3_REPO` at the single launch
chokepoint, and drop cwd auto-discovery entirely:

- `T3_REPO` names a teatree source tree → prepend its `src` to `sys.path`.
- `T3_REPO` unset → fall through to the installed editable / PyPI tree.
- **cwd is never consulted.**

Dogfooding a worktree's teatree source stays available via the explicit
`T3_REPO` opt-in (`T3_REPO=$PWD t3 …`) or a `uv run` prefix — never an accident
of where the process started. The dogfood skill's "run from a worktree" step
exercises overlay (entry-point) discovery, not bootstrap source selection, so it
is unaffected; its troubleshooting reference is updated to the explicit
mechanism.

## Anti-vacuity (RED-on-revert)

`TestMain::test_ignores_cwd_worktree_when_env_unset` was observed RED on the
pre-fix code — with cwd inside a sibling teatree worktree, the buggy shim
injected `…/ac/some-branch/teatree/src` at `sys.path[0]`, failing the assertion.
`TestEndToEndExecTreePin` drives the real resolution in a subprocess from a
sibling checkout carrying a sentinel `teatree` package and asserts the resolved
`teatree.__file__` is the install/configured tree, never the cwd checkout.

## Architecture pre-check — #2055

### 1. BLUEPRINT § alignment
§8 Command Tiers — `t3 = t3_bootstrap:main`, the shim that selects the teatree
source before importing `teatree.cli`. The change pins that selection; no
BLUEPRINT contradiction.

### 2. FSM phase boundaries
n/a — no state transition.

### 3. Extension-point contracts
n/a — runs before `teatree` is imported; no `OverlayBase` / scanner / hook /
`*Backend` Protocol touched.

### 4. Component boundaries
`src/t3_bootstrap/` — the single place Python is launched for `t3`. The fix
stays inside this one chokepoint.

### 5. Dependency direction
Added stdlib `os` only. The shim still imports nothing from `teatree` at module
scope. `uv run tach check` → all modules validated.

### 6. Test surface
`tests/test_t3_bootstrap.py`: `TestResolvePinnedSource` (env set/unset/blank/
non-teatree/missing-src/missing-dir, `~` expansion), `TestMain` (pin + the
#2055 cwd-must-not-win regression + env-wins-over-cwd), `TestEndToEndExecTreePin`
(real subprocess from a sibling checkout).

### 7. Resilience invariants
Pure `sys.path` selection, no external write. The change makes the launch
fail-safe by default: an unset `T3_REPO` falls through to the installed tree,
not the ambiguous nearest-pyproject.

### 8. Identity and key normalization
n/a — `T3_REPO` is a single explicit path.

### 9. Behavior preservation / capability deletion
Removed: cwd-based source auto-discovery (`_find_teatree_source(Path.cwd())`) and
its export — the #2055 footgun. "Global `t3` from a worktree runs that worktree's
src" is dropped **on cwd** and preserved via the explicit `T3_REPO` opt-in.
"Outside a teatree tree, fall through to the install" is preserved (unset
`T3_REPO`). No privacy/security matcher narrowed; no must-block test inverted.
The two pre-existing cwd-discovery tests are replaced by pinned-source +
cwd-must-not-win tests, not silently weakened.
