### PR TITLE
test(quality): fitness function — no manage.py interpreter-prefix literal outside runner_prefix (#2004)

### DIFF
--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -3,7 +3,6 @@
 import json as _json
 import logging
 import os
-import shutil
 import sys
 from pathlib import Path
 
@@ -13,6 +12,7 @@ from teatree.cli.autonomy import register_autonomy_commands
 from teatree.cli.django_groups import DJANGO_GROUPS, DjangoGroup
 from teatree.cli.speed import register_speed_commands
 from teatree.cli.teatree_gate import register_gate_commands
+from teatree.utils.django_db import runner_prefix
 from teatree.utils.run import run_streamed, spawn
 from teatree.utils.singleton import AlreadyRunningError, singleton
 
@@ -23,6 +23,18 @@ logger = logging.getLogger(__name__)
 # ``teatree.cli.django_groups`` but ``overlay`` stays its public home.
 __all__ = ["DJANGO_GROUPS", "OVERLAY_PROXY_COMMANDS", "DjangoGroup", "OverlayAppBuilder", "managepy", "managepy_core"]
 
+
+def _managepy_cmd(project_path: Path, *args: str) -> list[str]:
+    """Build the ``manage.py`` invocation for *project_path* via the shared prefix.
+
+    Routes through :func:`teatree.utils.django_db.runner_prefix` — the single
+    site that emits the interpreter prefix — so the overlay ``db_worker`` /
+    ``managepy`` paths inherit the pipenv-vs-uv detection instead of an
+    unconditional ``uv --directory`` (souliane/teatree#1976, #1973).
+    """
+    return [*runner_prefix(project_path), *args]
+
+
 OVERLAY_PROXY_COMMANDS: dict[str, tuple[str, str]] = {}
 """Maps proxy callback ``__name__`` -> ``(django_group, django_sub)``.
 
@@ -32,12 +44,6 @@ CLI reference generator to swap the proxy's stub help for the underlying
 reassigned per-leaf (``_run_{group}_{sub}``); object identity is not stable
 across Typer's ``get_command`` conversion.
 """
-
-
-def uv_cmd(project_path: Path, *args: str) -> list[str]:
-    """Build a ``uv --directory <path> run ...`` command list."""
-    uv = shutil.which("uv") or "uv"
-    return [uv, "--directory", str(project_path), "run", *args]
 
 
 def _base_env() -> dict[str, str]:
@@ -58,7 +64,7 @@ def _run_workers(project_path: Path, overlay_name: str, count: int, interval: fl
     processes = [
         spawn(
             [
-                *uv_cmd(project_path, "python", manage_py, "db_worker"),
+                *_managepy_cmd(project_path, manage_py, "db_worker"),
                 "--interval",
                 str(interval),
                 "--no-startup-delay",
@@ -97,7 +103,7 @@ def managepy(project_path: Path | None, *args: str, overlay_name: str = "") -> N
         env["T3_OVERLAY_NAME"] = overlay_name
 
     if project_path and (project_path / "manage.py").is_file():
-        cmd = uv_cmd(project_path, "python", "manage.py", *args)
+        cmd = _managepy_cmd(project_path, "manage.py", *args)
         run_streamed(cmd, cwd=project_path, env=env)
     else:
         env.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")

--- a/src/teatree/utils/django_db.py
+++ b/src/teatree/utils/django_db.py
@@ -84,14 +84,15 @@ def _is_config_error(combined: str) -> bool:
     return any(m in combined for m in _CONFIG_ERROR_MARKERS)
 
 
-def _migrate_runner_prefix(repo: Path) -> list[str]:
+def runner_prefix(repo: Path) -> list[str]:
     """Build the interpreter prefix that runs ``python`` from *repo*'s environment.
 
-    Pipenv repos (see :func:`_is_pipenv_repo`) resolve through ``pipenv run``
-    with ``PIPENV_PIPFILE`` pinned to *repo*'s ``Pipfile``, so pipenv resolves
-    *repo*'s populated venv regardless of the subprocess cwd. Everything else
-    keeps the uv path: ``uv --directory <repo> run`` auto-isolates the repo's
-    locked environment.
+    The SOLE site that emits a ``manage.py`` interpreter prefix (migrate +
+    overlay ``managepy`` / ``db_worker`` route here) so the pipenv-vs-uv
+    detection lives in one place; a hand-rolled second prefix silently diverges
+    (souliane/teatree#1976, #1973; pinned by ``test_runner_prefix_chokepoint``).
+    Pipenv repos (:func:`_is_pipenv_repo`) use ``pipenv run`` with
+    ``PIPENV_PIPFILE`` pinned (cwd-independent); else ``uv --directory <repo> run``.
     """
     if _is_pipenv_repo(repo):
         return ["env", f"PIPENV_PIPFILE={repo / 'Pipfile'}", "pipenv", "run", "python"]
@@ -324,7 +325,7 @@ class DjangoDbImporter:
         """
         if self._migrate_via_docker and self.cfg.dockerized_migrate is not None:
             return self.cfg.dockerized_migrate(manage_args, run_env)
-        runner = _migrate_runner_prefix(Path(self.cfg.main_repo_path))
+        runner = runner_prefix(Path(self.cfg.main_repo_path))
         return run_allowed_to_fail(
             [*runner, *manage_args], cwd=self.cfg.main_repo_path, env=run_env, expected_codes=None
         )
@@ -644,5 +645,6 @@ __all__ = [
     "DjangoDbImporter",
     "django_db_import",
     "prune_dslr_snapshots",
+    "runner_prefix",
     "validate_dump",
 ]

--- a/tests/quality/test_runner_prefix_chokepoint.py
+++ b/tests/quality/test_runner_prefix_chokepoint.py
@@ -1,0 +1,123 @@
+"""Runner-prefix chokepoint fitness function (#2004).
+
+The ONLY sanctioned site that emits the manage.py interpreter prefix
+(``uv --directory <repo> run python`` / ``pipenv run python``) is
+``runner_prefix`` in ``teatree.utils.django_db``. That one helper owns the
+pipenv-vs-uv dependency-manager detection (#1973); every other call site must
+route through it.
+
+PR #1976 regressed this: core assumed ``uv run`` universally for the
+reference-DB migrate while the overlay hand-rolled an unconditional
+``uv --directory`` prefix in ``cli.overlay.uv_cmd`` — two divergent
+interpreter-prefix implementations that drifted apart (#1973).
+
+This AST fitness test walks ``src/teatree/`` and flags any literal building an
+interpreter prefix for a Python / ``manage.py`` invocation outside the allowed
+home. It is the durable catch-all: a future re-introduction of a hand-rolled
+prefix anywhere goes RED here.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "teatree"
+
+# The sole module allowed to construct the manage.py interpreter prefix: the
+# manager-aware runner-prefix helper (#1973).
+_ALLOWED_MODULES = frozenset({"teatree.utils.django_db"})
+
+_MANAGER_TOKENS = frozenset({"uv", "pipenv"})
+_INTERPRETER_TOKENS = frozenset({"python", "manage.py"})
+
+
+def _module_name(path: Path) -> str:
+    rel = path.relative_to(_SRC_ROOT.parent).with_suffix("")
+    return ".".join(rel.parts)
+
+
+def _str_literals(node: ast.AST) -> list[str]:
+    return [n.value for n in ast.walk(node) if isinstance(n, ast.Constant) and isinstance(n.value, str)]
+
+
+def _is_interpreter_prefix_seq(node: ast.AST) -> bool:
+    """True iff *node* is a list/tuple literal building a manage.py interpreter prefix.
+
+    Two shapes both count, mirroring the only two the codebase ever uses.
+
+    Shape A — ``[..., "--directory", <repo>, "run", ...]`` — the uv
+    directory-isolation prefix. The discriminator is the ``--directory`` +
+    ``run`` pair, which is unique to running an isolated repo environment; the
+    ``uv`` binary itself may be a literal or resolved via ``shutil.which`` into
+    the list head, so keying on a ``"uv"`` literal would miss the
+    resolved-binary form.
+
+    Shape B — ``["uv"/"pipenv", "run", ..., "python"/"manage.py", ...]`` — a
+    manager ``run`` that targets the Python interpreter or ``manage.py``
+    directly.
+
+    A bare ``["uv", "run", "pytest"]`` / ``["uv", "sync"]`` / ``["uv", "pip", …]``
+    tooling command is deliberately NOT flagged: it does not invoke the app's
+    Python interpreter, so it does not depend on the pipenv-vs-uv detection.
+    """
+    if not isinstance(node, ast.List | ast.Tuple):
+        return False
+    literals = set(_str_literals(node))
+    if "--directory" in literals and "run" in literals:
+        return True
+    if not literals & _MANAGER_TOKENS:
+        return False
+    return "run" in literals and bool(literals & _INTERPRETER_TOKENS)
+
+
+def _offending_lines(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return sorted({node.lineno for node in ast.walk(tree) if _is_interpreter_prefix_seq(node)})
+
+
+def test_no_interpreter_prefix_literal_outside_the_runner_prefix_helper() -> None:
+    offenders: dict[str, list[int]] = {}
+    for path in sorted(_SRC_ROOT.rglob("*.py")):
+        if _module_name(path) in _ALLOWED_MODULES:
+            continue
+        lines = _offending_lines(path)
+        if lines:
+            offenders[str(path.relative_to(_SRC_ROOT.parent))] = lines
+    assert not offenders, (
+        "Hand-rolled manage.py interpreter prefix (uv --directory / pipenv run python) "
+        "outside the runner-prefix helper (teatree.utils.django_db.runner_prefix) — "
+        f"a second runner silently diverges from the pipenv-vs-uv detection (#1976, #1973): {offenders}"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        '["uv", "--directory", repo, "run", "python"]',
+        '[uv, "--directory", str(p), "run", "python", "manage.py"]',
+        '["pipenv", "run", "python"]',
+        '("uv", "run", "manage.py", "migrate")',
+        '["uv", "run", "python", "-m", "pytest"]',
+    ],
+)
+def test_predicate_flags_interpreter_prefix_shapes(source: str) -> None:
+    node = ast.parse(source, mode="eval").body
+    assert _is_interpreter_prefix_seq(node)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        '["uv", "run", "pytest"]',
+        '["uv", "sync"]',
+        '["uv", "pip", "install", "-e", str(p)]',
+        '("uv", "run", "--group", "mutation", "mutmut")',
+        '["uv", "run", "t3", "--help"]',
+        '["createdb", "-h", host]',
+        '["python", "manage.py", "migrate"]',
+    ],
+)
+def test_predicate_ignores_tooling_and_non_isolated_commands(source: str) -> None:
+    node = ast.parse(source, mode="eval").body
+    assert not _is_interpreter_prefix_seq(node)


### PR DESCRIPTION
Fixes #2004.

## What

Adds a structural fitness function that makes it a hard CI failure to hand-roll a `manage.py` interpreter prefix (`uv --directory … run python` / `pipenv run python`) anywhere outside the single runner-prefix helper, and folds the one existing offender into that helper so the tree is green.

PR #1976 regressed this: core assumed `uv run` universally for the reference-DB migrate while `cli.overlay` carried an unconditional `uv --directory` prefix in `uv_cmd` — two divergent interpreter-prefix implementations that drifted apart from the pipenv-vs-uv detection (#1973). A manager-specific prefix hand-rolled at a call site instead of the one manager-aware helper means a second runner silently diverges.

## How

- Promote `teatree.utils.django_db._migrate_runner_prefix` to a public `runner_prefix(repo)` — the SOLE site that emits the interpreter prefix.
- Fold `cli.overlay.uv_cmd` into `runner_prefix` via a thin `_managepy_cmd`, so the overlay `db_worker` / `managepy` paths inherit the pipenv-vs-uv detection instead of an unconditional `uv --directory`.
- `tests/quality/test_runner_prefix_chokepoint.py` (mirrors the existing `test_merge_sink_chokepoint.py` pattern): AST-walks `src/teatree`, flags any list/tuple literal building the interpreter prefix (`--directory` + `run`, or a manager token + `run` + `python`/`manage.py`), allowing only `teatree.utils.django_db`. A bare `uv sync` / `uv run pytest` / `uv pip install` tooling command is deliberately not flagged.

The registry-driven `chokepoints.yaml` only matches `ast.Call` nodes (method / module-attr calls); this rule keys on list/string literals, so — like the merge-sink gate — it lives as a standalone AST fitness test rather than a registry entry.

## Anti-vacuity

Reverting the overlay fold restores `uv_cmd`'s hand-rolled prefix and turns the test RED at `teatree/cli/overlay.py:40`; restoring the fix turns it GREEN. The predicate also carries positive/negative parametrized cases pinning that tooling commands stay exempt and both prefix shapes are caught.

## Architecture pre-check — #2004

**1. BLUEPRINT § alignment** — quality / architectural-fitness-function class (the chokepoint + fitness-test pattern). No BLUEPRINT section change required; mirrors the existing `test_merge_sink_chokepoint.py` (#1985), which is likewise un-catalogued prose.

**2. FSM phase boundaries** — n/a, no `Ticket.State` / `Worktree.State` transition.

**3. Extension-point contracts** — n/a, no `OverlayBase` / scanner / hook / Protocol surface touched.

**4. Component boundaries** — `runner_prefix` stays in `teatree.utils.django_db` (the manager-detection home); the overlay's thin `_managepy_cmd` stays in `teatree.cli.overlay`; the gate lives under `tests/quality/`.

**5. Dependency direction** — `teatree.cli` → `teatree.utils` is an existing, allowed edge (`tach.toml`); `uv run tach check` → "All modules validated!". No backwards edge.

**6. Test surface** — `test_runner_prefix_chokepoint.py` asserts zero offending literals on `src/teatree` (whole-tree AST walk) plus parametrized predicate cases. Existing migrate-runner-selection tests (`tests/django_db/test_migration.py`) and `test_managepy_calls_uv` continue to pin the resolved argv.

**7. Resilience invariants** — n/a, no external write introduced.

**8. Identity / key normalization** — n/a.

**9. Behavior preservation** — `_migrate_runner_prefix` → `runner_prefix` is a rename + promote (same body, bare `"uv"` preserved so the pinned `tests/django_db/test_migration.py` assertions still hold). `uv_cmd`'s only behavior change: it previously resolved `shutil.which("uv")` to an absolute path; the unified helper uses bare `"uv"` (PATH-resolved by the run wrapper, identical to the migrate path's long-standing behavior). `test_managepy_calls_uv` asserts `Path(cmd[0]).name == "uv"` — robust to both forms. No safety/privacy matcher narrowed; no must-block test inverted.

Refs #1976, #1973.
