### PR TITLE
fix(doctor): run check on bare t3 doctor instead of printing help

### DIFF
--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -41,7 +41,7 @@ from teatree.cli.recommended_authorizations import authorizations, report_missin
 from teatree.utils.django_bootstrap import ensure_django
 from teatree.utils.run import run_allowed_to_fail
 
-doctor_app = typer.Typer(no_args_is_help=True, help="Smoke-test hooks, imports, services.")
+doctor_app = typer.Typer(no_args_is_help=False, help="Smoke-test hooks, imports, services.")
 doctor_app.command()(authorizations)
 _REQUIRED_TOOLS = ("direnv", "git", "jq")
 _CLAUDE_PLUGIN_ID = "t3@souliane"
@@ -561,3 +561,10 @@ def check() -> bool:
     if ok:
         typer.echo("All checks passed")
     return ok
+
+
+@doctor_app.callback(invoke_without_command=True)
+def _doctor_default(ctx: typer.Context) -> None:
+    """Run ``check`` when ``t3 doctor`` is invoked with no subcommand (#2065)."""
+    if ctx.invoked_subcommand is None:
+        raise typer.Exit(code=0 if check() else 1)

--- a/tests/cli_doctor/test_doctor_check_command.py
+++ b/tests/cli_doctor/test_doctor_check_command.py
@@ -237,3 +237,74 @@ class TestDoctorCheckCommand:
             result = runner.invoke(app, ["doctor", "check"])
 
         assert "FAIL" in result.output
+
+
+class TestBareDoctorRunsChecks:
+    """Bare ``t3 doctor`` aliases to ``t3 doctor check`` (souliane/teatree#2065).
+
+    ``no_args_is_help=True`` made bare ``t3 doctor`` print the usage banner and
+    run no verification — a fresh user's verify step silently did nothing. The
+    group callback must run ``check`` when no subcommand is given, while leaving
+    the ``check`` and ``authorizations`` subcommands intact.
+    """
+
+    def _write_noop_toml(self, home: Path) -> None:
+        _write_teatree_toml(home / ".teatree.toml", "[teatree]\ncontribute = false\n")
+
+    def test_bare_doctor_runs_checks_not_help(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
+
+        with (
+            patch.object(teatree_cli_doctor.shutil, "which", side_effect=lambda t: f"/usr/bin/{t}"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+            patch("teatree.core.gates.schema_guard.pending_migrations", return_value=[]),
+        ):
+            result = runner.invoke(app, ["doctor"])
+
+        assert result.exit_code == 0, result.output
+        assert "All checks passed" in result.output
+        assert "Usage:" not in result.output
+
+    def test_bare_doctor_propagates_failure_exit_code(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
+
+        with (
+            patch.object(
+                teatree_cli_doctor.shutil,
+                "which",
+                side_effect=lambda t: None if t == "direnv" else f"/usr/bin/{t}",
+            ),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+        ):
+            result = runner.invoke(app, ["doctor"])
+
+        assert result.exit_code == 1
+        assert "FAIL  Required tool not found: direnv" in result.output
+
+    def test_check_subcommand_still_dispatches(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
+
+        with (
+            patch.object(teatree_cli_doctor.shutil, "which", side_effect=lambda t: f"/usr/bin/{t}"),
+            patch.object(IntrospectionHelpers, "editable_info", return_value=(False, "")),
+            patch.object(teatree_overlay_loader, "get_all_overlays", return_value={}),
+            patch("teatree.core.gates.schema_guard.pending_migrations", return_value=[]),
+        ):
+            result = runner.invoke(app, ["doctor", "check"])
+
+        assert result.exit_code == 0, result.output
+        assert "All checks passed" in result.output
+
+    def test_authorizations_subcommand_still_dispatches(self, tmp_path, monkeypatch):
+        _stage_home(tmp_path, monkeypatch)
+        self._write_noop_toml(tmp_path)
+
+        result = runner.invoke(app, ["doctor", "authorizations", "--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "authorizations" in result.output


### PR DESCRIPTION
## Summary

Bare `t3 doctor` printed the usage banner and ran no verification because the doctor Typer group used `no_args_is_help=True`. Every onboarding doc and most muscle memory treats `t3 doctor` as the verify command, so a fresh user's verify step silently did nothing.

This adds an `invoke_without_command` group callback that runs `check()` when no subcommand is given, preserving the exit status (0 pass / 1 fail). The `check` and `authorizations` subcommands are unchanged.

Fixes #2065

## Changes

- `src/teatree/cli/doctor.py`: `no_args_is_help=True` -> `False`; new `_doctor_default` callback running `check()` when `ctx.invoked_subcommand is None`, exiting `0`/`1` to preserve status.
- `tests/cli_doctor/test_doctor_check_command.py`: `TestBareDoctorRunsChecks` covering bare-invocation runs checks (not help), failure exit-code propagation, and both subcommands still dispatching.

## Anti-vacuity proof

Reverted only the production change (git stash of doctor.py): `test_bare_doctor_runs_checks_not_help` went RED — bare `t3 doctor` returned exit 2 with the Usage banner instead of running checks. Restored the fix: GREEN. The full module is 13/13 green.

## Architecture pre-check — #2065

1. **BLUEPRINT § alignment** — tactical CLI-ergonomics fix to one Typer group's no-subcommand behaviour. No BLUEPRINT section governs per-command `no_args_is_help`; no contradiction.
2. **FSM phase boundaries** — n/a, no state transition.
3. **Extension-point contracts** — n/a, no OverlayBase / scanner / hook / Backend Protocol touched. Only the doctor group's callback.
4. **Component boundaries** — `src/teatree/cli/`, coordination only; delegates to the existing `check()` entry point.
5. **Dependency direction** — no new imports; `tach check` validates all modules.
6. **Test surface** — `TestBareDoctorRunsChecks` asserts checks run (not help) on `["doctor"]`, exit 1 on a failing tool, and that `check` / `authorizations` still dispatch.
7. **Resilience invariants** — n/a, read-only local checks, no external write.
8. **Identity and key normalization** — n/a.
9. **Behavior preservation** — purely additive: `no_args_is_help=False` removes only auto-help-on-no-args, replaced by running `check`; subcommands and `--help` unchanged; no must-block test inverted.