### PR TITLE
fix(hooks): resolve glab --description body sources + stop grep false-positive in publish gate

### DIFF
--- a/src/teatree/hooks/_body_file_resolution.py
+++ b/src/teatree/hooks/_body_file_resolution.py
@@ -21,6 +21,7 @@ one-directionally. ``_command_parser`` calls back into here via a lazy import
 (at call time, not module load) so no cycle forms.
 """
 
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -32,6 +33,60 @@ from teatree.hooks._shell_lexer import Token, TokenKind, split_commands
 # Long options that point at a FILE whose content we should read. If the
 # file is missing or unreadable the parser appends the fail-closed sentinel.
 _BODY_FILE_FLAG_NAMES: Final[frozenset[str]] = frozenset({"--body-file", "--description-file", "--file"})
+
+# A body value that IS exactly a ``$(cat <path>)`` command substitution. Agents
+# pass a body inline as ``--description "$(cat <path>)"`` / ``--body "$(cat
+# <path>)"``; the lexer keeps the whole quoted value as ONE token with the
+# substitution UNEXPANDED, so the gate would scan the literal ``$(cat ...)``
+# string -- rejecting a clean file and missing a banned term inside it. The
+# path is read so the scan runs against the ACTUAL body. Backticks (``$(cat …)``
+# only -- the modern form) and a single optional ``-- `` are tolerated; the path
+# may be quoted.
+_CAT_SUBST_RE: Final[re.Pattern[str]] = re.compile(
+    r"^\$\(\s*cat\s+(?:--\s+)?(?P<path>'[^']+'|\"[^\"]+\"|\S+)\s*\)$",
+)
+
+# A body value that IS exactly a single shell-variable reference (``$VAR`` or
+# ``${VAR}``). Resolved best-effort from the hook subprocess's environment (it
+# inherits the agent's env, the same channel the ``ALLOW_BANNED_TERM`` override
+# reaches the gate through). An absent variable is genuinely unresolvable and
+# fails closed.
+_VAR_REF_RE: Final[re.Pattern[str]] = re.compile(r"^\$\{?(?P<name>[A-Za-z_][A-Za-z0-9_]*)\}?$")
+
+
+def resolve_inline_body_value(value: str, base: Path | None) -> str:
+    """Resolve a ``--description``/``--body`` value's indirection to the real body.
+
+    Three forms are resolved so the banned-terms / quote scan runs against the
+    ACTUAL published body rather than an unexpanded shell token:
+
+    - ``$(cat <path>)`` -- the file content (read via :func:`read_file_arg`,
+        ``base``-relative fallback for the cold-hook reset cwd). An unreadable
+        path yields the fail-closed sentinel.
+    - ``$VAR`` / ``${VAR}`` -- the environment variable's value when present in
+        the hook subprocess env; absent yields the fail-closed sentinel.
+    - anything else -- returned verbatim (a normal inline body).
+
+    A value the resolver returns verbatim that STILL carries an unexpanded
+    command-substitution marker (a mixed ``"prefix $(cat x)"`` the single-form
+    matchers above do not fully resolve) yields the fail-closed sentinel: the
+    embedded substitution's content is unreadable, so passing the literal would
+    let a leak inside it slip. Resolution is never a bypass -- an unresolvable
+    source always fails closed.
+    """
+    cat_match = _CAT_SUBST_RE.match(value)
+    if cat_match is not None:
+        path = cat_match.group("path").strip("'\"")
+        content = read_file_arg(path, base)
+        return content if content is not None else FAIL_CLOSED_SENTINEL
+    var_match = _VAR_REF_RE.match(value)
+    if var_match is not None:
+        resolved = os.environ.get(var_match.group("name"))
+        return resolved if resolved is not None else FAIL_CLOSED_SENTINEL
+    if "$(" in value or "`" in value:
+        return FAIL_CLOSED_SENTINEL
+    return value
+
 
 _HEREDOC_RE: Final[re.Pattern[str]] = re.compile(
     r"<<\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\1\b",

--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -40,51 +40,21 @@ from teatree.hooks._publish_detection import (
     command_has_opaque_forge_transport,
     command_has_token_aware_publish_surface,
     extract_title_fragments,
+    segment_is_substring_publish,
     segment_word_lists,
 )
-from teatree.hooks._shell_lexer import Token, TokenKind, is_command_separator, split_commands, tokenize
+from teatree.hooks._shell_lexer import Token, TokenKind, split_commands, tokenize
 
 if TYPE_CHECKING:
     from teatree.hooks._body_file_resolution import BodyFileContext
 
 # ── Publish-surface substring catalogues ────────────────────────────
 
-# Bash commands that publish to an external surface. The substring match
-# is sufficient — Bash strings come from the LLM, not from a shell, so
-# we don't have to worry about ``echo "gh issue create" | grep``-style
-# embedding.
-_BASH_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
-    "gh issue create",
-    "gh issue edit",
-    "gh issue comment",
-    "gh pr create",
-    "gh pr edit",
-    "gh pr comment",
-    "gh pr review",
-    "glab issue create",
-    "glab issue update",
-    "glab issue note create",
-    # ``glab issue note <id>`` (no ``create`` segment) is the real
-    # comment subcommand — trailing space pins the substring to the
-    # subcommand boundary so ``glab issue notebook`` would not match.
-    "glab issue note ",
-    "glab mr create",
-    "glab mr update",
-    "glab mr note create",
-    "glab mr note ",
-    "git commit -m",
-    "git commit --message",
-    "git commit -F",
-    "git commit --file",
-    "git tag --message",
-    "chat.postMessage",
-)
-# ``gh api`` / ``glab api`` is NOT a contiguous-substring publish: a bare
-# substring match flagged read-only GET calls (``gh api user``, ``gh api
-# repos/o/r/commits/main``) as publishes, so the destination-aware gates
-# over-blocked them (#1530). Raw-REST publishes are classified WRITE-only and
-# flag-order-robust by the token-aware :func:`_publish_detection.segment_is_api_write`
-# (effective method ≠ GET), reached via :func:`is_publish_command`.
+# The ``gh``/``glab``/``git``/``curl`` contiguous-substring spellings now live
+# in :data:`_publish_detection._LEADER_PUBLISH_SUBSTRINGS`, keyed by their owning
+# leader so a read-only ``grep``/``cat``/``rg`` that merely QUOTES one is not a
+# publish (the false positive). ``gh``/``glab api`` stays WRITE-only / token-aware
+# (:func:`_publish_detection.segment_is_api_write`, effective method ≠ GET, #1530).
 
 # t3 sub-commands that publish on the user's behalf. The overlay segment
 # between ``t3`` and the verb is arbitrary (one of the registered
@@ -125,47 +95,44 @@ def is_fail_closed_sentinel(text: str) -> bool:
     return FAIL_CLOSED_SENTINEL in text
 
 
-def normalize_for_substring_match(command: str) -> str:
-    r"""Return a publish-detection-friendly string for ``command``.
+def _segment_is_t3_publish(words: list[str]) -> bool:
+    """Return True iff ``words`` is a ``t3``-led segment carrying a publish verb.
 
-    Re-emits the lexed token stream as space-separated WORD tokens, with
-    one space between command segments. This collapses ``\<NL>`` (both
-    token-internal and between-token) and ANSI-C decoding so the
-    publish-substring matcher sees the same logical command bash would
-    execute.
+    Keyed to the segment's own leading executable so a read-only
+    ``grep "notify send"`` (leader ``grep``) is not misread as a ``t3`` post,
+    and a ``cd <wt> && t3 <overlay> notify send`` (the publish verb on its own
+    ``t3``-led segment) is correctly detected. The overlay segment between
+    ``t3`` and the verb is arbitrary, so the verb-segment substring is matched
+    against the segment's joined words.
     """
