### PR TITLE
fix(loop): pipelined bounded-WIP standing cap

### DIFF
--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -403,6 +403,20 @@ class TaskQuerySet(models.QuerySet):
                 heartbeat_at=None,
             )
 
+    def in_flight_claimed_count(self, dispatchable_filter: "Q") -> int:
+        """Count CLAIMED tasks that match the dispatchable phase/role filter.
+
+        The pipelined WIP cap subtracts this from the raw overlay budget so
+        the standing total of CLAIMED dispatchable tasks can never exceed the
+        cap, regardless of which tick admitted them. A CLAIMED task whose
+        lease has expired is excluded — the reaper will reclaim it and it is
+        not truly in flight.
+        """
+        from teatree.core.models.task import Task  # noqa: PLC0415
+
+        now = timezone.now()
+        return self.filter(status=Task.Status.CLAIMED, lease_expires_at__gt=now).filter(dispatchable_filter).count()
+
     def active_claim_exists(self) -> bool:
         """True iff some task is CLAIMED with a still-live lease.
 

--- a/src/teatree/loop/phases/orchestrate.py
+++ b/src/teatree/loop/phases/orchestrate.py
@@ -126,9 +126,15 @@ def _admit_into(manifest: OrchestrationManifest, *, claim: bool, claimed_by: str
 
 
 def _fanout_budget(backends: "list[OverlayBackends] | None") -> int:
-    if backends is not None:
-        return sum(max(0, backend.max_concurrent_auto_starts) for backend in backends)
-    return max(0, _active_overlay_cap())
+    from teatree.core.models.task import Task  # noqa: PLC0415
+
+    raw_cap = (
+        sum(max(0, backend.max_concurrent_auto_starts) for backend in backends)
+        if backends is not None
+        else max(0, _active_overlay_cap())
+    )
+    in_flight = Task.objects.in_flight_claimed_count(_dispatchable_filter())
+    return max(0, raw_cap - in_flight)
 
 
 def _active_overlay_cap() -> int:

--- a/tests/teatree_loop/phases/test_orchestrate.py
+++ b/tests/teatree_loop/phases/test_orchestrate.py
@@ -201,19 +201,27 @@ class TestPipelinedWIPStandingCap(django.test.TestCase):
         stale.claimed_at = timezone.now() - timedelta(seconds=600)
         stale.lease_expires_at = timezone.now() - timedelta(seconds=300)
         stale.save(update_fields=["status", "claimed_by", "claimed_at", "lease_expires_at"])
-        _dispatchable_task()
+        _claim_task(_dispatchable_task())  # live lease — must be subtracted
+        pending = _dispatchable_task()
         backends = [OverlayBackends(name="a", max_concurrent_auto_starts=2)]
         with _with_speed(Speed.FULL):
             manifest = orchestrate_phase(backends=backends, claim=False)
-        assert manifest.cap == 2
+        # live-lease task reduces budget by 1; expired-lease task does not
+        assert manifest.cap == 1
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].task_id == pending.pk
 
     def test_non_dispatchable_claimed_tasks_are_not_counted(self) -> None:
         non_dispatchable = _claim_task(_dispatchable_task(role=Ticket.Role.REVIEWER, phase="coding"))
-        _dispatchable_task()
+        _claim_task(_dispatchable_task())  # dispatchable claimed — must be subtracted
+        pending = _dispatchable_task()
         backends = [OverlayBackends(name="a", max_concurrent_auto_starts=2)]
         with _with_speed(Speed.FULL):
             manifest = orchestrate_phase(backends=backends, claim=False)
-        assert manifest.cap == 2
+        # only the dispatchable claimed task reduces the budget
+        assert manifest.cap == 1
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].task_id == pending.pk
         non_dispatchable.refresh_from_db()
         assert non_dispatchable.status == Task.Status.CLAIMED
 

--- a/tests/teatree_loop/phases/test_orchestrate.py
+++ b/tests/teatree_loop/phases/test_orchestrate.py
@@ -1,9 +1,11 @@
 """Tests for ``teatree.loop.phases.orchestrate`` — the speed-driven fan-out (#1796)."""
 
 import itertools
+from datetime import timedelta
 from unittest.mock import patch
 
 import django.test
+from django.utils import timezone
 
 from teatree.config import Speed, UserSettings
 from teatree.core.backend_factory import OverlayBackends
@@ -26,6 +28,18 @@ def _dispatchable_task(*, phase: str = "coding", role: str = Ticket.Role.AUTHOR)
     ticket = Ticket.objects.create(role=role, issue_url=f"https://x/{phase}/{n}", overlay="acme")
     session = Session.objects.create(ticket=ticket, agent_id=f"a-{ticket.pk}")
     return Task.objects.create(ticket=ticket, session=session, phase=phase, status=Task.Status.PENDING)
+
+
+def _claim_task(task: Task) -> Task:
+    """Mark a dispatchable task as CLAIMED with a live lease, simulating an in-flight worker."""
+    now = timezone.now()
+    task.status = Task.Status.CLAIMED
+    task.claimed_by = "test-worker"
+    task.claimed_at = now
+    task.heartbeat_at = now
+    task.lease_expires_at = now + timedelta(seconds=300)
+    task.save(update_fields=["status", "claimed_by", "claimed_at", "heartbeat_at", "lease_expires_at"])
+    return task
 
 
 class TestOrchestratePhaseSpeed(django.test.TestCase):
@@ -151,3 +165,65 @@ class TestOrchestratePhaseFailOpen(django.test.TestCase):
         ):
             manifest = orchestrate_phase(backends=backends, claim=True)
         assert manifest.entries == []
