### PR TITLE
fix(merge): require exactly-one SHA-matching candidate to close same-SHA ambiguity (#2338)

### DIFF
--- a/src/teatree/core/merge/pr_slug_resolution.py
+++ b/src/teatree/core/merge/pr_slug_resolution.py
@@ -311,14 +311,21 @@ def _reconcile_slug_against_reviewed_sha(
     slug's PR head SHA matches *reviewed_sha* the merge proceeds against
     it unchanged (the common path). When the SHAs disagree, the same
     PR number may live in a downstream overlay's repo at the right SHA;
-    the probe enumerates :func:`_iter_candidate_repo_slugs` and returns
-    the first candidate whose ``pulls/<N>`` head matches.
+    the probe enumerates :func:`_iter_candidate_repo_slugs` and recovers
+    the candidate whose ``pulls/<N>`` head matches — requiring EXACTLY ONE.
 
     No reviewed SHA, no probe (back-compat with legacy callers that did
     not carry the SHA). No candidate match raises a
     :class:`MergePreconditionError` whose message names every candidate
     considered so the diagnosis is unambiguous — never the opaque "head
     moved" escalation that hid the #1335 bug.
+
+    More than one candidate matching *reviewed_sha* is the #2338 same-SHA
+    ambiguity: two distinct repos (a fork/mirror, or an overlay working-repo
+    aliasing another) both expose PR <pr_id> at the reviewed SHA, so binding
+    to whichever was probed first would merge an unverified twin. That case
+    raises a :class:`MergePreconditionError` naming every ambiguous repo —
+    the gate never silently picks one.
     """
     if not reviewed_sha:
         return initial_slug
@@ -337,13 +344,27 @@ def _reconcile_slug_against_reviewed_sha(
     # The initial slug was already probed above — exclude it from the secondary
     # set so the candidates list in the error message reflects what was probed.
     other_candidates = [c for c in candidates if c != initial_slug]
-    match = _probe_candidate_repos(
+    matches = _probe_candidate_repos(
         pr_id=pr_id,
         reviewed_sha=reviewed_sha,
         candidates=other_candidates,
         host_kind=host_kind,
     )
-    if match:
+    if len(matches) > 1:
+        # #2338: a same-SHA multi-match is an ambiguity the merge gate must
+        # never resolve silently — binding to ``matches[0]`` could merge an
+        # unverified fork/mirror twin. Fail loud, naming every ambiguous repo.
+        msg = (
+            f"ambiguous merge candidate for PR #{pr_id}: {len(matches)} distinct "
+            f"repos expose PR #{pr_id} at the reviewed SHA {reviewed_sha} — "
+            f"{matches}. The merge gate refuses to pick one silently (a fork / "
+            f"mirror, or an overlay working-repo aliasing another, could shadow "
+            f"the reviewed work). Re-issue the CLEAR with an explicit owner/repo "
+            f"slug naming the intended repo (§17.4.3 step 2 / #2338)."
+        )
+        raise MergePreconditionError(msg)
+    if matches:
+        match = matches[0]
         logger.info(
             "merge_execution: cross-repo recovery for #%s — initial slug %r "
             "live=%s != reviewed=%s; probed %s, matched %r",
@@ -375,16 +396,23 @@ def _probe_candidate_repos(
     reviewed_sha: str,
     candidates: list[str],
     host_kind: str,
-) -> str:
-    """Return the candidate ``owner/repo`` whose PR <pr_id> head == *reviewed_sha*.
+) -> list[str]:
+    """Every candidate ``owner/repo`` whose PR <pr_id> head == *reviewed_sha* (#2338).
 
-    Iterates candidates in order and returns the first whose live head
-    SHA matches *reviewed_sha* — the #1335 recovery path: when the
-    initially-resolved repo's PR is an unrelated same-numbered PR, this
-    finds the repo that actually owns the reviewed work. Returns ``""``
-    when no candidate matches (a real force-push or a truly stale CLEAR).
+    Probes **all** candidates and returns the full list of those whose live
+    head SHA matches *reviewed_sha* — the #1335 recovery path enumerates the
+    repos that could own the reviewed work, and the caller requires EXACTLY
+    ONE to match. Returning every match (not just the first) is what lets the
+    caller detect a same-SHA ambiguity: when two distinct candidate repos
+    (a fork/mirror, or an overlay working-repo that aliases another) both
+    expose PR <pr_id> at the same reviewed SHA, binding silently to whichever
+    was probed first would merge an unverified twin. The list lets the caller
+    raise instead, naming every ambiguous repo.
+
+    The per-candidate swallow-failures contract is preserved: a probe error
+    surfaces as an empty head from :func:`fetch_live_head_sha`, which never
+    equals *reviewed_sha*, so a failing candidate is simply absent from the
+    matches — never counted, never raising on its own. Returns ``[]`` when no
+    candidate matches (a real force-push or a truly stale CLEAR).
     """
-    for slug in candidates:
-        if fetch_live_head_sha(slug, pr_id, host_kind=host_kind) == reviewed_sha:
-            return slug
-    return ""
+    return [slug for slug in candidates if fetch_live_head_sha(slug, pr_id, host_kind=host_kind) == reviewed_sha]

--- a/tests/teatree_core/test_merge_same_sha_candidate_ambiguity.py
+++ b/tests/teatree_core/test_merge_same_sha_candidate_ambiguity.py
@@ -1,0 +1,202 @@
+"""Same-SHA multi-candidate ambiguity must fail loud, never silently bind (#2338).
+
+The #1335 cross-repo probe (``_probe_candidate_repos``) recovers the repo whose
+PR #N head matches the reviewed SHA when the initially-resolved repo's PR is an
+unrelated same-numbered PR. The #2327 candidate-set widening (overlay
+working-repos) made it possible for TWO distinct candidate repos to expose PR #N
+at the SAME reviewed SHA — a fork/mirror, or a working-repo aliasing another. The
+pre-fix probe returned the FIRST match, so the merge silently bound to whichever
+was probed first, merging a potentially-unverified twin.
+
+The fix collects EVERY candidate whose PR #N head matches the reviewed SHA and
+requires EXACTLY ONE: a multi-match raises a :class:`MergePreconditionError`
+naming every ambiguous repo, never silently picks the first. The #1335
+different-SHA guard (a same-numbered PR at the WRONG SHA still raises, naming
+candidates) and the best-effort per-candidate swallow contract are preserved.
+
+The concrete repo names are neutral placeholders — core/tests stay
+overlay-agnostic (BLUEPRINT § 1). Only the forge subprocess (the network
+boundary) is stubbed; the candidate enumeration and reconciliation run through
+real teatree code.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.merge import MergePreconditionError, pr_slug_resolution
+
+pytestmark = pytest.mark.django_db
+
+_REVIEWED_SHA = "a" * 40  # the reviewed SHA carried by the CLEAR
+_WRONG_SHA = "b" * 40  # an unrelated same-numbered PR at the wrong SHA
+_PR_ID = 159
+
+_INITIAL_SLUG = "souliane/teatree"  # the clone-origin (wrong) repo, probed first
+_REPO_ONE = "downstream-org/downstream-overlay"
+_REPO_TWO = "mirror-org/downstream-overlay-fork"
+
+
+def _head_by_repo(matching: set[str]):
+    """A ``fetch_live_head_sha`` stub returning the reviewed SHA for *matching* repos.
+
+    Every repo in *matching* exposes PR #N at ``_REVIEWED_SHA``; every other repo
+    exposes it at ``_WRONG_SHA``. Which repo "owns" the reviewed work is decided
+    purely by membership in *matching*, so a same-SHA ambiguity is modelled by
+    putting two repos in the set.
+    """
+
+    def _fetch(slug: str, pr_id: int, *, host_kind: str = "github") -> str:
+        del pr_id, host_kind
+        return _REVIEWED_SHA if slug in matching else _WRONG_SHA
+
+    return _fetch
+
+
+class TestSameShaMultiCandidateRaises(TestCase):
+    """#2338: two candidates at the SAME reviewed SHA → raise naming both."""
+
+    def test_probe_returns_every_matching_candidate(self) -> None:
+        """The probe collects ALL matches, not just the first (the unit contract).
+
+        This is the assertion that goes RED on the pre-fix code: the old probe
+        returned a single ``str`` (the first match), so it could never surface
+        the second matching repo. Collecting every match is what lets the caller
+        detect the ambiguity.
+        """
+        with patch(
+            "teatree.core.merge.pr_slug_resolution.fetch_live_head_sha",
+            side_effect=_head_by_repo({_REPO_ONE, _REPO_TWO}),
+        ):
+            matches = pr_slug_resolution._probe_candidate_repos(
+                pr_id=_PR_ID,
+                reviewed_sha=_REVIEWED_SHA,
+                candidates=[_REPO_ONE, _REPO_TWO],
+                host_kind="github",
+            )
+
+        assert matches == [_REPO_ONE, _REPO_TWO], (
+            f"probe must return every candidate whose head matches the reviewed SHA; got {matches!r}"
+        )
+
+    def test_reconcile_raises_naming_every_ambiguous_repo(self) -> None:
+        """Two candidate repos at the reviewed SHA → reconciliation RAISES naming both.
+
+        This is the #2338 must-raise: the initial (clone-origin) repo's PR #N is
+        at the wrong SHA, and TWO distinct candidate repos expose PR #N at the
+        reviewed SHA. The pre-fix code silently returned the first; the fix
+        refuses, naming every ambiguous repo so the operator can re-issue an
+        explicit-slug CLEAR.
+        """
+        with (
+            patch(
+                "teatree.core.merge.pr_slug_resolution.fetch_live_head_sha",
+                side_effect=_head_by_repo({_REPO_ONE, _REPO_TWO}),
+            ),
+            patch(
+                "teatree.core.merge.pr_slug_resolution._iter_candidate_repo_slugs",
+                return_value=[_INITIAL_SLUG, _REPO_ONE, _REPO_TWO],
+            ),
+            pytest.raises(MergePreconditionError) as exc,
+        ):
+            pr_slug_resolution._reconcile_slug_against_reviewed_sha(
+                initial_slug=_INITIAL_SLUG,
+                pr_id=_PR_ID,
+                reviewed_sha=_REVIEWED_SHA,
+                host_kind="github",
+            )
+
+        message = str(exc.value)
+        assert _REPO_ONE in message, f"ambiguity error must name the first matching repo; got: {message}"
+        assert _REPO_TWO in message, f"ambiguity error must name the second matching repo; got: {message}"
+        assert "ambiguous" in message.lower()
+
+
+class TestSingleMatchHappyPathPreserved(TestCase):
+    """Regression: exactly one candidate at the reviewed SHA still resolves."""
+
+    def test_probe_returns_the_single_match(self) -> None:
+        with patch(
+            "teatree.core.merge.pr_slug_resolution.fetch_live_head_sha",
+            side_effect=_head_by_repo({_REPO_ONE}),
+        ):
+            matches = pr_slug_resolution._probe_candidate_repos(
+                pr_id=_PR_ID,
+                reviewed_sha=_REVIEWED_SHA,
+                candidates=[_REPO_ONE, _REPO_TWO],
+                host_kind="github",
+            )
+
+        assert matches == [_REPO_ONE]
+
+    def test_reconcile_recovers_the_single_matching_repo(self) -> None:
+        """One candidate matches the reviewed SHA → reconciliation returns it (no raise)."""
+        with (
+            patch(
+                "teatree.core.merge.pr_slug_resolution.fetch_live_head_sha",
+                side_effect=_head_by_repo({_REPO_ONE}),
+            ),
+            patch(
+                "teatree.core.merge.pr_slug_resolution._iter_candidate_repo_slugs",
+                return_value=[_INITIAL_SLUG, _REPO_ONE, _REPO_TWO],
+            ),
+        ):
+            resolved = pr_slug_resolution._reconcile_slug_against_reviewed_sha(
+                initial_slug=_INITIAL_SLUG,
+                pr_id=_PR_ID,
+                reviewed_sha=_REVIEWED_SHA,
+                host_kind="github",
+            )
+
+        assert resolved == _REPO_ONE
+
+
+class TestDifferentShaGuardPreserved(TestCase):
+    """Regression: the #1335 different-SHA guard still raises, naming candidates."""
+
+    def test_probe_returns_empty_when_no_candidate_matches(self) -> None:
+        with patch(
+            "teatree.core.merge.pr_slug_resolution.fetch_live_head_sha",
+            side_effect=_head_by_repo(set()),
+        ):
+            matches = pr_slug_resolution._probe_candidate_repos(
+                pr_id=_PR_ID,
+                reviewed_sha=_REVIEWED_SHA,
+                candidates=[_REPO_ONE, _REPO_TWO],
+                host_kind="github",
+            )
+
+        assert matches == []
+
+    def test_reconcile_raises_head_moved_naming_candidates(self) -> None:
+        """No candidate carries the reviewed SHA → the #1335 'head moved' raise.
+
+        The initial repo's PR #N and both candidates are all at the WRONG SHA;
+        the gate must still fail loud (a real force-push or a stale CLEAR),
+        naming every candidate considered — never silently binding a
+        same-numbered PR that does not carry the reviewed work.
+        """
+        with (
+            patch(
+                "teatree.core.merge.pr_slug_resolution.fetch_live_head_sha",
+                side_effect=_head_by_repo(set()),
+            ),
+            patch(
+                "teatree.core.merge.pr_slug_resolution._iter_candidate_repo_slugs",
+                return_value=[_INITIAL_SLUG, _REPO_ONE, _REPO_TWO],
+            ),
+            pytest.raises(MergePreconditionError) as exc,
+        ):
+            pr_slug_resolution._reconcile_slug_against_reviewed_sha(
+                initial_slug=_INITIAL_SLUG,
+                pr_id=_PR_ID,
+                reviewed_sha=_REVIEWED_SHA,
+                host_kind="github",
+            )
+
+        message = str(exc.value)
+        assert "PR head moved" in message
+        assert _INITIAL_SLUG in message
+        assert _REPO_ONE in message
+        assert _REPO_TWO in message


### PR DESCRIPTION
## ⚠ Substrate — independent cold review + `--human-authorize` required to merge

This change touches the §17.4.3 **merge gate** (`teatree.core.merge.pr_slug_resolution`). Per the blast-radius rule it is draft-locked: it needs an independent cold review (reviewer ≠ maker) and a recorded human sign-off to merge. **Do not merge on CI-green alone.**

Fixes #2338.

## Summary

`_probe_candidate_repos` in `src/teatree/core/merge/pr_slug_resolution.py` returned the **first** candidate repo whose PR `#N` head matched the reviewed SHA. The #1335 guard rejects a same-numbered PR at a *different* SHA, but the #2327 widening of the candidate set (overlay working-repos) made it possible for **two distinct candidate repos** to expose PR `#N` at the **same** reviewed SHA — a fork/mirror, or a working-repo aliasing another. The merge then bound silently to whichever was probed first, merging a potentially-unverified twin.

### The fix

- `_probe_candidate_repos` now **collects every** candidate whose PR `#N` head matches the reviewed SHA and returns the full list.
- `_reconcile_slug_against_reviewed_sha` requires **exactly one** match: a multi-match raises a `MergePreconditionError` **naming every ambiguous repo**, never silently picks the first. The remedy is an explicit `owner/repo` slug on the re-issued CLEAR.

### Invariants preserved

- The #1335 **different-SHA guard** still raises, naming every candidate considered (a same-numbered PR at the wrong SHA never binds).
- The **single-match recovery path** is unchanged.
- The **best-effort per-candidate swallow** contract holds — a probe error surfaces as an empty head, which never equals the reviewed SHA, so a failing candidate is simply absent from the matches (never counted, never raising on its own). A genuine multi-match is **not** swallowed — it raises.

## Anti-vacuity evidence

The new must-raise regression test (`test_reconcile_raises_naming_every_ambiguous_repo`) was verified **RED on `origin/main`**: the pre-fix probe silently returns the first match and does not raise. With the fix it goes green. The #1335 different-SHA guard and the single-match happy path stay green throughout.

- New test file: `tests/teatree_core/test_merge_same_sha_candidate_ambiguity.py` (6 tests).
- Existing `test_merge_execution_cross_repo.py` / `test_merge_candidate_working_repos.py` / `test_merge_repo_resolution.py` stay green (no #1335 / #2323 regression).

## Gates

- `uv run ruff check` — passed
- `uv run ruff format --check` — 2 files already formatted
- `uv run ty check` — All checks passed
- `uv run tach check` — All modules validated
- `uv run pytest --no-cov` on the merge module — 430 passed
- Branch coverage of `teatree.core.merge.pr_slug_resolution`: **95.12%** (≥93%)

## Architecture pre-check — #2338

**1. BLUEPRINT § alignment** — §17.4.3 SHA-bind merge gate; the cross-repo probe (`get_merge_candidate_repo_slugs`, #2323 / §6). Tightens the probe's resolution contract to require exactly-one SHA-matching candidate. Docstrings updated in-file; no BLUEPRINT prose contradicted.

**2. FSM phase boundaries** — n/a; no `Ticket.State` / `Worktree.State` transition. Hardens a guard that runs before the IN_REVIEW → MERGED keystone.

**3. Extension-point contracts** — consumes `OverlayBase.get_merge_candidate_repo_slugs()` read-only (unchanged) and `fetch_live_head_sha` (CodeHostBackend, unchanged). `_probe_candidate_repos` is module-private; its only caller is `_reconcile_slug_against_reviewed_sha`. No Protocol/scanner/hook surface change.

**4. Component boundaries** — entirely within `src/teatree/core/merge/pr_slug_resolution.py`, the existing home of the resolver and the #1335 guard. No new module.

**5. Dependency direction** — no new imports; reuses `MergePreconditionError` and `fetch_live_head_sha`. `tach check` green.

**6. Test surface** — must-raise (multi-match → raise naming both, unit + reconcile level), single-match regression, #1335 different-SHA regression, empty-no-match regression. Each pins an observable contract.

**7. Resilience invariants** — the probe is a read path; the mutation it gates (squash merge) is unchanged and keeps its §17.4.3 SHA-bind / idempotency invariants. The new multi-match raise is fail-loud — the correct posture for an ambiguity a merge gate must never resolve silently. Per-candidate swallow preserved.

**8. Identity and key normalization** — candidate slugs are already canonicalized up to `owner/repo` by `normalize_repo_slug` at the enumeration boundary; de-dup keeps the set unique by slug, so a multi-match means two genuinely distinct repos. No strip/split introduced; comparison stays on the fully-qualified slug.

**9. Behavior preservation / capability deletion** — preserved: no-match → `[]` (→ #1335 raise), exactly-one → recover, per-candidate probe error → swallowed. Changed (the fix, not a deletion): >1 match → was a silent first-pick, now raises naming all. Strengthening of the gate, not a narrowing of a privacy/security matcher. No must-block test inverted to must-not-block.
