### PR TITLE
feat(hooks): PreToolUse gate blocking secret-bearing file prints

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -6980,7 +6980,7 @@ def handle_block_secret_file_print(data: dict) -> bool:
     command = data.get("tool_input", {}).get("command", "")
     if not command or not _is_secret_print(command):
         return False
-    return emit_pretooluse_deny(_CREDENTIAL_PRINT_BLOCK_MSG)  # [skill-load-ok: teatree]
+    return _fail_open_or_deny(data, _CREDENTIAL_PRINT_BLOCK_MSG)
 
 
 # ── PreToolUse: block-out-of-band-merge (#126) ──────────────────────

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -6858,6 +6858,131 @@ def handle_block_direct_commands(data: dict) -> bool:
     return emit_pretooluse_deny(reason)
 
 
+# ── PreToolUse: block-secret-file-print (#2306) ──────────────────────
+#
+# Blocks Bash commands that route a known secret-bearing source to stdout.
+# The privacy scan gates COMMITS, but nothing gates a command that echoes a
+# secret to the transcript — once it lands there, rotation is the only remedy.
+#
+# Triggered by:
+#   - cat/head/tail of known secret-bearing paths (credential files, key files,
+#     .env files, pass stores)
+#   - `pass show …` whose stdout is NOT captured or redirected to a file
+#   - echo/printf of a pasted token literal (glpat-/ghp_/gho_/xoxb-/xoxp-/sk-)
+#
+# Allowed (must NOT false-positive):
+#   - Reading a value into a shell variable  (VAR=$(…))
+#   - Piping / redirecting to a file         (… > out.txt)
+#   - Using the value via env or header      (curl -H "Token: $VAR")
+#   - cat of ordinary non-secret files
+#   - echo of prose that MENTIONS a secret-file path
+#
+# Fails OPEN on any internal error — a gate bug must never wedge the agent
+# (consistent with the #1164 raw-review-post guard).
+
+_SECRET_PATHS_RE = re.compile(  # [skill-load-ok: souliane/teatree repo]
+    r"""(?x)
+    (?:~|/root|/home/[^/\s]+|/Users/[^/\s]+|\$HOME|\$\{HOME\}|\$\{?HOME\}?)
+    /(?:
+        \.teatree\.toml
+        | \.netrc
+        | \.config/gh/hosts\.yml
+        | (?:Library/Application\s+Support|\.config)/glab-cli/config\.yml
+        | \.ssh/(?:id_[a-z0-9_]+|.*\.pem|.*\.key)
+    )
+    | (?:^|[\s/])(?:\.env(?:\.[a-z]+)?|secrets?\.env|.*\.credentials?|.*\.pem|.*\.key|.*_account\.json)(?:\s|$|['")])
+    """,
+    re.IGNORECASE,
+)
+
+_TOKEN_LITERAL_RE = re.compile(
+    r"""(?:^|\s)(?:glpat[-_]|ghp_|gho_|xoxb-|xoxp-|sk-)\S+""",
+)
+
+_PRINT_CMDS_RE = re.compile(r"^\s*(?:cat|head|tail)\b")
+
+_PASS_SHOW_RE = re.compile(r"^\s*pass\s+show\b")
+
+_CAPTURE_OR_REDIRECT_RE = re.compile(  # [skill-load-ok: souliane/teatree repo]
+    r"""
+    \$\(            # subshell capture: $(…)
+    | >\s*\S+       # stdout redirect to a file or /dev/null
+    | \|\s*\S       # pipe to another command (value leaves stdout)
+    """,
+    re.VERBOSE,
+)
+
+_ECHO_SAFE_QUOTE_RE = re.compile(r"""^(?:'[^']*'|"[^"]*")$""")
+
+# [skill-load-ok: souliane/teatree repo]
+_CREDENTIAL_PRINT_BLOCK_MSG = (
+    "BLOCKED: this command would print a secret-bearing file or credential token "
+    "to the transcript. Reading a secret into the transcript is irrecoverable — "
+    "rotation is the only remedy. Instead, extract the value into a shell variable "
+    "(`TOKEN=$(pass show …)`) and use it via env/header without printing it. "
+    "Do NOT implement 'mask-then-print' — a masking regex is one edge case away "
+    "from leaking. The gate's job is to keep the value off stdout entirely."
+)
+
+
+def _command_captures_or_redirects(command: str) -> bool:
+    """Return True when the command's stdout is captured or redirected, not printed.
+
+    A variable-assignment prefix (``VAR=$(…)`` or ``export VAR=$(…)``) or a
+    stdout redirect (``> file``) or pipe (``| cmd``) means the secret value
+    does NOT land on the transcript. A plain ``pass show x`` with no such
+    construct does.
+    """
+    return bool(_CAPTURE_OR_REDIRECT_RE.search(command))
+
+
+def _echo_arg_is_token(command: str) -> bool:
+    """Return True when the echo/printf command carries a bare token literal.
+
+    Prose strings inside quotes that merely MENTION a secret path are not
+    treated as token prints — they contain no token literal.  Only an
+    unquoted or minimally-quoted arg that starts with a known token prefix
+    triggers a deny.
+    """
+    parts = command.split(None, 1)
+    if len(parts) < 2:  # noqa: PLR2004
+        return False
+    arg = parts[1].strip()
+    if _ECHO_SAFE_QUOTE_RE.match(arg):
+        return False
+    return bool(_TOKEN_LITERAL_RE.search(command))
+
+
+def _is_secret_print(command: str) -> bool:  # [skill-load-ok: souliane/teatree repo]
+    """Whether *command* would print a secret-bearing value to stdout."""
+    try:
+        if _command_captures_or_redirects(command):
+            return False
+        if _PRINT_CMDS_RE.match(command):
+            return bool(_SECRET_PATHS_RE.search(command))
+        if re.match(r"^\s*(?:echo|printf)\b", command):
+            return _echo_arg_is_token(command)
+        return bool(_PASS_SHOW_RE.match(command))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def handle_block_secret_file_print(data: dict) -> bool:
+    """Deny a Bash command that would print a secret-bearing file or token to stdout.
+
+    Blocks cat/head/tail of credential files, ``pass show`` without redirection,
+    and echo/printf of pasted token literals. Commands that capture the value
+    into a variable or redirect to a file pass through. Returns True when a
+    deny was emitted (caller stops the handler chain).
+    """
+    if data.get("tool_name") != "Bash":
+        return False
+    command = data.get("tool_input", {}).get("command", "")
+    if not command or not _is_secret_print(command):
+        return False
+    return emit_pretooluse_deny(_CREDENTIAL_PRINT_BLOCK_MSG)  # [skill-load-ok: teatree]
+
+
 # ── PreToolUse: block-out-of-band-merge (#126) ──────────────────────
 #
 # ``gh pr merge`` / ``glab mr merge`` bypass the FSM coherence mechanism
