### PR TITLE
fix(cli): restore deprecated post-evidence alias + correct stale rename/move references

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -16,7 +16,7 @@ loop_cadence_seconds = 720                 # /loop tick interval (default 12 min
 require_human_approval_to_merge = true     # training-wheel for `auto` overlays: push + PR create autonomous, merge stays gated
 require_human_approval_to_answer = true    # training-wheel: t3:answerer drafts + DMs for approval, posts only on confirm
 on_behalf_post_mode = "draft_or_ask"       # tri-state pre-gate (#960) over colleague-VISIBLE posts; drafts (post-draft-note) are exempt under every mode: draft_or_ask (default) | ask (both BLOCK every colleague-visible action, EXEMPT drafts) | immediate (gate off)
-on_behalf_auto_actions = ["post_e2e_evidence"]  # on-behalf actions that PROCEED even under ask/draft_or_ask (own-ticket self-documentation, not a colleague voice); clear to [] to re-gate E2E evidence
+on_behalf_auto_actions = ["post_e2e_evidence"]  # on-behalf actions that PROCEED even under ask/draft_or_ask (own-ticket self-documentation, not a colleague voice); clear to [] to re-gate test plan
 notify_on_post_on_behalf = true            # DM the user after every on-behalf post (#949)
 user_identity_aliases = []                 # cross-platform handles for the same human (#975/#976); consumed by TicketDispositionScanner + multi-identity scanning
 statusline_chain = []                      # extra statusline scripts (glob patterns) chained after the loop's zones
@@ -181,7 +181,7 @@ below mirrors it; consult the dataclass for type signatures and defaults.
 | `require_human_approval_to_answer` | Training-wheel for `t3:answerer`: drafts + DMs, posts only on confirm |
 | `ask_before_post_on_behalf` | Legacy boolean pre-gate over on-behalf posts (kept for back-compat — prefer `on_behalf_post_mode`) |
 | `on_behalf_post_mode` | Tri-state pre-gate (#960) over colleague-VISIBLE posts: `draft_or_ask` / `ask` / `immediate`, scoped per overlay so a client overlay can stay `ask` while a personal one runs `immediate`. Drafts (`post-draft-note`) are colleague-invisible and exempt under every mode — they never need approval |
-| `on_behalf_auto_actions` | Allowlist of on-behalf actions that PROCEED even under `ask`/`draft_or_ask` (default `["post_e2e_evidence"]`): the user's own-ticket self-documentation, not a colleague-facing voice, so they never need per-post approval. Clear to `[]` to re-gate E2E evidence; env `T3_ON_BEHALF_AUTO_ACTIONS` (comma-separated) wins |
+| `on_behalf_auto_actions` | Allowlist of on-behalf actions that PROCEED even under `ask`/`draft_or_ask` (default `["post_e2e_evidence"]`): the user's own-ticket self-documentation, not a colleague-facing voice, so they never need per-post approval. Clear to `[]` to re-gate test plan; env `T3_ON_BEHALF_AUTO_ACTIONS` (comma-separated) wins |
 | `notify_user_via_bot` | Whether the bot→operator `notify_user(...)` channel (#963) DMs the user via the overlay's Slack bot (out of scope for the on-behalf gates — see config.py for the boundary) |
 | `notify_on_post_on_behalf` | DM the user after every on-behalf post (#949) — per-overlay because noise tolerance differs |
 | `user_identity_aliases` | Per-overlay handles (e.g. different GitHub login on a client overlay), consumed by §5.6 scanners (#975/#976) |

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4659,6 +4659,8 @@ Usage: t3 teatree e2e [OPTIONS] COMMAND [ARGS]...
 │ project         Run E2E tests from the project's own test directory.         │
 │ post-test-plan  Post/update the ticket's single test-plan note (side-by-side │
 │                 Dev|Local test plan) from a manifest.                        │
+│ post-evidence   [Deprecated] Alias for post-test-plan (renamed; kept one     │
+│                 release for back-compat).                                    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -4839,6 +4841,36 @@ Usage: t3 teatree e2e post-test-plan [OPTIONS]
 
  The legacy ``post-evidence`` name is kept as a hidden, deprecated alias
  for one release so existing scripts keep working.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --manifest                                   TEXT                            │
+│ --ticket                                     TEXT                            │
+│ --title                                      TEXT                            │
+│ --mrs                                        TEXT  MR/PR URL(s) the test     │
+│                                                    plan covers (repeat or    │
+│                                                    comma-separate).          │
+│                                                    Supplements the           │
+│                                                    manifest's 'mrs'.         │
+│ --skip-validation    --no-skip-validation          User-authorised bypass of │
+│                                                    the image preflight       │
+│                                                    (red-box / duplicate      │
+│                                                    gates). Not for routine   │
+│                                                    use.                      │
+│                                                    [default:                 │
+│                                                    no-skip-validation]       │
+│ --help                                             Show this message and     │
+│                                                    exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree e2e post-evidence`
+
+```
+Usage: t3 teatree e2e post-evidence [OPTIONS]
+
+ (deprecated)
+ Deprecated alias for ``post-test-plan`` (renamed; kept one release for
+ back-compat).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --manifest                                   TEXT                            │
@@ -5060,6 +5092,8 @@ Usage: t3 teatree pr [OPTIONS] COMMAND [ARGS]...
 │ fetch-issue     Fetch issue details from the configured tracker.             │
 │ detect-tenant   Detect the current tenant variant from the overlay.          │
 │ post-test-plan  Post a test plan as a PR comment.                            │
+│ post-evidence   [Deprecated] Alias for post-test-plan (renamed; kept one     │
+│                 release for back-compat).                                    │
 │ sweep           List your open PRs across the forge for the /t3:sweeping-prs │
 │                 skill.                                                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -5197,6 +5231,27 @@ Usage: t3 teatree pr post-test-plan [OPTIONS] MR_IID
 
  The legacy ``post-evidence`` name is kept as a hidden, deprecated alias
  for one release so existing scripts keep working.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    mr_iid      INTEGER  [required]                                         │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --repo         TEXT                                                          │
+│ --title        TEXT  [default: Test Plan]                                    │
+│ --body         TEXT                                                          │
+│ --files        TEXT                                                          │
+│ --help               Show this message and exit.                             │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree pr post-evidence`
+
+```
+Usage: t3 teatree pr post-evidence [OPTIONS] MR_IID
+
+ (deprecated)
+ Deprecated alias for ``post-test-plan`` (renamed; kept one release for
+ back-compat).
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    mr_iid      INTEGER  [required]                                         │

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -91,6 +91,10 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
                 "post-test-plan",
                 "Post/update the ticket's single test-plan note (side-by-side Dev|Local test plan) from a manifest.",
             ),
+            (
+                "post-evidence",
+                "[Deprecated] Alias for post-test-plan (renamed; kept one release for back-compat).",
+            ),
         ],
     ),
     "db": DjangoGroup(
@@ -117,6 +121,7 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("fetch-issue", "Fetch issue details from the configured tracker."),
             ("detect-tenant", "Detect the current tenant variant from the overlay."),
             ("post-test-plan", "Post a test plan as a PR comment."),
+            ("post-evidence", "[Deprecated] Alias for post-test-plan (renamed; kept one release for back-compat)."),
             ("sweep", "List your open PRs across the forge for the /t3:sweeping-prs skill."),
         ],
     ),

