### PR TITLE
fix(overlay): segment-aware, ambiguity-safe URL-to-overlay inference

### DIFF
--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -10,8 +10,11 @@ import logging
 import os
 from functools import lru_cache
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from django.core.exceptions import ImproperlyConfigured
+
+from teatree.utils.url_slug import slug_from_issue_or_pr_url
 
 if TYPE_CHECKING:
     from teatree.core.models import Ticket, Worktree
@@ -213,18 +216,105 @@ def resolve_overlay_name(name: str) -> str | None:
     return _match_canonical_ep(name, known)
 
 
+def _url_to_slug(url: str) -> str:
+    """Normalize ``url`` to an ``owner/name`` slug for ownership matching.
+
+    ``infer_overlay_for_url`` is called with two input shapes. A full
+    issue/PR web URL (the ``workspace ticket`` / ``Ticket._infer_overlay``
+    path) is parsed via :func:`slug_from_issue_or_pr_url`, which strips the
+    ``/issues|pull|merge_requests/<n>`` suffix and handles GitLab subgroups.
+    A bare ``owner/repo`` slug (the merge-authorization path, where
+    ``MergeClear.slug`` is already ``owner/repo``) is returned as-is.
+
+    Returns the parsed slug, or ``""`` when neither shape yields a
+    multi-segment ``owner/name`` path.
+    """
+    issue_slug = slug_from_issue_or_pr_url(urlparse(url).path)
+    if issue_slug:
+        return issue_slug
+    # Bare-slug fallback: a path with no recognised forge issue/PR suffix.
+    path = urlparse(url).path if "://" in url else url
+    candidate = path.strip("/")
+    return candidate if candidate.count("/") >= 1 else ""
+
+
+def _full_slug_owns(repo_slug: str, url_slug: str) -> bool:
+    """True when the proper ``owner/name`` ``repo_slug`` owns ``url_slug``.
+
+    Segment/boundary-aware, not a raw substring: ``repo_slug`` must carry at
+    least one ``/`` (a real ``owner/name`` slug) and its ``/``-delimited
+    segments must align as a suffix of ``url_slug``. A bare relative token
+    (``t3-company``, as ``_discover_workspace_repos()`` emits) is rejected
+    here — it can never own a URL by its directory name, closing the #1120
+    misclassification where ``"t3-company" in <full URL>`` was True.
+
+    Examples (``repo_slug`` owns ``url_slug``?):
+
+    - ``company-fork-org/t3-company`` owns ``company-fork-org/t3-company`` (exact).
+    - ``subgroup/repo`` owns ``group/subgroup/repo`` (segment suffix).
+    - ``t3-company`` does NOT own ``company-fork-org/t3-company`` (bare token).
+    - ``acme/widget`` does NOT own ``acme/widget-extra`` (segment differs).
+    """
+    if "/" not in repo_slug:
+        return False
+    if repo_slug == url_slug:
+        return True
+    return url_slug.split("/")[-repo_slug.count("/") - 1 :] == repo_slug.split("/")
+
+
+def _bare_name_owns(repo_token: str, url_slug: str) -> bool:
+    """True when a bare repo-name ``repo_token`` matches ``url_slug``'s name segment.
+
+    The weak tiebreaker tier: a relative directory token (no ``/``) is
+    matched only against the trailing repo-name segment of ``url_slug``, on a
+    full-segment boundary. This preserves overlays that legitimately own a
+    repo but only expose its bare relative path (the bundled ``t3-teatree``
+    overlay, whose ``get_workspace_repos()`` returns ``["teatree"]``), without
+    the raw-substring collisions of the pre-#1120 matcher.
+    """
+    return "/" not in repo_token and url_slug.rsplit("/", 1)[-1] == repo_token
+
+
 def infer_overlay_for_url(url: str) -> str:
     """Return the overlay whose workspace repos own ``url``, or ``""``.
 
+    The single source of truth for URL→overlay inference, consumed by
+    ``Ticket._infer_overlay``, ``resolve_overlay_name_for_url`` (workspace
+    ticket), merge authorization, review-request routing, the eval corpus,
+    and loop persistence. ``url`` may be a full issue/PR web URL or a bare
+    ``owner/repo`` slug — both normalize to an ``owner/name`` via
+    :func:`_url_to_slug`.
+
     Routes through ``overlay.get_workspace_repos()`` rather than the raw
     ``config.workspace_repos`` attribute: overlays that compute their repo
-    list dynamically leave the attribute empty, so reading it directly
-    mis-attributes every one of their tickets. A registered entry that is
+    list dynamically leave the attribute empty. A registered entry that is
     not a full overlay, or whose hook raises, is skipped so one broken
     overlay can't poison inference for the others.
+
+    Matching is two-tier and ambiguity-safe (souliane/teatree#1120):
+
+    1. Full ``owner/name`` slug ownership (:func:`_full_slug_owns`) is
+        authoritative. A proper slug match always wins over a bare directory
+        token, so a sibling overlay clone's relative path (``t3-company``)
+        never out-votes the overlay that actually declares
+        ``company-fork-org/t3-company``.
+    2. Bare repo-name fallback (:func:`_bare_name_owns`) fires only when
+        NO overlay claims the URL by a full slug — preserving overlays that
+        expose only a bare relative path for a repo they own.
+
+    Within each tier, more than one matching overlay returns ``""`` rather
+    than an arbitrary first dict hit, so callers fall back to the explicit
+    ``T3_OVERLAY_NAME`` path (or a default) instead of a wrong-but-nonempty
+    attribution.
     """
     if not url:
         return ""
