### PR TITLE
fix(quality): enforce the git-branch-rename idiom the fixture gate documents

### DIFF
--- a/tests/quality/fixtures/git_fixture_default_branch/must_flag/rename_scoped_not_global.py.txt
+++ b/tests/quality/fixtures/git_fixture_default_branch/must_flag/rename_scoped_not_global.py.txt
@@ -1,0 +1,13 @@
+import subprocess
+
+
+def bare_init_no_rename(p):
+    # A bare init with neither ``-b main`` nor a rename — still flagged. Proves
+    # the rename exemption did not gut the gate.
+    subprocess.run(["git", "init", str(p)], check=True)
+
+
+def renames_a_different_repo(p):
+    # The rename lives in a different function, so it does not exempt the bare
+    # init above — the exemption is function-scoped.
+    subprocess.run(["git", "-C", str(p), "branch", "-M", "main"], check=True)

--- a/tests/quality/fixtures/git_fixture_default_branch/must_not_flag/init_then_rename.py.txt
+++ b/tests/quality/fixtures/git_fixture_default_branch/must_not_flag/init_then_rename.py.txt
@@ -1,0 +1,24 @@
+import subprocess
+
+
+def setup(p):
+    # The sanctioned rename idiom: a bare init whose branch is immediately
+    # renamed to ``main`` deterministically. The literal ``main`` ref exists
+    # regardless of the host's ``init.defaultBranch``, so this is safe.
+    subprocess.run(["git", "init", "-q", str(p)], check=True)
+    subprocess.run(["git", "-C", str(p), "branch", "-M", "main"], check=True)
+
+
+def setup_helper(repo):
+    _git(repo, "init", "-q")
+    _git(repo, "branch", "-m", "main")
+
+
+def setup_checkout(repo):
+    _git(repo, "init", "-q")
+    _git(repo, "checkout", "-b", "main")
+
+
+def setup_switch(repo):
+    _git(repo, "init", "-q")
+    _git(repo, "switch", "-c", "main")

