### PR TITLE
fix(redis): auto-reclaim ghost slots and flush stale cache/queue state

### DIFF
--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -87,29 +87,35 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
         """Claim the lowest free Redis DB index for the ticket, atomically.
 
         Idempotent: returns the existing index if the ticket already has one.
-        Raises RedisSlotsExhaustedError when every slot is in use.
+        Raises RedisSlotsExhaustedError when every non-ghost slot is in use.
 
-        The claim is the contention boundary: ``redis_db_index`` carries a
-        unique constraint, so the bare read-taken-set → pick-lowest-free →
-        ``save()`` shape let two concurrent worktree provisions both read the
-        same taken-set, both pick the same free index, and the loser's
-        ``save()`` raise an uncaught ``IntegrityError`` (the #804/#786 RMW
-        class on the production SQLite backend, where ``select_for_update`` is
-        a no-op). This mirrors the ``claim_next_pending`` / ``LoopLease.acquire``
-        compare-and-swap doctrine in its caught-collision form: each candidate
-        slot is claimed inside its own ``transaction.atomic`` and the unique
-        constraint is the CAS token, so a colliding loser catches the
-        ``IntegrityError`` and reselects the next free slot instead of
-        crashing. Exactly one writer wins each slot.
+        Ghost reclaim: before raising, scans for tickets that have at least
+        one Worktree row where every row's ``worktree_path`` no longer exists
+        on disk. Ghost slots are cleared and the allocation is retried once;
+        a non-ghost slot (any Worktree with a live on-disk path) is never
+        reclaimed. Tickets with no Worktree rows are not treated as ghosts
+        (they may be mid-provision).
+
+        The CAS shape is unchanged: ``redis_db_index`` carries a unique
+        constraint, so the read-taken-set → pick-lowest-free → ``save()``
+        loop lets two concurrent provisions race, the loser's ``save()``
+        raises a caught ``IntegrityError``, and exactly one writer wins each
+        slot. SQLite ``IMMEDIATE`` transaction mode serialises the write
+        window; ``select_for_update`` is a documented no-op on SQLite (#804).
         """
         if ticket.redis_db_index is not None:
             return int(ticket.redis_db_index)
         count = load_config().user.redis_db_count
+        ghost_reclaim_attempted = False
         for _ in range(count):
             taken = set(self.filter(redis_db_index__isnull=False).values_list("redis_db_index", flat=True))
             index = next((i for i in range(count) if i not in taken), None)
             if index is None:
-                break
+                if ghost_reclaim_attempted:
+                    break
+                ghost_reclaim_attempted = True
+                self._reclaim_ghost_slots(using=self.db)
+                continue
             try:
                 with transaction.atomic(using=self.db):
                     ticket.redis_db_index = index
@@ -120,6 +126,34 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
             return index
         msg = f"All {count} Redis DB slots are in use — release a ticket's slot first"
         raise RedisSlotsExhaustedError(msg)
+
+    def _reclaim_ghost_slots(self, *, using: str = "default") -> int:
+        """Clear ``redis_db_index`` on tickets whose backing worktrees are all gone.
+
+        A slot is a ghost when the ticket has at least one Worktree row and
+        every row either has no on-disk path recorded or has a path that no
+        longer exists as a directory. Tickets with no Worktree rows are not
+        reclaimed — they may be mid-provision (slot allocated, Worktree row
+        not yet written). Only the DB field is cleared; no Redis FLUSHDB is
+        issued (the worktrees are already gone so there is nothing to flush).
+        Returns the count of reclaimed slots.
+        """
+        from pathlib import Path  # noqa: PLC0415
+
+        candidates = list(self.using(using).filter(redis_db_index__isnull=False).prefetch_related("worktrees"))
+        reclaimed = 0
+        for candidate in candidates:
+            worktrees = list(candidate.worktrees.all())
+            if not worktrees:
+                is_ghost = False
+            else:
+                is_ghost = all(not wt.worktree_path or not Path(wt.worktree_path).exists() for wt in worktrees)
+            if is_ghost:
+                candidate.redis_db_index = None
+                candidate.save(update_fields=["redis_db_index"], using=using)
+                reclaimed += 1
+                logger.info("reclaimed ghost redis slot from ticket pk=%s", candidate.pk)
+        return reclaimed
 
 
 class WorktreeQuerySet(_OverlayFilterMixin, models.QuerySet):

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -138,7 +138,11 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
         not yet written). Each ghost slot's Redis DB is flushed before the
         field is cleared, matching ``Ticket.release_redis_slot``'s contract so
         the next ticket assigned the reclaimed slot starts with a clean
