### PR TITLE
fix(loop): resolve overlay from URL at three multi-overlay tick call sites

### DIFF
--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 
 from django.core.exceptions import ImproperlyConfigured
 
+from teatree.core.overlay_url import get_overlay_for_url
 from teatree.utils.url_slug import slug_from_issue_or_pr_url
 
 if TYPE_CHECKING:
@@ -21,6 +22,20 @@ if TYPE_CHECKING:
     from teatree.core.overlay import OverlayBase
 
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "frontend_repos_for_overlay",
+    "get_all_overlay_names",
+    "get_all_overlays",
+    "get_overlay",
+    "get_overlay_for_repo",
+    "get_overlay_for_ticket",
+    "get_overlay_for_url",
+    "get_overlay_for_worktree",
+    "infer_overlay_for_url",
+    "reset_overlay_cache",
+    "resolve_overlay_name",
+]
 
 
 def get_overlay(name: str | None = None) -> "OverlayBase":

--- a/src/teatree/core/overlay_url.py
+++ b/src/teatree/core/overlay_url.py
@@ -1,0 +1,36 @@
+"""Resolve an overlay instance from a forge URL.
+
+The URL-context counterpart of the ticket/worktree/repo resolvers in
+:mod:`teatree.core.overlay_loader`. Kept in its own module so the loader stays
+under the module-health public-function cap; it is re-exported from
+``overlay_loader`` for callers that import it alongside the sibling resolvers.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from teatree.core.overlay import OverlayBase
+
+
+def get_overlay_for_url(url: str) -> "OverlayBase":
+    """Resolve the overlay that owns the forge ``url``, raising if it can't.
+
+    The URL-context counterpart of ``get_overlay_for_ticket`` /
+    ``get_overlay_for_worktree``, for loop-tick call sites that hold a forge
+    issue/PR URL but no ticket/worktree row — the multi-overlay tick process
+    registers every installed overlay, so a bare ``get_overlay`` raises
+    ``Multiple overlays found`` (souliane/teatree#1814 class). The URL itself
+    records which overlay owns it via ``infer_overlay_for_url``'s repo-ownership
+    match, so resolution is unambiguous whenever the URL maps to exactly one
+    overlay.
+
+    When the URL maps to no overlay (or to more than one — ambiguous ownership),
+    resolution falls through to ``get_overlay`` with no name: the ambient
+    single-overlay default still resolves, and a genuinely ambiguous
+    multi-overlay environment raises the explicit ``Multiple overlays found
+    (...)`` error naming the installed overlays — fail loud, never silently pick
+    one.
+    """
+    from teatree.core.overlay_loader import get_overlay, infer_overlay_for_url  # noqa: PLC0415
+
+    return get_overlay(infer_overlay_for_url(url) or None)

--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -382,9 +382,9 @@ def _review_target_is_dead(pr_url: str) -> bool:
 
     try:
         from teatree.backends.loader import get_code_host_for_url  # noqa: PLC0415
-        from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
+        from teatree.core.overlay_loader import get_overlay_for_url  # noqa: PLC0415
 
-        host = get_code_host_for_url(get_overlay(), pr_url)
+        host = get_code_host_for_url(get_overlay_for_url(pr_url), pr_url)
         if host is None:
             return False
         state = host.get_pr_open_state(pr_url=pr_url)

--- a/src/teatree/loop/scanners/gitlab_approvals.py
+++ b/src/teatree/loop/scanners/gitlab_approvals.py
@@ -129,7 +129,7 @@ class GitLabApprovalsScanner:
 
         target_ref = _str_field(pr, "target_branch")
         title = _str_field(pr, "title")
-        guard = _overlay_loader.get_overlay().can_auto_merge(
+        guard = _overlay_loader.get_overlay_for_url(url).can_auto_merge(
             target_ref=target_ref or url,
             thread_ref=url,
         )

--- a/src/teatree/loop/scanners/incoming_events.py
+++ b/src/teatree/loop/scanners/incoming_events.py
@@ -38,6 +38,32 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _event_forge_url(event: "IncomingEvent") -> str:
+    """Best-effort forge URL/slug for *event*, for overlay resolution.
+
+    Prefers the merge request / pull request web URL carried in the webhook
+    payload (GitLab ``object_attributes.url``, GitHub ``pull_request.html_url``),
+    falling back to the ``owner/repo`` slug both receivers record as
+    ``channel_ref`` (GitLab ``project.path_with_namespace``, GitHub
+    ``repository.full_name``). Either shape is resolvable by
+    :func:`teatree.core.overlay_loader.infer_overlay_for_url`. Returns ``""``
+    when neither is present, so the caller falls back to the ambient
+    single-overlay default (and fails loud on genuine ambiguity).
+    """
+    payload = event.payload_json or {}
+    attrs = payload.get("object_attributes")
+    if isinstance(attrs, dict):
+        gitlab_url = attrs.get("url")
+        if isinstance(gitlab_url, str) and gitlab_url:
+            return gitlab_url
+    pr = payload.get("pull_request")
+    if isinstance(pr, dict):
+        github_url = pr.get("html_url")
+        if isinstance(github_url, str) and github_url:
+            return github_url
+    return event.channel_ref or ""
+
+
 @dataclass(slots=True)
 class IncomingEventsScanner:
     limit: int = 25
@@ -119,8 +145,19 @@ class IncomingEventsScanner:
 
     @staticmethod
     def _handle_schedule_merge(event: "IncomingEvent", action: RoutedAction) -> ScanSignal:
-        """Apply the overlay merge guard and return the appropriate signal."""
-        guard = _overlay_loader.get_overlay().can_auto_merge(
+        """Apply the overlay merge guard and return the appropriate signal.
+
+        ``can_auto_merge`` is per-overlay policy (freeze windows, approval
+        gates), so the guard must run against the overlay that owns the merge
+        target — not a bare ``get_overlay()`` that raises ``Multiple overlays
+        found`` in a multi-overlay install (souliane/teatree#1814 class). The
+        owning overlay is resolved from the event's forge URL/slug
+        (:func:`_event_forge_url`) which both webhook receivers record as the
+        ``owner/repo`` ``channel_ref``; an unresolvable / ambiguous event
+        falls through to ``get_overlay_for_url("")`` → ``get_overlay(None)``,
+        which fails loud naming the installed overlays rather than picking one.
+        """
+        guard = _overlay_loader.get_overlay_for_url(_event_forge_url(event)).can_auto_merge(
             target_ref=action.target_ref,
             thread_ref=action.detail,
         )

--- a/tests/teatree_loop/test_dispatch_review_target_live_state.py
+++ b/tests/teatree_loop/test_dispatch_review_target_live_state.py
@@ -11,9 +11,13 @@ the gate suppresses ONLY on a definite MERGED/CLOSED — OPEN and UNKNOWN still
 dispatch, so a transient lookup failure never silently drops a legitimate review.
 """
 
+import os
+from unittest.mock import patch
+
 import pytest
 
 from teatree.core.backend_protocols import PrOpenState
+from teatree.core.overlay import OverlayBase
 from teatree.loop import dispatch as dispatch_mod
 from teatree.loop.scanners.base import ScanSignal
 
@@ -119,3 +123,57 @@ class TestMentionReviewRequestSkipsMergedClosed:
         _bind_host(monkeypatch, _StubHost(PrOpenState.OPEN))
         actions = dispatch_mod.dispatch([_mention_signal()])
         assert any(a.kind == "agent" and a.zone == "t3:reviewer" for a in actions)
+
+
+class _RepoOverlay(OverlayBase):
+    def __init__(self, repos: list[str]) -> None:
+        self._repos = repos
+
+    def get_repos(self) -> list[str]:
+        return self._repos
+
+    def get_workspace_repos(self) -> list[str]:
+        return self._repos
+
+    def get_provision_steps(self, worktree: object) -> list:
+        _ = worktree
+        return []
+
+
+class TestReviewTargetMultiOverlay:
+    """Real ``get_overlay()`` ambiguity path — two overlays registered (TODO-282).
+
+    ``_review_target_is_dead`` resolved the overlay with a bare
+    ``get_overlay()`` to build the per-URL code host. With two overlays
+    registered and no ``T3_OVERLAY_NAME`` that raises ``Multiple overlays
+    found`` — caught by the function's own ``except Exception`` (fail-open),
+    so a genuinely MERGED/CLOSED MR is NEVER recognised as dead and a stale
+    reviewer is dispatched on every multi-overlay host. The fix resolves the
+    overlay from the MR URL, so the live MERGED state is read and the dead
+    target is correctly suppressed.
+
+    Only overlay discovery and the network host are stubbed; the URL→overlay
+    resolution is real.
+    """
+
+    def test_merged_target_recognised_dead_with_two_overlays(self) -> None:
+        url = "https://gitlab.com/acme/backend/-/merge_requests/55"
+        overlays = {
+            "acme": _RepoOverlay(["acme/backend"]),
+            "other": _RepoOverlay(["other/repo"]),
+        }
+        env_without_pin = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+        with (
+            patch.dict(os.environ, env_without_pin, clear=True),
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=overlays),
+            patch(
+                "teatree.backends.loader.get_code_host_for_url",
+                return_value=_StubHost(PrOpenState.MERGED),
+            ),
+        ):
+            result = dispatch_mod._review_target_is_dead(url)
+
+        assert result is True, (
+            "with two overlays registered, a MERGED MR must still be recognised dead — "
+            "a bare get_overlay() raises Multiple-overlays and the function fails open to False"
+        )

--- a/tests/teatree_loop/test_gitlab_approvals_scanner.py
+++ b/tests/teatree_loop/test_gitlab_approvals_scanner.py
@@ -7,6 +7,7 @@ calls are stubbed by an in-memory ``FakeCodeHost`` that conforms to
 doctrine).
 """
 
+import os
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import patch
@@ -18,6 +19,7 @@ import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.core.backend_protocols import ApprovalState, ReviewState
 from teatree.core.gates.merge_guard import MergeGuard
 from teatree.core.models import Ticket
+from teatree.core.overlay import OverlayBase
 from teatree.loop.scanners.base import ScannerError, ScannerErrorClass
 from teatree.loop.scanners.gitlab_approvals import GitLabApprovalsScanner
 from teatree.types import RawAPIDict
@@ -505,6 +507,81 @@ class TestPerPrIsolation(TestCase):
 
         with pytest.raises(ScannerError):
             scanner.scan()
+
+
+class _MergeGuardOverlay(OverlayBase):
+    """Concrete overlay owning a repo and returning a fixed merge guard."""
+
+    def __init__(self, *, repos: list[str], guard: MergeGuard) -> None:
+        self._repos = repos
+        self._guard = guard
+
+    def get_repos(self) -> list[str]:
+        return self._repos
+
+    def get_workspace_repos(self) -> list[str]:
+        return self._repos
+
+    def get_provision_steps(self, worktree: Any) -> list:
+        _ = worktree
+        return []
+
+    def can_auto_merge(self, *, target_ref: str, thread_ref: str) -> MergeGuard:
+        _ = (target_ref, thread_ref)
+        return self._guard
+
+
+class TestGitLabApprovalsMultiOverlay(TestCase):
+    """Real ``get_overlay()`` ambiguity path — two overlays registered (TODO-282).
+
+    The scanner held the approved MR's ``url`` but called bare
+    ``_overlay_loader.get_overlay()`` to reach ``can_auto_merge``. With two
+    overlays registered and no ``T3_OVERLAY_NAME``, that raises
+    ``ImproperlyConfigured("Multiple overlays found ...")`` — swallowed by the
+    per-PR ``except Exception`` in ``scan()``, so the approved MR emits NOTHING
+    and the merge is silently dropped. The fix resolves the overlay from the MR
+    URL (``get_overlay_for_url``), so the URL-owning overlay's merge policy runs.
+
+    Nothing about overlay resolution is mocked; only the code host (a network
+    external) is. The owning overlay returns an ESCALATE guard so the emitted
+    signal proves *that specific overlay's* policy ran, not a permissive default.
+    """
+
+    def test_resolves_url_owning_overlay_with_two_registered(self) -> None:
+        url = "https://gitlab.com/acme/backend/-/merge_requests/77"
+        host = FakeCodeHost(
+            my_prs=[_gitlab_mr(iid=77, sha="multi-1", project="acme/backend")],
+            approvals={
+                ("acme/backend", 77): ApprovalState(
+                    approvals_left=0,
+                    approved_by=["bob"],
+                    unresolved_resolvable=0,
+                ),
+            },
+        )
+        owner = _MergeGuardOverlay(
+            repos=["acme/backend"],
+            guard=MergeGuard(allowed=False, reason="freeze window", escalate=True),
+        )
+        other = _MergeGuardOverlay(
+            repos=["other/repo"],
+            guard=MergeGuard(allowed=True),
+        )
+        overlays = {"acme": owner, "other": other}
+        env_without_pin = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+        with (
+            patch.dict(os.environ, env_without_pin, clear=True),
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=overlays),
+        ):
+            signals = GitLabApprovalsScanner(host=host).scan()
+
+        assert len(signals) == 1, (
+            "with two overlays registered, the approved MR must still emit a signal — "
+            "a bare get_overlay() raises Multiple-overlays and the MR is silently dropped"
+        )
+        assert signals[0].kind == "incoming_event.merge_escalation"
+        assert signals[0].payload["reason"] == "freeze window"
+        assert signals[0].payload["thread_ref"] == url
 
 
 class TestHelperFunctions(TestCase):

--- a/tests/teatree_loop/test_incoming_events_scanner.py
+++ b/tests/teatree_loop/test_incoming_events_scanner.py
@@ -1,5 +1,6 @@
 """Behaviour tests for IncomingEventsScanner (#669, #654)."""
 
+import os
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -7,6 +8,7 @@ from django.test import TestCase
 import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.core.gates.merge_guard import MergeGuard
 from teatree.core.models import IncomingEvent, ReplyDispatch
+from teatree.core.overlay import OverlayBase
 from teatree.loop.scanners.incoming_events import IncomingEventsScanner
 
 
@@ -279,3 +281,110 @@ class _StubOverlay:
 
     def can_auto_merge(self, *, target_ref: str, thread_ref: str) -> MergeGuard:
         return self._guard
+
+
+class _MergeGuardOverlay(OverlayBase):
+    """Concrete overlay owning a repo and returning a fixed merge guard."""
+
+    def __init__(self, *, repos: list[str], guard: MergeGuard) -> None:
+        self._repos = repos
+        self._guard = guard
+
+    def get_repos(self) -> list[str]:
+        return self._repos
+
+    def get_workspace_repos(self) -> list[str]:
+        return self._repos
+
+    def get_provision_steps(self, worktree: object) -> list:
+        _ = worktree
+        return []
+
+    def can_auto_merge(self, *, target_ref: str, thread_ref: str) -> MergeGuard:
+        _ = (target_ref, thread_ref)
+        return self._guard
+
+
+class TestEventForgeUrl:
+    """``_event_forge_url`` extracts the forge URL/slug from a webhook event (TODO-282)."""
+
+    def _event(self, **payload: object) -> IncomingEvent:
+        return IncomingEvent(channel_ref="acme/repo", payload_json=dict(payload))
+
+    def test_prefers_gitlab_object_attributes_url(self) -> None:
+        from teatree.loop.scanners.incoming_events import _event_forge_url  # noqa: PLC0415
+
+        url = "https://gitlab.com/acme/backend/-/merge_requests/9"
+        event = self._event(object_attributes={"url": url})
+        assert _event_forge_url(event) == url
+
+    def test_prefers_github_pull_request_html_url(self) -> None:
+        from teatree.loop.scanners.incoming_events import _event_forge_url  # noqa: PLC0415
+
+        url = "https://github.com/acme/backend/pull/9"
+        event = self._event(pull_request={"html_url": url})
+        assert _event_forge_url(event) == url
+
+    def test_falls_back_to_channel_ref_slug(self) -> None:
+        from teatree.loop.scanners.incoming_events import _event_forge_url  # noqa: PLC0415
+
+        event = self._event()
+        assert _event_forge_url(event) == "acme/repo"
+
+    def test_empty_when_no_url_and_no_channel_ref(self) -> None:
+        from teatree.loop.scanners.incoming_events import _event_forge_url  # noqa: PLC0415
+
+        event = IncomingEvent(channel_ref="", payload_json={})
+        assert _event_forge_url(event) == ""
+
+    def test_non_string_url_falls_through(self) -> None:
+        from teatree.loop.scanners.incoming_events import _event_forge_url  # noqa: PLC0415
+
+        event = self._event(object_attributes={"url": 123}, pull_request={"html_url": None})
+        assert _event_forge_url(event) == "acme/repo"
+
+
+class TestScheduleMergeMultiOverlay(TestCase):
+    """Real ``get_overlay()`` ambiguity path — two overlays registered (TODO-282).
+
+    ``_handle_schedule_merge`` applies a *per-overlay* merge policy
+    (``can_auto_merge``) but resolved it with a bare ``get_overlay()``. With
+    two overlays registered and no ``T3_OVERLAY_NAME`` that raises ``Multiple
+    overlays found`` — swallowed by ``scan()``'s per-event ``except Exception``,
+    which marks the event processed and drops the approved merge. The fix
+    resolves the overlay from the event's forge URL (carried in the GitLab
+    webhook ``object_attributes.url``), so the URL-owning overlay's policy runs.
+
+    Only overlay discovery is patched (the entry-point external); the URL→overlay
+    resolution itself is real. The owning overlay returns an ESCALATE guard so
+    the emitted signal proves *that overlay's* policy ran, not a permissive default.
+    """
+
+    def test_resolves_url_owning_overlay_with_two_registered(self) -> None:
+        url = "https://gitlab.com/acme/backend/-/merge_requests/88"
+        _event(
+            source=IncomingEvent.Source.GITLAB,
+            body="approved",
+            key="gitlab:multi-overlay",
+            object_kind="merge_request",
+            object_attributes={"action": "approved", "iid": 88, "url": url},
+        )
+        owner = _MergeGuardOverlay(
+            repos=["acme/backend"],
+            guard=MergeGuard(allowed=False, reason="freeze window", escalate=True),
+        )
+        other = _MergeGuardOverlay(repos=["other/repo"], guard=MergeGuard(allowed=True))
+        overlays = {"acme": owner, "other": other}
+        env_without_pin = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+        with (
+            patch.dict(os.environ, env_without_pin, clear=True),
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=overlays),
+        ):
+            signals = IncomingEventsScanner().scan()
+
+        escalations = [s for s in signals if s.kind == "incoming_event.merge_escalation"]
+        assert len(escalations) == 1, (
+            "with two overlays registered, the approved merge must still resolve the URL-owning "
+            "overlay's policy — a bare get_overlay() raises Multiple-overlays and drops the merge"
+        )
+        assert escalations[0].payload["reason"] == "freeze window"

