### PR TITLE
fix(workspace): clean-all never blocks on stdin when not a TTY

### DIFF
--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -6,6 +6,7 @@ prefix) because the only public surface is the ``clean-all`` subcommand.
 """
 
 import re
+import sys
 from contextlib import suppress
 from fnmatch import fnmatch
 from pathlib import Path
@@ -475,6 +476,24 @@ def drop_orphan_databases() -> list[str]:
         )
         cleaned.append(f"Dropped orphan database: {db_name}")
     return cleaned
+
+
+def _is_interactive() -> bool:
+    """Whether ``clean-all`` may prompt on stdin.
+
+    True only when both stdin and stdout are confirmed TTYs. Any non-TTY
+    context — a piped stdin, an autonomous loop tick, a daemonised worker
+    whose stdin is closed (``isatty`` raises ``ValueError``) or absent
+    (``sys.stdin is None``) — resolves to ``False`` so the caller takes the
+    safe documented non-interactive path and never blocks reading stdin.
+
+    Fails closed to non-interactive: an unknown/unreadable stdin is treated
+    as not-a-TTY, never as a TTY that may be prompted.
+    """
+    try:
+        return bool(sys.stdin.isatty() and sys.stdout.isatty())
+    except (ValueError, AttributeError):
+        return False
 
 
 def resolve_unsynced_worktree(worktree: Worktree, exc: RuntimeError, *, interactive: bool) -> str:

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-import sys
 from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
@@ -23,6 +22,7 @@ from teatree.core.management.commands._workspace_cleanup import (
     WorktreeReaper,
     _die,
     _fix_drift,
+    _is_interactive,
     _raise_on_cleanup_failures,
     drop_orphan_databases,
     drop_orphaned_stashes,
@@ -573,7 +573,7 @@ class Command(TyperCommand):
         """Prune merged worktrees, stale branches, stashes, orphan databases + docker, and old DSLR snapshots."""
         workspace = _workspace_dir()
         cleaned: list[str] = []
-        interactive = sys.stdin.isatty() and sys.stdout.isatty()
+        interactive = _is_interactive()
         in_use = _wh.dslr_tenants_in_use()  # before cleanup loop reaps CREATED worktrees (#1306)
         reaper = WorktreeReaper(workspace)
         cleaned.extend(reaper.reap_squash_merged_worktrees(interactive=interactive))

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1477,6 +1477,76 @@ class TestWorkspaceCleanAll(TestCase):
     @_no_dslr_prune
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
+    def test_never_reads_stdin_when_not_a_tty(self) -> None:
+        """#279: clean-all must never block on a stdin prompt when not a TTY.
+
+        Anti-vacuous: ``builtins.input`` is patched to raise on any call, so a
+        single read of stdin fails the test. The EOFError fallback in
+        ``resolve_unsynced_worktree`` means a vacuous test (one that does not
+        assert ``input`` is uncalled) would pass even if the TTY guard were
+        removed — the input-raises patch is what makes this guard the fix.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "workspace"
+            repo_main = workspace / "frontend"
+            repo_main.mkdir(parents=True)
+            (repo_main / ".git").mkdir()
+
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/279")
+            stuck_wt_dir = workspace / "ac-frontend-279-ticket" / "frontend"
+            stuck_wt_dir.mkdir(parents=True)
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="frontend",
+                branch="ac-frontend-279-ticket",
+                extra={"worktree_path": str(stuck_wt_dir)},
+            )
+
+            def _classify(_repo: str, branch: str, target: str = "origin/main") -> cleanup_mod.BranchClassification:
+                return cleanup_mod.BranchClassification(
+                    genuinely_ahead=[
+                        cleanup_mod.BranchCommit(sha="abc123", subject="chore: unpushed", is_merge=False),
+                    ],
+                )
+
+            stdin_read_msg = "clean-all read stdin in a non-interactive context (#279)"
+
+            def _input_must_not_be_called(*_a: object, **_k: object) -> str:
+                raise AssertionError(stdin_read_msg)
+
+            non_tty = MagicMock()
+            non_tty.isatty.return_value = False
+            mock_config = MagicMock()
+            mock_config.user.workspace_dir = workspace
+            with (
+                patch.object(ws_cleanup_mod.sys, "stdin", non_tty),
+                patch.object(ws_cleanup_mod.sys, "stdout", non_tty),
+                patch("builtins.input", side_effect=_input_must_not_be_called),
+                patch.object(cleanup_mod, "load_config", return_value=mock_config),
+                patch.object(cleanup_mod, "git") as mock_git,
+                patch.object(cleanup_mod, "get_overlay") as mock_overlay,
+                patch.object(cleanup_mod, "classify_branch_commits", side_effect=_classify),
+                patch.object(cleanup_mod, "capture_recovery_artifact", return_value=None),
+            ):
+                mock_overlay.return_value.get_cleanup_steps.return_value = []
+                mock_git.status_porcelain.return_value = ""
+                mock_git.unsynced_commits.side_effect = lambda _repo, _branch: ["abc123 chore: unpushed"]
+                mock_git.commits_absent_from_all_remotes.return_value = []
+                mock_git.DETACHED_HEAD = git_mod.DETACHED_HEAD
+                mock_git.current_branch.side_effect = lambda _wt: "ac-frontend-279-ticket"
+                cleaned = cast("list[str]", call_command("workspace", "clean-all"))
+
+            assert any("ac-frontend-279-ticket" in c and "unsynced" in c.lower() for c in cleaned)
+            assert Worktree.objects.filter(branch="ac-frontend-279-ticket").count() == 1
+
+    @_no_prune
+    @_no_stash
+    @_no_orphan_dbs
+    @_no_orphan_docker
+    @_no_dslr_prune
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
     def test_push_or_abandon_failure_raises_system_exit_1(self) -> None:
         """clean-all must exit 1 when a push/abandon attempt genuinely failed.
 
@@ -1566,6 +1636,51 @@ class TestReapOrphanWorktreeDocker(TestCase):
 
         assert lines == [str(result)]
         assert "backend-wt9" in lines[0]
+
+
+class TestIsInteractive(TestCase):
+    """#279: TTY detection that fails closed to non-interactive."""
+
+    def test_both_tty_is_interactive(self) -> None:
+        tty = MagicMock()
+        tty.isatty.return_value = True
+        with (
+            patch.object(ws_cleanup_mod.sys, "stdin", tty),
+            patch.object(ws_cleanup_mod.sys, "stdout", tty),
+        ):
+            assert ws_cleanup_mod._is_interactive() is True
+
+    def test_stdin_not_tty_is_not_interactive(self) -> None:
+        stdin, stdout = MagicMock(), MagicMock()
+        stdin.isatty.return_value = False
+        stdout.isatty.return_value = True
+        with (
+            patch.object(ws_cleanup_mod.sys, "stdin", stdin),
+            patch.object(ws_cleanup_mod.sys, "stdout", stdout),
+        ):
+            assert ws_cleanup_mod._is_interactive() is False
+
+    def test_stdout_not_tty_is_not_interactive(self) -> None:
+        stdin, stdout = MagicMock(), MagicMock()
+        stdin.isatty.return_value = True
+        stdout.isatty.return_value = False
+        with (
+            patch.object(ws_cleanup_mod.sys, "stdin", stdin),
+            patch.object(ws_cleanup_mod.sys, "stdout", stdout),
+        ):
+            assert ws_cleanup_mod._is_interactive() is False
+
+    def test_closed_stdin_value_error_fails_closed(self) -> None:
+        """A daemonised worker's closed stdin raises ValueError on isatty()."""
+        stdin = MagicMock()
+        stdin.isatty.side_effect = ValueError("I/O operation on closed file.")
+        with patch.object(ws_cleanup_mod.sys, "stdin", stdin):
+            assert ws_cleanup_mod._is_interactive() is False
+
+    def test_none_stdin_fails_closed(self) -> None:
+        """Some runners leave sys.stdin as None; .isatty raises AttributeError."""
+        with patch.object(ws_cleanup_mod.sys, "stdin", None):
+            assert ws_cleanup_mod._is_interactive() is False
 
 
 class TestResolveUnsyncedWorktree(TestCase):


