### PR TITLE
refactor(tach): make project a declared leaf and split backends so gitlab to slack is explicit

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -2,6 +2,7 @@
 
 ```mermaid
 graph TD
+    teatree.project --> teatree.paths
     teatree.config --> teatree.paths
     teatree.config --> teatree.types
     teatree.config --> teatree.utils
@@ -22,8 +23,10 @@ graph TD
     teatree.repo_mode --> teatree.config
     teatree.skill_support --> teatree.types
     teatree.skill_support --> teatree.utils
+    teatree.skill_support --> teatree.project
     teatree.core --> teatree.types
     teatree.core --> teatree.paths
+    teatree.core --> teatree.project
     teatree.core --> teatree.config
     teatree.core --> teatree.utils
     teatree.core --> teatree.timeouts
@@ -42,6 +45,33 @@ graph TD
     teatree.backends --> teatree.utils
     teatree.backends --> teatree.core
     teatree.backends --> teatree.identity
+    teatree.backends --> teatree.backends.errors
+    teatree.backends --> teatree.backends.types
+    teatree.backends --> teatree.backends.forge_merge_rpc
+    teatree.backends --> teatree.backends.github
+    teatree.backends --> teatree.backends.gitlab
+    teatree.backends --> teatree.backends.slack
+    teatree.backends.forge_merge_rpc --> teatree.types
+    teatree.backends.forge_merge_rpc --> teatree.utils
+    teatree.backends.forge_merge_rpc --> teatree.core
+    teatree.backends.slack --> teatree.types
+    teatree.backends.slack --> teatree.utils
+    teatree.backends.slack --> teatree.core
+    teatree.backends.slack --> teatree.identity
+    teatree.backends.slack --> teatree.url_classify
+    teatree.backends.gitlab --> teatree.types
+    teatree.backends.gitlab --> teatree.utils
+    teatree.backends.gitlab --> teatree.core
+    teatree.backends.gitlab --> teatree.backends.errors
+    teatree.backends.gitlab --> teatree.backends.types
+    teatree.backends.gitlab --> teatree.backends.forge_merge_rpc
+    teatree.backends.gitlab --> teatree.backends.slack
+    teatree.backends.github --> teatree.types
+    teatree.backends.github --> teatree.utils
+    teatree.backends.github --> teatree.core
+    teatree.backends.github --> teatree.backends.errors
+    teatree.backends.github --> teatree.backends.types
+    teatree.backends.github --> teatree.backends.forge_merge_rpc
     teatree.contrib --> teatree.types
     teatree.contrib --> teatree.core
     teatree.contrib --> teatree.config
@@ -49,11 +79,14 @@ graph TD
     teatree.contrib --> teatree.utils
     teatree.contrib --> teatree.visual_qa
     teatree.cli --> teatree.paths
+    teatree.cli --> teatree.project
     teatree.cli --> teatree.config
     teatree.cli --> teatree.config_agent
     teatree.cli --> teatree.core
     teatree.cli --> teatree.agents
     teatree.cli --> teatree.backends
+    teatree.cli --> teatree.backends.gitlab
+    teatree.cli --> teatree.backends.slack
     teatree.cli --> teatree.eval
     teatree.cli --> teatree.skill_support
     teatree.cli --> teatree.claude_sessions
@@ -101,6 +134,9 @@ graph TD
     teatree.loop --> teatree.config
     teatree.loop --> teatree.core
     teatree.loop --> teatree.backends
+    teatree.loop --> teatree.backends.github
+    teatree.loop --> teatree.backends.gitlab
+    teatree.loop --> teatree.backends.slack
     teatree.loop --> teatree.notify
     teatree.loop --> teatree.messaging
     teatree.loop --> teatree.loop_enabled
@@ -134,6 +170,8 @@ graph TD
     teatree.templates
     teatree.claude_sessions
     teatree.overlay_init
+    teatree.backends.errors
+    teatree.backends.types
     teatree.cli._format_opts
     teatree.slack_mrkdwn
     teatree.memory_audit

--- a/scripts/hooks/check_tach_modules_declared.py
+++ b/scripts/hooks/check_tach_modules_declared.py
@@ -33,7 +33,6 @@ TACH_TOML = REPO_ROOT / "tach.toml"
 LEAF_MODULE_ALLOWLIST: frozenset[str] = frozenset(
     {
         "teatree._overlay_api",
-        "teatree.project",
         "teatree.urls",
     }
 )

--- a/tach.toml
+++ b/tach.toml
@@ -1,3 +1,24 @@
+# Module-boundary notes for two review findings (kept here as a file header so
+# toml-sort does not relocate them away from their tables):
+#
+# Finding #2 -- teatree.project must stay a foundation LEAF. It is re-exported
+# from teatree.__init__ as part of the overlay API (find_project_root), so an
+# overlay importing the overlay API pulls it in; it must never import back into
+# the rest of teatree. Its [[modules]] entry allows only the teatree.paths edge,
+# so tach rejects any new internal import. tests/quality/test_project_leaf.py
+# pins the same invariant at the AST level.
+#
+# Finding D7 -- the one cross-backend coupling (gitlab -> slack review-permalink
+# sync) is now a DECLARED edge instead of being hidden inside a single
+# teatree.backends node. teatree.backends is split into the aggregator parent
+# (loader / backend_provider / apps + noop/notion/sentry helpers), the concrete
+# backends (github / gitlab / slack), and the shared primitives
+# (errors / types / forge_merge_rpc). gitlab declares the slack edge; slack
+# stays a backend leaf (no outgoing sibling edge). Extracting the shared
+# primitives keeps the graph acyclic under forbid_circular_dependencies (else
+# gitlab/github <-> parent would cycle).
+# tests/quality/test_backends_explicit_coupling.py pins the explicit edge.
+
 interfaces = []
 forbid_circular_dependencies = true
 exclude = [
@@ -21,6 +42,11 @@ layers = [
 path = "teatree.paths"
 layer = "foundation"
 depends_on = []
+
+[[modules]]
+path = "teatree.project"
+layer = "foundation"
+depends_on = ["teatree.paths"]
 
 [[modules]]
 path = "teatree.types"
@@ -95,7 +121,7 @@ depends_on = ["teatree.paths", "teatree.utils", "teatree.config"]
 [[modules]]
 path = "teatree.skill_support"
 layer = "platform"
-depends_on = ["teatree.types", "teatree.utils"]
+depends_on = ["teatree.types", "teatree.utils", "teatree.project"]
 
 [[modules]]
 path = "teatree.core"
@@ -103,6 +129,7 @@ layer = "domain"
 depends_on = [
   "teatree.types",
   "teatree.paths",
+  "teatree.project",
   "teatree.config",
   "teatree.utils",
   "teatree.timeouts",
@@ -132,7 +159,64 @@ depends_on = [
   "teatree.types",
   "teatree.utils",
   "teatree.core",
-  "teatree.identity"
+  "teatree.identity",
+  "teatree.backends.errors",
+  "teatree.backends.types",
+  "teatree.backends.forge_merge_rpc",
+  "teatree.backends.github",
+  "teatree.backends.gitlab",
+  "teatree.backends.slack"
+]
+
+[[modules]]
+path = "teatree.backends.errors"
+layer = "domain"
+depends_on = []
+
+[[modules]]
+path = "teatree.backends.types"
+layer = "domain"
+depends_on = []
+
+[[modules]]
+path = "teatree.backends.forge_merge_rpc"
+layer = "domain"
+depends_on = ["teatree.types", "teatree.utils", "teatree.core"]
+
+[[modules]]
+path = "teatree.backends.slack"
+layer = "domain"
+depends_on = [
+  "teatree.types",
+  "teatree.utils",
+  "teatree.core",
+  "teatree.identity",
+  "teatree.url_classify"
+]
+
+[[modules]]
+path = "teatree.backends.gitlab"
+layer = "domain"
+depends_on = [
+  "teatree.types",
+  "teatree.utils",
+  "teatree.core",
+  "teatree.backends.errors",
+  "teatree.backends.types",
+  "teatree.backends.forge_merge_rpc",
+  "teatree.backends.slack"
+]
+
+[[modules]]
+path = "teatree.backends.github"
+layer = "domain"
+depends_on = [
+  "teatree.types",
+  "teatree.utils",
+  "teatree.core",
+  "teatree.backends.errors",
+  "teatree.backends.types",
+  "teatree.backends.forge_merge_rpc"
 ]
 
 [[modules]]
@@ -145,11 +229,14 @@ path = "teatree.cli"
 layer = "interface"
 depends_on = [
   "teatree.paths",
+  "teatree.project",
   "teatree.config",
   "teatree.config_agent",
   "teatree.core",
   "teatree.agents",
   "teatree.backends",
+  "teatree.backends.gitlab",
+  "teatree.backends.slack",
   "teatree.eval",
   "teatree.skill_support",
   "teatree.claude_sessions",
@@ -224,6 +311,9 @@ depends_on = [
   "teatree.config",
   "teatree.core",
   "teatree.backends",
+  "teatree.backends.github",
+  "teatree.backends.gitlab",
+  "teatree.backends.slack",
   "teatree.notify",
   "teatree.messaging",
   "teatree.loop_enabled"

--- a/tests/quality/test_backends_explicit_coupling.py
+++ b/tests/quality/test_backends_explicit_coupling.py
@@ -1,0 +1,60 @@
+"""Fitness function: the gitlab -> slack coupling stays EXPLICIT (finding D7).
+
+``teatree.backends`` was a single tach node, so the one cross-backend coupling
+(``gitlab/sync.py`` calls into ``slack/review_sync.py`` to attach review
+permalinks) was invisible in the dependency graph. The backends node is now
+split into the aggregator parent + the concrete backends (github / gitlab /
+slack) + the shared primitives, so that coupling is a DECLARED edge.
+
+This test guards the ``tach.toml`` declaration so the edge cannot be re-hidden
+(by collapsing the submodules back into one node, by dropping the declared
+``gitlab -> slack`` edge, or by giving slack an outgoing edge to a sibling
+backend). ``uv run tach check`` is the runtime gate that parses the actual import
+graph; this pins the declaration the same way ``test_tach_cycle_ratchet.py``
+pins the acyclic invariant.
+"""
+
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TACH = _REPO_ROOT / "tach.toml"
+
+_GITLAB = "teatree.backends.gitlab"
+_SLACK = "teatree.backends.slack"
+_GITHUB = "teatree.backends.github"
+_PARENT = "teatree.backends"
+
+
+def _modules() -> list[dict]:
+    return tomllib.loads(_TACH.read_text(encoding="utf-8"))["modules"]
+
+
+def _entry(path: str) -> dict:
+    return next(m for m in _modules() if m["path"] == path)
+
+
+def _depends(path: str) -> set[str]:
+    return set(_entry(path).get("depends_on", []))
+
+
+class TestBackendsAreSeparateNodes:
+    def test_concrete_backends_are_declared_modules(self) -> None:
+        paths = {m["path"] for m in _modules()}
+        assert {_GITLAB, _SLACK, _GITHUB} <= paths
+
+
+class TestGitlabSlackCouplingIsExplicit:
+    def test_gitlab_declares_the_slack_edge(self) -> None:
+        assert _SLACK in _depends(_GITLAB), (
+            "The gitlab -> slack review-permalink coupling must be a declared edge; "
+            "re-hiding it (collapsing the submodules or dropping this edge) defeats D7."
+        )
+
+
+class TestSlackStaysABackendLeaf:
+    def test_slack_has_no_outgoing_sibling_backend_edge(self) -> None:
+        slack_deps = _depends(_SLACK)
+        assert _GITLAB not in slack_deps
+        assert _GITHUB not in slack_deps
+        assert _PARENT not in slack_deps

--- a/tests/quality/test_project_leaf.py
+++ b/tests/quality/test_project_leaf.py
@@ -1,0 +1,77 @@
+"""Fitness function: ``teatree.project`` must stay a foundation LEAF (finding #2).
+
+``find_project_root`` is re-exported from ``teatree.__init__`` as part of the
+overlay API, so overlays import ``teatree.project`` transitively. If it grew an
+import back into the rest of teatree (``teatree.core``, ``teatree.config``,
+``teatree.cli``, …), an overlay's import of the overlay API would drag the whole
+substrate in. The only internal edge it may carry is ``teatree.paths`` (path
+resolution).
+
+Two halves, mirroring ``test_import_contracts.py``:
+
+``TestProjectLeafImports`` AST-scans ``src/teatree/project.py`` and asserts every
+internal ``teatree.*`` import resolves to the allowed ``teatree.paths`` leaf — a
+copy-pasted ``from teatree.core import …`` turns it red without waiting on tach.
+
+``TestProjectTachDeclaration`` pins the ``tach.toml`` ``[[modules]]`` entry so the
+constraint cannot be silently loosened (depends_on widened, layer raised, the
+entry deleted back into the leaf allowlist).
+"""
+
+import ast
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PROJECT_PY = _REPO_ROOT / "src" / "teatree" / "project.py"
+_TACH = _REPO_ROOT / "tach.toml"
+
+# The single internal edge teatree.project is allowed to carry.
+_ALLOWED_INTERNAL = {"teatree.paths"}
+
+
+def _internal_imports(source: Path) -> set[str]:
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("teatree"):
+            found.add(node.module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("teatree"):
+                    found.add(alias.name)
+    return found
+
+
+def _top_level_module(dotted: str) -> str:
+    parts = dotted.split(".")
+    return ".".join(parts[:2]) if len(parts) >= 2 else dotted
+
+
+def _module_entry(path: str) -> dict[str, object]:
+    data = tomllib.loads(_TACH.read_text(encoding="utf-8"))
+    return next(m for m in data["modules"] if m["path"] == path)
+
+
+class TestProjectLeafImports:
+    def test_imports_only_the_allowed_leaf(self) -> None:
+        forbidden = {imp for imp in _internal_imports(_PROJECT_PY) if _top_level_module(imp) not in _ALLOWED_INTERNAL}
+        assert not forbidden, (
+            f"teatree.project must stay a foundation leaf (overlay-API re-export). "
+            f"It may only import {sorted(_ALLOWED_INTERNAL)}; found forbidden internal "
+            f"imports: {sorted(forbidden)}"
+        )
+
+
+class TestProjectTachDeclaration:
+    def test_declared_as_foundation_leaf(self) -> None:
+        entry = _module_entry("teatree.project")
+        assert entry["layer"] == "foundation"
+        assert set(entry.get("depends_on", [])) == _ALLOWED_INTERNAL
+
+    def test_not_in_leaf_allowlist(self) -> None:
+        # A real [[modules]] entry constrains the edge; the leaf allowlist would
+        # leave it unconstrained. It must not be in both.
+        import scripts.hooks.check_tach_modules_declared as guard  # noqa: PLC0415
+
+        assert "teatree.project" not in guard.LEAF_MODULE_ALLOWLIST

--- a/tests/test_tach_cycle_ratchet.py
+++ b/tests/test_tach_cycle_ratchet.py
@@ -24,7 +24,14 @@ _TACH = _REPO / "tach.toml"
 # teatree.cli (the eval commands were already core-dependent before the split);
 # the split just promotes them to their own tach node — one new fan-in entry,
 # not new coupling.
-_CORE_FANIN_BASELINE = 13
+# Bumped 13 → 17 (D7 backends split): teatree.backends is split into the
+# aggregator parent + the concrete backend submodules (github / gitlab / slack)
+# and the shared forge_merge_rpc primitive, so the gitlab -> slack coupling
+# becomes a declared edge instead of being hidden inside one node. Each of the
+# four new nodes already imported teatree.core inside the monolithic
+# teatree.backends node — the split makes that pre-existing coupling visible as
+# four separate fan-in entries; it adds no new coupling.
+_CORE_FANIN_BASELINE = 17
 _MAX_DECLARED_TWO_CYCLES = 0
 
 


### PR DESCRIPTION
Tightens the tach module-boundary graph for two review findings. Pure boundary-configuration plus fitness tests — no `src/` runtime code changes.

## What landed

### Finding #2 — `teatree.project` leaf guard + fitness test
`teatree.project` is re-exported from `teatree.__init__` as part of the overlay API (`find_project_root`), so any overlay that imports the overlay API pulls it in. It must never import back into the rest of teatree, or the whole substrate gets dragged into an overlay. It was sitting in `check_tach_modules_declared`'s `LEAF_MODULE_ALLOWLIST` (unconstrained), despite already having a real internal import (`teatree.paths`) and internal importers.

- Promoted it to a declared `[[modules]]` entry at the `foundation` layer with `depends_on = ["teatree.paths"]` — tach now rejects any new internal import from it (verified: injecting a `teatree.core` import makes `tach check` fail with a layer violation).
- Repointed the three importing modules (`core`, `cli`, `skill_support`) and removed it from the leaf allowlist.
- New fitness test `tests/quality/test_project_leaf.py` pins the same leaf invariant at the AST level (observed RED on a forbidden import before being committed green) and pins the tach declaration so it can't be silently loosened.

### Finding D7 — backends split makes the gitlab→slack coupling explicit
`backends/gitlab/sync.py` calls `backends/slack/review_sync.fetch_review_permalinks`, but `teatree.backends` was a single tach node, so that cross-backend edge was invisible in the graph.

- Split `teatree.backends` into the aggregator parent (`loader` / `backend_provider` / `apps` + `noop`/`notion`/`sentry` helpers), the three concrete backends (`github` / `gitlab` / `slack`), and the shared primitives (`errors` / `types` / `forge_merge_rpc`).
- The `gitlab → slack` edge is now a **declared** `depends_on`; `slack` stays a backend leaf (no outgoing sibling edge). Verified: removing the declared edge makes `tach check` fail at `gitlab/sync.py:22` ("Module 'teatree.backends.gitlab' cannot depend on 'teatree.backends.slack'").
- Extracting the shared primitives is what keeps the graph acyclic under `forbid_circular_dependencies` (otherwise `gitlab`/`github` ↔ parent would cycle).
- New fitness test `tests/quality/test_backends_explicit_coupling.py` pins the explicit edge and the slack-is-a-leaf invariant so the coupling can't be re-hidden.
- `teatree.core` fan-in grows 13 → 17 — the four new backend nodes already imported `core` inside the monolithic node, so this is the same pre-existing coupling made visible, not new coupling. The cycle-ratchet baseline in `tests/test_tach_cycle_ratchet.py` is re-based with that rationale.
- `docs/dependency-graph.md` regenerated to match.

## Deliberately NOT done (D5 / D6 — exact deps / interfaces)

Left out on purpose to honour the conservative posture (no half-broken boundary config):

- **`tach --exact`** would require resolving unused-dependency declarations across **30 modules** (`config`/`core`/`agents`/`contrib`/`cli`/…) — a large unrelated cleanup spanning the whole graph, well beyond these findings. The repo's gate runs plain `tach check`, not `--exact`.
- **Module `interfaces`** start from an empty `interfaces = []` set across the entire codebase; declaring interface surfaces is a large new contract layer touching every module.

Both cascade into a big unrelated cleanup, so they belong in a dedicated change rather than landing a half-broken config here.

## Verification

- `tach check` → `✅ All modules validated!`
- modules-declared hook → exit 0
- `tests/quality/test_project_leaf.py`, `tests/quality/test_backends_explicit_coupling.py`, `tests/test_tach_cycle_ratchet.py`, `tests/quality/test_import_contracts.py`, `tests/test_tach_modules_declared_hook.py`, `tests/teatree_backends/test_loader.py` — all green.
- ruff check + format + ty-check + full pre-commit hook chain — green.

## Architecture pre-check
- **BLUEPRINT § alignment:** §17.6.2 (tach as the structural fitness function).
- **Component boundaries:** `tach.toml` only; no module relocation.
- **Dependency direction:** graph stays acyclic; `tach check` green; core fan-in ratchet re-based with rationale (visibility, not new coupling).
- **Test surface:** two AST/declaration fitness tests, both observed RED on a forbidden import / a dropped edge before being committed green.
- **Behavior preservation:** no behavior removed; no `src/` change.