--- a/tests/quality/test_git_fixture_default_branch.py
+++ b/tests/quality/test_git_fixture_default_branch.py
@@ -18,10 +18,22 @@ The scanner walks every test ``.py`` for a ``git init`` invocation — either a
 subprocess argument list (``[..., "git", "init", ...]``) or a varargs git
 helper call (``_git(repo, "init", ...)`` / ``run_git(repo, "init", ...)``) —
 and flags one that specifies neither ``-b`` / ``--initial-branch`` (born the
-branch) nor ``--bare`` (a bare repo has no working branch to assume). A bare
-init whose branch is immediately renamed with ``git branch -M`` is the
-deterministic-rename idiom and is exempt; a deliberate bare init declares
-intent with a ``# git-fixture: default-branch-ok`` pragma on the call line.
+branch) nor ``--bare`` (a bare repo has no working branch to assume).
+
+The deterministic-rename idiom is exempt: a bare ``git init`` whose enclosing
+function also names the branch ``main`` deterministically — ``git branch -M
+main`` / ``git branch -m main`` (rename after init), ``git checkout -b main``,
+or ``git switch -c main`` — is safe, because the literal ``main`` ref is created
+regardless of the host's ``init.defaultBranch``. The exemption is scoped to the
+enclosing function: a bare init at module scope, or one in a function that has
+no such rename, is still flagged. Repo paths in real fixtures are runtime
+expressions (``str(p)``, ``-C str(p)``), so the exemption is function-scoped
+rather than per-repo-path-correlated — a deliberately mixed function that bare-
+inits one repo while renaming a *different* repo would be under-flagged, but
+that shape does not occur and the function scope is the reliable seam.
+
+A deliberate bare init with no rename declares intent with a
+``# git-fixture: default-branch-ok`` pragma on the call line.
 """
 
 import ast
@@ -38,6 +50,19 @@ _PRAGMA = "git-fixture: default-branch-ok"
 # A ``git init`` that bornes or renames the branch is safe.
 _BORN_FLAGS = ("-b", "--initial-branch")
 _BARE_FLAGS = ("--bare",)
+
+# The default branch a deterministic rename must target for the init to be exempt.
+_RENAME_TARGET_BRANCH = "main"
+
+# (subcommand, flag) pairs that deterministically name the current branch, so a
+# preceding bare ``git init`` in the same function does not assume the ambient
+# default: ``git branch -M/-m main`` (rename), ``git checkout -b main`` /
+# ``git switch -c main`` (create-and-switch).
+_RENAME_IDIOMS = (
+    ("branch", ("-M", "-m")),
+    ("checkout", ("-b",)),
+    ("switch", ("-c",)),
+)
 
 # Global git flags that take a following value, so the subcommand is not the very
 # next token (``git -C <path> init`` → the subcommand is ``init``, not ``<path>``).
@@ -121,6 +146,23 @@ def _init_assumes_default_branch(args: list[str | None]) -> bool:
     return not _has_born_or_bare_flag(args)
 
 
+def _renames_branch_to_main(args: list[str | None]) -> bool:
+    """A git arg vector that deterministically names the current branch ``main``.
+
+    Matches ``branch -M/-m main``, ``checkout -b main``, and ``switch -c main``
+    — the create/rename idioms that make ``main`` a real ref after a bare init.
+    """
+    subcommand = _git_subcommand(args)
+    rest = args[args.index(subcommand) + 1 :] if subcommand in args else []
+    for verb, flags in _RENAME_IDIOMS:
+        if subcommand != verb:
+            continue
+        for i, token in enumerate(rest):
+            if token in flags and rest[i + 1 :] and rest[i + 1] == _RENAME_TARGET_BRANCH:
+                return True
+    return False
+
+
 def _call_helper_name(node: ast.Call) -> str | None:
     """The dotted-or-bare callee name of a call (``_git``, ``self._git``)."""
     func = node.func
@@ -131,20 +173,65 @@ def _call_helper_name(node: ast.Call) -> str | None:
     return None
 
 
+def _git_vector(node: ast.AST) -> list[str | None] | None:
+    """The git arg vector a node represents, or ``None`` if it is not a git call.
+
+    A subprocess argument list (``["git", "init", …]``) or a varargs git-helper
+    call (``_git(repo, "init", …)``).
+    """
+    if isinstance(node, ast.List):
+        return _git_list_args(node)
+    if isinstance(node, ast.Call) and _call_helper_name(node) in _GIT_HELPER_NAMES:
+        return _call_args(node)
+    return None
+
+
+def _enclosing_scopes(tree: ast.AST) -> dict[ast.AST, ast.AST]:
+    """Map each function-defining node in *tree* to the function it is nested in.
+
+    The module itself maps to itself; a node's nearest enclosing function (or the
+    module) is the scope its rename idiom is correlated within.
+    """
+    parent: dict[ast.AST, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parent[child] = node
+    return parent
+
+
+def _nearest_function_scope(node: ast.AST, parent: dict[ast.AST, ast.AST], module: ast.AST) -> ast.AST:
+    """The nearest enclosing ``def``/``async def`` of *node*, or the module itself."""
+    current = parent.get(node)
+    while current is not None:
+        if isinstance(current, ast.FunctionDef | ast.AsyncFunctionDef):
+            return current
+        current = parent.get(current)
+    return module
+
+
 def scan_source(source: str, path: Path) -> list[GitInitFinding]:
-    """Findings for one parsed source string."""
+    """Findings for one parsed source string.
+
+    A bare ``git init`` is exempt when its enclosing function also names the
+    branch ``main`` deterministically (the rename idiom) — see the module
+    docstring for why the correlation is function-scoped, not per-repo-path.
+    """
     tree = ast.parse(source)
     pragma = {i for i, line in enumerate(source.splitlines(), start=1) if _PRAGMA in line}
+    parent = _enclosing_scopes(tree)
+    rename_scopes: set[ast.AST] = set()
+    for node in ast.walk(tree):
+        vector = _git_vector(node)
+        if vector is not None and _renames_branch_to_main(vector):
+            rename_scopes.add(_nearest_function_scope(node, parent, tree))
     findings: list[GitInitFinding] = []
     for node in ast.walk(tree):
-        args: list[str | None] | None = None
-        if isinstance(node, ast.List):
-            args = _git_list_args(node)
-        elif isinstance(node, ast.Call) and _call_helper_name(node) in _GIT_HELPER_NAMES:
-            args = _call_args(node)
-        if args is None or not _init_assumes_default_branch(args):
+        vector = _git_vector(node)
+        if vector is None or not _init_assumes_default_branch(vector):
             continue
         if node.lineno in pragma:
+            continue
+        if _nearest_function_scope(node, parent, tree) in rename_scopes:
             continue
         findings.append(GitInitFinding(path, node.lineno))
     return findings
@@ -238,6 +325,53 @@ class TestScanner:
     def test_pragma_opts_out_a_deliberate_bare_init(self) -> None:
         src = f'subprocess.run(["git", "init", str(p)], check=True)  # {_PRAGMA}\n'
         assert scan_source(src, Path("x.py")) == []
+
+    def test_bare_init_then_branch_rename_to_main_is_not_flagged(self) -> None:
+        src = (
+            "def setup(p):\n"
+            '    subprocess.run(["git", "init", "-q", str(p)], check=True)\n'
+            '    subprocess.run(["git", "-C", str(p), "branch", "-M", "main"], check=True)\n'
+        )
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_bare_helper_init_then_branch_rename_to_main_is_not_flagged(self) -> None:
+        src = 'def setup(repo):\n    _git(repo, "init", "-q")\n    _git(repo, "branch", "-m", "main")\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_bare_init_then_checkout_new_main_is_not_flagged(self) -> None:
+        src = 'def setup(repo):\n    _git(repo, "init", "-q")\n    _git(repo, "checkout", "-b", "main")\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_bare_init_then_switch_new_main_is_not_flagged(self) -> None:
+        src = 'def setup(repo):\n    _git(repo, "init", "-q")\n    _git(repo, "switch", "-c", "main")\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_bare_init_with_no_rename_is_still_flagged(self) -> None:
+        src = 'def setup(p):\n    subprocess.run(["git", "init", str(p)], check=True)\n'
+        assert len(scan_source(src, Path("x.py"))) == 1
+
+    def test_rename_in_a_different_function_does_not_exempt(self) -> None:
+        src = (
+            "def setup(p):\n"
+            '    subprocess.run(["git", "init", str(p)], check=True)\n'
+            "\n"
+            "def other(p):\n"
+            '    subprocess.run(["git", "-C", str(p), "branch", "-M", "main"], check=True)\n'
+        )
+        assert len(scan_source(src, Path("x.py"))) == 1
+
+    def test_rename_to_a_non_main_branch_does_not_exempt(self) -> None:
+        src = 'def setup(p):\n    _git(p, "init", "-q")\n    _git(p, "branch", "-M", "trunk")\n'
+        assert len(scan_source(src, Path("x.py"))) == 1
+
+    def test_module_scope_bare_init_is_flagged_despite_a_function_rename(self) -> None:
+        src = (
+            'subprocess.run(["git", "init", str(p)], check=True)\n'
+            "\n"
+            "def setup(p):\n"
+            '    subprocess.run(["git", "-C", str(p), "branch", "-M", "main"], check=True)\n'
+        )
+        assert len(scan_source(src, Path("x.py"))) == 1
 
     def test_finding_carries_location(self) -> None:
         src = '\n\nsubprocess.run(["git", "init", str(p)], check=True)\n'

--- a/tests/teatree_core/management/commands/test__workspace_isolated_roots.py
+++ b/tests/teatree_core/management/commands/test__workspace_isolated_roots.py
@@ -8,7 +8,6 @@ never one that still holds a git checkout or any uncommitted/unpushed work
 """
 
 import shutil
