### PR TITLE
fix(resolve): refresh stale branch/path when auto-register reuses a row

### DIFF
--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -183,11 +183,7 @@ def _auto_register_from_git(cwd: str, ticket_hint: Ticket | None = None) -> Work
     repo_name = cwd_path.name
     existing = Worktree.objects.filter(branch=branch, repo_path=repo_name).first()
     if existing is not None:
-        extra = existing.extra or {}
-        if extra.get("worktree_path") != str(cwd_path):
-            extra["worktree_path"] = str(cwd_path)
-            existing.extra = extra
-            existing.save(update_fields=["extra"])
+        _refresh_reused_row(existing, branch, cwd_path)
         return existing
 
     ticket = (
@@ -199,7 +195,7 @@ def _auto_register_from_git(cwd: str, ticket_hint: Ticket | None = None) -> Work
             defaults={"variant": "", "repos": [repo_name]},
         )[0]
     )
-    wt, _wt_created = Worktree.objects.get_or_create(
+    wt, wt_created = Worktree.objects.get_or_create(
         ticket=ticket,
         repo_path=repo_name,
         defaults={
@@ -207,7 +203,34 @@ def _auto_register_from_git(cwd: str, ticket_hint: Ticket | None = None) -> Work
             "extra": {"worktree_path": str(cwd_path)},
         },
     )
+    if not wt_created:
+        _refresh_reused_row(wt, branch, cwd_path)
     return wt
+
+
+def _refresh_reused_row(worktree: Worktree, branch: str, cwd_path: Path) -> None:
+    """Re-point a reused row at the git worktree actually being resolved.
+
+    Both reuse arms above hand back an existing row whose recorded
+    ``branch``/``extra.worktree_path`` may describe a PREVIOUS worktree of
+    the same ticket+repo (the dir was re-created elsewhere, or the work
+    moved to a new branch). ``get_or_create`` ignores its ``defaults`` on
+    reuse, so without this refresh every downstream consumer (run
+    commands, provision steps) keeps acting on the stale path — e.g. a
+    frontend build silently lands in a different ticket's worktree
+    directory while the user is sitting in the current one.
+    """
+    update_fields: list[str] = []
+    if worktree.branch != branch:
+        worktree.branch = branch
+        update_fields.append("branch")
+    extra = worktree.extra or {}
+    if extra.get("worktree_path") != str(cwd_path):
+        extra["worktree_path"] = str(cwd_path)
+        worktree.extra = extra
+        update_fields.append("extra")
+    if update_fields:
+        worktree.save(update_fields=update_fields)
 
 
 def _workspace_owner_ticket(cwd_path: Path) -> Ticket | None:

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -471,6 +471,35 @@ class TestAutoRegisterReusesExistingWorktree(TestCase):
         assert result.extra["worktree_path"] == str(wt_dir)
         assert result.extra["some_other"] == "value"
 
+    def test_ticket_reuse_refreshes_stale_branch_and_path(self) -> None:
+        """Ticket+repo reuse must re-point the row at the worktree being resolved.
+
+        Bug: when a ticket already had a Worktree row for this repo (created
+        for an EARLIER worktree dir/branch of the same ticket),
+        ``get_or_create`` returned it with its defaults ignored — the row kept
+        the stale ``branch`` and ``extra.worktree_path``. Every downstream
+        consumer then acted on the stale directory: a frontend build invoked
+        from the new worktree silently ran inside the old directory.
+        """
+        ticket = Ticket.objects.create(issue_url="https://gitlab.com/org/repo/-/issues/321")
+        stale = Worktree.objects.create(
+            ticket=ticket,
+            repo_path="my-repo",
+            branch="feat/old-branch",
+            extra={"worktree_path": "/somewhere/else/my-repo", "keep": "me"},
+        )
+        wt_dir = self._make_git_worktree("my-repo")
+
+        with patch("teatree.core.resolve.git.current_branch", return_value="feat/new-branch"):
+            result = _auto_register_from_git(str(wt_dir), ticket_hint=ticket)
+
+        assert result is not None
+        assert result.pk == stale.pk
+        assert result.branch == "feat/new-branch"
+        assert result.extra["worktree_path"] == str(wt_dir)
+        assert result.extra["keep"] == "me"
+        assert Worktree.objects.count() == 1
+
     def test_creates_new_ticket_when_no_worktree_exists(self) -> None:
         """First-time auto-register still creates a fresh ``auto:<branch>`` ticket."""
         wt_dir = self._make_git_worktree("my-repo")


### PR DESCRIPTION
## Bug

Both reuse arms of `_auto_register_from_git` can return a `Worktree` row recorded for a previous worktree of the same ticket+repo. The branch+repo arm already backfills `extra.worktree_path`, but the ticket+repo arm uses `get_or_create`, whose `defaults` are ignored on reuse — the row keeps its stale `branch` and `extra.worktree_path`.

Every downstream consumer (run commands, provision steps) then acts on the stale directory. Observed live: `run build-frontend` invoked from the current ticket worktree resolved the ticket's old row and silently built inside a **different ticket's worktree directory** (cross-worktree write).

## Fix

One shared `_refresh_reused_row` re-points `branch` + `extra.worktree_path` at the git worktree actually being resolved, on both reuse arms, preserving unrelated `extra` keys.

## Tests

`test_ticket_reuse_refreshes_stale_branch_and_path` — observed RED on pre-fix code (row kept `feat/old-branch` + the stale path), green post-fix. Full `tests/teatree_core/test_resolve.py`: 55 passed. ruff clean.