### PR TITLE
fix(doctor): detect + clean an empty uv-built .venv in a Pipfile-managed clone (#2005)

### DIFF
--- a/src/teatree/cli/_doctor_checks.py
+++ b/src/teatree/cli/_doctor_checks.py
@@ -133,6 +133,43 @@ def _check_account_switch() -> bool:
     return False
 
 
+def _check_stale_uv_venv() -> bool:
+    """Detect + clean an empty uv-built ``.venv`` in a Pipfile-managed clone (#2005).
+
+    A clone carrying a ``Pipfile`` that also holds an in-project ``.venv`` built
+    by uv with nothing installed is a wrong-toolchain artifact — it shadows
+    pipenv's managed venvs and poisons both ``uv run`` and ``pipenv run``. Walks
+    every repo the other repo-scoped doctor gates audit (:func:`_collect_repos`),
+    removes each offending ``.venv``, and WARNs. Removal makes the next run a
+    no-op (idempotent). Crash-proof: any error degrades to a WARN so the doctor
+    run never aborts on this check.
+    """
+    import shutil  # noqa: PLC0415
+
+    from teatree.cli.update import _collect_repos  # noqa: PLC0415
+    from teatree.utils.venv_artifacts import find_stale_uv_venv  # noqa: PLC0415
+
+    ok = True
+    for _name, repo in _collect_repos():
+        try:
+            stale = find_stale_uv_venv(repo)
+            if stale is None:
+                continue
+            shutil.rmtree(stale)
+            typer.echo(
+                f"WARN  Removed empty uv-built .venv shadowing pipenv in {repo} ({stale.name}). "
+                "It poisoned both `uv run` and `pipenv run`; pipenv will rebuild its own venv."
+            )
+            ok = False
+        except OSError as exc:
+            typer.echo(
+                f"WARN  Could not remove empty uv-built .venv in {repo}: {exc}. "
+                "Delete it manually (`rm -rf .venv`), then re-run `t3 doctor check`."
+            )
+            ok = False
+    return ok
+
+
 def _check_legacy_overlay_alias() -> None:
     """Warn (never rewrite) on a stale legacy ``[overlays.<alias>]`` table.
 

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -27,6 +27,7 @@ from teatree.cli._doctor_checks import (
     _check_single_db,
     _check_singletons,
     _check_skills,
+    _check_stale_uv_venv,
 )
 from teatree.cli._doctor_plugin_repair import (
     _do_ensure_plugin_registered,
@@ -65,6 +66,7 @@ __all__ = (
     "_check_single_db",
     "_check_singletons",
     "_check_skills",
+    "_check_stale_uv_venv",
     "_do_ensure_plugin_registered",
     "_ensure_plugin_registered",
     "_find_host_project_root",
@@ -523,6 +525,7 @@ def check() -> bool:
     ok = _check_editable_sanity() and ok
     ok = _check_skills() and ok
     ok = _check_single_db() and ok
+    ok = _check_stale_uv_venv() and ok
 
     # ``check`` is a plain Typer command in the Django-free CLI group, so
     # Django is not configured by the time the self-DB schema guard runs.

--- a/src/teatree/utils/venv_artifacts.py
+++ b/src/teatree/utils/venv_artifacts.py
@@ -1,0 +1,59 @@
+"""Detect wrong-toolchain in-project virtualenv artifacts.
+
+A clone managed by pipenv (it carries a ``Pipfile``) that also holds an
+in-project ``.venv`` built by uv with nothing installed is a wrong-toolchain
+artifact: it shadows pipenv's managed venvs and poisons both ``uv run`` and
+``pipenv run`` (souliane/teatree#2005). The pipenv-vs-uv runner selection lives
+in :mod:`teatree.utils.django_db`; this module owns the orthogonal concern of
+spotting the residual empty uv venv so provision/doctor can clean it.
+"""
+
+from pathlib import Path
+
+#: Files uv/virtualenv drop into a freshly-built venv before any dependency is
+#: installed. A site-packages holding only these (no ``*.dist-info`` /
+#: ``*.egg-info`` and no real package) is an empty venv with nothing installed.
+_BOOTSTRAP_VENV_FILES = frozenset({"_virtualenv.pth", "_virtualenv.py", "__pycache__", "pip", "pip.dist-info"})
+
+
+def find_stale_uv_venv(repo: Path) -> Path | None:
+    """Return *repo*'s in-project ``.venv`` iff it is a stale uv-built empty one.
+
+    A clone carrying a ``Pipfile`` (pipenv-managed) that also has an in-project
+    ``.venv`` whose ``pyvenv.cfg`` was written by uv (a ``uv = ...`` line) and
+    which has no dependency installed is the wrong-toolchain artifact described
+    in the module docstring. Returns the offending ``.venv`` path so the caller
+    can warn or remove it; ``None`` when the repo is not pipenv-managed, has no
+    ``.venv``, the venv was not uv-built, or the venv actually has packages
+    installed.
+    """
+    if not (repo / "Pipfile").is_file():
+        return None
+    venv = repo / ".venv"
+    cfg = venv / "pyvenv.cfg"
+    if not cfg.is_file():
+        return None
+    try:
+        if not any(line.lstrip().startswith("uv ") for line in cfg.read_text(encoding="utf-8").splitlines()):
+            return None
+    except OSError:
+        return None
+    if _venv_has_packages(venv):
+        return None
+    return venv
+
+
+def _venv_has_packages(venv: Path) -> bool:
+    """True iff *venv*'s site-packages holds an installed distribution.
+
+    Walks every ``site-packages`` under the venv (``lib/python*/site-packages``
+    on POSIX, ``Lib/site-packages`` on Windows) and reports whether any entry
+    beyond the bootstrap files (:data:`_BOOTSTRAP_VENV_FILES`) is present — a
+    real package directory, module, or ``*.dist-info`` / ``*.egg-info``.
+    """
+    return any(
+        entry.name not in _BOOTSTRAP_VENV_FILES
+        for site in venv.glob("**/site-packages")
+        if site.is_dir()
+        for entry in site.iterdir()
+    )

--- a/tests/teatree_cli/test_stale_uv_venv_check.py
+++ b/tests/teatree_cli/test_stale_uv_venv_check.py
@@ -1,0 +1,72 @@
+"""``_check_stale_uv_venv`` — the `t3 doctor` empty-uv-venv gate (#2005).
+
+End-to-end against a real on-disk repo under ``tmp_path``: the check walks
+``_collect_repos()``, detects an empty uv-built ``.venv`` in a Pipfile-managed
+clone, removes it, and WARNs. A clean repo (no Pipfile, populated venv, or
+pipenv-built venv) is silent.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from teatree.cli._doctor_checks import _check_stale_uv_venv
+
+
+def _pipfile_repo(root: Path, name: str) -> Path:
+    repo = root / name
+    (repo).mkdir()
+    (repo / "Pipfile").write_text("[packages]\n", encoding="utf-8")
+    return repo
+
+
+def _uv_venv(repo: Path, *, packages: tuple[str, ...] = ()) -> Path:
+    venv = repo / ".venv"
+    site = venv / "lib" / "python3.13" / "site-packages"
+    site.mkdir(parents=True)
+    (venv / "pyvenv.cfg").write_text("home = /usr/bin\nuv = 0.9.24\n", encoding="utf-8")
+    (site / "_virtualenv.pth").write_text("import _virtualenv\n", encoding="utf-8")
+    for pkg in packages:
+        (site / f"{pkg}.dist-info").mkdir()
+    return venv
+
+
+class TestStaleUvVenvDoctorCheck:
+    def test_removes_empty_uv_venv_and_warns(self, tmp_path, capsys):
+        repo = _pipfile_repo(tmp_path, "clone")
+        venv = _uv_venv(repo)
+        with patch("teatree.cli.update._collect_repos", return_value=[("clone", repo)]):
+            assert _check_stale_uv_venv() is False
+        out = capsys.readouterr().out
+        assert "WARN" in out
+        assert str(repo) in out
+        assert not venv.exists()
+
+    def test_populated_uv_venv_is_silent_and_kept(self, tmp_path, capsys):
+        repo = _pipfile_repo(tmp_path, "clone")
+        venv = _uv_venv(repo, packages=("django",))
+        with patch("teatree.cli.update._collect_repos", return_value=[("clone", repo)]):
+            assert _check_stale_uv_venv() is True
+        assert capsys.readouterr().out == ""
+        assert venv.exists()
+
+    def test_uv_managed_repo_without_pipfile_is_silent(self, tmp_path, capsys):
+        repo = tmp_path / "uv-clone"
+        repo.mkdir()
+        venv = _uv_venv(repo)
+        with patch("teatree.cli.update._collect_repos", return_value=[("uv-clone", repo)]):
+            assert _check_stale_uv_venv() is True
+        assert capsys.readouterr().out == ""
+        assert venv.exists()
+
+    def test_removal_failure_degrades_to_warn(self, tmp_path, capsys):
+        repo = _pipfile_repo(tmp_path, "clone")
+        venv = _uv_venv(repo)
+        with (
+            patch("teatree.cli.update._collect_repos", return_value=[("clone", repo)]),
+            patch("shutil.rmtree", side_effect=OSError("permission denied")),
+        ):
+            assert _check_stale_uv_venv() is False
+        out = capsys.readouterr().out
+        assert "WARN" in out
+        assert "manually" in out
+        assert venv.exists()

--- a/tests/teatree_utils/test_venv_artifacts.py
+++ b/tests/teatree_utils/test_venv_artifacts.py
@@ -1,0 +1,72 @@
+"""``teatree.utils.venv_artifacts.find_stale_uv_venv`` (souliane/teatree#2005)."""
+
+from pathlib import Path
+
+import pytest
+
+from teatree.utils.venv_artifacts import find_stale_uv_venv
+
+
+def _make_venv(repo: Path, *, uv_built: bool, packages: tuple[str, ...] = ()) -> Path:
+    """Build a fake in-project ``.venv`` mirroring uv/virtualenv layout.
+
+    *uv_built* writes the ``uv =`` marker line into ``pyvenv.cfg`` that uv (and
+    not pipenv/virtualenv) emits. *packages* names installed distributions; an
+    empty tuple leaves only the ``_virtualenv.pth`` bootstrap file uv drops into
+    a freshly-built, dependency-free venv.
+    """
+    venv = repo / ".venv"
+    site = venv / "lib" / "python3.13" / "site-packages"
+    site.mkdir(parents=True)
+    cfg = "home = /usr/bin\nversion_info = 3.13.0\n"
+    if uv_built:
+        cfg += "uv = 0.9.24\n"
+    (venv / "pyvenv.cfg").write_text(cfg, encoding="utf-8")
+    (site / "_virtualenv.pth").write_text("import _virtualenv\n", encoding="utf-8")
+    (site / "_virtualenv.py").write_text("# virtualenv bootstrap\n", encoding="utf-8")
+    for pkg in packages:
+        (site / f"{pkg}.dist-info").mkdir()
+    return venv
+
+
+class TestFindStaleUvVenv:
+    def test_flags_empty_uv_venv_in_pipfile_repo(self, tmp_path: Path) -> None:
+        (tmp_path / "Pipfile").write_text("[packages]\n", encoding="utf-8")
+        venv = _make_venv(tmp_path, uv_built=True)
+        assert find_stale_uv_venv(tmp_path) == venv
+
+    def test_ignores_populated_uv_venv(self, tmp_path: Path) -> None:
+        (tmp_path / "Pipfile").write_text("[packages]\n", encoding="utf-8")
+        _make_venv(tmp_path, uv_built=True, packages=("django",))
+        assert find_stale_uv_venv(tmp_path) is None
+
+    def test_ignores_pipenv_built_venv(self, tmp_path: Path) -> None:
+        (tmp_path / "Pipfile").write_text("[packages]\n", encoding="utf-8")
+        _make_venv(tmp_path, uv_built=False)
+        assert find_stale_uv_venv(tmp_path) is None
+
+    def test_ignores_uv_managed_repo_without_pipfile(self, tmp_path: Path) -> None:
+        _make_venv(tmp_path, uv_built=True)
+        assert find_stale_uv_venv(tmp_path) is None
+
+    def test_returns_none_without_venv(self, tmp_path: Path) -> None:
+        (tmp_path / "Pipfile").write_text("[packages]\n", encoding="utf-8")
+        assert find_stale_uv_venv(tmp_path) is None
+
+    def test_non_dir_site_packages_match_is_skipped(self, tmp_path: Path) -> None:
+        """A stray file named ``site-packages`` is not iterated (kept empty)."""
+        (tmp_path / "Pipfile").write_text("[packages]\n", encoding="utf-8")
+        venv = _make_venv(tmp_path, uv_built=True)
+        (venv / "site-packages").write_text("not a directory\n", encoding="utf-8")
+        assert find_stale_uv_venv(tmp_path) == venv
+
+    def test_unreadable_pyvenv_cfg_is_ignored(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "Pipfile").write_text("[packages]\n", encoding="utf-8")
+        venv = _make_venv(tmp_path, uv_built=True)
+
+        def _boom(*_args: object, **_kwargs: object) -> str:
+            raise OSError
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        assert find_stale_uv_venv(tmp_path) is None
+        assert venv.exists()


### PR DESCRIPTION
## What

Adds a provision/doctor health check that detects and cleans an empty uv-built
`.venv` in a Pipfile-managed clone. Closes #2005.

A clone carrying a `Pipfile` that also holds an in-project `.venv` built by uv
with nothing installed is a wrong-toolchain artifact: it shadows pipenv's
managed venvs and breaks both `uv run` and `pipenv run`. PRs #1976/#1978
stopped core from re-creating it, but nothing guarded or removed an existing
one.

## How

- New focused module `src/teatree/utils/venv_artifacts.py` —
  `find_stale_uv_venv(repo)` returns the offending `.venv` when the repo has a
  `Pipfile`, its `.venv/pyvenv.cfg` carries a `uv = ...` line, and its
  site-packages holds only the uv/virtualenv bootstrap files (no `*.dist-info`
  / `*.egg-info` and no real package). It sits next to (not inside)
  `utils/django_db.py`, which already owns the pipenv-vs-uv runner selection —
  detecting the residual empty venv is the orthogonal concern, and
  `django_db.py` is at its module-health LOC cap.
- New doctor gate `_check_stale_uv_venv` in `cli/_doctor_checks.py`, wired into
  `cli/doctor.check()`. It walks every repo the other repo-scoped checks audit
  (`_collect_repos`), removes each offending venv, and warns. Removal makes the
  next run a no-op (idempotent); any `OSError` degrades to a warning so the
  doctor run never aborts.

## Tests

- `tests/utils/test_venv_artifacts.py` — pure detection: flags an empty uv
  venv in a Pipfile repo; ignores a populated uv venv, a pipenv-built venv, a
  uv-managed repo without a Pipfile, a repo with no venv, a non-dir
  `site-packages` glob match, and an unreadable `pyvenv.cfg`.
- `tests/cli_doctor/test_stale_uv_venv_check.py` — end-to-end against a real
  on-disk repo: removes the empty venv and warns; keeps a populated venv
  silently; silent on a non-Pipfile repo; degrades to a warning when removal
  fails.
- Anti-vacuous: stubbing `find_stale_uv_venv` to always return `None` turns the
  flag/removal tests RED (confirmed before the fix); 100% coverage on the new
  module and the new check.

## Architecture pre-check — #2005

### 1. BLUEPRINT § alignment
Doctor/provision health checks (`t3 doctor check`). BLUEPRINT does not
enumerate the individual `_check_*` helpers, so no section needs editing; this
adds one internal check to the existing aggregation. No new endpoint/model/
command/config.

### 2. FSM phase boundaries
n/a — no Ticket/Worktree state transition.

### 3. Extension-point contracts
n/a — no OverlayBase / scanner / hook / Protocol surface. The check iterates
`_collect_repos()`, the same enumeration the schema-guard and clone-currency
checks use.

### 4. Component boundaries
Detection → `utils/venv_artifacts.py` (a focused new module, distinct concern
from the DB import engine and below the LOC cap). Doctor wiring + cleanup →
`cli/_doctor_checks.py` where every other `_check_*` helper lives.

### 5. Dependency direction
`cli/_doctor_checks` → `utils.venv_artifacts` is a downward cli → utils edge.
`venv_artifacts` is pure-stdlib (Path I/O only). `uv run tach check` passes.

### 6. Test surface
Listed under Tests above — one assertion per behaviour, plus the anti-vacuous
RED confirmation.

### 7. Resilience invariants
Single external effect = `shutil.rmtree` of the offending `.venv`. Idempotent
(re-run finds no venv → no-op). Crash-proof: `OSError` degrades to a warning,
never aborts the doctor run. No network/Slack/DB write.

### 8. Identity and key normalization
n/a — repo paths are resolved absolute; no bare-vs-qualified identity.

### 9. Behavior preservation / capability deletion
Purely additive — one new detection function, one new doctor check. No existing
implementation replaced, no matcher narrowed, no must-block test inverted.

## Open questions & assumptions

- The empty-venv signature is "site-packages has no entry beyond the
  uv/virtualenv bootstrap files". A populated venv (any dist-info or package)
  is kept untouched.
- The gate auto-removes rather than only warning, which the issue permits as
  one of its two remediation options; removal is safe because pipenv rebuilds
  its own venv on the next run.
