### PR TITLE
fix(cleanup): resolve overlay from worktree field in cleanup_worktree (#295)

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -29,7 +29,7 @@ from teatree.core.branch_classification import (
 )
 from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Ticket, Worktree
-from teatree.core.overlay_loader import get_overlay
+from teatree.core.overlay_loader import get_overlay_for_worktree
 from teatree.core.worktree_env import compose_project, worktree_pg_connection
 from teatree.core.worktree_recovery import _has_unpushed_commits, capture_recovery_artifact
 from teatree.utils import git
@@ -525,7 +525,7 @@ def cleanup_worktree(worktree: Worktree, *, force: bool = False, strict_hygiene:
     """
     workspace = load_config().user.workspace_dir
     wt_path = _resolve_worktree_path(workspace, worktree)
-    overlay = get_overlay()
+    overlay = get_overlay_for_worktree(worktree)
 
     if Path(wt_path).is_dir() and git.status_porcelain(wt_path):
         logger.warning("%s has uncommitted changes — cleaning anyway (PR merged)", worktree.repo_path)

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -7,6 +7,7 @@ mock; the shared module-level ``_patch_*`` decorators and the
 ``_no_unpushed``/``_mock_workspace`` helpers are lifted unchanged.
 """
 
+from collections.abc import Iterator
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -14,11 +15,12 @@ from django.test import TestCase
 
 from teatree.core.cleanup import BranchClassification, BranchCommit, cleanup_worktree
 from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay import OverlayBase, ProvisionStep, RunCommands
 from teatree.utils.run import CommandFailedError
 
 _patch_config = patch("teatree.core.cleanup.load_config")
 _patch_git = patch("teatree.core.cleanup.git")
-_patch_overlay = patch("teatree.core.cleanup.get_overlay")
+_patch_overlay = patch("teatree.core.cleanup.get_overlay_for_worktree")
 _patch_classify = patch("teatree.core.cleanup.classify_branch_commits")
 # Pin the #2205 merged-evidence override to False so tests that set
 # ``commits_absent_from_all_remotes`` to a non-empty list still hit the
@@ -922,3 +924,131 @@ class TestCleanupWorktreeLoudTeardown(TestCase):
         assert result.errors == []
         assert "org/repo" in result.label
         assert "org/repo" in str(result)
+
+
+# ---------------------------------------------------------------------------
+# Multi-overlay regression (#295)
+# ---------------------------------------------------------------------------
+
+
+class _NamedOverlay(OverlayBase):
+    """Minimal OverlayBase with a string marker so tests can distinguish instances."""
+
+    def __init__(self, marker: str) -> None:
+        super().__init__()
+        self.marker = marker
+
+    def get_repos(self) -> list[str]:
+        return []
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        return []
+
+    def get_run_commands(self, worktree: Worktree) -> RunCommands:
+        return {}
+
+
+_OVERLAY_A = "overlay-alpha"
+_OVERLAY_B = "overlay-beta"
+
+
+class TestCleanupWorktreeMultiOverlay(TestCase):
+    """Regression: ``cleanup_worktree`` must not call bare ``get_overlay()`` (#295).
+
+    With two overlays installed, ``get_overlay()`` with no name raises
+    ``ImproperlyConfigured: Multiple overlays found``.  The fix derives the
+    overlay from the worktree's own field via ``get_overlay_for_worktree``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _register_both_overlays(self) -> Iterator[None]:
+        self.overlay_a = _NamedOverlay(_OVERLAY_A)
+        self.overlay_b = _NamedOverlay(_OVERLAY_B)
+        registry = {_OVERLAY_A: self.overlay_a, _OVERLAY_B: self.overlay_b}
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=registry):
+            yield
+
+    def _worktree(self, *, overlay: str) -> Worktree:
+        ticket = Ticket.objects.create(
+            overlay=overlay,
+            issue_url=f"https://example.com/issues/295-{overlay}",
+            state=Ticket.State.IN_REVIEW,
+        )
+        return Worktree.objects.create(
+            ticket=ticket,
+            overlay=overlay,
+            repo_path="org/repo",
+            branch="fix-295",
+            extra={"worktree_path": "/tmp/wt/org/repo"},
+        )
+
+    @patch("teatree.core.cleanup.load_config")
+    @patch("teatree.core.cleanup.git")
+    def test_cleanup_worktree_resolves_overlay_from_worktree_field(
+        self,
+        mock_git: MagicMock,
+        mock_config: MagicMock,
+    ) -> None:
+        """``cleanup_worktree`` must not raise when multiple overlays are installed.
+
+        Before #295's fix the bare ``get_overlay()`` call on line 528 of
+        ``cleanup.py`` raised ``ImproperlyConfigured: Multiple overlays found``
+        as soon as two overlays were in the registry.  After the fix,
+        ``get_overlay_for_worktree(worktree)`` is called and the correct
+        overlay is selected.
+        """
+        _mock_workspace(mock_config)
+        mock_git.commits_absent_from_all_remotes.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = []
+
+        # cleanup_worktree calls overlay.get_cleanup_steps — wire it on the real instance.
+        self.overlay_a.get_cleanup_steps = lambda wt: []  # type: ignore[method-assign]
+        self.overlay_b.get_cleanup_steps = lambda wt: []  # type: ignore[method-assign]
+        # Wire reap_worktree_external_resources too.
+        self.overlay_a.reap_worktree_external_resources = lambda wt: []  # type: ignore[method-assign]
+        self.overlay_b.reap_worktree_external_resources = lambda wt: []  # type: ignore[method-assign]
+
+        wt = self._worktree(overlay=_OVERLAY_A)
+        # Must NOT raise ImproperlyConfigured — and must complete successfully.
+        result = cleanup_worktree(wt)
+        assert result.clean is True
+
+    @patch("teatree.core.cleanup.load_config")
+    @patch("teatree.core.cleanup.git")
+    def test_cleanup_worktree_selects_correct_overlay(
+        self,
+        mock_git: MagicMock,
+        mock_config: MagicMock,
+    ) -> None:
+        """The overlay that matches the worktree field is the one whose steps run.
+
+        Each overlay tracks whether its ``get_cleanup_steps`` was called, so the
+        test can assert that overlay-B's steps were invoked and overlay-A's were not.
+        """
+        _mock_workspace(mock_config)
+        mock_git.commits_absent_from_all_remotes.return_value = []
+        mock_git.status_porcelain.return_value = ""
+        mock_git.unsynced_commits.return_value = []
+
+        a_called: list[bool] = []
+        b_called: list[bool] = []
+
+        def steps_a(wt: Worktree) -> list:
+            a_called.append(True)
+            return []
+
+        def steps_b(wt: Worktree) -> list:
+            b_called.append(True)
+            return []
+
+        self.overlay_a.get_cleanup_steps = steps_a  # type: ignore[method-assign]
+        self.overlay_b.get_cleanup_steps = steps_b  # type: ignore[method-assign]
+        self.overlay_a.reap_worktree_external_resources = lambda wt: []  # type: ignore[method-assign]
+        self.overlay_b.reap_worktree_external_resources = lambda wt: []  # type: ignore[method-assign]
+
+        wt = self._worktree(overlay=_OVERLAY_B)
+        cleanup_worktree(wt)
+
+        assert b_called, "overlay-B's cleanup steps were not invoked"
+        assert not a_called, "overlay-A's cleanup steps were invoked but should not have been"

--- a/tests/teatree_core/cleanup/test_drifted_branch.py
+++ b/tests/teatree_core/cleanup/test_drifted_branch.py
@@ -97,7 +97,7 @@ class _DriftedWorktreeFixture(TestCase):
     def _cleanup(self, worktree: Worktree, *, force: bool = False, pr_merged: bool = False) -> CleanupResult:
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
             patch("teatree.core.cleanup._branch_pr_is_merged", return_value=pr_merged),
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
@@ -220,7 +220,7 @@ class TestDetachedHeadUnpushedRefuses(_DriftedWorktreeFixture):
 
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
             patch("teatree.core.cleanup._branch_pr_is_merged", return_value=False),
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
@@ -393,7 +393,7 @@ class TestPhantomSlugBranchNotAGitRef(TestCase):
     def _cleanup(self, worktree: Worktree) -> CleanupResult:
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
             patch("teatree.core.cleanup._branch_pr_is_merged", return_value=False),
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
@@ -507,7 +507,7 @@ class TestSquashMergedBranchNoRemoteRefPruned(TestCase):
     def _cleanup(self, worktree: Worktree, *, pr_merged: bool = False) -> CleanupResult:
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
             patch("teatree.core.cleanup._branch_pr_is_merged", return_value=pr_merged),
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
@@ -605,7 +605,7 @@ class TestLocalOnlyMatchingTreeNotPruned(TestCase):
     def _cleanup(self, worktree: Worktree, *, pr_merged: bool = False) -> CleanupResult:
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
             patch("teatree.core.cleanup._branch_pr_is_merged", return_value=pr_merged),
         ):
             mock_config.return_value.user.workspace_dir = self.workspace

--- a/tests/teatree_core/cleanup/test_real_git_integration.py
+++ b/tests/teatree_core/cleanup/test_real_git_integration.py
@@ -59,7 +59,7 @@ class TestCleanupWorktreeRemovesOnDiskWorktree(TestCase):
     def _cleanup(self, worktree: Worktree) -> CleanupResult:
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
             mock_overlay.return_value.get_cleanup_steps.return_value = []
@@ -133,7 +133,7 @@ class TestCleanupWorktreeNamespacedClone(TestCase):
 
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
             mock_overlay.return_value.get_cleanup_steps.return_value = []
@@ -190,7 +190,7 @@ class TestCleanupReapsStalePrekHook(TestCase):
     def _cleanup(self, worktree: Worktree) -> CleanupResult:
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
             mock_overlay.return_value.get_cleanup_steps.return_value = []

--- a/tests/teatree_core/cleanup/test_recovery.py
+++ b/tests/teatree_core/cleanup/test_recovery.py
@@ -90,7 +90,7 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
     def _prune(self, worktree: Worktree) -> CleanupResult:
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
             mock_overlay.return_value.get_cleanup_steps.return_value = []
@@ -269,7 +269,7 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
 
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
             patch("teatree.core.cleanup.capture_recovery_artifact", side_effect=boom),
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
@@ -296,7 +296,7 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
 
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
             patch("teatree.core.cleanup.capture_recovery_artifact", side_effect=boom),
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
@@ -324,7 +324,7 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
 
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
             patch("teatree.core.cleanup.capture_recovery_artifact", side_effect=boom),
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
@@ -355,7 +355,7 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
 
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
             patch("teatree.core.cleanup.capture_recovery_artifact", side_effect=boom),
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
@@ -381,7 +381,7 @@ class TestCleanupWorktreeRecoversDirtyOrUnpushedWork(TestCase):
 
         with (
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
             patch("teatree.core.cleanup.capture_recovery_artifact", side_effect=boom),
             patch(
                 "teatree.core.cleanup.git.status_porcelain_strict",

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -3122,7 +3122,10 @@ class TestReapSquashMergedWorktreeRows(TestCase):
                 patch.object(ws_cleanup_mod, "_run_host_cli", return_value=ws_merged),
                 patch.object(cleanup_mod, "_branch_pr_is_merged", return_value=True),
                 patch.object(cleanup_mod, "capture_recovery_artifact", return_value=None),
+                patch.object(cleanup_mod, "get_overlay_for_worktree") as mock_overlay,
             ):
+                mock_overlay.return_value.get_cleanup_steps.return_value = []
+                mock_overlay.return_value.config.teardown_removes_pass_entries = False
                 cleaned = self._reap(workspace)
 
             assert not Worktree.objects.filter(pk=row.pk).exists(), (
@@ -3222,7 +3225,10 @@ class TestReapSquashMergedWorktreeRows(TestCase):
             with (
                 patch.object(ws_cleanup_mod, "_run_host_cli", return_value=ws_merged),
                 patch.object(cleanup_mod, "_branch_pr_is_merged", return_value=False),
+                patch.object(cleanup_mod, "get_overlay_for_worktree") as mock_overlay,
             ):
+                mock_overlay.return_value.get_cleanup_steps.return_value = []
+                mock_overlay.return_value.config.teardown_removes_pass_entries = False
                 cleaned = self._reap(workspace)
 
             assert Worktree.objects.filter(pk=row.pk).exists(), f"data-loss row must be kept; got: {cleaned!r}"

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1181,7 +1181,7 @@ class TestWorkspaceCleanAll(TestCase):
             with (
                 patch.object(cleanup_mod, "load_config", return_value=mock_config),
                 patch.object(cleanup_mod, "git") as mock_git,
-                patch.object(cleanup_mod, "get_overlay") as mock_overlay,
+                patch.object(cleanup_mod, "get_overlay_for_worktree") as mock_overlay,
                 # The fake repo (.git is a bare dir) can't satisfy a real
                 # ``git bundle``; isolate the recovery-capture seam so this test
                 # exercises the clean+pushed reap path, not the capture itself.
@@ -1283,7 +1283,7 @@ class TestWorkspaceCleanAll(TestCase):
             with (
                 patch.object(cleanup_mod, "load_config", return_value=mock_config),
                 patch.object(cleanup_mod, "git") as mock_git,
-                patch.object(cleanup_mod, "get_overlay") as mock_overlay,
+                patch.object(cleanup_mod, "get_overlay_for_worktree") as mock_overlay,
                 self.assertLogs("teatree.core.cleanup", level="WARNING") as logs,
             ):
                 mock_overlay.return_value.get_cleanup_steps.return_value = []
@@ -1493,7 +1493,7 @@ class TestWorkspaceCleanAll(TestCase):
             with (
                 patch.object(cleanup_mod, "load_config", return_value=mock_config),
                 patch.object(cleanup_mod, "git") as mock_git,
-                patch.object(cleanup_mod, "get_overlay") as mock_overlay,
+                patch.object(cleanup_mod, "get_overlay_for_worktree") as mock_overlay,
                 patch.object(cleanup_mod, "classify_branch_commits", side_effect=_classify),
                 # Isolate the recovery-capture seam — the fake repos (.git is a
                 # bare dir) can't satisfy a real ``git bundle``; this test
@@ -1575,7 +1575,7 @@ class TestWorkspaceCleanAll(TestCase):
                 patch("builtins.input", side_effect=_input_must_not_be_called),
                 patch.object(cleanup_mod, "load_config", return_value=mock_config),
                 patch.object(cleanup_mod, "git") as mock_git,
-                patch.object(cleanup_mod, "get_overlay") as mock_overlay,
+                patch.object(cleanup_mod, "get_overlay_for_worktree") as mock_overlay,
                 patch.object(cleanup_mod, "classify_branch_commits", side_effect=_classify),
                 patch.object(cleanup_mod, "capture_recovery_artifact", return_value=None),
             ):

--- a/tests/teatree_core/test_runners_teardown.py
+++ b/tests/teatree_core/test_runners_teardown.py
@@ -156,7 +156,7 @@ class TestWorktreeTeardownUnpushedGuard(TestCase):
         with (
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
             patch("teatree.core.cleanup.load_config") as mock_config,
-            patch("teatree.core.cleanup.get_overlay") as mock_overlay,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
         ):
             mock_config.return_value.user.workspace_dir = self.workspace
             mock_overlay.return_value.get_cleanup_steps.return_value = []

--- a/tests/teatree_core/test_workflows.py
+++ b/tests/teatree_core/test_workflows.py
@@ -276,8 +276,13 @@ class TestLifecycleProvision(TestCase):
             mock_sp.run.return_value = MagicMock(returncode=0)
             call_command("worktree", "provision", path=backend_path)
 
-        # Teardown
-        with patch.object(utils_run_mod, "subprocess") as mock_td_sp:
+        # Teardown — needs overlay mock because cleanup_worktree now calls
+        # get_overlay_for_worktree(worktree) which reads worktree.overlay='test'
+        # and resolves it against the installed overlay registry (#295).
+        with (
+            _patch_overlay(),
+            patch.object(utils_run_mod, "subprocess") as mock_td_sp,
+        ):
             mock_td_sp.run.return_value = MagicMock(returncode=0)
             call_command("worktree", "teardown", path=backend_path)
 
@@ -727,6 +732,7 @@ class TestToolAndCleanCommands(TestCase):
         active_wt.save()
 
         with (
+            _patch_overlay(),
             patch.object(ws_cleanup_mod, "prune_branches", return_value=[]),
             patch.object(ws_cleanup_mod, "drop_orphaned_stashes", return_value=[]),
             patch.object(ws_cleanup_mod, "drop_orphan_databases", return_value=[]),


### PR DESCRIPTION
## Summary

- `cleanup_worktree` called `get_overlay()` with no name — ambiguous when 2+ overlays are installed and raises `ImproperlyConfigured: Multiple overlays found` (same class of bug as #282)
- Fix: use `get_overlay_for_worktree(worktree)` which derives the overlay from `worktree.overlay` field, falling back to `worktree.ticket.overlay`
- Add `TestCleanupWorktreeMultiOverlay` with two regression tests that are RED on the buggy code and GREEN after the fix
- Update 5 test files that still patched the removed `teatree.core.cleanup.get_overlay` symbol (caught by `test_patch_targets_resolve.py`)

## Test plan

- [x] `tests/teatree_core/cleanup/test_cleanup_worktree.py::TestCleanupWorktreeMultiOverlay` — new regression tests, RED before fix, GREEN after
- [x] `tests/quality/test_patch_targets_resolve.py` — quality gate for stale patch targets: all 20 pass
- [x] `tests/teatree_core/cleanup/` — 81/81 pass