### PR DESCRIPTION
## Summary

`t3 <overlay> workspace clean-all` must run autonomously and never silent-block waiting on a `y/N` confirmation when there is no TTY to answer it (autonomous loop tick, piped stdin, daemonised worker).

The TTY guard was already in place inline (`sys.stdin.isatty() and sys.stdout.isatty()`), but:

1. It was an untested inline expression — no test proved that stdin is never read non-interactively (the existing `resolve_unsynced_worktree` EOFError fallback means a weaker test passes green even if the guard were removed).
2. It crashed instead of degrading: a daemonised worker whose stdin is **closed** makes `sys.stdin.isatty()` raise `ValueError`, and a runner that leaves `sys.stdin = None` makes it raise `AttributeError` — both abort the whole `clean-all` run, which is worse than blocking.

This extracts the detection into a small `_is_interactive()` helper in `_workspace_cleanup.py` that **fails closed to non-interactive** on every non-TTY condition, and adds the anti-vacuous regression test the TODO asks for.

The data-loss guards (#706 / #835 / #1506) are untouched: an uncertain or genuinely-unsynced worktree is still **kept** (`Skipped:`), never deleted. This change only stops the prompt from being issued — the safe documented behavior — when stdin is not a TTY.

Reference: harness TODO #279 (no existing GitHub backlog issue matched).

## Architecture pre-check — TODO #279

### 1. BLUEPRINT section alignment
Workspace cleanup (`/t3:workspace` "Cleanup Patterns"). Tactical robustness fix on the `clean-all` command path — no FSM/Protocol/overlay-contract surface changes.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition involved.

### 3. Extension-point contracts
n/a — no `OverlayBase` hook, scanner registration, or `*Backend` Protocol touched.

### 4. Component boundaries
`_is_interactive()` lives in `src/teatree/core/management/commands/_workspace_cleanup.py` alongside the other cleanup helpers it pairs with (`resolve_unsynced_worktree`, the consumer of the `interactive` flag). Consumed by `workspace.py::clean_all`. Kept private (`_` prefix) per the module convention ("the only public surface is the `clean-all` subcommand") and to stay under the module-health 10-public-function cap.

### 5. Dependency direction
Adds `import sys` to `_workspace_cleanup.py`; removes the now-unused `import sys` from `workspace.py`. No new cross-module edges. `tach` + import-linter pass.

### 6. Test surface
- `TestIsInteractive` (5 unit tests): both-TTY -> True; stdin-not-TTY -> False; stdout-not-TTY -> False; closed-stdin `ValueError` -> False; `None` stdin -> False.
- `TestWorkspaceCleanAll::test_never_reads_stdin_when_not_a_tty` (command-level, anti-vacuous): patches `builtins.input` to raise on **any** call while running the full `clean-all` command with a non-TTY stdin and an unsynced worktree. A single stdin read fails the test.

### 7. Resilience invariants
The helper is a pure read with no external write. The relevant invariant is **fail-safe degradation**: an unreadable/unknown stdin resolves to non-interactive (skip), never to interactive (prompt) — the conservative branch.

### 8. Identity and key normalization
n/a — no identity/key with bare-vs-qualified forms.

### 9. Behavior preservation / capability deletion
The interactive path (real TTY -> [P]ush / [A]bandon / [S]kip prompt) is fully preserved. The only behavior change is on the non-TTY/closed/None side: previously a closed stdin crashed; now it degrades to the same safe skip the piped-stdin case already took. No must-block test inverted; no data-loss guard narrowed.

## RED confirmation (anti-vacuous)

Both regression tests were observed RED on a deliberately-broken variant before the fix:

- `test_never_reads_stdin_when_not_a_tty`: forced `interactive = True` in `clean_all` (simulating the removed TTY guard) -> FAILED with `AssertionError: clean-all read stdin in a non-interactive context (#279)`.
- `TestIsInteractive::test_closed_stdin_value_error_fails_closed` (and `_none_stdin_fails_closed`): reverted `_is_interactive` to the bare `sys.stdin.isatty() and sys.stdout.isatty()` (no try/except) -> FAILED with the propagated `ValueError`.

Both pass GREEN with the fix in place. `ruff check`, `ruff format --check`, and `uv run ty check` pass on all changed files; new code is 100% covered.

## Open questions & assumptions

- **Assumption:** the cleanest fix is to harden detection and fail closed, rather than route the prompt through an explicit `--yes/--no-input` flag. The TODO scope is "never silent-block" + "default to the safe documented behavior", which the existing skip-on-non-interactive contract already defines; a flag would be additional surface beyond the ask. Happy to add an explicit `--non-interactive` flag if preferred.
- **Assumption:** `_is_interactive()` belongs private in `_workspace_cleanup.py` (consistent with `_die`, `_fix_drift`, `_raise_on_cleanup_failures` already imported privately by `workspace.py`) rather than promoted to a shared util — it has exactly one consumer.
