### PR TITLE
fix(hooks): scope banned-terms posting gate to public-surface targets

### DIFF
--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -9,19 +9,29 @@ what its issues/PRs are supposed to carry.
 :func:`resolve_publish_destination` extracts the target repo/namespace
 from the COMMAND ITSELF (the ``--repo``/``-R`` flag, the ``api`` URL path,
 or the cwd git remote) and :func:`is_public_destination` classifies THAT
-resolved target FAIL-CLOSED: a destination is PUBLIC (gate scans/blocks)
-UNLESS it is PROVABLY internal -- its namespace matches the CONFIG-DRIVEN
-``[teatree] internal_publish_namespaces`` allowlist (or the
-``T3_INTERNAL_PUBLISH_NAMESPACES`` env var), the ``[teatree] private_repos``
-allowlist, or the day-cached ``gh``/``glab`` live-visibility probe (the same
-fallback the private-repo carve-out applies to its command-resolved target).
-Resolving visibility from the command's target rather than the harness cwd
-is what lets a post FROM a public clone TO a provably-private repo skip the
-public-leak scan instead of over-blocking. With no allowlist configured and
-no probe-resolvable target, every destination stays PUBLIC, so behaviour is
-UNCHANGED for unconfigured users. An unresolvable destination is PUBLIC
-(scan). :func:`gate_skips_destination` is the composed predicate the gates
-call.
+resolved target FAIL-CLOSED against an INTERNAL DENYLIST: a destination is
+PUBLIC (gate scans/blocks) UNLESS it is PROVABLY internal -- its namespace
+matches the config-driven ``[teatree] internal_publish_namespaces`` allowlist
+(or the ``T3_INTERNAL_PUBLISH_NAMESPACES`` env var), the
+``[teatree] private_repos`` allowlist, or the day-cached ``gh``/``glab``
+live-visibility probe returns a CONFIRMED-PRIVATE verdict. Every OTHER target
+-- a genuinely-public non-teatree repo (a user's other public repos), a
+third-party repo, an UNKNOWN-visibility target, or an UNRESOLVABLE target --
+stays PUBLIC and is SCANNED. This is the only safe default: an allowlist of
+"surfaces to scan" would fail OPEN on a public repo nobody remembered to list,
+leaking an internal term unscanned onto a public surface. Resolving the target
+from the command rather than the harness cwd is what lets a post FROM a public
+clone TO a provably-private repo skip the public-leak scan instead of
+over-blocking. With nothing configured and no probe-resolvable private verdict,
+every destination stays PUBLIC, so behaviour is conservative for unconfigured
+users. :func:`gate_skips_destination` is the composed predicate the gates call.
+
+The hook process is overlay-agnostic and cannot import ``OverlayConfig``; it
+reads the internal denylist from ``~/.teatree.toml`` DIRECTLY (the
+``internal_publish_namespaces`` / ``private_repos`` readers in
+:mod:`teatree.hooks._repo_visibility` and this module). The canonical public
+teatree repo needs no entry -- it is public, so the fail-closed default already
+scans it.
 
 The shared command-parsing helpers (``_extract_repo_flag``, the
 eligible-verb sets) live in :mod:`teatree.hooks.publish_surface` and the
@@ -312,20 +322,15 @@ def _segment_is_skip_inert(words: list[str]) -> bool:
     return rest[0] in _SKIP_INERT_LEADERS and _segment_is_publish_inert(words)
 
 
-def _internal_publish_namespaces(config_path: Path | None = None) -> list[str]:
-    """Return the ``[teatree] internal_publish_namespaces`` allowlist (lower-cased).
+def _teatree_list_setting(key: str, env_var: str, config_path: Path | None) -> list[str]:
+    """Return a ``[teatree] <key>`` list unioned with ``<env_var>`` (lower-cased).
 
-    The list of host/namespace prefixes that are PROVABLY internal. Read
-    from the ``T3_INTERNAL_PUBLISH_NAMESPACES`` env var first (comma- or
-    space-separated, for a quick per-session override), then the
-    ``[teatree] internal_publish_namespaces`` key in ``~/.teatree.toml``.
-    DEFAULT is empty -- every destination stays PUBLIC, so behaviour is
-    unchanged for users who have not configured the allowlist.
-
-    No real company/customer namespace is hardcoded here; the allowlist
-    lives only in the user's private config / env.
+    The env var (comma- or space-separated) supplements the TOML list, mirroring
+    the established ``internal_publish_namespaces`` / ``T3_INTERNAL_PUBLISH_NAMESPACES``
+    shape. Reads the TOML directly (no Django/config import) to stay importable
+    from the hook process.
     """
-    env_raw = os.environ.get("T3_INTERNAL_PUBLISH_NAMESPACES", "")
+    env_raw = os.environ.get(env_var, "")
     env_entries = [e.strip().lower() for e in re.split(r"[,\s]+", env_raw) if e.strip()]
 
     import tomllib  # noqa: PLC0415
@@ -338,10 +343,26 @@ def _internal_publish_namespaces(config_path: Path | None = None) -> list[str]:
         except (OSError, ValueError):
             raw = {}
         teatree = raw.get("teatree", {}) if isinstance(raw, dict) else {}
-        entries = teatree.get("internal_publish_namespaces", []) if isinstance(teatree, dict) else []
+        entries = teatree.get(key, []) if isinstance(teatree, dict) else []
         if isinstance(entries, list):
             toml_entries = [str(e).strip().lower() for e in entries if str(e).strip()]
     return env_entries + toml_entries
+
+
+def _internal_publish_namespaces(config_path: Path | None = None) -> list[str]:
+    """Return the ``[teatree] internal_publish_namespaces`` denylist (lower-cased).
+
+    The list of host/namespace prefixes that are PROVABLY internal. Read
+    from the ``T3_INTERNAL_PUBLISH_NAMESPACES`` env var first (comma- or
+    space-separated, for a quick per-session override), then the
+    ``[teatree] internal_publish_namespaces`` key in ``~/.teatree.toml``.
+    DEFAULT is empty -- with nothing configured every destination stays PUBLIC
+    (scanned), so behaviour is conservative for unconfigured users.
+
+    No real company/customer namespace is hardcoded here; the denylist lives
+    only in the user's private config / env.
+    """
+    return _teatree_list_setting("internal_publish_namespaces", "T3_INTERNAL_PUBLISH_NAMESPACES", config_path)
 
 
 def is_public_destination(dest: Destination | None, *, config_path: Path | None = None) -> bool:
@@ -352,32 +373,32 @@ def is_public_destination(dest: Destination | None, *, config_path: Path | None 
     of these resolves its slug to private:
 
     - the ``[teatree] internal_publish_namespaces`` /
-        ``T3_INTERNAL_PUBLISH_NAMESPACES`` allowlist, as a case-insensitive
+        ``T3_INTERNAL_PUBLISH_NAMESPACES`` denylist, as a case-insensitive
         prefix-SEGMENT match (``internalcorp`` matches ``internalcorp/svc``
         and ``host/internalcorp/svc`` but not ``other/internalcorp-public``);
     - the existing ``[teatree] private_repos`` allowlist that the
         commit / pure-post carve-out already consults
-        (:func:`_repo_visibility.slug_is_allowlisted_private`, a
-        case-insensitive path-SEGMENT-prefix match), so a user's CURRENT
-        ``private_repos`` config makes their private namespaces skip the
-        public-leak scan without maintaining a second allowlist;
+        (:func:`_repo_visibility.slug_is_allowlisted_private`), so a user's
+        CURRENT ``private_repos`` config makes their private namespaces skip the
+        public-leak scan without maintaining a second list;
     - the day-cached ``gh``/``glab`` live-visibility probe
-        (:func:`_repo_visibility.slug_is_private`), the same fallback the
-        commit / pure-post carve-out (:func:`publish_surface.segment_target_is_private`)
-        already applies to its command-resolved target. Resolving visibility
-        from the COMMAND's target slug (the ``--repo``/``-R`` flag, the
-        ``api`` URL path, or the cwd remote) rather than the harness cwd is
-        what lets a post FROM a public clone TO a provably-private repo skip
-        the public-leak scan instead of over-blocking. The probe returns
-        ``None`` (unknown -- tool absent in-hook or auth differs) for an
-        unresolvable target, which stays PUBLIC.
+        (:func:`_repo_visibility.slug_is_private`) returning a CONFIRMED-PRIVATE
+        verdict. Resolving visibility from the COMMAND's target slug (the
+        ``--repo``/``-R`` flag, the ``api`` URL path, or the cwd remote) rather
+        than the harness cwd is what lets a post FROM a public clone TO a
+        provably-private repo skip the public-leak scan instead of over-blocking.
+        The probe returns ``None`` (unknown -- tool absent in-hook or auth
+        differs) for an unresolvable target, which stays PUBLIC.
 
-    A ``None`` destination (unresolvable target) is PUBLIC, a slug carrying an
-    unexpanded shell variable (``$``) is PUBLIC unconditionally (its runtime
-    value is unknowable, so neither allowlist nor probe can PROVE anything
-    about the repo the expanded command will actually hit), and a probe that
-    cannot prove the target private leaves it PUBLIC -- detection failure
-    never weakens the gate.
+    Every OTHER target stays PUBLIC and is SCANNED: a genuinely-public
+    non-teatree repo (a user's other public repos), a third-party repo, an
+    UNKNOWN-visibility target, a ``None`` destination (unresolvable target), an
+    empty slug, and a slug carrying an unexpanded shell variable (``$``, runtime
+    value unknowable). The public-surface default is fail-closed because an
+    allowlist of "surfaces to scan" would fail OPEN on a public repo nobody
+    remembered to list, leaking an internal term unscanned onto a public surface.
+    A probe that cannot prove the target private leaves it PUBLIC -- detection
+    failure never weakens the gate.
     """
     if dest is None:
         return True

--- a/tests/teatree_hooks/test_banned_terms_hook.py
+++ b/tests/teatree_hooks/test_banned_terms_hook.py
@@ -852,3 +852,115 @@ def test_kill_switch_default_on_still_blocks_a_public_post(
 
     assert blocked is True
     assert json.loads(captured.out)["permissionDecision"] == "deny"
+
+
+# ── #1415 internal-denylist scoping (fail-closed) ────────────────────────────
+#
+# The reported over-block fired on a publish to a PRIVATE internal remote the
+# user had not declared. The fix is config-driven and FAIL-CLOSED: a target named
+# in ``internal_publish_namespaces`` (the denylist) SKIPS the scan, while EVERY
+# non-internal target -- the public teatree repo, a USER-OWNED non-teatree PUBLIC
+# repo, an unknown/unresolvable target -- still SCANS. An allowlist of "surfaces
+# to scan" would fail OPEN on a public repo nobody listed and leak unscanned.
+
+_DENYLIST_CONFIG = '[teatree]\nbanned_terms = ["customercorp"]\ninternal_publish_namespaces = ["internal-eng"]\n'
+
+
+def test_live_hook_allows_customer_term_to_denylisted_internal_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # MUST-NOT-FIRE (the reported over-block, fixed via the denylist): a banned
+    # term in a publish to a PRIVATE internal GitLab namespace named in
+    # ``internal_publish_namespaces`` is ALLOWED -- it is provably internal.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _DENYLIST_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+    monkeypatch.delenv("GH_REPO", raising=False)
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'glab mr note 5 --repo internal-eng/internal-product --message "customercorp note"'},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is False
+    assert captured.out == ""  # no deny JSON
+
+
+def test_live_hook_blocks_customer_term_to_user_owned_non_teatree_public_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # F3 / MUST-FIRE (the leak path the review caught): a USER-OWNED non-teatree
+    # PUBLIC repo (e.g. a blog repo) is NOT in the denylist and the probe confirms
+    # it PUBLIC, so a banned term toward it must STILL hard-block. Reverting the
+    # fail-closed default (treating non-denylisted as skip) makes this go RED.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _DENYLIST_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+    monkeypatch.delenv("GH_REPO", raising=False)
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue create --repo ourorg/other-public-repo --body "customercorp leak"'},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is True
+    decision = json.loads(captured.out)
+    assert decision["permissionDecision"] == "deny"
+
+
+def test_live_hook_blocks_customer_term_to_unknown_visibility_non_denylisted_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # MUST-FIRE: a non-denylisted target whose visibility the in-hook probe cannot
+    # resolve (the common cold-hook state) stays PUBLIC and is scanned -- detection
+    # failure never opens the gate.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _DENYLIST_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+    monkeypatch.delenv("GH_REPO", raising=False)
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue create --repo someowner/mystery --body "customercorp note"'},
+        "cwd": str(_public_clone(tmp_path)),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is True
+    decision = json.loads(captured.out)
+    assert decision["permissionDecision"] == "deny"
+
+
+def test_live_hook_scans_unresolvable_target_failsafe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # FAIL-SAFE: a publish whose target cannot be resolved from the command (a
+    # flagless create whose cwd has NO git remote -> destination None) keeps
+    # scanning and blocks the term. An unparsable target is never a silent bypass.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _DENYLIST_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+    monkeypatch.delenv("GH_REPO", raising=False)
+
+    no_remote = tmp_path / "no-remote"
+    no_remote.mkdir()
+    _git(no_remote, "init", "-b", "main")
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": 'gh issue create --body "customercorp leak"'},
+        "cwd": str(no_remote),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
+    assert blocked is True
+    decision = json.loads(captured.out)
+    assert decision["permissionDecision"] == "deny"

--- a/tests/teatree_hooks/test_publish_destination.py
+++ b/tests/teatree_hooks/test_publish_destination.py
@@ -388,3 +388,55 @@ class TestGateSkipsDestination:
         monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: True)
         cmd = 'glab api --method PUT "projects/$opp/merge_requests/7562" --input /tmp/body.json'
         assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+
