### PR TITLE
feat(config): t3 config_setting get/import + typed bootstrap-file-only registry (#1775)

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -153,11 +153,23 @@ The model reaches the
 resolver via `django.apps.apps.get_model("core", "ConfigSetting")` (a runtime
 lookup, not a static import) so the `config` platform layer never takes a
 backwards edge on the `core` domain layer (tach-clean). Admin path:
-`t3 <overlay> config_setting set <key> <json> | clear <key> | list`. The pilot
-migrated setting is `issue_implementer_enabled` (a default-off boolean
-kill-switch). Bootstrap-readable settings (`DATABASE_URL` / data-dir /
-`DJANGO_SETTINGS_MODULE` / the offline `private_repos` allowlist) are explicitly
-out of scope — they must resolve before Django starts.
+`t3 <overlay> config_setting set <key> <json> | get <key> | clear <key> | list | import`.
+`get` is the read side of the dual-read store — it prints a setting's resolved
+value and names its source (`db` when a row exists, else `file/env`). `import` is
+the one-time dual-read migration ([#938](https://github.com/souliane/teatree/issues/938)):
+it seeds the store from every operational `[teatree]` toml key that is a registered
+`OVERLAY_OVERRIDABLE_SETTINGS` field (coerced through that registry's parser,
+upserted so a re-run is idempotent), skipping bootstrap-file-only and unknown keys.
+The pilot migrated setting is `issue_implementer_enabled` (a default-off boolean
+kill-switch).
+
+Bootstrap-readable settings (`DATABASE_URL` / data-dir / `DJANGO_SETTINGS_MODULE`
+/ the offline `private_repos` allowlist) are explicitly out of scope — they must
+resolve before Django starts. That boundary is a **typed allowlist**,
+`BOOTSTRAP_FILE_ONLY_SETTINGS` in `config/settings.py`, not just prose: a fitness
+function asserts `BOOTSTRAP_FILE_ONLY_SETTINGS ∩ OVERLAY_OVERRIDABLE_SETTINGS == ∅`,
+so a bootstrap key can never be made DB-overridable (and `config_setting set` /
+`import` therefore never write a row for one) without turning a test red.
 
 The active overlay is resolved via (in order): `T3_OVERLAY_NAME` env var
 (runtime truth; matches `get_overlay()`), cwd-based discovery, then the

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -6676,9 +6676,11 @@ Usage: t3 teatree config_setting [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ set    Upsert a DB override row for an overridable setting (JSON value).     │
-│ clear  Remove a DB override row, falling back to the file/env source.        │
-│ list   List every DB config override row (read-only).                        │
+│ set     Upsert a DB override row for an overridable setting (JSON value).    │
+│ get     Print a setting's resolved value and its source (db vs file/env).    │
+│ clear   Remove a DB override row, falling back to the file/env source.       │
+│ list    List every DB config override row (read-only).                       │
+│ import  Seed the DB store from operational  toml keys (one-time).            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -6709,6 +6711,28 @@ Usage: t3 teatree config_setting set [OPTIONS] KEY VALUE
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
+##### `t3 teatree config_setting get`
+
+```
+Usage: t3 teatree config_setting get [OPTIONS] KEY
+
+ Print the resolved value for *key* and name its source (DB vs file/env).
+
+ The read side of the dual-read store: when a ``ConfigSetting`` row exists
+ it is reported as the ``db`` source; otherwise the value falls through to
+ the file/env layer and is reported as the ``file/env`` source. Refuses a
+ key not in ``OVERLAY_OVERRIDABLE_SETTINGS`` so a typo is loud, not a
+ silent ``file/env`` answer for a non-setting.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    key      TEXT  UserSettings field name to read (must be overridable).   │
+│                     [required]                                               │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
 ##### `t3 teatree config_setting clear`
 
 ```
@@ -6733,6 +6757,25 @@ Usage: t3 teatree config_setting clear [OPTIONS] KEY
 Usage: t3 teatree config_setting list [OPTIONS]
 
  List every DB config override row (read-only).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree config_setting import`
+
+```
+Usage: t3 teatree config_setting import [OPTIONS]
+
+ Seed the DB store from the operational ```` toml keys (one-time migration).
+
+ The dual-read migration step (#938): every ```` key that is a
+ registered ``OVERLAY_OVERRIDABLE_SETTINGS`` field is coerced through that
+ registry's parser and upserted into the store, so existing installs move
+ their operational config into the DB. Bootstrap-file-only keys
+ (``private_repos`` / ``DATABASE_URL`` / …) and unknown keys are skipped —
+ only operational settings move. The upsert makes a re-run idempotent.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │

--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -45,8 +45,16 @@
           "name": "clear"
         },
         {
+          "help": "Print the resolved value for *key* and name its source (DB vs file/env)",
+          "name": "get"
+        },
+        {
           "help": "List every DB config override row (read-only)",
           "name": "list"
+        },
+        {
+          "help": "Seed the DB store from the operational ``[teatree]`` toml keys (one-time migration)",
+          "name": "import"
         }
       ]
     },

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -28,7 +28,9 @@ Edit the source command, not this file.
 | --- | --- |
 | `set` | Upsert the DB override row for *key* to the JSON-parsed *value* |
 | `clear` | Delete the DB override row for *key*; falls back to the file/env source |
+| `get` | Print the resolved value for *key* and name its source (DB vs file/env) |
 | `list` | List every DB config override row (read-only) |
+| `import` | Seed the DB store from the operational ``[teatree]`` toml keys (one-time migration) |
 
 ## `cost`
 

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -247,8 +247,10 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
         "DB-backed config override tier — env -> DB -> TOML precedence (#1775).",
         [
             ("set", "Upsert a DB override row for an overridable setting (JSON value)."),
+            ("get", "Print a setting's resolved value and its source (db vs file/env)."),
             ("clear", "Remove a DB override row, falling back to the file/env source."),
             ("list", "List every DB config override row (read-only)."),
+            ("import", "Seed the DB store from operational [teatree] toml keys (one-time)."),
         ],
         core_dispatch=True,
     ),

--- a/src/teatree/config/__init__.py
+++ b/src/teatree/config/__init__.py
@@ -45,6 +45,7 @@ from teatree.config.resolution import (
     get_effective_settings,
 )
 from teatree.config.settings import (
+    BOOTSTRAP_FILE_ONLY_SETTINGS,
     ENV_SETTING_OVERRIDES,
     OVERLAY_OVERRIDABLE_SETTINGS,
     E2ERepo,
@@ -62,6 +63,7 @@ from teatree.config_speak import resolve_speak, speak_from_subtable
 from teatree.paths import DATA_DIR, get_data_dir
 
 __all__ = [
+    "BOOTSTRAP_FILE_ONLY_SETTINGS",
     "CONFIG_PATH",
     "DATA_DIR",
     "ENV_SETTING_OVERRIDES",

--- a/src/teatree/config/settings.py
+++ b/src/teatree/config/settings.py
@@ -388,6 +388,30 @@ ENV_SETTING_OVERRIDES: dict[str, tuple[str, Callable[[str], Any]]] = {
 }
 
 
+# The irreducible bootstrap set (#1775): settings that must be readable BEFORE
+# Django — and therefore the DB — is available, so they can never move into the
+# ``ConfigSetting`` store. The publish gate reads ``private_repos`` from the raw
+# ``[teatree]`` toml with ``tomllib`` in a hook that runs with no Django;
+# ``DATABASE_URL`` / ``data_dir`` / ``DJANGO_SETTINGS_MODULE`` are the env/toml
+# keys the settings module itself needs to even OPEN the DB. This typed allowlist
+# is the single machine-checked home for that boundary (replacing the former
+# prose-only docstring): the disjoint-registries invariant
+# ``BOOTSTRAP_FILE_ONLY_SETTINGS ∩ OVERLAY_OVERRIDABLE_SETTINGS == ∅`` (a fitness
+# function in the tests) makes it
+# impossible to make a bootstrap key DB-overridable without turning a test red,
+# and ``config-setting set`` already refuses every key here (none is in the
+# overridable registry) so an admin can never stash a DB row for a file-only
+# setting.
+BOOTSTRAP_FILE_ONLY_SETTINGS: frozenset[str] = frozenset(
+    {
+        "DATABASE_URL",
+        "data_dir",
+        "DJANGO_SETTINGS_MODULE",
+        "private_repos",
+    }
+)
+
+
 @dataclass
 class OverlayEntry:
     name: str

--- a/src/teatree/core/management/commands/config_setting.py
+++ b/src/teatree/core/management/commands/config_setting.py
@@ -21,7 +21,7 @@ from typing import Annotated
 import typer
 from django_typer.management import TyperCommand, command
 
-from teatree.config import OVERLAY_OVERRIDABLE_SETTINGS
+from teatree.config import OVERLAY_OVERRIDABLE_SETTINGS, get_effective_settings, load_config
 from teatree.core.models import ConfigSetting
 
 
@@ -94,3 +94,56 @@ class Command(TyperCommand):
             return
         for row in rows:
             self.stdout.write(f"  {row.key} = {row.value!r}")
+
+    @command()
+    def get(
+        self,
+        key: Annotated[str, typer.Argument(help="UserSettings field name to read (must be overridable).")],
+    ) -> None:
+        """Print the resolved value for *key* and name its source (DB vs file/env).
+
+        The read side of the dual-read store: when a ``ConfigSetting`` row exists
+        it is reported as the ``db`` source; otherwise the value falls through to
+        the file/env layer and is reported as the ``file/env`` source. Refuses a
+        key not in ``OVERLAY_OVERRIDABLE_SETTINGS`` so a typo is loud, not a
+        silent ``file/env`` answer for a non-setting.
+        """
+        if key not in OVERLAY_OVERRIDABLE_SETTINGS:
+            self.stderr.write(f"  refusing: {key!r} is not an overridable setting (#1775 pilot scope)")
+            raise SystemExit(2)
+        stored = ConfigSetting.objects.get_effective(key)
+        if stored is not None:
+            self.stdout.write(f"  {key} = {stored!r}  [source: db]")
+            return
+        fallback = getattr(get_effective_settings(), key, None)
+        self.stdout.write(f"  {key} = {fallback!r}  [source: file/env]")
+
+    @command(name="import")
+    def import_toml(self) -> None:
+        """Seed the DB store from the operational ``[teatree]`` toml keys (one-time migration).
+
+        The dual-read migration step (#938): every ``[teatree]`` key that is a
+        registered ``OVERLAY_OVERRIDABLE_SETTINGS`` field is coerced through that
+        registry's parser and upserted into the store, so existing installs move
+        their operational config into the DB. Bootstrap-file-only keys
+        (``private_repos`` / ``DATABASE_URL`` / …) and unknown keys are skipped —
+        only operational settings move. The upsert makes a re-run idempotent.
+        """
+        teatree_table = load_config().raw.get("teatree", {})
+        if not isinstance(teatree_table, dict):
+            self.stdout.write("  (no [teatree] table to import)")
+            return
+        imported = 0
+        for key, raw_value in teatree_table.items():
+            parser = OVERLAY_OVERRIDABLE_SETTINGS.get(key)
+            if parser is None:
+                continue
+            try:
+                canonical = parser(raw_value)
+            except (ValueError, TypeError, AttributeError) as exc:
+                self.stderr.write(f"  skipping {key!r}: invalid value {raw_value!r}: {exc}")
+                continue
+            ConfigSetting.objects.set_value(key, canonical)
+            imported += 1
+            self.stdout.write(f"  imported {key} = {ConfigSetting.objects.get_effective(key)!r}")
+        self.stdout.write(f"  imported {imported} operational setting(s) into the DB store")

--- a/tests/config/test_bootstrap_file_only.py
+++ b/tests/config/test_bootstrap_file_only.py
@@ -1,0 +1,60 @@
+# test-path: cross-cutting
+"""The bootstrap-file-only boundary as a typed registry + fitness function (#1775).
+
+#1775 keeps an irreducible set of settings file-only: they must be readable
+*before* Django (and therefore the DB) is available, so they can never live in
+the ``ConfigSetting`` store. The boundary used to be documented only in a model
+docstring; ``BOOTSTRAP_FILE_ONLY_SETTINGS`` makes it a first-class typed
+allowlist with the machine-checked invariants below.
+
+The two invariants that keep the boundary honest:
+
+1.  **Disjoint registries** — a bootstrap key can never also be DB-overridable. If a key
+    is in ``OVERLAY_OVERRIDABLE_SETTINGS`` it CAN be moved to the DB; if it is in
+    ``BOOTSTRAP_FILE_ONLY_SETTINGS`` it must NOT be. The two registries must not
+    intersect, or the resolver would try to DB-override a setting needed before
+    the DB exists.
+2.  **Write-refusal** — ``config-setting set`` refuses a bootstrap key, so an
+    admin cannot stash a DB row for a file-only setting.
+"""
+
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.config import OVERLAY_OVERRIDABLE_SETTINGS
+from teatree.config.settings import BOOTSTRAP_FILE_ONLY_SETTINGS
+from teatree.core.models import ConfigSetting
+
+
+def test_bootstrap_registry_is_non_empty() -> None:
+    # The irreducible set is real: DATABASE_URL / data-dir / DJANGO_SETTINGS_MODULE
+    # / the offline private_repos allowlist all must stay file-readable pre-Django.
+    assert BOOTSTRAP_FILE_ONLY_SETTINGS
+
+
+def test_bootstrap_and_overridable_registries_are_disjoint() -> None:
+    # The fitness function: a file-only bootstrap key can never be DB-overridable.
+    # Goes RED the moment a bootstrap key is also added to OVERLAY_OVERRIDABLE_SETTINGS
+    # (or vice versa) — the boundary can no longer silently rot.
+    overlap = BOOTSTRAP_FILE_ONLY_SETTINGS & set(OVERLAY_OVERRIDABLE_SETTINGS)
+    assert overlap == set(), f"bootstrap keys must never be DB-overridable: {overlap}"
+
+
+def test_known_bootstrap_keys_are_present() -> None:
+    # The four #1775 names are the irreducible set the umbrella calls out by name.
+    for key in ("DATABASE_URL", "data_dir", "DJANGO_SETTINGS_MODULE", "private_repos"):
+        assert key in BOOTSTRAP_FILE_ONLY_SETTINGS
+
+
+class TestBootstrapKeyWriteRefusal(TestCase):
+    def test_set_refuses_a_bootstrap_file_only_key(self) -> None:
+        # A bootstrap key is not in OVERLAY_OVERRIDABLE_SETTINGS, so set already
+        # refuses it; this pins that the refusal covers EVERY bootstrap key and
+        # never writes a row for one.
+        for key in BOOTSTRAP_FILE_ONLY_SETTINGS:
+            with pytest.raises(SystemExit):
+                call_command("config_setting", "set", key, '"x"', stderr=StringIO())
+            assert ConfigSetting.objects.filter(key=key).exists() is False

--- a/tests/teatree_core/management/test_config_setting_command.py
+++ b/tests/teatree_core/management/test_config_setting_command.py
@@ -7,11 +7,13 @@ string, an int, or a list all round-trip into the override store.
 """
 
 from io import StringIO
+from pathlib import Path
 
 import pytest
 from django.core.management import call_command
 from django.test import TestCase
 
+import teatree.config as config_facade
 from teatree.config import get_effective_settings
 from teatree.config.enums import Mode
 from teatree.core.models import ConfigSetting
@@ -146,3 +148,64 @@ class TestConfigSettingList(TestCase):
         out = StringIO()
         call_command("config_setting", "list", stdout=out)
         assert "no" in out.getvalue().lower()
+
+
+class TestConfigSettingGet(TestCase):
+    def test_get_reports_stored_db_value(self) -> None:
+        ConfigSetting.objects.set_value("issue_implementer_max_concurrent", 7)
+        out = StringIO()
+        call_command("config_setting", "get", "issue_implementer_max_concurrent", stdout=out)
+        rendered = out.getvalue()
+        assert "7" in rendered
+        # The source is named so the operator knows it came from the DB tier, not
+        # the file/env fallback.
+        assert "db" in rendered.lower()
+
+    def test_get_reports_file_fallback_when_no_db_row(self) -> None:
+        # No DB row -> get reports the resolved file/env value and names the
+        # fallback source, so an absent override is visible (dual-read read-side).
+        assert ConfigSetting.objects.filter(key="issue_implementer_max_concurrent").exists() is False
+        out = StringIO()
+        call_command("config_setting", "get", "issue_implementer_max_concurrent", stdout=out)
+        rendered = out.getvalue().lower()
+        assert "file" in rendered or "fallback" in rendered
+
+    def test_get_rejects_non_overridable_key(self) -> None:
+        with pytest.raises(SystemExit):
+            call_command("config_setting", "get", "not_a_real_setting", stderr=StringIO())
+
+
+class TestConfigSettingImport(TestCase):
+    @pytest.fixture(autouse=True)
+    def _config_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.config_path = tmp_path / ".teatree.toml"
+        monkeypatch.setattr(config_facade, "CONFIG_PATH", self.config_path)
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+
+    def test_import_seeds_operational_keys_from_toml(self) -> None:
+        self.config_path.write_text(
+            "[teatree]\nissue_implementer_enabled = true\nissue_implementer_max_concurrent = 4\n",
+            encoding="utf-8",
+        )
+        call_command("config_setting", "import", stdout=StringIO())
+        assert ConfigSetting.objects.get_effective("issue_implementer_enabled") is True
+        assert ConfigSetting.objects.get_effective("issue_implementer_max_concurrent") == 4
+
+    def test_import_skips_bootstrap_and_unknown_keys(self) -> None:
+        # A bootstrap-file-only key (private_repos) and an unknown key must NOT be
+        # imported into the DB store — only operational overridable keys move.
+        self.config_path.write_text(
+            '[teatree]\nprivate_repos = ["acme/secret"]\nnot_a_real_setting = "x"\nmode = "auto"\n',
+            encoding="utf-8",
+        )
+        call_command("config_setting", "import", stdout=StringIO())
+        assert ConfigSetting.objects.filter(key="private_repos").exists() is False
+        assert ConfigSetting.objects.filter(key="not_a_real_setting").exists() is False
+        # The one operational key did move.
+        assert ConfigSetting.objects.get_effective("mode") == "auto"
+
+    def test_import_is_idempotent(self) -> None:
+        self.config_path.write_text("[teatree]\nissue_implementer_max_concurrent = 4\n", encoding="utf-8")
+        call_command("config_setting", "import", stdout=StringIO())
+        call_command("config_setting", "import", stdout=StringIO())
+        assert ConfigSetting.objects.filter(key="issue_implementer_max_concurrent").count() == 1


### PR DESCRIPTION
Completes the DB-backed operational settings store (#1775, #938). The model, the dual-read resolver, and the `set`/`clear`/`list` admin path already shipped on main; this fills the three gaps that remained against the umbrella's "move all config to the DB except bootstrap-readable settings" goal.

## What landed

- **`t3 <overlay> config_setting get <key>`** — the read side of the dual-read store. Prints a setting's resolved value and names its source (`db` when a `ConfigSetting` row exists, else `file/env`), so an absent override is visible. Refuses a non-overridable key so a typo is loud.
- **`t3 <overlay> config_setting import`** — the one-time dual-read migration (#938). Seeds the store from every operational `[teatree]` toml key that is a registered `OVERLAY_OVERRIDABLE_SETTINGS` field, coerced through that registry's parser and upserted (idempotent re-run). Bootstrap-file-only and unknown keys are skipped — only operational settings move.
- **`BOOTSTRAP_FILE_ONLY_SETTINGS`** — a typed allowlist (`config/settings.py`) making the file-only boundary first-class instead of a prose-only docstring. A fitness function asserts the bootstrap and overridable registries do not intersect, so a bootstrap key (`DATABASE_URL` / `data_dir` / `DJANGO_SETTINGS_MODULE` / `private_repos`) can never be made DB-overridable without turning a test red.

Docs (`docs/blueprint/configuration.md`, generated CLI reference + management-commands) updated for the new subcommands and the typed boundary.

## What remains (out of this increment)

- `t3 setup` elicitation of missing required settings into the DB (the #938 interactive-prompt-on-missing flow) — needs the owner's design-note review called for in #938 before implementation.
- Promoting more operational settings out of the file into the seeded DB store is now a registry/seed exercise, not new mechanism.

## Architecture pre-check — #1775 / #938

### 1. BLUEPRINT § alignment
The DB override tier + the text-file-vs-DB rule in `docs/blueprint/configuration.md` already document #1775 as the canonical-tier-is-the-DB pattern with a file fallback. Purely additive on the same precedence chain — the appendix is updated in this PR for `get`/`import` and the typed bootstrap allowlist.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
No `OverlayBase` / scanner / hook / Protocol surface change. `import` reuses the existing `OVERLAY_OVERRIDABLE_SETTINGS` registry + parsers and the `ConfigSetting` manager's `set_value`; the bootstrap registry is a new module-level constant consumed only by the fitness test and the existing write-refusal path.

### 4. Component boundaries
`BOOTSTRAP_FILE_ONLY_SETTINGS` lives in `config/settings.py` alongside the other override registries. `get`/`import` live in the `config_setting` management command, mirroring `set`/`clear`/`list`. Tests mirror src paths.

### 5. Dependency direction
No new cross-layer import. `tach check` green; `import-linter` green.

### 6. Test surface
`tests/config/test_bootstrap_file_only.py` (registry non-empty, no-intersection fitness function, known keys present, write-refusal across every bootstrap key) and `tests/teatree_core/management/test_config_setting_command.py` (`get` db-source + file/env-fallback + non-overridable refusal; `import` seeds operational keys, skips bootstrap/unknown, idempotent). The dual-read DB-wins precedence (`tests/config/test_db_config_tier.py`) was confirmed anti-vacuous: neutering the DB tier turns the precedence test red.

### 7. Resilience invariants
verify-by-re-read: `import` reports each seeded row by re-reading `get_effective`. idempotency: `import` upserts on the unique `key`. fallback-transport: the resolver's hot path already fails safe to the file/env layer. heartbeat / sub-agent return contract: n/a.

### 8. Identity and key normalization
Canonical key is the `UserSettings` field name — the same string in `OVERLAY_OVERRIDABLE_SETTINGS` and the `[teatree]` toml table. No strip/split to force a comparison; bootstrap keys match by exact field name.

### 9. Behavior preservation / capability deletion
n/a — purely additive. No behavior removed, no privacy/security matcher narrowed, no must-block test inverted. The bootstrap registry makes an existing prose boundary machine-checked.

## Open questions & assumptions

- `get` reports the effective resolved value with its source rather than only the raw DB row, since that is the most useful read for an operator checking dual-read state. A raw-row-only `get` would be a one-line change.
- `import` is invoked explicitly (not auto-run on first migrate) so the seed is a deliberate operator action with visible per-key output — matching the "one-time migration" framing in #938.