-import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -18,12 +17,9 @@ from django.test import TestCase
 from teatree import paths
 from teatree.core.management.commands import _workspace_isolated_roots as reaper
 from teatree.core.models import Ticket, Worktree
+from tests._git_repo import make_git_repo
 
 _REAP = "teatree.core.management.commands._workspace_isolated_roots"
-
-
-def _git(cwd: Path, *args: str) -> None:
-    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)  # noqa: S607
 
 
 def _make_env_dir(root: Path, slug: str) -> Path:
@@ -73,9 +69,7 @@ class TestReapOrphanIsolatedWorktreeRoots(TestCase):
 
     def test_dir_holding_a_git_checkout_is_skipped(self) -> None:
         slug = paths.isolated_slug(Path("/gone/with/git"))
-        env_dir = self.root / slug
-        env_dir.mkdir()
-        _git(env_dir, "init", "-b", "main")
+        env_dir = make_git_repo(self.root / slug, initial_commit=False)
 
         result = reaper.reap_orphan_isolated_worktree_roots()
 

--- a/tests/teatree_core/test_hook_router_block_edit_before_planned.py
+++ b/tests/teatree_core/test_hook_router_block_edit_before_planned.py
@@ -14,7 +14,6 @@ the resolver runs for real. RED with the field-name bug reintroduced.
 """
 
 import json
-import subprocess
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
@@ -23,23 +22,13 @@ from django.test import TestCase
 
 import hooks.scripts.hook_router as router
 from teatree.core.models import Ticket, Worktree
-
-_GIT_ENV = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e"}
+from tests._git_repo import make_git_repo, run_git
 
 
 def _git_repo(path: Path) -> str:
     """Init a real git repo at *path* and return its resolved toplevel."""
-    import os  # noqa: PLC0415
-
-    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")} | _GIT_ENV
-    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True, env=env)  # noqa: S607
-    return subprocess.run(
-        ["git", "-C", str(path), "rev-parse", "--show-toplevel"],  # noqa: S607
-        check=True,
-        capture_output=True,
-        text=True,
-        env=env,
-    ).stdout.strip()
+    make_git_repo(path, initial_commit=False)
+    return run_git(path, "rev-parse", "--show-toplevel")
 
 
 def _capture_block(data: dict) -> tuple[bool, dict | None]:

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -10,6 +10,7 @@ import pytest
 
 from teatree.loop.scanners.base import Scanner, ScanSignal
 from teatree.loop.tick import TickRequest, _repo_freshness, build_default_scanners, run_tick
+from tests._git_repo import make_git_repo
 
 
 @dataclass(slots=True)
@@ -98,12 +99,7 @@ def test_tick_meta_cadence_falls_back_to_toml(tmp_path: Path, monkeypatch: pytes
 
 
 def test_repo_freshness_on_real_git_repo(tmp_path: Path) -> None:
-    from teatree.utils.run import run_allowed_to_fail  # noqa: PLC0415
-
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    run_allowed_to_fail(["git", "init", "-b", "main"], cwd=repo, expected_codes=None)
-    run_allowed_to_fail(["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, expected_codes=None)
+    repo = make_git_repo(tmp_path / "repo")
     info = _repo_freshness(repo)
     assert info is not None
     assert isinstance(info["behind"], int)

--- a/tests/test_hook_router_plan_gate_escapes.py
+++ b/tests/test_hook_router_plan_gate_escapes.py
@@ -17,7 +17,6 @@ These tests drive the real handler + real DB rows — no monkeypatching of
 """
 
 import json
