### PR TITLE
test(timeouts): pin settings TEATREE_TIMEOUTS to timeouts CORE_DEFAULTS (#2019)

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -118,6 +118,7 @@ graph TD
     teatree.outbound_claim --> teatree.core
     teatree.settings --> teatree.config
     teatree.settings --> teatree.paths
+    teatree.settings --> teatree.timeouts
     teatree.cli_reference --> teatree.cli
     teatree.triage --> teatree.utils
     teatree.url_title_fetcher --> teatree.utils

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -6,6 +6,7 @@ Auto-discovers overlay Django apps via entry points and adds them to INSTALLED_A
 
 from teatree.config import default_logging
 from teatree.paths import CANONICAL_DB, DATA_DIR, DATA_DIR_AUTO_ISOLATED, seed_isolated_db
+from teatree.timeouts import CORE_DEFAULTS
 
 _DATA_DIR = DATA_DIR
 if DATA_DIR_AUTO_ISOLATED:
@@ -134,18 +135,11 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 LOGGING = default_logging("teatree")
 
 # Operation timeouts (seconds).  0 = no timeout.
-# Override per-overlay via OverlayBase.get_timeouts() or per-user
-# via [teatree.timeouts] in ~/.teatree.toml.
-TEATREE_TIMEOUTS = {
-    "setup": 120,
-    "start": 60,
-    "db_import": 180,
-    "docker_compose_up": 60,
-    "docker_compose_build": 600,
-    "docker_compose_down": 30,
-    "provision_step": 120,
-    "pre_run_step": 60,
-}
+# Sourced from the canonical CORE_DEFAULTS registry in teatree.timeouts so the
+# two surfaces cannot drift; tests/test_timeouts.py::TestTimeoutRegistryParity
+# pins the binding. Override per-overlay via OverlayBase.get_timeouts() or
+# per-user via [teatree.timeouts] in ~/.teatree.toml.
+TEATREE_TIMEOUTS = dict(CORE_DEFAULTS)
 TEATREE_CLAUDE_STATUSLINE_STATE_DIR = "/tmp/claude-statusline"  # noqa: S108 — fixed agent-controlled path, not user input
 
 TASKS = {

--- a/tach.toml
+++ b/tach.toml
@@ -272,7 +272,7 @@ depends_on = []
 [[modules]]
 path = "teatree.settings"
 layer = "platform"
-depends_on = ["teatree.config", "teatree.paths"]
+depends_on = ["teatree.config", "teatree.paths", "teatree.timeouts"]
 
 [[modules]]
 path = "teatree.cli_reference"

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase, override_settings
 
+from teatree import settings as teatree_settings
 from teatree.timeouts import (
     CORE_DEFAULTS,
     DB_IMPORT,
@@ -139,3 +140,28 @@ class TestLoadTimeouts(TestCase):
             val = cfg.get(op)
             assert val is not None, f"{op} should not be None"
             assert val > 0, f"{op} should have a positive default"
+
+
+class TestTimeoutRegistryParity:
+    """Fitness test binding the Django settings registry to CORE_DEFAULTS.
+
+    The tier-3 core defaults have two surfaces: ``CORE_DEFAULTS`` in
+    ``teatree.timeouts`` (the canonical, Django-free source) and
+    ``TEATREE_TIMEOUTS`` in ``teatree.settings`` (the Django-settings
+    surface that ``load_timeouts`` reads via ``django.conf.settings``).
+    They must stay identical — same keys, same values. A key present in one
+    registry but not the other silently falls to the 120s unknown-operation
+    fallback in ``TimeoutConfig.get`` (the #2014 bug class). This binding
+    makes that drift impossible.
+
+    The assertion targets the production ``teatree.settings`` module
+    directly, not the active ``django.conf.settings`` (the test harness
+    swaps in ``tests.django_settings``, which intentionally omits the
+    timeout registry).
+    """
+
+    def test_settings_registry_has_same_keys_as_core_defaults(self) -> None:
+        assert set(teatree_settings.TEATREE_TIMEOUTS) == set(CORE_DEFAULTS)
+
+    def test_settings_registry_equals_core_defaults(self) -> None:
+        assert teatree_settings.TEATREE_TIMEOUTS == CORE_DEFAULTS


### PR DESCRIPTION
Fixes #2019.

## Problem

The tier-3 timeout core defaults had two surfaces kept in sync by hand:

- `CORE_DEFAULTS` in `teatree.timeouts` — the canonical, Django-free source.
- The `TEATREE_TIMEOUTS` literal dict in `teatree.settings` — the Django-settings surface that `load_timeouts` reads via `django.conf.settings`.

Nothing bound them. A key present in one registry but not the other silently fell to the 120s unknown-operation fallback in `TimeoutConfig.get` — the [#2014](https://github.com/souliane/teatree/issues/2014) bug class.

## Change

- **`TestTimeoutRegistryParity`** (the deliverable the issue asks for): asserts equal key sets and equal keys+values. It targets the production `teatree.settings` module directly, not the active `django.conf.settings` — the test harness swaps in `tests.django_settings`, which intentionally omits the registry, so the active settings object would be the wrong target.
- **Source `TEATREE_TIMEOUTS` from `CORE_DEFAULTS`** (`dict(CORE_DEFAULTS)`) instead of duplicating the literals — removes the manual-sync surface at its root. The parity test then guards against any future re-introduction of drifting literals.
- **tach.toml**: declare the new `teatree.settings -> teatree.timeouts` dependency (same `platform` layer, no cycle). The dependency-graph doc regenerated automatically.

## Anti-vacuity proof

With the production change reverted to literals and one value diverged + one key dropped (`setup: 999`, `pre_run_step` removed), both assertions go RED — the key-set test caught the missing `pre_run_step` key (the exact #2014 silent-fallback class) and the equality test caught the value drift. Restored to the derived form, both GREEN.

## Architecture pre-check — #2019

**1. BLUEPRINT § alignment** — n/a. Timeout registry parity is a fitness-function test plus a duplication removal; no BLUEPRINT section governs the literal copy.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition.

**3. Extension-point contracts** — n/a for the binding. `OverlayBase.get_timeouts()` (tier 2) is unchanged; only the tier-3 core-default surface is touched.

**4. Component boundaries** — `src/teatree/settings.py` (Django settings) now derives from `src/teatree/timeouts.py` (the canonical registry). Test in `tests/test_timeouts.py`, mirroring the module under test.

**5. Dependency direction** — added `teatree.settings -> teatree.timeouts`, both `platform` layer. No backwards edge, no cycle (`teatree.timeouts` and its dep `teatree.config` never import `teatree.settings`). `uv run tach check` -> "All modules validated!".

**6. Test surface** — `TestTimeoutRegistryParity::test_settings_registry_has_same_keys_as_core_defaults` and `::test_settings_registry_equals_core_defaults`. Each fails if the two registries diverge by a key or a value.

**7. Resilience invariants** — n/a. No external write; pure import-time data binding.

**8. Identity and key normalization** — n/a. No bare-vs-qualified identity; the test compares full dicts.

**9. Behavior preservation / capability deletion** — the literal dict is replaced by `dict(CORE_DEFAULTS)`. Verified value-identical at runtime under the production settings module (all eight keys, same values). No behavior dropped; the only removed thing is the hand-maintained duplication.

## Gates

`uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `uv run tach check`, and `uv run pytest --no-cov -q tests/test_timeouts.py` (17 passed) — all green.
