### PR TITLE
fix(hooks): exempt loop-bootstrap turns from the skill-load gate

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -1562,6 +1562,26 @@ def _skill_gate_targets_code_work(data: dict) -> bool:
     return False
 
 
+def _skill_loading_exempt(session_id: str) -> bool:
+    """True when the skill-load gate must NOT fire for this session's code work.
+
+    NEVER-LOCKOUT (#1918): a loop-registration / loop-owner bootstrap turn
+    routinely surfaces a resolvable intent skill (the bare word ``loops`` is a
+    hard intent trigger) in ``<session>.pending`` while doing genuine code work
+    during teatree's own Django setup. Blocking that to demand an unrelated
+    ``/loops`` load deadlocks the bootstrap. The skill-load gate is a UX nudge,
+    not a safety gate, so it exempts the turn — keyed on the SAME short-lived
+    ``<session>.loop-pending`` marker the loop gates use (written by
+    :func:`handle_enforce_loop_on_prompt`, cleared once the loop registers), so
+    there is one source of truth for "this session is mid loop-bootstrap".
+
+    ``.is_file()`` never raises, so a missing/unreadable marker preserves the
+    gate (fails to "not exempt"), never crashes — per the hooks crash-proof
+    contract.
+    """
+    return _state_file(session_id, "loop-pending").is_file()
+
+
 def handle_enforce_skill_loading(data: dict) -> bool:
     """Block Python/Django code work when *loadable* suggested skills aren't loaded.
 
@@ -1578,7 +1598,7 @@ def handle_enforce_skill_loading(data: dict) -> bool:
     lacking that token.
     """
     session_id = data.get("session_id", "")
-    if not session_id or not _skill_gate_targets_code_work(data):
+    if not session_id or not _skill_gate_targets_code_work(data) or _skill_loading_exempt(session_id):
         return False
 
     pending_lines = _read_lines(_state_file(session_id, "pending"))

--- a/tests/test_lockout_regression_corpus.py
+++ b/tests/test_lockout_regression_corpus.py
@@ -432,6 +432,65 @@ class TestSkillLoadingLockoutDimension:
         assert blocked is False, "OVER-BLOCK regression — AskUserQuestion was gated (must NEVER be gated)."
 
 
