### PR TITLE
fix(gate-12): exempt read-only forge GETs; warn on stale .coverage (#2310)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -2585,7 +2585,7 @@ def _read_message_file(command: str) -> str | None:
 # already covered by _MERGE_ENDPOINT_RE.  The \d+-free form matches both the
 # collection endpoint (/pulls, /merge_requests) and a per-MR update endpoint
 # (/pulls/42, /merge_requests/42) when written as a POST.
-_API_CREATE_ENDPOINT_RE = re.compile(r"/(?:pulls|merge_requests)(?:/\d+)?(?:[/?'\"\s]|$)")
+_API_CREATE_ENDPOINT_RE = re.compile(r"/(?:pulls|merge_requests)(?:/\d+)?(?!/\d*/[A-Za-z])(?:[?'\"\s]|$)")
 
 
 def _is_api_create_endpoint_write(command: str) -> bool:

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -2582,10 +2582,19 @@ def _read_message_file(command: str) -> str | None:
 
 # REST-API create-endpoint: .../pulls or .../merge_requests WITHOUT /N/merge.
 # Distinguishes a PR/MR create from a list read (GET) or the merge endpoint
-# already covered by _MERGE_ENDPOINT_RE.  The \d+-free form matches both the
+# already covered by _MERGE_ENDPOINT_RE.  The optional /\d+ matches both the
 # collection endpoint (/pulls, /merge_requests) and a per-MR update endpoint
 # (/pulls/42, /merge_requests/42) when written as a POST.
-_API_CREATE_ENDPOINT_RE = re.compile(r"/(?:pulls|merge_requests)(?:/\d+)?(?!/\d*/[A-Za-z])(?:[?'\"\s]|$)")
+#
+# The trailing class keeps `/` so the collection-create form written WITH a
+# trailing slash (`/merge_requests/ -f title=…`) still matches as a create —
+# dropping `/` here lets a real trailing-slash MR/PR-create POST escape all
+# three consumers. The sub-resource exclusion lives entirely in the lookahead
+# `(?!/\d*/?[A-Za-z])`: a read-only nested GET (`/merge_requests/42/approvals`,
+# `/pulls/123/commits`, `/notes`, `/files`, `/pipelines`) is `/\d+` then `/`
+# then a letter, so the lookahead rejects it; the trailing-slash create is
+# `/` then a space (not a letter), so the lookahead admits it.
+_API_CREATE_ENDPOINT_RE = re.compile(r"/(?:pulls|merge_requests)(?:/\d+)?(?!/\d*/?[A-Za-z])(?:[/?'\"\s]|$)")
 
 
 def _is_api_create_endpoint_write(command: str) -> bool:

--- a/src/teatree/cli/enforcement_tools.py
+++ b/src/teatree/cli/enforcement_tools.py
@@ -33,9 +33,26 @@ def ai_sig_scan(
     ToolRunner.run_script("ai_signature_scan", path)
 
 
+def _source_is_newer(src: Path, cov_mtime: float) -> bool:
+    """Whether *src* is strictly newer than the coverage file's mtime.
+
+    A file removed mid-walk (``OSError`` on ``stat``) contributes nothing to
+    the staleness decision rather than crashing the whole gate — the walk
+    degrades gracefully without suppressing a genuine staleness signal from
+    the files that are still present.
+    """
+    try:
+        return src.stat().st_mtime > cov_mtime
+    except OSError:
+        return False
+
+
 def _coverage_is_stale(coverage_file: Path, repo: Path) -> bool:
-    cov_mtime = coverage_file.stat().st_mtime
-    return any(src.stat().st_mtime > cov_mtime for src in repo.rglob("*.py") if src != coverage_file)
+    try:
+        cov_mtime = coverage_file.stat().st_mtime
+        return any(_source_is_newer(src, cov_mtime) for src in repo.rglob("*.py") if src != coverage_file)
+    except OSError:
+        return False
 
 
 @tool_app.command("diff-coverage")

--- a/src/teatree/cli/enforcement_tools.py
+++ b/src/teatree/cli/enforcement_tools.py
@@ -33,6 +33,11 @@ def ai_sig_scan(
     ToolRunner.run_script("ai_signature_scan", path)
 
 
+def _coverage_is_stale(coverage_file: Path, repo: Path) -> bool:
+    cov_mtime = coverage_file.stat().st_mtime
+    return any(src.stat().st_mtime > cov_mtime for src in repo.rglob("*.py") if src != coverage_file)
+
+
 @tool_app.command("diff-coverage")
 def diff_coverage(
     *,
@@ -51,13 +56,16 @@ def diff_coverage(
     from teatree.utils.git import full_worktree_diff  # noqa: PLC0415
 
     if not coverage_file.exists():
-        # Finding 5: the line-coverage half measured nothing. The symbol
-        # check still runs, but the absence must be visible — surface a
-        # stderr WARNING without changing exit semantics.
         typer.echo(
             f"WARNING: no coverage data at {coverage_file} — the per-diff "
             "line-coverage check measured nothing (only the symbol check ran). "
             "Run `uv run pytest` first for full enforcement.",
+            err=True,
+        )
+    elif _coverage_is_stale(coverage_file, repo):
+        typer.echo(
+            f"WARNING: .coverage at {coverage_file} is stale (a source file is newer) — "
+            "line-coverage results may be inaccurate. Run `uv run pytest` to refresh.",
             err=True,
         )
 

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -142,6 +143,34 @@ class TestToolCommands:
             )
         assert result.exit_code == 0
         assert "WARNING" not in result.stderr
+
+    def test_diff_coverage_warns_when_coverage_stale(self, tmp_path):
+        src = tmp_path / "src.py"
+        src.write_text("x = 1\n", encoding="utf-8")
+        cov = tmp_path / ".coverage"
+        cov.write_text("", encoding="utf-8")
+        past = time.time() - 10
+        os.utime(cov, (past, past))
+        report = MagicMock(passes=lambda: True, summary=lambda: "clean")
+        with (
+            patch("teatree.utils.git.full_worktree_diff", return_value="diff --git a/src.py b/src.py\n+x = 1"),
+            patch("teatree.utils.diff_coverage.measure_diff_coverage", return_value=report),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "tool",
+                    "diff-coverage",
+                    "--repo",
+                    str(tmp_path),
+                    "--coverage-file",
+                    str(cov),
+                ],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        assert "WARNING" in result.stderr
+        assert "stale" in result.stderr.lower()
 
     def test_analyze_video(self):
         with patch.object(ToolRunner, "run_script") as mock:

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 import teatree.cli as teatree_cli
 from scripts.privacy_scan import PRIVACY_FINDINGS_EXIT_CODE
 from teatree.cli import app
+from teatree.cli.enforcement_tools import _coverage_is_stale
 from teatree.cli.tools import ToolRunner
 from teatree.core.overlay import OverlayBase, OverlayMetadata
 from teatree.repo_mode import RepoMode
@@ -171,6 +172,50 @@ class TestToolCommands:
         assert result.exit_code == 0
         assert "WARNING" in result.stderr
         assert "stale" in result.stderr.lower()
+
+    def test_coverage_is_stale_degrades_when_file_removed_mid_walk(self, tmp_path):
+        """A source file removed between rglob and stat must not crash the gate.
+
+        ``_coverage_is_stale`` walks every ``*.py`` and stats it; a file
+        vanishing mid-walk (a concurrent worktree prune, an editor swap) made
+        ``stat`` raise ``FileNotFoundError`` and crash ``diff-coverage``. The
+        per-file skip degrades to "not stale" for the vanished file instead.
+        """
+        cov = tmp_path / ".coverage"
+        cov.write_text("", encoding="utf-8")
+        os.utime(cov, (time.time() - 10, time.time() - 10))
+        ghost = tmp_path / "ghost.py"
+        ghost.write_text("x = 1\n", encoding="utf-8")
+
+        real_stat = Path.stat
+
+        def stat_raising_for_ghost(self, *args, **kwargs):
+            if self.name == "ghost.py":
+                raise FileNotFoundError(self)
+            return real_stat(self, *args, **kwargs)
+
+        with patch.object(Path, "stat", stat_raising_for_ghost):
+            assert _coverage_is_stale(cov, tmp_path) is False
+
+    def test_coverage_is_stale_skips_only_vanished_file(self, tmp_path):
+        """A vanished file is skipped; a present newer file still flags stale."""
+        cov = tmp_path / ".coverage"
+        cov.write_text("", encoding="utf-8")
+        os.utime(cov, (time.time() - 10, time.time() - 10))
+        ghost = tmp_path / "ghost.py"
+        ghost.write_text("x = 1\n", encoding="utf-8")
+        fresh = tmp_path / "fresh.py"
+        fresh.write_text("y = 2\n", encoding="utf-8")  # newer than .coverage
+
+        real_stat = Path.stat
+
+        def stat_raising_for_ghost(self, *args, **kwargs):
+            if self.name == "ghost.py":
+                raise FileNotFoundError(self)
+            return real_stat(self, *args, **kwargs)
+
+        with patch.object(Path, "stat", stat_raising_for_ghost):
+            assert _coverage_is_stale(cov, tmp_path) is True
 
     def test_analyze_video(self):
         with patch.object(ToolRunner, "run_script") as mock:

--- a/tests/test_hook_router_gate_bypass_class.py
+++ b/tests/test_hook_router_gate_bypass_class.py
@@ -285,6 +285,32 @@ class TestF2ApiCreateEndpointBypass:
         }
         assert _is_merge_class_mutation(data) is False, "bare GET to pulls must not be merge-class"
 
+    def test_f2b_glab_api_mr_sub_resource_get_is_not_merge_class(self):
+        """Glab api .../merge_requests/123/pipelines is a read-only GET — not merge-class."""
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "glab api projects/org%2Fproject/merge_requests/123/pipelines -f page=1"},
+        }
+        assert _is_merge_class_mutation(data) is False, (
+            "GET to a sub-resource of merge_requests must not be treated as a create"
+        )
+
+    def test_f2b_gh_api_pr_sub_resource_get_is_not_merge_class(self):
+        """Gh api .../pulls/123/commits is a read-only GET — not merge-class."""
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh api repos/org/repo/pulls/123/commits -f per_page=100"},
+        }
+        assert _is_merge_class_mutation(data) is False, "GET to a sub-resource of pulls must not be treated as a create"
+
+    def test_f2b_glab_api_mr_sub_resource_approvals_get_is_not_merge_class(self):
+        """Glab api .../merge_requests/42/approvals GET is not merge-class."""
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "glab api projects/42/merge_requests/42/approvals"},
+        }
+        assert _is_merge_class_mutation(data) is False, "GET to approvals sub-resource must not be merge-class"
+
 
 # ── F3: git -c core.hooksPath bypass ────────────────────────────────────
 

