### PR TITLE
fix(provision): gate worktree provision on db_import success

### DIFF
--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -86,8 +86,9 @@ class WorktreeProvisionRunner(RunnerBase):
         if setup_failure is not None:
             return RunnerResult(ok=False, detail=setup_failure)
 
-        if worktree.db_name and overlay.get_db_import_strategy(worktree) is not None:
-            self._run_db_import()
+        db_import_needed = worktree.db_name and overlay.get_db_import_strategy(worktree) is not None
+        if db_import_needed and not self._run_db_import():
+            return RunnerResult(ok=False, detail="db import failed")
 
         report = run_provision_steps(overlay.get_provision_steps(worktree))
         post_db_report = self._run_post_db_steps()
@@ -103,7 +104,7 @@ class WorktreeProvisionRunner(RunnerBase):
             return RunnerResult(ok=False, detail=f"health checks failed: {', '.join(health_failures)}")
         return RunnerResult(ok=True, detail=f"{len(report.steps)} step(s) ok")
 
-    def _run_db_import(self) -> None:
+    def _run_db_import(self) -> bool:
         from teatree.core.worktree_env import worktree_pg_connection  # noqa: PLC0415
         from teatree.utils.db import db_exists  # noqa: PLC0415
 
@@ -115,7 +116,7 @@ class WorktreeProvisionRunner(RunnerBase):
             try:
                 if db_exists(worktree.db_name, user=user, host=host, env=env or None):
                     logger.info("DB exists: %s — skipping import", worktree.db_name)
-                    return
+                    return True
             except FileNotFoundError:
                 pass
 
@@ -127,8 +128,9 @@ class WorktreeProvisionRunner(RunnerBase):
             extra.pop("db_import_failures", None)
             worktree.extra = extra
             worktree.save(update_fields=["extra"])
-        else:
-            logger.warning("DB import failed for %s — continuing", worktree.repo_path)
+            return True
+        logger.error("DB import failed for %s — aborting provision", worktree.repo_path)
+        return False
 
     def _run_post_db_steps(self) -> ProvisionReport:
         steps = list(self.overlay.get_post_db_steps(self.worktree))

