### PR TITLE
test(eval): pin review-posting discipline — inline findings + delegated post (#2173)

### DIFF
--- a/skills/review/evals.yaml
+++ b/skills/review/evals.yaml
@@ -64,3 +64,54 @@
       args.command: '~ "t3 slack react C_REVIEW 171\.5 question\b"'
     - no_tool_call_matching:
         Bash.command: '~ "t3 slack react \S+ \S+ (white_check_mark|heavy_check_mark|\+1)"'
+
+# A review finding anchored to specific code goes as an INLINE comment
+# (`t3 review post-comment <repo> <mr> "<finding>" --file <path> --line <N>`),
+# never as a general MR-level note that drops the anchor. SKILL.md § "Inline
+# first, general note second" + "Posting Comments" make `--file`/`--line` the
+# binding shape: a general note forces the author to hunt for the code the
+# finding refers to. The two positive matchers (`--file` AND `--line` present)
+# keep a no-op transcript red; the negative refuses any `post-comment` that
+# carries no `--file` (the general-note degradation, #72's silent foot-gun).
+- name: review_findings_posted_inline_not_general
+  scenario: "a code-anchored review finding is posted as an inline --file/--line comment, never a general MR note"
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    You are reviewing colleague MR !4120 on repo `my-org/my-repo`. You found one
+    blocking issue: the sweep loop in `src/teatree/core/sweep.py` reallocates the
+    candidate list on every call (line 88). Post that finding on the MR. Run the
+    ONE Bash command you would issue. One command only, no narration.
+  expect:
+    - tool_call: Bash
+      args.command: '~ "t3 review post-comment .*--file "'
+    - tool_call: Bash
+      args.command: '~ "t3 review post-comment .*--line "'
+    - no_tool_call_matching:
+        Bash.command: '~ "t3 review post-comment(?!.*--file)"'
+
+# Review comments are posted by a delegated reviewer / sub-agent, never authored
+# and posted inline by the main orchestrator. CLAUDE.md "main agent orchestrates
+# only" + the user directive "do not post review comment in main agent, use a
+# sub-agent (a cheap one) or the reviewer agent". The positive matcher requires
+# a `Task` dispatch that posts the finding (keeps the no-op red); the negative
+# refuses the orchestrator running `t3 review post-comment` itself in the
+# foreground via Bash. The negative keys on `Bash.command`, so the same text
+# inside the delegated `Task.prompt` does not trip it (arg-path isolation).
+- name: review_post_delegated_not_main_agent
+  scenario: "the orchestrator delegates posting a review comment to a sub-agent, never posts it itself in the foreground"
+  agent_path: skills/rules/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash, Task]
+  prompt: >-
+    You are the main orchestrating agent. A review finding is ready for colleague
+    MR `my-org/my-repo`!4120: an inline `t3 review post-comment` on
+    `src/teatree/core/sweep.py` line 88. Following the orchestrate-only boundary,
+    take the single action you would take now to get that comment posted.
+  expect:
+    - tool_call: Task
+      args.prompt: '~ "(?i)(post|comment).*(post-comment|--file|inline)"'
+    - no_tool_call_matching:
+        Bash.command: '~ "t3 review post-comment"'

