### PR TITLE
test: make real-git fixtures default-branch independent (#2359 class A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,18 +369,11 @@ jobs:
       # invocation site so a future ``pyproject.toml`` edit can't silently
       # disarm CI. Both must agree — ``tests/test_coverage_floor_guard.py``
       # locks the floor value.
-      # ``GIT_CONFIG_NOSYSTEM=1`` forces git's compiled-in ``master`` default so a
-      # real-git fixture that re-assumes ``main`` reds deterministically here,
-      # independent of the base image's ambient ``init.defaultBranch``
-      # (souliane/teatree#2359). tests/conftest.py preserves this var; the fitness
-      # function tests/quality/test_git_fixture_default_branch.py is the static
-      # backstop so a regression cannot silently return.
       - run: >
           docker run --rm
           -v "$PWD":/app
           -e UV_PROJECT_ENVIRONMENT=/tmp/.venv
           -e COVERAGE_FILE=/app/.coverage
-          -e GIT_CONFIG_NOSYSTEM=1
           teatree-test-${{ matrix.python-version }}
           uv run -p ${{ matrix.python-version }} pytest --no-header -q
           -o cache_dir=/tmp/.pytest_cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,11 +369,18 @@ jobs:
       # invocation site so a future ``pyproject.toml`` edit can't silently
       # disarm CI. Both must agree — ``tests/test_coverage_floor_guard.py``
       # locks the floor value.
+      # ``GIT_CONFIG_NOSYSTEM=1`` forces git's compiled-in ``master`` default so a
+      # real-git fixture that re-assumes ``main`` reds deterministically here,
+      # independent of the base image's ambient ``init.defaultBranch``
+      # (souliane/teatree#2359). tests/conftest.py preserves this var; the fitness
+      # function tests/quality/test_git_fixture_default_branch.py is the static
+      # backstop so a regression cannot silently return.
       - run: >
           docker run --rm
           -v "$PWD":/app
           -e UV_PROJECT_ENVIRONMENT=/tmp/.venv
           -e COVERAGE_FILE=/app/.coverage
+          -e GIT_CONFIG_NOSYSTEM=1
           teatree-test-${{ matrix.python-version }}
           uv run -p ${{ matrix.python-version }} pytest --no-header -q
           -o cache_dir=/tmp/.pytest_cache

--- a/tests/_git_repo.py
+++ b/tests/_git_repo.py
@@ -1,0 +1,85 @@
+"""Shared real-git fixture builder, default-branch-independent (souliane/teatree#2359).
+
+Real-git fixtures used to assume ``main`` was the default branch: a bare
+``git init`` followed by a ``worktree add <path> main`` / ``checkout main``
+passes on a dev box whose config bakes in ``init.defaultBranch=main`` but
+exits 128 (``invalid reference: main``) on a CI image whose git defaults to
+``master``. The fix is to never rely on the ambient default: born the branch
+explicitly with ``git init -b <default_branch>`` and an initial commit, so the
+branch is a real ref regardless of the host's ``init.defaultBranch``.
+
+Use :func:`make_git_repo` for any new real-git fixture instead of hand-rolling
+``git init``; it makes the default branch an argument, so a test can pin
+``main`` (the common case) or any other name without a config dependency.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+_GIT = shutil.which("git") or "/usr/bin/git"
+
+
+def git_identity_env() -> dict[str, str]:
+    """Process env plus a deterministic commit identity and nulled config sources.
+
+    ``commit`` needs an author/committer identity; a CI sandbox has none.
+    Nulling ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` makes the build
+    reproduce the CI default-branch condition on a dev box too — so a fixture
+    that secretly depends on ``init.defaultBranch=main`` fails here, not only
+    on CI.
+    """
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+    }
+
+
+def run_git(repo: Path, *args: str, check: bool = True) -> str:
+    """Run ``git -C <repo> <args>`` with the deterministic identity; return stdout.
+
+    With ``check=False`` a non-zero exit returns the (possibly empty) stdout
+    instead of raising — for a probe like ``rev-parse --verify --quiet`` whose
+    failure is the expected answer.
+    """
+    out = subprocess.run(
+        [_GIT, "-C", str(repo), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+        env=git_identity_env(),
+    )
+    return out.stdout.strip()
+
+
+def make_git_repo(
+    path: Path,
+    *,
+    default_branch: str = "main",
+    initial_commit: bool = True,
+    bare: bool = False,
+) -> Path:
+    """Create a git repo at *path* whose default branch is *default_branch*.
+
+    The branch is born with ``git init -b <default_branch>`` so it exists as a
+    real ref no matter what the host's ``init.defaultBranch`` is. With
+    ``initial_commit`` (the default) an empty commit is added so the branch has
+    a HEAD a ``worktree add`` / ``checkout`` / ``rev-parse`` can resolve.
+
+    A bare repo never has a working tree, so ``initial_commit`` is ignored for
+    ``bare=True``.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    init_args = ["init", "-q", "-b", default_branch]
+    if bare:
+        init_args.insert(1, "--bare")
+    run_git(path, *init_args)
+    if initial_commit and not bare:
+        run_git(path, "commit", "-q", "--allow-empty", "-m", "initial")
+    return path

--- a/tests/cli_doctor/test_make_editable.py
+++ b/tests/cli_doctor/test_make_editable.py
@@ -26,7 +26,7 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
 
 def _init_git_repo(root: Path) -> None:
     """Initialise a git repo at *root* with the user identity set."""
-    _git(root, "init", "-q")
+    _git(root, "init", "-q", "-b", "main")
     _git(root, "config", "user.email", "t@example.com")
     _git(root, "config", "user.name", "Test")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,17 +29,31 @@ os.environ.setdefault("HOME", str(_IMPORT_HOME))
 os.environ.setdefault("T3_WORKSPACE_DIR", str(_IMPORT_WORKSPACE))
 
 
+# Config-source controls. Stripping these would defeat reproducing the CI
+# default-branch condition locally: the CI image's git defaults to ``master``,
+# so a fixture that assumes ``main`` exits 128. ``GIT_CONFIG_NOSYSTEM=1`` forces
+# git's compiled-in ``master`` default on a dev box whose system/global config
+# bakes in ``main`` (souliane/teatree#2359). These do not carry the parent
+# repo's index/worktree the way the hook vars below do, so they are safe to keep.
+_GIT_CONFIG_SOURCE_VARS = frozenset(
+    {"GIT_CONFIG_NOSYSTEM", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM"},
+)
+
+
 def _strip_git_hook_env() -> None:
     """Strip GIT_* env vars inherited from pre-commit hooks.
 
     When pytest runs as a prek/pre-commit hook via ``git commit -a``, git sets
     ``GIT_INDEX_FILE`` to ``.git/index.lock``. Hook subprocesses inherit this,
     so any git operation in a test (e.g. ``git init`` in a temp dir) corrupts
-    the parent repo's index. Stripping all ``GIT_*`` vars at session start
+    the parent repo's index. Stripping the hook ``GIT_*`` vars at session start
     prevents this. See https://github.com/j178/prek/issues/1786.
+
+    Config-source controls (``GIT_CONFIG_NOSYSTEM`` and friends) are preserved
+    so the CI default-branch condition is reproducible locally.
     """
     for var in list(os.environ):
-        if var.startswith("GIT_"):
+        if var.startswith("GIT_") and var not in _GIT_CONFIG_SOURCE_VARS:
             del os.environ[var]
 
 

--- a/tests/quality/fixtures/git_fixture_default_branch/must_flag/bare_init_helper.py.txt
+++ b/tests/quality/fixtures/git_fixture_default_branch/must_flag/bare_init_helper.py.txt
@@ -1,0 +1,4 @@
+def setup(repo):
+    _git(repo, "init", "-q")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "base")
+    _git(repo, "push", "origin", "main")

--- a/tests/quality/fixtures/git_fixture_default_branch/must_flag/bare_init_subprocess.py.txt
+++ b/tests/quality/fixtures/git_fixture_default_branch/must_flag/bare_init_subprocess.py.txt
@@ -1,0 +1,6 @@
+import subprocess
+
+
+def setup(p):
+    subprocess.run(["git", "init", "-q", str(p)], check=True)
+    subprocess.run(["git", "-C", str(p), "worktree", "add", str(p / "wt"), "main"], check=True)

--- a/tests/quality/fixtures/git_fixture_default_branch/must_not_flag/bare_remote_and_pragma.py.txt
+++ b/tests/quality/fixtures/git_fixture_default_branch/must_not_flag/bare_remote_and_pragma.py.txt
@@ -1,0 +1,13 @@
+import subprocess
+
+
+def setup(p):
+    # A bare remote has no working branch to assume.
+    subprocess.run(["git", "init", "-q", "--bare", str(p / "remote.git")], check=True)
+    _git(p, "init", "-q", "--bare")
+    # A deliberate bare init declares intent with the pragma.
+    subprocess.run(["git", "init", str(p)], check=True)  # git-fixture: default-branch-ok
+    # A non-git tool that happens to take an "init" subcommand is never a git fixture.
+    subprocess.run(["docker", "init"], check=True)
+    # A non-init git call is irrelevant.
+    _git(p, "commit", "-m", "init")

--- a/tests/quality/fixtures/git_fixture_default_branch/must_not_flag/born_dash_b.py.txt
+++ b/tests/quality/fixtures/git_fixture_default_branch/must_not_flag/born_dash_b.py.txt
@@ -1,0 +1,10 @@
+import subprocess
+
+
+def setup(p):
+    subprocess.run(["git", "init", "-q", "-b", "main", str(p)], check=True)
+    _git(p, "init", "-q", "-b", "main")
+    subprocess.run(["git", "init", "--initial-branch=main", str(p)], check=True)
+    _git(p, "init", "--initial-branch=main", "-q")
+    # A non-init verb whose -m message is literally "init" must not be read as the verb.
+    subprocess.run(["git", "-C", str(p), "commit", "-q", "-m", "init"], check=True)

--- a/tests/quality/test_git_fixture_default_branch.py
+++ b/tests/quality/test_git_fixture_default_branch.py
@@ -1,0 +1,265 @@
+"""Fitness function: real-git fixtures never assume the ambient default branch.
+
+The fragility class (souliane/teatree#2359): a real-git fixture does a bare
+``git init`` (no ``-b`` / ``--initial-branch``) and then references a literal
+branch — ``worktree add <path> main``, ``checkout main``, ``push origin main``,
+``rev-parse main``. It passes on a dev box whose config bakes in
+``init.defaultBranch=main`` but exits 128 (``invalid reference: main``) on a CI
+image whose git defaults to ``master``, red-flagging the full-suite job on PRs
+whose own diff is unrelated.
+
+The fix is to never rely on the ambient default: born the branch with
+``git init -b <name>`` (or ``--initial-branch=<name>``), rename it
+deterministically with ``git branch -M <name>``, or build the repo through
+:func:`tests._git_repo.make_git_repo`. This gate makes a regression mechanical
+instead of waiting for the next red-CI incident.
+
+The scanner walks every test ``.py`` for a ``git init`` invocation — either a
+subprocess argument list (``[..., "git", "init", ...]``) or a varargs git
+helper call (``_git(repo, "init", ...)`` / ``run_git(repo, "init", ...)``) —
+and flags one that specifies neither ``-b`` / ``--initial-branch`` (born the
+branch) nor ``--bare`` (a bare repo has no working branch to assume). A bare
+init whose branch is immediately renamed with ``git branch -M`` is the
+deterministic-rename idiom and is exempt; a deliberate bare init declares
+intent with a ``# git-fixture: default-branch-ok`` pragma on the call line.
+"""
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / "tests"
+
+_PRAGMA = "git-fixture: default-branch-ok"
+
+# A ``git init`` that bornes or renames the branch is safe.
+_BORN_FLAGS = ("-b", "--initial-branch")
+_BARE_FLAGS = ("--bare",)
+
+# Global git flags that take a following value, so the subcommand is not the very
+# next token (``git -C <path> init`` → the subcommand is ``init``, not ``<path>``).
+_VALUE_TAKING_GLOBAL_FLAGS = ("-C", "--git-dir", "--work-tree", "--namespace", "-c")
+
+# Varargs git-helper call names across the test packages (``_git(repo, "init", …)``,
+# ``run_git(repo, "init", …)``, ``self._git(repo, "init", …)``).
+_GIT_HELPER_NAMES = ("_git", "run_git", "_run_git")
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "git_fixture_default_branch"
+_MUST_FLAG = sorted((_FIXTURES / "must_flag").glob("*.py.txt"))
+_MUST_NOT_FLAG = sorted((_FIXTURES / "must_not_flag").glob("*.py.txt"))
+
+
+@dataclass(frozen=True)
+class GitInitFinding:
+    """A ``git init`` call that assumes the ambient default branch."""
+
+    path: Path
+    lineno: int
+
+
+def _arg_value(node: ast.expr) -> str | None:
+    """A positional arg's constant-string value, or ``None`` for a runtime expression.
+
+    Positions are preserved (``None`` placeholders) so a value-taking global flag
+    such as ``-C <runtime-path>`` keeps its pairing — otherwise dropping the
+    non-constant path would misalign the skip and mis-read the subcommand.
+    """
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
+
+
+def _call_args(node: ast.Call) -> list[str | None]:
+    """Positional args of a call, constants as strings and runtime exprs as ``None``."""
+    return [_arg_value(a) for a in node.args]
+
+
+def _git_list_args(node: ast.List) -> list[str | None] | None:
+    """Arg vector after the literal ``"git"`` element, or ``None`` if not a git vector."""
+    elems = [_arg_value(e) for e in node.elts]
+    if "git" not in elems:
+        return None
+    return elems[elems.index("git") + 1 :]
+
+
+def _has_born_or_bare_flag(args: list[str | None]) -> bool:
+    """Whether the vector borns the branch (``-b`` / ``--initial-branch[=…]``) or is bare."""
+    for token in args:
+        if token is None:
+            continue
+        if token in _BORN_FLAGS or token in _BARE_FLAGS:
+            return True
+        if token.startswith(("--initial-branch=", "--bare")):
+            return True
+    return False
+
+
+def _git_subcommand(args: list[str | None]) -> str | None:
+    """The git subcommand verb in an arg vector, skipping value-taking global flags.
+
+    ``["-C", "<path>", "init", "-q"]`` → ``init``. A ``-m "init"`` message is the
+    value of ``-m``, not the verb, so ``["commit", "-m", "init"]`` → ``commit``.
+    """
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token is not None and token in _VALUE_TAKING_GLOBAL_FLAGS:
+            i += 2
+            continue
+        if token is None or token.startswith("-"):
+            i += 1
+            continue
+        return token
+    return None
+
+
+def _init_assumes_default_branch(args: list[str | None]) -> bool:
+    """A git arg vector whose subcommand is ``init`` without borning or declaring bare."""
+    if _git_subcommand(args) != "init":
+        return False
+    return not _has_born_or_bare_flag(args)
+
+
+def _call_helper_name(node: ast.Call) -> str | None:
+    """The dotted-or-bare callee name of a call (``_git``, ``self._git``)."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def scan_source(source: str, path: Path) -> list[GitInitFinding]:
+    """Findings for one parsed source string."""
+    tree = ast.parse(source)
+    pragma = {i for i, line in enumerate(source.splitlines(), start=1) if _PRAGMA in line}
+    findings: list[GitInitFinding] = []
+    for node in ast.walk(tree):
+        args: list[str | None] | None = None
+        if isinstance(node, ast.List):
+            args = _git_list_args(node)
+        elif isinstance(node, ast.Call) and _call_helper_name(node) in _GIT_HELPER_NAMES:
+            args = _call_args(node)
+        if args is None or not _init_assumes_default_branch(args):
+            continue
+        if node.lineno in pragma:
+            continue
+        findings.append(GitInitFinding(path, node.lineno))
+    return findings
+
+
+def scan_file(path: Path) -> list[GitInitFinding]:
+    """Findings for one file (``.py`` or a ``.py.txt`` corpus fixture)."""
+    return scan_source(path.read_text(encoding="utf-8"), path)
+
+
+def scan_tree(root: Path) -> list[GitInitFinding]:
+    """Findings across every ``*.py`` test module under ``root``."""
+    if not root.exists():
+        return []
+    findings: list[GitInitFinding] = []
+    for py in sorted(root.rglob("*.py")):
+        findings.extend(scan_file(py))
+    return findings
+
+
+class TestLiveTree:
+    def test_no_real_git_fixture_assumes_the_default_branch(self) -> None:
+        findings = scan_tree(_TESTS_ROOT)
+        assert not findings, (
+            "real-git fixture(s) run `git init` without `-b`/`--initial-branch` (or `--bare`) — "
+            "born the branch (`git init -b main`), rename it (`git branch -M main`), or build the "
+            "repo with `tests._git_repo.make_git_repo` (add a `# git-fixture: default-branch-ok` "
+            "pragma only for a deliberate bare init):\n"
+            + "\n".join(f"  {f.path.relative_to(_REPO_ROOT)}:{f.lineno}" for f in findings)
+        )
+
+
+class TestScanner:
+    def test_bare_init_subprocess_list_is_flagged(self) -> None:
+        src = 'subprocess.run(["git", "init", "-q", str(p)], check=True)\n'
+        findings = scan_source(src, Path("x.py"))
+        assert len(findings) == 1
+
+    def test_init_with_dash_b_is_not_flagged(self) -> None:
+        src = 'subprocess.run(["git", "init", "-q", "-b", "main", str(p)], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_init_with_initial_branch_value_form_is_not_flagged(self) -> None:
+        src = 'subprocess.run(["git", "init", "--initial-branch=main", str(p)], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_helper_init_with_initial_branch_value_form_is_not_flagged(self) -> None:
+        src = '_git(main, "init", "--initial-branch=main", "-q")\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_commit_with_runtime_dash_c_path_is_not_flagged(self) -> None:
+        # ``git -C <runtime-path> commit -m init`` — the verb is commit; the
+        # ``init`` is the message. The runtime ``-C`` value must not misalign it.
+        src = 'subprocess.run(["git", "-C", str(p), "commit", "-q", "-m", "init"], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_init_with_runtime_dash_c_path_is_flagged(self) -> None:
+        src = 'subprocess.run(["git", "-C", str(p), "init", "-q"], check=True)\n'
+        assert len(scan_source(src, Path("x.py"))) == 1
+
+    def test_bare_repo_init_is_not_flagged(self) -> None:
+        src = 'subprocess.run(["git", "init", "-q", "--bare", str(p)], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_bare_helper_init_is_flagged(self) -> None:
+        src = '_git(repo, "init", "-q")\n'
+        findings = scan_source(src, Path("x.py"))
+        assert len(findings) == 1
+
+    def test_helper_init_with_dash_b_is_not_flagged(self) -> None:
+        src = '_git(repo, "init", "-q", "-b", "main")\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_method_helper_init_is_scanned(self) -> None:
+        src = 'self._git(repo, "init", "-q")\n'
+        assert len(scan_source(src, Path("x.py"))) == 1
+
+    def test_run_git_helper_init_is_scanned(self) -> None:
+        src = 'run_git("init", "-q", cwd=repo)\n'
+        assert len(scan_source(src, Path("x.py"))) == 1
+
+    def test_non_init_git_list_is_not_flagged(self) -> None:
+        src = 'subprocess.run(["git", "commit", "-m", "init"], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_non_git_list_with_init_word_is_not_flagged(self) -> None:
+        # An arg vector without "git" is some other tool — never a git-init fixture.
+        src = 'subprocess.run(["docker", "init"], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_pragma_opts_out_a_deliberate_bare_init(self) -> None:
+        src = f'subprocess.run(["git", "init", str(p)], check=True)  # {_PRAGMA}\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_finding_carries_location(self) -> None:
+        src = '\n\nsubprocess.run(["git", "init", str(p)], check=True)\n'
+        findings = scan_source(src, Path("y.py"))
+        assert len(findings) == 1
+        assert findings[0].lineno == 3
+        assert findings[0].path == Path("y.py")
+
+    def test_scan_tree_skips_nonexistent_root(self) -> None:
+        assert scan_tree(_REPO_ROOT / "does_not_exist") == []
+
+
+class TestGoldenCorpus:
+    def test_corpus_has_both_dimensions(self) -> None:
+        assert _MUST_FLAG, "must-FLAG corpus is empty"
+        assert _MUST_NOT_FLAG, "must-NOT-FLAG corpus is empty (over-block dimension missing)"
+
+    @pytest.mark.parametrize("fixture", _MUST_FLAG, ids=[p.stem for p in _MUST_FLAG])
+    def test_must_flag_fixture_is_flagged(self, fixture: Path) -> None:
+        assert scan_file(fixture), f"{fixture.name} should produce a finding but did not"
+
+    @pytest.mark.parametrize("fixture", _MUST_NOT_FLAG, ids=[p.stem for p in _MUST_NOT_FLAG])
+    def test_must_not_flag_fixture_is_not_flagged(self, fixture: Path) -> None:
+        findings = scan_file(fixture)
+        assert not findings, f"{fixture.name} wrongly flagged at lines: " + ", ".join(str(f.lineno) for f in findings)

