### PR TITLE
fix(dream): gate MiniLoopMarker on successful pass; fix crash-path return (#1933)

### DIFF
--- a/src/teatree/cli/_doctor_checks.py
+++ b/src/teatree/cli/_doctor_checks.py
@@ -270,7 +270,7 @@ def _check_dream_staleness() -> bool:
         stale = DreamRunMarker.objects.is_stale(timezone.now())
     except Exception as exc:  # noqa: BLE001 — doctor check must never crash the run
         typer.echo(f"WARN  Dream-staleness check crashed: {exc.__class__.__name__}: {exc}")
-        return True
+        return False
     if not stale:
         return True
     typer.echo(

--- a/src/teatree/core/management/commands/dream.py
+++ b/src/teatree/core/management/commands/dream.py
@@ -73,11 +73,11 @@ class Command(TyperCommand):
             return
 
         try:
-            self._consolidate_and_mark(since=since, dry_run=dry_run, now=now)
+            succeeded = self._consolidate_and_mark(since=since, dry_run=dry_run, now=now)
         finally:
             LoopLease.objects.release(DREAM_LEASE_NAME, owner=owner)
 
-        if enforce_cadence:
+        if enforce_cadence and succeeded:
             MiniLoopMarker.objects.mark_fired(MINI_LOOP.name, now)
 
         # Re-read confirmation so a stamped success can be cited (resilience #7).
@@ -86,33 +86,31 @@ class Command(TyperCommand):
             stamped = marker.last_succeeded_at.isoformat() if marker and marker.last_succeeded_at else "none"
             self.stdout.write(f"      dream marker last_succeeded_at={stamped}")
 
-    def _consolidate_and_mark(self, *, since: dt.datetime | None, dry_run: bool, now: dt.datetime) -> None:
+    def _consolidate_and_mark(self, *, since: dt.datetime | None, dry_run: bool, now: dt.datetime) -> bool:
         from teatree.core.models import DreamRunMarker  # noqa: PLC0415
         from teatree.loops.dream import engine  # noqa: PLC0415
 
         try:
             result = engine.run_consolidation(overlay="", since=since, dry_run=dry_run)
         except Exception as exc:  # noqa: BLE001
-            # A failed pass bumps only the attempt timestamp — staleness keeps
-            # firing until a clean run lands (the alarm IS the fallback signal).
-            # A dry-run writes nothing, marker included, even on engine raise.
             if not dry_run:
                 DreamRunMarker.objects.mark_attempted(now)
             self.stdout.write(f"FAIL  dream pass raised: {type(exc).__name__}: {exc}")
-            return
+            return False
 
         if dry_run:
             self.stdout.write(
                 f"DRY   dream pass — {result.clusters_recorded} cluster(s) would be recorded "
                 f"from {result.members_replayed} member(s); no rows or marker written.",
             )
-            return
+            return False
 
         DreamRunMarker.objects.mark_succeeded(now)
         self.stdout.write(
             f"OK    dream pass — {result.clusters_recorded} cluster(s) recorded "
             f"from {result.members_replayed} member(s).",
         )
+        return True
 
 
 def _parse_since(raw: str) -> dt.datetime | None:

--- a/tests/teatree_cli/test_dream_staleness_check.py
+++ b/tests/teatree_cli/test_dream_staleness_check.py
@@ -57,9 +57,7 @@ class DreamStalenessOutputTestCase(TestCase):
 
 
 class DreamStalenessCrashTestCase(TestCase):
-    def test_is_stale_crash_degrades_to_ok_with_warn(self) -> None:
-        # A DB read error (offline / unmigrated self-DB) must never abort the
-        # doctor run — it degrades to True with a WARN naming the crash.
+    def test_is_stale_crash_returns_false_with_warn(self) -> None:
         buf = io.StringIO()
         with (
             patch.object(
@@ -70,7 +68,7 @@ class DreamStalenessCrashTestCase(TestCase):
             redirect_stdout(buf),
         ):
             result = _check_dream_staleness()
-        assert result is True
+        assert result is False
         out = buf.getvalue()
         assert "WARN" in out
         assert "RuntimeError" in out

--- a/tests/teatree_core/management_commands/test_dream.py
+++ b/tests/teatree_core/management_commands/test_dream.py
@@ -164,6 +164,14 @@ class DreamTickCadenceTestCase(TestCase):
             call_command("dream", "run", stdout=StringIO())
         engine.assert_called_once()
 
+    def test_tick_failed_engine_does_not_advance_cadence_ledger(self) -> None:
+        with patch(
+            "teatree.loops.dream.engine.run_consolidation",
+            side_effect=RuntimeError("engine boom"),
+        ):
+            call_command("dream", "tick", stdout=StringIO())
+        assert not MiniLoopMarker.objects.filter(name=DREAM_LOOP_NAME).exists()
+
 
 class DreamSinceTestCase(TestCase):
     def test_run_passes_since_to_engine(self) -> None:


### PR DESCRIPTION
Forward-fix for the two cold-review HOLD findings on [#2255](https://github.com/souliane/teatree/pull/2255) (#1933). #2255 squash-merged at the pre-fix commit, so `main` still carries both bugs; this PR re-applies the fixes onto current `main`.

## HOLD-1 (Medium) — failed dream tick advanced the cadence ledger

In `src/teatree/core/management/commands/dream.py`, `_consolidate_and_mark` swallowed an engine exception and returned, but `MiniLoopMarker.objects.mark_fired(...)` was called unconditionally after the try/finally. A failed tick advanced the cadence ledger, suppressing retries for a full cadence cycle. `_consolidate_and_mark` now returns `bool` (`True` only on a clean successful write; `False` on engine failure or dry-run), and the `tick` path gates `mark_fired` on that bool. DreamRunMarker's success/attempt distinction is unchanged.

## HOLD-2 (Low-Medium) — doctor crash path returned True

In `src/teatree/cli/_doctor_checks.py`, the except block of `_check_dream_staleness` echoed a WARN but returned `True` (OK), contradicting the `-> bool` contract. Now returns `False` on crash. The doctor-level WARN-not-FAIL decision still lives in `doctor.py` (it discards the return).

## Regression tests (anti-vacuity verified)

- `test_tick_failed_engine_does_not_advance_cadence_ledger` — RED on pre-fix source (`MiniLoopMarker` existed after a raising tick), GREEN after.
- `test_is_stale_crash_returns_false_with_warn` — RED on pre-fix source (`result` was `True`), GREEN after.

Both proven RED by reverting the two source files to `origin/main` while keeping the tests, then GREEN once the fix is restored.

## Architecture pre-check — #1933 (HOLD follow-up)

### 1. BLUEPRINT § alignment
Tactical bug fix to an existing management command and a doctor check; no BLUEPRINT section change.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / Protocol surface touched.

### 4. Component boundaries
`src/teatree/core/management/commands/dream.py` (ORM-touching command) and `src/teatree/cli/_doctor_checks.py` (CLI doctor check) — both pre-existing homes, unchanged.

### 5. Dependency direction
No imports added. `tach` green (verify-gates).

### 6. Test surface
`tests/teatree_core/management_commands/test_dream.py::DreamTickCadenceTestCase::test_tick_failed_engine_does_not_advance_cadence_ledger` and `tests/teatree_cli/test_dream_staleness_check.py::DreamStalenessCrashTestCase::test_is_stale_crash_returns_false_with_warn`.

### 7. Resilience invariants
The fix tightens the failure path: a failed external-engine pass no longer falsely advances the cadence ledger (the staleness alarm remains the fallback signal until a clean run lands). verify-by-re-read of the marker is unchanged.

### 8. Identity and key normalization
n/a.

### 9. Behavior preservation / capability deletion
Purely additive on the success path; the only behavior change is the two bugfixes above. DreamRunMarker success/attempt stamping preserved; the dry-run no-write contract preserved (dry-run returns `False`, so cadence is not advanced — consistent, since a dry-run never writes the marker either).

## Open questions & assumptions

- assumed: a dry-run tick should not advance the cadence ledger (dry-run returns `False`). A dry-run writes no marker and is a no-op rehearsal, so advancing the cadence would be wrong; this matches the existing dry-run-no-write contract.
