### PR TITLE
fix: e2e --linked-to resolves without a cwd worktree row (#2287)

### DIFF
--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -12,7 +12,7 @@ from teatree.config import load_e2e_repos
 from teatree.core.management.commands import _e2e_discovery as _disc
 from teatree.core.management.commands import _e2e_runners as _runners
 from teatree.core.management.commands import _test_plan
-from teatree.core.models import Ticket
+from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.resolve import resolve_worktree
 from teatree.core.worktree_env import compose_project
@@ -260,42 +260,38 @@ class Command(TyperCommand):
                 self.stderr.write(f"E2E preflight failed: {exc}")
                 raise SystemExit(1) from exc
 
-    def _resolve_target_env(
-        self,
-        resolved_target: str,
-        linked_ticket: Ticket | None,
-    ) -> tuple[str | None, str | None, dict[str, str] | None]:
-        """Build the per-target trio passed to ``_build_e2e_env``.
-
-        Returns ``(frontend_url, worktree_compose_project, env_cache_override)``.
-        For ``dev`` the BASE_URL is preserved and the other two stay None.
-        For ``local`` the frontend port is discovered (routed through
-        ``linked_ticket`` when provided), the compose project comes from the
-        linked worktree (else the resolved one), and the env-cache override
-        comes from the linked worktree's on-disk path (None when no link).
-        """
-        if resolved_target == "dev":
-            if not os.environ.get("BASE_URL"):
-                self.stderr.write("--target dev requires BASE_URL (the deployed environment URL) to be set.")
-                raise SystemExit(1)
-            return None, None, None
-
-        worktree = resolve_worktree()
-        frontend_port = _discover_frontend_port(worktree, linked_ticket=linked_ticket)
-        if frontend_port is None:
+    def _require_frontend_port(self, worktree: Worktree, linked_ticket: Ticket | None) -> int:
+        port = _discover_frontend_port(worktree, linked_ticket=linked_ticket)
+        if port is None:
             probed = ", ".join(_ticket_frontend_projects(worktree, linked_ticket=linked_ticket)) or "none"
             self.stderr.write(
                 f"Frontend not running (no docker `frontend` service in [{probed}], "
                 "no local process on 4200). Run `t3 <overlay> worktree start` first.",
             )
             raise SystemExit(1)
+        return port
 
-        frontend_url = f"http://localhost:{frontend_port}"
+    def _resolve_target_env(
+        self,
+        resolved_target: str,
+        linked_ticket: Ticket | None,
+    ) -> tuple[str | None, str | None, dict[str, str] | None]:
+        """Build the per-target trio passed to ``_build_e2e_env``."""
+        if resolved_target == "dev":
+            if not os.environ.get("BASE_URL"):
+                self.stderr.write("--target dev requires BASE_URL (the deployed environment URL) to be set.")
+                raise SystemExit(1)
+            return None, None, None
+
         if linked_ticket is not None:
             linked_wt = _resolve_linked_worktree(linked_ticket)
             if linked_wt is not None:
-                return frontend_url, compose_project(linked_wt), _linked_env_cache(linked_wt)
-        return frontend_url, compose_project(worktree), None
+                port = self._require_frontend_port(linked_wt, linked_ticket)
+                return f"http://localhost:{port}", compose_project(linked_wt), _linked_env_cache(linked_wt)
+
+        worktree = resolve_worktree()
+        port = self._require_frontend_port(worktree, linked_ticket)
+        return f"http://localhost:{port}", compose_project(worktree), None
 
     def _resolve_linked_ticket(self, linked_to: int) -> Ticket | None:
         """Resolve ``--linked-to <pk>`` to a Ticket or exit on misconfig.

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -590,6 +590,69 @@ class TestE2eExternal(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
+    def test_linked_to_resolves_without_cwd_worktree_row(self) -> None:
+        """``--linked-to`` succeeds even when cwd has no worktree row.
+
+        Regression for souliane/teatree#2287: ``_resolve_target_env`` called
+        ``resolve_worktree()`` unconditionally before the link routing, so
+        running from a standalone external e2e repo (no ``.t3-cache`` env
+        cache, no DB row for the cwd) raised ``WorktreeNotFoundError`` before
+        ``--linked-to`` could supply the backend worktree.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            backend_wt_dir = tmp_path / "backend-worktree"
+            backend_wt_dir.mkdir()
+            (backend_wt_dir / ".t3-env.cache").write_text(
+                f"WT_VARIANT=acme\nTICKET_DIR={backend_wt_dir.parent}\n",
+                encoding="utf-8",
+            )
+            standalone_e2e_dir = tmp_path / "standalone-e2e"
+            standalone_e2e_dir.mkdir()
+            private_dir = tmp_path / "private"
+            private_dir.mkdir()
+
+            backend_ticket = Ticket.objects.create(
+                overlay="test",
+                issue_url="https://example.com/issues/2287",
+                variant="acme",
+            )
+            Worktree.objects.create(
+                overlay="test",
+                ticket=backend_ticket,
+                repo_path="backend-repo",
+                branch="backend",
+                extra={"worktree_path": str(backend_wt_dir)},
+                state=Worktree.State.SERVICES_UP,
+            )
+
+            mock_result = MagicMock(returncode=0)
+            with (
+                patch.dict(
+                    "os.environ",
+                    {
+                        "T3_PRIVATE_TESTS": str(private_dir),
+                        "T3_ORIG_CWD": str(standalone_e2e_dir),
+                    },
+                    clear=False,
+                ),
+                patch.object(e2e_disc_mod, "get_service_port", return_value=4202),
+                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
+            ):
+                os.environ.pop("BASE_URL", None)
+                result = cast(
+                    "str",
+                    call_command("e2e", "external", target="local", linked_to=backend_ticket.pk),
+                )
+
+            assert "passed" in result
+            env = mock_run.call_args[1]["env"]
+            assert env["BASE_URL"] == "http://localhost:4202"
+            assert env["COMPOSE_PROJECT_NAME"] == f"backend-repo-wt{backend_ticket.ticket_number}"
+            assert env["CUSTOMER"] == "acme"
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
     def test_linked_to_unknown_ticket_exits_with_error(self) -> None:
         """``--linked-to <bogus-pk>`` is a misconfig — fail fast with exit 2.
 


### PR DESCRIPTION
## Summary

Running t3 e2e external with --linked-to from a standalone out-of-tree e2e repo raised WorktreeNotFoundError immediately, before the linked-ticket routing could supply the backend worktree. Root cause: _resolve_target_env called resolve_worktree() (cwd-based) unconditionally before checking linked_ticket.

Fix: check linked_ticket first and route through _resolve_linked_worktree (cwd-independent); only fall through to resolve_worktree() when no link is given. Extract _require_frontend_port to consolidate the duplicate frontend-not-running error block from both routing branches.

## Test plan

- New test test_linked_to_resolves_without_cwd_worktree_row in TestE2eExternal: confirmed RED on the buggy code, GREEN after fix. The cwd is a tmp dir with no worktree DB row; only the backend worktree reached via --linked-to is registered.
- All 46 tests in test_e2e.py pass.
- ruff check clean.
- All pre-commit hooks pass (module-health: 491 effective LOC, under 500).
