### PR TITLE
fix(loop): isolate per-loop and per-scanner failures so one bad actor never aborts the tick

### DIFF
--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -622,18 +622,29 @@ def _dispatch_one(signal: ScanSignal) -> list[DispatchAction]:
     return [DispatchAction(kind="statusline", zone=zone, detail=signal.summary, payload=signal.payload)]
 
 
-def dispatch(signals: list[ScanSignal]) -> list[DispatchAction]:
+def dispatch(
+    signals: list[ScanSignal],
+    *,
+    errors: dict[str, str] | None = None,
+) -> list[DispatchAction]:
     """Turn a flat list of signals into the actions the runtime should perform.
 
     Slack mentions/DMs that carry a PR URL also emit a derived
     ``review_channel.request`` agent action — the URL extraction lives here
     rather than in a second scanner so the messaging backend is hit once
     per tick.
+
+    Per-signal exceptions are swallowed so a bad handler never aborts the
+    tick.  When *errors* is supplied (a ``TickReport.errors`` dict), each
+    swallowed exception is recorded under ``'dispatch:<signal.kind>'`` so it
+    surfaces in the action-needed render.
     """
     actions: list[DispatchAction] = []
     for signal in signals:
         try:
             actions.extend(_dispatch_one(signal))
-        except Exception:
+        except Exception as exc:
             logger.exception("Signal %s raised during dispatch", signal.kind)
+            if errors is not None:
+                errors[f"dispatch:{signal.kind}"] = f"{type(exc).__name__}: {exc}"
     return actions

--- a/src/teatree/loop/phases/act.py
+++ b/src/teatree/loop/phases/act.py
@@ -17,6 +17,6 @@ if TYPE_CHECKING:
 
 
 def act_phase(report: "TickReport") -> None:
-    report.actions = dispatch(report.signals)
+    report.actions = dispatch(report.signals, errors=report.errors)
     _execute_mechanical(report)
     _persist_agent_dispatches(report)

--- a/src/teatree/loop/phases/scan.py
+++ b/src/teatree/loop/phases/scan.py
@@ -6,12 +6,16 @@ error keyed by its label. No dispatch, no rendering, no DB mutation —
 those belong to later phases.
 """
 
-from concurrent.futures import ThreadPoolExecutor
+import os
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 
 from teatree.loop.domain_jobs import _run_job
 from teatree.loop.job_identity import _ScannerJob
 from teatree.loop.scanners.base import ScanSignal
+
+_DEFAULT_PER_JOB_TIMEOUT: float = 60.0
+_POOL_WORKERS_PER_CPU: int = 4
 
 
 @dataclass(slots=True)
@@ -20,13 +24,41 @@ class ScanOutcome:
     errors: dict[str, str] = field(default_factory=dict)
 
 
-def scan_phase(jobs: list[_ScannerJob]) -> ScanOutcome:
+def scan_phase(
+    jobs: list[_ScannerJob],
+    *,
+    per_job_timeout: float = _DEFAULT_PER_JOB_TIMEOUT,
+) -> ScanOutcome:
+    """Fan out scanner jobs across a bounded thread pool.
+
+    Each job is given at most *per_job_timeout* seconds.  A job that exceeds
+    its budget is recorded as a timed-out error for that scanner label; the
+    tick continues with the remaining results.  The pool is shut down without
+    waiting for still-running threads so a hung scanner cannot freeze the tick.
+    """
     outcome = ScanOutcome()
     if not jobs:
         return outcome
-    with ThreadPoolExecutor(max_workers=max(1, len(jobs))) as pool:
-        for label, signals, error in pool.map(_run_job, jobs):
-            outcome.signals.extend(signals)
-            if error:
-                outcome.errors[label] = error
+    cpu = os.cpu_count() or 4
+    max_workers = min(len(jobs), cpu * _POOL_WORKERS_PER_CPU)
+    pool = ThreadPoolExecutor(max_workers=max(1, max_workers))
+    future_to_label: dict[Future[tuple[str, list[ScanSignal], str]], str] = {
+        pool.submit(_run_job, job): job.scanner.name for job in jobs
+    }
+    try:
+        for future, label in future_to_label.items():
+            try:
+                job_label, signals, error = future.result(timeout=per_job_timeout)
+                outcome.signals.extend(signals)
+                if error:
+                    outcome.errors[job_label] = error
+            except TimeoutError:
+                outcome.errors[label] = f"scanner timed out after {per_job_timeout}s"
+            except Exception as exc:  # noqa: BLE001
+                outcome.errors[label] = f"{type(exc).__name__}: {exc}"
+    finally:
+        # cancel_futures=True drops queued-but-unstarted futures; already-running
+        # threads cannot be interrupted but we stop waiting for them so the tick
+        # is not frozen by a single hung scanner.
+        pool.shutdown(wait=False, cancel_futures=True)
     return outcome

--- a/src/teatree/loops/fanout.py
+++ b/src/teatree/loops/fanout.py
@@ -19,6 +19,7 @@ never by importing the registry down into :mod:`teatree.loop`.
 """
 
 import datetime as dt
