### PR TITLE
fix(eval): metered benchmark/multi-trial --local run bypasses OAuth-token resolution

### DIFF
--- a/src/teatree/cli/eval/benchmark.py
+++ b/src/teatree/cli/eval/benchmark.py
@@ -21,10 +21,10 @@ from teatree.cli.eval.docker import DockerUnavailableError, run_eval_in_docker
 from teatree.cli.eval.metered_routing import should_route_to_docker, warn_local_metered
 from teatree.cli.eval.multi_trial import collect_matrix_rows, parse_model_tags
 from teatree.cli.eval.run_modes import RunGuards, persist_matrix_run
+from teatree.eval.backends import SDK_BACKEND, make_runner
 from teatree.eval.benchmark import render_benchmark_json, render_benchmark_text, summarize_benchmark
 from teatree.eval.discovery import discover_specs
 from teatree.eval.models import EvalSpec
-from teatree.eval.sdk_runner import SdkInProcessRunner
 from teatree.utils.django_bootstrap import ensure_django
 
 #: Generous per-run cap for the benchmark lane. The whole point of the benchmark
@@ -112,9 +112,23 @@ def benchmark(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 
     require_valid_format(output_format)
     tags = parse_model_tags(models)
     specs = _select_specs(scenarios)
-    runner = SdkInProcessRunner(max_turns_override=max_turns, require_executed=True, max_budget_usd=max_budget_usd)
+    runner = make_runner(
+        SDK_BACKEND, max_turns_override=max_turns, require_executed=True, max_budget_usd=max_budget_usd
+    )
     rows = collect_matrix_rows(specs, tags, runner=runner, trials=trials, require="any")
     RunGuards.executed(executed=sum(1 for row in rows if not row.skipped), collected=len(rows), required=True)
+    # The benchmark is always sdk-metered, yet (unlike the single-run lane and the
+    # suite) it lacked the unmetered-$0 guard: an executed-but-$0 run (auth ok but
+    # billing nothing, or mid-run quota exhaustion) would report a fake-green $0
+    # across every variant. Count only genuinely-graded cells (skipped = not
+    # provisioned, errored = $0 by construction); if any of those ran yet the lane
+    # metered nothing, fail loud like skip_guard.assert_sdk_run_was_metered.
+    graded = [row for row in rows if not row.skipped and not row.errored]
+    RunGuards.sdk_metered_total(
+        backend=SDK_BACKEND,
+        executed=len(graded),
+        total_cost_usd=sum(row.cost_usd for row in graded),
+    )
     if persist:
         persist_matrix_run(rows, models=tags, max_turns=max_turns, baseline=False)
     summaries = summarize_benchmark(rows, tags)

--- a/src/teatree/cli/eval/multi_trial.py
+++ b/src/teatree/cli/eval/multi_trial.py
@@ -20,12 +20,13 @@ from teatree.cli.eval.run_modes import (
     persist_pass_at_k_run,
     with_model,
 )
+from teatree.eval.backends import SDK_BACKEND, EvalRunner, make_runner
 from teatree.eval.matrix import MatrixRow, render_matrix_json, render_matrix_text
 from teatree.eval.model_variant import ModelVariantError, parse_model_variants
 from teatree.eval.models import EvalSpec
 from teatree.eval.pass_at_k import run_pass_at_k
 from teatree.eval.report import ScenarioResult, evaluate
-from teatree.eval.sdk_runner import MAX_BUDGET_USD, SdkInProcessRunner
+from teatree.eval.sdk_runner import MAX_BUDGET_USD
 
 #: How many extra attempts a single matrix/benchmark cell gets after its first
 #: failure. A clean-room scenario is idempotent (re-running costs only extra
@@ -63,7 +64,8 @@ def run_pass_at_k_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` C
     if require not in {"any", "all"}:
         typer.echo(f"unknown --require {require!r}; use 'any' or 'all'", err=True)
         raise typer.Exit(code=2)
-    runner = SdkInProcessRunner(
+    runner = make_runner(
+        SDK_BACKEND,
         max_turns_override=max_turns,
         require_executed=require_executed,
         max_budget_usd=max_budget_usd,
@@ -146,7 +148,8 @@ def run_model_matrix_lane(  # noqa: PLR0913 — each kwarg threads one `eval run
     a scenario's own) still win over this lane default at the runner's seam.
     """
     model_list = parse_model_tags(models)
-    runner = SdkInProcessRunner(
+    runner = make_runner(
+        SDK_BACKEND,
         max_turns_override=max_turns,
         require_executed=require_executed,
         max_budget_usd=max_budget_usd,
@@ -199,7 +202,7 @@ def collect_matrix_rows(  # noqa: PLR0913 — each kwarg threads one matrix/benc
     specs: list[EvalSpec],
     model_tags: list[str],
     *,
-    runner: SdkInProcessRunner,
+    runner: EvalRunner,
     trials: int,
     require: str,
     grader=None,  # noqa: ANN001 — JudgeGrader | None, kept local to the CLI.
@@ -219,7 +222,7 @@ def collect_matrix_rows(  # noqa: PLR0913 — each kwarg threads one matrix/benc
 
 
 def _resilient_matrix_trial(
-    runner: SdkInProcessRunner,
+    runner: EvalRunner,
     spec: EvalSpec,
     *,
     trials: int,
@@ -268,7 +271,7 @@ def _resilient_matrix_trial(
 
 
 def _matrix_trial(
-    runner: SdkInProcessRunner,
+    runner: EvalRunner,
     spec: EvalSpec,
     *,
     trials: int,

--- a/src/teatree/cli/eval/run_modes.py
+++ b/src/teatree/cli/eval/run_modes.py
@@ -47,12 +47,21 @@ class RunGuards:
 
     @staticmethod
     def sdk_metered(*, backend: str, executed: int, results: list[ScenarioResult]) -> None:
+        RunGuards.sdk_metered_total(
+            backend=backend, executed=executed, total_cost_usd=sum(r.run.cost_usd for r in results)
+        )
+
+    @staticmethod
+    def sdk_metered_total(*, backend: str, executed: int, total_cost_usd: float) -> None:
+        """Fail-loud the unmetered-$0 guard from a precomputed cost total.
+
+        The single-run lane sums ``ScenarioResult.run.cost_usd``; the benchmark /
+        matrix lane works in ``MatrixRow`` and sums ``cost_usd`` itself. Both share
+        this one ``UnmeteredSdkRunError`` → ``typer.Exit`` translation so a
+        fake-green $0 metered run turns RED identically wherever it is detected.
+        """
         try:
-            assert_sdk_run_was_metered(
-                backend=backend,
-                executed=executed,
-                total_cost_usd=sum(r.run.cost_usd for r in results),
-            )
+            assert_sdk_run_was_metered(backend=backend, executed=executed, total_cost_usd=total_cost_usd)
         except UnmeteredSdkRunError as exc:
             typer.echo(str(exc), err=True)
             raise typer.Exit(code=1) from None

--- a/tests/quality/test_metered_runner_chokepoint.py
+++ b/tests/quality/test_metered_runner_chokepoint.py
@@ -1,0 +1,107 @@
+"""Metered-runner construction chokepoint fitness function (souliane/teatree#2328).
+
+The metered ``SdkInProcessRunner`` must be built ONLY through
+``teatree.eval.backends.make_runner`` — the single non-Docker path that calls
+``ensure_oauth_token()`` before a metered runner exists. A lane that constructs
+``SdkInProcessRunner(...)`` directly bypasses that resolver, so on a host
+``--local`` run (token only in ``pass``, not the env) the isolated ``claude``
+child authenticates as nothing and the run reports a zero-cost auth failure. That
+is exactly the bypass the ``t3 eval benchmark`` and ``t3 eval run --trials k``
+lanes had.
+
+This AST gate walks the eval source tree and turns RED if any module OTHER than
+the allowed chokepoint constructs ``SdkInProcessRunner`` by name — so the bypass
+class cannot regress. The construction is allowed only in
+``teatree.eval.backends`` (the ``make_runner`` factory). Modeled on
+``tests/quality/test_spawn_model_chokepoint.py``.
+"""
+
+# test-path: cross-cutting
+import ast
+from pathlib import Path
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "teatree"
+
+#: The eval source subtrees scanned. Every metered-runner construction lives
+#: under one of these, so a bypass anywhere in eval is caught.
+_SCANNED_ROOTS = (
+    _SRC_ROOT / "cli" / "eval",
+    _SRC_ROOT / "eval",
+)
+
+_RUNNER_SYMBOL = "SdkInProcessRunner"
+
+#: The ONLY module allowed to construct the metered runner — the ``make_runner``
+#: factory that resolves the OAuth token first.
+_ALLOWED_MODULES = frozenset({"teatree.eval.backends"})
+
+
+def _module_dotted(path: Path) -> str:
+    rel = path.resolve().relative_to(_SRC_ROOT.parent).with_suffix("")
+    parts = rel.parts
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _constructs_runner(path: Path) -> list[int]:
+    """Lines in *path* that call ``SdkInProcessRunner(...)`` as a bare constructor."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == _RUNNER_SYMBOL:
+            hits.add(node.lineno)
+    return sorted(hits)
+
+
+def _eval_modules() -> list[Path]:
+    seen: dict[Path, None] = {}
+    for root in _SCANNED_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            seen[path.resolve()] = None
+    return list(seen)
+
+
+class TestMeteredRunnerChokepoint:
+    def test_scanned_roots_exist(self) -> None:
+        for root in _SCANNED_ROOTS:
+            assert root.is_dir(), root
+
+    def test_allowed_module_actually_constructs_the_runner(self) -> None:
+        # The chokepoint is real: backends.make_runner genuinely builds the runner.
+        # If this stops being true the allow-list is stale, not the gate.
+        backends = _SRC_ROOT / "eval" / "backends.py"
+        assert _constructs_runner(backends), "teatree.eval.backends no longer constructs SdkInProcessRunner"
+
+    def test_no_eval_module_constructs_the_runner_outside_the_chokepoint(self) -> None:
+        offenders: dict[str, list[int]] = {}
+        for path in _eval_modules():
+            module = _module_dotted(path)
+            if module in _ALLOWED_MODULES:
+                continue
+            lines = _constructs_runner(path)
+            if lines:
+                offenders[module] = lines
+        assert not offenders, (
+            f"{_RUNNER_SYMBOL} is constructed directly outside teatree.eval.backends — "
+            "the OAuth-token resolution in make_runner is bypassed, so a host --local "
+            f"metered run authenticates as nothing (souliane/teatree#2328): {offenders}"
+        )
+
+    def test_predicate_catches_a_bare_construction(self, tmp_path: Path) -> None:
+        bait = tmp_path / "bait.py"
+        bait.write_text(
+            "from teatree.eval.sdk_runner import SdkInProcessRunner\n"
+            "runner = SdkInProcessRunner(max_turns_override=None)\n",
+            encoding="utf-8",
+        )
+        assert _constructs_runner(bait)
+
+    def test_predicate_ignores_make_runner_routing(self, tmp_path: Path) -> None:
+        clean = tmp_path / "clean.py"
+        clean.write_text(
+            "from teatree.eval.backends import SDK_BACKEND, make_runner\n"
+            "runner = make_runner(SDK_BACKEND, max_turns_override=None)\n",
+            encoding="utf-8",
+        )
+        assert not _constructs_runner(clean)

--- a/tests/teatree_cli/eval/test_local_auth_resolution.py
+++ b/tests/teatree_cli/eval/test_local_auth_resolution.py
@@ -1,0 +1,111 @@
+"""The metered benchmark + multi-trial lanes resolve the OAuth token themselves.
+
+The single-trial ``t3 eval run`` lane builds its metered runner through
+``teatree.eval.backends.make_runner``, the only non-Docker path that calls
+``ensure_oauth_token()`` (env wins, else exported from the ``pass`` store). The
+``t3 eval benchmark`` and ``t3 eval run --trials k`` lanes must do the SAME — on
+a host ``--local`` run the token lives only in ``pass``, so a lane that builds
+``SdkInProcessRunner`` directly leaves the isolated ``claude`` child
+unauthenticated and the run reports a zero-cost auth failure.
+
+These tests pin that each metered lane calls ``ensure_oauth_token`` exactly where
+its runner is constructed. RED on the pre-fix direct construction (never resolves
+the token), GREEN once the lanes route through ``make_runner``.
+"""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from teatree.cli.eval.benchmark import benchmark
+from teatree.cli.eval.multi_trial import run_model_matrix_lane, run_pass_at_k_lane
+from teatree.eval.models import EvalRun, EvalSpec
+
+
+def _spec(name: str = "s", model: str = "claude-opus-4-8") -> EvalSpec:
+    return EvalSpec(
+        name=name,
+        scenario=f"scenario {name}",
+        agent_path="skills/code/SKILL.md",
+        prompt="do",
+        matchers=(),
+        source_path=Path("/tmp/spec.yaml"),
+        model=model,
+    )
+
+
+class _StubRunner:
+    """Records that it was built; grades every scenario as a metered pass."""
+
+    def __init__(self, **_: Any) -> None:
+        pass
+
+    def run(self, spec: EvalSpec) -> EvalRun:
+        return EvalRun(
+            spec_name=spec.name,
+            tool_calls=(),
+            text_blocks=(),
+            terminal_reason="end_turn",
+            is_error=False,
+            raw_stdout="",
+            raw_stderr="",
+            cost_usd=0.02,
+        )
+
+
+class TestPassAtKLaneResolvesOAuth:
+    def test_pass_at_k_lane_resolves_the_oauth_token_before_metering(self) -> None:
+        with (
+            patch("teatree.eval.backends.ensure_oauth_token", return_value="tok") as ensure,
+            patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
+        ):
+            run_pass_at_k_lane(
+                [_spec()],
+                max_turns=None,
+                trials=3,
+                require="any",
+                output_format="json",
+            )
+        ensure.assert_called_once_with()
+
+
+class TestMatrixLaneResolvesOAuth:
+    def test_matrix_lane_resolves_the_oauth_token_before_metering(self) -> None:
+        with (
+            patch("teatree.eval.backends.ensure_oauth_token", return_value="tok") as ensure,
+            patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
+        ):
+            run_model_matrix_lane(
+                [_spec()],
+                models="claude-opus-4-8,claude-sonnet-4-6",
+                max_turns=None,
+                trials=1,
+                require="any",
+                output_format="json",
+                persist=False,
+                baseline=False,
+                gate_regressions=False,
+            )
+        ensure.assert_called_once_with()
+
+
+class TestBenchmarkLaneResolvesOAuth:
+    def test_benchmark_lane_resolves_the_oauth_token_before_metering(self) -> None:
+        with (
+            patch("teatree.eval.backends.ensure_oauth_token", return_value="tok") as ensure,
+            patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
+            patch("teatree.cli.eval.benchmark.discover_specs", return_value=[_spec("alpha")]),
+            patch("teatree.cli.eval.benchmark.should_route_to_docker", return_value=False),
+            patch("teatree.cli.eval.benchmark.persist_matrix_run"),
+        ):
+            benchmark(
+                models="claude-opus-4-8@xhigh",
+                scenarios=None,
+                trials=1,
+                max_turns=None,
+                max_budget_usd=2.0,
+                output_format="json",
+                persist=False,
+                local=True,
+            )
+        ensure.assert_called_once_with()

--- a/tests/teatree_cli/eval/test_multi_trial_effort.py
+++ b/tests/teatree_cli/eval/test_multi_trial_effort.py
@@ -2,11 +2,11 @@
 
 The single-trial path threads the resolved ``--effort`` / ``METERED_DEFAULT_EFFORT``
 into ``make_runner(... effort=...)``; the always-metered pass@k (``--trials k>1``,
-the CI gate) and model-matrix lanes must do the SAME — they construct their own
-``SdkInProcessRunner`` and so must pass the lane effort, or the calibration never
-reaches the metered gate. A scenario's own ``model@effort`` still wins at the
-runner's per-scenario seam; the lane effort is the default for scenarios that
-declare none.
+the CI gate) and model-matrix lanes must do the SAME. They now build through that
+same ``make_runner`` chokepoint (so OAuth-token resolution can never be bypassed),
+and so must pass the lane effort, or the calibration never reaches the metered gate.
+A scenario's own ``model@effort`` still wins at the runner's per-scenario seam; the
+lane effort is the default for scenarios that declare none.
 """
 
 from collections.abc import Iterator
@@ -16,7 +16,6 @@ from unittest.mock import patch
 
 import pytest
 
-from teatree.cli.eval import multi_trial
 from teatree.cli.eval.multi_trial import run_model_matrix_lane, run_pass_at_k_lane
 from teatree.eval.models import EvalRun, EvalSpec
 
@@ -57,7 +56,10 @@ class _RecordingRunner:
 @pytest.fixture
 def recording_runner() -> Iterator[type[_RecordingRunner]]:
     _RecordingRunner.last_effort = None
-    with patch.object(multi_trial, "SdkInProcessRunner", _RecordingRunner):
+    with (
+        patch("teatree.eval.backends.ensure_oauth_token", return_value="tok"),
+        patch("teatree.eval.backends.SdkInProcessRunner", _RecordingRunner),
+    ):
         yield _RecordingRunner
 
 

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -467,7 +467,7 @@ class TestEvalPassAtK:
 
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _StubRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--trials", "3", "--no-persist"])
         assert result.exit_code == 0, result.output
@@ -486,7 +486,7 @@ class TestEvalPassAtK:
 
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _StubRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--require", "all", "--no-persist"])
         assert result.exit_code == 1
@@ -510,7 +510,7 @@ class TestEvalPassAtK:
 
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _StubRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--format", "json", "--no-persist"])
         assert result.exit_code == 0, result.output
@@ -533,7 +533,7 @@ class TestEvalPassAtK:
 
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _StubRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--no-persist"])
         assert result.exit_code != 0, result.output
@@ -602,7 +602,7 @@ class TestEvalRequireExecuted:
         specs = [_spec("alpha"), _spec("beta")]
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _SkippingRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _SkippingRunner),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--trials", "3", "--require-executed", "--no-persist"])
         assert result.exit_code != 0, result.output
@@ -614,7 +614,7 @@ class TestEvalRequireExecuted:
         specs = [_spec("alpha")]
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _SkippingRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _SkippingRunner),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--trials", "3", "--no-persist"])
         assert result.exit_code != 0, result.output
@@ -631,7 +631,7 @@ class TestEvalRequireExecuted:
 
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _PassingRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _PassingRunner),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--trials", "3", "--require-executed", "--no-persist"])
         assert result.exit_code == 0, result.output
@@ -744,7 +744,7 @@ class TestEvalBackend:
         specs = [_spec("alpha")]
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _PassRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--no-persist"])
         assert result.exit_code == 0, result.output
@@ -908,7 +908,7 @@ class TestEvalModelMatrix:
         specs = [_spec("alpha"), _spec("beta")]
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _PassRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--models", "opus,haiku", "--no-persist"])
         assert result.exit_code == 0, result.output
@@ -921,7 +921,7 @@ class TestEvalModelMatrix:
         specs = [_spec("alpha")]
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _PassRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
         ):
             result = CliRunner().invoke(
                 app, ["eval", "run", "--models", "opus,haiku", "--format", "json", "--no-persist"]
@@ -941,7 +941,7 @@ class TestEvalModelMatrix:
 
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _FailOnHaiku),
+            patch("teatree.eval.backends.SdkInProcessRunner", _FailOnHaiku),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--models", "opus,haiku", "--no-persist"])
         assert result.exit_code == 1, result.output
@@ -959,7 +959,7 @@ class TestEvalModelMatrix:
         specs = [_spec("alpha")]
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _PassRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
             CliRunner().invoke(app, ["eval", "run", "--models", "opus,haiku"])
@@ -971,7 +971,7 @@ class TestEvalModelMatrix:
         specs = [_spec("alpha")]
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _SkippingRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _SkippingRunner),
         ):
             result = CliRunner().invoke(
                 app, ["eval", "run", "--models", "opus,haiku", "--require-executed", "--no-persist"]
@@ -985,7 +985,7 @@ class TestEvalModelMatrix:
         specs = [_spec("alpha")]
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _SkippingRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _SkippingRunner),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--models", "opus,haiku", "--no-persist"])
         assert result.exit_code != 0, result.output
@@ -1000,7 +1000,7 @@ class TestEvalModelVariantMatrix:
         specs = [_spec("alpha")]
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _PassRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
         ):
             result = CliRunner().invoke(
                 app,
@@ -1014,7 +1014,7 @@ class TestEvalModelVariantMatrix:
         specs = [_spec("alpha")]
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _PassRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
             CliRunner().invoke(app, ["eval", "run", "--models", "opus@xhigh,opus@medium"])
@@ -1065,6 +1065,20 @@ class _AllErroredRunner:
         raise Exception(msg)  # noqa: TRY002 — mirrors the SDK's bare-Exception transient
 
 
+class _ZeroCostRunner:
+    """Executes every cell (not skipped, not errored) but meters $0.
+
+    This is the exact fake-green state the benchmark's missing unmetered-$0 guard
+    allowed: ``claude -p`` "ran", graded, but billed nothing — an auth failure or a
+    mid-run quota exhaustion — so the comparison reports $0 across every variant.
+    """
+
+    def __init__(self, *_: object, **__: object) -> None: ...
+
+    def run(self, spec: EvalSpec) -> EvalRun:
+        return _run(spec.name, tool_calls=_PASSING_CALL, cost_usd=0.0)
+
+
 class _BudgetCapturingRunner:
     """Records the ``max_budget_usd`` it was constructed with; passes every scenario."""
 
@@ -1096,7 +1110,7 @@ class TestEvalBenchmark:
         # runs in-process (Docker is the default; the marker breaks the re-route).
         with (
             patch("teatree.cli.eval.benchmark.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.benchmark.SdkInProcessRunner", runner),
+            patch("teatree.eval.backends.SdkInProcessRunner", runner),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
             return CliRunner().invoke(app, ["eval", "benchmark", *args], env={"T3_EVAL_IN_CONTAINER": "1"})
@@ -1206,6 +1220,27 @@ class TestEvalBenchmark:
         result = self._invoke(["--models", "opus@xhigh", "--no-persist"], specs=specs, runner=_AllErroredRunner)
         assert result.exit_code != 0, result.output
 
+    def test_executed_but_unmetered_zero_cost_fails_loud(self) -> None:
+        # Cells executed and graded (not skipped, not errored) yet the lane metered
+        # $0 — the exact fake-green an auth failure / quota exhaustion produces. The
+        # benchmark must fail loud like the single-run lane and the suite, never
+        # report $0 across every variant as a passing comparison.
+        specs = [_spec("alpha"), _spec("beta")]
+        result = self._invoke(["--models", "opus@xhigh", "--no-persist"], specs=specs, runner=_ZeroCostRunner)
+        assert result.exit_code != 0, result.output
+        assert "metered $0.00" in result.output
+
+    def test_unmetered_guard_does_not_fire_when_all_cells_skipped(self) -> None:
+        # The unmetered-$0 guard fires only on GRADED cells that billed nothing.
+        # An all-skipped run legitimately costs $0 — that is the executed() guard's
+        # job (executed 0), not the metered guard's. The two stay distinct: the
+        # all-skipped message, not the "metered $0.00" message.
+        specs = [_spec("alpha")]
+        result = self._invoke(["--models", "opus@xhigh", "--no-persist"], specs=specs, runner=_SkippingRunner)
+        assert result.exit_code != 0, result.output
+        assert "executed 0" in result.output
+        assert "metered $0.00" not in result.output
+
     def test_persists_one_matrix_record_with_variant_tags(self) -> None:
         specs = [_spec("alpha")]
         self._invoke(["--models", "opus@xhigh,fable@medium"], specs=specs)
@@ -1265,7 +1300,7 @@ class TestBenchmarkDockerByDefault:
         with (
             patch.dict("os.environ", {}, clear=True),
             patch("teatree.cli.eval.benchmark.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.benchmark.SdkInProcessRunner", _BenchmarkRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _BenchmarkRunner),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
             patch("teatree.cli.eval.benchmark.run_eval_in_docker") as docker,
         ):
@@ -1278,7 +1313,7 @@ class TestBenchmarkDockerByDefault:
         specs = [_spec("alpha")]
         with (
             patch("teatree.cli.eval.benchmark.discover_specs", return_value=specs),
-            patch("teatree.cli.eval.benchmark.SdkInProcessRunner", _BenchmarkRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _BenchmarkRunner),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
             patch("teatree.cli.eval.benchmark.run_eval_in_docker") as docker,
         ):
@@ -1318,7 +1353,7 @@ class TestMatrixCostRegressionGate:
 
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=[_spec("alpha")]),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _Cheap),
+            patch("teatree.eval.backends.SdkInProcessRunner", _Cheap),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
             CliRunner().invoke(app, ["eval", "run", "--models", model, "--baseline"])
@@ -1331,7 +1366,7 @@ class TestMatrixCostRegressionGate:
 
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=[_spec("alpha")]),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _Spendy),
+            patch("teatree.eval.backends.SdkInProcessRunner", _Spendy),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--models", "opus", "--gate-cost-regression"])
@@ -1342,7 +1377,7 @@ class TestMatrixCostRegressionGate:
         self._cheap_baseline("opus")
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=[_spec("alpha")]),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _CostRunner),
+            patch("teatree.eval.backends.SdkInProcessRunner", _CostRunner),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--models", "opus", "--gate-cost-regression"])
@@ -1356,7 +1391,7 @@ class TestMatrixCostRegressionGate:
 
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=[_spec("alpha")]),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _Cheap),
+            patch("teatree.eval.backends.SdkInProcessRunner", _Cheap),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
             CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--baseline"])
@@ -1366,7 +1401,7 @@ class TestMatrixCostRegressionGate:
 
         with (
             patch("teatree.cli.eval.app.discover_specs", return_value=[_spec("alpha")]),
-            patch("teatree.cli.eval.multi_trial.SdkInProcessRunner", _Spendy),
+            patch("teatree.eval.backends.SdkInProcessRunner", _Spendy),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
             result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--gate-cost-regression"])


### PR DESCRIPTION
Fixes #2328

## What and why

The metered `t3 eval benchmark` and `t3 eval run --trials k` lanes built `SdkInProcessRunner` directly, bypassing `make_runner` — the only non-Docker path that calls `ensure_oauth_token()`. On a host `--local` run, where the OAuth token lives only in `pass` (`anthropic/oauth-token`), not the env, the isolated `claude` child got no credentials and the run reported a zero-cost auth failure. CI hid the bug because `eval.yml` injects `CLAUDE_CODE_OAUTH_TOKEN` as an env var, so the in-container metered lane authenticates regardless of whether `ensure_oauth_token()` ran.

### Fix 1 — single constructor path (the issue)

Route the three direct constructions (`benchmark.py`, and both lanes in `multi_trial.py`) through `make_runner(SDK_BACKEND, …)` so `ensure_oauth_token()` always runs before a metered runner exists. The direct sites only ever passed knobs `make_runner` already exposes (`max_turns_override` / `require_executed` / `max_budget_usd` / `effort`), so no factory change was needed. An AST fitness test (`tests/quality/test_metered_runner_chokepoint.py`) pins that `SdkInProcessRunner` is constructed only inside `teatree.eval.backends`, so the bypass class cannot silently regress.

### Fix 2 — benchmark unmetered-zero-cost fail-loud guard (folded in, same lane)

While in `benchmark.py`: it ran only the all-skipped guard, missing the unmetered-zero-cost guard the single-run lane (`run_modes.RunGuards.sdk_metered`) and the suite (`all._assert_metered_sdk_ai_lane`) both apply. An executed-but-zero-cost benchmark (auth OK but billing nothing, or mid-run quota exhaustion) would report a fake-green zero cost across every variant. Added `RunGuards.sdk_metered_total` (shared with the single-run path through one `UnmeteredSdkRunError` to `typer.Exit` translation) and fire it on genuinely-graded cells only (`not skipped and not errored`) — so an all-errored / all-skipped run stays the `executed()` guard's job and the two guards remain distinct.

## Tests

- `tests/teatree_cli/eval/test_local_auth_resolution.py` (new) — each metered lane calls `ensure_oauth_token` when it builds its runner. RED on the pre-fix direct construction, GREEN after routing through `make_runner` (verified against the unfixed code first).
- `tests/quality/test_metered_runner_chokepoint.py` (new) — AST gate; verified RED by reintroducing a direct construction, GREEN on the fixed tree.
- `tests/teatree_cli/test_eval.py` — `test_executed_but_unmetered_zero_cost_fails_loud` (RED before the guard, GREEN after) plus `test_unmetered_guard_does_not_fire_when_all_cells_skipped` (negative test, keeps the two guards distinct).
- Existing benchmark/multi_trial runner patches retargeted from the lane-local symbol to `teatree.eval.backends.SdkInProcessRunner` (the construction moved to the chokepoint). `tests/quality/test_patch_targets_resolve.py` confirms every retargeted patch string resolves.

No live metered benchmark was run — the auth path is verified purely via mocked auth (no API spend).

## Architecture pre-check — #2328

1. **BLUEPRINT alignment** — eval harness backends; the auth chokepoint is `make_runner(SDK_BACKEND, …)`. Conformance fix to an existing chokepoint, no new section.
2. **FSM phase boundaries** — n/a.
3. **Extension-point contracts** — n/a. `make_runner` returns the `EvalRunner` Protocol; the matrix-loop annotations relaxed from `SdkInProcessRunner` to `EvalRunner`.
4. **Component boundaries** — typer wiring consumes `make_runner`; `RunGuards.sdk_metered_total` sits beside its sibling in `run_modes.py`. No business logic moved.
5. **Dependency direction** — cli to eval, unchanged. `uv run tach check` passes.
6. **Test surface** — see Tests above; the negative test keeps the unmetered and all-skipped guards distinct.
7. **Resilience invariants** — no new external write; `make_runner` is a pure factory and `ensure_oauth_token` no-ops when the env var is set (idempotent).
8. **Identity/key normalization** — n/a.
9. **Behavior preservation** — the three constructions pass exactly the knobs `make_runner` exposes; no knob dropped. Only intended behavior change: `ensure_oauth_token()` now runs before each metered runner, plus the new benchmark fail-loud guard. No must-block test inverted; no matcher narrowed.

## Open questions & assumptions

- **Chokepoint allow-list is `teatree.eval.backends` only.** A future legitimate non-factory construction must widen `_ALLOWED_MODULES` in the chokepoint test deliberately (the test fails loudly otherwise — that is the point).
- **`make_runner` knob set suffices for both lanes.** The pre-fix sites only passed `max_turns_override` / `require_executed` / `max_budget_usd` / `effort`, all already on `make_runner`. No `workspace` was passed (both default to `Path.cwd()`), so no factory extension was needed.
- **Scope of the matrix lane.** `run_model_matrix_lane` already exits non-zero on errored cells but does not yet run the unmetered-zero-cost guard — left out of scope to keep the PR to the benchmark lane the readiness review named; happy to extend if wanted.
- **Docs reviewed.** `src/teatree/eval/README.md` documents `--local` on host for both lanes (now true) and does not document construction internals, so no alignment edit was required.