-    tokens = tokenize(command)
-    out: list[str] = []
-    for tok in tokens:
-        if is_command_separator(tok):
-            out.append(" ")
-        else:
-            out.extend((tok.value, " "))
-    return "".join(out)
-
-
-def _is_t3_publish_invocation(joined: str) -> bool:
-    if not joined.lstrip().startswith("t3 "):
+    if words[0] != "t3":
         return False
+    joined = " ".join(words)
     return any(needle in joined for needle in _T3_PUBLISH_SUBSTRINGS)
 
 
 def is_publish_command(command: str) -> bool:
     """Return True iff the Bash command would publish to an external surface.
 
-    The contiguous substring catalogue (:data:`_BASH_PUBLISH_SUBSTRINGS`)
-    catches the common spellings; the token-aware per-segment checks
-    (:func:`_publish_detection.command_has_token_aware_publish_surface`) catch
-    the ``git [global-flags] commit`` after a ``-C``/``--git-dir`` flag and the
-    raw-REST ``gh``/``glab api`` WRITE (effective method ≠ GET) regardless of
-    flag ordering, so the body reaches the scanner. A read-only ``gh``/``glab
-    api`` GET is NOT a publish and is not flagged (#1530).
+    Detection is per-SEGMENT and keyed to each segment's own leading executable:
+
+    - the leader-keyed substring catalogue
+        (:func:`_publish_detection.segment_is_substring_publish`) catches the
+        common ``gh``/``glab``/``git``/``curl`` spellings ONLY in a segment whose
+        own leader is that tool -- so a read-only ``grep "glab mr create"`` /
+        ``cat | grep "gh issue create"`` / ``rg "git commit -m"`` that merely
+        QUOTES the spelling in an argument is NOT a publish;
+    - the ``t3`` publish verbs (:func:`_segment_is_t3_publish`), likewise keyed
+        to a ``t3``-led segment; and
+    - the token-aware per-segment checks
+        (:func:`_publish_detection.command_has_token_aware_publish_surface`) catch
+        the ``git [global-flags] commit`` after a ``-C``/``--git-dir`` flag and the
+        raw-REST ``gh``/``glab api`` WRITE (effective method ≠ GET) regardless of
+        flag ordering. A read-only ``gh``/``glab api`` GET is NOT a publish (#1530).
     """