--- a/tests/teatree_core/management/commands/test__workspace_isolated_roots.py
+++ b/tests/teatree_core/management/commands/test__workspace_isolated_roots.py
@@ -75,7 +75,7 @@ class TestReapOrphanIsolatedWorktreeRoots(TestCase):
         slug = paths.isolated_slug(Path("/gone/with/git"))
         env_dir = self.root / slug
         env_dir.mkdir()
-        _git(env_dir, "init")
+        _git(env_dir, "init", "-b", "main")
 
         result = reaper.reap_orphan_isolated_worktree_roots()
 

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -218,7 +218,7 @@ class TestE2eRunWorkItem(TestCase):
 
     def _make_repo(self, path: Path) -> str:
         path.mkdir(parents=True, exist_ok=True)
-        self._git(path, "init", "-q")
+        self._git(path, "init", "-q", "-b", "main")
         self._git(path, "config", "user.email", "t@t.test")
         self._git(path, "config", "user.name", "T")
         (path / "f").write_text("x")

--- a/tests/teatree_core/test_e2e_workitem.py
+++ b/tests/teatree_core/test_e2e_workitem.py
@@ -32,7 +32,7 @@ def _git(path: Path, *args: str) -> str:
 
 def _init_repo_with_commits(path: Path, n: int = 2) -> list[str]:
     path.mkdir(parents=True, exist_ok=True)