--- a/tests/teatree_core/management_commands/test_lifecycle.py
+++ b/tests/teatree_core/management_commands/test_lifecycle.py
@@ -170,8 +170,13 @@ class TestLifecycleSetup(TestCase):
 
     @_patch_overlays(FAILING_IMPORT_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_continues_on_db_import_failure(self) -> None:
-        """Setup continues with provision steps even when db_import fails."""
+    def test_aborts_on_db_import_failure(self) -> None:
+        """A failed db_import aborts provision with SystemExit(1) (#2208 fail-loud).
+
+        Previously the runner warned and continued, marking the worktree
+        PROVISIONED with no test DB. #2208 restores the same posture as the
+        standalone ``t3 db import``: a failed import is a provision failure.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
 
@@ -188,10 +193,10 @@ class TestLifecycleSetup(TestCase):
 
             with patch.object(utils_run_mod, "subprocess") as mock_sp:
                 mock_sp.run.return_value = MagicMock(returncode=0)
-                worktree_id = cast("int", call_command("worktree", "provision", path=str(wt_dir)))
+                with pytest.raises(SystemExit) as exc_info:
+                    call_command("worktree", "provision", path=str(wt_dir))
 
-            worktree = Worktree.objects.get(pk=worktree_id)
-            assert worktree.state == Worktree.State.PROVISIONED
+            assert exc_info.value.code == 1
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -663,7 +663,7 @@ class TestDbImportAutoRepair(TestCase):
             assert "db_import_failures" not in (wt.extra or {})
 
     @override_settings(**COMMAND_SETTINGS)
-    def test_retries_db_import_when_db_missing(self) -> None:
+    def test_aborts_when_db_missing_and_import_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             wt_path = str(tmp_path / "backend")
@@ -678,18 +678,19 @@ class TestDbImportAutoRepair(TestCase):
                 db_name="wt_100_acme",
             )
 
+            # db is missing → db_import is attempted; the mock overlay's import
+            # returns False → #2208 aborts provision with SystemExit(1) rather
+            # than warning and continuing.
             with (
                 patch.dict("os.environ", {"T3_ORIG_CWD": wt_path}),
                 patch.object(overlay_loader_mod, "_discover_overlays", return_value=_DB_MOCK_OVERLAY),
                 patch("teatree.utils.db.db_exists", return_value=False),
                 patch("teatree.utils.redis_container.ensure_running"),
+                pytest.raises(SystemExit) as exc_info,
             ):
                 call_command("worktree", "provision")
 
-            # db_import WAS called (and failed — DbOverlay always returns False)
-            wt = Worktree.objects.get(ticket=ticket)
-            # No circuit breaker counter — just a warning in stderr
-            assert "db_import_failures" not in (wt.extra or {})
+            assert exc_info.value.code == 1
 
 
 class TestUpdateTicketVariant(TestCase):

--- a/tests/teatree_core/test_runner_db_import.py
+++ b/tests/teatree_core/test_runner_db_import.py
@@ -1,10 +1,14 @@
-"""Tests for ``WorktreeProvisionRunner._run_db_import`` skip semantics.
+"""Tests for ``WorktreeProvisionRunner`` DB-import gating.
 
 Regression guard for #484: when a worktree has no associated database (the
 common case for frontend-only repos), the runner used to call
 ``overlay.db_import()`` anyway and log a misleading
 ``WARNING ... DB import failed for <repo> — continuing``. The runner now
 skips ``_run_db_import`` entirely when ``worktree.db_name`` is empty.
+
+Also guards the fail-loud contract: when a DB import is needed and fails,
+the runner aborts the provision (``ok=False``) before any provision or
+post-db step runs — pytest must never get a worktree with no test DB.
 """
 
 from pathlib import Path
@@ -22,14 +26,22 @@ from teatree.core.runners import WorktreeProvisionRunner
 class _RecordingOverlay(OverlayBase):
     """Overlay that records db_import calls and always returns a strategy."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, db_import_result: bool = True) -> None:
         super().__init__()
         self.db_import_calls: int = 0
+        self.provision_steps_calls: int = 0
+        self.post_db_steps_calls: int = 0
+        self._db_import_result = db_import_result
 
     def get_repos(self) -> list[str]:
         return ["backend"]
 
     def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        self.provision_steps_calls += 1
+        return []
+
+    def get_post_db_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        self.post_db_steps_calls += 1
         return []
 
     def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy | None:
@@ -45,7 +57,7 @@ class _RecordingOverlay(OverlayBase):
 
     def db_import(self, worktree: Worktree, **kwargs: Any) -> bool:
         self.db_import_calls += 1
-        return True
+        return self._db_import_result
 
 
 class TestRunnerSkipsDbImportWhenNoDbName(TestCase):
@@ -93,3 +105,26 @@ class TestRunnerSkipsDbImportWhenNoDbName(TestCase):
             WorktreeProvisionRunner(worktree, overlay=overlay).run()
 
         assert overlay.db_import_calls == 1
+
+    def test_failed_db_import_aborts_before_provision_steps(self) -> None:
+        """A failed DB import is a provision failure — abort before any post-db work.
+
+        Mirrors the fail-loud posture of the standalone ``t3 db import``
+        command: migrate/clone must not run against a worktree with no test DB.
+        """
+        worktree = self._make_worktree(db_name="wt_484")
+        overlay = _RecordingOverlay(db_import_result=False)
+
+        with (
+            patch(
+                "teatree.core.runners.worktree_provision._setup_worktree_dir",
+                return_value=None,
+            ),
+            patch("teatree.utils.db.db_exists", return_value=False),
+        ):
+            result = WorktreeProvisionRunner(worktree, overlay=overlay).run()
+
+        assert result.ok is False
+        assert overlay.db_import_calls == 1
+        assert overlay.provision_steps_calls == 0
+        assert overlay.post_db_steps_calls == 0


### PR DESCRIPTION
## Summary

The automatic worktree-provision runner (`WorktreeProvisionRunner`) treated a failed overlay `db_import` as a warning and proceeded to run the provision and post-db steps regardless. A worktree was therefore marked `PROVISIONED` with no test database: `pytest` then runs against a missing/empty DB and the migrate/clone steps are silently skipped. The failure was even counted (`db_import_failures`) yet never surfaced to the caller.

This restores the same posture the standalone `t3 db import` command already has (`db.py` exits non-zero on a failed import): a failed DB import is now a provision failure.

### Change

- `_run_db_import` returns `bool` — `True` on the db-exists skip and on a successful import, `False` when the import does not succeed.
- `run()` returns `RunnerResult(ok=False, detail="db import failed")` **before** `run_provision_steps` whenever a DB import was needed (`worktree.db_name` set and a strategy present) and did not succeed.
- The [#484](https://github.com/souliane/teatree/issues/484) skip semantics (no `db_name` => skip entirely, no failure) and the db-exists skip are preserved. Only the unsuccessful-import branch becomes a hard failure.

### RED / GREEN evidence

New regression test `test_failed_db_import_aborts_before_provision_steps` (patches `overlay.db_import` to return `False` with a strategy present):

- RED on pre-fix code: `assert result.ok is False` -> `AssertionError: assert True is False` (run returned `ok=True`, the bool was discarded) — exit 1.
- GREEN after the fix: 3 passed in the file; provision/post-db hooks observed not called (`provision_steps_calls == 0`, `post_db_steps_calls == 0`).
- `uv run ruff check` + `uv run ty check` on the changed files: all checks passed.
- Wider sweep `pytest -k "runner or provision"`: 219 passed, 1 skipped.

## Architecture pre-check — Relates-to #390

### 1. BLUEPRINT § alignment
Instantiates the [#390](https://github.com/souliane/teatree/issues/390) doctrine ("make silent subprocess failure + state drift ungrammatical") in the provision runner — a swallowed subprocess failure (`db_import`) producing state drift (provisioned-but-no-DB) becomes an observable `ok=False`. No new BLUEPRINT section needed.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition is added or moved. The runner already executes after the CREATED -> PROVISIONED flip; this only changes the runner's success verdict.

### 3. Extension-point contracts
No `OverlayBase` hook signature changes. `get_db_import_strategy`, `db_import`, `get_provision_steps`, `get_post_db_steps` are consumed exactly as before; only the runner's handling of `db_import`'s existing `bool` return changes.

### 4. Component boundaries
`src/teatree/core/runners/` — provision orchestration. Correct home; no straddling.

### 5. Dependency direction
No imports added. `uv run tach check` unaffected (no new edges).

### 6. Test surface
`tests/teatree_core/test_runner_db_import.py::test_failed_db_import_aborts_before_provision_steps` asserts `run().ok is False` and that `get_provision_steps` / `get_post_db_steps` were never called when `db_import` returns `False`. The pre-existing #484 skip tests still pass.

### 7. Resilience invariants
This is the fail-loud half of the resilience contract: a failed external step (`db_import`) is no longer swallowed; it propagates as a structured `RunnerResult(ok=False)` (sub-agent/runner return contract). Idempotence preserved — the db-exists skip still returns success on re-run.

### 8. Identity and key normalization
n/a — no identity keys involved.

### 9. Behavior preservation / capability deletion
The only behavior removed is the warn-and-continue branch on a failed import. Preserved: no-`db_name` skip (no failure), db-exists skip (success), `db_import_failures` counter clearing on success. No must-block test inverted.
