### PR TITLE
fix(notify): route notify_user text via chat.postMessage, not file-upload (#2054)

### DIFF
--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -261,14 +261,33 @@ def _deliver_dm(
     (b) ``post_message`` raises — transport/network error.
     (c) ``post_message`` returns ``ok:false`` (missing_scope,
     channel_not_found) or ``ok:true`` with no ``ts`` — nothing landed.
+
+    **Why ``post_message`` instead of ``deliver_user_dm`` (#2054):** the
+    speak chokepoint (:func:`teatree.core.speak.deliver_user_dm`) posts
+    the text body via ``post_audio_dm`` (``files.getUploadURLExternal`` +
+    ``files.completeUploadExternal``) when ``speak.slack`` is on and
+    synthesis succeeds. That response does NOT carry a ``ts`` at the top
+    level — Slack populates it only under
+    ``files[].shares.private.<channel>[].ts``, which is frequently absent.
+    Reading ``response.get("ts", "")`` therefore always returns ``""`` and
+    every delivery fails with "Slack post returned no message ts".
+
+    The fix: use ``backend.post_message`` (``chat.postMessage``) for the
+    canonical text delivery — it always returns ``{"ok": true, "ts": "…"}``
+    — and fire the speak side-effects (audio attachment + local playback)
+    independently via ``deliver_user_dm_sidecar`` so the DM and its audio
+    enrichment are independent concerns. A failure on the speak side never
+    suppresses the text delivery.
     """
-    from teatree.core.speak import deliver_user_dm  # noqa: PLC0415
+    from teatree.core.speak import deliver_user_dm_sidecar  # noqa: PLC0415
 
     try:
         channel = backend.open_dm(user_id)
         if not channel:
             return "", "", "open_dm returned an empty channel (Slack conversations.open ok:false)"
-        response = deliver_user_dm(backend, channel=channel, text=text, thread_ts=_active_dm_thread(channel))
+        thread_ts = _active_dm_thread(channel)
+        response = backend.post_message(channel=channel, text=text, thread_ts=thread_ts)
+        deliver_user_dm_sidecar(backend, channel=channel, text=text, thread_ts=thread_ts)
     except Exception as exc:  # noqa: BLE001 — notify must never bubble up
         return "", "", str(exc)
 

--- a/src/teatree/core/speak.py
+++ b/src/teatree/core/speak.py
@@ -283,14 +283,16 @@ def deliver_user_dm(
 ) -> RawAPIDict:
     """Post ONE bot→user DM, attaching spoken audio when ``slack`` is on (#2060).
 
-    The single chokepoint both bot→user DM egress points call. ``text`` is
-    the already-formatted DM body. When ``slack`` is on AND synthesis
-    succeeds, posts a SINGLE message via :meth:`post_audio_dm` carrying
-    ``text`` as the message + the audio inline; otherwise (``slack`` off,
-    ``say``/``afconvert`` absent, synthesis or upload failure) degrades to a
-    text-only :meth:`post_message` so the DM is never lost. Independently,
-    when ``local`` is ``dm`` or ``all`` the same text plays through the
-    speakers — never suppressed by ``slack`` (Slack never auto-plays).
+    The single chokepoint the ``notify post`` command calls for its direct
+    channel-post path (not the ``notify_user`` bot→user path — see
+    :func:`deliver_user_dm_sidecar` for that). ``text`` is the DM body.
+    When ``slack`` is on AND synthesis succeeds, posts a SINGLE message via
+    :meth:`post_audio_dm` carrying ``text`` as the message + the audio
+    inline; otherwise (``slack`` off, ``say``/``afconvert`` absent, synthesis
+    or upload failure) degrades to a text-only :meth:`post_message` so the
+    DM is never lost. Independently, when ``local`` is ``dm`` or ``all`` the
+    same text plays through the speakers — never suppressed by ``slack``
+    (Slack never auto-plays).
 
     Returns the raw Slack body of whichever post ran so the caller finalises
     its delivery row exactly as a plain ``post_message`` would. Never lets a
@@ -312,6 +314,43 @@ def deliver_user_dm(
         response = backend.post_message(channel=channel, text=text, thread_ts=thread_ts)
     _maybe_speak_local(config, text)
     return response
+
+
+def deliver_user_dm_sidecar(
+    backend: MessagingBackend,
+    *,
+    channel: str,
+    text: str,
+    thread_ts: str = "",
+) -> None:
+    """Run the speak side-effects for a bot→user DM — never raises (#2054).
+
+    Called by :func:`teatree.core.notify._deliver_dm` AFTER the canonical
+    ``post_message`` delivery has already landed and its ``ts`` has been
+    captured. This function owns the two enrichment arms that do NOT
+    produce the delivery ``ts``:
+
+    *   **Slack audio attachment** — when ``slack`` is on, attach a spoken
+        audio file to the DM via ``post_audio_dm``. The attachment is a
+        pure enhancement; if it fails the text DM already exists. The
+        ``post_audio_dm`` response is intentionally ignored here: the caller
+        already has the ``ts`` from ``post_message`` and does not need it.
+    *   **Local playback** — play the text through the machine's speakers
+        when ``local`` is ``dm`` or ``all``.
+
+    Both arms are best-effort: any exception is swallowed so a speak failure
+    can NEVER retroactively break a text DM that has already landed. The
+    caller (:func:`teatree.core.notify._deliver_dm`) wraps this call inside
+    its own ``except`` block, so a raise here would be caught before the
+    delivery outcome is affected — but returning ``None`` without raising is
+    the cleaner contract.
+    """
+    config = _resolve_speak_safe()
+    try:
+        _maybe_post_with_audio(backend, config, channel=channel, text=text, thread_ts=thread_ts)
+    except Exception as exc:  # noqa: BLE001 — sidecar must never break the delivered text DM
+        logger.debug("deliver_user_dm_sidecar audio attach failed: %s", exc)
+    _maybe_speak_local(config, text)
 
 
 def _resolve_speak_safe() -> SpeakConfig:

--- a/tests/teatree_core/test_notify_speak.py
+++ b/tests/teatree_core/test_notify_speak.py
@@ -40,6 +40,43 @@ class TestNotifyUserSpeaks(TestCase):
         backend.post_message.assert_called_once()
         backend.post_audio_dm.assert_not_called()
 
+    def test_delivers_via_chat_post_message_when_slack_on(self) -> None:
+        """Regression for #2054: notify_user must deliver via chat.postMessage.
+
+        Pre-fix: with speak.slack=True the text body was sent via
+        post_audio_dm (files.getUploadURLExternal +
+        files.completeUploadExternal). That response carries no ``ts`` at
+        the top level, so _deliver_dm logged "Slack post returned no message
+        ts" and returned False — the DM was never delivered.
+
+        Fix: _deliver_dm always uses backend.post_message (chat.postMessage)
+        for the canonical text delivery whose response reliably carries
+        ``ok:true`` + ``ts``. The audio side-effect (post_audio_dm) may
+        still run on a background path, but the ts used for audit and
+        idempotency comes from post_message, not from the file-upload
+        response.
+        """
+        backend = _backend()
+        # Simulate the pre-fix failure: post_audio_dm returns a body with no ts
+        # at the top level (the exact shape Slack's completeUploadExternal gives).
+        backend.post_audio_dm.return_value = {"ok": True, "files": [{"id": "F1"}]}
+        with (
+            patch("teatree.core.speak.resolve_speak", return_value=SpeakConfig(slack=True)),
+            patch("teatree.core.speak.synthesise", return_value=__import__("pathlib").Path("/tmp/x/speech.m4a")),
+            patch("teatree.core.speak.shutil.rmtree"),
+        ):
+            sent = notify_user(
+                "tests are green",
+                kind=NotifyKind.INFO,
+                idempotency_key="notify-audio-ts-regression",
+                backend=backend,
+                user_id="U_ME",
+            )
+        # Must be True: the DM must land even when audio body has no ts.
+        assert sent is True
+        # The text delivery goes via chat.postMessage (reliable ts source).
+        backend.post_message.assert_called_once()
+
     def test_attaches_audio_to_the_dm_when_slack_on(self) -> None:
         backend = _backend()
         with (
@@ -55,8 +92,10 @@ class TestNotifyUserSpeaks(TestCase):
                 user_id="U_ME",
             )
         assert sent is True
+        # After the fix, the audio attachment still runs as a side-effect.
         backend.post_audio_dm.assert_called_once()
-        backend.post_message.assert_not_called()
+        # The text delivery also always uses post_message (the reliable ts source).
+        backend.post_message.assert_called_once()
 
     def test_does_not_speak_when_delivery_fails(self) -> None:
         backend = _backend()


### PR DESCRIPTION
## Summary

- `notify_user` (the bot→user Slack DM path) never delivered when `speak.slack=True` because `_deliver_dm` routed through `deliver_user_dm`, which used `post_audio_dm` (file-upload API). That response carries no `ts` at the top level, so `posted_ts` was always empty and every delivery failed with "Slack post returned no message ts".
- Fix: `_deliver_dm` now calls `backend.post_message` (`chat.postMessage`) directly for the canonical text delivery — it reliably returns `ok:true` plus `ts`. Audio enrichment runs fire-and-forget via the new `deliver_user_dm_sidecar` helper; a failure there never affects the text DM.
- The `deliver_user_dm` chokepoint is preserved unchanged for the `notify post` command path (direct channel post, not the `notify_user` bot→user DM path).

## Test plan

- [x] Regression test `test_delivers_via_chat_post_message_when_slack_on` observed RED before fix, GREEN after
- [x] Updated `test_attaches_audio_to_the_dm_when_slack_on`: after fix, both `post_message` and `post_audio_dm` are called (text delivery + audio sidecar)
- [x] All 45 notify-related tests pass (including `test_notify_post_speaks.py` which exercises `deliver_user_dm` directly)
- [x] All speak tests pass (88 tests across `test_speak.py`, `test_speak_config.py`, `test_speak_chokepoint_does_not_retire.py`, etc.)
- [x] `prek run --all-files`: zero Failed
- [x] `makemigrations --check --dry-run`: no changes detected

Closes #2054