-import subprocess
 import tempfile
 from io import StringIO
 from pathlib import Path
@@ -30,28 +29,13 @@ from typer.testing import CliRunner
 import hooks.scripts.hook_router as router
 from teatree.cli.teatree_gate import PLAN_GATE_KEY, _gate_key_is_enabled, register_gate_commands
 from teatree.core.models import Ticket, Worktree
-
-_GIT_ENV = {
-    "GIT_AUTHOR_NAME": "t",
-    "GIT_AUTHOR_EMAIL": "t@e",
-    "GIT_COMMITTER_NAME": "t",
-    "GIT_COMMITTER_EMAIL": "t@e",
-}
+from tests._git_repo import make_git_repo, run_git
 
 
 def _git_repo(path: Path) -> str:
     """Init a real git repo at *path* and return its resolved toplevel."""
-    import os  # noqa: PLC0415
-
-    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")} | _GIT_ENV
-    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True, env=env)  # noqa: S607
-    return subprocess.run(
-        ["git", "-C", str(path), "rev-parse", "--show-toplevel"],  # noqa: S607
-        check=True,
-        capture_output=True,
-        text=True,
-        env=env,
-    ).stdout.strip()
+    make_git_repo(path, initial_commit=False)
+    return run_git(path, "rev-parse", "--show-toplevel")
 
 
 def _capture_block(data: dict) -> tuple[bool, dict | None]:


