### PR TITLE
fix(hooks): banned-terms gate — read-only gh/glab api GET stays skip-safe; pin cross-repo private downgrade

### DIFF
--- a/src/teatree/hooks/_publish_detection.py
+++ b/src/teatree/hooks/_publish_detection.py
@@ -174,6 +174,19 @@ def segment_is_api_write(words: list[str]) -> bool:
     return segment_is_api_call(words) and _api_effective_method(words) not in _API_READ_METHODS
 
 
+def segment_is_api_read(words: list[str]) -> bool:
+    """Return True iff ``words`` is a ``gh``/``glab api`` call whose method only READS.
+
+    The complement of :func:`segment_is_api_write` over the ``api`` surface: a
+    call whose effective method is ``GET``/``HEAD`` (``gh api user``, ``gh api
+    repos/o/r/issues --method GET``, ``glab api projects/42/issues``) posts NO
+    request body, so it cannot leak content onto a public surface and is not a
+    publish the gates must scan or fail-closed on. A non-``api`` segment is
+    neither a read nor a write.
+    """
+    return segment_is_api_call(words) and _api_effective_method(words) in _API_READ_METHODS
+
+
 def segment_is_git_commit_publish(words: list[str]) -> bool:
     """Return True iff ``words`` is a ``git [global-flags] commit`` with a body flag.
 

--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -39,7 +39,8 @@ from typing import Final
 
 from teatree.hooks._command_parser import first_segment_words
 from teatree.hooks._gh_glab_hiding import command_segments, token_has_substitution_marker, token_is_transport_construct
-from teatree.hooks._publish_detection import segment_is_api_call as _segment_is_api_call
+from teatree.hooks._publish_detection import segment_is_api_read as _segment_is_api_read
+from teatree.hooks._publish_detection import segment_is_api_write as _segment_is_api_write
 from teatree.hooks._repo_visibility import (
     _config_path,
     slug_for_cwd,
@@ -357,7 +358,7 @@ def gate_skips_destination(command: str, cwd: Path | None, *, config_path: Path 
     skip is the ALL-SEGMENTS inversion that mirrors
     :func:`publish_surface.command_is_pure_private_gh_glab_post`: skip ONLY
     when EVERY top-level segment is provably safe to skip and there is at
-    least one publish segment. A single public, unresolvable, ``api``, or
+    least one publish segment. A single public, unresolvable, ``api`` WRITE, or
     substitution/transport-carrying segment makes the WHOLE command scan
     (fail-closed). Otherwise a chained or substituted public post hides
     behind a leading internal segment and is never scanned.
@@ -365,7 +366,10 @@ def gate_skips_destination(command: str, cwd: Path | None, *, config_path: Path 
     A segment is skip-safe when it is one of:
 
     - a publish segment whose destination resolves to a provably-INTERNAL
-        repo/namespace, which carries no substitution/transport construct; or
+        repo/namespace, which carries no substitution/transport construct;
+    - a read-only ``gh``/``glab api`` GET (:func:`_segment_is_api_read`) --
+        a read posts NO body, so it can never leak content regardless of the
+        repo its URL names, and is skip-safe without resolving a destination; or
     - a segment that is PROVABLY a recognised navigation / local-only /
         git-transport command (:func:`_segment_is_skip_inert` -- its leading
         executable is in the closed ``_SKIP_INERT_LEADERS`` allowlist, e.g.
@@ -373,7 +377,8 @@ def gate_skips_destination(command: str, cwd: Path | None, *, config_path: Path 
         substitution/transport construct).
 
     Every OTHER segment is NOT skip-safe and makes the whole command scan
-    (fail-closed): a raw ``gh api`` / ``glab api`` call, a
+    (fail-closed): a raw ``gh api`` / ``glab api`` WRITE (effective method ≠
+    GET -- it carries a body to an arbitrary endpoint), a
     ``$(...)`` / process-substitution / redirection construct, a PUBLIC or
     unresolvable publish destination, and -- the closed inversion -- ANY
     segment whose leading word is an UNRECOGNISED executable (an interpreter
@@ -390,8 +395,10 @@ def gate_skips_destination(command: str, cwd: Path | None, *, config_path: Path 
         return False
     saw_internal_publish = False
     for words in segments:
-        if _segment_carries_substitution_or_transport(words) or _segment_is_api_call(words):
+        if _segment_carries_substitution_or_transport(words) or _segment_is_api_write(words):
             return False
+        if _segment_is_api_read(words):
+            continue
         dest = _destination_from_words(words, cwd)
         if dest is not None:
             if is_public_destination(dest, config_path=config_path):

--- a/tests/test_publish_destination.py
+++ b/tests/test_publish_destination.py
@@ -303,3 +303,29 @@ class TestGateSkipsDestination:
         cfg = _config(tmp_path, ["internalcorp"])
         cmd = f'gh pr create -R internalcorp/private-svc --body "ok" && {tail}'
         assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+
+    @pytest.mark.parametrize(
+        "read",
+        [
+            "gh api repos/souliane/teatree/issues",
+            "glab api projects/souliane%2Fteatree/issues",
+            "gh api repos/souliane/teatree/issues --method GET",
+            "glab api projects/42/merge_requests -X GET",
+        ],
+        ids=["gh-get", "glab-get", "gh-method-get", "glab-x-get"],
+    )
+    def test_read_only_api_chain_stays_skipped(self, tmp_path: Path, read: str) -> None:
+        # A read-only ``gh``/``glab api`` GET posts NO body, so it can never leak
+        # content -- regardless of the repo its URL names. Chained after a
+        # provably-internal post it must stay skip-safe, not over-block the whole
+        # command on the bare ``api`` word (#1530 over-block).
+        cfg = _config(tmp_path, ["internalcorp"])
+        cmd = f'gh pr create -R internalcorp/private-svc --body "ok" && {read}'
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+
+    def test_api_write_chain_still_fails_closed(self, tmp_path: Path) -> None:
+        # Leak guard: a chained ``api`` WRITE carries a body to an arbitrary
+        # endpoint, so a leading internal post must NOT let it skip the leak scan.
+        cfg = _config(tmp_path, ["internalcorp"])
+        cmd = "gh pr create -R internalcorp/private-svc --body ok && gh api repos/souliane/teatree/issues -f body=x"
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False

--- a/tests/test_publish_detection_api_method.py
+++ b/tests/test_publish_detection_api_method.py
@@ -12,6 +12,7 @@ from teatree.hooks._publish_detection import (
     _api_effective_method,
     command_has_token_aware_publish_surface,
     segment_is_api_call,
+    segment_is_api_read,
     segment_is_api_write,
 )
 
@@ -65,6 +66,41 @@ class TestSegmentIsApiWrite:
 
     def test_non_api_segment_is_not_a_write(self) -> None:
         assert not segment_is_api_write(["git", "status"])
+
+
+class TestSegmentIsApiRead:
+    """A read-only ``gh``/``glab api`` call posts NO body and can never leak content."""
+
+    @pytest.mark.parametrize(
+        "words",
+        [
+            ["gh", "api", "user"],
+            ["gh", "api", "repos/o/r/commits/main"],
+            ["gh", "api", "repos/o/r/issues", "--method", "GET"],
+            ["gh", "api", "repos/o/r/issues", "-X", "GET"],
+            ["glab", "api", "projects/42/merge_requests"],
+            ["glab", "api", "projects/42/issues", "-X", "POST", "-X", "GET"],
+        ],
+    )
+    def test_reads_are_reads(self, words: list[str]) -> None:
+        assert segment_is_api_read(words)
+        assert not segment_is_api_write(words)
+
+    @pytest.mark.parametrize(
+        "words",
+        [
+            ["gh", "api", "repos/o/r/issues", "-f", "body=x"],
+            ["gh", "api", "repos/o/r/issues", "-X", "POST"],
+            ["gh", "api", "repos/o/r/issues/1", "-X", "DELETE"],
+            ["glab", "api", "projects/42/notes", "-X", "PUT", "-f", "body=x"],
+        ],
+    )
+    def test_writes_are_not_reads(self, words: list[str]) -> None:
+        assert not segment_is_api_read(words)
+
+    def test_non_api_segment_is_not_a_read(self) -> None:
+        assert not segment_is_api_read(["git", "status"])
+        assert not segment_is_api_read(["gh", "pr", "create", "--body", "x"])
 
 
 class TestTokenAwarePublishSurface:

--- a/tests/test_publish_gate_golden_corpus.py
+++ b/tests/test_publish_gate_golden_corpus.py
@@ -9,7 +9,8 @@ out (legitimate internal/private and local-only work is allowed). The corpus
 is the regression guard for the five fixes:
 
 1. ALL-SEGMENTS skip (a chained public post behind an internal segment scans);
-2. fail-closed on substitution / transport / raw-REST api;
+2. fail-closed on substitution / transport / raw-REST api WRITE (a read-only
+    ``api`` GET posts no body and stays skip-safe);
 3. destination classification reuses the existing ``private_repos`` allowlist;
 4. file-based bodies (``--description-file``) are honoured;
 5. the commit gate resolves the real repo (``cd`` / walk-up) and fails OPEN on
@@ -215,6 +216,23 @@ class TestMustAllow:
         # ``--repo owner/name`` post (the gh pr create flag form).
         cmd = 'gh pr create --repo internalcorp/private-svc --title fix --body "acmecorp rollout"'
         assert _verdict(cmd, None, host_qualified_config) == "allow"
+
+    def test_internal_post_with_read_only_api_chain_allowed(self, config: Path) -> None:
+        # A read-only ``gh``/``glab api`` GET posts no body, so a leading internal
+        # post chained to a bare GET (even one whose URL names a PUBLIC repo) must
+        # NOT make the whole command scan -- the GET cannot leak. Pre-fix the bare
+        # ``api`` word fail-closed the skip and the internal body's domain word
+        # blocked (#1530 over-block).
+        cmd = 'gh pr create -R internalcorp/svc --body "acmecorp internal" && gh api repos/souliane/teatree/issues'
+        assert _verdict(cmd, None, config) == "allow"
+
+    def test_cross_repo_private_post_from_public_cwd_allowed(self, config: Path, tmp_path: Path) -> None:
+        # A post FROM a public clone TO a provably-private ``--repo`` target must
+        # downgrade on the TARGET slug, not the cwd: the carve-out and the
+        # destination skip both resolve the command's target (not the harness cwd).
+        public_cwd = _repo_with_remote(tmp_path / "pub", "git@github.com:souliane/teatree.git")
+        cmd = 'gh issue create -R internalcorp/svc --title "feat: acmecorp" --body "acmecorp internal"'
+        assert _verdict(cmd, public_cwd, config) == "allow"
 
 
 class TestMustDeny:


### PR DESCRIPTION
## What

The destination-aware publish gate (`gate_skips_destination`, the SKIP path the banned-terms #1415 and bare-reference #1530 gates call) refused the skip on **any** `gh`/`glab api` segment via `_segment_is_api_call`. That over-blocked a read-only `api` GET chained after a provably-internal post: a GET posts no body and can never leak content, yet its mere presence forced the leak scan, and the internal post's own domain words then blocked the whole command.

This splits the `api` surface by effective HTTP method:

- An `api` **WRITE** (effective method != GET) still refuses the skip — it carries a body to an arbitrary endpoint, so the existing leak guard is preserved.
- A read-only `api` **GET** (`segment_is_api_read`, new) is skip-safe without resolving a destination.

## TODO item (a) — already implemented

The TODO's part (a) ("apply the `private_repos` downgrade to cross-repo `gh`/`glab` posts — match the **target** repo slug, not just cwd") was already implemented on `main`:

- `12e53e6c` (#1804) resolves publish-target visibility from the command target, not the harness cwd.
- `0d48ac37` (#1595) / `278dabd6` (#1657) extended the carve-out to `gh`/`glab` create on a known-private target via `segment_target_is_private`.

Verified on `origin/main` (a post from a public clone to a `private_repos` `--repo` target downgrades through both the skip and the carve-out). Rather than re-implement, this PR pins the contract with a golden-corpus regression row so it cannot silently regress.

## Tests (TDD, anti-vacuous)

- `tests/test_publish_detection_api_method.py::TestSegmentIsApiRead` — the new read/write classifier.
- `tests/test_publish_destination.py::TestGateSkipsDestination::test_read_only_api_chain_stays_skipped` (4 GET spellings) + `test_api_write_chain_still_fails_closed` (leak guard).
- `tests/test_publish_gate_golden_corpus.py` — end-to-end `_verdict` rows: read-GET-chained-after-internal = ALLOW; cross-repo private post from a public cwd = ALLOW.

**Anti-vacuity proof:** reverting the `gate_skips_destination` change (restoring the blanket `_segment_is_api_call` fail-closed) turns `test_read_only_api_chain_stays_skipped[gh-get]` RED (`assert False is True`) and the golden `test_internal_post_with_read_only_api_chain_allowed` RED (`block != allow`). Restored → GREEN.

## Gates

- `uv run ruff check` / `ruff format --check` — clean on all touched files.
- `uv run ty check` — clean on both src modules.
- Touched-surface `pytest --no-cov` — 624 passed across the publish/banned/leak/carve suite. No new uncovered lines (the new `segment_is_api_read` and the `continue` branch are fully covered).

## Open questions & assumptions

- A read-only GET is treated as carrying no leak surface. The always-on secret scan (which runs **before** the skip short-circuit) still covers every surface independently, so a credential in a GET URL/flag is unaffected by this change.
- Part (a) verified-not-reimplemented per the stale-OPEN-issue gate.