--- a/tests/test_overlay_loader.py
+++ b/tests/test_overlay_loader.py
@@ -1,5 +1,6 @@
 """Tests for teatree.core.overlay_loader — TOML-based overlay discovery."""
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -7,6 +8,7 @@ from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ImproperlyConfigured
 
 import teatree.config as config_mod
 from teatree.config import TeaTreeConfig
@@ -15,6 +17,7 @@ from teatree.core.overlay_loader import (
     _discover_toml_overlays,
     frontend_repos_for_overlay,
     get_overlay_for_repo,
+    get_overlay_for_url,
     infer_overlay_for_url,
     resolve_overlay_name,
 )
@@ -328,6 +331,77 @@ class TestGetOverlayForRepo:
         with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
             assert get_overlay_for_repo(str(repo)) is overlays["a"]
         assert "failed during repo resolution" in caplog.text
+
+
+class TestGetOverlayForUrl:
+    """``get_overlay_for_url`` resolves the owning overlay from a forge URL (TODO-282).
+
+    The URL-context counterpart of ``get_overlay_for_ticket`` — for loop-tick
+    call sites that hold a forge URL but no ticket/worktree row. With two
+    overlays registered and no ``T3_OVERLAY_NAME``, a bare ``get_overlay()``
+    raises ``Multiple overlays found``; resolving from the URL's repo-ownership
+    match is unambiguous when exactly one overlay owns it, and fails loud
+    naming the installed overlays when it cannot be resolved.
+    """
+
+    def _overlay(self, repos: list[str]) -> _RepoOverlay:
+        return _RepoOverlay(repos)
+
+    def _two_overlays_no_pin(self, overlays: dict):
+        """Register the given overlays with ``T3_OVERLAY_NAME`` unset.
+
+        Drives the real ``get_overlay()`` ambiguity path — the conftest pins
+        ``T3_OVERLAY_NAME=t3-teatree`` globally, which would short-circuit the
+        multi-overlay resolution under test.
+        """
+        env_without_pin = {k: v for k, v in os.environ.items() if k != "T3_OVERLAY_NAME"}
+        return (
+            patch.dict(os.environ, env_without_pin, clear=True),
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=overlays),
+        )
+
+    def test_url_owned_by_one_of_two_overlays_resolves_that_overlay(self):
+        overlays = {
+            "a": self._overlay(["acme/widgets"]),
+            "b": self._overlay(["other/repo"]),
+        }
+        url = "https://github.com/acme/widgets/pull/7"
+        env_patch, discover_patch = self._two_overlays_no_pin(overlays)
+        with env_patch, discover_patch:
+            resolved = get_overlay_for_url(url)
+        assert resolved is overlays["a"], (
+            "with two overlays registered, the URL's owner must win — not crash on ambiguity"
+        )
+
+    def test_ambiguous_url_fails_loud_naming_overlays(self):
+        """A URL no overlay uniquely claims, with two overlays registered, fails loud.
+
+        Inference returns ``""`` (no single owner), so resolution falls to
+        ``get_overlay(None)`` which raises the explicit ``Multiple overlays
+        found (...)`` error naming the installed overlays — never silently
+        picks one.
+        """
+        overlays = {
+            "alpha": self._overlay(["acme/widgets"]),
+            "beta": self._overlay(["acme/widgets"]),
+        }
+        url = "https://github.com/acme/widgets/pull/7"
+        env_patch, discover_patch = self._two_overlays_no_pin(overlays)
+        with env_patch, discover_patch, pytest.raises(ImproperlyConfigured, match=r"Multiple overlays found"):
+            get_overlay_for_url(url)
+
+    def test_single_overlay_resolves_without_url_match(self):
+        overlays = {"only": self._overlay(["other/repo"])}
+        env_patch, discover_patch = self._two_overlays_no_pin(overlays)
+        with env_patch, discover_patch:
+            resolved = get_overlay_for_url("https://github.com/acme/widgets/pull/7")
+        assert resolved is overlays["only"]
+
+    def test_empty_url_falls_back_to_ambient_default(self):
+        overlays = {"only": self._overlay(["other/repo"])}
+        env_patch, discover_patch = self._two_overlays_no_pin(overlays)
+        with env_patch, discover_patch:
+            assert get_overlay_for_url("") is overlays["only"]
 
 
 class TestResolveOverlayName:


