### PR TITLE
fix(review-request): fall back to draft DM when review channel is unpostable

### DIFF
--- a/skills/review-request/SKILL.md
+++ b/skills/review-request/SKILL.md
@@ -94,7 +94,8 @@ This is the **only** sanctioned post path. **Never** post a review request with 
 
 - runs `review_request_check`'s live-channel dedup internally and prints `{"action": "suppress", ...}` + exits 0 with **no post** on a live duplicate;
 - requires a matching, unconsumed, exactly-scoped #960 `OnBehalfApproval`. With none it prints the exact `t3 review approve-on-behalf '<MR_URL>' review_request_post --approver <id>` remediation, refuses (`{"action": "refused", "reason": "on_behalf_not_approved"}`, exit 2), and **rolls back** the dedup claim so a later approved retry is not wedged;
-- on success posts once, consumes the approval (single-use), writes the #960 audit row, records the permalink, and prints `{"action": "post", "permalink": ...}`.
+- on success posts once, consumes the approval (single-use), writes the #960 audit row, records the permalink, and prints `{"action": "post", "permalink": ...}`;
+- when the review channel is unpostable (e.g. a Slack Connect channel that requires a user xoxp token the bot doesn't hold), emits a bot→user DM draft the user can forward manually and prints `{"action": "draft", "reason": "no_review_channel_or_token", ...}` + exits 0. **No channel post is made.** Surface the DM to the user so they can forward the review request; do not treat this as a silent success.
 
 The user records the approval (no terminal required) with `t3 review approve-on-behalf '<MR_URL>' review_request_post --approver <their-id>`; then re-run the post command. `--approver` is the user id that recorded it. The approver can never be the executing agent/loop (maker≠checker, enforced at record time).
 

--- a/src/teatree/core/management/commands/review_request_post.py
+++ b/src/teatree/core/management/commands/review_request_post.py
@@ -76,9 +76,9 @@ class Command(TyperCommand):
         """Post a review request after #1829 anti-vacuity + #1094 dedup + #960 approval.
 
         Machine-legible: prints a single JSON dict (``action`` is
-        ``post``/``suppress``/``refused``) and uses exit codes — ``0``
-        post/suppress, ``2`` refused (no recorded approval / no anti-vacuity
-        attestation).
+        ``post``/``draft``/``suppress``/``refused``) and uses exit codes —
+        ``0`` post/draft/suppress, ``2`` refused (no recorded approval / no
+        anti-vacuity attestation).
         """
         _ = approver  # the #960 approver is bound at approve-on-behalf record time.
 
@@ -100,9 +100,13 @@ class Command(TyperCommand):
             # that requires a user xoxp token the bot doesn't hold — #2231).
             # Fall back to a bot→user DM draft so the user can forward the
             # review request manually. Never silently suppress.
-            self._draft_dm_fallback(mr_url=mr_url, title=title)
+            sent = self._draft_dm_fallback(mr_url=mr_url, title=title)
             self._emit(
-                {"action": "draft", "reason": "no_review_channel_or_token", "mr_url": mr_url},
+                {
+                    "action": "draft" if sent else "suppress",
+                    "reason": "no_review_channel_or_token",
+                    "mr_url": mr_url,
+                },
                 exit_code=0,
             )
 
@@ -192,7 +196,7 @@ class Command(TyperCommand):
         )
 
     @staticmethod
-    def _draft_dm_fallback(*, mr_url: str, title: str) -> None:
+    def _draft_dm_fallback(*, mr_url: str, title: str) -> bool:
         """DM the user a draft review-request when the review channel is unpostable.
 
         Called when ``resolve_guard_target`` returns ``None`` — the review
@@ -200,19 +204,26 @@ class Command(TyperCommand):
         requires a user xoxp token the bot doesn't hold; #2231). A bot→user DM
         gives the user the full text they can forward manually, so the human
         review is never silently lost.
+
+        Returns the ``notify_user`` bool — ``True`` when the DM actually
+        landed, ``False`` when no backend / user_id is configured (NOOP). The
+        caller emits ``action=draft`` only on ``True``; ``False`` falls back to
+        ``action=suppress`` so a genuinely-undeliverable fallback stays loud
+        instead of masquerading as a draft.
         """
         from teatree.core.notify import NotifyKind, notify_user  # noqa: PLC0415
 