+
+class TestInternalDenylistScoping:
+    """#1415 fix: SCAN by default; SKIP only a PROVABLY-internal target (denylist).
+
+    The original over-block fired on a publish to a PRIVATE internal remote the
+    user had not declared. The fix is config-driven: with the user's internal
+    namespace in ``internal_publish_namespaces`` (the denylist), that internal
+    target SKIPS, while EVERY non-internal target -- a genuinely-public
+    non-teatree repo, an unknown target, an unresolvable target -- still SCANS.
+    The classifier stays FAIL-CLOSED so no public surface can leak unscanned.
+    """
+
+    def test_denylisted_internal_target_skips(self, tmp_path: Path) -> None:
+        # MUST-NOT-FIRE: the reported over-block, fixed via the denylist. A
+        # private internal namespace named in ``internal_publish_namespaces`` is
+        # provably internal, so the gate skips.
+        cfg = _config(tmp_path, ["internal-eng"])
+        cmd = 'glab mr note 5 -R internal-eng/internal-product --message "customercorp note"'
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+
+    def test_user_owned_non_teatree_public_repo_is_scanned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # F3 (the leak path the review caught): a USER-OWNED non-teatree PUBLIC
+        # repo (e.g. a blog repo) is NOT in the denylist and the probe confirms it
+        # PUBLIC, so it must SCAN. A fail-open allowlist would have skipped it and
+        # leaked an internal term onto a public surface.
+        cfg = _config(tmp_path, ["internal-eng"])
+        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        dest = publish_destination.Destination(slug="ourorg/other-public-repo", via="flag")
+        assert publish_destination.is_public_destination(dest, config_path=cfg) is True
+        cmd = 'gh issue create -R ourorg/other-public-repo --body "customercorp leak"'
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+
+    def test_unknown_visibility_non_denylisted_target_is_scanned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # MUST-FIRE: a target not in the denylist whose visibility the in-hook
+        # probe cannot resolve (the common cold-hook state) stays PUBLIC and is
+        # scanned -- detection failure never opens the gate.
+        cfg = _config(tmp_path, ["internal-eng"])
+        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        cmd = 'gh issue create -R someowner/mystery --body "customercorp note"'
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+
+    def test_unresolvable_target_is_scanned_failsafe(self, tmp_path: Path) -> None:
+        # FAIL-SAFE: a publish whose target cannot be resolved from the command
+        # at all keeps scanning -- an unparsable target is never a silent bypass.
+        cfg = _config(tmp_path, ["internal-eng"])
+        cmd = "curl -d x https://example.com"
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False


