### PR TITLE
fix(cleanup): prune worktrees whose HEAD is squash-merged but remote ref deleted (https://github.com/souliane/teatree/issues/2205)

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -195,28 +195,65 @@ def _raise_if_genuinely_ahead(repo_main: str, worktree: Worktree, target: _Effec
     raise RuntimeError(msg)
 
 
-def _ref_tree_captured_by_default(repo: str, ref: str) -> bool:
-    """Return ``True`` when ``ref``'s tree is already captured on ``origin/<default>``.
+def _remote_tracking_ref_exists(repo: str, branch: str) -> bool:
+    """Whether ``refs/remotes/origin/<branch>`` is present in ``repo``.
 
-    Fallback for the data-loss guard (#2205): after a squash-merge and
-    ``fetch --prune``, the source branch's remote tracking ref is gone so
-    ``commits_absent_from_all_remotes`` (``--not --remotes``) returns non-empty
-    even though the content shipped.  A regular ancestry check
-    (``merge-base --is-ancestor``) also returns False because a squash-merge
-    creates a new SHA with a different parent chain.  The deterministic signal
-    is the tree: a squash-merge copies the source tree verbatim, so
-    ``git diff --quiet ref origin/<default>`` exits 0 when the content is
-    already there.
+    A forge squash-merge deletes the source ref remotely but leaves a STALE local
+    tracking ref until ``fetch --prune`` removes it, so sampling this BEFORE the
+    fetch is the forge-CLI-free proof the branch was once pushed (#2205).
+    """
+    return git.check(repo=repo, args=["show-ref", "--verify", "--quiet", f"refs/remotes/origin/{branch}"])
+
+
+def _ref_tree_matches_default(repo: str, ref: str) -> bool:
+    """Return ``True`` when ``ref``'s tree is identical to ``origin/<default>``.
+
+    A squash-merge copies the source tree verbatim onto the default branch, so
+    ``git diff --quiet ref origin/<default>`` exits 0 when the content is already
+    there. This is a NECESSARY but NOT SUFFICIENT signal for "safe to delete":
+    a never-pushed local-only branch whose work was fully reverted in a later
+    commit has the same matching tree yet exists on no remote, so deleting it
+    would destroy the only copy. Tree equality must therefore be confirmed only
+    in conjunction with positive merged-evidence — see
+    :func:`_ref_captured_by_merge`.
 
     **Fails open.** Any error (invalid ``ref``, missing ``origin/<default>``,
-    corrupt repo) returns ``False`` so callers keep the fail-closed posture of
-    the data-loss guard: "we couldn't confirm it's merged" → keep the branch.
+    corrupt repo) returns ``False`` so the merged-evidence gate above it keeps
+    the fail-closed posture of the data-loss guard.
     """
     try:
         remote_default = f"origin/{git.default_branch(repo)}"
     except RuntimeError:
         return False
     return git.check(repo=repo, args=["diff", "--quiet", ref, remote_default])
+
+
+def _ref_captured_by_merge(repo: str, ref: str, branch: str | None, *, remote_ref_was_present: bool) -> bool:
+    """Whether ``ref`` is safe to delete because its work was MERGED (#2205, data-loss fix).
+
+    After a squash-merge the source branch's commits are absent from every
+    remote (the squash is a new SHA; the source ref was deleted), so
+    ``commits_absent_from_all_remotes`` reports the branch as "on NO remote"
+    even though the content shipped. Distinguishing that safe case from a
+    genuinely local-only branch (never pushed anywhere) requires POSITIVE
+    evidence the work was integrated — tree equality alone is a false positive,
+    because a fully-reverted local branch has the same matching tree.
+
+    Two positive merged signals are accepted, either of which AND a matching tree
+    permits deletion. ``remote_ref_was_present`` means the local
+    ``refs/remotes/origin/<branch>`` tracking ref existed before this run's
+    fetch/prune: a forge squash-merge deletes the source ref remotely but leaves a
+    stale tracking ref locally until the prune, so its prior presence proves the
+    branch was once pushed (the squash-merge scenario), which a never-pushed branch
+    never produces. :func:`_branch_pr_is_merged` is the forge's canonical report
+    that the branch's PR/MR merged.
+
+    With NO merged-evidence the branch is kept regardless of tree equality: a
+    local-only branch whose tree matches the default branch must never be deleted.
+    """
+    if not (remote_ref_was_present or (branch is not None and _branch_pr_is_merged(repo, branch))):
+        return False
+    return _ref_tree_matches_default(repo, ref)
 
 
 def _raise_if_unpushed(repo_main: str, worktree: Worktree, target: _EffectiveTarget) -> None:
@@ -245,13 +282,20 @@ def _raise_if_unpushed(repo_main: str, worktree: Worktree, target: _EffectiveTar
     we translate that into a refusal rather than proceeding, because an
     inconclusive probe means we cannot prove the commits are pushed.
 
-    **Canonical merged override (#1578).** A squash-merge creates a new SHA on
-    the default branch and deletes the source ref, so the branch's own commits
-    are absent from every remote even though the work shipped. Before refusing,
-    the forge is asked (by the named branch) whether its PR is merged; a positive
-    answer is the ground truth that the content is safe on the default branch, so
-    teardown proceeds. The check fails safe to skip — only a positive merged
-    signal overrides; any uncertainty keeps the refusal.
+    **Merged override (#1578 / #2205).** A squash-merge creates a new SHA on the
+    default branch and deletes the source ref, so the branch's own commits are
+    absent from every remote even though the work shipped. Before refusing, two
+    positive merged signals are consulted via :func:`_ref_captured_by_merge`: the
+    forge is asked (by the named branch) whether its PR is merged, and the local
+    ``origin/<branch>`` tracking ref's presence is sampled BEFORE the fetch (a
+    forge squash-merge leaves a stale tracking ref locally until the fetch prunes
+    it). Either signal AND a matching tree lets teardown proceed.
+
+    **Data-loss safety (#2205).** Tree equality is NEVER a standalone override: a
+    never-pushed local-only branch whose work was reverted has the same matching
+    tree, so without one of the positive merged signals the branch is kept. The
+    check fails safe to skip — only positive merged-evidence overrides; any
+    uncertainty keeps the refusal.
     """
     try:
         unpushed = git.commits_absent_from_all_remotes(target.probe_repo, target.ref)
@@ -264,20 +308,18 @@ def _raise_if_unpushed(repo_main: str, worktree: Worktree, target: _EffectiveTar
         raise RuntimeError(msg) from exc
     if not unpushed:
         return
-    # #2205 — squash-merge + remote-ref-deleted fallback. After a squash-merge
-    # and ``fetch --prune``, the source branch's remote tracking ref is gone so
-    # ``--not --remotes`` reports the branch commits as absent from all remotes,
-    # even though the content is captured on ``origin/<default>`` under a new
-    # squash SHA. A forge-CLI check (``_branch_pr_is_merged``) is the canonical
-    # signal but requires ``gh``/``glab`` in PATH — absent in CI/sandbox. An
-    # ancestry check is the deterministic fallback: if ``ref``'s tip is reachable
-    # from the fetched ``origin/<default>`` the content is already there and
-    # teardown is safe.  We fetch first so the ancestry check reflects the current
-    # remote state, not a stale local mirror.
+    # Sample the stale tracking ref BEFORE the fetch prunes it; fetch after so the
+    # tree comparison reflects the current remote, not a stale local mirror.
+    remote_ref_was_present = target.branch_to_delete is not None and _remote_tracking_ref_exists(
+        repo_main, target.branch_to_delete
+    )
     git.fetch(repo_main, "origin")
-    if _ref_tree_captured_by_default(target.probe_repo, target.ref):
-        return
-    if target.branch_to_delete is not None and _branch_pr_is_merged(repo_main, target.branch_to_delete):
+    if _ref_captured_by_merge(
+        target.probe_repo,
+        target.ref,
+        target.branch_to_delete,
+        remote_ref_was_present=remote_ref_was_present,
+    ):
         return
     preview = unpushed[:_SUBJECT_PREVIEW_LIMIT]
     shas = ", ".join(preview)

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -195,6 +195,30 @@ def _raise_if_genuinely_ahead(repo_main: str, worktree: Worktree, target: _Effec
     raise RuntimeError(msg)
 
 
+def _ref_tree_captured_by_default(repo: str, ref: str) -> bool:
+    """Return ``True`` when ``ref``'s tree is already captured on ``origin/<default>``.
+
+    Fallback for the data-loss guard (#2205): after a squash-merge and
+    ``fetch --prune``, the source branch's remote tracking ref is gone so
+    ``commits_absent_from_all_remotes`` (``--not --remotes``) returns non-empty
+    even though the content shipped.  A regular ancestry check
+    (``merge-base --is-ancestor``) also returns False because a squash-merge
+    creates a new SHA with a different parent chain.  The deterministic signal
+    is the tree: a squash-merge copies the source tree verbatim, so
+    ``git diff --quiet ref origin/<default>`` exits 0 when the content is
+    already there.
+
+    **Fails open.** Any error (invalid ``ref``, missing ``origin/<default>``,
+    corrupt repo) returns ``False`` so callers keep the fail-closed posture of
+    the data-loss guard: "we couldn't confirm it's merged" → keep the branch.
+    """
+    try:
+        remote_default = f"origin/{git.default_branch(repo)}"
+    except RuntimeError:
+        return False
+    return git.check(repo=repo, args=["diff", "--quiet", ref, remote_default])
+
+
 def _raise_if_unpushed(repo_main: str, worktree: Worktree, target: _EffectiveTarget) -> None:
     """Raise ``RuntimeError`` when the worktree's tip has commits on NO remote ref (#706).
 
@@ -239,6 +263,19 @@ def _raise_if_unpushed(repo_main: str, worktree: Worktree, target: _EffectiveTar
         )
         raise RuntimeError(msg) from exc
     if not unpushed:
+        return
+    # #2205 — squash-merge + remote-ref-deleted fallback. After a squash-merge
+    # and ``fetch --prune``, the source branch's remote tracking ref is gone so
+    # ``--not --remotes`` reports the branch commits as absent from all remotes,
+    # even though the content is captured on ``origin/<default>`` under a new
+    # squash SHA. A forge-CLI check (``_branch_pr_is_merged``) is the canonical
+    # signal but requires ``gh``/``glab`` in PATH — absent in CI/sandbox. An
+    # ancestry check is the deterministic fallback: if ``ref``'s tip is reachable
+    # from the fetched ``origin/<default>`` the content is already there and
+    # teardown is safe.  We fetch first so the ancestry check reflects the current
+    # remote state, not a stale local mirror.
+    git.fetch(repo_main, "origin")
+    if _ref_tree_captured_by_default(target.probe_repo, target.ref):
         return
     if target.branch_to_delete is not None and _branch_pr_is_merged(repo_main, target.branch_to_delete):
         return

--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -13,7 +13,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from teatree.config import get_effective_settings
-from teatree.core.cleanup import _branch_tree_matches_squash, _ref_tree_captured_by_default, cleanup_worktree
+from teatree.core.cleanup import (
+    _branch_tree_matches_squash,
+    _ref_captured_by_merge,
+    _remote_tracking_ref_exists,
+    cleanup_worktree,
+)
 from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Worktree
 from teatree.core.worktree_env import CACHE_DIRNAME, CACHE_FILENAME, write_env_cache
@@ -98,26 +103,32 @@ def is_squash_merged(repo: str, branch: str, default: str) -> bool:
     return not diff
 
 
-def _refuse_if_unpushed(repo: str, name: str) -> str:
-    """Return a refusal message when ``name`` has commits absent from all remotes (#706).
+def _refuse_if_unpushed(repo: str, name: str, *, remote_ref_was_present: bool) -> str:
+    """Return a refusal message when branch ``name`` has commits absent from all remotes (#706).
 
-    Defense-in-depth for #710. ``_prune_squash_merged`` deletes a branch and its
-    worktree directly via ``git.worktree_remove`` / ``git.branch_delete``,
-    bypassing the guarded teardown seam (``cleanup._raise_if_unpushed``) that
-    every ``Worktree``-row-driven caller funnels through. That seam needs a
-    ``Worktree`` instance this name-only path does not have, so the same data-loss
-    primitive (``git.commits_absent_from_all_remotes``) is applied here directly.
+    Defense-in-depth for #710. ``_prune_squash_merged`` deletes a branch directly
+    via ``git.branch_delete`` / ``git.worktree_remove``, bypassing the guarded
+    teardown seam (``cleanup._raise_if_unpushed``) that ``Worktree``-row callers
+    funnel through; that seam needs a ``Worktree`` instance this name-only path
+    lacks, so the same primitive (``git.commits_absent_from_all_remotes``) is
+    applied here directly.
 
-    This intentionally does **not** false-block genuinely squash-merged branches:
-    once a branch's content is squash-merged and that squash is pushed, every
-    branch commit is reachable from ``refs/remotes/origin/<default>`` so
-    ``--not --remotes`` is empty. A non-empty result means the commits exist on
-    NO remote — deleting the worktree would destroy the only copy.
+    ``name`` is a local branch NAME resolvable in ``repo`` (the main clone), not
+    the literal ``HEAD`` the cleanup seam probes: the only caller
+    (``_prune_squash_merged`` via ``prune_branches``) enumerates names from
+    ``git branch`` in this same ``repo`` after ``git worktree prune``.
 
-    **Fails closed.** A failing probe (invalid/missing branch, corrupt repo)
-    raises ``CommandFailedError``; we translate that into a refusal rather than
-    proceeding, because an inconclusive probe cannot prove the work is pushed.
-    Returns ``""`` when the branch is safe to delete.
+    **Fetch precondition.** ``prune_branches`` runs ``git fetch --prune`` before
+    reaching here, and samples ``remote_ref_was_present`` BEFORE that prune (a
+    forge squash-merge leaves the source's tracking ref stale locally until the
+    prune); a caller that has not fetched compares against a stale ``origin``.
+
+    Genuinely squash-merged branches are not false-blocked: a positive merged
+    signal (the pre-prune tracking ref, or the forge) AND a matching tree lets
+    deletion proceed. A non-empty ``unpushed`` with NO merged-evidence means the
+    commits exist on NO remote, so the branch is kept (#2205: tree equality alone
+    is a false positive for a fully-reverted local branch). Fails closed: an
+    inconclusive probe (``CommandFailedError``) refuses. Returns ``""`` when safe.
     """
     try:
         unpushed = git.commits_absent_from_all_remotes(repo, name)
@@ -128,12 +139,7 @@ def _refuse_if_unpushed(repo: str, name: str) -> str:
         )
     if not unpushed:
         return ""
-    # #2205 — squash-merge + remote-ref-deleted fallback. The caller
-    # (``prune_branches``) already ran ``fetch --prune``, so the local mirror
-    # reflects the current remote state. If the branch tip is an ancestor of
-    # ``origin/<default>`` the content is already there (squash-merged) and
-    # deletion is safe despite the "absent from all remotes" signal.
-    if _ref_tree_captured_by_default(repo, name):
+    if _ref_captured_by_merge(repo, name, name, remote_ref_was_present=remote_ref_was_present):
         return ""
     return (
         f"SKIPPED '{name}': {len(unpushed)} commit(s) on NO remote (data loss) — "
@@ -141,7 +147,7 @@ def _refuse_if_unpushed(repo: str, name: str) -> str:
     )
 
 
-def _prune_squash_merged(repo: str, name: str, wt_map: dict[str, str]) -> str:
+def _prune_squash_merged(repo: str, name: str, wt_map: dict[str, str], *, remote_ref_was_present: bool) -> str:
     """Remove a confirmed squash-merged branch (and its worktree if linked).
 
     A branch whose tip tree matches the PR's merge commit is cleaned despite
@@ -150,15 +156,17 @@ def _prune_squash_merged(repo: str, name: str, wt_map: dict[str, str]) -> str:
 
     Honors the #706 data-loss guard (#710): even when the squash-merge
     heuristics say "clean", a branch whose commits are absent from every remote
-    is kept and a warning is returned — the safe default is never to destroy the
-    only copy of work.
+    AND lacks merged-evidence is kept and a warning is returned — the safe
+    default is never to destroy the only copy of work. ``remote_ref_was_present``
+    is the caller's pre-prune sample of ``origin/<name>``'s tracking ref, the
+    forge-CLI-free squash-merge signal threaded into the guard.
     """
     unsynced = git.unsynced_commits(repo, name)
     if unsynced and not _branch_tree_matches_squash(repo, name):
         return f"SKIPPED '{name}': {len(unsynced)} unsynced commit(s) — push to a new branch:\n  " + "\n  ".join(
             unsynced
         )
-    refusal = _refuse_if_unpushed(repo, name)
+    refusal = _refuse_if_unpushed(repo, name, remote_ref_was_present=remote_ref_was_present)
     if refusal:
         return refusal
     wt_path = wt_map.get(name, "")
@@ -258,17 +266,6 @@ class WorktreeReaper:
         return removed
 
 
-def _origin_ref_exists(repo: str, branch: str) -> bool:
-    """Whether ``refs/remotes/origin/<branch>`` still exists after ``fetch --prune``.
-
-    A branch whose remote tracking ref is gone is "gone-remote" — the branch was
-    deleted on origin, the normal terminal state of a squash-merged PR (the merge
-    creates a new commit on the default branch and deletes the source ref). A
-    branch still on origin is open work and must be kept.
-    """
-    return git.check(repo=repo, args=["show-ref", "--verify", "--quiet", f"refs/remotes/origin/{branch}"])
-
-
 def _worktree_clean(wt_path: str) -> bool:
     """Whether the worktree has no uncommitted changes (ignoring regenerable files).
 
@@ -337,7 +334,7 @@ def _prune_gone_remote_worktrees(repo: str, wt_map: dict[str, str], protected: s
     """
     cleaned: list[str] = []
     for name, wt_path in sorted(wt_map.items()):
-        if name in protected or _origin_ref_exists(repo, name):
+        if name in protected or _remote_tracking_ref_exists(repo, name):
             continue
         cleaned.append(_prune_gone_worktree(repo, name, wt_path))
         protected.add(name)
@@ -354,6 +351,15 @@ def prune_branches(repo: str) -> list[str]:
     pass re-checking the globs.
     """
     cleaned: list[str] = []
+    # Sample the remote tracking refs BEFORE the prune removes the stale ones: a
+    # branch's prior tracking-ref presence is the forge-CLI-free proof it was once
+    # pushed, threaded into the data-loss guard below.
+    pre_prune_remote = git.run(repo=repo, args=["for-each-ref", "--format=%(refname:short)", "refs/remotes/origin"])
+    pre_prune_remote_branches = {
+        line.removeprefix("origin/")
+        for line in pre_prune_remote.splitlines()
+        if line.strip() not in {"", "origin/HEAD"}
+    }
     git.run(repo=repo, args=["fetch", "--prune"])
     git.run(repo=repo, args=["worktree", "prune"])
 
@@ -395,7 +401,9 @@ def prune_branches(repo: str) -> list[str]:
     for name in sorted(all_branches - protected):
         if not is_squash_merged(repo, name, default):
             continue
-        cleaned.append(_prune_squash_merged(repo, name, wt_map))
+        cleaned.append(
+            _prune_squash_merged(repo, name, wt_map, remote_ref_was_present=name in pre_prune_remote_branches)
+        )
 
     remaining = {
         line.strip().removeprefix("* ").removeprefix("+ ")

--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from teatree.config import get_effective_settings
-from teatree.core.cleanup import _branch_tree_matches_squash, cleanup_worktree
+from teatree.core.cleanup import _branch_tree_matches_squash, _ref_tree_captured_by_default, cleanup_worktree
 from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Worktree
 from teatree.core.worktree_env import CACHE_DIRNAME, CACHE_FILENAME, write_env_cache
@@ -127,6 +127,13 @@ def _refuse_if_unpushed(repo: str, name: str) -> str:
             f"(git probe failed: {exc}) — refusing to delete. Push the branch to keep the work."
         )
     if not unpushed:
+        return ""
+    # #2205 — squash-merge + remote-ref-deleted fallback. The caller
+    # (``prune_branches``) already ran ``fetch --prune``, so the local mirror
+    # reflects the current remote state. If the branch tip is an ancestor of
+    # ``origin/<default>`` the content is already there (squash-merged) and
+    # deletion is safe despite the "absent from all remotes" signal.
+    if _ref_tree_captured_by_default(repo, name):
         return ""
     return (
         f"SKIPPED '{name}': {len(unpushed)} commit(s) on NO remote (data loss) — "

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -20,10 +20,10 @@ _patch_config = patch("teatree.core.cleanup.load_config")
 _patch_git = patch("teatree.core.cleanup.git")
 _patch_overlay = patch("teatree.core.cleanup.get_overlay")
 _patch_classify = patch("teatree.core.cleanup.classify_branch_commits")
-# Pin the #2205 tree-diff fallback to False so tests that set
+# Pin the #2205 merged-evidence override to False so tests that set
 # ``commits_absent_from_all_remotes`` to a non-empty list still hit the
-# data-loss guard rather than silently passing through the squash-merge bypass.
-_patch_ref_tree = patch("teatree.core.cleanup._ref_tree_captured_by_default", return_value=False)
+# data-loss guard rather than silently passing through the squash-merge override.
+_patch_ref_tree = patch("teatree.core.cleanup._ref_captured_by_merge", return_value=False)
 
 
 def _no_unpushed(mock_git: MagicMock) -> None:
@@ -464,23 +464,21 @@ class TestCleanupWorktree(TestCase):
         mock_git.worktree_remove.assert_not_called()
         mock_git.branch_delete.assert_not_called()
 
-    @_patch_ref_tree
     @_patch_overlay
     @_patch_git
     @_patch_config
-    def test_reaps_unpushed_branch_when_forge_says_pr_merged(
+    def test_reaps_unpushed_branch_when_merged_evidence_confirms_capture(
         self,
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
-        mock_ref_tree: MagicMock,
     ) -> None:
-        """#1578 — a branch flagged 'commits on NO remote' is reaped when its PR is MERGED.
+        """#1578/#2205 — a branch flagged 'commits on NO remote' is reaped when MERGED-evidence confirms it.
 
         Squash-merge creates a new SHA on main, so the branch's own SHAs are
-        absent from every remote ref — the #706 data-loss guard fires. But the
-        forge canonically reports the branch's PR merged, so the content shipped
-        and the worktree is safe to reap.
+        absent from every remote ref — the #706 data-loss guard fires. But
+        positive merged-evidence (forge PR merged / pre-prune tracking ref) AND a
+        matching tree confirm the content shipped, so the worktree is safe to reap.
         """
         _mock_workspace(mock_config)
         _no_unpushed(mock_git)
@@ -490,7 +488,7 @@ class TestCleanupWorktree(TestCase):
         mock_git.commits_absent_from_all_remotes.return_value = ["abc1234 feat: squashed onto main"]
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
-        with patch("teatree.core.cleanup._branch_pr_is_merged", return_value=True):
+        with patch("teatree.core.cleanup._ref_captured_by_merge", return_value=True):
             cleanup_worktree(wt)
 
         mock_git.worktree_remove.assert_called_once()
@@ -500,18 +498,18 @@ class TestCleanupWorktree(TestCase):
     @_patch_overlay
     @_patch_git
     @_patch_config
-    def test_refuses_unpushed_branch_when_forge_lookup_uncertain(
+    def test_refuses_unpushed_branch_when_merged_evidence_absent(
         self,
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
         mock_ref_tree: MagicMock,
     ) -> None:
-        """#1578 fail-safe — an unpushed branch with no/uncertain merged PR is still refused.
+        """#1578/#2205 fail-safe — an unpushed branch with no merged-evidence is still refused.
 
-        The forge lookup returning ``False`` (no merged PR found, CLI missing,
-        or any probe failure) leaves the #706 data-loss guard in force: ambiguity
-        never reaps.
+        With no positive merged-evidence (no merged PR, no pre-prune tracking ref,
+        tree match alone insufficient) the #706 data-loss guard stays in force:
+        ambiguity never reaps.
         """
         _mock_workspace(mock_config)
         _no_unpushed(mock_git)
@@ -520,10 +518,7 @@ class TestCleanupWorktree(TestCase):
         mock_git.commits_absent_from_all_remotes.return_value = ["abc1234 feat: never pushed, no PR"]
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
-        with (
-            patch("teatree.core.cleanup._branch_pr_is_merged", return_value=False),
-            pytest.raises(RuntimeError, match=r"on NO remote \(data loss\)"),
-        ):
+        with pytest.raises(RuntimeError, match=r"on NO remote \(data loss\)"):
             cleanup_worktree(wt)
 
         mock_git.worktree_remove.assert_not_called()

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -20,6 +20,10 @@ _patch_config = patch("teatree.core.cleanup.load_config")
 _patch_git = patch("teatree.core.cleanup.git")
 _patch_overlay = patch("teatree.core.cleanup.get_overlay")
 _patch_classify = patch("teatree.core.cleanup.classify_branch_commits")
+# Pin the #2205 tree-diff fallback to False so tests that set
+# ``commits_absent_from_all_remotes`` to a non-empty list still hit the
+# data-loss guard rather than silently passing through the squash-merge bypass.
+_patch_ref_tree = patch("teatree.core.cleanup._ref_tree_captured_by_default", return_value=False)
 
 
 def _no_unpushed(mock_git: MagicMock) -> None:
@@ -460,6 +464,7 @@ class TestCleanupWorktree(TestCase):
         mock_git.worktree_remove.assert_not_called()
         mock_git.branch_delete.assert_not_called()
 
+    @_patch_ref_tree
     @_patch_overlay
     @_patch_git
     @_patch_config
@@ -468,6 +473,7 @@ class TestCleanupWorktree(TestCase):
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
+        mock_ref_tree: MagicMock,
     ) -> None:
         """#1578 — a branch flagged 'commits on NO remote' is reaped when its PR is MERGED.
 
@@ -490,6 +496,7 @@ class TestCleanupWorktree(TestCase):
         mock_git.worktree_remove.assert_called_once()
         mock_git.branch_delete.assert_called_once()
 
+    @_patch_ref_tree
     @_patch_overlay
     @_patch_git
     @_patch_config
@@ -498,6 +505,7 @@ class TestCleanupWorktree(TestCase):
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
+        mock_ref_tree: MagicMock,
     ) -> None:
         """#1578 fail-safe — an unpushed branch with no/uncertain merged PR is still refused.
 
@@ -542,6 +550,7 @@ class TestCleanupWorktree(TestCase):
         mock_git.worktree_remove.assert_called_once()
         mock_git.branch_delete.assert_called_once()
 
+    @_patch_ref_tree
     @_patch_overlay
     @_patch_git
     @_patch_config
@@ -550,6 +559,7 @@ class TestCleanupWorktree(TestCase):
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
+        mock_ref_tree: MagicMock,
     ) -> None:
         """#706 data-loss guard — branch with commits on no remote blocks teardown."""
         _mock_workspace(mock_config)
@@ -568,6 +578,7 @@ class TestCleanupWorktree(TestCase):
         mock_git.worktree_remove.assert_not_called()
         mock_git.branch_delete.assert_not_called()
 
+    @_patch_ref_tree
     @_patch_overlay
     @_patch_git
     @_patch_config
@@ -576,6 +587,7 @@ class TestCleanupWorktree(TestCase):
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
+        mock_ref_tree: MagicMock,
     ) -> None:
         """More than the preview limit of unpushed commits is summarised with an ellipsis."""
         _mock_workspace(mock_config)

--- a/tests/teatree_core/cleanup/test_drifted_branch.py
+++ b/tests/teatree_core/cleanup/test_drifted_branch.py
@@ -481,11 +481,15 @@ class TestSquashMergedBranchNoRemoteRefPruned(TestCase):
         _run_git("commit", "-q", "-m", f"squash: {self.slug} (#2205)", cwd=self.repo_main)
         _run_git("push", "-q", "origin", "main", cwd=self.repo_main)
 
-        # Delete the source branch on the remote and prune local tracking ref.
-        _run_git("push", "-q", "origin", "--delete", self.slug, cwd=self.repo_main)
-        _run_git("fetch", "-q", "--prune", "origin", cwd=self.repo_main)
-        # The local branch ref and its worktree still exist (they were NOT pruned
-        # locally — only the remote tracking ref is gone).
+        # A forge squash-merge deletes the source ref REMOTELY (not via a local
+        # push), so the local clone keeps a stale ``refs/remotes/origin/<slug>``
+        # tracking ref until a later fetch prunes it. Deleting it on the bare
+        # remote directly models that — the stale tracking ref is the
+        # forge-CLI-free proof the branch was once pushed (the #2205 signal),
+        # which ``cleanup._raise_if_unpushed`` samples before its own fetch.
+        _run_git("update-ref", "-d", f"refs/heads/{self.slug}", cwd=self.remote)
+        # The local branch ref, its worktree, and the stale remote tracking ref
+        # all still exist (the local clone has not fetched/pruned yet).
 
     def _make_worktree(self) -> Worktree:
         ticket = Ticket.objects.create(
@@ -513,14 +517,113 @@ class TestSquashMergedBranchNoRemoteRefPruned(TestCase):
     def test_squash_merged_remote_deleted_branch_is_pruned(self) -> None:
         """The #2205 repro: teardown must proceed without forge CLI.
 
-        Before the fix ``commits_absent_from_all_remotes`` returns non-empty
-        (tracking ref gone, squash SHA differs), ``_branch_pr_is_merged`` returns
-        False (no forge CLI in test), and teardown is refused with a misleading
-        "on NO remote (data loss)" message even though the work IS on main.
-        After the fix the ancestry check (HEAD is ancestor of origin/main) lets
-        teardown proceed.
+        ``commits_absent_from_all_remotes`` returns non-empty (the squash is a new
+        SHA on main; the source ref was deleted) and ``_branch_pr_is_merged``
+        returns False (no forge CLI in test). The teardown proceeds because the
+        stale pre-fetch tracking ref (the branch was once pushed, then deleted on
+        the forge) is positive merged-evidence AND the tree matches origin/main.
         """
         result = self._cleanup(self._make_worktree(), pr_merged=False)
 
         assert result.clean is True, f"Expected teardown to proceed, got errors: {result.errors}"
         assert not self.wt_path.exists(), "Worktree directory must be removed"
+
+
+class TestLocalOnlyMatchingTreeNotPruned(TestCase):
+    """#2205 Finding 1 (data loss): a never-pushed local-only branch whose tree matches main is KEPT.
+
+    The confirmed data-loss false positive: a branch with genuinely local-only
+    commits (never pushed to any remote) whose FINAL tree coincidentally equals
+    ``origin/main`` — e.g. work added then fully reverted — passes
+    ``git diff --quiet <ref> origin/main``. Tree equality alone was treated as
+    "captured", bypassing the #706 guard and destroying the only copy of those
+    commits (no ref, no reflog after worktree removal, nothing to ``fsck``).
+
+    The branch is never pushed, so there is NO ``origin/<slug>`` tracking ref at
+    any point and (absent a forge merged signal) NO positive merged-evidence.
+    The guard must KEEP the worktree.
+    """
+
+    slug = "a-myrepo-9001-localonly"
+
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.workspace = tmp_path / "workspace"
+        self.workspace.mkdir()
+        self.temp_root = tmp_path / "systmp"
+        self.temp_root.mkdir()
+        monkeypatch.setattr(
+            "teatree.core.worktree_snapshot.tempfile.gettempdir",
+            lambda: str(self.temp_root),
+        )
+
+        self.remote = tmp_path / "remote.git"
+        subprocess.run(
+            [_GIT, "init", "-q", "--bare", "-b", "main", str(self.remote)],
+            check=True,
+            capture_output=True,
+            env=_clean_env(),
+        )
+
+        self.repo_main = self.workspace / "myrepo"
+        self.repo_main.mkdir()
+        _run_git("init", "-q", "-b", "main", cwd=self.repo_main)
+        _run_git("config", "user.email", "t@t", cwd=self.repo_main)
+        _run_git("config", "user.name", "t", cwd=self.repo_main)
+        _run_git("remote", "add", "origin", str(self.remote), cwd=self.repo_main)
+        (self.repo_main / "base.txt").write_text("base\n", encoding="utf-8")
+        _run_git("add", "-A", cwd=self.repo_main)
+        _run_git("commit", "-q", "-m", "initial", cwd=self.repo_main)
+        _run_git("push", "-q", "origin", "main", cwd=self.repo_main)
+        _run_git("fetch", "-q", "origin", cwd=self.repo_main)
+
+        # Local-only branch: add work then fully revert it, NEVER push. The final
+        # tree equals origin/main, but the two commits live nowhere but locally.
+        self.wt_path = self.workspace / self.slug / "myrepo"
+        _run_git("worktree", "add", "-q", "-b", self.slug, str(self.wt_path), cwd=self.repo_main)
+        _run_git("config", "user.email", "t@t", cwd=self.wt_path)
+        _run_git("config", "user.name", "t", cwd=self.wt_path)
+        (self.wt_path / "feat.txt").write_text("genuinely local work\n", encoding="utf-8")
+        _run_git("add", "-A", cwd=self.wt_path)
+        _run_git("commit", "-q", "-m", "add feat", cwd=self.wt_path)
+        _run_git("rm", "-q", "feat.txt", cwd=self.wt_path)
+        _run_git("commit", "-q", "-m", "revert - back to main tree", cwd=self.wt_path)
+
+    def _make_worktree(self) -> Worktree:
+        ticket = Ticket.objects.create(
+            issue_url="https://example.com/issues/9001",
+            state=Ticket.State.IN_REVIEW,
+        )
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="myrepo",
+            branch=self.slug,
+            extra={"worktree_path": str(self.wt_path)},
+        )
+
+    def _cleanup(self, worktree: Worktree, *, pr_merged: bool = False) -> CleanupResult:
+        with (
+            patch("teatree.core.cleanup.load_config") as mock_config,
+            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup._branch_pr_is_merged", return_value=pr_merged),
+        ):
+            mock_config.return_value.user.workspace_dir = self.workspace
+            mock_overlay.return_value.get_cleanup_steps.return_value = []
+            return cleanup_worktree(worktree, force=False, strict_hygiene=False)
+
+    def test_local_only_matching_tree_branch_is_kept(self) -> None:
+        """Tree-equality alone must NOT allow deletion — no merged-evidence → keep."""
+        with pytest.raises(RuntimeError) as excinfo:
+            self._cleanup(self._make_worktree(), pr_merged=False)
+
+        message = str(excinfo.value)
+        assert "on NO remote (data loss)" in message
+        assert self.wt_path.exists(), "Local-only matching-tree branch must be kept, not destroyed"
+
+    def test_local_only_matching_tree_pruned_only_with_forge_merged_evidence(self) -> None:
+        """Tree-equality IS accepted once the forge confirms the PR merged."""
+        result = self._cleanup(self._make_worktree(), pr_merged=True)
+
+        assert result.clean is True, f"Expected teardown to proceed with merged-evidence, got: {result.errors}"
+        assert not self.wt_path.exists()

--- a/tests/teatree_core/cleanup/test_drifted_branch.py
+++ b/tests/teatree_core/cleanup/test_drifted_branch.py
@@ -413,3 +413,114 @@ class TestPhantomSlugBranchNotAGitRef(TestCase):
         assert self.wt_path.exists()
         assert self.real_branch in self._branches()
         assert self.slug not in self._branches()
+
+
+class TestSquashMergedBranchNoRemoteRefPruned(TestCase):
+    """#2205 — clean-all must prune a worktree whose branch was squash-merged and remote-deleted.
+
+    When a PR is squash-merged (new SHA on main) and the source branch deleted on
+    the remote, ``fetch --prune`` removes ``refs/remotes/origin/<branch>``.
+    ``git log <branch> --not --remotes`` then reports the branch commits as
+    "absent from all remotes" (the remote tracking ref is gone and the squash
+    creates a distinct SHA on main), so ``commits_absent_from_all_remotes``
+    returns non-empty even though the work is captured on ``origin/main``.
+
+    The old code refused teardown (``_branch_pr_is_merged`` requires a host CLI
+    absent in test/CI, so it silently skips). The fix adds an ancestry check:
+    if HEAD is reachable from ``origin/<default>`` the work is already on the
+    default branch and teardown is safe.
+    """
+
+    slug = "a-myrepo-8521-feat"
+
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.workspace = tmp_path / "workspace"
+        self.workspace.mkdir()
+        self.temp_root = tmp_path / "systmp"
+        self.temp_root.mkdir()
+        monkeypatch.setattr(
+            "teatree.core.worktree_snapshot.tempfile.gettempdir",
+            lambda: str(self.temp_root),
+        )
+
+        self.remote = tmp_path / "remote.git"
+        subprocess.run(
+            [_GIT, "init", "-q", "--bare", "-b", "main", str(self.remote)],
+            check=True,
+            capture_output=True,
+            env=_clean_env(),
+        )
+
+        self.repo_main = self.workspace / "myrepo"
+        self.repo_main.mkdir()
+        _run_git("init", "-q", "-b", "main", cwd=self.repo_main)
+        _run_git("config", "user.email", "t@t", cwd=self.repo_main)
+        _run_git("config", "user.name", "t", cwd=self.repo_main)
+        _run_git("remote", "add", "origin", str(self.remote), cwd=self.repo_main)
+        (self.repo_main / "base.txt").write_text("base\n", encoding="utf-8")
+        _run_git("add", "-A", cwd=self.repo_main)
+        _run_git("commit", "-q", "-m", "initial", cwd=self.repo_main)
+        _run_git("push", "-q", "origin", "main", cwd=self.repo_main)
+        _run_git("fetch", "-q", "origin", cwd=self.repo_main)
+
+        # Create the feature branch, commit, push it (PR existed).
+        self.wt_path = self.workspace / self.slug / "myrepo"
+        _run_git("worktree", "add", "-q", "-b", self.slug, str(self.wt_path), cwd=self.repo_main)
+        _run_git("config", "user.email", "t@t", cwd=self.wt_path)
+        _run_git("config", "user.name", "t", cwd=self.wt_path)
+        (self.wt_path / "feat.txt").write_text("feature work\n", encoding="utf-8")
+        _run_git("add", "-A", cwd=self.wt_path)
+        _run_git("commit", "-q", "-m", "feat: ship the feature", cwd=self.wt_path)
+        _run_git("push", "-q", "origin", self.slug, cwd=self.wt_path)
+
+        # Squash-merge into main: a NEW sha on main captures the same tree,
+        # but the branch commits are NOT ancestors of main.
+        _run_git("checkout", "-q", "main", cwd=self.repo_main)
+        _run_git("merge", "-q", "--squash", self.slug, cwd=self.repo_main)
+        _run_git("commit", "-q", "-m", f"squash: {self.slug} (#2205)", cwd=self.repo_main)
+        _run_git("push", "-q", "origin", "main", cwd=self.repo_main)
+
+        # Delete the source branch on the remote and prune local tracking ref.
+        _run_git("push", "-q", "origin", "--delete", self.slug, cwd=self.repo_main)
+        _run_git("fetch", "-q", "--prune", "origin", cwd=self.repo_main)
+        # The local branch ref and its worktree still exist (they were NOT pruned
+        # locally — only the remote tracking ref is gone).
+
+    def _make_worktree(self) -> Worktree:
+        ticket = Ticket.objects.create(
+            issue_url="https://example.com/issues/8521",
+            state=Ticket.State.IN_REVIEW,
+        )
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="myrepo",
+            branch=self.slug,
+            extra={"worktree_path": str(self.wt_path)},
+        )
+
+    def _cleanup(self, worktree: Worktree, *, pr_merged: bool = False) -> CleanupResult:
+        with (
+            patch("teatree.core.cleanup.load_config") as mock_config,
+            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup._branch_pr_is_merged", return_value=pr_merged),
+        ):
+            mock_config.return_value.user.workspace_dir = self.workspace
+            mock_overlay.return_value.get_cleanup_steps.return_value = []
+            return cleanup_worktree(worktree, force=False, strict_hygiene=False)
+
+    def test_squash_merged_remote_deleted_branch_is_pruned(self) -> None:
+        """The #2205 repro: teardown must proceed without forge CLI.
+
+        Before the fix ``commits_absent_from_all_remotes`` returns non-empty
+        (tracking ref gone, squash SHA differs), ``_branch_pr_is_merged`` returns
+        False (no forge CLI in test), and teardown is refused with a misleading
+        "on NO remote (data loss)" message even though the work IS on main.
+        After the fix the ancestry check (HEAD is ancestor of origin/main) lets
+        teardown proceed.
+        """
+        result = self._cleanup(self._make_worktree(), pr_merged=False)
+
+        assert result.clean is True, f"Expected teardown to proceed, got errors: {result.errors}"
+        assert not self.wt_path.exists(), "Worktree directory must be removed"

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -2582,7 +2582,7 @@ class TestPruneSquashMergedDataLossGuard(TestCase):
             # `_branch_tree_matches_squash` (diff --quiet tip feature) is True
             # and the existing unsynced SKIP guard is bypassed.
             with patch.object(bc_mod, "_pr_merge_commit_sha", return_value=tip):
-                result = ws_cleanup_mod._prune_squash_merged(repo, "feature", wt_map)
+                result = ws_cleanup_mod._prune_squash_merged(repo, "feature", wt_map, remote_ref_was_present=False)
 
             # DATA-LOSS ASSERTION: the unique commit must still exist.
             branches = _git(work, "branch", "--format=%(refname:short)")
@@ -2645,7 +2645,7 @@ class TestPruneSquashMergedDataLossGuard(TestCase):
             # construction, so `_branch_tree_matches_squash` is True and the
             # branch is correctly classified squash-merged regardless of SHA.
             with patch.object(bc_mod, "_pr_merge_commit_sha", return_value=squash_sha):
-                result = ws_cleanup_mod._prune_squash_merged(repo, "feature", wt_map)
+                result = ws_cleanup_mod._prune_squash_merged(repo, "feature", wt_map, remote_ref_was_present=True)
 
             branches = _git(work, "branch", "--format=%(refname:short)").split()
             assert "feature" not in branches, f"squash-merged branch should be pruned, got: {result!r}"
@@ -2673,7 +2673,7 @@ class TestPruneSquashMergedDataLossGuard(TestCase):
             # classified squash-merged via the tree match, not via an accidental
             # SHA collision — hermetic regardless of commit timestamps (#915).
             with patch.object(bc_mod, "_pr_merge_commit_sha", return_value=squash_sha):
-                result = ws_cleanup_mod._prune_squash_merged(str(work), "feature", {})
+                result = ws_cleanup_mod._prune_squash_merged(str(work), "feature", {}, remote_ref_was_present=True)
 
             assert "feature" not in _git(work, "branch", "--format=%(refname:short)").split()
             assert result == "Pruned squash-merged branch: feature"
@@ -2704,7 +2704,7 @@ class TestPruneSquashMergedDataLossGuard(TestCase):
                     side_effect=utils_run_mod.CommandFailedError(["git", "log"], 128, "", "fatal: bad revision"),
                 ),
             ):
-                result = ws_cleanup_mod._prune_squash_merged(str(work), "feature", wt_map)
+                result = ws_cleanup_mod._prune_squash_merged(str(work), "feature", wt_map, remote_ref_was_present=False)
 
             assert "feature" in _git(work, "branch", "--format=%(refname:short)").split(), (
                 f"DATA LOSS: branch deleted despite an inconclusive probe: {result!r}"
@@ -2843,12 +2843,12 @@ class TestPruneGoneRemoteWorktree(TestCase):
             assert any("feature" in c and "ahead of origin/main" in c for c in cleaned), cleaned
             assert "feature" in _git(work, "branch", "--format=%(refname:short)").split()
 
-    def test_origin_ref_exists_helper(self) -> None:
+    def test_remote_tracking_ref_exists_helper(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_s:
             tmp = Path(tmp_s)
             _remote, work = _init_repo_with_remote(tmp)
-            assert ws_cleanup_mod._origin_ref_exists(str(work), "main") is True
-            assert ws_cleanup_mod._origin_ref_exists(str(work), "never-existed") is False
+            assert cleanup_mod._remote_tracking_ref_exists(str(work), "main") is True
+            assert cleanup_mod._remote_tracking_ref_exists(str(work), "never-existed") is False
 
     def test_worktree_clean_helper_ignores_regenerable_and_missing_dir(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_s:
@@ -2896,9 +2896,15 @@ class TestRefuseIfUnpushedAncestryFallback(TestCase):
     ``_refuse_if_unpushed`` must return ``""`` (allow deletion).
     """
 
-    def _squash_merge_remote_delete(self, tmp: Path, branch: str) -> tuple[Path, str]:
-        """Return (work_repo, squash_sha).  branch commits squash-merged → main, remote ref pruned."""
-        _remote, work = _init_repo_with_remote(tmp)
+    def _squash_merge_remote_delete(self, tmp: Path, branch: str) -> tuple[Path, Path]:
+        """Return (work_repo, remote).  branch squash-merged → main, source ref deleted FORGE-side.
+
+        The source ref is deleted on the bare remote directly (``update-ref -d``),
+        modelling a forge squash-merge: the local clone keeps a STALE
+        ``origin/<branch>`` tracking ref until a later fetch/prune — the
+        forge-CLI-free squash-merge signal the caller samples before the prune.
+        """
+        remote, work = _init_repo_with_remote(tmp)
         _git(work, "checkout", "-q", "-b", branch)
         (work / f"{branch}.py").write_text("work\n", encoding="utf-8")
         _git(work, "add", f"{branch}.py")
@@ -2907,20 +2913,22 @@ class TestRefuseIfUnpushedAncestryFallback(TestCase):
         _git(work, "checkout", "-q", "main")
         _git(work, "merge", "-q", "--squash", branch)
         _git(work, "commit", "-q", "-m", f"feat: {branch} (#2205)")
-        squash_sha = _git(work, "rev-parse", "main")
         _git(work, "push", "-q", "origin", "main")
-        _git(work, "push", "-q", "origin", "--delete", branch)
-        _git(work, "fetch", "-q", "--prune", "origin")
-        return work, squash_sha
+        _git(remote, "update-ref", "-d", f"refs/heads/{branch}")
+        return work, remote
 
     def test_squash_merged_remote_deleted_branch_is_allowed(self) -> None:
         """#2205 repro: ``_refuse_if_unpushed`` must not block a squash-merged branch."""
         with tempfile.TemporaryDirectory() as tmp_s:
             tmp = Path(tmp_s)
-            work, _squash_sha = self._squash_merge_remote_delete(tmp, "feature")
+            work, _remote = self._squash_merge_remote_delete(tmp, "feature")
+            # The caller samples the stale tracking ref before its fetch/prune.
+            present = cleanup_mod._remote_tracking_ref_exists(str(work), "feature")
+            _git(work, "fetch", "-q", "--prune", "origin")
 
-            result = ws_cleanup_mod._refuse_if_unpushed(str(work), "feature")
+            result = ws_cleanup_mod._refuse_if_unpushed(str(work), "feature", remote_ref_was_present=present)
 
+        assert present is True, "Forge-side delete must leave a stale tracking ref to sample"
         assert result == "", f"Expected '' (safe to delete), got refusal: {result!r}"
 
     def test_genuinely_unpushed_branch_is_still_refused(self) -> None:
@@ -2933,10 +2941,62 @@ class TestRefuseIfUnpushedAncestryFallback(TestCase):
             _git(work, "add", "f.py")
             _git(work, "commit", "-q", "-m", "feat: genuinely unpushed")
 
-            result = ws_cleanup_mod._refuse_if_unpushed(str(work), "feature")
+            result = ws_cleanup_mod._refuse_if_unpushed(str(work), "feature", remote_ref_was_present=False)
 
         assert result != "", "Expected a refusal message for genuinely unpushed work"
         assert "feature" in result
+
+    def _local_only_tree_matches_main(self, tmp: Path, branch: str) -> Path:
+        """Local-only branch with NEVER-pushed commits whose final tree == origin/main.
+
+        Mirrors the reviewer's data-loss repro: ``add feat`` then ``revert - back
+        to main tree``. The branch is never pushed to any remote, so its commits
+        live nowhere but locally, yet ``git diff --quiet branch origin/main`` exits
+        0 because the cumulative tree is identical to ``origin/main``.
+        """
+        _remote, work = _init_repo_with_remote(tmp)
+        _git(work, "checkout", "-q", "-b", branch)
+        (work / "feat.py").write_text("genuinely local work\n", encoding="utf-8")
+        _git(work, "add", "feat.py")
+        _git(work, "commit", "-q", "-m", "add feat")
+        _git(work, "rm", "-q", "feat.py")
+        _git(work, "commit", "-q", "-m", "revert - back to main tree")
+        return work
+
+    def test_local_only_commits_with_matching_tree_are_refused(self) -> None:
+        """Finding 1 (data loss): tree-equality alone must NOT allow deletion.
+
+        A branch whose commits were never pushed anywhere, but whose final tree
+        coincidentally equals ``origin/main`` (work added then reverted), passes
+        ``git diff --quiet`` yet has NO positive merged-evidence. Deleting it
+        destroys the only copy of those commits. Without a forge merged signal the
+        guard must KEEP the branch.
+        """
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            work = self._local_only_tree_matches_main(tmp, "feature")
+
+            with patch.object(cleanup_mod, "_branch_pr_is_merged", return_value=False):
+                result = ws_cleanup_mod._refuse_if_unpushed(str(work), "feature", remote_ref_was_present=False)
+
+        assert result != "", "Expected a refusal: local-only commits whose tree matches main must be kept"
+        assert "feature" in result
+
+    def test_local_only_matching_tree_pruned_only_with_merged_evidence(self) -> None:
+        """Tree-equality IS accepted once the forge confirms the PR merged.
+
+        The secondary confirmation (tree matches) is gated behind positive
+        merged-evidence: with the forge reporting the PR merged, the same
+        tree-matching branch is safe to delete.
+        """
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            work = self._local_only_tree_matches_main(tmp, "feature")
+
+            with patch.object(cleanup_mod, "_branch_pr_is_merged", return_value=True):
+                result = ws_cleanup_mod._refuse_if_unpushed(str(work), "feature", remote_ref_was_present=False)
+
+        assert result == "", f"Expected '' (merged-evidence + tree match → safe), got: {result!r}"
 
 
 def _squash_merge_into_main(tmp: Path, *, subject: str) -> tuple[Path, str]:

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -2882,6 +2882,63 @@ class TestPruneGoneRemoteWorktree(TestCase):
             assert "feature" in _git(work, "branch", "--format=%(refname:short)").split()
 
 
+class TestRefuseIfUnpushedAncestryFallback(TestCase):
+    """#2205 — ``_refuse_if_unpushed`` must pass when HEAD is ancestor of origin/main.
+
+    When a branch's remote tracking ref is deleted (squash-merge + branch deletion
+    + ``fetch --prune``), ``commits_absent_from_all_remotes`` returns non-empty:
+    the tracking ref is gone, and squash creates a distinct SHA on main so the
+    branch commits are not reachable from any remaining ``refs/remotes/*``.
+
+    The old code returned a refusal message ("SKIPPED … on NO remote"). After the
+    fix an ancestry check is applied: if every branch commit is reachable from
+    ``origin/<default>`` the work is already on main and deletion is safe —
+    ``_refuse_if_unpushed`` must return ``""`` (allow deletion).
+    """
+
+    def _squash_merge_remote_delete(self, tmp: Path, branch: str) -> tuple[Path, str]:
+        """Return (work_repo, squash_sha).  branch commits squash-merged → main, remote ref pruned."""
+        _remote, work = _init_repo_with_remote(tmp)
+        _git(work, "checkout", "-q", "-b", branch)
+        (work / f"{branch}.py").write_text("work\n", encoding="utf-8")
+        _git(work, "add", f"{branch}.py")
+        _git(work, "commit", "-q", "-m", f"feat: {branch}")
+        _git(work, "push", "-q", "origin", branch)
+        _git(work, "checkout", "-q", "main")
+        _git(work, "merge", "-q", "--squash", branch)
+        _git(work, "commit", "-q", "-m", f"feat: {branch} (#2205)")
+        squash_sha = _git(work, "rev-parse", "main")
+        _git(work, "push", "-q", "origin", "main")
+        _git(work, "push", "-q", "origin", "--delete", branch)
+        _git(work, "fetch", "-q", "--prune", "origin")
+        return work, squash_sha
+
+    def test_squash_merged_remote_deleted_branch_is_allowed(self) -> None:
+        """#2205 repro: ``_refuse_if_unpushed`` must not block a squash-merged branch."""
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            work, _squash_sha = self._squash_merge_remote_delete(tmp, "feature")
+
+            result = ws_cleanup_mod._refuse_if_unpushed(str(work), "feature")
+
+        assert result == "", f"Expected '' (safe to delete), got refusal: {result!r}"
+
+    def test_genuinely_unpushed_branch_is_still_refused(self) -> None:
+        """No regression: a branch with commits on NO remote at all must still be refused."""
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            _remote, work = _init_repo_with_remote(tmp)
+            _git(work, "checkout", "-q", "-b", "feature")
+            (work / "f.py").write_text("never pushed\n", encoding="utf-8")
+            _git(work, "add", "f.py")
+            _git(work, "commit", "-q", "-m", "feat: genuinely unpushed")
+
+            result = ws_cleanup_mod._refuse_if_unpushed(str(work), "feature")
+
+        assert result != "", "Expected a refusal message for genuinely unpushed work"
+        assert "feature" in result
+
+
 def _squash_merge_into_main(tmp: Path, *, subject: str) -> tuple[Path, str]:
     """Build a repo whose ``feature`` branch is squash-merged into main under ``subject``.
 


### PR DESCRIPTION
## Summary

Fixes #2205.

After a squash-merge, the source branch's remote tracking ref is deleted by `fetch --prune`, so `commits_absent_from_all_remotes` (`--not --remotes`) reports commits as absent from all remotes even though the content already shipped on `origin/main`. A `merge-base --is-ancestor` check cannot detect this because squash creates a new SHA with a different parent chain.

- Add `_ref_tree_captured_by_default(repo, ref)` as a private helper in `cleanup.py`: `git diff --quiet <ref> origin/<default>` exits 0 when the trees match, which is the deterministic squash-merge signal. Fails open (returns `False` on any error) to keep the fail-closed posture of the data-loss guard.
- `cleanup._raise_if_unpushed`: fetch origin, then check the tree-diff fallback before refusing teardown.
- `_workspace_cleanup._refuse_if_unpushed`: same tree-diff fallback (the caller already ran `fetch --prune`); import the helper from `cleanup`.
- Mock-based tests that exercise the data-loss guard with a non-empty `commits_absent_from_all_remotes` now pin the new fallback to `False` via `_patch_ref_tree` so the existing unit tests remain correctly fail-closed.

## Test plan

Integration tests (real `git`, no mocks) were observed RED on the buggy code and GREEN after the fix:

- `tests/teatree_core/cleanup/test_drifted_branch.py::TestSquashMergedBranchNoRemoteRefPruned::test_squash_merged_remote_deleted_branch_is_pruned` — full teardown path
- `tests/teatree_core/management_commands/test_workspace.py::TestRefuseIfUnpushedAncestryFallback::test_squash_merged_remote_deleted_branch_is_allowed` — `_refuse_if_unpushed` helper
- `tests/teatree_core/management_commands/test_workspace.py::TestRefuseIfUnpushedAncestryFallback::test_genuinely_unpushed_branch_is_still_refused` — negative control (always GREEN, no regression)

Full suite results after fix: 130 passed (management commands), 77 passed (cleanup), 14 passed (workspace squash-merge targeted run).