-        cache/queue. Returns the count of reclaimed slots.
+        cache/queue. The flush is best-effort: when redis/docker is
+        unavailable (``flushdb`` raises ``RuntimeError`` because the docker
+        CLI is absent, e.g. CI) the DB row is still reclaimed so allocation
+        never fails on a missing cache backend. Returns the count of
+        reclaimed slots.
         """
         from pathlib import Path  # noqa: PLC0415
 
@@ -151,7 +155,14 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
             else:
                 is_ghost = all(not wt.worktree_path or not Path(wt.worktree_path).exists() for wt in worktrees)
             if is_ghost:
-                redis_container.flushdb(candidate.redis_db_index, db_count=load_config().user.redis_db_count)
+                try:
+                    redis_container.flushdb(candidate.redis_db_index, db_count=load_config().user.redis_db_count)
+                except RuntimeError as exc:
+                    logger.warning(
+                        "ghost slot %s flush skipped (%s); reclaiming DB row anyway",
+                        candidate.redis_db_index,
+                        exc,
+                    )
                 candidate.redis_db_index = None
                 candidate.save(update_fields=["redis_db_index"], using=using)
                 reclaimed += 1

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -10,6 +10,7 @@ from teatree.config import load_config
 from teatree.core.loop_lease_manager import LoopLeaseManager, LoopLeaseQuerySet, OwnershipStatus
 from teatree.core.models.errors import RedisSlotsExhaustedError
 from teatree.core.session_handover_manager import SessionHandoverManager, SessionHandoverQuerySet
+from teatree.utils import redis_container
 
 if TYPE_CHECKING:
     from teatree.core.models.task import Task
@@ -128,15 +129,16 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
         raise RedisSlotsExhaustedError(msg)
 
     def _reclaim_ghost_slots(self, *, using: str = "default") -> int:
-        """Clear ``redis_db_index`` on tickets whose backing worktrees are all gone.
+        """Flush and clear ``redis_db_index`` on tickets whose backing worktrees are all gone.
 
         A slot is a ghost when the ticket has at least one Worktree row and
         every row either has no on-disk path recorded or has a path that no
         longer exists as a directory. Tickets with no Worktree rows are not
         reclaimed — they may be mid-provision (slot allocated, Worktree row
-        not yet written). Only the DB field is cleared; no Redis FLUSHDB is
-        issued (the worktrees are already gone so there is nothing to flush).
-        Returns the count of reclaimed slots.
+        not yet written). Each ghost slot's Redis DB is flushed before the
+        field is cleared, matching ``Ticket.release_redis_slot``'s contract so
+        the next ticket assigned the reclaimed slot starts with a clean
+        cache/queue. Returns the count of reclaimed slots.
         """
         from pathlib import Path  # noqa: PLC0415
 
@@ -149,6 +151,7 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
             else:
                 is_ghost = all(not wt.worktree_path or not Path(wt.worktree_path).exists() for wt in worktrees)
             if is_ghost:
+                redis_container.flushdb(candidate.redis_db_index, db_count=load_config().user.redis_db_count)
                 candidate.redis_db_index = None
                 candidate.save(update_fields=["redis_db_index"], using=using)
                 reclaimed += 1

--- a/tests/teatree_core/test_redis_slots.py
+++ b/tests/teatree_core/test_redis_slots.py
@@ -145,8 +145,8 @@ class TestGhostSlotReclaim(TestCase):
         with patch("teatree.core.managers.load_config", return_value=patched_cfg):
             ghost_a = Ticket.objects.create()
             ghost_b = Ticket.objects.create()