+import logging
 
 from teatree.loop.job_identity import _ScannerJob
 from teatree.loops.base import BuildJobsContext
@@ -26,6 +27,8 @@ from teatree.loops.cadence_ledger import MiniLoopMarker
 from teatree.loops.config import LoopsConfig
 from teatree.loops.gating import elapsed_and_enabled
 from teatree.loops.registry import iter_loops
+
+logger = logging.getLogger(__name__)
 
 
 def build_registry_jobs(
@@ -37,6 +40,11 @@ def build_registry_jobs(
             continue
         if not elapsed_and_enabled(config, loop, now).should_fire:
             continue
-        jobs.extend(loop.build_jobs(**scanner_context))
+        try:
+            new_jobs = loop.build_jobs(**scanner_context)
+        except Exception:
+            logger.exception("Mini-loop %r raised during build_jobs — skipping", loop.name)
+            continue
+        jobs.extend(new_jobs)
         MiniLoopMarker.objects.mark_fired(loop.name, now)
     return jobs

--- a/tests/teatree_loop/phases/test_scan.py
+++ b/tests/teatree_loop/phases/test_scan.py
@@ -1,5 +1,6 @@
 """Tests for ``teatree.loop.phases.scan`` — the parallel read-then-signal stage."""
 
+import time
 from dataclasses import dataclass
 
 from teatree.loop.job_identity import _ScannerJob
@@ -58,3 +59,50 @@ def test_scan_phase_on_empty_jobs_returns_empty_outcome() -> None:
     outcome = scan_phase([])
     assert outcome.signals == []
     assert outcome.errors == {}
+
+
+@dataclass(slots=True)
+class _HungScanner:
+    name: str = "hung"
+
+    def scan(self) -> list[ScanSignal]:
+        # Sleep far longer than the test timeout; the pool must interrupt it.
+        time.sleep(60)
+        return []  # pragma: no cover — never reached under timeout
+
+
+def test_scan_phase_times_out_hung_scanner_and_records_error() -> None:
+    """A hung scanner is interrupted after per_job_timeout and its error is recorded (fix #4)."""
+    jobs = [
+        _ScannerJob(scanner=_HungScanner(), overlay=""),
+        _ScannerJob(scanner=_FixedScanner(name="ok", out=[ScanSignal(kind="my_pr.open", summary="x")]), overlay=""),
+    ]
+    outcome = scan_phase(jobs, per_job_timeout=0.1)
+    # The ok scanner's signal is present
+    assert any(s.summary == "x" for s in outcome.signals)
+    # The hung scanner's error is recorded
+    assert "hung" in outcome.errors
+    assert "timeout" in outcome.errors["hung"].lower() or "timed" in outcome.errors["hung"].lower()
+
+
+def test_scan_phase_worker_pool_is_bounded() -> None:
+    """Pool size is capped even when many jobs are present."""
+    import os  # noqa: PLC0415
+    from concurrent.futures import ThreadPoolExecutor  # noqa: PLC0415
+    from unittest.mock import patch  # noqa: PLC0415
+
+    max_seen: list[int] = []
+
+    def _capped_tpe(*, max_workers: int | None = None, **kwargs: object) -> ThreadPoolExecutor:
+        max_seen.append(max_workers or 0)
+        return ThreadPoolExecutor(max_workers=max_workers, **kwargs)  # type: ignore[arg-type]
+
+    jobs = [_ScannerJob(scanner=_FixedScanner(name=f"s{i}", out=[]), overlay="") for i in range(200)]
+    cpu = os.cpu_count() or 4
+    expected_cap = min(200, cpu * 4)
+
+    with patch("teatree.loop.phases.scan.ThreadPoolExecutor", side_effect=_capped_tpe):
+        scan_phase(jobs)
+
+    assert max_seen, "ThreadPoolExecutor was not called"
+    assert max_seen[0] <= expected_cap

--- a/tests/teatree_loop/test_dispatch.py
+++ b/tests/teatree_loop/test_dispatch.py
@@ -703,3 +703,43 @@ def test_one_raising_signal_does_not_abort_the_others(
     assert ("agent", "t3:reviewer") in zones
     assert all(a.kind != "agent" or a.zone != "boom" for a in actions)
     assert any("boom" in r.message for r in caplog.records)
+
+
+def test_dispatch_error_recorded_in_errors_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising signal kind is recorded under ``errors['dispatch:<kind>']`` (fix #3)."""
+    real_dispatch_one = dispatch_module._dispatch_one
+
+    def _flaky(signal: ScanSignal) -> list[DispatchAction]:
+        if signal.kind == "bang.signal":
+            msg = "dispatch exploded"
+            raise RuntimeError(msg)
+        return real_dispatch_one(signal)
+
+    monkeypatch.setattr(dispatch_module, "_dispatch_one", _flaky)
+
+    errors: dict[str, str] = {}
+    actions = dispatch(
+        [
+            ScanSignal(kind="my_pr.open", summary="PR ok"),
+            ScanSignal(kind="bang.signal", summary="this raises"),
+            ScanSignal(kind="reviewer_pr.new_sha", summary="MR x"),
+        ],
+        errors=errors,
+    )
+
+    # Other signals still routed
+    kinds = [a.kind for a in actions]
+    assert "statusline" in kinds
+    assert "agent" in kinds
+
+    # Raising signal's error is captured
+    assert "dispatch:bang.signal" in errors
+    assert "RuntimeError" in errors["dispatch:bang.signal"]
+
+
+def test_dispatch_without_errors_param_still_works() -> None:
+    """``dispatch()`` remains callable without the ``errors`` param (backward compat)."""
+    actions = dispatch([ScanSignal(kind="my_pr.open", summary="x")])
+    assert actions[0].kind == "statusline"

--- a/tests/teatree_loops/test_fanout.py
+++ b/tests/teatree_loops/test_fanout.py
@@ -270,3 +270,102 @@ class RunTickRegistrySeamTestCase(TestCase):
     def test_loop_tick_builder_marks_loops_fired(self) -> None:
         _registry_jobs_builder(TickRequest(backends=_backends()), NOW)
         assert MiniLoopMarker.objects.filter(name="dispatch").exists()
+
+
+class FanoutIsolationTestCase(TestCase):
+    """Fix (1)+(2): per-loop error isolation and mark-fired ordering.
+
+    A loop whose build_jobs raises must not abort the whole fan-out and
+    must NOT be marked fired.  Other loops still yield their jobs.
+    """
+
+    def _make_exploding_loop(self, name: str = "boom") -> object:
+        """Return a MiniLoop whose build_jobs always raises."""
+        from teatree.loops.base import MiniLoop  # noqa: PLC0415
+
+        def _raise(**_: object) -> list[object]:
+            msg = "build_jobs exploded"
+            raise RuntimeError(msg)
+
+        return MiniLoop(
+            name=name,
+            default_cadence_seconds=1,
+            build_jobs=_raise,
+        )
+
+    def _make_fixed_loop(self, name: str) -> object:
+        """Return a MiniLoop whose build_jobs returns one job keyed to *name*."""
+        from teatree.loop.job_identity import _ScannerJob  # noqa: PLC0415
+        from teatree.loop.scanners.base import ScanSignal  # noqa: PLC0415
+        from teatree.loops.base import MiniLoop  # noqa: PLC0415
+
+        @dataclass(slots=True)
+        class _FixedScannerLocal:
+            name: str
+
+            def scan(self) -> list[ScanSignal]:
+                return []
+
+        scanner = _FixedScannerLocal(name=name)
+        fixed_jobs: list[object] = [_ScannerJob(scanner=scanner, overlay="")]
+
+        def _build(**_: object) -> list[object]:
+            return list(fixed_jobs)
+
+        return MiniLoop(
+            name=name,
+            default_cadence_seconds=1,
+            build_jobs=_build,
+        )
+
+    def test_exploding_loop_does_not_abort_other_loops(self) -> None:
+        from unittest.mock import patch  # noqa: PLC0415
+
+        from teatree.loops.fanout import build_registry_jobs  # noqa: PLC0415
+
+        ok_loop = self._make_fixed_loop("ok_loop")
+        boom_loop = self._make_exploding_loop("boom_loop")
+
+        from teatree.loops.gating import GateDecision  # noqa: PLC0415
+
+        with (
+            patch("teatree.loops.fanout.iter_loops", return_value=(boom_loop, ok_loop)),
+            patch("teatree.loops.fanout.elapsed_and_enabled", return_value=GateDecision(should_fire=True)),
+        ):
+            jobs = build_registry_jobs(_context(), config=LoopsConfig(), now=NOW)
+
+        # The ok_loop's one job is present; the boom_loop contributed nothing
+        scanner_names = {job.scanner.name for job in jobs}
+        assert "ok_loop" in scanner_names
+
+    def test_exploding_loop_is_not_marked_fired(self) -> None:
+        from unittest.mock import patch  # noqa: PLC0415
+
+        from teatree.loops.fanout import build_registry_jobs  # noqa: PLC0415
+        from teatree.loops.gating import GateDecision  # noqa: PLC0415
+
+        boom_loop = self._make_exploding_loop("boom_explodes")
+
+        with (
+            patch("teatree.loops.fanout.iter_loops", return_value=(boom_loop,)),
+            patch("teatree.loops.fanout.elapsed_and_enabled", return_value=GateDecision(should_fire=True)),
+        ):
+            build_registry_jobs(_context(), config=LoopsConfig(), now=NOW)
+
+        assert not MiniLoopMarker.objects.filter(name="boom_explodes").exists()
+
+    def test_successful_loop_is_still_marked_fired(self) -> None:
+        from unittest.mock import patch  # noqa: PLC0415
+
+        from teatree.loops.fanout import build_registry_jobs  # noqa: PLC0415
+        from teatree.loops.gating import GateDecision  # noqa: PLC0415
+
+        ok_loop = self._make_fixed_loop("ok_fires")
+
+        with (
+            patch("teatree.loops.fanout.iter_loops", return_value=(ok_loop,)),
+            patch("teatree.loops.fanout.elapsed_and_enabled", return_value=GateDecision(should_fire=True)),
+        ):
+            build_registry_jobs(_context(), config=LoopsConfig(), now=NOW)
+
+        assert MiniLoopMarker.objects.filter(name="ok_fires").exists()


### PR DESCRIPTION
## Summary

Four resilience fixes to prevent a single bad loop or scanner from freezing or aborting the entire tick:

- **Fix 1 (fanout error isolation):** `build_registry_jobs` wraps each loop's `build_jobs` call in try/except so an exploding loop is skipped and remaining loops still produce their jobs.
- **Fix 2 (mark-fired ordering):** `MiniLoopMarker.mark_fired` is moved to after a successful `build_jobs` call so a loop that raised is not marked as fired and retries on the next cadence.
- **Fix 3 (dispatch error surfacing):** `dispatch()` gains an optional `errors=` parameter; per-signal exceptions are recorded under `report.errors['dispatch:<kind>']` and surface in `action_needed` instead of being silently swallowed. `act_phase` passes `report.errors` through.
- **Fix 4 (bounded scanner pool with timeout):** The scan thread pool is bounded to `min(n_jobs, cpu_count*4)` workers and each future is given a per-job timeout budget. A hung scanner is recorded as a timeout error; `pool.shutdown(wait=False)` ensures the tick is not frozen.

## Test plan

- All new tests were confirmed RED before the fix was applied (TDD).
- Full suite result: `uv run pytest tests/teatree_loops tests/teatree_loop --no-cov -x -q` passes 2104 tests.
- New tests cover each fix individually plus backward-compat for fix 3.