--- a/src/teatree/hooks/terminology_gate.py
+++ b/src/teatree/hooks/terminology_gate.py
@@ -87,7 +87,7 @@ def scan_text(text: str) -> list[tuple[int, TerminologyFinding]]:
 # phrase with its correction).
 _EXEMPT_SUFFIXES: tuple[str, ...] = (
     "src/teatree/hooks/terminology_gate.py",
-    "tests/test_terminology_gate.py",
+    "tests/teatree_hooks/test_terminology_gate.py",
 )
 
 

--- a/tests/teatree_hooks/test_terminology_gate.py
+++ b/tests/teatree_hooks/test_terminology_gate.py
@@ -72,8 +72,15 @@ class TestPathExemption:
     def test_gate_source_is_exempt(self) -> None:
         assert terminology_gate.path_is_exempt("src/teatree/hooks/terminology_gate.py")
 
-    def test_gate_test_is_exempt(self) -> None:
-        assert terminology_gate.path_is_exempt("tests/test_terminology_gate.py")
+    def test_gate_test_old_path_is_not_exempt(self) -> None:
+        # The file moved; the old path must NOT be exempt so it cannot be used
+        # as a bypass by files planted at the stale location.
+        assert not terminology_gate.path_is_exempt("tests/test_terminology_gate.py")
+
+    def test_gate_test_at_moved_path_is_exempt(self) -> None:
+        # The test file moved to tests/teatree_hooks/ — the exempt suffix must
+        # match the real location so the gate does not self-trip on its fixtures.
+        assert terminology_gate.path_is_exempt("tests/teatree_hooks/test_terminology_gate.py")
 
     def test_other_path_is_not_exempt(self) -> None:
         assert not terminology_gate.path_is_exempt("skills/todos/SKILL.md")

--- a/tests/test_cli_overlay_groups.py
+++ b/tests/test_cli_overlay_groups.py
@@ -18,6 +18,14 @@ def _lifecycle_subcommands() -> set[str]:
     return {name for name, _desc in DJANGO_GROUPS["lifecycle"].subcommands}
 
 
+def _e2e_subcommands() -> set[str]:
+    return {name for name, _desc in DJANGO_GROUPS["e2e"].subcommands}
+
+
+def _pr_subcommands() -> set[str]:
+    return {name for name, _desc in DJANGO_GROUPS["pr"].subcommands}
+
+
 def test_ticket_group_exposes_comment() -> None:
     assert "comment" in _ticket_subcommands()
 
@@ -37,3 +45,15 @@ def test_lifecycle_group_exposes_record_review_context() -> None:
 def test_lifecycle_subcommands_map_to_real_command_methods() -> None:
     for name in _lifecycle_subcommands():
         assert hasattr(LifecycleCommand, name.replace("-", "_")), name
+
+
+def test_e2e_group_exposes_deprecated_post_evidence_alias() -> None:
+    # The Django management command defines a hidden deprecated alias
+    # ``post-evidence``; without a bridge entry in DJANGO_GROUPS the alias
+    # is unreachable via ``t3 <overlay> e2e post-evidence``.
+    assert "post-evidence" in _e2e_subcommands()
+
+
+def test_pr_group_exposes_deprecated_post_evidence_alias() -> None:
+    # Same as above for the ``pr`` group.
+    assert "post-evidence" in _pr_subcommands()


### PR DESCRIPTION
## Summary

- FIX 1 (MAJOR): Restore post-evidence entries in DJANGO_GROUPS for both e2e and pr bridge groups.
- FIX 2: Update two stale E2E evidence prose occurrences in docs/blueprint/configuration.md to test plan.
- FIX 3: Update stale _EXEMPT_SUFFIXES entry in terminology_gate.py to the actual moved test file location.

## Test plan

All 24 tests in touched modules pass, ruff/format/skill-refs/mkdocs gates clean.
