### PR TITLE
feat(eval): pin e2e-evidence posting (use post-evidence CLI, ticket-not-MR, no hand-rolled uploads)

### DIFF
--- a/skills/e2e/evals.yaml
+++ b/skills/e2e/evals.yaml
@@ -1,0 +1,30 @@
+# Co-located behavioral evals for the e2e skill. `agent_path` is omitted —
+# discovery defaults it to skills/e2e/SKILL.md.
+# Fixtures live in tests/eval/fixtures/<name>_{pass,fail}.stream.jsonl.
+
+- name: e2e_evidence_uses_canonical_command
+  scenario: >-
+    the agent posts E2E evidence with `t3 <overlay> e2e post-evidence` — never
+    hand-rolling `glab/gh/curl .../uploads`, never posting on the MR surface,
+    never re-running E2E when local artifacts already exist
+  model: haiku
+  max_turns: 4
+  tools: [Bash]
+  prompt: >-
+    You are in a ticket worktree and have already run the E2E test for
+    issue #4242 on the local environment. The artifacts are on disk:
+    a screen recording at e2e/artifacts/4242/run.webm and before/after
+    screenshots at e2e/artifacts/4242/before.png and
+    e2e/artifacts/4242/after.png. The feature works. Post these as testing
+    evidence on the ticket. Plan the bash commands you would run, in order,
+    by invoking the Bash tool for each step. Do NOT re-run the E2E suite —
+    the artifacts already exist.
+  expect:
+    - tool_call: bash
+      args.command: contains "e2e post-evidence"
+    - no_tool_call_matching:
+        bash.command: '~ "(glab|gh)\s+api\b.*uploads"'
+    - no_tool_call_matching:
+        bash.command: '~ "curl\b.*/uploads"'
+    - no_tool_call_matching:
+        bash.command: '~ "mr note|merge_requests/\d+/notes|pr comment"'

--- a/tests/eval/fixtures/e2e_evidence_uses_canonical_command_fail.stream.jsonl
+++ b/tests/eval/fixtures/e2e_evidence_uses_canonical_command_fail.stream.jsonl
@@ -1,0 +1,7 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-e2e_evidence_uses_canonical_command-fail", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll upload the screenshots and video, then post them on the MR."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "glab api --method POST projects/widget%2Fexample/uploads --form file=@e2e/artifacts/4242/before.png", "description": "upload before screenshot"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "{\"markdown\": \"![before](/uploads/abc/before.png)\"}"}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_02", "name": "Bash", "input": {"command": "glab api --method POST projects/widget%2Fexample/uploads --form file=@e2e/artifacts/4242/after.png", "description": "upload after screenshot"}}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_03", "name": "Bash", "input": {"command": "glab mr note 42 --message \"Tested on local, works as expected. ![before](/uploads/abc/before.png) ![after](/uploads/def/after.png)\"", "description": "post evidence on the MR"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 3}

