### PR TITLE
fix(hooks): banned-terms gate — skip api writes whose URL proves an internal repo (#1415 over-block)

### DIFF
--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -73,15 +73,16 @@ class Destination:
     via: str
 
 
-# ``gh api repos/<owner>/<repo>/...`` -- the slug is the path segment after
+# ``gh api [/]repos/<owner>/<repo>/...`` -- the slug is the path segment after
 # ``repos/``. The trailing path (``/issues``, ``/pulls/1/comments``) is
-# discarded; only ``owner/repo`` identifies the destination.
-_GH_API_REPOS_RE: Final[re.Pattern[str]] = re.compile(r"^repos/([^/]+/[^/]+)")
+# discarded; only ``owner/repo`` identifies the destination. ``gh`` accepts
+# the endpoint with or without a leading ``/``.
+_GH_API_REPOS_RE: Final[re.Pattern[str]] = re.compile(r"^/?repos/([^/]+/[^/]+)")
 
-# ``glab api projects/<url-encoded ns%2Frepo>/...`` -- the project is a
+# ``glab api [/]projects/<url-encoded ns%2Frepo>/...`` -- the project is a
 # single URL-encoded path segment (``ns%2Frepo`` or ``ns%2Fsub%2Frepo``).
 # ``%2F`` decodes back to ``/`` so the slug matches the allowlist shape.
-_GLAB_API_PROJECTS_RE: Final[re.Pattern[str]] = re.compile(r"^projects/([^/?]+)")
+_GLAB_API_PROJECTS_RE: Final[re.Pattern[str]] = re.compile(r"^/?projects/([^/?]+)")
 
 # The ``owner/repo`` of a forge URL positional, before the resource segment
 # (GitLab ``/-/`` infix and nested group paths handled; ``.git`` suffix stripped).
@@ -97,8 +98,36 @@ _CURRENT_REPO_VERBS: Final[frozenset[tuple[str, str]]] = _GH_ELIGIBLE_VERBS | _G
 
 # Flags whose VALUE is the next token in a ``gh``/``glab api`` call -- skipped
 # (flag + value) so the bare endpoint URL is found regardless of ordering.
+# A flag NOT in this set and NOT in ``_API_BOOLEAN_FLAGS`` makes the URL
+# resolution AMBIGUOUS (its value could be misread as the endpoint, or the
+# endpoint as its value), so ``_api_url_arg`` fails closed on it.
 _API_VALUE_FLAGS: Final[frozenset[str]] = frozenset(
-    {"-f", "-F", "--field", "--raw-field", "-X", "--method", "--input", "-H", "--header"}
+    {
+        "-f",
+        "-F",
+        "--field",
+        "--raw-field",
+        "-X",
+        "--method",
+        "--input",
+        "-H",
+        "--header",
+        "--hostname",
+        "-q",
+        "--jq",
+        "-t",
+        "--template",
+        "--cache",
+        "-p",
+        "--preview",
+    }
+)
+
+# ``gh``/``glab api`` flags that take NO value -- skipped (flag only) so a
+# ``--paginate`` before the endpoint does not derail URL resolution. CLOSED
+# enumeration: an unrecognised flag is ambiguous and fails resolution closed.
+_API_BOOLEAN_FLAGS: Final[frozenset[str]] = frozenset(
+    {"--paginate", "-i", "--include", "--silent", "--verbose", "--slurp"}
 )
 
 # Leading executables a no-destination chained segment may carry and still be
@@ -116,12 +145,18 @@ _SKIP_INERT_LEADERS: Final[frozenset[str]] = frozenset({"cd", "pushd", "popd", "
 
 
 def _api_url_arg(words: list[str]) -> str | None:
-    """Return the first non-flag positional after ``gh``/``glab`` ``api``.
+    """Return the first non-flag positional after ``gh``/``glab`` ``api``, or ``None``.
 
     The URL path is the first WORD token following the ``api`` sub-command
-    that is not itself a flag or a flag value. Value-taking field flags and
-    their values are skipped so the bare endpoint path is found regardless
-    of flag ordering.
+    that is not itself a flag or a flag value. Known value-taking flags are
+    skipped with their value, known boolean flags and self-contained
+    ``--flag=value`` tokens alone, so the bare endpoint path is found
+    regardless of flag ordering. An UNRECOGNISED separated flag makes the
+    resolution AMBIGUOUS -- whether the next token is its value or the
+    endpoint is unknowable without that flag's arity, and a wrong guess
+    would let a flag VALUE that merely looks like an internal repo path
+    stand in for the real endpoint -- so resolution fails closed (``None``,
+    which the callers classify PUBLIC/unprovable).
     """
     try:
         start = words.index("api") + 1
@@ -133,9 +168,11 @@ def _api_url_arg(words: list[str]) -> str | None:
         if w in _API_VALUE_FLAGS:
             i += 2
             continue
-        if w.startswith("-"):
-            i += 1
-            continue
+        if w.startswith("-") and w != "-":
+            if w in _API_BOOLEAN_FLAGS or (w.startswith("--") and "=" in w):
+                i += 1
+                continue
+            return None
         return w
     return None
 
@@ -335,20 +372,44 @@ def is_public_destination(dest: Destination | None, *, config_path: Path | None 
         ``None`` (unknown -- tool absent in-hook or auth differs) for an
         unresolvable target, which stays PUBLIC.
 
-    A ``None`` destination (unresolvable target) is PUBLIC, and a probe that
+    A ``None`` destination (unresolvable target) is PUBLIC, a slug carrying an
+    unexpanded shell variable (``$``) is PUBLIC unconditionally (its runtime
+    value is unknowable, so neither allowlist nor probe can PROVE anything
+    about the repo the expanded command will actually hit), and a probe that
     cannot prove the target private leaves it PUBLIC -- detection failure
     never weakens the gate.
     """
     if dest is None:
         return True
     slug = dest.slug.strip().lower()
-    if not slug:
+    if not slug or "$" in slug:
         return True
     if any(slug_namespace_matches(entry, slug) for entry in _internal_publish_namespaces(config_path)):
         return False
     if slug_is_allowlisted_private(slug, config_path):
         return False
     return not slug_is_private(slug)
+
+
+def _api_write_targets_internal_repo(words: list[str], *, config_path: Path | None = None) -> bool:
+    """Return True iff a raw ``api`` WRITE segment provably targets an internal repo.
+
+    A ``gh api`` / ``glab api`` write carries its body only to the endpoint its
+    URL path names. When that path resolves to a repo slug
+    (``repos/<owner>/<repo>`` / ``projects/<ns>%2F<repo>``) that is provably
+    internal, the write cannot leak to a public surface -- updating an MR
+    description on a private customer project is the canonical case. The slug
+    must come from the URL path itself (``via="api"``): an ``-R`` flag does not
+    constrain a raw endpoint. An unresolvable path (a shell variable, a
+    flagless call, an ambiguous unknown flag, a non-repo endpoint) or a
+    public/unknown-visibility slug stays fail-closed.
+    """
+    if not words or words[0] not in {"gh", "glab"}:
+        return False
+    dest = _destination_from_api(words, words[0])
+    if dest is None or dest.via != "api":
+        return False
+    return not is_public_destination(dest, config_path=config_path)
 
 
 def gate_skips_destination(command: str, cwd: Path | None, *, config_path: Path | None = None) -> bool:
@@ -367,6 +428,12 @@ def gate_skips_destination(command: str, cwd: Path | None, *, config_path: Path 
 
     - a publish segment whose destination resolves to a provably-INTERNAL
         repo/namespace, which carries no substitution/transport construct;
+    - a raw ``gh``/``glab api`` WRITE whose URL path itself resolves to a
+        provably-INTERNAL repo (:func:`_api_write_targets_internal_repo`) --
+        the body lands only on that private project's surface, so updating
+        e.g. a private customer MR description is not a public leak. An api
+        WRITE with an unresolvable path (shell variable, non-repo endpoint)
+        or a public/unknown target still fails closed;
     - a read-only ``gh``/``glab api`` GET (:func:`_segment_is_api_read`) --
         a read posts NO body, so it can never leak content regardless of the
         repo its URL names, and is skip-safe without resolving a destination; or
@@ -377,8 +444,9 @@ def gate_skips_destination(command: str, cwd: Path | None, *, config_path: Path 
         substitution/transport construct).
 
     Every OTHER segment is NOT skip-safe and makes the whole command scan
-    (fail-closed): a raw ``gh api`` / ``glab api`` WRITE (effective method ≠
-    GET -- it carries a body to an arbitrary endpoint), a
+    (fail-closed): a raw ``gh api`` / ``glab api`` WRITE whose URL does not
+    prove an internal repo target (it carries a body to an arbitrary
+    endpoint), a
     ``$(...)`` / process-substitution / redirection construct, a PUBLIC or
     unresolvable publish destination, and -- the closed inversion -- ANY
     segment whose leading word is an UNRECOGNISED executable (an interpreter
@@ -395,8 +463,13 @@ def gate_skips_destination(command: str, cwd: Path | None, *, config_path: Path 
         return False
     saw_internal_publish = False
     for words in segments:
-        if _segment_carries_substitution_or_transport(words) or _segment_is_api_write(words):
+        if _segment_carries_substitution_or_transport(words):
             return False
+        if _segment_is_api_write(words):
+            if not _api_write_targets_internal_repo(words, config_path=config_path):
+                return False
+            saw_internal_publish = True
+            continue
         if _segment_is_api_read(words):
             continue
         dest = _destination_from_words(words, cwd)

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -1035,13 +1035,23 @@ class TestDestinationAwareGate:
         assert blocked is False
         assert capsys.readouterr().out == ""
 
-    def test_internal_glab_api_raw_rest_is_scanned_not_skipped(self, capsys: pytest.CaptureFixture[str]) -> None:
-        # Raw-REST ``gh api`` / ``glab api`` can target any surface (custom
-        # host, method, endpoint), so the destination gate never SKIPS an
-        # api segment even when its URL path resolves to an internal
-        # project -- mirroring the carve-out, which excludes api from its
-        # eligible verbs. The over-scan is recoverable via --allow-banned-term.
+    def test_internal_glab_api_raw_rest_with_provable_url_target_is_allowed(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # #1415 over-block fix: a raw ``gh``/``glab api`` WRITE carries its
+        # body only to the endpoint its URL path names, so a URL that itself
+        # resolves to a provably-internal project is skip-safe -- the gate no
+        # longer forces the --allow-banned-term escape hatch on every private
+        # MR/issue api update.
         cmd = "glab api projects/internalcorp%2Fprivate-svc/issues -f body=acmecorp"
+        blocked = handle_banned_terms_pretool(_bash(cmd))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_public_api_raw_rest_write_is_still_blocked(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # The carve-out is URL-proof-scoped: the same api WRITE shape toward a
+        # public repo still scans and denies.
+        cmd = "gh api repos/souliane/teatree/issues -f body=acmecorp"
         blocked = handle_banned_terms_pretool(_bash(cmd))
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"

--- a/tests/teatree_hooks/test_publish_destination.py
+++ b/tests/teatree_hooks/test_publish_destination.py
@@ -329,3 +329,62 @@ class TestGateSkipsDestination:
         cfg = _config(tmp_path, ["internalcorp"])
         cmd = "gh pr create -R internalcorp/private-svc --body ok && gh api repos/souliane/teatree/issues -f body=x"
         assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+
+    @pytest.mark.parametrize(
+        "write",
+        [
+            'glab api --method PUT "projects/internalcorp%2Fprivate-svc/merge_requests/7562" --input /tmp/body.json',
+            "glab api projects/internalcorp%2Fprivate-svc/merge_requests/7562 -X PUT --input /tmp/body.json",
+            "gh api repos/internalcorp/private-svc/issues -f body=hello",
+            "glab api projects/internalcorp%2Fprivate-svc/issues/5/notes -f body=hello",
+            "gh api /repos/internalcorp/private-svc/issues -f body=hello",
+            "gh api --paginate repos/internalcorp/private-svc/issues -f body=hello",
+        ],
+        ids=[
+            "glab-put-input-quoted",
+            "glab-x-put-input",
+            "gh-post-field",
+            "glab-note-post",
+            "gh-leading-slash",
+            "gh-boolean-flag-before-url",
+        ],
+    )
+    def test_api_write_to_internal_repo_is_skipped(self, tmp_path: Path, write: str) -> None:
+        # Over-block guard: an ``api`` WRITE whose URL path itself names a
+        # provably-internal repo carries its body only to that private project's
+        # surface (e.g. updating a customer MR description). It must skip the
+        # public-leak scan instead of forcing the override escape hatch.
+        cfg = _config(tmp_path, ["internalcorp"])
+        assert publish_destination.gate_skips_destination(write, None, config_path=cfg) is True
+
+    @pytest.mark.parametrize(
+        "write",
+        [
+            'glab api --method PUT "projects/$opp/merge_requests/7562" --input /tmp/body.json',
+            "gh api /user -f name=x",
+            "glab api projects/souliane%2Fteatree/issues -f title=x",
+            "gh api --jq repos/internalcorp/private-svc user/keys -f key=x",
+        ],
+        ids=["unexpanded-variable", "non-repo-endpoint", "public-repo", "unknown-flag-value-misparse"],
+    )
+    def test_api_write_without_provable_internal_target_fails_closed(self, tmp_path: Path, write: str) -> None:
+        # The carve-out needs the slug from the URL path itself: a shell
+        # variable, a non-repo endpoint, or a public repo stays fail-closed.
+        # The ``--jq`` row pins the value-misparse hole: a known value-taking
+        # flag's VALUE that merely LOOKS like an internal repo path must not
+        # stand in for the real (public-surface) endpoint positional.
+        cfg = _config(tmp_path, ["internalcorp"])
+        assert publish_destination.gate_skips_destination(write, None, config_path=cfg) is False
+
+    def test_unexpanded_variable_slug_unprovable_even_when_probe_answers_private(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The visibility probe is a PROOF source, but an unexpanded ``$var``
+        # slug has an unknowable runtime value -- no probe answer about the
+        # literal ``$opp`` string can prove anything about the repo the
+        # expanded command will actually hit. Even a private-answering probe
+        # must leave it PUBLIC (fail-closed).
+        cfg = _config(tmp_path, ["internalcorp"])
+        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: True)
+        cmd = 'glab api --method PUT "projects/$opp/merge_requests/7562" --input /tmp/body.json'
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False

--- a/tests/teatree_hooks/test_publish_gate_golden_corpus.py
+++ b/tests/teatree_hooks/test_publish_gate_golden_corpus.py
@@ -9,8 +9,10 @@ out (legitimate internal/private and local-only work is allowed). The corpus
 is the regression guard for the five fixes:
 
 1. ALL-SEGMENTS skip (a chained public post behind an internal segment scans);
-2. fail-closed on substitution / transport / raw-REST api WRITE (a read-only
-    ``api`` GET posts no body and stays skip-safe);
+2. fail-closed on substitution / transport / raw-REST api WRITE whose URL does
+    not prove an internal repo target (a read-only ``api`` GET posts no body
+    and stays skip-safe; an api WRITE whose URL path itself resolves to a
+    provably-internal repo skips -- the #1415 over-block carve-out);
 3. destination classification reuses the existing ``private_repos`` allowlist;
 4. file-based bodies (``--description-file``) are honoured;
 5. the commit gate resolves the real repo (``cd`` / walk-up) and fails OPEN on
@@ -226,6 +228,16 @@ class TestMustAllow:
         cmd = 'gh pr create -R internalcorp/svc --body "acmecorp internal" && gh api repos/souliane/teatree/issues'
         assert _verdict(cmd, None, config) == "allow"
 
+    def test_internal_raw_rest_api_write_allowed(self, config: Path, tmp_path: Path) -> None:
+        # #1415 over-block: a raw ``glab api`` WRITE whose URL path itself names
+        # a provably-internal project -- the exact MR-description-update shape
+        # that was over-blocked (``--method PUT ... --input <file>`` with domain
+        # words in the file body) -- must be allowed.
+        body = tmp_path / "body.json"
+        body.write_text('{"description": "acmecorp acmewidget rollout"}', encoding="utf-8")
+        cmd = f'glab api --method PUT "projects/internalcorp%2Fprivate-svc/merge_requests/7562" --input {body}'
+        assert _verdict(cmd, None, config) == "allow"
+
     def test_cross_repo_private_post_from_public_cwd_allowed(self, config: Path, tmp_path: Path) -> None:
         # A post FROM a public clone TO a provably-private ``--repo`` target must
         # downgrade on the TARGET slug, not the cwd: the carve-out and the
@@ -331,6 +343,15 @@ class TestMustDeny:
     def test_secret_in_api_title_field_blocks(self, config: Path) -> None:
         # Vector 4: a secret in a ``gh api -f title=`` field (not ``body=``) blocks.
         cmd = f"gh api repos/souliane/teatree/issues -f title={_FAKE_SECRET}"
+        assert _verdict(cmd, None, config) == "block"
+
+    def test_secret_on_internal_api_write_still_blocks(self, config: Path, tmp_path: Path) -> None:
+        # The #1415 api-write carve-out must NOT weaken the secrets-always-blocked
+        # invariant: a secret in the ``--input`` file body blocks even when the
+        # URL proves an internal target the destination gate now SKIPs.
+        body = tmp_path / "body.json"
+        body.write_text(f'{{"description": "token {_FAKE_SECRET}"}}', encoding="utf-8")
+        cmd = f'glab api --method PUT "projects/internalcorp%2Fprivate-svc/merge_requests/7562" --input {body}'
         assert _verdict(cmd, None, config) == "block"
 
     def test_secret_in_internal_short_title_flag_blocks(self, config: Path) -> None:


### PR DESCRIPTION
## What

Fixes the recurring [#1415](https://github.com/souliane/teatree/issues/1415) over-block: the banned-terms destination gate treated EVERY raw `gh`/`glab api` WRITE as never skip-safe ("body to an arbitrary endpoint"), so `glab api --method PUT "projects/<ns>%2F<repo>/merge_requests/<iid>" --input body.json` against a project in a private customer namespace (configured via `[teatree] private_repos` / `internal_publish_namespaces`) was denied even though the body lands only on that private project's surface.

A raw api WRITE is now skip-safe **iff its URL path itself resolves to a provably-internal repo** (`_api_write_targets_internal_repo`: `via=="api"` resolution + the existing fail-closed `is_public_destination` classification). Everything else stays fail-closed: unresolvable paths, non-repo endpoints, public/unknown-visibility targets, chained writes behind an internal segment.

## Hardening found while reviewing the carve-out

The URL resolution becomes load-bearing proof, so its parser must not guess:

- `_api_url_arg` now **fails closed on an unrecognised separated flag** — previously an unknown value-taking flag (e.g. `--jq`) was skipped by one token, letting its *value* be misread as the endpoint; a value that merely looks like an internal repo path could then stand in for the real (public-surface) endpoint. Known value flags consume two tokens, known boolean flags and `--flag=value` one, unknown → `None` (PUBLIC).
- `is_public_destination` treats a slug carrying an unexpanded shell variable (`$var`) as **PUBLIC unconditionally** — its runtime value is unknowable, so neither allowlist nor visibility probe can prove anything about the repo the expanded command actually hits (pinned by a test where a private-answering probe must still not skip).
- The api-path regexes accept the equally-valid leading-slash endpoint forms (`/repos/...`, `/projects/...`) — over-block reduction.

## Safety posture (security gate — reviewed against over-permissiveness)

- **Secrets-always-blocked is untouched**: `contains_secret` runs before the destination skip in `hook_router._run_banned_terms_pretool`; a new golden-corpus row pins a secret in the `--input` file body of an otherwise-skippable internal api write → still blocks.
- **Golden corpus**: gains the exact previously-over-blocked shape (`--method PUT` + `--input` file with domain words) as a must-ALLOW row — verified RED (blocked) on the pre-fix code; all existing public/unresolvable must-DENY rows unchanged.
- The one inverted test (`test_internal_glab_api_raw_rest_is_scanned_not_skipped` → `..._with_provable_url_target_is_allowed`) pinned the over-block behavior this change is explicitly directed to remove; its public-target sibling deny is added alongside.

## Architecture pre-check

1. **BLUEPRINT § alignment** — publish-surface privacy gates (#1415 destination-awareness); behavior change is a narrowing of an over-block within the documented fail-closed doctrine, no BLUEPRINT contradiction.
2. **FSM phase boundaries** — n/a, no `Ticket`/`Worktree` state transitions.
3. **Extension-point contracts** — none; single production caller `hook_router._run_banned_terms_pretool` verified unchanged in signature.
4. **Component boundaries** — `src/teatree/hooks/publish_destination.py` (existing owner of destination resolution + skip predicate); tests in `tests/teatree_hooks/`.
5. **Dependency direction** — no new imports; `tach` green (pre-commit).
6. **Test surface** — unit (`test_publish_destination.py`: 6 must-skip shapes incl. the quoted PUT/`--input` repro, 4 fail-closed shapes incl. unexpanded `$var` and the `--jq` misparse, probe-says-private `$var` guard), golden corpus (must-ALLOW repro row + secret must-DENY row), hook-level integration (`test_banned_terms_scanner.py` allow/deny pair through `handle_banned_terms_pretool`).
7. **Resilience invariants** — n/a, no external writes; the gate is a pure in-process predicate.
8. **Identity/key normalization** — slugs keep the existing `%2F`-decode + lowercase + host-symmetric `slug_namespace_matches` chokepoints; no new normalization seam.
9. **Behavior preservation / capability deletion** — the only narrowed matcher is the api-write always-scan, which is the explicitly user-directed #1415 fix; the inversion is enumerated above and bounded by URL-proof + the three hardening guards. No public/unresolvable case weakened (corpus rows unchanged and re-run green).

## Test results

- `uv run pytest tests/teatree_hooks/ --no-cov` — **1162 passed**
- `uv run ruff check` + `uv run ruff format --check` — clean
- Anti-vacuity: new must-skip unit rows and the corpus must-ALLOW row verified failing against the pre-fix `publish_destination.py` (stash/run/pop).
