### PR TITLE
refactor(hooks): extract shared _teatree_bool_setting helper for [teatree] flag readers

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -408,29 +408,44 @@ class _BreakerDecision:
     reason: str
 
 
-def _deny_circuit_breaker_enabled() -> bool:
-    """Whether the repeated-denial circuit breaker is enabled (default True).
+def _teatree_bool_setting(name: str, *, default: bool = True) -> bool:
+    """Best-effort read of a ``[teatree] <name>`` boolean flag from ``~/.teatree.toml``.
 
-    Best-effort read of ``[teatree] deny_circuit_breaker_enabled`` from
-    ``~/.teatree.toml``, mirroring :func:`_skill_loading_gate_enabled`'s
-    toml-read shape. Fails OPEN to enabled on a missing/broken config so the
-    breaker keeps its protective default; an explicit ``false`` is the one-line
-    kill-switch that makes the breaker a pure pass-through (never a code edit).
+    The single shared shape behind every ``[teatree] <flag>_enabled`` reader:
+    fails to ``default`` on a missing/broken config, a missing ``[teatree]``
+    table, a missing key, or a non-boolean value, and returns the configured
+    value only when it is a bare TOML boolean. So only a bare boolean ``false``
+    disables a ``default=True`` flag and only a bare boolean ``true`` enables a
+    ``default=False`` one — a QUOTED ``"false"`` / ``"true"`` (a string, not a
+    bool) is ignored and the default stands. An explicit bare boolean is the
+    one-line kill-switch / opt-in, never a code edit (NEVER-LOCKOUT).
     """
     import tomllib  # noqa: PLC0415
 
     config_path = Path.home() / ".teatree.toml"
     if not config_path.is_file():
-        return True
+        return default
     try:
         with config_path.open("rb") as f:
             config = tomllib.load(f)
     except Exception:  # noqa: BLE001
-        return True
+        return default
     teatree = config.get("teatree") if isinstance(config, dict) else None
     if not isinstance(teatree, dict):
-        return True
-    return teatree.get("deny_circuit_breaker_enabled") is not False
+        return default
+    value = teatree.get(name)
+    return value if isinstance(value, bool) else default
+
+
+def _deny_circuit_breaker_enabled() -> bool:
+    """Whether the repeated-denial circuit breaker is enabled (default True).
+
+    Fails OPEN to enabled on a missing/broken config so the breaker keeps its
+    protective default; an explicit ``false`` is the one-line kill-switch that
+    makes the breaker a pure pass-through (never a code edit). See
+    :func:`_teatree_bool_setting` for the shared bare-boolean semantics.
+    """
+    return _teatree_bool_setting("deny_circuit_breaker_enabled", default=True)
 
 
 def _deny_circuit_breaker_threshold() -> int:
@@ -1178,25 +1193,11 @@ def handle_enforce_loop_on_prompt(data: dict) -> None:
 def _loop_registration_gate_enabled() -> bool:
     """Whether the loop-registration PreToolUse gate is enabled (default True).
 
