### PR TITLE
feat(run): add run lint subcommand for the worktree lint pipeline

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -205,7 +205,7 @@ An overlay is a downstream Django project that customizes teatree for a specific
 | `get_repos()` | `list[str]` | Repositories to provision |
 | `get_provision_steps(worktree)` | `list[ProvisionStep]` | Ordered setup steps |
 
-Optional hooks cover env, services, Docker base images, DB import strategy, post-DB steps, symlinks, PR validation, sync targets, skill metadata, CI config, E2E config, variant detection, tool subcommands, visual QA targets, E2E env extras + preflight, and the auto-merge guard (`can_auto_merge` → `MergeGuard`). All default to empty / permissive so existing overlays keep working — core enforcement only activates for overlays that opt in.
+Optional hooks cover env, services, Docker base images, DB import strategy, post-DB steps, symlinks, PR validation, sync targets, skill metadata, CI config, E2E config, variant detection, tool subcommands, visual QA targets, E2E env extras + preflight, the per-worktree task commands (`get_test_command` → `run tests`, `get_lint_command` → `run lint`), and the auto-merge guard (`can_auto_merge` → `MergeGuard`). All default to empty / permissive so existing overlays keep working — core enforcement only activates for overlays that opt in.
 
 **Overlay API version pin.** `teatree.__overlay_api_version__` is bumped on any breaking change to the overlay-facing API. Overlays assert this at import to fail loudly when teatree diverges from what they were built against.
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3954,6 +3954,7 @@ Usage: t3 teatree run [OPTIONS] COMMAND [ARGS]...
 │ frontend        Start the frontend dev server.                               │
 │ build-frontend  Build the frontend for production/testing.                   │
 │ tests           Run the project test suite.                                  │
+│ lint            Run the overlay's lint pipeline on this worktree.            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -4027,6 +4028,22 @@ Usage: t3 teatree run tests [OPTIONS]
 
  Extra arguments after ``--`` are appended to the test command
  (e.g. ``t3 <overlay> run tests -- path/to/test.py -k name``).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │
+│ --help              Show this message and exit.                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree run lint`
+
+```
+Usage: t3 teatree run lint [OPTIONS]
+
+ Run the overlay's lint pipeline on this worktree.
+
+ Extra arguments after ``--`` are appended to the lint command
+ (e.g. ``t3 <overlay> run lint -- --files src/foo.py``).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --path        TEXT  Worktree path (auto-detects from PWD if empty).          │

--- a/docs/overlay-api.md
+++ b/docs/overlay-api.md
@@ -150,6 +150,10 @@ Steps to run before starting a specific service (e.g., copy customer config, ref
 
 The command to run the project test suite. Used by `run tests`. Defaults to `[]`.
 
+#### `get_lint_command(worktree: Worktree) -> list[str] | RunCommand`
+
+The command to lint this worktree (usually the project's `prek`/`pre-commit` config). Used by `run lint`. Defaults to `[]`; when empty, `run lint` exits non-zero so a caller that asked to lint is not told green.
+
 #### `get_verify_endpoints(worktree: Worktree) -> dict[str, str]`
 
 Custom health-check URL paths per service. Keys match `worktree.ports` entries (e.g., `"backend"`, `"frontend"`). Values are URL paths (e.g., `"/admin/login/"`). Services not listed fall back to `/`. Defaults to `{}`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,6 +41,7 @@ the `args` parameter to `subprocess.run()` or `subprocess.Popen()`
 |---|---|---|
 | `OverlayBase.get_run_commands()` | `dict[str, list[str]]` | `run backend`, `run build-frontend`, `run tests`, `worktree start` |
 | `OverlayBase.get_test_command()` | `list[str]` | `run tests` |
+| `OverlayBase.get_lint_command()` | `list[str]` | `run lint` |
 | `OverlayBase.get_services_config()` | `dict[str, ServiceSpec]` | `run backend`, `worktree start` (reads `start_command`) |
 | `OverlayBase.get_provision_steps()` | `list[ProvisionStep]` | `worktree provision` (calls `step.callable()`) |
 | `OverlayBase.get_post_db_steps()` | `list[ProvisionStep]` | `worktree provision` |

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -77,6 +77,7 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("frontend", "Start the frontend dev server."),
             ("build-frontend", "Build the frontend for production/testing."),
             ("tests", "Run the project test suite."),
+            ("lint", "Run the overlay's lint pipeline on this worktree."),
         ],
     ),
     "e2e": DjangoGroup(

--- a/src/teatree/contrib/t3_teatree/overlay.py
+++ b/src/teatree/contrib/t3_teatree/overlay.py
@@ -12,7 +12,7 @@ from teatree.core.models import Worktree
 from teatree.core.overlay import OverlayBase, OverlayConfig, OverlayMetadata
 from teatree.core.worktree_env import compose_project
 from teatree.docker.reap import reap_compose_project
-from teatree.types import ProvisionStep, RunCommands, SkillMetadata
+from teatree.types import ProvisionStep, SkillMetadata
 from teatree.utils.run import run_checked
 from teatree.visual_qa import matches_triggers
 
@@ -156,15 +156,12 @@ class TeatreeOverlay(OverlayBase):
         ]
 
     @override