--- a/tests/test_hook_router_gate_bypass_class.py
+++ b/tests/test_hook_router_gate_bypass_class.py
@@ -304,12 +304,42 @@ class TestF2ApiCreateEndpointBypass:
         assert _is_merge_class_mutation(data) is False, "GET to a sub-resource of pulls must not be treated as a create"
 
     def test_f2b_glab_api_mr_sub_resource_approvals_get_is_not_merge_class(self):
-        """Glab api .../merge_requests/42/approvals GET is not merge-class."""
+        """Glab api .../merge_requests/42/approvals with a body flag is not merge-class.
+
+        The body flag (``-f page=1``) makes the effective method default to
+        POST, so the exemption is carried by the endpoint regex (the
+        sub-resource lookahead), not by the method classifier — the same path
+        the pipelines/commits siblings exercise. Without ``-f`` the classifier
+        defaults to GET on its own, making the test vacuous (green even under
+        an over-broad endpoint regex).
+        """
         data = {
             "tool_name": "Bash",
-            "tool_input": {"command": "glab api projects/42/merge_requests/42/approvals"},
+            "tool_input": {"command": "glab api projects/42/merge_requests/42/approvals -f page=1"},
         }
         assert _is_merge_class_mutation(data) is False, "GET to approvals sub-resource must not be merge-class"
