### PR TITLE
fix(ci): remove dead semgrep-regressions-warn prek hook scanning absent .semgrep/warn

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -415,15 +415,6 @@ repos:
         args: [scan, --config=.semgrep/blocking, --error, --quiet]
         pass_filenames: false
         always_run: true
-      - id: semgrep
-        alias: semgrep-regressions-warn
-        name: Named regression-detector rules (advisory; never blocks)
-        additional_dependencies: [semgrep]
-        entry: bash -c 'semgrep scan --config .semgrep/warn --quiet || true'
-        pass_filenames: false
-        always_run: true
-        stages: [manual]
-
   # Phase 10 - Commit-msg
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: 37b5f04f364960e8e7b361d0dbaaf8f28ec06392  # v4.2.0

--- a/tests/test_ci_gates_fail_loud.py
+++ b/tests/test_ci_gates_fail_loud.py
@@ -76,6 +76,22 @@ class TestSemgrepRegressionsJobIsGone:
             args = " ".join(str(a) for a in hook.get("args", []))
             assert "--error" in args, "The blocking semgrep hook must pass --error so a finding fails CI."
 
+    def test_no_prek_hook_scans_absent_warn_dir(self) -> None:
+        # The semgrep-regressions-warn hook scanned .semgrep/warn (deleted in #2128).
+        # semgrep exits 0 on a missing config; the || true swallowed any non-zero —
+        # a fake-green scan. Restoring a hook targeting .semgrep/warn would silently
+        # pass on every run. This test is RED if that hook reappears.
+        warn_hooks = [
+            hook
+            for hook in _precommit_hooks()
+            if ".semgrep/warn" in str(hook.get("entry", ""))
+            or ".semgrep/warn" in " ".join(str(a) for a in hook.get("args", []))
+        ]
+        assert not warn_hooks, (
+            "No prek hook may scan .semgrep/warn — the directory does not exist. "
+            f"Offending hooks: {[h.get('alias') or h.get('id') for h in warn_hooks]}"
+        )
+
 
 class TestMutationFullGateRunsWhenUncertain:
     """Fix #2: the mutation-full weekly gate fails SAFE, not silent-skip.


### PR DESCRIPTION
## Summary

- Removes the `semgrep-regressions-warn` pre-commit hook (Phase 9 / manual stage) that scanned `.semgrep/warn`. That directory was deleted by #2128 when all rules were promoted to `.semgrep/blocking`. semgrep exits 0 on a missing config, and the hook's `|| true` swallowed any non-zero exit — a fake-green scan that always passed silently.
- Adds `test_no_prek_hook_scans_absent_warn_dir` to `TestSemgrepRegressionsJobIsGone` in `tests/test_ci_gates_fail_loud.py`. Restoring any prek hook that targets `.semgrep/warn` now turns this test RED immediately.

Closes #1928.

## Test plan

- [ ] `uv run pytest tests/test_ci_gates_fail_loud.py --no-cov -x -q` — all 9 tests green
- [ ] Pre-commit hooks all pass on commit (verified locally: all green)
- [ ] Verify `.semgrep/warn` directory is absent from repo root (confirmed — only `.semgrep/blocking/` exists)