-    def get_run_commands(self, worktree: Worktree) -> RunCommands:
-        return {
-            "test": ["uv", "run", "pytest"],
-            "lint": ["prek", "run", "--all-files"],
-        }
-
-    @override
     def get_test_command(self, worktree: Worktree) -> list[str]:
         return ["uv", "run", "pytest"]
+
+    @override
+    def get_lint_command(self, worktree: Worktree) -> list[str]:
+        return ["prek", "run", "--all-files"]
 
     @override
     def get_visual_qa_targets(self, changed_files: list[str]) -> list[str]:

--- a/src/teatree/core/management/commands/run.py
+++ b/src/teatree/core/management/commands/run.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, cast
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from teatree.core.models import Worktree
+
 import typer
 from django_typer.management import TyperCommand, command
 
@@ -117,24 +119,69 @@ class Command(TyperCommand):
         """
         worktree = resolve_worktree(path)
         overlay = get_overlay()
-        test_cmd = overlay.get_test_command(worktree)
-        if not test_cmd:
-            self.stderr.write("No test command configured in the overlay.")
+        return self._dispatch_task(
+            worktree,
+            overlay.get_test_command(worktree),
+            extra_args=ctx.args,
+            label="Tests",
+            missing_message="No test command configured in the overlay.",
+        )
+
+    @command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})
+    def lint(
+        self,
+        ctx: typer.Context,
+        path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),
+    ) -> str:
+        """Run the overlay's lint pipeline on this worktree.
+
+        Extra arguments after ``--`` are appended to the lint command
+        (e.g. ``t3 <overlay> run lint -- --files src/foo.py``).
+        """
+        worktree = resolve_worktree(path)
+        overlay = get_overlay()
+        return self._dispatch_task(
+            worktree,
+            overlay.get_lint_command(worktree),
+            extra_args=ctx.args,
+            label="Lint",
+            missing_message="No lint command configured in the overlay.",
+        )
+
+    def _dispatch_task(
+        self,
+        worktree: "Worktree",
+        cmd: list[str] | RunCommand,
+        *,
+        extra_args: list[str],
+        label: str,
+        missing_message: str,
+    ) -> str:
+        """Stream a worktree task command, surfacing a non-zero exit as ``SystemExit(1)``.
+
+        Shared by ``run tests`` and ``run lint``: an overlay that cannot run
+        the task explicitly asked for must stop the caller (CI/loop), not
+        exit 0 (#932). The ``label`` names the task in the success/failure
+        message; ``missing_message`` is shown when the overlay declares no
+        command.
+        """
+        if not cmd:
+            self.stderr.write(missing_message)
             raise SystemExit(1)
 
-        if isinstance(test_cmd, RunCommand):
-            args = list(test_cmd.args)
-            cwd: Path | str | None = test_cmd.cwd
+        if isinstance(cmd, RunCommand):
+            args = list(cmd.args)
+            cwd: Path | str | None = cmd.cwd
         else:
-            args = list(test_cmd)
+            args = list(cmd)
             cwd = None
 
-        args.extend(ctx.args)
-        env = {**os.environ, **overlay.get_env_extra(worktree)}
+        args.extend(extra_args)
+        env = {**os.environ, **get_overlay().get_env_extra(worktree)}
         env.pop("VIRTUAL_ENV", None)
 
         rc = run_streamed(args, cwd=cwd, env=env, check=False)
         if rc != 0:
-            self.stderr.write(f"Tests failed (exit {rc}).")
+            self.stderr.write(f"{label} failed (exit {rc}).")
             raise SystemExit(1)
-        return "Tests completed."
+        return f"{label} completed."

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -506,6 +506,17 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
     def get_test_command(self, worktree: "Worktree") -> list[str] | RunCommand:
         return []
 
+    def get_lint_command(self, worktree: "Worktree") -> list[str] | RunCommand:
+        """Return the argv (or ``RunCommand``) that lints this worktree.
+
+        Backs ``t3 <overlay> run lint`` — the single entry point for "lint
+        this worktree", mirroring :meth:`get_test_command` for ``run tests``.
+        The default is empty; an overlay that has a lint pipeline (usually its
+        ``prek``/``pre-commit`` config) returns it here. When empty, ``run
+        lint`` exits non-zero so a caller that asked to lint is not told green.
+        """
+        return []
+
     def get_e2e_env_extras(self, env_cache: dict[str, str]) -> dict[str, str]:
         _ = env_cache
         return {}

--- a/tests/teatree_core/management_commands/_overlays.py
+++ b/tests/teatree_core/management_commands/_overlays.py
@@ -112,6 +112,9 @@ class FullOverlay(OverlayBase):
     def get_test_command(self, worktree: Worktree) -> list[str]:
         return ["echo", "tests", worktree.repo_path]
 
+    def get_lint_command(self, worktree: Worktree) -> list[str]:
+        return ["echo", "lint", worktree.repo_path]
+
     def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy:
         return {"kind": "test", "source_database": "test_db"}
 

--- a/tests/teatree_core/management_commands/test_run.py
+++ b/tests/teatree_core/management_commands/test_run.py
@@ -227,6 +227,82 @@ class TestRunTestsFailureExitCode(TestCase):
             assert exc_info.value.code == 1
 
 
+class TestRunLint(TestCase):
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_calls_overlay_lint_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test")
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/backend",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+            )
+
+            mock_run = _popen_mock()
+            with patch.object(utils_run_mod, "Popen", mock_run):
+                result = cast("str", call_command("run", "lint", path=str(wt_dir)))
+
+            mock_run.assert_called_once()
+            assert "completed" in result.lower()
+
+    @_patch_overlays(MINIMAL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_no_command_raises_system_exit(self) -> None:
+        """`run lint` with no configured lint command is a genuine failure.
+
+        The caller explicitly asked to lint; an overlay that cannot lint must
+        stop the caller (CI/loop), not exit 0.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test")
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/backend",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+            )
+
+            with pytest.raises(SystemExit) as exc_info:
+                call_command("run", "lint", path=str(wt_dir))
+
+            assert exc_info.value.code == 1
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_failing_lint_raises_system_exit_1(self) -> None:
+        """A non-zero lint exit must surface as SystemExit(1) so CI/loop sees red."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            wt_dir = tmp_path / "backend"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test")
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/backend",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+            )
+
+            with (
+                patch.object(utils_run_mod, "Popen", _popen_mock(returncode=1)),
+                pytest.raises(SystemExit) as exc_info,
+            ):
+                call_command("run", "lint", path=str(wt_dir))
+
+            assert exc_info.value.code == 1
+
+
 class TestRunVerify(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/test_contrib_overlay.py
+++ b/tests/test_contrib_overlay.py
@@ -402,26 +402,20 @@ class TestInstallOverlaysEditableStep:
         mock_run.assert_not_called()
 
 
-class TestGetRunCommands(TestCase):
-    def test_returns_test_and_lint(self) -> None:
-        ticket = Ticket.objects.create(overlay="t3-teatree")
-        worktree = Worktree.objects.create(ticket=ticket, overlay="t3-teatree", repo_path="/tmp/teatree", branch="main")
-        overlay = TeatreeOverlay()
-        commands = overlay.get_run_commands(worktree)
-
-        assert "test" in commands
-        assert "lint" in commands
-        test_cmd = commands["test"]
-        assert isinstance(test_cmd, list)
-        assert "pytest" in test_cmd[-1]
-
-
 class TestGetTestCommand(TestCase):
     def test_returns_pytest_command(self) -> None:
         ticket = Ticket.objects.create(overlay="t3-teatree")
         worktree = Worktree.objects.create(ticket=ticket, overlay="t3-teatree", repo_path="/tmp/teatree", branch="main")
         overlay = TeatreeOverlay()
         assert overlay.get_test_command(worktree) == ["uv", "run", "pytest"]
+
+
+class TestGetLintCommand(TestCase):
+    def test_returns_prek_command(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree")
+        worktree = Worktree.objects.create(ticket=ticket, overlay="t3-teatree", repo_path="/tmp/teatree", branch="main")
+        overlay = TeatreeOverlay()
+        assert overlay.get_lint_command(worktree) == ["prek", "run", "--all-files"]
 
 
 class TestReapWorktreeExternalResources(TestCase):

--- a/tests/test_overlay_base.py
+++ b/tests/test_overlay_base.py
@@ -84,6 +84,11 @@ def test_get_test_command_returns_empty_list():
     assert overlay.get_test_command(_make_worktree()) == []
 
 
+def test_get_lint_command_returns_empty_list():
+    overlay = _MinimalOverlay()
+    assert overlay.get_lint_command(_make_worktree()) == []
+
+
 def test_get_e2e_preflight_returns_empty_list_by_default():
     overlay = _MinimalOverlay()
     assert overlay.get_e2e_preflight(customer="acme", base_url="https://dev.example.com") == []


### PR DESCRIPTION
## What

Add a `run lint` subcommand so `t3 <overlay> run lint` runs the overlay's lint pipeline on the current worktree, closing the gap where `run` exposed `backend` / `build-frontend` / `tests` but not `lint`. Previously linting was only reachable by invoking pre-commit directly.

## How

- New `OverlayBase.get_lint_command(worktree) -> list[str] | RunCommand` hook, mirroring `get_test_command` (default `[]`).
- New `run lint` subcommand in the `run` management command; a non-zero lint exit surfaces as `SystemExit(1)` so CI/loop never sees green on a failing lint (same contract as `run tests`, [#932](https://github.com/souliane/teatree/issues/932)).
- The shared argv/cwd/env/exit-code dispatch for `run tests` and `run lint` is factored into one private helper.
- The teatree overlay's lint pipeline moves from a vestigial (never-executed) `get_run_commands` entry to the dedicated `get_lint_command()` hook — one source of truth.
- `run lint` registered in the `DjangoGroup` table; CLI reference, `docs/overlay-api.md`, `docs/security.md`, and BLUEPRINT § 6 updated to match.

## Architecture pre-check — [#1379](https://github.com/souliane/teatree/issues/1379)

### 1. BLUEPRINT § alignment
§ 6 (Overlay System) — the optional-hooks prose now names the per-worktree task commands (`get_test_command` → `run tests`, `get_lint_command` → `run lint`).

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
Adds `OverlayBase.get_lint_command` (default `[]`, no overlay forced to act). Registered overlay updated: `t3_teatree` returns `["prek", "run", "--all-files"]`. No other registered overlay needs a non-default.

### 4. Component boundaries
`run lint` lives in `core/management/commands/run.py` (CLI coordination); the hook on `core/overlay.py` (the ABC); the declarative wiring in `cli/django_groups.py`. No business logic added to the CLI layer.

### 5. Dependency direction
No new imports across module boundaries (`Worktree` added under `TYPE_CHECKING` only). `tach` / `import-linter` green.

### 6. Test surface
- `test_run.py::TestRunLint` — `run lint` dispatches to the configured command (mock subprocess), exits 1 when no command is configured, and exits 1 on a failing lint.
- `test_overlay_base.py::test_get_lint_command_returns_empty_list` — default hook contract.
- `test_contrib_overlay.py::TestGetLintCommand` — teatree overlay returns the prek pipeline.

### 7. Resilience invariants
n/a — no external write; the command only streams a local subprocess.

### 8. Identity and key normalization
n/a — no identity keys.

### 9. Behavior preservation / capability deletion
Removed the `"test"` / `"lint"` keys from the teatree overlay's `get_run_commands` — those entries were never executed by any `run` subcommand (the lint key was the [#1379](https://github.com/souliane/teatree/issues/1379) bug: declared but unreachable). Test behavior is preserved via the dedicated `get_test_command` hook; lint behavior is now actually reachable via `get_lint_command`. No safety/privacy matcher narrowed; no must-block test inverted.

## Test evidence (anti-vacuous)

The regression test was observed RED on the unfixed tree: `run lint` raised `CommandError: No such command 'lint'` — the exact issue symptom — because the subcommand did not exist. After the fix the three `TestRunLint` cases pass. Full affected surface: 100 passed, 2 skipped.

Fixes [#1379](https://github.com/souliane/teatree/issues/1379)
