### PR TITLE
fix(hooks): banned-terms gate — normalize SSH host-alias remotes so own private repos downgrade (#1415)

### DIFF
--- a/src/teatree/hooks/_repo_visibility.py
+++ b/src/teatree/hooks/_repo_visibility.py
@@ -103,17 +103,27 @@ def slug_for_cwd(cwd: Path) -> str:
     allowlist entry matches a GitLab remote and a GitHub probe can be keyed by
     the same string.
 
-    Four remote forms normalize to a canonical slug:
+    Remote forms normalize to a canonical slug:
 
     - ``https://host/owner/repo`` -> ``host/owner/repo`` (host kept),
-    - ``user@host:owner/repo`` (standard SSH) -> ``host/owner/repo`` (real host
-        kept -- the ``user@`` segment proves the part before ``:`` is a host),
+    - ``user@host:owner/repo`` (SCP-style SSH) -> ``host/owner/repo`` ONLY when
+        ``host`` is a CANONICAL hostname (it contains a dot, e.g.
+        ``git@gitlab.com:org/repo`` -> ``gitlab.com/org/repo``). When ``host`` is
+        a dotless SSH CONFIG ALIAS (``git@gh-acct:owner/repo``, the ``Host
+        gh-acct`` form from ``~/.ssh/config`` that maps to a real ``HostName``),
+        the ``user@<alias>`` prefix is DROPPED -> ``owner/repo``: the alias is a
+        LOCAL name with no canonical identity, so keeping it glued ``gh-acct`` in
+        as the leading slug segment, where the dot-keyed host-strip / visibility
+        probe could not recognise it and a private own-repo failed to downgrade
+        (#1415). A dotted alias (``github.com-acct``) is kept as the host
+        segment but the downstream :func:`_strip_host_prefix` / probe already
+        strip a dotted leading segment, so it resolves correctly either way.
     - ``alias:owner/repo`` (SSH config ``Host alias``, no ``user@``) ->
-        ``owner/repo`` -- the alias is a LOCAL ``~/.ssh/config`` name with no
-        canonical identity, so it is DROPPED. Keeping it (the old verbatim
-        return) glued the alias into the slug, and an alias whose name contained
-        an allowlist entry then tripped the substring matcher and falsely
-        downgraded a PUBLIC repo (#1953).
+        ``owner/repo`` -- same rationale: a local alias with no canonical
+        identity is DROPPED. Keeping it (the old verbatim return) glued the alias
+        into the slug, and an alias whose name contained an allowlist entry then
+        tripped the substring matcher and falsely downgraded a PUBLIC repo
+        (#1953).
 
     ``FileNotFoundError`` (the ``git`` binary unresolved on the restricted hook
     PATH) and ``OSError`` are caught alongside ``CommandFailedError`` so a
@@ -132,10 +142,29 @@ def slug_for_cwd(cwd: Path) -> str:
         return cleaned.split("://", 1)[1]
     if ":" in cleaned and "/" not in cleaned.partition(":")[0]:
         host, _, path = cleaned.partition(":")
-        if "@" in host:
-            return f"{host.rsplit('@', 1)[-1]}/{path}"
+        real_host = host.rsplit("@", 1)[-1] if "@" in host else host
+        # A canonical hostname carries a dot (a TLD or a sub-domain); a dotless
+        # token is an SSH config Host ALIAS with no canonical identity, so drop
+        # it and keep only the canonical ``owner/repo`` key. This holds whether
+        # or not the remote carried a ``user@`` -- a ``user@gh-acct`` alias is no
+        # more canonical than a bare ``gh-acct`` one.
+        if _is_canonical_host(real_host):
+            return f"{real_host}/{path}"
         return path
     return cleaned
+
+
+def _is_canonical_host(host: str) -> bool:
+    """Return True iff ``host`` is a canonical hostname rather than an SSH alias.
+
+    A canonical hostname carries a dot (a registrable domain / sub-domain, e.g.
+    ``gitlab.com``, ``github.com``) or is the reserved ``localhost``. A dotless
+    token (``gh-acct``, ``work-github``) is an SSH config ``Host`` ALIAS -- a
+    local ``~/.ssh/config`` name with no canonical identity -- which must be
+    dropped from the slug so the dot-keyed host-strip / visibility probe key on
+    the real ``owner/repo`` instead of an unrecognisable alias segment (#1415).
+    """
+    return "." in host or host == "localhost"
 
 
 def _cache_root() -> Path:

--- a/tests/teatree_hooks/test_banned_terms_hook.py
+++ b/tests/teatree_hooks/test_banned_terms_hook.py
@@ -458,3 +458,225 @@ def test_live_hook_blocks_private_commit_chained_to_public_post(
     assert blocked is True
     decision = json.loads(captured.out)
     assert decision["permissionDecision"] == "deny"
+
+
+# ── #1415 misfire regression suite ──────────────────────────────────────────
+#
+# Four reported over-block surfaces. FM2 (SSH-alias) was genuinely RED on the
+# pre-fix code and is closed by the ``slug_for_cwd`` dotless-alias normalization
+# in ``_repo_visibility``. FM1/FM3/FM4 are kept here as live-hook regression
+# LOCKS over the exact reported command shapes: they assert the gate does NOT
+# fire on a branch-name-only term, a clean/own-private body-file, or a no-body
+# help invocation, so a future change to the body-walker / destination-skip /
+# publish-detection cannot silently re-introduce the misfire. Each allow case is
+# paired with an anti-vacuity must-block guard.
+
+_FM_CONFIG = '[teatree]\nbanned_terms = ["acmewidget"]\n'
+_FM_PRIVATE_CONFIG = '[teatree]\nbanned_terms = ["acmewidget"]\nprivate_repos = ["owner-org"]\n'
+
+_FM1_HEAD_ONLY = 'gh pr create --head ac-acmewidget-feature --title "Add feature" --body "clean public body"'
+_FM1_REF_FLAGS = "gh pr create -H acmewidget-topic --base acmewidget-main --title T --body clean"
+_FM1_BODY_TERM = 'gh pr create --head clean-branch --title T --body "rolling out acmewidget"'
+_FM3_CLEAN_BODY_FILE = 'gh pr create --title "Release" --body-file {body}'
+_FM3_PRIVATE_UNRESOLVABLE = "gh pr create --repo owner-org/private-product --title T --body-file /no/such/body.md"
+_FM3_PUBLIC_UNRESOLVABLE = "gh pr create --repo souliane/teatree --title T --body-file /no/such/body.md"
+
+
+def test_fm1_term_only_in_head_branch_name_does_not_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # FM1 (#1415): a banned term that appears ONLY in the ``--head`` branch name
+    # of a ``gh pr create`` -- never in the published title/body -- must NOT block.
+    # The body walker is an allowlist of body-bearing flags, so a non-body flag
+    # value (branch ref) never enters the scanned payload.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _FM_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    data = {"tool_name": "Bash", "tool_input": {"command": _FM1_HEAD_ONLY}, "cwd": str(_public_clone(tmp_path))}
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is False
+    assert captured.out == ""  # no deny JSON
+
+
+def test_fm1_term_in_base_and_short_head_flags_does_not_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # FM1 variant: the ``-H`` / ``--base`` ref flags carry the term, body clean.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _FM_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    data = {"tool_name": "Bash", "tool_input": {"command": _FM1_REF_FLAGS}, "cwd": str(_public_clone(tmp_path))}
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is False
+    assert captured.out == ""
+
+
+def test_fm1_term_in_actual_body_still_blocks_on_public_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # FM1 anti-vacuity guard: the SAME public command WITH the term in the real
+    # ``--body`` must STILL block. This proves the FM1 allow tests are not green
+    # merely because the gate stopped firing on this surface entirely.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _FM_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    data = {"tool_name": "Bash", "tool_input": {"command": _FM1_BODY_TERM}, "cwd": str(_public_clone(tmp_path))}
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is True
+    assert json.loads(captured.out)["permissionDecision"] == "deny"
+
+
+def test_fm2_useratalias_ssh_remote_own_private_repo_does_not_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # FM2 (#1415) LIVE: a clone whose ``origin`` uses a per-account dotless SSH
+    # config alias (``git@gh-acct:owner-org/private-product``) is the user's OWN
+    # known-private repo. The post must downgrade/skip via the offline allowlist
+    # with no probe tool -- before the slug fix the dotless ``gh-acct`` segment
+    # broke the allowlist match and the own private repo over-blocked.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _FM_PRIVATE_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+    monkeypatch.delenv("GH_REPO", raising=False)
+
+    repo = tmp_path / "alias-clone"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "remote", "add", "origin", "git@gh-acct:owner-org/private-product.git")
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue create --body "rolling out acmewidget"'},
+        "cwd": str(repo),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is False
+    assert captured.out == ""  # no deny JSON
+
+
+def test_fm2_useratalias_ssh_remote_public_repo_still_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # FM2 anti-vacuity guard: a clone using a dotless SSH alias but pointing at a
+    # PUBLIC repo NOT in the allowlist must STILL block a customer term -- the
+    # alias normalization must not blanket-downgrade every aliased remote.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _FM_PRIVATE_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+    monkeypatch.delenv("GH_REPO", raising=False)
+
+    repo = tmp_path / "alias-public"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "remote", "add", "origin", "git@gh-acct:souliane/teatree.git")
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue create --body "rolling out acmewidget"'},
+        "cwd": str(repo),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is True
+    assert json.loads(captured.out)["permissionDecision"] == "deny"
+
+
+def test_fm3_clean_body_file_to_public_repo_does_not_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # FM3 (#1415): a ``--body-file`` pointing at an EXISTING, clean file on a
+    # public repo must NOT fail-closed -- the file is read at scan time and the
+    # clean body produces no match.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _FM_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    body = tmp_path / "body.md"
+    body.write_text("A perfectly clean public release note.\n", encoding="utf-8")
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": _FM3_CLEAN_BODY_FILE.format(body=body)},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is False
+    assert captured.out == ""
+
+
+def test_fm3_unresolvable_body_file_to_own_private_repo_does_not_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # FM3 (#1415): an UNRESOLVABLE ``--body-file`` whose destination is the user's
+    # OWN allowlisted-private repo must NOT fail-closed -- the destination skip
+    # precedes the body scan, so an own/private post is never blocked on an
+    # unreadable body.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _FM_PRIVATE_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": _FM3_PRIVATE_UNRESOLVABLE},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is False
+    assert captured.out == ""
+
+
+def test_fm3_unresolvable_body_file_to_public_repo_still_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # FM3 anti-vacuity guard: an UNRESOLVABLE ``--body-file`` to a PUBLIC repo
+    # must STILL fail closed (an unscanned body must not slip onto a public
+    # surface) -- the FM3 allow cases must not have weakened the real protection.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _FM_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": _FM3_PUBLIC_UNRESOLVABLE},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is True
+    assert json.loads(captured.out)["permissionDecision"] == "deny"
+
+
+def test_fm4_help_invocation_does_not_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # FM4 (#1415): a ``--help`` invocation of a publish subcommand carries no
+    # publish body, so the gate must not fire on it (an empty payload is a no-op,
+    # not a fail-closed unresolvable body).
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _FM_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    cwd = str(_public_clone(tmp_path))
+    for command in ("glab mr note --help", "gh pr create --help", "gh issue comment -h"):
+        data = {"tool_name": "Bash", "tool_input": {"command": command}, "cwd": cwd}
+        blocked = handle_banned_terms_pretool(data)
+        captured = capsys.readouterr()
+        assert blocked is False, command
+        assert captured.out == "", command

--- a/tests/teatree_hooks/test_publish_surface.py
+++ b/tests/teatree_hooks/test_publish_surface.py
@@ -545,6 +545,26 @@ class TestSlugForCwdSshAliasNormalization:
         repo = _repo_with_remote(tmp_path / "r", "https://github.com/souliane/teatree.git")
         assert _repo_visibility.slug_for_cwd(repo) == "github.com/souliane/teatree"
 
+    def test_useratalias_ssh_alias_drops_dotless_host_alias(self, tmp_path: Path) -> None:
+        # FM2 (#1415): a per-account SSH config Host ALIAS carried WITH a ``user@``
+        # part (``git@gh-acct:owner/repo`` from a ``Host gh-acct`` block) was kept
+        # verbatim as ``gh-acct/owner/repo`` -- the dotless ``gh-acct`` glued in as
+        # the leading slug segment. The downstream dot-keyed host-strip / probe
+        # could not recognise it, so the canonical key was wrong. A dotless host
+        # is an alias with no canonical identity, so it is dropped -> ``owner/repo``.
+        repo = _repo_with_remote(tmp_path / "r", "git@gh-acct:owner-org/private-product.git")
+        assert _repo_visibility.slug_for_cwd(repo) == "owner-org/private-product"
+
+    def test_useratalias_dotted_host_alias_resolves_to_owner_repo_after_strip(self, tmp_path: Path) -> None:
+        # FM2 (#1415): the exact reported remote shape -- a per-account SSH alias
+        # whose name happens to embed the real host with a dot
+        # (``git@github.com-acct:Owner/Repo``). The dotted alias is kept as
+        # the host segment, but ``_strip_host_prefix`` (and the visibility probe)
+        # strip a dotted leading segment, so the canonical owner/repo key resolves.
+        repo = _repo_with_remote(tmp_path / "r", "git@github.com-acct:owner-org/private-product.git")
+        slug = _repo_visibility.slug_for_cwd(repo)
+        assert _repo_visibility._strip_host_prefix(slug) == "owner-org/private-product"
+
     def test_public_repo_with_alias_host_is_not_downgraded_end_to_end(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -554,6 +574,19 @@ class TestSlugForCwdSshAliasNormalization:
         repo = _repo_with_remote(tmp_path / "r", "gitlab-acmecorp:someorg/public-repo.git")
         monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
         assert publish_surface.commit_targets_private_repo(repo, config_path=cfg) is False
+
+    def test_useratalias_private_repo_downgrades_via_allowlist_end_to_end(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # FM2 end-to-end (#1415): a known-private own repo cloned through a dotless
+        # ``user@alias`` SSH remote must DOWNGRADE via the offline allowlist with
+        # no probe tool on PATH. Before the fix the slug carried the ``gh-acct``
+        # alias segment, so the ``owner-org`` allowlist entry did not match the
+        # leading segment and the own private repo over-blocked.
+        cfg = _config(tmp_path, ["owner-org"])
+        repo = _repo_with_remote(tmp_path / "r", "git@gh-acct:owner-org/private-product.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert publish_surface.commit_targets_private_repo(repo, config_path=cfg) is True
 
 
 class TestVisibilityProbeFallback:


### PR DESCRIPTION
## Summary

The banned-terms publish gate (#1415) over-blocked legitimate posts to the user's **own private repos** when those repos were cloned through a per-account **SSH config `Host` alias** remote (`git@<alias>:owner/repo`, the form a `~/.ssh/config` `Host` block maps to a real `HostName`).

`slug_for_cwd` resolves a repo's slug from its `origin` remote. For an SCP-style `user@host:owner/repo` remote it kept the host portion verbatim as the leading slug segment — but a dotless SSH alias (`gh-acct`) is a **local name with no canonical identity**. The downstream dot-keyed host-strip and the `gh`/`glab` visibility probe could not recognise it, so the `private_repos` allowlist match failed and the user's own private repo was hard-blocked instead of downgraded.

## The fix

Normalize at the slug boundary (the canonical-key seam): a `user@host:` host is kept only when it is a **canonical hostname** (carries a dot, or is `localhost`). A dotless alias is dropped, yielding the canonical `owner/repo` key the allowlist and probe both handle. A dotted alias (`github.com-acct`) is still kept as the host segment, but the existing host-strip already neutralises a dotted leading segment, so it resolves correctly either way. The change unifies the previously-separate `user@alias` and bare-`alias` branches behind one `_is_canonical_host` predicate.

## The four reported misfires

Investigation found that **one** of the four reported surfaces was genuinely broken on `main`; the other three were already correctly handled by prior fixes (#1953, #126, #1530, #2213, #1672). This PR fixes the real one and adds live-hook **regression locks** over all four exact command shapes (each allow case paired with an anti-vacuity must-block guard) so a future change cannot silently re-introduce any of them.

| # | Reported surface | Status on `main` |
|---|---|---|
| FM2 | own private repo via SSH host-alias remote not recognised | **was RED** — fixed here |
| FM1 | customer term only in a `--head` branch name | already green (body-walker is a body-flag allowlist; refs never scanned) |
| FM3 | clean / own-private `--body-file` over-blocked | already green (destination skip precedes the body scan) |
| FM4 | `--help` / no-body invocation | already green (empty payload is a no-op) |

The gate's real protection is intact: customer terms in actual published bodies to public/non-own destinations still hard-block (covered by the paired anti-vacuity guards: public repo + real `--body` still denies; unresolvable `--body-file` to a public repo still fails closed; aliased remote to a public repo still denies).

## Tests

- `tests/teatree_hooks/test_publish_surface.py` — 4 new `slug_for_cwd` SSH-alias normalization tests (the 2 dotless-alias ones go RED without the source fix; verified by reverting the fix).
- `tests/teatree_hooks/test_banned_terms_hook.py` — live-hook regression suite for FM1–FM4 (9 tests), incl. the FM2 end-to-end own-private-repo allow (RED without the fix) and the FM2 public-repo-still-blocks guard.

Full hooks suite green: `1220 passed`. `ruff check`/`format` clean, `ty check` clean, `tach check` clean.

## Architecture pre-check — #1415

### 1. BLUEPRINT § alignment
Touches the publish-surface gate's repo-identity resolution (the privacy-gate carve-out documented in the gate modules); no BLUEPRINT section change — this is a bug fix within the existing gate contract.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
None. `slug_for_cwd` / `_is_canonical_host` are internal hook helpers; no `OverlayBase`, scanner, or Protocol surface changes. Consumers (`commit_targets_private_repo`, `segment_target_is_private`, `is_public_destination`, the visibility probe) all key on the canonical slug and are unchanged.

### 4. Component boundaries
Stays in `src/teatree/hooks/_repo_visibility.py` (repo-visibility resolution for the gate). No straddle.

### 5. Dependency direction
No new imports. `tach check` green.

### 6. Test surface
Per behaviour: dotless `user@alias` SSH remote → canonical `owner/repo` slug (`test_useratalias_ssh_alias_drops_dotless_host_alias`); end-to-end own-private downgrade (`test_useratalias_private_repo_downgrades_via_allowlist_end_to_end`, `test_fm2_useratalias_ssh_remote_own_private_repo_does_not_block`); must-block guard (`test_fm2_useratalias_ssh_remote_public_repo_still_blocks`); standard dotted host / bare-alias contract preserved (existing tests stay green).

### 7. Resilience invariants
Read-only resolution path; no external write introduced. Detection stays **fail-safe for the leak direction**: an unresolvable/unknown remote yields no canonical private match, so the gate stays hard-blocking — a normalization failure never weakens the gate.

### 8. Identity and key normalization
This IS the canonical-key fix. The repo identity has a bare (`owner/repo`) and a host-qualified (`host/owner/repo`) form; the canonical key is the host-stripped `owner/repo`. The fix normalizes a non-canonical SSH-alias host **out** at the boundary (rather than letting a `split`/strip downstream fail to recognise it), so every consumer compares the same canonical key.

### 9. Behavior preservation / capability deletion
No capability removed. The standard `user@<dotted-host>:` (keep real host) and the bare-`<dotless-alias>:` (drop) behaviours are preserved; the change only adds dropping a **dotless** `user@<alias>:` host (previously kept, which was the bug). No must-block test was inverted; the privacy matcher is not narrowed — the anti-vacuity guards prove public/foreign leaks still block.
