### PR TITLE
test(eval): backfill fail fixture for e2e_evidence_one_note_per_ticket_via_manifest

### DIFF
--- a/tests/eval/fixtures/e2e_evidence_one_note_per_ticket_via_manifest_fail.stream.jsonl
+++ b/tests/eval/fixtures/e2e_evidence_one_note_per_ticket_via_manifest_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-e2e_evidence_one_note_per_ticket_via_manifest-fail", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "thinking, no command yet."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "gh issue comment 42 --body 'E2E evidence: screenshots and video captured for ticket 42'", "description": "post evidence note"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}


### PR DESCRIPTION
## Problem

`origin/main` was RED on the required `test (3.13)` CI job, blocking every open PR from merging.

Root cause: the `e2e_evidence_one_note_per_ticket_via_manifest` scenario in `src/teatree/eval/scenarios/e2e.yaml` is a behavioral (matcher-graded) scenario — it has both a positive matcher (`t3 .*e2e post-evidence .*--manifest`) and a negative matcher (`gh issue comment|glab issue note|...`). Without a `_fail` fixture, `test_every_behavioral_scenario_ships_a_fail_fixture` names it as an offender and exits non-zero.

## Approach

Add `tests/eval/fixtures/e2e_evidence_one_note_per_ticket_via_manifest_fail.stream.jsonl`: a 4-line JSONL transcript where the agent issues `gh issue comment 42 --body '...'` instead of `t3 e2e post-evidence --manifest`. This command simultaneously:

- misses the positive matcher → scenario is RED
- trips the negative matcher → scenario is RED

Both directions confirmed by `test_fail_fixture_drives_scenario_red[e2e_evidence_one_note_per_ticket_via_manifest...]` passing.

## Files

- `tests/eval/fixtures/e2e_evidence_one_note_per_ticket_via_manifest_fail.stream.jsonl` (new)

## Anti-vacuity strategy

The anti-vacuity gate itself (`test_every_behavioral_scenario_ships_a_fail_fixture`) is already anti-vacuous: `test_fixtureless_behavioral_scenario_is_caught_by_the_gate` constructs a synthetic fixtureless behavioral spec and asserts the gate flags it.

For the new fixture specifically: `test_fail_fixture_drives_scenario_red` runs the matchers against the fixture text and asserts the result is `passed=False`. That test passed, confirming the fixture is not trivially ignored.

## Risks

None. Adding a fixture file cannot break existing behavior. The CI lane classifier treats unrecognised extensions as `all=True` (fail-safe), so the `test (3.13)` job will run.