-    joined = normalize_for_substring_match(command)
-    if any(needle in joined for needle in _BASH_PUBLISH_SUBSTRINGS):
-        return True
-    if _is_t3_publish_invocation(joined):
-        return True
+    for words in segment_word_lists(command):
+        if segment_is_substring_publish(words) or _segment_is_t3_publish(words):
+            return True
     return command_has_token_aware_publish_surface(command)
 
 
@@ -317,27 +284,39 @@ def _walk_curl_args(words: list[str], payloads: list[str]) -> None:
         i += 1
 
 
-def _walk_body_flags(words: list[str], payloads: list[str]) -> None:
-    """Extract ``--body``/``-m``/``-b`` style payloads from a command.
+def _walk_body_flags(words: list[str], payloads: list[str], base: "Path | None") -> None:
+    """Extract ``--body``/``--description``/``--message``/``--title``/``-m``/``-b`` payloads.
 
     Handles both space-separated (``--body "x"``) and equals-separated
-    (``--body=x``) forms.
+    (``--body=x``) forms. Each extracted value is passed through
+    :func:`_body_file_resolution.resolve_inline_body_value`, which resolves a
+    ``$(cat <path>)`` command substitution to the file content and a ``$VAR`` to
+    its environment value (``base`` is the cold-hook cwd fallback for a relative
+    cat path); an unresolvable indirection yields the fail-closed sentinel so the
+    scan blocks rather than reads an unexpanded shell token.
     """
+    from teatree.hooks._body_file_resolution import resolve_inline_body_value  # noqa: PLC0415
+
     i = 0
     n = len(words)
     while i < n:
         word = words[i]
         if word in _BODY_FLAG_NAMES and i + 1 < n:
-            payloads.append(words[i + 1])
+            payloads.append(resolve_inline_body_value(words[i + 1], base))
             i += 2
             continue
+        attached_handled = False
         for flag in _BODY_FLAG_NAMES:
             attached = attached_value(word, flag + "=")
             if attached is not None:
-                payloads.append(attached)
+                payloads.append(resolve_inline_body_value(attached, base))
+                attached_handled = True
                 break
+        if attached_handled:
+            i += 1
+            continue
         if word in _BODY_SHORT_FLAGS and i + 1 < n:
-            payloads.append(words[i + 1])
+            payloads.append(resolve_inline_body_value(words[i + 1], base))
             i += 2
             continue
         i += 1
@@ -424,7 +403,7 @@ def _walk_command_segment(segment: list[Token], payloads: list[str], ctx: "BodyF
     first, _ = _first_two_words(segment)
     # All segments get the generic body-flag walker since gh, glab, git,
     # and t3 all accept ``--body``/``--message``/``-m``/``-b``.
-    _walk_body_flags(words, payloads)
+    _walk_body_flags(words, payloads, ctx.base)
     walk_body_file_flags(words, payloads, leader=first, ctx=ctx)
     # ``gh api`` / ``glab api`` field assignments.
     if first in {"gh", "glab"}:

--- a/src/teatree/hooks/_publish_detection.py
+++ b/src/teatree/hooks/_publish_detection.py
@@ -1,19 +1,28 @@
 r"""Token-aware publish/commit/api detection for the pre-publish gates (#1672).
 
 Split out of :mod:`teatree.hooks._command_parser` to keep that module under the
-project's per-file LOC ceiling. This module owns ONE concern: decide, by WORD
-position rather than contiguous substring, whether a Bash command segment is a
-publish surface the gates must scan.
+project's per-file LOC ceiling. This module owns publish-surface DETECTION:
+whether a Bash command segment is a publish the gates must scan. Two layers:
 
-The original detection (:data:`_command_parser._BASH_PUBLISH_SUBSTRINGS`) matches
-CONTIGUOUS substrings (``gh api ``, ``git commit -m``). An interspersed
-persistent flag breaks contiguity, so a real publish slipped detection unseen:
+- the leader-keyed contiguous-substring catalogue
+    (:data:`_LEADER_PUBLISH_SUBSTRINGS`, :func:`segment_is_substring_publish`) --
+    each spelling (``gh pr create``, ``git commit -m``, ``chat.postMessage``)
+    matches ONLY in a segment whose own leading executable is that spelling's
+    owning tool, so a read-only ``grep "glab mr create"`` that merely QUOTES the
+    spelling in an argument is not a publish; and
+- the token-aware per-WORD-position checks below, robust to interspersed
+    persistent flags.
+
+The contiguous-substring detection matches spellings like ``gh api ``,
+``git commit -m``. An interspersed persistent flag breaks contiguity, so a real
+publish would slip the substring detection unseen -- the token-aware checks
+close that:
 
 - ``gh --hostname H api ...`` / ``gh -X POST api ...`` -- a persistent flag
     before the ``api`` sub-command (:func:`segment_is_api_call`);
 - ``git -C <dir> commit -m ...`` / ``git --git-dir=x commit --message ...`` --
     a value-taking global flag before the ``commit`` verb
-    (:func:`segment_is_git_commit_publish`); and
+    (:func:`_segment_is_git_commit_publish`); and
 - ``sh -c "gh ... --body X"`` / ``eval`` / ``ssh host gh`` / ``xargs gh`` -- a
     forge call HIDDEN inside an interpreter argument the body walkers cannot
     descend into (:func:`segment_is_opaque_forge_transport`), which the gates
@@ -49,6 +58,43 @@ _GIT_COMMIT_BODY_ATTACHED: Final[tuple[str, ...]] = ("-m", "-F", "--message=", "
 # arg, an ``eval``/``ssh``/``xargs`` wrapper) is an OPAQUE forge transport the
 # walkers cannot reach -- so the body the post carries is unscannable.
 _PARSEABLE_FORGE_LEADERS: Final[frozenset[str]] = frozenset({"gh", "glab", "git", "curl"})
+
+# Contiguous-substring publish spellings, keyed by the LEADING executable that
+# owns each (the first word of the substring -- ``chat.postMessage`` is a Slack
+# REST endpoint reachable only via ``curl``). A substring is a publish ONLY when
+# it appears in a SEGMENT whose own leading executable (after a benign cd/env
+# prefix) is that leader: a read-only ``grep "glab mr create"`` / ``rg "git
+# commit -m"`` / ``cat | grep "gh issue create"`` merely QUOTES the substring in
+# an argument, so its leader is ``grep``/``rg``/``cat`` -- not a publish. Keying
+# detection to the segment leader closes that recurring false positive without
+# enumerating read-only tools (the inversion: prove the segment IS a forge call,
+# rather than denylist the inspection tools that can quote a forge string).
+_LEADER_PUBLISH_SUBSTRINGS: Final[tuple[tuple[str, str], ...]] = (
+    ("gh", "gh issue create"),
+    ("gh", "gh issue edit"),
+    ("gh", "gh issue comment"),
+    ("gh", "gh pr create"),
+    ("gh", "gh pr edit"),
+    ("gh", "gh pr comment"),
+    ("gh", "gh pr review"),
+    ("glab", "glab issue create"),
+    ("glab", "glab issue update"),
+    ("glab", "glab issue note create"),
+    # ``glab issue note <id>`` (no ``create`` segment) is the real comment
+    # subcommand -- trailing space pins it to the subcommand boundary so
+    # ``glab issue notebook`` would not match.
+    ("glab", "glab issue note "),
+    ("glab", "glab mr create"),
+    ("glab", "glab mr update"),
+    ("glab", "glab mr note create"),
+    ("glab", "glab mr note "),
+    ("git", "git commit -m"),
+    ("git", "git commit --message"),
+    ("git", "git commit -F"),
+    ("git", "git commit --file"),
+    ("git", "git tag --message"),
+    ("curl", "chat.postMessage"),
+)
 
 # Forge-tool markers detected as a SUBSTRING of any token, so a forge call
 # hidden inside a quoted interpreter argument is recognised as a transport.
@@ -187,7 +233,7 @@ def segment_is_api_read(words: list[str]) -> bool:
     return segment_is_api_call(words) and _api_effective_method(words) in _API_READ_METHODS
 
 
-def segment_is_git_commit_publish(words: list[str]) -> bool:
+def _segment_is_git_commit_publish(words: list[str]) -> bool:
     """Return True iff ``words`` is a ``git [global-flags] commit`` with a body flag.
 
     A leading ``cd``/``pushd`` navigation prefix and the value-taking ``git``
@@ -268,6 +314,28 @@ def segment_is_opaque_forge_transport(words: list[str]) -> bool:
     return carries_forge or carries_substitution
 
 
+def segment_is_substring_publish(words: list[str]) -> bool:
+    """Return True iff ``words`` is a publish by the leader-keyed substring catalogue.
+
+    The segment's own leading executable (after a benign ``cd``/``ENV=`` prefix)
+    must equal the leader that owns the matched substring -- so a read-only
+    ``grep "glab mr create"`` / ``cat | grep "gh issue create"`` / ``rg "git
+    commit -m"`` whose leader is ``grep``/``cat``/``rg`` is NOT a publish even
+    though it QUOTES the spelling in an argument. This is the per-segment,
+    leader-keyed replacement for the whole-command flattened substring match that
+    re-emitted quoted argument contents and produced that false positive. The
+    composed per-command form lives in :func:`_command_parser.is_publish_command`,
+    which already iterates segments (mirroring :func:`segment_is_api_write` and
+    the other per-segment predicates).
+    """
+    rest = _strip_cd_env_prefix(words)
+    if not rest:
+        return False
+    leader = rest[0]
+    joined = " ".join(rest)
+    return any(needle in joined for own_leader, needle in _LEADER_PUBLISH_SUBSTRINGS if own_leader == leader)
+
+
 def command_has_token_aware_publish_surface(command: str) -> bool:
     """Return True iff any segment is a token-aware ``api`` WRITE / ``git commit`` publish.
 
@@ -279,7 +347,7 @@ def command_has_token_aware_publish_surface(command: str) -> bool:
     and must not be force-classified as one (#1530).
     """
     return any(
-        segment_is_api_write(words) or segment_is_git_commit_publish(words) for words in segment_word_lists(command)
+        segment_is_api_write(words) or _segment_is_git_commit_publish(words) for words in segment_word_lists(command)
     )
 
 

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -471,6 +471,139 @@ class TestBodyFileWriteThenPostResolution:
         assert FAIL_CLOSED_SENTINEL in payload
 
 
+class TestCommandSubstitutionBodyResolution:
+    """A ``--description``/``--body`` ``$(cat <path>)`` resolves to the file content.
+
+    Agents pass a body as ``--description "$(cat <path>)"`` (glab) or
+    ``--body "$(cat <path>)"`` (gh). The gate previously read the literal
+    ``$(cat ...)`` string -- so a clean file was rejected (the literal was
+    not the body) and a banned term inside the file slipped through unread.
+    The resolver reads the cat'd file so the scan runs against the ACTUAL
+    body; an unreadable file fails closed.
+    """
+
+    def test_glab_description_cat_subst_resolves_clean_body(self, tmp_path: Path) -> None:
+        body = tmp_path / "body.md"
+        body.write_text("a clean release note about the docs refresh\n", encoding="utf-8")
+        cmd = f'glab mr create -R o/r --title t --description "$(cat {body})"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "a clean release note" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_glab_description_cat_subst_carries_banned_term(self, tmp_path: Path) -> None:
+        body = tmp_path / "body.md"
+        body.write_text("ship to acmecorp soon\n", encoding="utf-8")
+        cmd = f'glab mr create -R o/r --title t --description "$(cat {body})"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "acmecorp" in payload
+
+    def test_gh_body_cat_subst_resolves_clean_body(self, tmp_path: Path) -> None:
+        body = tmp_path / "body.md"
+        body.write_text("a clean release note about the docs refresh\n", encoding="utf-8")
+        cmd = f'gh pr create -R o/r --title t --body "$(cat {body})"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "a clean release note" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_cat_subst_quoted_path_resolves(self, tmp_path: Path) -> None:
+        body = tmp_path / "spaced body.md"
+        body.write_text("a clean release note here\n", encoding="utf-8")
+        cmd = f"glab mr create -R o/r --title t --description \"$(cat '{body}')\""
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "a clean release note" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_cat_subst_missing_file_fails_closed(self) -> None:
+        cmd = 'glab mr create -R o/r --title t --description "$(cat /no/such/cat-body-xyz.md)"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert FAIL_CLOSED_SENTINEL in payload
+
+
+class TestEnvVarBodyResolution:
+    """A ``--description``/``--body`` ``$VAR`` best-effort resolves from the hook env.
+
+    The agent may pass a body via a shell variable
+    (``--description "$BODY"``). The hook subprocess inherits the agent's
+    environment, so a present variable resolves to its value; an absent
+    variable is genuinely unresolvable and fails closed (the gate must scan
+    the real body or block, never read the literal ``$VAR`` token).
+    """
+
+    def test_present_env_var_resolves_clean_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PUBLISH_BODY", "a clean body from an env var")
+        cmd = 'glab mr create -R o/r --title t --description "$PUBLISH_BODY"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "a clean body from an env var" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_present_env_var_carries_banned_term(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PUBLISH_BODY", "ship to acmecorp soon")
+        cmd = 'gh pr create -R o/r --title t --body "$PUBLISH_BODY"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "acmecorp" in payload
+
+    def test_absent_env_var_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PUBLISH_BODY_ABSENT", raising=False)
+        cmd = 'glab mr create -R o/r --title t --description "$PUBLISH_BODY_ABSENT"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert FAIL_CLOSED_SENTINEL in payload
+
+
+class TestReadOnlyCommandsAreNotPublishes:
+    """A read-only command that merely QUOTES a publish substring is NOT a post.
+
+    The contiguous-substring publish detector re-emits every token of the
+    whole command, so a ``grep "glab mr create"`` / ``rg "git commit -m"`` /
+    ``cat | grep "gh issue create"`` argument used to be misread as a real
+    publish -- the recurring false positive that blocked legitimate read-only
+    inspection commands. Detection is keyed to a segment whose LEADING
+    executable is an actual forge/publish tool, so a non-mutating
+    grep/rg/cat/sed/awk/ls/head/tail that mentions the tokens is not scanned.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'grep -rn "glab mr" --include="*.py" . | grep -- --description',
+            'cat somefile | grep "glab mr create" | grep -- --description',
+            'rg "glab mr create" src/',
+            'grep -n "glab mr update" file.py',
+            'sed -n "s/glab mr create/x/" file',
+            'awk "/gh pr create/" file',
+            'ls | grep "gh issue create"',
+            'head -5 file | grep "glab mr note create"',
+            'tail -n 20 log | grep "git commit -m"',
+            'grep -rn "chat.postMessage" src/',
+            'grep -rn "git commit --message" .',
+        ],
+    )
+    def test_read_only_command_is_not_a_publish(self, command: str) -> None:
+        assert _command_parser.is_publish_command(command) is False
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "glab mr create -R o/r --title t --body x",
+            "cd /wt && glab mr create -R o/r --title t",
+            "gh issue create --title t --body x",
+            'git commit -m "msg"',
+            'git -C /wt commit -m "msg"',
+            "curl -X POST https://slack.com/api/chat.postMessage -d text=hi",
+            "t3 teatree notify send --message x",
+        ],
+    )
+    def test_real_publish_command_stays_detected(self, command: str) -> None:
+        assert _command_parser.is_publish_command(command) is True
+
+
 class TestOverride:
     def test_flag_in_first_segment_bypasses(self) -> None:
         cmd = 'gh issue create --title t --body "acmecorp" --allow-banned-term'

