### PR TITLE
feat(agent): single-toggle Fable kill-switch with Opus 4.8 fallback (#2237)

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -257,6 +257,9 @@ spawn inputs, not overridable `UserSettings`.
 [agent]
 session_model = "fable"           # interactive main-agent --model pin (so you never run /model by hand)
 session_effort = "xhigh"          # interactive main-agent --effort pin (strict CLI scale)
+# fable_enabled = false           # the single Fable kill-switch: flip to false to revert EVERY
+                                  # Fable pin to the Opus 4.8 baseline (default true == keep Fable)
+# fable_fallback = "opus"         # the model Fable downgrades to when disabled (default "opus" = Opus 4.8)
 
 [agent.phase_models]              # per-PHASE model tier for the spawned sub-agent (model_tiering)
 planning = "fable"                # pin a phase up; "" / "default" / "inherit" opts out
@@ -298,6 +301,23 @@ than the assumed-opus inherited default — `tier_rank(None)` equals
 `tier_rank("opus")`, so an `opus`-or-weaker floor is silently dropped (the phase
 still inherits) and only a `fable` floor pins it up. `t3 doctor` WARNs on a floor
 that names no known tier (likely a typo) since an unknown id ranks most-capable.
+
+**`fable_enabled` / `fable_fallback` (the single Fable kill-switch, teatree#2237).**
+Fable can be wired through several independent pins above (`session_model`, any
+`phase_models.<phase>`, any `skill_models.<skill>`). If Fable becomes
+unavailable, reverting to the Opus 4.8 baseline is **one flip**:
+`fable_enabled = false`. With it off, every resolved model value that is Fable —
+recognised by tier (`cost.tier_of_model`), so both the short alias `fable` and
+the full id `claude-fable-5` match — transparently downgrades to `fable_fallback`
+at the single resolution chokepoint (`model_tiering._downgrade_fable`, applied at
+the end of `resolve_spawn_model` covering every sub-agent spawn, plus the
+`session_model` `--model` pin in `cli/loop.py`). `fable_fallback` defaults to
+`"opus"` (the tier/cost machinery maps it to `claude-opus-4-8`), so Opus 4.8
+compatibility is preserved by construction. **The default is enabled** — an
+absent `fable_enabled` key counts as `true`, so existing configs that pin Fable
+keep resolving to Fable, byte-for-byte unchanged; only the explicit
+`fable_enabled = false` flips the revert. Non-Fable pins (`sonnet`, `haiku`,
+`opus`) and inheriting phases (`None`) pass through untouched either way.
 
 ### 10.2 Django Settings (framework-level, in teatree's settings.py)
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3747,6 +3747,11 @@ Usage: t3 teatree workspace ticket [OPTIONS] ISSUE_URL
  Idempotent: re-running over an already-started ticket merges new repos
  into ``ticket.repos`` so the next ``execute_provision`` picks them up.
 
+ Filesystem-evidence double-dispatch guard (#2217): before materialising a
+ worktree for issue ``N``, refuse when a *foreign* ``N-*`` worktree dir
+ already exists (someone may already be on it) unless ``--take-over`` is
+ passed. Re-provisioning the ticket's own existing dir is always allowed.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    issue_url      TEXT  [required]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -3754,6 +3759,8 @@ Usage: t3 teatree workspace ticket [OPTIONS] ISSUE_URL
 │ --variant            TEXT                                                    │
 │ --repos              TEXT                                                    │
 │ --description        TEXT                                                    │
+│ --take-over                Proceed even when another worktree dir for this   │
+│                            issue already exists (#2217).                     │
 │ --help                     Show this message and exit.                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/scripts/hooks/check_blueprint_sync.py
+++ b/scripts/hooks/check_blueprint_sync.py
@@ -1,8 +1,13 @@
-"""Commit-msg hook: warn when src/ changes but BLUEPRINT.md does not.
+"""Commit-msg hook: warn when src/ changes but the BLUEPRINT does not.
 
-Exits non-zero when source code changes without a corresponding BLUEPRINT.md
+Exits non-zero when source code changes without a corresponding BLUEPRINT
 update, unless the commit type is one that typically doesn't require it
 (test, docs, style, chore, ci, fix).
+
+The "BLUEPRINT" is the top-level ``BLUEPRINT.md`` plus its split appendix
+files under ``docs/blueprint/`` (e.g. ``configuration.md``,
+``loop-topology.md``) — the appendices ARE the BLUEPRINT, so updating one of
+them satisfies the sync requirement just as the monolith does.
 
 See: souliane/teatree#8
 """
@@ -25,12 +30,23 @@ def _staged_files() -> list[str]:
     return result.stdout.strip().splitlines()
 
 
+def _is_blueprint(path: str) -> bool:
+    """A staged path that counts as a BLUEPRINT update.
+
+    The top-level ``BLUEPRINT.md`` or any of its split appendix markdown files
+    under ``docs/blueprint/`` — the appendices are the BLUEPRINT's deep-mechanics
+    sections, so editing one satisfies the sync requirement.
+    """
+    return path == "BLUEPRINT.md" or (path.startswith("docs/blueprint/") and path.endswith(".md"))
+
+
 def _commit_message() -> str:
     min_args = 2
     if len(sys.argv) < min_args:
         return ""
     try:
-        return pathlib.Path(sys.argv[1]).open(encoding="utf-8").readline().strip()
+        with pathlib.Path(sys.argv[1]).open(encoding="utf-8") as fh:
+            return fh.readline().strip()
     except OSError:
         return ""
 
@@ -45,7 +61,7 @@ def main() -> int:
 
     files = _staged_files()
     has_src = any(f.startswith("src/") for f in files)
-    has_blueprint = "BLUEPRINT.md" in files
+    has_blueprint = any(_is_blueprint(f) for f in files)
 
     if has_src and not has_blueprint:
         print()

--- a/src/teatree/agents/model_tiering.py
+++ b/src/teatree/agents/model_tiering.py
@@ -24,8 +24,14 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from teatree.config import CONFIG_PATH
-from teatree.config_agent import _INHERIT_SENTINELS, resolve_agent_config
-from teatree.core.cost import tier_rank
+from teatree.config_agent import _INHERIT_SENTINELS, AgentConfig, resolve_agent_config
+from teatree.core.cost import tier_of_model, tier_rank
+
+# The :func:`teatree.core.cost.tier_of_model` tier key for Fable. Normalising a
+# model id to its tier recognises BOTH the short alias ``fable`` and the full
+# ``claude-fable-5`` (and any future dated Fable id), so the kill-switch matches
+# on the tier rather than a brittle ``== "fable"`` string compare.
+_FABLE_TIER = "fable"
 
 # Default phase -> model-tier mapping. planning is pinned UP to opus as a
 # structural floor; mechanical phases are downgraded to sonnet/haiku; coding
@@ -76,14 +82,36 @@ def resolve_spawn_model(phase: str, *, skills: Iterable[str], config_path: Path 
     absent config is byte-for-byte the prior :func:`resolve_phase_model`
     behaviour. MODEL only: there is no per-skill effort axis (effort is a
     session-wide pin set on the interactive loop spawn).
+
+    The resolved winner passes through :func:`_downgrade_fable` last: with the
+    ``[agent] fable_enabled`` kill-switch off (teatree#2237), a Fable winner
+    transparently downgrades to ``fable_fallback`` (Opus 4.8 baseline). This is
+    the single spawn chokepoint, so the downgrade covers every sub-agent spawn.
     """
+    config = resolve_agent_config(config_path=config_path)
     winner = resolve_phase_model(phase, config_path=config_path)
-    skill_models = resolve_agent_config(config_path=config_path).skill_models
     for skill in skills:
-        floor = skill_models.get(skill)
+        floor = config.skill_models.get(skill)
         if floor is not None and tier_rank(floor) > tier_rank(winner):
             winner = floor
-    return winner
+    return _downgrade_fable(winner, config)
+
+
+def _downgrade_fable(model: str | None, config: AgentConfig) -> str | None:
+    """Apply the single Fable kill-switch to one resolved *model* (teatree#2237).
+
+    When *model* is Fable — recognised by tier (the short alias ``fable`` OR the
+    full ``claude-fable-5``, via :func:`teatree.core.cost.tier_of_model`) — AND
+    ``config.fable_enabled`` is ``False``, return ``config.fable_fallback`` (the
+    Opus 4.8 baseline by default). Otherwise return *model* unchanged: a
+    non-Fable model, ``None`` (inherit), or Fable while the switch is on all pass
+    through untouched, so enabled/absent is byte-identical to today.
+    """
+    if model is None or config.fable_enabled:
+        return model
+    if tier_of_model(model) == _FABLE_TIER:
+        return config.fable_fallback
+    return model
 
 
 def _load_phase_model_overrides(config_path: Path | None) -> dict[str, str]:

--- a/src/teatree/cli/_doctor_checks.py
+++ b/src/teatree/cli/_doctor_checks.py
@@ -176,7 +176,8 @@ def _check_agent_session_pins() -> bool:
     A ``session_effort`` off the strict CLI scale (``low|medium|high|xhigh|max``)
     is a hard FAIL — ``resolve_agent_config`` raises, and we surface the message
     rather than letting it reach the interactive spawn. An unrecognised model in
-    ``session_model`` or any ``[agent.skill_models]`` floor is a WARN (it ranks
+    ``session_model``, any ``[agent.skill_models]`` floor, or the Fable
+    kill-switch ``fable_fallback`` (teatree#2237) is a WARN (it ranks
     most-capable via ``cost.tier_rank``, so it still works, but it is most likely
     a typo). An absent or all-valid config is silently OK.
     """
@@ -204,6 +205,11 @@ def _check_agent_session_pins() -> bool:
                 f"WARN  [agent.skill_models] {skill} = {floor!r} matches no known tier "
                 f"({', '.join(PRICE_TABLE)}); it will be treated as most-capable. Likely a typo."
             )
+    if not cfg.fable_enabled and _unrecognised(cfg.fable_fallback):
+        typer.echo(
+            f"WARN  [agent] fable_fallback {cfg.fable_fallback!r} matches no known tier "
+            f"({', '.join(PRICE_TABLE)}); Fable will downgrade to an unknown model. Likely a typo."
+        )
     return True
 
 

--- a/src/teatree/cli/loop.py
+++ b/src/teatree/cli/loop.py
@@ -263,13 +263,20 @@ def _session_pin_flags() -> list[str]:
     byte-for-byte today's behaviour. Effort is validated at parse time
     (``config_agent.resolve_agent_config``), so an off-scale value fails loudly
     rather than reaching the CLI.
+
+    The ``session_model`` pin passes through the same Fable kill-switch
+    (``_downgrade_fable``) the headless spawn chokepoint uses (teatree#2237), so
+    a Fable session pin downgrades to the Opus 4.8 baseline when
+    ``[agent] fable_enabled = false`` — the one flip reverts every surface.
     """
+    from teatree.agents.model_tiering import _downgrade_fable  # noqa: PLC0415
     from teatree.config_agent import resolve_agent_config  # noqa: PLC0415
 
     cfg = resolve_agent_config()
+    session_model = _downgrade_fable(cfg.session_model, cfg)
     flags: list[str] = []
-    if cfg.session_model:
-        flags.extend(["--model", cfg.session_model])
+    if session_model:
+        flags.extend(["--model", session_model])
     if cfg.session_effort:
         flags.extend(["--effort", cfg.session_effort])
     return flags

--- a/src/teatree/config_agent.py
+++ b/src/teatree/config_agent.py
@@ -83,11 +83,23 @@ class AgentConfig:
         ``None`` to inherit the user's default.
     *   ``session_effort`` — the interactive main-agent ``--effort`` pin (a
         member of :data:`EFFORT_SCALE`), or ``None`` to inherit.
+    *   ``fable_enabled`` — the single Fable kill-switch (teatree#2237).
+        ``True`` (the default, and absent-key) keeps every Fable pin resolving
+        to Fable, byte-identical to today. ``False`` transparently downgrades
+        every resolved Fable model value to :attr:`fable_fallback` across all
+        spawn surfaces and the session pin, so reverting to the Opus 4.8
+        baseline is one flip rather than editing every Fable pin.
+    *   ``fable_fallback`` — the model Fable downgrades to when disabled.
+        Default ``"opus"`` (which the tier/cost machinery maps to
+        ``claude-opus-4-8``), so Opus 4.8 compatibility is preserved by
+        construction. Normalised through :func:`_normalize_model`.
     """
 
     skill_models: dict[str, str | None] = field(default_factory=dict)
     session_model: str | None = None
     session_effort: str | None = None
+    fable_enabled: bool = True
+    fable_fallback: str = "opus"
 
 
 def _skill_models_from(raw: object) -> dict[str, str | None]:
@@ -102,16 +114,32 @@ def _skill_models_from(raw: object) -> dict[str, str | None]:
     return {str(skill): _normalize_model(model) for skill, model in raw.items()}
 
 
+def _fable_fallback_from(raw: object) -> str:
+    """Normalise the ``[agent] fable_fallback`` value to a non-empty model id.
+
+    Shares :func:`_normalize_model`'s boundary (whitespace strip + sentinel
+    handling). An absent key or a sentinel value (which normalises to ``None``)
+    falls back to the Opus 4.8 baseline ``"opus"`` — the fallback must always be
+    a concrete model id, never the inherit sentinel.
+    """
+    if raw is None:
+        return "opus"
+    return _normalize_model(raw) or "opus"
+
+
 def _agent_config_from_table(agent: Mapping[str, object]) -> AgentConfig:
     """Build an :class:`AgentConfig` from the parsed ``[agent]`` table.
 
     Effort is validated here (raises on an off-scale value); model values are
-    normalised through the inherit sentinels.
+    normalised through the inherit sentinels. The Fable kill-switch defaults to
+    enabled (absent key == enabled) so existing Fable-pinned users are unchanged.
     """
     return AgentConfig(
         skill_models=_skill_models_from(agent.get("skill_models")),
         session_model=_normalize_model(agent["session_model"]) if "session_model" in agent else None,
         session_effort=parse_effort(agent.get("session_effort")),
+        fable_enabled=bool(agent.get("fable_enabled", True)),
+        fable_fallback=_fable_fallback_from(agent.get("fable_fallback")),
     )
 
 

--- a/tests/teatree_agents/test_model_tiering.py
+++ b/tests/teatree_agents/test_model_tiering.py
@@ -238,3 +238,176 @@ class TestResolveSpawnModel:
 
         monkeypatch.setattr(ca_mod, "CONFIG_PATH", cfg)
         assert resolve_spawn_model("coding", skills=["code-review"]) == "fable"
+
+
+# The Fable-pinned surfaces (phase_models + skill_models + session_model) one
+# config carries, used to prove the kill-switch downgrades EVERY surface, not a
+# sampled subset. The ``[agent]`` scalar keys (the kill-switch + session_model)
+# must precede the sub-tables, so they are injected via a template.
+_FABLE_PHASE_PINS = (
+    'phase_models.planning = "fable"\n'
+    'phase_models.coding = "fable"\n'
+    'phase_models.debugging = "fable"\n'
+    'phase_models.reviewing = "fable"\n'
+    'phase_models.architectural_review = "fable"\n'
+)
+_FABLE_SKILL_PINS = (
+    "[agent.skill_models]\n"
+    'code-review = "fable"\n'
+    'architecture-design = "fable"\n'
+    't3-e2e = "claude-fable-5"\n'  # full id form, not the short alias
+)
+
+_ALL_PHASES = (
+    "planning",
+    "coding",
+    "debugging",
+    "reviewing",
+    "requesting_review",
+    "testing",
+    "shipping",
+    "retrospecting",
+    "architectural_review",
+    "scoping",
+)
+
+_SKILL_BUNDLES = (
+    [],
+    ["code-review"],
+    ["architecture-design"],
+    ["t3-e2e"],
+    ["code-review", "architecture-design", "t3-e2e"],
+    ["unlisted-skill"],
+)
+
+
+def _fable_pinned_cfg(tmp_path: Path, *, agent_scalars: str = "") -> Path:
+    """A Fable-pinned config: phase_models + skill_models + session_model = fable.
+
+    *agent_scalars* are extra ``[agent]`` scalar lines (the kill-switch keys),
+    placed before the phase pins so they stay inside the ``[agent]`` table.
+    """
+    cfg = tmp_path / ".teatree.toml"
+    _write_toml(
+        cfg,
+        "[agent]\n" + 'session_model = "fable"\n' + agent_scalars + _FABLE_PHASE_PINS + _FABLE_SKILL_PINS,
+    )
+    return cfg
+
+
+class TestFableKillSwitch:
+    """``[agent] fable_enabled`` single-toggle downgrade (teatree#2237).
+
+    When disabled, every resolved model value that is Fable (short ``fable`` or
+    full ``claude-fable-5``) transparently downgrades to ``fable_fallback``
+    (default ``opus`` = Opus 4.8) across every spawn + the session pin. Enabled
+    (and absent) is byte-identical to today.
+    """
+
+    def test_disabled_downgrades_every_phase_skill_combo_to_fallback(self, tmp_path: Path) -> None:
+        # Toggle OFF: NO Fable id for ANY (phase, skill-bundle) combination
+        # drawn from a Fable-pinned config. The fitness invariant the kill-switch
+        # guarantees is "no Fable id anywhere"; the comparison run below proves
+        # that wherever ON resolved to Fable, OFF resolved to the fallback.
+        from teatree.core.cost import tier_of_model  # noqa: PLC0415
+
+        on_dir = tmp_path / "on"
+        on_dir.mkdir()
+        off = _fable_pinned_cfg(tmp_path, agent_scalars="fable_enabled = false\n")
+        on = _fable_pinned_cfg(on_dir, agent_scalars="fable_enabled = true\n")
+        any_was_fable = False
+        for phase in _ALL_PHASES:
+            for bundle in _SKILL_BUNDLES:
+                on_resolved = resolve_spawn_model(phase, skills=bundle, config_path=on)
+                off_resolved = resolve_spawn_model(phase, skills=bundle, config_path=off)
+                assert off_resolved != "fable", (phase, bundle, off_resolved)
+                assert off_resolved != "claude-fable-5", (phase, bundle, off_resolved)
+                if on_resolved is not None and tier_of_model(on_resolved) == "fable":
+                    any_was_fable = True
+                    # Every combo that resolved to Fable when ON (short alias OR
+                    # the full claude-fable-5 id) now resolves to the fallback
+                    # (opus = Opus 4.8 baseline) when OFF.
+                    assert off_resolved == "opus", (phase, bundle, off_resolved)
+                else:
+                    # A non-Fable resolution is untouched by the kill-switch.
+                    assert off_resolved == on_resolved, (phase, bundle, on_resolved, off_resolved)
+        assert any_was_fable, "fixture must exercise at least one Fable resolution"
+
+    def test_enabled_is_byte_identical_to_today(self, tmp_path: Path) -> None:
+        # Toggle ON explicitly: Fable pins still resolve to Fable, preserving the
+        # exact id form (short alias from the phase/skill pins, full id from the
+        # t3-e2e floor) — the kill-switch ON is a no-op.
+        cfg = _fable_pinned_cfg(tmp_path, agent_scalars="fable_enabled = true\n")
+        assert resolve_spawn_model("planning", skills=[], config_path=cfg) == "fable"
+        assert resolve_spawn_model("coding", skills=["code-review"], config_path=cfg) == "fable"
+        # t3-e2e's floor is the full claude-fable-5 id, preserved byte-for-byte.
+        assert resolve_spawn_model("testing", skills=["t3-e2e"], config_path=cfg) == "claude-fable-5"
+
+    def test_absent_toggle_is_enabled_keeps_fable(self, tmp_path: Path) -> None:
+        # No fable_enabled key at all == enabled, so existing pins keep Fable.
+        cfg = _fable_pinned_cfg(tmp_path)
+        assert resolve_spawn_model("planning", skills=[], config_path=cfg) == "fable"
+        assert resolve_spawn_model("coding", skills=["architecture-design"], config_path=cfg) == "fable"
+
+    def test_fable_fallback_override_to_sonnet(self, tmp_path: Path) -> None:
+        cfg = _fable_pinned_cfg(tmp_path, agent_scalars='fable_enabled = false\nfable_fallback = "sonnet"\n')
+        assert resolve_spawn_model("planning", skills=[], config_path=cfg) == "sonnet"
+        assert resolve_spawn_model("coding", skills=["code-review"], config_path=cfg) == "sonnet"
+
+    def test_non_fable_pins_untouched_when_disabled(self, tmp_path: Path) -> None:
+        # The toggle only downgrades Fable; a sonnet/haiku pin is left alone.
+        cfg = tmp_path / ".teatree.toml"
+        _write_toml(
+            cfg,
+            '[agent]\nfable_enabled = false\nphase_models.reviewing = "sonnet"\nphase_models.retrospecting = "haiku"\n',
+        )
+        assert resolve_spawn_model("reviewing", skills=[], config_path=cfg) == "sonnet"
+        assert resolve_spawn_model("retrospecting", skills=[], config_path=cfg) == "haiku"
+
+    def test_inheriting_phase_stays_none_when_disabled(self, tmp_path: Path) -> None:
+        # An inheriting phase (None) is not Fable — it stays None, not the fallback.
+        cfg = tmp_path / ".teatree.toml"
+        _write_toml(cfg, "[agent]\nfable_enabled = false\n")
+        assert resolve_spawn_model("coding", skills=[], config_path=cfg) is None
+
+
+class TestDowngradeFableHelper:
+    """The pure ``_downgrade_fable(model, config)`` helper (teatree#2237)."""
+
+    def test_short_alias_downgrades_when_disabled(self) -> None:
+        from teatree.config_agent import AgentConfig  # noqa: PLC0415
+
+        cfg = AgentConfig(fable_enabled=False, fable_fallback="opus")
+        assert mt_mod._downgrade_fable("fable", cfg) == "opus"
+
+    def test_full_id_downgrades_when_disabled(self) -> None:
+        from teatree.config_agent import AgentConfig  # noqa: PLC0415
+
+        cfg = AgentConfig(fable_enabled=False, fable_fallback="opus")
+        assert mt_mod._downgrade_fable("claude-fable-5", cfg) == "opus"
+
+    def test_left_unchanged_when_enabled(self) -> None:
+        from teatree.config_agent import AgentConfig  # noqa: PLC0415
+
+        cfg = AgentConfig(fable_enabled=True, fable_fallback="opus")
+        assert mt_mod._downgrade_fable("fable", cfg) == "fable"
+        assert mt_mod._downgrade_fable("claude-fable-5", cfg) == "claude-fable-5"
+
+    def test_non_fable_unchanged_when_disabled(self) -> None:
+        from teatree.config_agent import AgentConfig  # noqa: PLC0415
+
+        cfg = AgentConfig(fable_enabled=False, fable_fallback="opus")
+        assert mt_mod._downgrade_fable("sonnet", cfg) == "sonnet"
+        assert mt_mod._downgrade_fable("opus", cfg) == "opus"
+
+    def test_none_unchanged_when_disabled(self) -> None:
+        from teatree.config_agent import AgentConfig  # noqa: PLC0415
+
+        cfg = AgentConfig(fable_enabled=False, fable_fallback="opus")
+        assert mt_mod._downgrade_fable(None, cfg) is None
+
+    def test_fallback_override_respected(self) -> None:
+        from teatree.config_agent import AgentConfig  # noqa: PLC0415
+
+        cfg = AgentConfig(fable_enabled=False, fable_fallback="sonnet")
+        assert mt_mod._downgrade_fable("fable", cfg) == "sonnet"

--- a/tests/teatree_cli/test_agent_session_pins_check.py
+++ b/tests/teatree_cli/test_agent_session_pins_check.py
@@ -114,3 +114,34 @@ class TestAgentSessionPinsCheck:
         _patch_config(monkeypatch, cfg)
         assert _check_agent_session_pins() is True
         assert capsys.readouterr().out == ""
+
+    def test_unknown_fable_fallback_warns_when_disabled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # teatree#2237: a typo'd fallback would silently downgrade Fable to an
+        # unknown model when the kill-switch is off — WARN on it.
+        cfg = _write(tmp_path, '[agent]\nfable_enabled = false\nfable_fallback = "opsu"\n')
+        _patch_config(monkeypatch, cfg)
+        assert _check_agent_session_pins() is True
+        out = capsys.readouterr().out
+        assert "WARN" in out
+        assert "fable_fallback" in out
+        assert "opsu" in out
+
+    def test_valid_fable_fallback_does_not_warn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        cfg = _write(tmp_path, '[agent]\nfable_enabled = false\nfable_fallback = "opus"\n')
+        _patch_config(monkeypatch, cfg)
+        assert _check_agent_session_pins() is True
+        assert capsys.readouterr().out == ""
+
+    def test_bad_fable_fallback_silent_when_enabled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The fallback never applies while Fable is enabled, so a typo there is
+        # not surfaced — no WARN.
+        cfg = _write(tmp_path, '[agent]\nfable_enabled = true\nfable_fallback = "opsu"\n')
+        _patch_config(monkeypatch, cfg)
+        assert _check_agent_session_pins() is True
+        assert capsys.readouterr().out == ""

--- a/tests/teatree_cli/test_cli_loop.py
+++ b/tests/teatree_cli/test_cli_loop.py
@@ -214,6 +214,43 @@ class TestStartCommandSessionPins:
         assert len(argv) == 2
         assert argv[-1].startswith("/loop ")
 
+    def test_fable_session_model_downgrades_to_opus_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # teatree#2237: the kill-switch downgrades the session --model pin too.
+        argv = self._spawn_argv(
+            monkeypatch,
+            tmp_path,
+            '[agent]\nfable_enabled = false\nsession_model = "fable"\n',
+        )
+        assert "--model" in argv
+        assert argv[argv.index("--model") + 1] == "opus"
+
+    def test_fable_full_id_session_model_downgrades_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        argv = self._spawn_argv(
+            monkeypatch,
+            tmp_path,
+            '[agent]\nfable_enabled = false\nsession_model = "claude-fable-5"\n',
+        )
+        assert argv[argv.index("--model") + 1] == "opus"
+
+    def test_fable_session_model_downgrades_to_fallback_override(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        argv = self._spawn_argv(
+            monkeypatch,
+            tmp_path,
+            '[agent]\nfable_enabled = false\nfable_fallback = "sonnet"\nsession_model = "fable"\n',
+        )
+        assert argv[argv.index("--model") + 1] == "sonnet"
+
+    def test_fable_session_model_kept_when_enabled(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        # Toggle ON (and absent): the Fable session pin is byte-identical to today.
+        argv = self._spawn_argv(monkeypatch, tmp_path, '[agent]\nsession_model = "fable"\n')
+        assert argv[argv.index("--model") + 1] == "fable"
+
 
 class TestStopCommand:
     def test_stop_explains_unregister(self) -> None:

--- a/tests/test_check_blueprint_sync_hook.py
+++ b/tests/test_check_blueprint_sync_hook.py
@@ -1,0 +1,104 @@
+"""Tests for the BLUEPRINT-sync commit-msg hook (souliane/teatree#8).
+
+The hook fails when ``src/`` changes without a corresponding BLUEPRINT update,
+unless the commit type is exempt (test/docs/style/chore/ci/fix). The
+"BLUEPRINT" is the top-level ``BLUEPRINT.md`` plus its split appendix files
+under ``docs/blueprint/`` — updating an appendix satisfies the requirement just
+as the monolith does (teatree#2237: the appendices ARE the BLUEPRINT).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.hooks import check_blueprint_sync as hook
+
+
+class TestIsBlueprint:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "BLUEPRINT.md",
+            "docs/blueprint/configuration.md",
+            "docs/blueprint/loop-topology.md",
+            "docs/blueprint/factory-architecture.md",
+        ],
+    )
+    def test_blueprint_paths_count(self, path: str) -> None:
+        assert hook._is_blueprint(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "docs/dependency-graph.md",
+            "docs/blueprint/notes.txt",
+            "src/teatree/config_agent.py",
+            "README.md",
+            "docs/blueprintish.md",
+        ],
+    )
+    def test_non_blueprint_paths_do_not_count(self, path: str) -> None:
+        assert hook._is_blueprint(path) is False
+
+
+class TestMain:
+    def _run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        *,
+        message: str,
+        staged: list[str],
+    ) -> int:
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text(message + "\n", encoding="utf-8")
+        monkeypatch.setattr(hook.sys, "argv", ["check_blueprint_sync.py", str(msg_file)])
+        monkeypatch.setattr(hook, "_staged_files", lambda: staged)
+        return hook.main()
+
+    def test_src_without_blueprint_fails(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        rc = self._run(
+            monkeypatch,
+            tmp_path,
+            message="feat(agent): something",
+            staged=["src/teatree/config_agent.py"],
+        )
+        assert rc == 1
+
+    def test_src_with_top_level_blueprint_passes(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        rc = self._run(
+            monkeypatch,
+            tmp_path,
+            message="feat(agent): something",
+            staged=["src/teatree/config_agent.py", "BLUEPRINT.md"],
+        )
+        assert rc == 0
+
+    def test_src_with_appendix_blueprint_passes(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        # The key teatree#2237 case: documenting in a docs/blueprint/ appendix
+        # satisfies the sync gate, so a feat commit need not touch BLUEPRINT.md.
+        rc = self._run(
+            monkeypatch,
+            tmp_path,
+            message="feat(agent): single-toggle Fable kill-switch",
+            staged=["src/teatree/config_agent.py", "docs/blueprint/configuration.md"],
+        )
+        assert rc == 0
+
+    def test_exempt_commit_type_passes_without_blueprint(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        rc = self._run(
+            monkeypatch,
+            tmp_path,
+            message="fix(agent): a bug",
+            staged=["src/teatree/config_agent.py"],
+        )
+        assert rc == 0
+
+    def test_no_src_change_passes(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        rc = self._run(
+            monkeypatch,
+            tmp_path,
+            message="feat(docs): docs only",
+            staged=["docs/blueprint/configuration.md"],
+        )
+        assert rc == 0

--- a/tests/test_config_agent.py
+++ b/tests/test_config_agent.py
@@ -52,6 +52,61 @@ class TestAgentConfigDefaults:
         assert cfg.session_model is None
         assert cfg.session_effort is None
 
+    def test_default_fable_kill_switch_is_enabled_with_opus_fallback(self) -> None:
+        # Absent key == enabled, so existing Fable-pinned users keep Fable; the
+        # fallback baseline is opus (Opus 4.8) per teatree#2237.
+        cfg = AgentConfig()
+        assert cfg.fable_enabled is True
+        assert cfg.fable_fallback == "opus"
+
+
+class TestFableKillSwitchParse:
+    """``[agent] fable_enabled`` / ``fable_fallback`` parsing (teatree#2237)."""
+
+    def test_fable_enabled_false_parsed(self, tmp_path: Path) -> None:
+        cfg = tmp_path / ".teatree.toml"
+        _write(cfg, "[agent]\nfable_enabled = false\n")
+        assert resolve_agent_config(config_path=cfg).fable_enabled is False
+
+    def test_fable_enabled_true_parsed(self, tmp_path: Path) -> None:
+        cfg = tmp_path / ".teatree.toml"
+        _write(cfg, "[agent]\nfable_enabled = true\n")
+        assert resolve_agent_config(config_path=cfg).fable_enabled is True
+
+    def test_absent_fable_enabled_defaults_to_enabled(self, tmp_path: Path) -> None:
+        cfg = tmp_path / ".teatree.toml"
+        _write(cfg, '[agent]\nsession_model = "fable"\n')
+        assert resolve_agent_config(config_path=cfg).fable_enabled is True
+
+    def test_fable_fallback_parsed(self, tmp_path: Path) -> None:
+        cfg = tmp_path / ".teatree.toml"
+        _write(cfg, '[agent]\nfable_fallback = "sonnet"\n')
+        assert resolve_agent_config(config_path=cfg).fable_fallback == "sonnet"
+
+    def test_fable_fallback_normalised_through_inherit_path(self, tmp_path: Path) -> None:
+        # The fallback is normalised through ``_normalize_model`` (whitespace
+        # stripped); it is a model id, so it shares that boundary.
+        cfg = tmp_path / ".teatree.toml"
+        _write(cfg, '[agent]\nfable_fallback = "  opus  "\n')
+        assert resolve_agent_config(config_path=cfg).fable_fallback == "opus"
+
+    def test_absent_fable_fallback_defaults_to_opus(self, tmp_path: Path) -> None:
+        cfg = tmp_path / ".teatree.toml"
+        _write(cfg, "[agent]\nfable_enabled = false\n")
+        assert resolve_agent_config(config_path=cfg).fable_fallback == "opus"
+
+    def test_missing_file_keeps_enabled_with_opus_fallback(self, tmp_path: Path) -> None:
+        resolved = resolve_agent_config(config_path=tmp_path / "nope.toml")
+        assert resolved.fable_enabled is True
+        assert resolved.fable_fallback == "opus"
+
+    def test_missing_agent_section_keeps_enabled_with_opus_fallback(self, tmp_path: Path) -> None:
+        cfg = tmp_path / ".teatree.toml"
+        _write(cfg, '[teatree]\nmode = "interactive"\n')
+        resolved = resolve_agent_config(config_path=cfg)
+        assert resolved.fable_enabled is True
+        assert resolved.fable_fallback == "opus"
+
 
 class TestSkillModelsParse:
     def test_parsed_from_agent_subtable(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Makes reverting Fable 5 to the Opus 4.8 baseline a **single toggle**, closing [#2237](https://github.com/souliane/teatree/issues/2237). Builds on the [#2216](https://github.com/souliane/teatree/issues/2216) model-tiering surface.

Today Fable is wired through several independent pins (`session_model`, any `[agent.phase_models].<phase>`, any `[agent.skill_models].<skill>`). Reverting meant editing every pin. Now:

- New `[agent] fable_enabled` boolean — default `true` (absent key == enabled), so existing Fable-pinned configs are byte-identical to today. Flip to `false` to revert every Fable surface at once.
- New `[agent] fable_fallback` — default `"opus"` (the tier/cost machinery maps it to `claude-opus-4-8`), so Opus 4.8 compatibility is preserved by construction.

When disabled, the single pure helper `model_tiering._downgrade_fable(model, config)` downgrades any Fable model — recognised by **tier** via `core.cost.tier_of_model`, so BOTH the short alias `fable` AND the full id `claude-fable-5` match (not a brittle `== "fable"`) — to `fable_fallback`. Applied at:

- The resolution chokepoint: end of `resolve_spawn_model` (covers every sub-agent spawn — guaranteed by `tests/quality/test_spawn_model_chokepoint.py`).
- The one extra site: the `session_model` `--model` pin in `cli/loop.py`.

Non-Fable pins (`sonnet`/`haiku`/`opus`) and inheriting phases (`None`) pass through untouched in both states.

`t3 doctor` WARNs on a typo'd `fable_fallback` (only when disabled — it never applies while Fable is on).

### Bundled fixes found mid-session

- `check_blueprint_sync` commit-msg hook only recognised the monolithic `BLUEPRINT.md`, not its split `docs/blueprint/*.md` appendices — so documenting `[agent]` config in its canonical home (`configuration.md`) spuriously failed the gate on a `feat` commit. The appendices ARE the BLUEPRINT, so an appendix edit now satisfies it (with a test, anti-vacuous against the old behaviour).
- That hook's `_commit_message` leaked an unclosed file handle; wrapped in a context manager.

## Tests

Focused suite (`--no-migrations --reuse-db`): **189 passed**.

- Toggle OFF: for the shipped defaults + a Fable-pinned config (phase_models + skill_models + session_model = fable, mixing short alias and full `claude-fable-5` id), `resolve_spawn_model` returns NO Fable id for ANY (phase, skill-bundle) combo and the fallback wherever ON resolved to Fable; `session_model` Fable → fallback. **Anti-vacuous proven:** removing the downgrade call turned this RED (`AssertionError: ('planning', [], 'fable')`); restored → GREEN.
- Toggle ON / absent: Fable pins still resolve to Fable, byte-identical.
- `fable_fallback` override → `sonnet` downgrades Fable to sonnet.
- Config parse: `fable_enabled` bool, `fable_fallback` string, fail-to-defaults (absent file/section → enabled, opus fallback).
- `tests/quality/test_spawn_model_chokepoint.py` stays green (chokepoint intact); full `tests/quality/` (428) + `tach check` green.

## Docs

- `docs/blueprint/configuration.md` §10.1.2 documents both keys + a commented `~/.teatree.toml` example pair. **BLUEPRINT.md untouched** (owned by a parallel PR). No in-repo `~/.teatree.toml` template exists to update.

## Architecture pre-check — #2237

### 1. BLUEPRINT § alignment
Builds on #2216 model-tiering (`config_agent.py`, `agents/model_tiering.py`, `core/cost.py`); documented in `docs/blueprint/configuration.md` §10.1.2. Pure config-resolution logic, SDK/API-portable per BLUEPRINT §2.

### 2. FSM phase boundaries
n/a — no `Ticket.State`/`Worktree.State` transitions.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / Protocol surface changed.

### 4. Component boundaries
`config_agent.py` (foundation: new fields + parsing), `agents/model_tiering.py` (domain: the `_downgrade_fable` helper at the chokepoint), `cli/loop.py` (the session pin site), `cli/_doctor_checks.py` (WARN). Fable detection reuses `core/cost.tier_of_model`.

### 5. Dependency direction
No backwards edge. `model_tiering` already depends on `config_agent` + `core.cost`; `cli` already depends on `agents`. `tach check` green.

### 6. Test surface
`tests/test_config_agent.py::TestFableKillSwitchParse`, `tests/teatree_agents/test_model_tiering.py::TestFableKillSwitch` + `TestDowngradeFableHelper`, `tests/teatree_cli/test_cli_loop.py` (session pin), `tests/teatree_cli/test_agent_session_pins_check.py` (doctor WARN), `tests/test_check_blueprint_sync_hook.py` (the bundled hook fix). Regression assertion observed RED then GREEN.

### 7. Resilience invariants
n/a — no external write. Pure deterministic resolution. Idempotent (the helper is a pure function); enabled/absent is a no-op.

### 8. Identity and key normalization
Fable is canonicalised UP to its tier via `tier_of_model` at the comparison boundary (recognises both the short alias and the full id), not stripped down to a substring — the design-skill normalization rule.

### 9. Behavior preservation / capability deletion
Purely additive. No behavior removed; enabled/absent is byte-identical to today (proven by the ON test + the existing chokepoint back-compat test). No must-block test inverted. The `check_blueprint_sync` change WIDENS what satisfies the gate (appendices now count) — it never narrows a safety/privacy matcher.

Closes #2237.