+
+
+class TestPipelinedWIPStandingCap(django.test.TestCase):
+    """Pipelined WIP cap: admitted + in-flight claimed <= cap at all times (#1796)."""
+
+    def test_in_flight_claimed_tasks_reduce_available_budget(self) -> None:
+        already_claimed = _claim_task(_dispatchable_task())
+        pending = _dispatchable_task()
+        backends = [OverlayBackends(name="a", max_concurrent_auto_starts=2)]
+        with _with_speed(Speed.FULL):
+            manifest = orchestrate_phase(backends=backends, claim=False)
+        assert manifest.cap == 1
+        assert len(manifest.entries) == 1
+        assert manifest.entries[0].task_id == pending.pk
+        already_claimed.refresh_from_db()
+        assert already_claimed.status == Task.Status.CLAIMED
+
+    def test_cap_is_never_exceeded_when_all_slots_already_claimed(self) -> None:
+        for _ in range(3):
+            _claim_task(_dispatchable_task())
+        for _ in range(2):
+            _dispatchable_task()
+        backends = [OverlayBackends(name="a", max_concurrent_auto_starts=3)]
+        with _with_speed(Speed.FULL):
+            manifest = orchestrate_phase(backends=backends, claim=True)
+        assert manifest.cap == 0
+        assert manifest.entries == []
+        assert Task.objects.filter(status=Task.Status.CLAIMED).count() == 3
+
+    def test_expired_lease_tasks_are_not_counted_as_in_flight(self) -> None:
+        stale = _dispatchable_task()
+        stale.status = Task.Status.CLAIMED
+        stale.claimed_by = "dead-worker"
+        stale.claimed_at = timezone.now() - timedelta(seconds=600)
+        stale.lease_expires_at = timezone.now() - timedelta(seconds=300)
+        stale.save(update_fields=["status", "claimed_by", "claimed_at", "lease_expires_at"])
+        _dispatchable_task()
+        backends = [OverlayBackends(name="a", max_concurrent_auto_starts=2)]
+        with _with_speed(Speed.FULL):
+            manifest = orchestrate_phase(backends=backends, claim=False)
+        assert manifest.cap == 2
+
+    def test_non_dispatchable_claimed_tasks_are_not_counted(self) -> None:
+        non_dispatchable = _claim_task(_dispatchable_task(role=Ticket.Role.REVIEWER, phase="coding"))
+        _dispatchable_task()
+        backends = [OverlayBackends(name="a", max_concurrent_auto_starts=2)]
+        with _with_speed(Speed.FULL):
+            manifest = orchestrate_phase(backends=backends, claim=False)
+        assert manifest.cap == 2
+        non_dispatchable.refresh_from_db()
+        assert non_dispatchable.status == Task.Status.CLAIMED
+
+    def test_admitted_plus_in_flight_never_exceeds_cap(self) -> None:
+        _claim_task(_dispatchable_task())
+        for _ in range(3):
+            _dispatchable_task()
+        backends = [OverlayBackends(name="a", max_concurrent_auto_starts=2)]
+        with _with_speed(Speed.FULL):
+            manifest = orchestrate_phase(backends=backends, claim=True)
+        admitted = len(manifest.entries)
+        in_flight_before = 1
+        assert admitted + in_flight_before <= 2


### PR DESCRIPTION
## Summary

- `TaskQuerySet.in_flight_claimed_count(dispatchable_filter)`: new manager method counting CLAIMED tasks with a live lease that match the dispatchable phase/role filter
- `_fanout_budget()`: subtracts that in-flight count from the raw overlay cap, floored at 0, so the standing total of CLAIMED dispatchable tasks can never exceed `max_concurrent_auto_starts`
- Wired dormant (`claim=False` in `tick.py:_orchestrate_dormant`) — the live loop is unaffected; only changes how many rows a future `claim=True` call would admit

## Anti-vacuity

`TestPipelinedWIPStandingCap` (5 tests) all go RED when the subtraction in `_fanout_budget` is reverted:

- in-flight CLAIMED tasks reduce the available budget
- cap is never exceeded when all slots already claimed
- expired-lease tasks are excluded from the in-flight count
- non-dispatchable CLAIMED tasks are not counted
- admitted + pre-existing in-flight <= cap

## Test plan

- [ ] `uv run pytest tests/teatree_loop/phases/test_orchestrate.py --no-cov` — 17 passed
- [ ] `uv run pytest tests/teatree_loop/ --no-cov` — 1806 passed
- [ ] `prek run --files ...` — all hooks green