### PR TITLE
docs(blueprint): add §2 SDK/API-portable principle (#2235)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -331,7 +331,7 @@ repos:
         always_run: true
         stages: [commit-msg]
       - id: check-blueprint-size
-        name: BLUEPRINT.md size cap (113KB)
+        name: BLUEPRINT.md size cap (114KB)
         language: system
         entry: uv run python scripts/hooks/check_blueprint_size.py
         files: ^BLUEPRINT\.md$

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -45,6 +45,7 @@ Infrastructure and orchestration are code; development methodology is skill-guid
 2. **Coordination needs transactional guarantees.** An FSM + ORM provide atomic transitions and row-locked workers. Coordination through JSON files cannot.
 3. **Code is testable; prose is not.** Core logic must reach >90% branch coverage.
 4. **One ABC with a handful of methods beats thirty thin extension points.** Overlay customization goes through `OverlayBase` — typed methods with defaults, no priority system, no plugin registries.
+5. **Terminal today, SDK/API-portable by design.** Teatree is driven through Claude Code's interactive terminal app today, but every architectural decision is made so the same flow can be driven through the Anthropic Agent SDK / API. Don't adopt a mechanism that only works in the terminal CLI when an SDK/API-portable equivalent exists. The terminal-driven flow keeps working; SDK/API-portability is the binding constraint when the two pull apart. This is why the headless executor (`agents/headless.py`) is kept deliberately slim — it is the swap point for an SDK runtime — and why dispatch, state, and skill-loading route through code rather than terminal-only affordances.
 
 ---
 

--- a/scripts/hooks/check_blueprint_size.py
+++ b/scripts/hooks/check_blueprint_size.py
@@ -4,9 +4,9 @@ The BLUEPRINT is architectural, not a prose mirror of the code. The
 companion #1128 corpus-budget gate sets per-file soft budgets that only
 fire when BLUEPRINT.md (or an appendix) is touched in the same commit;
 this #1180 gate is the deterministic hard cap that fires whenever the
-file changes and exceeds 112 KB.
+file changes and exceeds 114 KB.
 
-Threshold: 112 KB (112 * 1024 bytes). The hook is scoped to commits
+Threshold: 114 KB (114 * 1024 bytes). The hook is scoped to commits
 that touch ``BLUEPRINT.md`` (via ``files:`` in
 ``.pre-commit-config.yaml``), so it gates every growth event without
 re-running on unrelated commits. Escape hatch:
@@ -34,7 +34,8 @@ _BLUEPRINT_FILE = "BLUEPRINT.md"
 # spawn-model merge chokepoint and the session-level effort/model pins is
 # legit architectural growth, stacking on #2220's provisioning time-box section
 # after merging origin/main into the #2216 branch.
-_THRESHOLD_BYTES = 113 * 1024
+# Raised 113 -> 114 KB (#2235): the SDK/API-portable §2 architecture principle.
+_THRESHOLD_BYTES = 114 * 1024
 _OVERRIDE_ENV_VAR = "T3_BLUEPRINT_SIZE_OVERRIDE"
 
 


### PR DESCRIPTION
Closes [#2235](https://github.com/souliane/teatree/issues/2235).

Doc-only change: add a fifth standing principle to BLUEPRINT.md §2 "Code-First, Not Skills-First", raise the BLUEPRINT hard-cap one step to admit it, and fix a pre-existing docstring prose drift in the size hook.

## What changed

1. **BLUEPRINT.md §2 — new item 5.** "Terminal today, SDK/API-portable by design." Teatree is driven through Claude Code's interactive terminal app today, but every architectural decision is made so the same flow can be driven through the Anthropic Agent SDK / API. The terminal-driven flow keeps working; SDK/API-portability is the binding constraint when the two pull apart. The slim headless executor (`agents/headless.py`) is the swap point for an SDK runtime.
2. **`scripts/hooks/check_blueprint_size.py` — cap raise 113 → 114 KB.** The new standing principle adds ~780 B and would exceed the old 113 KB cap. Raised one step with a rationale comment matching the existing `# Raised N -> M KB (#XXXX): <reason>` pattern. This raise is sanctioned: the cap may be raised modestly for legit architectural growth, and a new standing principle qualifies.
3. **`scripts/hooks/check_blueprint_size.py` — docstring prose-drift fix.** The docstring read "112 KB" / "Threshold: 112 KB (112 * 1024 bytes)" while the constant had since moved on; both now read "114 KB" / "114 * 1024 bytes" to match the constant (the drift flagged during #2224 review).
4. **`.pre-commit-config.yaml` — hook display label 113KB → 114KB** so the label tracks the new cap.

## Architecture pre-check — #2235

### 1. BLUEPRINT § alignment
Touches §2 "Architecture Principle: Code-First, Not Skills-First". The change adds a list item to that section; the code change (raising `check_blueprint_size.py`'s cap) is the deterministic enforcement gate the BLUEPRINT growth requires, so code and doc land together.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / `*Backend` Protocol surface touched.

### 4. Component boundaries
`scripts/hooks/` — the size cap is a pre-commit hook handler, the correct home. `BLUEPRINT.md` and `.pre-commit-config.yaml` are the doc/config surfaces.

### 5. Dependency direction
No imports added; no module graph change. `uv run tach check` is unaffected (no `src/` change).

### 6. Test surface
`tests/test_check_blueprint_size.py` pins behaviour against `gate._THRESHOLD_BYTES` (dynamic, not a literal), so it tracks the new constant automatically and stays green. The hard-cap hook run against the live BLUEPRINT (116,278 B) under the new 114 KB cap (116,736 B) is the size assertion. No new test needed; no existing test pinned the old literal.

### 7. Resilience invariants
n/a — no external write.

### 8. Identity and key normalization
n/a.

### 9. Behavior preservation / capability deletion
Purely additive — the cap is raised, not narrowed; no behavior or matcher removed; no must-block test inverted.

## Verification

- `uv run python scripts/hooks/check_blueprint_size.py` → exit 0. Live size 116,278 B < cap 116,736 B (458 B headroom, above the ~200 B floor, so 114 KB is the right step).
- `uv run pytest --no-cov -q tests/test_check_blueprint_size.py` → 11 passed.
- `uv run ruff check scripts/hooks/check_blueprint_size.py` → all checks passed.
- All pre-commit hooks (incl. the BLUEPRINT size cap, corpus-architectural gate, conventional-commit) passed at commit time.