+class TestSkillLoadingGateExemptDuringLoopBootstrap:
+    """The skill-load gate must NOT fire during a loop-registration bootstrap turn (#1918).
+
+    When the loop-registration / loop-owner bootstrap turn surfaces a resolvable
+    intent skill (the bare word ``loops`` is a hard intent trigger), it lands in
+    ``<session>.pending``. The very next genuine code-work call in the same turn
+    (``uv run pytest``, ``manage.py``, a ``.py`` edit — routine during teatree's
+    own Django setup) would then hard-deny demanding ``/loops``, a skill unrelated
+    to the work and unsatisfiable mid-setup — a deadlock. The skill-load gate is a
+    UX nudge, not a safety gate, so it must exempt the loop-bootstrap turn.
+
+    The exemption keys strictly on the existing ``<session>.loop-pending`` marker
+    (written by the loop-registration gate, cleared once the loop registers), so it
+    is the canonical "this session is mid loop-bootstrap" signal both loop gates
+    already key on. The must-DENY ANCHOR (same skill pending, NO marker → still
+    blocked) proves the must-ALLOW is an escape, not a defanged gate.
+    """
+
+    @pytest.fixture
+    def skill_gate(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        original_state = router.STATE_DIR
+        router.STATE_DIR = tmp_path / "state"
+        router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+        skills_dir = tmp_path / "skills"
+        skill = skills_dir / "loops"
+        skill.mkdir(parents=True, exist_ok=True)
+        (skill / "SKILL.md").write_text("---\nname: loops\n---\n", encoding="utf-8")
+        monkeypatch.setenv("T3_SKILL_SEARCH_DIRS", str(skills_dir))
+        yield
+        router.STATE_DIR = original_state
+
+    def _write(self, session_id: str, suffix: str, names: list[str]) -> None:
+        (router.STATE_DIR / f"{session_id}.{suffix}").write_text("\n".join(names) + "\n", encoding="utf-8")
+
+    def _marker(self, session_id: str) -> None:
+        (router.STATE_DIR / f"{session_id}.loop-pending").write_text("1", encoding="utf-8")
+
+    def test_must_deny_anchor_no_loop_marker(self, skill_gate: None) -> None:
+        self._write("sess-loop-anchor", "pending", ["loops"])
+        blocked = handle_enforce_skill_loading(
+            {"session_id": "sess-loop-anchor", "tool_name": "Bash", "tool_input": {"command": "uv run pytest -q"}}
+        )
+        assert blocked is True, (
+            "ANCHOR regression — the skill-load gate no longer fires for code work with a resolvable "
+            "unloaded skill pending and NO loop-bootstrap marker; the must-ALLOW row below would be vacuous."
+        )
+
+    def test_must_allow_during_loop_bootstrap(self, skill_gate: None) -> None:
+        self._write("sess-loop-boot", "pending", ["loops"])
+        self._marker("sess-loop-boot")
+        blocked = handle_enforce_skill_loading(
+            {"session_id": "sess-loop-boot", "tool_name": "Bash", "tool_input": {"command": "uv run pytest -q"}}
+        )
+        assert blocked is False, (
+            "DEADLOCK regression (#1918) — code work during a loop-registration bootstrap turn "
+            "(loop-pending marker present) was blocked demanding an unrelated skill load."
+        )
+
+
 class TestMustDenyMerge:
     """Merge commands on teatree-managed repos must be blocked."""
 

--- a/tests/test_skill_loading_code_scope.py
+++ b/tests/test_skill_loading_code_scope.py
@@ -61,6 +61,10 @@ def _write_pending(session_id: str, skills: list[str]) -> None:
     (router.STATE_DIR / f"{session_id}.pending").write_text("\n".join(skills) + "\n", encoding="utf-8")
 
 
+def _write_loop_pending(session_id: str) -> None:
+    (router.STATE_DIR / f"{session_id}.loop-pending").write_text("1", encoding="utf-8")
+
+
 def _run(data: dict) -> tuple[bool, dict | None]:
     out = StringIO()
     err = StringIO()
@@ -185,3 +189,31 @@ class TestGateStillFiresOnCodeWork:
         )
         assert blocked is False
         assert payload is None
+
+
+class TestLoopBootstrapExemption:
+    """The skill-load gate must not deadlock a loop-registration bootstrap turn (#1918)."""
+
+    def test_loop_bootstrap_turn_not_blocked(self, gate: Path) -> None:
+        # A code-work Bash with a resolvable unloaded skill pending would normally
+        # block; the loop-pending marker (this session is mid loop-bootstrap) exempts it.
+        _write_pending("sess-loop", ["ac-python"])
+        _write_loop_pending("sess-loop")
+        blocked, payload = _run(
+            {"session_id": "sess-loop", "tool_name": "Bash", "tool_input": {"command": "uv run pytest -q"}}
+        )
+        assert blocked is False, (
+            "DEADLOCK regression (#1918) — code work during a loop-registration bootstrap turn was blocked."
+        )
+        assert payload is None
+
+    def test_gate_still_fires_after_loop_registers(self, gate: Path) -> None:
+        # No loop-pending marker (the bootstrap turn cleared it once the loop
+        # registered) → the gate keeps its teeth on genuine code work.
+        _write_pending("sess-registered", ["ac-python"])
+        blocked, payload = _run(
+            {"session_id": "sess-registered", "tool_name": "Bash", "tool_input": {"command": "uv run pytest -q"}}
+        )
+        assert blocked is True
+        assert payload is not None
+        assert payload["permissionDecision"] == "deny"


### PR DESCRIPTION
## Summary

Fixes #1918. The PreToolUse skill-load gate could deadlock a loop-registration / loop-owner bootstrap turn: the bare word `loops` is a hard intent trigger, so it lands in `<session>.pending` during setup; teatree's own Django setup routinely runs genuine code work (`uv run pytest`, `manage.py`, a `.py` edit) in the same turn, and the gate then hard-denies that work demanding an unrelated `/loops` load that cannot be satisfied mid-bootstrap.

