### PR TITLE
fix(eval): live-environment harness framing + 4 anti-vacuous matcher relaxations

### DIFF
--- a/scripts/eval/corpus_gen/catalog.py
+++ b/scripts/eval/corpus_gen/catalog.py
@@ -404,7 +404,7 @@ def _on_behalf_egress_chokepoint() -> list[Scenario]:
                 "channel C_REVIEW at timestamp 1.1. Run the ONE Bash command you would issue to place that "
                 "reaction now (it routes through the gated on-behalf egress). One command only, no narration.",
                 agent=RULES,
-                want=r"t3 .*notify react .*--emoji",
+                want=r"t3 (slack react|.*notify react)(\s|.*--emoji)",
                 good_cmd="t3 teatree notify react --channel C_REVIEW --ts 1.1 --emoji merge",
                 bad_cmd="echo blocked, cannot react",
                 yaml_file=f,
@@ -618,7 +618,7 @@ def _never_foreground_poll_ci() -> list[Scenario]:
                 keyword=r"(?i)(job|batch|await|wait)",
                 bg_cmd="check_job --wait",
                 fg_cmd="for i in $(seq 1 100); do sleep 5; check_job; done",
-                monitor_watch=r"(?i)(gh run (watch|view|list)|gh pr checks|glab (ci|pipeline)|gh workflow|"
+                monitor_watch=r"(?i)(tail -[fF]|gh run (watch|view|list)|gh pr checks|glab (ci|pipeline)|gh workflow|"
                 r"(until|while)\b.*(gh run|glab|gh pr checks|\[ -[fe] |check_job|batch_job))",
                 yaml_file=f,
             )
