### PR TITLE
fix(loop): route work-next-sdk headless dispatch through the shared loop-dispatch guard (#1375)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4568,7 +4568,9 @@ Usage: t3 teatree tasks [OPTIONS] COMMAND [ARGS]...
 │                       the current harness session's todos.                   │
 │ start                 Claim and run the next interactive task in the current │
 │                       terminal.                                              │
-│ work-next-sdk         Claim and execute an headless task.                    │
+│ work-next-sdk         Claim and execute a headless task; refuses             │
+│                       loop-dispatched phases unless                          │
+│                       LOOP_ALLOW_HEADLESS_DISPATCH.                          │
 │ work-next-user-input  Claim and execute a user input task.                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/docs/management-commands.md
+++ b/docs/management-commands.md
@@ -74,7 +74,7 @@ Task queue for multi-agent coordination.
 | Subcommand | Arguments | Returns | Description |
 |------------|-----------|---------|-------------|
 | `claim` | `execution_target`, `claimed_by` | task ID or None | Claims the next pending task of the given target type |
-| `work-next-sdk` | `claimed_by` | dict or None | Claims and completes the next SDK task using the configured runtime |
+| `work-next-sdk` | `claimed_by` | dict or None | Claims and completes the next headless task using the configured runtime; refuses loop-dispatched phases (records a `routing_error`) unless `LOOP_ALLOW_HEADLESS_DISPATCH` is set |
 | `work-next-user-input` | `claimed_by` | dict or None | Claims and completes the next user-input task |
 | `cancel` | `task_id`, `--confirm` | None | Cancels a pending or claimed task. Requires `--confirm` for claimed tasks. |
 | `list` | `--status`, `--execution-target` | list of dicts | Lists tasks, optionally filtered by status and/or execution target |

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -54,7 +54,7 @@ t3 <overlay> worktree provision          # Provision worktree (ports, DB, overla
 t3 <overlay> worktree start          # Start dev servers
 t3 <overlay> worktree status         # Show worktree state
 t3 <overlay> worktree teardown       # Stop services, clean up
-t3 <overlay> tasks work-next-sdk      # Claim and execute next headless task
+t3 <overlay> tasks work-next-sdk      # Claim/execute next headless task; refuses loop-dispatched phases unless LOOP_ALLOW_HEADLESS_DISPATCH
 t3 <overlay> tasks work-next-user-input  # Claim and launch next interactive task
 t3 <overlay> followup sync            # Daily ticket/PR sync
 ```

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -128,7 +128,13 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("create", "Enqueue the next-phase task for a ticket."),
             ("list", "List tasks with optional filters; --session scopes to the current harness session's todos."),
             ("start", "Claim and run the next interactive task in the current terminal."),
-            ("work-next-sdk", "Claim and execute an headless task."),
+            (
+                "work-next-sdk",
+                (
+                    "Claim and execute a headless task; refuses loop-dispatched "
+                    "phases unless LOOP_ALLOW_HEADLESS_DISPATCH."
+                ),
+            ),
             ("work-next-user-input", "Claim and execute a user input task."),
         ],
     ),

--- a/src/teatree/core/headless_dispatch.py
+++ b/src/teatree/core/headless_dispatch.py
@@ -44,3 +44,36 @@ def get_headless_runner() -> HeadlessRunner:
         )
         raise RuntimeError(msg)
     return _runner
+
+
+def loop_dispatch_refusal(task: "Task") -> str | None:
+    """Reason a headless dispatch of ``task`` is refused, or ``None`` to proceed.
+
+    The single fail-closed billing guard both headless entry points consult
+    (souliane/teatree#1375): a loop-dispatched phase task — one whose
+    ``(ticket.role, phase)`` has a registered phase agent (``Task.loop_dispatched``)
+    — must run INTERACTIVE in the in-session ``/loop`` slot, never as a metered
+    detached ``claude -p`` subprocess (post-2026-06-15 billing). Unless the single
+    ``LOOP_ALLOW_HEADLESS_DISPATCH`` toggle is explicitly enabled, return a
+    ``routing_error`` reason so the caller records a refusal instead of shelling
+    out. Free-form headless work (no registered phase agent) returns ``None`` and
+    proceeds.
+
+    Both ``core.tasks.execute_headless_task`` (the django-tasks worker) and
+    ``core.management.commands.tasks.Command._execute_sdk`` (the ``work-next-sdk``
+    CLI path) call this so the guard cannot drift between the two seams.
+    """
+    from django.conf import settings  # noqa: PLC0415
+
+    from teatree.core.models import Task  # noqa: PLC0415
+
+    if getattr(settings, "LOOP_ALLOW_HEADLESS_DISPATCH", False):
+        return None
+    if not Task.loop_dispatched(role=task.ticket.role, phase=task.phase):
+        return None
+    return (
+        f"refused headless dispatch for loop-dispatched phase "
+        f"(role={task.ticket.role!r}, phase={task.phase!r}): "
+        "this task must run INTERACTIVE via the /loop slot "
+        "(set LOOP_ALLOW_HEADLESS_DISPATCH=True to override)"
+    )

--- a/src/teatree/core/management/commands/tasks.py
+++ b/src/teatree/core/management/commands/tasks.py
@@ -375,7 +375,19 @@ class Command(TyperCommand):
     @staticmethod
     def _execute_sdk(task: Task) -> dict[str, str]:
         from teatree.agents.headless import run_headless  # noqa: PLC0415
+        from teatree.core.headless_dispatch import loop_dispatch_refusal  # noqa: PLC0415
         from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+
+        # Fail-closed billing guard, shared with ``execute_headless_task`` via
+        # the single ``loop_dispatch_refusal`` chokepoint (souliane/teatree#1375):
+        # a loop-dispatched phase task must run INTERACTIVE in the ``/loop`` slot,
+        # never as a metered ``claude -p`` here. The task is already CLAIMED by
+        # ``_claim_next_task``; record a FAILED refusal attempt so it is not left
+        # stuck CLAIMED under the loop slot.
+        refusal = loop_dispatch_refusal(task)
+        if refusal is not None:
+            task.complete_with_attempt(exit_code=1, error=refusal, result={"routing_error": refusal})
+            return {"exit_code": "1", "routing_error": refusal}
 
         attempt = run_headless(
             task,

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -1,7 +1,6 @@
 import logging
 from typing import TypedDict
 
-from django.conf import settings
 from django.db import transaction
 from django.tasks import task
 
@@ -25,6 +24,7 @@ class TransitionResult(TypedDict, total=False):
 def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
     import traceback  # noqa: PLC0415
 
+    from teatree.core.headless_dispatch import loop_dispatch_refusal  # noqa: PLC0415
     from teatree.core.overlay_loader import get_overlay_for_ticket  # noqa: PLC0415
 
     task_obj = Task.objects.get(pk=task_id)
@@ -45,26 +45,19 @@ def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
     # Fail-closed billing guard: a loop-dispatched phase task (one whose
     # (role, phase) has a registered phase agent) must run INTERACTIVE in the
     # in-session ``/loop`` slot, never as a metered detached ``claude -p``
-    # subprocess. Unless the single ``LOOP_ALLOW_HEADLESS_DISPATCH`` toggle is
-    # explicitly enabled, refuse here and record a ``routing_error`` instead
-    # of shelling out — closing the seam where a stray enqueue (a re-enqueue,
-    # a queue drainer, a manual ``enqueue``) would silently meter the loop's
-    # phase work.
-    if not getattr(settings, "LOOP_ALLOW_HEADLESS_DISPATCH", False) and Task.loop_dispatched(
-        role=task_obj.ticket.role,
-        phase=task_obj.phase,
-    ):
-        reason = (
-            f"refused headless dispatch for loop-dispatched phase "
-            f"(role={task_obj.ticket.role!r}, phase={task_obj.phase!r}): "
-            "this task must run INTERACTIVE via the /loop slot "
-            "(set LOOP_ALLOW_HEADLESS_DISPATCH=True to override)"
-        )
-        logger.warning("Task %s: %s", task_obj.pk, reason)
+    # subprocess. The predicate lives in ONE shared helper both headless entry
+    # points consult (``loop_dispatch_refusal``), so the ``work-next-sdk`` CLI
+    # path cannot drift from this seam (souliane/teatree#1375). Refuse here and
+    # record a ``routing_error`` instead of shelling out — closing the seam
+    # where a stray enqueue (a re-enqueue, a queue drainer, a manual
+    # ``enqueue``) would silently meter the loop's phase work.
+    routing_refusal = loop_dispatch_refusal(task_obj)
+    if routing_refusal is not None:
+        logger.warning("Task %s: %s", task_obj.pk, routing_refusal)
         if task_obj.status == Task.Status.PENDING:
             task_obj.claim(claimed_by="headless-routing-guard")
-        task_obj.complete_with_attempt(exit_code=1, error=reason, result={"routing_error": reason})
-        return {"exit_code": 1, "routing_error": reason}
+        task_obj.complete_with_attempt(exit_code=1, error=routing_refusal, result={"routing_error": routing_refusal})
+        return {"exit_code": 1, "routing_error": routing_refusal}
 
     # Claim here (when the worker actually starts) instead of at enqueue time
     if task_obj.status == Task.Status.PENDING:

--- a/tests/teatree_core/test_headless_dispatch.py
+++ b/tests/teatree_core/test_headless_dispatch.py
@@ -1,8 +1,42 @@
 """The core → agents headless-runner inversion registry (#1922)."""
 
 import pytest
+from django.test import TestCase, override_settings
 
 from teatree.core import headless_dispatch
+from teatree.core.headless_dispatch import loop_dispatch_refusal
+from teatree.core.models import Session, Task, Ticket
+
+
+class TestLoopDispatchRefusal(TestCase):
+    """``loop_dispatch_refusal`` — the single guard both headless entry points consult (#1375)."""
+
+    def _make_task(self, *, phase: str) -> Task:
+        ticket = Ticket.objects.create(overlay="test")
+        session = Session.objects.create(ticket=ticket, overlay="test", agent_id="agent-1")
+        task = Task.objects.create(ticket=ticket, session=session, phase=phase)
+        # Force HEADLESS via an UPDATE so ``Task.save``'s insert-time
+        # auto-route-to-interactive default does not re-fire.
+        task.route_to_headless(reason="forced headless for the test")
+        return task
+
+    @override_settings(LOOP_ALLOW_HEADLESS_DISPATCH=False)
+    def test_free_form_phase_is_not_refused(self) -> None:
+        task = self._make_task(phase="free-form-phase")
+        assert loop_dispatch_refusal(task) is None
+
+    @override_settings(LOOP_ALLOW_HEADLESS_DISPATCH=False)
+    def test_registered_phase_is_refused(self) -> None:
+        task = self._make_task(phase="answering")
+        reason = loop_dispatch_refusal(task)
+        assert reason is not None
+        assert "answering" in reason
+        assert "LOOP_ALLOW_HEADLESS_DISPATCH" in reason
+
+    @override_settings(LOOP_ALLOW_HEADLESS_DISPATCH=True)
+    def test_registered_phase_allowed_when_override_on(self) -> None:
+        task = self._make_task(phase="answering")
+        assert loop_dispatch_refusal(task) is None
 
 
 class TestHeadlessRunnerRegistry:

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -293,6 +293,50 @@ class TestTaskCommands(TestCase):
     def test_return_none_when_no_work_available(self) -> None:
         assert call_command("tasks", "work-next-sdk", claimed_by="worker-1") is None
 
+    @override_settings(LOOP_ALLOW_HEADLESS_DISPATCH=False)
+    def test_work_next_sdk_refuses_loop_dispatched_phase(self) -> None:
+        ticket = Ticket.objects.create(overlay="test")
+        session = Session.objects.create(ticket=ticket, overlay="test", agent_id="agent-1")
+        task = Task.objects.create(ticket=ticket, session=session, phase="answering")
+        # ``Task.save`` auto-routes a registered-phase HEADLESS insert to
+        # INTERACTIVE; force HEADLESS via ``route_to_headless`` (an UPDATE,
+        # not an insert) so the save default does not re-fire.
+        task.route_to_headless(reason="forced headless for the regression")
+        assert task.execution_target == Task.ExecutionTarget.HEADLESS
+
+        with patch.object(headless_mod, "run_headless", MagicMock()) as run_headless_mock:
+            sdk_result = cast(
+                "dict[str, str]",
+                call_command("tasks", "work-next-sdk", claimed_by="worker-1"),
+            )
+
+        run_headless_mock.assert_not_called()
+        assert "routing_error" in sdk_result
+        assert sdk_result["exit_code"] == "1"
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+
+        attempt = TaskAttempt.objects.get(task=task)
+        assert attempt.exit_code == 1
+        assert "routing_error" in attempt.result
+
+    @override_settings(LOOP_ALLOW_HEADLESS_DISPATCH=True)
+    def test_work_next_sdk_override_allows_loop_dispatched_phase(self) -> None:
+        ticket = Ticket.objects.create(overlay="test")
+        session = Session.objects.create(ticket=ticket, overlay="test", agent_id="agent-1")
+        task = Task.objects.create(ticket=ticket, session=session, phase="answering")
+        task.route_to_headless(reason="forced headless for the regression")
+
+        attempt = TaskAttempt(task=task, execution_target=task.execution_target, exit_code=0)
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(headless_mod, "run_headless", MagicMock(return_value=attempt)) as run_headless_mock,
+        ):
+            call_command("tasks", "work-next-sdk", claimed_by="worker-1")
+
+        run_headless_mock.assert_called_once()
+
 
 class TestTasksListSession(TestCase):
     """``t3 <overlay> tasks list --session`` scopes to the current Claude session."""


### PR DESCRIPTION
## Summary

The fail-closed guard that refuses a metered detached `claude -p` for a loop-dispatched phase existed at only **one** of the two headless-dispatch entry points. `core.tasks.execute_headless_task` (the django-tasks worker) refused a loop-dispatched phase, but the `work-next-sdk` CLI path (`Command._execute_sdk`) called `run_headless` unconditionally — shelling a long blocking `claude -p` for an answering/phase task. The agent harness backgrounded that subprocess (arming a Monitor) and returned, leaving the task stuck `claimed` under the loop slot.

Fixes #1375.

## What changed

- New single chokepoint `teatree.core.headless_dispatch.loop_dispatch_refusal(task) -> str | None`, beside the runner registry, holding the predicate + settings default + `routing_error` reason text in one place.
- `execute_headless_task` migrated to consult the shared helper (byte-equivalent to its old inline guard).
- `Command._execute_sdk` now consults the helper **before** `run_headless`; on a refusal it records a FAILED `TaskAttempt` via the same `complete_with_attempt` recorder the worker uses, so the already-claimed task is left FAILED/refused — never stuck `claimed`. The `LOOP_ALLOW_HEADLESS_DISPATCH` escape hatch is preserved on both paths.
- Help text / docs aligned (`django_groups.py`, `skills/teatree/SKILL.md`, `docs/management-commands.md`, regenerated `docs/generated/cli-reference.md`) so no stale "just executes" wording remains.

The harness-layer half (sub-agents arming Monitors on long blocking commands) is intentionally out of scope: removing the illegitimate dispatch means the harness is never handed a long blocking `claude -p` for loop phases.

## Verification (RED -> GREEN)

- `test_work_next_sdk_refuses_loop_dispatched_phase` (new): RED on the pre-fix `_execute_sdk` (mock `run_headless` is called once, no `routing_error`); GREEN after — `run_headless` not called, returned dict carries `routing_error`, a FAILED `TaskAttempt` with `result["routing_error"]` recorded, task status FAILED not CLAIMED. Anti-vacuity confirmed by reverting only the `_execute_sdk` guard call (helper kept so import resolves) -> RED, restore -> GREEN.
- `test_work_next_sdk_override_allows_loop_dispatched_phase` (new): `LOOP_ALLOW_HEADLESS_DISPATCH=True` -> `run_headless` is called (escape hatch preserved).
- `TestLoopDispatchRefusal` unit tests (new): None for a free-form phase, reason string for a registered `(role, phase)` under default-off, None under override-on. RED on pre-fix code via ImportError (helper did not exist).
- GREEN-preservation: existing `test_claim_and_complete_work` (blank-phase free-form headless task) still executes via `run_headless`.
- Existing `execute_headless_task` refusal tests (`test_interactive_dispatch.py`) all stay green — confirms the extraction is behavior-equivalent.
- `uv run ruff check` / `ruff format` clean; `ty check` clean; `tach check` clean; `makemigrations --check --dry-run` -> No changes detected (no migration).

## Architecture pre-check — #1375

**1. BLUEPRINT § alignment.** § "Interactive-by-default phase dispatch (post-2026-06-15 billing)". BLUEPRINT already states the contract ("`execute_headless_task` refuses a loop phase unless `LOOP_ALLOW_HEADLESS_DISPATCH`"); the defect was the second entry point bypassing it. No BLUEPRINT change beyond doc-alignment of the `work-next-sdk` help text.

**2. FSM phase boundaries.** n/a — no `Ticket.State` / `Worktree.State` transition added or moved. The refusal records FAILED via the existing `complete_with_attempt` -> `Task.fail()` transition.

**3. Extension-point contracts.** None. The helper lives in `core.headless_dispatch` beside the runner registry — no new Protocol/overlay/scanner/hook surface.

**4. Component boundaries.** Logic in `core.headless_dispatch` (the single chokepoint), consumed by the `core.tasks` worker and the `core.management.commands.tasks` CLI command (thin caller). No straddling.

**5. Dependency direction.** Only `core -> core` edges, the same modules the inline guard already used. `tach check` passes.

**6. Test surface.** Per-behavior tests named above (management-command + unit). 

**7. Resilience invariants.** No new external write. The refusal records a durable FAILED `TaskAttempt` (observable record) instead of leaving the task silently CLAIMED. Idempotent: a re-run claims the next task, never re-processes the failed one.

**8. Identity and key normalization.** n/a — no bare/qualified identity split; the `(role, phase)` predicate normalizes the phase internally.

**9. Behavior preservation / capability deletion.** SSOT extraction, not a rewrite: same `getattr(settings, "LOOP_ALLOW_HEADLESS_DISPATCH", False)` default-off, same `Task.loop_dispatched(role=ticket.role, phase=task.phase)` predicate, same `routing_error` reason text. No must-block test inverted, no privacy/security matcher narrowed. `_execute_sdk` gains the refusal it was missing (additive coverage).

## Open questions & assumptions

- The harness-prompt half of the issue's suggestion (b) — sub-agents arming Monitors on legitimate long blocking commands — is a separate concern; this PR removes the illegitimate dispatch so loop phases never reach that path.