-            Ticket.objects.allocate_redis_slot(ghost_a)
-            Ticket.objects.allocate_redis_slot(ghost_b)
+            ghost_a_index = Ticket.objects.allocate_redis_slot(ghost_a)
+            ghost_b_index = Ticket.objects.allocate_redis_slot(ghost_b)
             for ghost in (ghost_a, ghost_b):
                 Worktree.objects.create(
                     ticket=ghost,
@@ -156,7 +156,10 @@ class TestGhostSlotReclaim(TestCase):
                     extra={"worktree_path": "/nonexistent/path/that/is/gone"},
                 )
             newcomer = Ticket.objects.create()
-            index = Ticket.objects.allocate_redis_slot(newcomer)
+            with patch("teatree.core.managers.redis_container.flushdb") as mock_flush:
+                index = Ticket.objects.allocate_redis_slot(newcomer)
+        flushed_indices = {call.args[0] for call in mock_flush.call_args_list}
+        assert {ghost_a_index, ghost_b_index} <= flushed_indices
         assert index in {0, 1}
         newcomer.refresh_from_db()
         assert newcomer.redis_db_index == index
@@ -184,7 +187,7 @@ class TestGhostSlotReclaim(TestCase):
             live_tickets, live_dirs = self._fill_slots_with_live_worktrees(2)
             live_indices_before = {t.redis_db_index for t in live_tickets}
             ghost = Ticket.objects.create()
-            Ticket.objects.allocate_redis_slot(ghost)
+            ghost_index = Ticket.objects.allocate_redis_slot(ghost)
             Worktree.objects.create(
                 ticket=ghost,
                 overlay="test",
@@ -193,7 +196,9 @@ class TestGhostSlotReclaim(TestCase):
                 extra={"worktree_path": "/gone/path"},
             )
             newcomer = Ticket.objects.create()
-            index = Ticket.objects.allocate_redis_slot(newcomer)
+            with patch("teatree.core.managers.redis_container.flushdb") as mock_flush:
+                index = Ticket.objects.allocate_redis_slot(newcomer)
+        mock_flush.assert_called_once_with(ghost_index, db_count=patched_user.redis_db_count)
         assert index not in live_indices_before
         for live in live_tickets:
             live.refresh_from_db()
@@ -207,7 +212,7 @@ class TestGhostSlotReclaim(TestCase):
         patched_cfg = _replace(cfg, user=patched_user)
         with patch("teatree.core.managers.load_config", return_value=patched_cfg):
             ghost = Ticket.objects.create()
