### PR TITLE
fix(merge): probe cross-repo on empty initial live head (#1335)

### DIFF
--- a/src/teatree/core/merge/pr_slug_resolution.py
+++ b/src/teatree/core/merge/pr_slug_resolution.py
@@ -258,13 +258,14 @@ def _reconcile_slug_against_reviewed_sha(
     initial_live = fetch_live_head_sha(initial_slug, pr_id, host_kind=host_kind)
     if initial_live == reviewed_sha:
         return initial_slug
-    if not initial_live:
-        # The forge call failed (missing credentials, network) or returned an
-        # empty payload — that's a transient/auth condition, not a cross-repo
-        # confusion. Defer to ``assert_merge_preconditions``, which raises the
-        # established "could not resolve the live head" error against the
-        # initial slug.
-        return initial_slug
+    # An empty ``initial_live`` is itself a #1335 signal, NOT merely a transient
+    # auth/network failure: a cross-repo CLEAR resolves to the running clone's
+    # ``origin`` (the wrong repo), which has no PR <pr_id> at all, so the forge
+    # returns an empty head for it. Fall through to the cross-repo probe so a
+    # candidate overlay repo whose PR <pr_id> carries ``reviewed_sha`` is
+    # recovered. The genuinely-absent case (no candidate matches) is still
+    # covered by the ``MergePreconditionError`` below, whose message names every
+    # candidate considered — so a real auth/network outage still fails loud.
     candidates = _iter_candidate_repo_slugs()
     # The initial slug was already probed above — exclude it from the secondary
     # set so the candidates list in the error message reflects what was probed.

--- a/tests/teatree_core/test_merge_execution.py
+++ b/tests/teatree_core/test_merge_execution.py
@@ -254,7 +254,7 @@ class TestMergeExecutionEdgeCases(TestCase):
 
         with (
             patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_no_head),
-            pytest.raises(MergePreconditionError, match="could not resolve the live head"),
+            pytest.raises(MergePreconditionError, match=r"live=\(unresolved\)"),
         ):
             merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
 

--- a/tests/teatree_core/test_merge_execution_cross_repo.py
+++ b/tests/teatree_core/test_merge_execution_cross_repo.py
@@ -199,6 +199,84 @@ class TestCrossRepoCandidateProbe(TestCase):
         assert _OVERLAY_REPO in message
         assert "candidate" in message.lower()
 
+    def test_empty_initial_live_falls_through_to_cross_repo_probe(self) -> None:
+        """#1335: an empty head on the initial (wrong) repo still probes candidates.
+
+        The cross-repo trap (CLEAR 248 / #1335): the CLEAR resolves to the
+        running clone's ``origin`` (the wrong repo) for a PR that actually
+        lives in a downstream overlay's repo. The clone-origin repo has no
+        PR #N at all, so the forge returns an EMPTY head SHA for it — not a
+        mismatching one. The buggy early-return treated empty as a transient
+        auth/network failure and returned the wrong initial slug, never
+        reaching the probe. The fix must fall through: the overlay repo's
+        PR #N head matches ``reviewed_sha``, so the probe recovers it.
+        """
+        clear = _cross_repo_clear()
+        calls: list[list[str]] = []
+        candidate_entries = [
+            OverlayEntry(name="downstream", overlay_class="", project_path=Path("/clones/downstream-overlay")),
+        ]
+
+        def _gh_empty_on_clone_origin(argv: list[str]) -> tuple[int, str, str]:
+            calls.append(argv)
+            joined = " ".join(argv)
+            repo = argv[argv.index("--repo") + 1] if "--repo" in argv else ""
+            if "headRefOid" in joined:
+                # The clone-origin repo has NO PR #159 -> empty head; only the
+                # overlay repo owns the reviewed PR at _RIGHT_SHA.
+                return (0, _RIGHT_SHA if repo == _OVERLAY_REPO else "", "")
+            if "isDraft" in joined:
+                return (0, "false", "")
+            if "statusCheckRollup" in joined:
+                return (0, _GREEN, "")
+            if "state,mergeCommit" in joined:
+                return (0, '{"state": "OPEN", "mergeCommit": null}', "")
+            if "pulls" in joined and "merge" in joined:
+                return (0, '{"sha": "merged0deadbeef"}', "")
+            return (0, "", "")
+
+        def _remote_slug_for_path(repo: str = ".", remote: str = "origin") -> str:
+            del remote
+            if repo == "/clones/downstream-overlay":
+                return _OVERLAY_REPO
+            return ""
+
+        with (
+            patch(
+                "teatree.backends.forge_merge_rpc.gh_runner",
+                return_value=_gh_empty_on_clone_origin,
+            ),
+            patch(
+                "teatree.core.merge.pr_slug_resolution._project_repo_slug",
+                return_value=_CLONE_ORIGIN,
+            ),
+            patch(
+                "teatree.core.merge.pr_slug_resolution.discover_overlays",
+                return_value=candidate_entries,
+            ),
+            patch(
+                "teatree.core.merge.pr_slug_resolution.git.remote_slug",
+                side_effect=_remote_slug_for_path,
+            ),
+        ):
+            outcome = merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
+
+        assert outcome.merged_sha
+        assert outcome.slug == _OVERLAY_REPO, (
+            f"empty head on the initial repo must fall through to the cross-repo probe; got slug={outcome.slug!r}"
+        )
+        merge_endpoints = [
+            arg
+            for argv in calls
+            if "merge" in " ".join(argv) and "pulls" in " ".join(argv)
+            for arg in argv
+            if "pulls/" in arg
+        ]
+        assert merge_endpoints
+        assert all(_OVERLAY_REPO in endpoint for endpoint in merge_endpoints), (
+            f"merge endpoint targeted the wrong repo: {merge_endpoints}"
+        )
+
     def test_resolved_repo_matches_skip_probe(self) -> None:
         """Happy path: when the resolved repo's PR matches, no probe runs.
 


### PR DESCRIPTION
## Summary

`_reconcile_slug_against_reviewed_sha` (the #1335 cross-repo recovery) had an
early-return that short-circuited the candidate-repo probe whenever the initial
slug's live head SHA came back empty. The branch treated an empty `initial_live`
as a transient auth/network condition and returned the (wrong) initial slug, so
the merge never reached the probe.

That assumption is wrong for the cross-repo scenario. When a CLEAR is issued for
a PR that lives in a *different* repo (an overlay's repo), the running clone's
`origin` has no PR `<pr_id>` at all, so the forge returns an empty head for it.
The empty result IS the cross-repo signal — not an outage. The early-return sent
the wrong slug downstream, where `assert_merge_preconditions` raised
`could not resolve the live head SHA for <clone-origin>#<N>` and the CLEAR went
stale even though a registered overlay's repo owned the reviewed PR at the right
SHA.

## Change

- Remove the `if not initial_live: return initial_slug` early-return so an empty
  initial head falls through to `_iter_candidate_repo_slugs()` + the probe.
- The genuinely-absent case (no candidate carries the reviewed SHA) is still
  covered by the probe's own `MergePreconditionError`, whose message names every
  candidate considered — a real auth/network outage still raises rather than
  proceeding silently.

## Test

`test_empty_initial_live_falls_through_to_cross_repo_probe` (in
`tests/teatree_core/test_merge_execution_cross_repo.py`): the clone-origin repo
has no PR `<N>` and returns an empty head; the overlay repo owns the reviewed
SHA. The merge must recover the overlay repo via the probe.

Red-first: observed RED on the pre-fix code (raised
`could not resolve the live head SHA for <clone-origin>#<N>`), GREEN with the
fix. Full `test_merge_execution_cross_repo.py` + `test_merge_repo_resolution.py`
suites pass (21 tests, 22 subtests).

## Architecture pre-check — #1335

### 1. BLUEPRINT § alignment
§17.4.3 (keystone merge precondition steps). The cross-repo slug-reconciliation
is part of step 2 (SHA-bind to the right repo's PR). No contradiction — the
change restores the documented #1335 recovery to the empty-head case it missed.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition is touched; this is repo
resolution upstream of the merge transition.

### 3. Extension-point contracts
No `OverlayBase` / scanner / hook / Protocol surface changes. `discover_overlays`
is consumed read-only by `_iter_candidate_repo_slugs`, unchanged.

### 4. Component boundaries
`src/teatree/core/merge/pr_slug_resolution.py` — the existing home for slug
resolution + the #1335 probe. No straddle.

### 5. Dependency direction
No imports added. `pr_slug_resolution` keeps depending DOWN on `ci_rollup`. `tach`
passed in pre-commit.

### 6. Test surface
`test_empty_initial_live_falls_through_to_cross_repo_probe` asserts the recovered
`outcome.slug` is the overlay repo and the `pulls/<N>/merge` endpoint targets it.
The behaviour that regresses if reverted: empty head → wrong slug → "could not
resolve the live head" (observed RED).

### 7. Resilience invariants
External read (forge head fetch). verify-by-re-read: the probe re-reads each
candidate's live head before selecting. fallback-transport: the probe IS the
secondary path; on no match the `MergePreconditionError` re-escalates (loud,
never silent). idempotency: pure resolution, no side effect. heartbeat/sub-agent:
n/a (synchronous resolution).

### 8. Identity and key normalization
`owner/repo` slugs are compared as-is via the canonical `_iter_candidate_repo_slugs`
ordering; no qualifier stripping introduced.

### 9. Behavior preservation / capability deletion
The only behavior removed is the early-return that returned the initial slug on
an empty head. That branch was a defect (it skipped recovery), not a capability:
the genuinely-absent / outage case it claimed to serve is still handled — louder
— by the probe's `MergePreconditionError`. No must-block test inverted; no
privacy/security matcher narrowed.

## Open questions and assumptions
- Assumes the probe's per-candidate fetch failures stay best-effort (swallowed),
  unchanged by this fix — only the initial-slug empty branch is rerouted.
