### PR TITLE
test(loop): harden active-tickets isolation test against order-dependent state (#1924, #1961)

### DIFF
--- a/tests/teatree_loop/test_per_item_fault_isolation_1597.py
+++ b/tests/teatree_loop/test_per_item_fault_isolation_1597.py
@@ -259,27 +259,40 @@ class TestActiveTicketsIsolation(TestCase):
     """Sibling ticket still emits signal when processing the first ticket raises."""
 
     def test_failing_first_ticket_does_not_suppress_second_ticket_signal(self) -> None:
-        ticket_a = Ticket.objects.create(overlay="acme", issue_url="https://x/1", state="started")
-        Ticket.objects.create(overlay="acme", issue_url="https://x/2", state="coded")
+        # A unique per-test overlay so the scanner only ever sees THIS test's two
+        # tickets. ``ActiveTicketsScanner`` filters on ``overlay_name``, so scoping
+        # the scan to a private overlay makes the test independent of any ticket
+        # row another test leaves visible in the DB under a shared overlay name
+        # (the order-dependent isolation flake #1924/#1961).
+        overlay = "fault-iso-active-tickets"
+        ticket_a = Ticket.objects.create(overlay=overlay, issue_url="https://x/1", state="started")
+        Ticket.objects.create(overlay=overlay, issue_url="https://x/2", state="coded")
 
-        # Make _enqueue_short_describe raise on ticket_a by giving it a cached
-        # title (triggering the enqueue path) and making Session.objects.create raise.
+        # Drive the failure on ticket_a deterministically: give it a cached title
+        # so ``_enqueue_short_describe`` runs and calls ``Session.objects.create``,
+        # then make that one ticket's session creation raise. Keying the fault on
+        # the specific ticket — not a call-count over the global iteration order —
+        # keeps the reproduction independent of how many sessions any other code
+        # path happens to create first.
         Ticket.objects.filter(pk=ticket_a.pk).update(
             extra={"issue_title": "something"},
         )
 
         original_create = Session.objects.create
-        call_count = [0]
 
         def _raising_create(**kwargs: Any) -> Any:
-            call_count[0] += 1
-            if call_count[0] == 1:
+            if kwargs.get("ticket") is not None and kwargs["ticket"].pk == ticket_a.pk:
                 msg = "simulated DB error on first ticket"
                 raise RuntimeError(msg)
             return original_create(**kwargs)
 
-        with patch("teatree.core.models.session.Session.objects.create", side_effect=_raising_create):
-            signals = ActiveTicketsScanner().scan()
+        # ``addCleanup`` (not a ``with`` block) guarantees the patch is torn down
+        # even if an assertion or an unexpected error fires before the block would
+        # exit — the patched ``create`` can never outlive this test.
+        patcher = patch("teatree.core.models.session.Session.objects.create", side_effect=_raising_create)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        signals = ActiveTicketsScanner(overlay_name=overlay).scan()
 
         assert len(signals) == 1, "second ticket must emit its signal even though first raised"
         assert signals[0].payload["state"] == "coded"


### PR DESCRIPTION
## Summary

`tests/teatree_loop/test_per_item_fault_isolation_1597.py::TestActiveTicketsIsolation` was order-dependent: it passed in isolation but could fail under full-suite ordering with `RuntimeError: simulated DB error on first ticket`. That same fragility class is the suspected cause of the `test_pr_sweep_scanner.py` error-isolation flake tracked in #1961.

The root cause is that the test scanned **all** non-terminal tickets in the DB (no overlay filter) and keyed its injected fault on a **global call-count**, so the outcome depended on which ticket rows — and how many prior session creations — the surrounding suite happened to leave visible. That coupling to global state is the order-dependence.

## What changed (test-only)

- **Scope the scanner to a unique per-test overlay** (`ActiveTicketsScanner(overlay_name=...)`), so it can only ever see this test's own two tickets, never a row another test leaves in the DB.
- **Key the injected fault on the specific ticket pk** instead of a call-count over the global iteration order, so the reproduction is independent of how many sessions any other path creates first.
- **Start/stop the patch via `addCleanup`** rather than a `with` block, so the patched `create` is torn down even if an assertion fires first.

No production code is touched.

## Verification

- The test still genuinely guards the per-item fault-isolation behaviour from #1597: removing the scanner's per-item `try/except` makes it go RED (`RuntimeError`), and restoring it makes it GREEN.
- Both affected files pass together, and the polluter file passes under randomized ordering across several seeds.
- A controlled experiment with a committed ticket under a shared overlay name (the kind of leaked-in row that previously could inflate the global scan) no longer affects the test.
- `makemigrations --check` reports no changes; lint and format pass; the test-path-mirror ratchet holds.

## Note on reproduction

I could reliably reproduce the *fragility class* (global-scan + call-count coupling) but not the exact original cross-file ordering inside the bounded local scope. The original failures were full-suite CI runs; the fix removes the global-state coupling that makes the test sensitive to ordering at all, which is the robust way to close the class rather than chase one seed.

## Issue scope

- **Fixes #1924** — that issue names this exact file and its diagnosis (global-scan + leaked-row coupling) matches the fix precisely.
- **Refs #1961** — this hardens the order-dependence class behind it, but #1961's failing test (`test_pr_sweep_scanner.py::TestErrorIsolation`, which raises a *different* error string) was never root-caused to this fix and was not observed RED→GREEN here. Leaving #1961 open intentionally; close it manually only after the full suite is observed flake-free across several CI runs.

## Architecture pre-check

1. **BLUEPRINT § alignment** — n/a; test-infra hardening only, no architectural surface touched.
2. **FSM phase boundaries** — n/a; no `Ticket.State`/`Worktree.State` transition involved.
3. **Extension-point contracts** — n/a; no `OverlayBase`/scanner-registration/Protocol change.
4. **Component boundaries** — change confined to `tests/teatree_loop/`.
5. **Dependency direction** — no imports added.
6. **Test surface** — the modified test asserts the scanner's per-item isolation (second ticket emits its signal when the first ticket's session creation raises); proven anti-vacuous by reverting the scanner guard → RED.
7. **Resilience invariants** — n/a; no external write.
8. **Identity/key normalization** — n/a.
9. **Behavior preservation** — the test still guards exactly what it did before (per-item fault isolation); only its coupling to global DB/iteration state is removed. No assertion was weakened or inverted.