### PR DESCRIPTION
## What

The #1415 banned-terms posting gate scans publish-command bodies (`gh issue/pr create|edit|comment`, `glab mr|issue note|create`, the `gh api`/`glab api` REST paths) for banned/overlay terms, to stop them leaking onto a **public** surface. The reported over-block: a publish to a **private internal remote the user had not declared** was blocked, because the in-hook visibility probe is usually unavailable, so an undeclared internal namespace looked "unknown" and was treated as a public surface.

The correct fix is config-driven and **fail-CLOSED**, not a new allowlist:

- `is_public_destination` / `gate_skips_destination` **scan by default** and **skip only a provably-internal target** — a namespace in the `internal_publish_namespaces` / `private_repos` denylist (read directly from `~/.teatree.toml`), or a probe that returns a confirmed-PRIVATE verdict. Every other target — a genuinely-public **non-teatree** repo (e.g. a user's blog repos), a third-party repo, an **unknown-visibility** target, or an **unresolvable** target — stays public and is **scanned**.
- The over-block is resolved by declaring the user's internal namespace in `internal_publish_namespaces` (a local `~/.teatree.toml` change, not committed). The classifier itself stays fail-closed so no public surface can ever be skipped.

This keeps the leak protection intact: an allowlist of "surfaces to scan" would fail **open** on a public repo nobody remembered to list, leaking an internal term unscanned onto a public surface — the BLOCKER a cold review caught.

## Why this PR shape

The classifier's executable body is unchanged from `main` (still fail-closed). The PR's value is:

1. **Regression coverage pinning the fail-closed contract**, including the leak path the review caught — a USER-OWNED non-teatree PUBLIC repo with a banned term must STILL be scanned (`test_user_owned_non_teatree_public_repo_is_scanned`, `test_live_hook_blocks_customer_term_to_user_owned_non_teatree_public_repo`).
2. A small helper cleanup (`_teatree_list_setting`) factoring the `~/.teatree.toml` list read used by the internal-namespace denylist reader.
3. A docstring correction: the hook reads the internal denylist from `~/.teatree.toml` **directly** (it is overlay-agnostic and cannot import `OverlayConfig`).

## Tests

Each anti-vacuity test observed RED on revert (treating a non-denylisted target as skip = the fail-open bug) and GREEN with the fail-closed default:

- **MUST-NOT-FIRE**: an internal-namespace (denylisted) target with a banned body → SKIPS.
- **MUST-FIRE (public non-teatree)**: a user-owned non-teatree PUBLIC repo with a banned body → SCANNED + blocks. (Reverting the fail-closed default makes this RED.)
- **MUST-FIRE (unknown visibility)**: a non-denylisted target the probe cannot resolve → SCANNED + blocks.
- **FAIL-SAFE**: an unresolvable target → SCANNED + blocks.

Local gates green: `uv run ruff check` + `ruff format`, `ty check`, `uv run tach check`, and the four touched suites (363 tests pass).

## Architecture pre-check

**1. BLUEPRINT § alignment** — `docs/blueprint/factory-architecture.md` "Banned-terms posting gate (#1415)" and `docs/blueprint/configuration.md` §10 already describe the fail-closed denylist model; no doc change needed (the classifier contract is unchanged).

**2. FSM phase boundaries** — n/a; pure PreToolUse hook logic.

**3. Extension-point contracts** — no `OverlayBase`/scanner/Protocol change. The hook is overlay-agnostic (reads `~/.teatree.toml` directly).

**4. Component boundaries** — change is internal to `src/teatree/hooks/publish_destination.py` plus its tests; no new module.

**5. Dependency direction** — no new cross-tier imports; `tach check` green.

**6. Test surface** — the four tests above pin MUST-NOT-FIRE / MUST-FIRE(public+unknown) / FAIL-SAFE across the pure classifier and the live `handle_banned_terms_pretool` entrypoint.

**7. Resilience invariants** — no external write; read-only classifier. Fail-closed (scan unless provably internal) is the load-bearing invariant, explicitly tested.

**8. Identity and key normalization** — the slug is the canonical key, host-stripped to `owner/repo` via the one shared `slug_namespace_matches`; no new strip/split seam.

**9. Behavior preservation / capability deletion** — the classifier body is byte-identical to `main` (fail-closed preserved). No must-block test inverted to must-not-block; the new tests strengthen the public-surface leak guarantee.

## Open questions and assumptions

- The internal denylist (`internal_publish_namespaces` / `private_repos`) lives only in the user's private `~/.teatree.toml`; no real namespace is in teatree source or tests (synthetic placeholders only).
- A non-denylisted public/unknown/unresolvable target always scans; the `ALLOW_BANNED_TERM` override and the secret-on-every-surface block are unchanged.
