### PR TITLE
fix(ci): audit shipped surface, SHA-pin actions, add lock-upgrade workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  # Watches pyproject.toml and proposes bumps to version constraints.
+  # NOTE: Dependabot's pip ecosystem does NOT regenerate uv.lock — after
+  # merging a dependabot PR you must run `uv lock --upgrade <package>` locally
+  # (or let the weekly `uv-lock-upgrade` workflow open the lock-refresh PR).
+  # The `uv` package-ecosystem is not yet supported by Dependabot; track
+  # https://github.com/dependabot/dependabot-core/issues/10478 for native support.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -9,6 +15,8 @@ updates:
         patterns:
           - "*"
 
+  # SHA-pinned actions are kept current by Dependabot: it reads the `# vN`
+  # comment tag and proposes a PR when a new release resolves to a different SHA.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,14 @@ jobs:
       run_heavy_python: ${{ steps.classify.outputs.run_heavy_python }}
       all: ${{ steps.classify.outputs.all }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           # fetch-depth: 0 so the PR-vs-base ``git diff`` resolves.
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - name: Classify the PR diff into CI lanes
@@ -126,15 +126,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync
-      - uses: j178/prek-action@v2
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d  # v2
         env:
           SKIP: pytest,uv-audit,cyclonedx-sbom
       # Migration-graph linearity gate. Two PRs branching a migration off
@@ -157,14 +157,14 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           # fetch-depth: 0 so `git merge-base origin/main HEAD` resolves.
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync
@@ -193,13 +193,13 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync
@@ -224,13 +224,13 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync
@@ -247,11 +247,11 @@ jobs:
   docs-drift:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync --group docs
@@ -296,11 +296,11 @@ jobs:
     # the agent's tools.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync
@@ -320,11 +320,11 @@ jobs:
     # gate; it can never lock the agent's tools.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync
@@ -354,9 +354,9 @@ jobs:
       matrix:
         python-version: ["3.13"]
     steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
         with:
           context: .
           file: dev/Dockerfile.test
@@ -387,7 +387,7 @@ jobs:
           -e COVERAGE_FILE=/app/.coverage
           teatree-test-${{ matrix.python-version }}
           uv run -p ${{ matrix.python-version }} t3 ci coverage
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
           name: coverage-${{ matrix.python-version }}
@@ -459,14 +459,14 @@ jobs:
     timeout-minutes: 12
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           # fetch-depth: 0 so ``git merge-base origin/main HEAD`` resolves.
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync --group mutation
@@ -490,11 +490,11 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync --group mutation
@@ -539,11 +539,11 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync
@@ -566,35 +566,62 @@ jobs:
     # a preview feature and astral-sh/uv#19492 (OSV parser regression)
     # turned every PR red. ``pip-audit`` uses the same OSV backend and
     # is production-stable. See souliane/teatree#1264.
+    #
+    # AUDITED SURFACE: ``--no-default-groups --all-extras`` exports the SHIPPED
+    # runtime surface (all optional extras, no dev tooling). Previously ``uv sync``
+    # included dev group packages that never ship to users, inflating the CVE
+    # surface with development tools. Optional extras (markdown, notion, slack) ARE
+    # shipped to users and must be audited.
+    #
+    # ALLOWLIST: add unfixable transitive CVEs to ``requirements.audit.ignore`` —
+    # one ``VULN-ID  # package==version: justification`` entry per line. See that
+    # file for the format. Keep the list as short as possible; every entry is a
+    # conscious decision to ship with a known vulnerability.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
-      - run: uv sync
-      - run: uv export --format requirements-txt --no-emit-project --no-emit-workspace --no-header --quiet > requirements.audit.txt
-      - run: uvx pip-audit --strict --vulnerability-service osv --disable-pip -r requirements.audit.txt
+      - name: Export shipped runtime surface for audit
+        run: uv export --no-default-groups --all-extras --format requirements-txt --no-emit-workspace --no-header --quiet > requirements.audit.txt
+      - name: Read CVE allowlist
+        id: ignore
+        run: |
+          if [ -s requirements.audit.ignore ]; then
+            grep -v '^\s*#' requirements.audit.ignore | grep -v '^\s*$' \
+              | awk '{print "--ignore-vuln", $1}' | tr '\n' ' ' > /tmp/ignore_flags.txt
+            echo "flags=$(cat /tmp/ignore_flags.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "flags=" >> "$GITHUB_OUTPUT"
+          fi
+      - name: pip-audit (OSV backend; strict; allowlist applied)
+        env:
+          IGNORE_FLAGS: ${{ steps.ignore.outputs.flags }}
+        # shellcheck disable=SC2086 — word-splitting on IGNORE_FLAGS is intentional:
+        # it expands to zero or more ``--ignore-vuln GHSA-xxxx`` pairs from the
+        # committed requirements.audit.ignore allowlist (never user-supplied input).
+        run: uvx pip-audit --strict --vulnerability-service osv --disable-pip -r requirements.audit.txt $IGNORE_FLAGS
 
   # GATE: regenerates dist/sbom.json and fails if the committed copy is stale;
   # also uploads the SBOM as a workflow artifact for supply-chain visibility.
   sbom:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync
       - run: scripts/hooks/generate_sbom.sh
       - run: git diff --exit-code dist/sbom.json
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
           name: sbom

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,11 +20,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       - run: uv sync --group docs
@@ -33,9 +33,9 @@ jobs:
       - run: uv run python manage.py generate_all_docs
       - run: uv run python scripts/hooks/generate_cli_reference.py
       - run: uv run mkdocs build --strict
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5
         with:
           path: site
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -68,16 +68,16 @@ jobs:
   eval:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
       # Bounded retry: transient registry/network ReadTimeout, not a manual rerun.
       - name: Sync dependencies (retry on transient network failure)
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -133,7 +133,7 @@ jobs:
       # The end-of-run cost summary (report.py `_cost_summary`) prints the API spend.
       - name: Metered behavioral eval suite (in Docker; pass@k; --require-executed always armed)
         if: steps.gate.outputs.run_eval == 'true'
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           EVAL_BACKEND: ${{ inputs.backend || 'sdk' }}
@@ -155,7 +155,7 @@ jobs:
         run: uv run t3 eval all --backend "$EVAL_BACKEND" --html eval-report.html || true
       - name: Upload the HTML eval report
         if: always() && steps.gate.outputs.run_eval == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: eval-report
           path: eval-report.html

--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.issue.user.login != github.repository_owner
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/uv-lock-upgrade.yml
+++ b/.github/workflows/uv-lock-upgrade.yml
@@ -1,0 +1,74 @@
+# ============================================================
+# WEEKLY uv.lock REFRESH — closes the Dependabot pip gap
+# ============================================================
+#
+# Dependabot's ``pip`` ecosystem proposes bumps to pyproject.toml version
+# constraints but does NOT regenerate uv.lock.  After a dependabot PR merges,
+# the lockfile still pins the old hashes — the actual installed versions only
+# move when someone runs ``uv lock --upgrade``.
+#
+# This workflow closes that structural gap: once a week it runs
+# ``uv lock --upgrade``, and if the lockfile changed it opens (or updates) a
+# PR against main so a human can review and merge the hash refresh.
+#
+# Cadence: Sunday 03:00 UTC — offset from the dependabot weekly window so the
+# lock refresh sees any constraint bumps that landed during the week.
+# Also triggerable on-demand via workflow_dispatch.
+# ============================================================
+
+name: Weekly uv.lock refresh
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          # Full history so the PR branch can be force-pushed cleanly on reruns.
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.13"
+      - name: Upgrade the lockfile
+        run: uv lock --upgrade
+      - name: Check whether the lockfile changed
+        id: diff
+        run: |
+          if git diff --quiet uv.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Open or update the lock-refresh PR
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="chore/uv-lock-upgrade-$(date +%Y-%W)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add uv.lock
+          git commit -m "chore(deps): weekly uv.lock upgrade"
+          git push --force-with-lease origin "$BRANCH"
+          # Open a PR if one does not already exist for this branch.
+          if ! gh pr view "$BRANCH" --json number -q .number 2>/dev/null; then
+            PR_BODY="Automated weekly lockfile refresh via \`uv lock --upgrade\`.\n\nDependabot's \`pip\` ecosystem updates \`pyproject.toml\` constraints but does not regenerate \`uv.lock\`. This PR closes that gap by re-resolving all hashes after any constraint bumps that landed during the week.\n\nReview the diff, run CI, and merge when green."
+            gh pr create \
+              --title "chore(deps): weekly uv.lock upgrade" \
+              --body "$PR_BODY" \
+              --base main \
+              --label "dependencies"
+          fi

--- a/requirements.audit.ignore
+++ b/requirements.audit.ignore
@@ -1,0 +1,11 @@
+# pip-audit allowlist — unfixable transitive CVEs
+#
+# Add one entry per line in the format:
+#   VULN-ID  # package==version: one-line justification + link
+#
+# Example:
+#   GHSA-xxxx-xxxx-xxxx  # somepackage==1.2.3: upstream fix pending, no exploit vector in our use; see https://…
+#
+# Keep this list as short as possible. Every entry here is a conscious decision
+# to ship with a known vulnerability; document the reasoning and revisit when
+# a fixed version becomes available.

--- a/tests/quality/test_repo_root_minimal.py
+++ b/tests/quality/test_repo_root_minimal.py
@@ -43,6 +43,7 @@ ALLOWED_ROOT = frozenset(
         ".pre-commit-config.yaml",
         ".gitignore",
         ".gitlab-ci.yml",
+        "requirements.audit.ignore",  # per-CVE pip-audit allowlist (CI security gate)
         ".github",
         ".editorconfig",
         ".jscpd.json",

--- a/tests/test_repo_root_minimal.py
+++ b/tests/test_repo_root_minimal.py
@@ -58,6 +58,8 @@ _ALLOWED_ROOT_ENTRIES = frozenset(
         ".github",
         ".semgrep",
         ".vscode",
+        # CI / quality gates
+        "requirements.audit.ignore",  # per-CVE pip-audit allowlist (CI security gate)
         # Dotfiles
         ".claudeignore",
         ".codespell-dictionary.txt",


### PR DESCRIPTION
Wave-2 review fix (CI/deps).

Four CI security + dependency-hygiene improvements:

1. **pip-audit shipped surface only** — `uv export --no-default-groups --all-extras` so the audit covers the deployed runtime, not dev/test/lint tooling (kills false positives from never-shipped tools).
2. **`requirements.audit.ignore`** — opt-in per-CVE allowlist; each entry becomes a `--ignore-vuln` flag so one unfixable transitive CVE can't block unrelated PRs.
3. **SHA-pin all GitHub Actions** across every workflow, with trailing version tags so Dependabot's github-actions ecosystem keeps pins current automatically.
4. **`.github/workflows/uv-lock-upgrade.yml`** — weekly cron running `uv lock --upgrade`, opening a PR on changes (closes the gap Dependabot's pip ecosystem leaves: it bumps `pyproject.toml` constraints but never regenerates `uv.lock`).