--- a/tests/eval/fixtures/e2e_evidence_uses_canonical_command_pass.stream.jsonl
+++ b/tests/eval/fixtures/e2e_evidence_uses_canonical_command_pass.stream.jsonl
@@ -1,0 +1,5 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-e2e_evidence_uses_canonical_command-pass", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "The canonical command posts one idempotent comment on the ticket and uploads the media itself. I'll use it directly with the existing artifacts."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 acme e2e post-evidence --ticket 4242 --env local --before e2e/artifacts/4242/before.png --after e2e/artifacts/4242/after.png --video e2e/artifacts/4242/run.webm --assertion \"The widget renders the new summary panel\"", "description": "post E2E evidence on the ticket via the canonical CLI"}}]}}
+{"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "posted evidence comment on ticket #4242 (env=local)"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}


### PR DESCRIPTION
## What

Ships a co-located behavioral eval that pins the ONE sanctioned way to post E2E evidence: the `t3 <overlay> e2e post-evidence` CLI command. It grades RED when an agent hand-rolls the evidence flow instead.

The thrash this is the net for (observed twice in a single session): an agent uploads media via a hand-rolled `glab/gh api .../uploads` (or `curl .../uploads`), posts the evidence on the MR surface (`glab mr note` / `pr comment` / a raw `merge_requests/<n>/notes` call), and re-runs E2E even though the local artifacts already exist. The canonical command posts ONE idempotent comment on the **ticket** (never the MR), uploads media inside the CLI, and refuses bad evidence.

## Scenario `e2e_evidence_uses_canonical_command`

- **Positive** Bash matcher: `command contains "e2e post-evidence"` — so a no-op transcript fails (the matcher is not vacuous).
- **Negatives**: forbid hand-rolled uploads (`(glab|gh)\s+api\b.*uploads`, `curl\b.*/uploads`) and MR-surface posting (`mr note|merge_requests/\d+/notes|pr comment`).

## Anti-vacuity proof (both fixtures, scoped to the new scenario)

The fail fixture is the exact hand-rolled `glab api .../uploads` + MR-note thrash; the pass fixture is the canonical `post-evidence` invocation.

```
===== FAIL FIXTURE (must grade FAIL) =====
FAIL e2e_evidence_uses_canonical_command (success)
  - Expected a Bash tool call with command containing 'e2e post-evidence' ... (positive missing)
  - Did not expect any Bash tool call ... uploads, but found: glab api ... uploads
  - Did not expect any Bash tool call ... mr note ..., but found: glab mr note 42 ...
summary: 0 passed, 1 failed, 0 skipped (of 1)

===== PASS FIXTURE (must grade PASS) =====
PASS e2e_evidence_uses_canonical_command (success)
summary: 1 passed, 0 failed, 0 skipped (of 1)
```

Pinned for every PR by the per-PR anti-vacuity gate `tests/eval/test_scenarios_anti_vacuous.py` (fail fixture → RED, pass fixture → GREEN), which passes.

## Discovery path

Discovery reads co-located `skills/<name>/evals.yaml` (`discovery.py` resolves `DEFAULT_SKILLS_DIR = parents[3] / "skills"`). The `plugins/t3/skills` tree is an install-time symlink to `skills/` and is not tracked in this repo, so there is exactly one source-of-truth file: `skills/e2e/evals.yaml`. No mirror to keep in sync here.

## Gates

`uv run ruff check`, `uv run ruff format --check`, `uv run ty check` clean; eval suite green (`tests/ -k eval`: 1252 passed); readme-sync, corpus-generation (no drift), skill-coverage, discovery tests pass; all pre-commit and pre-push hooks (incl. banned-terms, skill-triggers, pinned-regressions, privacy-leak refusal) pass.

## Architecture pre-check

### 1. BLUEPRINT § alignment
BLUEPRINT § 11 (skill system) / `src/teatree/eval/README.md` § "Co-located evals". A behaviour-bearing skill ships its evals beside `SKILL.md`; this closes the e2e skill's evidence-posting behaviour with an anti-vacuous co-located scenario.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition. Pure eval data (YAML scenario + JSONL fixtures).

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / Protocol change. Uses the existing `EvalSpec` schema and the existing co-located-discovery hook unchanged.

### 4. Component boundaries
`skills/e2e/evals.yaml` (scenario spec, co-located with the owning skill) + `tests/eval/fixtures/*.stream.jsonl` (anti-vacuity fixtures). No `src/` change.

### 5. Dependency direction
n/a — no imports added.

### 6. Test surface
`tests/eval/test_scenarios_anti_vacuous.py` parametrizes the new scenario and asserts the `_fail` fixture drives the verdict RED and the `_pass` fixture GREEN. A toothless matcher would turn that gate red.

### 7. Resilience invariants
n/a — no external write. The scenario asserts the agent reaches for the resilient canonical command (idempotent, refuses bad evidence) rather than a hand-rolled non-idempotent path.

### 8. Identity and key normalization
Scenario name `e2e_evidence_uses_canonical_command` is unique across the flat catalog, co-located, and overlay surfaces (discovery rejects duplicates with a hard error). No bare/qualified ambiguity introduced.

### 9. Behavior preservation / capability deletion
n/a — purely additive. No existing scenario, fixture, or matcher removed or inverted.
