### PR TITLE
fix(gate): resolve banned-terms destination from the git command target, not ambient cwd (#1415)

### DIFF
--- a/src/teatree/hooks/_body_file_resolution.py
+++ b/src/teatree/hooks/_body_file_resolution.py
@@ -234,23 +234,32 @@ class BodyFileContext:
     base: Path | None = None
 
 
-def commit_body_file_base(command: str) -> Path | None:
+def commit_body_file_base(command: str, cwd: Path | None = None) -> Path | None:
     """Return the dir to resolve a ``git commit -F <relpath>`` body against.
 
     The base is the dir whose repo the commit LANDS in — the command's own
     leading ``cd``/``pushd`` plus ``-C``/``--git-dir`` directives, resolved
-    by :func:`_commit_repo_dir.effective_repo_dir` and walked up to the
+    by :func:`_commit_repo_dir.resolve_commit_dir` (a RELATIVE ``-C``/``cd``
+    target anchored on the ambient ``cwd``, mirroring the carve-out, so a
+    sub-agent's ``git -C ../worktree`` body file resolves against the dir the
+    agent ran in, not the cold hook's process cwd) and walked up to the
     enclosing repo root by :func:`_commit_repo_dir.git_root_for_dir`. ``None``
-    when the command names no commit dir (a plain ``git commit`` whose body
-    file is then resolved against the process cwd only) or when the dir is the
-    fail-closed sentinel (a ``-C`` value the gate cannot pin down statically).
+    when the command names no commit dir (a plain ``git commit`` with no
+    ``cwd`` whose body file is then resolved against the process cwd only) or
+    when the dir is the fail-closed sentinel (a ``-C`` value the gate cannot
+    pin down statically).
     """
     from teatree.hooks import _commit_repo_dir  # noqa: PLC0415
 
-    repo_dir = _commit_repo_dir.effective_repo_dir(command)
-    if repo_dir is None or repo_dir == _commit_repo_dir.UNRESOLVABLE_REPO_DIR:
+    # A plain ``git commit`` names no dir; keep the historical ``None`` so the
+    # caller's own ``cwd`` fallback governs (anchoring only changes a command
+    # that DOES name a relative ``cd``/``-C``/``--git-dir`` target).
+    if _commit_repo_dir.effective_repo_dir(command) is None:
         return None
-    return _commit_repo_dir.git_root_for_dir(Path(repo_dir))
+    commit_dir = _commit_repo_dir.resolve_commit_dir(command, cwd)
+    if commit_dir is None or commit_dir == _commit_repo_dir.UNRESOLVABLE_REPO_DIR:
+        return None
+    return _commit_repo_dir.git_root_for_dir(Path(commit_dir))
 
 
 def command_body_file_base(command: str) -> Path | None:

--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -462,7 +462,7 @@ def extract_bash_payload(command: str, *, fail_closed_body_file: bool = False, c
     ctx = BodyFileContext(
         heredoc_files=heredoc_files_map(command, tokens),
         fail_closed_body_file=fail_closed_body_file,
-        base=commit_body_file_base(command) or command_body_file_base(command) or cwd,
+        base=commit_body_file_base(command, cwd) or command_body_file_base(command) or cwd,
     )
     for segment in split_commands(tokens):
         _walk_command_segment(segment, parts, ctx)

--- a/src/teatree/hooks/_commit_carve_out.py
+++ b/src/teatree/hooks/_commit_carve_out.py
@@ -35,13 +35,16 @@ _FORGE_TOOL_MARKERS: Final[tuple[str, ...]] = ("gh", "glab", "curl")
 def commit_target_downgrades(command: str, cwd: Path | None, *, config_path: Path | None) -> bool:
     r"""Return True iff the commit BODY's repo target makes it downgrade-eligible.
 
-    The repo the commit lands in is resolved by ``effective_repo_dir`` -- a
+    The repo the commit lands in is resolved by ``resolve_commit_dir`` -- a
     leading ``cd``/``pushd`` prefix, then ``--git-dir`` else the ``-C``-adjusted
-    dir, never ``--work-tree`` -- else the ambient ``cwd``; the nearest enclosing
-    ``.git`` root is then walked up to. Three states: a known-PRIVATE enclosing
-    repo is downgrade-eligible (True); a resolvable but PUBLIC/unknown enclosing
-    repo hard-blocks (False), so a commit in the public clone keeps the block;
-    NO resolvable commit dir at all (no ``cd``/``-C``/``--git-dir``, no ambient
+    dir, never ``--work-tree`` -- anchored on the ambient ``cwd`` (a RELATIVE
+    ``-C``/``cd`` target, e.g. a sub-agent's ``git -C ../worktree``, resolves
+    against ``cwd``, never the cold hook's process cwd), else the ambient
+    ``cwd`` itself for a plain commit; the nearest enclosing ``.git`` root is
+    then walked up to. Three states: a known-PRIVATE enclosing repo is
+    downgrade-eligible (True); a resolvable but PUBLIC/unknown enclosing repo
+    hard-blocks (False), so a commit in the public clone keeps the block; NO
+    resolvable commit dir at all (no ``cd``/``-C``/``--git-dir``, no ambient
     cwd, or the dir is in no git repo) FAILS-OPEN (True), because a local commit
     cannot leak and git rejects a commit outside a repo.
 
@@ -50,13 +53,12 @@ def commit_target_downgrades(command: str, cwd: Path | None, *, config_path: Pat
     """
     from teatree.hooks.publish_surface import commit_targets_private_repo  # noqa: PLC0415
 
-    repo_dir = _commit_repo_dir.effective_repo_dir(command)
-    if repo_dir == _commit_repo_dir.UNRESOLVABLE_REPO_DIR:
+    commit_target = _commit_repo_dir.resolve_commit_dir(command, cwd)
+    if commit_target == _commit_repo_dir.UNRESOLVABLE_REPO_DIR:
         return False
-    commit_target = Path(repo_dir) if repo_dir else cwd
     if commit_target is None:
         return True
-    repo_root = _commit_repo_dir.git_root_for_dir(commit_target)
+    repo_root = _commit_repo_dir.git_root_for_dir(Path(commit_target))
     if repo_root is None:
         return True
     return commit_targets_private_repo(repo_root, config_path=config_path)

--- a/src/teatree/hooks/_commit_repo_dir.py
+++ b/src/teatree/hooks/_commit_repo_dir.py
@@ -141,6 +141,43 @@ def git_root_for_dir(start: Path) -> Path | None:
     return None
 
 
+def resolve_commit_dir(command: str, cwd: Path | None) -> Path | str | None:
+    """Resolve the dir whose repo a ``git`` command's commit LANDS in.
+
+    Combines the command-only parse (:func:`effective_repo_dir` -- a leading
+    ``cd``/``pushd`` prefix plus ``-C``/``--git-dir``, never ``--work-tree``)
+    with the AMBIENT hook ``cwd``: a RELATIVE parsed dir (``git -C
+    ../worktree``, the form a sub-agent's command takes when the harness has
+    reset the hook ``cwd`` to a sibling repo) is anchored on ``cwd`` so it
+    resolves against the dir the agent actually ran in, NOT the cold hook's
+    process cwd. Anchoring on the process cwd (the prior behaviour, an implicit
+    ``Path(repo_dir)`` with no base) silently mis-resolved the worktree -- a
+    relative public target then resolved to no repo and FAIL-OPENED the
+    carve-out (a banned-term leak to the public repo), and a relative private
+    target resolved by accident only when the process cwd happened to match.
+
+    Returns:
+    - :data:`UNRESOLVABLE_REPO_DIR` when ``effective_repo_dir`` could not pin
+        the ``-C`` value statically (a substitution marker) -- the caller must
+        then NOT downgrade (fail closed).
+    - an absolute :class:`~pathlib.Path` of the resolved commit dir when the
+        command named one (``cd``/``-C``/``--git-dir``), anchored on ``cwd``
+        when the parsed dir is relative and ``cwd`` is given.
+    - ``cwd`` itself for a plain ``git commit`` that named no dir (it lands in
+        the ambient cwd's repo), or ``None`` when neither resolves -- the
+        caller reads ``None`` as a genuinely-unresolvable LOCAL commit.
+    """
+    repo_dir = effective_repo_dir(command)
+    if repo_dir == UNRESOLVABLE_REPO_DIR:
+        return UNRESOLVABLE_REPO_DIR
+    if repo_dir is None:
+        return cwd
+    parsed = Path(repo_dir)
+    if parsed.is_absolute() or cwd is None:
+        return parsed
+    return cwd / parsed
+
+
 def effective_repo_dir(command: str) -> str | None:
     """Return the dir whose repo a ``git`` command's commit LANDS in, or ``None``.
 

--- a/src/teatree/hooks/publish_surface.py
+++ b/src/teatree/hooks/publish_surface.py
@@ -45,7 +45,11 @@ selects the repo, so it is excluded -- a ``--git-dir <PUBLIC> --work-tree
 work-tree would leak banned content to public history. A sub-agent's
 ``git -C <worktree> commit`` runs from an ambient hook cwd that has reset away
 from the worktree, so resolving from the command's own flag is what keeps the
-carve-out from over-blocking that commit.
+carve-out from over-blocking that commit. ``resolve_commit_dir`` anchors a
+RELATIVE ``-C``/``cd`` target (``git -C ../worktree``) on that ambient hook
+cwd, never the cold hook's process cwd -- otherwise a relative public target
+resolves to no repo and fail-opens the carve-out (a banned-term leak to the
+public repo), and a relative private target only resolves by accident.
 
 ``commit_targets_private_repo`` decides whether the commit's resolved repo
 is known-private. The "is this repo private?" question (offline

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -346,6 +346,34 @@ class TestRelativeBodyFileResolvesAgainstCommandDir:
         assert payload is not None
         assert "acmecorp" in payload
 
+    # REGRESSION (#1415): a sub-agent's ``git -C <RELATIVE worktree> commit -F
+    # <relative body>``. The relative ``-C`` worktree must be anchored on the
+    # AMBIENT hook cwd, not the cold hook's process cwd, so the relative body
+    # file (read from the worktree the commit lands in) is found and scanned.
+    def test_relative_dash_c_commit_body_file_anchored_on_ambient_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workspace = tmp_path / "workspace"
+        ambient_cwd = workspace / "sibling"
+        worktree = workspace / "worktree"
+        worktree.mkdir(parents=True)
+        ambient_cwd.mkdir()
+        _git(worktree, "init", "-q")
+        (worktree / "msg.txt").write_text("internal note about acmecorp\n", encoding="utf-8")
+        # Process cwd is OUTSIDE the workspace, so a process-cwd-relative parse
+        # cannot find the body -- only the ambient-cwd anchor reaches it.
+        process_cwd = tmp_path / "process"
+        process_cwd.mkdir()
+        monkeypatch.chdir(process_cwd)
+        payload = banned_terms_scanner.extract_publish_payload(
+            "Bash",
+            {"command": "git -C ../worktree commit -F msg.txt"},
+            ambient_cwd,
+        )
+        assert payload is not None
+        assert FAIL_CLOSED_SENTINEL not in payload
+        assert "acmecorp" in payload
+
 
 class TestHeredocBodyPairing:
     """A file-redirected heredoc is scanned only when its path is posted.

--- a/tests/teatree_hooks/test_publish_surface.py
+++ b/tests/teatree_hooks/test_publish_surface.py
@@ -1283,6 +1283,80 @@ class TestCarveOutApplies:
             is True
         )
 
+    # REGRESSION (#1415): a sub-agent's ``git -C <RELATIVE worktree>`` commit.
+    # The ambient hook cwd has reset away from the worktree to a SIBLING repo,
+    # and the in-command ``-C`` value is RELATIVE to that ambient cwd -- the
+    # form a worktree path takes when written relative to the workspace root.
+    # A relative target must be anchored on the AMBIENT cwd, not the cold
+    # hook's process cwd (which is outside any repo). Without the anchor, the
+    # relative ``-C`` resolves to a path in no git repo and the carve-out
+    # FAIL-OPENS for the wrong reason; here the resolved repo is allowlisted
+    # PRIVATE, so the carve-out must apply (downgrade) deterministically.
+    def test_relative_dash_c_private_target_anchored_on_ambient_cwd_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        # The ambient hook cwd is a SIBLING repo (public/unrelated), NOT the
+        # private worktree the relative ``-C`` names.
+        ambient_cwd = _repo_with_remote(workspace / "public-sibling", "git@github.com:some/public-sibling.git")
+        # The real target worktree (resolved relative to the AMBIENT cwd) is a
+        # private allowlisted repo, a sibling under workspace.
+        _repo_with_remote(workspace / "priv-worktree", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git")
+        # DECOY at the PROCESS-cwd-relative location: a PUBLIC repo at the same
+        # ``../priv-worktree`` relative path. If the gate (wrongly) anchored the
+        # relative ``-C`` on the process cwd, it would resolve HERE -> public ->
+        # hard-block, so this test fails unless the anchor uses the AMBIENT cwd.
+        process_cwd = tmp_path / "process" / "cwd"
+        process_cwd.mkdir(parents=True)
+        _repo_with_remote(tmp_path / "process" / "priv-worktree", "git@github.com:souliane/teatree.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        monkeypatch.chdir(process_cwd)
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                'git -C ../priv-worktree commit -m "acmewidget refinery"',
+                "acmewidget refinery",
+                ambient_cwd,
+                config_path=cfg,
+            )
+            is True
+        )
+
+    # REGRESSION (#1415) -- the load-bearing LEAK direction. The ambient hook
+    # cwd is an allowlisted PRIVATE repo, but the in-command relative ``-C``
+    # names a PUBLIC sibling worktree the commit actually lands in. Anchoring
+    # the relative target on the ambient cwd resolves it to the PUBLIC repo, so
+    # the carve-out must NOT apply -- the banned-term commit to the public repo
+    # stays HARD-BLOCKED. (Before the anchor, the relative path resolved to no
+    # repo at the process cwd and FAIL-OPENED, allowing a public leak.)
+    def test_relative_dash_c_public_target_from_private_ambient_cwd_stays_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        # Ambient cwd is a PRIVATE allowlisted repo.
+        ambient_cwd = _repo_with_remote(
+            workspace / "priv-sibling", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git"
+        )
+        # The real target worktree is a PUBLIC sibling under workspace.
+        _repo_with_remote(workspace / "public-worktree", "git@github.com:souliane/teatree.git")
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        (tmp_path / "non-git-process-cwd").mkdir()
+        monkeypatch.chdir(tmp_path / "non-git-process-cwd")
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                'git -C ../public-worktree commit -m "acmewidget refinery"',
+                "acmewidget refinery",
+                ambient_cwd,
+                config_path=cfg,
+            )
+            is False
+        )
+
 
 class TestOwnSlugTermDowngrades:
     """A commit tripping on its OWN repo-slug term (#126 follow-up).


### PR DESCRIPTION
## Problem (#1415)

The banned-terms posting gate's private-repo carve-out resolves where a `git commit` LANDS via `effective_repo_dir` (a leading `cd`/`-C`/`--git-dir`). But the parsed result can be **relative** (`git -C ../worktree`), and it was built into a bare `Path(repo_dir)` with no base — so `git_root_for_dir` resolved it against the **cold hook's process cwd**, not the ambient hook cwd the agent actually ran in.

When a sub-agent's ambient hook cwd has reset away to a sibling repo, a relative `-C <worktree>` mis-resolved both ways:

- **Leak (load-bearing):** a relative `-C` to a **public** repo resolved to no repo at the process cwd and the carve-out **fell open** — a banned-term commit reached the public repo unblocked.
- A relative `-C` to a private allowlisted repo only downgraded **by accident** when the process cwd happened to match.

## Fix

Add `resolve_commit_dir(command, cwd)` as the single resolution chokepoint in `_commit_repo_dir`:

- anchors a **relative** parsed dir on the **ambient cwd**,
- keeps an absolute dir as-is,
- returns the ambient cwd for a plain commit,
- preserves the unresolvable static-marker guard (fail-closed).

Wired into the commit carve-out (`commit_target_downgrades`) and the shared body-file base (`commit_body_file_base`) so both gates resolve the worktree the same way.

The gate stays **fully active** for public/unknown destinations — a public repo, or a repo not in `[teatree] private_repos`, still hard-blocks. This is a **precision fix, not a relaxation**.

## Tests (RED before, GREEN after)

- `test_relative_dash_c_private_target_anchored_on_ambient_cwd_downgrades` — a relative `-C` private target from a public-sibling ambient cwd downgrades (with a decoy public repo at the process-cwd-relative location, so the test only passes when the anchor uses the ambient cwd).
- `test_relative_dash_c_public_target_from_private_ambient_cwd_stays_blocked` — the inverse leak direction: a relative `-C` **public** target from a private ambient cwd stays **hard-blocked**.
- `test_relative_dash_c_commit_body_file_anchored_on_ambient_cwd` — a relative `-C` commit body file is read from the anchored worktree.

Full gate/hook/eval suites: 2464 passed, 29 skipped.

Closes #1415
