### PR TITLE
fix(e2e): omit the empty video row in the evidence note (#272)

### DIFF
--- a/src/teatree/core/management/commands/_e2e_evidence_render.py
+++ b/src/teatree/core/management/commands/_e2e_evidence_render.py
@@ -540,16 +540,21 @@ def _workflow_table(state: EvidenceState, workflow: str) -> list[str]:
     """Render one workflow's block: heading, test-plan steps, then the ``| Dev | Local |`` table.
 
     The optional ``**How to test:**`` numbered step list (the written test plan)
-    renders above the table. Table row 1 = each side's video (``—`` when absent);
-    then one row per screenshot pair (dev capture left, local capture right; ``—``
-    where a side has fewer captures — e.g. dev not deployed yet, all ``—``).
+    renders above the table. The video row (each side's clip, ``—`` when absent)
+    renders only when at least one side carries a video — an all-em-dash video
+    row carries no information, so a screenshot-only workflow omits it entirely
+    (#272 standard). One screenshot-pair row follows per capture (dev capture
+    left, local capture right; ``—`` where a side has fewer captures — e.g. dev
+    not deployed yet).
     """
     dev_video, dev_images = _cells(state["dev"], workflow)
     local_video, local_images = _cells(state["local"], workflow)
 
     lines = [f"### {workflow}", ""]
     lines.extend(_test_plan_block(state, workflow))
-    lines.extend(["| Dev | Local |", "|---|---|", f"| {dev_video} | {local_video} |"])
+    lines.extend(["| Dev | Local |", "|---|---|"])
+    if dev_video != _EMPTY_CELL or local_video != _EMPTY_CELL:
+        lines.append(f"| {dev_video} | {local_video} |")
     for i in range(max(len(dev_images), len(local_images))):
         left = dev_images[i] if i < len(dev_images) else _EMPTY_CELL
         right = local_images[i] if i < len(local_images) else _EMPTY_CELL

--- a/tests/teatree_core/e2e_command/test_post_evidence.py
+++ b/tests/teatree_core/e2e_command/test_post_evidence.py
@@ -148,14 +148,32 @@ class TestRenderBody:
         body = _evidence.render_body(state)
         assert "⚠️ Not yet on dev: client!6331 (unmerged), product!7585 (draft) — expected gap." in body
 
-    def test_workflow_with_no_video_omits_video_cell_content(self) -> None:
+    def test_empty_video_row_is_omitted_when_neither_side_has_a_video(self) -> None:
+        # Screenshots only on local, no video on either side (#272 standard): the
+        # all-em-dash video row carries no information, so it is omitted entirely
+        # rather than rendered as `| — | — |`.
         state = self._state(
             local={"commits": {}, "workflows": {"Search": self._embedded(images=("![i](/uploads/s/x.png)",))}},
         )
         body = _evidence.render_body(state)
-        # No local video → the video cell is the em-dash placeholder, not blank.
-        assert "| — | — |" in body  # dev side absent + local video absent
+        assert "| — | — |" not in body  # the empty video row is dropped, not rendered blank
+        # The screenshot pair row still renders (dev absent → em-dash left, local image right).
         assert "| — | ![i](/uploads/s/x.png) |" in body
+        # The comparison table itself still renders (heading + header + the image row).
+        assert "### Search" in body
+        assert "| Dev | Local |" in body
+
+    def test_video_row_renders_when_at_least_one_side_has_a_video(self) -> None:
+        # Local has a video, dev does not → the video row is kept (it carries the
+        # local clip), with the missing dev side as an em-dash.
+        state = self._state(
+            local={
+                "commits": {},
+                "workflows": {"Login": self._embedded(video="![v](/uploads/s/loc.webm)")},
+            },
+        )
+        body = _evidence.render_body(state)
+        assert "| — | ![v](/uploads/s/loc.webm) |" in body
 
     def test_mrs_line_omitted_when_no_mrs(self) -> None:
         state = self._state(mrs=[], local={"commits": {}, "workflows": {"Wf": self._embedded(images=("![i](u)",))}})


### PR DESCRIPTION
## What

`t3 <overlay> e2e post-evidence` renders a side-by-side Dev | Local comparison
table per workflow. The first table row was the video row, and it was emitted
unconditionally — so a screenshot-only workflow (no clip on either side) rendered
an all-em-dash `| — | — |` row that carries no information.

This omits the video row entirely when neither the dev nor the local side has a
video, and keeps it (with an em-dash for the missing side) when at least one side
does. It is the last remaining render gap from the #272 evidence standard
(video-at-top, before/after step-by-step plan, full-ticket scope, multi-repo MR
links, terse, omit-empty-video-row). The other elements were already implemented
by the #2156 / #2172 / #2181 work; this fills the one that was missing.

## Why

The standard wants the video at the top of the comparison only when there is a
video. An empty video row is visual noise in the posted note.

## Architecture pre-check — TODO-637 (#272)

1. **BLUEPRINT § alignment** — Tactical render-formatting fix inside one pure
   function (`_workflow_table`) of the evidence-note builder; no BLUEPRINT section
   contract changes.
2. **FSM phase boundaries** — n/a (no `Ticket.State` / `Worktree.State`
   transition touched).
3. **Extension-point contracts** — n/a (no `OverlayBase` / scanner / hook /
   Protocol surface touched).
4. **Component boundaries** — change stays in
   `core/management/commands/_e2e_evidence_render.py`, the pure string/JSON render
   layer; no ORM / code-host / CLI logic added.
5. **Dependency direction** — no imports added; `uv run tach check` passes.
6. **Test surface** — `tests/teatree_core/e2e_command/test_post_evidence.py`:
   `TestRenderBody::test_empty_video_row_is_omitted_when_neither_side_has_a_video`
   (the row is dropped, the image row and table heading still render) and
   `test_video_row_renders_when_at_least_one_side_has_a_video` (a present video
   keeps the row). The first was observed RED on pre-fix code (`| — | — |` was
   present), GREEN after.
7. **Resilience invariants** — n/a (pure transform; no external write added).
8. **Identity and key normalization** — n/a (no new identity/key handling).
9. **Behavior preservation / capability deletion** — the only behavior change is
   the empty-video-row case: it used to render `| — | — |`, now it is omitted. The
   prior test that asserted the empty row IS rendered
   (`test_workflow_with_no_video_omits_video_cell_content`) encoded the old
   behavior the #272 standard supersedes; it was replaced by the two tests above.
   No privacy/security matcher is touched; no must-block test was inverted.

## Open questions & assumptions

- Draft-by-default is governed by the on-behalf gate (`on_behalf_post_mode`) and
  is out of scope for this render-only change — it is tracked separately in #2156.
- The before/after step-by-step plan is the `**How to test:**` numbered steps plus
  the side-by-side Dev | Local table; full-ticket scope is the multi-repo MR links
  and per-repo commit provenance. Both were already present; only the empty-video
  row remained.

## Test

`uv run pytest --no-cov -q tests/teatree_core/e2e_command/` — 41 passed. Lint, ruff
format, and ty all clean on the changed files; tach green.
