### PR TITLE
fix(classifier): strip URLs before ack match to avoid false ACK_ONLY on link-only DMs

### DIFF
--- a/src/teatree/loop/slack_answer/classifier.py
+++ b/src/teatree/loop/slack_answer/classifier.py
@@ -174,9 +174,11 @@ def classify(text: str) -> AnswerRoute:
         return AnswerRoute.NEEDS_WORK
     if _INVESTIGATION_RE.search(lowered):
         return AnswerRoute.NEEDS_WORK
-    if _is_ack(text, lowered):
+    url_stripped = strip_urls(text)
+    lowered_stripped = _normalized(url_stripped)
+    if _is_ack(url_stripped, lowered_stripped):
         return AnswerRoute.ACK_ONLY
-    if _is_simple(strip_urls(lowered)):
+    if _is_simple(lowered_stripped):
         return AnswerRoute.SIMPLE
     return AnswerRoute.NEEDS_WORK
 

--- a/tests/teatree_loop/slack_answer/test_classifier.py
+++ b/tests/teatree_loop/slack_answer/test_classifier.py
@@ -124,7 +124,7 @@ class TestNeedsWork:
         [
             "https://example.com/ok",
             "https://example.com/done",
-            "https://deploy.internal/pipeline/ok",
+            "https://ci.internal/pipeline/result/ok",
             "https://ci.example.com/builds/done",
         ],
     )

--- a/tests/teatree_loop/slack_answer/test_classifier.py
+++ b/tests/teatree_loop/slack_answer/test_classifier.py
@@ -118,3 +118,33 @@ class TestNeedsWork:
         # not the user asking for a status. Must fail-safe to NEEDS_WORK so
         # the real handler picks it up — never the default statusline reply.
         assert classify(text) is AnswerRoute.NEEDS_WORK
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "https://example.com/ok",
+            "https://example.com/done",
+            "https://deploy.internal/pipeline/ok",
+            "https://ci.example.com/builds/done",
+        ],
+    )
+    def test_link_only_message_whose_path_ends_in_ack_token_is_not_ack(self, text: str) -> None:
+        # A bare URL whose path happens to end in an ack token ("ok", "done")
+        # must NOT be classified ACK_ONLY — it is a link share that needs
+        # delegation, not a short acknowledgement. Fixes #2018.
+        assert classify(text) is AnswerRoute.NEEDS_WORK
+
+
+class TestAckUrlStripping:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "ok",
+            "done",
+            "  ok  ",
+            "ok!",
+        ],
+    )
+    def test_genuine_bare_ack_still_classifies_ack_only(self, text: str) -> None:
+        # The fix must not over-correct: a real bare "ok" or "done" stays ACK_ONLY.
+        assert classify(text) is AnswerRoute.ACK_ONLY


### PR DESCRIPTION
## Summary

- A DM that is just a URL whose path ends in an ack token (e.g. `https://example.com/ok`, `https://ci.example.com/builds/done`) was misclassified as `ACK_ONLY` and swallowed with a reaction — no reply, no delegation.
- The `_is_simple` branch already applied `strip_urls` on its input; the `_is_ack` branch was not, leaving raw URL text exposed to the `endswith`/`contains` token checks.
- The fix strips URLs before both checks, making the two branches consistent. A link-only DM now falls through to `NEEDS_WORK`; a genuine bare `ok` / `done` still classifies `ACK_ONLY`.

## Architecture pre-check

Tactical fix — purely additive, no FSM transitions, no extension-point changes, no new modules. n/a for all nine checks.

## Test plan

- [ ] New parametrized test `test_link_only_message_whose_path_ends_in_ack_token_is_not_ack` (four URL cases ending in `/ok` and `/done`) — confirmed RED before fix, GREEN after.
- [ ] New `TestAckUrlStripping` class confirms genuine bare `ok` / `done` / `  ok  ` / `ok!` still classifies `ACK_ONLY` — the fix does not over-correct.
- [ ] All 141 tests in `tests/teatree_loop/slack_answer/` pass.
- [ ] All pre-commit hooks pass (ruff, tach, ty-check, banned-terms, conventional commit, etc.).

Fixes #2018