### PR TITLE
fix(cli): fail loud on swallowed exit codes and vacuous-green eval lanes

### DIFF
--- a/src/teatree/cli/dogfood.py
+++ b/src/teatree/cli/dogfood.py
@@ -17,7 +17,6 @@ from teatree.cli.overlay import managepy_core
 
 dogfood_app = typer.Typer(
     name="dogfood",
-    no_args_is_help=True,
     help="Overlay-smoke commands — exercise CLI paths so bugs surface in the loop, not in E2E.",
     context_settings={
         "allow_extra_args": True,
@@ -25,6 +24,22 @@ dogfood_app = typer.Typer(
         "ignore_unknown_options": True,
     },
 )
+
+
+@dogfood_app.callback(invoke_without_command=True)
+def _root(ctx: typer.Context) -> None:
+    """Print help and exit 0 when invoked with no sub-command.
+
+    The callback (rather than the app's ``no_args_is_help``) is what forces a
+    real Typer *group*: a single-command Typer app collapses into that command,
+    so bare ``t3 dogfood`` would run ``overlay-provision-smoke`` instead of
+    showing help. With the callback present the app stays a group, and a bare
+    invocation lands here. ``no_args_is_help`` is not used because a Click group
+    exits 2 on the no-command help path; the cron/loop recipe wants a clean 0.
+    """
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit(code=0)
 
 
 @dogfood_app.command(

--- a/src/teatree/cli/eval/all.py
+++ b/src/teatree/cli/eval/all.py
@@ -42,6 +42,7 @@ from teatree.eval.negative_control import NegativeControlOutcome, run_negative_c
 from teatree.eval.parallel import DEFAULT_PARALLEL, run_specs
 from teatree.eval.regression_corpus import RegressionReport, run_regression_corpus
 from teatree.eval.report import ScenarioResult, evaluate
+from teatree.eval.skip_guard import UnmeteredSdkRunError, assert_sdk_run_was_metered
 from teatree.eval.transcript_conformance import InvariantResult
 from teatree.eval.trigger_qa import TriggerQAReport, run_trigger_qa
 from teatree.utils.django_bootstrap import ensure_django
@@ -132,9 +133,24 @@ def transcript_replay_lane(results: list[InvariantResult] | None) -> LaneResult:
     )
 
 
+@dataclasses.dataclass(frozen=True)
+class AiLaneOutcome:
+    """The AI lane's summary plus the graded per-scenario results.
+
+    ``results`` is threaded out so the suite chokepoint can sum each run's
+    ``cost_usd`` and run the unmetered-$0 guard (:func:`assert_sdk_run_was_metered`)
+    on the metered (``--backend sdk``) path — the same vacuous-green guard the
+    ``eval run`` boundary applies via ``RunGuards.sdk_metered``. It is empty when
+    the lane did not grade (no transcripts on the subscription path).
+    """
+
+    lane: LaneResult
+    results: list[ScenarioResult]
+
+
 def run_ai_lane(
     specs: list[EvalSpec], *, backend: str, target_dir: Path, parallel: int = DEFAULT_PARALLEL
-) -> LaneResult:
+) -> AiLaneOutcome:
     try:
         runner = make_runner(backend, transcript_dir=target_dir)
     except UnknownBackendError as exc:
@@ -142,10 +158,10 @@ def run_ai_lane(
         raise typer.Exit(code=2) from None
     if isinstance(runner, SubscriptionTranscriptRunner) and not _any_transcript_present(specs, runner):
         _emit_subscription_recipe(specs, target_dir)
-        return _ai_lane_result([], backend=backend, graded=False)
+        return AiLaneOutcome(lane=_ai_lane_result([], backend=backend, graded=False), results=[])
     runs = run_specs(runner, specs, parallel=parallel)
     results = list(starmap(evaluate, zip(specs, runs, strict=True)))
-    return _ai_lane_result(results, backend=backend, graded=True)
+    return AiLaneOutcome(lane=_ai_lane_result(results, backend=backend, graded=True), results=results)
 
 
 def _any_transcript_present(specs: list[EvalSpec], runner: SubscriptionTranscriptRunner) -> bool:
@@ -326,13 +342,15 @@ def run_full_suite(  # noqa: PLR0913 — the single eval-suite chokepoint: each 
         _timed(lambda: corpus_grade_lane(grade_shipped_corpus())),
         _timed(lambda: skill_command_validity_lane(validate_shipped_skill_commands())),
     ]
+    ai_results: list[ScenarioResult] = []
     if not free_only:
         # The AI lane runs first. It is itself backend-gated: the default
         # subscription backend grades on-disk transcripts (no API spend) and never
         # shells the metered runner, so it is safe on the bare-`t3 eval` path.
-        lanes.append(
-            _timed(lambda: run_ai_lane(discover_specs(), backend=backend, target_dir=target_dir, parallel=parallel))
-        )
+        started = time.monotonic()
+        ai_outcome = run_ai_lane(discover_specs(), backend=backend, target_dir=target_dir, parallel=parallel)
+        ai_results = ai_outcome.results
+        lanes.append(dataclasses.replace(ai_outcome.lane, duration_s=time.monotonic() - started))
     if metered:
         # The ADVISORY Tier-3 prose-judge fires the LIVE metered ClaudeJudge, so it
         # is gated on the explicit metered opt-in (`--backend sdk`), NOT merely on
@@ -345,9 +363,30 @@ def run_full_suite(  # noqa: PLR0913 — the single eval-suite chokepoint: each 
     print_verdict(lanes)
     if html_path is not None:
         _write_html_report(lanes, html_path)
+    # The metered (`--backend sdk`) AI lane: an sdk run that executed scenarios
+    # but billed $0 never actually executed (the `--bare` OAuth bug — `claude -p`
+    # authenticated as nothing, made zero tool calls, billed nothing). Mirror the
+    # `eval run` boundary's RunGuards.sdk_metered: fail loud rather than read the
+    # green AI lane as validated. The subscription backend is unmetered by design,
+    # so the guard short-circuits there (`backend != "sdk"`).
+    _assert_metered_sdk_ai_lane(backend=backend, results=ai_results)
     real_failure = any(not lane.passed and not lane.skipped for lane in lanes)
     strict_failure = strict and any(lane.needs_setup for lane in lanes)
     if real_failure or strict_failure:
+        sys.exit(1)
+
+
+def _assert_metered_sdk_ai_lane(*, backend: str, results: list[ScenarioResult]) -> None:
+    """Turn an executed-but-$0 sdk AI lane RED — the suite mirror of ``RunGuards.sdk_metered``."""
+    executed = sum(1 for r in results if not r.skipped)
+    try:
+        assert_sdk_run_was_metered(
+            backend=backend,
+            executed=executed,
+            total_cost_usd=sum(r.run.cost_usd for r in results),
+        )
+    except UnmeteredSdkRunError as exc:
+        typer.echo(str(exc), err=True)
         sys.exit(1)
 
 

--- a/src/teatree/cli/eval/corpus.py
+++ b/src/teatree/cli/eval/corpus.py
@@ -66,16 +66,43 @@ def grade_shipped_corpus() -> list[CorpusGradeRow]:
     return grade_corpus_rows(discover_corpus(), directory=CORPUS_DIR, judge=None)
 
 
+#: Surfaced when the corpus deterministically graded ZERO entries — the lane is
+#: unrunnable for setup reasons (an all-judge / empty corpus under ``--no-judge``),
+#: so it reads as needs-setup (``--strict`` fails on it), never a vacuous green.
+CORPUS_NO_GRADED_HINT = (
+    "no matcher-gradable corpus entries (all judge-oracle / empty) — add a matcher/both entry "
+    "or run with --judge; nothing was deterministically validated"
+)
+
+
 def corpus_grade_lane(rows: list[CorpusGradeRow]) -> LaneResult:
-    """Fold graded rows into the free ``corpus-grade`` lane for ``t3 eval all``."""
+    """Fold graded rows into the free ``corpus-grade`` lane for ``t3 eval all``.
+
+    ``graded == 0`` (every entry judge-skipped, or an empty corpus) is NOT a
+    green pass — there is nothing deterministically validated, so a green row
+    would be vacuous. It surfaces as a setup-skip (``setup_hint`` set →
+    ``needs_setup`` → ``--strict`` fails, the verdict flags it not-yet-validated),
+    mirroring the AI lane's no-transcripts skip.
+    """
     failed = sum(1 for row in rows if row.verdict == "fail")
     skipped = sum(1 for row in rows if row.verdict == "skip")
+    graded = len(rows) - skipped
+    detail = f"{graded} graded, {failed} failed, {skipped} judge-skipped"
+    if graded == 0:
+        return LaneResult(
+            name="corpus-grade",
+            cost="free",
+            passed=True,
+            skipped=True,
+            detail=detail,
+            setup_hint=CORPUS_NO_GRADED_HINT,
+        )
     return LaneResult(
         name="corpus-grade",
         cost="free",
         passed=failed == 0,
         skipped=False,
-        detail=f"{len(rows) - skipped} graded, {failed} failed, {skipped} judge-skipped",
+        detail=detail,
     )
 
 

--- a/src/teatree/core/management/commands/dogfood.py
+++ b/src/teatree/core/management/commands/dogfood.py
@@ -17,6 +17,11 @@ Subcommands:
 
 The room for sibling smokes is the ``t3 dogfood`` namespace itself —
 add subcommands here.
+
+Non-zero exits use ``raise SystemExit(N)``, never ``typer.Exit`` — these
+commands run under Django's ``call_command`` (django-typer), which swallows a
+``typer.Exit`` into a *returned* code and exits 0, so a categorised failure
+would silently report success to cron/CI/the loop. ``SystemExit`` propagates.
 """
 
 from typing import Annotated
@@ -116,14 +121,15 @@ class Command(TyperCommand):
         """Run the overlay provision smoke against a fixture ticket.
 
         Exits 0 on PASS, 11-19 on categorised failure (see
-        :func:`_exit_code_for`). DMs the user via
+        :func:`_exit_code_for`) via ``raise SystemExit(code)`` so the code
+        propagates under ``call_command``. DMs the user via
         :func:`teatree.notify.notify_user` on any non-PASS outcome
         unless ``--no-notify-on-failure`` is passed (CI hook).
         """
         target_overlay = overlay or _resolve_active_overlay()
         if not target_overlay:
             typer.echo("error: no overlay resolved — pass --overlay <name>.", err=True)
-            raise typer.Exit(code=2)
+            raise SystemExit(2)
 
         steps = default_steps(
             overlay=target_overlay,
@@ -156,7 +162,7 @@ class Command(TyperCommand):
 
         code = _exit_code_for(report.outcome)
         if code != 0:
-            raise typer.Exit(code=code)
+            raise SystemExit(code)
 
 
 def _resolve_active_overlay() -> str:

--- a/tests/teatree_cli/eval/test_corpus.py
+++ b/tests/teatree_cli/eval/test_corpus.py
@@ -12,7 +12,8 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from teatree.cli import app
-from teatree.cli.eval.corpus import CorpusGradeRow, grade_shipped_corpus
+from teatree.cli.eval.corpus import CORPUS_NO_GRADED_HINT, CorpusGradeRow, corpus_grade_lane, grade_shipped_corpus
+from teatree.eval.corpus_loader import discover_corpus
 from teatree.eval.report import JudgeOutcome
 
 _WORKTREE_COMMAND = "git worktree add ../wt HEAD"
@@ -220,3 +221,55 @@ class TestShippedCorpusLaneBody:
         row = grade_shipped_corpus()[0]
         assert isinstance(row, CorpusGradeRow)
         assert row.oracle in {"matcher", "judge", "both"}
+
+    def test_shipped_corpus_has_a_deterministically_gradable_entry(self) -> None:
+        """The free corpus-grade lane must validate >=1 matcher/both entry deterministically.
+
+        If the corpus ever became all-judge (or empty), the ``--no-judge`` free
+        lane would grade nothing and read green for free — decorative, vacuous.
+        """
+        deterministic = [label for label in discover_corpus() if label.oracle in {"matcher", "both"}]
+        assert deterministic, (
+            "shipped corpus has no matcher/both entry — the free corpus-grade lane would grade "
+            "ZERO entries under --no-judge and read as a vacuous green. Add a deterministically-"
+            "gradable entry."
+        )
+        # And it actually grades (not skips) in the free lane.
+        graded_ids = {label.entry_id for label in deterministic}
+        rows = {row.entry_id: row for row in grade_shipped_corpus()}
+        assert any(rows[entry_id].verdict in {"pass", "fail"} for entry_id in graded_ids)
+
+
+class TestCorpusGradeLane:
+    """The free ``corpus-grade`` lane folding of graded rows (vacuous-green guard)."""
+
+    def test_zero_graded_is_a_setup_skip_not_a_green_pass(self) -> None:
+        # An all-judge corpus under --no-judge: every row SKIPs, so the lane
+        # graded nothing. It must surface as needs-setup, never a green pass.
+        all_judge = [CorpusGradeRow(entry_id="j", oracle="judge", verdict="skip", detail="judge")]
+        lane = corpus_grade_lane(all_judge)
+        assert lane.skipped is True
+        assert lane.needs_setup is True
+        assert lane.setup_hint == CORPUS_NO_GRADED_HINT
+        # status must NOT be the green PASS — it is the needs-setup skip.
+        assert lane.status == "SKIPPED — needs setup"
+
+    def test_empty_corpus_is_a_setup_skip(self) -> None:
+        lane = corpus_grade_lane([])
+        assert lane.needs_setup is True
+
+    def test_one_graded_entry_makes_it_a_real_pass(self) -> None:
+        rows = [CorpusGradeRow(entry_id="m", oracle="matcher", verdict="pass", detail="1 matcher(s) ok")]
+        lane = corpus_grade_lane(rows)
+        assert lane.skipped is False
+        assert lane.needs_setup is False
+        assert lane.passed is True
+
+    def test_a_failing_graded_entry_still_fails(self) -> None:
+        rows = [
+            CorpusGradeRow(entry_id="m", oracle="matcher", verdict="fail", detail="1/1 matchers failed"),
+            CorpusGradeRow(entry_id="j", oracle="judge", verdict="skip", detail="judge"),
+        ]
+        lane = corpus_grade_lane(rows)
+        assert lane.skipped is False
+        assert lane.passed is False

--- a/tests/teatree_cli/test_cli_dogfood.py
+++ b/tests/teatree_cli/test_cli_dogfood.py
@@ -34,14 +34,15 @@ def test_dogfood_overlay_provision_smoke_forwards_extra_args() -> None:
 
 
 def test_dogfood_top_level_no_args_exits_cleanly_with_help_hint() -> None:
-    """``t3 dogfood`` (no args) triggers the auto-help path — ``no_args_is_help`` is on."""
+    """``t3 dogfood`` (no args) prints help and exits 0 — never runs a sub-command."""
     runner = CliRunner()
     result = runner.invoke(dogfood_app, [])
-    # The Typer app is configured with ``no_args_is_help=True`` so a bare
-    # invocation must not crash — the help renderer prints to a Rich
-    # stream that may not land on ``result.output``, so we assert on the
-    # clean exit code, not the captured text.
+    # The ``invoke_without_command`` callback keeps the app a real group (a
+    # single-command Typer app would collapse into that command and run
+    # ``overlay-provision-smoke`` on a bare invocation). A no-args call lands
+    # in the callback, prints help, and exits 0 for the cron/loop recipe.
     assert result.exit_code == 0
+    assert "Usage" in result.output
 
 
 def test_dogfood_overlay_provision_smoke_help_renders_without_crashing() -> None:

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from teatree.cli import app
+from teatree.cli.eval.all import AiLaneOutcome
 from teatree.cli.eval.corpus import CorpusGradeRow
 from teatree.cli.eval.docker import DockerUnavailableError
 from teatree.cli.eval.verdict import LaneResult
@@ -86,6 +87,19 @@ def _run(
 
 
 _PASSING_CALL = (EvalToolCall(name="Bash", input={"command": "git worktree add ../wt HEAD"}, turn=1),)
+
+
+def _ai_outcome(
+    *, passed: bool = True, detail: str = "1 graded", results: tuple[ScenarioResult, ...] = ()
+) -> AiLaneOutcome:
+    """A metered-sdk AI lane outcome for `run_ai_lane` mocks.
+
+    ``results`` defaults empty — `executed == 0` short-circuits the suite's
+    unmetered-$0 guard, so a lane-only stub stays green. A test exercising the
+    guard supplies a real graded `ScenarioResult` with a non-zero/zero cost.
+    """
+    lane = LaneResult(name="ai-eval", cost="metered (sdk)", passed=passed, skipped=False, detail=detail)
+    return AiLaneOutcome(lane=lane, results=list(results))
 
 
 class TestEvalList:
@@ -1578,11 +1592,10 @@ class TestEvalSuiteSdkBackendDockerByDefault:
         docker.assert_called_once()
 
     def test_sdk_backend_local_escape_runs_on_host_with_warning(self, tmp_path: Path) -> None:
-        ai_pass = LaneResult(name="ai-eval", cost="metered (sdk)", passed=True, skipped=False, detail="1 graded")
         with (
             patch.dict("os.environ", {}, clear=True),
             _patch_all_lanes([_spec("worktree_first")]),
-            patch("teatree.cli.eval.all.run_ai_lane", return_value=ai_pass),
+            patch("teatree.cli.eval.all.run_ai_lane", return_value=_ai_outcome()),
             patch("teatree.cli.eval.all.run_eval_in_docker") as docker,
         ):
             result = CliRunner().invoke(
@@ -1593,11 +1606,10 @@ class TestEvalSuiteSdkBackendDockerByDefault:
         assert "WARNING" in result.output
 
     def test_sdk_backend_in_container_runs_in_process(self, tmp_path: Path) -> None:
-        ai_pass = LaneResult(name="ai-eval", cost="metered (sdk)", passed=True, skipped=False, detail="1 graded")
         with (
             patch.dict("os.environ", {"T3_EVAL_IN_CONTAINER": "1"}),
             _patch_all_lanes([_spec("worktree_first")]),
-            patch("teatree.cli.eval.all.run_ai_lane", return_value=ai_pass),
+            patch("teatree.cli.eval.all.run_ai_lane", return_value=_ai_outcome()),
             patch("teatree.cli.eval.all.run_eval_in_docker") as docker,
         ):
             result = CliRunner().invoke(app, ["eval", "all", "--backend", "sdk", "--transcript-dir", str(tmp_path)])
@@ -2190,6 +2202,28 @@ class TestEvalAllCorpusGradeLane:
         assert result.exit_code == 1, result.output
         assert "corpus-grade" in result.output
 
+    def test_all_judge_corpus_is_not_a_green_pass_and_strict_catches_it(self, tmp_path: Path) -> None:
+        # A corpus that graded nothing deterministically (all judge-skipped) must
+        # not read as a green PASS: default stays exit 0 but flags needs-setup,
+        # and --strict fails on it (the vacuous-green guard).
+        all_skip = [CorpusGradeRow(entry_id="j_entry", oracle="judge", verdict="skip", detail="judge")]
+        with (
+            _patch_all_lanes([_spec("worktree_first")]),
+            patch("teatree.cli.eval.all.grade_shipped_corpus", return_value=all_skip),
+        ):
+            default_run = CliRunner().invoke(app, ["eval", "all", "--free-only", "--transcript-dir", str(tmp_path)])
+        assert default_run.exit_code == 0, default_run.output
+        assert "needs setup" in default_run.output.lower(), default_run.output
+
+        with (
+            _patch_all_lanes([_spec("worktree_first")]),
+            patch("teatree.cli.eval.all.grade_shipped_corpus", return_value=all_skip),
+        ):
+            strict_run = CliRunner().invoke(
+                app, ["eval", "all", "--free-only", "--strict", "--transcript-dir", str(tmp_path)]
+            )
+        assert strict_run.exit_code == 1, strict_run.output
+
 
 class TestEvalAllSkillCommandValidityLane:
     """Tier-1 (#550) runs as a free lane and FAILs on a stale `t3 …` reference."""
@@ -2215,10 +2249,9 @@ class TestEvalAllSkillProseJudgeLaneAdvisory:
         # the explicit metered opt-in (`--backend sdk`), never the default lane.
         # The metered AI lane is stubbed to a pass so the assertion isolates the
         # prose-judge lane's presence, not the AI runner's verdict.
-        ai_pass = LaneResult(name="ai-eval", cost="metered (sdk)", passed=True, skipped=False, detail="1 graded")
         with (
             _patch_all_lanes([_spec("worktree_first")]),
-            patch("teatree.cli.eval.all.run_ai_lane", return_value=ai_pass),
+            patch("teatree.cli.eval.all.run_ai_lane", return_value=_ai_outcome()),
         ):
             result = CliRunner().invoke(app, ["eval", "all", "--backend", "sdk", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output
@@ -2255,11 +2288,59 @@ class TestEvalAllSkillProseJudgeLaneAdvisory:
     def test_low_prose_score_does_not_fail_the_suite(self, tmp_path: Path) -> None:
         # a weakest skill scored 0.2 is rendered + nominated but never fails the run
         weak = ProseJudgeReport(scores=(ProseScore("worst", 0.0, "advisory"),), skipped=0)
-        ai_pass = LaneResult(name="ai-eval", cost="metered (sdk)", passed=True, skipped=False, detail="1 graded")
         with (
             _patch_all_lanes([_spec("worktree_first")]),
             patch("teatree.cli.eval.all.run_prose_judge", return_value=weak),
-            patch("teatree.cli.eval.all.run_ai_lane", return_value=ai_pass),
+            patch("teatree.cli.eval.all.run_ai_lane", return_value=_ai_outcome()),
         ):
             result = CliRunner().invoke(app, ["eval", "all", "--backend", "sdk", "--transcript-dir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+
+
+class TestEvalAllSdkMeteredGuard:
+    """The suite mirror of ``RunGuards.sdk_metered`` (#) — an sdk AI lane that meters $0 fails loud.
+
+    A metered (``--backend sdk``) AI lane that graded scenarios but billed $0 is
+    the vacuous-green ``$0.00 (no metered calls)`` state (the ``--bare`` OAuth
+    bug). ``t3 eval run`` already turns this RED at its boundary; ``t3 eval all``
+    must too, otherwise a green AI-lane row reads as validated when nothing ran.
+    """
+
+    def test_executed_but_unmetered_sdk_suite_fails_loud(self, tmp_path: Path) -> None:
+        # Graded (not skipped), matchers pass, but $0 metered → vacuous-green.
+        graded_zero = evaluate(_spec("alpha"), _run("alpha", tool_calls=_PASSING_CALL, cost_usd=0.0))
+        outcome = _ai_outcome(results=(graded_zero,))
+        with (
+            _patch_all_lanes([_spec("worktree_first")]),
+            patch("teatree.cli.eval.all.run_prose_judge", return_value=_prose_report()),
+            patch("teatree.cli.eval.all.run_ai_lane", return_value=outcome),
+        ):
+            result = CliRunner().invoke(app, ["eval", "all", "--backend", "sdk", "--transcript-dir", str(tmp_path)])
+        assert result.exit_code == 1, result.output
+        assert "metered" in result.output.lower(), result.output
+
+    def test_metered_sdk_suite_passes(self, tmp_path: Path) -> None:
+        # The same graded run WITH real metered cost stays green — proves the
+        # guard keys on cost, not on the AI-lane verdict (anti-vacuous companion).
+        graded_cost = evaluate(_spec("alpha"), _run("alpha", tool_calls=_PASSING_CALL, cost_usd=0.0556))
+        outcome = _ai_outcome(results=(graded_cost,))
+        with (
+            _patch_all_lanes([_spec("worktree_first")]),
+            patch("teatree.cli.eval.all.run_prose_judge", return_value=_prose_report()),
+            patch("teatree.cli.eval.all.run_ai_lane", return_value=outcome),
+        ):
+            result = CliRunner().invoke(app, ["eval", "all", "--backend", "sdk", "--transcript-dir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+
+    def test_subscription_suite_with_zero_cost_stays_green(self, tmp_path: Path) -> None:
+        # The default subscription backend is unmetered by design — a $0 graded
+        # run must NOT trip the sdk-only guard.
+        graded_zero = evaluate(_spec("alpha"), _run("alpha", tool_calls=_PASSING_CALL, cost_usd=0.0))
+        lane = LaneResult(name="ai-eval", cost="subscription", passed=True, skipped=False, detail="1 graded")
+        outcome = AiLaneOutcome(lane=lane, results=[graded_zero])
+        with (
+            _patch_all_lanes([_spec("worktree_first")]),
+            patch("teatree.cli.eval.all.run_ai_lane", return_value=outcome),
+        ):
+            result = CliRunner().invoke(app, ["eval", "all", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output

--- a/tests/teatree_core/management_commands/test_command_failure_signalling.py
+++ b/tests/teatree_core/management_commands/test_command_failure_signalling.py
@@ -40,7 +40,14 @@ from pathlib import Path
 
 import pytest
 
-_COMMANDS_DIR = Path(__file__).resolve().parents[3] / "src" / "teatree" / "core" / "management" / "commands"
+_SRC_ROOT = Path(__file__).resolve().parents[3] / "src" / "teatree"
+_COMMANDS_DIR = _SRC_ROOT / "core" / "management" / "commands"
+
+
+def _management_command_modules() -> list[Path]:
+    """Every ``src/teatree/**/management/commands/*.py`` module (any overlay-agnostic command tree)."""
+    return sorted(p for p in _SRC_ROOT.glob("**/management/commands/*.py"))
+
 
 # Case-insensitive substrings that mark a returned string as failure
 # signalling. Kept low-false-positive: only words/phrases that, in a
@@ -121,6 +128,137 @@ class TestCommandFailureSignalling:
                 )
         assert not violations, "Commands must raise SystemExit(1) on failure, not return a string:\n" + "\n".join(
             violations,
+        )
+
+
+def _is_command_or_initialize_decorator(decorator: ast.expr) -> bool:
+    """True for ``@command``/``@initialize`` (with or without a call/attribute form)."""
+    target = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if isinstance(target, ast.Name):
+        return target.id in {"command", "initialize"}
+    if isinstance(target, ast.Attribute):
+        return target.attr in {"command", "initialize"}
+    return False
+
+
+def _is_typer_exit_raise(node: ast.Raise) -> bool:
+    """True for ``raise typer.Exit(...)`` / ``raise Exit(...)`` (the django-typer-swallowed primitive)."""
+    exc = node.exc
+    target = exc.func if isinstance(exc, ast.Call) else exc
+    if isinstance(target, ast.Attribute):
+        return target.attr == "Exit"
+    if isinstance(target, ast.Name):
+        return target.id == "Exit"
+    return False
+
+
+def _offending_typer_exits(source: str) -> list[tuple[str, int]]:
+    """``(method_name, lineno)`` for every ``raise typer.Exit`` inside a @command/@initialize method."""
+    tree = ast.parse(source)
+    return [
+        (func.name, stmt.lineno)
+        for func in ast.walk(tree)
+        if isinstance(func, ast.FunctionDef)
+        and any(_is_command_or_initialize_decorator(d) for d in func.decorator_list)
+        for stmt in ast.walk(func)
+        if isinstance(stmt, ast.Raise) and _is_typer_exit_raise(stmt)
+    ]
+
+
+class TestNoTyperExitInManagementCommands:
+    """``raise typer.Exit`` is swallowed under ``call_command`` — management commands must raise SystemExit.
+
+    django-typer runs a ``TyperCommand`` subcommand under Django's
+    ``call_command``, which catches ``typer.Exit`` and *returns* its code (the
+    process exits 0). A categorised non-zero exit therefore reports success to
+    cron/CI/the loop unless the command raises ``SystemExit(N)``. typer.Exit
+    remains correct in the ``src/teatree/cli/*.py`` typer-runner files, so this
+    guard is scoped to ``management/commands`` only.
+    """
+
+    def test_no_command_raises_typer_exit(self) -> None:
+        violations: list[str] = []
+        for module in _management_command_modules():
+            for func_name, lineno in _offending_typer_exits(module.read_text()):
+                violations.append(
+                    f"{module.name}:{lineno} — @command/@initialize `{func_name}` does "
+                    f"`raise typer.Exit(...)`; under `call_command` that is swallowed to exit 0. "
+                    f"Use `raise SystemExit(N)` instead.",
+                )
+        assert not violations, (
+            "Management commands must raise SystemExit(N), not typer.Exit (swallowed under call_command):\n"
+            + "\n".join(violations)
+        )
+
+
+def _typer_exit_source(raise_stmt: str, *, decorator: str = "@command()") -> str:
+    """Minimal decorated method whose body is ``raise_stmt``."""
+    return textwrap.dedent(
+        f"""
+        class Command:
+            {decorator}
+            def sub(self):
+                {raise_stmt}
+        """,
+    )
+
+
+class TestTyperExitDetection:
+    """The AST detector is precise: it flags the swallowed primitive, not SystemExit."""
+
+    @pytest.mark.parametrize(
+        "raise_stmt",
+        [
+            "raise typer.Exit(code=2)",
+            "raise typer.Exit()",
+            "raise typer.Exit(1)",
+            "raise Exit(code=3)",
+        ],
+    )
+    def test_typer_exit_is_flagged(self, raise_stmt: str) -> None:
+        offences = _offending_typer_exits(_typer_exit_source(raise_stmt))
+        assert offences, f"{raise_stmt!r} should be flagged"
+        assert offences[0][0] == "sub"
+
+    @pytest.mark.parametrize(
+        "raise_stmt",
+        [
+            "raise SystemExit(2)",
+            "raise SystemExit(code)",
+            "raise RuntimeError('boom')",
+            "return 'done'",
+        ],
+    )
+    def test_systemexit_and_other_raises_do_not_trip(self, raise_stmt: str) -> None:
+        assert _offending_typer_exits(_typer_exit_source(raise_stmt)) == []
+
+    def test_initialize_decorated_method_is_also_scanned(self) -> None:
+        source = _typer_exit_source("raise typer.Exit(code=2)", decorator="@initialize()")
+        assert _offending_typer_exits(source)
+
+    def test_undecorated_helper_is_not_scanned(self) -> None:
+        source = textwrap.dedent(
+            """
+            def _helper():
+                raise typer.Exit(code=2)
+            """,
+        )
+        assert _offending_typer_exits(source) == []
+
+    def test_shipped_management_commands_are_clean(self) -> None:
+        """The live command tree raises SystemExit everywhere — no swallowed typer.Exit.
+
+        Pins the claim that the fix landed across the whole tree. A NEW command
+        that raises typer.Exit must be fixed to SystemExit, not exempted here.
+        """
+        flagged: set[tuple[str, str]] = {
+            (module.name, func_name)
+            for module in _management_command_modules()
+            for func_name, _lineno in _offending_typer_exits(module.read_text())
+        }
+        assert flagged == set(), (
+            "Management command(s) raising typer.Exit (swallowed under call_command) — "
+            f"fix to raise SystemExit(N): {sorted(flagged)}"
         )
 
 

--- a/tests/teatree_core/management_commands/test_dogfood.py
+++ b/tests/teatree_core/management_commands/test_dogfood.py
@@ -8,35 +8,41 @@ require Docker / overlay infra.
 We also verify the DM-on-failure plumbing (``notify_user`` is called
 with a body naming the failing step and command) without making a real
 Slack call.
+
+The exit-code assertions go through Django's ``call_command`` (the real
+production entry path for ``t3 dogfood``) so they pin the *propagated*
+code. django-typer swallows a ``typer.Exit`` into a returned value (exit
+0); the command therefore ``raise SystemExit(code)`` and these tests use
+``pytest.raises(SystemExit)`` to read the genuine code — a ``typer.Exit``
+here would regress to a silent exit 0.
 """
 
 from unittest.mock import patch
 
 import pytest
-import typer
+from django.core.management import call_command
 
-from teatree.core.management.commands.dogfood import Command as DogfoodCommand
 from teatree.loop.dogfood_smoke import SmokeOutcomeKind, SmokeReport, SmokeStep, StepResult
 
 pytestmark = pytest.mark.django_db
 
 
 def _call_smoke(capsys: pytest.CaptureFixture[str], *args: str) -> tuple[str, int]:
-    """Invoke the inner ``overlay_provision_smoke`` subcommand directly.
+    """Invoke ``t3 dogfood overlay-provision-smoke`` via ``call_command``.
 
-    django-typer wraps the bound command in a proxy that swallows
-    ``typer.Exit`` codes (normalising every non-zero outcome to 1), so we
-    can't assert the categorised exit codes via the proxy's ``CliRunner``
-    path. Calling the method directly preserves the
-    ``typer.Exit(code=N)`` raise so the test can inspect the actual code.
+    This is the production entry path — django-typer runs the subcommand
+    under Django's ``call_command``, which swallows a ``typer.Exit`` into a
+    returned value (process exits 0). The command therefore raises
+    ``SystemExit(code)`` on a non-zero outcome, so the harness reads the
+    propagated code off ``SystemExit`` (and treats a clean return — the PASS
+    and dry-run paths — as code 0).
     """
-    cmd = DogfoodCommand()
     kwargs = _parse_args(args)
     code = 0
     try:
-        cmd.overlay_provision_smoke(**kwargs)
-    except typer.Exit as exc:
-        code = int(exc.exit_code or 0)
+        call_command("dogfood", "overlay-provision-smoke", **kwargs)
+    except SystemExit as exc:
+        code = int(exc.code or 0)
     captured = capsys.readouterr()
     return captured.out, code
 


### PR DESCRIPTION
## Summary

Four fail-loud gaps where a failure — or an unvalidated state — silently reported success.

### 1. dogfood exit codes swallowed
`src/teatree/core/management/commands/dogfood.py` raised `typer.Exit(code=N)` in two places (the `_exit_code_for` mapping path and the no-overlay `code=2` path). Under django-typer's `call_command` (the production `t3 dogfood` entry path) `typer.Exit` is caught and its code is **returned**, so the process exits 0 — a categorised provision-smoke failure reported success to cron/CI/the loop. Both sites now `raise SystemExit(N)` (the canonical primitive documented in `config_setting.py`). `test_dogfood.py` now invokes via `call_command` and asserts the propagated code with `pytest.raises(SystemExit)`.

### 2. exit-code fitness gap
`test_command_failure_signalling.py` forbade returning a failure-string but not `raise typer.Exit`. Added a sibling AST guard `TestNoTyperExitInManagementCommands` that walks every `@command`/`@initialize`-decorated method in `src/teatree/**/management/commands/*.py` and FAILs on any `raise typer.Exit(...)` / `raise Exit(...)`, pointing at `raise SystemExit(N)`. Scoped to management commands only — `typer.Exit` remains correct in the `src/teatree/cli/*.py` typer-runner files.

### 3. eval suite had no unmetered-$0 guard
`src/teatree/cli/eval/all.py` `run_full_suite` now threads the AI lane's per-scenario `ScenarioResult`s out via a new `AiLaneOutcome` value object and calls `assert_sdk_run_was_metered` after the metered AI lane. An sdk run that graded scenarios but billed $0 (the `--bare` OAuth bug — authenticated as nothing, zero tool calls, billed nothing) now fails loud, mirroring `RunGuards.sdk_metered` (`run_modes.py`) and the existing `eval run` boundary guard (`app.py:376`).

### 4. corpus lane vacuous-green
`src/teatree/cli/eval/corpus.py` `corpus_grade_lane` reported PASS at zero graded entries (an all-judge / empty corpus under `--no-judge`). It now surfaces as a needs-setup SKIP, so `--strict` catches it and the closing verdict can't read it as validated. An anti-vacuous test pins that the shipped corpus has at least one matcher-graded (deterministically-gradable) entry, and an all-judge corpus does not count as a green pass.

## Tests

`uv run pytest tests/teatree_core/management_commands tests/teatree_cli/test_eval.py tests/teatree_cli/eval/test_corpus.py` — **763 passed, 12 skipped**. Every regression test was observed RED before its fix (revert-and-confirm). `ruff check`, `ruff format`, `ty check`, and `tach check` are clean; all pre-commit hooks pass.

## Architecture pre-check

**1. BLUEPRINT § alignment** — § "Behavioral eval harness" / "Ground-truth corpus + audit data layer". Bug fixes within the documented lane model; the existing prose ("the same body is the free `corpus-grade` lane", "a setup-skip stays exit 0 by default; `--strict` makes it non-zero") still holds.

**2. FSM phase boundaries** — n/a (no `Ticket.State` / `Worktree.State` transition).

**3. Extension-point contracts** — n/a (no `OverlayBase` / scanner / hook / `*Backend` Protocol change). `AiLaneOutcome` is an internal value object, not an extension point.

**4. Component boundaries** — changes stay in `cli/eval/` (lane orchestration) and `core/management/commands/dogfood.py` (command surface) — the correct homes.

**5. Dependency direction** — `cli/eval/all.py` now imports `teatree.eval.skip_guard` (the eval engine), the same direction the `eval run` path already uses. `uv run tach check` ✅.

**6. Test surface** — every behaviour has a named test; each regression test confirmed RED on the pre-fix code: dogfood exit-code (typer.Exit → swallowed-to-0), the fitness guard (reintroduce typer.Exit → red), the metered-$0 suite guard (disable guard → exit 0), and the corpus zero-graded skip (disable skip → vacuous green).

**7. Resilience invariants** — fail-loud guards are deterministic and idempotent; no new external write.

**8. Identity and key normalization** — n/a.

**9. Behavior preservation / capability deletion** — dogfood exit-code values are unchanged (11–19, 2); only the propagation primitive is fixed. No must-block test inverted to must-not-block.
