### PR TITLE
ci: add advisory uv audit dependency-vulnerability lane (#2292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@
 #   5. Test suite            — test, test-shim
 #   6. Architecture / quality fitness gates — mutation-diff, mutation-full,
 #                              banned-terms-tree
-#   7. Security & supply chain — uv-audit, sbom
+#   7. Security & supply chain — uv-audit, sbom, uv-audit-advisory
 #
 # THE METERED AI EVAL DOES NOT RUN HERE
 #   The metered behavioral-eval suite (`t3 eval run --backend sdk`, which shells
@@ -87,8 +87,8 @@ jobs:
     # skip the HEAVY ``test`` + ``mutation-diff`` lanes. Any unrecognised
     # path, any python change, or any config/CI/semgrep change forces
     # ``run_heavy_python=true`` (run everything) — uncertainty never
-    # skips. Security/quality gates (semgrep, sbom, uv-audit) and the
-    # docs gates are NOT gated here; they always run.
+    # skips. Security/quality gates (semgrep, sbom, uv-audit, the advisory
+    # uv-audit-advisory) and the docs gates are NOT gated here; they always run.
     #
     # On push-to-main and on the schedule there is no base to diff, so
     # this job is PR-only and the downstream ``if:`` conditions run the
@@ -653,6 +653,43 @@ jobs:
         with:
           name: sbom
           path: dist/sbom.json
+
+  # ADVISORY (never blocks): uv-native, uv.lock-accurate, OSV-backed vulnerability
+  # scan via `uv audit` (https://astral.sh/blog/uv-audit). Runs ALONGSIDE — never
+  # replaces — the blocking `uv-audit` (pip-audit) gate and the `sbom` SBOM-diff
+  # gate above. Kept advisory because `uv audit` is still a PREVIEW feature with
+  # possible breaking changes (the same astral-sh/uv#19492 OSV-parser regression
+  # that moved the blocking gate to pip-audit, souliane/teatree#1264). The uv
+  # version is PINNED so preview flag churn can't break this lane out from under
+  # us; promote to a gate (drop continue-on-error, un-pin) once `uv audit` is
+  # stable. Allowlist of accepted advisories: `[tool.teatree.uv_audit].ignore`
+  # in pyproject.toml.
+  #
+  # Job key `uv-audit-advisory` is DELIBERATELY distinct from the load-bearing
+  # `uv-audit` (UV_AUDIT_CHECK_NAME in src/teatree/loop/scanners/pr_sweep.py) so
+  # the two never collide.
+  uv-audit-advisory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+          # PIN the uv version: `uv audit` is preview, so a floating `latest`
+          # could change flags out from under this lane. Bump deliberately.
+          version: "0.11.15"
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.13"
+      # `--frozen` audits the locked `uv.lock` resolution without re-locking;
+      # `--no-default-groups` audits the SHIPPED runtime surface (mirrors the
+      # blocking gate's `--no-default-groups`, excluding dev-only tooling).
+      # `|| true` plus `continue-on-error: true` are the two independent
+      # guards keeping this lane non-blocking: a finding, a preview crash, or
+      # an offline/network hiccup is reported but never reds the build.
+      - name: uv audit (advisory; OSV; never blocks)
+        continue-on-error: true
+        run: uv audit --frozen --no-default-groups --output-format text || true
 
   # The metered behavioral-eval suite (`t3 eval run --backend sdk`, `claude -p`)
   # is NOT a job here. It runs in the standalone `.github/workflows/eval.yml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -480,3 +480,17 @@ unresolved-attribute = "ignore"
 [tool.uv]
 managed = true
 package = true
+
+# --- uv audit advisory lane (souliane/teatree#2292) ---
+# Allowlist for accepted advisories surfaced by the NON-BLOCKING `uv audit`
+# preview lane (CI job `uv-audit-advisory`). The advisory lane never reds the
+# build, so this list is informational today; it documents the structure the
+# lane will read once `uv audit` is promoted to blocking. The blocking gate is
+# still pip-audit (`requirements.audit.ignore`), which is the file to edit to
+# suppress a vulnerability that would otherwise fail CI.
+#
+# Add OSV / GHSA ids, one per `ignore` entry, e.g.
+#   ignore = [ "GHSA-xxxx-xxxx-xxxx" ]  # package==1.2.3: justification + link
+
+[tool.teatree.uv_audit]
+ignore = [  ]

--- a/tests/test_ci_uv_audit_advisory.py
+++ b/tests/test_ci_uv_audit_advisory.py
@@ -1,0 +1,124 @@
+"""Tests for the advisory ``uv audit`` CI lane (souliane/teatree#2292).
+
+``uv audit`` (Astral, https://astral.sh/blog/uv-audit) is a uv-native,
+``uv.lock``-accurate, OSV-backed vulnerability scanner. It is still a PREVIEW
+feature with possible breaking changes, so it runs as a SEPARATE, NON-BLOCKING
+advisory lane — never the blocking gate. The blocking gate stays ``pip-audit``
+(the ``uv-audit`` job, #1264) and the SBOM-diff gate (``sbom``) is untouched:
+``uv audit`` runs ALONGSIDE both, it does not replace them.
+
+These tests pin:
+- the advisory job is DISTINCT from the load-bearing ``uv-audit`` job key (UV_AUDIT_CHECK_NAME in pr_sweep.py);
+- it actually invokes ``uv audit``;
+- it is NON-BLOCKING (a finding never reds the build);
+- the uv version is PINNED so preview flag churn can't break the lane;
+- the existing blocking pip-audit gate and SBOM-diff gate still exist.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+_ADVISORY_JOB = "uv-audit-advisory"
+_BLOCKING_JOB = "uv-audit"
+
+
+def _load_ci_jobs() -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))["jobs"])
+
+
+def _job_run_commands(job: dict[str, Any]) -> list[str]:
+    return [step.get("run", "") for step in job["steps"] if isinstance(step, dict)]
+
+
+class TestUvAuditAdvisoryJob:
+    def test_advisory_job_exists_and_is_distinct_from_blocking_gate(self) -> None:
+        jobs = _load_ci_jobs()
+        assert _ADVISORY_JOB in jobs, f"Expected a distinct advisory job '{_ADVISORY_JOB}' running 'uv audit'."
+        assert _ADVISORY_JOB != _BLOCKING_JOB, (
+            "The advisory lane must not reuse the load-bearing 'uv-audit' job key "
+            "(UV_AUDIT_CHECK_NAME in src/teatree/loop/scanners/pr_sweep.py)."
+        )
+
+    def test_advisory_job_invokes_uv_audit(self) -> None:
+        jobs = _load_ci_jobs()
+        joined = " ".join(_job_run_commands(jobs[_ADVISORY_JOB]))
+        assert "uv audit" in joined, "The advisory lane must invoke 'uv audit'."
+
+    def test_advisory_job_reads_the_lockfile_frozen(self) -> None:
+        # ``--frozen`` audits the locked ``uv.lock`` resolution without
+        # re-locking — the lockfile-accurate scan the ticket asks for.
+        jobs = _load_ci_jobs()
+        joined = " ".join(_job_run_commands(jobs[_ADVISORY_JOB]))
+        assert "--frozen" in joined, "The advisory lane must audit the locked 'uv.lock' resolution (--frozen)."
+
+    def test_advisory_job_is_non_blocking(self) -> None:
+        # Non-blocking has two independent guards so a single mistake can't
+        # silently turn the advisory lane into a gate:
+        #  - the audit step carries ``continue-on-error: true``;
+        #  - the command tolerates a non-zero exit (``|| true``).
+        jobs = _load_ci_jobs()
+        steps = [s for s in jobs[_ADVISORY_JOB]["steps"] if isinstance(s, dict)]
+        audit_steps = [s for s in steps if "uv audit" in s.get("run", "")]
+        assert audit_steps, "Expected a step that runs 'uv audit'."
+        for step in audit_steps:
+            assert step.get("continue-on-error") is True, (
+                "The 'uv audit' step must set continue-on-error: true so a "
+                "finding (or preview/network hiccup) never reds the build."
+            )
+            assert "|| true" in step["run"], (
+                "The 'uv audit' command must tolerate a non-zero exit (|| true) "
+                "so preview instability never fails the lane."
+            )
+
+    def test_advisory_job_pins_uv_version(self) -> None:
+        # setup-uv must pin a fixed ``version:`` so a future uv release with
+        # preview flag churn can't break the advisory lane out from under us.
+        jobs = _load_ci_jobs()
+        setup_uv_steps = [
+            s
+            for s in jobs[_ADVISORY_JOB]["steps"]
+            if isinstance(s, dict) and "astral-sh/setup-uv" in str(s.get("uses", ""))
+        ]
+        assert setup_uv_steps, "The advisory lane must use astral-sh/setup-uv."
+        pinned = [str(s.get("with", {}).get("version", "")) for s in setup_uv_steps]
+        assert any(v and v != "latest" for v in pinned), (
+            "The advisory lane must pin a fixed uv version (setup-uv 'version:' "
+            "input), not float on 'latest', so preview flag churn can't break it."
+        )
+
+    def test_blocking_pip_audit_gate_still_present(self) -> None:
+        # The advisory lane runs ALONGSIDE the existing gate — it does not
+        # replace it. The blocking gate keeps its name and pip-audit tool.
+        jobs = _load_ci_jobs()
+        assert _BLOCKING_JOB in jobs, "The blocking pip-audit gate must remain."
+        joined = " ".join(_job_run_commands(jobs[_BLOCKING_JOB]))
+        assert "pip-audit" in joined, "The blocking 'uv-audit' gate must still invoke pip-audit."
+
+    def test_sbom_diff_gate_not_removed(self) -> None:
+        # Ticket decision: run uv audit alongside the #2288 SBOM-diff gate,
+        # do not remove the SBOM gate.
+        jobs = _load_ci_jobs()
+        assert "sbom" in jobs, "The #2288 SBOM-diff gate must not be removed."
+        joined = " ".join(_job_run_commands(jobs["sbom"]))
+        assert "git diff --exit-code dist/sbom.json" in joined, (
+            "The SBOM-diff gate must keep failing on a stale dist/sbom.json."
+        )
+
+
+class TestUvAuditAllowlistConfig:
+    def test_pyproject_has_uv_audit_allowlist_placeholder(self) -> None:
+        # A documented, empty allowlist structure for accepted advisories.
+        text = _PYPROJECT.read_text(encoding="utf-8")
+        assert "[tool.teatree.uv_audit]" in text, (
+            "pyproject.toml must declare a [tool.teatree.uv_audit] allowlist "
+            "placeholder for accepted advisories (empty/documented)."
+        )
+        assert "ignore = [" in text.split("[tool.teatree.uv_audit]", 1)[1][:600], (
+            "The [tool.teatree.uv_audit] section must document an 'ignore' allowlist key (empty placeholder is fine)."
+        )


### PR DESCRIPTION
## What this wires

Adds a separate, **NON-BLOCKING advisory** CI lane (`uv-audit-advisory`) that runs Astral's [`uv audit`](https://astral.sh/blog/uv-audit) against the locked `uv.lock` resolution (`--frozen --no-default-groups`). It is uv-native, lockfile-accurate, and OSV-backed, and also surfaces adverse package statuses (e.g. deprecation) the current gate misses.

## Non-blocking + pinned rationale

`uv audit` is still a **preview** feature with possible breaking changes (the [astral-sh/uv#19492](https://github.com/astral-sh/uv/issues/19492) OSV-parser regression is exactly why the *blocking* gate runs `pip-audit`, [#1264](https://github.com/souliane/teatree/issues/1264)). So the lane stays advisory, with **two independent guards** so a single mistake can't silently turn it into a gate:

- `continue-on-error: true` on the audit step, and
- a tolerant non-zero exit (`|| true`) on the command.

A finding, a preview crash, or an offline/network hiccup is reported but never reds the build. The **uv version is pinned** (`setup-uv` `version: "0.11.15"`) so preview flag churn can't break the lane out from under us. Promote to a gate (drop `continue-on-error`, un-pin) once `uv audit` is stable.

## Relationship to the existing gates (run alongside, do not replace)

- The blocking `uv-audit` (pip-audit, OSV) gate is **untouched** — same name, same tool. The job key `uv-audit-advisory` is deliberately distinct from the load-bearing `uv-audit` (`UV_AUDIT_CHECK_NAME` in `src/teatree/loop/scanners/pr_sweep.py`) so the PR-sweep scanner's fallback escape hatch keeps matching.
- The [#2288](https://github.com/souliane/teatree/issues/2288) `sbom` SBOM-diff gate is **not removed** — `uv audit` runs *alongside* it.

## Config

Adds a documented `[tool.teatree.uv_audit].ignore` allowlist placeholder in `pyproject.toml` for accepted advisories (empty today; the blocking gate's suppression file stays `requirements.audit.ignore`).

## Offline / preview behavior

Verified locally: `uv audit --frozen --no-default-groups` audits the shipped surface (180 packages) cleanly, and the `|| true` form exits 0 regardless — the lane degrades to a no-op-green rather than hard-erroring.

## Architecture pre-check

1. **BLUEPRINT §**: no § governs individual CI job lanes; the SOT is the `ci.yml` legend (updated: group 7 + preflight always-run list now name the advisory lane). § 13 Quality Gates lists tooling, not lanes — unchanged.
2. **FSM phase boundaries**: n/a (no state transition).
3. **Extension-point contracts**: the load-bearing `uv-audit` string is preserved; the new lane is a distinct job key, no scanner contract touched.
4. **Component boundaries**: CI YAML + `pyproject.toml` config + a YAML-shape regression test mirroring `tests/test_ci_audit_uses_pip_audit.py`.
5. **Dependency direction**: no `src` import added; `tach` unaffected.
6. **Test surface**: `tests/test_ci_uv_audit_advisory.py` pins distinct job, `uv audit` invocation, `--frozen` lockfile read, non-blocking (both guards), pinned uv version, blocking gate present, SBOM gate present, allowlist placeholder. The non-blocking assertion was verified anti-vacuous (removing `continue-on-error` turns it RED).
7. **Resilience invariants**: non-blocking is the core invariant — idempotent, fail-OPEN by design (advisory), pinned version isolates from upstream churn. No external write.
8. **Identity/key normalization**: job key `uv-audit-advisory` is canonical; never stripped to `uv-audit`.
9. **Behavior preservation**: purely additive — no gate weakened, no must-block test inverted, SBOM gate retained.

## Test seam

A Python seam test was added (`tests/test_ci_uv_audit_advisory.py`) since the wiring is exercised via the workflow YAML + pyproject config shape — the test asserts the non-blocking semantics and the allowlist structure deterministically.

Closes #2292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