-    Best-effort read of ``[teatree] loop_registration_gate_enabled`` from
-    ``~/.teatree.toml`` (mirrors :func:`_deny_circuit_breaker_enabled`'s shape).
     Fails OPEN to enabled on a missing/broken config; an explicit ``false`` is
-    the one-line durable kill-switch — never a code edit (NEVER-LOCKOUT).
+    the one-line durable kill-switch — never a code edit (NEVER-LOCKOUT). See
+    :func:`_teatree_bool_setting` for the shared bare-boolean semantics.
     """
-    import tomllib  # noqa: PLC0415
-
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return True
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return True
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return True
-    return teatree.get("loop_registration_gate_enabled") is not False
+    return _teatree_bool_setting("loop_registration_gate_enabled", default=True)
 
 
 _LOOP_REGISTRATION_EXEMPT_TOOLS = frozenset(
@@ -1757,26 +1758,12 @@ _SKIP_SKILL_GATE_RE = re.compile(r"\[skip-skill-gate:\s*(\S[^\]]*?)\s*\]")
 def _skill_loading_gate_enabled() -> bool:
     """Whether the skill-loading-on-task-create gate is enabled (default True).
 
-    Best-effort read of ``[teatree] skill_loading_gate_enabled`` from
-    ``~/.teatree.toml``, mirroring :func:`_orchestrator_bash_gate_enabled`'s
-    toml-read shape. Fails OPEN to enabled on a missing/broken config so the
-    gate keeps its protective default; an explicit ``false`` is the
-    one-line kill-switch (never a code edit).
+    Fails OPEN to enabled on a missing/broken config so the gate keeps its
+    protective default; an explicit ``false`` is the one-line kill-switch
+    (never a code edit). See :func:`_teatree_bool_setting` for the shared
+    bare-boolean semantics.
     """
-    import tomllib  # noqa: PLC0415
-
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return True
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return True
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return True
-    return teatree.get("skill_loading_gate_enabled") is not False
+    return _teatree_bool_setting("skill_loading_gate_enabled", default=True)
 
 
 def _task_text_skip_token(text: str) -> str | None:
@@ -2019,26 +2006,12 @@ def _ticket_state_for_cwd(cwd: str) -> str | None:
 def _plan_edit_gate_enabled() -> bool:
     """Whether the plan-edit gate is enabled (default True).
 
-    Best-effort read of ``[teatree] plan_edit_gate_enabled`` from
-    ``~/.teatree.toml``, mirroring :func:`_skill_loading_gate_enabled`'s
-    toml-read shape. Fails OPEN to enabled on a missing/broken config so the
-    gate keeps its protective default; an explicit ``false`` is the one-line
-    kill-switch (``t3 <overlay> gate plan disable``, never a code edit).
+    Fails OPEN to enabled on a missing/broken config so the gate keeps its
+    protective default; an explicit ``false`` is the one-line kill-switch
+    (``t3 <overlay> gate plan disable``, never a code edit). See
+    :func:`_teatree_bool_setting` for the shared bare-boolean semantics.
     """
-    import tomllib  # noqa: PLC0415
-
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return True
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return True
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return True
-    return teatree.get("plan_edit_gate_enabled") is not False
+    return _teatree_bool_setting("plan_edit_gate_enabled", default=True)
 
 
 def handle_block_edit_before_planned(data: dict) -> bool:
@@ -2771,26 +2744,13 @@ def _mcp_privacy_gate_enabled() -> bool:
     quote-scanner and #1218 bare-reference gates (#171): until the Slack
     matcher was added to ``hooks.json`` these handlers never fired on a
     Slack MCP write, so this flag lets the operator disable that arm alone
-    without a code edit if the now-live gate misfires. Mirrors
-    :func:`_orchestrator_bash_gate_enabled`'s toml-read shape — fails OPEN
-    to enabled on a missing/broken config (the arm is the same risk class
-    as the already-live Bash arm of the same gate), an explicit ``false``
-    disables it. The Bash arm of both gates is unaffected by this flag.
+    without a code edit if the now-live gate misfires. Fails OPEN to enabled
+    on a missing/broken config (the arm is the same risk class as the
+    already-live Bash arm of the same gate), an explicit ``false`` disables
+    it. The Bash arm of both gates is unaffected by this flag. See
+    :func:`_teatree_bool_setting` for the shared bare-boolean semantics.
     """
-    import tomllib  # noqa: PLC0415
-
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return True
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return True
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return True
-    return teatree.get("mcp_privacy_gate_enabled") is not False
+    return _teatree_bool_setting("mcp_privacy_gate_enabled", default=True)
 
 
 def _is_slack_mcp_tool(tool_name: str) -> bool:
@@ -2948,20 +2908,13 @@ def _slack_tool_suffix(tool_name: str) -> str:
 
 
 def _self_dm_gate_enabled() -> bool:
-    import tomllib  # noqa: PLC0415
+    """Whether the self-DM gate is enabled (default True).
 
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return True
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return True
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return True
-    return teatree.get("self_dm_gate_enabled") is not False
+    Fails OPEN to enabled on a missing/broken config; an explicit ``false``
+    is the one-line kill-switch. See :func:`_teatree_bool_setting` for the
+    shared bare-boolean semantics.
+    """
+    return _teatree_bool_setting("self_dm_gate_enabled", default=True)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -3196,22 +3149,10 @@ def _dispatch_quote_gate_on_task_create_enabled() -> bool:
     True only on an explicit ``true``. This deliberately DIFFERS from
     :func:`_mcp_privacy_gate_enabled` (which fails OPEN to enabled): the Slack-MCP
     arm is the same risk class as an already-live gate, whereas this fan-out
-    gate's enforcement semantics are not yet validated.
+    gate's enforcement semantics are not yet validated. See
+    :func:`_teatree_bool_setting` for the shared bare-boolean semantics.
     """
-    import tomllib  # noqa: PLC0415
-
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return False
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return False
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return False
-    return teatree.get("dispatch_quote_gate_on_task_create_enabled") is True
+    return _teatree_bool_setting("dispatch_quote_gate_on_task_create_enabled", default=False)
 
 
 def handle_dispatch_prompt_quote_scanner_on_task_create(data: dict) -> bool:
@@ -3710,26 +3651,12 @@ def _is_orchestration_action(data: dict) -> bool:
 def _orchestrator_bash_gate_enabled() -> bool:
     """Whether the heavy-Bash boundary gate is enabled (default True).
 
-    Best-effort read of ``[teatree] orchestrator_bash_gate_enabled`` from
-    ``~/.teatree.toml``. Fails OPEN to enabled on a missing/broken config so
-    the gate keeps its protective default; an explicit ``false`` is the
-    kill-switch that lets the user disable it with one config line (never a
-    code edit).
+    Fails OPEN to enabled on a missing/broken config so the gate keeps its
+    protective default; an explicit ``false`` is the kill-switch that lets the
+    user disable it with one config line (never a code edit). See
+    :func:`_teatree_bool_setting` for the shared bare-boolean semantics.
     """
-    import tomllib  # noqa: PLC0415
-
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return True
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return True
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return True
-    return teatree.get("orchestrator_bash_gate_enabled") is not False
+    return _teatree_bool_setting("orchestrator_bash_gate_enabled", default=True)
 
 
 def _orchestrator_boundary_agent_gate_enabled() -> bool:
@@ -3754,22 +3681,10 @@ def _orchestrator_boundary_agent_gate_enabled() -> bool:
     signal exists only on the Agent-matcher path, not the TaskCreated one.)
 
     Fails CLOSED to disabled (missing/broken config → False; only an explicit
-    ``true`` enables).
+    ``true`` enables). See :func:`_teatree_bool_setting` for the shared
+    bare-boolean semantics.
     """
-    import tomllib  # noqa: PLC0415
-
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return False
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return False
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return False
-    return teatree.get("orchestrator_boundary_agent_gate_enabled") is True
+    return _teatree_bool_setting("orchestrator_boundary_agent_gate_enabled", default=False)
 
 
 def _deny_foreground_agent_dispatch(data: dict) -> bool:

--- a/tests/test_hook_router_teatree_bool_setting.py
+++ b/tests/test_hook_router_teatree_bool_setting.py
@@ -1,0 +1,163 @@
+"""Tests for the shared ``_teatree_bool_setting`` helper (#1694).
+
+``hook_router`` carried ~10 near-identical ``[teatree] <flag>_enabled``
+boolean toml readers (try / ``tomllib.load`` / ``except Exception`` ->
+default). They are extracted to one ``_teatree_bool_setting(name, *, default)``
+helper and every reader delegates to it.
+
+Two behaviors the helper must preserve exactly. A fail-OPEN reader
+(``default=True``) returns ``True`` on a missing/empty/broken config and on
+any value except a bare boolean ``false`` (a quoted ``"false"`` does NOT
+disable). A fail-CLOSED reader (``default=False``) returns ``False`` on a
+missing/empty/broken config and on any value except a bare boolean ``true``
+(a quoted ``"true"`` does NOT enable).
+
+The delegation assertions are anti-vacuous: monkeypatching the helper
+flips every reader's output, which can only happen if the reader routes
+through the helper.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+
+# (reader function name, [teatree] key) — every [teatree]-table boolean flag reader.
+_FAIL_OPEN_READERS: tuple[tuple[str, str], ...] = (
+    ("_deny_circuit_breaker_enabled", "deny_circuit_breaker_enabled"),
+    ("_loop_registration_gate_enabled", "loop_registration_gate_enabled"),
+    ("_skill_loading_gate_enabled", "skill_loading_gate_enabled"),
+    ("_plan_edit_gate_enabled", "plan_edit_gate_enabled"),
+    ("_mcp_privacy_gate_enabled", "mcp_privacy_gate_enabled"),
+    ("_self_dm_gate_enabled", "self_dm_gate_enabled"),
+    ("_orchestrator_bash_gate_enabled", "orchestrator_bash_gate_enabled"),
+)
+
+_FAIL_CLOSED_READERS: tuple[tuple[str, str], ...] = (
+    ("_dispatch_quote_gate_on_task_create_enabled", "dispatch_quote_gate_on_task_create_enabled"),
+    ("_orchestrator_boundary_agent_gate_enabled", "orchestrator_boundary_agent_gate_enabled"),
+)
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Route ``Path.home()`` (hence the toml read) at an empty tmp dir."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    return tmp_path
+
+
+def _write_teatree(home_dir: Path, body: str) -> None:
+    (home_dir / ".teatree.toml").write_text(f"[teatree]\n{body}", encoding="utf-8")
+
+
+class TestTeatreeBoolSetting:
+    def test_missing_config_returns_default(self, home: Path) -> None:
+        assert router._teatree_bool_setting("any_flag", default=True) is True
+        assert router._teatree_bool_setting("any_flag", default=False) is False
+
+    def test_empty_teatree_table_returns_default(self, home: Path) -> None:
+        _write_teatree(home, "")
+        assert router._teatree_bool_setting("any_flag", default=True) is True
+        assert router._teatree_bool_setting("any_flag", default=False) is False
+
+    def test_broken_toml_returns_default(self, home: Path) -> None:
+        (home / ".teatree.toml").write_text("this is = not = valid [[[", encoding="utf-8")
+        assert router._teatree_bool_setting("any_flag", default=True) is True
+        assert router._teatree_bool_setting("any_flag", default=False) is False
+
+    def test_explicit_false_disables_a_default_true_flag(self, home: Path) -> None:
+        _write_teatree(home, "any_flag = false\n")
+        assert router._teatree_bool_setting("any_flag", default=True) is False
+
+    def test_explicit_true_enables_a_default_false_flag(self, home: Path) -> None:
+        _write_teatree(home, "any_flag = true\n")
+        assert router._teatree_bool_setting("any_flag", default=False) is True
+
+    def test_quoted_false_does_not_disable_a_default_true_flag(self, home: Path) -> None:
+        # Documented invariant: only a bare boolean ``false`` disables.
+        _write_teatree(home, 'any_flag = "false"\n')
+        assert router._teatree_bool_setting("any_flag", default=True) is True
+
+    def test_quoted_true_does_not_enable_a_default_false_flag(self, home: Path) -> None:
+        _write_teatree(home, 'any_flag = "true"\n')
+        assert router._teatree_bool_setting("any_flag", default=False) is False
+
+    def test_explicit_true_keeps_a_default_true_flag_enabled(self, home: Path) -> None:
+        _write_teatree(home, "any_flag = true\n")
+        assert router._teatree_bool_setting("any_flag", default=True) is True
+
+    def test_explicit_false_keeps_a_default_false_flag_disabled(self, home: Path) -> None:
+        _write_teatree(home, "any_flag = false\n")
+        assert router._teatree_bool_setting("any_flag", default=False) is False
+
+
+class TestFailOpenReadersBehavior:
+    @pytest.mark.parametrize(("reader", "key"), _FAIL_OPEN_READERS)
+    def test_defaults_enabled_without_config(self, reader: str, key: str, home: Path) -> None:
+        assert getattr(router, reader)() is True
+
+    @pytest.mark.parametrize(("reader", "key"), _FAIL_OPEN_READERS)
+    def test_bare_false_disables(self, reader: str, key: str, home: Path) -> None:
+        _write_teatree(home, f"{key} = false\n")
+        assert getattr(router, reader)() is False
+
+    @pytest.mark.parametrize(("reader", "key"), _FAIL_OPEN_READERS)
+    def test_quoted_false_does_not_disable(self, reader: str, key: str, home: Path) -> None:
+        _write_teatree(home, f'{key} = "false"\n')
+        assert getattr(router, reader)() is True
+
+
+class TestFailClosedReadersBehavior:
+    @pytest.mark.parametrize(("reader", "key"), _FAIL_CLOSED_READERS)
+    def test_defaults_disabled_without_config(self, reader: str, key: str, home: Path) -> None:
+        assert getattr(router, reader)() is False
+
+    @pytest.mark.parametrize(("reader", "key"), _FAIL_CLOSED_READERS)
+    def test_bare_true_enables(self, reader: str, key: str, home: Path) -> None:
+        _write_teatree(home, f"{key} = true\n")
+        assert getattr(router, reader)() is True
+
+    @pytest.mark.parametrize(("reader", "key"), _FAIL_CLOSED_READERS)
+    def test_quoted_true_does_not_enable(self, reader: str, key: str, home: Path) -> None:
+        _write_teatree(home, f'{key} = "true"\n')
+        assert getattr(router, reader)() is False
+
+
+class TestReadersDelegateToHelper:
+    """Patching the helper flips every reader's output.
+
+    Anti-vacuous: that flip can only happen if the reader routes through
+    ``_teatree_bool_setting``.
+    """
+
+    @pytest.mark.parametrize(("reader", "key"), _FAIL_OPEN_READERS)
+    def test_fail_open_reader_routes_through_helper(
+        self, reader: str, key: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[tuple[str, bool]] = []
+
+        def _fake(name: str, *, default: bool = True) -> bool:
+            seen.append((name, default))
+            return not default
+
+        monkeypatch.setattr(router, "_teatree_bool_setting", _fake)
+        # A fail-open reader defaults True, so the fake (which returns ``not
+        # default``) forces it False — observable only through delegation.
+        assert getattr(router, reader)() is False
+        assert (key, True) in seen
+
+    @pytest.mark.parametrize(("reader", "key"), _FAIL_CLOSED_READERS)
+    def test_fail_closed_reader_routes_through_helper(
+        self, reader: str, key: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[tuple[str, bool]] = []
+
+        def _fake(name: str, *, default: bool = True) -> bool:
+            seen.append((name, default))
+            return not default
+
+        monkeypatch.setattr(router, "_teatree_bool_setting", _fake)
+        # A fail-closed reader defaults False, so the fake forces it True.
+        assert getattr(router, reader)() is True
+        assert (key, False) in seen


### PR DESCRIPTION
## What & why

`hooks/scripts/hook_router.py` carried ~10 near-identical `[teatree] <flag>_enabled` boolean toml readers — each its own `try` / `tomllib.load` / `except Exception -> default` block. This extracts the shared shape into one `_teatree_bool_setting(name, *, default)` helper and routes every reader through it, per [#1694](https://github.com/souliane/teatree/issues/1694) (split from [#1681](https://github.com/souliane/teatree/issues/1681)).

The helper documents the bare-boolean rule in one place: only a bare TOML boolean `false`/`true` flips a flag — a quoted `"false"`/`"true"` (a string, not a bool) is ignored and the default stands.

Readers routed through the helper:

- Fail-OPEN (`default=True`): `_deny_circuit_breaker_enabled`, `_loop_registration_gate_enabled`, `_skill_loading_gate_enabled`, `_plan_edit_gate_enabled`, `_mcp_privacy_gate_enabled`, `_self_dm_gate_enabled`, `_orchestrator_bash_gate_enabled`
- Fail-CLOSED (`default=False`): `_dispatch_quote_gate_on_task_create_enabled`, `_orchestrator_boundary_agent_gate_enabled`

Behavior is unchanged — the public reader names are preserved (heavily referenced by tests via `monkeypatch.setattr` / `patch.object`); only the bodies now delegate. The `[loops]`-table readers and the int/string/list readers are out of scope (the issue targets `[teatree]` boolean flag readers).

## Tests (anti-vacuous)

New `tests/test_hook_router_teatree_bool_setting.py`:

- Helper semantics across missing/empty/broken config, bare vs quoted `true`/`false`, for both defaults.
- Per-reader behavior (defaults, bare-false/true flip, quoted-no-flip).
- A delegation suite that monkeypatches `_teatree_bool_setting` to return `not default` and asserts every reader's output flips — observable **only** if the reader routes through the helper.

RED confirmed before the fix: the suite failed with `AttributeError: module 'hooks.scripts.hook_router' has no attribute '_teatree_bool_setting'` (helper absent), and the delegation assertions cannot pass against the pre-fix inline readers (the patched helper is never called and the reader returns its real default). GREEN after: 45 new tests pass, plus 286 existing hook_router/reader tests stay green.

## Architecture pre-check — [#1694](https://github.com/souliane/teatree/issues/1694)

## 1. BLUEPRINT § alignment
Hooks-internal refactor of `hook_router.py`; no BLUEPRINT section changes. The hooks conventions (`hooks/CLAUDE.md`) describe these `[teatree] <flag>_enabled` kill-switches; semantics are preserved, so no doc drift.

## 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition touched.

## 3. Extension-point contracts
n/a — no `OverlayBase` hook, scanner registration, or `*Backend` Protocol touched. Internal hook helpers only.

## 4. Component boundaries
`hooks/scripts/` (Claude Code hook handlers). The helper is a module-private config reader living beside its consumers; no business logic added.

## 5. Dependency direction
No new imports across module boundaries; `tomllib` (stdlib) only, as before. `uv run tach check` passes.

## 6. Test surface
`tests/test_hook_router_teatree_bool_setting.py` — helper semantics + per-reader behavior + a delegation assertion per reader (the regression guard: flipping the helper flips the reader).

## 7. Resilience invariants
n/a — no external write. The readers are best-effort config reads that fail to their default on any error (unchanged).

## 8. Identity and key normalization
n/a — no identity with bare vs qualified forms.

## 9. Behavior preservation / capability deletion
Replaces existing reader bodies. Each reader's exact contract is preserved: fail-OPEN readers stay `value is not False`-equivalent (`default=True`), fail-CLOSED readers stay `value is True`-equivalent (`default=False`). No safety/privacy matcher narrowed; no must-block test inverted. The 286 existing reader tests remain green as the preservation proof.

Fixes [#1694](https://github.com/souliane/teatree/issues/1694).
