### PR TITLE
fix(slack-setup): migrate tokens when slack_token_ref is rewritten to canonical form

### DIFF
--- a/src/teatree/cli/slack_manifest.py
+++ b/src/teatree/cli/slack_manifest.py
@@ -1,0 +1,237 @@
+"""Slack app-manifest helpers — build, compare, and call the Slack manifest API.
+
+Extracted from :mod:`teatree.cli.slack_setup` to keep that module under the
+LOC ceiling.  All public symbols remain importable from ``slack_setup`` via
+explicit re-export for backward compatibility.
+"""
+
+import json
+import urllib.parse
+from typing import Any
+
+import httpx
+
+type SlackManifest = dict[str, Any]
+
+_CONFIG_TOKEN_REF = "teatree/slack-app-config-token"  # noqa: S105 — pass key name, not a secret
+_CONFIG_REFRESH_REF = "teatree/slack-app-config-refresh"
+
+
+class SlackManifestError(RuntimeError):
+    """Slack ``apps.manifest.*`` (or ``tooling.tokens.rotate``) returned ok=False."""
+
+
+_BOT_SCOPES = [
+    "app_mentions:read",
+    "channels:history",
+    "channels:read",
+    "chat:write",
+    "files:write",
+    "groups:history",
+    "groups:read",
+    "im:history",
+    "im:read",
+    "im:write",
+    "mpim:history",
+    "mpim:read",
+    "reactions:read",
+    "reactions:write",
+    "users:read",
+    "users:read.email",
+]
+_BOT_ONLY_SCOPES = frozenset(
+    {
+        "chat:write.customize",
+        "chat:write.public",
+    }
+)
+# Scopes for the human user's OAuth token (``xoxp-…``). ``SlackBotBackend``
+# routes every outbound call (``chat.postMessage``, ``reactions.add`` /
+# ``reactions.get``) through this token for Slack-Connect externally-shared
+# channels — and for any channel whose Connect membership cannot be
+# confirmed, where writes/reactions fail toward the user xoxp while reads
+# fail safe to the bot (see ``SlackBotBackend._channel_token``, #1110) —
+# because those channels reject the bot token with
+# ``mcp_externally_shared_channel_restricted`` — hence ``chat:write``
+# (posting) plus ``reactions:read`` / ``reactions:write``.
+# ``build_manifest`` must declare a ``user`` scopes section or a reinstall
+# never re-prompts for these grants and the xoxp token keeps whatever Slack
+# defaulted (empirically: no reaction scopes).
+# A manifest reinstall re-prompts OAuth consent for *exactly* this set and
+# drops any user scope not listed, so the set must be a SUPERSET that keeps
+# the capability the xoxp token is already relied on for: ``chat:write``
+# (posting into Slack-Connect channels under the user's identity) and
+# ``users:read`` (handle/id resolution). Listing only the two reaction
+# scopes would silently revoke those on reinstall.
+_USER_SCOPES = [
+    "canvases:read",
+    "canvases:write",
+    "channels:history",
+    "chat:write",
+    "files:read",
+    "groups:history",
+    "im:history",
+    "mpim:history",
+    "reactions:read",
+    "reactions:write",
+    "search:read.files",
+    "search:read.im",
+    "search:read.mpim",
+    "search:read.private",
+    "search:read.public",
+    "search:read.users",
+    "users:read",
+    "users:read.email",
+]
+_BOT_EVENTS = ["app_mention", "message.im"]
+
+
+def _user_scopes_carry_no_bot_only_scope() -> None:
+    leaked = _BOT_ONLY_SCOPES.intersection(_USER_SCOPES)
+    if leaked:
+        joined = ", ".join(sorted(leaked))
+        message = f"_USER_SCOPES contains bot-only scope(s) Slack rejects on a user token: {joined}"
+        raise AssertionError(message)
+
+
+_user_scopes_carry_no_bot_only_scope()
+
+
+def build_manifest(*, overlay_name: str, display_name: str = "") -> SlackManifest:
+    """Build the Slack app manifest payload for *overlay_name*.
+
+    The returned dict matches Slack's app-manifest schema. Display name
+    defaults to ``teatree-<overlay>`` when not overridden.
+    """
+    name = display_name or f"teatree-{overlay_name}"
+    return {
+        "display_information": {
+            "name": name,
+            "description": f"Teatree agent bot for the {overlay_name} overlay.",
+        },
+        "features": {
+            "app_home": {
+                "home_tab_enabled": False,
+                "messages_tab_enabled": True,
+                "messages_tab_read_only_enabled": False,
+            },
+            "bot_user": {"display_name": name, "always_online": True},
+        },
+        "oauth_config": {"scopes": {"bot": _BOT_SCOPES, "user": _USER_SCOPES}},
+        "settings": {
+            "event_subscriptions": {"bot_events": _BOT_EVENTS},
+            "interactivity": {"is_enabled": False},
+            "org_deploy_enabled": False,
+            "socket_mode_enabled": True,
+            "token_rotation_enabled": False,
+        },
+    }
+
+
+_SLACK_CREATE_APP_URL = "https://api.slack.com/apps?new_app=1&manifest_json="
+
+
+def manifest_install_url(manifest: SlackManifest) -> str:
+    """Return the Slack ``api.slack.com/apps`` URL pre-filled with *manifest*.
+
+    Slack may ignore the ``manifest_json`` query parameter depending on
+    the workspace auth state. :func:`~teatree.cli.slack_setup.slack_bot_setup`
+    prints the manifest JSON as a fallback so the user can always paste it
+    manually.
+    """
+    encoded = urllib.parse.quote(json.dumps(manifest, separators=(",", ":")))
+    return f"{_SLACK_CREATE_APP_URL}{encoded}"
+
+
+def app_manifest_editor_url(app_id: str) -> str:
+    """Deep link to the app's manifest editor (degraded-path target)."""
+    return f"https://api.slack.com/apps/{app_id}/app-manifest"
+
+
+def app_install_url(app_id: str) -> str:
+    """Deep link to the app's install page (the one manual OAuth-consent step)."""
+    return f"https://api.slack.com/apps/{app_id}/install-on-team"
+
+
+def _slack_app_api(method: str, payload: dict[str, Any], *, token: str) -> dict[str, Any]:
+    """POST to ``https://slack.com/api/<method>`` with a bearer *token*."""
+    response = httpx.post(
+        f"https://slack.com/api/{method}",
+        headers={"Authorization": f"Bearer {token}"},
+        data=payload,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return dict(response.json())
+
+
+def export_manifest(*, app_id: str, config_token: str) -> SlackManifest:
+    """Return the Slack app's current manifest via ``apps.manifest.export``."""
+    result = _slack_app_api("apps.manifest.export", {"app_id": app_id}, token=config_token)
+    if not result.get("ok"):
+        raise SlackManifestError(str(result.get("error", "unknown error")))
+    return dict(result["manifest"])
+
+
+def update_manifest(*, app_id: str, manifest: SlackManifest, config_token: str) -> dict[str, Any]:
+    """Apply *manifest* to the app in place via ``apps.manifest.update``."""
+    result = _slack_app_api(
+        "apps.manifest.update",
+        {"app_id": app_id, "manifest": json.dumps(manifest)},
+        token=config_token,
+    )
+    if not result.get("ok"):
+        raise SlackManifestError(str(result.get("error", "unknown error")))
+    return result
+
+
+def rotate_config_token(*, refresh_token: str) -> tuple[str, str]:
+    """Rotate the app-config token pair via ``tooling.tokens.rotate``.
+
+    Returns ``(access_token, refresh_token)``.
+    """
+    result = _slack_app_api("tooling.tokens.rotate", {"refresh_token": refresh_token}, token=refresh_token)
+    if not result.get("ok"):
+        raise SlackManifestError(str(result.get("error", "unknown error")))
+    return str(result["token"]), str(result["refresh_token"])
+
+
+def _scope_set(manifest: SlackManifest, kind: str) -> set[str]:
+    return set(manifest.get("oauth_config", {}).get("scopes", {}).get(kind, []))
+
+
+def manifests_equivalent(a: SlackManifest, b: SlackManifest) -> bool:
+    """Compare only the teatree-owned manifest fields, order-insensitively."""
+
+    def shape(m: SlackManifest) -> tuple[Any, ...]:
+        settings = m.get("settings", {})
+        return (
+            _scope_set(m, "bot"),
+            _scope_set(m, "user"),
+            frozenset(settings.get("event_subscriptions", {}).get("bot_events", [])),
+            settings.get("socket_mode_enabled"),
+            m.get("display_information", {}).get("name"),
+        )
+
+    return shape(a) == shape(b)
+
+
+__all__ = [
+    "_BOT_ONLY_SCOPES",
+    "_BOT_SCOPES",
+    "_CONFIG_REFRESH_REF",
+    "_CONFIG_TOKEN_REF",
+    "_USER_SCOPES",
+    "SlackManifest",
+    "SlackManifestError",
+    "_slack_app_api",
+    "_user_scopes_carry_no_bot_only_scope",
+    "app_install_url",
+    "app_manifest_editor_url",
+    "build_manifest",
+    "export_manifest",
+    "manifest_install_url",
+    "manifests_equivalent",
+    "rotate_config_token",
+    "update_manifest",
+]

--- a/src/teatree/cli/slack_manifest.py
+++ b/src/teatree/cli/slack_manifest.py
@@ -218,7 +218,6 @@ def manifests_equivalent(a: SlackManifest, b: SlackManifest) -> bool:
 
 __all__ = [
     "_BOT_ONLY_SCOPES",
-    "_BOT_SCOPES",
     "_CONFIG_REFRESH_REF",
     "_CONFIG_TOKEN_REF",
     "_USER_SCOPES",

--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -21,235 +21,75 @@ browser OAuth-consent reinstall click at the app-specific deep link.
 
 With no recorded app id and no ``--update``, the original create-from-manifest
 walkthrough runs and records the new app id for next time.
+
+Manifest-building and Slack API helpers live in
+:mod:`teatree.cli.slack_manifest`; this module re-exports them so existing
+callers are unaffected.
 """
 
 import json
 import re
 import time
-import urllib.parse
 import webbrowser
 from pathlib import Path
-from typing import Any
 
-import httpx
 import typer
 
 from teatree.backends.slack.bot import SlackBotBackend
+from teatree.cli.slack_manifest import (
+    _BOT_ONLY_SCOPES,
+    _CONFIG_REFRESH_REF,
+    _CONFIG_TOKEN_REF,
+    _USER_SCOPES,
+    SlackManifest,
+    SlackManifestError,
+    _slack_app_api,
+    _user_scopes_carry_no_bot_only_scope,
+    app_install_url,
+    app_manifest_editor_url,
+    build_manifest,
+    export_manifest,
+    manifest_install_url,
+    manifests_equivalent,
+    rotate_config_token,
+    update_manifest,
+)
 from teatree.cli.slack_token_store import SlackTokenWriteError, app_token_slot, bot_token_slot, store_slack_token
 from teatree.config import CONFIG_PATH, discover_overlays
 from teatree.utils.secrets import read_pass, write_pass
 
-type SlackManifest = dict[str, Any]
-
-_CONFIG_TOKEN_REF = "teatree/slack-app-config-token"  # noqa: S105 — pass key name, not a secret
-_CONFIG_REFRESH_REF = "teatree/slack-app-config-refresh"
-
-
-class SlackManifestError(RuntimeError):
-    """Slack ``apps.manifest.*`` (or ``tooling.tokens.rotate``) returned ok=False."""
-
-
-_BOT_SCOPES = [
-    "app_mentions:read",
-    "channels:history",
-    "channels:read",
-    "chat:write",
-    "files:write",
-    "groups:history",
-    "groups:read",
-    "im:history",
-    "im:read",
-    "im:write",
-    "mpim:history",
-    "mpim:read",
-    "reactions:read",
-    "reactions:write",
-    "users:read",
-    "users:read.email",
-]
-_BOT_ONLY_SCOPES = frozenset(
-    {
-        "chat:write.customize",
-        "chat:write.public",
-    }
-)
-# Scopes for the human user's OAuth token (``xoxp-…``). ``SlackBotBackend``
-# routes every outbound call (``chat.postMessage``, ``reactions.add`` /
-# ``reactions.get``) through this token for Slack-Connect externally-shared
-# channels — and for any channel whose Connect membership cannot be
-# confirmed, where writes/reactions fail toward the user xoxp while reads
-# fail safe to the bot (see ``SlackBotBackend._channel_token``, #1110) —
-# because those channels reject the bot token with
-# ``mcp_externally_shared_channel_restricted`` — hence ``chat:write``
-# (posting) plus ``reactions:read`` / ``reactions:write``.
-# ``build_manifest`` must declare a ``user`` scopes section or a reinstall
-# never re-prompts for these grants and the xoxp token keeps whatever Slack
-# defaulted (empirically: no reaction scopes).
-# A manifest reinstall re-prompts OAuth consent for *exactly* this set and
-# drops any user scope not listed, so the set must be a SUPERSET that keeps
-# the capability the xoxp token is already relied on for: ``chat:write``
-# (posting into Slack-Connect channels under the user's identity) and
-# ``users:read`` (handle/id resolution). Listing only the two reaction
-# scopes would silently revoke those on reinstall.
-_USER_SCOPES = [
-    "canvases:read",
-    "canvases:write",
-    "channels:history",
-    "chat:write",
-    "files:read",
-    "groups:history",
-    "im:history",
-    "mpim:history",
-    "reactions:read",
-    "reactions:write",
-    "search:read.files",
-    "search:read.im",
-    "search:read.mpim",
-    "search:read.private",
-    "search:read.public",
-    "search:read.users",
-    "users:read",
-    "users:read.email",
+# Re-exported so existing ``from teatree.cli.slack_setup import …`` callers
+# keep working without touching their imports.
+__all__ = [
+    "_BOT_ONLY_SCOPES",
+    "_CONFIG_REFRESH_REF",
+    "_CONFIG_TOKEN_REF",
+    "_USER_SCOPES",
+    "SlackManifest",
+    "SlackManifestError",
+    "_export_with_rotation",
+    "_slack_app_api",
+    "_user_scopes_carry_no_bot_only_scope",
+    "app_install_url",
+    "app_manifest_editor_url",
+    "build_manifest",
+    "export_manifest",
+    "manifest_install_url",
+    "manifests_equivalent",
+    "rotate_config_token",
+    "slack_bot_setup",
+    "update_manifest",
+    "write_overlay_settings",
 ]
 
-
-def _user_scopes_carry_no_bot_only_scope() -> None:
-    leaked = _BOT_ONLY_SCOPES.intersection(_USER_SCOPES)
-    if leaked:
-        joined = ", ".join(sorted(leaked))
-        message = f"_USER_SCOPES contains bot-only scope(s) Slack rejects on a user token: {joined}"
-        raise AssertionError(message)
-
-
-_user_scopes_carry_no_bot_only_scope()
-_BOT_EVENTS = ["app_mention", "message.im"]
+_APP_ID_RE = re.compile(r"^A[A-Z0-9]{6,}$")
+_BOT_TOKEN_RE = re.compile(r"^xoxb-[A-Za-z0-9-]+$")
+_APP_TOKEN_RE = re.compile(r"^xapp-[A-Za-z0-9-]+$")
+_USER_ID_RE = re.compile(r"^[UW][A-Z0-9]{6,}$")
 
 _SMOKE_TEST_TIMEOUT_SECONDS = 120
 _SMOKE_TEST_POLL_SECONDS = 3
 _SMOKE_TEST_REACTION = "white_check_mark"
-
-_BOT_TOKEN_RE = re.compile(r"^xoxb-[A-Za-z0-9-]+$")
-_APP_TOKEN_RE = re.compile(r"^xapp-[A-Za-z0-9-]+$")
-_USER_ID_RE = re.compile(r"^[UW][A-Z0-9]{6,}$")
-_APP_ID_RE = re.compile(r"^A[A-Z0-9]{6,}$")
-
-
-def build_manifest(*, overlay_name: str, display_name: str = "") -> SlackManifest:
-    """Build the Slack app manifest payload for *overlay_name*.
-
-    The returned dict matches Slack's app-manifest schema. Display name
-    defaults to ``teatree-<overlay>`` when not overridden.
-    """
-    name = display_name or f"teatree-{overlay_name}"
-    return {
-        "display_information": {
-            "name": name,
-            "description": f"Teatree agent bot for the {overlay_name} overlay.",
-        },
-        "features": {
-            "app_home": {
-                "home_tab_enabled": False,
-                "messages_tab_enabled": True,
-                "messages_tab_read_only_enabled": False,
-            },
-            "bot_user": {"display_name": name, "always_online": True},
-        },
-        "oauth_config": {"scopes": {"bot": _BOT_SCOPES, "user": _USER_SCOPES}},
-        "settings": {
-            "event_subscriptions": {"bot_events": _BOT_EVENTS},
-            "interactivity": {"is_enabled": False},
-            "org_deploy_enabled": False,
-            "socket_mode_enabled": True,
-            "token_rotation_enabled": False,
-        },
-    }
-
-
-_SLACK_CREATE_APP_URL = "https://api.slack.com/apps?new_app=1&manifest_json="
-
-
-def manifest_install_url(manifest: SlackManifest) -> str:
-    """Return the Slack ``api.slack.com/apps`` URL pre-filled with *manifest*.
-
-    Slack may ignore the ``manifest_json`` query parameter depending on
-    the workspace auth state. :func:`slack_bot_setup` prints the manifest
-    JSON as a fallback so the user can always paste it manually.
-    """
-    encoded = urllib.parse.quote(json.dumps(manifest, separators=(",", ":")))
-    return f"{_SLACK_CREATE_APP_URL}{encoded}"
-
-
-def app_manifest_editor_url(app_id: str) -> str:
-    """Deep link to the app's manifest editor (degraded-path target)."""
-    return f"https://api.slack.com/apps/{app_id}/app-manifest"
-
-
-def app_install_url(app_id: str) -> str:
-    """Deep link to the app's install page (the one manual OAuth-consent step)."""
-    return f"https://api.slack.com/apps/{app_id}/install-on-team"
-
-
-def _slack_app_api(method: str, payload: dict[str, Any], *, token: str) -> dict[str, Any]:
-    """POST to ``https://slack.com/api/<method>`` with a bearer *token*."""
-    response = httpx.post(
-        f"https://slack.com/api/{method}",
-        headers={"Authorization": f"Bearer {token}"},
-        data=payload,
-        timeout=30,
-    )
-    response.raise_for_status()
-    return dict(response.json())
-
-
-def export_manifest(*, app_id: str, config_token: str) -> SlackManifest:
-    """Return the Slack app's current manifest via ``apps.manifest.export``."""
-    result = _slack_app_api("apps.manifest.export", {"app_id": app_id}, token=config_token)
-    if not result.get("ok"):
-        raise SlackManifestError(str(result.get("error", "unknown error")))
-    return dict(result["manifest"])
-
-
-def update_manifest(*, app_id: str, manifest: SlackManifest, config_token: str) -> dict[str, Any]:
-    """Apply *manifest* to the app in place via ``apps.manifest.update``."""
-    result = _slack_app_api(
-        "apps.manifest.update",
-        {"app_id": app_id, "manifest": json.dumps(manifest)},
-        token=config_token,
-    )
-    if not result.get("ok"):
-        raise SlackManifestError(str(result.get("error", "unknown error")))
-    return result
-
-
-def rotate_config_token(*, refresh_token: str) -> tuple[str, str]:
-    """Rotate the app-config token pair via ``tooling.tokens.rotate``.
-
-    Returns ``(access_token, refresh_token)``.
-    """
-    result = _slack_app_api("tooling.tokens.rotate", {"refresh_token": refresh_token}, token=refresh_token)
-    if not result.get("ok"):
-        raise SlackManifestError(str(result.get("error", "unknown error")))
-    return str(result["token"]), str(result["refresh_token"])
-
-
-def _scope_set(manifest: SlackManifest, kind: str) -> set[str]:
-    return set(manifest.get("oauth_config", {}).get("scopes", {}).get(kind, []))
-
-
-def manifests_equivalent(a: SlackManifest, b: SlackManifest) -> bool:
-    """Compare only the teatree-owned manifest fields, order-insensitively."""
-
-    def shape(m: SlackManifest) -> tuple[Any, ...]:
-        settings = m.get("settings", {})
-        return (
-            _scope_set(m, "bot"),
-            _scope_set(m, "user"),
-            frozenset(settings.get("event_subscriptions", {}).get("bot_events", [])),
-            settings.get("socket_mode_enabled"),
-            m.get("display_information", {}).get("name"),
-        )
-
-    return shape(a) == shape(b)
 
 
 def write_overlay_settings(
@@ -523,6 +363,63 @@ def _run_token_walkthrough(
         raise typer.Exit(code=1)
 
 
+def _migrate_token_ref(
+    config_path: Path,
+    overlay: str,
+    old_ref: str,
+    new_ref: str,
+    *,
+    skip_smoke_test: bool,
+) -> None:
+    """Copy tokens from *old_ref* slots to *new_ref* slots, rewrite the TOML, and smoke-test.
+
+    Raises :class:`typer.Exit` (code 1) when either old-slot value is absent
+    (nothing to migrate — the user must store tokens first).  The copy uses
+    :func:`store_slack_token` so validation and backup-before-overwrite
+    invariants are preserved.  After the copy the TOML ``slack_token_ref`` is
+    updated to *new_ref* and an optional smoke test is run, then the function
+    raises :class:`typer.Exit` (code 0) so the caller can return immediately.
+    """
+    old_bot = read_pass(f"{old_ref}-bot")
+    old_app = read_pass(f"{old_ref}-app")
+    if not old_bot or not old_app:
+        typer.echo(
+            f"ERROR Cannot migrate `{old_ref}` → `{new_ref}`: "
+            f"no token stored under `{old_ref}-bot` / `{old_ref}-app`. "
+            "Store the tokens first, then rerun."
+        )
+        raise typer.Exit(code=1)
+
+    typer.echo(f"INFO  Migrating tokens from `{old_ref}` → `{new_ref}` …")
+    try:
+        store_slack_token(bot_token_slot(new_ref), old_bot, echo=typer.echo)
+        store_slack_token(app_token_slot(new_ref), old_app, echo=typer.echo)
+    except SlackTokenWriteError as exc:
+        typer.echo(f"ERROR Migration failed: {exc}")
+        raise typer.Exit(code=1) from exc
+    typer.echo(f"OK    Tokens migrated to `{new_ref}-bot` and `{new_ref}-app`.")
+
+    user_id = _read_overlay_field(config_path, overlay, "slack_user_id")
+    app_id = _read_overlay_field(config_path, overlay, "slack_app_id")
+    write_overlay_settings(
+        config_path,
+        overlay,
+        slack_user_id=user_id,
+        slack_token_ref=new_ref,
+        slack_app_id=app_id,
+    )
+    typer.echo(f"OK    Rewrote `[overlays.{overlay}].slack_token_ref` to `{new_ref}` in {config_path}.")
+
+    typer.echo("Step — Smoke test.")
+    if skip_smoke_test:
+        typer.echo("      Skipped per `--skip-smoke-test`.")
+        raise typer.Exit(code=0)
+    bot_token = read_pass(f"{new_ref}-bot")
+    if not _smoke_test(bot_token=bot_token, user_id=user_id):
+        raise typer.Exit(code=1)
+    raise typer.Exit(code=0)
+
+
 def slack_bot_setup(
     *,
     overlay: str = typer.Option(..., "--overlay", help="Overlay name as registered in `~/.teatree.toml`."),
@@ -542,6 +439,10 @@ def slack_bot_setup(
     """Register or update a per-overlay Slack bot and store its tokens via ``pass``."""
     _validate_overlay(overlay)
     token_ref = f"teatree/{overlay}/slack"
+
+    existing_ref = _read_overlay_field(config_path, overlay, "slack_token_ref")
+    if existing_ref and existing_ref != token_ref:
+        _migrate_token_ref(config_path, overlay, existing_ref, token_ref, skip_smoke_test=skip_smoke_test)
 
     if not reset:
         recorded_app_id = _read_overlay_field(config_path, overlay, "slack_app_id")

--- a/src/teatree/cli/slack_setup.py
+++ b/src/teatree/cli/slack_setup.py
@@ -32,6 +32,7 @@ import re
 import time
 import webbrowser
 from pathlib import Path
+from typing import NoReturn
 
 import typer
 
@@ -370,7 +371,7 @@ def _migrate_token_ref(
     new_ref: str,
     *,
     skip_smoke_test: bool,
-) -> None:
+) -> NoReturn:
     """Copy tokens from *old_ref* slots to *new_ref* slots, rewrite the TOML, and smoke-test.
 
     Raises :class:`typer.Exit` (code 1) when either old-slot value is absent

--- a/tests/test_slack_setup.py
+++ b/tests/test_slack_setup.py
@@ -185,7 +185,7 @@ class TestUserScopesExcludeBotOnly:
     def test_guard_raises_when_a_bot_only_scope_leaks_in(self) -> None:
         leaked = min(_BOT_ONLY_SCOPES)
         with (
-            patch("teatree.cli.slack_setup._USER_SCOPES", [*_USER_SCOPES, leaked]),
+            patch("teatree.cli.slack_manifest._USER_SCOPES", [*_USER_SCOPES, leaked]),
             pytest.raises(AssertionError, match=re.escape(leaked)),
         ):
             _user_scopes_carry_no_bot_only_scope()
@@ -584,7 +584,7 @@ class TestManifestsEquivalent:
 class TestExportUpdateRotate:
     def test_export_returns_manifest(self) -> None:
         with patch(
-            "teatree.cli.slack_setup._slack_app_api",
+            "teatree.cli.slack_manifest._slack_app_api",
             return_value={"ok": True, "manifest": {"display_information": {"name": "x"}}},
         ):
             manifest = export_manifest(app_id="A123456", config_token="xoxe.xoxp-1")
@@ -593,7 +593,7 @@ class TestExportUpdateRotate:
     def test_export_not_ok_raises_manifest_error(self) -> None:
         with (
             patch(
-                "teatree.cli.slack_setup._slack_app_api",
+                "teatree.cli.slack_manifest._slack_app_api",
                 return_value={"ok": False, "error": "invalid_auth"},
             ),
             pytest.raises(SlackManifestError, match="invalid_auth"),
@@ -609,7 +609,7 @@ class TestExportUpdateRotate:
             captured["token"] = token
             return {"ok": True, "permissions_updated": True}
 
-        with patch("teatree.cli.slack_setup._slack_app_api", side_effect=fake_api):
+        with patch("teatree.cli.slack_manifest._slack_app_api", side_effect=fake_api):
             result = update_manifest(
                 app_id="A123456",
                 manifest={"display_information": {"name": "x"}},
@@ -623,7 +623,7 @@ class TestExportUpdateRotate:
     def test_update_not_ok_raises_manifest_error(self) -> None:
         with (
             patch(
-                "teatree.cli.slack_setup._slack_app_api",
+                "teatree.cli.slack_manifest._slack_app_api",
                 return_value={"ok": False, "error": "failed_constraint"},
             ),
             pytest.raises(SlackManifestError, match="failed_constraint"),
@@ -632,7 +632,7 @@ class TestExportUpdateRotate:
 
     def test_rotate_returns_access_and_refresh(self) -> None:
         with patch(
-            "teatree.cli.slack_setup._slack_app_api",
+            "teatree.cli.slack_manifest._slack_app_api",
             return_value={"ok": True, "token": "xoxe.xoxp-NEW", "refresh_token": "xoxe-NEWREFRESH"},
         ):
             access, refresh = rotate_config_token(refresh_token="xoxe-OLD")
@@ -642,7 +642,7 @@ class TestExportUpdateRotate:
     def test_rotate_not_ok_raises_manifest_error(self) -> None:
         with (
             patch(
-                "teatree.cli.slack_setup._slack_app_api",
+                "teatree.cli.slack_manifest._slack_app_api",
                 return_value={"ok": False, "error": "token_expired"},
             ),
             pytest.raises(SlackManifestError, match="token_expired"),
@@ -737,7 +737,7 @@ class TestUpdatePathModeResolution:
             patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
             patch(
-                "teatree.cli.slack_setup._slack_app_api",
+                "teatree.cli.slack_manifest._slack_app_api",
                 return_value={"ok": True, "manifest": build_manifest(overlay_name="acme")},
             ),
         ):
@@ -759,7 +759,7 @@ class TestUpdatePathModeResolution:
             patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
             patch(
-                "teatree.cli.slack_setup._slack_app_api",
+                "teatree.cli.slack_manifest._slack_app_api",
                 return_value={"ok": True, "manifest": build_manifest(overlay_name="acme")},
             ),
         ):
@@ -834,7 +834,7 @@ class TestUpdatePathBehavior:
             patch("teatree.cli.slack_token_store.read_pass", return_value=""),
             patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True) as smoke,
-            patch("teatree.cli.slack_setup._slack_app_api", side_effect=fake_api),
+            patch("teatree.cli.slack_manifest._slack_app_api", side_effect=fake_api),
         ):
             result = _invoke_setup(tmp_path, inputs="", args=["--overlay", "acme"], config=config)
 
@@ -862,7 +862,7 @@ class TestUpdatePathBehavior:
             patch("teatree.cli.slack_token_store.read_pass", return_value=""),
             patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
-            patch("teatree.cli.slack_setup._slack_app_api", side_effect=fake_api),
+            patch("teatree.cli.slack_manifest._slack_app_api", side_effect=fake_api),
         ):
             result = _invoke_setup(tmp_path, inputs="", args=["--overlay", "acme"], config=config)
 
@@ -903,7 +903,7 @@ class TestUpdatePathBehavior:
             patch("teatree.cli.slack_setup.read_pass", side_effect=fake_read),
             patch("teatree.cli.slack_setup.write_pass", side_effect=fake_write),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
-            patch("teatree.cli.slack_setup._slack_app_api", side_effect=fake_api),
+            patch("teatree.cli.slack_manifest._slack_app_api", side_effect=fake_api),
         ):
             result = _invoke_setup(tmp_path, inputs="", args=["--overlay", "acme"], config=config)
 
@@ -928,7 +928,7 @@ class TestUpdatePathBehavior:
             patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
             patch(
-                "teatree.cli.slack_setup._slack_app_api",
+                "teatree.cli.slack_manifest._slack_app_api",
                 return_value={"ok": False, "error": "token_expired"},
             ),
         ):
@@ -988,7 +988,7 @@ class TestSlackAppApi:
             captured["data"] = data
             return FakeResponse()
 
-        with patch("teatree.cli.slack_setup.httpx.post", side_effect=fake_post):
+        with patch("teatree.cli.slack_manifest.httpx.post", side_effect=fake_post):
             result = _slack_app_api("apps.manifest.export", {"app_id": "A1"}, token="xoxe.xoxp-1")
 
         assert captured["url"] == "https://slack.com/api/apps.manifest.export"
@@ -1011,7 +1011,7 @@ class TestUpdatePathSmokeFailure:
             patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=False),
             patch(
-                "teatree.cli.slack_setup._slack_app_api",
+                "teatree.cli.slack_manifest._slack_app_api",
                 return_value={"ok": True, "manifest": build_manifest(overlay_name="acme")},
             ),
         ):
@@ -1063,7 +1063,7 @@ class TestUpdatePathSmokeFailure:
             patch("teatree.cli.slack_token_store.write_pass", return_value=True),
             patch("teatree.cli.slack_setup._smoke_test", return_value=True),
             patch(
-                "teatree.cli.slack_setup._slack_app_api",
+                "teatree.cli.slack_manifest._slack_app_api",
                 return_value={"ok": False, "error": "ratelimited"},
             ),
         ):
@@ -1120,3 +1120,144 @@ class TestValidateOverlayKnownList:
         assert "teatree" in known  # t3-teatree contains the substring
         known_names = {n.strip() for n in known.split(",")}
         assert "teatree" not in known_names
+
+
+class TestTokenRefMigration:
+    """setup slack-bot must migrate tokens when rewriting slack_token_ref to canonical form.
+
+    Regression guard for #2047: when the TOML has a stale ``slack_token_ref``
+    (e.g. ``teatree/teatree/slack``) and the command computes a different
+    canonical ref (``teatree/t3-teatree/slack``), the tokens under the old ref
+    must be copied to the new ref slots before the TOML is rewritten.  Without
+    the migration the new canonical ref points at empty pass entries and the
+    smoke test immediately fails with a misleading "token may lack im:write"
+    error.
+    """
+
+    def _config_with_old_ref(self, tmp_path: Path, old_ref: str) -> Path:
+        config = tmp_path / "teatree.toml"
+        config.write_text(
+            f'[overlays.acme]\nslack_user_id = "U01ABCD1234"\nslack_token_ref = "{old_ref}"\n',
+            encoding="utf-8",
+        )
+        return config
+
+    def test_tokens_under_old_ref_are_migrated_to_canonical_ref(self, tmp_path: Path) -> None:
+        """After setup, the canonical ref's slots hold the tokens that lived under the old ref."""
+        old_ref = "teatree/old-acme/slack"
+        config = self._config_with_old_ref(tmp_path, old_ref)
+        store: dict[str, str] = {
+            f"{old_ref}-bot": "xoxb-1-oldbot",
+            f"{old_ref}-app": "xapp-1-oldapp",
+        }
+
+        def fake_read(key: str) -> str:
+            return store.get(key, "")
+
+        def fake_write(key: str, value: str) -> bool:
+            store[key] = value
+            return True
+
+        canonical_ref = "teatree/acme/slack"
+        with (
+            patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
+            patch("teatree.cli.slack_token_store.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_token_store.write_pass", side_effect=fake_write),
+            patch("teatree.cli.slack_setup.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_setup.write_pass", side_effect=fake_write),
+            patch("teatree.cli.slack_setup.webbrowser.open"),
+            patch("teatree.cli.slack_setup._smoke_test", return_value=True),
+        ):
+            result = _invoke_setup(
+                tmp_path,
+                inputs="",
+                args=["--overlay", "acme", "--skip-smoke-test"],
+                config=config,
+            )
+
+        assert result.exit_code == 0, result.stdout
+        assert store.get(f"{canonical_ref}-bot") == "xoxb-1-oldbot"
+        assert store.get(f"{canonical_ref}-app") == "xapp-1-oldapp"
+
+    def test_rewrite_refused_when_old_ref_is_empty(self, tmp_path: Path) -> None:
+        """When no token is stored under the old ref, setup refuses to rewrite to the canonical ref.
+
+        Rewriting to a canonical ref that would also be empty is never safe;
+        the user must store tokens first (or run the full create path).
+        """
+        old_ref = "teatree/old-acme/slack"
+        config = self._config_with_old_ref(tmp_path, old_ref)
+
+        def fake_read(_key: str) -> str:
+            return ""
+
+        with (
+            patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
+            patch("teatree.cli.slack_token_store.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_token_store.write_pass", return_value=True),
+            patch("teatree.cli.slack_setup.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_setup.write_pass", return_value=True),
+            patch("teatree.cli.slack_setup.webbrowser.open"),
+        ):
+            result = _invoke_setup(
+                tmp_path,
+                inputs="",
+                args=["--overlay", "acme", "--skip-smoke-test"],
+                config=config,
+            )
+
+        assert result.exit_code == 1
+        assert "no token stored" in result.stdout.lower() or "cannot migrate" in result.stdout.lower()
+        document = cast("dict[str, Any]", tomlkit.parse(config.read_text(encoding="utf-8")))
+        assert document["overlays"]["acme"]["slack_token_ref"] == old_ref
+
+    def test_no_migration_when_ref_already_canonical(self, tmp_path: Path) -> None:
+        """When the existing ref is already canonical, setup runs normally without migration.
+
+        A ``slack_app_id`` is present so the command takes the update path
+        (no interactive token prompts), making the assertion deterministic.
+        The key guard is that the store is NOT modified by migration: the bot
+        slot still holds its original value after setup completes.
+        """
+        canonical_ref = "teatree/acme/slack"
+        config = tmp_path / "teatree.toml"
+        config.write_text(
+            f'[overlays.acme]\nslack_user_id = "U01ABCD1234"\n'
+            f'slack_token_ref = "{canonical_ref}"\nslack_app_id = "A0123456789"\n',
+            encoding="utf-8",
+        )
+        store: dict[str, str] = {
+            f"{canonical_ref}-bot": "xoxb-1-existing",
+            f"{canonical_ref}-app": "xapp-1-existing",
+        }
+        writes: list[str] = []
+
+        def fake_read(key: str) -> str:
+            return store.get(key, "")
+
+        def fake_write(key: str, value: str) -> bool:
+            writes.append(key)
+            store[key] = value
+            return True
+
+        with (
+            patch("teatree.cli.slack_setup.discover_overlays", return_value=_stub_overlays()),
+            patch("teatree.cli.slack_token_store.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_token_store.write_pass", side_effect=fake_write),
+            patch("teatree.cli.slack_setup.read_pass", side_effect=fake_read),
+            patch("teatree.cli.slack_setup.write_pass", side_effect=fake_write),
+            patch("teatree.cli.slack_setup.webbrowser.open"),
+            patch("teatree.cli.slack_setup._smoke_test", return_value=True),
+            patch("teatree.cli.slack_setup._run_update_path"),
+        ):
+            result = _invoke_setup(
+                tmp_path,
+                inputs="",
+                args=["--overlay", "acme", "--skip-smoke-test"],
+                config=config,
+            )
+
+        assert result.exit_code == 0, result.stdout
+        # Migration must not have written anything — the canonical ref was already correct.
+        assert not any(canonical_ref in w for w in writes), f"Unexpected migration write(s): {writes}"
+        assert store.get(f"{canonical_ref}-bot") == "xoxb-1-existing"


### PR DESCRIPTION
## Summary

- `slack_bot_setup` always computed the canonical `teatree/{overlay}/slack` ref without reading the existing `slack_token_ref` from TOML. When they differed, the stored bot and app tokens were orphaned, and the smoke test immediately failed with a misleading "token may lack `im:write`" error.
- The command now reads the existing ref, detects a mismatch, copies tokens from the old ref slots to the new canonical slots via `store_slack_token` (prefix-validated, backup-before-overwrite), rewrites the TOML, and smoke-tests before exiting.
- Extracted Slack manifest helpers into a new `slack_manifest` module to keep `slack_setup` under the 500-LOC health ceiling; all public symbols remain importable from `slack_setup` via explicit re-export.

Fixes #2047.

## Test plan

- [ ] `TestTokenRefMigration::test_tokens_under_old_ref_are_migrated_to_canonical_ref` — tokens under old ref are copied to canonical slots
- [ ] `TestTokenRefMigration::test_rewrite_refused_when_old_ref_is_empty` — exits 1 and leaves TOML unchanged when old ref has no tokens
- [ ] `TestTokenRefMigration::test_no_migration_when_ref_already_canonical` — no migration writes when ref is already canonical
- [ ] All 83 existing tests in `tests/test_slack_setup.py` remain green