### PR DESCRIPTION
## Summary

A cold review of PR #2362 found two coherence gaps in the git-fixture default-branch fitness function. This PR closes both.

## F1 — the gate rejected an idiom it documents as allowed

The fitness function advertises three sanctioned safe idioms: git init -b main, a git branch -M main rename after a bare init, and make_git_repo. But the scanner only inspected the init call's own flags, with no logic to detect a following rename. A fixture doing a bare git init then git branch -M main was wrongly flagged (findings=1) even though it is safe — so a future fixture written in that documented idiom would get a false RED.

The fix makes the scanner match its documented contract. A bare git init is now exempt when its enclosing function also names the branch main deterministically: git branch -M/-m main (rename), git checkout -b main, or git switch -c main. Repo paths in real fixtures are runtime expressions (str(p), -C str(p)), so the correlation is function-scoped rather than per-repo-path; the module docstring states this scoping precisely rather than hiding the gap.

The exemption is bounded so it does not gut the gate: a rename in a different function does not exempt the bare init, a rename to a non-main branch does not exempt, and a module-scope bare init stays flagged despite a function-level rename.

Anti-vacuity: a new must-not-flag corpus fixture (init_then_rename) produces 4 findings on the pre-fix flat scanner (RED) and 0 on the fixed scanner (GREEN), proving the exemption is load-bearing. A new must-flag corpus fixture (rename_scoped_not_global) keeps a bare init flagged when the rename lives in a different function, proving the gate is not weakened.

## F2 — make_git_repo now earns its place

The helper added in #2362 was built and unit-tested but adopted by zero fixtures. Four swept fixtures that just need an initialized repo are migrated to make_git_repo: test_tick repo-freshness, the two plan-gate _git_repo helpers, and the isolated-roots git-checkout case. Bespoke git setups (content-specific initial commits, multi-commit SHA ladders, bare remotes) stay on inline git init -b main, which the gate allows — they are not contorted through the helper.

## Verification

gate + helper test files green (135 tests); migrated fixtures pass under a simulated CI master-default (GIT_CONFIG_NOSYSTEM plus a hostile init.defaultBranch=master); ruff check, ruff format --check, ty check, tach, module-health all clean.

## Architecture pre-check

Tactical test-tooling change (a fitness-function scanner and test fixtures, no src/teatree). 1 BLUEPRINT alignment: n/a. 2 FSM: n/a. 3 extension-point contracts: n/a. 4 component boundaries: tests/quality fitness function and tests/_git_repo helper, unchanged module homes. 5 dependency direction: tach green. 6 test surface: the gate's own corpus and scanner unit tests assert the new exemption and its bounds. 7 resilience: n/a. 8 identity normalization: n/a. 9 behavior preservation: the scanner is widened, not narrowed — no must-block test inverted; the must-flag corpus fixture pins that the rename exemption stays function-scoped.

Relates-to #2359