### PR TITLE
fix(speak): lock timeout falls through to play; away gate at playback not config

### DIFF
--- a/src/teatree/core/speak.py
+++ b/src/teatree/core/speak.py
@@ -21,26 +21,24 @@ and delivers spoken agent text. Two distinct deliveries share one config:
     and only when ``local == all`` — in-client turns are never Slack messages,
     so there is no double-play to suppress.
 
-**Cross-process speaker mutual exclusion (#2152, bounded #2156).** Local
-playback fans out from two independent sources — each DM's
-:func:`_maybe_speak_local` leg and the detached ``t3 speak`` Stop-hook read —
-each spawning its own ``say``. Without serialization concurrent reads
-(in-process daemon threads AND separate detached subprocesses) talk over each
-other. :func:`_speak_local` therefore takes a single machine-wide
-:func:`fcntl.flock` on a lockfile under the teatree state dir
-(:func:`_speaker_lock_path`) around the actual ``say`` call, guaranteeing MUTUAL
-EXCLUSION (no two ``say`` calls overlap). The lock is acquired with a BOUNDED
-wait, not blocking: :func:`_serial_speaker` retries a non-blocking acquire for a
-short total budget (:data:`_SPEAKER_LOCK_WAIT_BUDGET_S`) and, if the speaker is
-still busy, DROPS the read as stale instead of queuing it. A blocking acquire is
-not FIFO and builds an unbounded backlog under a flood of fan-out reads — a
-message could play many minutes after it was printed — so the queue caps latency
-at the budget and the spec is honoured: the lock prevents two reads playing at
-once, but every read either plays promptly or is dropped, never multi-minute
-late. The non-blocking daemon-thread dispatch for in-process callers is
-unchanged — the thread waits on the lock, never the caller's egress path. The
-lock is best-effort: a lockfile that cannot be opened fails OPEN (the read still
-plays) so a lock error never mutes audio.
+**Availability gate at playback, not at config.** The ``away`` state silences
+LOCAL playback — not the ``slack`` arm, which still reaches the user's phone.
+This gate belongs at the PLAYBACK call site (:func:`_speak_local`), not in
+:func:`resolve_speak`. :func:`resolve_speak` returns the user's configured
+:class:`~teatree.types.SpeakConfig` unchanged regardless of availability;
+:func:`_speak_local` consults :func:`_is_away` and skips the ``say`` call when
+away. The user's configured ``local`` is never mutated or overridden by
+presence — only actual playback is gated.
+
+**Cross-process speaker mutual exclusion (#2152).** Local playback fans out
+from two independent sources — each DM's :func:`_maybe_speak_local` leg and
+the detached ``t3 speak`` Stop-hook read — each spawning its own ``say``.
+:func:`_speak_local` therefore takes a single machine-wide :func:`fcntl.flock`
+on a lockfile under the teatree state dir (:func:`_speaker_lock_path`) around
+the actual ``say`` call. The lock is best-effort: if the lockfile cannot be
+opened, or the wait budget elapses before the lock is free, the read falls
+through and plays anyway — a brief overlap is better than a silenced read, and
+a lock error must never mute audio.
 
 The whole feature is gated on the macOS ``say`` binary being on ``PATH``
 (:func:`binary_available`): when it is absent :func:`resolve_speak` forces the
@@ -68,7 +66,7 @@ from typing import IO
 from teatree.config import get_effective_settings
 from teatree.core.backend_protocols import MessagingBackend
 from teatree.paths import get_data_dir
-from teatree.types import LocalPlayback, RawAPIDict, SpeakConfig
+from teatree.types import RawAPIDict, SpeakConfig
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail, run_checked
 
 logger = logging.getLogger(__name__)
@@ -115,47 +113,26 @@ def binary_available() -> bool:
 
 
 def resolve_speak() -> SpeakConfig:
-    """The EFFECTIVE speak config: binary-presence gate, then the away-gate.
+    """The user's configured speak settings — binary-presence gate only.
 
-    The single place both gates are applied — every call site resolves
-    through here so neither can drift between the DM egress, the on-behalf
-    self-DM, and the Stop hook. The default :class:`SpeakConfig` is inert
-    (``local = off``, ``slack = false``).
-
-    Two gates, in order:
-
-    *   **Binary presence** — when ``say`` is absent the whole feature is
-        forced inert (silent off macOS).
-    *   **Away** — when availability resolves to ``away`` the configured
-        ``local`` is forced to :attr:`~teatree.types.LocalPlayback.OFF` so no
-        local audio plays while the user is unreachable, WITHOUT touching the
-        user's ``[teatree.speak]`` config. ``slack`` is preserved from the
-        configured value: a Slack-attached audio rendition still reaches the
-        user's phone regardless of presence. Both local consumers —
-        :func:`speak` (the Stop-hook in-client read) and the local leg of
-        :func:`deliver_user_dm` — resolve through here, so forcing ``local``
-        off here silences ALL local playback when away. The away check is
-        exception-safe: if availability resolution raises, the user is treated
-        as NOT away (local plays), so a transient resolution failure can never
-        spuriously mute local audio.
+    Returns the effective user config when the ``say`` binary is present,
+    otherwise an inert :class:`SpeakConfig` (``local = off``,
+    ``slack = false``). The away gate is NOT applied here: availability
+    affects PLAYBACK, not the config value. Call sites that drive local audio
+    (:func:`_speak_local`, :func:`_maybe_speak_local`) consult
+    :func:`_is_away` themselves so the user's configured ``local`` is always
+    preserved and availability never mutates it.
     """
     if not binary_available():
         return SpeakConfig()
-    config = get_effective_settings().speak
-    if _is_away():
-        return SpeakConfig(local=LocalPlayback.OFF, slack=config.slack)
-    return config
+    return get_effective_settings().speak
 
 
 def _is_away() -> bool:
     """Whether availability resolves to ``away`` — never raises.
 
     A resolution failure degrades to NOT away (returns ``False``): the
-    away-gate must never suppress local audio on a transient error, and —
-    because :func:`_resolve_speak_safe` catches everything and degrades to an
-    inert config (``slack`` off) — an away-check that raised inside
-    :func:`resolve_speak` would spuriously turn ``slack`` off too. Containing
-    the exception here keeps both axes correct under a resolution failure.
+    away-gate must never suppress local audio on a transient error.
     """
     from teatree.core import availability  # noqa: PLC0415
 
@@ -314,7 +291,8 @@ def _maybe_speak_local(config: SpeakConfig, text: str) -> None:
     The local-speakers leg of a bot→user DM, independent of the Slack-audio
     attach (Slack never auto-plays): run on a daemon thread so the caller's
     egress path is never delayed, and contained so a synthesis/play failure
-    never breaks the DM.
+    never breaks the DM. The away gate is applied inside :func:`_speak_local`
+    at actual playback time.
     """
     if not config.speaks_dms():
         return
@@ -338,25 +316,22 @@ def _speaker_lock_path() -> Path:
 
 @contextmanager
 def _serial_speaker() -> Iterator[bool]:
-    """Try to hold the cross-process speaker lock for one ``say`` — bounded (#2156).
+    """Try to hold the cross-process speaker lock for one ``say`` — best-effort (#2152).
 
-    Yields ``True`` when the caller may play (lock held, or the lockfile could
-    not be opened so the fail-open path lets the read through), ``False`` when
-    the read should be DROPPED as stale.
+    Yields ``True`` always — either with the lock held (serialized, no
+    overlap), or without it (fail-open: lock unavailable or budget elapsed).
+    Yields ``False`` to signal to the caller that serialization was skipped so
+    it can log accordingly; ``False`` does NOT mean the read is dropped.
 
-    The lock guarantees MUTUAL EXCLUSION (no two ``say`` calls overlap) but
-    must NEVER build a multi-minute backlog: it is acquired NON-BLOCKING
-    (:data:`fcntl.LOCK_EX` | :data:`fcntl.LOCK_NB`) in a short retry loop with a
-    total budget of :data:`_SPEAKER_LOCK_WAIT_BUDGET_S`. If the lock is acquired
-    within the budget the caller plays and the lock is released in a ``finally``;
-    if it cannot be acquired the caller drops the read (latency is thus capped at
-    the budget instead of growing without bound under a flood of fan-out reads).
+    The lock prevents two ``say`` calls from overlapping when acquired within
+    the budget. If the budget elapses (speaker still busy) the read falls
+    through and plays anyway — a brief overlap is better than a silenced read,
+    and the budget keeps the wait from blocking the daemon thread indefinitely.
 
     Best-effort: if the lockfile cannot be opened (no state dir, permissions)
-    the read still plays (yields ``True``) — a lock error must never mute audio
-    (mirrors the away-gate's exception-safety doctrine). Runs INSIDE the daemon
-    thread, never on the caller's egress path, so the bounded wait never delays a
-    DM or turn.
+    the read still plays — a lock error must never mute audio. Runs INSIDE the
+    daemon thread, never on the caller's egress path, so the bounded wait
+    never delays a DM or turn.
     """
     try:
         lock_path = _speaker_lock_path()
@@ -400,26 +375,31 @@ def _acquire_within_budget(lock_fh: IO[str]) -> bool:
 
 
 def _speak_local(text: str) -> None:
-    """Play ``text`` through the macOS speakers via ``say`` — no-op if absent.
+    """Play ``text`` through the macOS speakers via ``say`` — no-op if absent or away.
+
+    Applies the away gate at the playback call site: if the user is currently
+    away, the read is skipped silently. This keeps availability out of config
+    resolution — :func:`resolve_speak` returns the user's configured value
+    unchanged; only playback is gated.
 
     Mutually exclusive machine-wide: the actual ``say`` call runs under the
     cross-process :func:`_serial_speaker` lock so concurrent local reads (in
     other threads or separate ``t3 speak`` subprocesses) never overlap. The lock
-    is bounded (#2156): if it cannot be acquired within the wait budget the
-    speaker is saturated and this read is DROPPED as stale rather than queued —
-    a 15-min-late read is worse than a dropped one, and latency stays capped at
-    the budget. Failure of ``say`` itself is tolerated (``run_allowed_to_fail``
-    with ``expected_codes=None``); a transport/timeout error is logged and
-    dropped so the speak seam never raises into the caller.
+    is best-effort: if it cannot be acquired within the wait budget, the read
+    falls through and plays anyway (without serialization) — a concurrent overlap
+    is better than a silenced read. Failure of ``say`` itself is tolerated
+    (``run_allowed_to_fail`` with ``expected_codes=None``); a transport/timeout
+    error is logged and dropped so the speak seam never raises into the caller.
     """
+    if _is_away():
+        return
     say_bin = shutil.which(SAY_BINARY)
     if say_bin is None:
         return
     try:
         with _serial_speaker() as may_play:
             if not may_play:
-                logger.debug("speaker busy; dropping stale read")
-                return
+                logger.debug("speaker busy; playing without serialization")
             run_allowed_to_fail([say_bin, text], expected_codes=None, timeout=_SPEAK_SUBPROCESS_TIMEOUT)
     except (OSError, TimeoutExpired, CommandFailedError) as exc:
         logger.debug("local say failed: %s", exc)

--- a/src/teatree/core/speak.py
+++ b/src/teatree/core/speak.py
@@ -83,14 +83,15 @@ _SPEAKER_LOCK_FILENAME = "speaker.lock"
 
 # Bounded wait for the speaker lock (#2156). The lock is acquired NON-BLOCKING
 # in a short retry loop with a total budget: a read that cannot acquire it
-# within the budget is DROPPED as stale rather than queued. Local reads fan out
-# from many sources (every bot→user DM local-play leg + every Stop-hook
-# ``t3 speak`` read), so an unbounded blocking acquire builds a multi-minute
-# backlog under a flood — a message could play 15 min after it was printed. A
-# dropped read is strictly better than a 15-min-late one: mutual exclusion is
-# preserved and latency is capped at the budget. The budget is short relative to
-# a single read (a ``say`` of the capped excerpt is well under a second), so a
-# read only drops when the speaker is genuinely saturated.
+# within the budget falls through and plays without serialization rather than
+# being dropped. Local reads fan out from many sources (every bot→user DM
+# local-play leg + every Stop-hook ``t3 speak`` read), so an unbounded blocking
+# acquire builds a multi-minute backlog under a flood — a message could play
+# 15 min after it was printed. A brief overlap is strictly better than a
+# 15-min-late read: serialization holds in the common case and latency is capped
+# at the budget. The budget is short relative to a single read (a ``say`` of the
+# capped excerpt is well under a second), so a read only falls through when the
+# speaker is genuinely saturated.
 _SPEAKER_LOCK_WAIT_BUDGET_S = 2.0
 _SPEAKER_LOCK_RETRY_INTERVAL_S = 0.05
 

--- a/tests/teatree_core/test_speak.py
+++ b/tests/teatree_core/test_speak.py
@@ -52,45 +52,36 @@ class TestBinaryGate:
             assert speak_mod.resolve_speak() == configured
 
 
-class TestAwayGateResolveSpeak:
-    """Away suppresses LOCAL playback while preserving ``slack`` — without touching config."""
+class TestResolveSpeak:
+    """``resolve_speak()`` returns the user's config unchanged — availability is not consulted."""
 
-    def test_away_forces_local_off_but_preserves_slack(self) -> None:
+    def test_away_does_not_mutate_local(self) -> None:
+        configured = SpeakConfig(local=LocalPlayback.ALL, slack=True)
         with (
             patch.object(speak_mod, "binary_available", return_value=True),
-            patch.object(
-                speak_mod,
-                "get_effective_settings",
-                return_value=MagicMock(speak=SpeakConfig(local=LocalPlayback.ALL, slack=True)),
-            ),
+            patch.object(speak_mod, "get_effective_settings", return_value=MagicMock(speak=configured)),
             patch.object(availability, "resolve_mode", return_value=_resolution(availability.MODE_AWAY)),
         ):
             resolved = speak_mod.resolve_speak()
-        assert resolved.local is LocalPlayback.OFF
+        assert resolved.local is LocalPlayback.ALL, "away must not mutate the configured local value"
         assert resolved.slack is True
 
-    def test_present_preserves_local(self) -> None:
+    def test_present_returns_configured(self) -> None:
+        configured = SpeakConfig(local=LocalPlayback.ALL, slack=True)
         with (
             patch.object(speak_mod, "binary_available", return_value=True),
-            patch.object(
-                speak_mod,
-                "get_effective_settings",
-                return_value=MagicMock(speak=SpeakConfig(local=LocalPlayback.ALL, slack=True)),
-            ),
+            patch.object(speak_mod, "get_effective_settings", return_value=MagicMock(speak=configured)),
             patch.object(availability, "resolve_mode", return_value=_resolution(availability.MODE_PRESENT)),
         ):
             resolved = speak_mod.resolve_speak()
         assert resolved.local is LocalPlayback.ALL
         assert resolved.slack is True
 
-    def test_availability_raising_is_treated_as_present(self) -> None:
+    def test_availability_raising_returns_configured(self) -> None:
+        configured = SpeakConfig(local=LocalPlayback.ALL, slack=True)
         with (
             patch.object(speak_mod, "binary_available", return_value=True),
-            patch.object(
-                speak_mod,
-                "get_effective_settings",
-                return_value=MagicMock(speak=SpeakConfig(local=LocalPlayback.ALL, slack=True)),
-            ),
+            patch.object(speak_mod, "get_effective_settings", return_value=MagicMock(speak=configured)),
             patch.object(availability, "resolve_mode", side_effect=RuntimeError("boom")),
         ):
             resolved = speak_mod.resolve_speak()
@@ -98,54 +89,50 @@ class TestAwayGateResolveSpeak:
         assert resolved.slack is True
 
 
-class TestAwayGateConsumers:
-    """The away-gate silences BOTH local consumers while Slack audio still attaches."""
+class TestAwayGateAtPlayback:
+    """The away gate lives in ``_speak_local`` (playback call site), not in ``resolve_speak``.
 
-    def test_away_speak_does_not_play_locally(self) -> None:
+    Anti-vacuous: revert the ``_is_away()`` check in ``_speak_local`` and the
+    ``test_away_skips_say_call`` test goes RED (``run_allowed_to_fail`` IS called
+    when away, violating the gate).
+    """
+
+    def test_away_skips_say_call(self, tmp_path: Path) -> None:
         with (
-            patch.object(speak_mod, "binary_available", return_value=True),
-            patch.object(
-                speak_mod,
-                "get_effective_settings",
-                return_value=MagicMock(speak=SpeakConfig(local=LocalPlayback.ALL, slack=True)),
-            ),
+            patch.object(speak_mod.shutil, "which", return_value="/usr/bin/say"),
+            patch.object(speak_mod, "_speaker_lock_path", return_value=tmp_path / "speaker.lock"),
             patch.object(availability, "resolve_mode", return_value=_resolution(availability.MODE_AWAY)),
-            patch.object(speak_mod, "_speak_local") as local,
+            patch.object(speak_mod, "run_allowed_to_fail") as run,
         ):
-            speak_mod.speak("tests are green", block=True)
-        local.assert_not_called()
+            speak_mod._speak_local("hello while away")
+        run.assert_not_called()
 
-    def test_away_dm_still_attaches_slack_audio_but_no_local_play(self, tmp_path: Path) -> None:
-        audio = tmp_path / "speech.m4a"
-        audio.write_bytes(b"x")
-        backend = _backend()
+    def test_present_calls_say(self, tmp_path: Path) -> None:
         with (
-            patch.object(speak_mod, "binary_available", return_value=True),
-            patch.object(
-                speak_mod,
-                "get_effective_settings",
-                return_value=MagicMock(speak=SpeakConfig(local=LocalPlayback.ALL, slack=True)),
-            ),
-            patch.object(availability, "resolve_mode", return_value=_resolution(availability.MODE_AWAY)),
-            patch.object(speak_mod, "synthesise", return_value=audio),
-            patch.object(speak_mod.threading, "Thread") as thread_cls,
+            patch.object(speak_mod.shutil, "which", return_value="/usr/bin/say"),
+            patch.object(speak_mod, "_speaker_lock_path", return_value=tmp_path / "speaker.lock"),
+            patch.object(availability, "resolve_mode", return_value=_resolution(availability.MODE_PRESENT)),
+            patch.object(speak_mod, "run_allowed_to_fail") as run,
         ):
-            speak_mod.deliver_user_dm(backend, channel="D-USER", text="hi")
-        backend.post_audio_dm.assert_called_once()
-        thread_cls.assert_not_called()
+            speak_mod._speak_local("hello while present")
+        run.assert_called_once()
 
-    def test_availability_raising_lets_local_play_slack_unaffected(self, tmp_path: Path) -> None:
-        audio = tmp_path / "speech.m4a"
-        audio.write_bytes(b"x")
-        backend = _backend()
+    def test_availability_raising_treats_as_present_and_calls_say(self, tmp_path: Path) -> None:
         with (
-            patch.object(speak_mod, "binary_available", return_value=True),
-            patch.object(
-                speak_mod,
-                "get_effective_settings",
-                return_value=MagicMock(speak=SpeakConfig(local=LocalPlayback.ALL, slack=True)),
-            ),
+            patch.object(speak_mod.shutil, "which", return_value="/usr/bin/say"),
+            patch.object(speak_mod, "_speaker_lock_path", return_value=tmp_path / "speaker.lock"),
             patch.object(availability, "resolve_mode", side_effect=RuntimeError("boom")),
+            patch.object(speak_mod, "run_allowed_to_fail") as run,
+        ):
+            speak_mod._speak_local("hello when resolution failed")
+        run.assert_called_once()
+
+    def test_away_dm_still_attaches_slack_audio(self, tmp_path: Path) -> None:
+        audio = tmp_path / "speech.m4a"
+        audio.write_bytes(b"x")
+        backend = _backend()
+        with (
+            patch.object(speak_mod, "resolve_speak", return_value=SpeakConfig(local=LocalPlayback.ALL, slack=True)),
             patch.object(speak_mod, "synthesise", return_value=audio),
             patch.object(speak_mod.threading, "Thread") as thread_cls,
         ):
@@ -369,13 +356,14 @@ class TestDeliverUserDmAttachAudio:
 
 
 class TestSpeakLocal:
-    # Each test pins its own per-test lockfile so the bounded acquire (#2156)
-    # never races a concurrent holder on the shared real lockfile and drops the
-    # read — these assert the un-contended path.
+    # Each test pins its own per-test lockfile so the bounded wait never races a
+    # concurrent holder on the shared real lockfile — these assert the
+    # uncontended, present-user path.
     def test_runs_say_with_text(self, tmp_path: Path) -> None:
         with (
             patch.object(speak_mod.shutil, "which", return_value="/usr/bin/say"),
             patch.object(speak_mod, "_speaker_lock_path", return_value=tmp_path / "speaker.lock"),
+            patch.object(speak_mod, "_is_away", return_value=False),
             patch.object(speak_mod, "run_allowed_to_fail") as run,
         ):
             speak_mod._speak_local("hello")
@@ -387,6 +375,7 @@ class TestSpeakLocal:
         with (
             patch.object(speak_mod.shutil, "which", return_value=None),
             patch.object(speak_mod, "_speaker_lock_path", return_value=tmp_path / "speaker.lock"),
+            patch.object(speak_mod, "_is_away", return_value=False),
             patch.object(speak_mod, "run_allowed_to_fail") as run,
         ):
             speak_mod._speak_local("hello")
@@ -396,6 +385,7 @@ class TestSpeakLocal:
         with (
             patch.object(speak_mod.shutil, "which", return_value="/usr/bin/say"),
             patch.object(speak_mod, "_speaker_lock_path", return_value=tmp_path / "speaker.lock"),
+            patch.object(speak_mod, "_is_away", return_value=False),
             patch.object(speak_mod, "run_allowed_to_fail", side_effect=OSError("nope")),
         ):
             speak_mod._speak_local("hello")  # must not raise

--- a/tests/teatree_core/test_speak_serial_lock.py
+++ b/tests/teatree_core/test_speak_serial_lock.py
@@ -1,21 +1,20 @@
-"""Cross-process speaker mutual exclusion around ``say`` (#2152, bounded #2156).
+"""Cross-process speaker mutual exclusion around ``say`` (#2152).
 
 Two local reads — whether two in-process daemon threads or two separate
 detached ``t3 speak`` subprocesses — must never run ``say`` at the same time,
 or messages talk over each other. :func:`_speak_local` wraps the actual ``say``
 call in a single cross-process ``fcntl.flock`` on a lockfile under the teatree
-state dir, so plays are mutually exclusive machine-wide. The lock is acquired
-with a BOUNDED wait, not blocking: a read that cannot acquire it within the wait
-budget is DROPPED as stale rather than queued, so a flood of fan-out reads can
-never build a multi-minute backlog (#2156).
+state dir, so plays are mutually exclusive machine-wide when the lock is
+available. The lock is best-effort: if the wait budget elapses the read falls
+through and plays anyway — a brief overlap is better than a silenced read.
 
 Observability: a fake ``say`` script (on PATH ahead of the real one) appends
 ``START <ns>`` / ``STOP <ns>`` to a log with a sleep between, so two concurrent
 plays that overlapped would interleave (a second START before the first STOP).
 The lock makes the second START land at-or-after the first STOP. The fake is a
 real subprocess (the lock must serialize real processes), not a mock — only the
-binary itself is faked. :class:`TestBoundedWaitDropsStaleRead` covers the #2156
-bounded-drop behaviour with a real cross-process lock holder.
+binary itself is faked. :class:`TestBoundedWaitFallsThrough` covers the
+fall-through behaviour with a real cross-process lock holder.
 """
 
 import threading
@@ -63,6 +62,7 @@ class TestSerialLock:
         with (
             patch.object(speak_mod.shutil, "which", return_value=str(say)),
             patch.object(speak_mod, "_speaker_lock_path", return_value=lock),
+            patch.object(speak_mod, "_is_away", return_value=False),
         ):
             threads = [threading.Thread(target=speak_mod._speak_local, args=(str(log),)) for _ in range(2)]
             for t in threads:
@@ -106,6 +106,7 @@ class TestSerialLockCrossProcess:
                 with (
                     patch.object(speak_mod.shutil, "which", return_value={str(say)!r}),
                     patch.object(speak_mod, "_speaker_lock_path", return_value=lock),
+                    patch.object(speak_mod, "_is_away", return_value=False),
                 ):
                     speak_mod._speak_local({str(log)!r})
                 """
@@ -138,6 +139,7 @@ class TestLockPath:
         with (
             patch.object(speak_mod.shutil, "which", return_value=str(say)),
             patch.object(speak_mod, "_speaker_lock_path", side_effect=OSError("no state dir")),
+            patch.object(speak_mod, "_is_away", return_value=False),
             patch.object(speak_mod, "run_allowed_to_fail") as run,
         ):
             speak_mod._speak_local("hello")
@@ -157,27 +159,26 @@ fh.close()
 """
 
 
-class TestBoundedWaitDropsStaleRead:
-    """The #2156 regression: a busy speaker must DROP a read, not queue it for minutes.
+class TestBoundedWaitFallsThrough:
+    """A busy speaker must NOT silence a read — the lock is best-effort, not a gate.
 
     A separate REAL process holds the REAL ``fcntl.flock`` on the lockfile (no
     mock of teatree code or the lock). While it is held far longer than the wait
-    budget, an in-process ``_speak_local`` must return WITHIN ~the budget and
-    must NOT invoke ``say`` — proving mutual exclusion is preserved (it never
-    overlapped the holder) while latency is capped at the budget instead of
-    blocking for the full hold. Only the ``say`` subprocess is mocked.
+    budget, an in-process ``_speak_local`` must return WITHIN ~the budget AND
+    still invoke ``say`` — proving the bounded wait falls through to playing (no
+    serialization) rather than dropping the read silently.
 
-    Anti-vacuity: revert the fix (restore an unbounded blocking ``LOCK_EX`` in
-    ``_acquire_within_budget`` / ``_serial_speaker``) and this test HANGS for the
-    whole hold (``HOLD_S``) — far past ``BUDGET_S`` — so the elapsed-time and
-    not-called assertions fail. It guards the bounded behaviour, not just "a
-    lock exists".
+    Anti-vacuity: revert the fix (change ``_serial_speaker`` to return early
+    without calling ``say`` when the budget elapses) and
+    ``test_busy_speaker_falls_through_and_still_calls_say`` goes RED
+    (``run_allowed_to_fail`` is NOT called — the read is silently dropped). It
+    guards the fall-through behaviour, not just "a lock exists".
     """
 
     BUDGET_S = 0.3
     HOLD_S = 5.0
 
-    def test_busy_speaker_drops_read_within_budget_without_calling_say(self, tmp_path: Path) -> None:
+    def test_busy_speaker_falls_through_and_still_calls_say(self, tmp_path: Path) -> None:
         import subprocess  # noqa: PLC0415
         import sys  # noqa: PLC0415
         import time  # noqa: PLC0415
@@ -189,7 +190,6 @@ class TestBoundedWaitDropsStaleRead:
 
         holder = subprocess.Popen([sys.executable, str(holder_script), str(lock), str(ready), str(self.HOLD_S)])
         try:
-            # Wait until the holder has the exclusive lock (bounded wait, not a sleep).
             deadline = time.monotonic() + 10
             while not ready.exists():
                 assert time.monotonic() < deadline, "holder never acquired the lock"
@@ -200,18 +200,19 @@ class TestBoundedWaitDropsStaleRead:
                 patch.object(speak_mod.shutil, "which", return_value="/usr/bin/say"),
                 patch.object(speak_mod, "_speaker_lock_path", return_value=lock),
                 patch.object(speak_mod, "_SPEAKER_LOCK_WAIT_BUDGET_S", self.BUDGET_S),
+                patch.object(speak_mod, "_is_away", return_value=False),
                 patch.object(speak_mod, "run_allowed_to_fail") as run,
             ):
                 start = time.monotonic()
                 speak_mod._speak_local("hello while the speaker is busy")
                 elapsed = time.monotonic() - start
 
-            # Dropped, not queued: it never ran ``say`` (mutual exclusion preserved).
-            run.assert_not_called()
+            # Falls through, not dropped: ``say`` is still called even though the lock is held.
+            run.assert_called_once()
             # Latency capped at the budget — NOT the full hold a blocking acquire would wait.
             assert elapsed < self.HOLD_S, (
                 f"speak blocked for {elapsed:.2f}s (>= the {self.HOLD_S}s hold) — "
-                f"unbounded blocking acquire, not bounded-wait-then-drop"
+                f"unbounded blocking acquire, not bounded-wait-then-fall-through"
             )
             assert elapsed < self.BUDGET_S + 1.0, f"speak took {elapsed:.2f}s — far over the {self.BUDGET_S}s budget"
         finally:
@@ -226,6 +227,7 @@ class TestBoundedWaitDropsStaleRead:
             patch.object(speak_mod.shutil, "which", return_value="/usr/bin/say"),
             patch.object(speak_mod, "_speaker_lock_path", return_value=lock),
             patch.object(speak_mod, "_SPEAKER_LOCK_WAIT_BUDGET_S", self.BUDGET_S),
+            patch.object(speak_mod, "_is_away", return_value=False),
             patch.object(speak_mod, "run_allowed_to_fail") as run,
         ):
             start = time.monotonic()


### PR DESCRIPTION
## Problem

Local TTS playback was completely silent despite `speak.local = "all"` and availability resolving to `present`.

Two bugs in `src/teatree/core/speak.py` combined to silence audio:

**Bug 1 — lock budget shorter than a `say` invocation (regression).**
`_SPEAKER_LOCK_WAIT_BUDGET_S = 2.0s` but a typical `say` call for ~600 chars takes 4+ seconds. When the first Stop-hook `t3 speak` subprocess held the lock while playing, the next subprocess exhausted its 2.0s budget and was *silently dropped*. Every read after the first was lost. The module docstring already said "a lock error never mutes audio" — the drop violated that principle.

**Bug 2 — away gate in config resolution (design).**
`resolve_speak()` returned `SpeakConfig(local=OFF)` when `_is_away()` was true, overriding the user's configured value. Availability belongs at the *playback call site*, not at config resolution.

## Fix

**Fix 1:** When `_acquire_within_budget` times out, `_serial_speaker` now yields `False` to signal unserialized play rather than returning early. `_speak_local` falls through and calls `say` regardless — a brief potential overlap is better than a silenced read. The bounded wait still caps the daemon-thread block time.

**Fix 2:** `resolve_speak()` returns the user's configured `SpeakConfig` unchanged (no availability check). `_speak_local` calls `_is_away()` at the top and returns early if away. The user's `local` value is never mutated by presence state.

## Anti-vacuous proofs

- `TestBoundedWaitFallsThrough.test_busy_speaker_falls_through_and_still_calls_say`: revert `_serial_speaker` to drop on timeout → `run.assert_called_once()` RED.
- `TestAwayGateAtPlayback.test_away_skips_say_call`: remove `_is_away()` from `_speak_local` → `run.assert_not_called()` RED.
- `TestResolveSpeak.test_away_does_not_mutate_local`: revert to old `resolve_speak()` → `resolved.local is LocalPlayback.OFF` instead of `ALL` → RED.

## Scope

- `src/teatree/core/speak.py`
- `tests/teatree_core/test_speak.py`
- `tests/teatree_core/test_speak_serial_lock.py`

Slack `speak audio attach not ok: missing_scope` is a separate Slack `files:write` scope bug — not fixed here.