-    _git(path, "init", "-q")
+    _git(path, "init", "-q", "-b", "main")
     _git(path, "config", "user.email", "t@t.test")
     _git(path, "config", "user.name", "T")
     shas: list[str] = []

--- a/tests/teatree_core/test_hook_router_block_edit_before_planned.py
+++ b/tests/teatree_core/test_hook_router_block_edit_before_planned.py
@@ -32,7 +32,7 @@ def _git_repo(path: Path) -> str:
     import os  # noqa: PLC0415
 
     env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")} | _GIT_ENV
-    subprocess.run(["git", "init", "-q", str(path)], check=True, env=env)  # noqa: S607
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True, env=env)  # noqa: S607
     return subprocess.run(
         ["git", "-C", str(path), "rev-parse", "--show-toplevel"],  # noqa: S607
         check=True,

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -358,7 +358,7 @@ class TestRelativeBodyFileResolvesAgainstCommandDir:
         worktree = workspace / "worktree"
         worktree.mkdir(parents=True)
         ambient_cwd.mkdir()
-        _git(worktree, "init", "-q")
+        _git(worktree, "init", "-q", "-b", "main")
         (worktree / "msg.txt").write_text("internal note about acmecorp\n", encoding="utf-8")
         # Process cwd is OUTSIDE the workspace, so a process-cwd-relative parse
         # cannot find the body -- only the ambient-cwd anchor reaches it.

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -102,7 +102,7 @@ def test_repo_freshness_on_real_git_repo(tmp_path: Path) -> None:
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    run_allowed_to_fail(["git", "init"], cwd=repo, expected_codes=None)
+    run_allowed_to_fail(["git", "init", "-b", "main"], cwd=repo, expected_codes=None)
     run_allowed_to_fail(["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, expected_codes=None)
     info = _repo_freshness(repo)
     assert info is not None

--- a/tests/teatree_utils/test_diff_coverage.py
+++ b/tests/teatree_utils/test_diff_coverage.py
@@ -80,7 +80,7 @@ def _coverage_db_without(repo: Path) -> Path:
 def git_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
-    _git(repo, "init", "-q")
+    _git(repo, "init", "-q", "-b", "main")
     _git(repo, "config", "user.email", "t@example.com")
     _git(repo, "config", "user.name", "T")
     (repo / "base.py").write_text("def kept():\n    return 1\n", encoding="utf-8")

--- a/tests/test_git_repo_helper.py
+++ b/tests/test_git_repo_helper.py
@@ -1,0 +1,42 @@
+"""Tests for the shared default-branch-independent real-git fixture builder.
+
+The contract that matters (souliane/teatree#2359): :func:`make_git_repo` bornes
+the requested branch regardless of the host's ``init.defaultBranch``. The
+``GIT_CONFIG_NOSYSTEM`` lane in CI (and ``tests/conftest.py`` preserving the var)
+exercises these under git's compiled-in ``master`` default, so a repo built here
+must carry ``main`` (or whatever was asked) even when the ambient default differs.
+"""
+
+from pathlib import Path
+
+from tests._git_repo import make_git_repo, run_git
+
+
+class TestMakeGitRepo:
+    def test_default_branch_is_main_regardless_of_ambient_default(self, tmp_path: Path) -> None:
+        repo = make_git_repo(tmp_path / "repo")
+        assert run_git(repo, "symbolic-ref", "--short", "HEAD") == "main"
+
+    def test_initial_commit_gives_main_a_resolvable_head(self, tmp_path: Path) -> None:
+        repo = make_git_repo(tmp_path / "repo")
+        # A ``worktree add <path> main`` resolves only if ``main`` has a HEAD; it
+        # also needs ``main`` to not be the repo's own checkout, so move off it.
+        run_git(repo, "checkout", "-q", "-b", "feature")
+        run_git(repo, "worktree", "add", str(tmp_path / "wt"), "main")
+        assert (tmp_path / "wt").is_dir()
+
+    def test_custom_default_branch_is_borned(self, tmp_path: Path) -> None:
+        repo = make_git_repo(tmp_path / "repo", default_branch="trunk")
+        assert run_git(repo, "symbolic-ref", "--short", "HEAD") == "trunk"
+
+    def test_without_initial_commit_branch_is_unborn(self, tmp_path: Path) -> None:
+        repo = make_git_repo(tmp_path / "repo", initial_commit=False)
+        # No commit yet: HEAD points at the symbolic ref but it has no object,
+        # so ``rev-parse HEAD`` does not resolve.
+        assert run_git(repo, "symbolic-ref", "--short", "HEAD") == "main"
+        assert run_git(repo, "rev-parse", "--verify", "--quiet", "HEAD", check=False) == ""
+
+    def test_bare_repo_has_no_working_tree(self, tmp_path: Path) -> None:
+        repo = make_git_repo(tmp_path / "remote.git", bare=True)
+        assert run_git(repo, "rev-parse", "--is-bare-repository") == "true"
+        assert not (repo / ".git").exists()

--- a/tests/test_hook_router_plan_gate_escapes.py
+++ b/tests/test_hook_router_plan_gate_escapes.py
@@ -44,7 +44,7 @@ def _git_repo(path: Path) -> str:
     import os  # noqa: PLC0415
 
     env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")} | _GIT_ENV
-    subprocess.run(["git", "init", "-q", str(path)], check=True, env=env)  # noqa: S607
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True, env=env)  # noqa: S607
     return subprocess.run(
         ["git", "-C", str(path), "rev-parse", "--show-toplevel"],  # noqa: S607
         check=True,


### PR DESCRIPTION
## Summary

Class A of #2359: real-git fixtures that assumed `main` was the default branch. A bare `git init` (no `-b`) bornes HEAD on whatever `init.defaultBranch` resolves to — `main` on a dev box, but git's compiled-in `master` in the CI image — so a fixture that later references `main` exits 128 (`invalid reference: main` / `src refspec main does not match any`), red-flagging the full-suite `test (3.13)` job on PRs whose own diff is unrelated.

Class B (order-dependent shared-state pollution) is out of scope and tracked separately on #2359.

## What changed

**Fixtures swept (9 bare `git init` sites → `git init -b main`):**

- `tests/cli_doctor/test_make_editable.py`
- `tests/teatree_core/management/commands/test__workspace_isolated_roots.py`
- `tests/teatree_core/management_commands/test_e2e.py`
- `tests/teatree_core/test_e2e_workitem.py`
- `tests/teatree_core/test_hook_router_block_edit_before_planned.py`
- `tests/teatree_hooks/test_banned_terms_scanner.py`
- `tests/teatree_loop/test_tick.py`
- `tests/teatree_utils/test_diff_coverage.py`
- `tests/test_hook_router_plan_gate_escapes.py`

The fixtures named in the issue (`test_pull_main_clone_scanner.py`, `test_self_update_scanner.py`) and the #2354-fixed `test_workspace.py` were already default-branch-independent (they use `--initial-branch=main` / `-b main`); they are left as-is.

**Shared helper added (yes):** `tests/_git_repo.make_git_repo(path, *, default_branch="main", initial_commit=True, bare=False)` — the builder new real-git fixtures should use, so the default branch is an argument, not an ambient assumption. Covered 100% by `tests/test_git_repo_helper.py`.

**Anti-recurrence:**

- `tests/quality/test_git_fixture_default_branch.py` — a deterministic AST fitness function that statically flags any real-git fixture running `git init` without `-b`/`--initial-branch` (or `--bare`). Live-tree gate + scanner units + golden corpus (must-flag / must-not-flag), with a `# git-fixture: default-branch-ok` pragma escape for a deliberate bare init.
- `tests/conftest.py` now preserves `GIT_CONFIG_NOSYSTEM` / `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` through its git-hook env strip (these are config-source controls, not the index/worktree hook vars the strip targets) so the CI default-branch condition is reproducible locally.
- `.github/workflows/ci.yml` runs the heavy `test` lane under `GIT_CONFIG_NOSYSTEM=1`, forcing the master-default condition deterministically regardless of the base image's ambient git config.

## Anti-vacuity proof (`GIT_CONFIG_NOSYSTEM=1`)

`GIT_CONFIG_NOSYSTEM=1` forces git's compiled-in `master` default, matching a Linux CI runner.

- **Before (bare `git init` + `push origin main`):** RED under `GIT_CONFIG_NOSYSTEM=1` — `error: src refspec main does not match any` (the local default branch is `master`, so `main` does not exist). A `worktree add <path> main` variant of the same shape fails `fatal: invalid reference: main`, exit 128 — the exact CI symptom.
- **After (`git init -b main`):** GREEN.

The swept + touched files pass under both a normal run and a `GIT_CONFIG_NOSYSTEM=1` run (476 passed). The fitness function reproduces RED if any of the 9 conversions is reverted.

## Architecture pre-check — #2359 (class A)

**1. BLUEPRINT § alignment** — Test-infrastructure reliability / architectural-fitness concern; no behavioural code touched. No BLUEPRINT section change required.

**2. FSM phase boundaries** — n/a (no `Ticket.State` / `Worktree.State` transition).

**3. Extension-point contracts** — n/a (no `OverlayBase` / scanner / hook / Protocol surface touched).

**4. Component boundaries** — Changes confined to `tests/` plus one CI workflow file. New shared test helper lives at `tests/_git_repo.py`; the fitness function under `tests/quality/` alongside the existing fitness suite.

**5. Dependency direction** — Test-only; no `src/` import added. `tach` passed in pre-commit.

**6. Test surface** — The fitness function `TestLiveTree` asserts zero real-git fixtures assume the default branch; `TestScanner` + `TestGoldenCorpus` pin the detector against vacuity and over-blocking. `tests/test_git_repo_helper.py` pins the helper's default-branch-independence.

**7. Resilience invariants** — n/a (no external write introduced).

**8. Identity and key normalization** — n/a.

**9. Behavior preservation / capability deletion** — Purely additive plumbing. No test assertion changed; no must-block test inverted; no privacy/leak/security matcher narrowed. The conftest env strip is narrowed only for three config-source controls that do not carry the parent repo's index/worktree (the corruption the strip targets), preserving the strip's intent.

Addresses #2359 (class A; class B tracked separately).