+    url_slug = _url_to_slug(url)
+    if not url_slug:
+        return ""
+
+    full_matches: list[str] = []
+    bare_matches: list[str] = []
     for name, overlay in get_all_overlays().items():
         getter = getattr(overlay, "get_workspace_repos", None)
         if not callable(getter):
@@ -234,10 +324,15 @@ def infer_overlay_for_url(url: str) -> str:
         except Exception:
             logger.warning("Overlay %r get_workspace_repos() failed during inference", name, exc_info=True)
             continue
-        for repo_slug in repo_slugs or []:
-            if isinstance(repo_slug, str) and repo_slug in url:
-                return name
-    return ""
+        slugs = [s for s in repo_slugs or [] if isinstance(s, str)]
+        if any(_full_slug_owns(s, url_slug) for s in slugs):
+            full_matches.append(name)
+        elif any(_bare_name_owns(s, url_slug) for s in slugs):
+            bare_matches.append(name)
+
+    if full_matches:
+        return full_matches[0] if len(full_matches) == 1 else ""
+    return bare_matches[0] if len(bare_matches) == 1 else ""
 
 
 @lru_cache(maxsize=1)

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1011,6 +1011,53 @@ class TestWorkspaceMultiOverlayResolution(TestCase):
             assert resolve_overlay_name_for_url("https://example.com/alpha-corp/backend/issues/77") is None
 
     @override_settings(**SETTINGS)