--- a/tests/teatree_hooks/test_publish_gate_golden_corpus.py
+++ b/tests/teatree_hooks/test_publish_gate_golden_corpus.py
@@ -177,6 +177,32 @@ class TestMustAllow:
         cmd = 'gh pr create -R internalcorp/private-svc --title "feat: acmecorp" --body "acmecorp internal"'
         assert _verdict(cmd, None, config) == "allow"
 
+    def test_clean_description_cat_subst_to_public_repo_allows(self, config: Path, tmp_path: Path) -> None:
+        # A clean ``--description "$(cat <file>)"`` toward a PUBLIC repo must be
+        # READ and ALLOWED -- the resolver scans the cat'd file, not the literal
+        # ``$(cat ...)`` token (which other gates would treat as an unresolved
+        # body and over-block). The companion must-DENY proves the same path
+        # BLOCKS when the file carries a banned term -- resolution is not a hole.
+        body = tmp_path / "body.md"
+        body.write_text("## What\na clean release note about the docs refresh\n", encoding="utf-8")
+        cmd = f'glab mr create -R souliane/teatree --title fix --description "$(cat {body})"'
+        assert _verdict(cmd, None, config) == "allow"
+
+    def test_clean_body_env_var_to_public_repo_allows(self, config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A clean ``--body "$VAR"`` toward a PUBLIC repo, the var present in the
+        # hook env, is resolved + allowed.
+        monkeypatch.setenv("PUBLISH_BODY", "a clean status update")
+        cmd = 'gh pr create -R souliane/teatree --title fix --body "$PUBLISH_BODY"'
+        assert _verdict(cmd, None, config) == "allow"
+
+    def test_read_only_grep_of_publish_tokens_allows(self, config: Path) -> None:
+        # The recurring false positive: a read-only ``grep`` that merely QUOTES
+        # ``glab mr create`` + ``--description`` is NOT a publish, so the gate
+        # does not scan it. ``acmecorp`` in the grep pattern would have blocked
+        # a legitimate inspection command pre-fix.
+        cmd = 'grep -rn "glab mr create" --include="*.py" . | grep -- --description'
+        assert _verdict(cmd, None, config) == "allow"
+
     def test_internal_gh_pr_short_body_file(self, config: Path, tmp_path: Path) -> None:
         # Over-block guard for the ``gh`` short ``-F`` (``--body-file``) form: a
         # private ``-R`` target is skipped before the file body is scanned, so a
@@ -260,6 +286,36 @@ class TestMustDeny:
 
     def test_substitution_public_post_inside_internal_body(self, config: Path) -> None:
         cmd = 'glab mr create -R acme-internal/x --description "$(gh pr create -R souliane/teatree --body acmecorp)"'
+        assert _verdict(cmd, None, config) == "block"
+
+    def test_banned_description_cat_subst_to_public_repo_blocks(self, config: Path, tmp_path: Path) -> None:
+        # The cmd-subst resolver is NOT a hole: a banned term inside the cat'd
+        # file toward a PUBLIC repo is read and BLOCKS, exactly like an inline
+        # ``--description "acmecorp"``.
+        body = tmp_path / "body.md"
+        body.write_text("ship to acmecorp next week\n", encoding="utf-8")
+        cmd = f'glab mr create -R souliane/teatree --title fix --description "$(cat {body})"'
+        assert _verdict(cmd, None, config) == "block"
+
+    def test_banned_body_env_var_to_public_repo_blocks(self, config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The env-var resolver is NOT a hole: a banned term in the resolved
+        # variable toward a PUBLIC repo BLOCKS.
+        monkeypatch.setenv("PUBLISH_BODY", "ship to acmecorp")
+        cmd = 'gh pr create -R souliane/teatree --title fix --body "$PUBLISH_BODY"'
+        assert _verdict(cmd, None, config) == "block"
+
+    def test_unresolvable_description_cat_subst_to_public_repo_fails_closed(self, config: Path) -> None:
+        # A ``$(cat <missing>)`` toward a PUBLIC repo cannot be read, so it fails
+        # closed (the sentinel blocks) rather than slipping an unread body.
+        cmd = 'glab mr create -R souliane/teatree --title fix --description "$(cat /no/such/cat-xyz.md)"'
+        assert _verdict(cmd, None, config) == "block"
+
+    def test_unresolvable_body_env_var_to_public_repo_fails_closed(
+        self, config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A ``$VAR`` absent from the hook env toward a PUBLIC repo fails closed.
+        monkeypatch.delenv("PUBLISH_BODY_ABSENT", raising=False)
+        cmd = 'gh pr create -R souliane/teatree --title fix --body "$PUBLISH_BODY_ABSENT"'
         assert _verdict(cmd, None, config) == "block"
 
     def test_raw_rest_api_to_public(self, config: Path) -> None:


### PR DESCRIPTION
## What

The pre-publish banned-terms / quote gate validated the RAW argv of a forge
post, so a body passed as a command substitution or a shell variable was
scanned literally, and a read-only command that merely quoted a publish
spelling was misclassified as a post.

Body-source resolution (extends the description-file file form already handled):
- a description/body/message/title/-m/-b value of the form cat-command-
  substitution now reads the referenced file so the scan runs against the
  ACTUAL body (was the literal unexpanded token);
- a description/body value that is a single shell-variable reference best-effort
  resolves from the hook subprocess environment;
- an unresolvable source (missing file, absent variable, mixed unexpanded
  substitution) appends the fail-closed sentinel and BLOCKS. Resolution is
  never a bypass: a banned term inside a resolved file/variable toward a public
  repo now BLOCKS where it previously slipped as a clean literal.

Publish detection false positive:
- the contiguous-substring catalogue moved to a leader-keyed table
  (_publish_detection._LEADER_PUBLISH_SUBSTRINGS) matched per-SEGMENT against
  the segment's own leading executable, so a read-only grep/rg/cat/sed/awk/ls/
  head/tail that quotes a publish spelling is no longer treated as a post. The
  t3 publish detection is likewise segment-leader-keyed. Real gh/glab/git/curl/
  t3 posts stay detected.

The dead whole-command normalize_for_substring_match and _BASH_PUBLISH_SUBSTRINGS
are removed. All consumers (banned_terms_scanner, quote_scanner, ai_signature
gate, publish_destination, publish_surface) scan the resolved payload / call
is_publish_command unchanged.

## Why

Three agents this session hit the false-reject: a legitimate file/variable-based
description was rejected (forcing the entire body inline), and a read-only grep
mentioning the tokens false-fired. The literal-substitution case was also a real
leak: a banned term inside a cat-substituted file to a public repo was allowed
unscanned.

## Tests

TestCommandSubstitutionBodyResolution, TestEnvVarBodyResolution,
TestReadOnlyCommandsAreNotPublishes, plus golden-corpus must-ALLOW/must-DENY
rows (clean-resolves-allows, banned-blocks, unresolvable-fails-closed,
read-only-grep-allows). Proven RED-before-green: a banned term inside a
cat-substituted file to a public repo was ALLOWED pre-fix, BLOCKS post-fix.

## Open questions & assumptions

- A shell-variable body is resolved from os.environ (the hook subprocess
  inherits the agent env, the same channel the ALLOW_BANNED_TERM override uses);
  an absent variable fails closed.
- Only the pure single-token cat-substitution and pure single-token variable
  forms are resolved; any other value carrying an unexpanded substitution marker
  fails closed.

## Architecture pre-check

1. BLUEPRINT alignment: BLUEPRINT.md "Banned-terms posting gate (#1415)" + the
   #1213 quote-scanner; both share extract_bash_payload / is_publish_command.
   Consistent with existing gate prose; no new section.
2. FSM phase boundaries: n/a (no state transition).
3. Extension-point contracts: n/a (no OverlayBase / scanner / Protocol change).
   Consumers pick up the fix unchanged.
4. Component boundaries: src/teatree/hooks/ only (_command_parser,
   _publish_detection, _body_file_resolution).
5. Dependency direction: teatree.hooks depends only on teatree.utils; no new
   cross-layer import. tach check green.
6. Test surface: the three new test classes + golden-corpus rows above.
7. Resilience invariants: no external write. Load-bearing invariant is
   FAIL-CLOSED on any unresolvable body source. Pure idempotent functions.
8. Identity/key normalization: n/a; cat-substitution reuses the existing
   read_file_arg(path, base) resolution chain.
9. Behavior preservation: detection NARROWED for read-only commands only
   (removes a false positive, not a leak gate). Substitution/variable resolution
   ADDS coverage (a banned term inside a cat-substituted file to a public repo
   now blocks). No must-block test inverted; no privacy matcher weakened.