@@ -8506,6 +8631,7 @@ _HANDLERS: dict[str, list] = {
         handle_banned_terms_pretool,
         handle_enforce_skill_loading,
         handle_block_direct_commands,
+        handle_block_secret_file_print,
         handle_block_out_of_band_merge,
         handle_block_raw_review_post,
         handle_validate_mr_metadata,

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -6890,7 +6890,14 @@ _SECRET_PATHS_RE = re.compile(  # [skill-load-ok: souliane/teatree repo]
         | (?:Library/Application\s+Support|\.config)/glab-cli/config\.yml
         | \.ssh/(?:id_[a-z0-9_]+|.*\.pem|.*\.key)
     )
-    | (?:^|[\s/])(?:\.env(?:\.[a-z]+)?|secrets?\.env|.*\.credentials?|.*\.pem|.*\.key|.*_account\.json)(?:\s|$|['")])
+    | (?:^|[\s/])(?:
+        \.env(?!\.(?:example|sample|template|dist)\b)(?:\.[a-z]+)?
+        | secrets?\.env
+        | .*\.credentials?
+        | .*\.pem
+        | .*\.key
+        | .*_account\.json
+    )(?:\s|$|['")])
     """,
     re.IGNORECASE,
 )
@@ -6903,14 +6910,15 @@ _PRINT_CMDS_RE = re.compile(r"^\s*(?:cat|head|tail)\b")
 
 _PASS_SHOW_RE = re.compile(r"^\s*pass\s+show\b")
 
-_CAPTURE_OR_REDIRECT_RE = re.compile(  # [skill-load-ok: souliane/teatree repo]
+_CAPTURE_RE = re.compile(  # [skill-load-ok: souliane/teatree repo]
     r"""
     \$\(            # subshell capture: $(…)
     | >\s*\S+       # stdout redirect to a file or /dev/null
-    | \|\s*\S       # pipe to another command (value leaves stdout)
     """,
     re.VERBOSE,
 )
+
+_RE_EMITTER_SINK_RE = re.compile(r"^\s*(?:cat|less|more|tee|grep|head|tail)\b")
 
 _ECHO_SAFE_QUOTE_RE = re.compile(r"""^(?:'[^']*'|"[^"]*")$""")
 
@@ -6929,27 +6937,34 @@ def _command_captures_or_redirects(command: str) -> bool:
     """Return True when the command's stdout is captured or redirected, not printed.
 
     A variable-assignment prefix (``VAR=$(…)`` or ``export VAR=$(…)``) or a
-    stdout redirect (``> file``) or pipe (``| cmd``) means the secret value
-    does NOT land on the transcript. A plain ``pass show x`` with no such
-    construct does.
+    stdout redirect (``> file``) keeps the secret off the transcript. A pipe
+    is a capture only when its sink consumes the value — a sink that re-emits
+    to the transcript (``cat`` / ``less`` / ``more`` / ``tee`` / ``grep`` /
+    ``head`` / ``tail``, incl. ``tee /dev/tty``) still displays the secret and
+    is NOT a capture. A plain ``pass show x`` with no such construct prints.
     """
-    return bool(_CAPTURE_OR_REDIRECT_RE.search(command))
+    if _CAPTURE_RE.search(command):
+        return True
+    segments = command.split("|")
+    if len(segments) < 2:  # noqa: PLR2004
+        return False
+    return not any(_RE_EMITTER_SINK_RE.match(segment) for segment in segments[1:])
 
 
 def _echo_arg_is_token(command: str) -> bool:
-    """Return True when the echo/printf command carries a bare token literal.
+    """Return True when the echo/printf command carries a token literal.
 
     Prose strings inside quotes that merely MENTION a secret path are not
-    treated as token prints — they contain no token literal.  Only an
-    unquoted or minimally-quoted arg that starts with a known token prefix
-    triggers a deny.
+    treated as token prints — they contain no token literal. A fully-quoted
+    arg whose CONTENT is itself a token literal still lands on the transcript,
+    so it is treated as a token. Only quoted prose (no token shape) passes.
     """
     parts = command.split(None, 1)
     if len(parts) < 2:  # noqa: PLR2004
         return False
     arg = parts[1].strip()
     if _ECHO_SAFE_QUOTE_RE.match(arg):
-        return False
+        return bool(_TOKEN_LITERAL_RE.search(arg[1:-1]))
     return bool(_TOKEN_LITERAL_RE.search(command))
 
 

--- a/tests/test_block_secret_file_print_hook.py
+++ b/tests/test_block_secret_file_print_hook.py
@@ -153,3 +153,101 @@ class TestAllowsBenignCommands:
 
     def test_empty_command_passes_through(self, capsys: pytest.CaptureFixture[str]) -> None:
         assert handle_block_secret_file_print(_bash_event("")) is not True
+
+
+class TestBlocksQuotedTokenLiterals:
+    """A token literal inside quotes still prints to the transcript and is blocked."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo "glpat-synthetictoken123"',
+            "echo 'ghp_synthetictoken456'",
+            'printf "xoxb-synthetic-789"',
+            "echo 'sk-syntheticopenaikey'",
+        ],
+    )
+    def test_quoted_token_is_denied(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_secret_file_print(_bash_event(command)) is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert deny["permissionDecision"] == "deny"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'echo "just some prose"',
+            "echo 'The config lives at ~/.teatree.toml'",
+            'printf "hello world\\n"',
+        ],
+    )
+    def test_quoted_prose_is_allowed(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_secret_file_print(_bash_event(command)) is not True
+        assert capsys.readouterr().out.strip() == ""
+
+
+class TestBlocksReEmitterPipes:
+    """A pipe whose sink re-displays the secret to the transcript is still blocked."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat .env | grep -v '^#'",
+            "cat ~/.teatree.toml | less",
+            "cat .env | tee /dev/tty",
+            "cat ~/.netrc | cat",
+            "cat ~/.teatree.toml | more",
+            "head ~/.netrc | tail -n 2",
+            "cat .env | tee leak.txt",
+        ],
+    )
+    def test_re_emitter_pipe_is_denied(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_secret_file_print(_bash_event(command)) is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert deny["permissionDecision"] == "deny"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat .env > /tmp/x",
+            "VAR=$(cat .env)",
+            "cat ~/.teatree.toml > /tmp/cfg_backup.toml",
+            "cat .env | gzip > /tmp/x.gz",
+        ],
+    )
+    def test_genuine_capture_is_allowed(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_secret_file_print(_bash_event(command)) is not True
+        assert capsys.readouterr().out.strip() == ""
+
+
+class TestAllowsCommittedEnvTemplates:
+    """Standard committed non-secret env templates pass; a real .env still blocks."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat .env.example",
+            "cat .env.sample",
+            "cat .env.template",
+            "cat .env.dist",
+            "head .env.example",
+        ],
+    )
+    def test_env_template_is_allowed(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_secret_file_print(_bash_event(command)) is not True
+        assert capsys.readouterr().out.strip() == ""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat .env",
+            "cat .env.local",
+            "cat .env.production",
+        ],
+    )
+    def test_real_env_still_denied(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_secret_file_print(_bash_event(command)) is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert deny["permissionDecision"] == "deny"

--- a/tests/test_block_secret_file_print_hook.py
+++ b/tests/test_block_secret_file_print_hook.py
@@ -1,0 +1,155 @@
+"""Tests for the secret-file-print deny gate in hook_router (#2306).
+
+A Bash command that routes a known secret-bearing source to stdout — via
+cat/head/tail/printf/echo of credential/config files, or pass show without
+redirection, or an echoed token literal — is BLOCKED. Reading into a variable,
+piping to a file, or any non-Bash tool passes through. Fails OPEN on parse
+error (consistent with the raw-review-post guard).
+"""
+
+import json
+
+import pytest
+
+from hooks.scripts.hook_router import handle_block_secret_file_print
+
+
+def _bash_event(command: str, tool_name: str = "Bash") -> dict:
+    return {
+        "session_id": "sess-secret-print",
+        "tool_name": tool_name,
+        "tool_input": {"command": command},
+    }
+
+
+def _parse_deny(capsys: pytest.CaptureFixture[str]) -> dict | None:
+    output = capsys.readouterr().out.strip()
+    return json.loads(output) if output else None
+
+
+class TestBlocksSecretFilePrints:
+    """Commands that print a known secret-bearing file to stdout are blocked."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # cat of known secret files
+            "cat ~/.teatree.toml",
+            "cat $HOME/.teatree.toml",
+            'cat "${HOME}/.teatree.toml"',
+            "cat ~/.netrc",
+            "cat ~/.config/gh/hosts.yml",
+            'cat "~/Library/Application Support/glab-cli/config.yml"',
+            "cat ~/.config/glab-cli/config.yml",
+            "cat ~/.ssh/id_rsa",
+            "cat ~/.ssh/id_ed25519",
+            "cat .env",
+            "cat .env.local",
+            "cat .env.production",
+            "cat secrets.env",
+            "cat my.credentials",
+            "cat service_account.json",
+            "cat server.pem",
+            "cat client.key",
+            # head/tail of secret files
+            "head ~/.teatree.toml",
+            "head -n 5 ~/.netrc",
+            "tail -n 20 ~/.config/gh/hosts.yml",
+            "tail ~/.ssh/id_rsa",
+            # pass show without redirection
+            "pass show email/work",
+            "pass show -c personal/github",
+            "pass show infra/api-key",
+            # echo of a pasted token literal
+            "echo glpat-abc123xyz",
+            "echo ghp_sometoken123",
+            "echo gho_oauthtoken",
+            "echo xoxb-slack-token",
+            "echo xoxp-slack-token",
+            "echo sk-openai-key",
+            # printf of a token literal
+            "printf glpat-secret",
+            # cat with absolute path matching secret pattern
+            "cat /Users/user/.teatree.toml",
+            "cat /home/user/.netrc",
+            "cat /root/.ssh/id_rsa",
+        ],
+    )
+    def test_secret_print_is_denied(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_secret_file_print(_bash_event(command)) is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert deny["permissionDecision"] == "deny"
+
+    def test_deny_message_is_actionable(self, capsys: pytest.CaptureFixture[str]) -> None:
+        handle_block_secret_file_print(_bash_event("cat ~/.teatree.toml"))
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        reason = deny["permissionDecisionReason"]
+        assert "BLOCKED" in reason
+        assert "secret" in reason.lower() or "credential" in reason.lower()
+
+
+class TestAllowsBenignCommands:
+    """Non-printing uses, variable captures, and file redirections pass through."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # Extracting into a variable — stdout never carries the secret
+            "TOKEN=$(pass show infra/api-key)",
+            "export TOKEN=$(pass show infra/api-key)",
+            "TOK=$(cat ~/.netrc | grep password | awk '{print $2}')",
+            "PASS=$(cat ~/.teatree.toml | grep token | cut -d= -f2)",
+            # Piping to a file — value stays off stdout
+            "pass show email/work > /tmp/pw.txt",
+            "cat ~/.teatree.toml > /tmp/cfg_backup.toml",
+            "cat ~/.netrc >> /tmp/backup.txt",
+            # Redirecting to /dev/null (test/check pattern)
+            "cat ~/.teatree.toml > /dev/null",
+            # curl using the token via env/header — value never echoed
+            'curl -H "PRIVATE-TOKEN: $TOKEN" https://gitlab.com/api/v4/user',
+            'curl -H "Authorization: Bearer $TOKEN" https://api.github.com/user',
+            # cat of non-secret files
+            "cat README.md",
+            "cat src/teatree/core/models.py",
+            "cat /etc/hosts",
+            "cat ~/.gitconfig",
+            "cat ~/.bashrc",
+            "head -n 10 README.md",
+            "tail -f /var/log/app.log",
+            # echo of safe strings (mentioning secret file paths in prose)
+            "echo 'Do not cat ~/.teatree.toml'",
+            "echo 'The config lives at ~/.teatree.toml'",
+            # echo of non-token strings
+            "echo hello world",
+            "echo 'manage.py runserver is not allowed'",
+            # grep for patterns in secret files (doesn't print whole file)
+            "grep -c '' ~/.teatree.toml",
+            # pass without show — list/edit/generate/etc. are safe
+            "pass ls",
+            "pass list",
+            "pass generate email/new 20",
+            "pass edit email/work",
+            # wc, stat, ls on secret files — metadata only
+            "wc -l ~/.teatree.toml",
+            "stat ~/.teatree.toml",
+            "ls -la ~/.ssh/",
+            # git commands that happen to touch config paths
+            "git config --global user.email",
+            "git diff HEAD",
+            # Unrelated general commands
+            "uv run pytest --no-cov -q",
+            "ruff check src/",
+            "t3 teatree worktree start",
+        ],
+    )
+    def test_command_is_allowed(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_secret_file_print(_bash_event(command)) is not True
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_ignores_non_bash_tools(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_secret_file_print(_bash_event("cat ~/.teatree.toml", tool_name="Read")) is not True
+
+    def test_empty_command_passes_through(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_secret_file_print(_bash_event("")) is not True

--- a/tests/test_gate_liveness_corpus.py
+++ b/tests/test_gate_liveness_corpus.py
@@ -560,6 +560,18 @@ def _raw_review_allow(_ctx: GateContext) -> dict:
     return _bash("glab api projects/1/merge_requests/1/discussions")
 
 
+# block-secret-file-print (PreToolUse Bash): printing a credential file to the
+# transcript denies; capturing the value into a variable allows.
+
+
+def _secret_print_deny(_ctx: GateContext) -> dict:
+    return _bash("cat ~/.teatree.toml")
+
+
+def _secret_print_allow(_ctx: GateContext) -> dict:
+    return _bash("TOKEN=$(pass show infra/api-key)")
+
+
 # classifier-deny stop gate (Stop): a pending classifier-deny marker emits the
 # STOP-and-explain systemMessage; no marker allows the Stop chain to proceed.
 
@@ -751,6 +763,14 @@ GATE_REGISTRY: Final[tuple[GateRow, ...]] = (
         matched="Bash",
         deny_input=_raw_review_deny,
         allow_input=_raw_review_allow,
+    ),
+    GateRow(
+        gate_id="block-secret-file-print",
+        handler=router.handle_block_secret_file_print,
+        event="PreToolUse",
+        matched="Bash",
+        deny_input=_secret_print_deny,
+        allow_input=_secret_print_allow,
     ),
     GateRow(
         gate_id="classifier-deny-stop-gate",


### PR DESCRIPTION
Closes #2306

Adds handle_block_secret_file_print to the PreToolUse handler chain. Blocks cat/head/tail of known credential files, pass show without redirection, and echo/printf of pasted token literals. Variable-capture and stdout redirects pass through. Non-Bash tools exempt; fails open on parse errors.

71 parametrized tests cover blocked and allowed commands.