+    def test_ticket_stamps_true_owner_overlay_not_bare_path_sibling(self) -> None:
+        """``workspace ticket`` stamps the slug-owning overlay, not a bare-path sibling (#1120).
+
+        End-to-end at the command seam: with both ``t3-teatree`` (whose
+        ``get_workspace_repos()`` carries the bare relative path
+        ``t3-company`` exactly as ``_discover_workspace_repos()`` emits it)
+        and ``t3-company`` (whose list carries the proper ``owner/name``
+        slug) registered and ``T3_OVERLAY_NAME`` unset, a ticket for the
+        reporter's ``company-fork-org/t3-company`` URL must be attributed to
+        ``t3-company``. Pre-fix the raw-substring match made the first
+        dict hit (``t3-teatree``) win, poisoning every later step.
+        """
+        from teatree.core.overlay import OverlayBase  # noqa: PLC0415
+
+        class TeatreeSibling(FullOverlay):
+            def get_workspace_repos(self) -> list[str]:
+                return ["teatree", "t3-company"]
+
+        class CompanyOverlay(FullOverlay):
+            def get_workspace_repos(self) -> list[str]:
+                return ["company-fork-org/t3-company"]
+
+        result: dict[str, OverlayBase] = {
+            "t3-teatree": TeatreeSibling(),
+            "t3-company": CompanyOverlay(),
+        }
+
+        def _fake_discover() -> dict[str, OverlayBase]:
+            return result
+
+        _fake_discover.cache_clear = lambda: None
+
+        url = "https://github.com/company-fork-org/t3-company/issues/147"
+        env_without_overlay = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+        provisioner = MagicMock()
+        provisioner.run.return_value = RunnerResult(ok=True, detail="ok")
+        with (
+            patch.dict(os.environ, env_without_overlay, clear=True),
+            patch.object(overlay_loader_mod, "_discover_overlays", new=_fake_discover),
+            patch.object(workspace_mod, "WorktreeProvisioner", return_value=provisioner),
+        ):
+            ticket_id = cast("int", call_command("workspace", "ticket", url, repos="backend"))
+
+        ticket = Ticket.objects.get(pk=ticket_id)
+        assert ticket.overlay == "t3-company"
+
+    @override_settings(**SETTINGS)
     def test_teardown_does_not_need_overlay_resolution(self) -> None:
         """``workspace teardown`` does not call ``get_overlay()`` on the hot path.
 

--- a/tests/test_overlay_loader.py
+++ b/tests/test_overlay_loader.py
@@ -151,6 +151,83 @@ class TestInferOverlayForUrl:
             assert infer_overlay_for_url("https://gitlab.com/acme/widgets/-/issues/7") == "ok"
         assert "failed during inference" in caplog.text
 
+    def test_bare_relative_path_does_not_own_sibling_slug_url(self):
+        """A bare relative path (``t3-company``) must not own a sibling clone's URL (#1120).
+
+        ``t3-teatree.get_workspace_repos()`` falls back to
+        ``_discover_workspace_repos()``, which emits each discovered overlay
+        as a workspace-RELATIVE bare path (``"t3-company"``), not an
+        ``owner/name`` slug. With a raw-substring match, the bare token
+        ``"t3-company"`` is a substring of the reporter's URL
+        ``.../company-fork-org/t3-company/issues/147`` and the first
+        dict-iteration hit (``t3-teatree``) wins — poisoning the ticket's
+        overlay attribution. The real owner is ``t3-company``, whose
+        ``get_workspace_repos()`` carries the proper ``owner/name`` slug.
+        """
+        url = "https://github.com/company-fork-org/t3-company/issues/147"
+        overlays = {
+            "t3-teatree": self._overlay(["teatree", "t3-company"]),
+            "t3-company": self._overlay(["company-fork-org/t3-company"]),
+        }
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
+            assert infer_overlay_for_url(url) == "t3-company"
+
+        # Guard against dict-iteration order: reversing the insertion order
+        # must still resolve the true owner (the slug match wins, not the
+        # first hit).
+        reversed_overlays = {
+            "t3-company": self._overlay(["company-fork-org/t3-company"]),
+            "t3-teatree": self._overlay(["teatree", "t3-company"]),
+        }
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value=reversed_overlays):
+            assert infer_overlay_for_url(url) == "t3-company"
+
+    def test_ambiguous_match_returns_empty(self):
+        """Two overlays both owning the URL fail safe to ``""`` (#1120).
+
+        Returning the first dict hit would silently bind the ticket to an
+        arbitrary one of the two. ``""`` instead routes ``get_overlay(None)``
+        to the explicit ``ImproperlyConfigured`` listing installed overlays,
+        so the operator passes ``T3_OVERLAY_NAME`` rather than getting a
+        wrong-but-nonempty attribution.
+        """
+        url = "https://github.com/company-fork-org/t3-company/issues/147"
+        overlays = {
+            "first": self._overlay(["company-fork-org/t3-company"]),
+            "second": self._overlay(["company-fork-org/t3-company"]),
+        }
+        with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
+            assert infer_overlay_for_url(url) == ""
+
+    def test_segment_boundary_prevents_prefix_collision(self):
+        """``acme/widget`` must not own ``acme/widget-extra`` (#1120).
+
+        The slug ``acme/widget`` IS a raw substring of
+        ``.../acme/widget-extra/issues/1``, so the old matcher wrongly
+        claimed the URL. A segment-boundary match rejects it: the trailing
+        path segment ``widget`` does not equal ``widget-extra``.
+        """
+        url = "https://github.com/acme/widget-extra/issues/1"
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"a": self._overlay(["acme/widget"])},
+        ):
+            assert infer_overlay_for_url(url) == ""
+
+    def test_gitlab_subgroup_slug_resolves(self):
+        """A GitLab subgroup ``owner/name`` slug still resolves its URL (#1120).
+
+        The boundary-aware match must not regress GitLab subgroup paths
+        (``group/subgroup/repo``) — the full project path parses correctly
+        and the equal slug wins.
+        """
+        url = "https://gitlab.com/group/subgroup/repo/-/issues/3"
+        with patch(
+            "teatree.core.overlay_loader.get_all_overlays",
+            return_value={"gl": self._overlay(["group/subgroup/repo"])},
+        ):
+            assert infer_overlay_for_url(url) == "gl"
+
 
 def _init_repo_with_origin(path: Path, origin_url: str) -> None:
     """Create a real git repo at ``path`` with ``origin`` set to ``origin_url``."""


### PR DESCRIPTION
## What

`infer_overlay_for_url` is the single source of truth for mapping an
issue/PR URL (or a bare `owner/repo` slug) to the overlay that owns it.
It matched each overlay's `get_workspace_repos()` entries against the
**full URL with a raw substring test** and returned the **first
dict-iteration hit**.

A bundled overlay whose `get_workspace_repos()` falls back to
`_discover_workspace_repos()` emits each discovered sibling clone as a
workspace-**relative bare path** (e.g. `t3-company`), not an `owner/name`
slug. With substring matching, that bare token is a substring of a
sibling repo's URL `.../company-fork-org/t3-company/issues/147`, so the
first overlay that merely had the sibling directory checked out claimed
the URL — and the wrong overlay name was stamped onto the `Ticket` at
`workspace ticket` time, poisoning every later step (overlay resolution,
`pr create`) that trusts the stamped name. This is the upstream
root-cause of the ship/pr-open failure.

## What changed

Make the chokepoint slug/boundary-aware and ambiguity-safe — one
function, six consumers, signature unchanged (no consumer migration):

- Normalize the input to an `owner/name` slug via
  `teatree.utils.url_slug` (handles both a full issue/PR URL — including
  GitLab subgroups — and a bare `owner/repo` slug).
- Match in two tiers. A proper `owner/name` slug owner is authoritative:
  a **segment-boundary suffix** match, never a raw substring, so a bare
  directory token can no longer own a URL and a real slug always wins.
  A bare repo-name token is a weak fallback used **only when no full slug
  claims the URL**, matched against the trailing name segment on a
  boundary (this preserves overlays that expose only a bare relative path
  for a repo they genuinely own).
- Within each tier, more than one match returns `""` so callers fall back
  to the explicit `T3_OVERLAY_NAME` path (or their existing default)
  instead of an arbitrary first dict hit.

## Verification (RED -> GREEN)

Each regression test was observed RED on the pre-fix code (revert-to-
confirm via `git stash` of the source), GREEN after:

- `tests/test_overlay_loader.py::TestInferOverlayForUrl`
  - `test_bare_relative_path_does_not_own_sibling_slug_url` — the repro;
    pre-fix returns `t3-teatree` (bare-token substring hit), post-fix
    `t3-company` (the real slug owner). Asserted under both dict orders.
  - `test_ambiguous_match_returns_empty` — two overlays both owning the
    URL return `""` (pre-fix returned the first hit).
  - `test_segment_boundary_prevents_prefix_collision` — `acme/widget`
    does not own `acme/widget-extra` (pre-fix the substring matched).
  - `test_gitlab_subgroup_slug_resolves` — subgroup `owner/name` still
    resolves (regression-keep).
- `tests/teatree_core/management_commands/test_workspace.py::TestWorkspaceMultiOverlayResolution::test_ticket_stamps_true_owner_overlay_not_bare_path_sibling`
  — end-to-end at the `workspace ticket` seam: the created
  `Ticket.overlay == "t3-company"` (pre-fix recorded the bare-path
  sibling).
- All existing `TestInferOverlayForUrl`, `TestWorkspaceMultiOverlayResolution`,
  and the merge-authorization substrate-autonomy suite stay GREEN — the
  merge consumer passes a bare `owner/repo` slug, exercised by the
  two-tier fallback.

Local gates: `ruff check`/`format`, `tach check`, `lint-imports`, `ty
check`, editorconfig, and `makemigrations --check --dry-run` (no
migration) all clean. New code is fully covered by the added tests.

## Relationship to #2141

Complementary, no overlap. PR #2141 is the **ShipExecutor wrong-repo
safety net** (`ship.py` only) — it fails loud when `host.create_pr`
returns a URL on the wrong repo. This PR is the **upstream root-cause
fix** in `overlay_loader.py` that stops the wrong overlay from being
inferred in the first place. They own different decisions and do not
both try to own the wrong-overlay determination.

## Architecture pre-check

1. **BLUEPRINT alignment** — §6 Overlay System. `infer_overlay_for_url`
   is the documented single inference seam (loop/persistence references
   it as the source of truth); no contract change.
2. **FSM phase boundaries** — n/a (pure inference; no `Ticket.State`
   transition added or moved).
3. **Extension-point contracts** — no `OverlayBase` hook signature
   changes. Still reads `get_workspace_repos()`; overlays unchanged.
4. **Component boundaries** — `src/teatree/core/overlay_loader.py`
   (resolution logic); URL parsing delegated to the existing
   `teatree.utils.url_slug` rather than reimplemented.
5. **Dependency direction** — adds `core` -> `utils` (allowed, the lower
   layer). `tach check` and `lint-imports` pass.
6. **Test surface** — unit (`TestInferOverlayForUrl`) + integration at
   the command seam (`test_ticket_stamps_true_owner...`); each behaviour
   has an assertion that was RED pre-fix.
7. **Resilience invariants** — no new external write. The stricter empty
   result is fail-safe: every consumer already handles `""` (explicit
   env, scan_tag, or default). Per-overlay try/except guards retained.
8. **Identity normalization** — this IS the fix: canonicalize every
   reference UP to the fully-qualified `owner/name` form before matching;
   a bare relative token is no longer trusted to own a URL.
9. **Behavior preservation** — the old substring match is replaced; the
   only intentionally-dropped behavior is the unsafe substring/first-hit
   match. The bare repo-name fallback preserves the legitimate
   single-overlay / bundled-overlay resolution the merge-authorization
   consumer relies on (covered by its existing GREEN suite). No
   must-block test inverted.

Fixes #1120