--- a/src/teatree/eval/README.md
+++ b/src/teatree/eval/README.md
@@ -393,6 +393,7 @@ class, where it is pinned, and the originating fix:
 | forge backend resolves by repo origin host, not token precedence | `regression_corpus` (`forge_from_remote`) | [#2085](https://github.com/souliane/teatree/pull/2085) |
 | pre-push gates reconcile a renamed/stale branch (read what exists, not the stale `<N>-ticket` ref) | `regression_corpus` (`resolve_and_reconcile_branch`) | [#2102](https://github.com/souliane/teatree/pull/2102) |
 | MR description first line validated client-side (the GitLab CI gate's own rule, no validator round-trip) | `regression_corpus` (`validate_mr_metadata`) | [#2098](https://github.com/souliane/teatree/pull/2098) |
+| review findings posted INLINE (`--file`/`--line`), never a general MR note; posting delegated to a sub-agent, never the main orchestrator in the foreground | `skills/review/evals.yaml` (`review_findings_posted_inline_not_general`, `review_post_delegated_not_main_agent`, co-located) | [#2173](https://github.com/souliane/teatree/issues/2173) |
 
 The on-behalf / answerer-draft, sweep-merge-never-rebase, review-branch-current,
 skill-ref-resolve, and per-phase scenarios (answerer, sweeping-prs, review,

--- a/tests/eval/fixtures/review_findings_posted_inline_not_general_fail.stream.jsonl
+++ b/tests/eval/fixtures/review_findings_posted_inline_not_general_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_findings_posted_inline_not_general-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Posting the whole review as one general MR-level note."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 review post-comment my-org/my-repo 4120 \"Review of MR !4120. The sweep loop in src/teatree/core/sweep.py around line 88 reallocates the candidate list on every call; hoist the allocation. Otherwise the change looks fine.\""}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_findings_posted_inline_not_general_noop.stream.jsonl
+++ b/tests/eval/fixtures/review_findings_posted_inline_not_general_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_findings_posted_inline_not_general-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Deciding how to phrase the finding; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_findings_posted_inline_not_general_pass.stream.jsonl
+++ b/tests/eval/fixtures/review_findings_posted_inline_not_general_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_findings_posted_inline_not_general-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Anchoring the finding to the exact file and line so the author sees the offending code."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 review post-comment my-org/my-repo 4120 \"This loop reallocates the candidate list on every call; hoist the allocation out of the loop.\" --file src/teatree/core/sweep.py --line 88"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_post_delegated_not_main_agent_fail.stream.jsonl
+++ b/tests/eval/fixtures/review_post_delegated_not_main_agent_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_post_delegated_not_main_agent-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Posting the review comment myself in the foreground."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 review post-comment my-org/my-repo 4120 \"This loop reallocates the candidate list on every call; hoist the allocation.\" --file src/teatree/core/sweep.py --line 88"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_post_delegated_not_main_agent_noop.stream.jsonl
+++ b/tests/eval/fixtures/review_post_delegated_not_main_agent_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_post_delegated_not_main_agent-noop", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Considering whether to delegate; no tool calls yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval/fixtures/review_post_delegated_not_main_agent_pass.stream.jsonl
+++ b/tests/eval/fixtures/review_post_delegated_not_main_agent_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-review_post_delegated_not_main_agent-pass", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Delegating the post to a cheap reviewer sub-agent rather than posting in the main agent."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Task", "input": {"subagent_type": "t3:reviewer", "description": "post inline review comment", "prompt": "Post the review finding as an inline comment on colleague MR my-org/my-repo!4120: run `t3 review post-comment my-org/my-repo 4120 \"This loop reallocates the candidate list on every call; hoist the allocation.\" --file src/teatree/core/sweep.py --line 88`."}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}


### PR DESCRIPTION
## What

Two co-located, anti-vacuous behavioral evals enforcing how code-review findings are POSTED, in `skills/review/evals.yaml`:

1. **`review_findings_posted_inline_not_general`** — a code-anchored finding is posted as an **inline** comment via `t3 review post-comment <repo> <mr> "<finding>" --file <path> --line <N>`, never a general MR-level note that drops the anchor.
   - Positive matchers require BOTH `--file` and `--line` (so a no-op transcript stays red).
   - Negative matcher refuses any `post-comment` carrying no `--file` (the general-note degradation): regex `t3 review post-comment(?!.*--file)`.
2. **`review_post_delegated_not_main_agent`** — the orchestrator delegates posting the comment to a sub-agent (`Task` dispatch) and never runs `t3 review post-comment` itself in the foreground via `Bash`.
   - Positive matcher requires a `Task` dispatch whose prompt posts the finding.
   - Negative matcher keys on `Bash.command`, so the same text inside the delegated `Task.prompt` does not trip it (arg-path isolation).

Each scenario ships `_pass` / `_fail` / `_noop` transcript fixtures under `tests/eval/fixtures/`. A failure-class row was added to the eval README catalog.

## Anti-vacuity proof (real grading path: `evaluate(spec, run)`)

```
=== review_findings_posted_inline_not_general [fail] -> verdict=FAIL ===
  [RED ] Expected a Bash tool call with command matching regex 't3 review post-comment .*--file '
  [RED ] Expected a Bash tool call with command matching regex 't3 review post-comment .*--line '
  [RED ] Did not expect any Bash tool call with command matching 't3 review post-comment(?!.*--file)', but found:
=== review_findings_posted_inline_not_general [pass] -> verdict=PASS ===
=== review_findings_posted_inline_not_general [noop] -> verdict=FAIL ===

=== review_post_delegated_not_main_agent [fail] -> verdict=FAIL ===
  [RED ] Expected a Task tool call with prompt matching regex '(?i)(post|comment).*(post-comment|--file|inline)'
  [RED ] Did not expect any Bash tool call with command matching 't3 review post-comment', but found:
=== review_post_delegated_not_main_agent [pass] -> verdict=PASS ===
=== review_post_delegated_not_main_agent [noop] -> verdict=FAIL ===
```

The anti-vacuity gate (`tests/eval/test_scenarios_anti_vacuous.py`) enforces this on every PR: `_fail` -> RED, `_pass` -> GREEN, `_noop` -> RED.

## Verification

```
uv run pytest --no-cov -q tests/eval/test_scenarios_anti_vacuous.py \
  tests/eval/test_discovery.py tests/eval/test_skill_eval_coverage.py \
  tests/eval/test_readme_sync.py tests/eval/test_loader.py
# 484 passed, 16 skipped
uv run ruff check   # All checks passed!
```

## Architecture pre-check — #2173

### 1. BLUEPRINT § alignment
§11 (skill system) + the eval harness doc `src/teatree/eval/README.md`. Co-located skill evals are the documented convention (`skills/CLAUDE.md` § "Ship co-located evals"); these are added to the existing `skills/review/evals.yaml` and the README failure-class catalog. No BLUEPRINT prose change required.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition; these are static YAML scenarios + JSONL fixtures.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / `*Backend` Protocol change. Discovery picks the new specs up via the existing `_discover_colocated_specs` walk of `skills/*/evals.yaml`.

### 4. Component boundaries
Scenarios live beside the skill they grade (`skills/review/evals.yaml`); fixtures live in `tests/eval/fixtures/` like every other scenario. No new module.

### 5. Dependency direction
n/a — no Python import added. `uv run ruff check` passes; no `src/` logic touched (only the eval README doc).

### 6. Test surface
The behaviour contract is the anti-vacuity gate itself: `tests/eval/test_scenarios_anti_vacuous.py` asserts `_fail` -> RED, `_pass` -> GREEN, `_noop` -> RED through `evaluate(spec, run)`. Discovery (`test_discovery.py`) asserts the YAML loads with no duplicate name; coverage (`test_skill_eval_coverage.py`) and README-sync (`test_readme_sync.py`) stay green.

### 7. Resilience invariants
n/a — no external write introduced. The scenarios *grade* whether the agent's review post is anchored/delegated; they do not themselves post.

### 8. Identity and key normalization
Scenario names are the canonical keys; discovery rejects a duplicate across the flat catalog / co-located / overlay surfaces with a hard `EvalSpecError`. No bare-vs-qualified stripping.

### 9. Behavior preservation / capability deletion
n/a — purely additive. No existing scenario, matcher, or fixture removed or inverted.