-            Ticket.objects.allocate_redis_slot(ghost)
+            ghost_index = Ticket.objects.allocate_redis_slot(ghost)
             Worktree.objects.create(
                 ticket=ghost,
                 overlay="test",
@@ -218,9 +223,11 @@ class TestGhostSlotReclaim(TestCase):
             assert ghost.redis_db_index is not None
             _filler_ticket, filler_dir = _make_live_ticket()
             newcomer = Ticket.objects.create()
-            Ticket.objects.allocate_redis_slot(newcomer)
-            ghost.refresh_from_db()
-            assert ghost.redis_db_index is None
+            with patch("teatree.core.managers.redis_container.flushdb") as mock_flush:
+                Ticket.objects.allocate_redis_slot(newcomer)
+        mock_flush.assert_called_once_with(ghost_index, db_count=patched_user.redis_db_count)
+        ghost.refresh_from_db()
+        assert ghost.redis_db_index is None
         filler_dir.rmdir()
 
 

--- a/tests/teatree_core/test_redis_slots.py
+++ b/tests/teatree_core/test_redis_slots.py
@@ -7,7 +7,9 @@ across tickets. Slot count is configurable via ``teatree.redis_db_count`` in
 RedisSlotsExhaustedError. Slots are released on ticket cleanup (FLUSHDB + clear field).
 """
 
+import tempfile
 from dataclasses import replace as _replace
+from pathlib import Path
 from unittest.mock import ANY, patch
 
 import pytest
@@ -16,8 +18,24 @@ from django.test import TestCase
 from teatree.config import load_config
 from teatree.core.models import Ticket
 from teatree.core.models.errors import RedisSlotsExhaustedError
+from teatree.core.models.worktree import Worktree
 
 REDIS_DB_COUNT = load_config().user.redis_db_count
+
+
+def _make_live_ticket() -> tuple[Ticket, Path]:
+    """Create a ticket with an allocated slot backed by a real on-disk directory."""
+    tmpdir = Path(tempfile.mkdtemp())
+    ticket = Ticket.objects.create()
+    Ticket.objects.allocate_redis_slot(ticket)
+    Worktree.objects.create(
+        ticket=ticket,
+        overlay="test",
+        repo_path="org/repo",
+        branch="main",
+        extra={"worktree_path": str(tmpdir)},
+    )
+    return ticket, tmpdir
 
 
 class TestAllocateRedisSlot(TestCase):
@@ -50,26 +68,160 @@ class TestAllocateRedisSlot(TestCase):
         second = Ticket.objects.allocate_redis_slot(ticket)
         assert first == second
 
-    def test_raises_when_all_slots_are_in_use(self) -> None:
-        tickets = [Ticket.objects.create() for _ in range(REDIS_DB_COUNT)]
-        for ticket in tickets:
-            Ticket.objects.allocate_redis_slot(ticket)
+    def test_raises_when_all_live_slots_are_in_use(self) -> None:
+        live_tickets = []
+        live_dirs = []
+        for _ in range(REDIS_DB_COUNT):
+            ticket, tmpdir = _make_live_ticket()
+            live_tickets.append(ticket)
+            live_dirs.append(tmpdir)
         overflow = Ticket.objects.create()
-        with pytest.raises(RedisSlotsExhaustedError):
-            Ticket.objects.allocate_redis_slot(overflow)
+        try:
+            with pytest.raises(RedisSlotsExhaustedError):
+                Ticket.objects.allocate_redis_slot(overflow)
+        finally:
+            for d in live_dirs:
+                d.rmdir()
 
     def test_slot_count_is_configurable(self) -> None:
         cfg = load_config()
         patched_user = _replace(cfg.user, redis_db_count=2)
         patched_cfg = _replace(cfg, user=patched_user)
         with patch("teatree.core.managers.load_config", return_value=patched_cfg):
-            a = Ticket.objects.create()
-            b = Ticket.objects.create()
-            Ticket.objects.allocate_redis_slot(a)
-            Ticket.objects.allocate_redis_slot(b)
+            _a_ticket, a_dir = _make_live_ticket()
+            _b_ticket, b_dir = _make_live_ticket()
+            overflow = Ticket.objects.create()
+            try:
+                with pytest.raises(RedisSlotsExhaustedError):
+                    Ticket.objects.allocate_redis_slot(overflow)
+            finally:
+                a_dir.rmdir()
+                b_dir.rmdir()
+
+
+class TestGhostSlotReclaim(TestCase):
+    """``allocate_redis_slot`` auto-reclaims ghosts before raising exhaustion.
+
+    A ghost is a ticket whose ``redis_db_index`` is set but all its Worktree
+    rows have ``worktree_path`` values that no longer exist on disk (or it has
+    no Worktree rows at all — a failed provision that allocated then deleted
+    without releasing). The allocator must reclaim those before raising
+    ``RedisSlotsExhaustedError``, so exhaustion-from-leaks cannot occur without
+    manual intervention.
+
+    Anti-vacuity: with the old code (no ghost reclaim in ``allocate_redis_slot``),
+    tests that try to allocate past a ghost-filled cap go RED — the overflow
+    allocation raises ``RedisSlotsExhaustedError`` even though ghost slots are
+    present. Restoring the reclaim makes them GREEN.
+    """
+
+    def _fill_slots_with_live_worktrees(self, count: int) -> tuple[list[Ticket], list[Path]]:
+        """Allocate ``count`` slots, each backed by a real on-disk directory."""
+        dirs: list[Path] = []
+        tickets: list[Ticket] = []
+        for _ in range(count):
+            ticket, tmpdir = _make_live_ticket()
+            tickets.append(ticket)
+            dirs.append(tmpdir)
+        return tickets, dirs
+
+    def test_zero_worktree_tickets_are_not_reclaimed_as_ghosts(self) -> None:
+        cfg = load_config()
+        patched_user = _replace(cfg.user, redis_db_count=2)
+        patched_cfg = _replace(cfg, user=patched_user)
+        with patch("teatree.core.managers.load_config", return_value=patched_cfg):
+            no_wt_a = Ticket.objects.create()
+            no_wt_b = Ticket.objects.create()
+            Ticket.objects.allocate_redis_slot(no_wt_a)
+            Ticket.objects.allocate_redis_slot(no_wt_b)
+            newcomer = Ticket.objects.create()
+            with pytest.raises(RedisSlotsExhaustedError):
+                Ticket.objects.allocate_redis_slot(newcomer)
+
+    def test_allocation_succeeds_when_ghost_slots_have_missing_on_disk_path(self) -> None:
+        cfg = load_config()
+        patched_user = _replace(cfg.user, redis_db_count=2)
+        patched_cfg = _replace(cfg, user=patched_user)
+        with patch("teatree.core.managers.load_config", return_value=patched_cfg):
+            ghost_a = Ticket.objects.create()
+            ghost_b = Ticket.objects.create()
+            Ticket.objects.allocate_redis_slot(ghost_a)
+            Ticket.objects.allocate_redis_slot(ghost_b)
+            for ghost in (ghost_a, ghost_b):
+                Worktree.objects.create(
+                    ticket=ghost,
+                    overlay="test",
+                    repo_path="org/repo",
+                    branch="main",
+                    extra={"worktree_path": "/nonexistent/path/that/is/gone"},
+                )
+            newcomer = Ticket.objects.create()
+            index = Ticket.objects.allocate_redis_slot(newcomer)
+        assert index in {0, 1}
+        newcomer.refresh_from_db()
+        assert newcomer.redis_db_index == index
+
+    def test_live_non_ghost_slot_is_never_reclaimed(self) -> None:
+        cfg = load_config()
+        patched_user = _replace(cfg.user, redis_db_count=2)
+        patched_cfg = _replace(cfg, user=patched_user)
+        with patch("teatree.core.managers.load_config", return_value=patched_cfg):
+            live_tickets, live_dirs = self._fill_slots_with_live_worktrees(2)
             overflow = Ticket.objects.create()
             with pytest.raises(RedisSlotsExhaustedError):
                 Ticket.objects.allocate_redis_slot(overflow)
+            for live in live_tickets:
+                live.refresh_from_db()
+                assert live.redis_db_index is not None
+        for d in live_dirs:
+            d.rmdir()
+
+    def test_mixed_live_and_ghost_slots_reclaims_only_ghosts(self) -> None:
+        cfg = load_config()
+        patched_user = _replace(cfg.user, redis_db_count=3)
+        patched_cfg = _replace(cfg, user=patched_user)
+        with patch("teatree.core.managers.load_config", return_value=patched_cfg):
+            live_tickets, live_dirs = self._fill_slots_with_live_worktrees(2)
+            live_indices_before = {t.redis_db_index for t in live_tickets}
+            ghost = Ticket.objects.create()
+            Ticket.objects.allocate_redis_slot(ghost)
+            Worktree.objects.create(
+                ticket=ghost,
+                overlay="test",
+                repo_path="org/repo",
+                branch="main",
+                extra={"worktree_path": "/gone/path"},
+            )
+            newcomer = Ticket.objects.create()
+            index = Ticket.objects.allocate_redis_slot(newcomer)
+        assert index not in live_indices_before
+        for live in live_tickets:
+            live.refresh_from_db()
+            assert live.redis_db_index in live_indices_before
+        for d in live_dirs:
+            d.rmdir()
+
+    def test_ghost_slots_cleared_in_db_after_reclaim(self) -> None:
+        cfg = load_config()
+        patched_user = _replace(cfg.user, redis_db_count=2)
+        patched_cfg = _replace(cfg, user=patched_user)
+        with patch("teatree.core.managers.load_config", return_value=patched_cfg):
+            ghost = Ticket.objects.create()
+            Ticket.objects.allocate_redis_slot(ghost)
+            Worktree.objects.create(
+                ticket=ghost,
+                overlay="test",
+                repo_path="org/repo",
+                branch="main",
+                extra={"worktree_path": "/nonexistent/ghost/path"},
+            )
+            assert ghost.redis_db_index is not None
+            _filler_ticket, filler_dir = _make_live_ticket()
+            newcomer = Ticket.objects.create()
+            Ticket.objects.allocate_redis_slot(newcomer)
+            ghost.refresh_from_db()
+            assert ghost.redis_db_index is None
+        filler_dir.rmdir()
 
 
 class TestReleaseRedisSlot(TestCase):

--- a/tests/teatree_core/test_redis_slots.py
+++ b/tests/teatree_core/test_redis_slots.py
@@ -260,6 +260,44 @@ class TestGhostSlotReclaimFlushes(TestCase):
         mock_flush.assert_called_once_with(ghost_index, db_count=patched_user.redis_db_count)
         filler_dir.rmdir()
 
+    def test_reclaim_proceeds_when_flush_fails_without_docker(self) -> None:
+        """A best-effort cache flush must never block the DB-level reclaim.
+
+        ``redis_container.flushdb`` raises ``RuntimeError`` when the docker CLI
+        is absent (CI, any host without docker). The ghost slot's DB row must
+        still be reclaimed so allocation succeeds instead of propagating the
+        flush failure. Anti-vacuity: drop the swallow in ``_reclaim_ghost_slots``
+        and the ``allocate_redis_slot`` call below re-raises the RuntimeError.
+        """
+        cfg = load_config()
+        patched_user = _replace(cfg.user, redis_db_count=2)
+        patched_cfg = _replace(cfg, user=patched_user)
+        with patch("teatree.core.managers.load_config", return_value=patched_cfg):
+            ghost_a = Ticket.objects.create()
+            ghost_b = Ticket.objects.create()
+            Ticket.objects.allocate_redis_slot(ghost_a)
+            Ticket.objects.allocate_redis_slot(ghost_b)
+            for ghost in (ghost_a, ghost_b):
+                Worktree.objects.create(
+                    ticket=ghost,
+                    overlay="test",
+                    repo_path="org/repo",
+                    branch="main",
+                    extra={"worktree_path": "/nonexistent/path/that/is/gone"},
+                )
+            newcomer = Ticket.objects.create()
+            with patch(
+                "teatree.core.managers.redis_container.flushdb",
+                side_effect=RuntimeError("docker CLI not found on PATH"),
+            ):
+                index = Ticket.objects.allocate_redis_slot(newcomer)
+        assert index in {0, 1}
+        newcomer.refresh_from_db()
+        assert newcomer.redis_db_index == index
+        for ghost in (ghost_a, ghost_b):
+            ghost.refresh_from_db()
+        assert ghost_a.redis_db_index is None or ghost_b.redis_db_index is None
+
 
 class TestReleaseRedisSlot(TestCase):
     def test_clears_field_and_flushes_redis_db(self) -> None:

--- a/tests/teatree_core/test_redis_slots.py
+++ b/tests/teatree_core/test_redis_slots.py
@@ -224,6 +224,36 @@ class TestGhostSlotReclaim(TestCase):
         filler_dir.rmdir()
 
 
+class TestGhostSlotReclaimFlushes(TestCase):
+    """``_reclaim_ghost_slots`` must FLUSHDB each ghost slot before clearing the field.
+
+    Anti-vacuity: remove the ``redis_container.flushdb`` call from
+    ``_reclaim_ghost_slots`` and this test goes RED — ``mock_flush`` records
+    zero calls. Restoring the flush makes it GREEN.
+    """
+
+    def test_reclaim_flushes_ghost_slot_db(self) -> None:
+        cfg = load_config()
+        patched_user = _replace(cfg.user, redis_db_count=2)
+        patched_cfg = _replace(cfg, user=patched_user)
+        with patch("teatree.core.managers.load_config", return_value=patched_cfg):
+            ghost = Ticket.objects.create()
+            ghost_index = Ticket.objects.allocate_redis_slot(ghost)
+            Worktree.objects.create(
+                ticket=ghost,
+                overlay="test",
+                repo_path="org/repo",
+                branch="main",
+                extra={"worktree_path": "/nonexistent/ghost/path"},
+            )
+            _filler, filler_dir = _make_live_ticket()
+            newcomer = Ticket.objects.create()
+            with patch("teatree.core.managers.redis_container.flushdb") as mock_flush:
+                Ticket.objects.allocate_redis_slot(newcomer)
+        mock_flush.assert_called_once_with(ghost_index, db_count=patched_user.redis_db_count)
+        filler_dir.rmdir()
+
+
 class TestReleaseRedisSlot(TestCase):
     def test_clears_field_and_flushes_redis_db(self) -> None:
         ticket = Ticket.objects.create()

--- a/tests/teatree_core/test_redis_slots_concurrent.py
+++ b/tests/teatree_core/test_redis_slots_concurrent.py
@@ -58,7 +58,8 @@ def _make_alias(tmp_path: Path) -> str:
         "TEST": {},
     }
     with connections[alias].cursor() as cur:
-        # Hand-maintained mirror of the Ticket schema — add any new Ticket column here too.
+        # Hand-maintained mirrors of the schemas queried by allocate_redis_slot
+        # and _reclaim_ghost_slots — add any new column here too.
         cur.execute(
             """
             CREATE TABLE teatree_ticket (
@@ -75,6 +76,21 @@ def _make_alias(tmp_path: Path) -> str:
                 short_description VARCHAR(80) NOT NULL DEFAULT '',
                 redis_db_index INTEGER NULL UNIQUE,
                 remote_missing BOOLEAN NOT NULL DEFAULT 0
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE teatree_worktree (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                overlay VARCHAR(255) NOT NULL DEFAULT '',
+                ticket_id INTEGER NOT NULL REFERENCES teatree_ticket(id),
+                repo_path VARCHAR(500) NOT NULL DEFAULT '',
+                branch VARCHAR(255) NOT NULL DEFAULT '',
+                state VARCHAR(32) NOT NULL DEFAULT 'created',
+                db_name VARCHAR(255) NOT NULL DEFAULT '',
+                extra TEXT NOT NULL DEFAULT '{}',
+                last_used_at DATETIME NULL
             )
             """
         )
@@ -175,6 +191,18 @@ class TestAllocateRedisSlotConcurrentExhaustion:
             taken = [Ticket.objects.using(alias).create() for _ in range(count - 1)]
             for ticket in taken:
                 Ticket.objects.using(alias).allocate_redis_slot(ticket)
+                # Give each pre-allocated ticket a live-path Worktree row so
+                # _reclaim_ghost_slots does not treat them as ghosts and reclaim
+                # them before the two racing allocators contend for the last slot.
+                Ticket.objects.using(alias).filter(pk=ticket.pk).using(alias)
+                from django.db import connections as _conns  # noqa: PLC0415
+
+                with _conns[alias].cursor() as cur:
+                    cur.execute(
+                        "INSERT INTO teatree_worktree (ticket_id, overlay, repo_path, branch, extra)"
+                        " VALUES (?, '', 'org/repo', 'main', ?)",
+                        [ticket.pk, f'{{"worktree_path": "{tmp_path}"}}'],
+                    )
             a = Ticket.objects.using(alias).create()
             b = Ticket.objects.using(alias).create()
             results = _run_two_allocators(alias, (a.pk, b.pk))

--- a/tests/teatree_core/test_redis_slots_concurrent.py
+++ b/tests/teatree_core/test_redis_slots_concurrent.py
@@ -194,7 +194,6 @@ class TestAllocateRedisSlotConcurrentExhaustion:
                 # Give each pre-allocated ticket a live-path Worktree row so
                 # _reclaim_ghost_slots does not treat them as ghosts and reclaim
                 # them before the two racing allocators contend for the last slot.
-                Ticket.objects.using(alias).filter(pk=ticket.pk).using(alias)
                 from django.db import connections as _conns  # noqa: PLC0415
 
                 with _conns[alias].cursor() as cur:


### PR DESCRIPTION
Recreates #2294 closed by the leak-scrub force-push on 2026-06-12. Both cherry-picks applied cleanly without conflict.
Before raising RedisSlotsExhaustedError, scans for tickets whose every Worktree row points to a nonexistent disk path, clears redis_db_index, and retries. Prevents slot exhaustion from failed provisions.
Tickets with no Worktree rows are treated as live to avoid TOCTOU races. The reclaim path now calls flushdb before clearing the index, matching the normal release path. Without it the next allocation inherits dead cache and queued Celery messages.
17 tests pass. TestGhostSlotReclaimFlushes.test_reclaim_flushes_ghost_slot_db goes red when flushdb is removed.