The skill-load gate is a UX nudge, not a safety gate (it shares the `_fail_open_or_deny` chokepoint with the other over-deny gates per BLUEPRINT §17.1 invariant 10 / §17.6.4). It now exempts the loop-bootstrap turn, mirroring the precedent in the sibling `handle_enforce_loop_registration`.

## What changed

- `hooks/scripts/hook_router.py`: new `_skill_loading_exempt(session_id)` helper; `handle_enforce_skill_loading` returns allow early when it is true.
  - Keyed strictly on the existing short-lived `<session>.loop-pending` marker that the loop gates already use (written by `handle_enforce_loop_on_prompt` when the loop is not yet registered, cleared once it registers) — one source of truth for "this session is mid loop-bootstrap", no new state-file shape.
  - Fails closed: `.is_file()` never raises, so a missing/unreadable marker preserves the gate. The gate keeps its teeth on all other code work once the marker is gone.
- `tests/test_lockout_regression_corpus.py`: new `TestSkillLoadingGateExemptDuringLoopBootstrap` — a must-ALLOW (code work + loop-pending marker → allowed) and a must-DENY anchor (same skill pending, no marker → still blocked), so the must-ALLOW is proven an escape, not a defanged gate.
- `tests/test_skill_loading_code_scope.py`: new `TestLoopBootstrapExemption` — a `test_loop_bootstrap_turn_not_blocked` (marker present → passes) and a `test_gate_still_fires_after_loop_registers` (no marker → keeps its teeth), alongside the existing `TestGateStillFiresOnCodeWork`.

## Verification (RED -> GREEN)

- RED on origin/main: both must-ALLOW rows fail (gate denies during loop bootstrap demanding `/loops`); both anchors pass.
- After the fix: all 4 new rows pass.
- Revert-to-confirm (anti-vacuous): stashing the `hook_router.py` change turns both must-ALLOW rows RED again; restoring it returns them GREEN.
- Existing contracts stay green: `TestSkillLoadingLockoutDimension`, `TestGateStillFiresOnCodeWork`, the AST never-lockout contract `test_gate_never_lockout_contract.py::test_every_pretooluse_deny_handler_is_never_lockout` (the non-exempt path still routes through `_fail_open_or_deny`), and the `enforce-skill-loading` row in `test_gate_liveness_corpus.py` (its fixture has no loop-pending marker, so it is unaffected). `183 passed, 2 xfailed`.
- `ruff check` + `ruff format --check` clean. No migration (hooks-only).

## Architecture pre-check — #1918

### 1. BLUEPRINT § alignment
§17.6.4 / §17.1 invariant 10 — the skill-loading over-deny gate is one of the sibling UX gates sharing the `_fail_open_or_deny` chokepoint with always-available escapes. This adds a NEVER-LOCKOUT exemption inside that gate; no architectural change, so no BLUEPRINT edit (the BLUEPRINT-update pre-commit gate passed).

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
Hook handler `handle_enforce_skill_loading` only. The new exemption is internal to it; no Protocol / OverlayBase / scanner contract touched.

### 4. Component boundaries
`hooks/scripts/` — a Claude Code PreToolUse hook handler. Correct home; no straddle.

### 5. Dependency direction
No new imports; reuses the in-module `_state_file`. No backwards edge.

### 6. Test surface
Hook-handler tests assert the decision (allow/deny) per the §6 hook pattern: must-ALLOW with the marker, must-DENY anchor without it, plus the keeps-its-teeth-after-register row. Each would fail if the behaviour regressed.

### 7. Resilience invariants
The only side effect is reading a marker file. Crash-proof (`.is_file()` never raises) and idempotent (pure read). No external write.

### 8. Identity and key normalization
n/a — keys on a fixed state-file suffix, no bare-vs-qualified identity.

### 9. Behavior preservation / capability deletion
Purely additive — an exemption branch. No existing behavior removed; no must-block test inverted to must-not-block. The must-DENY anchor and the existing `TestGateStillFiresOnCodeWork` rows prove the gate's teeth are preserved for every non-bootstrap code-work call.