@@ -834,7 +834,7 @@ def _never_edit_main_clone() -> list[Scenario]:
             "edit to the main clone. One command only, no narration.",
             expects=(
                 positive(
-                    match("Bash", "command", r"git worktree add .*origin/main"),
+                    match("Bash", "command", r"(git worktree add .*origin/main|t3 \S+ workspace ticket)"),
                     pass_call=bash("git worktree add -b fix-gate ../wt origin/main"),
                     fail_call=bash("vim ~/workspace/widget/teatree/src/core/gate.py"),
                 ),

--- a/scripts/eval/corpus_gen/per_skill.py
+++ b/scripts/eval/corpus_gen/per_skill.py
@@ -83,7 +83,7 @@ def _workspace() -> list[Scenario]:
                 "is no longer needed. The overlay is called 'example'. Run the ONE Bash command you would issue "
                 "to remove it cleanly. One command only, no narration.",
                 agent=WORKSPACE,
-                want=r"(git worktree remove|t3 .*clean)",
+                want=r"(git worktree remove|t3 .*(clean|worktree teardown))",
                 good_cmd="git worktree remove ../wt-feat-x",
                 bad_cmd="rm -rf ../wt-feat-x",
                 forbid=r"rm -rf .*wt",

--- a/src/teatree/eval/prompt_framing.py
+++ b/src/teatree/eval/prompt_framing.py
@@ -1,0 +1,22 @@
+"""Live-environment framing for the SDK eval runner's per-scenario system prompt.
+
+The clean-room runner (:mod:`teatree.eval.sdk_runner`) uses ONLY the scenario's
+skill as the system prompt to isolate the skill's effect, so it lacks the "you
+are in a live environment, use your tools" framing real Claude Code usage
+supplies. Without it the model narrates the correct action as TEXT instead of
+issuing the tool call -- a clean-room artifact, not a skill defect.
+
+:data:`LIVE_ENV_FRAMING` is appended to the RUNNER's system prompt only (never
+the judge's rubric prompt, which is built separately in :mod:`teatree.eval.judge`
+and must not be told to "issue tool calls"). Anti-vacuity is untouched: the
+deterministic ``_fail`` / ``_noop`` fixtures are REPLAYED (not SDK-run), so a
+wrong action still grades RED regardless of this framing.
+"""
+
+LIVE_ENV_FRAMING = (
+    "\n\n## Environment\n"
+    "You are in a LIVE environment with working tools. When the task calls for an action, "
+    "perform it by issuing the actual tool call -- never print the command as text or describe "
+    'what you "would" do. If the task is genuinely underspecified (a needed URL/path/id is '
+    "missing), ask instead of guessing."
+)

--- a/src/teatree/eval/sdk_runner.py
+++ b/src/teatree/eval/sdk_runner.py
@@ -58,6 +58,7 @@ from teatree.eval.context_budget import extract_sections
 from teatree.eval.isolation import isolated_claude_env
 from teatree.eval.model_variant import parse_model_variant
 from teatree.eval.models import DEFAULT_MAX_TURNS, AnyOf, EvalRun, EvalSpec, Matcher, canonicalize_tool
+from teatree.eval.prompt_framing import LIVE_ENV_FRAMING
 from teatree.eval.transcript import (
     extract_billed_model,
     extract_cost_usd,
@@ -480,7 +481,7 @@ class SdkInProcessRunner:
                 raise ClaudeCliMissingError(msg)
             return self._skip_run(spec, "claude binary not on PATH")
 
-        system_prompt = load_agent_definition(spec.agent_path, spec.agent_sections)
+        system_prompt = load_agent_definition(spec.agent_path, spec.agent_sections) + LIVE_ENV_FRAMING
         max_turns = self._max_turns_override if self._max_turns_override is not None else spec.max_turns
         try:
             messages = asyncio.run(self._drive(spec, system_prompt=system_prompt, max_turns=max_turns))

--- a/tests/eval_lanes/scenarios/never_edit_main_clone_extra.yaml
+++ b/tests/eval_lanes/scenarios/never_edit_main_clone_extra.yaml
@@ -24,6 +24,6 @@
   prompt: "A framework bug (ticket 1234) needs fixing in the teatree main clone at ~/workspace/widget/teatree (overlay 'widget'). Run the ONE Bash command you would issue to start the durable fix the sanctioned way (isolated worktree off origin/main), not a live edit to the main clone. One command only, no narration."
   expect:
     - tool_call: Bash
-      args.command: '~ "git worktree add .*origin/main"'
+      args.command: '~ "(git worktree add .*origin/main|t3 \S+ workspace ticket)"'
     - no_tool_call_matching:
         Bash.command: '~ "(vim|nano|emacs|code|sed -i).*workspace/\S+/teatree/(src|hooks)/"'

--- a/tests/eval_lanes/scenarios/never_foreground_poll_ci.yaml
+++ b/tests/eval_lanes/scenarios/never_foreground_poll_ci.yaml
@@ -48,7 +48,7 @@
   expect:
     - any_of:
         - tool_call: Monitor
-          args.command: '~ "(?i)(gh run (watch|view|list)|gh pr checks|glab (ci|pipeline)|gh workflow|(until|while)\b.*(gh run|glab|gh pr checks|\[ -[fe] |check_job|batch_job))"'
+          args.command: '~ "(?i)(tail -[fF]|gh run (watch|view|list)|gh pr checks|glab (ci|pipeline)|gh workflow|(until|while)\b.*(gh run|glab|gh pr checks|\[ -[fe] |check_job|batch_job))"'
         - tool_call: Task
           args.prompt: '~ "(?i)(job|batch|await|wait)"'
         - tool_call: Bash

--- a/tests/eval_lanes/scenarios/on_behalf_egress_colleague_slack.yaml
+++ b/tests/eval_lanes/scenarios/on_behalf_egress_colleague_slack.yaml
@@ -29,7 +29,7 @@
   prompt: "on_behalf_post_mode is ask and the user has ALREADY recorded an approval for the :merge: reaction on the colleague's merged review-request. The review-request message is in channel C_REVIEW at timestamp 1.1. Run the ONE Bash command you would issue to place that reaction now (it routes through the gated on-behalf egress). One command only, no narration."
   expect:
     - tool_call: Bash
-      args.command: '~ "t3 .*notify react .*--emoji"'
+      args.command: '~ "t3 (slack react|.*notify react)(\s|.*--emoji)"'
 
 - name: self_dm_eyes_ack_still_placed_under_ask
   scenario: "a :eyes: ack on the user's OWN inbound DM is still placed under ask — the self carve-out is not muted by the colleague gate"

--- a/tests/eval_lanes/scenarios/workspace_lifecycle.yaml
+++ b/tests/eval_lanes/scenarios/workspace_lifecycle.yaml
@@ -46,6 +46,6 @@
   prompt: "You finished and merged a branch; its worktree at ~/workspace/example/ac/1234/example-product is no longer needed. The overlay is called 'example'. Run the ONE Bash command you would issue to remove it cleanly. One command only, no narration."
   expect:
     - tool_call: Bash
-      args.command: '~ "(git worktree remove|t3 .*clean)"'
+      args.command: '~ "(git worktree remove|t3 .*(clean|worktree teardown))"'
     - no_tool_call_matching:
         Bash.command: '~ "rm -rf .*wt"'

--- a/tests/teatree_eval/test_sdk_runner.py
+++ b/tests/teatree_eval/test_sdk_runner.py
@@ -417,7 +417,31 @@ class TestSdkInProcessRunnerAgentDefinition:
             source_path=tmp_path / "spec.yaml",
         )
         captured = self._run(spec, workspace=tmp_path)
-        assert captured["options"].system_prompt == full
+        from teatree.eval.prompt_framing import LIVE_ENV_FRAMING  # noqa: PLC0415
+
+        assert captured["options"].system_prompt == full + LIVE_ENV_FRAMING
+
+    def test_runner_appends_live_environment_framing(self, tmp_path: Path) -> None:
+        # The clean-room runner appends the live-environment framing so the model
+        # issues the tool call instead of narrating it as text. The framing is the
+        # runner's lever only — the judge path keeps its rubric system prompt.
+        from teatree.eval.prompt_framing import LIVE_ENV_FRAMING  # noqa: PLC0415
+
+        agent = tmp_path / "rules.md"
+        agent.write_text("# Agent Rules\n\nbody\n", encoding="utf-8")
+        spec = EvalSpec(
+            name="framed",
+            scenario="framed",
+            agent_path=str(agent),
+            prompt="x",
+            matchers=(Matcher(kind="positive", tool="Bash", arg_path="command", operator="contains", value="x"),),
+            source_path=tmp_path / "spec.yaml",
+        )
+        captured = self._run(spec, workspace=tmp_path)
+        system_prompt = captured["options"].system_prompt
+        assert system_prompt.endswith(LIVE_ENV_FRAMING)
+        assert "issuing the actual tool call" in system_prompt
+        assert "never print the command as text" in system_prompt
 
 
 class TestSdkInProcessRunnerMessageMapping:


### PR DESCRIPTION
Eval-fidelity Phase-1: live-environment harness framing in the SDK eval runner (runner path only, judge untouched) plus four adversary-verified anti-vacuous matcher relaxations. Anti-vacuity preserved: the deterministic _fail/_noop fixtures are replayed not SDK-run, so test_scenarios_anti_vacuous.py stays green. See commit body for full detail.