+        canonical = canonical_mr_url(mr_url)
         subject = title or _DEFAULT_TITLE
         text = (
             f"The review channel is unpostable (no token — Slack Connect channel?). "
             f"Please forward this review request manually:\n\n"
-            f"{subject} {mr_url}"
+            f"{subject} {canonical}"
         )
-        notify_user(
+        return notify_user(
             text,
             kind=NotifyKind.INFO,
-            idempotency_key=f"review_request_draft:{mr_url}",
+            idempotency_key=f"review_request_draft:{canonical}",
         )
 
     @staticmethod

--- a/src/teatree/core/management/commands/review_request_post.py
+++ b/src/teatree/core/management/commands/review_request_post.py
@@ -2,16 +2,21 @@
 
 The post-half of #1084/#1094. One classifier-legible transaction:
 
-1.  #1094 ``review_request_guard`` live-channel dedup (``resolve_guard_target``
-    + ``should_post_review_request`` — the latter takes the atomic
-    ``ReviewRequestPost`` claim internally). ``suppress`` → no post.
-2.  #960 ``require_on_behalf_approval`` — the single chokepoint. No recorded,
+1.  ``resolve_guard_target`` — resolves the postable review channel. When it
+    returns ``None`` (e.g. a Slack Connect channel the bot token cannot post
+    to — #2231), a bot→user DM draft is sent via ``notify_user`` and the
+    command exits with ``action=draft`` / ``reason=no_review_channel_or_token``
+    (exit 0). No channel post is made; no dedup claim is taken.
+2.  #1094 ``review_request_guard`` live-channel dedup
+    (``should_post_review_request`` — takes the atomic ``ReviewRequestPost``
+    claim internally). ``suppress`` → no post.
+3.  #960 ``require_on_behalf_approval`` — the single chokepoint. No recorded,
     unconsumed, exactly-scoped ``OnBehalfApproval`` → ``OnBehalfPostBlockedError``
     (its ``str`` already names the exact ``t3 review approve-on-behalf``
     remediation). On that refusal the just-created guard claim is rolled
     back (Risk-c: an orphan claim would make every future legitimate post
     suppress with ``already_claimed`` forever).
-3.  Only then post to the review channel, persist the permalink record.
+4.  Only then post to the review channel, persist the permalink record.
 
 ``action``/``target`` are the canonical strings, derived once via
 ``canonical_mr_url`` so the dedup claim and the #960 approval scope are

--- a/src/teatree/core/management/commands/review_request_post.py
+++ b/src/teatree/core/management/commands/review_request_post.py
@@ -91,8 +91,13 @@ class Command(TyperCommand):
 
         target = resolve_guard_target()
         if target is None:
+            # The review channel is unpostable (e.g. a Slack Connect channel
+            # that requires a user xoxp token the bot doesn't hold — #2231).
+            # Fall back to a bot→user DM draft so the user can forward the
+            # review request manually. Never silently suppress.
+            self._draft_dm_fallback(mr_url=mr_url, title=title)
             self._emit(
-                {"action": "suppress", "reason": "no_review_channel_or_token", "mr_url": mr_url},
+                {"action": "draft", "reason": "no_review_channel_or_token", "mr_url": mr_url},
                 exit_code=0,
             )
 
@@ -179,6 +184,30 @@ class Command(TyperCommand):
         self._emit(
             {"action": "post", "permalink": permalink, "mr_url": canonical},
             exit_code=0,
+        )
+
+    @staticmethod
+    def _draft_dm_fallback(*, mr_url: str, title: str) -> None:
+        """DM the user a draft review-request when the review channel is unpostable.
+
+        Called when ``resolve_guard_target`` returns ``None`` — the review
+        channel is configured but unpostable (e.g. a Slack Connect channel that
+        requires a user xoxp token the bot doesn't hold; #2231). A bot→user DM
+        gives the user the full text they can forward manually, so the human
+        review is never silently lost.
+        """
+        from teatree.core.notify import NotifyKind, notify_user  # noqa: PLC0415
+
+        subject = title or _DEFAULT_TITLE
+        text = (
+            f"The review channel is unpostable (no token — Slack Connect channel?). "
+            f"Please forward this review request manually:\n\n"
+            f"{subject} {mr_url}"
+        )
+        notify_user(
+            text,
+            kind=NotifyKind.INFO,
+            idempotency_key=f"review_request_draft:{mr_url}",
         )
 
     @staticmethod

--- a/tests/teatree_core/test_review_request_post_command.py
+++ b/tests/teatree_core/test_review_request_post_command.py
@@ -171,6 +171,28 @@ class TestReviewRequestPostDedup(TestCase):
         assert len(notified) == 1
         assert _MR_URL in notified[0]["text"]
 
+    def test_failed_dm_fallback_emits_suppress_not_draft(self) -> None:
+        """Failed DM fallback must emit action=suppress, not action=draft.
+
+        When ``notify_user`` returns ``False`` (no backend / no user_id),
+        the review request notification never reached anyone. Emitting
+        ``action=draft`` in that case is the same silent-loss class #2231
+        targeted. The correct outcome is ``action=suppress`` so the caller
+        knows the notification did not land.
+        """
+        with (
+            patch(f"{_CMD}.resolve_guard_target", return_value=None),
+            patch("teatree.core.notify.notify_user", return_value=False),
+        ):
+            code, payload = _run()
+        assert code == 0
+        # notify_user returned False → the DM was not delivered → suppress,
+        # not draft.  This assertion is RED on the pre-fix code (which always
+        # emits action=draft).
+        assert payload["action"] == "suppress"
+        assert payload["reason"] == "no_review_channel_or_token"
+        assert payload["mr_url"] == _MR_URL
+
     def test_dedup_suppress_does_not_post(self) -> None:
         backend = _FakeBackend()
         decision = GuardDecision(

--- a/tests/teatree_core/test_review_request_post_command.py
+++ b/tests/teatree_core/test_review_request_post_command.py
@@ -149,12 +149,27 @@ class TestReviewRequestPostAntiVacuityGate(_DataDirMixin, TestCase):
 
 
 class TestReviewRequestPostDedup(TestCase):
-    def test_no_review_channel_or_token_suppresses(self) -> None:
-        with patch(f"{_CMD}.resolve_guard_target", return_value=None):
+    def test_no_review_channel_or_token_falls_back_to_draft_dm(self) -> None:
+        """#2231: unpostable Connect channel → draft DM, not silent suppress."""
+        notified: list[dict[str, str]] = []
+
+        def _capture_notify(text: str, *, kind: object, idempotency_key: str, **_kw: object) -> bool:
+            notified.append({"text": text, "idempotency_key": idempotency_key})
+            return True
+
+        with (
+            patch(f"{_CMD}.resolve_guard_target", return_value=None),
+            patch("teatree.core.notify.notify_user", side_effect=_capture_notify),
+        ):
             code, payload = _run()
         assert code == 0
-        assert payload["action"] == "suppress"
+        assert payload["action"] == "draft"
         assert payload["reason"] == "no_review_channel_or_token"
+        assert payload["mr_url"] == _MR_URL
+        # The bot must DM the user with the review request text so they can
+        # forward it manually to the review channel.
+        assert len(notified) == 1
+        assert _MR_URL in notified[0]["text"]
 
     def test_dedup_suppress_does_not_post(self) -> None:
         backend = _FakeBackend()


### PR DESCRIPTION
## Summary

- When `resolve_guard_target()` returns `None` (e.g. a Slack Connect channel that needs a user xoxp token the bot doesn't hold), the command previously silently suppressed with `no_review_channel_or_token` — the human review notification was never sent.
- Now it falls back to a bot→user DM containing the full review request text so the user can forward it manually to the review channel.
- Emits `{"action": "draft", "reason": "no_review_channel_or_token"}` instead of `{"action": "suppress"}` so callers can distinguish "draft fallback" from "already posted" dedup suppression.

Closes #2231.

## Test plan

- [x] `TestReviewRequestPostDedup::test_no_review_channel_or_token_falls_back_to_draft_dm` — new test observed RED before the fix, asserts `action=draft` and exactly one DM containing the MR URL
- [x] All 16 tests in `tests/teatree_core/test_review_request_post_command.py` pass
- [x] All pre-commit hooks pass (ruff, tach, ty-check, banned-terms, …)