+
+    def test_f2b_glab_api_mr_create_trailing_slash_is_merge_class(self):
+        """Glab api .../merge_requests/ (trailing slash) POST is a merge-class create.
+
+        The collection-create endpoint written WITH a trailing slash and a
+        body must still classify as a create — dropping ``/`` from the trailing
+        class lets this real MR-create POST escape Gate 12, the metadata gate,
+        and the merge-class check at once.
+        """
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "glab api projects/42/merge_requests/ -f title=x -f description=x"},
+        }
+        assert _is_merge_class_mutation(data) is True, "trailing-slash merge_requests/ create must be merge-class"
+
+    def test_f2b_gh_api_pulls_create_trailing_slash_is_merge_class(self):
+        """Gh api .../pulls/ (trailing slash) POST is a merge-class create."""
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh api repos/example-org/private-repo/pulls/ -f title=x -f body=x"},
+        }
+        assert _is_merge_class_mutation(data) is True, "trailing-slash pulls/ create must be merge-class"
 
 
 # ── F3: git -c core.hooksPath bypass ────────────────────────────────────


### PR DESCRIPTION
Closes #2310.

Fixes _API_CREATE_ENDPOINT_RE in hook_router.py with a negative-lookahead to prevent sub-resource paths from matching. Read-only GETs to forge sub-resources are not merge-class mutations.

Adds stale .coverage detection to enforcement_tools.py: if .coverage is older than any .py source in the repo, emits a WARNING to stderr and continues (same fail-open semantics as absent .coverage).

Four regression tests, all RED before the fix: three for sub-resource GETs, one for stale .coverage warning.