### PR DESCRIPTION
## What & why

Three loop-tick call sites resolved the active overlay with a bare `get_overlay()` (no name). In a multi-overlay install with no `T3_OVERLAY_NAME`, `get_overlay()` raises `ImproperlyConfigured` ("Multiple overlays found (...)"), and each site swallows that in a surrounding `except`:

- `_review_target_is_dead` (`loop/dispatch.py`) — fails open, so a stale `t3:reviewer` is dispatched on every MERGED/CLOSED MR.
- `GitLabApprovalsScanner._scan_one` (`loop/scanners/gitlab_approvals.py`) — the approved MR emits no signal and the merge is silently dropped.
- `IncomingEventsScanner._handle_schedule_merge` (`loop/scanners/incoming_events.py`) — `can_auto_merge` is per-overlay policy (freeze windows, approval gates); the approved merge is silently dropped.

This is the same class already fixed for ticket/worktree context: #1605, #1609, #1814, #1975 (and the validate-mr variant #1527).

## Fix

Add `get_overlay_for_url(url)` — the URL-context counterpart of the existing `get_overlay_for_ticket` / `get_overlay_for_worktree` / `get_overlay_for_repo` resolvers. It maps the forge URL to its owning overlay via the existing `infer_overlay_for_url` repo-ownership match, and on no/ambiguous match falls through to `get_overlay(None)`: the ambient single-overlay default still resolves, and a genuinely ambiguous multi-overlay environment fails loud naming the installed overlays rather than silently picking one.

