### PR TITLE
fix(update): report per-clone commit count in t3 update summary (#2020)

### DIFF
--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -88,6 +88,7 @@ class RepoUpdate:
     old_sha: str = ""
     new_sha: str = ""
     reason: str = ""
+    advanced: int = 0
 
     @property
     def is_error(self) -> bool:
@@ -96,7 +97,8 @@ class RepoUpdate:
     @property
     def summary_line(self) -> str:
         if self.status is UpdateStatus.UPDATED:
-            return f"OK    {self.name}: updated {self.old_sha} -> {self.new_sha}"
+            plural = "commit" if self.advanced == 1 else "commits"
+            return f"OK    {self.name}: +{self.advanced} {plural} ({self.old_sha} -> {self.new_sha})"
         if self.status is UpdateStatus.UP_TO_DATE:
             return f"OK    {self.name}: up-to-date"
         if self.status is UpdateStatus.SKIPPED:
@@ -115,6 +117,16 @@ def _git(repo: Path, *args: str, expected_codes: tuple[int, ...] | None = (0,)) 
 
 def _short_sha(repo: Path) -> str:
     return _git(repo, "rev-parse", "--short", "HEAD").stdout.strip()
+
+
+def _commit_count(repo: Path, old_sha: str, new_sha: str) -> int:
+    """Count commits the ff-pull added (``git rev-list --count old..new``).
+
+    Both endpoints are SHAs this function's caller just resolved from the
+    repo's own HEAD before and after the fast-forward, so the range is always
+    valid and the audited ``git`` runs with the strict default exit code.
+    """
+    return int(_git(repo, "rev-list", "--count", f"{old_sha}..{new_sha}").stdout.strip())
 
 
 def _current_branch(repo: Path) -> str:
@@ -300,7 +312,8 @@ def update_repo(name: str, repo: Path, *, is_primary: bool = False) -> RepoUpdat
     new_sha = _short_sha(repo)
     if new_sha == old_sha:
         return RepoUpdate(name, UpdateStatus.UP_TO_DATE)
-    return RepoUpdate(name, UpdateStatus.UPDATED, old_sha=old_sha, new_sha=new_sha)
+    advanced = _commit_count(repo, old_sha, new_sha)
+    return RepoUpdate(name, UpdateStatus.UPDATED, old_sha=old_sha, new_sha=new_sha, advanced=advanced)
 
 
 def _running_clone() -> Path | None:

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -68,15 +68,16 @@ def _clone(tmp_path: Path, bare: Path, name: str = "clone") -> Path:
     return clone
 
 
-def _advance_remote(tmp_path: Path, bare: Path) -> str:
-    """Push a new commit to the bare remote; return its short sha."""
+def _advance_remote(tmp_path: Path, bare: Path, commits: int = 1) -> str:
+    """Push *commits* new commits to the bare remote; return the head short sha."""
     work = tmp_path / "advance"
     _git(tmp_path, "clone", str(bare), str(work))
     _git(work, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
     _git(work, "config", "user.name", "Tester")
-    (work / "f.txt").write_text("v2\n")
-    _git(work, "add", "f.txt")
-    _git(work, "commit", "-m", "second")
+    for n in range(commits):
+        (work / "f.txt").write_text(f"v{n + 2}\n")
+        _git(work, "add", "f.txt")
+        _git(work, "commit", "-m", f"advance {n}")
     _git(work, "push", "origin", "main")
     return _git(work, "rev-parse", "--short", "HEAD")
 
@@ -101,7 +102,19 @@ class TestUpdateRepoCleanFastForward:
         assert result.status is UpdateStatus.UPDATED
         assert result.old_sha == old_sha
         assert result.new_sha == new_sha
+        assert result.advanced == 1
         assert _git(clone, "rev-parse", "--short", "HEAD") == new_sha
+
+    def test_records_count_of_commits_advanced(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _advance_remote(tmp_path, bare, commits=4)
+
+        result = update_repo("clone", clone)
+
+        assert result.status is UpdateStatus.UPDATED
+        assert result.advanced == 4
+        assert "+4 commits" in result.summary_line
 
 
 class TestUpdateRepoUpToDate:
@@ -303,7 +316,7 @@ class TestPrimaryCloneOffDefaultBranchFailsLoud:
 
 class TestRepoUpdateSummary:
     def test_summary_line_shapes(self) -> None:
-        updated = RepoUpdate("core", UpdateStatus.UPDATED, old_sha="aaaaaaa", new_sha="bbbbbbb")
+        updated = RepoUpdate("core", UpdateStatus.UPDATED, old_sha="aaaaaaa", new_sha="bbbbbbb", advanced=3)
         up = RepoUpdate("ovl", UpdateStatus.UP_TO_DATE)
         skipped = RepoUpdate("ovl2", UpdateStatus.SKIPPED, reason="dirty working tree")
 
@@ -314,6 +327,14 @@ class TestRepoUpdateSummary:
         assert "dirty working tree" in skipped.summary_line
         assert updated.is_error is False
         assert RepoUpdate("x", UpdateStatus.FAILED, reason="boom").is_error is True
+
+    def test_updated_summary_reports_commit_count(self) -> None:
+        one = RepoUpdate("core", UpdateStatus.UPDATED, old_sha="aaaaaaa", new_sha="bbbbbbb", advanced=1)
+        many = RepoUpdate("ovl", UpdateStatus.UPDATED, old_sha="ccccccc", new_sha="ddddddd", advanced=7)
+
+        assert "+1 commit " in one.summary_line
+        assert "+1 commits" not in one.summary_line
+        assert "+7 commits" in many.summary_line
 
 
 class TestUpdateCommandExitCode:
@@ -614,7 +635,23 @@ class TestRunUpdateEndToEnd:
         assert "Summary:" in out
         assert old_sha in out
         assert new_sha in out
+        assert "+1 commit " in out
         assert _git(clone, "rev-parse", "--short", "HEAD") == new_sha
+
+    def test_summary_reports_multi_commit_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _advance_remote(tmp_path, bare, commits=3)
+
+        monkeypatch.setattr(update_mod, "_collect_repos", lambda: [("clone", clone)])
+        monkeypatch.setattr(update_mod, "_reinstall_and_resetup", lambda _r: None)
+        monkeypatch.setattr(update_mod, "ensure_self_db_migrated", lambda: False)
+
+        update_mod._run_update()
+
+        assert "+3 commits" in capsys.readouterr().out
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

Closes [#2020](https://github.com/souliane/teatree/issues/2020).

`t3 update` previously summarised an advanced clone as `updated <old> -> <new>`, which gave no sense of how far the clone actually moved. It now reports the number of commits each clone advanced, derived from `git rev-list --count <old>..<new>`:

```
OK    teatree: +4 commits (1111111 -> 2222222)
OK    overlay: +1 commit (3333333 -> 4444444)
OK    other: up-to-date
```

Up-to-date and skipped clones render exactly as before. The count lives on a new `RepoUpdate.advanced` field (default `0`) and is formatted in `summary_line`, so it shows both on the dataclass and in the end-of-run `Summary:` block printed by `_run_update`. Singular/plural is handled (`+1 commit` vs `+N commits`).

## Implementation

- `RepoUpdate.advanced: int = 0` — count of commits the fast-forward added.
- `_commit_count(repo, old_sha, new_sha)` — thin `git rev-list --count old..new` wrapper. Both endpoints are SHAs the caller just resolved from the repo's own HEAD before and after the ff-pull, so the range is always valid and it uses the audited `git` with the strict default exit code (no defensive zero-fallback, no uncoverable branch).
- `update_repo` populates `advanced` on the `UPDATED` path only.

No change to exit codes, the skip/fail paths, or any CLI/model/config surface — purely the rendered text of an existing command.

## Tests (anti-vacuous, observed RED before the fix)

- `tests/test_cli_update.py::TestUpdateRepoCleanFastForward::test_records_count_of_commits_advanced` — real `git` repos under `tmp_path`, pushes 4 commits to the bare remote, asserts `result.advanced == 4` and `"+4 commits" in result.summary_line`.
- `TestRepoUpdateSummary::test_updated_summary_reports_commit_count` — pins the singular/plural rendering (`+1 commit ` vs `+7 commits`).
- `TestRunUpdateEndToEnd::test_summary_reports_multi_commit_count` — asserts `+3 commits` appears in the rendered `Summary:` block of the full `_run_update` flow.
- The pre-existing `test_clean_on_default_branch_fast_forwards` and `test_real_repo_summary_and_zero_exit` gained `advanced`/`+1 commit ` assertions.

RED confirmation: on the pre-fix code these failed with `AttributeError: 'RepoUpdate' object has no attribute 'advanced'`. Green after the fix; all 60 tests in `test_cli_update.py` + `test_self_update.py` pass. New lines are 100% covered (the one remaining miss in `update.py` is the pre-existing `_running_clone` `__file__ is None` defensive branch, unchanged by this PR). `ruff check`, `ruff format --check`, and `ty check` all clean on the two changed files.

## Architecture pre-check — #2020

## 1. BLUEPRINT § alignment
`t3 update` is catalogued at BLUEPRINT.md §1 (Global CLI) and its setup-rerun behaviour at the skills-prune section. Neither documents the summary output **format**, and this change adds/removes/renames no command, model, endpoint, or config — only the rendered text of one already-documented command's summary line. No BLUEPRINT change warranted; commit typed `fix` per the blueprint-sync hook's sanctioned escape for non-surface changes.

## 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

## 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / `*Backend` Protocol touched. The only consumers of `RepoUpdate` / `summary_line` are `cli/update.py` and its test file; the new field defaults to `0`, so every existing construction stays valid.

## 4. Component boundaries
`src/teatree/cli/update.py` — a formatter/result-shape tweak in the CLI layer where the type already lives. No business logic relocated.

## 5. Dependency direction
No new imports. `git rev-list` reuses the existing `_git` audited subprocess wrapper. No backwards edge.

## 6. Test surface
Each new behaviour (count recorded, count rendered, singular/plural, end-to-end Summary line) has a named assertion in `tests/test_cli_update.py`, all observed RED before the fix.

## 7. Resilience invariants
n/a — read-only `git rev-list` on the local clone; no external write, no DB row outside the request cycle.

## 8. Identity and key normalization
n/a — no bare-vs-qualified identity handling.

## 9. Behavior preservation / capability deletion
Purely additive to the `UPDATED` rendering path. The `updated <old> -> <new>` substring changed to `+N commits (<old> -> <new>)`; the old/new SHAs are still both present (existing tests asserting their presence still pass). No must-block test inverted; no privacy/security matcher touched.
