### PR TITLE
fix(merge): honor autonomy=full by resolving the carve-out overlay from the recovered repo (not the raw slug)

### DIFF
--- a/src/teatree/core/merge/authorization.py
+++ b/src/teatree/core/merge/authorization.py
@@ -139,7 +139,7 @@ def _assert_clear_authorized(
     if (
         clear.is_substrate()
         and not clear.human_merge_authorized_by(presented)
-        and not _overlay_grants_full_substrate_autonomy(clear)
+        and not _overlay_grants_full_substrate_autonomy(clear, resolved_slug=slug)
     ):
         detail = (
             "no human authoriser recorded on the CLEAR and the overlay autonomy is not full"
@@ -163,25 +163,42 @@ def _assert_clear_authorized(
     return clear
 
 
-def _resolve_clear_overlay_name(clear: "MergeClear") -> str:
+def _resolve_clear_overlay_name(clear: "MergeClear", *, resolved_slug: str = "") -> str:
     """The overlay name to resolve autonomy against for *clear*.
 
-    The CLEAR's ``ticket.overlay`` is authoritative when present, but the loop
-    routinely issues a CLEAR with no linked ticket (every substrate CLEAR in
-    the live ledger). The CLEAR always carries the ``owner/repo`` ``slug``, so
-    the overlay is recovered from it via :func:`infer_overlay_for_url` — the
-    same workspace-repos inference ``ticket.overlay`` itself is populated from.
-    Returns ``""`` when neither source resolves an overlay.
+    Resolution order, first non-empty wins:
+
+    1.  ``clear.ticket.overlay`` — authoritative when the CLEAR carries a
+        linked ticket.
+    2.  :func:`infer_overlay_for_url` on the CLEAR's stored ``slug`` — the same
+        workspace-repos inference ``ticket.overlay`` itself is populated from.
+        This resolves only when the stored slug is an ``owner/repo``.
+    3.  :func:`infer_overlay_for_url` on *resolved_slug* — the real
+        ``owner/repo`` the merge keystone recovered for this CLEAR
+        (:func:`resolve_pr_repo_slug` →
+        :func:`_reconcile_slug_against_reviewed_sha`). The loop routinely
+        issues a ticket-less substrate CLEAR whose stored ``slug`` is a *branch
+        name* (``merge-candidate-working-repos``), not ``owner/repo`` — step 2
+        returns ``""`` for it, so without this step the carve-out resolves the
+        global (babysit) overlay and wrongly refuses a merge the overlay
+        genuinely stands ``full`` for. Threading the merge's already-recovered
+        slug makes the autonomy check resolve the SAME repo the bound merge
+        targets.
+
+    Returns ``""`` when no source resolves an overlay (the fail-closed default).
     """
     from teatree.core.overlay_loader import infer_overlay_for_url  # noqa: PLC0415
 
     overlay_name = str(getattr(getattr(clear, "ticket", None), "overlay", "") or "").strip()
     if overlay_name:
         return overlay_name
-    return infer_overlay_for_url(str(getattr(clear, "slug", "") or "")).strip()
+    from_stored = infer_overlay_for_url(str(getattr(clear, "slug", "") or "")).strip()
+    if from_stored:
+        return from_stored
+    return infer_overlay_for_url(resolved_slug.strip()).strip()
 
 
-def _overlay_grants_full_substrate_autonomy(clear: "MergeClear") -> bool:
+def _overlay_grants_full_substrate_autonomy(clear: "MergeClear", *, resolved_slug: str = "") -> bool:
     """Whether the CLEAR's overlay stands at ``autonomy = full`` (invariant 4 carve-out).
 
     Resolves the effective autonomy for the CLEAR's overlay
@@ -192,10 +209,16 @@ def _overlay_grants_full_substrate_autonomy(clear: "MergeClear") -> bool:
     (``notify`` / ``babysit``), or an unresolvable overlay, is fail-closed:
     the per-CLEAR human authoriser stays mandatory. The carve-out touches ONLY
     the per-PR sign-off — every other substrate-merge floor guard runs unchanged.
+
+    *resolved_slug* is the real ``owner/repo`` the merge keystone recovered for
+    this CLEAR (threaded from :func:`assert_merge_preconditions`'s ``slug``
+    kwarg). It is the recovery source for a ticket-less CLEAR whose stored
+    ``slug`` is a branch name rather than ``owner/repo`` — see
+    :func:`_resolve_clear_overlay_name`.
     """
     from teatree.config import Autonomy, get_effective_settings  # noqa: PLC0415
 
-    overlay_name = _resolve_clear_overlay_name(clear)
+    overlay_name = _resolve_clear_overlay_name(clear, resolved_slug=resolved_slug)
     if not overlay_name:
         return False
     return get_effective_settings(overlay_name=overlay_name).autonomy is Autonomy.FULL

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -623,12 +623,12 @@ def _substrate_clear(ticket: Ticket, **overrides: object) -> MergeClear:
     return MergeClear.objects.create(**defaults)
 
 
-def _assert_preconditions(clear: MergeClear, *, human_authorized: str = "") -> object:
+def _assert_preconditions(clear: MergeClear, *, human_authorized: str = "", slug: str | None = None) -> object:
     with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_stub):
         return assert_merge_preconditions(
             clear=clear,
             executing_loop_identity="merge-loop",
-            slug=clear.slug,
+            slug=clear.slug if slug is None else slug,
             pr_id=clear.pr_id,
             human_authorized=human_authorized,
         )
@@ -776,3 +776,61 @@ class TestFullAutonomyStandingGrantSatisfiesSubstrateSignoff(TestCase):
         clear = _substrate_clear(None, pr_id=1743, slug="unknown-owner/unknown-repo")
         with _overlay_autonomy("t3-teatree", "full"), pytest.raises(MergePreconditionError, match="substrate"):
             _assert_preconditions(clear)
+
+
+class TestBranchSlugClearResolvesOverlayFromRecoveredRepo(TestCase):
+    """A branch-name-slug CLEAR resolves its overlay from the merge's recovered repo.
+
+    The loop issues ticket-less substrate CLEARs whose stored ``slug`` is a
+    *branch name* (``merge-candidate-working-repos``), not ``owner/repo``. The
+    merge keystone recovers the real ``owner/repo`` via
+    ``resolve_pr_repo_slug`` → ``_reconcile_slug_against_reviewed_sha`` and
+    threads it into ``assert_merge_preconditions`` as the ``slug`` kwarg. The
+    autonomy carve-out must resolve its overlay from that recovered slug — not
+    the raw branch-name slug, which maps to no overlay (the global babysit
+    default) and wrongly refuses a merge the overlay genuinely stands ``full``
+    for. Fail-closed is preserved: a branch-slug CLEAR whose recovered repo is
+    NOT full (or unresolvable) still requires the per-PR human authoriser.
+    """
+
+    def test_full_autonomy_branch_slug_passes_via_recovered_repo(self) -> None:
+        """MUST-ALLOW: branch-name slug + recovered owner/repo at full satisfies the sign-off.
+
+        RED before the fix: the carve-out resolved the overlay from the raw
+        branch-name ``slug`` (→ no overlay → babysit) and refused with
+        "the overlay autonomy is not full" despite the recovered repo's overlay
+        standing at full.
+        """
+        clear = _substrate_clear(None, pr_id=1750, slug="merge-candidate-working-repos")
+        with _overlay_autonomy("t3-teatree", "full"):
+            precheck = _assert_preconditions(clear, slug="souliane/teatree")
+        assert precheck is not None
+
+    def test_full_autonomy_branch_slug_without_recovered_repo_still_refused(self) -> None:
+        """MUST-DENY: a branch-name slug with no recovered owner/repo fails closed.
+
+        When the merge cannot recover a real repo (the recovered slug is still
+        the branch name), the overlay is unresolvable — fail-closed: the per-PR
+        human authoriser stays mandatory even under a full overlay.
+        """
+        clear = _substrate_clear(None, pr_id=1751, slug="merge-candidate-working-repos")
+        with _overlay_autonomy("t3-teatree", "full"), pytest.raises(MergePreconditionError, match="substrate"):
+            _assert_preconditions(clear, slug="merge-candidate-working-repos")
+
+    def test_branch_slug_recovered_repo_at_babysit_still_refused(self) -> None:
+        """MUST-DENY: branch slug recovers a real repo, but its overlay is below full.
+
+        The recovery succeeds (the recovered ``owner/repo`` maps to ``t3-teatree``),
+        but the overlay stands at babysit — fail-closed: the carve-out fires only
+        for a genuinely-full overlay, so the per-PR human authoriser stays mandatory.
+        This is the no-silent-widening guard: recovery never lowers the floor.
+        """
+        clear = _substrate_clear(None, pr_id=1752, slug="merge-candidate-working-repos")
+        with _overlay_autonomy("t3-teatree", "babysit"), pytest.raises(MergePreconditionError, match="substrate"):
+            _assert_preconditions(clear, slug="souliane/teatree")
+
+    def test_branch_slug_recovered_repo_maps_to_no_overlay_refused(self) -> None:
+        """MUST-DENY: a branch slug whose recovered repo maps to no overlay fails closed."""
+        clear = _substrate_clear(None, pr_id=1753, slug="merge-candidate-working-repos")
+        with _overlay_autonomy("t3-teatree", "full"), pytest.raises(MergePreconditionError, match="substrate"):
+            _assert_preconditions(clear, slug="unknown-owner/unknown-repo")


### PR DESCRIPTION
## Bug

The substrate-merge `autonomy = full` carve-out was never honored, so every substrate merge demanded a per-PR `--human-authorize` even with the overlay standing at `full`. Root cause: `_overlay_grants_full_substrate_autonomy` resolved the overlay purely from `clear.slug`, but `ticket clear PR_ID SLUG` accepts a short/branch-name slug (e.g. `merge-candidate-working-repos`). `infer_overlay_for_url('<branch-name>')` → `''` → autonomy resolves to the global default (BABYSIT), not the overlay's FULL. Repro: PR #2327's substrate merge was refused "the overlay autonomy is not full" despite `t3 teatree autonomy show` = `full`.

The merge's own repo resolution already *recovers* the real `owner/repo` (cross-repo SHA-bind probe), but the autonomy check ignored it and used the raw stored slug.

## Fix

Thread the already-recovered `owner/repo` slug (available at the `merge_ticket_pr` call site) into `_overlay_grants_full_substrate_autonomy` / `_resolve_clear_overlay_name` as a third resolution step: `clear.ticket.overlay` → `infer_overlay_for_url(clear.slug)` → `infer_overlay_for_url(resolved_slug)`. The autonomy check now resolves the SAME repo the bound merge targets — no duplicate probe.

## Safety — fail-closed preserved (no widening)

The carve-out fires ONLY when a real overlay genuinely stands at `full`. Three MUST-DENY tests pin the floor: branch slug with no recovered repo → refused; recovered repo whose overlay is `babysit` → refused (recovery never lowers the floor); recovered repo mapping to no overlay → refused. All 11 pre-existing carve-out tests (notify/babysit-refused, maker≠checker, SHA-bind, CI-green, not-draft, cross-overlay-no-leak) pass unchanged.

## Anti-vacuous proof

`test_full_autonomy_branch_slug_passes_via_recovered_repo` (branch slug, recovered repo at `full`) goes RED on `origin/main` with the exact production refusal, GREEN after the fix.

## Gates

`ruff check` / `ruff format` / `ty check` / `tach check` all green. Touched suite 134 passed + 25 subtests; full merge suite no regressions. `teatree.core.merge.authorization` branch coverage **100%** (≥93% gate).

## ⚠ Substrate

Touches the merge authorization gate — needs an independent cold review (reviewer ≠ maker) and a `--human-authorize` to merge. This is the last substrate merge needing the per-PR step: once it lands, `autonomy = full` is honored end-to-end.