The schedule-merge handler has no MR URL on the routed action (the refs are Slack channel/thread refs), so it reads the forge URL from the webhook payload (`object_attributes.url` for GitLab, `pull_request.html_url` for GitHub), falling back to the `owner/repo` `channel_ref` both receivers record (`path_with_namespace` / `full_name`).

The new resolver lives in its own `teatree.core.overlay_url` module (re-exported from `overlay_loader` for callers) so the loader stays under the module-health public-function cap.

## Tests (anti-vacuous)

Each call-site regression test was confirmed RED on the pre-fix code (the swallowed `Multiple overlays found (acme, other)` raise) before the fix:

- `tests/test_overlay_loader.py::TestGetOverlayForUrl` — URL owner resolves under two overlays; ambiguous URL fails loud naming overlays; single-overlay + empty-URL defaults.
- `tests/teatree_loop/test_gitlab_approvals_scanner.py::TestGitLabApprovalsMultiOverlay`
- `tests/teatree_loop/test_incoming_events_scanner.py::TestScheduleMergeMultiOverlay` (+ `TestEventForgeUrl` for the payload extractor)
- `tests/teatree_loop/test_dispatch_review_target_live_state.py::TestReviewTargetMultiOverlay`

100% coverage on the new code. Lint / format / ty / tach clean.

