### PR TITLE
fix(update): fail loud when the primary clone is parked off its default branch (#2134)

### DIFF
--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -8,8 +8,10 @@ For teatree core (``$T3_REPO``) and every registered overlay repo, this:
 
 1. ``git fetch`` the origin.
 2. Resolves the default branch from ``origin/HEAD``.
-3. Skips a non-default-branch / no-upstream checkout, and a
-    tracked-dirty tree (loudly). Untracked-only files do not block it.
+3. Skips a non-default-branch / no-upstream checkout for an overlay; for
+    the primary/running clone those same states FAIL LOUD (#2134, the
+    running editable ``t3`` must never silently rot behind origin). A
+    tracked-dirty tree is refused loudly. Untracked-only files do not block.
 4. Otherwise ``git pull --ff-only`` — fast-forward only, never merge/rebase.
 5. Reinstalls advanced editable installs, then runs ``t3 setup``.
 6. Probes the teatree self-DB (``python -m teatree migrate --check`` in the
@@ -54,6 +56,14 @@ update_app = typer.Typer(
     help="Sync teatree core and registered overlays to their default branch.",
     invoke_without_command=True,
 )
+
+# The configured main clone and the work-tree the interpreter actually imports
+# ``teatree`` from. These are the *primary* clones — the editable ``t3`` the
+# agent runs — so a non-default-branch / no-upstream checkout is a fail-loud
+# currency hazard there, not a soft overlay skip (#2134).
+_CORE_REPO_NAME = "teatree"
+_RUNNING_REPO_NAME = "teatree (running)"
+_PRIMARY_REPO_NAMES = frozenset({_CORE_REPO_NAME, _RUNNING_REPO_NAME})
 
 
 class UpdateStatus(enum.Enum):
@@ -154,27 +164,66 @@ def _has_upstream(repo: Path) -> bool:
     return result.returncode == 0 and bool(result.stdout.strip())
 
 
-def _check_origin(name: str, repo: Path) -> RepoUpdate | None:
+def _check_origin(name: str, repo: Path, *, is_primary: bool) -> RepoUpdate | None:
+    del is_primary  # origin presence is not primary-clone-sensitive
     if _has_origin_remote(repo):
         return None
     return RepoUpdate(name, UpdateStatus.SKIPPED, reason="no 'origin' remote configured")
 
 
-def _check_fetch(name: str, repo: Path) -> RepoUpdate | None:
+def _check_fetch(name: str, repo: Path, *, is_primary: bool) -> RepoUpdate | None:
+    del is_primary  # a fetch failure is already a hard FAILED for every repo
     fetch = _git(repo, "fetch", "origin", expected_codes=None)
     if fetch.returncode == 0:
         return None
     return RepoUpdate(name, UpdateStatus.FAILED, reason=f"git fetch failed: {fetch.stderr.strip()}")
 
 
-def _check_default_branch(name: str, repo: Path) -> RepoUpdate | None:
+def _warn_primary_off_default(name: str, repo: Path, current: str, default_branch: str | None) -> None:
+    """Emit a prominent, un-missable block when the primary clone can't sync.
+
+    The primary/running clone parked off its default branch (or with no
+    upstream) means the editable ``t3`` the agent is running silently diverges
+    from origin/main — a real currency hazard (#2134). Mirror the loud,
+    multi-line WARNING shape of :func:`_check_clean` rather than a quiet SKIP
+    line, naming the current branch and the one-line fix.
+    """
+    target = default_branch or "main"
+    typer.echo("")
+    typer.echo(f"!! WARNING: {name} is on branch {current!r}, not its default branch {target!r} — cannot sync.")
+    typer.echo(f"!! The running editable t3 from {repo} will stay STALE behind origin until this is resolved.")
+    typer.echo(f"!! Fix: git switch {target} && git pull --ff-only")
+    typer.echo("")
+
+
+def _check_default_branch(name: str, repo: Path, *, is_primary: bool) -> RepoUpdate | None:
     default_branch = _default_branch(repo)
     if default_branch is None:
         return RepoUpdate(name, UpdateStatus.SKIPPED, reason="no origin/HEAD (no remote / no upstream)")
-    if not _has_upstream(repo):
-        return RepoUpdate(name, UpdateStatus.SKIPPED, reason="no upstream tracking branch")
     current = _current_branch(repo)
+    if not _has_upstream(repo):
+        if is_primary:
+            _warn_primary_off_default(name, repo, current, default_branch)
+            return RepoUpdate(
+                name,
+                UpdateStatus.FAILED,
+                reason=(
+                    f"on branch {current!r} with no upstream — running t3 is STALE; "
+                    f"`git switch {default_branch} && git pull --ff-only`"
+                ),
+            )
+        return RepoUpdate(name, UpdateStatus.SKIPPED, reason="no upstream tracking branch")
     if current != default_branch:
+        if is_primary:
+            _warn_primary_off_default(name, repo, current, default_branch)
+            return RepoUpdate(
+                name,
+                UpdateStatus.FAILED,
+                reason=(
+                    f"on branch {current!r}, not default {default_branch!r} — running t3 is STALE; "
+                    f"`git switch {default_branch} && git pull --ff-only`"
+                ),
+            )
         return RepoUpdate(
             name,
             UpdateStatus.SKIPPED,
@@ -183,15 +232,17 @@ def _check_default_branch(name: str, repo: Path) -> RepoUpdate | None:
     return None
 
 
-def _check_clean(name: str, repo: Path) -> RepoUpdate | None:
+def _check_clean(name: str, repo: Path, *, is_primary: bool) -> RepoUpdate | None:
     """Refuse a ff-pull only on uncommitted *tracked* changes — loudly.
 
     Untracked files (e.g. the loop's ``.loop-review-state.json`` runtime
     artifact) are tolerated: a fast-forward never touches them, so the
     update must proceed (#924).  When tracked changes do block the pull,
     this is NOT a silent ``SKIP`` line — it emits a prominent, multi-line
-    WARNING so a stale running editable ``t3`` can never be invisible.
+    WARNING so a stale running editable ``t3`` can never be invisible.  This
+    is already loud for every repo, so it does not branch on *is_primary*.
     """
+    del is_primary
     tracked = _tracked_dirty_paths(repo)
     if not tracked:
         return None
@@ -216,25 +267,28 @@ def _check_clean(name: str, repo: Path) -> RepoUpdate | None:
 _PRECONDITIONS = (_check_origin, _check_fetch, _check_default_branch, _check_clean)
 
 
-def _precondition_block(name: str, repo: Path) -> RepoUpdate | None:
+def _precondition_block(name: str, repo: Path, *, is_primary: bool) -> RepoUpdate | None:
     """Return the first terminal skip/fail outcome, or ``None`` if all clear."""
     for guard in _PRECONDITIONS:
-        blocked = guard(name, repo)
+        blocked = guard(name, repo, is_primary=is_primary)
         if blocked is not None:
             return blocked
     return None
 
 
-def update_repo(name: str, repo: Path) -> RepoUpdate:
+def update_repo(name: str, repo: Path, *, is_primary: bool = False) -> RepoUpdate:
     """Fetch and fast-forward *repo* to its default branch, or skip safely.
 
-    Never stashes, resets, or clobbers: a tracked-dirty tree (warned
-    loudly), a non-default branch, or a missing upstream each yield
-    :class:`UpdateStatus.SKIPPED` with a reason.  An untracked-only tree
-    is NOT dirt — the ff-pull proceeds.  A failed ``git fetch`` / ``git
-    pull`` yields :class:`UpdateStatus.FAILED`.
+    Never stashes, resets, or clobbers.  For an *overlay* repo a non-default
+    branch or a missing upstream yields a soft :class:`UpdateStatus.SKIPPED`.
+    For the *primary*/running clone (``is_primary=True``) those same states are
+    a fail-loud currency hazard — the editable ``t3`` the agent runs would
+    silently diverge from origin/main — so they yield
+    :class:`UpdateStatus.FAILED` plus a prominent warning (#2134).  An
+    untracked-only tree is NOT dirt — the ff-pull proceeds.  A failed ``git
+    fetch`` / ``git pull`` always yields :class:`UpdateStatus.FAILED`.
     """
-    blocked = _precondition_block(name, repo)
+    blocked = _precondition_block(name, repo, is_primary=is_primary)
     if blocked is not None:
         return blocked
 
@@ -287,13 +341,13 @@ def _collect_repos() -> list[tuple[str, Path]]:
     core = _find_main_clone()
     if core is not None:
         resolved = core.resolve()
-        repos.append(("teatree", resolved))
+        repos.append((_CORE_REPO_NAME, resolved))
         seen.add(resolved)
 
     running = _running_clone()
     if running is not None and running not in seen:
         seen.add(running)
-        repos.append(("teatree (running)", running))
+        repos.append((_RUNNING_REPO_NAME, running))
 
     for entry in discover_overlays():
         if entry.project_path is None:
@@ -364,7 +418,7 @@ def _run_update() -> None:
     results: list[RepoUpdate] = []
     for name, path in repos:
         typer.echo(f"Updating {name} ({path}) ...")
-        results.append(update_repo(name, path))
+        results.append(update_repo(name, path, is_primary=name in _PRIMARY_REPO_NAMES))
 
     _reinstall_and_resetup(results)
     # Probe-gated and decoupled from the per-run UPDATED flag (#929): an

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -210,6 +210,97 @@ class TestUpdateRepoSkips:
         assert result.is_error is False
 
 
+class TestPrimaryCloneOffDefaultBranchFailsLoud:
+    """The primary/running clone parked off its default branch must fail loud (#2134).
+
+    A non-default-branch (or no-upstream) primary clone must FAIL LOUD — non-zero
+    exit + a prominent warning naming the current branch and the one-line fix —
+    never a quiet ``SKIP`` folded into an otherwise-green summary. A stale dev
+    install silently diverges from main, so the running agent keeps executing
+    outdated code. Overlays keep the soft skip (they are not the editable ``t3``
+    being run).
+    """
+
+    def test_primary_feature_branch_fails_loud(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _git(clone, "checkout", "-b", "feature/wip")
+
+        result = update_repo("teatree", clone, is_primary=True)
+
+        assert result.status is UpdateStatus.FAILED
+        assert result.is_error is True
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert "feature/wip" in out
+        assert "git switch" in out
+        # Never clobbered — the clone stays on its branch.
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "feature/wip"
+
+    def test_primary_non_default_branch_with_upstream_fails_loud(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _git(clone, "checkout", "-b", "feature/tracked")
+        _git(clone, "push", "-u", "origin", "feature/tracked")
+
+        result = update_repo("teatree (running)", clone, is_primary=True)
+
+        assert result.status is UpdateStatus.FAILED
+        assert result.is_error is True
+        assert "feature/tracked" in result.reason
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert "feature/tracked" in out
+        assert "git switch" in out
+
+    def test_primary_no_upstream_fails_loud(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # A clone whose default branch has no upstream tracking branch (a
+        # detached/local-only checkout the dev forgot to push): for the
+        # primary clone this is fail-loud, not a quiet skip.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _git(clone, "checkout", "-b", "review-branch")
+
+        result = update_repo("teatree", clone, is_primary=True)
+
+        assert result.status is UpdateStatus.FAILED
+        assert result.is_error is True
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert "git switch" in out
+
+    def test_overlay_off_default_branch_still_soft_skips(self, tmp_path: Path) -> None:
+        # An overlay (not the running t3) parked off-branch keeps the soft
+        # SKIP — only the primary clone is the fail-loud currency hazard.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _git(clone, "checkout", "-b", "feature/wip")
+
+        result = update_repo("some-overlay", clone, is_primary=False)
+
+        assert result.status is UpdateStatus.SKIPPED
+        assert result.is_error is False
+
+    def test_run_update_exits_nonzero_when_primary_off_default_branch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # End-to-end: _run_update collects the primary clone parked off its
+        # default branch and exits non-zero (fail-loud) — not the green
+        # success-shaped summary the bug produced.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _git(clone, "checkout", "-b", "feature/wip")
+
+        monkeypatch.setattr(update_mod, "_collect_repos", lambda: [("teatree", clone)])
+        monkeypatch.setattr(update_mod, "_reinstall_and_resetup", lambda _r: None)
+        monkeypatch.setattr(update_mod, "ensure_self_db_migrated", lambda: False)
+
+        with pytest.raises((SystemExit, click.exceptions.Exit)):
+            update_mod._run_update()
+
+
 class TestRepoUpdateSummary:
     def test_summary_line_shapes(self) -> None:
         updated = RepoUpdate("core", UpdateStatus.UPDATED, old_sha="aaaaaaa", new_sha="bbbbbbb")
@@ -230,7 +321,7 @@ class TestUpdateCommandExitCode:
 
     def _run(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, results: list[RepoUpdate]) -> int:
         monkeypatch.setattr(update_mod, "_collect_repos", lambda: [("core", tmp_path)])
-        monkeypatch.setattr(update_mod, "update_repo", lambda name, path: results.pop(0))
+        monkeypatch.setattr(update_mod, "update_repo", lambda name, path, *, is_primary=False: results.pop(0))
         monkeypatch.setattr(update_mod, "_reinstall_and_resetup", lambda repos: None)
         monkeypatch.setattr(update_mod, "ensure_self_db_migrated", lambda: False)
 


### PR DESCRIPTION
Fixes #2134.

## Problem

`t3 update` printed `SKIP  teatree: skipped (no upstream tracking branch)` and exited 0 when the primary teatree clone was parked on a feature/review branch (or had no upstream). The sync failure was folded into an otherwise-green summary, so the editable `t3` the agent runs silently diverged from origin/main — gates, loop logic, and CLI behaviour rot behind main with no error surfaced. This is a fail-loud violation: a maintenance command that cannot do its job reported success-shaped output.

## Fix

Thread an `is_primary` flag through `update_repo` -> `_precondition_block` -> the precondition guards. The core (`teatree`) and running (`teatree (running)`) clones are the primary/editable ones; overlays are not.

For a **primary** clone, a non-default-branch or no-upstream checkout now:
- emits a prominent multi-line `!! WARNING:` block (mirroring the existing `_check_clean` tracked-dirty warning) naming the current branch and the one-line fix `git switch <default> && git pull --ff-only`, and
- returns `UpdateStatus.FAILED`, so `RepoUpdate.is_error` is `True` and `_run_update` raises `typer.Exit(code=1)`.

Overlays keep the soft `SKIP` (they are not the running `t3`). The `no origin/HEAD` (genuinely no remote) case stays a soft skip for every repo — it is a config state, not a parked-off-branch hazard.

## Anti-vacuity proof

Added `TestPrimaryCloneOffDefaultBranchFailsLoud` (5 tests). Verified RED before the fix: with the `is_primary` signature kept but the FAILED branch logic reverted to the old always-SKIPPED behaviour, all 5 tests failed with `AssertionError: assert <UpdateStatus.SKIPPED> is <UpdateStatus.FAILED>`. Restoring the fix turns them green. The tests assert the observable contract the bug violated (status `FAILED`, non-zero `_run_update` exit, `WARNING` + current branch name + `git switch` hint in captured output), not a structurally-guaranteed post-condition.

## Architecture pre-check — #2134

### 1. BLUEPRINT § alignment
n/a — tactical fix to one CLI command's outcome classification; no BLUEPRINT section governs `t3 update`'s per-repo skip-vs-fail policy. Fail-loud-not-skip-as-pass is the CLAUDE.md "no tech debt / fail loud" doctrine.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / Protocol surface changed. The precondition guards share a uniform `(name, repo, *, is_primary)` signature, updated together.

### 4. Component boundaries
`src/teatree/cli/update.py` — stays within the existing CLI module; no business logic moved.

### 5. Dependency direction
No imports added. `uv run tach check` and `uv run lint-imports` both pass.

### 6. Test surface
`tests/test_cli_update.py::TestPrimaryCloneOffDefaultBranchFailsLoud` — primary feature-branch -> FAILED + warning; primary non-default-with-upstream -> FAILED; primary no-upstream -> FAILED; overlay off-branch -> still SKIPPED; `_run_update` exits non-zero for a primary off-branch clone.

### 7. Resilience invariants
n/a — no external write. The change is read-only git inspection plus a stronger local exit code; idempotent (re-running yields the same FAILED until the branch is fixed).

### 8. Identity and key normalization
The primary-clone names (`teatree`, `teatree (running)`) are now module constants (`_CORE_REPO_NAME`, `_RUNNING_REPO_NAME`, `_PRIMARY_REPO_NAMES`) shared by `_collect_repos` (producer) and `_run_update` (consumer) — one source of truth, no string-literal drift.

### 9. Behavior preservation / capability deletion
Additive for overlays (soft SKIP unchanged) and for the `no origin/HEAD`, fetch-failure, tracked-dirty, and ff-pull paths. The only behavior change is the intended SKIP->FAILED for a **primary** clone on a non-default / no-upstream branch. No must-block test inverted; the existing overlay-style skip tests (`test_feature_branch_checkout_skips`, `test_non_default_branch_with_upstream_skips`, `test_no_upstream_skips`) use a non-primary name and stay green.