## Architecture pre-check — TODO-282

**1. BLUEPRINT § alignment** — §6 Overlay System. Same multi-overlay-ambiguity class as #1605/#1609/#1814/#1975, now closed for URL-only loop-tick context. No BLUEPRINT contradiction; additive helper.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition; the merge-guard signals feed the existing §17.4 keystone path unchanged.

**3. Extension-point contracts** — consumes `OverlayBase.can_auto_merge` and `OverlayBase.get_workspace_repos` (via `infer_overlay_for_url`). No contract change, no new hook, no overlay update needed.

**4. Component boundaries** — `overlay_url.py` sits beside `overlay_loader.py` in `core/`; the three call-site fixes stay in their loop modules. Concern-split keeps the loader under the module-health cap.

**5. Dependency direction** — no new cross-layer edge. `overlay_url` lazy-imports `get_overlay` / `infer_overlay_for_url` from `overlay_loader` (no cycle). `tach check` clean.

**6. Test surface** — listed above; each FSM-adjacent behaviour asserted on the emitted signal kind/payload, not a structural post-condition.

**7. Resilience invariants** — read path (verify-by-re-read n/a); idempotency unchanged (approvals SHA gate, event `processed_at`); fallback-transport is the fail-loud `get_overlay(None)` on ambiguity; heartbeat/sub-agent-return n/a.

**8. Identity & key normalization** — forge URL → overlay name is canonicalized UP through the existing `infer_overlay_for_url` repo-ownership match (the single source of truth); no qualifier stripping introduced.

**9. Behavior preservation / capability deletion** — purely additive at the call sites (`get_overlay()` → `get_overlay_for_url(...)`). Single-overlay and `T3_OVERLAY_NAME`-pinned behaviour preserved exactly. No matcher narrowed, no must-block test inverted.

## Open questions & assumptions

- **Scope.** Fixed the three loop-tick sites that run in the all-overlays-registered tick process and carry resolvable URL context. Other bare `get_overlay()` calls (`core/sync.py`, `backends/slack/review_sync.py`, `backends/gitlab/sync_issues.py`, `core/notify.py`, `core/cleanup.py`, `core/skill_cache.py`, `agents/skill_bundle.py`) run under a subprocess `T3_OVERLAY_NAME` pin or are already `try/except`-wrapped best-effort — left out to keep this PR focused. Happy to widen if wanted.
- **Schedule-merge fallback.** Assumes the GitLab/GitHub webhook receivers keep recording the `owner/repo` slug as `channel_ref` (GitLab `path_with_namespace` / GitHub `full_name`); relied on when the payload carries no MR/PR URL.

Refs TODO #282.
